### PR TITLE
Make source runtime CLI signal-aware

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -309,7 +309,8 @@ func runSourceRuntime(args []string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
-	ctx := context.Background()
+	ctx, stop := sourceRuntimeCommandContext()
+	defer stop()
 	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("open dependencies: %w", err)
@@ -424,6 +425,14 @@ func sourceRuntimeCommandLeaseStore(store ports.StateStore) ports.SourceRuntimeL
 
 func sourceRuntimeCommandLeaseOwner() string {
 	return strings.Replace(sourceruntime.DefaultAPILeaseOwner(), "cerebro-api:", "cerebro-cli:", 1)
+}
+
+func sourceRuntimeCommandContext() (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(context.Background(), sourceRuntimeCommandSignals()...)
+}
+
+func sourceRuntimeCommandSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
 }
 
 func parseSourceCommandArgs(args []string) (string, map[string]string, *cerebrov1.SourceCursor, error) {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -24,6 +25,23 @@ func TestRunRejectsUnsupportedCommand(t *testing.T) {
 	var usage usageError
 	if !errors.As(err, &usage) {
 		t.Fatalf("run(unsupported) error = %v, want usageError", err)
+	}
+}
+
+func TestSourceRuntimeCommandSignalsIncludeSIGTERM(t *testing.T) {
+	signals := sourceRuntimeCommandSignals()
+	if len(signals) != 2 || signals[0] != os.Interrupt || signals[1] != syscall.SIGTERM {
+		t.Fatalf("sourceRuntimeCommandSignals() = %#v, want interrupt and SIGTERM", signals)
+	}
+}
+
+func TestSourceRuntimeCommandContextCanBeCanceled(t *testing.T) {
+	ctx, cancel := sourceRuntimeCommandContext()
+	cancel()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("source runtime command context did not cancel")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Use an interrupt/SIGTERM-aware context for `source-runtime` CLI commands instead of `context.Background()`.
- Keep dependency opening, secret resolution, sync, and lease release paths tied to the command lifecycle.
- Add focused tests for the source-runtime command signal set and cancellable context.

## Test plan
- `go test ./cmd/cerebro`


Made with [Cursor](https://cursor.com)