### PR TITLE
fix: keep MCP capabilities SDK-compatible

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -342,15 +342,12 @@ func (app *App) mcpInitializeResult(r *http.Request, rawParams json.RawMessage) 
 			"tools":     map[string]any{"listChanged": false},
 			"resources": map[string]any{"subscribe": false, "listChanged": false},
 			"prompts":   map[string]any{"listChanged": false},
-			"experimental": map[string]any{
-				"stateless": true,
-			},
 		},
 		"serverInfo": map[string]any{
 			"name":        buildinfo.ServiceName,
 			"title":       "Cerebro",
 			"version":     buildinfo.Version,
-			"description": "Writer security graph and findings MCP server. POST requests are stateless; MCP session IDs are echoed for client correlation only.",
+			"description": "Writer security graph and findings MCP server. POST requests are stateless.",
 		},
 	}
 }

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -73,6 +73,9 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 			t.Fatalf("initialize missing %s capability in %#v", capability, capabilities)
 		}
 	}
+	if _, ok := capabilities["experimental"]; ok {
+		t.Fatalf("initialize experimental capabilities = %#v, want omitted for SDK compatibility", capabilities["experimental"])
+	}
 	if sessionID != "" {
 		t.Fatalf("Mcp-Session-Id header = %q, want empty for stateless MCP", sessionID)
 	}


### PR DESCRIPTION
### Why
Native Droid's MCP SDK rejects the initialize response because `capabilities.experimental.stateless` is a boolean, but the SDK schema expects experimental capability values to be object-shaped.

### What changed
- Omit the non-standard `experimental.stateless` initialize capability.
- Keep stateless transport behavior via no `Mcp-Session-Id` header and 405 on `GET /api/v1/mcp`.
- Add a regression assertion that `experimental` capabilities stay omitted.

### Validation
Commands run:
- `go test ./internal/bootstrap -run 'TestMCP' -count=1`
- `go test ./internal/bootstrap -count=1`
- `make lint-bootstrap openapi-check openapi-lint`
- Reproduced against prod with MCP SDK 1.29.0: current `v2.1.179` fails on `capabilities.experimental.stateless` zod validation.

### Security
- [x] No secrets in diff
- [x] New deps: none
