### PR TITLE
feat: evaluate graph finding rules directly

### DIFF
--- a/cmd/cerebro/finding_rule.go
+++ b/cmd/cerebro/finding_rule.go
@@ -16,7 +16,9 @@ import (
 	"github.com/writer/cerebro/internal/findings"
 )
 
-const findingRuleUsage = "usage: %s finding-rule new <rule-id> source_id=<source> event_kinds=<kind[,kind]> [name=<name>] [output_kind=<kind>] [severity=<severity>] [status=<status>] [maturity=<maturity>] [tags=<tag[,tag]>] [required_attributes=<attr[,attr]>] [fingerprint_fields=<field[,field]>] [lifecycle_kind=<kind>] [lifecycle_anchor=<anchor>] [lifecycle_ttl=<duration>] [pack=<pack>] [output_dir=<dir>] [dry_run=true] [force=true]"
+const findingRuleNewUsage = "usage: %s finding-rule new <rule-id> source_id=<source> event_kinds=<kind[,kind]> [name=<name>] [output_kind=<kind>] [severity=<severity>] [status=<status>] [maturity=<maturity>] [tags=<tag[,tag]>] [required_attributes=<attr[,attr]>] [fingerprint_fields=<field[,field]>] [lifecycle_kind=<kind>] [lifecycle_anchor=<anchor>] [lifecycle_ttl=<duration>] [pack=<pack>] [output_dir=<dir>] [dry_run=true] [force=true]"
+
+const findingRuleGraphEvaluateUsage = "usage: %s finding-rule graph-evaluate <runtime-id> rule_id=<graph-rule-id>"
 
 var errScaffoldDurableStateDefaultFingerprint = errors.New("lifecycle_kind=durable_state requires fingerprint_fields to include stable non-default fields; default [event_id] is event-scoped")
 
@@ -84,7 +86,7 @@ type findingRuleTemplateFixture struct {
 
 func runFindingRule(args []string) error {
 	if len(args) == 0 {
-		return usageError(fmt.Sprintf(findingRuleUsage, os.Args[0]))
+		return usageError(fmt.Sprintf("%s\n%s", fmt.Sprintf(findingRuleNewUsage, os.Args[0]), fmt.Sprintf(findingRuleGraphEvaluateUsage, os.Args[0])))
 	}
 	switch args[0] {
 	case "new":
@@ -97,14 +99,16 @@ func runFindingRule(args []string) error {
 			return err
 		}
 		return printJSON(result)
+	case "graph-evaluate":
+		return runFindingRuleGraphEvaluate(args[1:])
 	default:
-		return usageError(fmt.Sprintf(findingRuleUsage, os.Args[0]))
+		return usageError(fmt.Sprintf("%s\n%s", fmt.Sprintf(findingRuleNewUsage, os.Args[0]), fmt.Sprintf(findingRuleGraphEvaluateUsage, os.Args[0])))
 	}
 }
 
 func parseFindingRuleNewArgs(args []string) (findingRuleScaffoldRequest, error) {
 	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
-		return findingRuleScaffoldRequest{}, usageError(fmt.Sprintf(findingRuleUsage, os.Args[0]))
+		return findingRuleScaffoldRequest{}, usageError(fmt.Sprintf(findingRuleNewUsage, os.Args[0]))
 	}
 	ruleID := strings.TrimSpace(args[0])
 	if err := validateScaffoldRuleID(ruleID); err != nil {
@@ -121,7 +125,7 @@ func parseFindingRuleNewArgs(args []string) (findingRuleScaffoldRequest, error) 
 	sourceID := values["source_id"]
 	eventKinds := splitCSV(values["event_kinds"])
 	if strings.TrimSpace(sourceID) == "" || len(eventKinds) == 0 {
-		return findingRuleScaffoldRequest{}, usageError(fmt.Sprintf(findingRuleUsage, os.Args[0]))
+		return findingRuleScaffoldRequest{}, usageError(fmt.Sprintf(findingRuleNewUsage, os.Args[0]))
 	}
 	outputKind := strings.TrimSpace(values["output_kind"])
 	if outputKind == "" {

--- a/cmd/cerebro/finding_rule_graph_evaluate.go
+++ b/cmd/cerebro/finding_rule_graph_evaluate.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/bootstrap"
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type findingRuleGraphEvaluateOptions struct {
+	RuntimeID string
+	RuleID    string
+}
+
+type findingRuleGraphEvaluateResult struct {
+	RuntimeID   string                                     `json:"runtime_id"`
+	SourceID    string                                     `json:"source_id,omitempty"`
+	TenantID    string                                     `json:"tenant_id,omitempty"`
+	Evaluations []findingRuleGraphEvaluateEvaluationResult `json:"evaluations"`
+}
+
+type findingRuleGraphEvaluateEvaluationResult struct {
+	RuleID          string   `json:"rule_id"`
+	RunID           string   `json:"run_id,omitempty"`
+	Status          string   `json:"status,omitempty"`
+	RowsRead        uint32   `json:"rows_read"`
+	Truncated       bool     `json:"truncated,omitempty"`
+	FindingsEmitted int      `json:"findings_emitted"`
+	FindingIDs      []string `json:"finding_ids,omitempty"`
+	EvidenceCount   int      `json:"evidence_count"`
+	StartedAt       string   `json:"started_at,omitempty"`
+	FinishedAt      string   `json:"finished_at,omitempty"`
+}
+
+func runFindingRuleGraphEvaluate(args []string) error {
+	options, err := parseFindingRuleGraphEvaluateArgs(args)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("open dependencies: %w", err)
+	}
+	defer func() {
+		if err := closeDeps(); err != nil {
+			log.Printf("close dependencies: %v", err)
+		}
+	}()
+	service := findings.New(
+		sourceRuntimeStore(deps.StateStore),
+		eventReplayer(deps.AppendLog),
+		findingStore(deps.StateStore),
+		findingEvaluationRunStore(deps.StateStore),
+		findingEvidenceStore(deps.StateStore),
+		claimStore(deps.StateStore),
+	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(findingGraphQueryStore(deps.GraphStore)).WithAppendLog(deps.AppendLog)
+	evaluation, err := service.EvaluateSourceRuntimeGraphRules(ctx, findings.EvaluateGraphRulesRequest{
+		RuntimeID: options.RuntimeID,
+		RuleIDs:   []string{options.RuleID},
+	})
+	result := summarizeFindingRuleGraphEvaluation(evaluation)
+	if printErr := printJSON(result); printErr != nil {
+		return printErr
+	}
+	return err
+}
+
+func parseFindingRuleGraphEvaluateArgs(args []string) (findingRuleGraphEvaluateOptions, error) {
+	if len(args) < 2 || strings.TrimSpace(args[0]) == "" {
+		return findingRuleGraphEvaluateOptions{}, usageError(fmt.Sprintf(findingRuleGraphEvaluateUsage, os.Args[0]))
+	}
+	options := findingRuleGraphEvaluateOptions{RuntimeID: strings.TrimSpace(args[0])}
+	values := map[string]string{}
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return findingRuleGraphEvaluateOptions{}, fmt.Errorf("invalid graph-evaluate argument %q; want key=value", arg)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key != "rule_id" {
+			return findingRuleGraphEvaluateOptions{}, fmt.Errorf("unsupported graph-evaluate argument %q", key)
+		}
+		if _, exists := values[key]; exists {
+			return findingRuleGraphEvaluateOptions{}, fmt.Errorf("duplicate graph-evaluate argument %q", key)
+		}
+		values[key] = value
+	}
+	options.RuleID = values["rule_id"]
+	if options.RuleID == "" {
+		return findingRuleGraphEvaluateOptions{}, usageError(fmt.Sprintf(findingRuleGraphEvaluateUsage, os.Args[0]))
+	}
+	return options, nil
+}
+
+func summarizeFindingRuleGraphEvaluation(result *findings.EvaluateGraphRulesResult) *findingRuleGraphEvaluateResult {
+	if result == nil {
+		return &findingRuleGraphEvaluateResult{}
+	}
+	summary := &findingRuleGraphEvaluateResult{
+		Evaluations: make([]findingRuleGraphEvaluateEvaluationResult, 0, len(result.Evaluations)),
+	}
+	if runtime := result.Runtime; runtime != nil {
+		summary.RuntimeID = strings.TrimSpace(runtime.GetId())
+		summary.SourceID = strings.TrimSpace(runtime.GetSourceId())
+		summary.TenantID = strings.TrimSpace(runtime.GetTenantId())
+	}
+	for _, evaluation := range result.Evaluations {
+		if evaluation == nil {
+			continue
+		}
+		summary.Evaluations = append(summary.Evaluations, summarizeFindingRuleGraphRuleEvaluation(evaluation))
+	}
+	return summary
+}
+
+func summarizeFindingRuleGraphRuleEvaluation(evaluation *findings.GraphRuleEvaluationResult) findingRuleGraphEvaluateEvaluationResult {
+	summary := findingRuleGraphEvaluateEvaluationResult{
+		RowsRead:        evaluation.RowsRead,
+		Truncated:       evaluation.Truncated,
+		FindingsEmitted: len(evaluation.Findings),
+		FindingIDs:      findingRecordIDs(evaluation.Findings),
+		EvidenceCount:   len(evaluation.Evidence),
+	}
+	if rule := evaluation.Rule; rule != nil {
+		summary.RuleID = strings.TrimSpace(rule.GetId())
+	}
+	if run := evaluation.Run; run != nil {
+		summary.RunID = strings.TrimSpace(run.GetId())
+		summary.Status = strings.TrimSpace(run.GetStatus())
+		summary.StartedAt = formatProtoTimestamp(run.GetStartedAt())
+		summary.FinishedAt = formatProtoTimestamp(run.GetFinishedAt())
+	}
+	return summary
+}
+
+func findingRecordIDs(records []*ports.FindingRecord) []string {
+	ids := make([]string, 0, len(records))
+	for _, record := range records {
+		if record == nil || strings.TrimSpace(record.ID) == "" {
+			continue
+		}
+		ids = append(ids, strings.TrimSpace(record.ID))
+	}
+	return ids
+}
+
+func formatProtoTimestamp(timestamp *timestamppb.Timestamp) string {
+	if timestamp == nil {
+		return ""
+	}
+	return timestamp.AsTime().UTC().Format(time.RFC3339Nano)
+}

--- a/cmd/cerebro/finding_rule_test.go
+++ b/cmd/cerebro/finding_rule_test.go
@@ -11,6 +11,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestParseFindingRuleNewArgsAppliesDefaults(t *testing.T) {
@@ -36,6 +42,82 @@ func TestParseFindingRuleNewArgsAppliesDefaults(t *testing.T) {
 	}
 	if !request.DryRun {
 		t.Fatal("DryRun = false, want true")
+	}
+}
+
+func TestParseFindingRuleGraphEvaluateArgs(t *testing.T) {
+	options, err := parseFindingRuleGraphEvaluateArgs([]string{"runtime-1", "rule_id=cloud-exposed-privileged-compute-role"})
+	if err != nil {
+		t.Fatalf("parseFindingRuleGraphEvaluateArgs() error = %v", err)
+	}
+	if options.RuntimeID != "runtime-1" || options.RuleID != "cloud-exposed-privileged-compute-role" {
+		t.Fatalf("options = %+v", options)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing runtime", args: []string{"rule_id=cloud-exposed-privileged-compute-role"}},
+		{name: "missing rule id", args: []string{"runtime-1"}},
+		{name: "blank rule id", args: []string{"runtime-1", "rule_id="}},
+		{name: "duplicate rule id", args: []string{"runtime-1", "rule_id=one", "rule_id=two"}},
+		{name: "unknown key", args: []string{"runtime-1", "rule_id=one", "event_limit=100"}},
+		{name: "non key value", args: []string{"runtime-1", "rule_id=one", "extra"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseFindingRuleGraphEvaluateArgs(tt.args); err == nil {
+				t.Fatalf("parseFindingRuleGraphEvaluateArgs(%v) error = nil, want error", tt.args)
+			}
+		})
+	}
+}
+
+func TestSummarizeFindingRuleGraphEvaluation(t *testing.T) {
+	started := time.Date(2026, 6, 3, 4, 5, 6, 0, time.UTC)
+	finished := started.Add(2 * time.Second)
+	summary := summarizeFindingRuleGraphEvaluation(&findings.EvaluateGraphRulesResult{
+		Runtime: &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "aws", TenantId: "writer"},
+		Evaluations: []*findings.GraphRuleEvaluationResult{
+			{
+				Rule: &cerebrov1.RuleSpec{Id: "cloud-exposed-privileged-compute-role"},
+				Run: &cerebrov1.FindingEvaluationRun{
+					Id:         "run-1",
+					Status:     "completed",
+					StartedAt:  timestamppb.New(started),
+					FinishedAt: timestamppb.New(finished),
+				},
+				RowsRead:  3,
+				Truncated: true,
+				Findings: []*ports.FindingRecord{
+					{ID: "finding-1"},
+					{ID: "finding-2"},
+				},
+				Evidence: []*cerebrov1.FindingEvidence{
+					{Id: "evidence-1"},
+				},
+			},
+		},
+	})
+	if summary.RuntimeID != "runtime-1" || summary.SourceID != "aws" || summary.TenantID != "writer" {
+		t.Fatalf("runtime summary = %+v", summary)
+	}
+	if len(summary.Evaluations) != 1 {
+		t.Fatalf("len(Evaluations) = %d, want 1", len(summary.Evaluations))
+	}
+	evaluation := summary.Evaluations[0]
+	if evaluation.RuleID != "cloud-exposed-privileged-compute-role" || evaluation.RunID != "run-1" || evaluation.Status != "completed" {
+		t.Fatalf("evaluation metadata = %+v", evaluation)
+	}
+	if evaluation.RowsRead != 3 || !evaluation.Truncated || evaluation.FindingsEmitted != 2 || evaluation.EvidenceCount != 1 {
+		t.Fatalf("evaluation counts = %+v", evaluation)
+	}
+	if strings.Join(evaluation.FindingIDs, ",") != "finding-1,finding-2" {
+		t.Fatalf("FindingIDs = %#v", evaluation.FindingIDs)
+	}
+	if evaluation.StartedAt == "" || evaluation.FinishedAt == "" {
+		t.Fatalf("timestamps missing: %+v", evaluation)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `cerebro finding-rule graph-evaluate <runtime-id> rule_id=<graph-rule-id>` to evaluate exactly one graph finding rule for an existing source runtime.
- Reuse the existing graph-rule service and emit a compact JSON summary of rows, findings, evidence, and run metadata.
- Add parser and summary regression coverage.

## Validation
- `go test ./cmd/cerebro -count=1`
- `make test`
- `make build && make lint`
- `make proto-lint openapi-check catalog-check detection-catalog-check oss-audit`
- `make check-structural check-structural-test check-arch`