### PR TITLE
docs: document liveness and readiness routes

### DIFF
--- a/.deepsec/data/cerebro/INFO.md
+++ b/.deepsec/data/cerebro/INFO.md
@@ -8,7 +8,7 @@ Cerebro is Writer's Go security operations platform for cloud/SaaS source ingest
 
 - API auth is configured in `internal/config` and enforced by `authMiddleware`, `authConnectInterceptor`, and tenant helpers in `internal/bootstrap/auth.go`.
 - Tenant-scoped API keys must be checked against explicit `tenant_id` fields, tenant-bearing URNs, runtime/findings/report records loaded by ID, and graph ingest/workflow operations that otherwise default to global scope.
-- `/health`, `/healthz`, and `/openapi.yaml` are intentionally public; most `/platform/*`, `/source-runtimes/*`, `/findings/*`, `/reports/*`, and Connect RPC paths are protected when `CEREBRO_API_AUTH_ENABLED=true`.
+- `/health`, `/healthz`, `/livez`, and `/openapi.yaml` are intentionally public; `/health` is dependency-aware readiness while `/healthz` and `/livez` are liveness-only. Most `/platform/*`, `/source-runtimes/*`, `/findings/*`, `/reports/*`, and Connect RPC paths are protected when `CEREBRO_API_AUTH_ENABLED=true`.
 
 ## Threat model
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ CLI / JSON HTTP / Connect / MCP clients
               +--> Optional graph store: Neo4j/Aura
 ```
 
-External dependency drivers are opt-in. With no external drivers configured, the server can start and serve lightweight routes such as `/health`, `/healthz`, and `/sources`. Durable runtime, claim, finding, report, replay, and graph operations require their corresponding stores.
+External dependency drivers are opt-in. With no external drivers configured, the server can start and serve lightweight routes such as `/health`, `/healthz`, `/livez`, and `/sources`. `/health` is the dependency-aware readiness check; `/healthz` and `/livez` are liveness-only checks. Durable runtime, claim, finding, report, replay, and graph operations require their corresponding stores.
 
 ---
 
@@ -266,7 +266,7 @@ Connect RPC procedures are served under `/cerebro.v1.BootstrapService/{Method}`.
 
 Major route groups include:
 
-- Public health and metadata: `/health`, `/healthz`, `/openapi.yaml`, OAuth protected-resource/authorization-server metadata.
+- Public health and metadata: `/health` readiness, `/healthz` and `/livez` liveness, `/openapi.yaml`, OAuth protected-resource/authorization-server metadata.
 - Source catalog and previews: `/sources`, `/sources/{sourceID}/check`, `/discover`, `/read`.
 - Source runtime operations: `/source-runtimes`, runtime `sync`, claims, findings, candidates, evidence, evaluation runs, and graph ingest runs.
 - Finding and candidate lifecycle: `/finding-rules`, `/findings/*`, `/finding-candidates/*`, `/finding-evidence/*`, `/finding-evaluation-runs/*`.

--- a/docs/API_CONTRACTS_AUTOGEN.md
+++ b/docs/API_CONTRACTS_AUTOGEN.md
@@ -2,9 +2,9 @@
 
 Generated-by-hand snapshot for the current bootstrap service. Source of truth: `api/openapi.yaml` and `proto/cerebro/v1/bootstrap.proto`.
 
-- HTTP operations: **67** across **65** paths.
+- HTTP operations: **68** across **66** paths.
 - Connect RPCs: **38**.
-- Public unauthenticated routes when auth is enabled: `/health`, `/healthz`, `/openapi.yaml`.
+- Public unauthenticated routes when auth is enabled: `/health`, `/healthz`, `/livez`, `/openapi.yaml`.
 - Preferred shared platform namespace: `/platform/*`.
 - Legacy `/graph/*` compatibility aliases have been removed; use `/platform/graph/*`.
 
@@ -12,7 +12,7 @@ Generated-by-hand snapshot for the current bootstrap service. Source of truth: `
 
 | Family | Routes |
 | --- | --- |
-| Health/contracts | `/health`, `/healthz`, `/openapi.yaml` |
+| Health/contracts | `/health` readiness, `/healthz` and `/livez` liveness, `/openapi.yaml` |
 | Sources | `/sources`, `/sources/{sourceID}/check`, `/sources/{sourceID}/discover`, `/sources/{sourceID}/read` |
 | Source runtimes | `/source-runtimes/{runtimeID}`, `/source-runtimes/{runtimeID}/sync`, `/source-runtimes/{runtimeID}/graph-ingest-runs` |
 | Claims/findings | `/source-runtimes/{runtimeID}/claims`, `/source-runtimes/{runtimeID}/findings`, finding lifecycle routes |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -12,8 +12,9 @@ Set `CEREBRO_API_AUTH_ENABLED=true` and pass `Authorization: Bearer <key>` or `X
 
 ## Public routes
 
-- `GET /health`
-- `GET /healthz`
+- `GET /health` - dependency-aware readiness; returns unavailable when configured dependencies are degraded.
+- `GET /healthz` - liveness-only process check.
+- `GET /livez` - liveness-only process check.
 - `GET /openapi.yaml`
 
 ## Preferred platform routes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,7 +29,7 @@ CLI / JSON HTTP / Connect clients
               +--> Neo4j/Aura graph store (optional)
 ```
 
-The service can start without optional stores and serve lightweight routes such as `/health`, `/healthz`, `/openapi.yaml`, and `/sources`. Durable runtime, claim, finding, report, replay, and graph operations require the configured store for that operation.
+The service can start without optional stores and serve lightweight routes such as `/health`, `/healthz`, `/livez`, `/openapi.yaml`, and `/sources`. `/health` reports dependency-aware readiness; `/healthz` and `/livez` are liveness-only. Durable runtime, claim, finding, report, replay, and graph operations require the configured store for that operation.
 
 ## Store boundaries
 
@@ -47,7 +47,7 @@ Kuzu and embedded/in-memory database backends are intentionally rejected by conf
 - Current platform routes prefer `/platform/*` for shared platform resources.
 - Legacy `/graph/*` aliases have been removed; use the `/platform/graph/*` routes or the matching Connect RPCs.
 - HTTP-only surfaces are route-grouped in `internal/bootstrap/routes.go` so platform, internal, and public routes are explicit while the remaining Connect coverage gap is closed.
-- Public unauthenticated routes are limited to `/health`, `/healthz`, and `/openapi.yaml` when API auth is enabled.
+- Public unauthenticated routes are limited to `/health`, `/healthz`, `/livez`, `/openapi.yaml`, OAuth metadata routes, and `/.well-known/device-jwks.json` when API auth is enabled.
 
 ## Postgres migrations
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,7 +4,7 @@ Cerebro `main` uses a small bootstrap configuration surface.
 
 ## Minimal local configuration
 
-No external stores are required for `/health`, `/healthz`, `/openapi.yaml`, `/sources`, and source preview routes that do not need provider credentials.
+No external stores are required for `/health`, `/healthz`, `/livez`, `/openapi.yaml`, `/sources`, and source preview routes that do not need provider credentials. `/health` reports dependency-aware readiness; `/healthz` and `/livez` are liveness-only.
 
 ```bash
 make serve


### PR DESCRIPTION
## Summary
- Document `/livez` as a public liveness route.
- Clarify `/health` is dependency-aware readiness and `/healthz` is liveness-only.
- Update the public unauthenticated route docs called out by Droid feedback on #799.

## Test plan
- `make openapi-check`
- `python3 scripts/oss_audit.py`

Made with [Cursor](https://cursor.com)