### PR TITLE
Add platform readiness foundations

### DIFF
--- a/.deepsec/package.json
+++ b/.deepsec/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "workspaces": [],
   "dependencies": {
-    "deepsec": "^1.1.11"
+    "@anthropic-ai/sdk": "^0.100.1",
+    "deepsec": "^2.0.12"
   }
 }

--- a/.deepsec/pnpm-lock.yaml
+++ b/.deepsec/pnpm-lock.yaml
@@ -8,60 +8,65 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.100.1
+        version: 0.100.1(zod@4.1.11)
       deepsec:
-        specifier: ^1.1.11
-        version: 1.1.11(zod@3.24.4)
+        specifier: ^2.0.12
+        version: 2.0.12(@anthropic-ai/sdk@0.100.1(zod@4.1.11))(@modelcontextprotocol/sdk@1.29.0(zod@4.1.11))(zod@4.1.11)
 
 packages:
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.128':
-    resolution: {integrity: sha512-RAzmB1ls+GWA/YiyfZLWdFYmj3md5emk7mCEeiKSKl2UN4i+tDWy2m/hjIvMFIzBqJJeGmZZSMnf3S0sL/GbhQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.162':
+    resolution: {integrity: sha512-hafbfEtDeYko1rYCgIBAQbYnFXzd/hHf3IcoaD8mmlCQOAQhKA8gT/RPdLuuzQHdOjEgqDGTNOU+IjwL+msYcw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.128':
-    resolution: {integrity: sha512-dDPJHxUhL2sgIB8Q2AnBi4xsApImeW0zf1nbL7gBNSc9RWhGoGQAbPm0KaQ7/03jdom30z1VT5VMhQ5KeEYOIw==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.162':
+    resolution: {integrity: sha512-BNg2Mh/4zc2Jsgpq7Mj8+UH8iJ9xzHS/0CmusBMik0H2Bn7Hra5R/f+csAfZOzSflQl4CNQdGOB2bir7d2n8Ww==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.128':
-    resolution: {integrity: sha512-ZCZEg42St0SCMMZFCvEtkF1LBFMYBxJRXzRno+12vOYYhC6R0l8jPjlgA2ZkN2Lb+TCEOO3fjeWJdZLL/NDM4w==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.162':
+    resolution: {integrity: sha512-Jr4cyfqzb5V2+p/1PynIfGROOI0JNtV3vBMAgckAdtDzpIFk4mV2T8936tsZzgZr04y40YH1HlQpnJDr92I+Fw==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.128':
-    resolution: {integrity: sha512-+GbB33eJSlZUWs84nsibY2nyAFQT96WYLGCteVn62Vv6ZK90NrZsm7lwurjw7oYNnvpzXorhZ2/XpQnWvOK6aQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.162':
+    resolution: {integrity: sha512-zCXYSimaXWQKZASfDJkoKXQr//toYDGIi16wKDh02Rqcr4mqFi9f5SBw/UCyimkGyYkNx3e+bmC+o/tFrLSTWw==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.128':
-    resolution: {integrity: sha512-sUSJEtvEt2iiMvgUuBGmBJjLhwHxDKOxVBSsXZaY46KAv3ZwLtLuc5xv2XFHId1B5+nMh7b7mr+HAiBmbMUODA==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.162':
+    resolution: {integrity: sha512-gW9Gpk7W3w3zGFHBDyY8uer/PE6T0pB+emN1aafZAomfseIH1ixJ6ya5Fw2cIS/K0/4oR2pvu4AprlbRBtr45Q==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.128':
-    resolution: {integrity: sha512-aBBXD6OLN/lq9S1p+BNjuEml0lYIoHunFdzFl49B0fsxEAnz1RfJDrpSNpIUAaL5FMZIaFvLqXtbFRy41N2fxg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.162':
+    resolution: {integrity: sha512-FO2+zDuSTsZ/5MqxIwExLxG0c2auA5wO6iICwZdUOWtboC6yU2AEgp4mzF0jbe1UOP0J27uODFpvz7uRpWipkg==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.128':
-    resolution: {integrity: sha512-9Ao2J5KgfkfKxUZK3dbQEGonPYcbUyn7Cn7ykZuP91FN/5ux3Tz90YRJW6UtZdWHoDkmFF0FS8P/jiZuyWPLfw==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.162':
+    resolution: {integrity: sha512-TZQifFDBdhzt1u6wbbpQ2AZcRkhNVYx1iZVfydAbs3L7ZMK264LjRPytBK4n4S413Is1XyLHbGMvEUNA3N+Tng==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.128':
-    resolution: {integrity: sha512-7oxPkgjw1vPZbx6+Qwt9mGouqfpRz5jDcuQ37koayzMdTVzmgCsKAqqbJSpOQfkFGv6gTjcrLWBlk3oapZfBYA==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.162':
+    resolution: {integrity: sha512-8ZYDgNxkGp47xwpcEZ6/qUXd4BByA8hTnNf4fJD6+P1wWi7Ofxc/d5jwXSYwajYvBvbbktQDthmGzjtoK3lXUw==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.2.128':
-    resolution: {integrity: sha512-KI7H9bocPahGDrrQGME5Eh5a4RTqGrN1fQ69uLs6Ik4icXBZXouCx4Ecum450jMVy58myeh9ahYYLlpDAbQXPA==}
+  '@anthropic-ai/claude-agent-sdk@0.3.162':
+    resolution: {integrity: sha512-piAlpc1h6FUMCNU+bnYNNLX1lOgMlFnqZmIhn6Myv48MaNRaecFaZEuVLY+UxV0kjGiQFYHBLR4fk/rRwi2SAA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.81.0':
-    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+  '@anthropic-ai/sdk@0.100.1':
+    resolution: {integrity: sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -69,8 +74,8 @@ packages:
       zod:
         optional: true
 
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@hono/node-server@1.19.14':
@@ -78,6 +83,10 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -134,12 +143,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@0.1.1':
+    resolution: {integrity: sha512-LMRMEai3Z+BODyxGcU9+KiWrS/UElNiOLKiNRfGNt2Vu3NTEmXgFeXG9wBfocAnTe5yJCX/DY6k3k7S/LkPp/g==}
+    engines: {node: '>= 18'}
+
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
-  '@vercel/sandbox@1.10.0':
-    resolution: {integrity: sha512-rGA8KJB5ZwQeygzsndgrbHsys3HGWKHQaRQlmyIEHce2BFuTfQUgivHDj5DCZhWiyjjSEodLHpoJkZBd95K0/Q==}
+  '@vercel/oidc@3.6.0':
+    resolution: {integrity: sha512-a2HjItW75qSZfyyDbZ2XDFTQAfNKM93uloZABPgx6t8IrdbCgf+EQBeSypQVP2jHrZ3LHApDgLFCf1frRgPwLg==}
+    engines: {node: '>= 20'}
+
+  '@vercel/sandbox@1.10.2':
+    resolution: {integrity: sha512-rWhYfIyW0Va0gFxtz434LhVirV+eQs+AK0QQWtsOPw2oTvOSA4iogQqemRqvRPPbqI8nfZOz6kbCsytVa20gdw==}
 
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
@@ -170,8 +193,12 @@ packages:
       react-native-b4a:
         optional: true
 
-  bare-events@2.8.2:
-    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
     peerDependencies:
       bare-abort-controller: '*'
     peerDependenciesMeta:
@@ -181,6 +208,10 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -194,6 +225,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
@@ -201,6 +236,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -227,8 +266,8 @@ packages:
       supports-color:
         optional: true
 
-  deepsec@1.1.11:
-    resolution: {integrity: sha512-hIWcS0k5ki+7PapjpFjTVT88kKXb4/kYEFrmW0GLxP5ZVvB0OYf4TzCUqeGfpwP7bY9E0FiqWlQRfo0X/PSyew==}
+  deepsec@2.0.12:
+    resolution: {integrity: sha512-E2bq8EJ9LmEPc68axbM3WMbimkWjKUorxg/72EgP1oaYsoQGJhfnhS8pfrPfPs7WHLI3hTlv8NI6rY/cZOdoNw==}
     hasBin: true
 
   depd@2.0.0:
@@ -254,8 +293,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   escape-html@1.0.3:
@@ -268,16 +307,20 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
-  eventsource-parser@3.0.8:
-    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  express-rate-limit@8.5.0:
-    resolution: {integrity: sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==}
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -292,8 +335,11 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
-  fast-uri@3.1.1:
-    resolution: {integrity: sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==}
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -318,6 +364,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -326,17 +376,21 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.16:
-    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -345,8 +399,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -356,11 +410,15 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   jose@6.2.3:
@@ -391,6 +449,9 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
@@ -399,12 +460,32 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -420,6 +501,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   os-paths@4.4.0:
     resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
@@ -447,8 +532,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -509,15 +594,29 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  streamx@2.25.0:
-    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+  streamx@2.26.0:
+    resolution: {integrity: sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+    engines: {node: '>=18'}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -529,12 +628,12 @@ packages:
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.27.1:
+    resolution: {integrity: sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==}
     engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
@@ -557,9 +656,17 @@ packages:
     resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
     engines: {node: '>=6'}
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
   xdg-portable@7.3.0:
     resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
     engines: {node: '>= 6.0'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -569,81 +676,86 @@ packages:
   zod@3.24.4:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+
 snapshots:
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.128':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.162':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.128':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.162':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.128':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.162':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.128':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.162':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.128':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.162':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.128':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.162':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.128':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.162':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.128':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.162':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.128(zod@3.24.4)':
+  '@anthropic-ai/claude-agent-sdk@0.3.162(@anthropic-ai/sdk@0.100.1(zod@4.1.11))(@modelcontextprotocol/sdk@1.29.0(zod@4.1.11))(zod@4.1.11)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@3.24.4)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.24.4)
-      zod: 3.24.4
+      '@anthropic-ai/sdk': 0.100.1(zod@4.1.11)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.1.11)
+      zod: 4.1.11
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.128
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.128
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.128
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.128
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.128
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.128
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.128
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.128
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.162
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.162
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.162
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.162
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.162
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.162
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.162
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.162
 
-  '@anthropic-ai/sdk@0.81.0(zod@3.24.4)':
+  '@anthropic-ai/sdk@0.100.1(zod@4.1.11)':
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
     optionalDependencies:
-      zod: 3.24.4
+      zod: 4.1.11
 
-  '@babel/runtime@7.29.2': {}
+  '@babel/runtime@7.29.7': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.16)':
+  '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
-      hono: 4.12.16
+      hono: 4.12.23
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.24.4)':
+  '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.16)
+      minipass: 7.1.3
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.1.11)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.23)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.1.0
       express: 5.2.1
-      express-rate-limit: 8.5.0(express@5.2.1)
-      hono: 4.12.16
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.23
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.24.4
-      zod-to-json-schema: 3.25.2(zod@3.24.4)
+      zod: 4.1.11
+      zod-to-json-schema: 3.25.2(zod@4.1.11)
     transitivePeerDependencies:
       - supports-color
 
@@ -678,9 +790,25 @@ snapshots:
   '@openai/codex@0.125.0-win32-x64':
     optional: true
 
+  '@stablelib/base64@1.0.1': {}
+
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@0.1.1':
+    dependencies:
+      execa: 5.1.1
+
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/sandbox@1.10.0':
+  '@vercel/oidc@3.6.0':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 0.1.1
+
+  '@vercel/sandbox@1.10.2':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@workflow/serde': 4.1.0-beta.2
@@ -689,7 +817,7 @@ snapshots:
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.25.0
+      undici: 7.27.1
       xdg-app-paths: 5.1.0
       zod: 3.24.4
     transitivePeerDependencies:
@@ -710,7 +838,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.1
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -720,7 +848,9 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  bare-events@2.8.2: {}
+  balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -730,11 +860,15 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   bytes@3.1.2: {}
 
@@ -748,9 +882,13 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  chownr@3.0.0: {}
+
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -771,18 +909,21 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  deepsec@1.1.11(zod@3.24.4):
+  deepsec@2.0.12(@anthropic-ai/sdk@0.100.1(zod@4.1.11))(@modelcontextprotocol/sdk@1.29.0(zod@4.1.11))(zod@4.1.11):
     dependencies:
-      '@anthropic-ai/claude-agent-sdk': 0.2.128(zod@3.24.4)
+      '@anthropic-ai/claude-agent-sdk': 0.3.162(@anthropic-ai/sdk@0.100.1(zod@4.1.11))(@modelcontextprotocol/sdk@1.29.0(zod@4.1.11))(zod@4.1.11)
       '@openai/codex': 0.125.0
       '@openai/codex-sdk': 0.125.0
-      '@vercel/sandbox': 1.10.0
-      jiti: 2.6.1
+      '@vercel/oidc': 3.6.0
+      '@vercel/sandbox': 1.10.2
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      tar: 7.5.16
     transitivePeerDependencies:
-      - '@cfworker/json-schema'
+      - '@anthropic-ai/sdk'
+      - '@modelcontextprotocol/sdk'
       - bare-abort-controller
       - react-native-b4a
-      - supports-color
       - zod
 
   depd@2.0.0: {}
@@ -801,7 +942,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-object-atoms@1.1.1:
+  es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
@@ -811,20 +952,32 @@ snapshots:
 
   events-universal@1.0.1:
     dependencies:
-      bare-events: 2.8.2
+      bare-events: 2.9.1
     transitivePeerDependencies:
       - bare-abort-controller
 
-  eventsource-parser@3.0.8: {}
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.1.0
 
-  express-rate-limit@8.5.0(express@5.2.1):
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -848,13 +1001,13 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -863,7 +1016,9 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
-  fast-uri@3.1.1: {}
+  fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.2: {}
 
   finalhandler@2.1.1:
     dependencies:
@@ -887,28 +1042,30 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
+
+  get-stream@6.0.1: {}
 
   gopd@1.2.0: {}
 
   has-symbols@1.1.0: {}
 
-  hasown@2.0.3:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.16: {}
+  hono@4.12.23: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -918,27 +1075,31 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  human-signals@2.1.0: {}
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
   is-promise@4.0.0: {}
 
+  is-stream@2.0.1: {}
+
   isexe@2.0.0: {}
 
-  jiti@2.6.1: {}
+  jiti@2.7.0: {}
 
   jose@6.2.3: {}
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
@@ -953,15 +1114,33 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  merge-stream@2.0.0: {}
+
   mime-db@1.54.0: {}
 
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
 
+  mimic-fn@2.1.0: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   ms@2.1.3: {}
 
   negotiator@1.0.0: {}
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
 
   object-assign@4.1.1: {}
 
@@ -974,6 +1153,10 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   os-paths@4.4.0: {}
 
@@ -992,7 +1175,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -1082,9 +1265,16 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@3.0.7: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
-  streamx@2.25.0:
+  streamx@2.26.0:
     dependencies:
       events-universal: 1.0.1
       fast-fifo: 1.3.2
@@ -1093,14 +1283,24 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  strip-final-newline@2.0.0: {}
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.8.1
       fast-fifo: 1.3.2
-      streamx: 2.25.0
+      streamx: 2.26.0
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  tar@7.5.16:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   text-decoder@1.2.7:
     dependencies:
@@ -1112,13 +1312,13 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  type-is@2.0.1:
+  type-is@2.1.0:
     dependencies:
-      content-type: 1.0.5
+      content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  undici@7.25.0: {}
+  undici@7.27.1: {}
 
   unpipe@1.0.0: {}
 
@@ -1134,12 +1334,21 @@ snapshots:
     dependencies:
       xdg-portable: 7.3.0
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
   xdg-portable@7.3.0:
     dependencies:
       os-paths: 4.4.0
 
-  zod-to-json-schema@3.25.2(zod@3.24.4):
+  yallist@5.0.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.1.11):
     dependencies:
-      zod: 3.24.4
+      zod: 4.1.11
 
   zod@3.24.4: {}
+
+  zod@4.1.11: {}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# Default ownership for broad platform changes.
+* @writer/security
+
+# Runtime, contracts, release, and supply-chain surfaces require explicit review.
+/.github/ @writer/security
+/.goreleaser.yaml @writer/security
+/Dockerfile @writer/security
+/Dockerfile.runtime @writer/security
+/Makefile @writer/security
+/go.mod @writer/security
+/go.sum @writer/security
+/api/ @writer/security
+/proto/ @writer/security
+/gen/ @writer/security
+/internal/bootstrap/ @writer/security
+/internal/config/ @writer/security
+/internal/statestore/ @writer/security
+/internal/graphstore/ @writer/security
+/internal/findings/ @writer/security
+/internal/deviceauth/ @writer/security
+/internal/mcpoauth/ @writer/security
+/scripts/ @writer/security
+/tools/ @writer/security
+/policies/ @writer/security
+/sources/ @writer/security
+/sdk/python/ @writer/security
+/sdk/typescript/ @writer/security

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,68 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: "gomod"
+    directory: "/tools/linters"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"
+      - "tooling"
+    groups:
+      linter-go-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/sdk/typescript"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "typescript"
+      - "sdk"
+    groups:
+      typescript-sdk:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/sdk/python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+      - "sdk"
+    groups:
+      python-sdk:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/.deepsec"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "deepsec"
+    groups:
+      deepsec:
+        patterns:
+          - "*"
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
             command: make test
           - name: sdk
             command: make sdk-test
+          - name: sdk-dependency-audit
+            command: make sdk-dependency-audit
           - name: mcp
             command: make mcp-contract-check mcp-sdk-compat
           - name: lint
@@ -31,6 +33,8 @@ jobs:
             command: make openapi-check openapi-lint
           - name: catalog
             command: make catalog-check detection-catalog-check
+          - name: docs-drift
+            command: make docs-drift-check
           - name: readme
             command: make readme-check
           - name: oss-audit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '17 4 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
   contents: write
   packages: write
   id-token: write
+  attestations: write
 
 concurrency:
   group: release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
@@ -144,6 +145,13 @@ jobs:
             mkdir -p ".dist/linux-${arch}"
             CGO_ENABLED=0 GOOS=linux GOARCH="${arch}" go build -trimpath -ldflags "${ldflags}" -o ".dist/linux-${arch}/cerebro" ./cmd/cerebro
           done
+
+      - name: Attest runtime binaries
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: |
+            .dist/linux-amd64/cerebro
+            .dist/linux-arm64/cerebro
 
       - name: Upload linux/amd64 runtime binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -277,6 +285,13 @@ jobs:
         run: |
           set -euo pipefail
           cosign sign --yes "${IMAGE_BASE}@${DIGEST}"
+
+      - name: Attest release image provenance
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true
 
   notify-infra-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -24,14 +24,14 @@ jobs:
       - name: Run Gitleaks
         run: |
           set -euo pipefail
-          go run github.com/gitleaks/gitleaks/v8@latest detect \
+          go run github.com/zricethezav/gitleaks/v8@latest detect \
             --source . \
             --redact \
             --report-format sarif \
             --report-path gitleaks.sarif
 
       - name: Upload Gitleaks SARIF
-        if: always()
+        if: always() && hashFiles('gitleaks.sarif') != ''
         uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         with:
           sarif_file: gitleaks.sarif

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run Gitleaks
         run: |
           set -euo pipefail
-          go run github.com/zricethezav/gitleaks/v8@latest detect \
+          go run github.com/zricethezav/gitleaks/v8@v8.30.1 detect \
             --source . \
             --no-git \
             --redact \

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,37 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '9 5 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        run: |
+          set -euo pipefail
+          go run github.com/gitleaks/gitleaks/v8@latest detect \
+            --source . \
+            --redact \
+            --report-format sarif \
+            --report-path gitleaks.sarif
+
+      - name: Upload Gitleaks SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: gitleaks.sarif

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,14 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
 
       - name: Run Gitleaks
         run: |
           set -euo pipefail
           go run github.com/zricethezav/gitleaks/v8@latest detect \
             --source . \
+            --no-git \
             --redact \
             --report-format sarif \
             --report-path gitleaks.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,37 @@
+name: Semgrep
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '41 4 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Semgrep
+        run: python3 -m pip install --user semgrep
+
+      - name: Run Semgrep
+        run: |
+          set -euo pipefail
+          python3 -m semgrep scan \
+            --config .semgrep/cerebro.yml \
+            --sarif \
+            --output semgrep.sarif
+
+      - name: Upload Semgrep SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -29,6 +29,7 @@ jobs:
           set -euo pipefail
           semgrep scan \
             --config .semgrep/cerebro.yml \
+            --error \
             --sarif \
             --output semgrep.sarif
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,18 +20,20 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Semgrep
-        run: python3 -m pip install --user semgrep
+        run: |
+          python3 -m pip install --user semgrep
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run Semgrep
         run: |
           set -euo pipefail
-          python3 -m semgrep scan \
+          semgrep scan \
             --config .semgrep/cerebro.yml \
             --sarif \
             --output semgrep.sarif
 
       - name: Upload Semgrep SARIF
-        if: always()
+        if: always() && hashFiles('semgrep.sarif') != ''
         uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         with:
           sarif_file: semgrep.sarif

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -6,6 +6,9 @@ rules:
   operation-tags: error
   operation-description: off
   operation-operationId: off
+  # Cerebro documents intentional rejection operations, such as GET /api/v1/mcp
+  # returning 405 to prevent clients from treating it as an SSE transport.
+  operation-success-response: off
 
   no-undocumented-tag:
     description: Placeholder tags are not allowed in committed OpenAPI contracts.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check readme-check oss-audit govulncheck docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check docs-drift-check readme-check oss-audit govulncheck docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -73,6 +73,10 @@ sdk-typescript-test:
 
 sdk-typescript-check:
 	cd sdk/typescript && npm ci && npm run typecheck
+
+sdk-dependency-audit:
+	python3 -m pip install --user pip-audit
+	python3 scripts/sdk_dependency_audit.py
 
 workflow-e2e-test:
 	go test $(WORKFLOW_E2E_PACKAGES) -run '$(WORKFLOW_E2E_TESTS)$$' -count=1 -v
@@ -174,6 +178,9 @@ detection-catalog-generate:
 detection-catalog-check:
 	go run ./tools/detectioncatalog --check
 
+docs-drift-check:
+	python3 scripts/docs_drift_check.py
+
 readme-check:
 	@base_ref="$(README_CHECK_BASE)"; \
 	if git rev-parse --verify "$$base_ref" >/dev/null 2>&1; then \
@@ -241,7 +248,7 @@ hooks:
 pre-commit:
 	./scripts/pre_commit_checks.sh
 
-check: build test sdk-test lint proto-lint proto-generate-check check-structural check-structural-test check-arch
+check: build test sdk-test lint proto-lint proto-generate-check docs-drift-check check-structural check-structural-test check-arch
 
 check-structural: check-structural-build
 	@$(LINTER_BIN) $(APP_PACKAGES)
@@ -257,4 +264,4 @@ check-arch:
 
 check-hook-integrity: check-arch
 
-verify: build test sdk-test mcp-contract-check mcp-sdk-compat lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check detection-catalog-check readme-check oss-audit release-smoke check-structural check-structural-test check-arch
+verify: build test sdk-test sdk-dependency-audit mcp-contract-check mcp-sdk-compat lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check detection-catalog-check docs-drift-check readme-check oss-audit release-smoke check-structural check-structural-test check-arch

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1936,11 +1936,8 @@ components:
             - source_runtime_sync
             - graph_ingest_runtime
             - finding_rules_evaluate
-            - finding_candidates_evaluate
             - findings_evaluate
             - report_run
-            - vulndb_sync_job_run
-            - graph_rebuild_dry_run
         tenant_id:
           type: string
         subject_type:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -225,6 +225,39 @@ paths:
         - Sources
       parameters:
         - $ref: '#/components/parameters/runtimeID'
+        - name: claim_id
+          in: query
+          schema:
+            type: string
+        - name: subject_urn
+          in: query
+          schema:
+            type: string
+        - name: predicate
+          in: query
+          schema:
+            type: string
+        - name: object_urn
+          in: query
+          schema:
+            type: string
+        - name: object_value
+          in: query
+          schema:
+            type: string
+        - name: claim_type
+          in: query
+          schema:
+            type: string
+        - name: status
+          in: query
+          schema:
+            type: string
+        - name: source_event_id
+          in: query
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limitQuery'
       responses:
         '200':
           description: Claim list.
@@ -1686,6 +1719,13 @@ paths:
       summary: Create a platform job
       tags:
         - Platform
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            maxLength: 255
       requestBody:
         required: true
         content:
@@ -2057,7 +2097,6 @@ components:
         - tenant_id
         - action
         - target
-        - trusted_scope
       properties:
         tenant_id:
           type: string
@@ -2074,7 +2113,8 @@ components:
           type: string
         trusted_scope:
           type: boolean
-          description: Must be true for mutating runtime response actions.
+          readOnly: true
+          description: Server-derived authorization marker for mutating runtime response actions.
         attributes:
           type: object
           additionalProperties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1637,6 +1637,211 @@ paths:
           description: Invalid client metadata.
         '429':
           description: Per-client-IP dynamic registration rate limit exceeded.
+  /metrics:
+    get:
+      operationId: getMetrics
+      summary: Export Prometheus-compatible metrics
+      tags:
+        - Platform
+      responses:
+        '200':
+          description: Metrics in Prometheus text exposition format.
+          content:
+            text/plain:
+              schema:
+                type: string
+  /platform/jobs:
+    get:
+      operationId: listPlatformJobs
+      summary: List platform jobs
+      tags:
+        - Platform
+      parameters:
+        - name: tenant_id
+          in: query
+          schema:
+            type: string
+        - name: kind
+          in: query
+          schema:
+            type: string
+        - name: status
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Platform jobs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobListResponse'
+    post:
+      operationId: createPlatformJob
+      summary: Create a platform job
+      tags:
+        - Platform
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePlatformJobRequest'
+      responses:
+        '202':
+          description: Job accepted and queued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobResponse'
+        '200':
+          description: Existing idempotent job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobResponse'
+  /platform/jobs/{jobID}:
+    get:
+      operationId: getPlatformJob
+      summary: Get one platform job
+      tags:
+        - Platform
+      parameters:
+        - $ref: '#/components/parameters/jobID'
+      responses:
+        '200':
+          description: Platform job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobResponse'
+  /platform/jobs/{jobID}/cancel:
+    post:
+      operationId: cancelPlatformJob
+      summary: Request platform job cancellation
+      tags:
+        - Platform
+      parameters:
+        - $ref: '#/components/parameters/jobID'
+      responses:
+        '200':
+          description: Cancelled or cancellation-requested job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobResponse'
+  /platform/jobs/{jobID}/events:
+    get:
+      operationId: listPlatformJobEvents
+      summary: List platform job events
+      tags:
+        - Platform
+      parameters:
+        - $ref: '#/components/parameters/jobID'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Job event timeline.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobEventListResponse'
+  /platform/runtime-response/actions:
+    post:
+      operationId: executeRuntimeResponseAction
+      summary: Execute a runtime response action
+      tags:
+        - Platform
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RuntimeResponseExecuteRequest'
+      responses:
+        '202':
+          description: Runtime response action accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeBlocklistEntryResponse'
+        '422':
+          description: Action is not supported by the configured executor surface.
+  /platform/runtime-response/blocklist:
+    get:
+      operationId: listRuntimeBlocklist
+      summary: List runtime response blocklist entries
+      tags:
+        - Platform
+      parameters:
+        - name: tenant_id
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: type
+          in: query
+          schema:
+            type: string
+            enum: [ip, domain]
+        - name: include_revoked
+          in: query
+          schema:
+            type: boolean
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Runtime blocklist entries.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeBlocklistListResponse'
+  /platform/runtime-response/blocklist/{entryID}/revoke:
+    post:
+      operationId: revokeRuntimeBlocklistEntry
+      summary: Revoke a runtime response blocklist entry
+      tags:
+        - Platform
+      parameters:
+        - $ref: '#/components/parameters/entryID'
+        - name: tenant_id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Revoked runtime blocklist entry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeBlocklistEntryResponse'
+  /platform/runtime-response/capabilities:
+    get:
+      operationId: listRuntimeResponseCapabilities
+      summary: List runtime response capability coverage
+      tags:
+        - Platform
+      responses:
+        '200':
+          description: Runtime response capabilities and executor modes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeResponseCapabilitiesResponse'
 
 components:
   securitySchemes:
@@ -1670,6 +1875,18 @@ components:
         type: string
     runID:
       name: runID
+      in: path
+      required: true
+      schema:
+        type: string
+    jobID:
+      name: jobID
+      in: path
+      required: true
+      schema:
+        type: string
+    entryID:
+      name: entryID
       in: path
       required: true
       schema:
@@ -1708,6 +1925,246 @@ components:
         type: integer
         minimum: 1
   schemas:
+    CreatePlatformJobRequest:
+      type: object
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          enum:
+            - source_runtime_sync
+            - graph_ingest_runtime
+            - finding_rules_evaluate
+            - finding_candidates_evaluate
+            - findings_evaluate
+            - report_run
+            - vulndb_sync_job_run
+            - graph_rebuild_dry_run
+        tenant_id:
+          type: string
+        subject_type:
+          type: string
+        subject_id:
+          type: string
+        idempotency_key:
+          type: string
+        payload:
+          type: object
+          additionalProperties: true
+    PlatformJobResponse:
+      type: object
+      required:
+        - job
+      properties:
+        job:
+          $ref: '#/components/schemas/PlatformJob'
+    PlatformJobListResponse:
+      type: object
+      required:
+        - jobs
+      properties:
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlatformJob'
+    PlatformJobEventListResponse:
+      type: object
+      required:
+        - events
+      properties:
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlatformJobEvent'
+    PlatformJob:
+      type: object
+      required:
+        - id
+        - kind
+        - status
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+        status:
+          type: string
+          enum: [queued, running, completed, failed, cancelled]
+        tenant_id:
+          type: string
+        subject_type:
+          type: string
+        subject_id:
+          type: string
+        idempotency_key:
+          type: string
+        progress_percent:
+          type: integer
+          minimum: 0
+          maximum: 100
+        message:
+          type: string
+        error:
+          type: string
+        payload:
+          type: object
+          additionalProperties: true
+        result:
+          type: object
+          additionalProperties: true
+        result_refs:
+          type: object
+          additionalProperties:
+            type: string
+        cancel_requested:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+        finished_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    PlatformJobEvent:
+      type: object
+      required:
+        - job_id
+        - sequence
+        - type
+      properties:
+        job_id:
+          type: string
+        sequence:
+          type: integer
+        type:
+          type: string
+        status:
+          type: string
+        message:
+          type: string
+        payload:
+          type: object
+          additionalProperties: true
+        created_at:
+          type: string
+          format: date-time
+    RuntimeResponseExecuteRequest:
+      type: object
+      required:
+        - tenant_id
+        - action
+        - target
+        - trusted_scope
+      properties:
+        tenant_id:
+          type: string
+        action:
+          type: string
+          enum: [block_ip, block_domain, scale_down, kill_process, isolate_container, isolate_host, quarantine_file, revoke_credentials]
+        target:
+          type: string
+        reason:
+          type: string
+        source:
+          type: string
+        source_job_id:
+          type: string
+        trusted_scope:
+          type: boolean
+          description: Must be true for mutating runtime response actions.
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+        expires_at:
+          type: string
+          format: date-time
+    RuntimeResponseCapabilitiesResponse:
+      type: object
+      required:
+        - capabilities
+      properties:
+        capabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/RuntimeResponseCapability'
+    RuntimeResponseCapability:
+      type: object
+      required:
+        - action
+        - mode
+        - supported
+        - requires_trusted_scope
+      properties:
+        action:
+          type: string
+        mode:
+          type: string
+        supported:
+          type: boolean
+        requires_trusted_scope:
+          type: boolean
+    RuntimeBlocklistEntryResponse:
+      type: object
+      required:
+        - entry
+      properties:
+        entry:
+          $ref: '#/components/schemas/RuntimeBlocklistEntry'
+    RuntimeBlocklistListResponse:
+      type: object
+      required:
+        - entries
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/RuntimeBlocklistEntry'
+    RuntimeBlocklistEntry:
+      type: object
+      required:
+        - id
+        - tenant_id
+        - type
+        - value
+      properties:
+        id:
+          type: string
+        tenant_id:
+          type: string
+        type:
+          type: string
+          enum: [ip, domain]
+        value:
+          type: string
+        reason:
+          type: string
+        source:
+          type: string
+        source_job_id:
+          type: string
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+        expires_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        revoked_at:
+          type: string
+          format: date-time
     DeviceEnrollRequest:
       type: object
       required: [bootstrap_token, hardware_uuid]

--- a/docs/ACTION_ENGINE_ARCHITECTURE.md
+++ b/docs/ACTION_ENGINE_ARCHITECTURE.md
@@ -6,7 +6,7 @@ The immediate goal is modest and structural:
 
 - keep `remediation` and `runtime response` as application-facing concepts
 - unify their execution model underneath
-- persist action executions and timelines in the shared execution store instead of process-local state
+- persist action executions and timelines through shared platform jobs instead of process-local state
 
 ## Why This Exists
 
@@ -27,7 +27,7 @@ Keeping that duplicated would make issue `#154` worse, not better. "Actual execu
 
 ## Core Model
 
-`internal/actionengine` is the shared substrate.
+The shared substrate should be implemented as a small action layer on top of platform jobs.
 
 It defines:
 
@@ -42,7 +42,7 @@ This is intentionally smaller than a general workflow engine. It is the minimum 
 
 ## Persistence Boundary
 
-The action engine persists through `internal/executionstore` using namespace `action_engine`.
+Action execution should persist through the platform job tables using action-specific job kinds and event types.
 
 That gives Cerebro one shared durability seam for:
 
@@ -50,11 +50,11 @@ That gives Cerebro one shared durability seam for:
 - image scans
 - function scans
 - connector validation
-- action executions
+- action executions and runtime response operations
 
 This is the correct boundary for now because it prevents new subsystems from drifting back into ad hoc in-memory orchestration.
 
-Longer term, the execution-store backend may move beyond SQLite. The contract should stay stable even if the storage implementation changes.
+The contract should stay stable even if execution later moves from in-process workers to a separate worker fleet.
 
 ## Application Adapters
 
@@ -62,21 +62,21 @@ The current integration keeps external behavior stable while removing duplicated
 
 ### Remediation
 
-`internal/remediation/executor.go` now:
+The remediation adapter should:
 
 - converts a remediation rule into an action-engine playbook
 - converts trigger data into a generic signal
-- executes through the shared action engine
+- execute through the shared action/job layer
 - maps shared execution state/results back onto remediation-native execution records
 
 ### Runtime Response
 
-`internal/runtime/response.go` now:
+The runtime response adapter should:
 
 - converts a response policy into an action-engine playbook
 - converts findings into a generic signal
 - persists the full finding context through `TriggerData`
-- executes approvals and action steps through the shared action engine
+- execute approvals and action steps through the shared action/job layer
 
 Preserving the original finding payload is important. Approval-based executions must resume with the same context that triggered them, not a partially reconstructed placeholder.
 
@@ -108,5 +108,5 @@ The point is not to copy those systems wholesale. The point is to keep Cerebro's
 
 1. Land issue `#154` on top of this substrate so runtime and remediation stop carrying separate executor growth.
 2. Expose shared action executions/events through a typed platform or security read surface.
-3. Move more execution families onto the shared execution store without inventing new persistence silos.
-4. Decide whether the execution-store backend remains SQLite or becomes a multi-worker store.
+3. Move more execution families onto platform jobs without inventing new persistence silos.
+4. Add a worker-safe runtime response capability surface with distributed blocklist state and capability coverage reporting.

--- a/docs/API_CONTRACTS_AUTOGEN.md
+++ b/docs/API_CONTRACTS_AUTOGEN.md
@@ -2,7 +2,7 @@
 
 Generated-by-hand snapshot for the current bootstrap service. Source of truth: `api/openapi.yaml` and `proto/cerebro/v1/bootstrap.proto`.
 
-- HTTP operations: **68** across **66** paths.
+- HTTP operations: **78** across **75** paths.
 - Connect RPCs: **38**.
 - Public unauthenticated routes when auth is enabled: `/health`, `/healthz`, `/livez`, `/openapi.yaml`, OAuth metadata/authorization endpoints, `/.well-known/device-jwks.json`, `/platform/devices/enroll`, and `/platform/devices/token`.
 - Preferred shared platform namespace: `/platform/*`.
@@ -12,7 +12,7 @@ Generated-by-hand snapshot for the current bootstrap service. Source of truth: `
 
 | Family | Routes |
 | --- | --- |
-| Health/contracts | `/health` readiness, `/healthz` and `/livez` liveness, `/openapi.yaml` |
+| Health/contracts | `/health` readiness, `/healthz` and `/livez` liveness, `/metrics`, `/openapi.yaml` |
 | OAuth/device bootstrap | `/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`, `/oauth/authorize`, `/oauth/callback`, `/oauth/token`, `/oauth/revoke`, `/oauth/register`, `/.well-known/device-jwks.json`, `/platform/devices/enroll`, `/platform/devices/token` |
 | Sources | `/sources`, `/sources/{sourceID}/check`, `/sources/{sourceID}/discover`, `/sources/{sourceID}/read` |
 | Source runtimes | `/source-runtimes/{runtimeID}`, `/source-runtimes/{runtimeID}/sync`, `/source-runtimes/{runtimeID}/graph-ingest-runs` |
@@ -21,3 +21,5 @@ Generated-by-hand snapshot for the current bootstrap service. Source of truth: `
 | Platform knowledge | `/platform/knowledge/decisions`, `/platform/knowledge/actions`, `/platform/knowledge/outcomes` |
 | Platform workflow | `/platform/workflow/replay` |
 | Platform graph | `/platform/graph/neighborhood`, `/platform/graph/ingest-health`, `/platform/graph/ingest-runs*` |
+| Platform jobs | `/platform/jobs`, `/platform/jobs/{jobID}`, `/platform/jobs/{jobID}/events`, `/platform/jobs/{jobID}/cancel` |
+| Runtime response | `/platform/runtime-response/capabilities`, `/platform/runtime-response/actions`, `/platform/runtime-response/blocklist*` |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -32,5 +32,15 @@ Set `CEREBRO_API_AUTH_ENABLED=true` and pass `Authorization: Bearer <key>` or `X
 - `GET /platform/graph/ingest-health`
 - `GET /platform/graph/ingest-runs`
 - `GET /platform/graph/ingest-runs/{runID}`
+- `GET /metrics` - Prometheus-compatible process/API metrics; authenticated when API auth is enabled.
+- `POST /platform/jobs`
+- `GET /platform/jobs`
+- `GET /platform/jobs/{jobID}`
+- `GET /platform/jobs/{jobID}/events`
+- `POST /platform/jobs/{jobID}/cancel`
+- `GET /platform/runtime-response/capabilities`
+- `POST /platform/runtime-response/actions`
+- `GET /platform/runtime-response/blocklist`
+- `POST /platform/runtime-response/blocklist/{entryID}/revoke`
 
 Legacy `/graph/*` aliases have been removed; use `/platform/graph/*` routes instead.

--- a/docs/FILESYSTEM_ANALYZER_ARCHITECTURE.md
+++ b/docs/FILESYSTEM_ANALYZER_ARCHITECTURE.md
@@ -8,7 +8,7 @@ Cerebro's workload filesystem analyzer is now the shared catalog-and-finding sub
 - Separate execution orchestration from filesystem cataloging.
 - Keep package inventory, secret detection, misconfiguration analysis, and SBOM generation under one contract.
 - Treat vulnerability matching as a pluggable layer so the analyzer can use the persisted vulnerability knowledge pipeline from issue `#181` without hard-coding one scanner backend.
-- Keep scan runtimes on one shared execution-store schema instead of growing per-runtime persistence silos.
+- Keep scan runtimes on shared platform job semantics instead of growing per-runtime persistence silos.
 
 ## Current Contract
 
@@ -55,13 +55,7 @@ Current analyzer responsibilities:
 
 ## Runtime Integration
 
-The analyzer is now reused by:
-
-- `internal/workloadscan.FilesystemAnalyzer`
-- `internal/imagescan.FilesystemAnalyzer`
-- `internal/functionscan.FilesystemAnalyzer`
-
-That means the execution runtimes are now responsible for:
+The analyzer contract is intended to be reused by workload, image, and function scan adapters. Those adapters are responsible for:
 
 - acquisition and materialization
 - lifecycle events
@@ -76,24 +70,14 @@ And the analyzer is responsible for:
 
 This is the correct boundary.
 
-## Shared Execution Store
+## Shared Execution State
 
-The scan runtimes no longer persist through three independent SQLite schemas hidden behind separate implementations.
+Scan runtimes should not persist through per-runtime local stores. They should use the shared platform job model:
 
-Shared package:
-
-- `internal/executionstore`
-
-Current behavior:
-
-- one shared `execution_runs` table keyed by `namespace + run_id`
-- one shared `execution_events` table keyed by `namespace + run_id + sequence`
-- runtime wrappers in:
-  - `internal/workloadscan`
-  - `internal/imagescan`
-  - `internal/functionscan`
-
-This is still SQLite-backed and single-node, but it is now one execution substrate instead of three similar stores pretending to be separate systems.
+- one shared job table keyed by job ID and tenant
+- one shared job-event timeline keyed by job ID and sequence
+- job `kind` values for workload, image, function, vulnerability-sync, graph, and finding execution
+- Postgres-backed leases for worker-safe execution
 
 ## OSS Patterns Reused
 
@@ -133,4 +117,4 @@ Cerebro should keep those stages separate.
 1. Extend the vulnerability database with NVD, GitHub Advisory, and distro feeds.
 2. Extend the now-landed workload scan graph projection from issue `#182` to image/function scan families and richer claim/evidence projection.
 3. Extend package coverage for RPM, Ruby gems, and .NET `.deps.json`.
-4. Move execution resources and vuln sync jobs onto a multi-worker backend if SQLite becomes the scaling bottleneck.
+4. Move scan execution resources and vulnerability sync jobs onto the shared platform job backend.

--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -162,25 +162,22 @@ curl \
 
 This reads normalized persisted findings, not transient rule output.
 
-## Current Built-In Rule
+## Current Built-In Catalog
 
-Today the built-in catalog contains one rule:
+The built-in public detection catalog currently contains 74 rules across cloud, identity, GitHub, GRC, runtime, endpoint, and vulnerability domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
-- `identity-okta-policy-rule-lifecycle-tampering`
-
-It lives in `internal/findings/okta_policy_rule_lifecycle_tampering_rule.go`.
-
-Why it was extracted into its own file:
+Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 
 - the service should not know Okta-specific event semantics
-- rule logic should be independently testable
-- future rules should look like sibling registrations, not more service branching
+- rule logic stays independently testable
+- future rules remain sibling registrations, not service branching
 
 ## Code Map
 
 - `internal/findings/registry.go` — rule interface and rule catalog
 - `internal/findings/service.go` — replay orchestration, explicit rule selection, and durable evaluation run lifecycle
-- `internal/findings/okta_policy_rule_lifecycle_tampering_rule.go` — first built-in finding rule
+- `internal/findings/*_rule.go` — built-in signal and graph-backed finding rules
+- `internal/findings/public_detection_catalog.json` — generated public detection catalog
 - `internal/statestore/postgres/findingevaluationruns.go` — persisted evaluation run storage and query filters
 - `internal/bootstrap/app.go` — HTTP and ConnectRPC exposure
 - `proto/cerebro/v1/bootstrap.proto` — transport contract for rule listing, rule-scoped evaluation, and run inspection

--- a/docs/FUNCTION_SCAN_ARCHITECTURE.md
+++ b/docs/FUNCTION_SCAN_ARCHITECTURE.md
@@ -7,21 +7,21 @@ Cerebro's serverless function scanning pipeline should be durable, API-driven, a
 - Model function scan runs and lifecycle events as typed persisted records.
 - Acquire deployment packages through control-plane APIs instead of VM snapshots or ad hoc local exports.
 - Reconstruct the effective function filesystem safely enough for shared analyzer reuse.
-- Reuse the same execution-store durability boundary as workload and image scans.
+- Reuse the same platform job durability boundary as workload and image scans.
 - Keep provider-specific package acquisition behind narrow interfaces so deeper analyzers and graph integration can evolve independently.
 
 ## Runtime Model
 
-The runtime persists state through `internal/functionscan.SQLiteRunStore`, which now wraps the shared `internal/executionstore` schema.
+The current bootstrap repository does not ship a dedicated function-scan runtime package. Function-scan execution should persist through shared platform jobs and Postgres-backed job events.
 
 Persisted records:
 
-- `RunRecord`: one execution resource for a submitted function package scan
-- `RunEvent`: append-only lifecycle and debugging timeline
+- `Job`: one execution resource for a submitted function package scan
+- `JobEvent`: append-only lifecycle and debugging timeline
 - `FilesystemArtifact`: materialized package metadata, retention, and cleanup timestamps
 - `AppliedArtifact`: ordered package/layer application metadata
 
-By default, function scans now use the same `EXECUTION_STORE_FILE` fallback as workload and image scans. The underlying persistence schema is shared, with `namespace` separating execution resources by runtime type.
+The underlying persistence schema should be shared, with `kind` separating execution resources by runtime type.
 
 ## Execution Pipeline
 
@@ -36,13 +36,13 @@ Current run stages:
 
 The pipeline is intentionally narrow:
 
-- provider metadata/package acquisition belongs in `internal/functionscan`
+- provider metadata/package acquisition belongs in narrow provider adapters
 - vulnerability/secret/runtime analysis belongs in the shared filesystem analyzer seam
 - graph contextualization belongs in later issue `#182`
 
 ## Provider Substrate
 
-Current provider support:
+Target provider support:
 
 - `AWSProvider`
 - `GCPProvider`
@@ -116,7 +116,7 @@ The implementation is intentionally borrowing shape from a few mature projects:
 
 ## Known Limits
 
-- SQLite is durable, but still single-node.
+- The dedicated function scan runtime is not implemented in this bootstrap repository yet.
 - GCP v2 container-backed functions are described, but full container-image fallback should converge with the image-scan runtime instead of duplicating registry logic here.
 - Runtime EOL detection is currently curated/manual rather than sourced from a continuously-updated advisory feed.
 - The analyzer can now use the persisted vulnerability database, but richer advisory-source coverage and ecosystem-specific fix intelligence are still incomplete.

--- a/docs/IMAGE_SCAN_ARCHITECTURE.md
+++ b/docs/IMAGE_SCAN_ARCHITECTURE.md
@@ -8,19 +8,19 @@ Cerebro's container image scanning pipeline should be durable, registry-neutral,
 - Reuse the existing registry client surface instead of inventing one-off sync-only paths.
 - Resolve multi-arch manifests, config blobs, and layer downloads directly from registries.
 - Reconstruct root filesystems safely enough for shared analyzers without requiring a full local image pull.
-- Keep execution-state semantics compatible with the existing workload-scan runtime on top of one shared execution store.
+- Keep execution-state semantics compatible with platform jobs and the Postgres state store.
 
 ## Runtime Model
 
-The runtime persists state through `internal/imagescan.SQLiteRunStore`, which now wraps the shared `internal/executionstore` schema.
+The current bootstrap repository does not ship a dedicated image-scan runtime package. Image-scan execution should persist through shared platform jobs and Postgres-backed job events.
 
 Persisted records:
 
-- `RunRecord`: one execution resource for a submitted image scan
-- `RunEvent`: append-only lifecycle and debugging timeline
+- `Job`: one execution resource for a submitted image scan
+- `JobEvent`: append-only lifecycle and debugging timeline
 - `FilesystemArtifact`: materialized rootfs metadata, retention, and cleanup timestamps
 
-By default, image scans now use the same `EXECUTION_STORE_FILE` fallback as workload scans. The underlying persistence schema is shared, with `namespace` separating image/function/workload execution resources.
+The underlying persistence schema should be shared, with `kind` separating image, function, workload, and advisory execution resources.
 
 ## Execution Pipeline
 
@@ -35,13 +35,13 @@ Current run stages:
 
 The pipeline is intentionally narrow:
 
-- registry manifest/config/layer mechanics belong in `internal/scanner`
-- execution/state handling belongs in `internal/imagescan`
+- registry manifest/config/layer mechanics belong in provider/scanner adapters
+- execution/state handling belongs in the shared platform job service
 - vulnerability/package/secret analysis depth belongs in later analyzer issues
 
 ## Registry Substrate
 
-Current registry support is implemented through the existing scanner clients:
+Target registry support should be implemented through narrow scanner clients:
 
 - `ECRClient`
 - `GCRClient`
@@ -97,7 +97,7 @@ The current implementation intentionally borrows shape from a few mature project
 
 ## Known Limits
 
-- SQLite is durable, but still single-node.
+- The dedicated image scan runtime is not implemented in this bootstrap repository yet.
 - The rootfs materializer is local-disk based, not yet remote-worker aware.
 - The analyzer can now use the persisted vulnerability knowledge pipeline from issue `#181`, but broader source coverage and distro-specific matching are still incomplete.
 - Running-workload correlation and graph contextualization are later issues (`#179` / `#182`).

--- a/docs/NON_GOALS.md
+++ b/docs/NON_GOALS.md
@@ -165,7 +165,7 @@ Each section lists what Cerebro will not do, why that boundary exists, where in 
 
 ### Runtime response will not mutate from unauthenticated identifiers.
 
-- `scale_down`, `block_ip`, and `block_domain` require a trusted actuation scope on the request. Cerebro will not accept a runtime target identifier from an unauthenticated source, treat a finding payload as a containment authorization, or fail open when actuation scope is missing.
+- Runtime response mutations require a server-derived trusted actuation scope. Cerebro will not accept a runtime target identifier from an unauthenticated source, treat a finding payload as a containment authorization, or fail open when actuation scope is missing.
 - Why: containment is the highest-stakes runtime side effect Cerebro performs. The trusted actuation scope is what keeps a malformed finding from triggering a real outage.
 - Enforced in: [`docs/RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md`](./RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md) "Direct Action Semantics" and "Cerebro will not mutate containment state from unauthenticated runtime target identifiers".
 - What would change this: a stronger authorization model that subsumes trusted actuation scope; loosening current behavior is not on the table.

--- a/docs/RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md
+++ b/docs/RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md
@@ -22,31 +22,24 @@ These are actions Cerebro can perform itself without a remote agent:
 
 - `block_ip`
 - `block_domain`
-- `scale_down`
 
 Current behavior:
 
 - `block_ip` and `block_domain` update the runtime blocklist immediately
-- `scale_down` uses a Kubernetes client when the finding carries an explicit workload target
-
-For `scale_down`, the target must resolve to a typed workload reference like:
-
-- `deployment:namespace/name`
-- `statefulset:namespace/name`
-
-Resolution currently uses runtime finding metadata first, then explicit resource identifiers where available.
+- `scale_down` is advertised as unsupported until a Kubernetes executor is wired in
 
 ### 2. Ensemble-delegated executors
 
 These actions depend on a host, container, or cloud-side actuator:
 
+- `scale_down`
 - `kill_process`
 - `isolate_container`
 - `isolate_host`
 - `quarantine_file`
 - `revoke_credentials`
 
-They use the same remote tool invocation path as remediation:
+The intended future path is the same remote tool invocation path as remediation:
 
 - `RemoteTools.CallTool(...)`
 
@@ -61,9 +54,9 @@ Default tool names are:
 - `security.runtime.block_ip`
 - `security.runtime.block_domain`
 
-If no remote tool provider is configured, these actions fail with a typed capability error instead of silently pretending to succeed.
+Until a remote tool provider is configured and wired, these actions fail with a typed capability error instead of silently pretending to succeed.
 
-If no trusted actuation scope is attached to the execution context, these actions fail closed before any local or remote containment target is invoked.
+If no server-derived trusted actuation scope is attached to the execution context, these actions fail closed before any local or remote containment target is invoked.
 
 ### 3. Control-plane side effects handled elsewhere
 
@@ -96,7 +89,7 @@ The local blocklist update is the guaranteed action.
 
 ### Kubernetes scale down
 
-`scale_down` uses a Kubernetes client loaded from:
+`scale_down` is a planned direct executor. It should use a Kubernetes client loaded from:
 
 - explicit kubeconfig/context if configured in the scaler
 - otherwise normal default kubeconfig loading
@@ -107,9 +100,9 @@ This is intentionally narrow:
 - `deployment`
 - `statefulset`
 
-Anything else must resolve through metadata or fall back to a remote tool.
+Anything else should resolve through metadata or fall back to a remote tool.
 
-`scale_down`, `block_ip`, and `block_domain` also require a trusted actuation scope. Cerebro will not mutate containment state from unauthenticated runtime target identifiers.
+`block_ip` and `block_domain` require a server-derived trusted actuation scope. Cerebro will not mutate containment state from unauthenticated runtime target identifiers.
 
 ## Follow-On Gaps
 

--- a/docs/RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md
+++ b/docs/RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md
@@ -90,7 +90,7 @@ That is better than a half-local, half-stubbed action set where policies "succee
 
 `block_ip` and `block_domain` now produce immediate containment state inside the runtime blocklist.
 
-If a remote tool provider is present, Cerebro also attempts best-effort remote enforcement with the matching `security.runtime.*` tool.
+The blocklist is persisted through the Postgres state store and exposed through `/platform/runtime-response/blocklist`, so multiple bootstrap replicas see the same containment state.
 
 The local blocklist update is the guaranteed action.
 
@@ -117,10 +117,12 @@ This cut is intentionally not the end state.
 
 Still missing:
 
-1. Persisted/runtime-distributed blocklist propagation instead of process-local memory only.
+1. Remote propagation from the durable blocklist into concrete network/device controls.
 2. Stronger target resolution from graph identity instead of heuristic runtime metadata.
 3. Provider-native credential revocation and host/network isolation for common clouds.
-4. Typed API visibility into runtime action capability coverage and executor mode.
+4. Kubernetes `scale_down` and remote-tool executors wired behind the same trusted-scope checks.
+
+Capability coverage is visible at `/platform/runtime-response/capabilities`; unsupported actions return typed errors instead of successful-looking no-ops.
 
 ## GitHub Reference Points
 

--- a/docs/RUNTIME_VISIBILITY_ARCHITECTURE.md
+++ b/docs/RUNTIME_VISIBILITY_ARCHITECTURE.md
@@ -7,7 +7,7 @@ The design goal is practical:
 - reuse the existing runtime detection, response, action-execution, and graph seams
 - ingest richer runtime telemetry than the current `RuntimeEvent` shape can represent safely
 - project runtime observations and response outcomes into the graph as durable evidence
-- keep high-volume raw telemetry out of the graph and out of the shared execution store hot path
+- keep high-volume raw telemetry out of the graph and out of the platform job hot path
 - make runtime visibility provider-pluggable instead of coupling the system to one sensor
 
 This document complements [RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md](./RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md) and [GRAPH_INTELLIGENCE_LAYER.md](./GRAPH_INTELLIGENCE_LAYER.md).
@@ -16,10 +16,10 @@ This document complements [RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md](./RUNTIME
 
 Today Cerebro already has:
 
-- runtime event ingest under `POST /api/v1/runtime/events`
-- rule-based runtime detections in `internal/runtime`
-- runtime response execution through the shared action engine
-- durable execution state through `internal/executionstore`
+- runtime evidence modeled as source/runtime events and projected by the existing source-runtime pipeline
+- a runtime finding rule in `internal/findings` for active threat evidence
+- workflow decision/action/outcome events through `internal/knowledge` and `internal/workflowevents`
+- graph-level evidence modeling through promoted entities and links
 - graph-level causal modeling through `triggered_by` and `caused_by`
 
 That is the right control-plane skeleton, but it is not yet runtime visibility.
@@ -30,7 +30,7 @@ Current gaps:
 - raw runtime observations are not durably modeled as a first-class substrate.
 - runtime observations are not projected into the graph as `observation` or `evidence`.
 - response outcomes are not joined back into the same causal graph.
-- the shared execution store is the right place for ingestion jobs and checkpoints, not the right place for every raw runtime event.
+- platform jobs are the right place for ingestion jobs and checkpoints, not the right place for every raw runtime event.
 
 ## Principles
 
@@ -230,7 +230,7 @@ type RuntimeObservation struct {
 
 Important rule:
 
-- `internal/runtime.RuntimeEvent` should become a compatibility envelope or derived simplified view, not the canonical ingest model.
+- the current `runtime.evidence` event shape should become a compatibility envelope or derived simplified view, not the canonical ingest model.
 
 ## Observation Kinds
 
@@ -253,11 +253,11 @@ Do not overload one generic `event_type` string forever. Use a stable enum-like 
 
 Add provider adapters under a dedicated package such as:
 
-- `internal/runtime/adapters/tetragon`
-- `internal/runtime/adapters/hubble`
-- `internal/runtime/adapters/k8saudit`
-- `internal/runtime/adapters/otel`
-- `internal/runtime/adapters/falco`
+- `internal/runtimevisibility/adapters/tetragon`
+- `internal/runtimevisibility/adapters/hubble`
+- `internal/runtimevisibility/adapters/k8saudit`
+- `internal/runtimevisibility/adapters/otel`
+- `internal/runtimevisibility/adapters/falco`
 
 Each adapter should do only three things:
 
@@ -289,7 +289,7 @@ Recommended pipeline:
 
 1. provider adapter emits normalized `RuntimeObservation`
 2. observation is written to a streaming ingest path
-3. checkpoint/run metadata is persisted through `internal/executionstore`
+3. checkpoint/run metadata is persisted through platform jobs
 4. raw observations go to bounded short-retention storage
 5. detection engine evaluates normalized observations
 6. graph materialization promotes selected observations into graph state
@@ -298,7 +298,7 @@ Recommended pipeline:
 
 ## Storage Boundaries
 
-### Use `executionstore` For
+### Use Platform Jobs For
 
 - ingestion run metadata
 - source checkpoints and cursors
@@ -307,12 +307,12 @@ Recommended pipeline:
 - response execution history
 - replay and reconciliation state
 
-### Do Not Use `executionstore` For
+### Do Not Use Platform Jobs For
 
 - every raw runtime observation at production event rates
 - long retention of packet/process/file event streams
 
-The current backend-neutral execution contract is the right control-plane seam, not the raw telemetry lake.
+The platform job contract is the right control-plane seam, not the raw telemetry lake.
 
 ## Raw Retention Strategy
 
@@ -371,9 +371,9 @@ This is why the graph integration matters. Runtime visibility without entity bin
 
 ## Detection Integration
 
-The current detection engine should evolve from:
+The current detection layer should evolve from:
 
-- direct evaluation of narrow `RuntimeEvent`
+- direct evaluation of narrow `runtime.evidence` attributes
 
 to:
 
@@ -425,8 +425,8 @@ Examples:
 
 - define `RuntimeObservation`
 - add provider adapter seams
-- add ingestion-run/checkpoint persistence via `executionstore`
-- keep current `/api/v1/runtime/events` as a compatibility path
+- add ingestion-run/checkpoint persistence via platform jobs
+- keep current `runtime.evidence` event ingestion as a compatibility path
 
 ### Phase 2. First Real Sensor Path
 
@@ -494,15 +494,15 @@ Success criteria:
 
 - Do not make OpenTelemetry the only runtime source.
 - Do not treat Falco alerts as the canonical runtime graph model.
-- Do not write every raw runtime event into SQLite-backed execution state.
-- Do not create a second orchestration/execution subsystem beside `internal/actionengine`.
+- Do not write every raw runtime event into platform job state.
+- Do not create a second orchestration/execution subsystem beside platform jobs.
 - Do not store every syscall or flow forever in the graph.
 
 ## Initial API Direction
 
 Near-term compatibility:
 
-- preserve `POST /api/v1/runtime/events`
+- preserve `runtime.evidence` event ingestion through source runtimes and device telemetry where configured
 - add a typed internal ingest path for normalized observations
 
 Longer-term platform direction:

--- a/docs/VULNERABILITY_DB_ARCHITECTURE.md
+++ b/docs/VULNERABILITY_DB_ARCHITECTURE.md
@@ -25,8 +25,10 @@ Primary persisted objects:
 
 Current storage:
 
-- SQLite via `internal/vulndb.SQLiteStore`
-- persisted by default at `VULNDB_STATE_FILE`
+- `internal/vulndb.FileStore` for CLI-local advisory work, persisted as JSON at `.cerebro-vulndb.json` by default or the caller-provided `state_file` / `VULNDB_STATE_FILE`
+- Postgres through `internal/statestore/postgres/vulndb.go` when `store=postgres` / `store=state` or `CEREBRO_STATE_STORE_DRIVER=postgres` is configured
+
+The file-backed store is a developer/operator convenience for offline imports and local matching. The bootstrap runtime's durable platform state remains Postgres, consistent with the three-store architecture.
 
 Current operator surface:
 
@@ -34,7 +36,11 @@ Current operator surface:
 - `cerebro vulndb import-osv`
 - `cerebro vulndb import-kev`
 - `cerebro vulndb import-epss`
+- `cerebro vulndb import-nvd`
 - `cerebro vulndb sync`
+- `cerebro vulndb job-put`
+- `cerebro vulndb job-run`
+- `cerebro vulndb job-run-due`
 - remote feed URLs require `https://` by default; plaintext `http://` is only allowed with `--allow-insecure-http`
 
 ## Data Model
@@ -94,17 +100,18 @@ Implemented now:
 - OSV bulk JSON / JSONL import
 - CISA KEV import
 - EPSS CSV import
+- NVD CVE API 2.0 JSON import
 - persisted per-source sync state
+- persisted sync-job metadata with leases for scheduled/worker execution
 - withdrawn advisories stay persisted for provenance, but matching excludes them from emitted scan results
 - sync state should be keyed by stable logical source labels (`osv`, `cisa-kev`, `epss`) instead of raw feed URLs
 - redirect handling must preserve transport policy; `https://` feeds cannot silently downgrade to `http://`
 
 Not yet implemented:
 
-- NVD delta ingestion
 - GitHub Advisory Database ingestion
 - distro-specific advisory feeds (`deb`, `rpm`, `apk`, vendor OVAL, etc.)
-- scheduled sync jobs on the shared execution store
+- first-class platform job API exposure for advisory sync jobs
 
 OSV is the best first ingestion source because it already aggregates much of the open-source ecosystem surface into one schema. KEV and EPSS are layered on top as exploitability enrichers.
 

--- a/docs/WORKLOAD_SCAN_ARCHITECTURE.md
+++ b/docs/WORKLOAD_SCAN_ARCHITECTURE.md
@@ -29,13 +29,13 @@ The pipeline is intentionally split so later issues can swap analyzers, transfer
 
 ## Persisted Runtime Model
 
-The runtime persists state through `internal/workloadscan.SQLiteRunStore`, which now wraps the shared `internal/executionstore` schema.
+The current bootstrap repository does not ship a dedicated workload-scan runtime package. Workload-scan execution should persist through the shared platform job model and the Postgres state store, not through a scan-specific embedded store.
 
 Persisted records:
 
-- `RunRecord`: one execution resource for a submitted workload scan
+- `Job`: one platform execution resource for a submitted workload scan
 - `VolumeScanRecord`: per-source-volume progress, artifacts, and cleanup state
-- `RunEvent`: append-only lifecycle/event timeline for debugging and future API surfacing
+- `JobEvent`: append-only lifecycle/event timeline for debugging and API surfacing
 
 This is the current durability boundary:
 
@@ -43,7 +43,7 @@ This is the current durability boundary:
 - reconciliation can find leaked artifacts from persisted failed/incomplete runs
 - cleanup is not dependent on the original process remaining alive
 
-This is explicitly better than a process-local in-memory queue, but it is not yet the final distributed execution architecture.
+This is intentionally aligned with the three-store architecture: JetStream for events, Postgres for current execution state, and Neo4j/Aura for graph projection.
 
 ## Provider Seams
 
@@ -57,10 +57,8 @@ The runtime depends on narrow interfaces:
 
 Current concrete implementations:
 
-- `AWSProvider`
-- `LocalMounter`
-- `FilesystemAnalyzer`
-- `SQLiteRunStore`
+- provider, mounter, and analyzer adapters should live behind the platform job execution boundary
+- durable state should be stored in Postgres through the shared job tables
 
 This allows the issue stack to progress in layers:
 
@@ -109,6 +107,7 @@ The runtime emits webhook-compatible lifecycle events:
 These events are a bridge into the broader intelligence/reporting platform without making workload scanning a one-off subsystem.
 
 Successful workload scans are also projected into the security graph during graph activation from the shared execution store. That projection currently creates:
+Successful workload scans should project into the security graph from durable scan/job records and emitted lifecycle events. That projection should create:
 
 - `workload_scan` nodes
 - `package` nodes
@@ -124,7 +123,6 @@ Older successful scans for the same workload are retained with temporal superses
 
 Current controls:
 
-- `WORKLOAD_SCAN_STATE_FILE`
 - `WORKLOAD_SCAN_MOUNT_BASE_PATH`
 - `WORKLOAD_SCAN_MAX_CONCURRENT_SNAPSHOTS`
 - `WORKLOAD_SCAN_CLEANUP_TIMEOUT`
@@ -141,9 +139,9 @@ These are meant to bound:
 
 ## Known Limits
 
-- The runtime is SQLite-backed and single-node durable today, not yet multi-worker/distributed.
+- The dedicated workload scan runtime is not implemented in this bootstrap repository yet.
 - The analyzer now catalogs OS/package/SBOM/secret/config data through the shared filesystem analyzer, but RPM/Windows/deeper ecosystem coverage is still incomplete.
-- The execution surface is CLI-first; there is no first-class platform API/job resource yet.
+- The execution surface should use first-class platform jobs rather than scan-specific run storage.
 - Persisted run state is durable and now hydrates into the security graph on graph activation, but real-time graph refresh still depends on the next graph rebuild/incremental-apply cycle.
 
 ## Next Steps
@@ -153,4 +151,4 @@ These are meant to bound:
 3. Expose run resources and events through the platform API.
 4. Project package/vulnerability matches into first-class observations/evidence/claims instead of node/edge projection alone.
 5. Add a real-time graph refresh path for `security.workload_scan.completed`.
-6. Decide whether the long-term state backend remains SQLite or moves to a multi-worker execution store.
+6. Implement provider adapters on top of the shared platform job backend.

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -242,21 +242,30 @@ func authorizeSourceRuntimeIDTenant(ctx context.Context, store ports.SourceRunti
 	if !hasAuthContext(ctx) {
 		return nil
 	}
+	_, err := sourceRuntimeTenantID(ctx, store, runtimeID, allowMissing)
+	return err
+}
+
+func sourceRuntimeTenantID(ctx context.Context, store ports.SourceRuntimeStore, runtimeID string, allowMissing bool) (string, error) {
 	id := strings.TrimSpace(runtimeID)
 	if id == "" {
-		return nil
+		return "", nil
 	}
 	if store == nil {
-		return sourceruntime.ErrRuntimeUnavailable
+		return "", sourceruntime.ErrRuntimeUnavailable
 	}
 	runtime, err := store.GetSourceRuntime(ctx, id)
 	if err != nil {
 		if allowMissing && errors.Is(err, ports.ErrSourceRuntimeNotFound) {
-			return nil
+			return "", nil
 		}
-		return err
+		return "", err
 	}
-	return authorizeTenantScopeRequired(ctx, runtime.GetTenantId())
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if err := authorizeTenantScopeRequired(ctx, tenantID); err != nil {
+		return "", err
+	}
+	return tenantID, nil
 }
 
 func authorizePutSourceRuntimeTenant(ctx context.Context, store ports.SourceRuntimeStore, runtime *cerebrov1.SourceRuntime) error {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -33,6 +33,7 @@ import (
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/knowledge"
 	"github.com/writer/cerebro/internal/mcpoauth"
+	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/reports"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -179,12 +180,12 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	mux := http.NewServeMux()
 	app.mux = mux
 	app.registerRoutes(mux, cfg, deps, sources)
-	app.handler = authMiddleware(cfg.Auth, AuthDependencies{
+	app.handler = observability.Middleware(authMiddleware(cfg.Auth, AuthDependencies{
 		DeviceVerifier: app.deviceVerifier,
 		DPoPVerifier:   app.dpopVerifier,
 		RiskScorer:     app.riskScorer,
 		Observations:   app.observationStore,
-	}, mux)
+	}, mux))
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           app.handler,
@@ -231,6 +232,10 @@ func (a *App) handleOpenAPI(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/yaml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(apicontract.OpenAPIYAML)
+}
+
+func (a *App) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	observability.Default.Handler().ServeHTTP(w, r)
 }
 
 func authorizeSourceRuntimeIDTenant(ctx context.Context, store ports.SourceRuntimeStore, runtimeID string, allowMissing bool) error {
@@ -3353,6 +3358,22 @@ func reportStore(store ports.StateStore) ports.ReportStore {
 		return nil
 	}
 	return reportStore
+}
+
+func jobStore(store ports.StateStore) ports.JobStore {
+	jobs, ok := store.(ports.JobStore)
+	if !ok || isNilInterface(jobs) {
+		return nil
+	}
+	return jobs
+}
+
+func runtimeBlocklistStore(store ports.StateStore) ports.RuntimeBlocklistStore {
+	blocklist, ok := store.(ports.RuntimeBlocklistStore)
+	if !ok || isNilInterface(blocklist) {
+		return nil
+	}
+	return blocklist
 }
 
 func eventReplayer(appendLog ports.AppendLog) ports.EventReplayer {

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -577,6 +577,7 @@ func authorizeFindingCandidatePromotion(ctx context.Context) error {
 const (
 	scopeCosmoSecurityRead       = "cerebro.cosmo.security.read"
 	scopeFindingCandidatePromote = "cerebro.finding_candidates.promote"
+	scopeRuntimeResponseWrite    = "cerebro.runtime_response.write"
 )
 
 func scopeForDeviceRoute(method string, path string) string {
@@ -644,6 +645,14 @@ func authorizePrincipalScope(principal authPrincipal, required string) error {
 	return nil
 }
 
+func hasRuntimeResponseTrustedScope(ctx context.Context) bool {
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	if !ok || !principalScopeRestricted(auth.principal) {
+		return true
+	}
+	return containsAuthValue(auth.principal.Scopes, scopeRuntimeResponseWrite)
+}
+
 func principalScopeRestricted(principal authPrincipal) bool {
 	return len(principal.Scopes) > 0
 }
@@ -666,6 +675,9 @@ func scopeForHTTPRequest(r *http.Request) string {
 	if r.Method != http.MethodGet {
 		if r.Method == http.MethodPost && strings.HasPrefix(path, "/finding-candidates/") && (strings.HasSuffix(path, "/promote") || strings.HasSuffix(path, "/reject")) {
 			return scopeFindingCandidatePromote
+		}
+		if r.Method == http.MethodPost && (path == "/platform/runtime-response/actions" || (strings.HasPrefix(path, "/platform/runtime-response/blocklist/") && strings.HasSuffix(path, "/revoke"))) {
+			return scopeRuntimeResponseWrite
 		}
 		return ""
 	}
@@ -697,6 +709,10 @@ func scopeForHTTPRequest(r *http.Request) string {
 	case path == "/platform/graph/ingest-runs", strings.HasPrefix(path, "/platform/graph/ingest-runs/"):
 		return scopeCosmoSecurityRead
 	case strings.HasPrefix(path, "/report-runs/"):
+		return scopeCosmoSecurityRead
+	case path == "/platform/jobs", strings.HasPrefix(path, "/platform/jobs/"):
+		return scopeCosmoSecurityRead
+	case path == "/platform/runtime-response/capabilities", path == "/platform/runtime-response/blocklist":
 		return scopeCosmoSecurityRead
 	default:
 		return ""

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -935,13 +935,6 @@ func (w *accessAuditResponseWriter) WriteHeader(status int) {
 	}
 }
 
-func (w *accessAuditResponseWriter) Write(data []byte) (int, error) {
-	if w.status == 0 {
-		w.WriteHeader(http.StatusOK)
-	}
-	return w.ResponseWriter.Write(data)
-}
-
 func (w *accessAuditResponseWriter) Flush() {
 	if w == nil {
 		return

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -537,6 +537,22 @@ func authorizeTenantScopeRequired(ctx context.Context, tenantID string) error {
 	return authorizeTenantID(ctx, tenantID)
 }
 
+func effectiveTenantFilter(ctx context.Context, requestedTenantID string) (string, error) {
+	tenantID := strings.TrimSpace(requestedTenantID)
+	if tenantID == "" {
+		if auth, ok := ctx.Value(authContextKey{}).(authContext); ok {
+			tenantID = strings.TrimSpace(auth.principal.TenantID)
+		}
+	}
+	if tenantID == "" && requiresTenantFilter(ctx) {
+		return "", errTenantForbidden
+	}
+	if err := authorizeTenantID(ctx, tenantID); err != nil {
+		return "", err
+	}
+	return tenantID, nil
+}
+
 func authorizeTenantID(ctx context.Context, tenantID string) error {
 	auth, ok := ctx.Value(authContextKey{}).(authContext)
 	if !ok {

--- a/internal/bootstrap/http_doer.go
+++ b/internal/bootstrap/http_doer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/sourcehttp"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 const maxHTTPDoerResponseBytes = 4 << 20
@@ -27,6 +28,9 @@ func (d *stdHTTPDoer) Post(ctx context.Context, url string, headers map[string]s
 	}
 	for k, v := range headers {
 		req.Header.Set(k, v)
+	}
+	if traceparent := telemetry.TraceParent(ctx); traceparent != "" && req.Header.Get("Traceparent") == "" {
+		req.Header.Set("Traceparent", traceparent)
 	}
 	resp, err := d.client.Do(req)
 	if err != nil {

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -63,6 +63,12 @@ func (a *App) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 	if request.Payload == nil {
 		request.Payload = map[string]any{}
 	}
+	tenantID, err := effectiveTenantFilter(r.Context(), request.TenantID)
+	if err != nil {
+		writeJobError(w, err)
+		return
+	}
+	request.TenantID = tenantID
 	if err := authorizeJobCreate(r.Context(), a.deps.StateStore, request); err != nil {
 		writeJobError(w, err)
 		return
@@ -96,15 +102,16 @@ func (a *App) handleListJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	filter := ports.JobFilter{
-		TenantID: r.URL.Query().Get("tenant_id"),
-		Kind:     r.URL.Query().Get("kind"),
-		Status:   r.URL.Query().Get("status"),
-		Limit:    limit,
+		Kind:   strings.TrimSpace(r.URL.Query().Get("kind")),
+		Status: strings.TrimSpace(r.URL.Query().Get("status")),
+		Limit:  limit,
 	}
-	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
+	tenantID, err := effectiveTenantFilter(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
 		writeJobError(w, err)
 		return
 	}
+	filter.TenantID = tenantID
 	jobs, err := a.jobService().List(r.Context(), filter)
 	if err != nil {
 		writeJobError(w, err)
@@ -281,7 +288,7 @@ func authorizeJobCreate(ctx context.Context, store ports.StateStore, request cre
 		}
 		return authorizeTenantID(ctx, parameters["tenant_id"])
 	default:
-		return nil
+		return fmt.Errorf("%w: unsupported job kind %q", platformjobs.ErrInvalidRequest, strings.TrimSpace(request.Kind))
 	}
 }
 

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -69,10 +69,12 @@ func (a *App) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	request.TenantID = tenantID
-	if err := authorizeJobCreate(r.Context(), a.deps.StateStore, request); err != nil {
+	tenantID, err = authorizeJobCreate(r.Context(), a.deps.StateStore, request)
+	if err != nil {
 		writeJobError(w, err)
 		return
 	}
+	request.TenantID = tenantID
 	job, created, err := a.jobService().Create(r.Context(), ports.CreateJobRequest{
 		Kind:           request.Kind,
 		TenantID:       request.TenantID,
@@ -273,23 +275,46 @@ func (a *App) runReportJob(ctx context.Context, job *ports.Job, _ *platformjobs.
 	return protoToMap(response), refs, nil
 }
 
-func authorizeJobCreate(ctx context.Context, store ports.StateStore, request createJobHTTPRequest) error {
+func authorizeJobCreate(ctx context.Context, store ports.StateStore, request createJobHTTPRequest) (string, error) {
 	if err := authorizeTenantID(ctx, request.TenantID); err != nil {
-		return err
+		return "", err
 	}
 	switch strings.TrimSpace(request.Kind) {
 	case platformjobs.KindSourceRuntimeSync, platformjobs.KindGraphIngestRuntime, platformjobs.KindFindingRulesEvaluate, platformjobs.KindFindingsEvaluate:
 		runtimeID := stringPayload(request.Payload, "runtime_id", request.SubjectID)
-		return authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(store), runtimeID, false)
+		runtimeTenantID, err := sourceRuntimeTenantID(ctx, sourceRuntimeStore(store), runtimeID, false)
+		if err != nil {
+			return "", err
+		}
+		if err := requireMatchingJobTenant(request.TenantID, runtimeTenantID); err != nil {
+			return "", err
+		}
+		return firstNonEmpty(request.TenantID, runtimeTenantID), nil
 	case platformjobs.KindReportRun:
 		parameters := stringMapPayload(request.Payload, "parameters")
 		if request.TenantID != "" && parameters["tenant_id"] == "" {
 			parameters["tenant_id"] = request.TenantID
 		}
-		return authorizeTenantID(ctx, parameters["tenant_id"])
+		reportTenantID := parameters["tenant_id"]
+		if err := authorizeTenantID(ctx, reportTenantID); err != nil {
+			return "", err
+		}
+		if err := requireMatchingJobTenant(request.TenantID, reportTenantID); err != nil {
+			return "", err
+		}
+		return firstNonEmpty(request.TenantID, reportTenantID), nil
 	default:
-		return fmt.Errorf("%w: unsupported job kind %q", platformjobs.ErrInvalidRequest, strings.TrimSpace(request.Kind))
+		return "", fmt.Errorf("%w: unsupported job kind %q", platformjobs.ErrInvalidRequest, strings.TrimSpace(request.Kind))
 	}
+}
+
+func requireMatchingJobTenant(jobTenantID string, targetTenantID string) error {
+	jobTenantID = strings.TrimSpace(jobTenantID)
+	targetTenantID = strings.TrimSpace(targetTenantID)
+	if jobTenantID == "" || targetTenantID == "" || jobTenantID == targetTenantID {
+		return nil
+	}
+	return errTenantForbidden
 }
 
 func writeJobError(w http.ResponseWriter, err error) {

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -1,0 +1,390 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphingest"
+	platformjobs "github.com/writer/cerebro/internal/jobs"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceruntime"
+)
+
+type createJobHTTPRequest struct {
+	Kind           string         `json:"kind"`
+	TenantID       string         `json:"tenant_id"`
+	SubjectType    string         `json:"subject_type"`
+	SubjectID      string         `json:"subject_id"`
+	IdempotencyKey string         `json:"idempotency_key"`
+	Payload        map[string]any `json:"payload"`
+}
+
+type jobResponse struct {
+	Job *ports.Job `json:"job"`
+}
+
+type jobListResponse struct {
+	Jobs []*ports.Job `json:"jobs"`
+}
+
+type jobEventListResponse struct {
+	Events []*ports.JobEvent `json:"events"`
+}
+
+func (a *App) jobService() *platformjobs.Service {
+	service := platformjobs.New(jobStore(a.deps.StateStore))
+	service.WithRunner(platformjobs.KindSourceRuntimeSync, a.runSourceRuntimeSyncJob)
+	service.WithRunner(platformjobs.KindGraphIngestRuntime, a.runGraphIngestRuntimeJob)
+	service.WithRunner(platformjobs.KindFindingRulesEvaluate, a.runFindingRulesEvaluateJob)
+	service.WithRunner(platformjobs.KindFindingsEvaluate, a.runFindingsEvaluateJob)
+	service.WithRunner(platformjobs.KindReportRun, a.runReportJob)
+	return service
+}
+
+func (a *App) handleCreateJob(w http.ResponseWriter, r *http.Request) {
+	var request createJobHTTPRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxProtoJSONBodyBytes)).Decode(&request); err != nil {
+		writeJobError(w, fmt.Errorf("%w: decode job request: %w", platformjobs.ErrInvalidRequest, err))
+		return
+	}
+	if request.IdempotencyKey == "" {
+		request.IdempotencyKey = r.Header.Get("Idempotency-Key")
+	}
+	if request.Payload == nil {
+		request.Payload = map[string]any{}
+	}
+	if err := authorizeJobCreate(r.Context(), a.deps.StateStore, request); err != nil {
+		writeJobError(w, err)
+		return
+	}
+	job, created, err := a.jobService().Create(r.Context(), ports.CreateJobRequest{
+		Kind:           request.Kind,
+		TenantID:       request.TenantID,
+		SubjectType:    request.SubjectType,
+		SubjectID:      request.SubjectID,
+		IdempotencyKey: request.IdempotencyKey,
+		Payload:        request.Payload,
+	})
+	if err != nil {
+		writeJobError(w, err)
+		return
+	}
+	if created {
+		a.jobService().StartAsync(r.Context(), job)
+	}
+	status := http.StatusAccepted
+	if !created {
+		status = http.StatusOK
+	}
+	writeJSON(w, status, jobResponse{Job: job})
+}
+
+func (a *App) handleListJobs(w http.ResponseWriter, r *http.Request) {
+	limit, err := uint32QueryParam(r, "limit")
+	if err != nil {
+		writeJobError(w, err)
+		return
+	}
+	filter := ports.JobFilter{
+		TenantID: r.URL.Query().Get("tenant_id"),
+		Kind:     r.URL.Query().Get("kind"),
+		Status:   r.URL.Query().Get("status"),
+		Limit:    limit,
+	}
+	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
+		writeJobError(w, err)
+		return
+	}
+	jobs, err := a.jobService().List(r.Context(), filter)
+	if err != nil {
+		writeJobError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, jobListResponse{Jobs: jobs})
+}
+
+func (a *App) handleGetJob(w http.ResponseWriter, r *http.Request) {
+	job, err := a.jobService().Get(r.Context(), r.PathValue("jobID"))
+	if err != nil {
+		writeJobError(w, err)
+		return
+	}
+	if err := authorizeTenantID(r.Context(), job.TenantID); err != nil {
+		writeJobError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, jobResponse{Job: job})
+}
+
+func (a *App) handleListJobEvents(w http.ResponseWriter, r *http.Request) {
+	job, err := a.jobService().Get(r.Context(), r.PathValue("jobID"))
+	if err != nil {
+		writeJobError(w, err)
+		return
+	}
+	if err := authorizeTenantID(r.Context(), job.TenantID); err != nil {
+		writeJobError(w, err)
+		return
+	}
+	limit, err := uint32QueryParam(r, "limit")
+	if err != nil {
+		writeJobError(w, err)
+		return
+	}
+	events, err := a.jobService().Events(r.Context(), job.ID, limit)
+	if err != nil {
+		writeJobError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, jobEventListResponse{Events: events})
+}
+
+func (a *App) handleCancelJob(w http.ResponseWriter, r *http.Request) {
+	existing, err := a.jobService().Get(r.Context(), r.PathValue("jobID"))
+	if err != nil {
+		writeJobError(w, err)
+		return
+	}
+	if err := authorizeTenantID(r.Context(), existing.TenantID); err != nil {
+		writeJobError(w, err)
+		return
+	}
+	job, err := a.jobService().Cancel(r.Context(), existing.ID)
+	if err != nil {
+		writeJobError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, jobResponse{Job: job})
+}
+
+func (a *App) runSourceRuntimeSyncJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+	if runtimeID == "" {
+		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
+	}
+	response, err := a.runtimeService().SyncWithLease(ctx, &cerebrov1.SyncSourceRuntimeRequest{
+		Id:        runtimeID,
+		PageLimit: uint32Payload(job.Payload, "page_limit"),
+	}, sourceruntime.SyncWithLeaseOptions{LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore)})
+	if err != nil {
+		return nil, nil, err
+	}
+	return protoToMap(response), nil, nil
+}
+
+func (a *App) runGraphIngestRuntimeJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+	if runtimeID == "" {
+		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
+	}
+	result, err := a.graphIngestService().RunRuntime(ctx, graphingest.RuntimeRequest{
+		RuntimeID: runtimeID,
+		PageLimit: uint32Payload(job.Payload, "page_limit"),
+		Trigger:   "platform_job",
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	refs := map[string]string{}
+	if result.Run.ID != "" {
+		refs["graph_ingest_run_id"] = result.Run.ID
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return nil, nil, err
+	}
+	out := map[string]any{}
+	_ = json.Unmarshal(payload, &out)
+	return out, refs, nil
+}
+
+func (a *App) runFindingRulesEvaluateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+	if runtimeID == "" {
+		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
+	}
+	result, err := a.findingService().EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
+		RuntimeID:  runtimeID,
+		RuleIDs:    stringSlicePayload(job.Payload, "rule_ids"),
+		EventLimit: uint32Payload(job.Payload, "event_limit"),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return nil, nil, err
+	}
+	out := map[string]any{}
+	_ = json.Unmarshal(payload, &out)
+	return out, nil, nil
+}
+
+func (a *App) runFindingsEvaluateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+	if runtimeID == "" {
+		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
+	}
+	result, err := a.findingService().EvaluateSourceRuntime(ctx, findings.EvaluateRequest{
+		RuntimeID:  runtimeID,
+		RuleID:     stringPayload(job.Payload, "rule_id", ""),
+		EventLimit: uint32Payload(job.Payload, "event_limit"),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return protoToMap(findingResponse(result)), nil, nil
+}
+
+func (a *App) runReportJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+	reportID := stringPayload(job.Payload, "report_id", job.SubjectID)
+	if reportID == "" {
+		return nil, nil, fmt.Errorf("%w: report_id is required", platformjobs.ErrInvalidRequest)
+	}
+	parameters := stringMapPayload(job.Payload, "parameters")
+	if job.TenantID != "" && parameters["tenant_id"] == "" {
+		parameters["tenant_id"] = job.TenantID
+	}
+	response, err := a.reportService().Run(ctx, &cerebrov1.RunReportRequest{ReportId: reportID, Parameters: parameters})
+	if err != nil {
+		return nil, nil, err
+	}
+	refs := map[string]string{}
+	if response.GetRun() != nil {
+		refs["report_run_id"] = response.GetRun().GetId()
+	}
+	return protoToMap(response), refs, nil
+}
+
+func authorizeJobCreate(ctx context.Context, store ports.StateStore, request createJobHTTPRequest) error {
+	if err := authorizeTenantID(ctx, request.TenantID); err != nil {
+		return err
+	}
+	switch strings.TrimSpace(request.Kind) {
+	case platformjobs.KindSourceRuntimeSync, platformjobs.KindGraphIngestRuntime, platformjobs.KindFindingRulesEvaluate, platformjobs.KindFindingsEvaluate:
+		runtimeID := stringPayload(request.Payload, "runtime_id", request.SubjectID)
+		return authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(store), runtimeID, false)
+	case platformjobs.KindReportRun:
+		parameters := stringMapPayload(request.Payload, "parameters")
+		if request.TenantID != "" && parameters["tenant_id"] == "" {
+			parameters["tenant_id"] = request.TenantID
+		}
+		return authorizeTenantID(ctx, parameters["tenant_id"])
+	default:
+		return nil
+	}
+}
+
+func writeJobError(w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, platformjobs.ErrInvalidRequest), errors.Is(err, errInvalidHTTPRequest):
+		status = http.StatusBadRequest
+	case errors.Is(err, ports.ErrJobNotFound):
+		status = http.StatusNotFound
+	case errors.Is(err, platformjobs.ErrRuntimeUnavailable):
+		status = http.StatusServiceUnavailable
+	case errors.Is(err, errTenantForbidden):
+		status = http.StatusForbidden
+	}
+	writeJSON(w, status, map[string]string{"error": err.Error()})
+}
+
+func protoToMap(message proto.Message) map[string]any {
+	payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(message)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+	out := map[string]any{}
+	_ = json.Unmarshal(payload, &out)
+	return out
+}
+
+func stringPayload(payload map[string]any, key string, fallback string) string {
+	if value, ok := payload[key]; ok {
+		switch typed := value.(type) {
+		case string:
+			if strings.TrimSpace(typed) != "" {
+				return strings.TrimSpace(typed)
+			}
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func uint32Payload(payload map[string]any, key string) uint32 {
+	value, ok := payload[key]
+	if !ok {
+		return 0
+	}
+	switch typed := value.(type) {
+	case float64:
+		if typed > 0 {
+			return uint32(typed)
+		}
+	case json.Number:
+		parsed, _ := strconv.ParseUint(string(typed), 10, 32)
+		return uint32(parsed)
+	case string:
+		parsed, _ := strconv.ParseUint(strings.TrimSpace(typed), 10, 32)
+		return uint32(parsed)
+	}
+	return 0
+}
+
+func stringSlicePayload(payload map[string]any, key string) []string {
+	value, ok := payload[key]
+	if !ok {
+		return nil
+	}
+	switch typed := value.(type) {
+	case []string:
+		return typed
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
+				values = append(values, strings.TrimSpace(text))
+			}
+		}
+		return values
+	case string:
+		if strings.TrimSpace(typed) == "" {
+			return nil
+		}
+		return []string{strings.TrimSpace(typed)}
+	default:
+		return nil
+	}
+}
+
+func stringMapPayload(payload map[string]any, key string) map[string]string {
+	result := map[string]string{}
+	value, ok := payload[key]
+	if !ok {
+		return result
+	}
+	switch typed := value.(type) {
+	case map[string]string:
+		for k, v := range typed {
+			result[k] = v
+		}
+	case map[string]any:
+		for k, v := range typed {
+			if text, ok := v.(string); ok {
+				result[k] = text
+			}
+		}
+	}
+	return result
+}

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -28,6 +28,8 @@ func (app *App) registerRoutes(mux *http.ServeMux, cfg config.Config, deps Depen
 	app.registerSourceRoutes(mux)
 	app.registerKnowledgeRoutes(mux)
 	app.registerGraphRoutes(mux)
+	app.registerJobRoutes(mux)
+	app.registerRuntimeResponseRoutes(mux)
 	app.registerSourceRuntimeRoutes(mux)
 	app.registerMCPRoutes(mux)
 	app.registerDeviceRoutes(mux)
@@ -43,6 +45,7 @@ func (app *App) registerPublicRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /health", routeSurfacePublicHTTP, app.handleHealth)
 	registerHTTPRoute(mux, "GET /healthz", routeSurfacePublicHTTP, app.handleLiveness)
 	registerHTTPRoute(mux, "GET /livez", routeSurfacePublicHTTP, app.handleLiveness)
+	registerHTTPRoute(mux, "GET /metrics", routeSurfacePlatformHTTP, app.handleMetrics)
 	registerHTTPRoute(mux, "GET /openapi.yaml", routeSurfacePublicHTTP, app.handleOpenAPI)
 }
 
@@ -117,6 +120,21 @@ func (app *App) registerGraphRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /platform/graph/ingest-health", routeSurfacePlatformHTTP, app.handleCheckGraphIngestHealth)
 	registerHTTPRoute(mux, "GET /platform/graph/ingest-runs", routeSurfacePlatformHTTP, app.handleListGraphIngestRuns)
 	registerHTTPRoute(mux, "GET /platform/graph/ingest-runs/{runID}", routeSurfacePlatformHTTP, app.handleGetGraphIngestRun)
+}
+
+func (app *App) registerJobRoutes(mux *http.ServeMux) {
+	registerHTTPRoute(mux, "POST /platform/jobs", routeSurfacePlatformHTTP, app.handleCreateJob)
+	registerHTTPRoute(mux, "GET /platform/jobs", routeSurfacePlatformHTTP, app.handleListJobs)
+	registerHTTPRoute(mux, "GET /platform/jobs/{jobID}", routeSurfacePlatformHTTP, app.handleGetJob)
+	registerHTTPRoute(mux, "GET /platform/jobs/{jobID}/events", routeSurfacePlatformHTTP, app.handleListJobEvents)
+	registerHTTPRoute(mux, "POST /platform/jobs/{jobID}/cancel", routeSurfacePlatformHTTP, app.handleCancelJob)
+}
+
+func (app *App) registerRuntimeResponseRoutes(mux *http.ServeMux) {
+	registerHTTPRoute(mux, "GET /platform/runtime-response/capabilities", routeSurfacePlatformHTTP, app.handleRuntimeResponseCapabilities)
+	registerHTTPRoute(mux, "POST /platform/runtime-response/actions", routeSurfacePlatformHTTP, app.handleExecuteRuntimeResponse)
+	registerHTTPRoute(mux, "GET /platform/runtime-response/blocklist", routeSurfacePlatformHTTP, app.handleListRuntimeBlocklist)
+	registerHTTPRoute(mux, "POST /platform/runtime-response/blocklist/{entryID}/revoke", routeSurfacePlatformHTTP, app.handleRevokeRuntimeBlocklistEntry)
 }
 
 func (app *App) registerSourceRuntimeRoutes(mux *http.ServeMux) {

--- a/internal/bootstrap/runtime_response.go
+++ b/internal/bootstrap/runtime_response.go
@@ -37,10 +37,12 @@ func (a *App) handleExecuteRuntimeResponse(w http.ResponseWriter, r *http.Reques
 		writeRuntimeResponseError(w, fmt.Errorf("%w: decode runtime response request: %w", runtimeresponse.ErrInvalidRequest, err))
 		return
 	}
-	if err := authorizeTenantID(r.Context(), request.TenantID); err != nil {
+	tenantID, err := effectiveTenantFilter(r.Context(), request.TenantID)
+	if err != nil {
 		writeRuntimeResponseError(w, err)
 		return
 	}
+	request.TenantID = tenantID
 	entry, err := a.runtimeResponseService().Execute(r.Context(), request)
 	if err != nil {
 		writeRuntimeResponseError(w, err)
@@ -56,7 +58,6 @@ func (a *App) handleListRuntimeBlocklist(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	filter := ports.RuntimeBlocklistFilter{
-		TenantID:       strings.TrimSpace(r.URL.Query().Get("tenant_id")),
 		Type:           strings.TrimSpace(r.URL.Query().Get("type")),
 		IncludeRevoked: false,
 		Limit:          limit,
@@ -69,10 +70,12 @@ func (a *App) handleListRuntimeBlocklist(w http.ResponseWriter, r *http.Request)
 		}
 		filter.IncludeRevoked = parsed
 	}
-	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
+	tenantID, err := effectiveTenantFilter(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
 		writeRuntimeResponseError(w, err)
 		return
 	}
+	filter.TenantID = tenantID
 	entries, err := a.runtimeResponseService().List(r.Context(), filter)
 	if err != nil {
 		writeRuntimeResponseError(w, err)
@@ -82,8 +85,8 @@ func (a *App) handleListRuntimeBlocklist(w http.ResponseWriter, r *http.Request)
 }
 
 func (a *App) handleRevokeRuntimeBlocklistEntry(w http.ResponseWriter, r *http.Request) {
-	tenantID := strings.TrimSpace(r.URL.Query().Get("tenant_id"))
-	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+	tenantID, err := effectiveTenantFilter(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
 		writeRuntimeResponseError(w, err)
 		return
 	}

--- a/internal/bootstrap/runtime_response.go
+++ b/internal/bootstrap/runtime_response.go
@@ -43,6 +43,7 @@ func (a *App) handleExecuteRuntimeResponse(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	request.TenantID = tenantID
+	request.TrustedScope = hasRuntimeResponseTrustedScope(r.Context())
 	entry, err := a.runtimeResponseService().Execute(r.Context(), request)
 	if err != nil {
 		writeRuntimeResponseError(w, err)

--- a/internal/bootstrap/runtime_response.go
+++ b/internal/bootstrap/runtime_response.go
@@ -1,0 +1,113 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/runtimeresponse"
+)
+
+type runtimeCapabilitiesResponse struct {
+	Capabilities []runtimeresponse.Capability `json:"capabilities"`
+}
+
+type runtimeBlocklistResponse struct {
+	Entry *ports.RuntimeBlocklistEntry `json:"entry"`
+}
+
+type runtimeBlocklistListResponse struct {
+	Entries []*ports.RuntimeBlocklistEntry `json:"entries"`
+}
+
+func (a *App) runtimeResponseService() *runtimeresponse.Service {
+	return runtimeresponse.New(runtimeBlocklistStore(a.deps.StateStore))
+}
+
+func (a *App) handleRuntimeResponseCapabilities(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, runtimeCapabilitiesResponse{Capabilities: a.runtimeResponseService().Capabilities()})
+}
+
+func (a *App) handleExecuteRuntimeResponse(w http.ResponseWriter, r *http.Request) {
+	var request runtimeresponse.ExecuteRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxProtoJSONBodyBytes)).Decode(&request); err != nil {
+		writeRuntimeResponseError(w, fmt.Errorf("%w: decode runtime response request: %w", runtimeresponse.ErrInvalidRequest, err))
+		return
+	}
+	if err := authorizeTenantID(r.Context(), request.TenantID); err != nil {
+		writeRuntimeResponseError(w, err)
+		return
+	}
+	entry, err := a.runtimeResponseService().Execute(r.Context(), request)
+	if err != nil {
+		writeRuntimeResponseError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, runtimeBlocklistResponse{Entry: entry})
+}
+
+func (a *App) handleListRuntimeBlocklist(w http.ResponseWriter, r *http.Request) {
+	limit, err := uint32QueryParam(r, "limit")
+	if err != nil {
+		writeRuntimeResponseError(w, err)
+		return
+	}
+	filter := ports.RuntimeBlocklistFilter{
+		TenantID:       strings.TrimSpace(r.URL.Query().Get("tenant_id")),
+		Type:           strings.TrimSpace(r.URL.Query().Get("type")),
+		IncludeRevoked: false,
+		Limit:          limit,
+	}
+	if includeRevoked := strings.TrimSpace(r.URL.Query().Get("include_revoked")); includeRevoked != "" {
+		parsed, err := boolQueryParam(r, "include_revoked")
+		if err != nil {
+			writeRuntimeResponseError(w, err)
+			return
+		}
+		filter.IncludeRevoked = parsed
+	}
+	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
+		writeRuntimeResponseError(w, err)
+		return
+	}
+	entries, err := a.runtimeResponseService().List(r.Context(), filter)
+	if err != nil {
+		writeRuntimeResponseError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, runtimeBlocklistListResponse{Entries: entries})
+}
+
+func (a *App) handleRevokeRuntimeBlocklistEntry(w http.ResponseWriter, r *http.Request) {
+	tenantID := strings.TrimSpace(r.URL.Query().Get("tenant_id"))
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		writeRuntimeResponseError(w, err)
+		return
+	}
+	entry, err := a.runtimeResponseService().Revoke(r.Context(), tenantID, r.PathValue("entryID"))
+	if err != nil {
+		writeRuntimeResponseError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, runtimeBlocklistResponse{Entry: entry})
+}
+
+func writeRuntimeResponseError(w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, runtimeresponse.ErrInvalidRequest), errors.Is(err, errInvalidHTTPRequest):
+		status = http.StatusBadRequest
+	case errors.Is(err, runtimeresponse.ErrUnsupportedAction):
+		status = http.StatusUnprocessableEntity
+	case errors.Is(err, runtimeresponse.ErrRuntimeUnavailable):
+		status = http.StatusServiceUnavailable
+	case errors.Is(err, ports.ErrRuntimeBlocklistEntryNotFound):
+		status = http.StatusNotFound
+	case errors.Is(err, errTenantForbidden):
+		status = http.StatusForbidden
+	}
+	writeJSON(w, status, map[string]string{"error": err.Error()})
+}

--- a/internal/bootstrap/tenant_filter_test.go
+++ b/internal/bootstrap/tenant_filter_test.go
@@ -1,0 +1,46 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+func TestEffectiveTenantFilterDefaultsPrincipalTenant(t *testing.T) {
+	ctx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		principal: authPrincipal{TenantID: "writer"},
+	})
+
+	tenantID, err := effectiveTenantFilter(ctx, "")
+	if err != nil {
+		t.Fatalf("effectiveTenantFilter error = %v", err)
+	}
+	if tenantID != "writer" {
+		t.Fatalf("tenantID = %q, want writer", tenantID)
+	}
+}
+
+func TestEffectiveTenantFilterRejectsAmbiguousAllowedTenantScope(t *testing.T) {
+	ctx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		cfg:       config.AuthConfig{AllowedTenants: []string{"writer"}},
+		principal: authPrincipal{},
+	})
+
+	_, err := effectiveTenantFilter(ctx, "")
+	if !errors.Is(err, errTenantForbidden) {
+		t.Fatalf("effectiveTenantFilter error = %v, want %v", err, errTenantForbidden)
+	}
+}
+
+func TestEffectiveTenantFilterRejectsCrossTenantRequest(t *testing.T) {
+	ctx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		principal: authPrincipal{TenantID: "writer"},
+	})
+
+	_, err := effectiveTenantFilter(ctx, "other")
+	if !errors.Is(err, errTenantForbidden) {
+		t.Fatalf("effectiveTenantFilter error = %v, want %v", err, errTenantForbidden)
+	}
+}

--- a/internal/bootstrap/tenant_filter_test.go
+++ b/internal/bootstrap/tenant_filter_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/writer/cerebro/internal/config"
@@ -31,6 +32,60 @@ func TestEffectiveTenantFilterRejectsAmbiguousAllowedTenantScope(t *testing.T) {
 	_, err := effectiveTenantFilter(ctx, "")
 	if !errors.Is(err, errTenantForbidden) {
 		t.Fatalf("effectiveTenantFilter error = %v, want %v", err, errTenantForbidden)
+	}
+}
+
+func TestScopeForHTTPRequestCoversPlatformJobAndRuntimeResponseReads(t *testing.T) {
+	for _, path := range []string{
+		"/platform/jobs",
+		"/platform/jobs/job-123",
+		"/platform/jobs/job-123/events",
+		"/platform/runtime-response/capabilities",
+		"/platform/runtime-response/blocklist",
+	} {
+		request, err := http.NewRequest(http.MethodGet, path, nil)
+		if err != nil {
+			t.Fatalf("NewRequest(%q) error = %v", path, err)
+		}
+		if got := scopeForHTTPRequest(request); got != scopeCosmoSecurityRead {
+			t.Fatalf("scopeForHTTPRequest(%s) = %q, want %q", path, got, scopeCosmoSecurityRead)
+		}
+	}
+}
+
+func TestRuntimeResponseTrustedScopeIsServerDerived(t *testing.T) {
+	request, err := http.NewRequest(http.MethodPost, "/platform/runtime-response/actions", nil)
+	if err != nil {
+		t.Fatalf("NewRequest error = %v", err)
+	}
+	if got := scopeForHTTPRequest(request); got != scopeRuntimeResponseWrite {
+		t.Fatalf("scopeForHTTPRequest(runtime response action) = %q, want %q", got, scopeRuntimeResponseWrite)
+	}
+
+	restricted := context.WithValue(context.Background(), authContextKey{}, authContext{
+		principal: authPrincipal{Scopes: []string{scopeCosmoSecurityRead}},
+	})
+	if hasRuntimeResponseTrustedScope(restricted) {
+		t.Fatal("read-only scoped principal has trusted runtime response scope")
+	}
+
+	writer := context.WithValue(context.Background(), authContextKey{}, authContext{
+		principal: authPrincipal{Scopes: []string{scopeRuntimeResponseWrite}},
+	})
+	if !hasRuntimeResponseTrustedScope(writer) {
+		t.Fatal("runtime response write scope was not trusted")
+	}
+}
+
+func TestRequireMatchingJobTenantRejectsMismatchedTargetTenant(t *testing.T) {
+	if err := requireMatchingJobTenant("tenant-a", "tenant-a"); err != nil {
+		t.Fatalf("matching tenants error = %v", err)
+	}
+	if err := requireMatchingJobTenant("", "tenant-a"); err != nil {
+		t.Fatalf("empty job tenant should allow target-derived tenant, got %v", err)
+	}
+	if err := requireMatchingJobTenant("tenant-a", "tenant-b"); !errors.Is(err, errTenantForbidden) {
+		t.Fatalf("mismatched tenants error = %v, want %v", err, errTenantForbidden)
 	}
 }
 

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -1,0 +1,172 @@
+package jobs
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var (
+	ErrInvalidRequest     = errors.New("invalid job request")
+	ErrRuntimeUnavailable = errors.New("job runtime is unavailable")
+)
+
+const (
+	KindSourceRuntimeSync         = "source_runtime_sync"
+	KindGraphIngestRuntime        = "graph_ingest_runtime"
+	KindFindingRulesEvaluate      = "finding_rules_evaluate"
+	KindFindingCandidatesEvaluate = "finding_candidates_evaluate"
+	KindFindingsEvaluate          = "findings_evaluate"
+	KindReportRun                 = "report_run"
+	KindVulnDBSyncJobRun          = "vulndb_sync_job_run"
+	KindGraphRebuildDryRun        = "graph_rebuild_dry_run"
+)
+
+type Runner func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error)
+
+type Service struct {
+	store   ports.JobStore
+	runners map[string]Runner
+	now     func() time.Time
+}
+
+func New(store ports.JobStore) *Service {
+	return &Service{store: store, runners: map[string]Runner{}, now: func() time.Time { return time.Now().UTC() }}
+}
+
+func (s *Service) WithRunner(kind string, runner Runner) *Service {
+	if s == nil {
+		return nil
+	}
+	kind = strings.TrimSpace(kind)
+	if kind == "" || runner == nil {
+		return s
+	}
+	s.runners[kind] = runner
+	return s
+}
+
+func (s *Service) Create(ctx context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
+	if s == nil || s.store == nil {
+		return nil, false, ErrRuntimeUnavailable
+	}
+	request.Kind = strings.TrimSpace(request.Kind)
+	if request.Kind == "" {
+		return nil, false, fmt.Errorf("%w: kind is required", ErrInvalidRequest)
+	}
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.SubjectType = strings.TrimSpace(request.SubjectType)
+	request.SubjectID = strings.TrimSpace(request.SubjectID)
+	request.IdempotencyKey = strings.TrimSpace(request.IdempotencyKey)
+	if request.Payload == nil {
+		request.Payload = map[string]any{}
+	}
+	job, created, err := s.store.CreateJob(ctx, request)
+	if err != nil {
+		return nil, false, err
+	}
+	if created {
+		_, _ = s.store.AppendJobEvent(ctx, ports.JobEvent{JobID: job.ID, Type: "created", Status: job.Status, Message: "job created"})
+	}
+	return job, created, nil
+}
+
+func (s *Service) StartAsync(parent context.Context, job *ports.Job) {
+	if s == nil || job == nil {
+		return
+	}
+	runner := s.runners[job.Kind]
+	if runner == nil {
+		return
+	}
+	ctx := context.WithoutCancel(parent)
+	go func() {
+		_ = s.Run(ctx, job.ID)
+	}()
+}
+
+func (s *Service) Run(ctx context.Context, jobID string) error {
+	if s == nil || s.store == nil {
+		return ErrRuntimeUnavailable
+	}
+	job, err := s.store.GetJob(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if job.Status != ports.JobStatusQueued {
+		return nil
+	}
+	runner := s.runners[job.Kind]
+	if runner == nil {
+		return nil
+	}
+	now := s.now()
+	job, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusRunning, Message: "job running", StartedAt: &now})
+	if err != nil {
+		return err
+	}
+	_, _ = s.store.AppendJobEvent(ctx, ports.JobEvent{JobID: job.ID, Type: "started", Status: ports.JobStatusRunning, Message: "job started"})
+	result, refs, runErr := runner(ctx, job, s)
+	finished := s.now()
+	if runErr != nil {
+		_, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusFailed, Error: runErr.Error(), Message: "job failed", FinishedAt: &finished})
+		_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "failed", Status: ports.JobStatusFailed, Message: runErr.Error()})
+		if err != nil {
+			return err
+		}
+		return runErr
+	}
+	progress := uint32(100)
+	_, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusCompleted, Progress: &progress, Message: "job completed", Result: result, ResultRefs: refs, FinishedAt: &finished})
+	_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "completed", Status: ports.JobStatusCompleted, Message: "job completed"})
+	return err
+}
+
+func (s *Service) Get(ctx context.Context, id string) (*ports.Job, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	return s.store.GetJob(ctx, id)
+}
+
+func (s *Service) List(ctx context.Context, filter ports.JobFilter) ([]*ports.Job, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	return s.store.ListJobs(ctx, filter)
+}
+
+func (s *Service) Events(ctx context.Context, jobID string, limit uint32) ([]*ports.JobEvent, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	return s.store.ListJobEvents(ctx, jobID, limit)
+}
+
+func (s *Service) Cancel(ctx context.Context, jobID string) (*ports.Job, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	requested := true
+	finished := s.now()
+	job, err := s.store.UpdateJob(ctx, jobID, ports.JobUpdate{Status: ports.JobStatusCancelled, Message: "job cancellation requested", CancelRequested: &requested, FinishedAt: &finished})
+	if err != nil {
+		return nil, err
+	}
+	_, _ = s.store.AppendJobEvent(ctx, ports.JobEvent{JobID: job.ID, Type: "cancelled", Status: ports.JobStatusCancelled, Message: "job cancellation requested"})
+	return job, nil
+}
+
+func NewID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("job-%d", time.Now().UnixNano())
+	}
+	return "job-" + hex.EncodeToString(b[:])
+}

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -94,10 +94,17 @@ func (s *Service) StartAsync(parent context.Context, job *ports.Job) {
 	}()
 }
 
-func (s *Service) Run(ctx context.Context, jobID string) error {
+func (s *Service) Run(ctx context.Context, jobID string) (err error) {
 	if s == nil || s.store == nil {
 		return ErrRuntimeUnavailable
 	}
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			return
+		}
+		err = s.failPanickedJob(context.WithoutCancel(ctx), jobID, recovered)
+	}()
 	job, err := s.store.GetJob(ctx, jobID)
 	if err != nil {
 		return err
@@ -144,6 +151,30 @@ func (s *Service) Run(ctx context.Context, jobID string) error {
 		_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "completed", Status: ports.JobStatusCompleted, Message: "job completed"})
 	}
 	return err
+}
+
+func (s *Service) failPanickedJob(ctx context.Context, jobID string, recovered any) error {
+	panicErr := fmt.Errorf("job panic: %v", recovered)
+	jobID = strings.TrimSpace(jobID)
+	if s == nil || s.store == nil || jobID == "" {
+		return panicErr
+	}
+	finished := s.now()
+	_, err := s.store.UpdateJob(ctx, jobID, ports.JobUpdate{
+		Status:          ports.JobStatusFailed,
+		Message:         "job failed",
+		Error:           panicErr.Error(),
+		FinishedAt:      &finished,
+		AllowedStatuses: []string{ports.JobStatusQueued, ports.JobStatusRunning},
+	})
+	if err != nil {
+		if errors.Is(err, ports.ErrJobUpdateConflict) {
+			return panicErr
+		}
+		return fmt.Errorf("%w; mark job failed: %w", panicErr, err)
+	}
+	_, _ = s.store.AppendJobEvent(ctx, ports.JobEvent{JobID: jobID, Type: "failed", Status: ports.JobStatusFailed, Message: panicErr.Error()})
+	return panicErr
 }
 
 func (s *Service) Get(ctx context.Context, id string) (*ports.Job, error) {

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -60,6 +60,9 @@ func (s *Service) Create(ctx context.Context, request ports.CreateJobRequest) (*
 	if request.Kind == "" {
 		return nil, false, fmt.Errorf("%w: kind is required", ErrInvalidRequest)
 	}
+	if s.runners[request.Kind] == nil {
+		return nil, false, fmt.Errorf("%w: unsupported job kind %q", ErrInvalidRequest, request.Kind)
+	}
 	request.TenantID = strings.TrimSpace(request.TenantID)
 	request.SubjectType = strings.TrimSpace(request.SubjectType)
 	request.SubjectID = strings.TrimSpace(request.SubjectID)
@@ -104,27 +107,42 @@ func (s *Service) Run(ctx context.Context, jobID string) error {
 	}
 	runner := s.runners[job.Kind]
 	if runner == nil {
+		finished := s.now()
+		if _, err := s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusFailed, Message: "job runner unavailable", Error: "job runner unavailable", FinishedAt: &finished, AllowedStatuses: []string{ports.JobStatusQueued}}); err == nil {
+			_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "failed", Status: ports.JobStatusFailed, Message: "job runner unavailable"})
+		}
 		return nil
 	}
 	now := s.now()
-	job, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusRunning, Message: "job running", StartedAt: &now})
+	job, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusRunning, Message: "job running", StartedAt: &now, AllowedStatuses: []string{ports.JobStatusQueued}})
 	if err != nil {
+		if errors.Is(err, ports.ErrJobUpdateConflict) {
+			return nil
+		}
 		return err
 	}
 	_, _ = s.store.AppendJobEvent(ctx, ports.JobEvent{JobID: job.ID, Type: "started", Status: ports.JobStatusRunning, Message: "job started"})
 	result, refs, runErr := runner(ctx, job, s)
 	finished := s.now()
 	if runErr != nil {
-		_, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusFailed, Error: runErr.Error(), Message: "job failed", FinishedAt: &finished})
-		_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "failed", Status: ports.JobStatusFailed, Message: runErr.Error()})
+		_, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusFailed, Error: runErr.Error(), Message: "job failed", FinishedAt: &finished, AllowedStatuses: []string{ports.JobStatusRunning}})
 		if err != nil {
+			if errors.Is(err, ports.ErrJobUpdateConflict) {
+				return runErr
+			}
 			return err
 		}
+		_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "failed", Status: ports.JobStatusFailed, Message: runErr.Error()})
 		return runErr
 	}
 	progress := uint32(100)
-	_, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusCompleted, Progress: &progress, Message: "job completed", Result: result, ResultRefs: refs, FinishedAt: &finished})
-	_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "completed", Status: ports.JobStatusCompleted, Message: "job completed"})
+	_, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusCompleted, Progress: &progress, Message: "job completed", Result: result, ResultRefs: refs, FinishedAt: &finished, AllowedStatuses: []string{ports.JobStatusRunning}})
+	if errors.Is(err, ports.ErrJobUpdateConflict) {
+		return nil
+	}
+	if err == nil {
+		_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "completed", Status: ports.JobStatusCompleted, Message: "job completed"})
+	}
 	return err
 }
 
@@ -153,13 +171,32 @@ func (s *Service) Cancel(ctx context.Context, jobID string) (*ports.Job, error) 
 	if s == nil || s.store == nil {
 		return nil, ErrRuntimeUnavailable
 	}
-	requested := true
-	finished := s.now()
-	job, err := s.store.UpdateJob(ctx, jobID, ports.JobUpdate{Status: ports.JobStatusCancelled, Message: "job cancellation requested", CancelRequested: &requested, FinishedAt: &finished})
+	existing, err := s.store.GetJob(ctx, jobID)
 	if err != nil {
 		return nil, err
 	}
-	_, _ = s.store.AppendJobEvent(ctx, ports.JobEvent{JobID: job.ID, Type: "cancelled", Status: ports.JobStatusCancelled, Message: "job cancellation requested"})
+	switch existing.Status {
+	case ports.JobStatusCompleted, ports.JobStatusFailed, ports.JobStatusCancelled:
+		return existing, nil
+	}
+	requested := true
+	finished := s.now()
+	update := ports.JobUpdate{Message: "job cancellation requested", CancelRequested: &requested, AllowedStatuses: []string{existing.Status}}
+	event := ports.JobEvent{JobID: existing.ID, Type: "cancellation_requested", Status: existing.Status, Message: "job cancellation requested"}
+	if existing.Status == ports.JobStatusQueued {
+		update.Status = ports.JobStatusCancelled
+		update.FinishedAt = &finished
+		event.Type = "cancelled"
+		event.Status = ports.JobStatusCancelled
+	}
+	job, err := s.store.UpdateJob(ctx, jobID, update)
+	if err != nil {
+		if errors.Is(err, ports.ErrJobUpdateConflict) {
+			return s.store.GetJob(ctx, jobID)
+		}
+		return nil, err
+	}
+	_, _ = s.store.AppendJobEvent(ctx, event)
 	return job, nil
 }
 

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -15,6 +15,7 @@ import (
 var (
 	ErrInvalidRequest     = errors.New("invalid job request")
 	ErrRuntimeUnavailable = errors.New("job runtime is unavailable")
+	ErrJobPanic           = errors.New("job panic")
 )
 
 const (
@@ -154,7 +155,7 @@ func (s *Service) Run(ctx context.Context, jobID string) (err error) {
 }
 
 func (s *Service) failPanickedJob(ctx context.Context, jobID string, recovered any) error {
-	panicErr := fmt.Errorf("job panic: %v", recovered)
+	panicErr := fmt.Errorf("%w: %v", ErrJobPanic, recovered)
 	jobID = strings.TrimSpace(jobID)
 	if s == nil || s.store == nil || jobID == "" {
 		return panicErr

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -1,0 +1,205 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestCreateRejectsUnsupportedKind(t *testing.T) {
+	service := New(newMemoryJobStore())
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		return nil, nil, nil
+	})
+
+	_, _, err := service.Create(context.Background(), ports.CreateJobRequest{Kind: KindGraphRebuildDryRun})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Create unsupported kind error = %v, want %v", err, ErrInvalidRequest)
+	}
+}
+
+func TestCancelDoesNotOverwriteTerminalJob(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-complete"] = &ports.Job{ID: "job-complete", Kind: KindReportRun, Status: ports.JobStatusCompleted}
+	service := New(store)
+
+	job, err := service.Cancel(context.Background(), "job-complete")
+	if err != nil {
+		t.Fatalf("Cancel terminal job error = %v", err)
+	}
+	if job.Status != ports.JobStatusCompleted {
+		t.Fatalf("status = %q, want %q", job.Status, ports.JobStatusCompleted)
+	}
+	if got := len(store.events); got != 0 {
+		t.Fatalf("events = %d, want 0", got)
+	}
+}
+
+func TestCancelRunningJobRequestsCancellationWithoutTerminalTransition(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-running"] = &ports.Job{ID: "job-running", Kind: KindReportRun, Status: ports.JobStatusRunning}
+	service := New(store)
+
+	job, err := service.Cancel(context.Background(), "job-running")
+	if err != nil {
+		t.Fatalf("Cancel running job error = %v", err)
+	}
+	if job.Status != ports.JobStatusRunning {
+		t.Fatalf("status = %q, want %q", job.Status, ports.JobStatusRunning)
+	}
+	if !job.CancelRequested {
+		t.Fatal("CancelRequested = false, want true")
+	}
+	if len(store.events) != 1 || store.events[0].Type != "cancellation_requested" {
+		t.Fatalf("events = %#v, want one cancellation_requested event", store.events)
+	}
+}
+
+type memoryJobStore struct {
+	mu     sync.Mutex
+	nextID int
+	jobs   map[string]*ports.Job
+	events []*ports.JobEvent
+}
+
+func newMemoryJobStore() *memoryJobStore {
+	return &memoryJobStore{jobs: map[string]*ports.Job{}, nextID: 1}
+}
+
+func (s *memoryJobStore) Ping(context.Context) error {
+	return nil
+}
+
+func (s *memoryJobStore) CreateJob(_ context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := "job-test"
+	if s.nextID > 1 {
+		id = fmt.Sprintf("job-test-%d", s.nextID)
+	}
+	s.nextID++
+	job := &ports.Job{
+		ID:             id,
+		Kind:           request.Kind,
+		Status:         ports.JobStatusQueued,
+		TenantID:       request.TenantID,
+		SubjectType:    request.SubjectType,
+		SubjectID:      request.SubjectID,
+		IdempotencyKey: request.IdempotencyKey,
+		Payload:        cloneAnyMap(request.Payload),
+	}
+	s.jobs[id] = cloneJob(job)
+	return cloneJob(job), true, nil
+}
+
+func (s *memoryJobStore) GetJob(_ context.Context, id string) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[id]
+	if !ok {
+		return nil, ports.ErrJobNotFound
+	}
+	return cloneJob(job), nil
+}
+
+func (s *memoryJobStore) ListJobs(context.Context, ports.JobFilter) ([]*ports.Job, error) {
+	return nil, nil
+}
+
+func (s *memoryJobStore) UpdateJob(_ context.Context, id string, update ports.JobUpdate) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[id]
+	if !ok {
+		return nil, ports.ErrJobNotFound
+	}
+	if len(update.AllowedStatuses) > 0 && !containsStatus(update.AllowedStatuses, job.Status) {
+		return nil, ports.ErrJobUpdateConflict
+	}
+	if update.Status != "" {
+		job.Status = update.Status
+	}
+	if update.Progress != nil {
+		job.Progress = *update.Progress
+	}
+	if update.Message != "" {
+		job.Message = update.Message
+	}
+	if update.Error != "" {
+		job.Error = update.Error
+	}
+	if update.Result != nil {
+		job.Result = cloneAnyMap(update.Result)
+	}
+	if update.ResultRefs != nil {
+		job.ResultRefs = cloneStringMap(update.ResultRefs)
+	}
+	if update.StartedAt != nil {
+		job.StartedAt = *update.StartedAt
+	}
+	if update.FinishedAt != nil {
+		job.FinishedAt = *update.FinishedAt
+	}
+	if update.CancelRequested != nil {
+		job.CancelRequested = *update.CancelRequested
+	}
+	return cloneJob(job), nil
+}
+
+func (s *memoryJobStore) AppendJobEvent(_ context.Context, event ports.JobEvent) (*ports.JobEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cloned := event
+	s.events = append(s.events, &cloned)
+	return &cloned, nil
+}
+
+func (s *memoryJobStore) ListJobEvents(context.Context, string, uint32) ([]*ports.JobEvent, error) {
+	return nil, nil
+}
+
+func containsStatus(values []string, status string) bool {
+	for _, value := range values {
+		if value == status {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneJob(job *ports.Job) *ports.Job {
+	if job == nil {
+		return nil
+	}
+	cloned := *job
+	cloned.Payload = cloneAnyMap(job.Payload)
+	cloned.Result = cloneAnyMap(job.Result)
+	cloned.ResultRefs = cloneStringMap(job.ResultRefs)
+	return &cloned
+}
+
+func cloneAnyMap(values map[string]any) map[string]any {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -56,6 +57,33 @@ func TestCancelRunningJobRequestsCancellationWithoutTerminalTransition(t *testin
 	}
 	if len(store.events) != 1 || store.events[0].Type != "cancellation_requested" {
 		t.Fatalf("events = %#v, want one cancellation_requested event", store.events)
+	}
+}
+
+func TestRunRecoversRunnerPanicAndMarksJobFailed(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-panic"] = &ports.Job{ID: "job-panic", Kind: KindReportRun, Status: ports.JobStatusQueued}
+	service := New(store)
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		panic("boom")
+	})
+
+	err := service.Run(context.Background(), "job-panic")
+	if err == nil || !strings.Contains(err.Error(), "job panic: boom") {
+		t.Fatalf("Run panic error = %v, want job panic", err)
+	}
+	job, err := store.GetJob(context.Background(), "job-panic")
+	if err != nil {
+		t.Fatalf("GetJob error = %v", err)
+	}
+	if job.Status != ports.JobStatusFailed {
+		t.Fatalf("status = %q, want %q", job.Status, ports.JobStatusFailed)
+	}
+	if !strings.Contains(job.Error, "job panic: boom") {
+		t.Fatalf("job error = %q, want panic detail", job.Error)
+	}
+	if len(store.events) < 2 || store.events[len(store.events)-1].Type != "failed" {
+		t.Fatalf("events = %#v, want final failed event", store.events)
 	}
 }
 

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
 
@@ -69,7 +68,7 @@ func TestRunRecoversRunnerPanicAndMarksJobFailed(t *testing.T) {
 	})
 
 	err := service.Run(context.Background(), "job-panic")
-	if err == nil || !strings.Contains(err.Error(), "job panic: boom") {
+	if !errors.Is(err, ErrJobPanic) {
 		t.Fatalf("Run panic error = %v, want job panic", err)
 	}
 	job, err := store.GetJob(context.Background(), "job-panic")
@@ -79,7 +78,7 @@ func TestRunRecoversRunnerPanicAndMarksJobFailed(t *testing.T) {
 	if job.Status != ports.JobStatusFailed {
 		t.Fatalf("status = %q, want %q", job.Status, ports.JobStatusFailed)
 	}
-	if !strings.Contains(job.Error, "job panic: boom") {
+	if job.Error != "job panic: boom" {
 		t.Fatalf("job error = %q, want panic detail", job.Error)
 	}
 	if len(store.events) < 2 || store.events[len(store.events)-1].Type != "failed" {

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -290,7 +290,7 @@ func dynamicRouteLabel(parts []string) (string, bool) {
 	case match(parts, "source-runtimes", "*"):
 		return "/source-runtimes/{runtimeID}", true
 	case len(parts) == 3 && parts[0] == "source-runtimes":
-		return "/source-runtimes/{runtimeID}/" + parts[2], true
+		return sourceRuntimeSubresourceRouteLabel(parts[2]), true
 	case len(parts) == 4 && parts[0] == "source-runtimes" && parts[2] == "finding-candidates" && parts[3] == "evaluate":
 		return "/source-runtimes/{runtimeID}/finding-candidates/evaluate", true
 	case len(parts) == 4 && parts[0] == "source-runtimes" && parts[2] == "finding-rules" && parts[3] == "evaluate":
@@ -299,6 +299,15 @@ func dynamicRouteLabel(parts []string) (string, bool) {
 		return "/source-runtimes/{runtimeID}/findings/evaluate", true
 	default:
 		return "", false
+	}
+}
+
+func sourceRuntimeSubresourceRouteLabel(subresource string) string {
+	switch subresource {
+	case "sync", "graph-ingest-runs", "claims", "findings", "finding-candidates", "finding-evidence", "finding-evaluation-runs":
+		return "/source-runtimes/{runtimeID}/" + subresource
+	default:
+		return "/source-runtimes/{runtimeID}/{subresource}"
 	}
 }
 

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -85,12 +85,36 @@ func Middleware(next http.Handler) http.Handler {
 
 type statusRecorder struct {
 	http.ResponseWriter
-	status int
+	status      int
+	wroteHeader bool
 }
 
 func (r *statusRecorder) WriteHeader(status int) {
+	if r.wroteHeader {
+		return
+	}
 	r.status = status
+	r.wroteHeader = true
 	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *statusRecorder) Flush() {
+	if r == nil {
+		return
+	}
+	if !r.wroteHeader {
+		r.WriteHeader(http.StatusOK)
+	}
+	if flusher, ok := r.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter {
+	if r == nil {
+		return nil
+	}
+	return r.ResponseWriter
 }
 
 func normalizeRouteLabel(path string) string {
@@ -98,23 +122,189 @@ func normalizeRouteLabel(path string) string {
 	if path == "" {
 		return "/"
 	}
-	parts := strings.Split(path, "/")
-	for i, part := range parts {
-		if looksVariable(part) {
-			parts[i] = "{id}"
-		}
+	if _, ok := exactRouteLabels[path]; ok {
+		return path
 	}
-	return strings.Join(parts, "/")
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if label, ok := dynamicRouteLabel(parts); ok {
+		return label
+	}
+	return unmatchedRouteLabel(parts)
 }
 
-func looksVariable(part string) bool {
-	if len(part) >= 12 && strings.HasPrefix(part, "job-") {
-		return true
+var exactRouteLabels = map[string]struct{}{
+	"/":                                     {},
+	"/health":                               {},
+	"/healthz":                              {},
+	"/livez":                                {},
+	"/metrics":                              {},
+	"/openapi.yaml":                         {},
+	"/.well-known/oauth-protected-resource": {},
+	"/.well-known/oauth-protected-resource/api/v1/mcp":                    {},
+	"/.well-known/oauth-authorization-server":                             {},
+	"/.well-known/device-jwks.json":                                       {},
+	"/oauth/authorize":                                                    {},
+	"/oauth/callback":                                                     {},
+	"/oauth/token":                                                        {},
+	"/oauth/revoke":                                                       {},
+	"/oauth/register":                                                     {},
+	"/reports":                                                            {},
+	"/grc/dashboard":                                                      {},
+	"/grc/ask":                                                            {},
+	"/grc/findings":                                                       {},
+	"/grc/controls":                                                       {},
+	"/grc/evidence":                                                       {},
+	"/finding-rules":                                                      {},
+	"/endpoint-vulnerability-findings":                                    {},
+	"/sources":                                                            {},
+	"/platform/knowledge/decisions":                                       {},
+	"/platform/knowledge/actions":                                         {},
+	"/platform/knowledge/actions/recommendation":                          {},
+	"/platform/knowledge/outcomes":                                        {},
+	"/platform/workflow/replay":                                           {},
+	"/platform/graph/neighborhood":                                        {},
+	"/platform/graph/impact/package":                                      {},
+	"/platform/graph/impact/asset":                                        {},
+	"/platform/graph/attack-paths":                                        {},
+	"/platform/graph/crown-jewel-rankings":                                {},
+	"/platform/graph/aws-public-endpoint-insights":                        {},
+	"/platform/graph/ingest-health":                                       {},
+	"/platform/graph/ingest-runs":                                         {},
+	"/platform/jobs":                                                      {},
+	"/platform/runtime-response/capabilities":                             {},
+	"/platform/runtime-response/actions":                                  {},
+	"/platform/runtime-response/blocklist":                                {},
+	"/platform/devices/enroll":                                            {},
+	"/platform/devices/token":                                             {},
+	"/platform/devices/bootstrap-tokens":                                  {},
+	"/platform/telemetry/ingest":                                          {},
+	"/source-runtimes":                                                    {},
+	"/api/v1/mcp":                                                         {},
+	"/cerebro.v1.BootstrapService/Health":                                 {},
+	"/cerebro.v1.BootstrapService/Ingest":                                 {},
+	"/cerebro.v1.BootstrapService/ListEvents":                             {},
+	"/cerebro.v1.BootstrapService/ListStreams":                            {},
+	"/cerebro.v1.BootstrapService/ListViews":                              {},
+	"/cerebro.v1.BootstrapService/ListRules":                              {},
+	"/cerebro.v1.BootstrapService/ListActions":                            {},
+	"/cerebro.v1.BootstrapService/ListAgents":                             {},
+	"/cerebro.v1.BootstrapService/ListSourceRuntimes":                     {},
+	"/cerebro.v1.BootstrapService/CheckSourceRuntime":                     {},
+	"/cerebro.v1.BootstrapService/DiscoverSourceRuntime":                  {},
+	"/cerebro.v1.BootstrapService/ReadSourceRuntime":                      {},
+	"/cerebro.v1.BootstrapService/PutSourceRuntime":                       {},
+	"/cerebro.v1.BootstrapService/GetSourceRuntime":                       {},
+	"/cerebro.v1.BootstrapService/SyncSourceRuntime":                      {},
+	"/cerebro.v1.BootstrapService/ListClaims":                             {},
+	"/cerebro.v1.BootstrapService/WriteClaims":                            {},
+	"/cerebro.v1.BootstrapService/ListFindings":                           {},
+	"/cerebro.v1.BootstrapService/ListFindingCandidates":                  {},
+	"/cerebro.v1.BootstrapService/ListFindingEvidence":                    {},
+	"/cerebro.v1.BootstrapService/ListFindingEvaluationRuns":              {},
+	"/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindingCandidates": {},
+	"/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindingRules":      {},
+	"/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindings":          {},
+}
+
+func dynamicRouteLabel(parts []string) (string, bool) {
+	switch {
+	case match(parts, "reports", "*", "runs"):
+		return "/reports/{reportID}/runs", true
+	case match(parts, "report-runs", "*"):
+		return "/report-runs/{runID}", true
+	case match(parts, "grc", "entities", "*", "impact"):
+		return "/grc/entities/{entityID}/impact", true
+	case match(parts, "grc", "audit-packets", "*"):
+		return "/grc/audit-packets/{packetID}", true
+	case match(parts, "findings", "*"):
+		return "/findings/{findingID}", true
+	case match(parts, "findings", "*", "resolve"):
+		return "/findings/{findingID}/resolve", true
+	case match(parts, "findings", "*", "suppress"):
+		return "/findings/{findingID}/suppress", true
+	case match(parts, "findings", "*", "assign"):
+		return "/findings/{findingID}/assign", true
+	case match(parts, "findings", "*", "due"):
+		return "/findings/{findingID}/due", true
+	case match(parts, "findings", "*", "notes"):
+		return "/findings/{findingID}/notes", true
+	case match(parts, "findings", "*", "tickets"):
+		return "/findings/{findingID}/tickets", true
+	case match(parts, "finding-candidates", "*"):
+		return "/finding-candidates/{candidateID}", true
+	case match(parts, "finding-candidates", "*", "promote"):
+		return "/finding-candidates/{candidateID}/promote", true
+	case match(parts, "finding-candidates", "*", "reject"):
+		return "/finding-candidates/{candidateID}/reject", true
+	case match(parts, "finding-evaluation-runs", "*"):
+		return "/finding-evaluation-runs/{runID}", true
+	case match(parts, "finding-evidence", "*"):
+		return "/finding-evidence/{evidenceID}", true
+	case match(parts, "sources", "*", "check"):
+		return "/sources/{sourceID}/check", true
+	case match(parts, "sources", "*", "discover"):
+		return "/sources/{sourceID}/discover", true
+	case match(parts, "sources", "*", "read"):
+		return "/sources/{sourceID}/read", true
+	case match(parts, "platform", "graph", "impact", "vulnerability", "*"):
+		return "/platform/graph/impact/vulnerability/{id}", true
+	case match(parts, "platform", "graph", "ingest-runs", "*"):
+		return "/platform/graph/ingest-runs/{runID}", true
+	case match(parts, "platform", "jobs", "*"):
+		return "/platform/jobs/{jobID}", true
+	case match(parts, "platform", "jobs", "*", "events"):
+		return "/platform/jobs/{jobID}/events", true
+	case match(parts, "platform", "jobs", "*", "cancel"):
+		return "/platform/jobs/{jobID}/cancel", true
+	case match(parts, "platform", "runtime-response", "blocklist", "*", "revoke"):
+		return "/platform/runtime-response/blocklist/{entryID}/revoke", true
+	case match(parts, "platform", "endpoints", "*", "vulnerability-findings"):
+		return "/platform/endpoints/{deviceKey}/vulnerability-findings", true
+	case match(parts, "platform", "devices", "*", "revoke"):
+		return "/platform/devices/{deviceID}/revoke", true
+	case match(parts, "source-runtimes", "*"):
+		return "/source-runtimes/{runtimeID}", true
+	case len(parts) == 3 && parts[0] == "source-runtimes":
+		return "/source-runtimes/{runtimeID}/" + parts[2], true
+	case len(parts) == 4 && parts[0] == "source-runtimes" && parts[2] == "finding-candidates" && parts[3] == "evaluate":
+		return "/source-runtimes/{runtimeID}/finding-candidates/evaluate", true
+	case len(parts) == 4 && parts[0] == "source-runtimes" && parts[2] == "finding-rules" && parts[3] == "evaluate":
+		return "/source-runtimes/{runtimeID}/finding-rules/evaluate", true
+	case len(parts) == 4 && parts[0] == "source-runtimes" && parts[2] == "findings" && parts[3] == "evaluate":
+		return "/source-runtimes/{runtimeID}/findings/evaluate", true
+	default:
+		return "", false
 	}
-	if len(part) >= 8 && strings.ContainsAny(part, "0123456789") {
-		return true
+}
+
+func match(parts []string, pattern ...string) bool {
+	if len(parts) != len(pattern) {
+		return false
 	}
-	return false
+	for i, want := range pattern {
+		if want == "*" {
+			if strings.TrimSpace(parts[i]) == "" {
+				return false
+			}
+			continue
+		}
+		if parts[i] != want {
+			return false
+		}
+	}
+	return true
+}
+
+func unmatchedRouteLabel(parts []string) string {
+	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
+		return "/{unmatched}"
+	}
+	switch parts[0] {
+	case ".well-known", "api", "cerebro.v1.BootstrapService", "finding-candidates", "finding-evaluation-runs", "finding-evidence", "finding-rules", "findings", "grc", "health", "healthz", "livez", "metrics", "oauth", "openapi.yaml", "platform", "report-runs", "reports", "source-runtimes", "sources":
+		return "/" + parts[0] + "/{unmatched}"
+	default:
+		return "/{unmatched}"
+	}
 }
 
 func metricKey(name string, labels map[string]string) string {

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -1,0 +1,143 @@
+package observability
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/writer/cerebro/internal/telemetry"
+)
+
+var Default = NewRegistry()
+
+type Registry struct {
+	mu       sync.Mutex
+	counters map[string]float64
+}
+
+func NewRegistry() *Registry {
+	return &Registry{counters: map[string]float64{}}
+}
+
+func (r *Registry) Inc(name string, labels map[string]string) {
+	r.Add(name, labels, 1)
+}
+
+func (r *Registry) Add(name string, labels map[string]string, value float64) {
+	if r == nil || strings.TrimSpace(name) == "" {
+		return
+	}
+	key := metricKey(name, labels)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counters[key] += value
+}
+
+func (r *Registry) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		_, _ = w.Write([]byte(r.Render()))
+	})
+}
+
+func (r *Registry) Render() string {
+	if r == nil {
+		return ""
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	keys := make([]string, 0, len(r.counters))
+	for key := range r.counters {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var out strings.Builder
+	for _, key := range keys {
+		out.WriteString(key)
+		out.WriteByte(' ')
+		out.WriteString(strconv.FormatFloat(r.counters[key], 'f', -1, 64))
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := telemetry.WithTraceParent(r.Context(), r.Header.Get("Traceparent"))
+		r = r.WithContext(ctx)
+		started := time.Now()
+		recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(recorder, r)
+		labels := map[string]string{
+			"method":      r.Method,
+			"route":       normalizeRouteLabel(r.URL.Path),
+			"status_code": strconv.Itoa(recorder.status),
+		}
+		Default.Inc("cerebro_http_requests_total", labels)
+		Default.Add("cerebro_http_request_duration_seconds_sum", labels, time.Since(started).Seconds())
+		Default.Inc("cerebro_http_request_duration_seconds_count", labels)
+	})
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func normalizeRouteLabel(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "/"
+	}
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		if looksVariable(part) {
+			parts[i] = "{id}"
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+func looksVariable(part string) bool {
+	if len(part) >= 12 && strings.HasPrefix(part, "job-") {
+		return true
+	}
+	if len(part) >= 8 && strings.ContainsAny(part, "0123456789") {
+		return true
+	}
+	return false
+}
+
+func metricKey(name string, labels map[string]string) string {
+	if len(labels) == 0 {
+		return name
+	}
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf(`%s=%q`, sanitizeLabelName(key), labels[key]))
+	}
+	return name + "{" + strings.Join(parts, ",") + "}"
+}
+
+func sanitizeLabelName(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "label"
+	}
+	replacer := strings.NewReplacer("-", "_", ".", "_", "/", "_")
+	return replacer.Replace(value)
+}

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -73,7 +73,7 @@ func Middleware(next http.Handler) http.Handler {
 		recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(recorder, r)
 		labels := map[string]string{
-			"method":      r.Method,
+			"method":      normalizeMethodLabel(r.Method),
 			"route":       normalizeRouteLabel(r.URL.Path),
 			"status_code": strconv.Itoa(recorder.status),
 		}
@@ -115,6 +115,31 @@ func (r *statusRecorder) Unwrap() http.ResponseWriter {
 		return nil
 	}
 	return r.ResponseWriter
+}
+
+func normalizeMethodLabel(method string) string {
+	switch strings.ToUpper(strings.TrimSpace(method)) {
+	case http.MethodConnect:
+		return http.MethodConnect
+	case http.MethodDelete:
+		return http.MethodDelete
+	case http.MethodGet:
+		return http.MethodGet
+	case http.MethodHead:
+		return http.MethodHead
+	case http.MethodOptions:
+		return http.MethodOptions
+	case http.MethodPatch:
+		return http.MethodPatch
+	case http.MethodPost:
+		return http.MethodPost
+	case http.MethodPut:
+		return http.MethodPut
+	case http.MethodTrace:
+		return http.MethodTrace
+	default:
+		return "OTHER"
+	}
 }
 
 func normalizeRouteLabel(path string) string {

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -14,6 +15,15 @@ func TestNormalizeRouteLabelBoundsUnknownPaths(t *testing.T) {
 	}
 	if got := normalizeRouteLabel("/platform/random-attacker-path"); got != "/platform/{unmatched}" {
 		t.Fatalf("unknown platform route label = %q", got)
+	}
+}
+
+func TestNormalizeMethodLabelBoundsUnknownMethods(t *testing.T) {
+	if got := normalizeMethodLabel("post"); got != http.MethodPost {
+		t.Fatalf("method label = %q, want %q", got, http.MethodPost)
+	}
+	if got := normalizeMethodLabel("BREW-COFFEE-" + strings.Repeat("x", 128)); got != "OTHER" {
+		t.Fatalf("unknown method label = %q, want OTHER", got)
 	}
 }
 

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -1,0 +1,63 @@
+package observability
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNormalizeRouteLabelBoundsUnknownPaths(t *testing.T) {
+	if got := normalizeRouteLabel("/platform/jobs/job-123/events"); got != "/platform/jobs/{jobID}/events" {
+		t.Fatalf("job route label = %q", got)
+	}
+	if got := normalizeRouteLabel("/totally/random/path"); got != "/{unmatched}" {
+		t.Fatalf("unknown route label = %q", got)
+	}
+	if got := normalizeRouteLabel("/platform/random-attacker-path"); got != "/platform/{unmatched}" {
+		t.Fatalf("unknown platform route label = %q", got)
+	}
+}
+
+func TestStatusRecorderPreservesFlushAndUnwrap(t *testing.T) {
+	inner := &flushResponseWriter{headers: http.Header{}}
+	recorder := &statusRecorder{ResponseWriter: inner, status: http.StatusOK}
+
+	flusher, ok := any(recorder).(http.Flusher)
+	if !ok {
+		t.Fatal("statusRecorder does not implement http.Flusher")
+	}
+	flusher.Flush()
+	if !inner.flushed {
+		t.Fatal("inner writer was not flushed")
+	}
+	if inner.status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", inner.status, http.StatusOK)
+	}
+	if recorder.Unwrap() != inner {
+		t.Fatal("Unwrap did not return inner writer")
+	}
+}
+
+type flushResponseWriter struct {
+	headers http.Header
+	status  int
+	flushed bool
+}
+
+func (w *flushResponseWriter) Header() http.Header {
+	return w.headers
+}
+
+func (w *flushResponseWriter) Write(data []byte) (int, error) {
+	if w.status == 0 {
+		w.WriteHeader(http.StatusOK)
+	}
+	return len(data), nil
+}
+
+func (w *flushResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+func (w *flushResponseWriter) Flush() {
+	w.flushed = true
+}

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -16,6 +16,9 @@ func TestNormalizeRouteLabelBoundsUnknownPaths(t *testing.T) {
 	if got := normalizeRouteLabel("/platform/random-attacker-path"); got != "/platform/{unmatched}" {
 		t.Fatalf("unknown platform route label = %q", got)
 	}
+	if got := normalizeRouteLabel("/source-runtimes/runtime-123/" + strings.Repeat("x", 128)); got != "/source-runtimes/{runtimeID}/{subresource}" {
+		t.Fatalf("unknown source-runtime subresource label = %q", got)
+	}
 }
 
 func TestNormalizeMethodLabelBoundsUnknownMethods(t *testing.T) {

--- a/internal/ports/jobs.go
+++ b/internal/ports/jobs.go
@@ -9,6 +9,9 @@ import (
 // ErrJobNotFound indicates that a platform job does not exist.
 var ErrJobNotFound = errors.New("platform job not found")
 
+// ErrJobUpdateConflict indicates that a conditional job state update lost a race.
+var ErrJobUpdateConflict = errors.New("platform job update conflict")
+
 const (
 	JobStatusQueued    = "queued"
 	JobStatusRunning   = "running"
@@ -79,6 +82,7 @@ type JobUpdate struct {
 	StartedAt       *time.Time
 	FinishedAt      *time.Time
 	CancelRequested *bool
+	AllowedStatuses []string
 }
 
 // JobStore persists platform jobs and their timeline events.

--- a/internal/ports/jobs.go
+++ b/internal/ports/jobs.go
@@ -1,0 +1,93 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrJobNotFound indicates that a platform job does not exist.
+var ErrJobNotFound = errors.New("platform job not found")
+
+const (
+	JobStatusQueued    = "queued"
+	JobStatusRunning   = "running"
+	JobStatusCompleted = "completed"
+	JobStatusFailed    = "failed"
+	JobStatusCancelled = "cancelled"
+)
+
+// Job is the shared execution resource for long-running platform work.
+type Job struct {
+	ID              string            `json:"id"`
+	Kind            string            `json:"kind"`
+	Status          string            `json:"status"`
+	TenantID        string            `json:"tenant_id,omitempty"`
+	SubjectType     string            `json:"subject_type,omitempty"`
+	SubjectID       string            `json:"subject_id,omitempty"`
+	IdempotencyKey  string            `json:"idempotency_key,omitempty"`
+	Progress        uint32            `json:"progress_percent,omitempty"`
+	Message         string            `json:"message,omitempty"`
+	Error           string            `json:"error,omitempty"`
+	Payload         map[string]any    `json:"payload,omitempty"`
+	Result          map[string]any    `json:"result,omitempty"`
+	ResultRefs      map[string]string `json:"result_refs,omitempty"`
+	CancelRequested bool              `json:"cancel_requested,omitempty"`
+	CreatedAt       time.Time         `json:"created_at,omitempty"`
+	StartedAt       time.Time         `json:"started_at,omitempty"`
+	FinishedAt      time.Time         `json:"finished_at,omitempty"`
+	UpdatedAt       time.Time         `json:"updated_at,omitempty"`
+}
+
+// JobEvent records an append-only job timeline entry.
+type JobEvent struct {
+	JobID     string         `json:"job_id"`
+	Sequence  uint64         `json:"sequence"`
+	Type      string         `json:"type"`
+	Status    string         `json:"status,omitempty"`
+	Message   string         `json:"message,omitempty"`
+	Payload   map[string]any `json:"payload,omitempty"`
+	CreatedAt time.Time      `json:"created_at,omitempty"`
+}
+
+// CreateJobRequest scopes durable job creation.
+type CreateJobRequest struct {
+	Kind           string
+	TenantID       string
+	SubjectType    string
+	SubjectID      string
+	IdempotencyKey string
+	Payload        map[string]any
+}
+
+// JobFilter scopes job listing.
+type JobFilter struct {
+	TenantID string
+	Kind     string
+	Status   string
+	Limit    uint32
+}
+
+// JobUpdate describes a partial job state update.
+type JobUpdate struct {
+	Status          string
+	Progress        *uint32
+	Message         string
+	Error           string
+	Result          map[string]any
+	ResultRefs      map[string]string
+	StartedAt       *time.Time
+	FinishedAt      *time.Time
+	CancelRequested *bool
+}
+
+// JobStore persists platform jobs and their timeline events.
+type JobStore interface {
+	StateStore
+	CreateJob(context.Context, CreateJobRequest) (*Job, bool, error)
+	GetJob(context.Context, string) (*Job, error)
+	ListJobs(context.Context, JobFilter) ([]*Job, error)
+	UpdateJob(context.Context, string, JobUpdate) (*Job, error)
+	AppendJobEvent(context.Context, JobEvent) (*JobEvent, error)
+	ListJobEvents(context.Context, string, uint32) ([]*JobEvent, error)
+}

--- a/internal/ports/runtime_response.go
+++ b/internal/ports/runtime_response.go
@@ -1,0 +1,38 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var ErrRuntimeBlocklistEntryNotFound = errors.New("runtime blocklist entry not found")
+
+type RuntimeBlocklistEntry struct {
+	ID          string            `json:"id"`
+	TenantID    string            `json:"tenant_id"`
+	Type        string            `json:"type"`
+	Value       string            `json:"value"`
+	Reason      string            `json:"reason,omitempty"`
+	Source      string            `json:"source,omitempty"`
+	SourceJobID string            `json:"source_job_id,omitempty"`
+	Attributes  map[string]string `json:"attributes,omitempty"`
+	ExpiresAt   time.Time         `json:"expires_at,omitempty"`
+	CreatedAt   time.Time         `json:"created_at,omitempty"`
+	UpdatedAt   time.Time         `json:"updated_at,omitempty"`
+	RevokedAt   time.Time         `json:"revoked_at,omitempty"`
+}
+
+type RuntimeBlocklistFilter struct {
+	TenantID       string
+	Type           string
+	IncludeRevoked bool
+	Limit          uint32
+}
+
+type RuntimeBlocklistStore interface {
+	StateStore
+	PutRuntimeBlocklistEntry(context.Context, RuntimeBlocklistEntry) (*RuntimeBlocklistEntry, error)
+	ListRuntimeBlocklistEntries(context.Context, RuntimeBlocklistFilter) ([]*RuntimeBlocklistEntry, error)
+	RevokeRuntimeBlocklistEntry(context.Context, string, string) (*RuntimeBlocklistEntry, error)
+}

--- a/internal/runtimeresponse/service.go
+++ b/internal/runtimeresponse/service.go
@@ -1,0 +1,159 @@
+package runtimeresponse
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var (
+	ErrInvalidRequest     = errors.New("invalid runtime response request")
+	ErrUnsupportedAction  = errors.New("unsupported runtime response action")
+	ErrRuntimeUnavailable = errors.New("runtime response store is unavailable")
+)
+
+const (
+	ActionBlockIP     = "block_ip"
+	ActionBlockDomain = "block_domain"
+)
+
+type Capability struct {
+	Action        string `json:"action"`
+	Mode          string `json:"mode"`
+	Supported     bool   `json:"supported"`
+	RequiresScope bool   `json:"requires_trusted_scope"`
+}
+
+type ExecuteRequest struct {
+	TenantID     string            `json:"tenant_id"`
+	Action       string            `json:"action"`
+	Target       string            `json:"target"`
+	Reason       string            `json:"reason,omitempty"`
+	Source       string            `json:"source,omitempty"`
+	SourceJobID  string            `json:"source_job_id,omitempty"`
+	Attributes   map[string]string `json:"attributes,omitempty"`
+	ExpiresAt    time.Time         `json:"expires_at,omitempty"`
+	TrustedScope bool              `json:"trusted_scope,omitempty"`
+}
+
+type Service struct {
+	store ports.RuntimeBlocklistStore
+	now   func() time.Time
+}
+
+func New(store ports.RuntimeBlocklistStore) *Service {
+	return &Service{store: store, now: func() time.Time { return time.Now().UTC() }}
+}
+
+func (s *Service) Capabilities() []Capability {
+	return []Capability{
+		{Action: ActionBlockIP, Mode: "local_blocklist", Supported: s != nil && s.store != nil, RequiresScope: true},
+		{Action: ActionBlockDomain, Mode: "local_blocklist", Supported: s != nil && s.store != nil, RequiresScope: true},
+		{Action: "scale_down", Mode: "remote_or_provider", Supported: false, RequiresScope: true},
+		{Action: "kill_process", Mode: "remote_tool", Supported: false, RequiresScope: true},
+		{Action: "isolate_container", Mode: "remote_tool", Supported: false, RequiresScope: true},
+		{Action: "isolate_host", Mode: "remote_tool", Supported: false, RequiresScope: true},
+		{Action: "quarantine_file", Mode: "remote_tool", Supported: false, RequiresScope: true},
+		{Action: "revoke_credentials", Mode: "remote_tool", Supported: false, RequiresScope: true},
+	}
+}
+
+func (s *Service) Execute(ctx context.Context, request ExecuteRequest) (*ports.RuntimeBlocklistEntry, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	request.Action = strings.TrimSpace(request.Action)
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.Target = strings.TrimSpace(request.Target)
+	if request.TenantID == "" {
+		return nil, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
+	}
+	if request.Target == "" {
+		return nil, fmt.Errorf("%w: target is required", ErrInvalidRequest)
+	}
+	if !request.TrustedScope {
+		return nil, fmt.Errorf("%w: trusted_scope is required for %s", ErrInvalidRequest, request.Action)
+	}
+	entryType := ""
+	value := request.Target
+	switch request.Action {
+	case ActionBlockIP:
+		ip := net.ParseIP(value)
+		if ip == nil {
+			return nil, fmt.Errorf("%w: target must be an IP address", ErrInvalidRequest)
+		}
+		value = ip.String()
+		entryType = "ip"
+	case ActionBlockDomain:
+		domain := normalizeDomain(value)
+		if domain == "" {
+			return nil, fmt.Errorf("%w: target must be a domain", ErrInvalidRequest)
+		}
+		value = domain
+		entryType = "domain"
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedAction, request.Action)
+	}
+	return s.store.PutRuntimeBlocklistEntry(ctx, ports.RuntimeBlocklistEntry{
+		ID:          newID(),
+		TenantID:    request.TenantID,
+		Type:        entryType,
+		Value:       value,
+		Reason:      strings.TrimSpace(request.Reason),
+		Source:      strings.TrimSpace(request.Source),
+		SourceJobID: strings.TrimSpace(request.SourceJobID),
+		Attributes:  request.Attributes,
+		ExpiresAt:   request.ExpiresAt,
+	})
+}
+
+func (s *Service) List(ctx context.Context, filter ports.RuntimeBlocklistFilter) ([]*ports.RuntimeBlocklistEntry, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	return s.store.ListRuntimeBlocklistEntries(ctx, filter)
+}
+
+func (s *Service) Revoke(ctx context.Context, tenantID string, id string) (*ports.RuntimeBlocklistEntry, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	return s.store.RevokeRuntimeBlocklistEntry(ctx, tenantID, id)
+}
+
+func normalizeDomain(value string) string {
+	value = strings.Trim(strings.ToLower(strings.TrimSpace(value)), ".")
+	if value == "" || strings.ContainsAny(value, "/:@") || strings.Contains(value, "..") {
+		return ""
+	}
+	labels := strings.Split(value, ".")
+	if len(labels) < 2 {
+		return ""
+	}
+	for _, label := range labels {
+		if label == "" || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return ""
+		}
+		for _, ch := range label {
+			if (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') && ch != '-' {
+				return ""
+			}
+		}
+	}
+	return value
+}
+
+func newID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("rr-%d", time.Now().UnixNano())
+	}
+	return "rr-" + hex.EncodeToString(b[:])
+}

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 const MaxBodyBytes = 8 << 20
@@ -155,6 +157,12 @@ func (rt SafeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	base := rt.Base
 	if base == nil {
 		base = http.DefaultTransport
+	}
+	if req != nil {
+		if traceparent := telemetry.TraceParent(req.Context()); traceparent != "" && req.Header.Get("Traceparent") == "" {
+			req = req.Clone(req.Context())
+			req.Header.Set("Traceparent", traceparent)
+		}
 	}
 	if req != nil && req.URL != nil {
 		addrs, err := SafeResolvedHostAddrs(req.Context(), rt.SourceID, req.URL.Hostname(), rt.AllowLoopback, rt.LookupIPAddrs)

--- a/internal/statestore/postgres/jobs.go
+++ b/internal/statestore/postgres/jobs.go
@@ -1,0 +1,393 @@
+package postgres
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureJobStatements = []string{
+	`CREATE TABLE IF NOT EXISTS platform_jobs (
+  id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  status TEXT NOT NULL,
+  tenant_id TEXT NOT NULL DEFAULT '',
+  subject_type TEXT NOT NULL DEFAULT '',
+  subject_id TEXT NOT NULL DEFAULT '',
+  idempotency_key TEXT NOT NULL DEFAULT '',
+  progress_percent INTEGER NOT NULL DEFAULT 0,
+  message TEXT NOT NULL DEFAULT '',
+  error TEXT NOT NULL DEFAULT '',
+  payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  result_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  result_refs_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  cancel_requested BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  started_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS platform_jobs_idempotency_idx ON platform_jobs (tenant_id, idempotency_key) WHERE idempotency_key <> ''`,
+	`CREATE INDEX IF NOT EXISTS platform_jobs_tenant_status_idx ON platform_jobs (tenant_id, status, updated_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS platform_jobs_kind_updated_idx ON platform_jobs (kind, updated_at DESC)`,
+	`CREATE TABLE IF NOT EXISTS platform_job_events (
+  job_id TEXT NOT NULL REFERENCES platform_jobs(id) ON DELETE CASCADE,
+  sequence BIGSERIAL PRIMARY KEY,
+  type TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT '',
+  message TEXT NOT NULL DEFAULT '',
+  payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS platform_job_events_job_sequence_idx ON platform_job_events (job_id, sequence ASC)`,
+}
+
+// CreateJob inserts a platform job or returns the existing idempotent job.
+func (s *Store) CreateJob(ctx context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
+	if s == nil || s.db == nil {
+		return nil, false, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, false, err
+	}
+	job := &ports.Job{
+		ID:             newPlatformJobID(),
+		Kind:           strings.TrimSpace(request.Kind),
+		Status:         ports.JobStatusQueued,
+		TenantID:       strings.TrimSpace(request.TenantID),
+		SubjectType:    strings.TrimSpace(request.SubjectType),
+		SubjectID:      strings.TrimSpace(request.SubjectID),
+		IdempotencyKey: strings.TrimSpace(request.IdempotencyKey),
+		Payload:        cloneMap(request.Payload),
+	}
+	payload, err := json.Marshal(job.Payload)
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal job payload: %w", err)
+	}
+	row := s.db.QueryRowContext(ctx, `
+INSERT INTO platform_jobs (
+  id, kind, status, tenant_id, subject_type, subject_id, idempotency_key, payload_json
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+ON CONFLICT (tenant_id, idempotency_key) WHERE idempotency_key <> ''
+DO UPDATE SET updated_at = platform_jobs.updated_at
+RETURNING id, (xmax = 0) AS inserted`,
+		job.ID,
+		job.Kind,
+		job.Status,
+		job.TenantID,
+		job.SubjectType,
+		job.SubjectID,
+		job.IdempotencyKey,
+		string(payload),
+	)
+	var id string
+	var inserted bool
+	if err := row.Scan(&id, &inserted); err != nil {
+		return nil, false, fmt.Errorf("insert platform job: %w", err)
+	}
+	stored, err := s.GetJob(ctx, id)
+	if err != nil {
+		return nil, false, err
+	}
+	return stored, inserted, nil
+}
+
+// GetJob loads one platform job.
+func (s *Store) GetJob(ctx context.Context, id string) (*ports.Job, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, errors.New("job id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	row := s.db.QueryRowContext(ctx, `
+SELECT id, kind, status, tenant_id, subject_type, subject_id, idempotency_key,
+       progress_percent, message, error, payload_json::text, result_json::text,
+       result_refs_json::text, cancel_requested, created_at, started_at, finished_at, updated_at
+FROM platform_jobs
+WHERE id = $1`, id)
+	job, err := scanJob(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrJobNotFound, id)
+		}
+		return nil, fmt.Errorf("query platform job %q: %w", id, err)
+	}
+	return job, nil
+}
+
+// ListJobs returns platform jobs matching the supplied filter.
+func (s *Store) ListJobs(ctx context.Context, filter ports.JobFilter) ([]*ports.Job, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	clauses := []string{"1=1"}
+	args := []any{}
+	addTextFilter(&clauses, &args, "tenant_id", filter.TenantID)
+	addTextFilter(&clauses, &args, "kind", filter.Kind)
+	addTextFilter(&clauses, &args, "status", filter.Status)
+	limit := filter.Limit
+	if limit == 0 || limit > 200 {
+		limit = 50
+	}
+	args = append(args, limit)
+	query := fmt.Sprintf(`
+SELECT id, kind, status, tenant_id, subject_type, subject_id, idempotency_key,
+       progress_percent, message, error, payload_json::text, result_json::text,
+       result_refs_json::text, cancel_requested, created_at, started_at, finished_at, updated_at
+FROM platform_jobs
+WHERE %s
+ORDER BY updated_at DESC, id ASC
+LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list platform jobs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	jobs := []*ports.Job{}
+	for rows.Next() {
+		job, err := scanJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
+// UpdateJob applies a partial job state update.
+func (s *Store) UpdateJob(ctx context.Context, id string, update ports.JobUpdate) (*ports.Job, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, errors.New("job id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	job, err := s.GetJob(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(update.Status) != "" {
+		job.Status = strings.TrimSpace(update.Status)
+	}
+	if update.Progress != nil {
+		job.Progress = *update.Progress
+	}
+	if update.Message != "" {
+		job.Message = update.Message
+	}
+	if update.Error != "" {
+		job.Error = update.Error
+	}
+	if update.Result != nil {
+		job.Result = cloneMap(update.Result)
+	}
+	if update.ResultRefs != nil {
+		job.ResultRefs = cloneStringMap(update.ResultRefs)
+	}
+	if update.StartedAt != nil {
+		job.StartedAt = update.StartedAt.UTC()
+	}
+	if update.FinishedAt != nil {
+		job.FinishedAt = update.FinishedAt.UTC()
+	}
+	if update.CancelRequested != nil {
+		job.CancelRequested = *update.CancelRequested
+	}
+	result, err := json.Marshal(job.Result)
+	if err != nil {
+		return nil, err
+	}
+	refs, err := json.Marshal(job.ResultRefs)
+	if err != nil {
+		return nil, err
+	}
+	var started any
+	if !job.StartedAt.IsZero() {
+		started = job.StartedAt
+	}
+	var finished any
+	if !job.FinishedAt.IsZero() {
+		finished = job.FinishedAt
+	}
+	if _, err := s.db.ExecContext(ctx, `
+UPDATE platform_jobs
+SET status = $2, progress_percent = $3, message = $4, error = $5,
+    result_json = $6::jsonb, result_refs_json = $7::jsonb,
+    started_at = COALESCE($8, started_at), finished_at = COALESCE($9, finished_at),
+    cancel_requested = $10, updated_at = NOW()
+WHERE id = $1`,
+		id, job.Status, job.Progress, job.Message, job.Error, string(result), string(refs), started, finished, job.CancelRequested); err != nil {
+		return nil, fmt.Errorf("update platform job %q: %w", id, err)
+	}
+	return s.GetJob(ctx, id)
+}
+
+// AppendJobEvent appends one timeline event.
+func (s *Store) AppendJobEvent(ctx context.Context, event ports.JobEvent) (*ports.JobEvent, error) {
+	if strings.TrimSpace(event.JobID) == "" {
+		return nil, errors.New("job id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(event.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal job event payload: %w", err)
+	}
+	row := s.db.QueryRowContext(ctx, `
+INSERT INTO platform_job_events (job_id, type, status, message, payload_json)
+VALUES ($1, $2, $3, $4, $5::jsonb)
+RETURNING sequence, created_at`,
+		strings.TrimSpace(event.JobID),
+		strings.TrimSpace(event.Type),
+		strings.TrimSpace(event.Status),
+		strings.TrimSpace(event.Message),
+		string(payload),
+	)
+	event.JobID = strings.TrimSpace(event.JobID)
+	if err := row.Scan(&event.Sequence, &event.CreatedAt); err != nil {
+		return nil, fmt.Errorf("append platform job event: %w", err)
+	}
+	return &event, nil
+}
+
+// ListJobEvents returns the timeline for one job.
+func (s *Store) ListJobEvents(ctx context.Context, jobID string, limit uint32) ([]*ports.JobEvent, error) {
+	jobID = strings.TrimSpace(jobID)
+	if jobID == "" {
+		return nil, errors.New("job id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	if _, err := s.GetJob(ctx, jobID); err != nil {
+		return nil, err
+	}
+	if limit == 0 || limit > 500 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT job_id, sequence, type, status, message, payload_json::text, created_at
+FROM platform_job_events
+WHERE job_id = $1
+ORDER BY sequence ASC
+LIMIT $2`, jobID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list platform job events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	events := []*ports.JobEvent{}
+	for rows.Next() {
+		event, err := scanJobEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+func (s *Store) ensureJobTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.jobTablesReady, "platform job", ensureJobStatements)
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanJob(row scanner) (*ports.Job, error) {
+	job := &ports.Job{}
+	var payload, result, refs string
+	var started, finished sql.NullTime
+	if err := row.Scan(
+		&job.ID, &job.Kind, &job.Status, &job.TenantID, &job.SubjectType, &job.SubjectID, &job.IdempotencyKey,
+		&job.Progress, &job.Message, &job.Error, &payload, &result, &refs, &job.CancelRequested,
+		&job.CreatedAt, &started, &finished, &job.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	job.Payload = map[string]any{}
+	job.Result = map[string]any{}
+	job.ResultRefs = map[string]string{}
+	_ = json.Unmarshal([]byte(payload), &job.Payload)
+	_ = json.Unmarshal([]byte(result), &job.Result)
+	_ = json.Unmarshal([]byte(refs), &job.ResultRefs)
+	if started.Valid {
+		job.StartedAt = started.Time
+	}
+	if finished.Valid {
+		job.FinishedAt = finished.Time
+	}
+	return job, nil
+}
+
+func scanJobEvent(row scanner) (*ports.JobEvent, error) {
+	event := &ports.JobEvent{}
+	var payload string
+	if err := row.Scan(&event.JobID, &event.Sequence, &event.Type, &event.Status, &event.Message, &payload, &event.CreatedAt); err != nil {
+		return nil, err
+	}
+	event.Payload = map[string]any{}
+	_ = json.Unmarshal([]byte(payload), &event.Payload)
+	return event, nil
+}
+
+func addTextFilter(clauses *[]string, args *[]any, column string, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	*args = append(*args, value)
+	*clauses = append(*clauses, fmt.Sprintf("%s = $%d", column, len(*args)))
+}
+
+func cloneMap(values map[string]any) map[string]any {
+	cloned := map[string]any{}
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	cloned := map[string]string{}
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func newPlatformJobID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("job-%d", time.Now().UnixNano())
+	}
+	return "job-" + hex.EncodeToString(b[:])
+}

--- a/internal/statestore/postgres/jobs.go
+++ b/internal/statestore/postgres/jobs.go
@@ -230,15 +230,32 @@ func (s *Store) UpdateJob(ctx context.Context, id string, update ports.JobUpdate
 	if !job.FinishedAt.IsZero() {
 		finished = job.FinishedAt
 	}
-	if _, err := s.db.ExecContext(ctx, `
+	allowedStatuses := normalizeJobStatuses(update.AllowedStatuses)
+	args := []any{id, job.Status, job.Progress, job.Message, job.Error, string(result), string(refs), started, finished, job.CancelRequested}
+	clauses := []string{"id = $1"}
+	if len(allowedStatuses) > 0 {
+		placeholders := make([]string, 0, len(allowedStatuses))
+		for _, status := range allowedStatuses {
+			args = append(args, status)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		clauses = append(clauses, "status IN ("+strings.Join(placeholders, ", ")+")")
+	}
+	resultExec, err := s.db.ExecContext(ctx, fmt.Sprintf(`
 UPDATE platform_jobs
 SET status = $2, progress_percent = $3, message = $4, error = $5,
     result_json = $6::jsonb, result_refs_json = $7::jsonb,
     started_at = COALESCE($8, started_at), finished_at = COALESCE($9, finished_at),
     cancel_requested = $10, updated_at = NOW()
-WHERE id = $1`,
-		id, job.Status, job.Progress, job.Message, job.Error, string(result), string(refs), started, finished, job.CancelRequested); err != nil {
+WHERE %s`, strings.Join(clauses, " AND ")), args...)
+	if err != nil {
 		return nil, fmt.Errorf("update platform job %q: %w", id, err)
+	}
+	if rows, _ := resultExec.RowsAffected(); rows == 0 {
+		if len(allowedStatuses) > 0 {
+			return nil, fmt.Errorf("%w: %s", ports.ErrJobUpdateConflict, id)
+		}
+		return nil, fmt.Errorf("%w: %s", ports.ErrJobNotFound, id)
 	}
 	return s.GetJob(ctx, id)
 }
@@ -357,6 +374,23 @@ func scanJobEvent(row scanner) (*ports.JobEvent, error) {
 	event.Payload = map[string]any{}
 	_ = json.Unmarshal([]byte(payload), &event.Payload)
 	return event, nil
+}
+
+func normalizeJobStatuses(values []string) []string {
+	seen := map[string]struct{}{}
+	statuses := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		statuses = append(statuses, value)
+	}
+	return statuses
 }
 
 func addTextFilter(clauses *[]string, args *[]any, column string, value string) {

--- a/internal/statestore/postgres/jobs.go
+++ b/internal/statestore/postgres/jobs.go
@@ -214,6 +214,10 @@ func (s *Store) UpdateJob(ctx context.Context, id string, update ports.JobUpdate
 	if update.CancelRequested != nil {
 		job.CancelRequested = *update.CancelRequested
 	}
+	var cancelRequested any
+	if update.CancelRequested != nil {
+		cancelRequested = job.CancelRequested
+	}
 	result, err := json.Marshal(job.Result)
 	if err != nil {
 		return nil, err
@@ -231,7 +235,7 @@ func (s *Store) UpdateJob(ctx context.Context, id string, update ports.JobUpdate
 		finished = job.FinishedAt
 	}
 	allowedStatuses := normalizeJobStatuses(update.AllowedStatuses)
-	args := []any{id, job.Status, job.Progress, job.Message, job.Error, string(result), string(refs), started, finished, job.CancelRequested}
+	args := []any{id, job.Status, job.Progress, job.Message, job.Error, string(result), string(refs), started, finished, cancelRequested}
 	clauses := []string{"id = $1"}
 	if len(allowedStatuses) > 0 {
 		placeholders := make([]string, 0, len(allowedStatuses))
@@ -246,7 +250,7 @@ UPDATE platform_jobs
 SET status = $2, progress_percent = $3, message = $4, error = $5,
     result_json = $6::jsonb, result_refs_json = $7::jsonb,
     started_at = COALESCE($8, started_at), finished_at = COALESCE($9, finished_at),
-    cancel_requested = $10, updated_at = NOW()
+    cancel_requested = COALESCE($10, cancel_requested), updated_at = NOW()
 WHERE %s`, strings.Join(clauses, " AND ")), args...)
 	if err != nil {
 		return nil, fmt.Errorf("update platform job %q: %w", id, err)

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -30,6 +30,8 @@ type Store struct {
 	mcpOAuthTablesReady       bool
 	startupLeaseTableReady    bool
 	askTrajectoryReady        bool
+	jobTablesReady            bool
+	runtimeBlocklistReady     bool
 }
 
 // Open opens a Postgres-backed current-state store.

--- a/internal/statestore/postgres/runtime_response.go
+++ b/internal/statestore/postgres/runtime_response.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -180,5 +179,3 @@ func scanRuntimeBlocklistEntry(row scanner) (*ports.RuntimeBlocklistEntry, error
 	}
 	return entry, nil
 }
-
-var _ = time.Time{}

--- a/internal/statestore/postgres/runtime_response.go
+++ b/internal/statestore/postgres/runtime_response.go
@@ -1,0 +1,184 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureRuntimeBlocklistStatements = []string{
+	`CREATE TABLE IF NOT EXISTS runtime_blocklist_entries (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  entry_type TEXT NOT NULL,
+  entry_value TEXT NOT NULL,
+  reason TEXT NOT NULL DEFAULT '',
+  source TEXT NOT NULL DEFAULT '',
+  source_job_id TEXT NOT NULL DEFAULT '',
+  attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  expires_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS runtime_blocklist_active_value_idx ON runtime_blocklist_entries (tenant_id, entry_type, entry_value) WHERE revoked_at IS NULL`,
+	`CREATE INDEX IF NOT EXISTS runtime_blocklist_tenant_type_idx ON runtime_blocklist_entries (tenant_id, entry_type, updated_at DESC)`,
+}
+
+func (s *Store) PutRuntimeBlocklistEntry(ctx context.Context, entry ports.RuntimeBlocklistEntry) (*ports.RuntimeBlocklistEntry, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureRuntimeBlocklistTables(ctx); err != nil {
+		return nil, err
+	}
+	entry.ID = strings.TrimSpace(entry.ID)
+	entry.TenantID = strings.TrimSpace(entry.TenantID)
+	entry.Type = strings.TrimSpace(entry.Type)
+	entry.Value = strings.TrimSpace(entry.Value)
+	if entry.ID == "" || entry.TenantID == "" || entry.Type == "" || entry.Value == "" {
+		return nil, errors.New("runtime blocklist id, tenant_id, type, and value are required")
+	}
+	attrs, err := json.Marshal(entry.Attributes)
+	if err != nil {
+		return nil, fmt.Errorf("marshal runtime blocklist attributes: %w", err)
+	}
+	var expires any
+	if !entry.ExpiresAt.IsZero() {
+		expires = entry.ExpiresAt.UTC()
+	}
+	row := s.db.QueryRowContext(ctx, `
+INSERT INTO runtime_blocklist_entries (
+  id, tenant_id, entry_type, entry_value, reason, source, source_job_id, attributes_json, expires_at
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
+ON CONFLICT (tenant_id, entry_type, entry_value) WHERE revoked_at IS NULL
+DO UPDATE SET reason = EXCLUDED.reason,
+              source = EXCLUDED.source,
+              source_job_id = EXCLUDED.source_job_id,
+              attributes_json = EXCLUDED.attributes_json,
+              expires_at = EXCLUDED.expires_at,
+              updated_at = NOW()
+RETURNING id`, entry.ID, entry.TenantID, entry.Type, entry.Value, entry.Reason, entry.Source, entry.SourceJobID, string(attrs), expires)
+	if err := row.Scan(&entry.ID); err != nil {
+		return nil, fmt.Errorf("upsert runtime blocklist entry: %w", err)
+	}
+	return s.getRuntimeBlocklistEntry(ctx, entry.ID)
+}
+
+func (s *Store) ListRuntimeBlocklistEntries(ctx context.Context, filter ports.RuntimeBlocklistFilter) ([]*ports.RuntimeBlocklistEntry, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureRuntimeBlocklistTables(ctx); err != nil {
+		return nil, err
+	}
+	clauses := []string{"1=1"}
+	args := []any{}
+	addTextFilter(&clauses, &args, "tenant_id", filter.TenantID)
+	addTextFilter(&clauses, &args, "entry_type", filter.Type)
+	if !filter.IncludeRevoked {
+		clauses = append(clauses, "revoked_at IS NULL")
+	}
+	limit := filter.Limit
+	if limit == 0 || limit > 500 {
+		limit = 100
+	}
+	args = append(args, limit)
+	query := fmt.Sprintf(`
+SELECT id, tenant_id, entry_type, entry_value, reason, source, source_job_id, attributes_json::text,
+       expires_at, revoked_at, created_at, updated_at
+FROM runtime_blocklist_entries
+WHERE %s
+ORDER BY updated_at DESC, id ASC
+LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list runtime blocklist entries: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	entries := []*ports.RuntimeBlocklistEntry{}
+	for rows.Next() {
+		entry, err := scanRuntimeBlocklistEntry(rows)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	return entries, rows.Err()
+}
+
+func (s *Store) RevokeRuntimeBlocklistEntry(ctx context.Context, tenantID string, id string) (*ports.RuntimeBlocklistEntry, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureRuntimeBlocklistTables(ctx); err != nil {
+		return nil, err
+	}
+	id = strings.TrimSpace(id)
+	tenantID = strings.TrimSpace(tenantID)
+	if id == "" {
+		return nil, errors.New("runtime blocklist entry id is required")
+	}
+	clauses := []string{"id = $1"}
+	args := []any{id}
+	if tenantID != "" {
+		args = append(args, tenantID)
+		clauses = append(clauses, fmt.Sprintf("tenant_id = $%d", len(args)))
+	}
+	query := fmt.Sprintf(`UPDATE runtime_blocklist_entries SET revoked_at = NOW(), updated_at = NOW() WHERE %s`, strings.Join(clauses, " AND "))
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("revoke runtime blocklist entry %q: %w", id, err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return nil, fmt.Errorf("%w: %s", ports.ErrRuntimeBlocklistEntryNotFound, id)
+	}
+	return s.getRuntimeBlocklistEntry(ctx, id)
+}
+
+func (s *Store) getRuntimeBlocklistEntry(ctx context.Context, id string) (*ports.RuntimeBlocklistEntry, error) {
+	row := s.db.QueryRowContext(ctx, `
+SELECT id, tenant_id, entry_type, entry_value, reason, source, source_job_id, attributes_json::text,
+       expires_at, revoked_at, created_at, updated_at
+FROM runtime_blocklist_entries
+WHERE id = $1`, id)
+	entry, err := scanRuntimeBlocklistEntry(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrRuntimeBlocklistEntryNotFound, id)
+		}
+		return nil, err
+	}
+	return entry, nil
+}
+
+func (s *Store) ensureRuntimeBlocklistTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.runtimeBlocklistReady, "runtime blocklist", ensureRuntimeBlocklistStatements)
+}
+
+func scanRuntimeBlocklistEntry(row scanner) (*ports.RuntimeBlocklistEntry, error) {
+	entry := &ports.RuntimeBlocklistEntry{}
+	var attrs string
+	var expires, revoked sql.NullTime
+	if err := row.Scan(&entry.ID, &entry.TenantID, &entry.Type, &entry.Value, &entry.Reason, &entry.Source, &entry.SourceJobID, &attrs, &expires, &revoked, &entry.CreatedAt, &entry.UpdatedAt); err != nil {
+		return nil, err
+	}
+	entry.Attributes = map[string]string{}
+	_ = json.Unmarshal([]byte(attrs), &entry.Attributes)
+	if expires.Valid {
+		entry.ExpiresAt = expires.Time.UTC()
+	}
+	if revoked.Valid {
+		entry.RevokedAt = revoked.Time.UTC()
+	}
+	return entry, nil
+}
+
+var _ = time.Time{}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -103,7 +103,8 @@ func ParseTraceParent(header string) (string, string, bool) {
 	}
 	traceID := strings.ToLower(parts[1])
 	spanID := strings.ToLower(parts[2])
-	if len(traceID) != 32 || len(spanID) != 16 || allZero(traceID) || allZero(spanID) || !isLowerHex(traceID) || !isLowerHex(spanID) {
+	flags := strings.ToLower(parts[3])
+	if len(traceID) != 32 || len(spanID) != 16 || len(flags) != 2 || allZero(traceID) || allZero(spanID) || !isLowerHex(traceID) || !isLowerHex(spanID) || !isLowerHex(flags) {
 		return "", "", false
 	}
 	return traceID, spanID, true

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -77,6 +78,37 @@ func Start(ctx context.Context, name string, attributes Attributes) (context.Con
 	return next, span
 }
 
+// WithTraceParent seeds telemetry context from a W3C traceparent header.
+func WithTraceParent(ctx context.Context, header string) context.Context {
+	traceID, spanID, ok := ParseTraceParent(header)
+	if !ok {
+		return ctx
+	}
+	return context.WithValue(ctx, spanContextKey{}, spanContext{TraceID: traceID, SpanID: spanID})
+}
+
+// TraceParent returns a W3C traceparent header for the current telemetry span.
+func TraceParent(ctx context.Context) string {
+	current, _ := ctx.Value(spanContextKey{}).(spanContext)
+	if current.TraceID == "" || current.SpanID == "" {
+		return ""
+	}
+	return "00-" + current.TraceID + "-" + current.SpanID + "-01"
+}
+
+func ParseTraceParent(header string) (string, string, bool) {
+	parts := strings.Split(strings.TrimSpace(header), "-")
+	if len(parts) != 4 || parts[0] != "00" {
+		return "", "", false
+	}
+	traceID := strings.ToLower(parts[1])
+	spanID := strings.ToLower(parts[2])
+	if len(traceID) != 32 || len(spanID) != 16 || allZero(traceID) || allZero(spanID) || !isLowerHex(traceID) || !isLowerHex(spanID) {
+		return "", "", false
+	}
+	return traceID, spanID, true
+}
+
 func Event(ctx context.Context, name string, attributes Attributes) {
 	current, _ := ctx.Value(spanContextKey{}).(spanContext)
 	emit("event", &Span{name: name, traceID: current.TraceID, spanID: current.SpanID}, attributes)
@@ -145,4 +177,22 @@ func randomHex(bytes int) string {
 		return hex.EncodeToString([]byte(time.Now().UTC().Format(time.RFC3339Nano)))
 	}
 	return hex.EncodeToString(buf)
+}
+
+func isLowerHex(value string) bool {
+	for _, ch := range value {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func allZero(value string) bool {
+	for _, ch := range value {
+		if ch != '0' {
+			return false
+		}
+	}
+	return value != ""
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -79,6 +79,25 @@ func TestTelemetryFieldsDoNotUseRawErrorKey(t *testing.T) {
 	}
 }
 
+func TestParseTraceParentValidatesTraceFlags(t *testing.T) {
+	traceID, spanID, ok := ParseTraceParent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	if !ok {
+		t.Fatal("valid traceparent was rejected")
+	}
+	if traceID != "4bf92f3577b34da6a3ce929d0e0e4736" || spanID != "00f067aa0ba902b7" {
+		t.Fatalf("traceparent parsed as traceID=%q spanID=%q", traceID, spanID)
+	}
+	for _, header := range []string{
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-0",
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-001",
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-zz",
+	} {
+		if _, _, ok := ParseTraceParent(header); ok {
+			t.Fatalf("malformed traceparent flags accepted: %q", header)
+		}
+	}
+}
+
 func captureOutput(t *testing.T, fn func()) (string, string) {
 	t.Helper()
 	oldStdout := os.Stdout

--- a/scripts/docs_drift_check.py
+++ b/scripts/docs_drift_check.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Fail fast on documentation claims that drift from the bootstrap runtime."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+FORBIDDEN_DOC_MARKERS = {
+    "docs/FINDINGS_PLATFORM_ARCHITECTURE.md": [
+        "Today the built-in catalog contains one rule",
+        "first built-in finding rule",
+    ],
+    "docs/VULNERABILITY_DB_ARCHITECTURE.md": [
+        "SQLite via `internal/vulndb.SQLiteStore`",
+        "persisted by default at `VULNDB_STATE_FILE`",
+    ],
+    "docs/WORKLOAD_SCAN_ARCHITECTURE.md": [
+        "internal/workloadscan.SQLiteRunStore",
+        "internal/executionstore",
+        "SQLiteRunStore",
+        "SQLite-backed",
+    ],
+    "docs/IMAGE_SCAN_ARCHITECTURE.md": [
+        "internal/imagescan.SQLiteRunStore",
+        "internal/executionstore",
+        "SQLite is durable",
+    ],
+    "docs/FUNCTION_SCAN_ARCHITECTURE.md": [
+        "internal/functionscan.SQLiteRunStore",
+        "internal/executionstore",
+        "SQLite is durable",
+    ],
+    "docs/FILESYSTEM_ANALYZER_ARCHITECTURE.md": [
+        "internal/workloadscan.FilesystemAnalyzer",
+        "internal/imagescan.FilesystemAnalyzer",
+        "internal/functionscan.FilesystemAnalyzer",
+        "internal/executionstore",
+        "SQLite-backed",
+    ],
+    "docs/ACTION_ENGINE_ARCHITECTURE.md": [
+        "internal/executionstore",
+        "backend remains SQLite",
+    ],
+    "docs/RUNTIME_VISIBILITY_ARCHITECTURE.md": [
+        "POST /api/v1/runtime/events",
+        "in `internal/runtime`",
+        "internal/executionstore",
+        "SQLite-backed execution state",
+    ],
+}
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def check_forbidden_markers() -> list[str]:
+    failures: list[str] = []
+    for rel, markers in FORBIDDEN_DOC_MARKERS.items():
+        body = read(rel)
+        for marker in markers:
+            if marker in body:
+                failures.append(f"{rel}: stale marker still present: {marker!r}")
+    return failures
+
+
+def check_findings_catalog_reference() -> list[str]:
+    catalog = json.loads(read("internal/findings/public_detection_catalog.json"))
+    count = len(catalog.get("detections") or [])
+    body = read("docs/FINDINGS_PLATFORM_ARCHITECTURE.md")
+    expected = f"currently contains {count} rules"
+    if expected not in body:
+        return [
+            "docs/FINDINGS_PLATFORM_ARCHITECTURE.md: "
+            f"expected public detection catalog count phrase {expected!r}"
+        ]
+    return []
+
+
+def main() -> int:
+    failures = []
+    failures.extend(check_forbidden_markers())
+    failures.extend(check_findings_catalog_reference())
+    if failures:
+        print("docs drift check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("docs drift check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sdk_dependency_audit.py
+++ b/scripts/sdk_dependency_audit.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import pathlib
 import subprocess
-import sys
 import tempfile
 import tomllib
 

--- a/scripts/sdk_dependency_audit.py
+++ b/scripts/sdk_dependency_audit.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Audit SDK dependency manifests without installing the SDK packages globally."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+import tomllib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def run(command: list[str], cwd: pathlib.Path | None = None) -> int:
+    print("+", " ".join(command))
+    return subprocess.run(command, cwd=str(cwd) if cwd else None, check=False).returncode
+
+
+def python_requirements_from_pyproject(pyproject: pathlib.Path) -> list[str]:
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    return list(data.get("project", {}).get("dependencies", []) or [])
+
+
+def audit_python_sdk() -> int:
+    dependencies = python_requirements_from_pyproject(ROOT / "sdk" / "python" / "pyproject.toml")
+    if not dependencies:
+        print("sdk/python has no project dependencies to audit")
+        return 0
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as requirements:
+        for dependency in dependencies:
+            requirements.write(dependency + "\n")
+        requirements_path = pathlib.Path(requirements.name)
+    try:
+        return run(["python3", "-m", "pip_audit", "--requirement", str(requirements_path)])
+    finally:
+        requirements_path.unlink(missing_ok=True)
+
+
+def main() -> int:
+    failures = 0
+    failures += run(["npm", "audit", "--audit-level=high"], ROOT / "sdk" / "typescript")
+    failures += audit_python_sdk()
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -60,6 +60,38 @@ class Client:
         result, _ = self._request_json("GET", f"/platform/graph/neighborhood?{parse.urlencode(query)}")
         return result
 
+    def create_job(self, payload: Dict[str, Any], idempotency_key: str = "") -> Any:
+        headers = {"Idempotency-Key": idempotency_key} if idempotency_key else None
+        result, _ = self._request_json("POST", "/platform/jobs", payload, headers)
+        return result
+
+    def list_jobs(self, filters: Optional[Dict[str, Any]] = None) -> Any:
+        query: Dict[str, str] = {}
+        for key, value in (filters or {}).items():
+            if value in (None, ""):
+                continue
+            query[key] = str(value)
+        path = "/platform/jobs"
+        if query:
+            path = f"{path}?{parse.urlencode(query)}"
+        result, _ = self._request_json("GET", path)
+        return result
+
+    def get_job(self, job_id: str) -> Any:
+        result, _ = self._request_json("GET", f"/platform/jobs/{parse.quote(job_id, safe='')}")
+        return result
+
+    def list_job_events(self, job_id: str, limit: int = 0) -> Any:
+        path = f"/platform/jobs/{parse.quote(job_id, safe='')}/events"
+        if limit > 0:
+            path = f"{path}?{parse.urlencode({'limit': str(limit)})}"
+        result, _ = self._request_json("GET", path)
+        return result
+
+    def cancel_job(self, job_id: str) -> Any:
+        result, _ = self._request_json("POST", f"/platform/jobs/{parse.quote(job_id, safe='')}/cancel")
+        return result
+
     def integration(self, runtime_id: str, tenant_id: str, integration: str) -> "IntegrationClient":
         return IntegrationClient(self, runtime_id=runtime_id, tenant_id=tenant_id, integration=integration)
 

--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -55,6 +55,34 @@ export class Client {
         }
         return this.requestJson("GET", `/platform/graph/neighborhood?${query.toString()}`);
     }
+    async createJob(request, idempotencyKey = "") {
+        const headers = {};
+        if (idempotencyKey) {
+            headers["Idempotency-Key"] = idempotencyKey;
+        }
+        return this.requestJson("POST", "/platform/jobs", request, headers);
+    }
+    async listJobs(options = {}) {
+        const query = new URLSearchParams();
+        for (const [key, value] of Object.entries(options)) {
+            if (value === undefined || value === null || value === "") {
+                continue;
+            }
+            query.set(key, String(value));
+        }
+        const suffix = query.toString() ? `?${query.toString()}` : "";
+        return this.requestJson("GET", `/platform/jobs${suffix}`);
+    }
+    async getJob(jobId) {
+        return this.requestJson("GET", `/platform/jobs/${encodeURIComponent(jobId)}`);
+    }
+    async listJobEvents(jobId, limit = 0) {
+        const suffix = limit > 0 ? `?limit=${encodeURIComponent(String(limit))}` : "";
+        return this.requestJson("GET", `/platform/jobs/${encodeURIComponent(jobId)}/events${suffix}`);
+    }
+    async cancelJob(jobId) {
+        return this.requestJson("POST", `/platform/jobs/${encodeURIComponent(jobId)}/cancel`);
+    }
     integration(options) {
         return new IntegrationClient(this, options);
     }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -94,6 +94,22 @@ export interface IntegrationOptions {
   integration: string;
 }
 
+export interface CreateJobRequest {
+  kind: string;
+  tenant_id?: string;
+  subject_type?: string;
+  subject_id?: string;
+  idempotency_key?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface ListJobsOptions {
+  tenant_id?: string;
+  kind?: string;
+  status?: string;
+  limit?: number;
+}
+
 export class APIError extends Error {
   statusCode: number;
   code?: string;
@@ -158,6 +174,39 @@ export class Client {
       query.set("limit", String(limit));
     }
     return this.requestJson<GraphNeighborhood>("GET", `/platform/graph/neighborhood?${query.toString()}`);
+  }
+
+  async createJob(request: CreateJobRequest, idempotencyKey = ""): Promise<Record<string, unknown>> {
+    const headers: Record<string, string> = {};
+    if (idempotencyKey) {
+      headers["Idempotency-Key"] = idempotencyKey;
+    }
+    return this.requestJson<Record<string, unknown>>("POST", "/platform/jobs", request, headers);
+  }
+
+  async listJobs(options: ListJobsOptions = {}): Promise<Record<string, unknown>> {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(options)) {
+      if (value === undefined || value === null || value === "") {
+        continue;
+      }
+      query.set(key, String(value));
+    }
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    return this.requestJson<Record<string, unknown>>("GET", `/platform/jobs${suffix}`);
+  }
+
+  async getJob(jobId: string): Promise<Record<string, unknown>> {
+    return this.requestJson<Record<string, unknown>>("GET", `/platform/jobs/${encodeURIComponent(jobId)}`);
+  }
+
+  async listJobEvents(jobId: string, limit = 0): Promise<Record<string, unknown>> {
+    const suffix = limit > 0 ? `?limit=${encodeURIComponent(String(limit))}` : "";
+    return this.requestJson<Record<string, unknown>>("GET", `/platform/jobs/${encodeURIComponent(jobId)}/events${suffix}`);
+  }
+
+  async cancelJob(jobId: string): Promise<Record<string, unknown>> {
+    return this.requestJson<Record<string, unknown>>("POST", `/platform/jobs/${encodeURIComponent(jobId)}/cancel`);
   }
 
   integration(options: IntegrationOptions): IntegrationClient {

--- a/sdk/typescript/test/jira.test.mjs
+++ b/sdk/typescript/test/jira.test.mjs
@@ -37,6 +37,10 @@ test("jira subpath imports the exported source entrypoint", async () => {
 test("source bridge is importable at runtime", async () => {
   const mod = await import(path.join(srcDir, "index.js"));
   assert.equal(typeof mod.Client, "function");
+  const client = new mod.Client({ baseUrl: "https://cerebro.example.com" });
+  for (const method of ["createJob", "listJobs", "getJob", "listJobEvents", "cancelJob"]) {
+    assert.equal(typeof client[method], "function");
+  }
 
   const pkg = JSON.parse(await readFile(path.resolve(here, "../package.json"), "utf8"));
   assert.equal(pkg.main, "./src/index.js");

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -200,6 +200,7 @@ func TestSourceCDKOwnsExternalHTTPClients(t *testing.T) {
 			}
 			if strings.HasPrefix(rel, "sources"+string(filepath.Separator)) ||
 				strings.HasPrefix(rel, filepath.Join("internal", "bootstrap")+string(filepath.Separator)) ||
+				strings.HasPrefix(rel, filepath.Join("internal", "observability")+string(filepath.Separator)) ||
 				strings.HasPrefix(rel, filepath.Join("internal", "sourcehttp")+string(filepath.Separator)) {
 				continue
 			}


### PR DESCRIPTION
## Summary
- Add durable platform jobs, runtime response blocklist state, metrics/trace propagation, and Python/TypeScript SDK helpers.
- Harden CI/security posture with CodeQL, Semgrep, Gitleaks, expanded Dependabot, SDK audits, docs drift checks, and release attestations.
- Update the DeepSec dependency graph to resolve the open npm Dependabot alerts for `@anthropic-ai/sdk`, `hono`, `fast-uri`, `ip-address`, and `qs`.

## Test plan
- `pnpm audit --audit-level low` in `.deepsec`
- `make openapi-lint openapi-check docs-drift-check`
- `go test ./...`
- `make sdk-test`
- `make lint`
- `make check-structural check-structural-test check-arch`
- `make catalog-check detection-catalog-check`
- `make proto-lint proto-generate-check`

Made with [Cursor](https://cursor.com)