### PR TITLE
fix: include tooling map owners in source events

### DIFF
--- a/sources/securitytoolingmap/source.go
+++ b/sources/securitytoolingmap/source.go
@@ -57,6 +57,7 @@ func New() (*Source, error) {
 					"url":              "url",
 					"status":           "status",
 					"lifecycle_owner":  "lifecycle_owner",
+					"owners":           "owners",
 					"primary_language": "primary_language",
 					"categories":       "categories",
 					"capabilities":     "capabilities",

--- a/sources/securitytoolingmap/source_test.go
+++ b/sources/securitytoolingmap/source_test.go
@@ -38,8 +38,10 @@ func TestReadToolFamily(t *testing.T) {
 					"name":            "agent-gateway",
 					"org":             "WriterInternal",
 					"repo":            "agent-gateway",
+					"repository":      "WriterInternal/agent-gateway",
 					"status":          "beta",
 					"lifecycle_owner": "Security",
+					"owners":          []string{"Security"},
 					"categories":      []string{"ai_security", "dlp"},
 					"depends_on":      []string{"security"},
 				},
@@ -71,6 +73,9 @@ func TestReadToolFamily(t *testing.T) {
 	}
 	if event.Attributes["tool_id"] != "agent-gateway" || event.Attributes["repo"] != "agent-gateway" {
 		t.Fatalf("attrs = %#v, want tool inventory attributes", event.Attributes)
+	}
+	if event.Attributes["repository"] != "WriterInternal/agent-gateway" || event.Attributes["owners"] != "Security" {
+		t.Fatalf("attrs = %#v, want repository and owners attributes", event.Attributes)
 	}
 	if event.Attributes["categories"] != "ai_security,dlp" {
 		t.Fatalf("categories = %q, want ai_security,dlp", event.Attributes["categories"])


### PR DESCRIPTION
## Summary
- Include `owners` from security-tooling-map exports in Cerebro source event attributes.
- Extend the source test fixture to verify repository and owners metadata survive ingest.

## Test plan
- `go test ./sources/securitytoolingmap`


Made with [Cursor](https://cursor.com)