### PR TITLE
docs: add README drift checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
             command: make openapi-check openapi-lint
           - name: catalog
             command: make catalog-check detection-catalog-check
+          - name: readme
+            command: make readme-check
           - name: oss-audit
             command: make oss-audit
           - name: structural

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
             command: make openapi-check openapi-lint
           - name: catalog
             command: make catalog-check detection-catalog-check
+          - name: readme
+            command: make readme-check
           - name: oss-audit
             command: make oss-audit
           - name: structural

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build serve test workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check oss-audit govulncheck droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: build serve test workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check readme-check oss-audit govulncheck droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -130,6 +130,10 @@ detection-catalog-generate:
 detection-catalog-check:
 	go run ./tools/detectioncatalog --check
 
+readme-check:
+	git diff --check README.md
+	python3 scripts/readme_check.py
+
 oss-audit:
 	python3 scripts/oss_audit.py
 
@@ -181,4 +185,4 @@ check-arch:
 
 check-hook-integrity: check-arch
 
-verify: build test lint proto-lint openapi-check openapi-lint catalog-check detection-catalog-check oss-audit check-structural check-structural-test check-arch
+verify: build test lint proto-lint openapi-check openapi-lint catalog-check detection-catalog-check readme-check oss-audit check-structural check-structural-test check-arch

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ Cerebro has historical and forward-looking docs in `docs/`. For current runtime 
 
 Cerebro exposes JSON HTTP, Connect RPC, CLI, and release artifacts. This repository does not ship an end-user web console, a SIEM/CSPM/CNAPP/EDR/SOAR replacement, an endpoint sensor, a plugin marketplace, a general-purpose graph database product, autonomous remediation, or a cloud-specific control plane.
 
+### Cross-repo contract
+
 This public repository is authoritative for runtime behavior, CLI/API contracts, source catalogs, configuration semantics, and release artifacts. Environment-specific deployment details, stack configuration, account wiring, hostnames, and rollout procedures intentionally live outside this public repo.
+
+The handoff to deployment repositories is the release payload: container images plus `cerebro-runtime-contract.json`. Treat that contract as the bridge between public runtime releases and environment-specific promotion/deploy automation.
+
+Volatile details should stay in their source-of-truth files and be linked from here: configuration variables in `docs/CONFIG_ENV_VARS.md`, API shape in `api/openapi.yaml`, source capabilities in `sources/*/catalog.yaml`, and release/deploy handoff data in `cerebro-runtime-contract.json`.
 
 See [Non-goals](docs/NON_GOALS.md) before changing storage shape, Source CDK boundaries, graph/Cypher behavior, findings workflow contracts, action/runtime response semantics, platform/security namespace boundaries, or public product language.
 

--- a/scripts/readme_check.py
+++ b/scripts/readme_check.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Validate README facts that tend to drift."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"readme-check: {message}")
+
+
+def go_toolchain() -> str:
+    match = re.search(r"^toolchain\s+(go[0-9.]+)\s*$", read(ROOT / "go.mod"), re.MULTILINE)
+    if not match:
+        fail("go.mod does not declare a toolchain")
+    return match.group(1)
+
+
+def builtin_source_ids() -> list[str]:
+    registry = read(ROOT / "internal" / "sourceregistry" / "registry.go")
+    return sorted(set(re.findall(r'name:\s+"([^"]+)"', registry)))
+
+
+def readme_source_ids(readme: str) -> list[str]:
+    match = re.search(r"## Built-in sources\n\n(\| Source ID \|.*?)(?:\n---|\n## )", readme, re.S)
+    if not match:
+        fail("README is missing the Built-in sources table")
+    return sorted(set(re.findall(r"^\| `([^`]+)` \|", match.group(1), re.MULTILINE)))
+
+
+def usage_commands() -> list[str]:
+    main_go = read(ROOT / "cmd" / "cerebro" / "main.go")
+    match = re.search(r"\[([a-z|-]+)\]", main_go)
+    if not match:
+        fail("could not find top-level CLI usage in cmd/cerebro/main.go")
+    return sorted(match.group(1).split("|"))
+
+
+def readme_commands(readme: str) -> list[str]:
+    match = re.search(r"Top-level commands are (.+?)\.", readme)
+    if not match:
+        fail("README is missing top-level command sentence")
+    return sorted(re.findall(r"`([^`]+)`", match.group(1)))
+
+
+def repository_env_vars() -> set[str]:
+    values: set[str] = set()
+    for path in [*ROOT.glob("internal/config/*.go"), ROOT / ".env.example"]:
+        if not path.exists():
+            continue
+        values.update(re.findall(r"CEREBRO_[A-Z0-9_]+", read(path)))
+    return values
+
+
+def exact_readme_env_vars(readme: str) -> set[str]:
+    values = set(re.findall(r"`(CEREBRO_[A-Z0-9_]+)`", readme))
+    # Wildcard families such as CEREBRO_MCP_OAUTH_* are intentionally prose.
+    return {value for value in values if not value.endswith("_")}
+
+
+def require_contains(readme: str, snippets: list[str]) -> None:
+    missing = [snippet for snippet in snippets if snippet not in readme]
+    if missing:
+        fail("README missing required text: " + ", ".join(missing))
+
+
+def main() -> int:
+    readme = read(README)
+
+    toolchain = go_toolchain()
+    if toolchain not in readme:
+        fail(f"README does not mention current Go toolchain {toolchain}")
+
+    sources = builtin_source_ids()
+    documented_sources = readme_source_ids(readme)
+    if documented_sources != sources:
+        fail(f"built-in source table drift: README={documented_sources} registry={sources}")
+
+    commands = usage_commands()
+    documented_commands = readme_commands(readme)
+    if documented_commands != commands:
+        fail(f"top-level command drift: README={documented_commands} CLI={commands}")
+
+    env_vars = repository_env_vars()
+    documented_env_vars = exact_readme_env_vars(readme)
+    missing_env_vars = sorted(documented_env_vars - env_vars)
+    if missing_env_vars:
+        fail("README documents env vars not found in config sources: " + ", ".join(missing_env_vars))
+
+    require_contains(
+        readme,
+        [
+            "This public repository is authoritative for runtime behavior",
+            "Environment-specific deployment details",
+            "cerebro-runtime-contract.json",
+        ],
+    )
+
+    print("readme-check: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add a README fact checker for Go toolchain, built-in source IDs, top-level CLI commands, documented env vars, and cross-repo contract anchors.
- Add `make readme-check`, wire it into `make verify`, CI, and release verification.
- Clarify the public/runtime-to-deploy contract and keep volatile details pointed at source-of-truth files.

## Validation
- `make readme-check`
- `make verify`
- `actionlint -color=false .github/workflows/ci.yml .github/workflows/release.yml`
