### PR TITLE
Add SDK and proto verification guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,12 @@ jobs:
             command: make build
           - name: test
             command: make test
+          - name: sdk
+            command: make sdk-test
           - name: lint
             command: make lint
-          - name: proto-lint
-            command: make proto-lint
+          - name: proto
+            command: make proto-lint proto-generate-check proto-breaking
           - name: openapi
             command: make openapi-check openapi-lint
           - name: catalog
@@ -33,6 +35,8 @@ jobs:
             command: make check-structural check-structural-test check-arch
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ Only repo-specific, non-obvious guidance lives here.
 
 ## Preferred validation entrypoints
 
-- Use `make devex-changed` for diff-aware local preflight.
-- Use `make devex-pr` for broader PR-parity validation.
+- Use focused `make` targets while iterating, then `make verify` for broader PR-parity validation.
+- Use `make sdk-test` after SDK changes and `make proto-generate-check proto-breaking` after proto changes.
 - Prefer `make openapi-check` / `make openapi-sync` instead of hand-editing route placeholders.
 - Run `python3 scripts/oss_audit.py` after public-facing docs/config/example changes.
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test:
 sdk-test: sdk-python-test sdk-typescript-test sdk-typescript-check
 
 sdk-python-test:
-	cd sdk/python && python3 -m unittest discover -s tests
+	cd sdk/python && python3 -m pip install 'protobuf>=5.29.5,<6' && python3 -m unittest discover -s tests
 
 sdk-typescript-test:
 	cd sdk/typescript && npm test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build serve test workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check oss-audit govulncheck droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check oss-audit govulncheck droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -6,6 +6,7 @@ GOLANGCI_LINT_VERSION ?= v2.11.4
 BUF := GOFLAGS= GOTOOLCHAIN=go1.26.3 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
 GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.3 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
 SPECTRAL := npx --yes @stoplight/spectral-cli@6.15.0
+PROTO_BREAKING_BASE ?= origin/main
 APP_PACKAGES := ./api/... ./cmd/... ./internal/... ./sources/...
 LINTER_MODULE := ./tools/linters
 LINTER_BIN := $(GO_BIN)/cerebrolint
@@ -54,6 +55,17 @@ serve: build
 
 test:
 	go test ./...
+
+sdk-test: sdk-python-test sdk-typescript-test sdk-typescript-check
+
+sdk-python-test:
+	cd sdk/python && python3 -m unittest discover -s tests
+
+sdk-typescript-test:
+	cd sdk/typescript && npm test
+
+sdk-typescript-check:
+	cd sdk/typescript && npm run typecheck
 
 workflow-e2e-test:
 	go test $(WORKFLOW_E2E_PACKAGES) -run '$(WORKFLOW_E2E_TESTS)$$' -count=1 -v
@@ -112,6 +124,12 @@ proto-lint:
 proto-generate:
 	$(BUF) generate
 
+proto-generate-check: proto-generate
+	git diff --exit-code -- gen sdk/python/cerebro/v1
+
+proto-breaking:
+	$(BUF) breaking --against '.git#branch=$(PROTO_BREAKING_BASE)'
+
 openapi-check:
 	go run ./scripts/openapi_route_parity.go
 
@@ -165,7 +183,7 @@ hooks:
 pre-commit:
 	./scripts/pre_commit_checks.sh
 
-check: build test lint proto-lint check-structural check-structural-test check-arch
+check: build test sdk-test lint proto-lint proto-generate-check check-structural check-structural-test check-arch
 
 check-structural: check-structural-build
 	@$(LINTER_BIN) $(APP_PACKAGES)
@@ -181,4 +199,4 @@ check-arch:
 
 check-hook-integrity: check-arch
 
-verify: build test lint proto-lint openapi-check openapi-lint catalog-check detection-catalog-check oss-audit check-structural check-structural-test check-arch
+verify: build test sdk-test lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check detection-catalog-check oss-audit check-structural check-structural-test check-arch

--- a/devex/codegen_catalog.json
+++ b/devex/codegen_catalog.json
@@ -9,447 +9,145 @@
       "change_reason": "API route or OpenAPI surface changed",
       "triggers": [
         "api/openapi.yaml",
-        "internal/api/**",
+        "internal/bootstrap/routes.go",
         "scripts/openapi_route_parity.go"
       ],
       "generator": {
         "make_target": "openapi-sync",
         "command": [
-          "go",
-          "run",
-          "./scripts/openapi_route_parity.go",
-          "--write"
+          "make",
+          "openapi-sync"
         ],
-        "summary": "Regenerate OpenAPI route parity placeholders and write the contract file."
+        "summary": "Regenerate OpenAPI route placeholders and write the contract file."
       },
       "checks": [
         {
           "key": "openapi-check",
-          "summary": "Verify route parity and OpenAPI linting",
+          "summary": "Verify registered HTTP routes are represented in OpenAPI",
           "make_target": "openapi-check",
           "command": [
             "make",
             "openapi-check"
           ],
           "include_in_pr_generated_step": true
+        },
+        {
+          "key": "openapi-lint",
+          "summary": "Lint the OpenAPI contract",
+          "make_target": "openapi-lint",
+          "command": [
+            "make",
+            "openapi-lint"
+          ]
         }
       ],
       "outputs": [
         "api/openapi.yaml"
       ],
       "ci_jobs": [
-        "openapi-route-parity"
+        "openapi"
       ]
     },
     {
-      "id": "config-docs",
-      "title": "Config Docs",
-      "summary": "Generates the environment/config reference from the live config loading surface.",
-      "change_reason": "config loading or config docs changed",
+      "id": "proto",
+      "title": "Proto Contracts",
+      "summary": "Keeps proto definitions, generated Go/Python outputs, and breaking-change checks aligned.",
+      "change_reason": "proto definitions or generated SDK/runtime types changed",
       "triggers": [
-        "internal/app/app_config.go",
-        "internal/config/**",
-        "scripts/generate_config_docs/**",
-        "docs/CONFIG_ENV_VARS.md"
+        "buf.gen.yaml",
+        "buf.yaml",
+        "proto/**"
       ],
       "generator": {
-        "make_target": "config-docs",
+        "make_target": "proto-generate",
         "command": [
-          "go",
-          "run",
-          "./scripts/generate_config_docs/main.go"
+          "make",
+          "proto-generate"
         ],
-        "summary": "Regenerate the config and environment variable reference docs."
+        "summary": "Regenerate Go and Python proto artifacts."
       },
       "checks": [
         {
-          "key": "config-docs-check",
-          "summary": "Verify generated config docs are up to date",
-          "make_target": "config-docs-check",
+          "key": "proto-lint",
+          "summary": "Lint proto definitions",
+          "make_target": "proto-lint",
           "command": [
             "make",
-            "config-docs-check"
-          ],
-          "include_in_pr_generated_step": true
-        }
-      ],
-      "outputs": [
-        "docs/CONFIG_ENV_VARS.md"
-      ],
-      "ci_jobs": [
-        "config-docs-drift"
-      ]
-    },
-    {
-      "id": "api-contracts",
-      "title": "HTTP API Contracts",
-      "summary": "Generates the machine-readable HTTP API baseline and enforces OpenAPI compatibility across endpoint evolution.",
-      "change_reason": "HTTP API route or schema surface changed",
-      "triggers": [
-        "api/openapi.yaml",
-        "internal/api/**",
-        "scripts/generate_api_contract_docs/**",
-        "scripts/check_api_contract_compat/**",
-        "internal/apicontractcompat/**",
-        "docs/API_CONTRACTS_AUTOGEN.md",
-        "docs/API_CONTRACTS.json"
-      ],
-      "generator": {
-        "make_target": "api-contract-docs",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_api_contract_docs/main.go"
-        ],
-        "summary": "Regenerate the HTTP API contract catalog artifacts."
-      },
-      "checks": [
+            "proto-lint"
+          ]
+        },
         {
-          "key": "api-contract-docs-check",
-          "summary": "Verify generated HTTP API contract docs are up to date",
-          "make_target": "api-contract-docs-check",
+          "key": "proto-generate-check",
+          "summary": "Verify generated proto outputs are up to date",
+          "make_target": "proto-generate-check",
           "command": [
             "make",
-            "api-contract-docs-check"
+            "proto-generate-check"
           ],
           "include_in_pr_generated_step": true
         },
         {
-          "key": "api-contract-compat",
-          "summary": "Enforce HTTP API contract compatibility",
-          "command": [
-            "go",
-            "run",
-            "./scripts/check_api_contract_compat/main.go",
-            "--require-baseline",
-            "--base-ref={base_ref}"
-          ],
-          "env": {
-            "API_CONTRACT_BASE_REF": "{base_ref}"
-          }
-        }
-      ],
-      "outputs": [
-        "docs/API_CONTRACTS_AUTOGEN.md",
-        "docs/API_CONTRACTS.json"
-      ],
-      "ci_jobs": [
-        "api-contract-docs-drift",
-        "api-contract-compat"
-      ]
-    },
-    {
-      "id": "ontology-docs",
-      "title": "Graph Ontology Docs",
-      "summary": "Generates ontology reference docs and runs guardrails for ingest-schema drift.",
-      "change_reason": "ontology or ingest mapping inputs changed",
-      "triggers": [
-        "internal/graph/node.go",
-        "internal/graph/edge.go",
-        "internal/graph/schema_registry.go",
-        "internal/graph/schema_registry_test.go",
-        "internal/graphingest/**",
-        "scripts/generate_graph_ontology_docs/**",
-        "docs/GRAPH_ONTOLOGY_AUTOGEN.md"
-      ],
-      "generator": {
-        "make_target": "ontology-docs",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_graph_ontology_docs/main.go"
-        ],
-        "summary": "Regenerate the graph ontology catalog docs."
-      },
-      "checks": [
-        {
-          "key": "ontology-docs-check",
-          "summary": "Verify generated ontology docs are up to date",
-          "make_target": "ontology-docs-check",
+          "key": "proto-breaking",
+          "summary": "Check proto compatibility against the configured base branch",
+          "make_target": "proto-breaking",
           "command": [
             "make",
-            "ontology-docs-check"
-          ],
-          "include_in_pr_generated_step": true
-        },
-        {
-          "key": "graph-ontology-guardrails",
-          "summary": "Run graph ingest ontology guardrail tests",
-          "make_target": "graph-ontology-guardrails",
-          "command": [
-            "make",
-            "graph-ontology-guardrails"
+            "proto-breaking"
           ]
         }
       ],
       "outputs": [
-        "docs/GRAPH_ONTOLOGY_AUTOGEN.md"
+        "gen/cerebro/v1",
+        "sdk/python/cerebro/v1"
       ],
       "ci_jobs": [
-        "ontology-docs-drift",
-        "graph-ontology-guardrails"
+        "proto"
       ]
     },
     {
-      "id": "cloudevents",
-      "title": "CloudEvents Contracts",
-      "summary": "Generates platform and ingest event catalogs and enforces baseline compatibility.",
-      "change_reason": "CloudEvents-producing surfaces changed",
+      "id": "detection-catalog",
+      "title": "Detection Catalog",
+      "summary": "Keeps generated detection catalog artifacts aligned with policy definitions.",
+      "change_reason": "policy definitions or detection catalog generation changed",
       "triggers": [
-        "internal/platformevents/**",
-        "internal/webhooks/**",
-        "internal/graphingest/**",
-        "internal/api/server_handlers_graph_writeback.go",
-        "scripts/generate_cloudevents_docs/**",
-        "scripts/check_cloudevents_contract_compat/**",
-        "docs/CLOUDEVENTS_AUTOGEN.md",
-        "docs/CLOUDEVENTS_CONTRACTS.json"
+        "policies/**",
+        "tools/detectioncatalog/**"
       ],
       "generator": {
-        "make_target": "cloudevents-docs",
+        "make_target": "detection-catalog-generate",
         "command": [
-          "go",
-          "run",
-          "./scripts/generate_cloudevents_docs/main.go"
+          "make",
+          "detection-catalog-generate"
         ],
-        "summary": "Regenerate the CloudEvents contract catalog artifacts."
+        "summary": "Regenerate detection catalog artifacts."
       },
       "checks": [
         {
-          "key": "cloudevents-docs-check",
-          "summary": "Verify generated CloudEvents docs are up to date",
-          "make_target": "cloudevents-docs-check",
+          "key": "detection-catalog-check",
+          "summary": "Verify detection catalog artifacts are up to date",
+          "make_target": "detection-catalog-check",
           "command": [
             "make",
-            "cloudevents-docs-check"
+            "detection-catalog-check"
           ],
           "include_in_pr_generated_step": true
         },
         {
-          "key": "cloudevents-contract-compat",
-          "summary": "Enforce CloudEvents contract compatibility",
+          "key": "catalog-check",
+          "summary": "Validate policy catalog metadata",
+          "make_target": "catalog-check",
           "command": [
-            "go",
-            "run",
-            "./scripts/check_cloudevents_contract_compat/main.go",
-            "--require-baseline",
-            "--base-ref={base_ref}"
-          ],
-          "env": {
-            "MAPPER_CONTRACT_BASE_REF": "{base_ref}"
-          }
+            "make",
+            "catalog-check"
+          ]
         }
       ],
       "outputs": [
-        "docs/CLOUDEVENTS_AUTOGEN.md",
-        "docs/CLOUDEVENTS_CONTRACTS.json"
+        "docs/POLICIES.md"
       ],
       "ci_jobs": [
-        "cloudevents-docs-drift",
-        "cloudevents-contract-compat"
+        "catalog"
       ]
-    },
-    {
-      "id": "report-contracts",
-      "title": "Report Contracts",
-      "summary": "Generates report registry artifacts and enforces report contract compatibility.",
-      "change_reason": "report runtime or report contracts changed",
-      "triggers": [
-        "internal/graph/report*",
-        "internal/api/server_handlers_graph_intelligence.go",
-        "internal/api/server_handlers_platform.go",
-        "scripts/generate_report_contract_docs/**",
-        "scripts/check_report_contract_compat/**",
-        "docs/GRAPH_REPORT_CONTRACTS_AUTOGEN.md",
-        "docs/GRAPH_REPORT_CONTRACTS.json"
-      ],
-      "generator": {
-        "make_target": "report-contract-docs",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_report_contract_docs/main.go"
-        ],
-        "summary": "Regenerate the report contract catalog artifacts."
-      },
-      "checks": [
-        {
-          "key": "report-contract-docs-check",
-          "summary": "Verify generated report contract docs are up to date",
-          "make_target": "report-contract-docs-check",
-          "command": [
-            "make",
-            "report-contract-docs-check"
-          ],
-          "include_in_pr_generated_step": true
-        },
-        {
-          "key": "report-contract-compat",
-          "summary": "Enforce report contract compatibility",
-          "command": [
-            "go",
-            "run",
-            "./scripts/check_report_contract_compat/main.go",
-            "--require-baseline",
-            "--base-ref={base_ref}"
-          ],
-          "env": {
-            "REPORT_CONTRACT_BASE_REF": "{base_ref}"
-          }
-        }
-      ],
-      "outputs": [
-        "docs/GRAPH_REPORT_CONTRACTS_AUTOGEN.md",
-        "docs/GRAPH_REPORT_CONTRACTS.json"
-      ],
-      "ci_jobs": [
-        "report-contract-docs-drift",
-        "report-contract-compat"
-      ]
-    },
-    {
-      "id": "entity-facets",
-      "title": "Entity Facet Contracts",
-      "summary": "Generates facet contract catalogs and enforces compatibility across facet evolution.",
-      "change_reason": "entity facet surfaces changed",
-      "triggers": [
-        "internal/graph/entity_facet*",
-        "internal/graph/entity_facets.go",
-        "internal/graph/entity_subresources.go",
-        "internal/graph/entity_summary_report.go",
-        "internal/api/server_handlers_platform_entities.go",
-        "scripts/generate_entity_facet_docs/**",
-        "scripts/check_entity_facet_compat/**",
-        "docs/GRAPH_ENTITY_FACETS_AUTOGEN.md",
-        "docs/GRAPH_ENTITY_FACETS.json",
-        "docs/GRAPH_ENTITY_FACET_ARCHITECTURE.md"
-      ],
-      "generator": {
-        "make_target": "entity-facet-docs",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_entity_facet_docs/main.go"
-        ],
-        "summary": "Regenerate the entity facet contract catalog artifacts."
-      },
-      "checks": [
-        {
-          "key": "entity-facet-docs-check",
-          "summary": "Verify generated entity facet docs are up to date",
-          "make_target": "entity-facet-docs-check",
-          "command": [
-            "make",
-            "entity-facet-docs-check"
-          ],
-          "include_in_pr_generated_step": true
-        },
-        {
-          "key": "entity-facet-contract-compat",
-          "summary": "Enforce entity facet contract compatibility",
-          "command": [
-            "go",
-            "run",
-            "./scripts/check_entity_facet_compat/main.go",
-            "--require-baseline",
-            "--base-ref={base_ref}"
-          ],
-          "env": {
-            "ENTITY_FACET_BASE_REF": "{base_ref}"
-          }
-        }
-      ],
-      "outputs": [
-        "docs/GRAPH_ENTITY_FACETS_AUTOGEN.md",
-        "docs/GRAPH_ENTITY_FACETS.json"
-      ],
-      "ci_jobs": [
-        "entity-facet-docs-drift",
-        "entity-facet-contract-compat"
-      ]
-    },
-    {
-      "id": "connector-provisioning",
-      "title": "Connector Provisioning Contracts",
-      "summary": "Generates the cloud connector provisioning catalog used by CLI scaffolding, validation, and rollout docs.",
-      "change_reason": "connector provisioning contracts changed",
-      "triggers": [
-        "internal/connectors/**",
-        "internal/cli/connector*",
-        "scripts/generate_connector_docs/**",
-        "docs/CONNECTOR_PROVISIONING_AUTOGEN.md",
-        "docs/CONNECTOR_PROVISIONING_CATALOG.json",
-        "docs/CONNECTOR_PROVISIONING_ARCHITECTURE.md",
-        "Makefile"
-      ],
-      "generator": {
-        "make_target": "connector-docs",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_connector_docs/main.go"
-        ],
-        "summary": "Regenerate the connector provisioning catalog artifacts."
-      },
-      "checks": [
-        {
-          "key": "connector-docs-check",
-          "summary": "Verify generated connector provisioning docs are up to date",
-          "make_target": "connector-docs-check",
-          "command": [
-            "make",
-            "connector-docs-check"
-          ],
-          "include_in_pr_generated_step": true
-        }
-      ],
-      "outputs": [
-        "docs/CONNECTOR_PROVISIONING_AUTOGEN.md",
-        "docs/CONNECTOR_PROVISIONING_CATALOG.json"
-      ],
-      "ci_jobs": []
-    },
-    {
-      "id": "devex-codegen-catalog",
-      "title": "DevEx Codegen Catalog",
-      "summary": "Publishes the machine-readable CI-to-local codegen map used by DevEx tooling.",
-      "change_reason": "codegen governance surfaces changed",
-      "triggers": [
-        "devex/codegen_catalog.json",
-        "internal/devex/**",
-        "scripts/generate_devex_codegen_docs/**",
-        "docs/DEVEX_CODEGEN_AUTOGEN.md",
-        "docs/DEVEX_CODEGEN_CATALOG.json",
-        "Makefile",
-        ".github/workflows/ci.yml",
-        "docs/DEVELOPMENT.md"
-      ],
-      "generator": {
-        "make_target": "devex-codegen",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_devex_codegen_docs/main.go"
-        ],
-        "summary": "Regenerate the DevEx codegen catalog docs and JSON artifact."
-      },
-      "checks": [
-        {
-          "key": "devex-codegen-check",
-          "summary": "Verify generated DevEx codegen docs are up to date",
-          "make_target": "devex-codegen-check",
-          "command": [
-            "make",
-            "devex-codegen-check"
-          ],
-          "include_in_pr_generated_step": true
-        }
-      ],
-      "outputs": [
-        "docs/DEVEX_CODEGEN_AUTOGEN.md",
-        "docs/DEVEX_CODEGEN_CATALOG.json"
-      ],
-      "ci_jobs": []
     }
   ]
 }

--- a/docs/DEVEX_CODEGEN_AUTOGEN.md
+++ b/docs/DEVEX_CODEGEN_AUTOGEN.md
@@ -1,24 +1,18 @@
 # DevEx Codegen Catalog
 
-Generated from `devex/codegen_catalog.json` via `go run ./scripts/generate_devex_codegen_docs/main.go`.
+Maintained from `devex/codegen_catalog.json`.
 
 - Catalog API version: **devex.cerebro/v1alpha1**
 - Catalog kind: **CodegenCatalog**
-- Families: **9**
+- Families: **3**
 
-## CI to Local Map
+## CI To Local Map
 
 | Family | Generator | Local Checks | CI Jobs | Outputs |
 |---|---|---|---|---|
-| `openapi` | `openapi-sync` | `openapi-check` | `openapi-route-parity` | `api/openapi.yaml` |
-| `config-docs` | `config-docs` | `config-docs-check` | `config-docs-drift` | `docs/CONFIG_ENV_VARS.md` |
-| `api-contracts` | `api-contract-docs` | `api-contract-compat`, `api-contract-docs-check` | `api-contract-compat`, `api-contract-docs-drift` | `docs/API_CONTRACTS.json`, `docs/API_CONTRACTS_AUTOGEN.md` |
-| `ontology-docs` | `ontology-docs` | `graph-ontology-guardrails`, `ontology-docs-check` | `graph-ontology-guardrails`, `ontology-docs-drift` | `docs/GRAPH_ONTOLOGY_AUTOGEN.md` |
-| `cloudevents` | `cloudevents-docs` | `cloudevents-contract-compat`, `cloudevents-docs-check` | `cloudevents-contract-compat`, `cloudevents-docs-drift` | `docs/CLOUDEVENTS_AUTOGEN.md`, `docs/CLOUDEVENTS_CONTRACTS.json` |
-| `report-contracts` | `report-contract-docs` | `report-contract-compat`, `report-contract-docs-check` | `report-contract-compat`, `report-contract-docs-drift` | `docs/GRAPH_REPORT_CONTRACTS.json`, `docs/GRAPH_REPORT_CONTRACTS_AUTOGEN.md` |
-| `entity-facets` | `entity-facet-docs` | `entity-facet-contract-compat`, `entity-facet-docs-check` | `entity-facet-contract-compat`, `entity-facet-docs-drift` | `docs/GRAPH_ENTITY_FACETS.json`, `docs/GRAPH_ENTITY_FACETS_AUTOGEN.md` |
-| `connector-provisioning` | `connector-docs` | `connector-docs-check` | - | `docs/CONNECTOR_PROVISIONING_AUTOGEN.md`, `docs/CONNECTOR_PROVISIONING_CATALOG.json` |
-| `devex-codegen-catalog` | `devex-codegen` | `devex-codegen-check` | - | `docs/DEVEX_CODEGEN_AUTOGEN.md`, `docs/DEVEX_CODEGEN_CATALOG.json` |
+| `openapi` | `openapi-sync` | `openapi-check`, `openapi-lint` | `openapi` | `api/openapi.yaml` |
+| `proto` | `proto-generate` | `proto-breaking`, `proto-generate-check`, `proto-lint` | `proto` | `gen/cerebro/v1`, `sdk/python/cerebro/v1` |
+| `detection-catalog` | `detection-catalog-generate` | `catalog-check`, `detection-catalog-check` | `catalog` | `docs/POLICIES.md` |
 
 ## Families
 
@@ -27,116 +21,43 @@ Generated from `devex/codegen_catalog.json` via `go run ./scripts/generate_devex
 Keeps registered routes, placeholder synchronization, and OpenAPI linting aligned.
 
 - Change reason: API route or OpenAPI surface changed
-- Generator: `openapi-sync` -> `openapi-sync`
+- Generator: `openapi-sync` -> `make openapi-sync`
 - Checks:
-  - `openapi-check` -> `openapi-check`
-- Triggers: `api/openapi.yaml`, `internal/api/**`, `scripts/openapi_route_parity.go`
+  - `openapi-check` -> `make openapi-check`
+  - `openapi-lint` -> `make openapi-lint`
+- Triggers: `api/openapi.yaml`, `internal/bootstrap/routes.go`, `scripts/openapi_route_parity.go`
 - Outputs: `api/openapi.yaml`
-- CI jobs: `openapi-route-parity`
+- CI jobs: `openapi`
 
-### `config-docs`
+### `proto`
 
-Generates the environment/config reference from the live config loading surface.
+Keeps proto definitions, generated Go/Python outputs, and breaking-change checks aligned.
 
-- Change reason: config loading or config docs changed
-- Generator: `config-docs` -> `config-docs`
+- Change reason: proto definitions or generated SDK/runtime types changed
+- Generator: `proto-generate` -> `make proto-generate`
 - Checks:
-  - `config-docs-check` -> `config-docs-check`
-- Triggers: `docs/CONFIG_ENV_VARS.md`, `internal/app/app_config.go`, `internal/config/**`, `scripts/generate_config_docs/**`
-- Outputs: `docs/CONFIG_ENV_VARS.md`
-- CI jobs: `config-docs-drift`
+  - `proto-lint` -> `make proto-lint`
+  - `proto-generate-check` -> `make proto-generate-check`
+  - `proto-breaking` -> `make proto-breaking`
+- Triggers: `buf.gen.yaml`, `buf.yaml`, `proto/**`
+- Outputs: `gen/cerebro/v1`, `sdk/python/cerebro/v1`
+- CI jobs: `proto`
 
-### `api-contracts`
+### `detection-catalog`
 
-Generates the machine-readable HTTP API baseline and enforces OpenAPI compatibility across endpoint evolution.
+Keeps generated detection catalog artifacts aligned with policy definitions.
 
-- Change reason: HTTP API route or schema surface changed
-- Generator: `api-contract-docs` -> `api-contract-docs`
+- Change reason: policy definitions or detection catalog generation changed
+- Generator: `detection-catalog-generate` -> `make detection-catalog-generate`
 - Checks:
-  - `api-contract-docs-check` -> `api-contract-docs-check`
-  - `api-contract-compat` -> `go run ./scripts/check_api_contract_compat/main.go --require-baseline --base-ref={base_ref}`
-- Triggers: `api/openapi.yaml`, `docs/API_CONTRACTS.json`, `docs/API_CONTRACTS_AUTOGEN.md`, `internal/api/**`, `internal/apicontractcompat/**`, `scripts/check_api_contract_compat/**`, `scripts/generate_api_contract_docs/**`
-- Outputs: `docs/API_CONTRACTS.json`, `docs/API_CONTRACTS_AUTOGEN.md`
-- CI jobs: `api-contract-compat`, `api-contract-docs-drift`
-
-### `ontology-docs`
-
-Generates ontology reference docs and runs guardrails for ingest-schema drift.
-
-- Change reason: ontology or ingest mapping inputs changed
-- Generator: `ontology-docs` -> `ontology-docs`
-- Checks:
-  - `ontology-docs-check` -> `ontology-docs-check`
-  - `graph-ontology-guardrails` -> `graph-ontology-guardrails`
-- Triggers: `docs/GRAPH_ONTOLOGY_AUTOGEN.md`, `internal/graph/edge.go`, `internal/graph/node.go`, `internal/graph/schema_registry.go`, `internal/graph/schema_registry_test.go`, `internal/graphingest/**`, `scripts/generate_graph_ontology_docs/**`
-- Outputs: `docs/GRAPH_ONTOLOGY_AUTOGEN.md`
-- CI jobs: `graph-ontology-guardrails`, `ontology-docs-drift`
-
-### `cloudevents`
-
-Generates platform and ingest event catalogs and enforces baseline compatibility.
-
-- Change reason: CloudEvents-producing surfaces changed
-- Generator: `cloudevents-docs` -> `cloudevents-docs`
-- Checks:
-  - `cloudevents-docs-check` -> `cloudevents-docs-check`
-  - `cloudevents-contract-compat` -> `go run ./scripts/check_cloudevents_contract_compat/main.go --require-baseline --base-ref={base_ref}`
-- Triggers: `docs/CLOUDEVENTS_AUTOGEN.md`, `docs/CLOUDEVENTS_CONTRACTS.json`, `internal/api/server_handlers_graph_writeback.go`, `internal/graphingest/**`, `internal/platformevents/**`, `internal/webhooks/**`, `scripts/check_cloudevents_contract_compat/**`, `scripts/generate_cloudevents_docs/**`
-- Outputs: `docs/CLOUDEVENTS_AUTOGEN.md`, `docs/CLOUDEVENTS_CONTRACTS.json`
-- CI jobs: `cloudevents-contract-compat`, `cloudevents-docs-drift`
-
-### `report-contracts`
-
-Generates report registry artifacts and enforces report contract compatibility.
-
-- Change reason: report runtime or report contracts changed
-- Generator: `report-contract-docs` -> `report-contract-docs`
-- Checks:
-  - `report-contract-docs-check` -> `report-contract-docs-check`
-  - `report-contract-compat` -> `go run ./scripts/check_report_contract_compat/main.go --require-baseline --base-ref={base_ref}`
-- Triggers: `docs/GRAPH_REPORT_CONTRACTS.json`, `docs/GRAPH_REPORT_CONTRACTS_AUTOGEN.md`, `internal/api/server_handlers_graph_intelligence.go`, `internal/api/server_handlers_platform.go`, `internal/graph/report*`, `scripts/check_report_contract_compat/**`, `scripts/generate_report_contract_docs/**`
-- Outputs: `docs/GRAPH_REPORT_CONTRACTS.json`, `docs/GRAPH_REPORT_CONTRACTS_AUTOGEN.md`
-- CI jobs: `report-contract-compat`, `report-contract-docs-drift`
-
-### `entity-facets`
-
-Generates facet contract catalogs and enforces compatibility across facet evolution.
-
-- Change reason: entity facet surfaces changed
-- Generator: `entity-facet-docs` -> `entity-facet-docs`
-- Checks:
-  - `entity-facet-docs-check` -> `entity-facet-docs-check`
-  - `entity-facet-contract-compat` -> `go run ./scripts/check_entity_facet_compat/main.go --require-baseline --base-ref={base_ref}`
-- Triggers: `docs/GRAPH_ENTITY_FACETS.json`, `docs/GRAPH_ENTITY_FACETS_AUTOGEN.md`, `docs/GRAPH_ENTITY_FACET_ARCHITECTURE.md`, `internal/api/server_handlers_platform_entities.go`, `internal/graph/entity_facet*`, `internal/graph/entity_facets.go`, `internal/graph/entity_subresources.go`, `internal/graph/entity_summary_report.go`, `scripts/check_entity_facet_compat/**`, `scripts/generate_entity_facet_docs/**`
-- Outputs: `docs/GRAPH_ENTITY_FACETS.json`, `docs/GRAPH_ENTITY_FACETS_AUTOGEN.md`
-- CI jobs: `entity-facet-contract-compat`, `entity-facet-docs-drift`
-
-### `connector-provisioning`
-
-Generates the cloud connector provisioning catalog used by CLI scaffolding, validation, and rollout docs.
-
-- Change reason: connector provisioning contracts changed
-- Generator: `connector-docs` -> `connector-docs`
-- Checks:
-  - `connector-docs-check` -> `connector-docs-check`
-- Triggers: `Makefile`, `docs/CONNECTOR_PROVISIONING_ARCHITECTURE.md`, `docs/CONNECTOR_PROVISIONING_AUTOGEN.md`, `docs/CONNECTOR_PROVISIONING_CATALOG.json`, `internal/cli/connector*`, `internal/connectors/**`, `scripts/generate_connector_docs/**`
-- Outputs: `docs/CONNECTOR_PROVISIONING_AUTOGEN.md`, `docs/CONNECTOR_PROVISIONING_CATALOG.json`
-- CI jobs: -
-
-### `devex-codegen-catalog`
-
-Publishes the machine-readable CI-to-local codegen map used by DevEx tooling.
-
-- Change reason: codegen governance surfaces changed
-- Generator: `devex-codegen` -> `devex-codegen`
-- Checks:
-  - `devex-codegen-check` -> `devex-codegen-check`
-- Triggers: `.github/workflows/ci.yml`, `Makefile`, `devex/codegen_catalog.json`, `docs/DEVELOPMENT.md`, `docs/DEVEX_CODEGEN_AUTOGEN.md`, `docs/DEVEX_CODEGEN_CATALOG.json`, `internal/devex/**`, `scripts/generate_devex_codegen_docs/**`
-- Outputs: `docs/DEVEX_CODEGEN_AUTOGEN.md`, `docs/DEVEX_CODEGEN_CATALOG.json`
-- CI jobs: -
+  - `detection-catalog-check` -> `make detection-catalog-check`
+  - `catalog-check` -> `make catalog-check`
+- Triggers: `policies/**`, `tools/detectioncatalog/**`
+- Outputs: `docs/POLICIES.md`
+- CI jobs: `catalog`
 
 ## Notes
 
 - `devex/codegen_catalog.json` is the source of truth for generator families, trigger globs, local checks, and CI job mapping.
 - `docs/DEVEX_CODEGEN_CATALOG.json` is the machine-readable artifact for editors and external tooling.
-- `scripts/devex.py` consumes this catalog so new generator families stop requiring handwritten routing branches.
+- Retired generator families are intentionally omitted until their scripts and Make targets exist again.

--- a/docs/DEVEX_CODEGEN_CATALOG.json
+++ b/docs/DEVEX_CODEGEN_CATALOG.json
@@ -9,444 +9,144 @@
       "change_reason": "API route or OpenAPI surface changed",
       "triggers": [
         "api/openapi.yaml",
-        "internal/api/**",
+        "internal/bootstrap/routes.go",
         "scripts/openapi_route_parity.go"
       ],
       "generator": {
-        "summary": "Regenerate OpenAPI route parity placeholders and write the contract file.",
         "make_target": "openapi-sync",
         "command": [
-          "go",
-          "run",
-          "./scripts/openapi_route_parity.go",
-          "--write"
-        ]
+          "make",
+          "openapi-sync"
+        ],
+        "summary": "Regenerate OpenAPI route placeholders and write the contract file."
       },
       "checks": [
         {
           "key": "openapi-check",
-          "summary": "Verify route parity and OpenAPI linting",
+          "summary": "Verify registered HTTP routes are represented in OpenAPI",
           "make_target": "openapi-check",
           "command": [
             "make",
             "openapi-check"
           ],
           "include_in_pr_generated_step": true
+        },
+        {
+          "key": "openapi-lint",
+          "summary": "Lint the OpenAPI contract",
+          "make_target": "openapi-lint",
+          "command": [
+            "make",
+            "openapi-lint"
+          ]
         }
       ],
       "outputs": [
         "api/openapi.yaml"
       ],
       "ci_jobs": [
-        "openapi-route-parity"
+        "openapi"
       ]
     },
     {
-      "id": "config-docs",
-      "title": "Config Docs",
-      "summary": "Generates the environment/config reference from the live config loading surface.",
-      "change_reason": "config loading or config docs changed",
+      "id": "proto",
+      "title": "Proto Contracts",
+      "summary": "Keeps proto definitions, generated Go/Python outputs, and breaking-change checks aligned.",
+      "change_reason": "proto definitions or generated SDK/runtime types changed",
       "triggers": [
-        "internal/app/app_config.go",
-        "internal/config/**",
-        "scripts/generate_config_docs/**",
-        "docs/CONFIG_ENV_VARS.md"
+        "buf.gen.yaml",
+        "buf.yaml",
+        "proto/**"
       ],
       "generator": {
-        "summary": "Regenerate the config and environment variable reference docs.",
-        "make_target": "config-docs",
+        "make_target": "proto-generate",
         "command": [
-          "go",
-          "run",
-          "./scripts/generate_config_docs/main.go"
-        ]
+          "make",
+          "proto-generate"
+        ],
+        "summary": "Regenerate Go and Python proto artifacts."
       },
       "checks": [
         {
-          "key": "config-docs-check",
-          "summary": "Verify generated config docs are up to date",
-          "make_target": "config-docs-check",
+          "key": "proto-lint",
+          "summary": "Lint proto definitions",
+          "make_target": "proto-lint",
           "command": [
             "make",
-            "config-docs-check"
-          ],
-          "include_in_pr_generated_step": true
-        }
-      ],
-      "outputs": [
-        "docs/CONFIG_ENV_VARS.md"
-      ],
-      "ci_jobs": [
-        "config-docs-drift"
-      ]
-    },
-    {
-      "id": "api-contracts",
-      "title": "HTTP API Contracts",
-      "summary": "Generates the machine-readable HTTP API baseline and enforces OpenAPI compatibility across endpoint evolution.",
-      "change_reason": "HTTP API route or schema surface changed",
-      "triggers": [
-        "api/openapi.yaml",
-        "internal/api/**",
-        "scripts/generate_api_contract_docs/**",
-        "scripts/check_api_contract_compat/**",
-        "internal/apicontractcompat/**",
-        "docs/API_CONTRACTS_AUTOGEN.md",
-        "docs/API_CONTRACTS.json"
-      ],
-      "generator": {
-        "summary": "Regenerate the HTTP API contract catalog artifacts.",
-        "make_target": "api-contract-docs",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_api_contract_docs/main.go"
-        ]
-      },
-      "checks": [
+            "proto-lint"
+          ]
+        },
         {
-          "key": "api-contract-docs-check",
-          "summary": "Verify generated HTTP API contract docs are up to date",
-          "make_target": "api-contract-docs-check",
+          "key": "proto-generate-check",
+          "summary": "Verify generated proto outputs are up to date",
+          "make_target": "proto-generate-check",
           "command": [
             "make",
-            "api-contract-docs-check"
+            "proto-generate-check"
           ],
           "include_in_pr_generated_step": true
         },
         {
-          "key": "api-contract-compat",
-          "summary": "Enforce HTTP API contract compatibility",
-          "command": [
-            "go",
-            "run",
-            "./scripts/check_api_contract_compat/main.go",
-            "--require-baseline",
-            "--base-ref={base_ref}"
-          ],
-          "env": {
-            "API_CONTRACT_BASE_REF": "{base_ref}"
-          }
-        }
-      ],
-      "outputs": [
-        "docs/API_CONTRACTS_AUTOGEN.md",
-        "docs/API_CONTRACTS.json"
-      ],
-      "ci_jobs": [
-        "api-contract-docs-drift",
-        "api-contract-compat"
-      ]
-    },
-    {
-      "id": "ontology-docs",
-      "title": "Graph Ontology Docs",
-      "summary": "Generates ontology reference docs and runs guardrails for ingest-schema drift.",
-      "change_reason": "ontology or ingest mapping inputs changed",
-      "triggers": [
-        "internal/graph/node.go",
-        "internal/graph/edge.go",
-        "internal/graph/schema_registry.go",
-        "internal/graph/schema_registry_test.go",
-        "internal/graphingest/**",
-        "scripts/generate_graph_ontology_docs/**",
-        "docs/GRAPH_ONTOLOGY_AUTOGEN.md"
-      ],
-      "generator": {
-        "summary": "Regenerate the graph ontology catalog docs.",
-        "make_target": "ontology-docs",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_graph_ontology_docs/main.go"
-        ]
-      },
-      "checks": [
-        {
-          "key": "ontology-docs-check",
-          "summary": "Verify generated ontology docs are up to date",
-          "make_target": "ontology-docs-check",
+          "key": "proto-breaking",
+          "summary": "Check proto compatibility against the configured base branch",
+          "make_target": "proto-breaking",
           "command": [
             "make",
-            "ontology-docs-check"
-          ],
-          "include_in_pr_generated_step": true
-        },
-        {
-          "key": "graph-ontology-guardrails",
-          "summary": "Run graph ingest ontology guardrail tests",
-          "make_target": "graph-ontology-guardrails",
-          "command": [
-            "make",
-            "graph-ontology-guardrails"
+            "proto-breaking"
           ]
         }
       ],
       "outputs": [
-        "docs/GRAPH_ONTOLOGY_AUTOGEN.md"
+        "gen/cerebro/v1",
+        "sdk/python/cerebro/v1"
       ],
       "ci_jobs": [
-        "ontology-docs-drift",
-        "graph-ontology-guardrails"
+        "proto"
       ]
     },
     {
-      "id": "cloudevents",
-      "title": "CloudEvents Contracts",
-      "summary": "Generates platform and ingest event catalogs and enforces baseline compatibility.",
-      "change_reason": "CloudEvents-producing surfaces changed",
+      "id": "detection-catalog",
+      "title": "Detection Catalog",
+      "summary": "Keeps generated detection catalog artifacts aligned with policy definitions.",
+      "change_reason": "policy definitions or detection catalog generation changed",
       "triggers": [
-        "internal/platformevents/**",
-        "internal/webhooks/**",
-        "internal/graphingest/**",
-        "internal/api/server_handlers_graph_writeback.go",
-        "scripts/generate_cloudevents_docs/**",
-        "scripts/check_cloudevents_contract_compat/**",
-        "docs/CLOUDEVENTS_AUTOGEN.md",
-        "docs/CLOUDEVENTS_CONTRACTS.json"
+        "policies/**",
+        "tools/detectioncatalog/**"
       ],
       "generator": {
-        "summary": "Regenerate the CloudEvents contract catalog artifacts.",
-        "make_target": "cloudevents-docs",
+        "make_target": "detection-catalog-generate",
         "command": [
-          "go",
-          "run",
-          "./scripts/generate_cloudevents_docs/main.go"
-        ]
+          "make",
+          "detection-catalog-generate"
+        ],
+        "summary": "Regenerate detection catalog artifacts."
       },
       "checks": [
         {
-          "key": "cloudevents-docs-check",
-          "summary": "Verify generated CloudEvents docs are up to date",
-          "make_target": "cloudevents-docs-check",
+          "key": "detection-catalog-check",
+          "summary": "Verify detection catalog artifacts are up to date",
+          "make_target": "detection-catalog-check",
           "command": [
             "make",
-            "cloudevents-docs-check"
+            "detection-catalog-check"
           ],
           "include_in_pr_generated_step": true
         },
         {
-          "key": "cloudevents-contract-compat",
-          "summary": "Enforce CloudEvents contract compatibility",
+          "key": "catalog-check",
+          "summary": "Validate policy catalog metadata",
+          "make_target": "catalog-check",
           "command": [
-            "go",
-            "run",
-            "./scripts/check_cloudevents_contract_compat/main.go",
-            "--require-baseline",
-            "--base-ref={base_ref}"
-          ],
-          "env": {
-            "MAPPER_CONTRACT_BASE_REF": "{base_ref}"
-          }
+            "make",
+            "catalog-check"
+          ]
         }
       ],
       "outputs": [
-        "docs/CLOUDEVENTS_AUTOGEN.md",
-        "docs/CLOUDEVENTS_CONTRACTS.json"
+        "docs/POLICIES.md"
       ],
       "ci_jobs": [
-        "cloudevents-docs-drift",
-        "cloudevents-contract-compat"
-      ]
-    },
-    {
-      "id": "report-contracts",
-      "title": "Report Contracts",
-      "summary": "Generates report registry artifacts and enforces report contract compatibility.",
-      "change_reason": "report runtime or report contracts changed",
-      "triggers": [
-        "internal/graph/report*",
-        "internal/api/server_handlers_graph_intelligence.go",
-        "internal/api/server_handlers_platform.go",
-        "scripts/generate_report_contract_docs/**",
-        "scripts/check_report_contract_compat/**",
-        "docs/GRAPH_REPORT_CONTRACTS_AUTOGEN.md",
-        "docs/GRAPH_REPORT_CONTRACTS.json"
-      ],
-      "generator": {
-        "summary": "Regenerate the report contract catalog artifacts.",
-        "make_target": "report-contract-docs",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_report_contract_docs/main.go"
-        ]
-      },
-      "checks": [
-        {
-          "key": "report-contract-docs-check",
-          "summary": "Verify generated report contract docs are up to date",
-          "make_target": "report-contract-docs-check",
-          "command": [
-            "make",
-            "report-contract-docs-check"
-          ],
-          "include_in_pr_generated_step": true
-        },
-        {
-          "key": "report-contract-compat",
-          "summary": "Enforce report contract compatibility",
-          "command": [
-            "go",
-            "run",
-            "./scripts/check_report_contract_compat/main.go",
-            "--require-baseline",
-            "--base-ref={base_ref}"
-          ],
-          "env": {
-            "REPORT_CONTRACT_BASE_REF": "{base_ref}"
-          }
-        }
-      ],
-      "outputs": [
-        "docs/GRAPH_REPORT_CONTRACTS_AUTOGEN.md",
-        "docs/GRAPH_REPORT_CONTRACTS.json"
-      ],
-      "ci_jobs": [
-        "report-contract-docs-drift",
-        "report-contract-compat"
-      ]
-    },
-    {
-      "id": "entity-facets",
-      "title": "Entity Facet Contracts",
-      "summary": "Generates facet contract catalogs and enforces compatibility across facet evolution.",
-      "change_reason": "entity facet surfaces changed",
-      "triggers": [
-        "internal/graph/entity_facet*",
-        "internal/graph/entity_facets.go",
-        "internal/graph/entity_subresources.go",
-        "internal/graph/entity_summary_report.go",
-        "internal/api/server_handlers_platform_entities.go",
-        "scripts/generate_entity_facet_docs/**",
-        "scripts/check_entity_facet_compat/**",
-        "docs/GRAPH_ENTITY_FACETS_AUTOGEN.md",
-        "docs/GRAPH_ENTITY_FACETS.json",
-        "docs/GRAPH_ENTITY_FACET_ARCHITECTURE.md"
-      ],
-      "generator": {
-        "summary": "Regenerate the entity facet contract catalog artifacts.",
-        "make_target": "entity-facet-docs",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_entity_facet_docs/main.go"
-        ]
-      },
-      "checks": [
-        {
-          "key": "entity-facet-docs-check",
-          "summary": "Verify generated entity facet docs are up to date",
-          "make_target": "entity-facet-docs-check",
-          "command": [
-            "make",
-            "entity-facet-docs-check"
-          ],
-          "include_in_pr_generated_step": true
-        },
-        {
-          "key": "entity-facet-contract-compat",
-          "summary": "Enforce entity facet contract compatibility",
-          "command": [
-            "go",
-            "run",
-            "./scripts/check_entity_facet_compat/main.go",
-            "--require-baseline",
-            "--base-ref={base_ref}"
-          ],
-          "env": {
-            "ENTITY_FACET_BASE_REF": "{base_ref}"
-          }
-        }
-      ],
-      "outputs": [
-        "docs/GRAPH_ENTITY_FACETS_AUTOGEN.md",
-        "docs/GRAPH_ENTITY_FACETS.json"
-      ],
-      "ci_jobs": [
-        "entity-facet-docs-drift",
-        "entity-facet-contract-compat"
-      ]
-    },
-    {
-      "id": "connector-provisioning",
-      "title": "Connector Provisioning Contracts",
-      "summary": "Generates the cloud connector provisioning catalog used by CLI scaffolding, validation, and rollout docs.",
-      "change_reason": "connector provisioning contracts changed",
-      "triggers": [
-        "internal/connectors/**",
-        "internal/cli/connector*",
-        "scripts/generate_connector_docs/**",
-        "docs/CONNECTOR_PROVISIONING_AUTOGEN.md",
-        "docs/CONNECTOR_PROVISIONING_CATALOG.json",
-        "docs/CONNECTOR_PROVISIONING_ARCHITECTURE.md",
-        "Makefile"
-      ],
-      "generator": {
-        "summary": "Regenerate the connector provisioning catalog artifacts.",
-        "make_target": "connector-docs",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_connector_docs/main.go"
-        ]
-      },
-      "checks": [
-        {
-          "key": "connector-docs-check",
-          "summary": "Verify generated connector provisioning docs are up to date",
-          "make_target": "connector-docs-check",
-          "command": [
-            "make",
-            "connector-docs-check"
-          ],
-          "include_in_pr_generated_step": true
-        }
-      ],
-      "outputs": [
-        "docs/CONNECTOR_PROVISIONING_AUTOGEN.md",
-        "docs/CONNECTOR_PROVISIONING_CATALOG.json"
-      ]
-    },
-    {
-      "id": "devex-codegen-catalog",
-      "title": "DevEx Codegen Catalog",
-      "summary": "Publishes the machine-readable CI-to-local codegen map used by DevEx tooling.",
-      "change_reason": "codegen governance surfaces changed",
-      "triggers": [
-        "devex/codegen_catalog.json",
-        "internal/devex/**",
-        "scripts/generate_devex_codegen_docs/**",
-        "docs/DEVEX_CODEGEN_AUTOGEN.md",
-        "docs/DEVEX_CODEGEN_CATALOG.json",
-        "Makefile",
-        ".github/workflows/ci.yml",
-        "docs/DEVELOPMENT.md"
-      ],
-      "generator": {
-        "summary": "Regenerate the DevEx codegen catalog docs and JSON artifact.",
-        "make_target": "devex-codegen",
-        "command": [
-          "go",
-          "run",
-          "./scripts/generate_devex_codegen_docs/main.go"
-        ]
-      },
-      "checks": [
-        {
-          "key": "devex-codegen-check",
-          "summary": "Verify generated DevEx codegen docs are up to date",
-          "make_target": "devex-codegen-check",
-          "command": [
-            "make",
-            "devex-codegen-check"
-          ],
-          "include_in_pr_generated_step": true
-        }
-      ],
-      "outputs": [
-        "docs/DEVEX_CODEGEN_AUTOGEN.md",
-        "docs/DEVEX_CODEGEN_CATALOG.json"
+        "catalog"
       ]
     }
   ]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -7,6 +7,19 @@ name = "cerebro-sdk"
 version = "0.1.0"
 description = "Generated Python SDK for the Cerebro Agent SDK and report runtime"
 requires-python = ">=3.10"
+license = "Apache-2.0"
+dependencies = [
+  "protobuf>=5.29.5,<6",
+]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+
+[project.urls]
+Repository = "https://github.com/writer/cerebro"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,13 +1,34 @@
 {
   "name": "@writer/cerebro-sdk",
   "version": "0.1.0",
+  "description": "TypeScript SDK for the Cerebro Agent SDK and report runtime",
+  "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.ts",
+  "files": [
+    "src",
+    "examples",
+    "package.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/writer/cerebro.git",
+    "directory": "sdk/typescript"
+  },
   "scripts": {
-    "test": "node --test test/*.mjs"
+    "check": "npm run typecheck && npm test",
+    "test": "node --test test/*.mjs",
+    "typecheck": "npx --yes --package typescript tsc --noEmit"
   },
   "exports": {
-    ".": "./src/index.js",
-    "./jira": "./src/jira.js"
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.js"
+    },
+    "./jira": {
+      "types": "./src/jira.ts",
+      "default": "./src/jira.js"
+    }
   }
 }

--- a/sdk/typescript/test/jira.test.mjs
+++ b/sdk/typescript/test/jira.test.mjs
@@ -40,8 +40,11 @@ test("source bridge is importable at runtime", async () => {
 
   const pkg = JSON.parse(await readFile(path.resolve(here, "../package.json"), "utf8"));
   assert.equal(pkg.main, "./src/index.js");
-  assert.equal(pkg.exports["."], "./src/index.js");
-  assert.equal(pkg.exports["./jira"], "./src/jira.js");
+  assert.equal(pkg.types, "./src/index.ts");
+  assert.equal(pkg.exports["."].default, "./src/index.js");
+  assert.equal(pkg.exports["."].types, "./src/index.ts");
+  assert.equal(pkg.exports["./jira"].default, "./src/jira.js");
+  assert.equal(pkg.exports["./jira"].types, "./src/jira.ts");
 
   const jira = await import(path.join(srcDir, "jira.js"));
   assert.equal(typeof jira.buildJiraWorkspaceClaims, "function");


### PR DESCRIPTION
## Summary
- Wire Python/TypeScript SDK tests and TypeScript typechecking into Makefile and CI.
- Add proto generated drift and breaking-change checks to verification.
- Update SDK package metadata and trim DevEx codegen docs to runnable targets.

## Test plan
- `make sdk-test`
- `make proto-generate-check`
- `make proto-breaking`
- `npm pack --dry-run` in `sdk/typescript`
- `python3 -m build` in `sdk/python`

Made with [Cursor](https://cursor.com)