### PR TITLE
feat: add OAuth for Cerebro MCP

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -17,6 +17,7 @@ tags:
   - name: Health
   - name: Knowledge
   - name: MCP
+  - name: OAuth
   - name: Platform
   - name: Reports
   - name: Sources
@@ -1323,6 +1324,240 @@ paths:
       responses:
         '200':
           description: JWK Set document.
+  /.well-known/oauth-authorization-server:
+    get:
+      summary: OAuth authorization server metadata
+      description: Publishes Cerebro's OAuth 2.1 authorization-server metadata for MCP clients.
+      tags:
+        - OAuth
+      security: []
+      responses:
+        '200':
+          description: Authorization server metadata document.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+  /.well-known/oauth-protected-resource:
+    get:
+      summary: OAuth protected resource metadata
+      description: Publishes OAuth protected-resource metadata for the Cerebro MCP resource.
+      tags:
+        - OAuth
+      security: []
+      responses:
+        '200':
+          description: Protected resource metadata document.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+  /.well-known/oauth-protected-resource/api/v1/mcp:
+    get:
+      summary: OAuth protected resource metadata for MCP
+      description: Path-specific OAuth protected-resource metadata for `/api/v1/mcp`.
+      tags:
+        - OAuth
+      security: []
+      responses:
+        '200':
+          description: Protected resource metadata document.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+  /oauth/authorize:
+    get:
+      summary: Start MCP OAuth authorization
+      description: Validates the downstream MCP OAuth request and redirects the human to upstream Writer SSO/OIDC.
+      tags:
+        - OAuth
+      security: []
+      parameters:
+        - name: response_type
+          in: query
+          schema:
+            type: string
+            enum: [code]
+        - name: client_id
+          in: query
+          schema:
+            type: string
+        - name: redirect_uri
+          in: query
+          schema:
+            type: string
+            format: uri
+        - name: scope
+          in: query
+          schema:
+            type: string
+        - name: state
+          in: query
+          schema:
+            type: string
+        - name: code_challenge
+          in: query
+          schema:
+            type: string
+        - name: code_challenge_method
+          in: query
+          schema:
+            type: string
+            enum: [S256]
+        - name: resource
+          in: query
+          schema:
+            type: string
+            format: uri
+      responses:
+        '302':
+          description: Redirect to upstream Writer SSO/OIDC.
+        '400':
+          description: Invalid OAuth authorization request.
+  /oauth/callback:
+    get:
+      summary: Complete upstream Writer SSO/OIDC callback
+      description: Consumes upstream OIDC callback state and redirects the MCP client with a one-time authorization code.
+      tags:
+        - OAuth
+      security: []
+      responses:
+        '302':
+          description: Redirect to the registered MCP client callback with an authorization code.
+        '400':
+          description: Invalid or expired callback state.
+        '403':
+          description: Authenticated human is not authorized for MCP access.
+  /oauth/token:
+    post:
+      summary: Exchange MCP OAuth authorization or refresh token
+      description: Issues a resource-bound bearer capability token for MCP after PKCE verification or refresh-token rotation.
+      tags:
+        - OAuth
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [grant_type, client_id, resource]
+              additionalProperties:
+                type: string
+              properties:
+                grant_type:
+                  type: string
+                  enum: [authorization_code, refresh_token]
+                client_id:
+                  type: string
+                resource:
+                  type: string
+                  format: uri
+                code:
+                  type: string
+                redirect_uri:
+                  type: string
+                  format: uri
+                code_verifier:
+                  type: string
+                refresh_token:
+                  type: string
+      responses:
+        '200':
+          description: OAuth token response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [access_token, token_type, expires_in]
+                properties:
+                  access_token:
+                    type: string
+                  token_type:
+                    type: string
+                    enum: [Bearer]
+                  expires_in:
+                    type: integer
+                  refresh_token:
+                    type: string
+                  scope:
+                    type: string
+        '400':
+          description: Invalid token request or grant.
+        '401':
+          description: Client authentication failed.
+  /oauth/register:
+    post:
+      summary: Dynamically register an MCP OAuth client
+      description: Registers a public MCP client with loopback redirect URIs for OAuth authorization-code + PKCE.
+      tags:
+        - OAuth
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [redirect_uris]
+              properties:
+                client_name:
+                  type: string
+                redirect_uris:
+                  type: array
+                  items:
+                    type: string
+                    format: uri
+                grant_types:
+                  type: array
+                  items:
+                    type: string
+                    enum: [authorization_code, refresh_token]
+                response_types:
+                  type: array
+                  items:
+                    type: string
+                    enum: [code]
+                token_endpoint_auth_method:
+                  type: string
+                  enum: [none]
+      responses:
+        '201':
+          description: Dynamic client registration response.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [client_id, redirect_uris, grant_types, response_types, token_endpoint_auth_method]
+                properties:
+                  client_id:
+                    type: string
+                  client_name:
+                    type: string
+                  redirect_uris:
+                    type: array
+                    items:
+                      type: string
+                      format: uri
+                  grant_types:
+                    type: array
+                    items:
+                      type: string
+                  response_types:
+                    type: array
+                    items:
+                      type: string
+                  token_endpoint_auth_method:
+                    type: string
+                    enum: [none]
+        '400':
+          description: Invalid client metadata.
+        '429':
+          description: Per-client-IP dynamic registration rate limit exceeded.
 
 components:
   securitySchemes:

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -32,6 +32,7 @@ import (
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/knowledge"
+	"github.com/writer/cerebro/internal/mcpoauth"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/reports"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -52,18 +53,20 @@ type Dependencies struct {
 
 // App is the minimal Connect/bootstrap composition root for the rewrite skeleton.
 type App struct {
-	cfg              config.Config
-	deps             Dependencies
-	sources          *sourcecdk.Registry
-	mux              *http.ServeMux
-	handler          http.Handler
-	server           *http.Server
-	deviceService    *deviceauth.Service
-	deviceHandler    *deviceAuthHTTPHandler
-	deviceVerifier   *deviceauth.JWTVerifier
-	dpopVerifier     *deviceauth.DPoPVerifier
-	riskScorer       *risk.Scorer
-	observationStore risk.ObservationStore
+	cfg                   config.Config
+	deps                  Dependencies
+	sources               *sourcecdk.Registry
+	mux                   *http.ServeMux
+	handler               http.Handler
+	server                *http.Server
+	deviceService         *deviceauth.Service
+	deviceHandler         *deviceAuthHTTPHandler
+	deviceVerifier        *deviceauth.JWTVerifier
+	dpopVerifier          *deviceauth.DPoPVerifier
+	riskScorer            *risk.Scorer
+	observationStore      risk.ObservationStore
+	mcpOAuthService       *mcpoauth.Service
+	mcpOAuthRegisterLimit *deviceauth.TokenBucket
 }
 
 type bootstrapService struct {
@@ -84,6 +87,9 @@ var (
 	errDeviceAuthRequiresAPIAuth          = errors.New("device-auth requires CEREBRO_API_AUTH_ENABLED=true")
 	errDeviceAuthRequiresStore            = errors.New("device-auth requires a device-auth capable state store")
 	errDeviceAuthRequiresSharedDPoPReplay = errors.New("device-auth DPoP replay protection requires shared state for multiple replicas")
+	errMCPOAuthRequiresAPIAuth            = errors.New("MCP OAuth requires CEREBRO_API_AUTH_ENABLED=true")
+	errMCPOAuthRequiresStore              = errors.New("MCP OAuth requires an OAuth-capable state store")
+	errMCPOAuthRequiresCapabilitySecrets  = errors.New("MCP OAuth requires CEREBRO_CAPABILITY_TOKEN_SECRETS")
 )
 
 // New constructs the minimal bootstrap app and registers the Connect handlers.
@@ -100,6 +106,12 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	if cfg.Auth.DeviceAuth.Enabled && !cfg.Auth.Enabled {
 		return nil, errDeviceAuthRequiresAPIAuth
 	}
+	if cfg.Auth.MCPOAuth.Enabled && !cfg.Auth.Enabled {
+		return nil, errMCPOAuthRequiresAPIAuth
+	}
+	if cfg.Auth.MCPOAuth.Enabled && len(cfg.Auth.CapabilityTokenSecrets) == 0 {
+		return nil, errMCPOAuthRequiresCapabilitySecrets
+	}
 	if cfg.Auth.DeviceAuth.Enabled && deviceAuthReplicaCount(cfg.Auth.DeviceAuth) > 1 {
 		dpop := deviceauth.NewDPoPVerifier(cfg.Auth.DeviceAuth.ClockSkew, cfg.Auth.DeviceAuth.DPoPProofTTL)
 		if !dpop.ReplayStateShared() {
@@ -109,6 +121,10 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	deviceStore := deviceAuthStore(deps.StateStore)
 	if cfg.Auth.DeviceAuth.Enabled && deviceStore == nil {
 		return nil, errDeviceAuthRequiresStore
+	}
+	oauthStore := mcpOAuthStore(deps.StateStore)
+	if cfg.Auth.MCPOAuth.Enabled && oauthStore == nil {
+		return nil, errMCPOAuthRequiresStore
 	}
 	if deviceStore != nil {
 		dpop := deviceauth.NewDPoPVerifier(cfg.Auth.DeviceAuth.ClockSkew, cfg.Auth.DeviceAuth.DPoPProofTTL)
@@ -136,6 +152,27 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 			app.observationStore = obsStore
 			app.deviceHandler = newDeviceAuthHTTPHandler(service, cfg.Auth.DeviceAuth, cfg.Auth.RequestOrigin)
 		}
+	}
+	if cfg.Auth.MCPOAuth.Enabled {
+		app.mcpOAuthRegisterLimit = deviceauth.NewTokenBucket(oauthRegisterRatePerSecond, oauthRegisterBurst)
+		service, err := mcpoauth.NewService(cfg.Auth.MCPOAuth, oauthStore, func(ctx context.Context, grant mcpoauth.AccessGrant, ttl time.Duration, now time.Time) (string, error) {
+			return issueCapabilityToken(cfg.Auth, capabilityClaims{
+				Audience:       cfg.Auth.CapabilityTokenAudience,
+				Subject:        grant.Subject,
+				IssuedAt:       now.Unix(),
+				CredentialID:   "mcp-oauth",
+				ClientID:       grant.ClientID,
+				Resource:       grant.Resource,
+				TenantID:       grant.TenantID,
+				AllowedTenants: grant.AllowedTenants,
+				Scopes:         grant.Scopes,
+				Groups:         grant.Groups,
+			}, ttl, now)
+		}, mcpoauth.WithOIDCProvider(newMCPOAuthOIDCClient(cfg.Auth.MCPOAuth.Upstream)))
+		if err != nil {
+			return nil, fmt.Errorf("MCP OAuth bootstrap failed: %w", err)
+		}
+		app.mcpOAuthService = service
 	}
 	mux := http.NewServeMux()
 	app.mux = mux
@@ -3234,6 +3271,14 @@ func deviceAuthStore(store ports.StateStore) deviceauth.Store {
 		return nil
 	}
 	return deviceStore
+}
+
+func mcpOAuthStore(store ports.StateStore) mcpoauth.Store {
+	oauthStore, ok := store.(mcpoauth.Store)
+	if !ok || isNilInterface(oauthStore) {
+		return nil
+	}
+	return oauthStore
 }
 
 func deviceRiskObservationStore(store ports.StateStore) risk.ObservationStore {

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"strings"
@@ -43,6 +44,7 @@ type authPrincipal struct {
 	CredentialID   string
 	ClientID       string
 	AuthMode       string
+	TokenResource  string
 	AllowedTenants []string
 	Scopes         []string
 	Groups         []string
@@ -110,7 +112,7 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 		principal, deviceJKT, presentedToken, ok := authenticateRequest(cfg, deps.DeviceVerifier, r)
 		if !ok {
 			denialReason = "unauthenticated"
-			writeAuthError(recorder, http.StatusUnauthorized, "unauthorized")
+			writeAuthErrorForRequest(recorder, r, cfg, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 		if deviceJKT != "" {
@@ -140,9 +142,14 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 			principal.RiskScore = decision.Score
 			principal.RiskLevel = decision.Level
 		}
+		if err := authorizeMCPTokenResource(cfg, principal, r); err != nil {
+			denialReason = "resource_forbidden"
+			writeAuthErrorForRequest(recorder, r, cfg, http.StatusUnauthorized, "unauthorized")
+			return
+		}
 		if tenantID := auditResult.RequestedTenantID; tenantID != "" && !tenantAllowed(cfg, principal, tenantID) {
 			denialReason = "tenant_forbidden"
-			writeAuthError(recorder, http.StatusForbidden, "tenant forbidden")
+			writeAuthErrorForRequest(recorder, r, cfg, http.StatusForbidden, "tenant forbidden")
 			return
 		}
 		auth := authContext{
@@ -155,7 +162,7 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 		}
 		if err := authorizeHTTPRequestScope(auth, r); err != nil {
 			denialReason = "scope_forbidden"
-			writeAuthError(recorder, http.StatusForbidden, "scope forbidden")
+			writeAuthErrorForRequest(recorder, r, cfg, http.StatusForbidden, "scope forbidden")
 			return
 		}
 		outcome = "allowed"
@@ -216,6 +223,10 @@ func isPublicPath(path string) bool {
 	case "/health", "/healthz", "/openapi.yaml":
 		return true
 	case "/.well-known/device-jwks.json":
+		return true
+	case oauthProtectedResourceMetadataPath, oauthProtectedResourceMetadataMCPPath, oauthAuthorizationServerMetadataPath:
+		return true
+	case oauthAuthorizePath, oauthCallbackPath, oauthTokenPath, oauthRegisterPath:
 		return true
 	default:
 		return false
@@ -371,6 +382,7 @@ func authenticateCapabilityToken(cfg config.AuthConfig, token string, now time.T
 		CredentialID:   strings.TrimSpace(claims.CredentialID),
 		ClientID:       strings.TrimSpace(claims.ClientID),
 		AuthMode:       "capability_token",
+		TokenResource:  strings.TrimSpace(claims.Resource),
 		AllowedTenants: allowedTenants,
 		Scopes:         scopes,
 		Groups:         normalizeAuthList(claims.Groups),
@@ -385,6 +397,7 @@ type capabilityClaims struct {
 	IssuedAt       int64    `json:"iat,omitempty"`
 	CredentialID   string   `json:"credential_id,omitempty"`
 	ClientID       string   `json:"client_id,omitempty"`
+	Resource       string   `json:"resource,omitempty"`
 	TenantID       string   `json:"tenant_id,omitempty"`
 	AllowedTenants []string `json:"allowed_tenants,omitempty"`
 	Scopes         []string `json:"scopes,omitempty"`
@@ -404,6 +417,42 @@ func validCapabilitySignature(signingInput []byte, signature []byte, secrets []s
 		}
 	}
 	return false
+}
+
+func issueCapabilityToken(cfg config.AuthConfig, claims capabilityClaims, ttl time.Duration, now time.Time) (string, error) {
+	if len(cfg.CapabilityTokenSecrets) == 0 {
+		return "", fmt.Errorf("capability token secret is required")
+	}
+	secret := strings.TrimSpace(cfg.CapabilityTokenSecrets[0])
+	if secret == "" {
+		return "", fmt.Errorf("capability token secret is empty")
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	claims.IssuedAt = now.UTC().Unix()
+	claims.ExpiresAt = now.UTC().Add(ttl).Unix()
+	if strings.TrimSpace(claims.Audience) == "" {
+		claims.Audience = cfg.CapabilityTokenAudience
+	}
+	headerBytes, err := json.Marshal(map[string]string{"alg": "HS256", "typ": "JWT"})
+	if err != nil {
+		return "", fmt.Errorf("marshal capability token header: %w", err)
+	}
+	payloadBytes, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal capability token claims: %w", err)
+	}
+	header := base64.RawURLEncoding.EncodeToString(headerBytes)
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	signingInput := header + "." + payload
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(signingInput))
+	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return signingInput + "." + signature, nil
 }
 
 func requestTenantHint(r *http.Request) string {
@@ -522,6 +571,19 @@ func authorizeHTTPRequestScope(auth authContext, r *http.Request) error {
 	}
 	scope := scopeForHTTPRequest(r)
 	return authorizePrincipalScope(auth.principal, scope)
+}
+
+func authorizeMCPTokenResource(cfg config.AuthConfig, principal authPrincipal, r *http.Request) error {
+	if !cfg.MCPOAuth.Enabled || principal.CredentialID != "mcp-oauth" {
+		return nil
+	}
+	if strings.TrimSpace(principal.TokenResource) != strings.TrimSpace(cfg.MCPOAuth.Resource) {
+		return errScopeForbidden
+	}
+	if r == nil || r.URL == nil || r.URL.Path != mcpEndpointPath {
+		return errScopeForbidden
+	}
+	return nil
 }
 
 func authorizeConnectProcedureScope(ctx context.Context, procedure string) error {
@@ -819,11 +881,22 @@ func appendTenantID(rawTenantID string, seen map[string]struct{}, tenants *[]str
 
 func writeAuthError(w http.ResponseWriter, status int, message string) {
 	w.Header().Set("Content-Type", "application/json")
-	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+	if (status == http.StatusUnauthorized || status == http.StatusForbidden) && w.Header().Get("WWW-Authenticate") == "" {
 		w.Header().Set("WWW-Authenticate", "Bearer")
 	}
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+func writeAuthErrorForRequest(w http.ResponseWriter, r *http.Request, cfg config.AuthConfig, status int, message string) {
+	if cfg.MCPOAuth.Enabled && r != nil && r.URL != nil && r.URL.Path == mcpEndpointPath && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
+		challenge := `Bearer resource_metadata="` + mcpOAuthResourceMetadataURL(r, cfg) + `", scope="` + scopeCosmoSecurityRead + `"`
+		if status == http.StatusForbidden {
+			challenge += `, error="insufficient_scope", error_description="MCP access requires the ` + scopeCosmoSecurityRead + ` scope"`
+		}
+		w.Header().Set("WWW-Authenticate", challenge)
+	}
+	writeAuthError(w, status, message)
 }
 
 type accessAuditResponseWriter struct {

--- a/internal/bootstrap/mcp_oauth_test.go
+++ b/internal/bootstrap/mcp_oauth_test.go
@@ -1,0 +1,807 @@
+package bootstrap
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/mcpoauth"
+)
+
+func TestMCPOAuthFlowIssuesCapabilityTokenForMCP(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	var upstreamNonce string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authorize":
+			upstreamNonce = r.URL.Query().Get("nonce")
+			redirectURI := r.URL.Query().Get("redirect_uri")
+			values := url.Values{}
+			values.Set("code", "upstream-code")
+			values.Set("state", r.URL.Query().Get("state"))
+			http.Redirect(w, r, redirectURI+"?"+values.Encode(), http.StatusFound)
+		case "/token":
+			clientID, secret, ok := r.BasicAuth()
+			if !ok || clientID != "writer-client" || secret != "writer-secret" {
+				t.Fatalf("upstream token BasicAuth = (%q,%q,%v)", clientID, secret, ok)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("upstream ParseForm: %v", err)
+			}
+			if got := r.Form.Get("code"); got != "upstream-code" {
+				t.Fatalf("upstream code = %q, want upstream-code", got)
+			}
+			idToken := signOIDCIDToken(t, key, map[string]any{
+				"iss":    "https://writer-sso.example",
+				"aud":    "writer-client",
+				"sub":    "user-1",
+				"email":  "user@example.com",
+				"groups": []string{"secops"},
+				"nonce":  upstreamNonce,
+				"iat":    time.Now().Unix(),
+				"exp":    time.Now().Add(time.Hour).Unix(),
+			})
+			_ = json.NewEncoder(w).Encode(map[string]any{"id_token": idToken, "token_type": "Bearer"})
+		case "/jwks":
+			_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{rsaJWK("test-kid", &key.PublicKey)}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	store := newMemoryMCPOAuthStore()
+	clientRedirect := "http://127.0.0.1/callback"
+	cfg := testMCPOAuthConfig(clientRedirect, upstream.URL)
+	app, err := NewWithError(cfg, Dependencies{StateStore: store}, nil)
+	if err != nil {
+		t.Fatalf("NewWithError: %v", err)
+	}
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	metadataResp, err := server.Client().Get(server.URL + oauthProtectedResourceMetadataMCPPath)
+	if err != nil {
+		t.Fatalf("GET protected resource metadata: %v", err)
+	}
+	var metadata map[string]any
+	if err := json.NewDecoder(metadataResp.Body).Decode(&metadata); err != nil {
+		t.Fatalf("Decode metadata: %v", err)
+	}
+	_ = metadataResp.Body.Close()
+	if metadata["resource"] != "https://cerebro.example/api/v1/mcp" {
+		t.Fatalf("resource metadata = %#v", metadata)
+	}
+
+	unauthReq, err := http.NewRequest(http.MethodPost, server.URL+mcpEndpointPath, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	if err != nil {
+		t.Fatalf("NewRequest unauth MCP: %v", err)
+	}
+	unauthResp, err := server.Client().Do(unauthReq)
+	if err != nil {
+		t.Fatalf("POST unauth MCP: %v", err)
+	}
+	_ = unauthResp.Body.Close()
+	if unauthResp.StatusCode != http.StatusUnauthorized || !strings.Contains(unauthResp.Header.Get("WWW-Authenticate"), "resource_metadata=") {
+		t.Fatalf("unauth MCP status/header = %d %q", unauthResp.StatusCode, unauthResp.Header.Get("WWW-Authenticate"))
+	}
+	if !strings.Contains(unauthResp.Header.Get("WWW-Authenticate"), `scope="`+scopeCosmoSecurityRead+`"`) {
+		t.Fatalf("unauth MCP missing scope challenge: %q", unauthResp.Header.Get("WWW-Authenticate"))
+	}
+
+	codeVerifier := strings.Repeat("a", 64)
+	codeChallenge := pkceChallenge(codeVerifier)
+	authURL := server.URL + oauthAuthorizePath + "?" + url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"droid"},
+		"redirect_uri":          {clientRedirect},
+		"state":                 {"client-state"},
+		"scope":                 {scopeCosmoSecurityRead},
+		"resource":              {"https://cerebro.example/api/v1/mcp"},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+	}.Encode()
+	noRedirect := noRedirectClient(server)
+	authResp, err := noRedirect.Get(authURL)
+	if err != nil {
+		t.Fatalf("GET authorize: %v", err)
+	}
+	_ = authResp.Body.Close()
+	if authResp.StatusCode != http.StatusFound || !strings.HasPrefix(authResp.Header.Get("Location"), upstream.URL+"/authorize") {
+		t.Fatalf("authorize status/location = %d %q", authResp.StatusCode, authResp.Header.Get("Location"))
+	}
+	upstreamResp, err := noRedirect.Get(authResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("GET upstream authorize: %v", err)
+	}
+	_ = upstreamResp.Body.Close()
+	callbackLocation := strings.Replace(upstreamResp.Header.Get("Location"), "https://cerebro.example", server.URL, 1)
+	if upstreamResp.StatusCode != http.StatusFound || !strings.HasPrefix(callbackLocation, server.URL+oauthCallbackPath) {
+		t.Fatalf("upstream status/location = %d %q", upstreamResp.StatusCode, upstreamResp.Header.Get("Location"))
+	}
+	callbackResp, err := noRedirect.Get(callbackLocation)
+	if err != nil {
+		t.Fatalf("GET callback: %v", err)
+	}
+	_ = callbackResp.Body.Close()
+	if callbackResp.StatusCode != http.StatusFound || !strings.HasPrefix(callbackResp.Header.Get("Location"), clientRedirect) {
+		t.Fatalf("callback status/location = %d %q", callbackResp.StatusCode, callbackResp.Header.Get("Location"))
+	}
+	clientCallback, err := url.Parse(callbackResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse client callback: %v", err)
+	}
+	if got := clientCallback.Query().Get("state"); got != "client-state" {
+		t.Fatalf("client callback state = %q, want client-state", got)
+	}
+	code := clientCallback.Query().Get("code")
+	if code == "" {
+		t.Fatalf("client callback missing code: %s", clientCallback.String())
+	}
+
+	missingResource := exchangeMCPOAuthTokenRaw(t, server, url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {"droid"},
+		"redirect_uri":  {clientRedirect},
+		"code":          {code},
+		"code_verifier": {codeVerifier},
+	})
+	_ = missingResource.Body.Close()
+	if missingResource.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing resource token status = %d, want 400", missingResource.StatusCode)
+	}
+
+	tokenResp := exchangeMCPOAuthToken(t, server, url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {"droid"},
+		"redirect_uri":  {clientRedirect},
+		"resource":      {"https://cerebro.example/api/v1/mcp"},
+		"code":          {code},
+		"code_verifier": {codeVerifier},
+	})
+	if tokenResp.AccessToken == "" || tokenResp.RefreshToken == "" || tokenResp.TokenType != "Bearer" {
+		t.Fatalf("token response = %#v", tokenResp)
+	}
+	store.mu.Lock()
+	originalRefreshRecord := store.refresh[hashKey(mcpoauth.HashToken(tokenResp.RefreshToken))].value
+	store.mu.Unlock()
+	replay := exchangeMCPOAuthTokenRaw(t, server, url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {"droid"},
+		"redirect_uri":  {clientRedirect},
+		"resource":      {"https://cerebro.example/api/v1/mcp"},
+		"code":          {code},
+		"code_verifier": {codeVerifier},
+	})
+	_ = replay.Body.Close()
+	if replay.StatusCode != http.StatusBadRequest {
+		t.Fatalf("replayed authorization code status = %d, want 400", replay.StatusCode)
+	}
+
+	mcpReq, err := http.NewRequest(http.MethodPost, server.URL+mcpEndpointPath, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	if err != nil {
+		t.Fatalf("NewRequest MCP: %v", err)
+	}
+	mcpReq.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
+	mcpReq.Header.Set("Content-Type", "application/json")
+	mcpReq.Header.Set("MCP-Protocol-Version", mcpProtocolVersion)
+	mcpResp, err := server.Client().Do(mcpReq)
+	if err != nil {
+		t.Fatalf("POST MCP with OAuth token: %v", err)
+	}
+	defer func() { _ = mcpResp.Body.Close() }()
+	if mcpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(mcpResp.Body)
+		t.Fatalf("MCP status = %d body=%s", mcpResp.StatusCode, body)
+	}
+	var mcpPayload map[string]any
+	if err := json.NewDecoder(mcpResp.Body).Decode(&mcpPayload); err != nil {
+		t.Fatalf("decode MCP payload: %v", err)
+	}
+	if mcpPayload["error"] != nil {
+		t.Fatalf("MCP returned error: %#v", mcpPayload)
+	}
+
+	nonMCPReq, err := http.NewRequest(http.MethodGet, server.URL+"/reports", nil)
+	if err != nil {
+		t.Fatalf("NewRequest non-MCP: %v", err)
+	}
+	nonMCPReq.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
+	nonMCPResp, err := server.Client().Do(nonMCPReq)
+	if err != nil {
+		t.Fatalf("GET reports with MCP OAuth token: %v", err)
+	}
+	_ = nonMCPResp.Body.Close()
+	if nonMCPResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("non-MCP status with MCP OAuth token = %d, want 401", nonMCPResp.StatusCode)
+	}
+
+	refreshed := exchangeMCPOAuthToken(t, server, url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {"droid"},
+		"resource":      {"https://cerebro.example/api/v1/mcp"},
+		"refresh_token": {tokenResp.RefreshToken},
+	})
+	if refreshed.AccessToken == "" || refreshed.RefreshToken == "" || refreshed.RefreshToken == tokenResp.RefreshToken {
+		t.Fatalf("refresh response = %#v", refreshed)
+	}
+	store.mu.Lock()
+	rotatedRefreshRecord := store.refresh[hashKey(mcpoauth.HashToken(refreshed.RefreshToken))].value
+	store.mu.Unlock()
+	if !rotatedRefreshRecord.ExpiresAt.Equal(originalRefreshRecord.ExpiresAt) {
+		t.Fatalf("rotated refresh expiration = %v, want family expiration %v", rotatedRefreshRecord.ExpiresAt, originalRefreshRecord.ExpiresAt)
+	}
+}
+
+func TestMCPOAuthCallbackRejectsMissingSecurityGroup(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	var upstreamNonce string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authorize":
+			upstreamNonce = r.URL.Query().Get("nonce")
+			redirectURI := r.URL.Query().Get("redirect_uri")
+			values := url.Values{"code": {"upstream-code"}, "state": {r.URL.Query().Get("state")}}
+			http.Redirect(w, r, redirectURI+"?"+values.Encode(), http.StatusFound)
+		case "/token":
+			idToken := signOIDCIDToken(t, key, map[string]any{
+				"iss":    "https://writer-sso.example",
+				"aud":    "writer-client",
+				"sub":    "user-1",
+				"groups": []string{"not-security"},
+				"nonce":  upstreamNonce,
+				"iat":    time.Now().Unix(),
+				"exp":    time.Now().Add(time.Hour).Unix(),
+			})
+			_ = json.NewEncoder(w).Encode(map[string]any{"id_token": idToken, "token_type": "Bearer"})
+		case "/jwks":
+			_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{rsaJWK("test-kid", &key.PublicKey)}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	clientRedirect := "http://127.0.0.1/callback"
+	app, err := NewWithError(testMCPOAuthConfig(clientRedirect, upstream.URL), Dependencies{StateStore: newMemoryMCPOAuthStore()}, nil)
+	if err != nil {
+		t.Fatalf("NewWithError: %v", err)
+	}
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+	noRedirect := noRedirectClient(server)
+
+	authResp, err := noRedirect.Get(server.URL + oauthAuthorizePath + "?" + url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"droid"},
+		"redirect_uri":          {clientRedirect},
+		"state":                 {"client-state"},
+		"code_challenge":        {pkceChallenge(strings.Repeat("a", 64))},
+		"code_challenge_method": {"S256"},
+	}.Encode())
+	if err != nil {
+		t.Fatalf("GET authorize: %v", err)
+	}
+	_ = authResp.Body.Close()
+	upstreamResp, err := noRedirect.Get(authResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("GET upstream authorize: %v", err)
+	}
+	_ = upstreamResp.Body.Close()
+	callbackLocation := strings.Replace(upstreamResp.Header.Get("Location"), "https://cerebro.example", server.URL, 1)
+	callbackResp, err := noRedirect.Get(callbackLocation)
+	if err != nil {
+		t.Fatalf("GET callback: %v", err)
+	}
+	_ = callbackResp.Body.Close()
+	if callbackResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("callback status = %d, want 403", callbackResp.StatusCode)
+	}
+}
+
+func TestMCPOAuthOIDCRefreshesJWKSOnUnknownKID(t *testing.T) {
+	oldKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey old: %v", err)
+	}
+	newKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey new: %v", err)
+	}
+	var jwksMu sync.Mutex
+	useNewKey := false
+	jwksRequests := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/jwks" {
+			http.NotFound(w, r)
+			return
+		}
+		jwksMu.Lock()
+		jwksRequests++
+		serveNewKey := useNewKey
+		jwksMu.Unlock()
+		if serveNewKey {
+			_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{rsaJWK("new-kid", &newKey.PublicKey)}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{rsaJWK("old-kid", &oldKey.PublicKey)}})
+	}))
+	defer upstream.Close()
+
+	client := newMCPOAuthOIDCClient(config.MCPOAuthUpstreamConfig{
+		Issuer:      "https://writer-sso.example",
+		JWKSURI:     upstream.URL + "/jwks",
+		ClientID:    "writer-client",
+		GroupsClaim: "groups",
+	})
+	oldToken := signOIDCIDTokenWithKID(t, oldKey, "old-kid", map[string]any{
+		"iss":    "https://writer-sso.example",
+		"aud":    "writer-client",
+		"sub":    "user-1",
+		"groups": []string{"secops"},
+		"nonce":  "nonce-1",
+		"iat":    time.Now().Unix(),
+		"exp":    time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := client.verifyIDToken(context.Background(), oldToken, "nonce-1"); err != nil {
+		t.Fatalf("verify old token: %v", err)
+	}
+
+	jwksMu.Lock()
+	useNewKey = true
+	jwksMu.Unlock()
+	newToken := signOIDCIDTokenWithKID(t, newKey, "new-kid", map[string]any{
+		"iss":    "https://writer-sso.example",
+		"aud":    "writer-client",
+		"sub":    "user-1",
+		"groups": []string{"secops"},
+		"nonce":  "nonce-2",
+		"iat":    time.Now().Unix(),
+		"exp":    time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := client.verifyIDToken(context.Background(), newToken, "nonce-2"); err != nil {
+		t.Fatalf("verify token after JWKS rotation: %v", err)
+	}
+	jwksMu.Lock()
+	requests := jwksRequests
+	jwksMu.Unlock()
+	if requests < 2 {
+		t.Fatalf("JWKS requests = %d, want at least 2 after unknown kid refresh", requests)
+	}
+}
+
+func TestMCPOAuthDynamicClientRegistration(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/authorize" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	clientRedirect := "http://127.0.0.1:39123/callback"
+	cfg := testMCPOAuthConfig(clientRedirect, upstream.URL)
+	cfg.Auth.MCPOAuth.Clients = nil
+	app, err := NewWithError(cfg, Dependencies{StateStore: newMemoryMCPOAuthStore()}, nil)
+	if err != nil {
+		t.Fatalf("NewWithError: %v", err)
+	}
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	metadataResp, err := server.Client().Get(server.URL + oauthAuthorizationServerMetadataPath)
+	if err != nil {
+		t.Fatalf("GET authorization server metadata: %v", err)
+	}
+	var metadata map[string]any
+	if err := json.NewDecoder(metadataResp.Body).Decode(&metadata); err != nil {
+		t.Fatalf("Decode metadata: %v", err)
+	}
+	_ = metadataResp.Body.Close()
+	if metadata["registration_endpoint"] != "https://cerebro.example/oauth/register" {
+		t.Fatalf("registration_endpoint = %#v", metadata["registration_endpoint"])
+	}
+
+	registerBody := strings.NewReader(`{"client_name":"Droid","redirect_uris":["` + clientRedirect + `"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"none"}`)
+	registerResp, err := server.Client().Post(server.URL+oauthRegisterPath, "application/json", registerBody)
+	if err != nil {
+		t.Fatalf("POST register: %v", err)
+	}
+	defer func() { _ = registerResp.Body.Close() }()
+	if registerResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(registerResp.Body)
+		t.Fatalf("register status = %d body=%s", registerResp.StatusCode, body)
+	}
+	var registered mcpoauth.ClientRegistrationResponse
+	if err := json.NewDecoder(registerResp.Body).Decode(&registered); err != nil {
+		t.Fatalf("decode register response: %v", err)
+	}
+	if registered.ClientID == "" || registered.TokenEndpointAuthMethod != "none" {
+		t.Fatalf("registered client = %#v", registered)
+	}
+
+	noRedirect := noRedirectClient(server)
+	authResp, err := noRedirect.Get(server.URL + oauthAuthorizePath + "?" + url.Values{
+		"response_type":         {"code"},
+		"client_id":             {registered.ClientID},
+		"redirect_uri":          {clientRedirect},
+		"state":                 {"client-state"},
+		"resource":              {"https://cerebro.example/api/v1/mcp"},
+		"code_challenge":        {pkceChallenge(strings.Repeat("a", 64))},
+		"code_challenge_method": {"S256"},
+	}.Encode())
+	if err != nil {
+		t.Fatalf("GET authorize: %v", err)
+	}
+	_ = authResp.Body.Close()
+	if authResp.StatusCode != http.StatusFound || !strings.HasPrefix(authResp.Header.Get("Location"), upstream.URL+"/authorize") {
+		t.Fatalf("authorize status/location = %d %q", authResp.StatusCode, authResp.Header.Get("Location"))
+	}
+
+	badRegisterResp, err := server.Client().Post(server.URL+oauthRegisterPath, "application/json", strings.NewReader(`{"redirect_uris":["https://evil.example/callback"]}`))
+	if err != nil {
+		t.Fatalf("POST bad register: %v", err)
+	}
+	_ = badRegisterResp.Body.Close()
+	if badRegisterResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("bad register status = %d, want 400", badRegisterResp.StatusCode)
+	}
+}
+
+func TestMCPOAuthDynamicClientRegistrationRateLimitsByClientIP(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	cfg := testMCPOAuthConfig("http://127.0.0.1:39123/callback", upstream.URL)
+	cfg.Auth.MCPOAuth.Clients = nil
+	app, err := NewWithError(cfg, Dependencies{StateStore: newMemoryMCPOAuthStore()}, nil)
+	if err != nil {
+		t.Fatalf("NewWithError: %v", err)
+	}
+	handler := app.Handler()
+	body := `{"client_name":"Droid","redirect_uris":["http://127.0.0.1:39123/callback"],"grant_types":["authorization_code"],"response_types":["code"],"token_endpoint_auth_method":"none"}`
+	for i := 0; i < oauthRegisterBurst; i++ {
+		req := httptest.NewRequest(http.MethodPost, oauthRegisterPath, strings.NewReader(body))
+		req.RemoteAddr = "198.51.100.10:12345"
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		if resp.Code != http.StatusCreated {
+			t.Fatalf("registration %d status = %d body=%s, want 201", i+1, resp.Code, resp.Body.String())
+		}
+	}
+	req := httptest.NewRequest(http.MethodPost, oauthRegisterPath, strings.NewReader(body))
+	req.RemoteAddr = "198.51.100.10:12345"
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusTooManyRequests {
+		t.Fatalf("rate-limited registration status = %d body=%s, want 429", resp.Code, resp.Body.String())
+	}
+}
+
+func testMCPOAuthConfig(clientRedirect string, upstreamBase string) config.Config {
+	return config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled:                 true,
+			CapabilityTokenSecrets:  []string{"capability-secret"},
+			CapabilityTokenAudience: "cerebro-api",
+			RequestOrigin: config.RequestOriginConfig{
+				PublicOrigin: "https://cerebro.example",
+			},
+			MCPOAuth: config.MCPOAuthConfig{
+				Enabled:                   true,
+				Issuer:                    "https://cerebro.example",
+				Resource:                  "https://cerebro.example/api/v1/mcp",
+				AccessTTL:                 time.Hour,
+				RefreshTTL:                24 * time.Hour,
+				CodeTTL:                   5 * time.Minute,
+				StateTTL:                  5 * time.Minute,
+				TenantID:                  "writer",
+				DynamicClientRegistration: true,
+				Clients: []config.MCPOAuthClient{{
+					ClientID:     "droid",
+					RedirectURIs: []string{clientRedirect},
+					Public:       true,
+				}},
+				Upstream: config.MCPOAuthUpstreamConfig{
+					Issuer:                "https://writer-sso.example",
+					AuthorizationEndpoint: upstreamBase + "/authorize",
+					TokenEndpoint:         upstreamBase + "/token",
+					JWKSURI:               upstreamBase + "/jwks",
+					ClientID:              "writer-client",
+					ClientSecret:          "writer-secret",
+					RedirectURI:           "https://cerebro.example/oauth/callback",
+					Scopes:                []string{"openid", "email", "profile", "groups"},
+					GroupsClaim:           "groups",
+					SecurityGroups:        []string{"secops"},
+				},
+			},
+		},
+	}
+}
+
+func exchangeMCPOAuthToken(t *testing.T, server *httptest.Server, form url.Values) mcpoauth.TokenResponse {
+	t.Helper()
+	resp := exchangeMCPOAuthTokenRaw(t, server, form)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("token status = %d body=%s", resp.StatusCode, body)
+	}
+	var decoded mcpoauth.TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	return decoded
+}
+
+func exchangeMCPOAuthTokenRaw(t *testing.T, server *httptest.Server, form url.Values) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, server.URL+oauthTokenPath, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("NewRequest token: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST token: %v", err)
+	}
+	return resp
+}
+
+func noRedirectClient(server *httptest.Server) *http.Client {
+	base := server.Client()
+	return &http.Client{
+		Transport:     base.Transport,
+		Timeout:       base.Timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
+type memoryMCPOAuthStore struct {
+	mu       sync.Mutex
+	clients  map[string]mcpoauth.OAuthClient
+	states   map[string]memoryState
+	codes    map[string]memoryCode
+	refresh  map[string]memoryRefresh
+	families map[string]bool
+}
+
+type memoryState struct {
+	value    mcpoauth.LoginState
+	consumed bool
+}
+
+type memoryCode struct {
+	value    mcpoauth.AuthorizationCode
+	consumed bool
+}
+
+type memoryRefresh struct {
+	value    mcpoauth.RefreshToken
+	consumed bool
+}
+
+func newMemoryMCPOAuthStore() *memoryMCPOAuthStore {
+	return &memoryMCPOAuthStore{
+		clients:  map[string]mcpoauth.OAuthClient{},
+		states:   map[string]memoryState{},
+		codes:    map[string]memoryCode{},
+		refresh:  map[string]memoryRefresh{},
+		families: map[string]bool{},
+	}
+}
+
+func (s *memoryMCPOAuthStore) Ping(context.Context) error { return nil }
+
+func (s *memoryMCPOAuthStore) SaveOAuthClient(_ context.Context, client mcpoauth.OAuthClient) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clients[client.ClientID] = client
+	return nil
+}
+
+func (s *memoryMCPOAuthStore) GetOAuthClient(_ context.Context, clientID string) (mcpoauth.OAuthClient, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	client, ok := s.clients[clientID]
+	if !ok {
+		return mcpoauth.OAuthClient{}, mcpoauth.ErrNotFound
+	}
+	return client, nil
+}
+
+func (s *memoryMCPOAuthStore) SaveLoginState(_ context.Context, state mcpoauth.LoginState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.states[hashKey(state.StateHash)] = memoryState{value: state}
+	return nil
+}
+
+func (s *memoryMCPOAuthStore) ConsumeLoginState(_ context.Context, stateHash [32]byte, now time.Time) (mcpoauth.LoginState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := hashKey(stateHash)
+	record, ok := s.states[key]
+	if !ok {
+		return mcpoauth.LoginState{}, mcpoauth.ErrNotFound
+	}
+	if record.consumed {
+		return mcpoauth.LoginState{}, mcpoauth.ErrConsumed
+	}
+	if !now.Before(record.value.ExpiresAt) {
+		return mcpoauth.LoginState{}, mcpoauth.ErrExpired
+	}
+	record.consumed = true
+	s.states[key] = record
+	return record.value, nil
+}
+
+func (s *memoryMCPOAuthStore) SaveAuthorizationCode(_ context.Context, code mcpoauth.AuthorizationCode) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.codes[hashKey(code.CodeHash)] = memoryCode{value: code}
+	return nil
+}
+
+func (s *memoryMCPOAuthStore) ConsumeAuthorizationCode(_ context.Context, codeHash [32]byte, now time.Time) (mcpoauth.AuthorizationCode, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := hashKey(codeHash)
+	record, ok := s.codes[key]
+	if !ok {
+		return mcpoauth.AuthorizationCode{}, mcpoauth.ErrNotFound
+	}
+	if record.consumed {
+		return mcpoauth.AuthorizationCode{}, mcpoauth.ErrConsumed
+	}
+	if !now.Before(record.value.ExpiresAt) {
+		return mcpoauth.AuthorizationCode{}, mcpoauth.ErrExpired
+	}
+	record.consumed = true
+	s.codes[key] = record
+	return record.value, nil
+}
+
+func (s *memoryMCPOAuthStore) SaveOAuthRefreshToken(_ context.Context, token mcpoauth.RefreshToken) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.refresh[hashKey(token.TokenHash)] = memoryRefresh{value: token}
+	return nil
+}
+
+func (s *memoryMCPOAuthStore) ConsumeOAuthRefreshToken(_ context.Context, tokenHash [32]byte, now time.Time) (mcpoauth.RefreshToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := hashKey(tokenHash)
+	record, ok := s.refresh[key]
+	if !ok {
+		return mcpoauth.RefreshToken{}, mcpoauth.ErrNotFound
+	}
+	if s.families[record.value.FamilyID] || record.consumed {
+		s.families[record.value.FamilyID] = true
+		return mcpoauth.RefreshToken{}, mcpoauth.ErrReplay
+	}
+	if !now.Before(record.value.ExpiresAt) {
+		return mcpoauth.RefreshToken{}, mcpoauth.ErrExpired
+	}
+	record.consumed = true
+	s.refresh[key] = record
+	return record.value, nil
+}
+
+func (s *memoryMCPOAuthStore) RevokeOAuthRefreshFamily(_ context.Context, familyID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.families[familyID] = true
+	return nil
+}
+
+func hashKey(hash [32]byte) string {
+	return hex.EncodeToString(hash[:])
+}
+
+func pkceChallenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func signOIDCIDToken(t *testing.T, key *rsa.PrivateKey, claims map[string]any) string {
+	return signOIDCIDTokenWithKID(t, key, "test-kid", claims)
+}
+
+func signOIDCIDTokenWithKID(t *testing.T, key *rsa.PrivateKey, kid string, claims map[string]any) string {
+	t.Helper()
+	header, err := json.Marshal(map[string]string{"alg": "RS256", "typ": "JWT", "kid": kid})
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(header) + "." + base64.RawURLEncoding.EncodeToString(payload)
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("sign id token: %v", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature)
+}
+
+func rsaJWK(kid string, key *rsa.PublicKey) map[string]string {
+	exponent := big.NewInt(int64(key.E)).Bytes()
+	return map[string]string{
+		"kty": "RSA",
+		"use": "sig",
+		"alg": "RS256",
+		"kid": kid,
+		"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(exponent),
+	}
+}
+
+func TestMCPOAuthTokenEndpointRejectsPKCEMismatch(t *testing.T) {
+	store := newMemoryMCPOAuthStore()
+	code, err := mcpoauth.NewOpaqueToken("code")
+	if err != nil {
+		t.Fatalf("NewOpaqueToken: %v", err)
+	}
+	store.codes[hashKey(mcpoauth.HashToken(code))] = memoryCode{value: mcpoauth.AuthorizationCode{
+		CodeHash:      mcpoauth.HashToken(code),
+		ClientID:      "droid",
+		RedirectURI:   "http://127.0.0.1/callback",
+		Resource:      "https://cerebro.example/api/v1/mcp",
+		Subject:       "user@example.com",
+		TenantID:      "writer",
+		Scopes:        []string{scopeCosmoSecurityRead},
+		Groups:        []string{"security"},
+		CodeChallenge: pkceChallenge(strings.Repeat("a", 64)),
+		CreatedAt:     time.Now(),
+		ExpiresAt:     time.Now().Add(time.Minute),
+	}}
+	app, err := NewWithError(testMCPOAuthConfig("http://127.0.0.1/callback", "http://127.0.0.1"), Dependencies{StateStore: store}, nil)
+	if err != nil {
+		t.Fatalf("NewWithError: %v", err)
+	}
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+	resp := exchangeMCPOAuthTokenRaw(t, server, url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {"droid"},
+		"redirect_uri":  {"http://127.0.0.1/callback"},
+		"resource":      {"https://cerebro.example/api/v1/mcp"},
+		"code":          {code},
+		"code_verifier": {strings.Repeat("b", 64)},
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PKCE mismatch status = %d body=%s", resp.StatusCode, body)
+	}
+}

--- a/internal/bootstrap/oauth_handlers.go
+++ b/internal/bootstrap/oauth_handlers.go
@@ -1,0 +1,191 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/mcpoauth"
+)
+
+const (
+	oauthProtectedResourceMetadataPath          = "/.well-known/oauth-protected-resource"
+	oauthProtectedResourceMetadataMCPPath       = "/.well-known/oauth-protected-resource/api/v1/mcp"
+	oauthAuthorizationServerMetadataPath        = "/.well-known/oauth-authorization-server"
+	oauthAuthorizePath                          = "/oauth/authorize"
+	oauthCallbackPath                           = "/oauth/callback"
+	oauthTokenPath                              = "/oauth/token"
+	oauthRegisterPath                           = "/oauth/register"
+	oauthMaxFormBytes                     int64 = 1 << 20
+	oauthRegisterRatePerSecond                  = 0.2
+	oauthRegisterBurst                          = 5
+)
+
+func (app *App) handleOAuthProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
+	cfg := app.cfg.Auth.MCPOAuth
+	resource := strings.TrimSpace(cfg.Resource)
+	if resource == "" {
+		resource = externalOrigin(r, app.cfg.Auth.RequestOrigin) + mcpEndpointPath
+	}
+	issuer := strings.TrimSpace(cfg.Issuer)
+	if issuer == "" {
+		issuer = externalOrigin(r, app.cfg.Auth.RequestOrigin)
+	}
+	writeOAuthJSON(w, http.StatusOK, map[string]any{
+		"resource":                 resource,
+		"authorization_servers":    []string{issuer},
+		"bearer_methods_supported": []string{"header"},
+		"scopes_supported":         []string{scopeCosmoSecurityRead},
+	})
+}
+
+func (app *App) handleOAuthAuthorizationServerMetadata(w http.ResponseWriter, r *http.Request) {
+	cfg := app.cfg.Auth.MCPOAuth
+	issuer := strings.TrimSpace(cfg.Issuer)
+	if issuer == "" {
+		issuer = externalOrigin(r, app.cfg.Auth.RequestOrigin)
+	}
+	metadata := map[string]any{
+		"issuer":                                issuer,
+		"authorization_endpoint":                issuer + oauthAuthorizePath,
+		"token_endpoint":                        issuer + oauthTokenPath,
+		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"code_challenge_methods_supported":      []string{"S256"},
+		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post", "none"},
+		"scopes_supported":                      []string{scopeCosmoSecurityRead},
+		"resource_indicators_supported":         true,
+	}
+	if cfg.DynamicClientRegistration {
+		metadata["registration_endpoint"] = issuer + oauthRegisterPath
+	}
+	writeOAuthJSON(w, http.StatusOK, metadata)
+}
+
+func (app *App) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	if app.mcpOAuthService == nil {
+		writeOAuthError(w, mcpoauthOAuthError("server_error", "MCP OAuth is not configured", http.StatusServiceUnavailable))
+		return
+	}
+	redirectURL, err := app.mcpOAuthService.Authorize(r.Context(), r.URL.Query())
+	if err != nil {
+		writeOAuthError(w, err)
+		return
+	}
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+func (app *App) handleOAuthCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	if app.mcpOAuthService == nil {
+		writeOAuthError(w, mcpoauthOAuthError("server_error", "MCP OAuth is not configured", http.StatusServiceUnavailable))
+		return
+	}
+	redirectURL, err := app.mcpOAuthService.Callback(r.Context(), r.URL.Query())
+	if err != nil {
+		writeOAuthError(w, err)
+		return
+	}
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+func (app *App) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	if app.mcpOAuthService == nil {
+		writeOAuthError(w, mcpoauthOAuthError("server_error", "MCP OAuth is not configured", http.StatusServiceUnavailable))
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, oauthMaxFormBytes)
+	if err := r.ParseForm(); err != nil {
+		writeOAuthError(w, mcpoauthOAuthError("invalid_request", "invalid form body", http.StatusBadRequest))
+		return
+	}
+	response, err := app.mcpOAuthService.Token(r.Context(), r.Header.Get("Authorization"), r.PostForm)
+	if err != nil {
+		writeOAuthError(w, err)
+		return
+	}
+	writeOAuthJSON(w, http.StatusOK, response)
+}
+
+func (app *App) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	if app.mcpOAuthService == nil {
+		writeOAuthError(w, mcpoauthOAuthError("server_error", "MCP OAuth is not configured", http.StatusServiceUnavailable))
+		return
+	}
+	if app.mcpOAuthRegisterLimit != nil {
+		origin := resolveRequestOrigin(r, app.cfg.Auth.RequestOrigin)
+		clientIP := firstNonEmpty(origin.ClientIP, "unknown")
+		if !app.mcpOAuthRegisterLimit.Allow(clientIP) {
+			writeOAuthError(w, mcpoauthOAuthError("rate_limited", "too many dynamic client registration attempts", http.StatusTooManyRequests))
+			return
+		}
+	}
+	defer func() { _ = r.Body.Close() }()
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, oauthMaxFormBytes))
+	var request mcpoauth.ClientRegistrationRequest
+	if err := decoder.Decode(&request); err != nil {
+		writeOAuthError(w, mcpoauthOAuthError("invalid_client_metadata", "invalid JSON body", http.StatusBadRequest))
+		return
+	}
+	response, err := app.mcpOAuthService.RegisterClient(r.Context(), request)
+	if err != nil {
+		writeOAuthError(w, err)
+		return
+	}
+	writeOAuthJSON(w, http.StatusCreated, response)
+}
+
+func writeOAuthJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeOAuthError(w http.ResponseWriter, err error) {
+	var oauthErr *mcpoauth.OAuthError
+	if !errors.As(err, &oauthErr) {
+		oauthErr = mcpoauthOAuthError("server_error", "OAuth request failed", http.StatusInternalServerError)
+	}
+	if oauthErr.Status == http.StatusUnauthorized {
+		w.Header().Set("WWW-Authenticate", `Basic realm="cerebro-oauth"`)
+	}
+	writeOAuthJSON(w, oauthErr.Status, map[string]string{
+		"error":             oauthErr.Code,
+		"error_description": oauthErr.Description,
+	})
+}
+
+func mcpoauthOAuthError(code string, description string, status int) *mcpoauth.OAuthError {
+	return &mcpoauth.OAuthError{Code: code, Description: description, Status: status}
+}
+
+func externalOrigin(r *http.Request, cfg config.RequestOriginConfig) string {
+	origin := resolveRequestOrigin(r, cfg)
+	return origin.Scheme + "://" + origin.Host
+}
+
+func mcpOAuthResourceMetadataURL(r *http.Request, cfg config.AuthConfig) string {
+	return externalOrigin(r, cfg.RequestOrigin) + oauthProtectedResourceMetadataMCPPath
+}

--- a/internal/bootstrap/oauth_oidc.go
+++ b/internal/bootstrap/oauth_oidc.go
@@ -1,0 +1,521 @@
+package bootstrap
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/mcpoauth"
+)
+
+const (
+	maxOAuthOIDCResponseBytes  = 2 << 20
+	oauthOIDCDiscoveryCacheTTL = time.Hour
+	oauthOIDCJWKSCacheTTL      = 5 * time.Minute
+)
+
+type mcpOAuthOIDCClient struct {
+	cfg        config.MCPOAuthUpstreamConfig
+	httpClient *http.Client
+
+	mu                 sync.Mutex
+	discovery          *oauthOIDCDiscovery
+	discoveryExpiresAt time.Time
+	jwks               *oauthJWKSet
+	jwksExpiresAt      time.Time
+}
+
+func newMCPOAuthOIDCClient(cfg config.MCPOAuthUpstreamConfig) *mcpOAuthOIDCClient {
+	return &mcpOAuthOIDCClient{
+		cfg:        cfg,
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (c *mcpOAuthOIDCClient) AuthorizationEndpoint(ctx context.Context) (string, error) {
+	if endpoint := strings.TrimSpace(c.cfg.AuthorizationEndpoint); endpoint != "" {
+		return endpoint, nil
+	}
+	discovery, err := c.discover(ctx)
+	if err != nil {
+		return "", err
+	}
+	if discovery.AuthorizationEndpoint == "" {
+		return "", fmt.Errorf("mcpoauth: upstream discovery missing authorization_endpoint")
+	}
+	return discovery.AuthorizationEndpoint, nil
+}
+
+func (c *mcpOAuthOIDCClient) tokenEndpoint(ctx context.Context) (string, error) {
+	if endpoint := strings.TrimSpace(c.cfg.TokenEndpoint); endpoint != "" {
+		return endpoint, nil
+	}
+	discovery, err := c.discover(ctx)
+	if err != nil {
+		return "", err
+	}
+	if discovery.TokenEndpoint == "" {
+		return "", fmt.Errorf("mcpoauth: upstream discovery missing token_endpoint")
+	}
+	return discovery.TokenEndpoint, nil
+}
+
+func (c *mcpOAuthOIDCClient) jwksURI(ctx context.Context) (string, error) {
+	if uri := strings.TrimSpace(c.cfg.JWKSURI); uri != "" {
+		return uri, nil
+	}
+	discovery, err := c.discover(ctx)
+	if err != nil {
+		return "", err
+	}
+	if discovery.JWKSURI == "" {
+		return "", fmt.Errorf("mcpoauth: upstream discovery missing jwks_uri")
+	}
+	return discovery.JWKSURI, nil
+}
+
+func (c *mcpOAuthOIDCClient) ExchangeCode(ctx context.Context, code string, nonce string) (mcpoauth.Identity, error) {
+	tokenEndpoint, err := c.tokenEndpoint(ctx)
+	if err != nil {
+		return mcpoauth.Identity{}, err
+	}
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", strings.TrimSpace(code))
+	form.Set("redirect_uri", c.cfg.RedirectURI)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return mcpoauth.Identity{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(c.cfg.ClientID, c.cfg.ClientSecret)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return mcpoauth.Identity{}, fmt.Errorf("mcpoauth: upstream token exchange failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := readOAuthOIDCLimited(resp.Body, maxOAuthOIDCResponseBytes)
+	if err != nil {
+		return mcpoauth.Identity{}, fmt.Errorf("mcpoauth: read upstream token response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("access_denied", "upstream token exchange failed", http.StatusBadGateway)
+	}
+	var decoded struct {
+		IDToken     string `json:"id_token"`
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		Error       string `json:"error"`
+		Description string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return mcpoauth.Identity{}, fmt.Errorf("mcpoauth: decode upstream token response: %w", err)
+	}
+	if decoded.Error != "" {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("access_denied", decoded.Error, http.StatusBadGateway)
+	}
+	if decoded.IDToken == "" {
+		return mcpoauth.Identity{}, fmt.Errorf("mcpoauth: upstream token response missing id_token")
+	}
+	return c.verifyIDToken(ctx, decoded.IDToken, nonce)
+}
+
+func (c *mcpOAuthOIDCClient) verifyIDToken(ctx context.Context, token string, nonce string) (mcpoauth.Identity, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token is malformed", http.StatusBadGateway)
+	}
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token header is malformed", http.StatusBadGateway)
+	}
+	var header struct {
+		Alg string `json:"alg"`
+		KID string `json:"kid"`
+		Typ string `json:"typ"`
+	}
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token header is malformed", http.StatusBadGateway)
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token payload is malformed", http.StatusBadGateway)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token payload is malformed", http.StatusBadGateway)
+	}
+	keySet, err := c.loadJWKS(ctx)
+	if err != nil {
+		return mcpoauth.Identity{}, err
+	}
+	if err := verifyOAuthJWTSignature(parts[0]+"."+parts[1], parts[2], header, keySet); err != nil {
+		if !isOAuthSigningKeyUnknown(err) {
+			return mcpoauth.Identity{}, err
+		}
+		keySet, err = c.refreshJWKS(ctx)
+		if err != nil {
+			return mcpoauth.Identity{}, err
+		}
+		if err := verifyOAuthJWTSignature(parts[0]+"."+parts[1], parts[2], header, keySet); err != nil {
+			return mcpoauth.Identity{}, err
+		}
+	}
+	if got := oauthStringClaim(claims, "iss"); got != c.cfg.Issuer {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token issuer mismatch", http.StatusBadGateway)
+	}
+	if !oauthAudienceContains(claims["aud"], c.cfg.ClientID) {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token audience mismatch", http.StatusBadGateway)
+	}
+	now := time.Now().UTC()
+	if exp := oauthInt64Claim(claims, "exp"); exp <= 0 || now.After(time.Unix(exp, 0).Add(time.Minute)) {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token expired", http.StatusBadGateway)
+	}
+	if nbf := oauthInt64Claim(claims, "nbf"); nbf > 0 && now.Add(time.Minute).Before(time.Unix(nbf, 0)) {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token not yet valid", http.StatusBadGateway)
+	}
+	if expectedNonce := strings.TrimSpace(nonce); expectedNonce != "" && oauthStringClaim(claims, "nonce") != expectedNonce {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token nonce mismatch", http.StatusBadGateway)
+	}
+	subject := oauthStringClaim(claims, "sub")
+	if subject == "" {
+		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token missing subject", http.StatusBadGateway)
+	}
+	email := firstNonEmpty(oauthStringClaim(claims, "email"), oauthStringClaim(claims, "preferred_username"), subject)
+	return mcpoauth.Identity{
+		Subject: subject,
+		Email:   email,
+		Groups:  oauthStringListClaim(claims, c.cfg.GroupsClaim),
+	}, nil
+}
+
+type oauthOIDCDiscovery struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	JWKSURI               string `json:"jwks_uri"`
+}
+
+func (c *mcpOAuthOIDCClient) discover(ctx context.Context) (oauthOIDCDiscovery, error) {
+	now := time.Now()
+	c.mu.Lock()
+	if c.discovery != nil && now.Before(c.discoveryExpiresAt) {
+		discovery := *c.discovery
+		c.mu.Unlock()
+		return discovery, nil
+	}
+	c.mu.Unlock()
+
+	issuer := strings.TrimRight(c.cfg.Issuer, "/")
+	discoveryURL := issuer + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+	if err != nil {
+		return oauthOIDCDiscovery{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return oauthOIDCDiscovery{}, fmt.Errorf("mcpoauth: upstream OIDC discovery failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := readOAuthOIDCLimited(resp.Body, maxOAuthOIDCResponseBytes)
+	if err != nil {
+		return oauthOIDCDiscovery{}, err
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return oauthOIDCDiscovery{}, fmt.Errorf("mcpoauth: upstream OIDC discovery status %d", resp.StatusCode)
+	}
+	var discovery oauthOIDCDiscovery
+	if err := json.Unmarshal(body, &discovery); err != nil {
+		return oauthOIDCDiscovery{}, fmt.Errorf("mcpoauth: decode upstream OIDC discovery: %w", err)
+	}
+	if discovery.Issuer != c.cfg.Issuer {
+		return oauthOIDCDiscovery{}, fmt.Errorf("mcpoauth: upstream discovery issuer mismatch")
+	}
+	c.mu.Lock()
+	c.discovery = &discovery
+	c.discoveryExpiresAt = time.Now().Add(oauthOIDCDiscoveryCacheTTL)
+	c.mu.Unlock()
+	return discovery, nil
+}
+
+type oauthJWKSet struct {
+	Keys []oauthJWK `json:"keys"`
+}
+
+type oauthJWK struct {
+	KTY string `json:"kty"`
+	KID string `json:"kid"`
+	Alg string `json:"alg"`
+	Use string `json:"use"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+	CRV string `json:"crv"`
+	X   string `json:"x"`
+	Y   string `json:"y"`
+}
+
+func (c *mcpOAuthOIDCClient) loadJWKS(ctx context.Context) (oauthJWKSet, error) {
+	return c.loadJWKSWithForce(ctx, false)
+}
+
+func (c *mcpOAuthOIDCClient) refreshJWKS(ctx context.Context) (oauthJWKSet, error) {
+	return c.loadJWKSWithForce(ctx, true)
+}
+
+func (c *mcpOAuthOIDCClient) loadJWKSWithForce(ctx context.Context, force bool) (oauthJWKSet, error) {
+	now := time.Now()
+	c.mu.Lock()
+	if !force && c.jwks != nil && now.Before(c.jwksExpiresAt) {
+		keys := *c.jwks
+		c.mu.Unlock()
+		return keys, nil
+	}
+	c.mu.Unlock()
+
+	jwksURI, err := c.jwksURI(ctx)
+	if err != nil {
+		return oauthJWKSet{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURI, nil)
+	if err != nil {
+		return oauthJWKSet{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return oauthJWKSet{}, fmt.Errorf("mcpoauth: fetch upstream JWKS: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := readOAuthOIDCLimited(resp.Body, maxOAuthOIDCResponseBytes)
+	if err != nil {
+		return oauthJWKSet{}, err
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return oauthJWKSet{}, fmt.Errorf("mcpoauth: upstream JWKS status %d", resp.StatusCode)
+	}
+	var keys oauthJWKSet
+	if err := json.Unmarshal(body, &keys); err != nil {
+		return oauthJWKSet{}, fmt.Errorf("mcpoauth: decode upstream JWKS: %w", err)
+	}
+	c.mu.Lock()
+	c.jwks = &keys
+	c.jwksExpiresAt = time.Now().Add(oauthOIDCJWKSCacheTTL)
+	c.mu.Unlock()
+	return keys, nil
+}
+
+func isOAuthSigningKeyUnknown(err error) bool {
+	var oauthErr *mcpoauth.OAuthError
+	return errors.As(err, &oauthErr) && oauthErr.Code == "invalid_grant" && strings.Contains(oauthErr.Description, "signing key is unknown")
+}
+
+func verifyOAuthJWTSignature(signingInput string, signatureSegment string, header struct {
+	Alg string `json:"alg"`
+	KID string `json:"kid"`
+	Typ string `json:"typ"`
+}, keys oauthJWKSet) error {
+	signature, err := base64.RawURLEncoding.DecodeString(signatureSegment)
+	if err != nil {
+		return mcpoauthOAuthError("invalid_grant", "upstream id_token signature is malformed", http.StatusBadGateway)
+	}
+	key, ok := findOAuthJWK(keys, header.KID, header.Alg)
+	if !ok {
+		return mcpoauthOAuthError("invalid_grant", "upstream id_token signing key is unknown", http.StatusBadGateway)
+	}
+	digest := sha256.Sum256([]byte(signingInput))
+	switch header.Alg {
+	case "RS256":
+		pub, err := oauthRSAPublicKey(key)
+		if err != nil {
+			return err
+		}
+		if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, digest[:], signature); err != nil {
+			return mcpoauthOAuthError("invalid_grant", "upstream id_token signature is invalid", http.StatusBadGateway)
+		}
+		return nil
+	case "ES256":
+		pub, err := oauthECDSAPublicKey(key)
+		if err != nil {
+			return err
+		}
+		if len(signature) != 64 {
+			return mcpoauthOAuthError("invalid_grant", "upstream id_token ECDSA signature is malformed", http.StatusBadGateway)
+		}
+		r := new(big.Int).SetBytes(signature[:32])
+		s := new(big.Int).SetBytes(signature[32:])
+		if !ecdsa.Verify(pub, digest[:], r, s) {
+			return mcpoauthOAuthError("invalid_grant", "upstream id_token signature is invalid", http.StatusBadGateway)
+		}
+		return nil
+	default:
+		return mcpoauthOAuthError("invalid_grant", "upstream id_token algorithm is unsupported", http.StatusBadGateway)
+	}
+}
+
+func findOAuthJWK(keys oauthJWKSet, kid string, alg string) (oauthJWK, bool) {
+	var fallback oauthJWK
+	for _, key := range keys.Keys {
+		if key.Use != "" && key.Use != "sig" {
+			continue
+		}
+		if key.Alg != "" && alg != "" && key.Alg != alg {
+			continue
+		}
+		if kid != "" && key.KID == kid {
+			return key, true
+		}
+		if kid == "" && fallback.KTY == "" {
+			fallback = key
+		}
+	}
+	if kid == "" && fallback.KTY != "" {
+		return fallback, true
+	}
+	return oauthJWK{}, false
+}
+
+func oauthRSAPublicKey(key oauthJWK) (*rsa.PublicKey, error) {
+	if key.KTY != "RSA" {
+		return nil, mcpoauthOAuthError("invalid_grant", "upstream signing key is not RSA", http.StatusBadGateway)
+	}
+	nBytes, err := base64.RawURLEncoding.DecodeString(key.N)
+	if err != nil {
+		return nil, mcpoauthOAuthError("invalid_grant", "upstream RSA key modulus is invalid", http.StatusBadGateway)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(key.E)
+	if err != nil {
+		return nil, mcpoauthOAuthError("invalid_grant", "upstream RSA key exponent is invalid", http.StatusBadGateway)
+	}
+	e := new(big.Int).SetBytes(eBytes).Int64()
+	if e <= 1 {
+		return nil, mcpoauthOAuthError("invalid_grant", "upstream RSA key exponent is invalid", http.StatusBadGateway)
+	}
+	return &rsa.PublicKey{N: new(big.Int).SetBytes(nBytes), E: int(e)}, nil
+}
+
+func oauthECDSAPublicKey(key oauthJWK) (*ecdsa.PublicKey, error) {
+	if key.KTY != "EC" || key.CRV != "P-256" {
+		return nil, mcpoauthOAuthError("invalid_grant", "upstream signing key is not ES256", http.StatusBadGateway)
+	}
+	xBytes, err := base64.RawURLEncoding.DecodeString(key.X)
+	if err != nil {
+		return nil, mcpoauthOAuthError("invalid_grant", "upstream EC key x coordinate is invalid", http.StatusBadGateway)
+	}
+	yBytes, err := base64.RawURLEncoding.DecodeString(key.Y)
+	if err != nil {
+		return nil, mcpoauthOAuthError("invalid_grant", "upstream EC key y coordinate is invalid", http.StatusBadGateway)
+	}
+	if len(xBytes) != 32 || len(yBytes) != 32 {
+		return nil, mcpoauthOAuthError("invalid_grant", "upstream EC key coordinate length is invalid", http.StatusBadGateway)
+	}
+	encoded := make([]byte, 65)
+	encoded[0] = 4
+	copy(encoded[1:33], xBytes)
+	copy(encoded[33:], yBytes)
+	if _, err := ecdh.P256().NewPublicKey(encoded); err != nil {
+		return nil, mcpoauthOAuthError("invalid_grant", "upstream EC key is not on P-256", http.StatusBadGateway)
+	}
+	return &ecdsa.PublicKey{Curve: elliptic.P256(), X: new(big.Int).SetBytes(xBytes), Y: new(big.Int).SetBytes(yBytes)}, nil
+}
+
+func oauthAudienceContains(value any, expected string) bool {
+	switch typed := value.(type) {
+	case string:
+		return typed == expected
+	case []any:
+		for _, item := range typed {
+			if text, ok := item.(string); ok && text == expected {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func oauthStringClaim(claims map[string]any, key string) string {
+	value, ok := claims[key]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
+}
+
+func oauthInt64Claim(claims map[string]any, key string) int64 {
+	value, ok := claims[key]
+	if !ok {
+		return 0
+	}
+	switch typed := value.(type) {
+	case float64:
+		return int64(typed)
+	case json.Number:
+		parsed, _ := typed.Int64()
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func oauthStringListClaim(claims map[string]any, key string) []string {
+	value, ok := claims[key]
+	if !ok {
+		return nil
+	}
+	var out []string
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
+				out = append(out, strings.TrimSpace(text))
+			}
+		}
+	case []string:
+		for _, text := range typed {
+			if strings.TrimSpace(text) != "" {
+				out = append(out, strings.TrimSpace(text))
+			}
+		}
+	case string:
+		split := strings.FieldsFunc(typed, func(r rune) bool { return r == ',' || r == ' ' })
+		for _, text := range split {
+			if strings.TrimSpace(text) != "" {
+				out = append(out, strings.TrimSpace(text))
+			}
+		}
+	}
+	return out
+}
+
+func readOAuthOIDCLimited(r io.Reader, limit int64) ([]byte, error) {
+	limited := io.LimitReader(r, limit+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("response body exceeds %d bytes", limit)
+	}
+	return body, nil
+}

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -21,6 +21,7 @@ const (
 func (app *App) registerRoutes(mux *http.ServeMux, cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) {
 	app.registerConnectRoutes(mux, cfg, deps, sources)
 	app.registerPublicRoutes(mux)
+	app.registerOAuthRoutes(mux)
 	app.registerReportRoutes(mux)
 	app.registerGRCRoutes(mux)
 	app.registerFindingRoutes(mux)
@@ -42,6 +43,16 @@ func (app *App) registerPublicRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "/health", routeSurfacePublicHTTP, app.handleHealth)
 	registerHTTPRoute(mux, "/healthz", routeSurfacePublicHTTP, app.handleHealth)
 	registerHTTPRoute(mux, "GET /openapi.yaml", routeSurfacePublicHTTP, app.handleOpenAPI)
+}
+
+func (app *App) registerOAuthRoutes(mux *http.ServeMux) {
+	registerHTTPRoute(mux, "GET /.well-known/oauth-protected-resource", routeSurfacePublicHTTP, app.handleOAuthProtectedResourceMetadata)
+	registerHTTPRoute(mux, "GET /.well-known/oauth-protected-resource/api/v1/mcp", routeSurfacePublicHTTP, app.handleOAuthProtectedResourceMetadata)
+	registerHTTPRoute(mux, "GET /.well-known/oauth-authorization-server", routeSurfacePublicHTTP, app.handleOAuthAuthorizationServerMetadata)
+	registerHTTPRoute(mux, "GET /oauth/authorize", routeSurfacePublicHTTP, app.handleOAuthAuthorize)
+	registerHTTPRoute(mux, "GET /oauth/callback", routeSurfacePublicHTTP, app.handleOAuthCallback)
+	registerHTTPRoute(mux, "POST /oauth/token", routeSurfacePublicHTTP, app.handleOAuthToken)
+	registerHTTPRoute(mux, "POST /oauth/register", routeSurfacePublicHTTP, app.handleOAuthRegister)
 }
 
 func (app *App) registerReportRoutes(mux *http.ServeMux) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,7 +101,51 @@ type AuthConfig struct {
 	CapabilityTokenAudience string
 	AllowedTenants          []string
 	DeviceAuth              DeviceAuthConfig
+	MCPOAuth                MCPOAuthConfig
 	RequestOrigin           RequestOriginConfig
+}
+
+// MCPOAuthClient is one OAuth client allowed to request MCP access tokens from
+// Cerebro. Redirect URI comparison is exact-match.
+type MCPOAuthClient struct {
+	ClientID     string   `json:"client_id"`
+	ClientSecret string   `json:"client_secret,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	RedirectURIs []string `json:"redirect_uris"`
+	Public       bool     `json:"public,omitempty"`
+}
+
+// MCPOAuthConfig configures Cerebro's OAuth 2.1 authorization-server surface
+// for MCP clients. Cerebro acts as the authorization server to MCP clients and
+// delegates human login to the upstream Writer OIDC provider.
+type MCPOAuthConfig struct {
+	Enabled                   bool
+	Issuer                    string
+	Resource                  string
+	Clients                   []MCPOAuthClient
+	DynamicClientRegistration bool
+	AccessTTL                 time.Duration
+	RefreshTTL                time.Duration
+	CodeTTL                   time.Duration
+	StateTTL                  time.Duration
+	TenantID                  string
+	AllowedTenants            []string
+	Upstream                  MCPOAuthUpstreamConfig
+}
+
+// MCPOAuthUpstreamConfig describes the upstream Writer OIDC application that
+// authenticates the human before Cerebro issues an MCP capability token.
+type MCPOAuthUpstreamConfig struct {
+	Issuer                string
+	AuthorizationEndpoint string
+	TokenEndpoint         string
+	JWKSURI               string
+	ClientID              string
+	ClientSecret          string
+	RedirectURI           string
+	Scopes                []string
+	GroupsClaim           string
+	SecurityGroups        []string
 }
 
 // RequestOriginConfig controls how bootstrap reconstructs client IPs and public
@@ -235,6 +279,11 @@ func Load() (Config, error) {
 	if len(cfg.Auth.CapabilityTokenSecrets) > 0 && cfg.Auth.CapabilityTokenAudience == "" {
 		cfg.Auth.CapabilityTokenAudience = "cerebro-api"
 	}
+	mcpOAuth, err := loadMCPOAuthConfig(cfg.Auth.RequestOrigin.PublicOrigin)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Auth.MCPOAuth = mcpOAuth
 	deviceAuth, err := loadDeviceAuthConfig()
 	if err != nil {
 		return Config{}, err
@@ -307,6 +356,20 @@ func Load() (Config, error) {
 	}
 	if cfg.Auth.Enabled && len(cfg.Auth.APIKeys) == 0 && len(cfg.Auth.APICredentials) == 0 && len(cfg.Auth.CapabilityTokenSecrets) == 0 {
 		return Config{}, fmt.Errorf("CEREBRO_API_KEYS, CEREBRO_API_CREDENTIALS_JSON, or CEREBRO_CAPABILITY_TOKEN_SECRETS is required when CEREBRO_API_AUTH_ENABLED=true")
+	}
+	if cfg.Auth.MCPOAuth.Enabled {
+		if !cfg.Auth.Enabled {
+			return Config{}, fmt.Errorf("CEREBRO_API_AUTH_ENABLED=true is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+		}
+		if cfg.Auth.RequestOrigin.PublicOrigin == "" {
+			return Config{}, fmt.Errorf("CEREBRO_PUBLIC_ORIGIN is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+		}
+		if cfg.StateStore.Driver != StateStoreDriverPostgres {
+			return Config{}, fmt.Errorf("CEREBRO_STATE_STORE_DRIVER=postgres and CEREBRO_POSTGRES_DSN are required when CEREBRO_MCP_OAUTH_ENABLED=true")
+		}
+		if len(cfg.Auth.CapabilityTokenSecrets) == 0 {
+			return Config{}, fmt.Errorf("CEREBRO_CAPABILITY_TOKEN_SECRETS is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+		}
 	}
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,6 +33,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_CIDRS", "")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_COUNT", "")
+	clearMCPOAuthEnv(t)
 	clearDeviceAuthEnv(t)
 
 	cfg, err := Load()
@@ -96,6 +97,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "https://api.writer.com")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_CIDRS", "10.0.0.0/8, 192.168.0.0/16")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_COUNT", "1")
+	clearMCPOAuthEnv(t)
 	clearDeviceAuthEnv(t)
 
 	cfg, err := Load()
@@ -178,6 +180,7 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_CIDRS", "")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_COUNT", "")
+	clearMCPOAuthEnv(t)
 	clearDeviceAuthEnv(t)
 }
 
@@ -215,6 +218,30 @@ func clearDeviceAuthEnv(t *testing.T) {
 	t.Setenv("CEREBRO_DEVICE_AUTH_APPLE_TEAM_ID", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_APPLE_BUNDLE_IDS", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON", "")
+}
+
+func clearMCPOAuthEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CEREBRO_MCP_OAUTH_ENABLED", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_ISSUER", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_RESOURCE", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_ACCESS_TTL", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_REFRESH_TTL", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_CODE_TTL", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_STATE_TTL", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_TENANT_ID", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_ALLOWED_TENANTS", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_AUTHORIZATION_ENDPOINT", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_TOKEN_ENDPOINT", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_JWKS_URI", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_SCOPES", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_GROUPS_CLAIM", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_SECURITY_GROUPS", "")
 }
 
 func TestLoadRejectsRequiredDeviceAuthAttestationWithoutVerifier(t *testing.T) {
@@ -330,6 +357,149 @@ func TestLoadParsesCapabilityTokenConfig(t *testing.T) {
 	}
 	if cfg.Auth.CapabilityTokenAudience != "cerebro-api" {
 		t.Fatalf("CapabilityTokenAudience = %q, want cerebro-api", cfg.Auth.CapabilityTokenAudience)
+	}
+}
+
+func TestLoadParsesMCPOAuthConfig(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "secret-1")
+	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "https://cerebro.example")
+	t.Setenv("CEREBRO_STATE_STORE_DRIVER", StateStoreDriverPostgres)
+	t.Setenv("CEREBRO_POSTGRES_DSN", "postgres://127.0.0.1:5432/cerebro?sslmode=disable")
+	t.Setenv("CEREBRO_MCP_OAUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON", `[{"client_id":"droid","redirect_uris":["http://127.0.0.1/callback"],"public":true}]`)
+	t.Setenv("CEREBRO_MCP_OAUTH_TENANT_ID", "writer")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER", "https://sso.example")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID", "writer-client")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", "writer-secret")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI", "https://cerebro.example/oauth/callback")
+	t.Setenv("CEREBRO_MCP_OAUTH_SECURITY_GROUPS", "secops,secops")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !cfg.Auth.MCPOAuth.Enabled {
+		t.Fatal("MCPOAuth.Enabled = false, want true")
+	}
+	if cfg.Auth.MCPOAuth.Issuer != "https://cerebro.example" || cfg.Auth.MCPOAuth.Resource != "https://cerebro.example/api/v1/mcp" {
+		t.Fatalf("MCPOAuth issuer/resource = %#v", cfg.Auth.MCPOAuth)
+	}
+	if len(cfg.Auth.MCPOAuth.Clients) != 1 || cfg.Auth.MCPOAuth.Clients[0].ClientID != "droid" {
+		t.Fatalf("MCPOAuth.Clients = %#v", cfg.Auth.MCPOAuth.Clients)
+	}
+	if !cfg.Auth.MCPOAuth.DynamicClientRegistration {
+		t.Fatal("MCPOAuth.DynamicClientRegistration = false, want true")
+	}
+	if cfg.Auth.MCPOAuth.RefreshTTL != 24*time.Hour {
+		t.Fatalf("MCPOAuth.RefreshTTL = %v, want 24h", cfg.Auth.MCPOAuth.RefreshTTL)
+	}
+	if got := cfg.Auth.MCPOAuth.Upstream.SecurityGroups; len(got) != 1 || got[0] != "secops" {
+		t.Fatalf("SecurityGroups = %#v, want [secops]", got)
+	}
+}
+
+func TestLoadRejectsMCPOAuthHTTPNonLoopbackURLs(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "public origin", key: "CEREBRO_PUBLIC_ORIGIN", value: "http://cerebro.example"},
+		{name: "upstream issuer", key: "CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER", value: "http://sso.example"},
+		{name: "upstream redirect", key: "CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI", value: "http://cerebro.example/oauth/callback"},
+		{name: "upstream token endpoint", key: "CEREBRO_MCP_OAUTH_UPSTREAM_TOKEN_ENDPOINT", value: "http://sso.example/oauth/token"},
+		{name: "client redirect", key: "CEREBRO_MCP_OAUTH_CLIENTS_JSON", value: `[{"client_id":"droid","redirect_uris":["http://evil.example/callback"],"public":true}]`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setValidMCPOAuthEnv(t)
+			t.Setenv(tt.key, tt.value)
+			if _, err := Load(); err == nil {
+				t.Fatal("Load() error = nil, want MCP OAuth HTTPS requirement error")
+			}
+		})
+	}
+}
+
+func TestLoadRejectsMCPOAuthPublicClientWithSecret(t *testing.T) {
+	setValidMCPOAuthEnv(t)
+	t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON", `[{"client_id":"droid","client_secret":"secret","redirect_uris":["http://127.0.0.1/callback"],"public":true}]`)
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want public client secret rejection")
+	}
+}
+
+func setValidMCPOAuthEnv(t *testing.T) {
+	t.Helper()
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "secret-1")
+	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "https://cerebro.example")
+	t.Setenv("CEREBRO_STATE_STORE_DRIVER", StateStoreDriverPostgres)
+	t.Setenv("CEREBRO_POSTGRES_DSN", "postgres://127.0.0.1:5432/cerebro?sslmode=disable")
+	t.Setenv("CEREBRO_MCP_OAUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON", `[{"client_id":"droid","redirect_uris":["http://127.0.0.1/callback"],"public":true}]`)
+	t.Setenv("CEREBRO_MCP_OAUTH_TENANT_ID", "writer")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER", "https://sso.example")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID", "writer-client")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", "writer-secret")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI", "https://cerebro.example/oauth/callback")
+	t.Setenv("CEREBRO_MCP_OAUTH_SECURITY_GROUPS", "secops")
+}
+
+func TestLoadRejectsMCPOAuthWithoutClientsWhenDCRDisabled(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "secret-1")
+	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "https://cerebro.example")
+	t.Setenv("CEREBRO_STATE_STORE_DRIVER", StateStoreDriverPostgres)
+	t.Setenv("CEREBRO_POSTGRES_DSN", "postgres://127.0.0.1:5432/cerebro?sslmode=disable")
+	t.Setenv("CEREBRO_MCP_OAUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_MCP_OAUTH_DYNAMIC_CLIENT_REGISTRATION_ENABLED", "false")
+	t.Setenv("CEREBRO_MCP_OAUTH_TENANT_ID", "writer")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER", "https://sso.example")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID", "writer-client")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", "writer-secret")
+	t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI", "https://cerebro.example/oauth/callback")
+	t.Setenv("CEREBRO_MCP_OAUTH_SECURITY_GROUPS", "secops")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want client/DCR requirement error")
+	}
+}
+
+func TestLoadRejectsMCPOAuthWithoutProductionRequirements(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		unset string
+	}{
+		{name: "api auth", unset: "CEREBRO_API_AUTH_ENABLED"},
+		{name: "public origin", unset: "CEREBRO_PUBLIC_ORIGIN"},
+		{name: "state store", unset: "CEREBRO_POSTGRES_DSN"},
+		{name: "capability secret", unset: "CEREBRO_CAPABILITY_TOKEN_SECRETS"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clearDependencyEnv(t)
+			t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+			t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "secret-1")
+			t.Setenv("CEREBRO_PUBLIC_ORIGIN", "https://cerebro.example")
+			t.Setenv("CEREBRO_STATE_STORE_DRIVER", StateStoreDriverPostgres)
+			t.Setenv("CEREBRO_POSTGRES_DSN", "postgres://127.0.0.1:5432/cerebro?sslmode=disable")
+			t.Setenv("CEREBRO_MCP_OAUTH_ENABLED", "true")
+			t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON", `[{"client_id":"droid","redirect_uris":["http://127.0.0.1/callback"],"public":true}]`)
+			t.Setenv("CEREBRO_MCP_OAUTH_TENANT_ID", "writer")
+			t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER", "https://sso.example")
+			t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID", "writer-client")
+			t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", "writer-secret")
+			t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI", "https://cerebro.example/oauth/callback")
+			t.Setenv("CEREBRO_MCP_OAUTH_SECURITY_GROUPS", "secops")
+			t.Setenv(tt.unset, "")
+
+			if _, err := Load(); err == nil {
+				t.Fatal("Load() error = nil, want MCP OAuth production requirement error")
+			}
+		})
 	}
 }
 

--- a/internal/config/mcp_oauth.go
+++ b/internal/config/mcp_oauth.go
@@ -1,0 +1,218 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultMCPOAuthAccessTTL  = 10 * time.Minute
+	defaultMCPOAuthRefreshTTL = 24 * time.Hour
+	defaultMCPOAuthCodeTTL    = 5 * time.Minute
+	defaultMCPOAuthStateTTL   = 10 * time.Minute
+)
+
+func loadMCPOAuthConfig(publicOrigin string) (MCPOAuthConfig, error) {
+	enabled, err := parseBoolEnv("CEREBRO_MCP_OAUTH_ENABLED", false)
+	if err != nil {
+		return MCPOAuthConfig{}, err
+	}
+	cfg := MCPOAuthConfig{
+		Enabled:        enabled,
+		Issuer:         strings.TrimRight(strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_ISSUER")), "/"),
+		Resource:       strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_RESOURCE")),
+		TenantID:       strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_TENANT_ID")),
+		AllowedTenants: parseCSV(os.Getenv("CEREBRO_MCP_OAUTH_ALLOWED_TENANTS")),
+		Upstream: MCPOAuthUpstreamConfig{
+			Issuer:                strings.TrimRight(strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER")), "/"),
+			AuthorizationEndpoint: strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_UPSTREAM_AUTHORIZATION_ENDPOINT")),
+			TokenEndpoint:         strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_UPSTREAM_TOKEN_ENDPOINT")),
+			JWKSURI:               strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_UPSTREAM_JWKS_URI")),
+			ClientID:              strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID")),
+			ClientSecret:          strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET")),
+			RedirectURI:           strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI")),
+			Scopes:                parseCSV(os.Getenv("CEREBRO_MCP_OAUTH_UPSTREAM_SCOPES")),
+			GroupsClaim:           strings.TrimSpace(os.Getenv("CEREBRO_MCP_OAUTH_UPSTREAM_GROUPS_CLAIM")),
+			SecurityGroups:        parseCSV(os.Getenv("CEREBRO_MCP_OAUTH_SECURITY_GROUPS")),
+		},
+	}
+	if cfg.Issuer == "" {
+		cfg.Issuer = strings.TrimRight(strings.TrimSpace(publicOrigin), "/")
+	}
+	if cfg.Resource == "" && strings.TrimSpace(publicOrigin) != "" {
+		cfg.Resource = strings.TrimRight(strings.TrimSpace(publicOrigin), "/") + "/api/v1/mcp"
+	}
+	if cfg.Upstream.GroupsClaim == "" {
+		cfg.Upstream.GroupsClaim = "groups"
+	}
+	if len(cfg.Upstream.Scopes) == 0 {
+		cfg.Upstream.Scopes = []string{"openid", "email", "profile", "groups"}
+	}
+	if cfg.AccessTTL, err = parseDurationEnv("CEREBRO_MCP_OAUTH_ACCESS_TTL", defaultMCPOAuthAccessTTL); err != nil {
+		return MCPOAuthConfig{}, err
+	}
+	if cfg.RefreshTTL, err = parseDurationEnv("CEREBRO_MCP_OAUTH_REFRESH_TTL", defaultMCPOAuthRefreshTTL); err != nil {
+		return MCPOAuthConfig{}, err
+	}
+	if cfg.CodeTTL, err = parseDurationEnv("CEREBRO_MCP_OAUTH_CODE_TTL", defaultMCPOAuthCodeTTL); err != nil {
+		return MCPOAuthConfig{}, err
+	}
+	if cfg.StateTTL, err = parseDurationEnv("CEREBRO_MCP_OAUTH_STATE_TTL", defaultMCPOAuthStateTTL); err != nil {
+		return MCPOAuthConfig{}, err
+	}
+	if cfg.DynamicClientRegistration, err = parseBoolEnv("CEREBRO_MCP_OAUTH_DYNAMIC_CLIENT_REGISTRATION_ENABLED", true); err != nil {
+		return MCPOAuthConfig{}, err
+	}
+	clients, err := parseMCPOAuthClients(os.Getenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON"))
+	if err != nil {
+		return MCPOAuthConfig{}, err
+	}
+	cfg.Clients = clients
+	if cfg.Enabled {
+		if err := validateMCPOAuthConfig(cfg); err != nil {
+			return MCPOAuthConfig{}, err
+		}
+	}
+	return cfg, nil
+}
+
+func parseMCPOAuthClients(raw string) ([]MCPOAuthClient, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var clients []MCPOAuthClient
+	if err := json.Unmarshal([]byte(raw), &clients); err != nil {
+		return nil, fmt.Errorf("parse CEREBRO_MCP_OAUTH_CLIENTS_JSON: %w", err)
+	}
+	for index := range clients {
+		clients[index].ClientID = strings.TrimSpace(clients[index].ClientID)
+		clients[index].ClientSecret = strings.TrimSpace(clients[index].ClientSecret)
+		clients[index].Name = strings.TrimSpace(clients[index].Name)
+		clients[index].RedirectURIs = normalizeStringSlice(clients[index].RedirectURIs)
+		if clients[index].ClientID == "" {
+			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d] requires client_id", index)
+		}
+		if clients[index].Public && clients[index].ClientSecret != "" {
+			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d] must not set client_secret when public=true", index)
+		}
+		if clients[index].ClientSecret == "" {
+			clients[index].Public = true
+		}
+		if len(clients[index].RedirectURIs) == 0 {
+			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d] requires at least one redirect_uri", index)
+		}
+		for _, redirectURI := range clients[index].RedirectURIs {
+			if err := validateAbsoluteHTTPURL("redirect_uri", redirectURI); err != nil {
+				return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d]: %w", index, err)
+			}
+		}
+	}
+	return clients, nil
+}
+
+func validateMCPOAuthConfig(cfg MCPOAuthConfig) error {
+	if cfg.Issuer == "" {
+		return fmt.Errorf("CEREBRO_MCP_OAUTH_ISSUER or CEREBRO_PUBLIC_ORIGIN is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+	}
+	if err := validateAbsoluteHTTPOrigin("CEREBRO_MCP_OAUTH_ISSUER", cfg.Issuer); err != nil {
+		return err
+	}
+	if cfg.Resource == "" {
+		return fmt.Errorf("CEREBRO_MCP_OAUTH_RESOURCE or CEREBRO_PUBLIC_ORIGIN is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+	}
+	if err := validateAbsoluteHTTPURL("CEREBRO_MCP_OAUTH_RESOURCE", cfg.Resource); err != nil {
+		return err
+	}
+	if len(cfg.Clients) == 0 && !cfg.DynamicClientRegistration {
+		return fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON or CEREBRO_MCP_OAUTH_DYNAMIC_CLIENT_REGISTRATION_ENABLED=true is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+	}
+	if cfg.TenantID == "" && len(cfg.AllowedTenants) == 0 {
+		return fmt.Errorf("CEREBRO_MCP_OAUTH_TENANT_ID or CEREBRO_MCP_OAUTH_ALLOWED_TENANTS is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+	}
+	if cfg.Upstream.Issuer == "" {
+		return fmt.Errorf("CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+	}
+	if err := validateAbsoluteHTTPOrigin("CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER", cfg.Upstream.Issuer); err != nil {
+		return err
+	}
+	if cfg.Upstream.ClientID == "" {
+		return fmt.Errorf("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+	}
+	if cfg.Upstream.ClientSecret == "" {
+		return fmt.Errorf("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+	}
+	if cfg.Upstream.RedirectURI == "" {
+		return fmt.Errorf("CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+	}
+	if err := validateAbsoluteHTTPURL("CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI", cfg.Upstream.RedirectURI); err != nil {
+		return err
+	}
+	if len(cfg.Upstream.SecurityGroups) == 0 {
+		return fmt.Errorf("CEREBRO_MCP_OAUTH_SECURITY_GROUPS is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+	}
+	if cfg.Upstream.AuthorizationEndpoint != "" {
+		if err := validateAbsoluteHTTPURL("CEREBRO_MCP_OAUTH_UPSTREAM_AUTHORIZATION_ENDPOINT", cfg.Upstream.AuthorizationEndpoint); err != nil {
+			return err
+		}
+	}
+	if cfg.Upstream.TokenEndpoint != "" {
+		if err := validateAbsoluteHTTPURL("CEREBRO_MCP_OAUTH_UPSTREAM_TOKEN_ENDPOINT", cfg.Upstream.TokenEndpoint); err != nil {
+			return err
+		}
+	}
+	if cfg.Upstream.JWKSURI != "" {
+		if err := validateAbsoluteHTTPURL("CEREBRO_MCP_OAUTH_UPSTREAM_JWKS_URI", cfg.Upstream.JWKSURI); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAbsoluteHTTPOrigin(name string, raw string) error {
+	parsed, err := url.Parse(strings.TrimRight(strings.TrimSpace(raw), "/"))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("%s must be an http(s) origin", name)
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return fmt.Errorf("%s must use http or https", name)
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || strings.Trim(parsed.Path, "/") != "" {
+		return fmt.Errorf("%s must not include user info, path, query, or fragment", name)
+	}
+	if parsed.Scheme != "https" && !isLoopbackOAuthHost(parsed.Hostname()) {
+		return fmt.Errorf("%s must use https unless it targets loopback", name)
+	}
+	return nil
+}
+
+func validateAbsoluteHTTPURL(name string, raw string) error {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("%s must be an absolute http(s) URL", name)
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return fmt.Errorf("%s must use http or https", name)
+	}
+	if parsed.User != nil || parsed.Fragment != "" {
+		return fmt.Errorf("%s must not include user info or fragment", name)
+	}
+	if parsed.Scheme != "https" && !isLoopbackOAuthHost(parsed.Hostname()) {
+		return fmt.Errorf("%s must use https unless it targets loopback", name)
+	}
+	return nil
+}
+
+func isLoopbackOAuthHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/mcpoauth/oidc.go
+++ b/internal/mcpoauth/oidc.go
@@ -1,0 +1,14 @@
+package mcpoauth
+
+import "context"
+
+type OIDCProvider interface {
+	AuthorizationEndpoint(context.Context) (string, error)
+	ExchangeCode(context.Context, string, string) (Identity, error)
+}
+
+type Identity struct {
+	Subject string
+	Email   string
+	Groups  []string
+}

--- a/internal/mcpoauth/service.go
+++ b/internal/mcpoauth/service.go
@@ -1,0 +1,712 @@
+package mcpoauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+// AccessGrant is the claim set Cerebro places into an MCP capability token.
+type AccessGrant struct {
+	Subject        string
+	Email          string
+	ClientID       string
+	Resource       string
+	TenantID       string
+	AllowedTenants []string
+	Scopes         []string
+	Groups         []string
+}
+
+// AccessTokenIssuer mints a signed bearer access token for an OAuth grant.
+type AccessTokenIssuer func(context.Context, AccessGrant, time.Duration, time.Time) (string, error)
+
+type Service struct {
+	cfg        config.MCPOAuthConfig
+	store      Store
+	oidc       OIDCProvider
+	issueToken AccessTokenIssuer
+	now        func() time.Time
+}
+
+type ServiceOption func(*Service)
+
+func WithOIDCProvider(provider OIDCProvider) ServiceOption {
+	return func(s *Service) {
+		if provider != nil {
+			s.oidc = provider
+		}
+	}
+}
+
+func WithNow(now func() time.Time) ServiceOption {
+	return func(s *Service) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+func NewService(cfg config.MCPOAuthConfig, store Store, issueToken AccessTokenIssuer, opts ...ServiceOption) (*Service, error) {
+	if store == nil {
+		return nil, fmt.Errorf("mcpoauth: store is required")
+	}
+	if issueToken == nil {
+		return nil, fmt.Errorf("mcpoauth: access token issuer is required")
+	}
+	s := &Service{
+		cfg:        cfg,
+		store:      store,
+		issueToken: issueToken,
+		now:        time.Now,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.oidc == nil {
+		return nil, fmt.Errorf("mcpoauth: OIDC provider is required")
+	}
+	return s, nil
+}
+
+const (
+	statusBadRequest          = 400
+	statusUnauthorized        = 401
+	statusForbidden           = 403
+	statusInternalServerError = 500
+	statusBadGateway          = 502
+)
+
+type OAuthError struct {
+	Code        string
+	Description string
+	Status      int
+}
+
+func (e *OAuthError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Description == "" {
+		return e.Code
+	}
+	return e.Code + ": " + e.Description
+}
+
+func oauthError(code string, description string, status int) *OAuthError {
+	if status == 0 {
+		status = statusBadRequest
+	}
+	return &OAuthError{Code: code, Description: description, Status: status}
+}
+
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+type ClientRegistrationRequest struct {
+	ClientName              string   `json:"client_name,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+}
+
+type ClientRegistrationResponse struct {
+	ClientID                string   `json:"client_id"`
+	ClientName              string   `json:"client_name,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+}
+
+func (s *Service) RegisterClient(ctx context.Context, request ClientRegistrationRequest) (ClientRegistrationResponse, error) {
+	if !s.cfg.DynamicClientRegistration {
+		return ClientRegistrationResponse{}, oauthError("invalid_request", "dynamic client registration is disabled", statusBadRequest)
+	}
+	redirectURIs := normalizeStrings(request.RedirectURIs)
+	if len(redirectURIs) == 0 {
+		return ClientRegistrationResponse{}, oauthError("invalid_client_metadata", "redirect_uris is required", statusBadRequest)
+	}
+	for _, redirectURI := range redirectURIs {
+		if !validDynamicRedirectURI(redirectURI) {
+			return ClientRegistrationResponse{}, oauthError("invalid_redirect_uri", "dynamic clients may only register loopback redirect URIs", statusBadRequest)
+		}
+	}
+	if !grantTypesAllowed(request.GrantTypes) {
+		return ClientRegistrationResponse{}, oauthError("invalid_client_metadata", "grant_types must be authorization_code and optional refresh_token", statusBadRequest)
+	}
+	if !responseTypesAllowed(request.ResponseTypes) {
+		return ClientRegistrationResponse{}, oauthError("invalid_client_metadata", "response_types must be code", statusBadRequest)
+	}
+	method := strings.TrimSpace(request.TokenEndpointAuthMethod)
+	if method == "" {
+		method = "none"
+	}
+	if method != "none" {
+		return ClientRegistrationResponse{}, oauthError("invalid_client_metadata", "only public clients with token_endpoint_auth_method=none are supported", statusBadRequest)
+	}
+	clientID, err := NewOpaqueToken("mcp_client")
+	if err != nil {
+		return ClientRegistrationResponse{}, fmt.Errorf("mcpoauth: generate dynamic client id: %w", err)
+	}
+	client := OAuthClient{
+		ClientID:     clientID,
+		Name:         strings.TrimSpace(request.ClientName),
+		RedirectURIs: redirectURIs,
+		Public:       true,
+		CreatedAt:    s.now().UTC(),
+	}
+	if err := s.store.SaveOAuthClient(ctx, client); err != nil {
+		return ClientRegistrationResponse{}, fmt.Errorf("mcpoauth: save dynamic client: %w", err)
+	}
+	return ClientRegistrationResponse{
+		ClientID:                clientID,
+		ClientName:              client.Name,
+		RedirectURIs:            cloneStrings(client.RedirectURIs),
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+	}, nil
+}
+
+func (s *Service) Authorize(ctx context.Context, query url.Values) (string, error) {
+	if query.Get("response_type") != "code" {
+		return "", oauthError("unsupported_response_type", "response_type must be code", statusBadRequest)
+	}
+	client, ok := s.client(ctx, query.Get("client_id"))
+	if !ok {
+		return "", oauthError("unauthorized_client", "unknown OAuth client", statusBadRequest)
+	}
+	redirectURI := strings.TrimSpace(query.Get("redirect_uri"))
+	if !redirectURIAllowed(client, redirectURI) {
+		return "", oauthError("invalid_request", "redirect_uri is not registered for client", statusBadRequest)
+	}
+	clientState := strings.TrimSpace(query.Get("state"))
+	if clientState == "" {
+		return "", oauthError("invalid_request", "state is required", statusBadRequest)
+	}
+	resource := strings.TrimSpace(query.Get("resource"))
+	if resource == "" {
+		resource = s.cfg.Resource
+	}
+	if resource != s.cfg.Resource {
+		return "", oauthError("invalid_target", "resource is not this MCP server", statusBadRequest)
+	}
+	scopes, err := normalizeRequestedScopes(query.Get("scope"))
+	if err != nil {
+		return "", err
+	}
+	codeChallenge := strings.TrimSpace(query.Get("code_challenge"))
+	if codeChallenge == "" || query.Get("code_challenge_method") != "S256" {
+		return "", oauthError("invalid_request", "PKCE S256 code_challenge is required", statusBadRequest)
+	}
+	stateToken, err := NewOpaqueToken("state")
+	if err != nil {
+		return "", fmt.Errorf("mcpoauth: generate state: %w", err)
+	}
+	nonce, err := NewOpaqueToken("nonce")
+	if err != nil {
+		return "", fmt.Errorf("mcpoauth: generate nonce: %w", err)
+	}
+	now := s.now().UTC()
+	if err := s.store.SaveLoginState(ctx, LoginState{
+		StateHash:     HashToken(stateToken),
+		ClientID:      client.ClientID,
+		RedirectURI:   redirectURI,
+		ClientState:   clientState,
+		Resource:      resource,
+		Scopes:        scopes,
+		CodeChallenge: codeChallenge,
+		Nonce:         nonce,
+		CreatedAt:     now,
+		ExpiresAt:     now.Add(s.cfg.StateTTL),
+	}); err != nil {
+		return "", fmt.Errorf("mcpoauth: save login state: %w", err)
+	}
+	authEndpoint, err := s.oidc.AuthorizationEndpoint(ctx)
+	if err != nil {
+		return "", err
+	}
+	upstream := url.Values{}
+	upstream.Set("response_type", "code")
+	upstream.Set("client_id", s.cfg.Upstream.ClientID)
+	upstream.Set("redirect_uri", s.cfg.Upstream.RedirectURI)
+	upstream.Set("scope", strings.Join(s.cfg.Upstream.Scopes, " "))
+	upstream.Set("state", stateToken)
+	upstream.Set("nonce", nonce)
+	return appendQuery(authEndpoint, upstream), nil
+}
+
+func (s *Service) Callback(ctx context.Context, query url.Values) (string, error) {
+	if upstreamErr := strings.TrimSpace(query.Get("error")); upstreamErr != "" {
+		return "", oauthError("access_denied", upstreamErr, statusBadRequest)
+	}
+	stateToken, err := NormalizeOpaqueToken(query.Get("state"))
+	if err != nil {
+		return "", oauthError("invalid_request", "state is required", statusBadRequest)
+	}
+	upstreamCode := strings.TrimSpace(query.Get("code"))
+	if upstreamCode == "" {
+		return "", oauthError("invalid_request", "code is required", statusBadRequest)
+	}
+	login, err := s.store.ConsumeLoginState(ctx, HashToken(stateToken), s.now().UTC())
+	if err != nil {
+		return "", tokenStoreError("invalid_request", "login state is invalid", err)
+	}
+	identity, err := s.oidc.ExchangeCode(ctx, upstreamCode, login.Nonce)
+	if err != nil {
+		return "", err
+	}
+	if !containsAny(identity.Groups, s.cfg.Upstream.SecurityGroups) {
+		return "", oauthError("access_denied", "authenticated user is not in an authorized security group", statusForbidden)
+	}
+	codeToken, err := NewOpaqueToken("code")
+	if err != nil {
+		return "", fmt.Errorf("mcpoauth: generate code: %w", err)
+	}
+	now := s.now().UTC()
+	if err := s.store.SaveAuthorizationCode(ctx, AuthorizationCode{
+		CodeHash:       HashToken(codeToken),
+		ClientID:       login.ClientID,
+		RedirectURI:    login.RedirectURI,
+		Resource:       login.Resource,
+		Subject:        firstNonEmpty(identity.Email, identity.Subject),
+		Email:          identity.Email,
+		TenantID:       strings.TrimSpace(s.cfg.TenantID),
+		AllowedTenants: cloneStrings(s.cfg.AllowedTenants),
+		Scopes:         cloneStrings(login.Scopes),
+		Groups:         []string{"security"},
+		CodeChallenge:  login.CodeChallenge,
+		CreatedAt:      now,
+		ExpiresAt:      now.Add(s.cfg.CodeTTL),
+	}); err != nil {
+		return "", fmt.Errorf("mcpoauth: save authorization code: %w", err)
+	}
+	redirect, err := url.Parse(login.RedirectURI)
+	if err != nil {
+		return "", fmt.Errorf("mcpoauth: parse client redirect uri: %w", err)
+	}
+	values := redirect.Query()
+	values.Set("code", codeToken)
+	values.Set("state", login.ClientState)
+	redirect.RawQuery = values.Encode()
+	return redirect.String(), nil
+}
+
+func (s *Service) Token(ctx context.Context, authorizationHeader string, form url.Values) (TokenResponse, error) {
+	client, err := s.authenticateClient(ctx, authorizationHeader, form)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	resource, err := s.tokenRequestResource(form)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	switch form.Get("grant_type") {
+	case "authorization_code":
+		return s.exchangeAuthorizationCode(ctx, client, resource, form)
+	case "refresh_token":
+		return s.exchangeRefreshToken(ctx, client, resource, form)
+	default:
+		return TokenResponse{}, oauthError("unsupported_grant_type", "grant_type must be authorization_code or refresh_token", statusBadRequest)
+	}
+}
+
+func (s *Service) tokenRequestResource(form url.Values) (string, error) {
+	resource := strings.TrimSpace(form.Get("resource"))
+	if resource == "" {
+		return "", oauthError("invalid_target", "resource is required", statusBadRequest)
+	}
+	if resource != s.cfg.Resource {
+		return "", oauthError("invalid_target", "resource is not this MCP server", statusBadRequest)
+	}
+	return resource, nil
+}
+
+func (s *Service) exchangeAuthorizationCode(ctx context.Context, client config.MCPOAuthClient, resource string, form url.Values) (TokenResponse, error) {
+	code, err := NormalizeOpaqueToken(form.Get("code"))
+	if err != nil {
+		return TokenResponse{}, oauthError("invalid_grant", "code is required", statusBadRequest)
+	}
+	redirectURI := strings.TrimSpace(form.Get("redirect_uri"))
+	if !redirectURIAllowed(client, redirectURI) {
+		return TokenResponse{}, oauthError("invalid_grant", "redirect_uri is invalid", statusBadRequest)
+	}
+	codeVerifier := strings.TrimSpace(form.Get("code_verifier"))
+	if !validCodeVerifier(codeVerifier) {
+		return TokenResponse{}, oauthError("invalid_grant", "code_verifier is invalid", statusBadRequest)
+	}
+	record, err := s.store.ConsumeAuthorizationCode(ctx, HashToken(code), s.now().UTC())
+	if err != nil {
+		return TokenResponse{}, tokenStoreError("invalid_grant", "authorization code is invalid", err)
+	}
+	if record.ClientID != client.ClientID || record.RedirectURI != redirectURI {
+		return TokenResponse{}, oauthError("invalid_grant", "authorization code was issued to a different client", statusBadRequest)
+	}
+	if record.Resource != resource {
+		return TokenResponse{}, oauthError("invalid_target", "authorization code was issued for a different resource", statusBadRequest)
+	}
+	if !verifyPKCES256(codeVerifier, record.CodeChallenge) {
+		return TokenResponse{}, oauthError("invalid_grant", "PKCE verification failed", statusBadRequest)
+	}
+	return s.issueTokenPair(ctx, refreshGrantFromCode(record, ""), 0)
+}
+
+func (s *Service) exchangeRefreshToken(ctx context.Context, client config.MCPOAuthClient, resource string, form url.Values) (TokenResponse, error) {
+	refreshToken, err := NormalizeOpaqueToken(form.Get("refresh_token"))
+	if err != nil {
+		return TokenResponse{}, oauthError("invalid_grant", "refresh_token is required", statusBadRequest)
+	}
+	record, err := s.store.ConsumeOAuthRefreshToken(ctx, HashToken(refreshToken), s.now().UTC())
+	if err != nil {
+		if errors.Is(err, ErrReplay) && strings.TrimSpace(record.FamilyID) != "" {
+			_ = s.store.RevokeOAuthRefreshFamily(ctx, record.FamilyID)
+		}
+		return TokenResponse{}, tokenStoreError("invalid_grant", "refresh token is invalid", err)
+	}
+	if record.ClientID != client.ClientID {
+		_ = s.store.RevokeOAuthRefreshFamily(ctx, record.FamilyID)
+		return TokenResponse{}, oauthError("invalid_grant", "refresh token was issued to a different client", statusBadRequest)
+	}
+	if record.Resource != resource {
+		_ = s.store.RevokeOAuthRefreshFamily(ctx, record.FamilyID)
+		return TokenResponse{}, oauthError("invalid_target", "refresh token was issued for a different resource", statusBadRequest)
+	}
+	return s.issueTokenPair(ctx, refreshGrantFromRefresh(record), record.Generation+1)
+}
+
+func (s *Service) issueTokenPair(ctx context.Context, grant RefreshToken, generation int) (TokenResponse, error) {
+	now := s.now().UTC()
+	access, err := s.issueToken(ctx, AccessGrant{
+		Subject:        grant.Subject,
+		Email:          grant.Email,
+		ClientID:       grant.ClientID,
+		Resource:       grant.Resource,
+		TenantID:       grant.TenantID,
+		AllowedTenants: cloneStrings(grant.AllowedTenants),
+		Scopes:         cloneStrings(grant.Scopes),
+		Groups:         cloneStrings(grant.Groups),
+	}, s.cfg.AccessTTL, now)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	refreshPlain, err := NewOpaqueToken("refresh")
+	if err != nil {
+		return TokenResponse{}, fmt.Errorf("mcpoauth: generate refresh token: %w", err)
+	}
+	familyID := strings.TrimSpace(grant.FamilyID)
+	if familyID == "" {
+		familyID, err = NewFamilyID()
+		if err != nil {
+			return TokenResponse{}, fmt.Errorf("mcpoauth: generate refresh family: %w", err)
+		}
+	}
+	if err := s.store.SaveOAuthRefreshToken(ctx, RefreshToken{
+		TokenHash:      HashToken(refreshPlain),
+		ClientID:       grant.ClientID,
+		Resource:       grant.Resource,
+		Subject:        grant.Subject,
+		Email:          grant.Email,
+		TenantID:       grant.TenantID,
+		AllowedTenants: cloneStrings(grant.AllowedTenants),
+		Scopes:         cloneStrings(grant.Scopes),
+		Groups:         cloneStrings(grant.Groups),
+		FamilyID:       familyID,
+		Generation:     generation,
+		CreatedAt:      now,
+		ExpiresAt:      refreshExpiresAt(grant, now, s.cfg.RefreshTTL),
+	}); err != nil {
+		return TokenResponse{}, fmt.Errorf("mcpoauth: issue refresh token: %w", err)
+	}
+	return TokenResponse{
+		AccessToken:  access,
+		TokenType:    "Bearer",
+		ExpiresIn:    int64(s.cfg.AccessTTL.Seconds()),
+		RefreshToken: refreshPlain,
+		Scope:        strings.Join(grant.Scopes, " "),
+	}, nil
+}
+
+func refreshGrantFromCode(code AuthorizationCode, familyID string) RefreshToken {
+	return RefreshToken{
+		ClientID:       code.ClientID,
+		Resource:       code.Resource,
+		Subject:        code.Subject,
+		Email:          code.Email,
+		TenantID:       code.TenantID,
+		AllowedTenants: cloneStrings(code.AllowedTenants),
+		Scopes:         cloneStrings(code.Scopes),
+		Groups:         cloneStrings(code.Groups),
+		FamilyID:       familyID,
+	}
+}
+
+func refreshGrantFromRefresh(token RefreshToken) RefreshToken {
+	return RefreshToken{
+		ClientID:       token.ClientID,
+		Resource:       token.Resource,
+		Subject:        token.Subject,
+		Email:          token.Email,
+		TenantID:       token.TenantID,
+		AllowedTenants: cloneStrings(token.AllowedTenants),
+		Scopes:         cloneStrings(token.Scopes),
+		Groups:         cloneStrings(token.Groups),
+		FamilyID:       token.FamilyID,
+		ExpiresAt:      token.ExpiresAt,
+	}
+}
+
+func refreshExpiresAt(grant RefreshToken, now time.Time, ttl time.Duration) time.Time {
+	if !grant.ExpiresAt.IsZero() {
+		return grant.ExpiresAt
+	}
+	return now.Add(ttl)
+}
+
+func (s *Service) authenticateClient(ctx context.Context, authorizationHeader string, form url.Values) (config.MCPOAuthClient, error) {
+	clientID, secret, hasSecret := basicClientCredentials(authorizationHeader)
+	if clientID == "" {
+		clientID = strings.TrimSpace(form.Get("client_id"))
+		secret = strings.TrimSpace(form.Get("client_secret"))
+		hasSecret = secret != ""
+	}
+	client, ok := s.client(ctx, clientID)
+	if !ok {
+		return config.MCPOAuthClient{}, oauthError("invalid_client", "unknown OAuth client", statusUnauthorized)
+	}
+	if client.ClientSecret == "" {
+		return client, nil
+	}
+	if !hasSecret || !constantTimeEqual(secret, client.ClientSecret) {
+		return config.MCPOAuthClient{}, oauthError("invalid_client", "client authentication failed", statusUnauthorized)
+	}
+	return client, nil
+}
+
+func (s *Service) client(ctx context.Context, clientID string) (config.MCPOAuthClient, bool) {
+	clientID = strings.TrimSpace(clientID)
+	for _, client := range s.cfg.Clients {
+		if client.ClientID == clientID {
+			return client, true
+		}
+	}
+	client, err := s.store.GetOAuthClient(ctx, clientID)
+	if err == nil {
+		return config.MCPOAuthClient{
+			ClientID:     client.ClientID,
+			ClientSecret: client.ClientSecret,
+			Name:         client.Name,
+			RedirectURIs: cloneStrings(client.RedirectURIs),
+			Public:       client.Public,
+		}, true
+	}
+	return config.MCPOAuthClient{}, false
+}
+
+func redirectURIAllowed(client config.MCPOAuthClient, redirectURI string) bool {
+	redirectURI = strings.TrimSpace(redirectURI)
+	if redirectURI == "" {
+		return false
+	}
+	for _, allowed := range client.RedirectURIs {
+		if redirectURI == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func validDynamicRedirectURI(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme != "http" || parsed.Host == "" || parsed.User != nil || parsed.Fragment != "" {
+		return false
+	}
+	host := parsed.Hostname()
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func grantTypesAllowed(values []string) bool {
+	values = normalizeStrings(values)
+	if len(values) == 0 {
+		return true
+	}
+	seenAuthCode := false
+	for _, value := range values {
+		switch value {
+		case "authorization_code":
+			seenAuthCode = true
+		case "refresh_token":
+		default:
+			return false
+		}
+	}
+	return seenAuthCode
+}
+
+func responseTypesAllowed(values []string) bool {
+	values = normalizeStrings(values)
+	if len(values) == 0 {
+		return true
+	}
+	return len(values) == 1 && values[0] == "code"
+}
+
+func normalizeRequestedScopes(raw string) ([]string, error) {
+	fields := strings.Fields(strings.TrimSpace(raw))
+	if len(fields) == 0 {
+		return []string{ScopeSecurityRead}, nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(fields))
+	for _, scope := range fields {
+		if scope != ScopeSecurityRead {
+			return nil, oauthError("invalid_scope", "requested scope is not supported", statusBadRequest)
+		}
+		if _, ok := seen[scope]; ok {
+			continue
+		}
+		seen[scope] = struct{}{}
+		out = append(out, scope)
+	}
+	if len(out) == 0 {
+		return nil, oauthError("invalid_scope", "requested scope is not supported", statusBadRequest)
+	}
+	return out, nil
+}
+
+func validCodeVerifier(verifier string) bool {
+	if len(verifier) < 43 || len(verifier) > 128 {
+		return false
+	}
+	for _, r := range verifier {
+		switch {
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '.' || r == '_' || r == '~':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func verifyPKCES256(verifier string, challenge string) bool {
+	sum := sha256.Sum256([]byte(verifier))
+	expected := base64.RawURLEncoding.EncodeToString(sum[:])
+	return constantTimeEqual(expected, strings.TrimSpace(challenge))
+}
+
+func basicClientCredentials(header string) (string, string, bool) {
+	parts := strings.Fields(strings.TrimSpace(header))
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Basic") {
+		return "", "", false
+	}
+	decoded, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", "", false
+	}
+	clientID, secret, ok := strings.Cut(string(decoded), ":")
+	if !ok {
+		return "", "", false
+	}
+	return strings.TrimSpace(clientID), secret, true
+}
+
+func tokenStoreError(code string, description string, err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ErrNotFound), errors.Is(err, ErrExpired), errors.Is(err, ErrConsumed), errors.Is(err, ErrReplay):
+		return oauthError(code, description, statusBadRequest)
+	default:
+		return err
+	}
+}
+
+func appendQuery(raw string, values url.Values) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	query := parsed.Query()
+	for key, vals := range values {
+		for _, value := range vals {
+			query.Add(key, value)
+		}
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+func containsAny(values []string, allowed []string) bool {
+	for _, value := range values {
+		for _, allow := range allowed {
+			if strings.EqualFold(strings.TrimSpace(value), strings.TrimSpace(allow)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalizeStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func constantTimeEqual(a string, b string) bool {
+	if a == "" || b == "" || len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func cloneStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}

--- a/internal/mcpoauth/service_test.go
+++ b/internal/mcpoauth/service_test.go
@@ -1,0 +1,101 @@
+package mcpoauth
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+func TestTokenRefreshReplayRevokesFamily(t *testing.T) {
+	store := &replayRefreshStore{
+		consumeRecord: RefreshToken{FamilyID: "family-1"},
+		consumeErr:    ErrReplay,
+	}
+	service, err := NewService(config.MCPOAuthConfig{
+		Resource:   "https://cerebro.example/api/v1/mcp",
+		AccessTTL:  time.Minute,
+		RefreshTTL: time.Hour,
+		Clients: []config.MCPOAuthClient{{
+			ClientID: "droid",
+			Public:   true,
+		}},
+	}, store, func(context.Context, AccessGrant, time.Duration, time.Time) (string, error) {
+		return "access-token", nil
+	}, WithOIDCProvider(stubOIDCProvider{}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = service.Token(context.Background(), "", url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {"droid"},
+		"resource":      {"https://cerebro.example/api/v1/mcp"},
+		"refresh_token": {"stolen-refresh-token"},
+	})
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) || oauthErr.Code != "invalid_grant" {
+		t.Fatalf("Token replay error = %v, want invalid_grant OAuthError", err)
+	}
+	if len(store.revokedFamilies) != 1 || store.revokedFamilies[0] != "family-1" {
+		t.Fatalf("revokedFamilies = %#v, want [family-1]", store.revokedFamilies)
+	}
+}
+
+func TestTokenDoesNotBypassClientSecretWhenPublicFlagIsSet(t *testing.T) {
+	service, err := NewService(config.MCPOAuthConfig{
+		Resource:   "https://cerebro.example/api/v1/mcp",
+		AccessTTL:  time.Minute,
+		RefreshTTL: time.Hour,
+		Clients: []config.MCPOAuthClient{{
+			ClientID:     "droid",
+			ClientSecret: "secret",
+			Public:       true,
+		}},
+	}, &replayRefreshStore{}, func(context.Context, AccessGrant, time.Duration, time.Time) (string, error) {
+		return "access-token", nil
+	}, WithOIDCProvider(stubOIDCProvider{}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = service.Token(context.Background(), "", url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {"droid"},
+		"resource":      {"https://cerebro.example/api/v1/mcp"},
+		"refresh_token": {"refresh-token"},
+	})
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) || oauthErr.Code != "invalid_client" {
+		t.Fatalf("Token without client secret error = %v, want invalid_client OAuthError", err)
+	}
+}
+
+type replayRefreshStore struct {
+	Store
+	consumeRecord   RefreshToken
+	consumeErr      error
+	revokedFamilies []string
+}
+
+func (s *replayRefreshStore) ConsumeOAuthRefreshToken(context.Context, [32]byte, time.Time) (RefreshToken, error) {
+	return s.consumeRecord, s.consumeErr
+}
+
+func (s *replayRefreshStore) RevokeOAuthRefreshFamily(_ context.Context, familyID string) error {
+	s.revokedFamilies = append(s.revokedFamilies, familyID)
+	return nil
+}
+
+type stubOIDCProvider struct{}
+
+func (stubOIDCProvider) AuthorizationEndpoint(context.Context) (string, error) {
+	return "https://sso.example/authorize", nil
+}
+
+func (stubOIDCProvider) ExchangeCode(context.Context, string, string) (Identity, error) {
+	return Identity{}, nil
+}

--- a/internal/mcpoauth/store.go
+++ b/internal/mcpoauth/store.go
@@ -1,0 +1,97 @@
+package mcpoauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"strings"
+	"time"
+)
+
+const ScopeSecurityRead = "cerebro.cosmo.security.read"
+
+// Store persists OAuth state. Implementations must consume states, codes, and
+// refresh tokens atomically to prevent replay.
+type Store interface {
+	SaveOAuthClient(ctx context.Context, client OAuthClient) error
+	GetOAuthClient(ctx context.Context, clientID string) (OAuthClient, error)
+	SaveLoginState(ctx context.Context, state LoginState) error
+	ConsumeLoginState(ctx context.Context, stateHash [32]byte, now time.Time) (LoginState, error)
+	SaveAuthorizationCode(ctx context.Context, code AuthorizationCode) error
+	ConsumeAuthorizationCode(ctx context.Context, codeHash [32]byte, now time.Time) (AuthorizationCode, error)
+	SaveOAuthRefreshToken(ctx context.Context, token RefreshToken) error
+	ConsumeOAuthRefreshToken(ctx context.Context, tokenHash [32]byte, now time.Time) (RefreshToken, error)
+	RevokeOAuthRefreshFamily(ctx context.Context, familyID string) error
+}
+
+// OAuthClient is a dynamically registered MCP OAuth client.
+type OAuthClient struct {
+	ClientID     string
+	ClientSecret string
+	Name         string
+	RedirectURIs []string
+	Public       bool
+	CreatedAt    time.Time
+}
+
+// LoginState tracks Cerebro's upstream OIDC redirect state for one pending
+// downstream OAuth authorization request.
+type LoginState struct {
+	StateHash     [32]byte
+	ClientID      string
+	RedirectURI   string
+	ClientState   string
+	Resource      string
+	Scopes        []string
+	CodeChallenge string
+	Nonce         string
+	CreatedAt     time.Time
+	ExpiresAt     time.Time
+}
+
+// AuthorizationCode is a single-use code issued by Cerebro to the MCP client
+// after upstream OIDC login succeeds.
+type AuthorizationCode struct {
+	CodeHash       [32]byte
+	ClientID       string
+	RedirectURI    string
+	Resource       string
+	Subject        string
+	Email          string
+	TenantID       string
+	AllowedTenants []string
+	Scopes         []string
+	Groups         []string
+	CodeChallenge  string
+	CreatedAt      time.Time
+	ExpiresAt      time.Time
+}
+
+// RefreshToken tracks a single-use refresh token lineage.
+type RefreshToken struct {
+	TokenHash      [32]byte
+	ClientID       string
+	Resource       string
+	Subject        string
+	Email          string
+	TenantID       string
+	AllowedTenants []string
+	Scopes         []string
+	Groups         []string
+	FamilyID       string
+	Generation     int
+	CreatedAt      time.Time
+	ExpiresAt      time.Time
+	FamilyRevoked  bool
+}
+
+var (
+	ErrNotFound = errors.New("mcpoauth: token not found")
+	ErrExpired  = errors.New("mcpoauth: token expired")
+	ErrConsumed = errors.New("mcpoauth: token already consumed")
+	ErrReplay   = errors.New("mcpoauth: refresh token replay detected")
+)
+
+func HashToken(token string) [32]byte {
+	return sha256.Sum256([]byte(strings.TrimSpace(token)))
+}

--- a/internal/mcpoauth/tokens.go
+++ b/internal/mcpoauth/tokens.go
@@ -1,0 +1,34 @@
+package mcpoauth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"strings"
+)
+
+const opaqueTokenBytes = 32
+
+func NewOpaqueToken(prefix string) (string, error) {
+	buf := make([]byte, opaqueTokenBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	token := base64.RawURLEncoding.EncodeToString(buf)
+	if strings.TrimSpace(prefix) == "" {
+		return token, nil
+	}
+	return strings.TrimSpace(prefix) + "_" + token, nil
+}
+
+func NormalizeOpaqueToken(token string) (string, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", errors.New("mcpoauth: opaque token is empty")
+	}
+	return token, nil
+}
+
+func NewFamilyID() (string, error) {
+	return NewOpaqueToken("fam")
+}

--- a/internal/statestore/postgres/mcp_oauth.go
+++ b/internal/statestore/postgres/mcp_oauth.go
@@ -1,0 +1,400 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/mcpoauth"
+)
+
+var ensureMCPOAuthStatements = []string{
+	`CREATE TABLE IF NOT EXISTS mcp_oauth_clients (
+  client_id TEXT PRIMARY KEY,
+  client_secret TEXT NOT NULL DEFAULT '',
+  client_name TEXT NOT NULL DEFAULT '',
+  redirect_uris_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  public BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL
+)`,
+	`CREATE TABLE IF NOT EXISTS mcp_oauth_login_states (
+  state_hash BYTEA PRIMARY KEY,
+  client_id TEXT NOT NULL,
+  redirect_uri TEXT NOT NULL,
+  client_state TEXT NOT NULL DEFAULT '',
+  resource TEXT NOT NULL,
+  scopes_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  code_challenge TEXT NOT NULL,
+  nonce TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ
+)`,
+	`CREATE INDEX IF NOT EXISTS mcp_oauth_login_states_expires_idx ON mcp_oauth_login_states (expires_at)`,
+	`CREATE TABLE IF NOT EXISTS mcp_oauth_authorization_codes (
+  code_hash BYTEA PRIMARY KEY,
+  client_id TEXT NOT NULL,
+  redirect_uri TEXT NOT NULL,
+  resource TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  email TEXT NOT NULL DEFAULT '',
+  tenant_id TEXT NOT NULL DEFAULT '',
+  allowed_tenants_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  scopes_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  groups_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  code_challenge TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ
+)`,
+	`CREATE INDEX IF NOT EXISTS mcp_oauth_authorization_codes_client_idx ON mcp_oauth_authorization_codes (client_id)`,
+	`CREATE INDEX IF NOT EXISTS mcp_oauth_authorization_codes_expires_idx ON mcp_oauth_authorization_codes (expires_at)`,
+	`CREATE TABLE IF NOT EXISTS mcp_oauth_refresh_tokens (
+  token_hash BYTEA PRIMARY KEY,
+  client_id TEXT NOT NULL,
+  resource TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  email TEXT NOT NULL DEFAULT '',
+  tenant_id TEXT NOT NULL DEFAULT '',
+  allowed_tenants_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  scopes_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  groups_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  family_id TEXT NOT NULL,
+  generation INTEGER NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  family_revoked BOOLEAN NOT NULL DEFAULT FALSE
+)`,
+	`CREATE INDEX IF NOT EXISTS mcp_oauth_refresh_tokens_client_idx ON mcp_oauth_refresh_tokens (client_id)`,
+	`CREATE INDEX IF NOT EXISTS mcp_oauth_refresh_tokens_family_idx ON mcp_oauth_refresh_tokens (family_id)`,
+	`CREATE INDEX IF NOT EXISTS mcp_oauth_refresh_tokens_expires_idx ON mcp_oauth_refresh_tokens (expires_at)`,
+}
+
+func (s *Store) SaveOAuthClient(ctx context.Context, client mcpoauth.OAuthClient) error {
+	if err := s.ensureMCPOAuthTables(ctx); err != nil {
+		return err
+	}
+	redirectURIs, err := stringSliceJSON(client.RedirectURIs)
+	if err != nil {
+		return fmt.Errorf("marshal mcp oauth client redirect URIs: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO mcp_oauth_clients (
+  client_id, client_secret, client_name, redirect_uris_json, public, created_at
+) VALUES ($1,$2,$3,$4::jsonb,$5,$6)`,
+		strings.TrimSpace(client.ClientID),
+		strings.TrimSpace(client.ClientSecret),
+		strings.TrimSpace(client.Name),
+		redirectURIs,
+		client.Public,
+		nullableUTC(client.CreatedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("save mcp oauth client: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetOAuthClient(ctx context.Context, clientID string) (mcpoauth.OAuthClient, error) {
+	if err := s.ensureMCPOAuthTables(ctx); err != nil {
+		return mcpoauth.OAuthClient{}, err
+	}
+	var client mcpoauth.OAuthClient
+	var redirectJSON string
+	row := s.db.QueryRowContext(ctx, `
+SELECT client_id, client_secret, client_name, redirect_uris_json::text, public, created_at
+FROM mcp_oauth_clients
+WHERE client_id = $1`, strings.TrimSpace(clientID))
+	if err := row.Scan(&client.ClientID, &client.ClientSecret, &client.Name, &redirectJSON, &client.Public, &client.CreatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return mcpoauth.OAuthClient{}, mcpoauth.ErrNotFound
+		}
+		return mcpoauth.OAuthClient{}, fmt.Errorf("lookup mcp oauth client: %w", err)
+	}
+	redirectURIs, err := stringSliceFromJSON(redirectJSON)
+	if err != nil {
+		return mcpoauth.OAuthClient{}, err
+	}
+	client.RedirectURIs = redirectURIs
+	return client, nil
+}
+
+func (s *Store) SaveLoginState(ctx context.Context, state mcpoauth.LoginState) error {
+	if err := s.ensureMCPOAuthTables(ctx); err != nil {
+		return err
+	}
+	scopes, err := stringSliceJSON(state.Scopes)
+	if err != nil {
+		return fmt.Errorf("marshal mcp oauth state scopes: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO mcp_oauth_login_states (
+  state_hash, client_id, redirect_uri, client_state, resource, scopes_json,
+  code_challenge, nonce, created_at, expires_at
+) VALUES ($1,$2,$3,$4,$5,$6::jsonb,$7,$8,$9,$10)`,
+		state.StateHash[:],
+		strings.TrimSpace(state.ClientID),
+		strings.TrimSpace(state.RedirectURI),
+		strings.TrimSpace(state.ClientState),
+		strings.TrimSpace(state.Resource),
+		scopes,
+		strings.TrimSpace(state.CodeChallenge),
+		strings.TrimSpace(state.Nonce),
+		nullableUTC(state.CreatedAt),
+		nullableUTC(state.ExpiresAt),
+	)
+	if err != nil {
+		return fmt.Errorf("save mcp oauth login state: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ConsumeLoginState(ctx context.Context, stateHash [32]byte, now time.Time) (mcpoauth.LoginState, error) {
+	if err := s.ensureMCPOAuthTables(ctx); err != nil {
+		return mcpoauth.LoginState{}, err
+	}
+	var result mcpoauth.LoginState
+	err := s.runInTx(ctx, func(tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT client_id, redirect_uri, client_state, resource, scopes_json::text,
+       code_challenge, nonce, created_at, expires_at, consumed_at
+FROM mcp_oauth_login_states
+WHERE state_hash = $1
+FOR UPDATE`, stateHash[:])
+		var scopesJSON string
+		var consumedAt sql.NullTime
+		if err := row.Scan(&result.ClientID, &result.RedirectURI, &result.ClientState, &result.Resource, &scopesJSON, &result.CodeChallenge, &result.Nonce, &result.CreatedAt, &result.ExpiresAt, &consumedAt); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return mcpoauth.ErrNotFound
+			}
+			return fmt.Errorf("lookup mcp oauth login state: %w", err)
+		}
+		if consumedAt.Valid {
+			return mcpoauth.ErrConsumed
+		}
+		if !now.Before(result.ExpiresAt) {
+			return mcpoauth.ErrExpired
+		}
+		scopes, err := stringSliceFromJSON(scopesJSON)
+		if err != nil {
+			return err
+		}
+		result.Scopes = scopes
+		if _, err := tx.ExecContext(ctx, `UPDATE mcp_oauth_login_states SET consumed_at = $2 WHERE state_hash = $1`, stateHash[:], now.UTC()); err != nil {
+			return fmt.Errorf("consume mcp oauth login state: %w", err)
+		}
+		result.StateHash = stateHash
+		return nil
+	})
+	return result, err
+}
+
+func (s *Store) SaveAuthorizationCode(ctx context.Context, code mcpoauth.AuthorizationCode) error {
+	if err := s.ensureMCPOAuthTables(ctx); err != nil {
+		return err
+	}
+	allowedTenants, err := stringSliceJSON(code.AllowedTenants)
+	if err != nil {
+		return fmt.Errorf("marshal allowed tenants: %w", err)
+	}
+	scopes, err := stringSliceJSON(code.Scopes)
+	if err != nil {
+		return fmt.Errorf("marshal scopes: %w", err)
+	}
+	groups, err := stringSliceJSON(code.Groups)
+	if err != nil {
+		return fmt.Errorf("marshal groups: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO mcp_oauth_authorization_codes (
+  code_hash, client_id, redirect_uri, resource, subject, email, tenant_id,
+  allowed_tenants_json, scopes_json, groups_json, code_challenge, created_at, expires_at
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10::jsonb,$11,$12,$13)`,
+		code.CodeHash[:],
+		strings.TrimSpace(code.ClientID),
+		strings.TrimSpace(code.RedirectURI),
+		strings.TrimSpace(code.Resource),
+		strings.TrimSpace(code.Subject),
+		strings.TrimSpace(code.Email),
+		strings.TrimSpace(code.TenantID),
+		allowedTenants,
+		scopes,
+		groups,
+		strings.TrimSpace(code.CodeChallenge),
+		nullableUTC(code.CreatedAt),
+		nullableUTC(code.ExpiresAt),
+	)
+	if err != nil {
+		return fmt.Errorf("save mcp oauth authorization code: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ConsumeAuthorizationCode(ctx context.Context, codeHash [32]byte, now time.Time) (mcpoauth.AuthorizationCode, error) {
+	if err := s.ensureMCPOAuthTables(ctx); err != nil {
+		return mcpoauth.AuthorizationCode{}, err
+	}
+	var result mcpoauth.AuthorizationCode
+	err := s.runInTx(ctx, func(tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT client_id, redirect_uri, resource, subject, email, tenant_id, allowed_tenants_json::text,
+       scopes_json::text, groups_json::text, code_challenge, created_at, expires_at, consumed_at
+FROM mcp_oauth_authorization_codes
+WHERE code_hash = $1
+FOR UPDATE`, codeHash[:])
+		var allowedJSON, scopesJSON, groupsJSON string
+		var consumedAt sql.NullTime
+		if err := row.Scan(&result.ClientID, &result.RedirectURI, &result.Resource, &result.Subject, &result.Email, &result.TenantID, &allowedJSON, &scopesJSON, &groupsJSON, &result.CodeChallenge, &result.CreatedAt, &result.ExpiresAt, &consumedAt); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return mcpoauth.ErrNotFound
+			}
+			return fmt.Errorf("lookup mcp oauth authorization code: %w", err)
+		}
+		if consumedAt.Valid {
+			return mcpoauth.ErrConsumed
+		}
+		if !now.Before(result.ExpiresAt) {
+			return mcpoauth.ErrExpired
+		}
+		var err error
+		if result.AllowedTenants, err = stringSliceFromJSON(allowedJSON); err != nil {
+			return err
+		}
+		if result.Scopes, err = stringSliceFromJSON(scopesJSON); err != nil {
+			return err
+		}
+		if result.Groups, err = stringSliceFromJSON(groupsJSON); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE mcp_oauth_authorization_codes SET consumed_at = $2 WHERE code_hash = $1`, codeHash[:], now.UTC()); err != nil {
+			return fmt.Errorf("consume mcp oauth authorization code: %w", err)
+		}
+		result.CodeHash = codeHash
+		return nil
+	})
+	return result, err
+}
+
+func (s *Store) SaveOAuthRefreshToken(ctx context.Context, token mcpoauth.RefreshToken) error {
+	if err := s.ensureMCPOAuthTables(ctx); err != nil {
+		return err
+	}
+	allowedTenants, err := stringSliceJSON(token.AllowedTenants)
+	if err != nil {
+		return fmt.Errorf("marshal allowed tenants: %w", err)
+	}
+	scopes, err := stringSliceJSON(token.Scopes)
+	if err != nil {
+		return fmt.Errorf("marshal scopes: %w", err)
+	}
+	groups, err := stringSliceJSON(token.Groups)
+	if err != nil {
+		return fmt.Errorf("marshal groups: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO mcp_oauth_refresh_tokens (
+  token_hash, client_id, resource, subject, email, tenant_id, allowed_tenants_json,
+  scopes_json, groups_json, family_id, generation, created_at, expires_at, family_revoked
+) VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8::jsonb,$9::jsonb,$10,$11,$12,$13,
+  EXISTS (SELECT 1 FROM mcp_oauth_refresh_tokens WHERE family_id = $10 AND family_revoked)
+)`,
+		token.TokenHash[:],
+		strings.TrimSpace(token.ClientID),
+		strings.TrimSpace(token.Resource),
+		strings.TrimSpace(token.Subject),
+		strings.TrimSpace(token.Email),
+		strings.TrimSpace(token.TenantID),
+		allowedTenants,
+		scopes,
+		groups,
+		strings.TrimSpace(token.FamilyID),
+		token.Generation,
+		nullableUTC(token.CreatedAt),
+		nullableUTC(token.ExpiresAt),
+	)
+	if err != nil {
+		return fmt.Errorf("issue mcp oauth refresh token: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ConsumeOAuthRefreshToken(ctx context.Context, tokenHash [32]byte, now time.Time) (mcpoauth.RefreshToken, error) {
+	if err := s.ensureMCPOAuthTables(ctx); err != nil {
+		return mcpoauth.RefreshToken{}, err
+	}
+	var result mcpoauth.RefreshToken
+	replay := false
+	err := s.runInTx(ctx, func(tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT client_id, resource, subject, email, tenant_id, allowed_tenants_json::text,
+       scopes_json::text, groups_json::text, family_id, generation, created_at,
+       expires_at, consumed_at, family_revoked
+FROM mcp_oauth_refresh_tokens
+WHERE token_hash = $1
+FOR UPDATE`, tokenHash[:])
+		var allowedJSON, scopesJSON, groupsJSON string
+		var consumedAt sql.NullTime
+		if err := row.Scan(&result.ClientID, &result.Resource, &result.Subject, &result.Email, &result.TenantID, &allowedJSON, &scopesJSON, &groupsJSON, &result.FamilyID, &result.Generation, &result.CreatedAt, &result.ExpiresAt, &consumedAt, &result.FamilyRevoked); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return mcpoauth.ErrNotFound
+			}
+			return fmt.Errorf("lookup mcp oauth refresh token: %w", err)
+		}
+		if result.FamilyRevoked {
+			replay = true
+			return nil
+		}
+		if consumedAt.Valid {
+			if _, err := tx.ExecContext(ctx, `UPDATE mcp_oauth_refresh_tokens SET family_revoked = TRUE WHERE family_id = $1`, result.FamilyID); err != nil {
+				return fmt.Errorf("revoke mcp oauth refresh family: %w", err)
+			}
+			replay = true
+			return nil
+		}
+		if !now.Before(result.ExpiresAt) {
+			return mcpoauth.ErrExpired
+		}
+		var err error
+		if result.AllowedTenants, err = stringSliceFromJSON(allowedJSON); err != nil {
+			return err
+		}
+		if result.Scopes, err = stringSliceFromJSON(scopesJSON); err != nil {
+			return err
+		}
+		if result.Groups, err = stringSliceFromJSON(groupsJSON); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE mcp_oauth_refresh_tokens SET consumed_at = $2 WHERE token_hash = $1`, tokenHash[:], now.UTC()); err != nil {
+			return fmt.Errorf("consume mcp oauth refresh token: %w", err)
+		}
+		result.TokenHash = tokenHash
+		return nil
+	})
+	if err == nil && replay {
+		err = mcpoauth.ErrReplay
+	}
+	return result, err
+}
+
+func (s *Store) RevokeOAuthRefreshFamily(ctx context.Context, familyID string) error {
+	if err := s.ensureMCPOAuthTables(ctx); err != nil {
+		return err
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE mcp_oauth_refresh_tokens SET family_revoked = TRUE WHERE family_id = $1`, strings.TrimSpace(familyID))
+	if err != nil {
+		return fmt.Errorf("revoke mcp oauth refresh family: %w", err)
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return mcpoauth.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) ensureMCPOAuthTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.mcpOAuthTablesReady, "mcp_oauth", ensureMCPOAuthStatements)
+}

--- a/internal/statestore/postgres/mcp_oauth_test.go
+++ b/internal/statestore/postgres/mcp_oauth_test.go
@@ -1,0 +1,86 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/mcpoauth"
+)
+
+func TestMCPOAuthSchemaIncludesReplaySafeState(t *testing.T) {
+	joined := strings.Join(ensureMCPOAuthStatements, "\n")
+	for _, want := range []string{
+		"CREATE TABLE IF NOT EXISTS mcp_oauth_clients",
+		"CREATE TABLE IF NOT EXISTS mcp_oauth_login_states",
+		"CREATE TABLE IF NOT EXISTS mcp_oauth_authorization_codes",
+		"CREATE TABLE IF NOT EXISTS mcp_oauth_refresh_tokens",
+		"state_hash BYTEA PRIMARY KEY",
+		"code_hash BYTEA PRIMARY KEY",
+		"token_hash BYTEA PRIMARY KEY",
+		"resource TEXT NOT NULL",
+		"consumed_at TIMESTAMPTZ",
+		"family_revoked BOOLEAN NOT NULL DEFAULT FALSE",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("MCP OAuth schema missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestConsumeOAuthRefreshTokenReplayRevokesFamilyIntegration(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CEREBRO_POSTGRES_DSN"))
+	if dsn == "" {
+		t.Skip("set CEREBRO_POSTGRES_DSN to run MCP OAuth refresh replay integration test")
+	}
+	ctx := context.Background()
+	store, err := Open(config.StateStoreConfig{Driver: config.StateStoreDriverPostgres, PostgresDSN: dsn})
+	if err != nil {
+		t.Fatalf("open postgres store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	familyID := "test-mcp-oauth-replay-" + now.Format("20060102150405.000000000")
+	defer func() {
+		_, _ = store.db.ExecContext(ctx, `DELETE FROM mcp_oauth_refresh_tokens WHERE family_id = $1`, familyID)
+	}()
+	firstHash := mcpoauth.HashToken(familyID + "-refresh-1")
+	secondHash := mcpoauth.HashToken(familyID + "-refresh-2")
+	base := mcpoauth.RefreshToken{
+		ClientID:  "droid",
+		Resource:  "https://cerebro.example/api/v1/mcp",
+		Subject:   "user@example.com",
+		TenantID:  "writer",
+		Scopes:    []string{mcpoauth.ScopeSecurityRead},
+		Groups:    []string{"security"},
+		FamilyID:  familyID,
+		CreatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	}
+	first := base
+	first.TokenHash = firstHash
+	first.Generation = 0
+	if err := store.SaveOAuthRefreshToken(ctx, first); err != nil {
+		t.Fatalf("save first refresh token: %v", err)
+	}
+	second := base
+	second.TokenHash = secondHash
+	second.Generation = 1
+	if err := store.SaveOAuthRefreshToken(ctx, second); err != nil {
+		t.Fatalf("save second refresh token: %v", err)
+	}
+	if _, err := store.ConsumeOAuthRefreshToken(ctx, firstHash, now.Add(time.Minute)); err != nil {
+		t.Fatalf("consume first refresh token: %v", err)
+	}
+	if _, err := store.ConsumeOAuthRefreshToken(ctx, firstHash, now.Add(2*time.Minute)); !errors.Is(err, mcpoauth.ErrReplay) {
+		t.Fatalf("replay first refresh token error = %v, want ErrReplay", err)
+	}
+	if _, err := store.ConsumeOAuthRefreshToken(ctx, secondHash, now.Add(3*time.Minute)); !errors.Is(err, mcpoauth.ErrReplay) {
+		t.Fatalf("consume second token after family replay error = %v, want ErrReplay", err)
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -27,6 +27,7 @@ type Store struct {
 	findingCandidateReady     bool
 	vulnDBTablesReady         bool
 	deviceAuthTablesReady     bool
+	mcpOAuthTablesReady       bool
 	startupLeaseTableReady    bool
 	askTrajectoryReady        bool
 }


### PR DESCRIPTION
## Summary
- add OAuth authorization-server and protected-resource metadata for MCP clients
- support authorization-code + PKCE, public dynamic client registration, upstream OIDC authorization, and refresh-token rotation
- issue resource-bound capability tokens for MCP requests

## Tests
- go test ./internal/mcpoauth ./internal/bootstrap ./internal/config ./internal/statestore/postgres
- make openapi-check
- make lint-bootstrap
- make droid-review-preflight
- make droid-review-sast
- make verify