### PR TITLE
Fix confidential MCP OAuth dynamic client registration

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1526,7 +1526,7 @@ paths:
   /oauth/register:
     post:
       summary: Dynamically register an MCP OAuth client
-      description: Registers a public MCP client with loopback redirect URIs for OAuth authorization-code + PKCE.
+      description: Registers an MCP client with loopback redirect URIs for OAuth authorization-code + PKCE. Confidential dynamic clients receive a generated client secret.
       tags:
         - OAuth
       security: []
@@ -1557,7 +1557,7 @@ paths:
                     enum: [code]
                 token_endpoint_auth_method:
                   type: string
-                  enum: [none]
+                  enum: [none, client_secret_basic, client_secret_post]
       responses:
         '201':
           description: Dynamic client registration response.
@@ -1569,6 +1569,11 @@ paths:
                 properties:
                   client_id:
                     type: string
+                  client_secret:
+                    type: string
+                  client_secret_expires_at:
+                    type: integer
+                    description: Zero means the generated dynamic client secret does not expire.
                   client_name:
                     type: string
                   redirect_uris:
@@ -1586,7 +1591,7 @@ paths:
                       type: string
                   token_endpoint_auth_method:
                     type: string
-                    enum: [none]
+                    enum: [none, client_secret_basic, client_secret_post]
         '400':
           description: Invalid client metadata.
         '429':

--- a/internal/bootstrap/mcp_oauth_test.go
+++ b/internal/bootstrap/mcp_oauth_test.go
@@ -503,7 +503,8 @@ func TestMCPOAuthDynamicClientRegistration(t *testing.T) {
 	clientRedirect := "http://127.0.0.1:39123/callback"
 	cfg := testMCPOAuthConfig(clientRedirect, upstream.URL)
 	cfg.Auth.MCPOAuth.Clients = nil
-	app, err := NewWithError(cfg, Dependencies{StateStore: newMemoryMCPOAuthStore()}, nil)
+	store := newMemoryMCPOAuthStore()
+	app, err := NewWithError(cfg, Dependencies{StateStore: store}, nil)
 	if err != nil {
 		t.Fatalf("NewWithError: %v", err)
 	}
@@ -570,6 +571,86 @@ func TestMCPOAuthDynamicClientRegistration(t *testing.T) {
 	_ = badRegisterResp.Body.Close()
 	if badRegisterResp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("bad register status = %d, want 400", badRegisterResp.StatusCode)
+	}
+
+	confidentialRegisterResp, err := server.Client().Post(server.URL+oauthRegisterPath, "application/json", strings.NewReader(`{"client_name":"Droid confidential","redirect_uris":["`+clientRedirect+`"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"client_secret_basic"}`))
+	if err != nil {
+		t.Fatalf("POST confidential register: %v", err)
+	}
+	defer func() { _ = confidentialRegisterResp.Body.Close() }()
+	if confidentialRegisterResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(confidentialRegisterResp.Body)
+		t.Fatalf("confidential register status = %d body=%s", confidentialRegisterResp.StatusCode, body)
+	}
+	var confidential mcpoauth.ClientRegistrationResponse
+	if err := json.NewDecoder(confidentialRegisterResp.Body).Decode(&confidential); err != nil {
+		t.Fatalf("decode confidential register response: %v", err)
+	}
+	if confidential.ClientID == "" || confidential.ClientSecret == "" || confidential.TokenEndpointAuthMethod != "client_secret_basic" || confidential.ClientSecretExpiresAt == nil || *confidential.ClientSecretExpiresAt != 0 {
+		t.Fatalf("confidential client = %#v", confidential)
+	}
+	store.mu.Lock()
+	storedConfidential := store.clients[confidential.ClientID]
+	store.mu.Unlock()
+	if storedConfidential.Public || storedConfidential.ClientSecret == "" || storedConfidential.ClientSecret == confidential.ClientSecret {
+		t.Fatalf("stored confidential client = %#v", storedConfidential)
+	}
+	wrongSecretResp := exchangeMCPOAuthTokenRaw(t, server, url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {confidential.ClientID},
+		"client_secret": {"wrong-secret"},
+		"resource":      {"https://cerebro.example/api/v1/mcp"},
+		"refresh_token": {"refresh_dummy"},
+	})
+	_ = wrongSecretResp.Body.Close()
+	if wrongSecretResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("wrong confidential secret token status = %d, want 401", wrongSecretResp.StatusCode)
+	}
+	correctSecretReq, err := http.NewRequest(http.MethodPost, server.URL+oauthTokenPath, strings.NewReader(url.Values{
+		"grant_type":    {"refresh_token"},
+		"resource":      {"https://cerebro.example/api/v1/mcp"},
+		"refresh_token": {"refresh_dummy"},
+	}.Encode()))
+	if err != nil {
+		t.Fatalf("NewRequest confidential token: %v", err)
+	}
+	correctSecretReq.SetBasicAuth(confidential.ClientID, confidential.ClientSecret)
+	correctSecretReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	correctSecretResp, err := server.Client().Do(correctSecretReq)
+	if err != nil {
+		t.Fatalf("POST confidential token: %v", err)
+	}
+	_ = correctSecretResp.Body.Close()
+	if correctSecretResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("correct confidential secret token status = %d, want 400 invalid_grant", correctSecretResp.StatusCode)
+	}
+
+	postRegisterResp, err := server.Client().Post(server.URL+oauthRegisterPath, "application/json", strings.NewReader(`{"client_name":"Droid post","redirect_uris":["`+clientRedirect+`"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"client_secret_post"}`))
+	if err != nil {
+		t.Fatalf("POST client_secret_post register: %v", err)
+	}
+	defer func() { _ = postRegisterResp.Body.Close() }()
+	if postRegisterResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(postRegisterResp.Body)
+		t.Fatalf("client_secret_post register status = %d body=%s", postRegisterResp.StatusCode, body)
+	}
+	var postClient mcpoauth.ClientRegistrationResponse
+	if err := json.NewDecoder(postRegisterResp.Body).Decode(&postClient); err != nil {
+		t.Fatalf("decode client_secret_post response: %v", err)
+	}
+	if postClient.ClientID == "" || postClient.ClientSecret == "" || postClient.TokenEndpointAuthMethod != "client_secret_post" {
+		t.Fatalf("client_secret_post client = %#v", postClient)
+	}
+	postSecretResp := exchangeMCPOAuthTokenRaw(t, server, url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {postClient.ClientID},
+		"client_secret": {postClient.ClientSecret},
+		"resource":      {"https://cerebro.example/api/v1/mcp"},
+		"refresh_token": {"refresh_dummy"},
+	})
+	_ = postSecretResp.Body.Close()
+	if postSecretResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("client_secret_post token status = %d, want 400 invalid_grant", postSecretResp.StatusCode)
 	}
 }
 

--- a/internal/mcpoauth/service.go
+++ b/internal/mcpoauth/service.go
@@ -129,6 +129,8 @@ type ClientRegistrationRequest struct {
 
 type ClientRegistrationResponse struct {
 	ClientID                string   `json:"client_id"`
+	ClientSecret            string   `json:"client_secret,omitempty"`
+	ClientSecretExpiresAt   *int64   `json:"client_secret_expires_at,omitempty"`
 	ClientName              string   `json:"client_name,omitempty"`
 	RedirectURIs            []string `json:"redirect_uris"`
 	GrantTypes              []string `json:"grant_types"`
@@ -159,31 +161,47 @@ func (s *Service) RegisterClient(ctx context.Context, request ClientRegistration
 	if method == "" {
 		method = "none"
 	}
-	if method != "none" {
-		return ClientRegistrationResponse{}, oauthError("invalid_client_metadata", "only public clients with token_endpoint_auth_method=none are supported", statusBadRequest)
+	switch method {
+	case "none", "client_secret_basic", "client_secret_post":
+	default:
+		return ClientRegistrationResponse{}, oauthError("invalid_client_metadata", "token_endpoint_auth_method must be none, client_secret_basic, or client_secret_post", statusBadRequest)
 	}
 	clientID, err := NewOpaqueToken("mcp_client")
 	if err != nil {
 		return ClientRegistrationResponse{}, fmt.Errorf("mcpoauth: generate dynamic client id: %w", err)
 	}
+	clientSecret := ""
+	if method != "none" {
+		clientSecret, err = NewOpaqueToken("mcp_client_secret")
+		if err != nil {
+			return ClientRegistrationResponse{}, fmt.Errorf("mcpoauth: generate dynamic client secret: %w", err)
+		}
+	}
 	client := OAuthClient{
 		ClientID:     clientID,
+		ClientSecret: storedClientSecret(clientSecret),
 		Name:         strings.TrimSpace(request.ClientName),
 		RedirectURIs: redirectURIs,
-		Public:       true,
+		Public:       clientSecret == "",
 		CreatedAt:    s.now().UTC(),
 	}
 	if err := s.store.SaveOAuthClient(ctx, client); err != nil {
 		return ClientRegistrationResponse{}, fmt.Errorf("mcpoauth: save dynamic client: %w", err)
 	}
-	return ClientRegistrationResponse{
+	response := ClientRegistrationResponse{
 		ClientID:                clientID,
+		ClientSecret:            clientSecret,
 		ClientName:              client.Name,
 		RedirectURIs:            cloneStrings(client.RedirectURIs),
 		GrantTypes:              []string{"authorization_code", "refresh_token"},
 		ResponseTypes:           []string{"code"},
-		TokenEndpointAuthMethod: "none",
-	}, nil
+		TokenEndpointAuthMethod: method,
+	}
+	if clientSecret != "" {
+		neverExpires := int64(0)
+		response.ClientSecretExpiresAt = &neverExpires
+	}
+	return response, nil
 }
 
 func (s *Service) Authorize(ctx context.Context, query url.Values) (string, error) {
@@ -595,6 +613,16 @@ func clientSecretMatches(client config.MCPOAuthClient, presented string) bool {
 	return constantTimeEqual(fmt.Sprintf("%x", sum[:]), expectedHash)
 }
 
+const storedClientSecretSHA256Prefix = "sha256:"
+
+func storedClientSecret(secret string) string {
+	if secret == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(secret))
+	return storedClientSecretSHA256Prefix + fmt.Sprintf("%x", sum[:])
+}
+
 type grantEntitlement struct {
 	TenantID       string
 	AllowedTenants []string
@@ -674,13 +702,19 @@ func (s *Service) client(ctx context.Context, clientID string) (config.MCPOAuthC
 	}
 	client, err := s.store.GetOAuthClient(ctx, clientID)
 	if err == nil {
-		return config.MCPOAuthClient{
+		result := config.MCPOAuthClient{
 			ClientID:     client.ClientID,
-			ClientSecret: client.ClientSecret,
 			Name:         client.Name,
 			RedirectURIs: cloneStrings(client.RedirectURIs),
 			Public:       client.Public,
-		}, true
+		}
+		storedSecret := strings.TrimSpace(client.ClientSecret)
+		if strings.HasPrefix(storedSecret, storedClientSecretSHA256Prefix) {
+			result.ClientSecretSHA256 = strings.TrimPrefix(storedSecret, storedClientSecretSHA256Prefix)
+		} else {
+			result.ClientSecret = storedSecret
+		}
+		return result, true
 	}
 	return config.MCPOAuthClient{}, false
 }


### PR DESCRIPTION
## Summary
- support confidential MCP OAuth DCR clients using `client_secret_basic` and `client_secret_post`
- return generated dynamic client secrets and store only SHA-256 hashes at rest
- update OpenAPI and coverage for public, basic, and post client registration paths

## Validation
- `go test ./...`
- `make lint`
- `make openapi-check`
- `make openapi-lint`