### PR TITLE
fix: keep MCP transport stateless

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -220,21 +220,10 @@ func (app *App) handleMCPStream(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 		return
 	}
-	if !app.mcpValidOrigin(r) {
-		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-		return
-	}
-	sessionID := mcpSessionID(r)
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Mcp-Session-Id", sessionID)
+	w.Header().Set("Allow", http.MethodPost)
 	w.Header().Set("MCP-Protocol-Version", mcpProtocolVersion)
 	w.Header().Set("X-Cerebro-MCP-Stateless", "true")
-	_, _ = fmt.Fprintf(w, "event: ready\ndata: %s\n\n", mcpEndpointPath)
-	if flusher, ok := w.(http.Flusher); ok {
-		flusher.Flush()
-	}
+	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 }
 
 func (app *App) handleMCPRequest(r *http.Request, request mcpJSONRPCRequest) mcpJSONRPCResponse {
@@ -2283,22 +2272,11 @@ func mcpUint32Arg(args map[string]any, key string) (uint32, error) {
 }
 
 func mcpWriteJSONRPC(w http.ResponseWriter, r *http.Request, response mcpJSONRPCResponse) {
-	sessionID := mcpSessionID(r)
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Mcp-Session-Id", sessionID)
 	w.Header().Set("MCP-Protocol-Version", mcpProtocolVersion)
 	w.Header().Set("X-Cerebro-MCP-Stateless", "true")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(response)
-}
-
-func mcpSessionID(r *http.Request) string {
-	if r != nil {
-		if sessionID := strings.TrimSpace(r.Header.Get("Mcp-Session-Id")); sessionID != "" {
-			return sessionID
-		}
-	}
-	return "cerebro-stateless"
 }
 
 func mcpNegotiatedProtocolVersion(r *http.Request, rawParams json.RawMessage) string {

--- a/internal/bootstrap/mcp_oauth_test.go
+++ b/internal/bootstrap/mcp_oauth_test.go
@@ -212,6 +212,9 @@ func TestMCPOAuthFlowIssuesCapabilityTokenForMCP(t *testing.T) {
 		body, _ := io.ReadAll(mcpResp.Body)
 		t.Fatalf("MCP status = %d body=%s", mcpResp.StatusCode, body)
 	}
+	if got := mcpResp.Header.Get("Mcp-Session-Id"); got != "" {
+		t.Fatalf("MCP OAuth Mcp-Session-Id = %q, want empty for stateless MCP", got)
+	}
 	var mcpPayload map[string]any
 	if err := json.NewDecoder(mcpResp.Body).Decode(&mcpPayload); err != nil {
 		t.Fatalf("decode MCP payload: %v", err)

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -73,11 +73,11 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 			t.Fatalf("initialize missing %s capability in %#v", capability, capabilities)
 		}
 	}
-	if sessionID == "" {
-		t.Fatal("Mcp-Session-Id header empty")
+	if sessionID != "" {
+		t.Fatalf("Mcp-Session-Id header = %q, want empty for stateless MCP", sessionID)
 	}
 
-	toolsResp, _ := postMCP(t, server, sessionID, map[string]any{
+	toolsResp, _ := postMCP(t, server, "", map[string]any{
 		"jsonrpc": "2.0",
 		"id":      2,
 		"method":  "tools/list",
@@ -134,6 +134,32 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 		if !names[want] {
 			t.Fatalf("tools/list missing %s in %#v", want, names)
 		}
+	}
+}
+
+func TestMCPStatelessGETIsNotSSEEndpoint(t *testing.T) {
+	server := newMCPTestServer(t, &stubRuntimeStore{})
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+mcpEndpointPath, nil)
+	if err != nil {
+		t.Fatalf("NewRequest GET MCP: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/v1/mcp error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("GET /api/v1/mcp status = %d, want %d", resp.StatusCode, http.StatusMethodNotAllowed)
+	}
+	if got := resp.Header.Get("Mcp-Session-Id"); got != "" {
+		t.Fatalf("GET /api/v1/mcp Mcp-Session-Id = %q, want empty", got)
+	}
+	if contentType := resp.Header.Get("Content-Type"); strings.HasPrefix(contentType, "text/event-stream") {
+		t.Fatalf("GET /api/v1/mcp Content-Type = %q, want non-SSE", contentType)
 	}
 }
 
@@ -1204,10 +1230,6 @@ func TestMCPOriginProtocolAndNotificationHandling(t *testing.T) {
 	if response["error"] != nil {
 		t.Fatalf("tools/list error = %#v", response["error"])
 	}
-	if got := sessionIDOrDefault(t, server, ""); got != "cerebro-stateless" {
-		t.Fatalf("stateless session id = %q, want cerebro-stateless", got)
-	}
-
 	unsupportedReq, err := http.NewRequest(http.MethodPost, server.URL+mcpEndpointPath, strings.NewReader(`{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}`))
 	if err != nil {
 		t.Fatalf("NewRequest unsupported: %v", err)
@@ -1316,17 +1338,6 @@ func postMCP(t *testing.T, server *httptest.Server, sessionID string, payload ma
 func postMCPWithoutAuth(t *testing.T, server *httptest.Server, payload map[string]any) (map[string]any, string) {
 	t.Helper()
 	return postMCPWithAuthHeader(t, server, "", payload, "")
-}
-
-func sessionIDOrDefault(t *testing.T, server *httptest.Server, sessionID string) string {
-	t.Helper()
-	_, returned := postMCP(t, server, sessionID, map[string]any{
-		"jsonrpc": "2.0",
-		"id":      999,
-		"method":  "ping",
-		"params":  map[string]any{},
-	})
-	return returned
 }
 
 func postMCPWithAuthHeader(t *testing.T, server *httptest.Server, sessionID string, payload map[string]any, authHeader string) (map[string]any, string) {


### PR DESCRIPTION
### Why
Native Droid MCP OAuth can complete token exchange but fail authenticated reconnect when the server advertises a synthetic MCP session/SSE surface for a stateless Streamable HTTP endpoint.

### What changed
- Stop emitting `Mcp-Session-Id` for stateless MCP responses.
- Return 405 for `GET /api/v1/mcp` instead of advertising an SSE stream.
- Add regression coverage for stateless MCP and OAuth responses.

### Validation
Commands run:
- `go test ./internal/bootstrap -run 'TestMCP|TestMCPOAuth' -count=1 -v`
- `go test ./internal/bootstrap -count=1`
- `make lint-bootstrap openapi-check openapi-lint`

### Security
- [x] No secrets in diff
- [x] Secret scan: pre-commit passed
- [x] New deps: none
