### PR TITLE
fix: prefer public MCP OAuth clients

### DIFF
--- a/internal/bootstrap/mcp_oauth_test.go
+++ b/internal/bootstrap/mcp_oauth_test.go
@@ -423,8 +423,12 @@ func TestMCPOAuthDynamicClientRegistration(t *testing.T) {
 	if metadata["registration_endpoint"] != "https://cerebro.example/oauth/register" {
 		t.Fatalf("registration_endpoint = %#v", metadata["registration_endpoint"])
 	}
+	authMethods, ok := metadata["token_endpoint_auth_methods_supported"].([]any)
+	if !ok || len(authMethods) == 0 || authMethods[0] != "none" {
+		t.Fatalf("token_endpoint_auth_methods_supported = %#v, want none first for public MCP clients", metadata["token_endpoint_auth_methods_supported"])
+	}
 
-	registerBody := strings.NewReader(`{"client_name":"Droid","redirect_uris":["` + clientRedirect + `"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"none"}`)
+	registerBody := strings.NewReader(`{"client_name":"Droid","redirect_uris":["` + clientRedirect + `"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"]}`)
 	registerResp, err := server.Client().Post(server.URL+oauthRegisterPath, "application/json", registerBody)
 	if err != nil {
 		t.Fatalf("POST register: %v", err)

--- a/internal/bootstrap/oauth_handlers.go
+++ b/internal/bootstrap/oauth_handlers.go
@@ -54,7 +54,7 @@ func (app *App) handleOAuthAuthorizationServerMetadata(w http.ResponseWriter, r 
 		"response_types_supported":              []string{"code"},
 		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 		"code_challenge_methods_supported":      []string{"S256"},
-		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post", "none"},
+		"token_endpoint_auth_methods_supported": []string{"none", "client_secret_basic", "client_secret_post"},
 		"scopes_supported":                      []string{scopeCosmoSecurityRead},
 		"resource_indicators_supported":         true,
 	}


### PR DESCRIPTION
## Summary
- advertise `none` first in OAuth token endpoint auth methods for MCP public-client compatibility
- cover omitted `token_endpoint_auth_method` dynamic registration with a regression assertion

## Validation
- `go test ./internal/bootstrap ./internal/mcpoauth -run 'TestMCPOAuthDynamicClientRegistration|TestMCPOAuth' -count=1 -v`
- `make openapi-check`
- `make check`
