### PR TITLE
Harden contract and release guardrails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
+      is_stable_release: ${{ steps.resolve.outputs.is_stable_release }}
     steps:
       - name: Resolve release tag
         id: resolve
@@ -39,8 +40,14 @@ jobs:
             echo "ERROR: tag '${tag}' must match vMAJOR.MINOR.PATCH[-PRERELEASE]"
             exit 1
           fi
+          if [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            is_stable_release=true
+          else
+            is_stable_release=false
+          fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "Resolved release tag: ${tag}"
+          echo "is_stable_release=${is_stable_release}" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag: ${tag} (stable=${is_stable_release})"
 
   release-verify:
     name: Verify release (${{ matrix.name }})
@@ -54,10 +61,12 @@ jobs:
             command: make build
           - name: test
             command: make test
+          - name: sdk
+            command: make sdk-test
           - name: lint
             command: make lint
-          - name: proto-lint
-            command: make proto-lint
+          - name: proto
+            command: make proto-lint proto-generate-check proto-breaking
           - name: openapi
             command: make openapi-check openapi-lint
           - name: catalog
@@ -68,6 +77,8 @@ jobs:
             command: make oss-audit
           - name: release-smoke
             command: make release-smoke
+          - name: docker-smoke
+            command: make docker-smoke
           - name: structural
             command: make check-structural check-structural-test check-arch
     steps:
@@ -236,9 +247,13 @@ jobs:
             "${IMAGE_BASE}:${RELEASE_TAG}-amd64" \
             "${IMAGE_BASE}:${RELEASE_TAG}-arm64"
 
-          docker buildx imagetools create -t "${IMAGE_BASE}:latest" \
-            "${IMAGE_BASE}:${RELEASE_TAG}-amd64" \
-            "${IMAGE_BASE}:${RELEASE_TAG}-arm64"
+          if [ "${{ needs.resolve-tag.outputs.is_stable_release }}" = "true" ]; then
+            docker buildx imagetools create -t "${IMAGE_BASE}:latest" \
+              "${IMAGE_BASE}:${RELEASE_TAG}-amd64" \
+              "${IMAGE_BASE}:${RELEASE_TAG}-arm64"
+          else
+            echo "Skipping latest tag for prerelease ${RELEASE_TAG}"
+          fi
 
           digest="$(docker buildx imagetools inspect "${IMAGE_BASE}:${RELEASE_TAG}" --format '{{.Manifest.Digest}}')"
           if [ -z "${digest}" ]; then

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ docker-smoke:
 	mkdir -p .dist
 	CGO_ENABLED=0 GOOS=linux GOARCH="$(DOCKER_SMOKE_GOARCH)" go build -trimpath -o .dist/cerebro ./cmd/cerebro
 	docker build -f Dockerfile.runtime -t "$(DOCKER_SMOKE_IMAGE)" .
+	@test -n "$$(docker run --rm "$(DOCKER_SMOKE_IMAGE)" version)"
 
 release-smoke:
 	$(GORELEASER) check

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1807,7 +1807,8 @@ components:
             type: string
         ttl_seconds:
           type: integer
-          minimum: 1
+          minimum: 0
+          description: Optional override in seconds. Omit or set 0 to use the configured default TTL.
     IssueBootstrapTokenResponse:
       type: object
       required: [token_id, token, expires_at]

--- a/docs/API_CONTRACTS_AUTOGEN.md
+++ b/docs/API_CONTRACTS_AUTOGEN.md
@@ -4,7 +4,7 @@ Generated-by-hand snapshot for the current bootstrap service. Source of truth: `
 
 - HTTP operations: **68** across **66** paths.
 - Connect RPCs: **38**.
-- Public unauthenticated routes when auth is enabled: `/health`, `/healthz`, `/livez`, `/openapi.yaml`.
+- Public unauthenticated routes when auth is enabled: `/health`, `/healthz`, `/livez`, `/openapi.yaml`, OAuth metadata/authorization endpoints, `/.well-known/device-jwks.json`, `/platform/devices/enroll`, and `/platform/devices/token`.
 - Preferred shared platform namespace: `/platform/*`.
 - Legacy `/graph/*` compatibility aliases have been removed; use `/platform/graph/*`.
 
@@ -13,6 +13,7 @@ Generated-by-hand snapshot for the current bootstrap service. Source of truth: `
 | Family | Routes |
 | --- | --- |
 | Health/contracts | `/health` readiness, `/healthz` and `/livez` liveness, `/openapi.yaml` |
+| OAuth/device bootstrap | `/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`, `/oauth/authorize`, `/oauth/callback`, `/oauth/token`, `/oauth/revoke`, `/oauth/register`, `/.well-known/device-jwks.json`, `/platform/devices/enroll`, `/platform/devices/token` |
 | Sources | `/sources`, `/sources/{sourceID}/check`, `/sources/{sourceID}/discover`, `/sources/{sourceID}/read` |
 | Source runtimes | `/source-runtimes/{runtimeID}`, `/source-runtimes/{runtimeID}/sync`, `/source-runtimes/{runtimeID}/graph-ingest-runs` |
 | Claims/findings | `/source-runtimes/{runtimeID}/claims`, `/source-runtimes/{runtimeID}/findings`, finding lifecycle routes |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -16,6 +16,10 @@ Set `CEREBRO_API_AUTH_ENABLED=true` and pass `Authorization: Bearer <key>` or `X
 - `GET /healthz` - liveness-only process check.
 - `GET /livez` - liveness-only process check.
 - `GET /openapi.yaml`
+- `GET /.well-known/oauth-protected-resource` and `GET /.well-known/oauth-authorization-server` - MCP OAuth metadata.
+- `GET /oauth/authorize`, `GET /oauth/callback`, `POST /oauth/token`, `POST /oauth/revoke`, and `POST /oauth/register` - OAuth authorization-server endpoints.
+- `GET /.well-known/device-jwks.json` - public device-token signing keys.
+- `POST /platform/devices/enroll` and `POST /platform/devices/token` - unauthenticated device bootstrap/token exchange routes; requests are validated with bootstrap tokens, refresh tokens, DPoP, and rate limits.
 
 ## Preferred platform routes
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -3979,6 +3979,19 @@ func TestBackfillFindingRiskSkipsMissingStateStore(t *testing.T) {
 	}
 }
 
+func TestPublicCollectionRoutesRejectUndocumentedMethods(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, nil)
+	handler := app.Handler()
+	for _, path := range []string{"/health", "/healthz", "/livez", "/sources"} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		if resp.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("POST %s status = %d, want %d", path, resp.Code, http.StatusMethodNotAllowed)
+		}
+	}
+}
+
 func TestBootstrapHealthPingsUseTimeoutContext(t *testing.T) {
 	stateStore := &deadlineAwareStore{}
 	response := healthResponse(context.Background(), config.Config{ImageTag: "v9.9.9"}, Dependencies{StateStore: stateStore})

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -40,9 +40,9 @@ func (app *App) registerConnectRoutes(mux *http.ServeMux, cfg config.Config, dep
 }
 
 func (app *App) registerPublicRoutes(mux *http.ServeMux) {
-	registerHTTPRoute(mux, "/health", routeSurfacePublicHTTP, app.handleHealth)
-	registerHTTPRoute(mux, "/healthz", routeSurfacePublicHTTP, app.handleLiveness)
-	registerHTTPRoute(mux, "/livez", routeSurfacePublicHTTP, app.handleLiveness)
+	registerHTTPRoute(mux, "GET /health", routeSurfacePublicHTTP, app.handleHealth)
+	registerHTTPRoute(mux, "GET /healthz", routeSurfacePublicHTTP, app.handleLiveness)
+	registerHTTPRoute(mux, "GET /livez", routeSurfacePublicHTTP, app.handleLiveness)
 	registerHTTPRoute(mux, "GET /openapi.yaml", routeSurfacePublicHTTP, app.handleOpenAPI)
 }
 
@@ -92,7 +92,7 @@ func (app *App) registerFindingRoutes(mux *http.ServeMux) {
 }
 
 func (app *App) registerSourceRoutes(mux *http.ServeMux) {
-	registerHTTPRoute(mux, "/sources", routeSurfacePlatformHTTP, app.handleSources)
+	registerHTTPRoute(mux, "GET /sources", routeSurfacePlatformHTTP, app.handleSources)
 	registerHTTPRoute(mux, "GET /sources/{sourceID}/check", routeSurfacePlatformHTTP, app.handleCheckSource)
 	registerHTTPRoute(mux, "GET /sources/{sourceID}/discover", routeSurfacePlatformHTTP, app.handleDiscoverSource)
 	registerHTTPRoute(mux, "GET /sources/{sourceID}/read", routeSurfacePlatformHTTP, app.handleReadSource)
@@ -150,7 +150,7 @@ func (app *App) registerDeviceRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /platform/devices/bootstrap-tokens", routeSurfacePlatformHTTP, app.deviceHandler.handleIssueBootstrapToken)
 	registerHTTPRoute(mux, "POST /platform/devices/{deviceID}/revoke", routeSurfacePlatformHTTP, app.deviceHandler.handleRevoke)
 	registerHTTPRoute(mux, "POST /platform/telemetry/ingest", routeSurfacePlatformHTTP, app.deviceHandler.handleIngestTelemetry)
-	registerHTTPRoute(mux, "GET /.well-known/device-jwks.json", routeSurfaceInternalHTTP, app.deviceHandler.handleJWKS)
+	registerHTTPRoute(mux, "GET /.well-known/device-jwks.json", routeSurfacePublicHTTP, app.deviceHandler.handleJWKS)
 }
 
 func registerHTTPRoute(mux *http.ServeMux, pattern string, _ bootstrapRouteSurface, handler http.HandlerFunc) {

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -46,6 +46,13 @@ func TestOpenAPIContractDescribesCurrentBootstrapSurface(t *testing.T) {
 	if !strings.Contains(endpointFindings, "#/components/schemas/EndpointVulnerabilityFindingsResponse") {
 		t.Fatal("/endpoint-vulnerability-findings must use the endpoint vulnerability response contract")
 	}
+	bootstrapTokenSchema, _, ok := strings.Cut(string(body), "    IssueBootstrapTokenResponse:")
+	if !ok {
+		t.Fatal("api/openapi.yaml missing IssueBootstrapTokenResponse schema")
+	}
+	if !strings.Contains(bootstrapTokenSchema, "        ttl_seconds:\n          type: integer\n          minimum: 0") {
+		t.Fatal("IssueBootstrapTokenRequest.ttl_seconds must allow 0 to select the default TTL")
+	}
 	endpointTenantParam, _, ok := strings.Cut(endpointFindings, "        - name: device_id")
 	if !ok {
 		t.Fatal("/endpoint-vulnerability-findings must document the device_id query parameter")
@@ -97,6 +104,69 @@ func TestSDKHTTPRoutesExistInOpenAPI(t *testing.T) {
 		for _, marker := range []string{"/source-runtimes/", "/platform/graph/neighborhood"} {
 			if !bytes.Contains(body, []byte(marker)) {
 				t.Fatalf("%s no longer references expected SDK route marker %q; update SDK route parity guardrail", rel, marker)
+			}
+		}
+	}
+}
+
+func TestBootstrapPublicHTTPRoutesStayMethodScopedAndDocumented(t *testing.T) {
+	root := repoRoot(t)
+	routes, err := os.ReadFile(filepath.Join(root, "internal", "bootstrap", "routes.go"))
+	if err != nil {
+		t.Fatalf("read routes.go: %v", err)
+	}
+	for _, marker := range []string{
+		`registerHTTPRoute(mux, "GET /health", routeSurfacePublicHTTP`,
+		`registerHTTPRoute(mux, "GET /healthz", routeSurfacePublicHTTP`,
+		`registerHTTPRoute(mux, "GET /livez", routeSurfacePublicHTTP`,
+		`registerHTTPRoute(mux, "GET /openapi.yaml", routeSurfacePublicHTTP`,
+		`registerHTTPRoute(mux, "GET /.well-known/device-jwks.json", routeSurfacePublicHTTP`,
+		`registerHTTPRoute(mux, "GET /sources", routeSurfacePlatformHTTP`,
+	} {
+		if !bytes.Contains(routes, []byte(marker)) {
+			t.Fatalf("routes.go missing method-scoped route marker %q", marker)
+		}
+	}
+	for _, stale := range []string{
+		`registerHTTPRoute(mux, "/health"`,
+		`registerHTTPRoute(mux, "/healthz"`,
+		`registerHTTPRoute(mux, "/livez"`,
+		`registerHTTPRoute(mux, "/sources"`,
+		`"GET /.well-known/device-jwks.json", routeSurfaceInternalHTTP`,
+	} {
+		if bytes.Contains(routes, []byte(stale)) {
+			t.Fatalf("routes.go contains stale route marker %q", stale)
+		}
+	}
+
+	auth, err := os.ReadFile(filepath.Join(root, "internal", "bootstrap", "auth.go"))
+	if err != nil {
+		t.Fatalf("read auth.go: %v", err)
+	}
+	for _, public := range []string{
+		`"/.well-known/device-jwks.json"`,
+		`oauthProtectedResourceMetadataPath`,
+		`oauthAuthorizationServerMetadataPath`,
+		`oauthTokenPath`,
+		`oauthRegisterPath`,
+	} {
+		if !bytes.Contains(auth, []byte(public)) {
+			t.Fatalf("auth.go missing public route marker %q", public)
+		}
+	}
+	for _, doc := range []string{"docs/API_REFERENCE.md", "docs/API_CONTRACTS_AUTOGEN.md"} {
+		body, err := os.ReadFile(filepath.Join(root, doc))
+		if err != nil {
+			t.Fatalf("read %s: %v", doc, err)
+		}
+		for _, marker := range []string{
+			"/.well-known/device-jwks.json",
+			"/.well-known/oauth-authorization-server",
+			"/oauth/token",
+			"/oauth/register",
+		} {
+			if !bytes.Contains(body, []byte(marker)) {
+				t.Fatalf("%s missing public route marker %q", doc, marker)
 			}
 		}
 	}

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -72,6 +72,40 @@ func TestDockerfileCanBuildCurrentBootstrapBinary(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowKeepsCIParityAndStableLatestGuard(t *testing.T) {
+	root := repoRoot(t)
+	releaseBody, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+	release := string(releaseBody)
+	for _, marker := range []string{
+		"command: make sdk-test",
+		"command: make proto-lint proto-generate-check proto-breaking",
+		"command: make docker-smoke",
+		"is_stable_release:",
+		`if [ "${{ needs.resolve-tag.outputs.is_stable_release }}" = "true" ]; then`,
+		"Skipping latest tag for prerelease",
+	} {
+		if !strings.Contains(release, marker) {
+			t.Fatalf("release workflow missing required marker %q", marker)
+		}
+	}
+	latestIndex := strings.Index(release, `docker buildx imagetools create -t "${IMAGE_BASE}:latest"`)
+	stableGuardIndex := strings.Index(release, `if [ "${{ needs.resolve-tag.outputs.is_stable_release }}" = "true" ]; then`)
+	if latestIndex == -1 || stableGuardIndex == -1 || stableGuardIndex > latestIndex {
+		t.Fatal("release workflow must guard latest image publication behind stable-release check")
+	}
+
+	makefile, err := os.ReadFile(filepath.Join(root, "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	if !strings.Contains(string(makefile), `docker run --rm "$(DOCKER_SMOKE_IMAGE)" version`) {
+		t.Fatal("docker-smoke must run the built image entrypoint, not only build it")
+	}
+}
+
 func TestSDKDoesNotReferenceRetiredAgentSDKRoutes(t *testing.T) {
 	root := repoRoot(t)
 	for _, rel := range []string{


### PR DESCRIPTION
## Summary
- Scope health/source collection routes to documented HTTP methods and align public route metadata/docs.
- Fix the bootstrap token TTL OpenAPI schema to allow `0` as the server default behavior.
- Bring release verification closer to CI parity, run Docker smoke images, and prevent prereleases from updating `latest`.

## Test plan
- `go test ./internal/bootstrap ./tools/archtests`
- `make openapi-check openapi-lint release-smoke`
- `make docker-smoke`


Made with [Cursor](https://cursor.com)