### PR TITLE
fix: harden MCP spec compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
             command: make test
           - name: sdk
             command: make sdk-test
+          - name: mcp
+            command: make mcp-contract-check mcp-sdk-compat
           - name: lint
             command: make lint
           - name: proto

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ vendor/
 # Go
 *.test
 go.work
+tmp/
 
 # Environment
 .env

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check readme-check oss-audit govulncheck docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check readme-check oss-audit govulncheck docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -35,6 +35,9 @@ GRAPH_REBUILD_PAGE_LIMIT ?= 1
 GRAPH_REBUILD_EVENT_LIMIT ?= 100
 GRAPH_REBUILD_PREVIEW_LIMIT ?= 10
 CANDIDATE_SMOKE_EVENT_LIMIT ?= 25
+MCP_SDK_ROOT ?= tmp/mcp-sdk-compat
+MCP_SDK_PACKAGE ?= @modelcontextprotocol/sdk@latest
+MCP_SDK_TEST_TOKEN ?= mcp-sdk-test-key
 DROID_REVIEW_BASE ?= origin/main
 DROID_REVIEW_HEAD ?= HEAD
 DROID_PREFLIGHT_JSON_OUT ?= tmp/droid-preflight.json
@@ -115,6 +118,25 @@ graph-rebuild-dryrun: build
 candidate-smoke:
 	@if [ -z "$(RUNTIME_ID)" ]; then echo "RUNTIME_ID is required, e.g. make candidate-smoke RUNTIME_ID=writer-okta-audit RULE_ID=rule-id CEREBRO_BASE_URL=https://..." >&2; exit 2; fi
 	CEREBRO_CANDIDATE_SMOKE_RUNTIME_ID="$(RUNTIME_ID)" CEREBRO_CANDIDATE_SMOKE_RULE_ID="$(RULE_ID)" CEREBRO_CANDIDATE_SMOKE_EVENT_LIMIT="$(CANDIDATE_SMOKE_EVENT_LIMIT)" python3 scripts/candidate_smoke.py
+
+mcp-contract-check:
+	python3 scripts/mcp_contract_check.py
+
+mcp-smoke:
+	python3 scripts/mcp_smoke.py
+
+mcp-sdk-compat: build
+	@set -e; \
+	mkdir -p "$(MCP_SDK_ROOT)"; \
+	if [ ! -f "$(MCP_SDK_ROOT)/package.json" ]; then printf '%s\n' '{"type":"module","private":true}' > "$(MCP_SDK_ROOT)/package.json"; fi; \
+	npm install --prefix "$(MCP_SDK_ROOT)" --no-audit --no-fund "$(MCP_SDK_PACKAGE)"; \
+	port=$$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'); \
+	log="tmp/mcp-sdk-compat-server.log"; \
+	CEREBRO_HTTP_ADDR="127.0.0.1:$$port" CEREBRO_API_AUTH_ENABLED=true CEREBRO_API_KEYS="$(MCP_SDK_TEST_TOKEN):mcp-sdk:writer" ./bin/cerebro serve > "$$log" 2>&1 & pid=$$!; \
+	trap 'kill "$$pid" >/dev/null 2>&1 || true; wait "$$pid" >/dev/null 2>&1 || true' EXIT; \
+	for _ in $$(seq 1 50); do python3 -c 'import sys, urllib.request; url=sys.argv[1]; urllib.request.urlopen(url, timeout=0.5).read()' "http://127.0.0.1:$$port/health" >/dev/null 2>&1 && break; sleep 0.1; done; \
+	CEREBRO_BASE_URL="http://127.0.0.1:$$port" CEREBRO_MCP_BEARER_TOKEN="$(MCP_SDK_TEST_TOKEN)" python3 scripts/mcp_smoke.py --skip-unauthenticated-check; \
+	CEREBRO_MCP_URL="http://127.0.0.1:$$port/api/v1/mcp" CEREBRO_MCP_BEARER_TOKEN="$(MCP_SDK_TEST_TOKEN)" CEREBRO_MCP_SDK_ROOT="$(CURDIR)/$(MCP_SDK_ROOT)" node scripts/mcp_sdk_compat.mjs
 
 lint: lint-bootstrap
 	$(GOLANGCI_LINT) run --timeout 5m $(APP_PACKAGES)
@@ -234,4 +256,4 @@ check-arch:
 
 check-hook-integrity: check-arch
 
-verify: build test sdk-test lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check detection-catalog-check readme-check oss-audit release-smoke check-structural check-structural-test check-arch
+verify: build test sdk-test mcp-contract-check mcp-sdk-compat lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check detection-catalog-check readme-check oss-audit release-smoke check-structural check-structural-test check-arch

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -64,16 +64,12 @@ paths:
           description: Embedded OpenAPI YAML.
   /api/v1/mcp:
     get:
-      summary: Open MCP Streamable HTTP event stream
+      summary: Reject MCP stateful event-stream transport
       tags:
         - MCP
       responses:
-        '200':
-          description: MCP server-sent event stream.
-          content:
-            text/event-stream:
-              schema:
-                type: string
+        '405':
+          description: Cerebro's MCP route is stateless Streamable HTTP over POST only; GET is not an SSE endpoint.
     post:
       summary: Invoke MCP JSON-RPC method
       tags:
@@ -93,6 +89,14 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+        '202':
+          description: Accepted MCP notification or client message with no response body.
+        '400':
+          description: Unsupported or invalid MCP protocol version.
+        '401':
+          description: Authentication is required.
+        '403':
+          description: Request origin or authorization scope is not allowed.
   /sources:
     get:
       summary: List registered sources

--- a/docs/MCP_DROID_SETUP.md
+++ b/docs/MCP_DROID_SETUP.md
@@ -157,6 +157,7 @@ Useful local validation:
 ```bash
 go test ./internal/bootstrap -run 'TestMCP' -count=1
 go test ./internal/bootstrap -count=1
+make mcp-contract-check mcp-sdk-compat
 make lint-bootstrap openapi-check openapi-lint
 ```
 
@@ -215,6 +216,12 @@ For native Droid validation, verify both:
 
 - OAuth authentication completes.
 - The server reconnects as `connected` and tool listing is populated.
+
+For a deployed endpoint with a short-lived bearer/API token available locally, run:
+
+```bash
+CEREBRO_BASE_URL=https://<cerebro-origin> CEREBRO_MCP_BEARER_TOKEN=<redacted> scripts/mcp_smoke.py
+```
 
 ## Security notes
 

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -19,6 +19,7 @@ import (
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourceruntime"
+	"github.com/writer/cerebro/internal/telemetry"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -182,13 +183,16 @@ type mcpRiskReasonCount struct {
 }
 
 func (app *App) handleMCP(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		mcpTelemetryEvent(r, "", "", http.StatusMethodNotAllowed, 0, "http_method", time.Since(started))
 		return
 	}
 	if !app.mcpValidOrigin(r) {
 		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		mcpTelemetryEvent(r, "", "", http.StatusForbidden, 0, "origin_forbidden", time.Since(started))
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
@@ -200,18 +204,27 @@ func (app *App) handleMCP(w http.ResponseWriter, r *http.Request) {
 			JSONRPC: "2.0",
 			Error:   &mcpError{Code: -32700, Message: "parse error"},
 		})
+		mcpTelemetryEvent(r, "", "", http.StatusOK, -32700, "parse_error", time.Since(started))
 		return
 	}
 	if request.Method == "" && (len(request.Result) != 0 || request.Error != nil) {
 		w.WriteHeader(http.StatusAccepted)
+		mcpTelemetryEvent(r, "", "", http.StatusAccepted, 0, "client_message", time.Since(started))
 		return
 	}
 	if len(request.ID) == 0 && strings.TrimSpace(request.Method) != "" {
 		w.WriteHeader(http.StatusAccepted)
+		mcpTelemetryEvent(r, request.Method, mcpToolNameFromParams(request.Method, request.Params), http.StatusAccepted, 0, "notification", time.Since(started))
+		return
+	}
+	if request.Method != "initialize" && !mcpSupportedProtocolVersion(strings.TrimSpace(r.Header.Get("MCP-Protocol-Version"))) {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		mcpTelemetryEvent(r, request.Method, mcpToolNameFromParams(request.Method, request.Params), http.StatusBadRequest, -32600, "unsupported_protocol_version", time.Since(started))
 		return
 	}
 	response := app.handleMCPRequest(r, request)
 	mcpWriteJSONRPC(w, r, response)
+	mcpTelemetryEvent(r, request.Method, mcpToolNameFromParams(request.Method, request.Params), http.StatusOK, mcpResponseErrorCode(response), mcpResponseOutcome(response), time.Since(started))
 }
 
 func (app *App) handleMCPStream(w http.ResponseWriter, r *http.Request) {
@@ -233,10 +246,6 @@ func (app *App) handleMCPRequest(r *http.Request, request mcpJSONRPCRequest) mcp
 	}
 	if request.JSONRPC != "2.0" || strings.TrimSpace(request.Method) == "" {
 		response.Error = &mcpError{Code: -32600, Message: "invalid request"}
-		return response
-	}
-	if request.Method != "initialize" && !mcpSupportedProtocolVersion(strings.TrimSpace(r.Header.Get("MCP-Protocol-Version"))) {
-		response.Error = &mcpError{Code: -32600, Message: "unsupported protocol version"}
 		return response
 	}
 	if err := authorizeMCPMethodScope(r.Context(), request.Method); err != nil {
@@ -1164,7 +1173,7 @@ func mcpTools() []mcpTool {
 				"runtime_id": map[string]any{"type": "string"},
 				"tenant_id":  map[string]any{"type": "string"},
 				"source_id":  map[string]any{"type": "string"},
-				"limit":      map[string]any{"type": "integer", "minimum": 1},
+				"limit":      mcpLimitSchema(maxMCPListLimit, "runtimes"),
 			}, nil),
 			OutputSchema: mcpOutputSchema(map[string]any{"runtimes": map[string]any{"type": "array"}}),
 			Annotations:  mcpReadOnlyAnnotations("List Source Runtimes"),
@@ -1182,7 +1191,7 @@ func mcpTools() []mcpTool {
 				"resource_urn": map[string]any{"type": "string"},
 				"event_id":     map[string]any{"type": "string"},
 				"policy_id":    map[string]any{"type": "string"},
-				"limit":        map[string]any{"type": "integer", "minimum": 1},
+				"limit":        mcpLimitSchema(maxMCPListLimit, "findings"),
 				"order":        map[string]any{"type": "string", "enum": []string{"last_observed", "priority", "risk_score"}},
 			}, []string{"runtime_id"}),
 			OutputSchema: mcpOutputSchema(map[string]any{"findings": map[string]any{"type": "array"}}),
@@ -1212,7 +1221,7 @@ func mcpTools() []mcpTool {
 				"resource_urn": map[string]any{"type": "string"},
 				"event_id":     map[string]any{"type": "string"},
 				"policy_id":    map[string]any{"type": "string"},
-				"limit":        map[string]any{"type": "integer", "minimum": 1, "maximum": maxMCPListLimit},
+				"limit":        mcpLimitSchema(maxMCPListLimit, "findings"),
 			}, nil),
 			OutputSchema: mcpOutputSchema(map[string]any{"findings": map[string]any{"type": "array"}}),
 			Annotations:  mcpReadOnlyAnnotations("Search Findings"),
@@ -1240,7 +1249,7 @@ func mcpTools() []mcpTool {
 				"event_id":       map[string]any{"type": "string"},
 				"graph_root_urn": map[string]any{"type": "string"},
 				"graph_path_urn": map[string]any{"type": "string"},
-				"limit":          map[string]any{"type": "integer", "minimum": 1, "maximum": maxMCPEvidenceLimit},
+				"limit":          mcpLimitSchema(maxMCPEvidenceLimit, "evidence records"),
 			}, []string{"runtime_id"}),
 			OutputSchema: mcpOutputSchema(map[string]any{"evidence": map[string]any{"type": "array"}}),
 			Annotations:  mcpReadOnlyAnnotations("List Finding Evidence"),
@@ -1265,7 +1274,7 @@ func mcpTools() []mcpTool {
 				"entity_type": map[string]any{"type": "string"},
 				"tenant_id":   map[string]any{"type": "string"},
 				"runtime_id":  map[string]any{"type": "string"},
-				"limit":       map[string]any{"type": "integer", "minimum": 1, "maximum": maxMCPAssetLimit},
+				"limit":       mcpLimitSchema(maxMCPAssetLimit, "assets"),
 			}, nil),
 			OutputSchema: mcpOutputSchema(map[string]any{"assets": map[string]any{"type": "array"}}),
 			Annotations:  mcpReadOnlyAnnotations("Search Assets"),
@@ -1288,7 +1297,7 @@ func mcpTools() []mcpTool {
 				"tenant_id":  map[string]any{"type": "string"},
 				"runtime_id": map[string]any{"type": "string"},
 				"status":     map[string]any{"type": "string", "enum": []string{"open", "resolved", "suppressed"}},
-				"limit":      map[string]any{"type": "integer", "minimum": 1, "maximum": maxMCPRiskLimit},
+				"limit":      mcpLimitSchema(maxMCPRiskLimit, "risk findings"),
 			}, nil),
 			OutputSchema: mcpOutputSchema(nil),
 			Annotations:  mcpReadOnlyAnnotations("Risk Summary"),
@@ -1299,7 +1308,7 @@ func mcpTools() []mcpTool {
 			Description: "Return a bounded graph neighborhood around a Cerebro URN visible to the authenticated caller.",
 			InputSchema: mcpObjectSchema(map[string]any{
 				"root_urn": map[string]any{"type": "string"},
-				"limit":    map[string]any{"type": "integer", "minimum": 1},
+				"limit":    mcpLimitSchema(maxMCPNeighborhoodLimit, "graph neighbors"),
 			}, []string{"root_urn"}),
 			OutputSchema: mcpOutputSchema(nil),
 			Annotations:  mcpReadOnlyAnnotations("Graph Neighborhood"),
@@ -1314,7 +1323,7 @@ func mcpTools() []mcpTool {
 				"identifier": map[string]any{"type": "string"},
 				"root_urn":   map[string]any{"type": "string"},
 				"depth":      map[string]any{"type": "integer", "minimum": 1},
-				"limit":      map[string]any{"type": "integer", "minimum": 1},
+				"limit":      mcpLimitSchema(maxMCPImpactLimit, "impact rows"),
 			}, nil),
 			OutputSchema: mcpOutputSchema(nil),
 			Annotations:  mcpReadOnlyAnnotations("Graph Impact"),
@@ -1326,7 +1335,7 @@ func mcpTools() []mcpTool {
 			InputSchema: mcpObjectSchema(map[string]any{
 				"tenant_id":  map[string]any{"type": "string"},
 				"account_id": map[string]any{"type": "string"},
-				"limit":      map[string]any{"type": "integer", "minimum": 1, "maximum": maxMCPGraphLimit},
+				"limit":      mcpLimitSchema(maxMCPGraphLimit, "attack path rows"),
 			}, nil),
 			OutputSchema: mcpOutputSchema(nil),
 			Annotations:  mcpReadOnlyAnnotations("Graph Attack Paths"),
@@ -1337,8 +1346,8 @@ func mcpTools() []mcpTool {
 			Description: "Bundle finding, evidence, assets, and graph context for one finding so an agent can investigate without many round trips.",
 			InputSchema: mcpObjectSchema(map[string]any{
 				"finding_id":  map[string]any{"type": "string"},
-				"limit":       map[string]any{"type": "integer", "minimum": 1, "maximum": maxMCPEvidenceLimit},
-				"asset_limit": map[string]any{"type": "integer", "minimum": 1, "maximum": maxMCPAssetLimit},
+				"limit":       mcpLimitSchema(maxMCPEvidenceLimit, "evidence records"),
+				"asset_limit": mcpLimitSchema(maxMCPAssetLimit, "related assets"),
 				"skip_graph":  map[string]any{"type": "boolean"},
 				"compact":     map[string]any{"type": "boolean"},
 			}, []string{"finding_id"}),
@@ -1426,6 +1435,15 @@ func mcpOutputSchema(properties map[string]any) map[string]any {
 	}
 }
 
+func mcpLimitSchema(max int, itemName string) map[string]any {
+	return map[string]any{
+		"type":        "integer",
+		"minimum":     1,
+		"maximum":     max,
+		"description": fmt.Sprintf("Maximum %s to return. Values above %d are clamped.", itemName, max),
+	}
+}
+
 func cloneMCPProperties(properties map[string]any) map[string]any {
 	cloned := make(map[string]any, len(properties)+1)
 	for key, value := range properties {
@@ -1442,6 +1460,95 @@ func mcpReadOnlyAnnotations(title string) map[string]any {
 		"idempotentHint":  true,
 		"openWorldHint":   true,
 	}
+}
+
+func mcpTelemetryEvent(r *http.Request, method string, tool string, statusCode int, jsonRPCErrorCode int, outcome string, duration time.Duration) {
+	if r == nil {
+		return
+	}
+	method = mcpSanitizeTelemetryValue(method, 96)
+	tool = mcpSanitizeTelemetryValue(tool, 128)
+	outcome = mcpSanitizeTelemetryValue(outcome, 64)
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "http.method", Value: r.Method},
+		telemetry.Field{Key: "http.route", Value: "POST /api/v1/mcp"},
+		telemetry.Field{Key: "http.status_code", Value: statusCode},
+		telemetry.Field{Key: "mcp.method", Value: method},
+		telemetry.Field{Key: "mcp.outcome", Value: outcome},
+		telemetry.Field{Key: "mcp.protocol_version", Value: mcpSanitizeTelemetryValue(r.Header.Get("MCP-Protocol-Version"), 32)},
+		telemetry.Field{Key: "duration_ms", Value: duration.Milliseconds()},
+	)
+	if tool != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "mcp.tool", Value: tool})
+	}
+	if jsonRPCErrorCode != 0 {
+		attrs = attrs.WithField(telemetry.Field{Key: "mcp.jsonrpc_error_code", Value: jsonRPCErrorCode})
+	}
+	if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok {
+		if tenantID := strings.TrimSpace(auth.principal.TenantID); tenantID != "" {
+			attrs = attrs.WithField(telemetry.Field{Key: "tenant_id", Value: mcpSanitizeTelemetryValue(tenantID, 128)})
+		}
+		if principal := strings.TrimSpace(auth.principal.Name); principal != "" {
+			attrs = attrs.WithField(telemetry.Field{Key: "principal", Value: mcpSanitizeTelemetryValue(principal, 128)})
+		}
+	}
+	telemetry.Event(r.Context(), "cerebro.mcp.request", attrs)
+}
+
+func mcpResponseErrorCode(response mcpJSONRPCResponse) int {
+	if response.Error == nil {
+		return 0
+	}
+	return response.Error.Code
+}
+
+func mcpResponseOutcome(response mcpJSONRPCResponse) string {
+	if response.Error != nil {
+		return mcpJSONRPCErrorOutcome(response.Error)
+	}
+	return "ok"
+}
+
+func mcpJSONRPCErrorOutcome(err *mcpError) string {
+	if err == nil {
+		return "ok"
+	}
+	switch err.Code {
+	case -32700:
+		return "parse_error"
+	case -32600:
+		return "invalid_request"
+	case -32601:
+		return "method_not_found"
+	case -32602:
+		return "invalid_params"
+	default:
+		return "jsonrpc_error"
+	}
+}
+
+func mcpToolNameFromParams(method string, rawParams json.RawMessage) string {
+	if method != "tools/call" || len(rawParams) == 0 {
+		return ""
+	}
+	var params mcpToolCallParams
+	if err := decodeMCPJSON(rawParams, &params); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(params.Name)
+}
+
+func mcpSanitizeTelemetryValue(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	replacer := strings.NewReplacer("\n", " ", "\r", " ", "\t", " ")
+	value = replacer.Replace(value)
+	if limit > 0 && len(value) > limit {
+		value = value[:limit]
+	}
+	return value
 }
 
 func mcpResources() []mcpResource {
@@ -2279,24 +2386,47 @@ func mcpWriteJSONRPC(w http.ResponseWriter, r *http.Request, response mcpJSONRPC
 func mcpNegotiatedProtocolVersion(r *http.Request, rawParams json.RawMessage) string {
 	version := strings.TrimSpace(r.Header.Get("MCP-Protocol-Version"))
 	if mcpSupportedProtocolVersion(version) && version != "" {
-		return version
+		return mcpFirstProtocolVersion(version)
 	}
 	params := map[string]any{}
 	if len(rawParams) != 0 && decodeMCPJSON(rawParams, &params) == nil {
 		if requested := mcpStringArg(params, "protocolVersion"); mcpSupportedProtocolVersion(requested) && requested != "" {
-			return requested
+			return mcpFirstProtocolVersion(requested)
 		}
 	}
 	return mcpProtocolVersion
 }
 
 func mcpSupportedProtocolVersion(version string) bool {
-	switch strings.TrimSpace(version) {
-	case "", mcpProtocolVersion, "2025-06-18", "2025-03-26":
+	version = strings.TrimSpace(version)
+	if version == "" {
 		return true
-	default:
-		return false
 	}
+	sawVersion := false
+	values := strings.Split(version, ",")
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		sawVersion = true
+		switch strings.TrimSpace(value) {
+		case mcpProtocolVersion, "2025-06-18", "2025-03-26":
+			continue
+		default:
+			return false
+		}
+	}
+	return sawVersion
+}
+
+func mcpFirstProtocolVersion(version string) string {
+	for _, value := range strings.Split(strings.TrimSpace(version), ",") {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (app *App) mcpValidOrigin(r *http.Request) bool {

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -166,6 +166,105 @@ func TestMCPStatelessGETIsNotSSEEndpoint(t *testing.T) {
 	}
 }
 
+func TestMCPRejectsUnsupportedProtocolVersionWithHTTPBadRequest(t *testing.T) {
+	server := newMCPTestServer(t, &stubRuntimeStore{})
+	defer server.Close()
+
+	request := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+		"params":  map[string]any{},
+	}
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal MCP request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, server.URL+mcpEndpointPath, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest POST MCP: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("MCP-Protocol-Version", "2099-01-01")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/v1/mcp error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("POST /api/v1/mcp status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestMCPSupportsDuplicateCompatibleProtocolHeaders(t *testing.T) {
+	server := newMCPTestServer(t, &stubRuntimeStore{})
+	defer server.Close()
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+		"params":  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("marshal MCP request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, server.URL+mcpEndpointPath, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest POST MCP: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("MCP-Protocol-Version", mcpProtocolVersion)
+	req.Header.Add("MCP-Protocol-Version", mcpProtocolVersion)
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/v1/mcp error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /api/v1/mcp status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestMCPNotificationReturnsAcceptedEmptyBody(t *testing.T) {
+	server := newMCPTestServer(t, &stubRuntimeStore{})
+	defer server.Close()
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+		"params":  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("marshal MCP notification: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, server.URL+mcpEndpointPath, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest POST MCP: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("MCP-Protocol-Version", mcpProtocolVersion)
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/v1/mcp notification error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("POST /api/v1/mcp notification status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read notification response: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("notification response body = %q, want empty", data)
+	}
+}
+
 func TestMCPResourcesAndPrompts(t *testing.T) {
 	server := newMCPTestServer(t, &stubRuntimeStore{})
 	defer server.Close()
@@ -1246,12 +1345,8 @@ func TestMCPOriginProtocolAndNotificationHandling(t *testing.T) {
 		t.Fatalf("unsupported protocol POST error = %v", err)
 	}
 	defer func() { _ = unsupportedResp.Body.Close() }()
-	var unsupported map[string]any
-	if err := json.NewDecoder(unsupportedResp.Body).Decode(&unsupported); err != nil {
-		t.Fatalf("Decode unsupported protocol: %v", err)
-	}
-	if unsupported["error"].(map[string]any)["message"] != "unsupported protocol version" {
-		t.Fatalf("unsupported response = %#v", unsupported)
+	if unsupportedResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unsupported protocol status = %d, want %d", unsupportedResp.StatusCode, http.StatusBadRequest)
 	}
 
 	notificationReq, err := http.NewRequest(http.MethodPost, server.URL+mcpEndpointPath, strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`))

--- a/scripts/mcp_contract_check.py
+++ b/scripts/mcp_contract_check.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Detect drift between MCP implementation, OpenAPI, and Droid setup docs."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MCP_GO = ROOT / "internal" / "bootstrap" / "mcp.go"
+OPENAPI = ROOT / "api" / "openapi.yaml"
+DOCS = ROOT / "docs" / "MCP_DROID_SETUP.md"
+
+
+def main() -> int:
+    mcp_go = MCP_GO.read_text()
+    openapi = OPENAPI.read_text()
+    docs = DOCS.read_text()
+
+    failures: list[str] = []
+    require('mcpProtocolVersion          = "2025-11-25"' in mcp_go, "mcp.go protocol version must stay on 2025-11-25", failures)
+    require('w.Header().Set("Allow", http.MethodPost)' in mcp_go, "GET /api/v1/mcp must advertise POST only", failures)
+    require("http.StatusAccepted" in mcp_go, "MCP notifications must keep 202 Accepted handling", failures)
+    require("http.StatusBadRequest" in mcp_go and "unsupported_protocol_version" in mcp_go, "unsupported MCP protocol versions must remain HTTP 400-observable", failures)
+    require('"experimental"' not in mcp_go, "initialize capabilities must not reintroduce primitive experimental values", failures)
+
+    mcp_block = extract_path_block(openapi, "/api/v1/mcp:")
+    require("'405':" in mcp_block and "not an SSE endpoint" in mcp_block, "OpenAPI must document GET /api/v1/mcp as 405 non-SSE", failures)
+    require("'202':" in mcp_block and "'400':" in mcp_block, "OpenAPI must document MCP notification 202 and protocol-version 400 responses", failures)
+    require("text/event-stream" not in mcp_block, "OpenAPI MCP path must not advertise SSE event-stream content", failures)
+
+    for phrase in [
+        "protocolVersion\": \"2025-11-25\"",
+        "Fire-and-forget JSON-RPC notifications can return `202 Accepted`",
+        "`GET /api/v1/mcp` is not an SSE endpoint and returns `405 Method Not Allowed`",
+        "make mcp-contract-check mcp-sdk-compat",
+        "scripts/mcp_smoke.py",
+    ]:
+        require(phrase in docs, f"docs/MCP_DROID_SETUP.md missing {phrase!r}", failures)
+
+    if failures:
+        print("mcp_contract_check: failed", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("mcp_contract_check: ok")
+    return 0
+
+
+def extract_path_block(openapi: str, path_header: str) -> str:
+    match = re.search(rf"^  {re.escape(path_header)}\n(?P<body>(?:    .*\n|      .*\n|        .*\n|          .*\n|            .*\n|              .*\n|                .*\n)*)", openapi, re.MULTILINE)
+    return match.group("body") if match else ""
+
+
+def require(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mcp_sdk_compat.mjs
+++ b/scripts/mcp_sdk_compat.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const endpoint = process.env.CEREBRO_MCP_URL;
+const token = process.env.CEREBRO_MCP_BEARER_TOKEN;
+const sdkRoot = process.env.CEREBRO_MCP_SDK_ROOT || path.join(process.cwd(), "tmp", "mcp-sdk-compat");
+
+if (!endpoint) {
+  console.error("mcp_sdk_compat: CEREBRO_MCP_URL is required");
+  process.exit(2);
+}
+if (!token) {
+  console.error("mcp_sdk_compat: CEREBRO_MCP_BEARER_TOKEN is required");
+  process.exit(2);
+}
+
+const requireFromSdkRoot = createRequire(path.join(sdkRoot, "package.json"));
+const clientModule = await import(pathToFileURL(requireFromSdkRoot.resolve("@modelcontextprotocol/sdk/client/index.js")).href);
+const transportModule = await import(pathToFileURL(requireFromSdkRoot.resolve("@modelcontextprotocol/sdk/client/streamableHttp.js")).href);
+
+const { Client } = clientModule;
+const { StreamableHTTPClientTransport } = transportModule;
+
+const client = new Client({ name: "cerebro-mcp-sdk-compat", version: "0" });
+const transport = new StreamableHTTPClientTransport(new URL(endpoint), {
+  requestInit: {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  },
+});
+
+try {
+  await client.connect(transport);
+  const tools = await client.listTools();
+  const toolNames = new Set((tools.tools || []).map((tool) => tool.name));
+  if (!toolNames.has("cerebro.version")) {
+    throw new Error("tools/list missing cerebro.version");
+  }
+  const result = await client.callTool({ name: "cerebro.version", arguments: {} });
+  if (result?.isError) {
+    throw new Error("cerebro.version returned isError");
+  }
+  console.log(`mcp_sdk_compat: SDK connected and listed ${toolNames.size} tools`);
+} finally {
+  await client.close();
+}

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Smoke-test Cerebro's stateless MCP HTTP endpoint without printing secrets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+PROTOCOL_VERSION = "2025-11-25"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=os.environ.get("CEREBRO_MCP_URL", ""), help="MCP endpoint URL; defaults to CEREBRO_BASE_URL + /api/v1/mcp")
+    parser.add_argument("--base-url", default=os.environ.get("CEREBRO_BASE_URL", ""), help="Cerebro origin used when --url is omitted")
+    parser.add_argument("--bearer-token", default=os.environ.get("CEREBRO_MCP_BEARER_TOKEN", ""), help="Bearer/API token for authenticated MCP calls")
+    parser.add_argument("--skip-unauthenticated-check", action="store_true", help="Do not assert the unauthenticated OAuth challenge")
+    parser.add_argument("--skip-authenticated-check", action="store_true", help="Only check unauthenticated behavior")
+    args = parser.parse_args()
+
+    url = mcp_url(args.url, args.base_url)
+    if not url:
+        print("mcp_smoke: provide --url or CEREBRO_BASE_URL", file=sys.stderr)
+        return 2
+
+    if not args.skip_unauthenticated_check:
+        check_unauthenticated_challenge(url)
+
+    if args.skip_authenticated_check:
+        print("mcp_smoke: unauthenticated checks passed")
+        return 0
+
+    if not args.bearer_token:
+        print("mcp_smoke: --bearer-token or CEREBRO_MCP_BEARER_TOKEN is required for authenticated checks", file=sys.stderr)
+        return 2
+
+    check_authenticated_get(url, args.bearer_token)
+    init = rpc(url, args.bearer_token, 1, "initialize", {
+        "protocolVersion": PROTOCOL_VERSION,
+        "capabilities": {},
+        "clientInfo": {"name": "cerebro-mcp-smoke", "version": "0"},
+    })
+    result = init.get("result") or {}
+    capabilities = result.get("capabilities") or {}
+    experimental = capabilities.get("experimental")
+    if experimental is not None and not isinstance(experimental, dict):
+        raise SmokeError("initialize capabilities.experimental must be omitted or object-shaped")
+    if result.get("protocolVersion") != PROTOCOL_VERSION:
+        raise SmokeError(f"initialize negotiated {result.get('protocolVersion')!r}, want {PROTOCOL_VERSION!r}")
+
+    tools = rpc(url, args.bearer_token, 2, "tools/list", {"limit": 100}).get("result", {}).get("tools", [])
+    if not isinstance(tools, list) or len(tools) < 10:
+        raise SmokeError(f"tools/list returned {len(tools) if isinstance(tools, list) else 'non-list'} tools, want at least 10")
+    names = {tool.get("name") for tool in tools if isinstance(tool, dict)}
+    if "cerebro.version" not in names:
+        raise SmokeError("tools/list is missing cerebro.version")
+
+    version = rpc(url, args.bearer_token, 3, "tools/call", {"name": "cerebro.version", "arguments": {}})
+    if version.get("result", {}).get("isError") is True:
+        raise SmokeError("cerebro.version returned an MCP tool error")
+
+    bad_version_status, _, _ = request(url, "POST", json.dumps({
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/list",
+        "params": {},
+    }).encode(), auth=args.bearer_token, protocol_version="2099-01-01")
+    if bad_version_status != 400:
+        raise SmokeError(f"unsupported MCP-Protocol-Version status {bad_version_status}, want 400")
+
+    print(f"mcp_smoke: authenticated checks passed ({len(tools)} tools)")
+    return 0
+
+
+def mcp_url(url: str, base_url: str) -> str:
+    url = url.strip()
+    if url:
+        return url
+    base_url = base_url.strip().rstrip("/")
+    if not base_url:
+        return ""
+    return f"{base_url}/api/v1/mcp"
+
+
+def check_unauthenticated_challenge(url: str) -> None:
+    status, headers, _ = request(url, "POST", b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}')
+    if status != 401:
+        raise SmokeError(f"unauthenticated MCP status {status}, want 401")
+    challenge = headers.get("www-authenticate", "")
+    if "Bearer" not in challenge or "resource_metadata" not in challenge:
+        raise SmokeError("unauthenticated challenge is missing Bearer resource metadata")
+
+
+def check_authenticated_get(url: str, token: str) -> None:
+    status, headers, _ = request(url, "GET", auth=token)
+    if status != 405:
+        raise SmokeError(f"authenticated GET status {status}, want 405")
+    if headers.get("mcp-session-id"):
+        raise SmokeError("authenticated GET unexpectedly returned Mcp-Session-Id")
+    if headers.get("content-type", "").startswith("text/event-stream"):
+        raise SmokeError("authenticated GET unexpectedly advertised text/event-stream")
+
+
+def rpc(url: str, token: str, rpc_id: int, method: str, params: dict) -> dict:
+    payload = json.dumps({"jsonrpc": "2.0", "id": rpc_id, "method": method, "params": params}).encode()
+    status, headers, body = request(url, "POST", payload, auth=token)
+    if status != 200:
+        raise SmokeError(f"{method} status {status}, want 200")
+    if headers.get("mcp-session-id"):
+        raise SmokeError(f"{method} unexpectedly returned Mcp-Session-Id")
+    if not headers.get("content-type", "").startswith("application/json"):
+        raise SmokeError(f"{method} content-type {headers.get('content-type')!r}, want application/json")
+    try:
+        parsed = json.loads(body.decode())
+    except json.JSONDecodeError as exc:
+        raise SmokeError(f"{method} returned invalid JSON") from exc
+    if parsed.get("error"):
+        raise SmokeError(f"{method} returned JSON-RPC error code {parsed['error'].get('code')}")
+    return parsed
+
+
+def request(url: str, method: str, body: bytes | None = None, auth: str = "", protocol_version: str = PROTOCOL_VERSION) -> tuple[int, dict[str, str], bytes]:
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": protocol_version,
+        "User-Agent": "cerebro-mcp-smoke/0",
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    if auth:
+        headers["Authorization"] = f"Bearer {auth}"
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, normalize_headers(resp.headers), resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, normalize_headers(exc.headers), exc.read()
+    except urllib.error.URLError as exc:
+        raise SmokeError(f"request failed: {exc.reason}") from exc
+
+
+def normalize_headers(headers) -> dict[str, str]:
+    return {key.lower(): value for key, value in headers.items()}
+
+
+class SmokeError(RuntimeError):
+    pass
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SmokeError as exc:
+        print(f"mcp_smoke: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- harden MCP Streamable HTTP handling against current spec expectations: notification 202s, unsupported protocol-version HTTP 400s, duplicate compatible protocol headers, and no SSE/session drift
- add sanitized MCP request telemetry and richer limit descriptions in tool schemas
- add MCP contract, deploy smoke, and official SDK compatibility checks wired into Make/CI
- align OpenAPI and Droid setup docs with the stateless POST-only contract

## Validation
- go test ./internal/bootstrap -run 'TestMCP' -count=1
- make mcp-sdk-compat
- make test
- make sdk-test
- make lint
- make mcp-contract-check openapi-check openapi-lint readme-check oss-audit
