### PR TITLE
Deepen MCP observability

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -182,17 +182,24 @@ type mcpRiskReasonCount struct {
 	Count  int    `json:"count"`
 }
 
+type mcpTelemetryDetails struct {
+	RequestKind      string
+	JSONRPCIDPresent bool
+	ParamsPresent    bool
+	Response         *mcpJSONRPCResponse
+}
+
 func (app *App) handleMCP(w http.ResponseWriter, r *http.Request) {
 	started := time.Now()
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-		mcpTelemetryEvent(r, "", "", http.StatusMethodNotAllowed, 0, "http_method", "", time.Since(started))
+		mcpTelemetryEvent(r, "", "", http.StatusMethodNotAllowed, 0, "http_method", "", time.Since(started), mcpTelemetryDetails{RequestKind: "transport_reject"})
 		return
 	}
 	if !app.mcpValidOrigin(r) {
 		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-		mcpTelemetryEvent(r, "", "", http.StatusForbidden, 0, "origin_forbidden", "", time.Since(started))
+		mcpTelemetryEvent(r, "", "", http.StatusForbidden, 0, "origin_forbidden", "", time.Since(started), mcpTelemetryDetails{RequestKind: "transport_reject"})
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
@@ -204,27 +211,40 @@ func (app *App) handleMCP(w http.ResponseWriter, r *http.Request) {
 			JSONRPC: "2.0",
 			Error:   &mcpError{Code: -32700, Message: "parse error"},
 		})
-		mcpTelemetryEvent(r, "", "", http.StatusOK, -32700, "parse_error", "", time.Since(started))
+		mcpTelemetryEvent(r, "", "", http.StatusOK, -32700, "parse_error", "", time.Since(started), mcpTelemetryDetails{RequestKind: "parse_error"})
 		return
 	}
 	if request.Method == "" && (len(request.Result) != 0 || request.Error != nil) {
 		w.WriteHeader(http.StatusAccepted)
-		mcpTelemetryEvent(r, "", "", http.StatusAccepted, 0, "client_message", "", time.Since(started))
+		mcpTelemetryEvent(r, "", "", http.StatusAccepted, 0, "client_message", "", time.Since(started), mcpTelemetryDetails{RequestKind: "client_message"})
 		return
 	}
 	if len(request.ID) == 0 && strings.TrimSpace(request.Method) != "" {
 		w.WriteHeader(http.StatusAccepted)
-		mcpTelemetryEvent(r, request.Method, mcpToolNameFromParams(request.Method, request.Params), http.StatusAccepted, 0, "notification", "", time.Since(started))
+		mcpTelemetryEvent(r, request.Method, mcpToolNameFromParams(request.Method, request.Params), http.StatusAccepted, 0, "notification", "", time.Since(started), mcpTelemetryDetails{
+			RequestKind:      "notification",
+			ParamsPresent:    len(request.Params) != 0,
+			JSONRPCIDPresent: false,
+		})
 		return
 	}
 	if request.Method != "initialize" && !mcpSupportedProtocolVersion(strings.TrimSpace(r.Header.Get("MCP-Protocol-Version"))) {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-		mcpTelemetryEvent(r, request.Method, mcpToolNameFromParams(request.Method, request.Params), http.StatusBadRequest, -32600, "unsupported_protocol_version", "", time.Since(started))
+		mcpTelemetryEvent(r, request.Method, mcpToolNameFromParams(request.Method, request.Params), http.StatusBadRequest, -32600, "unsupported_protocol_version", "", time.Since(started), mcpTelemetryDetails{
+			RequestKind:      "request",
+			ParamsPresent:    len(request.Params) != 0,
+			JSONRPCIDPresent: len(request.ID) != 0,
+		})
 		return
 	}
 	response := app.handleMCPRequest(r, request)
 	mcpWriteJSONRPC(w, r, response)
-	mcpTelemetryEvent(r, request.Method, mcpToolNameFromParams(request.Method, request.Params), http.StatusOK, mcpResponseErrorCode(response), mcpResponseOutcome(response), mcpResponseToolErrorKind(response), time.Since(started))
+	mcpTelemetryEvent(r, request.Method, mcpToolNameFromParams(request.Method, request.Params), http.StatusOK, mcpResponseErrorCode(response), mcpResponseOutcome(response), mcpResponseToolErrorKind(response), time.Since(started), mcpTelemetryDetails{
+		RequestKind:      "request",
+		ParamsPresent:    len(request.Params) != 0,
+		JSONRPCIDPresent: len(request.ID) != 0,
+		Response:         &response,
+	})
 }
 
 func (app *App) handleMCPStream(w http.ResponseWriter, r *http.Request) {
@@ -232,14 +252,14 @@ func (app *App) handleMCPStream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", http.MethodGet)
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-		mcpTelemetryEvent(r, "", "", http.StatusMethodNotAllowed, 0, "http_method", "", time.Since(started))
+		mcpTelemetryEvent(r, "", "", http.StatusMethodNotAllowed, 0, "http_method", "", time.Since(started), mcpTelemetryDetails{RequestKind: "transport_reject"})
 		return
 	}
 	w.Header().Set("Allow", http.MethodPost)
 	w.Header().Set("MCP-Protocol-Version", mcpProtocolVersion)
 	w.Header().Set("X-Cerebro-MCP-Stateless", "true")
 	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-	mcpTelemetryEvent(r, "", "", http.StatusMethodNotAllowed, 0, "stateless_get_rejected", "", time.Since(started))
+	mcpTelemetryEvent(r, "", "", http.StatusMethodNotAllowed, 0, "stateless_get_rejected", "", time.Since(started), mcpTelemetryDetails{RequestKind: "transport_reject"})
 }
 
 func (app *App) handleMCPRequest(r *http.Request, request mcpJSONRPCRequest) mcpJSONRPCResponse {
@@ -1465,25 +1485,45 @@ func mcpReadOnlyAnnotations(title string) map[string]any {
 	}
 }
 
-func mcpTelemetryEvent(r *http.Request, method string, tool string, statusCode int, jsonRPCErrorCode int, outcome string, toolErrorKind string, duration time.Duration) {
+func mcpTelemetryEvent(r *http.Request, method string, tool string, statusCode int, jsonRPCErrorCode int, outcome string, toolErrorKind string, duration time.Duration, details ...mcpTelemetryDetails) {
 	if r == nil {
 		return
+	}
+	detail := mcpTelemetryDetails{}
+	if len(details) != 0 {
+		detail = details[0]
 	}
 	method = mcpSanitizeTelemetryValue(method, 96)
 	tool = mcpSanitizeTelemetryValue(tool, 128)
 	outcome = mcpSanitizeTelemetryValue(outcome, 64)
 	toolErrorKind = mcpSanitizeTelemetryValue(toolErrorKind, 64)
+	requestKind := mcpSanitizeTelemetryValue(detail.RequestKind, 64)
+	if requestKind == "" {
+		requestKind = "request"
+	}
 	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "http.method", Value: r.Method},
 		telemetry.Field{Key: "http.route", Value: mcpTelemetryHTTPRoute(r)},
 		telemetry.Field{Key: "http.status_code", Value: statusCode},
+		telemetry.Field{Key: "mcp.request_kind", Value: requestKind},
 		telemetry.Field{Key: "mcp.method", Value: method},
 		telemetry.Field{Key: "mcp.outcome", Value: outcome},
 		telemetry.Field{Key: "mcp.protocol_version", Value: mcpSanitizeTelemetryValue(r.Header.Get("MCP-Protocol-Version"), 32)},
 		telemetry.Field{Key: "mcp.transport", Value: "stateless_http"},
 		telemetry.Field{Key: "mcp.stateless", Value: true},
+		telemetry.Field{Key: "mcp.accepts_json", Value: mcpHeaderAccepts(r.Header.Get("Accept"), "application/json")},
+		telemetry.Field{Key: "mcp.accepts_sse", Value: mcpHeaderAccepts(r.Header.Get("Accept"), "text/event-stream")},
+		telemetry.Field{Key: "mcp.session_header_present", Value: strings.TrimSpace(r.Header.Get("Mcp-Session-Id")) != ""},
+		telemetry.Field{Key: "mcp.jsonrpc_id_present", Value: detail.JSONRPCIDPresent},
+		telemetry.Field{Key: "mcp.params_present", Value: detail.ParamsPresent},
 		telemetry.Field{Key: "duration_ms", Value: duration.Milliseconds()},
 	)
+	if contentType := mcpMediaType(r.Header.Get("Content-Type")); contentType != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "mcp.content_type", Value: contentType})
+	}
+	for _, field := range mcpResponseTelemetryFields(detail.Response) {
+		attrs = attrs.WithField(field)
+	}
 	if requestID := accessAuditRequestID(r); requestID != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "request_id", Value: requestID})
 	}
@@ -1532,6 +1572,92 @@ func mcpTelemetryHTTPRoute(r *http.Request) string {
 		return mcpEndpointPath
 	}
 	return method + " " + mcpEndpointPath
+}
+
+func mcpHeaderAccepts(header string, mediaType string) bool {
+	mediaType = strings.ToLower(strings.TrimSpace(mediaType))
+	for _, part := range strings.Split(header, ",") {
+		if mcpMediaType(part) == mediaType || mcpMediaType(part) == "*/*" {
+			return true
+		}
+	}
+	return false
+}
+
+func mcpMediaType(header string) string {
+	value := strings.ToLower(strings.TrimSpace(header))
+	if value == "" {
+		return ""
+	}
+	mediaType, _, _ := strings.Cut(value, ";")
+	return mcpSanitizeTelemetryValue(strings.TrimSpace(mediaType), 96)
+}
+
+func mcpResponseTelemetryFields(response *mcpJSONRPCResponse) []telemetry.Field {
+	if response == nil {
+		return nil
+	}
+	if response.Error != nil {
+		return []telemetry.Field{
+			{Key: "mcp.response_shape", Value: "jsonrpc_error"},
+			{Key: "mcp.response_error", Value: true},
+		}
+	}
+	switch result := response.Result.(type) {
+	case mcpToolResult:
+		return []telemetry.Field{
+			{Key: "mcp.response_shape", Value: "tool_result"},
+			{Key: "mcp.tool_result_error", Value: result.IsError},
+			{Key: "mcp.tool_result_content_count", Value: len(result.Content)},
+			{Key: "mcp.structured_content_present", Value: result.StructuredContent != nil},
+		}
+	case map[string]any:
+		fields := []telemetry.Field{{Key: "mcp.response_shape", Value: mcpMapResponseShape(result)}}
+		if version := mcpAnyString(result["protocolVersion"]); version != "" {
+			fields = append(fields, telemetry.Field{Key: "mcp.initialize_protocol_version", Value: mcpSanitizeTelemetryValue(version, 32)})
+		}
+		if key, count, found := mcpListResponseCount(result); found {
+			fields = append(fields,
+				telemetry.Field{Key: "mcp.list_key", Value: key},
+				telemetry.Field{Key: "mcp.list_count", Value: count},
+				telemetry.Field{Key: "mcp.list_has_next_cursor", Value: strings.TrimSpace(mcpAnyString(result["nextCursor"])) != ""},
+			)
+		}
+		return fields
+	default:
+		return []telemetry.Field{{Key: "mcp.response_shape", Value: "other"}}
+	}
+}
+
+func mcpMapResponseShape(result map[string]any) string {
+	if _, ok := result["protocolVersion"]; ok {
+		return "initialize"
+	}
+	if _, _, ok := mcpListResponseCount(result); ok {
+		return "list"
+	}
+	if len(result) == 0 {
+		return "empty_object"
+	}
+	return "object"
+}
+
+func mcpListResponseCount(result map[string]any) (string, int, bool) {
+	for _, key := range []string{"tools", "resources", "resourceTemplates", "prompts"} {
+		switch items := result[key].(type) {
+		case []mcpTool:
+			return key, len(items), true
+		case []mcpResource:
+			return key, len(items), true
+		case []mcpResourceTemplate:
+			return key, len(items), true
+		case []mcpPrompt:
+			return key, len(items), true
+		case []any:
+			return key, len(items), true
+		}
+	}
+	return "", 0, false
 }
 
 func mcpResponseErrorCode(response mcpJSONRPCResponse) int {

--- a/internal/bootstrap/mcp_oauth_test.go
+++ b/internal/bootstrap/mcp_oauth_test.go
@@ -771,6 +771,42 @@ func TestMCPOAuthAuditTelemetryIncludesSafeRegistrationShape(t *testing.T) {
 	}
 }
 
+func TestMCPOAuthAuditTelemetryIncludesSafeRevocationShape(t *testing.T) {
+	app := &App{cfg: testMCPOAuthConfig("http://127.0.0.1:39123/callback", "https://writer-sso.example")}
+	form := url.Values{
+		"client_id":       {"droid"},
+		"token":           {"test-token"},
+		"token_type_hint": {"refresh_token"},
+	}
+	req := httptest.NewRequest(http.MethodPost, oauthRevokePath, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if err := req.ParseForm(); err != nil {
+		t.Fatalf("ParseForm: %v", err)
+	}
+
+	stderr := captureBootstrapStderr(t, func() {
+		app.emitOAuthAuditEvent(req, "revoke", http.StatusOK, "success", "", "droid", time.Now())
+	})
+	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"name":                          "cerebro.oauth.mcp",
+		"operation":                     "revoke",
+		"outcome":                       "success",
+		"status_code":                   float64(http.StatusOK),
+		"oauth.client_auth_method":      "none",
+		"oauth.token_type_hint_present": true,
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	for _, key := range []string{"token", "token_type_hint", "client_secret", "access_token", "refresh_token"} {
+		if _, exists := payload[key]; exists {
+			t.Fatalf("telemetry recorded sensitive revocation field %q: %#v", key, payload)
+		}
+	}
+}
+
 func testMCPOAuthConfig(clientRedirect string, upstreamBase string) config.Config {
 	return config.Config{
 		HTTPAddr:        "127.0.0.1:0",

--- a/internal/bootstrap/mcp_oauth_test.go
+++ b/internal/bootstrap/mcp_oauth_test.go
@@ -689,6 +689,88 @@ func TestMCPOAuthDynamicClientRegistrationRateLimitsByClientIP(t *testing.T) {
 	}
 }
 
+func TestMCPOAuthAuditTelemetryIncludesSafeTokenShape(t *testing.T) {
+	cfg := testMCPOAuthConfig("http://127.0.0.1:39123/callback", "https://writer-sso.example")
+	app := &App{cfg: cfg}
+	form := url.Values{
+		"grant_type": {"authorization_code"},
+		"client_id":  {"droid"},
+		"resource":   {"https://cerebro.example/api/v1/mcp"},
+		"scope":      {scopeCosmoSecurityRead},
+		"code":       {"test-code"},
+	}
+	req := httptest.NewRequest(http.MethodPost, oauthTokenPath, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("droid:test-client-credential")))
+	req.Header.Set("X-Request-ID", "oauth-req-1")
+	if err := req.ParseForm(); err != nil {
+		t.Fatalf("ParseForm: %v", err)
+	}
+
+	stderr := captureBootstrapStderr(t, func() {
+		app.emitOAuthAuditEvent(req, "token", http.StatusBadRequest, "rejected", "invalid_target", "droid", time.Now())
+	})
+	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"name":                       "cerebro.oauth.mcp",
+		"operation":                  "token",
+		"outcome":                    "rejected",
+		"status_code":                float64(http.StatusBadRequest),
+		"reason":                     "invalid_target",
+		"request_id":                 "oauth-req-1",
+		"oauth.grant_type":           "authorization_code",
+		"oauth.client_auth_method":   "client_secret_basic",
+		"oauth.resource_present":     true,
+		"oauth.resource_matches_mcp": true,
+		"oauth.scope_count":          float64(1),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	for _, key := range []string{"resource", "code", "client_secret", "access_token", "refresh_token"} {
+		if _, exists := payload[key]; exists {
+			t.Fatalf("telemetry recorded sensitive OAuth field %q: %#v", key, payload)
+		}
+	}
+}
+
+func TestMCPOAuthAuditTelemetryIncludesSafeRegistrationShape(t *testing.T) {
+	app := &App{cfg: testMCPOAuthConfig("http://127.0.0.1:39123/callback", "https://writer-sso.example")}
+	request := mcpoauth.ClientRegistrationRequest{
+		ClientName:              "Droid",
+		RedirectURIs:            []string{"http://127.0.0.1:39123/callback"},
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+	}
+	req := httptest.NewRequest(http.MethodPost, oauthRegisterPath, nil)
+
+	stderr := captureBootstrapStderr(t, func() {
+		app.emitOAuthAuditEvent(req, "register", http.StatusCreated, "success", "", "mcp_client_redacted", time.Now(), oauthAuditRegistrationFields(request)...)
+	})
+	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"name":                      "cerebro.oauth.mcp",
+		"operation":                 "register",
+		"outcome":                   "success",
+		"status_code":               float64(http.StatusCreated),
+		"oauth.redirect_uri_count":  float64(1),
+		"oauth.grant_type_count":    float64(2),
+		"oauth.response_type_count": float64(1),
+		"oauth.client_auth_method":  "none",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	for _, key := range []string{"redirect_uris", "client_name", "client_secret"} {
+		if _, exists := payload[key]; exists {
+			t.Fatalf("telemetry recorded raw registration field %q: %#v", key, payload)
+		}
+	}
+}
+
 func testMCPOAuthConfig(clientRedirect string, upstreamBase string) config.Config {
 	return config.Config{
 		HTTPAddr:        "127.0.0.1:0",

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -339,6 +339,81 @@ func TestMCPTelemetryIncludesSafeToolContext(t *testing.T) {
 	}
 }
 
+func TestMCPTelemetryIncludesInitializeShape(t *testing.T) {
+	server := newMCPTestServer(t, &stubRuntimeStore{})
+	defer server.Close()
+
+	stderr := captureBootstrapStderr(t, func() {
+		postMCP(t, server, "", map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "initialize",
+			"params": map[string]any{
+				"protocolVersion": mcpProtocolVersion,
+				"clientInfo": map[string]any{
+					"name":    "droid-test",
+					"version": "0.0.0",
+				},
+				"capabilities": map[string]any{},
+			},
+		})
+	})
+
+	payload := decodeMCPTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"mcp.method":                      "initialize",
+		"mcp.request_kind":                "request",
+		"mcp.outcome":                     "ok",
+		"mcp.accepts_json":                true,
+		"mcp.accepts_sse":                 true,
+		"mcp.jsonrpc_id_present":          true,
+		"mcp.params_present":              true,
+		"mcp.session_header_present":      false,
+		"mcp.response_shape":              "initialize",
+		"mcp.initialize_protocol_version": mcpProtocolVersion,
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+}
+
+func TestMCPTelemetryIncludesListShape(t *testing.T) {
+	server := newMCPTestServer(t, &stubRuntimeStore{})
+	defer server.Close()
+
+	stderr := captureBootstrapStderr(t, func() {
+		postMCP(t, server, "client-session", map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "tools/list",
+			"params":  map[string]any{},
+		})
+	})
+
+	payload := decodeMCPTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"mcp.method":                 "tools/list",
+		"mcp.request_kind":           "request",
+		"mcp.outcome":                "ok",
+		"mcp.response_shape":         "list",
+		"mcp.list_key":               "tools",
+		"mcp.list_has_next_cursor":   false,
+		"mcp.session_header_present": true,
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	count, ok := payload["mcp.list_count"].(float64)
+	if !ok || count < 1 {
+		t.Fatalf("telemetry mcp.list_count = %#v, want positive number; payload=%#v", payload["mcp.list_count"], payload)
+	}
+	if _, exists := payload["tools"]; exists {
+		t.Fatalf("telemetry recorded raw tools list: %#v", payload)
+	}
+}
+
 func TestMCPTelemetryClassifiesToolErrors(t *testing.T) {
 	server := newMCPTestServer(t, nil)
 	defer server.Close()

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -288,6 +288,7 @@ func TestMCPTelemetryIncludesSafeToolContext(t *testing.T) {
 		}
 		req.Header.Set("Authorization", "Bearer test-key")
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
 		req.Header.Set("MCP-Protocol-Version", mcpProtocolVersion)
 		req.Header.Set("X-Request-ID", "req-mcp-123")
 		resp, err := server.Client().Do(req)
@@ -303,21 +304,31 @@ func TestMCPTelemetryIncludesSafeToolContext(t *testing.T) {
 
 	payload := decodeMCPTelemetryPayload(t, stderr)
 	for key, want := range map[string]any{
-		"name":             "cerebro.mcp.request",
-		"http.method":      http.MethodPost,
-		"http.route":       "POST /api/v1/mcp",
-		"http.status_code": float64(http.StatusOK),
-		"mcp.method":       "tools/call",
-		"mcp.tool":         "cerebro.version",
-		"mcp.tool_known":   true,
-		"mcp.tool_family":  "version",
-		"mcp.outcome":      "ok",
-		"mcp.transport":    "stateless_http",
-		"mcp.stateless":    true,
-		"request_id":       "req-mcp-123",
-		"auth_mode":        "api_key",
-		"tenant_id":        "writer",
-		"principal":        "tester",
+		"name":                           "cerebro.mcp.request",
+		"http.method":                    http.MethodPost,
+		"http.route":                     "POST /api/v1/mcp",
+		"http.status_code":               float64(http.StatusOK),
+		"mcp.method":                     "tools/call",
+		"mcp.request_kind":               "request",
+		"mcp.tool":                       "cerebro.version",
+		"mcp.tool_known":                 true,
+		"mcp.tool_family":                "version",
+		"mcp.outcome":                    "ok",
+		"mcp.transport":                  "stateless_http",
+		"mcp.stateless":                  true,
+		"mcp.accepts_json":               true,
+		"mcp.accepts_sse":                false,
+		"mcp.content_type":               "application/json",
+		"mcp.jsonrpc_id_present":         true,
+		"mcp.params_present":             true,
+		"mcp.response_shape":             "tool_result",
+		"mcp.tool_result_error":          false,
+		"mcp.tool_result_content_count":  float64(1),
+		"mcp.structured_content_present": true,
+		"request_id":                     "req-mcp-123",
+		"auth_mode":                      "api_key",
+		"tenant_id":                      "writer",
+		"principal":                      "tester",
 	} {
 		if got := payload[key]; got != want {
 			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
@@ -351,12 +362,14 @@ func TestMCPTelemetryClassifiesToolErrors(t *testing.T) {
 
 	payload := decodeMCPTelemetryPayload(t, stderr)
 	for key, want := range map[string]any{
-		"mcp.method":          "tools/call",
-		"mcp.tool":            "cerebro.runtimes.status",
-		"mcp.tool_family":     "runtimes",
-		"mcp.outcome":         "tool_error",
-		"mcp.tool_error":      true,
-		"mcp.tool_error_kind": "runtime_unavailable",
+		"mcp.method":            "tools/call",
+		"mcp.tool":              "cerebro.runtimes.status",
+		"mcp.tool_family":       "runtimes",
+		"mcp.outcome":           "tool_error",
+		"mcp.tool_error":        true,
+		"mcp.tool_error_kind":   "runtime_unavailable",
+		"mcp.response_shape":    "tool_result",
+		"mcp.tool_result_error": true,
 	} {
 		if got := payload[key]; got != want {
 			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
@@ -394,8 +407,10 @@ func TestMCPGETTelemetryRecordsStatelessRejection(t *testing.T) {
 		"http.route":       "GET /api/v1/mcp",
 		"http.status_code": float64(http.StatusMethodNotAllowed),
 		"mcp.outcome":      "stateless_get_rejected",
+		"mcp.request_kind": "transport_reject",
 		"mcp.transport":    "stateless_http",
 		"mcp.stateless":    true,
+		"mcp.accepts_sse":  true,
 	} {
 		if got := payload[key]; got != want {
 			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)

--- a/internal/bootstrap/oauth_handlers.go
+++ b/internal/bootstrap/oauth_handlers.go
@@ -218,13 +218,14 @@ func (app *App) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 		writeOAuthError(w, mcpoauthOAuthError("invalid_client_metadata", "invalid JSON body", http.StatusBadRequest))
 		return
 	}
+	auditFields := oauthAuditRegistrationFields(request)
 	response, err := app.mcpOAuthService.RegisterClient(r.Context(), request)
 	if err != nil {
-		app.emitOAuthAuditEvent(r, "register", oauthErrorStatus(err), oauthAuditOutcome(err), oauthErrorCode(err), "", started)
+		app.emitOAuthAuditEvent(r, "register", oauthErrorStatus(err), oauthAuditOutcome(err), oauthErrorCode(err), "", started, auditFields...)
 		writeOAuthError(w, err)
 		return
 	}
-	app.emitOAuthAuditEvent(r, "register", http.StatusCreated, "success", "", response.ClientID, started)
+	app.emitOAuthAuditEvent(r, "register", http.StatusCreated, "success", "", response.ClientID, started, auditFields...)
 	writeOAuthJSON(w, http.StatusCreated, response)
 }
 
@@ -263,7 +264,7 @@ func (app *App) allowOAuthEndpoint(w http.ResponseWriter, r *http.Request, opera
 	return true
 }
 
-func (app *App) emitOAuthAuditEvent(r *http.Request, operation string, status int, outcome string, reason string, clientID string, started time.Time) {
+func (app *App) emitOAuthAuditEvent(r *http.Request, operation string, status int, outcome string, reason string, clientID string, started time.Time, extraFields ...telemetry.Field) {
 	if r == nil {
 		return
 	}
@@ -289,7 +290,120 @@ func (app *App) emitOAuthAuditEvent(r *http.Request, operation string, status in
 	if reason = strings.TrimSpace(reason); reason != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "reason", Value: reason})
 	}
+	if requestID := accessAuditRequestID(r); requestID != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "request_id", Value: requestID})
+	}
+	for _, field := range app.oauthAuditRequestFields(r) {
+		attrs = attrs.WithField(field)
+	}
+	for _, field := range extraFields {
+		attrs = attrs.WithField(field)
+	}
 	telemetry.Event(r.Context(), "cerebro.oauth.mcp", attrs)
+}
+
+func (app *App) oauthAuditRequestFields(r *http.Request) []telemetry.Field {
+	if r == nil || r.Form == nil {
+		return nil
+	}
+	path := ""
+	if r.URL != nil {
+		path = r.URL.Path
+	}
+	var fields []telemetry.Field
+	switch path {
+	case oauthTokenPath:
+		grantType := oauthAuditGrantType(r.Form.Get("grant_type"))
+		if grantType != "" {
+			fields = append(fields, telemetry.Field{Key: "oauth.grant_type", Value: grantType})
+		}
+		fields = append(fields,
+			telemetry.Field{Key: "oauth.client_auth_method", Value: oauthAuditTokenAuthMethod(r)},
+			telemetry.Field{Key: "oauth.scope_count", Value: len(strings.Fields(r.Form.Get("scope")))},
+		)
+		resourcePresent, resourceMatchesMCP := app.oauthAuditResourceShape(r)
+		fields = append(fields,
+			telemetry.Field{Key: "oauth.resource_present", Value: resourcePresent},
+			telemetry.Field{Key: "oauth.resource_matches_mcp", Value: resourceMatchesMCP},
+		)
+	case oauthRevokePath:
+		fields = append(fields,
+			telemetry.Field{Key: "oauth.client_auth_method", Value: oauthAuditTokenAuthMethod(r)},
+			telemetry.Field{Key: "oauth.token_type_hint_present", Value: strings.TrimSpace(r.Form.Get("token_type_hint")) != ""},
+		)
+	}
+	return fields
+}
+
+func oauthAuditRegistrationFields(request mcpoauth.ClientRegistrationRequest) []telemetry.Field {
+	return []telemetry.Field{
+		{Key: "oauth.redirect_uri_count", Value: len(normalizeAuthList(request.RedirectURIs))},
+		{Key: "oauth.grant_type_count", Value: len(normalizeAuthList(request.GrantTypes))},
+		{Key: "oauth.response_type_count", Value: len(normalizeAuthList(request.ResponseTypes))},
+		{Key: "oauth.client_auth_method", Value: oauthAuditClientAuthMethod(request.TokenEndpointAuthMethod)},
+	}
+}
+
+func oauthAuditGrantType(raw string) string {
+	switch strings.TrimSpace(raw) {
+	case "authorization_code", "refresh_token", "client_credentials":
+		return strings.TrimSpace(raw)
+	case "":
+		return ""
+	default:
+		return "other"
+	}
+}
+
+func oauthAuditTokenAuthMethod(r *http.Request) string {
+	if r == nil {
+		return "unknown"
+	}
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(r.Header.Get("Authorization"))), "basic ") {
+		return "client_secret_basic"
+	}
+	if r.Form != nil && strings.TrimSpace(r.Form.Get("client_secret")) != "" {
+		return "client_secret_post"
+	}
+	if r.Form != nil && strings.TrimSpace(r.Form.Get("client_id")) != "" {
+		return "none"
+	}
+	return "unknown"
+}
+
+func oauthAuditClientAuthMethod(raw string) string {
+	switch strings.TrimSpace(raw) {
+	case "", "none":
+		return "none"
+	case "client_secret_basic", "client_secret_post":
+		return strings.TrimSpace(raw)
+	default:
+		return "other"
+	}
+}
+
+func (app *App) oauthAuditResourceShape(r *http.Request) (bool, bool) {
+	if r == nil || r.Form == nil {
+		return false, false
+	}
+	resources := r.Form["resource"]
+	resourcePresent := false
+	resourceMatchesMCP := false
+	expected := strings.TrimSpace(app.cfg.Auth.MCPOAuth.Resource)
+	if expected == "" {
+		expected = externalOrigin(r, app.cfg.Auth.RequestOrigin) + mcpEndpointPath
+	}
+	for _, resource := range resources {
+		resource = strings.TrimSpace(resource)
+		if resource == "" {
+			continue
+		}
+		resourcePresent = true
+		if resource == expected {
+			resourceMatchesMCP = true
+		}
+	}
+	return resourcePresent, resourceMatchesMCP
 }
 
 func oauthErrorStatus(err error) int {


### PR DESCRIPTION
## Summary
- add safe MCP request/response-shape telemetry for negotiation, request kind, JSON-RPC shape, and list/tool results
- add safe OAuth MCP audit shape telemetry for token and dynamic registration requests
- extend MCP/OAuth telemetry tests without logging raw OAuth payload fields

## Validation
- go -C /Users/jonathan/cerebro-mcp-oauth-dcr-default test ./internal/bootstrap -run 'Test(MCPTelemetry|MCPOAuthAuditTelemetry)' -count=1
- go -C /Users/jonathan/cerebro-mcp-oauth-dcr-default test ./internal/bootstrap -run 'Test(MCP|MCPOAuth)' -count=1
- go -C /Users/jonathan/cerebro-mcp-oauth-dcr-default test ./internal/bootstrap -count=1
- make -C /Users/jonathan/cerebro-mcp-oauth-dcr-default lint
- make -C /Users/jonathan/cerebro-mcp-oauth-dcr-default mcp-contract-check mcp-sdk-compat
- git -C /Users/jonathan/cerebro-mcp-oauth-dcr-default diff --check