### PR TITLE
Improve runtime sync leases and health checks

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -26,22 +26,33 @@ tags:
 paths:
   /health:
     get:
-      summary: Health check
+      summary: Readiness check
       tags:
         - Health
       security: []
       responses:
         '200':
-          description: Service health and dependency status.
+          description: Service is ready and configured dependencies are healthy.
+        '503':
+          description: Service is live but one or more configured dependencies are degraded.
   /healthz:
     get:
-      summary: Health check alias
+      summary: Liveness check
       tags:
         - Health
       security: []
       responses:
         '200':
-          description: Service health and dependency status.
+          description: Service process is live.
+  /livez:
+    get:
+      summary: Liveness check
+      tags:
+        - Health
+      security: []
+      responses:
+        '200':
+          description: Service process is live.
   /openapi.yaml:
     get:
       summary: Current OpenAPI contract

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -380,9 +380,12 @@ func runSourceRuntime(args []string) error {
 		if err != nil {
 			return err
 		}
-		response, err := service.Sync(ctx, &cerebrov1.SyncSourceRuntimeRequest{
+		response, err := service.SyncWithLease(ctx, &cerebrov1.SyncSourceRuntimeRequest{
 			Id:        runtimeID,
 			PageLimit: pageLimit,
+		}, sourceruntime.SyncWithLeaseOptions{
+			LeaseStore: sourceRuntimeCommandLeaseStore(deps.StateStore),
+			LeaseOwner: sourceRuntimeCommandLeaseOwner(),
 		})
 		if err != nil {
 			return err
@@ -395,6 +398,18 @@ func runSourceRuntime(args []string) error {
 
 func configureSourceRuntimeCommandService(service *sourceruntime.Service) *sourceruntime.Service {
 	return service.WithConfigResolver(appconfig.ResolveSourceRuntimeConfigSecretReferences)
+}
+
+func sourceRuntimeCommandLeaseStore(store ports.StateStore) ports.SourceRuntimeLeaseStore {
+	leaseStore, ok := store.(ports.SourceRuntimeLeaseStore)
+	if !ok {
+		return nil
+	}
+	return leaseStore
+}
+
+func sourceRuntimeCommandLeaseOwner() string {
+	return strings.Replace(sourceruntime.DefaultAPILeaseOwner(), "cerebro-api:", "cerebro-cli:", 1)
 }
 
 func parseSourceCommandArgs(args []string) (string, map[string]string, *cerebrov1.SourceCursor, error) {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -386,6 +386,42 @@ func TestConfigureSourceRuntimeCommandServiceResolvesEnvReferences(t *testing.T)
 	}
 }
 
+func TestSourceRuntimeCommandSyncUsesLeaseStore(t *testing.T) {
+	source := &commandTokenSource{}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &commandRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-command-token": {
+			Id:       "writer-command-token",
+			SourceId: "command_token",
+			Config:   map[string]string{"token": "inline-token"},
+		},
+	}}
+
+	service := configureSourceRuntimeCommandService(sourceruntime.New(registry, store, &commandAppendLog{}, nil))
+	if _, err := service.SyncWithLease(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-command-token"}, sourceruntime.SyncWithLeaseOptions{
+		LeaseStore: sourceRuntimeCommandLeaseStore(store),
+		LeaseOwner: "cli-test-owner",
+		LeaseTTL:   time.Hour,
+	}); err != nil {
+		t.Fatalf("SyncWithLease() error = %v", err)
+	}
+	if store.leaseID != "writer-command-token" || store.releaseID != "writer-command-token" {
+		t.Fatalf("lease/release = %q/%q, want writer-command-token/writer-command-token", store.leaseID, store.releaseID)
+	}
+	if store.leaseOwner != "cli-test-owner" || store.releaseOwner != "cli-test-owner" {
+		t.Fatalf("lease owners = %q/%q, want cli-test-owner", store.leaseOwner, store.releaseOwner)
+	}
+}
+
+func TestSourceRuntimeCommandLeaseOwnerIdentifiesCLI(t *testing.T) {
+	if owner := sourceRuntimeCommandLeaseOwner(); !strings.HasPrefix(owner, "cerebro-cli:") {
+		t.Fatalf("sourceRuntimeCommandLeaseOwner() = %q, want cerebro-cli prefix", owner)
+	}
+}
+
 func TestParseSourceCommandArgsAllowsUnsetSensitiveEnvReference(t *testing.T) {
 	_, _, _, err := parseSourceCommandArgs([]string{"github", "token=env:CEREBRO_MISSING_TOKEN"})
 	if err != nil {
@@ -480,7 +516,11 @@ func (s *commandTokenSource) Read(_ context.Context, config sourcecdk.Config, _ 
 }
 
 type commandRuntimeStore struct {
-	runtimes map[string]*cerebrov1.SourceRuntime
+	runtimes     map[string]*cerebrov1.SourceRuntime
+	leaseID      string
+	leaseOwner   string
+	releaseID    string
+	releaseOwner string
 }
 
 type basicStateStore struct{}
@@ -585,6 +625,22 @@ func (s *commandRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*c
 		return nil, ports.ErrSourceRuntimeNotFound
 	}
 	return runtime, nil
+}
+
+func (s *commandRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtimeID string, owner string, _ time.Duration) (bool, error) {
+	s.leaseID = runtimeID
+	s.leaseOwner = owner
+	return true, nil
+}
+
+func (s *commandRuntimeStore) RenewSourceRuntimeLease(context.Context, string, string, time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (s *commandRuntimeStore) ReleaseSourceRuntimeLease(_ context.Context, runtimeID string, owner string) error {
+	s.releaseID = runtimeID
+	s.releaseOwner = owner
+	return nil
 }
 
 type commandAppendLog struct{}

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -216,7 +216,15 @@ func (a *App) Shutdown(ctx context.Context) error {
 
 func (a *App) handleHealth(w http.ResponseWriter, r *http.Request) {
 	response := publicHealthResponse(r.Context(), a.deps)
-	writeProtoJSON(w, http.StatusOK, response)
+	statusCode := http.StatusOK
+	if response.GetStatus() == "degraded" {
+		statusCode = http.StatusServiceUnavailable
+	}
+	writeProtoJSON(w, statusCode, response)
+}
+
+func (a *App) handleLiveness(w http.ResponseWriter, _ *http.Request) {
+	writeProtoJSON(w, http.StatusOK, publicLivenessResponse())
 }
 
 func (a *App) handleOpenAPI(w http.ResponseWriter, _ *http.Request) {
@@ -2551,6 +2559,13 @@ func publicHealthResponse(ctx context.Context, deps Dependencies) *cerebrov1.Che
 		Status:     status,
 		CheckedAt:  timestamppb.Now(),
 		Components: components,
+	}
+}
+
+func publicLivenessResponse() *cerebrov1.CheckHealthResponse {
+	return &cerebrov1.CheckHealthResponse{
+		Status:    "live",
+		CheckedAt: timestamppb.Now(),
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -3915,6 +3915,63 @@ func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
 	}
 }
 
+func TestBootstrapReadinessReturnsUnavailableWhenDegraded(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		StateStore: stubStore{err: errors.New("state store unavailable")},
+	}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /health response body: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("GET /health status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /health response: %v", err)
+	}
+	if payload["status"] != "degraded" {
+		t.Fatalf("health status = %#v, want degraded", payload["status"])
+	}
+}
+
+func TestBootstrapLivenessDoesNotPingDependencies(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		StateStore: stubStore{err: errors.New("state store unavailable")},
+	}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	for _, path := range []string{"/healthz", "/livez"} {
+		resp, err := server.Client().Get(server.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s error = %v", path, err)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			_ = resp.Body.Close()
+			t.Fatalf("decode %s response: %v", path, err)
+		}
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close %s response body: %v", path, closeErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s status = %d, want %d", path, resp.StatusCode, http.StatusOK)
+		}
+		if payload["status"] != "live" {
+			t.Fatalf("%s status = %#v, want live", path, payload["status"])
+		}
+	}
+}
+
 func TestBackfillFindingRiskSkipsMissingStateStore(t *testing.T) {
 	app := New(config.Config{}, Dependencies{}, nil)
 	if err := app.BackfillFindingRisk(context.Background()); err != nil {

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -221,7 +221,7 @@ func authInterceptor(cfg config.AuthConfig) connect.Interceptor {
 
 func isPublicPath(path string) bool {
 	switch path {
-	case "/health", "/healthz", "/openapi.yaml":
+	case "/health", "/healthz", "/livez", "/openapi.yaml":
 		return true
 	case "/.well-known/device-jwks.json":
 		return true

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -41,7 +41,8 @@ func (app *App) registerConnectRoutes(mux *http.ServeMux, cfg config.Config, dep
 
 func (app *App) registerPublicRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "/health", routeSurfacePublicHTTP, app.handleHealth)
-	registerHTTPRoute(mux, "/healthz", routeSurfacePublicHTTP, app.handleHealth)
+	registerHTTPRoute(mux, "/healthz", routeSurfacePublicHTTP, app.handleLiveness)
+	registerHTTPRoute(mux, "/livez", routeSurfacePublicHTTP, app.handleLiveness)
 	registerHTTPRoute(mux, "GET /openapi.yaml", routeSurfacePublicHTTP, app.handleOpenAPI)
 }
 


### PR DESCRIPTION
## Summary
- Make CLI source-runtime sync use durable leases when the state store supports them.
- Split `/health` readiness from cheap `/healthz` and `/livez` liveness checks.
- Document readiness/liveness behavior in OpenAPI and cover it with focused tests.

## Test plan
- `go test ./cmd/cerebro ./internal/bootstrap`
- `make openapi-check`
- `make test`

Made with [Cursor](https://cursor.com)