### PR TITLE
Add runtime and release guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
             command: make readme-check
           - name: oss-audit
             command: make oss-audit
+          - name: release-smoke
+            command: make release-smoke
+          - name: docker-smoke
+            command: make docker-smoke
           - name: structural
             command: make check-structural check-structural-test check-arch
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
             command: make readme-check
           - name: oss-audit
             command: make oss-audit
+          - name: release-smoke
+            command: make release-smoke
           - name: structural
             command: make check-structural check-structural-test check-arch
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ USER cerebro
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD curl -fsS http://127.0.0.1:8080/health || exit 1
+  CMD curl -fsS http://127.0.0.1:8080/livez || exit 1
 
 ENTRYPOINT ["/usr/local/bin/cerebro"]
 CMD ["serve"]

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -14,7 +14,7 @@ USER cerebro
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:8080/health >/dev/null || exit 1
+  CMD wget -qO- http://127.0.0.1:8080/livez >/dev/null || exit 1
 
 ENTRYPOINT ["/usr/local/bin/cerebro"]
 CMD ["serve"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check readme-check oss-audit govulncheck droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check readme-check oss-audit govulncheck docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -6,8 +6,11 @@ GOLANGCI_LINT_VERSION ?= v2.11.4
 BUF := GOFLAGS= GOTOOLCHAIN=go1.26.3 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
 GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.3 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
 SPECTRAL := npx --yes @stoplight/spectral-cli@6.15.0
+GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.3 go run github.com/goreleaser/goreleaser/v2@v2.16.0
 PROTO_BREAKING_BASE ?= origin/main
 README_CHECK_BASE ?= origin/main
+DOCKER_SMOKE_IMAGE ?= cerebro-runtime-smoke:local
+DOCKER_SMOKE_GOARCH ?= amd64
 APP_PACKAGES := ./api/... ./cmd/... ./internal/... ./sources/...
 LINTER_MODULE := ./tools/linters
 LINTER_BIN := $(GO_BIN)/cerebrolint
@@ -66,7 +69,7 @@ sdk-typescript-test:
 	cd sdk/typescript && npm test
 
 sdk-typescript-check:
-	cd sdk/typescript && npm run typecheck
+	cd sdk/typescript && npm ci && npm run typecheck
 
 workflow-e2e-test:
 	go test $(WORKFLOW_E2E_PACKAGES) -run '$(WORKFLOW_E2E_TESTS)$$' -count=1 -v
@@ -165,6 +168,27 @@ oss-audit:
 govulncheck:
 	$(GOVULNCHECK) ./...
 
+docker-smoke:
+	@command -v docker >/dev/null || { echo "docker is required for docker-smoke" >&2; exit 2; }
+	mkdir -p .dist
+	CGO_ENABLED=0 GOOS=linux GOARCH="$(DOCKER_SMOKE_GOARCH)" go build -trimpath -o .dist/cerebro ./cmd/cerebro
+	docker build -f Dockerfile.runtime -t "$(DOCKER_SMOKE_IMAGE)" .
+
+release-smoke:
+	$(GORELEASER) check
+
+doctor:
+	@command -v git >/dev/null || { echo "missing required tool: git" >&2; exit 2; }
+	@command -v go >/dev/null || { echo "missing required tool: go" >&2; exit 2; }
+	@command -v python3 >/dev/null || { echo "missing required tool: python3" >&2; exit 2; }
+	@command -v npm >/dev/null || { echo "missing required tool: npm" >&2; exit 2; }
+	@command -v docker >/dev/null || echo "optional tool missing: docker (needed for make docker-smoke)"
+	@command -v gh >/dev/null || echo "optional tool missing: gh (needed for PR/release triage)"
+	@go version
+	@python3 --version
+	@npm --version
+	@echo "developer toolchain looks ready"
+
 droid-review-preflight:
 	go test ./tools/droidreview/...
 	go run ./tools/droidreview --base "$(DROID_REVIEW_BASE)" --head "$(DROID_REVIEW_HEAD)" --json-out "$(DROID_PREFLIGHT_JSON_OUT)"
@@ -210,4 +234,4 @@ check-arch:
 
 check-hook-integrity: check-arch
 
-verify: build test sdk-test lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check detection-catalog-check readme-check oss-audit check-structural check-structural-test check-arch
+verify: build test sdk-test lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check detection-catalog-check readme-check oss-audit release-smoke check-structural check-structural-test check-arch

--- a/README.md
+++ b/README.md
@@ -303,6 +303,9 @@ make lint           # golangci-lint over app packages
 make proto-lint     # buf lint
 make check          # build, tests, lint, proto lint, structural checks, arch tests
 make verify         # CI-parity local verification
+make doctor         # check required local developer tools
+make release-smoke  # validate GoReleaser config
+make docker-smoke   # build the runtime Dockerfile locally
 make oss-audit      # public repository hygiene scan
 make clean          # remove bin/
 ```

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -177,6 +177,10 @@ paths:
       responses:
         '200':
           description: Stored source runtime.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PutSourceRuntimeResponse'
     get:
       summary: Get source runtime configuration
       tags:
@@ -186,6 +190,10 @@ paths:
       responses:
         '200':
           description: Stored source runtime.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSourceRuntimeResponse'
   /source-runtimes/{runtimeID}/sync:
     post:
       summary: Sync one source runtime through the append log and projections
@@ -216,15 +224,29 @@ paths:
       responses:
         '200':
           description: Claim list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListClaimsResponse'
     post:
       summary: Write claims for one runtime
       tags:
         - Sources
       parameters:
         - $ref: '#/components/parameters/runtimeID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WriteClaimsRequest'
       responses:
         '200':
           description: Claim write result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WriteClaimsResponse'
   /source-runtimes/{runtimeID}/findings:
     get:
       summary: List findings for one runtime
@@ -904,6 +926,10 @@ paths:
       responses:
         '200':
           description: Neighborhood result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetEntityNeighborhoodResponse'
   /platform/graph/impact/vulnerability/{id}:
     get:
       summary: Query vulnerability impact graph
@@ -1830,19 +1856,155 @@ components:
       required: [runtime]
       properties:
         runtime:
+          $ref: '#/components/schemas/SourceRuntime'
+    PutSourceRuntimeResponse:
+      type: object
+      properties:
+        runtime:
+          $ref: '#/components/schemas/SourceRuntime'
+    GetSourceRuntimeResponse:
+      type: object
+      properties:
+        runtime:
+          $ref: '#/components/schemas/SourceRuntime'
+    SourceRuntime:
+      type: object
+      required: [source_id, tenant_id]
+      properties:
+        id:
+          type: string
+        source_id:
+          type: string
+        tenant_id:
+          type: string
+        config:
           type: object
-          required: [id, sourceId, tenantId]
-          properties:
-            id:
-              type: string
-            sourceId:
-              type: string
-            tenantId:
-              type: string
-            config:
-              type: object
-              additionalProperties:
-                type: string
+          additionalProperties:
+            type: string
+        checkpoint:
+          type: object
+          additionalProperties: true
+        next_cursor:
+          type: object
+          additionalProperties: true
+        last_synced_at:
+          type: string
+          format: date-time
+    EntityRef:
+      type: object
+      required: [urn, entity_type]
+      properties:
+        urn:
+          type: string
+        entity_type:
+          type: string
+        label:
+          type: string
+    Claim:
+      type: object
+      required: [predicate]
+      properties:
+        id:
+          type: string
+        subject_urn:
+          type: string
+        subject_ref:
+          $ref: '#/components/schemas/EntityRef'
+        predicate:
+          type: string
+        object_urn:
+          type: string
+        object_ref:
+          $ref: '#/components/schemas/EntityRef'
+        object_value:
+          type: string
+        claim_type:
+          type: string
+        status:
+          type: string
+        source_event_id:
+          type: string
+        observed_at:
+          type: string
+          format: date-time
+        valid_from:
+          type: string
+          format: date-time
+        valid_to:
+          type: string
+          format: date-time
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+    WriteClaimsRequest:
+      type: object
+      required: [claims]
+      properties:
+        runtime_id:
+          type: string
+          description: Optional in HTTP JSON; the path runtimeID is authoritative.
+        claims:
+          type: array
+          items:
+            $ref: '#/components/schemas/Claim'
+        replace_existing:
+          type: boolean
+    WriteClaimsResponse:
+      type: object
+      properties:
+        claims_written:
+          type: integer
+          minimum: 0
+        entities_upserted:
+          type: integer
+          minimum: 0
+        relation_links_projected:
+          type: integer
+          minimum: 0
+        claims_retracted:
+          type: integer
+          minimum: 0
+    ListClaimsResponse:
+      type: object
+      properties:
+        claims:
+          type: array
+          items:
+            $ref: '#/components/schemas/Claim'
+    GraphEntity:
+      type: object
+      required: [urn, entity_type, label]
+      properties:
+        urn:
+          type: string
+        entity_type:
+          type: string
+        label:
+          type: string
+    GraphRelation:
+      type: object
+      required: [from_urn, relation, to_urn]
+      properties:
+        from_urn:
+          type: string
+        relation:
+          type: string
+        to_urn:
+          type: string
+    GetEntityNeighborhoodResponse:
+      type: object
+      properties:
+        root:
+          $ref: '#/components/schemas/GraphEntity'
+        neighbors:
+          type: array
+          items:
+            $ref: '#/components/schemas/GraphEntity'
+        relations:
+          type: array
+          items:
+            $ref: '#/components/schemas/GraphRelation'
     FindingEvaluationRun:
       type: object
       properties:

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -100,8 +100,8 @@ func serve() error {
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	startGRCReadModelWarmup(ctx, deps.StateStore, log.Printf)
-	startFindingRiskBackfill(ctx, app, log.Printf)
+	grcWarmupDone := startGRCReadModelWarmup(ctx, deps.StateStore, log.Printf)
+	riskBackfillDone := startFindingRiskBackfill(ctx, app, log.Printf)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -123,7 +123,21 @@ func serve() error {
 		if err := <-errCh; err != nil {
 			return fmt.Errorf("serve: %w", err)
 		}
+		waitForStartupJobs(shutdownCtx, grcWarmupDone, riskBackfillDone)
 		return nil
+	}
+}
+
+func waitForStartupJobs(ctx context.Context, jobs ...<-chan struct{}) {
+	for _, job := range jobs {
+		if job == nil {
+			continue
+		}
+		select {
+		case <-job:
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -55,6 +55,26 @@ func TestStartFindingRiskBackfillDoesNotBlockStartup(t *testing.T) {
 	}
 }
 
+func TestWaitForStartupJobsWaitsForCompletion(t *testing.T) {
+	done := make(chan struct{})
+	waited := make(chan struct{})
+	go func() {
+		waitForStartupJobs(context.Background(), done)
+		close(waited)
+	}()
+	select {
+	case <-waited:
+		t.Fatal("waitForStartupJobs returned before job completed")
+	default:
+	}
+	close(done)
+	select {
+	case <-waited:
+	case <-time.After(time.Second):
+		t.Fatal("waitForStartupJobs did not return after job completed")
+	}
+}
+
 func TestStartFindingRiskBackfillLogsErrors(t *testing.T) {
 	backfiller := &errorFindingRiskBackfiller{err: errors.New("boom")}
 	logged := make(chan string, 1)

--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -15,12 +15,18 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_APPEND_LOG_DRIVER` | inferred | Append-log driver. Supported: `jetstream`. |
 | `CEREBRO_JETSTREAM_URL` | unset | NATS JetStream URL. Setting this infers `jetstream`. |
 | `CEREBRO_JETSTREAM_SUBJECT_PREFIX` | `events` | Subject prefix for append-log events. |
+| `CEREBRO_JETSTREAM_DRAIN_TIMEOUT` | NATS default | Optional timeout for graceful NATS connection drain during shutdown. |
 | `CEREBRO_STATE_STORE_DRIVER` | inferred | State-store driver. Supported: `postgres`. |
 | `CEREBRO_POSTGRES_DSN` | unset | Postgres connection string. Setting this infers `postgres`. |
+| `CEREBRO_POSTGRES_MAX_OPEN_CONNS` | Go default | Optional `database/sql` maximum open connections. |
+| `CEREBRO_POSTGRES_MAX_IDLE_CONNS` | Go default | Optional `database/sql` maximum idle connections. |
+| `CEREBRO_POSTGRES_CONN_MAX_LIFETIME` | Go default | Optional maximum lifetime for pooled Postgres connections. |
+| `CEREBRO_POSTGRES_CONN_MAX_IDLE_TIME` | Go default | Optional maximum idle time for pooled Postgres connections. |
 | `CEREBRO_GRAPH_STORE_DRIVER` | inferred | Graph-store driver. Supported: `neo4j`. |
 | `CEREBRO_NEO4J_URI` | unset | Neo4j/Aura URI. Setting this infers `neo4j`. |
 | `CEREBRO_NEO4J_USERNAME` | unset | Neo4j/Aura username. |
 | `CEREBRO_NEO4J_PASSWORD` | unset | Neo4j/Aura password. |
 | `CEREBRO_NEO4J_DATABASE` | unset | Optional Neo4j database name. |
+| `CEREBRO_NEO4J_QUERY_TIMEOUT` | unset | Optional timeout applied to Neo4j read transactions. |
 
 `CEREBRO_KUZU_PATH` is rejected. Kuzu is no longer a supported graph backend.

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 	"time"
@@ -83,12 +84,26 @@ func Open(cfg config.AppendLogConfig) (*Log, error) {
 	if err != nil {
 		return nil, err
 	}
-	nc, err := nats.Connect(
-		url,
+	options := []nats.Option{
 		nats.Name("cerebro"),
 		nats.Timeout(connectTimeout),
 		nats.RetryOnFailedConnect(false),
-	)
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(2 * time.Second),
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			log.Printf("nats disconnected: %v", err)
+		}),
+		nats.ReconnectHandler(func(conn *nats.Conn) {
+			log.Printf("nats reconnected: %s", conn.ConnectedUrl())
+		}),
+		nats.ClosedHandler(func(_ *nats.Conn) {
+			log.Print("nats connection closed")
+		}),
+	}
+	if cfg.JetStreamDrainTimeout > 0 {
+		options = append(options, nats.DrainTimeout(cfg.JetStreamDrainTimeout))
+	}
+	nc, err := nats.Connect(url, options...)
 	if err != nil {
 		return nil, fmt.Errorf("connect nats: %w", err)
 	}
@@ -110,7 +125,10 @@ func (l *Log) Close() error {
 	if l == nil || l.conn == nil {
 		return nil
 	}
-	l.conn.Close()
+	if err := l.conn.Drain(); err != nil {
+		l.conn.Close()
+		return fmt.Errorf("drain nats connection: %w", err)
+	}
 	return nil
 }
 

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -94,7 +95,7 @@ func Open(cfg config.AppendLogConfig) (*Log, error) {
 			log.Printf("nats disconnected: %v", err)
 		}),
 		nats.ReconnectHandler(func(conn *nats.Conn) {
-			log.Printf("nats reconnected: %s", conn.ConnectedUrl())
+			log.Printf("nats reconnected: %s", redactNATSURL(conn.ConnectedUrl()))
 		}),
 		nats.ClosedHandler(func(_ *nats.Conn) {
 			log.Print("nats connection closed")
@@ -130,6 +131,19 @@ func (l *Log) Close() error {
 		return fmt.Errorf("drain nats connection: %w", err)
 	}
 	return nil
+}
+
+func redactNATSURL(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return ""
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Host == "" {
+		return "<redacted>"
+	}
+	parsed.User = nil
+	return parsed.String()
 }
 
 // Ping verifies that JetStream is reachable.

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -100,6 +100,18 @@ func TestAppendPublishesEnvelope(t *testing.T) {
 	}
 }
 
+func TestRedactNATSURLRemovesCredentials(t *testing.T) {
+	if got := redactNATSURL("nats://user:secret@nats.example:4222"); got != "nats://nats.example:4222" {
+		t.Fatalf("redactNATSURL() = %q, want credential-free URL", got)
+	}
+	if got := redactNATSURL("nats://token@nats.example:4222"); got != "nats://nats.example:4222" {
+		t.Fatalf("redactNATSURL() token URL = %q, want credential-free URL", got)
+	}
+	if got := redactNATSURL("://user:secret@nats.example:4222"); got != "<redacted>" {
+		t.Fatalf("redactNATSURL() malformed URL = %q, want <redacted>", got)
+	}
+}
+
 func TestAppendPublishesCanonicalSecuritySubjectWithoutLegacyPrefix(t *testing.T) {
 	pub := &fakePublisher{}
 	log := &Log{js: pub, subjectPrefix: "events"}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,21 +42,27 @@ type AppendLogConfig struct {
 	Driver                 string
 	JetStreamURL           string
 	JetStreamSubjectPrefix string
+	JetStreamDrainTimeout  time.Duration
 }
 
 // StateStoreConfig selects and configures the current-state store driver.
 type StateStoreConfig struct {
-	Driver      string
-	PostgresDSN string
+	Driver                  string
+	PostgresDSN             string
+	PostgresMaxOpenConns    int
+	PostgresMaxIdleConns    int
+	PostgresConnMaxLifetime time.Duration
+	PostgresConnMaxIdleTime time.Duration
 }
 
 // GraphStoreConfig selects and configures the graph projection store driver.
 type GraphStoreConfig struct {
-	Driver        string
-	Neo4jURI      string
-	Neo4jUsername string
-	Neo4jPassword string
-	Neo4jDatabase string
+	Driver            string
+	Neo4jURI          string
+	Neo4jUsername     string
+	Neo4jPassword     string
+	Neo4jDatabase     string
+	Neo4jQueryTimeout time.Duration
 }
 
 // GraphAgentLLMConfig selects and configures the graph ask LLM adapter.
@@ -315,6 +321,24 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	if cfg.GraphAgentLLM.Temperature, err = parseFloatEnv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.AppendLog.JetStreamDrainTimeout, err = parseDurationEnv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.StateStore.PostgresMaxOpenConns, err = parseIntEnv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.StateStore.PostgresMaxIdleConns, err = parseIntEnv("CEREBRO_POSTGRES_MAX_IDLE_CONNS", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.StateStore.PostgresConnMaxLifetime, err = parseDurationEnv("CEREBRO_POSTGRES_CONN_MAX_LIFETIME", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.StateStore.PostgresConnMaxIdleTime, err = parseDurationEnv("CEREBRO_POSTGRES_CONN_MAX_IDLE_TIME", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.GraphStore.Neo4jQueryTimeout, err = parseDurationEnv("CEREBRO_NEO4J_QUERY_TIMEOUT", 0); err != nil {
 		return Config{}, err
 	}
 	cfg.GraphAgentLLM.OpenRouterAPIKey = strings.TrimSpace(os.Getenv("CEREBRO_OPENROUTER_API_KEY"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,13 +15,19 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", "")
 	t.Setenv("CEREBRO_JETSTREAM_URL", "")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
+	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "")
 	t.Setenv("CEREBRO_STATE_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_POSTGRES_DSN", "")
+	t.Setenv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", "")
+	t.Setenv("CEREBRO_POSTGRES_MAX_IDLE_CONNS", "")
+	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_LIFETIME", "")
+	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_IDLE_TIME", "")
 	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_NEO4J_URI", "")
 	t.Setenv("CEREBRO_NEO4J_USERNAME", "")
 	t.Setenv("CEREBRO_NEO4J_PASSWORD", "")
 	t.Setenv("CEREBRO_NEO4J_DATABASE", "")
+	t.Setenv("CEREBRO_NEO4J_QUERY_TIMEOUT", "")
 	clearGraphAgentEnv(t)
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "")
@@ -73,13 +79,19 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", AppendLogDriverJetStream)
 	t.Setenv("CEREBRO_JETSTREAM_URL", "nats://127.0.0.1:4222")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "cerebro.events")
+	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "4s")
 	t.Setenv("CEREBRO_STATE_STORE_DRIVER", StateStoreDriverPostgres)
 	t.Setenv("CEREBRO_POSTGRES_DSN", "postgres://127.0.0.1:5432/cerebro?sslmode=disable")
+	t.Setenv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", "20")
+	t.Setenv("CEREBRO_POSTGRES_MAX_IDLE_CONNS", "5")
+	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_LIFETIME", "30m")
+	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_IDLE_TIME", "5m")
 	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", GraphStoreDriverNeo4j)
 	t.Setenv("CEREBRO_NEO4J_URI", "neo4j+s://example.databases.neo4j.io")
 	t.Setenv("CEREBRO_NEO4J_USERNAME", "neo4j")
 	t.Setenv("CEREBRO_NEO4J_PASSWORD", "test-password")
 	t.Setenv("CEREBRO_NEO4J_DATABASE", "cerebro")
+	t.Setenv("CEREBRO_NEO4J_QUERY_TIMEOUT", "45s")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_PROVIDER", "stub")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL", "claude-sonnet-4-6")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_SONNET", "anthropic.claude-sonnet-example")
@@ -119,11 +131,20 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.AppendLog.JetStreamSubjectPrefix != "cerebro.events" {
 		t.Fatalf("JetStreamSubjectPrefix = %q, want %q", cfg.AppendLog.JetStreamSubjectPrefix, "cerebro.events")
 	}
+	if cfg.AppendLog.JetStreamDrainTimeout != 4*time.Second {
+		t.Fatalf("JetStreamDrainTimeout = %v, want 4s", cfg.AppendLog.JetStreamDrainTimeout)
+	}
 	if cfg.StateStore.Driver != StateStoreDriverPostgres {
 		t.Fatalf("StateStore.Driver = %q, want %q", cfg.StateStore.Driver, StateStoreDriverPostgres)
 	}
+	if cfg.StateStore.PostgresMaxOpenConns != 20 || cfg.StateStore.PostgresMaxIdleConns != 5 || cfg.StateStore.PostgresConnMaxLifetime != 30*time.Minute || cfg.StateStore.PostgresConnMaxIdleTime != 5*time.Minute {
+		t.Fatalf("StateStore pool config = %#v", cfg.StateStore)
+	}
 	if cfg.GraphStore.Driver != GraphStoreDriverNeo4j {
 		t.Fatalf("GraphStore.Driver = %q, want %q", cfg.GraphStore.Driver, GraphStoreDriverNeo4j)
+	}
+	if cfg.GraphStore.Neo4jQueryTimeout != 45*time.Second {
+		t.Fatalf("Neo4jQueryTimeout = %v, want 45s", cfg.GraphStore.Neo4jQueryTimeout)
 	}
 	if cfg.GraphAgentLLM.Provider != "stub" || cfg.GraphAgentLLM.MaxTokens != 900 || cfg.GraphAgentLLM.Temperature != 0.25 {
 		t.Fatalf("GraphAgentLLM = %#v", cfg.GraphAgentLLM)
@@ -162,13 +183,19 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", "")
 	t.Setenv("CEREBRO_JETSTREAM_URL", "")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
+	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "")
 	t.Setenv("CEREBRO_STATE_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_POSTGRES_DSN", "")
+	t.Setenv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", "")
+	t.Setenv("CEREBRO_POSTGRES_MAX_IDLE_CONNS", "")
+	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_LIFETIME", "")
+	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_IDLE_TIME", "")
 	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_NEO4J_URI", "")
 	t.Setenv("CEREBRO_NEO4J_USERNAME", "")
 	t.Setenv("CEREBRO_NEO4J_PASSWORD", "")
 	t.Setenv("CEREBRO_NEO4J_DATABASE", "")
+	t.Setenv("CEREBRO_NEO4J_QUERY_TIMEOUT", "")
 	clearGraphAgentEnv(t)
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "")

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -94,7 +94,7 @@ func (s *Store) Ping(ctx context.Context) error {
 	if s == nil || s.driver == nil {
 		return errors.New("neo4j is not configured")
 	}
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		value, err := queryOneValue(ctx, tx, "RETURN 1 AS ok", nil)
 		if err != nil {
 			return nil, err
@@ -115,7 +115,7 @@ func (s *Store) Counts(ctx context.Context) (Counts, error) {
 		return Counts{}, err
 	}
 	var counts Counts
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		var err error
 		counts.Nodes, err = countQuery(ctx, tx, "MATCH (e:Entity) RETURN count(e)", nil)
 		if err != nil {
@@ -141,7 +141,7 @@ func (s *Store) RelationCounts(ctx context.Context, relations []string) (_ Relat
 		return RelationCounts{}, nil
 	}
 	counts := make(RelationCounts, len(relations))
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		result, err := tx.Run(ctx, `UNWIND $relations AS relation
 OPTIONAL MATCH ()-[r:RELATION]->()
 WHERE r.relation = relation
@@ -182,7 +182,7 @@ WHERE NOT (right.relation IN $suppressed_relations)
   AND NOT ((left.relation + '|' + right.relation) IN $suppressed_relation_pairs)
 RETURN src.urn, src.label, left.relation, mid.urn, mid.label, right.relation, dst.urn, dst.label
 ORDER BY src.urn, left.relation, mid.urn, right.relation, dst.urn LIMIT %d`, limit)
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		traversals = traversals[:0]
 		result, err := tx.Run(ctx, query, suppressedPathParams())
 		if err != nil {
@@ -224,7 +224,7 @@ WHERE NOT (right.relation IN $suppressed_relations)
   AND NOT ((left.relation + '|' + right.relation) IN $suppressed_relation_pairs)
 RETURN src.entity_type, left.relation, mid.entity_type, right.relation, dst.entity_type, count(*)
 ORDER BY count(*) DESC, src.entity_type, left.relation, mid.entity_type, right.relation, dst.entity_type LIMIT %d`, limit)
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		patterns = patterns[:0]
 		result, err := tx.Run(ctx, query, suppressedPathParams())
 		if err != nil {
@@ -263,7 +263,7 @@ func (s *Store) Topology(ctx context.Context) (Topology, error) {
 		{func(v int64) { topology.SinksOnly = v }, "MATCH (e:Entity) WHERE (:Entity)-[:RELATION]->(e) AND NOT (e)-[:RELATION]->(:Entity) RETURN count(e)"},
 		{func(v int64) { topology.Intermediates = v }, "MATCH (e:Entity) WHERE (:Entity)-[:RELATION]->(e) AND (e)-[:RELATION]->(:Entity) RETURN count(e)"},
 	}
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		for _, item := range queries {
 			value, err := countQuery(ctx, tx, item.query, nil)
 			if err != nil {
@@ -284,7 +284,7 @@ func (s *Store) IntegrityChecks(ctx context.Context) ([]IntegrityCheck, error) {
 		return nil, err
 	}
 	checks, queries := integrityCheckDefinitions()
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		for i, query := range queries {
 			actual, err := countQuery(ctx, tx, query, nil)
 			if err != nil {
@@ -325,7 +325,7 @@ WITH resource, finding
 ORDER BY finding.urn
 LIMIT $limit`
 	if request.DryRun {
-		value, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		value, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 			return queryOneValue(ctx, tx, query+`
 RETURN count(finding)`, params)
 		})
@@ -614,7 +614,7 @@ WITH collect(DISTINCT e) AS entities, count(DISTINCT rel) AS links
 `
 	if request.DryRun {
 		var matchedEntities, matchedLinks int64
-		if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 			result, err := tx.Run(ctx, query+`RETURN size(entities), links`, params)
 			if err != nil {
 				return nil, err
@@ -681,7 +681,7 @@ func (s *Store) CleanupEndpointOwnerIDLinks(ctx context.Context, request ports.P
 	query := endpointOwnerIDLinkCleanupQuery(conditions, request.DryRun)
 	if request.DryRun {
 		var matched int64
-		if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 			value, err := queryOneValue(ctx, tx, query, params)
 			if err != nil {
 				return nil, err
@@ -813,7 +813,7 @@ func (s *Store) GetEntityNeighborhood(ctx context.Context, rootURN string, limit
 		Neighbors: []*ports.NeighborhoodNode{},
 		Relations: []*ports.NeighborhoodRelation{},
 	}
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		neighborhood = &ports.EntityNeighborhood{
 			Neighbors: []*ports.NeighborhoodNode{},
 			Relations: []*ports.NeighborhoodRelation{},
@@ -873,7 +873,7 @@ func (s *Store) ExecuteReadCypher(ctx context.Context, request ports.CypherQuery
 		rowLimit = ports.MaxCypherQueryRows
 	}
 	var rows []ports.CypherRow
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		rows = nil
 		result, err := tx.Run(ctx, query, request.Params)
 		if err != nil {
@@ -917,7 +917,7 @@ func (s *Store) ExplainReadCypher(ctx context.Context, request ports.CypherQuery
 		return nil, err
 	}
 	var plan *ports.CypherPlan
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		result, err := tx.Run(ctx, "EXPLAIN "+query, request.Params)
 		if err != nil {
 			return nil, err
@@ -976,7 +976,7 @@ func (s *Store) GetIngestCheckpoint(ctx context.Context, id string) (IngestCheck
 	}
 	var checkpoint IngestCheckpoint
 	var found bool
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		checkpoint = IngestCheckpoint{}
 		found = false
 		result, err := tx.Run(ctx, `MATCH (c:IngestCheckpoint {id: $id})
@@ -1129,7 +1129,7 @@ func (s *Store) GetIngestRun(ctx context.Context, id string) (IngestRun, bool, e
 	}
 	var run IngestRun
 	var found bool
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		run = IngestRun{}
 		found = false
 		result, err := tx.Run(ctx, ingestRunReturnQuery("MATCH (r:IngestRun {id: $id})"), map[string]any{"id": normalizedID})
@@ -1183,7 +1183,7 @@ func (s *Store) ListIngestRuns(ctx context.Context, filter IngestRunFilter) (_ [
 	}
 	query := ingestRunReturnQuery(prefix) + fmt.Sprintf(" ORDER BY coalesce(r.started_at, '') DESC, r.id DESC LIMIT %d", limit)
 	var runs []IngestRun
-	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		runs = runs[:0]
 		result, err := tx.Run(ctx, query, params)
 		if err != nil {
@@ -1240,7 +1240,7 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *Store) read(ctx context.Context, work neo4jdriver.ManagedTransactionWork) (any, error) {
+func (s *Store) read(ctx context.Context, work func(context.Context, neo4jdriver.ManagedTransaction) (any, error)) (any, error) {
 	if s.queryTimeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, s.queryTimeout)
@@ -1248,7 +1248,9 @@ func (s *Store) read(ctx context.Context, work neo4jdriver.ManagedTransactionWor
 	}
 	session := s.driver.NewSession(ctx, neo4jdriver.SessionConfig{DatabaseName: s.database})
 	defer func() { _ = session.Close(ctx) }()
-	return session.ExecuteRead(ctx, work)
+	return session.ExecuteRead(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		return work(ctx, tx)
+	})
 }
 
 func (s *Store) write(ctx context.Context, work neo4jdriver.ManagedTransactionWork) (any, error) {

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -30,11 +31,13 @@ SET e.tenant_id = $tenant_id,
 RETURN coalesce(e.attributes_json, '{}'), coalesce(e.attributes_version, 0)`
 
 var errConcurrentAttributeMerge = errors.New("concurrent attribute merge")
+var mutatingCypherPattern = regexp.MustCompile(`(?i)\b(CREATE|MERGE|SET|DELETE|DETACH|REMOVE|DROP|LOAD\s+CSV)\b|\bCALL\s+(DB|APOC)\.`)
 
 // Store is a Neo4j/Aura-backed graph projection store implementation.
 type Store struct {
-	driver   neo4jdriver.DriverWithContext
-	database string
+	driver       neo4jdriver.DriverWithContext
+	database     string
+	queryTimeout time.Duration
 
 	mu          sync.Mutex
 	schemaReady bool
@@ -75,7 +78,7 @@ func Open(cfg config.GraphStoreConfig) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open neo4j: %w", err)
 	}
-	return &Store{driver: driver, database: database}, nil
+	return &Store{driver: driver, database: database, queryTimeout: cfg.Neo4jQueryTimeout}, nil
 }
 
 // CloseContext closes the underlying driver.
@@ -859,6 +862,9 @@ func (s *Store) ExecuteReadCypher(ctx context.Context, request ports.CypherQuery
 	if query == "" {
 		return nil, errors.New("cypher query is required")
 	}
+	if err := validateReadOnlyCypher(query); err != nil {
+		return nil, err
+	}
 	if err := s.requireConfigured(); err != nil {
 		return nil, err
 	}
@@ -903,6 +909,9 @@ func (s *Store) ExplainReadCypher(ctx context.Context, request ports.CypherQuery
 	query := strings.TrimSpace(request.Query)
 	if query == "" {
 		return nil, errors.New("cypher query is required")
+	}
+	if err := validateReadOnlyCypher(query); err != nil {
+		return nil, err
 	}
 	if err := s.requireConfigured(); err != nil {
 		return nil, err
@@ -1232,6 +1241,11 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 }
 
 func (s *Store) read(ctx context.Context, work neo4jdriver.ManagedTransactionWork) (any, error) {
+	if s.queryTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.queryTimeout)
+		defer cancel()
+	}
 	session := s.driver.NewSession(ctx, neo4jdriver.SessionConfig{DatabaseName: s.database})
 	defer func() { _ = session.Close(ctx) }()
 	return session.ExecuteRead(ctx, work)
@@ -1250,6 +1264,24 @@ func consume(ctx context.Context, tx neo4jdriver.ManagedTransaction, query strin
 	}
 	_, err = result.Consume(ctx)
 	return nil, err
+}
+
+func validateReadOnlyCypher(query string) error {
+	if match := mutatingCypherPattern.FindString(stripCypherComments(query)); match != "" {
+		return fmt.Errorf("read cypher must not contain mutating clause %q", strings.TrimSpace(match))
+	}
+	return nil
+}
+
+func stripCypherComments(query string) string {
+	lines := strings.Split(query, "\n")
+	for index, line := range lines {
+		if comment := strings.Index(line, "//"); comment >= 0 {
+			line = line[:comment]
+		}
+		lines[index] = line
+	}
+	return strings.Join(lines, "\n")
 }
 
 func queryOneValue(ctx context.Context, tx neo4jdriver.ManagedTransaction, query string, params map[string]any) (any, error) {

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1267,21 +1267,88 @@ func consume(ctx context.Context, tx neo4jdriver.ManagedTransaction, query strin
 }
 
 func validateReadOnlyCypher(query string) error {
-	if match := mutatingCypherPattern.FindString(stripCypherComments(query)); match != "" {
+	if match := mutatingCypherPattern.FindString(stripCypherNonCode(query)); match != "" {
 		return fmt.Errorf("read cypher must not contain mutating clause %q", strings.TrimSpace(match))
 	}
 	return nil
 }
 
-func stripCypherComments(query string) string {
-	lines := strings.Split(query, "\n")
-	for index, line := range lines {
-		if comment := strings.Index(line, "//"); comment >= 0 {
-			line = line[:comment]
+func stripCypherNonCode(query string) string {
+	var out strings.Builder
+	out.Grow(len(query))
+	for i := 0; i < len(query); {
+		if i+1 < len(query) && query[i] == '/' && query[i+1] == '/' {
+			i = writeCypherMaskedUntilNewline(&out, query, i)
+			continue
 		}
-		lines[index] = line
+		if i+1 < len(query) && query[i] == '/' && query[i+1] == '*' {
+			i = writeCypherMaskedBlockComment(&out, query, i)
+			continue
+		}
+		switch query[i] {
+		case '\'', '"', '`':
+			i = writeCypherMaskedQuoted(&out, query, i, query[i])
+		default:
+			out.WriteByte(query[i])
+			i++
+		}
 	}
-	return strings.Join(lines, "\n")
+	return out.String()
+}
+
+func writeCypherMaskedUntilNewline(out *strings.Builder, query string, start int) int {
+	for i := start; i < len(query); i++ {
+		if query[i] == '\n' {
+			out.WriteByte('\n')
+			return i + 1
+		}
+		out.WriteByte(' ')
+	}
+	return len(query)
+}
+
+func writeCypherMaskedBlockComment(out *strings.Builder, query string, start int) int {
+	for i := start; i < len(query); i++ {
+		if query[i] == '\n' {
+			out.WriteByte('\n')
+		} else {
+			out.WriteByte(' ')
+		}
+		if i > start && query[i-1] == '*' && query[i] == '/' {
+			return i + 1
+		}
+	}
+	return len(query)
+}
+
+func writeCypherMaskedQuoted(out *strings.Builder, query string, start int, quote byte) int {
+	out.WriteByte(' ')
+	for i := start + 1; i < len(query); i++ {
+		if query[i] == '\n' {
+			out.WriteByte('\n')
+		} else {
+			out.WriteByte(' ')
+		}
+		if query[i] == '\\' && quote != '`' && i+1 < len(query) {
+			i++
+			if query[i] == '\n' {
+				out.WriteByte('\n')
+			} else {
+				out.WriteByte(' ')
+			}
+			continue
+		}
+		if query[i] != quote {
+			continue
+		}
+		if i+1 < len(query) && query[i+1] == quote {
+			i++
+			out.WriteByte(' ')
+			continue
+		}
+		return i + 1
+	}
+	return len(query)
 }
 
 func queryOneValue(ctx context.Context, tx neo4jdriver.ManagedTransaction, query string, params map[string]any) (any, error) {

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -74,6 +74,10 @@ func TestValidateReadOnlyCypherRejectsMutatingClauses(t *testing.T) {
 		"MATCH (asset:Entity) RETURN asset",
 		"MATCH (n) RETURN n.tenant_id AS tenant_id",
 		"// SET in a comment\nMATCH (n) RETURN n",
+		"/* CREATE and REMOVE inside a block comment */\nMATCH (n) RETURN n",
+		"MATCH (n) RETURN 'SET password remediation by creating a ticket' AS remediation",
+		`MATCH (n) RETURN "DELETE stale permissions" AS remediation`,
+		"MATCH (n) RETURN `CREATE` AS quoted_identifier",
 	} {
 		if err := validateReadOnlyCypher(query); err != nil {
 			t.Fatalf("validateReadOnlyCypher(%q) error = %v, want nil", query, err)

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -59,6 +59,28 @@ func TestEndpointOwnerIDLinkCleanupQueryOrdersLimitedBatch(t *testing.T) {
 	}
 }
 
+func TestValidateReadOnlyCypherRejectsMutatingClauses(t *testing.T) {
+	for _, query := range []string{
+		"MATCH (n) SET n.seen = true RETURN n",
+		"MATCH (n) DETACH DELETE n",
+		"MERGE (n:Entity {urn: $urn}) RETURN n",
+		"CALL db.labels()",
+	} {
+		if err := validateReadOnlyCypher(query); err == nil {
+			t.Fatalf("validateReadOnlyCypher(%q) error = nil, want non-nil", query)
+		}
+	}
+	for _, query := range []string{
+		"MATCH (asset:Entity) RETURN asset",
+		"MATCH (n) RETURN n.tenant_id AS tenant_id",
+		"// SET in a comment\nMATCH (n) RETURN n",
+	} {
+		if err := validateReadOnlyCypher(query); err != nil {
+			t.Fatalf("validateReadOnlyCypher(%q) error = %v, want nil", query, err)
+		}
+	}
+}
+
 func TestIntegrityChecksIncludeOpenFindingPrimaryAnchorInvariant(t *testing.T) {
 	checks, queries := integrityCheckDefinitions()
 	if len(checks) != len(queries) {

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -389,7 +389,7 @@ func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 
 func projectedEntityAttributes(t *testing.T, ctx context.Context, store *Store, urn string) map[string]string {
 	t.Helper()
-	value, err := store.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	value, err := store.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		return queryOneValue(ctx, tx, "MATCH (e:Entity {urn: $urn}) RETURN e.attributes_json", map[string]any{"urn": urn})
 	})
 	if err != nil {
@@ -404,7 +404,7 @@ func projectedEntityAttributes(t *testing.T, ctx context.Context, store *Store, 
 
 func projectedLinkAttributes(t *testing.T, ctx context.Context, store *Store, link *ports.ProjectedLink) map[string]string {
 	t.Helper()
-	values, err := store.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	values, err := store.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		result, err := tx.Run(ctx, `MATCH (:Entity {urn: $from_urn})-[r:RELATION {relation: $relation}]->(:Entity {urn: $to_urn})
 RETURN count(r), collect(r.attributes_json)`, map[string]any{
 			"from_urn": link.FromURN,
@@ -439,7 +439,7 @@ RETURN count(r), collect(r.attributes_json)`, map[string]any{
 
 func neo4jProjectedLinkExists(t *testing.T, ctx context.Context, store *Store, link *ports.ProjectedLink) bool {
 	t.Helper()
-	value, err := store.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+	value, err := store.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		return queryOneValue(ctx, tx, `MATCH (:Entity {urn: $from_urn})-[r:RELATION {relation: $relation}]->(:Entity {urn: $to_urn}) RETURN count(r)`, map[string]any{
 			"from_urn": link.FromURN,
 			"relation": link.Relation,

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -7,12 +7,16 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
 
 const MaxBodyBytes = 8 << 20
 const DefaultTimeout = 30 * time.Second
+const DefaultRetryMaxAttempts = 3
+const DefaultRetryBackoff = 250 * time.Millisecond
+const MaxRetryAfter = 5 * time.Second
 
 type ClientOptions struct {
 	SourceID      string
@@ -20,6 +24,18 @@ type ClientOptions struct {
 	BaseTransport http.RoundTripper
 	AllowLoopback bool
 	LookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)
+}
+
+type RetryOptions struct {
+	MaxAttempts  int
+	Backoff      time.Duration
+	MaxBodyBytes int
+}
+
+type ResponseBody struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
 }
 
 func NewClient(options ClientOptions) *http.Client {
@@ -247,6 +263,81 @@ func IsLoopbackHost(host string) bool {
 
 func ReadLimitedBody(body io.Reader) ([]byte, error) {
 	return ReadLimitedBodyWithLimit(body, MaxBodyBytes)
+}
+
+func DoWithRetry(ctx context.Context, client *http.Client, req *http.Request, options RetryOptions) (ResponseBody, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	attempts := options.MaxAttempts
+	if attempts <= 0 {
+		attempts = DefaultRetryMaxAttempts
+	}
+	backoff := options.Backoff
+	if backoff <= 0 {
+		backoff = DefaultRetryBackoff
+	}
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		nextReq := req.Clone(ctx)
+		resp, err := client.Do(nextReq)
+		if err != nil {
+			lastErr = err
+		} else {
+			body, readErr := ReadLimitedBodyWithLimit(resp.Body, options.MaxBodyBytes)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				return ResponseBody{}, readErr
+			}
+			result := ResponseBody{StatusCode: resp.StatusCode, Header: resp.Header.Clone(), Body: body}
+			if attempt == attempts || !RetryableStatus(resp.StatusCode) {
+				return result, nil
+			}
+			if err := sleepRetry(ctx, retryDelay(resp.Header.Get("Retry-After"), backoff, attempt)); err != nil {
+				return ResponseBody{}, err
+			}
+			continue
+		}
+		if attempt == attempts {
+			return ResponseBody{}, lastErr
+		}
+		if err := sleepRetry(ctx, retryDelay("", backoff, attempt)); err != nil {
+			return ResponseBody{}, err
+		}
+	}
+	return ResponseBody{}, lastErr
+}
+
+func RetryableStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status == http.StatusBadGateway || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout || status >= 500
+}
+
+func retryDelay(rawRetryAfter string, backoff time.Duration, attempt int) time.Duration {
+	if seconds, err := strconv.Atoi(strings.TrimSpace(rawRetryAfter)); err == nil && seconds > 0 {
+		if delay := time.Duration(seconds) * time.Second; delay < MaxRetryAfter {
+			return delay
+		}
+		return MaxRetryAfter
+	}
+	delay := backoff
+	for i := 1; i < attempt; i++ {
+		delay *= 2
+	}
+	if delay > MaxRetryAfter {
+		return MaxRetryAfter
+	}
+	return delay
+}
+
+func sleepRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func ReadLimitedBodyWithLimit(body io.Reader, maxBytes int) ([]byte, error) {

--- a/internal/sourcehttp/safe_test.go
+++ b/internal/sourcehttp/safe_test.go
@@ -1,8 +1,12 @@
 package sourcehttp
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNormalizeBaseURLRejectsUnsafeHosts(t *testing.T) {
@@ -40,5 +44,46 @@ func TestReadLimitedBodyWithLimitRejectsCustomOversizedResponse(t *testing.T) {
 	_, err := ReadLimitedBodyWithLimit(strings.NewReader("abcdef"), 5)
 	if err == nil {
 		t.Fatal("ReadLimitedBodyWithLimit() error = nil, want oversized response error")
+	}
+}
+
+func TestDoWithRetryRetriesRetryableStatus(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts == 1 {
+			http.Error(w, "try again", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	resp, err := DoWithRetry(context.Background(), server.Client(), req, RetryOptions{Backoff: time.Nanosecond})
+	if err != nil {
+		t.Fatalf("DoWithRetry() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusOK || string(resp.Body) != `{"ok":true}` {
+		t.Fatalf("DoWithRetry() response = %d %q, want 200 body", resp.StatusCode, string(resp.Body))
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestDoWithRetryPreservesCustomBodyLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("abcdef"))
+	}))
+	defer server.Close()
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	if _, err := DoWithRetry(context.Background(), server.Client(), req, RetryOptions{MaxBodyBytes: 5}); err == nil {
+		t.Fatal("DoWithRetry() error = nil, want oversized response error")
 	}
 }

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -42,6 +42,18 @@ func Open(cfg config.StateStoreConfig) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open postgres: %w", err)
 	}
+	if cfg.PostgresMaxOpenConns > 0 {
+		db.SetMaxOpenConns(cfg.PostgresMaxOpenConns)
+	}
+	if cfg.PostgresMaxIdleConns > 0 {
+		db.SetMaxIdleConns(cfg.PostgresMaxIdleConns)
+	}
+	if cfg.PostgresConnMaxLifetime > 0 {
+		db.SetConnMaxLifetime(cfg.PostgresConnMaxLifetime)
+	}
+	if cfg.PostgresConnMaxIdleTime > 0 {
+		db.SetConnMaxIdleTime(cfg.PostgresConnMaxIdleTime)
+	}
 	return &Store{db: db}, nil
 }
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "@writer/cerebro-sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@writer/cerebro-sdk",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "check": "npm run typecheck && npm test",
     "test": "node --test test/*.mjs",
-    "typecheck": "npx --yes --package typescript tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "exports": {
     ".": {
@@ -30,5 +30,8 @@
       "types": "./src/jira.ts",
       "default": "./src/jira.js"
     }
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
   }
 }

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -282,22 +282,17 @@ func (s *Source) getJSON(ctx context.Context, settings settings, query url.Value
 			LookupIPAddrs: lookupIPAddrs(s),
 		})
 	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	body, err := sourcehttp.ReadLimitedBody(resp.Body)
+	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})
 	if err != nil {
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return decodeResponseError(s.options.SourceID, resp.StatusCode, body)
+		return decodeResponseError(s.options.SourceID, resp.StatusCode, resp.Body)
 	}
 	if target == nil {
 		return nil
 	}
-	if err := json.Unmarshal(body, target); err != nil {
+	if err := json.Unmarshal(resp.Body, target); err != nil {
 		return fmt.Errorf("decode %s response: %w", s.options.SourceID, err)
 	}
 	return nil

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -941,26 +941,18 @@ func (s *Source) getJSON(ctx context.Context, settings settings, requestPath str
 	} else {
 		client = oktaHTTPClientNoRedirect(client, s != nil && s.allowLoopbackBaseURL, oktaLookupIPAddrs(s))
 	}
-	resp, err := client.Do(req)
+	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{MaxBodyBytes: maxOktaBodyBytes})
 	if err != nil {
 		return nil, fmt.Errorf("request %s: %w", requestPath, err)
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
 	headers := resp.Header.Clone()
-
-	body, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxOktaBodyBytes)
-	if err != nil {
-		return headers, fmt.Errorf("read %s response: %w", requestPath, err)
-	}
 	if resp.StatusCode >= http.StatusMultipleChoices {
-		return headers, decodeResponseError(resp.StatusCode, body)
+		return headers, decodeResponseError(resp.StatusCode, resp.Body)
 	}
-	if target == nil || len(body) == 0 {
+	if target == nil || len(resp.Body) == 0 {
 		return headers, nil
 	}
-	if err := json.Unmarshal(body, target); err != nil {
+	if err := json.Unmarshal(resp.Body, target); err != nil {
 		return headers, fmt.Errorf("decode %s response: %w", requestPath, err)
 	}
 	return headers, nil

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -66,6 +66,42 @@ func TestOpenAPIContractDescribesCurrentBootstrapSurface(t *testing.T) {
 	}
 }
 
+func TestSDKHTTPRoutesExistInOpenAPI(t *testing.T) {
+	root := repoRoot(t)
+	openAPI, err := os.ReadFile(filepath.Join(root, "api", "openapi.yaml"))
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	contracts := map[string][]string{
+		filepath.Join("sdk", "typescript", "src", "index.ts"): {
+			"/source-runtimes/{runtimeID}:",
+			"/source-runtimes/{runtimeID}/claims:",
+			"/platform/graph/neighborhood:",
+		},
+		filepath.Join("sdk", "python", "cerebro_sdk", "client.py"): {
+			"/source-runtimes/{runtimeID}:",
+			"/source-runtimes/{runtimeID}/claims:",
+			"/platform/graph/neighborhood:",
+		},
+	}
+	for rel, routes := range contracts {
+		body, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		for _, route := range routes {
+			if !bytes.Contains(openAPI, []byte("  "+route)) {
+				t.Fatalf("api/openapi.yaml missing SDK route %s required by %s", route, rel)
+			}
+		}
+		for _, marker := range []string{"/source-runtimes/", "/platform/graph/neighborhood"} {
+			if !bytes.Contains(body, []byte(marker)) {
+				t.Fatalf("%s no longer references expected SDK route marker %q; update SDK route parity guardrail", rel, marker)
+			}
+		}
+	}
+}
+
 func TestSourceCDKOwnsExternalHTTPClients(t *testing.T) {
 	root := repoRoot(t)
 	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {

--- a/tools/archtests/graph_store_guardrails_test.go
+++ b/tools/archtests/graph_store_guardrails_test.go
@@ -294,7 +294,7 @@ func TestGraphStoreConfigExposesApprovedFields(t *testing.T) {
 		}
 		return false
 	})
-	want := []string{"Driver", "Neo4jURI", "Neo4jUsername", "Neo4jPassword", "Neo4jDatabase"}
+	want := []string{"Driver", "Neo4jURI", "Neo4jUsername", "Neo4jPassword", "Neo4jDatabase", "Neo4jQueryTimeout"}
 	if strings.Join(fields, ",") != strings.Join(want, ",") {
 		t.Fatalf("GraphStoreConfig fields = %v, want exactly %v", fields, want)
 	}


### PR DESCRIPTION
## Summary
- Expand OpenAPI schemas for SDK-backed source runtime, claims, and graph neighborhood routes, plus add SDK route parity guardrails.
- Add runtime dependency hardening for Postgres pools, Neo4j read query timeout/validation, JetStream reconnect/drain, source HTTP retries, and startup job shutdown waits.
- Pin TypeScript SDK tooling and add release/Docker/developer smoke targets wired into CI/release verification.

## Test plan
- go test ./cmd/cerebro ./internal/config ./internal/sourcehttp ./internal/graphstore/neo4j ./internal/statestore/postgres ./internal/appendlog/jetstream ./sources/internal/jsonapi ./sources/okta ./tools/archtests
- make sdk-test openapi-check openapi-lint release-smoke
- make docker-smoke


Made with [Cursor](https://cursor.com)