### PR TITLE
feat: harden MCP OAuth for M2M

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1434,8 +1434,8 @@ paths:
           description: Authenticated human is not authorized for MCP access.
   /oauth/token:
     post:
-      summary: Exchange MCP OAuth authorization or refresh token
-      description: Issues a resource-bound bearer capability token for MCP after PKCE verification or refresh-token rotation.
+      summary: Exchange MCP OAuth token grants
+      description: Issues a resource-bound bearer capability token for MCP after PKCE verification, refresh-token rotation, or confidential client_credentials authentication.
       tags:
         - OAuth
       security: []
@@ -1451,7 +1451,7 @@ paths:
               properties:
                 grant_type:
                   type: string
-                  enum: [authorization_code, refresh_token]
+                  enum: [authorization_code, refresh_token, client_credentials]
                 client_id:
                   type: string
                 resource:
@@ -1488,6 +1488,39 @@ paths:
                     type: string
         '400':
           description: Invalid token request or grant.
+        '401':
+          description: Client authentication failed.
+  /oauth/revoke:
+    post:
+      summary: Revoke an MCP OAuth refresh token
+      description: Revokes the refresh-token family associated with a client-owned MCP OAuth refresh token. Access tokens remain short-lived and resource-bound.
+      tags:
+        - OAuth
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [token]
+              additionalProperties:
+                type: string
+              properties:
+                token:
+                  type: string
+                token_type_hint:
+                  type: string
+                  enum: [refresh_token]
+                client_id:
+                  type: string
+                client_secret:
+                  type: string
+      responses:
+        '200':
+          description: Token revocation processed.
+        '400':
+          description: Invalid revocation request.
         '401':
           description: Client authentication failed.
   /oauth/register:

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -67,6 +67,7 @@ type App struct {
 	observationStore      risk.ObservationStore
 	mcpOAuthService       *mcpoauth.Service
 	mcpOAuthRegisterLimit *deviceauth.TokenBucket
+	mcpOAuthEndpointLimit *deviceauth.TokenBucket
 }
 
 type bootstrapService struct {
@@ -155,6 +156,7 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	}
 	if cfg.Auth.MCPOAuth.Enabled {
 		app.mcpOAuthRegisterLimit = deviceauth.NewTokenBucket(oauthRegisterRatePerSecond, oauthRegisterBurst)
+		app.mcpOAuthEndpointLimit = deviceauth.NewTokenBucket(oauthEndpointRatePerSecond, oauthEndpointBurst)
 		service, err := mcpoauth.NewService(cfg.Auth.MCPOAuth, oauthStore, func(ctx context.Context, grant mcpoauth.AccessGrant, ttl time.Duration, now time.Time) (string, error) {
 			return issueCapabilityToken(cfg.Auth, capabilityClaims{
 				Audience:       cfg.Auth.CapabilityTokenAudience,

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
@@ -226,7 +227,7 @@ func isPublicPath(path string) bool {
 		return true
 	case oauthProtectedResourceMetadataPath, oauthProtectedResourceMetadataMCPPath, oauthAuthorizationServerMetadataPath:
 		return true
-	case oauthAuthorizePath, oauthCallbackPath, oauthTokenPath, oauthRegisterPath:
+	case oauthAuthorizePath, oauthCallbackPath, oauthTokenPath, oauthRevokePath, oauthRegisterPath:
 		return true
 	default:
 		return false
@@ -346,6 +347,7 @@ func authenticateCapabilityToken(cfg config.AuthConfig, token string, now time.T
 	var header struct {
 		Algorithm string `json:"alg"`
 		Type      string `json:"typ"`
+		KeyID     string `json:"kid,omitempty"`
 	}
 	if err := json.Unmarshal(headerBytes, &header); err != nil || header.Algorithm != "HS256" {
 		return authPrincipal{}, false
@@ -402,6 +404,7 @@ type capabilityClaims struct {
 	AllowedTenants []string `json:"allowed_tenants,omitempty"`
 	Scopes         []string `json:"scopes,omitempty"`
 	Groups         []string `json:"groups,omitempty"`
+	JWTID          string   `json:"jti,omitempty"`
 }
 
 func validCapabilitySignature(signingInput []byte, signature []byte, secrets []string) bool {
@@ -438,7 +441,14 @@ func issueCapabilityToken(cfg config.AuthConfig, claims capabilityClaims, ttl ti
 	if strings.TrimSpace(claims.Audience) == "" {
 		claims.Audience = cfg.CapabilityTokenAudience
 	}
-	headerBytes, err := json.Marshal(map[string]string{"alg": "HS256", "typ": "JWT"})
+	if strings.TrimSpace(claims.JWTID) == "" {
+		jti, err := randomTokenID()
+		if err != nil {
+			return "", err
+		}
+		claims.JWTID = jti
+	}
+	headerBytes, err := json.Marshal(map[string]string{"alg": "HS256", "typ": "JWT", "kid": "0"})
 	if err != nil {
 		return "", fmt.Errorf("marshal capability token header: %w", err)
 	}
@@ -453,6 +463,14 @@ func issueCapabilityToken(cfg config.AuthConfig, claims capabilityClaims, ttl ti
 	_, _ = mac.Write([]byte(signingInput))
 	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
 	return signingInput + "." + signature, nil
+}
+
+func randomTokenID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate token id: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw[:]), nil
 }
 
 func requestTenantHint(r *http.Request) string {
@@ -574,8 +592,11 @@ func authorizeHTTPRequestScope(auth authContext, r *http.Request) error {
 }
 
 func authorizeMCPTokenResource(cfg config.AuthConfig, principal authPrincipal, r *http.Request) error {
-	if !cfg.MCPOAuth.Enabled || principal.CredentialID != "mcp-oauth" {
+	if principal.CredentialID != "mcp-oauth" {
 		return nil
+	}
+	if !cfg.MCPOAuth.Enabled {
+		return errScopeForbidden
 	}
 	if strings.TrimSpace(principal.TokenResource) != strings.TrimSpace(cfg.MCPOAuth.Resource) {
 		return errScopeForbidden

--- a/internal/bootstrap/mcp_oauth_test.go
+++ b/internal/bootstrap/mcp_oauth_test.go
@@ -249,6 +249,105 @@ func TestMCPOAuthFlowIssuesCapabilityTokenForMCP(t *testing.T) {
 	if !rotatedRefreshRecord.ExpiresAt.Equal(originalRefreshRecord.ExpiresAt) {
 		t.Fatalf("rotated refresh expiration = %v, want family expiration %v", rotatedRefreshRecord.ExpiresAt, originalRefreshRecord.ExpiresAt)
 	}
+	revokeResp := revokeMCPOAuthTokenRaw(t, server, url.Values{
+		"client_id": {"droid"},
+		"token":     {refreshed.RefreshToken},
+	})
+	_ = revokeResp.Body.Close()
+	if revokeResp.StatusCode != http.StatusOK {
+		t.Fatalf("revoke status = %d, want 200", revokeResp.StatusCode)
+	}
+	revokedRefresh := exchangeMCPOAuthTokenRaw(t, server, url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {"droid"},
+		"resource":      {"https://cerebro.example/api/v1/mcp"},
+		"refresh_token": {refreshed.RefreshToken},
+	})
+	_ = revokedRefresh.Body.Close()
+	if revokedRefresh.StatusCode != http.StatusBadRequest {
+		t.Fatalf("revoked refresh status = %d, want 400", revokedRefresh.StatusCode)
+	}
+}
+
+func TestMCPOAuthClientCredentialsIssuesMCPOnlyToken(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	cfg := testMCPOAuthConfig("http://127.0.0.1/callback", upstream.URL)
+	cfg.Auth.MCPOAuth.Clients = []config.MCPOAuthClient{{
+		ClientID:       "panopticon",
+		ClientSecret:   "client-secret",
+		GrantTypes:     []string{"client_credentials"},
+		AllowedTenants: []string{"writer"},
+		Scopes:         []string{scopeCosmoSecurityRead},
+		Groups:         []string{"security"},
+	}}
+	app, err := NewWithError(cfg, Dependencies{StateStore: newMemoryMCPOAuthStore()}, nil)
+	if err != nil {
+		t.Fatalf("NewWithError: %v", err)
+	}
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	form := url.Values{
+		"grant_type": {"client_credentials"},
+		"resource":   {"https://cerebro.example/api/v1/mcp"},
+		"scope":      {scopeCosmoSecurityRead},
+	}
+	req, err := http.NewRequest(http.MethodPost, server.URL+oauthTokenPath, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("NewRequest token: %v", err)
+	}
+	req.SetBasicAuth("panopticon", "client-secret")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("client_credentials status = %d body=%s", resp.StatusCode, body)
+	}
+	var tokenResp mcpoauth.TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	if tokenResp.AccessToken == "" || tokenResp.RefreshToken != "" {
+		t.Fatalf("client_credentials token response = %#v", tokenResp)
+	}
+
+	mcpReq, err := http.NewRequest(http.MethodPost, server.URL+mcpEndpointPath, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	if err != nil {
+		t.Fatalf("NewRequest MCP: %v", err)
+	}
+	mcpReq.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
+	mcpReq.Header.Set("Content-Type", "application/json")
+	mcpReq.Header.Set("MCP-Protocol-Version", mcpProtocolVersion)
+	mcpResp, err := server.Client().Do(mcpReq)
+	if err != nil {
+		t.Fatalf("POST MCP with M2M token: %v", err)
+	}
+	_ = mcpResp.Body.Close()
+	if mcpResp.StatusCode != http.StatusOK {
+		t.Fatalf("MCP status with M2M token = %d, want 200", mcpResp.StatusCode)
+	}
+
+	nonMCPReq, err := http.NewRequest(http.MethodGet, server.URL+"/reports", nil)
+	if err != nil {
+		t.Fatalf("NewRequest non-MCP: %v", err)
+	}
+	nonMCPReq.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
+	nonMCPResp, err := server.Client().Do(nonMCPReq)
+	if err != nil {
+		t.Fatalf("GET reports with M2M token: %v", err)
+	}
+	_ = nonMCPResp.Body.Close()
+	if nonMCPResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("non-MCP status with M2M token = %d, want 401", nonMCPResp.StatusCode)
+	}
 }
 
 func TestMCPOAuthCallbackRejectsMissingSecurityGroup(t *testing.T) {
@@ -574,6 +673,20 @@ func exchangeMCPOAuthTokenRaw(t *testing.T, server *httptest.Server, form url.Va
 	return resp
 }
 
+func revokeMCPOAuthTokenRaw(t *testing.T, server *httptest.Server, form url.Values) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, server.URL+oauthRevokePath, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("NewRequest revoke: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST revoke: %v", err)
+	}
+	return resp
+}
+
 func noRedirectClient(server *httptest.Server) *http.Client {
 	base := server.Client()
 	return &http.Client{
@@ -719,6 +832,17 @@ func (s *memoryMCPOAuthStore) RevokeOAuthRefreshFamily(_ context.Context, family
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.families[familyID] = true
+	return nil
+}
+
+func (s *memoryMCPOAuthStore) RevokeOAuthRefreshToken(_ context.Context, tokenHash [32]byte, clientID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.refresh[hashKey(tokenHash)]
+	if !ok || record.value.ClientID != clientID {
+		return nil
+	}
+	s.families[record.value.FamilyID] = true
 	return nil
 }
 

--- a/internal/bootstrap/oauth_handlers.go
+++ b/internal/bootstrap/oauth_handlers.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/mcpoauth"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 const (
@@ -17,10 +19,13 @@ const (
 	oauthAuthorizePath                          = "/oauth/authorize"
 	oauthCallbackPath                           = "/oauth/callback"
 	oauthTokenPath                              = "/oauth/token"
+	oauthRevokePath                             = "/oauth/revoke"
 	oauthRegisterPath                           = "/oauth/register"
 	oauthMaxFormBytes                     int64 = 1 << 20
 	oauthRegisterRatePerSecond                  = 0.2
 	oauthRegisterBurst                          = 5
+	oauthEndpointRatePerSecond                  = 2.0
+	oauthEndpointBurst                          = 20
 )
 
 func (app *App) handleOAuthProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
@@ -51,8 +56,9 @@ func (app *App) handleOAuthAuthorizationServerMetadata(w http.ResponseWriter, r 
 		"issuer":                                issuer,
 		"authorization_endpoint":                issuer + oauthAuthorizePath,
 		"token_endpoint":                        issuer + oauthTokenPath,
+		"revocation_endpoint":                   issuer + oauthRevokePath,
 		"response_types_supported":              []string{"code"},
-		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token", "client_credentials"},
 		"code_challenge_methods_supported":      []string{"S256"},
 		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post", "none"},
 		"scopes_supported":                      []string{scopeCosmoSecurityRead},
@@ -65,72 +71,134 @@ func (app *App) handleOAuthAuthorizationServerMetadata(w http.ResponseWriter, r 
 }
 
 func (app *App) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
+	clientID := r.URL.Query().Get("client_id")
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", http.MethodGet)
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		app.emitOAuthAuditEvent(r, "authorize", http.StatusMethodNotAllowed, "rejected", "method_not_allowed", clientID, started)
 		return
 	}
 	if app.mcpOAuthService == nil {
 		writeOAuthError(w, mcpoauthOAuthError("server_error", "MCP OAuth is not configured", http.StatusServiceUnavailable))
+		app.emitOAuthAuditEvent(r, "authorize", http.StatusServiceUnavailable, "error", "not_configured", clientID, started)
+		return
+	}
+	if !app.allowOAuthEndpoint(w, r, "authorize", clientID, started) {
 		return
 	}
 	redirectURL, err := app.mcpOAuthService.Authorize(r.Context(), r.URL.Query())
 	if err != nil {
 		writeOAuthError(w, err)
+		app.emitOAuthAuditEvent(r, "authorize", oauthErrorStatus(err), oauthAuditOutcome(err), oauthErrorCode(err), clientID, started)
 		return
 	}
+	app.emitOAuthAuditEvent(r, "authorize", http.StatusFound, "success", "", clientID, started)
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 func (app *App) handleOAuthCallback(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", http.MethodGet)
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		app.emitOAuthAuditEvent(r, "callback", http.StatusMethodNotAllowed, "rejected", "method_not_allowed", "", started)
 		return
 	}
 	if app.mcpOAuthService == nil {
 		writeOAuthError(w, mcpoauthOAuthError("server_error", "MCP OAuth is not configured", http.StatusServiceUnavailable))
+		app.emitOAuthAuditEvent(r, "callback", http.StatusServiceUnavailable, "error", "not_configured", "", started)
+		return
+	}
+	if !app.allowOAuthEndpoint(w, r, "callback", "", started) {
 		return
 	}
 	redirectURL, err := app.mcpOAuthService.Callback(r.Context(), r.URL.Query())
 	if err != nil {
 		writeOAuthError(w, err)
+		app.emitOAuthAuditEvent(r, "callback", oauthErrorStatus(err), oauthAuditOutcome(err), oauthErrorCode(err), "", started)
 		return
 	}
+	app.emitOAuthAuditEvent(r, "callback", http.StatusFound, "success", "", "", started)
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 func (app *App) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		app.emitOAuthAuditEvent(r, "token", http.StatusMethodNotAllowed, "rejected", "method_not_allowed", "", started)
 		return
 	}
 	if app.mcpOAuthService == nil {
 		writeOAuthError(w, mcpoauthOAuthError("server_error", "MCP OAuth is not configured", http.StatusServiceUnavailable))
+		app.emitOAuthAuditEvent(r, "token", http.StatusServiceUnavailable, "error", "not_configured", "", started)
+		return
+	}
+	if !app.allowOAuthEndpoint(w, r, "token", "", started) {
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, oauthMaxFormBytes)
 	if err := r.ParseForm(); err != nil {
 		writeOAuthError(w, mcpoauthOAuthError("invalid_request", "invalid form body", http.StatusBadRequest))
+		app.emitOAuthAuditEvent(r, "token", http.StatusBadRequest, "rejected", "invalid_request", "", started)
 		return
 	}
-	response, err := app.mcpOAuthService.Token(r.Context(), r.Header.Get("Authorization"), r.PostForm)
+	clientID := r.Form.Get("client_id")
+	response, err := app.mcpOAuthService.Token(r.Context(), r.Header.Get("Authorization"), r.Form)
 	if err != nil {
 		writeOAuthError(w, err)
+		app.emitOAuthAuditEvent(r, "token", oauthErrorStatus(err), oauthAuditOutcome(err), oauthErrorCode(err), clientID, started)
 		return
 	}
+	app.emitOAuthAuditEvent(r, "token", http.StatusOK, "success", "", clientID, started)
 	writeOAuthJSON(w, http.StatusOK, response)
 }
 
-func (app *App) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
+func (app *App) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		app.emitOAuthAuditEvent(r, "revoke", http.StatusMethodNotAllowed, "rejected", "method_not_allowed", "", started)
 		return
 	}
 	if app.mcpOAuthService == nil {
 		writeOAuthError(w, mcpoauthOAuthError("server_error", "MCP OAuth is not configured", http.StatusServiceUnavailable))
+		app.emitOAuthAuditEvent(r, "revoke", http.StatusServiceUnavailable, "error", "not_configured", "", started)
+		return
+	}
+	if !app.allowOAuthEndpoint(w, r, "revoke", "", started) {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, oauthMaxFormBytes)
+	if err := r.ParseForm(); err != nil {
+		writeOAuthError(w, mcpoauthOAuthError("invalid_request", "invalid form body", http.StatusBadRequest))
+		app.emitOAuthAuditEvent(r, "revoke", http.StatusBadRequest, "rejected", "invalid_request", "", started)
+		return
+	}
+	clientID := r.Form.Get("client_id")
+	if _, err := app.mcpOAuthService.Revoke(r.Context(), r.Header.Get("Authorization"), r.Form); err != nil {
+		writeOAuthError(w, err)
+		app.emitOAuthAuditEvent(r, "revoke", oauthErrorStatus(err), oauthAuditOutcome(err), oauthErrorCode(err), clientID, started)
+		return
+	}
+	app.emitOAuthAuditEvent(r, "revoke", http.StatusOK, "success", "", clientID, started)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (app *App) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		app.emitOAuthAuditEvent(r, "register", http.StatusMethodNotAllowed, "rejected", "method_not_allowed", "", started)
+		return
+	}
+	if app.mcpOAuthService == nil {
+		writeOAuthError(w, mcpoauthOAuthError("server_error", "MCP OAuth is not configured", http.StatusServiceUnavailable))
+		app.emitOAuthAuditEvent(r, "register", http.StatusServiceUnavailable, "error", "not_configured", "", started)
 		return
 	}
 	if app.mcpOAuthRegisterLimit != nil {
@@ -138,6 +206,7 @@ func (app *App) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 		clientIP := firstNonEmpty(origin.ClientIP, "unknown")
 		if !app.mcpOAuthRegisterLimit.Allow(clientIP) {
 			writeOAuthError(w, mcpoauthOAuthError("rate_limited", "too many dynamic client registration attempts", http.StatusTooManyRequests))
+			app.emitOAuthAuditEvent(r, "register", http.StatusTooManyRequests, "rejected", "rate_limited", "", started)
 			return
 		}
 	}
@@ -145,14 +214,17 @@ func (app *App) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, oauthMaxFormBytes))
 	var request mcpoauth.ClientRegistrationRequest
 	if err := decoder.Decode(&request); err != nil {
+		app.emitOAuthAuditEvent(r, "register", http.StatusBadRequest, "rejected", "invalid_request", "", started)
 		writeOAuthError(w, mcpoauthOAuthError("invalid_client_metadata", "invalid JSON body", http.StatusBadRequest))
 		return
 	}
 	response, err := app.mcpOAuthService.RegisterClient(r.Context(), request)
 	if err != nil {
+		app.emitOAuthAuditEvent(r, "register", oauthErrorStatus(err), oauthAuditOutcome(err), oauthErrorCode(err), "", started)
 		writeOAuthError(w, err)
 		return
 	}
+	app.emitOAuthAuditEvent(r, "register", http.StatusCreated, "success", "", response.ClientID, started)
 	writeOAuthJSON(w, http.StatusCreated, response)
 }
 
@@ -177,6 +249,75 @@ func writeOAuthError(w http.ResponseWriter, err error) {
 	})
 }
 
+func (app *App) allowOAuthEndpoint(w http.ResponseWriter, r *http.Request, operation string, clientID string, started time.Time) bool {
+	if app.mcpOAuthEndpointLimit == nil {
+		return true
+	}
+	origin := resolveRequestOrigin(r, app.cfg.Auth.RequestOrigin)
+	key := operation + ":" + firstNonEmpty(origin.ClientIP, "unknown")
+	if !app.mcpOAuthEndpointLimit.Allow(key) {
+		writeOAuthError(w, mcpoauthOAuthError("rate_limited", "too many OAuth requests", http.StatusTooManyRequests))
+		app.emitOAuthAuditEvent(r, operation, http.StatusTooManyRequests, "rejected", "rate_limited", clientID, started)
+		return false
+	}
+	return true
+}
+
+func (app *App) emitOAuthAuditEvent(r *http.Request, operation string, status int, outcome string, reason string, clientID string, started time.Time) {
+	if r == nil {
+		return
+	}
+	origin := resolveRequestOrigin(r, app.cfg.Auth.RequestOrigin)
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "operation", Value: strings.TrimSpace(operation)},
+		telemetry.Field{Key: "outcome", Value: strings.TrimSpace(outcome)},
+		telemetry.Field{Key: "status", Value: status},
+		telemetry.Field{Key: "status_code", Value: status},
+		telemetry.Field{Key: "method", Value: r.Method},
+		telemetry.Field{Key: "route", Value: accessAuditRoute(r)},
+		telemetry.Field{Key: "duration_ms", Value: time.Since(started).Milliseconds()},
+	)
+	if clientIP := strings.TrimSpace(origin.ClientIP); clientIP != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "client_ip", Value: clientIP})
+	}
+	if remoteIP := strings.TrimSpace(origin.RemoteIP); remoteIP != "" && remoteIP != strings.TrimSpace(origin.ClientIP) {
+		attrs = attrs.WithField(telemetry.Field{Key: "remote_ip", Value: remoteIP})
+	}
+	if clientID = strings.TrimSpace(clientID); clientID != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "client_id", Value: clientID})
+	}
+	if reason = strings.TrimSpace(reason); reason != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "reason", Value: reason})
+	}
+	telemetry.Event(r.Context(), "cerebro.oauth.mcp", attrs)
+}
+
+func oauthErrorStatus(err error) int {
+	var oauthErr *mcpoauth.OAuthError
+	if errors.As(err, &oauthErr) && oauthErr.Status != 0 {
+		return oauthErr.Status
+	}
+	return http.StatusInternalServerError
+}
+
+func oauthErrorCode(err error) string {
+	var oauthErr *mcpoauth.OAuthError
+	if errors.As(err, &oauthErr) {
+		return oauthErr.Code
+	}
+	return "server_error"
+}
+
+func oauthAuditOutcome(err error) string {
+	status := oauthErrorStatus(err)
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		return "denied"
+	}
+	if status >= 500 {
+		return "error"
+	}
+	return "rejected"
+}
 func mcpoauthOAuthError(code string, description string, status int) *mcpoauth.OAuthError {
 	return &mcpoauth.OAuthError{Code: code, Description: description, Status: status}
 }

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -52,6 +52,7 @@ func (app *App) registerOAuthRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /oauth/authorize", routeSurfacePublicHTTP, app.handleOAuthAuthorize)
 	registerHTTPRoute(mux, "GET /oauth/callback", routeSurfacePublicHTTP, app.handleOAuthCallback)
 	registerHTTPRoute(mux, "POST /oauth/token", routeSurfacePublicHTTP, app.handleOAuthToken)
+	registerHTTPRoute(mux, "POST /oauth/revoke", routeSurfacePublicHTTP, app.handleOAuthRevoke)
 	registerHTTPRoute(mux, "POST /oauth/register", routeSurfacePublicHTTP, app.handleOAuthRegister)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,11 +108,29 @@ type AuthConfig struct {
 // MCPOAuthClient is one OAuth client allowed to request MCP access tokens from
 // Cerebro. Redirect URI comparison is exact-match.
 type MCPOAuthClient struct {
-	ClientID     string   `json:"client_id"`
-	ClientSecret string   `json:"client_secret,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	RedirectURIs []string `json:"redirect_uris"`
-	Public       bool     `json:"public,omitempty"`
+	ClientID           string   `json:"client_id"`
+	ClientSecret       string   `json:"client_secret,omitempty"`
+	ClientSecretSHA256 string   `json:"client_secret_sha256,omitempty"`
+	Name               string   `json:"name,omitempty"`
+	RedirectURIs       []string `json:"redirect_uris"`
+	GrantTypes         []string `json:"grant_types,omitempty"`
+	Public             bool     `json:"public,omitempty"`
+	TenantID           string   `json:"tenant_id,omitempty"`
+	AllowedTenants     []string `json:"allowed_tenants,omitempty"`
+	Scopes             []string `json:"scopes,omitempty"`
+	Groups             []string `json:"groups,omitempty"`
+}
+
+// MCPOAuthEntitlement maps an authenticated upstream user/client to the
+// tenants and scopes Cerebro may place into OAuth-issued MCP tokens.
+type MCPOAuthEntitlement struct {
+	Subject        string   `json:"subject,omitempty"`
+	Email          string   `json:"email,omitempty"`
+	ClientID       string   `json:"client_id,omitempty"`
+	Groups         []string `json:"groups,omitempty"`
+	TenantID       string   `json:"tenant_id,omitempty"`
+	AllowedTenants []string `json:"allowed_tenants,omitempty"`
+	Scopes         []string `json:"scopes,omitempty"`
 }
 
 // MCPOAuthConfig configures Cerebro's OAuth 2.1 authorization-server surface
@@ -130,6 +148,7 @@ type MCPOAuthConfig struct {
 	StateTTL                  time.Duration
 	TenantID                  string
 	AllowedTenants            []string
+	Entitlements              []MCPOAuthEntitlement
 	Upstream                  MCPOAuthUpstreamConfig
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -226,6 +226,8 @@ func clearMCPOAuthEnv(t *testing.T) {
 	t.Setenv("CEREBRO_MCP_OAUTH_ISSUER", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_RESOURCE", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_DYNAMIC_CLIENT_REGISTRATION_ENABLED", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_ACCESS_TTL", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_REFRESH_TTL", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_CODE_TTL", "")
@@ -389,14 +391,34 @@ func TestLoadParsesMCPOAuthConfig(t *testing.T) {
 	if len(cfg.Auth.MCPOAuth.Clients) != 1 || cfg.Auth.MCPOAuth.Clients[0].ClientID != "droid" {
 		t.Fatalf("MCPOAuth.Clients = %#v", cfg.Auth.MCPOAuth.Clients)
 	}
-	if !cfg.Auth.MCPOAuth.DynamicClientRegistration {
-		t.Fatal("MCPOAuth.DynamicClientRegistration = false, want true")
+	if cfg.Auth.MCPOAuth.DynamicClientRegistration {
+		t.Fatal("MCPOAuth.DynamicClientRegistration = true, want false by default")
 	}
 	if cfg.Auth.MCPOAuth.RefreshTTL != 24*time.Hour {
 		t.Fatalf("MCPOAuth.RefreshTTL = %v, want 24h", cfg.Auth.MCPOAuth.RefreshTTL)
 	}
 	if got := cfg.Auth.MCPOAuth.Upstream.SecurityGroups; len(got) != 1 || got[0] != "secops" {
 		t.Fatalf("SecurityGroups = %#v, want [secops]", got)
+	}
+}
+
+func TestLoadParsesMCPOAuthM2MClientAndEntitlements(t *testing.T) {
+	setValidMCPOAuthEnv(t)
+	t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON", `[
+		{"client_id":"droid","redirect_uris":["http://127.0.0.1/callback"],"public":true},
+		{"client_id":"panopticon","client_secret":"secret","grant_types":["client_credentials"],"allowed_tenants":["writer"],"scopes":["cerebro.cosmo.security.read"]}
+	]`)
+	t.Setenv("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON", `[{"groups":["secops"],"allowed_tenants":["writer"],"scopes":["cerebro.cosmo.security.read"]}]`)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := cfg.Auth.MCPOAuth.Clients[1].GrantTypes; len(got) != 1 || got[0] != "client_credentials" {
+		t.Fatalf("M2M grant types = %#v", got)
+	}
+	if len(cfg.Auth.MCPOAuth.Entitlements) != 1 || cfg.Auth.MCPOAuth.Entitlements[0].Groups[0] != "secops" {
+		t.Fatalf("Entitlements = %#v", cfg.Auth.MCPOAuth.Entitlements)
 	}
 }
 

--- a/internal/config/mcp_oauth.go
+++ b/internal/config/mcp_oauth.go
@@ -65,7 +65,7 @@ func loadMCPOAuthConfig(publicOrigin string) (MCPOAuthConfig, error) {
 	if cfg.StateTTL, err = parseDurationEnv("CEREBRO_MCP_OAUTH_STATE_TTL", defaultMCPOAuthStateTTL); err != nil {
 		return MCPOAuthConfig{}, err
 	}
-	if cfg.DynamicClientRegistration, err = parseBoolEnv("CEREBRO_MCP_OAUTH_DYNAMIC_CLIENT_REGISTRATION_ENABLED", true); err != nil {
+	if cfg.DynamicClientRegistration, err = parseBoolEnv("CEREBRO_MCP_OAUTH_DYNAMIC_CLIENT_REGISTRATION_ENABLED", false); err != nil {
 		return MCPOAuthConfig{}, err
 	}
 	clients, err := parseMCPOAuthClients(os.Getenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON"))
@@ -73,6 +73,11 @@ func loadMCPOAuthConfig(publicOrigin string) (MCPOAuthConfig, error) {
 		return MCPOAuthConfig{}, err
 	}
 	cfg.Clients = clients
+	entitlements, err := parseMCPOAuthEntitlements(os.Getenv("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON"))
+	if err != nil {
+		return MCPOAuthConfig{}, err
+	}
+	cfg.Entitlements = entitlements
 	if cfg.Enabled {
 		if err := validateMCPOAuthConfig(cfg); err != nil {
 			return MCPOAuthConfig{}, err
@@ -93,18 +98,37 @@ func parseMCPOAuthClients(raw string) ([]MCPOAuthClient, error) {
 	for index := range clients {
 		clients[index].ClientID = strings.TrimSpace(clients[index].ClientID)
 		clients[index].ClientSecret = strings.TrimSpace(clients[index].ClientSecret)
+		clients[index].ClientSecretSHA256 = strings.ToLower(strings.TrimSpace(clients[index].ClientSecretSHA256))
 		clients[index].Name = strings.TrimSpace(clients[index].Name)
 		clients[index].RedirectURIs = normalizeStringSlice(clients[index].RedirectURIs)
+		var err error
+		clients[index].GrantTypes, err = normalizeOAuthGrantTypes(clients[index].GrantTypes)
+		if err != nil {
+			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d]: %w", index, err)
+		}
+		clients[index].TenantID = strings.TrimSpace(clients[index].TenantID)
+		clients[index].AllowedTenants = normalizeStringSlice(clients[index].AllowedTenants)
+		clients[index].Scopes = normalizeStringSlice(clients[index].Scopes)
+		clients[index].Groups = normalizeStringSlice(clients[index].Groups)
 		if clients[index].ClientID == "" {
 			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d] requires client_id", index)
 		}
-		if clients[index].Public && clients[index].ClientSecret != "" {
-			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d] must not set client_secret when public=true", index)
+		if clients[index].Public && (clients[index].ClientSecret != "" || clients[index].ClientSecretSHA256 != "") {
+			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d] must not set client_secret or client_secret_sha256 when public=true", index)
 		}
-		if clients[index].ClientSecret == "" {
+		if clients[index].ClientSecret == "" && clients[index].ClientSecretSHA256 == "" {
 			clients[index].Public = true
 		}
-		if len(clients[index].RedirectURIs) == 0 {
+		if containsString(clients[index].GrantTypes, "client_credentials") && clients[index].Public {
+			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d] must set client_secret or client_secret_sha256 for client_credentials", index)
+		}
+		if clients[index].ClientSecretSHA256 != "" && !validSHA256Hex(clients[index].ClientSecretSHA256) {
+			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d] client_secret_sha256 must be a SHA-256 hex digest", index)
+		}
+		if containsString(clients[index].GrantTypes, "client_credentials") && clients[index].TenantID == "" && len(clients[index].AllowedTenants) == 0 {
+			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d] requires tenant_id or allowed_tenants for client_credentials", index)
+		}
+		if containsString(clients[index].GrantTypes, "authorization_code") && len(clients[index].RedirectURIs) == 0 {
 			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON[%d] requires at least one redirect_uri", index)
 		}
 		for _, redirectURI := range clients[index].RedirectURIs {
@@ -114,6 +138,58 @@ func parseMCPOAuthClients(raw string) ([]MCPOAuthClient, error) {
 		}
 	}
 	return clients, nil
+}
+
+func parseMCPOAuthEntitlements(raw string) ([]MCPOAuthEntitlement, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var entitlements []MCPOAuthEntitlement
+	if err := json.Unmarshal([]byte(raw), &entitlements); err != nil {
+		return nil, fmt.Errorf("parse CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON: %w", err)
+	}
+	for index := range entitlements {
+		entitlements[index].Subject = strings.TrimSpace(entitlements[index].Subject)
+		entitlements[index].Email = strings.TrimSpace(entitlements[index].Email)
+		entitlements[index].ClientID = strings.TrimSpace(entitlements[index].ClientID)
+		entitlements[index].Groups = normalizeStringSlice(entitlements[index].Groups)
+		entitlements[index].TenantID = strings.TrimSpace(entitlements[index].TenantID)
+		entitlements[index].AllowedTenants = normalizeStringSlice(entitlements[index].AllowedTenants)
+		entitlements[index].Scopes = normalizeStringSlice(entitlements[index].Scopes)
+		if entitlements[index].Subject == "" && entitlements[index].Email == "" && entitlements[index].ClientID == "" && len(entitlements[index].Groups) == 0 {
+			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON[%d] requires subject, email, client_id, or groups", index)
+		}
+		if entitlements[index].TenantID == "" && len(entitlements[index].AllowedTenants) == 0 {
+			return nil, fmt.Errorf("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON[%d] requires tenant_id or allowed_tenants", index)
+		}
+	}
+	return entitlements, nil
+}
+
+func normalizeOAuthGrantTypes(values []string) ([]string, error) {
+	values = normalizeStringSlice(values)
+	if len(values) == 0 {
+		return []string{"authorization_code", "refresh_token"}, nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		switch value {
+		case "authorization_code", "refresh_token", "client_credentials":
+		default:
+			return nil, fmt.Errorf("unsupported grant_type %q", value)
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return []string{"authorization_code", "refresh_token"}, nil
+	}
+	return out, nil
 }
 
 func validateMCPOAuthConfig(cfg MCPOAuthConfig) error {
@@ -132,8 +208,11 @@ func validateMCPOAuthConfig(cfg MCPOAuthConfig) error {
 	if len(cfg.Clients) == 0 && !cfg.DynamicClientRegistration {
 		return fmt.Errorf("CEREBRO_MCP_OAUTH_CLIENTS_JSON or CEREBRO_MCP_OAUTH_DYNAMIC_CLIENT_REGISTRATION_ENABLED=true is required when CEREBRO_MCP_OAUTH_ENABLED=true")
 	}
-	if cfg.TenantID == "" && len(cfg.AllowedTenants) == 0 {
-		return fmt.Errorf("CEREBRO_MCP_OAUTH_TENANT_ID or CEREBRO_MCP_OAUTH_ALLOWED_TENANTS is required when CEREBRO_MCP_OAUTH_ENABLED=true")
+	if requiresInteractiveEntitlement(cfg) && cfg.TenantID == "" && len(cfg.AllowedTenants) == 0 && len(cfg.Entitlements) == 0 {
+		return fmt.Errorf("CEREBRO_MCP_OAUTH_TENANT_ID, CEREBRO_MCP_OAUTH_ALLOWED_TENANTS, or CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON is required for authorization_code when CEREBRO_MCP_OAUTH_ENABLED=true")
+	}
+	if !requiresInteractiveEntitlement(cfg) && !hasClientCredentialsTenantGrant(cfg.Clients) {
+		return fmt.Errorf("client_credentials clients require tenant_id or allowed_tenants when CEREBRO_MCP_OAUTH_ENABLED=true")
 	}
 	if cfg.Upstream.Issuer == "" {
 		return fmt.Errorf("CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER is required when CEREBRO_MCP_OAUTH_ENABLED=true")
@@ -172,6 +251,27 @@ func validateMCPOAuthConfig(cfg MCPOAuthConfig) error {
 		}
 	}
 	return nil
+}
+
+func hasClientCredentialsTenantGrant(clients []MCPOAuthClient) bool {
+	for _, client := range clients {
+		if containsString(client.GrantTypes, "client_credentials") && (client.TenantID != "" || len(client.AllowedTenants) > 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func requiresInteractiveEntitlement(cfg MCPOAuthConfig) bool {
+	if cfg.DynamicClientRegistration {
+		return true
+	}
+	for _, client := range cfg.Clients {
+		if containsString(client.GrantTypes, "authorization_code") {
+			return true
+		}
+	}
+	return false
 }
 
 func validateAbsoluteHTTPOrigin(name string, raw string) error {
@@ -215,4 +315,28 @@ func isLoopbackOAuthHost(host string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func validSHA256Hex(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/internal/mcpoauth/service.go
+++ b/internal/mcpoauth/service.go
@@ -117,6 +117,8 @@ type TokenResponse struct {
 	Scope        string `json:"scope,omitempty"`
 }
 
+type RevokeResponse struct{}
+
 type ClientRegistrationRequest struct {
 	ClientName              string   `json:"client_name,omitempty"`
 	RedirectURIs            []string `json:"redirect_uris"`
@@ -191,6 +193,9 @@ func (s *Service) Authorize(ctx context.Context, query url.Values) (string, erro
 	client, ok := s.client(ctx, query.Get("client_id"))
 	if !ok {
 		return "", oauthError("unauthorized_client", "unknown OAuth client", statusBadRequest)
+	}
+	if !clientGrantAllowed(client, "authorization_code") {
+		return "", oauthError("unauthorized_client", "client is not allowed to use authorization_code", statusUnauthorized)
 	}
 	redirectURI := strings.TrimSpace(query.Get("redirect_uri"))
 	if !redirectURIAllowed(client, redirectURI) {
@@ -275,6 +280,10 @@ func (s *Service) Callback(ctx context.Context, query url.Values) (string, error
 	if !containsAny(identity.Groups, s.cfg.Upstream.SecurityGroups) {
 		return "", oauthError("access_denied", "authenticated user is not in an authorized security group", statusForbidden)
 	}
+	entitlement, err := s.entitlementForIdentity(identity, login.ClientID, login.Scopes)
+	if err != nil {
+		return "", err
+	}
 	codeToken, err := NewOpaqueToken("code")
 	if err != nil {
 		return "", fmt.Errorf("mcpoauth: generate code: %w", err)
@@ -287,9 +296,9 @@ func (s *Service) Callback(ctx context.Context, query url.Values) (string, error
 		Resource:       login.Resource,
 		Subject:        firstNonEmpty(identity.Email, identity.Subject),
 		Email:          identity.Email,
-		TenantID:       strings.TrimSpace(s.cfg.TenantID),
-		AllowedTenants: cloneStrings(s.cfg.AllowedTenants),
-		Scopes:         cloneStrings(login.Scopes),
+		TenantID:       entitlement.TenantID,
+		AllowedTenants: cloneStrings(entitlement.AllowedTenants),
+		Scopes:         cloneStrings(entitlement.Scopes),
 		Groups:         []string{"security"},
 		CodeChallenge:  login.CodeChallenge,
 		CreatedAt:      now,
@@ -319,12 +328,42 @@ func (s *Service) Token(ctx context.Context, authorizationHeader string, form ur
 	}
 	switch form.Get("grant_type") {
 	case "authorization_code":
+		if !clientGrantAllowed(client, "authorization_code") {
+			return TokenResponse{}, oauthError("unauthorized_client", "client is not allowed to use authorization_code", statusUnauthorized)
+		}
 		return s.exchangeAuthorizationCode(ctx, client, resource, form)
 	case "refresh_token":
+		if !clientGrantAllowed(client, "refresh_token") {
+			return TokenResponse{}, oauthError("unauthorized_client", "client is not allowed to use refresh_token", statusUnauthorized)
+		}
 		return s.exchangeRefreshToken(ctx, client, resource, form)
+	case "client_credentials":
+		if !clientGrantAllowed(client, "client_credentials") {
+			return TokenResponse{}, oauthError("unauthorized_client", "client is not allowed to use client_credentials", statusUnauthorized)
+		}
+		return s.exchangeClientCredentials(ctx, client, resource, form)
 	default:
-		return TokenResponse{}, oauthError("unsupported_grant_type", "grant_type must be authorization_code or refresh_token", statusBadRequest)
+		return TokenResponse{}, oauthError("unsupported_grant_type", "grant_type must be authorization_code, refresh_token, or client_credentials", statusBadRequest)
 	}
+}
+
+func (s *Service) Revoke(ctx context.Context, authorizationHeader string, form url.Values) (RevokeResponse, error) {
+	client, err := s.authenticateClient(ctx, authorizationHeader, form)
+	if err != nil {
+		return RevokeResponse{}, err
+	}
+	rawToken := form.Get("token")
+	if strings.TrimSpace(rawToken) == "" {
+		return RevokeResponse{}, oauthError("invalid_request", "token is required", statusBadRequest)
+	}
+	token, err := NormalizeOpaqueToken(rawToken)
+	if err != nil {
+		return RevokeResponse{}, nil
+	}
+	if err := s.store.RevokeOAuthRefreshToken(ctx, HashToken(token), client.ClientID); err != nil {
+		return RevokeResponse{}, fmt.Errorf("mcpoauth: revoke refresh token: %w", err)
+	}
+	return RevokeResponse{}, nil
 }
 
 func (s *Service) tokenRequestResource(form url.Values) (string, error) {
@@ -388,6 +427,48 @@ func (s *Service) exchangeRefreshToken(ctx context.Context, client config.MCPOAu
 		return TokenResponse{}, oauthError("invalid_target", "refresh token was issued for a different resource", statusBadRequest)
 	}
 	return s.issueTokenPair(ctx, refreshGrantFromRefresh(record), record.Generation+1)
+}
+
+func (s *Service) exchangeClientCredentials(ctx context.Context, client config.MCPOAuthClient, resource string, form url.Values) (TokenResponse, error) {
+	if client.Public || !clientSecretConfigured(client) {
+		return TokenResponse{}, oauthError("unauthorized_client", "client_credentials requires confidential client authentication", statusUnauthorized)
+	}
+	scopes, err := normalizeRequestedScopes(form.Get("scope"))
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	allowedScopes := cloneStrings(client.Scopes)
+	if len(allowedScopes) == 0 {
+		allowedScopes = []string{ScopeSecurityRead}
+	}
+	if !scopesAllowed(scopes, allowedScopes) {
+		return TokenResponse{}, oauthError("invalid_scope", "requested scope is not allowed for client", statusBadRequest)
+	}
+	grant := AccessGrant{
+		Subject:        "service:" + client.ClientID,
+		ClientID:       client.ClientID,
+		Resource:       resource,
+		TenantID:       strings.TrimSpace(client.TenantID),
+		AllowedTenants: cloneStrings(client.AllowedTenants),
+		Scopes:         scopes,
+		Groups:         []string{"security"},
+	}
+	if len(client.Groups) > 0 {
+		grant.Groups = cloneStrings(client.Groups)
+	}
+	if grant.TenantID == "" && len(grant.AllowedTenants) == 0 {
+		return TokenResponse{}, oauthError("invalid_client", "client_credentials client has no tenant grant", statusUnauthorized)
+	}
+	access, err := s.issueToken(ctx, grant, s.cfg.AccessTTL, s.now().UTC())
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	return TokenResponse{
+		AccessToken: access,
+		TokenType:   "Bearer",
+		ExpiresIn:   int64(s.cfg.AccessTTL.Seconds()),
+		Scope:       strings.Join(scopes, " "),
+	}, nil
 }
 
 func (s *Service) issueTokenPair(ctx context.Context, grant RefreshToken, generation int) (TokenResponse, error) {
@@ -489,13 +570,99 @@ func (s *Service) authenticateClient(ctx context.Context, authorizationHeader st
 	if !ok {
 		return config.MCPOAuthClient{}, oauthError("invalid_client", "unknown OAuth client", statusUnauthorized)
 	}
-	if client.ClientSecret == "" {
+	if !clientSecretConfigured(client) {
 		return client, nil
 	}
-	if !hasSecret || !constantTimeEqual(secret, client.ClientSecret) {
+	if !hasSecret || !clientSecretMatches(client, secret) {
 		return config.MCPOAuthClient{}, oauthError("invalid_client", "client authentication failed", statusUnauthorized)
 	}
 	return client, nil
+}
+
+func clientSecretConfigured(client config.MCPOAuthClient) bool {
+	return strings.TrimSpace(client.ClientSecret) != "" || strings.TrimSpace(client.ClientSecretSHA256) != ""
+}
+
+func clientSecretMatches(client config.MCPOAuthClient, presented string) bool {
+	if secret := strings.TrimSpace(client.ClientSecret); secret != "" && constantTimeEqual(presented, secret) {
+		return true
+	}
+	expectedHash := strings.ToLower(strings.TrimSpace(client.ClientSecretSHA256))
+	if expectedHash == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(presented))
+	return constantTimeEqual(fmt.Sprintf("%x", sum[:]), expectedHash)
+}
+
+type grantEntitlement struct {
+	TenantID       string
+	AllowedTenants []string
+	Scopes         []string
+}
+
+func (s *Service) entitlementForIdentity(identity Identity, clientID string, requestedScopes []string) (grantEntitlement, error) {
+	if len(s.cfg.Entitlements) == 0 {
+		return grantEntitlement{
+			TenantID:       strings.TrimSpace(s.cfg.TenantID),
+			AllowedTenants: cloneStrings(s.cfg.AllowedTenants),
+			Scopes:         cloneStrings(requestedScopes),
+		}, nil
+	}
+	for _, entitlement := range s.cfg.Entitlements {
+		if !entitlementMatches(entitlement, identity, clientID) {
+			continue
+		}
+		allowedScopes := cloneStrings(entitlement.Scopes)
+		if len(allowedScopes) == 0 {
+			allowedScopes = []string{ScopeSecurityRead}
+		}
+		if !scopesAllowed(requestedScopes, allowedScopes) {
+			return grantEntitlement{}, oauthError("invalid_scope", "requested scope is not allowed for user", statusBadRequest)
+		}
+		return grantEntitlement{
+			TenantID:       strings.TrimSpace(entitlement.TenantID),
+			AllowedTenants: cloneStrings(entitlement.AllowedTenants),
+			Scopes:         cloneStrings(requestedScopes),
+		}, nil
+	}
+	return grantEntitlement{}, oauthError("access_denied", "authenticated user has no Cerebro tenant entitlement", statusForbidden)
+}
+
+func entitlementMatches(entitlement config.MCPOAuthEntitlement, identity Identity, clientID string) bool {
+	if entitlement.ClientID != "" && entitlement.ClientID != strings.TrimSpace(clientID) {
+		return false
+	}
+	if entitlement.Subject != "" && entitlement.Subject != strings.TrimSpace(identity.Subject) {
+		return false
+	}
+	if entitlement.Email != "" && !strings.EqualFold(entitlement.Email, strings.TrimSpace(identity.Email)) {
+		return false
+	}
+	if len(entitlement.Groups) > 0 && !containsAny(identity.Groups, entitlement.Groups) {
+		return false
+	}
+	return entitlement.ClientID != "" || entitlement.Subject != "" || entitlement.Email != "" || len(entitlement.Groups) > 0
+}
+
+func clientGrantAllowed(client config.MCPOAuthClient, grant string) bool {
+	grants := client.GrantTypes
+	if len(grants) == 0 {
+		grants = []string{"authorization_code", "refresh_token"}
+	}
+	return containsString(grants, grant)
+}
+
+func scopesAllowed(requested []string, allowed []string) bool {
+	if len(requested) == 0 {
+		return false
+	}
+	for _, scope := range requested {
+		if !containsString(allowed, scope) {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Service) client(ctx context.Context, clientID string) (config.MCPOAuthClient, bool) {
@@ -516,6 +683,15 @@ func (s *Service) client(ctx context.Context, clientID string) (config.MCPOAuthC
 		}, true
 	}
 	return config.MCPOAuthClient{}, false
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func redirectURIAllowed(client config.MCPOAuthClient, redirectURI string) bool {

--- a/internal/mcpoauth/service_test.go
+++ b/internal/mcpoauth/service_test.go
@@ -2,6 +2,8 @@ package mcpoauth
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"net/url"
 	"testing"
@@ -72,6 +74,79 @@ func TestTokenDoesNotBypassClientSecretWhenPublicFlagIsSet(t *testing.T) {
 	if !errors.As(err, &oauthErr) || oauthErr.Code != "invalid_client" {
 		t.Fatalf("Token without client secret error = %v, want invalid_client OAuthError", err)
 	}
+}
+
+func TestClientCredentialsAcceptsHashedClientSecret(t *testing.T) {
+	sum := sha256.Sum256([]byte("client-secret"))
+	service, err := NewService(config.MCPOAuthConfig{
+		Resource:  "https://cerebro.example/api/v1/mcp",
+		AccessTTL: time.Minute,
+		Clients: []config.MCPOAuthClient{{
+			ClientID:           "panopticon",
+			ClientSecretSHA256: base16Lower(sum[:]),
+			GrantTypes:         []string{"client_credentials"},
+			AllowedTenants:     []string{"writer"},
+			Scopes:             []string{ScopeSecurityRead},
+		}},
+	}, &replayRefreshStore{}, func(_ context.Context, grant AccessGrant, _ time.Duration, _ time.Time) (string, error) {
+		if grant.ClientID != "panopticon" || len(grant.AllowedTenants) != 1 || grant.AllowedTenants[0] != "writer" {
+			t.Fatalf("grant = %#v", grant)
+		}
+		return "access-token", nil
+	}, WithOIDCProvider(stubOIDCProvider{}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	response, err := service.Token(context.Background(), "Basic "+base64.StdEncoding.EncodeToString([]byte("panopticon:client-secret")), url.Values{
+		"grant_type": {"client_credentials"},
+		"resource":   {"https://cerebro.example/api/v1/mcp"},
+	})
+	if err != nil {
+		t.Fatalf("Token error = %v", err)
+	}
+	if response.AccessToken != "access-token" || response.RefreshToken != "" {
+		t.Fatalf("response = %#v", response)
+	}
+}
+
+func TestEntitlementForIdentityScopesTenantGrant(t *testing.T) {
+	service := &Service{cfg: config.MCPOAuthConfig{
+		Entitlements: []config.MCPOAuthEntitlement{{
+			Groups:         []string{"secops"},
+			AllowedTenants: []string{"writer"},
+			Scopes:         []string{ScopeSecurityRead},
+		}},
+	}}
+	entitlement, err := service.entitlementForIdentity(Identity{
+		Subject: "user-1",
+		Email:   "user@example.com",
+		Groups:  []string{"secops"},
+	}, "droid", []string{ScopeSecurityRead})
+	if err != nil {
+		t.Fatalf("entitlementForIdentity error = %v", err)
+	}
+	if got := entitlement.AllowedTenants; len(got) != 1 || got[0] != "writer" {
+		t.Fatalf("AllowedTenants = %#v, want [writer]", got)
+	}
+
+	_, err = service.entitlementForIdentity(Identity{
+		Subject: "user-2",
+		Groups:  []string{"engineering"},
+	}, "droid", []string{ScopeSecurityRead})
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) || oauthErr.Code != "access_denied" {
+		t.Fatalf("missing entitlement error = %v, want access_denied", err)
+	}
+}
+
+func base16Lower(raw []byte) string {
+	const alphabet = "0123456789abcdef"
+	out := make([]byte, len(raw)*2)
+	for i, b := range raw {
+		out[i*2] = alphabet[b>>4]
+		out[i*2+1] = alphabet[b&0x0f]
+	}
+	return string(out)
 }
 
 type replayRefreshStore struct {

--- a/internal/mcpoauth/store.go
+++ b/internal/mcpoauth/store.go
@@ -22,6 +22,7 @@ type Store interface {
 	SaveOAuthRefreshToken(ctx context.Context, token RefreshToken) error
 	ConsumeOAuthRefreshToken(ctx context.Context, tokenHash [32]byte, now time.Time) (RefreshToken, error)
 	RevokeOAuthRefreshFamily(ctx context.Context, familyID string) error
+	RevokeOAuthRefreshToken(ctx context.Context, tokenHash [32]byte, clientID string) error
 }
 
 // OAuthClient is a dynamically registered MCP OAuth client.

--- a/internal/statestore/postgres/mcp_oauth.go
+++ b/internal/statestore/postgres/mcp_oauth.go
@@ -395,6 +395,22 @@ func (s *Store) RevokeOAuthRefreshFamily(ctx context.Context, familyID string) e
 	return nil
 }
 
+func (s *Store) RevokeOAuthRefreshToken(ctx context.Context, tokenHash [32]byte, clientID string) error {
+	if err := s.ensureMCPOAuthTables(ctx); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `
+UPDATE mcp_oauth_refresh_tokens
+SET family_revoked = TRUE
+WHERE family_id IN (
+  SELECT family_id FROM mcp_oauth_refresh_tokens WHERE token_hash = $1 AND client_id = $2
+)`, tokenHash[:], strings.TrimSpace(clientID))
+	if err != nil {
+		return fmt.Errorf("revoke mcp oauth refresh token: %w", err)
+	}
+	return nil
+}
+
 func (s *Store) ensureMCPOAuthTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.mcpOAuthTablesReady, "mcp_oauth", ensureMCPOAuthStatements)
 }


### PR DESCRIPTION
## Summary
- Default MCP OAuth dynamic client registration off and add entitlement-aware tenant/scope grants.
- Add confidential `client_credentials` support for M2M MCP clients, including hashed client-secret support and no refresh tokens.
- Add `/oauth/revoke`, OAuth audit events, endpoint rate limiting, MCP-only token confinement, `jti`/`kid`, tests, and OpenAPI updates.

## Validation
- `go test ./...`
- `make lint`
- `make openapi-check`
- `make openapi-lint`
- Live local smoke: temporary PostgreSQL + built `cerebro serve`; verified metadata, DCR disabled, bad client secret rejected, M2M token issuance, MCP access allowed, non-MCP access denied, and revoke request validation.
