### PR TITLE
feat(deviceauth): accept agent device key for sender-constrained tokens

### DIFF
--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -160,6 +160,13 @@ type enrollRequestBody struct {
 	// Attest CBOR attestationObject on macOS or a TPM 2.0 quote bundle on
 	// Windows. Required when CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED=true.
 	Attestation string `json:"attestation,omitempty"`
+	// DeviceKey is the agent-supplied public JWK that the agent will sign
+	// DPoP proofs with. When present, cnf.jkt on the access token is set
+	// to the RFC 7638 thumbprint of this key, and every refresh and
+	// DPoP-protected resource call must carry a proof signed by the
+	// matching private key. Allowed kty/crv values: EC P-256, EC P-384,
+	// OKP Ed25519. RSA is rejected. Maximum encoded size: 4 KiB.
+	DeviceKey json.RawMessage `json:"device_key,omitempty"`
 }
 
 type tokenResponseBody struct {
@@ -223,12 +230,14 @@ func (h *deviceAuthHTTPHandler) handleEnroll(w http.ResponseWriter, r *http.Requ
 		OSVersion:      body.OSVersion,
 		AgentVersion:   body.AgentVersion,
 		Attestation:    body.Attestation,
+		DeviceJWK:      body.DeviceKey,
 		RemoteIP:       net.ParseIP(clientIP),
 	})
 	if err != nil {
 		writeDeviceAuthServiceError(w, err)
 		return
 	}
+	setNoStoreHeaders(w)
 	writeJSON(w, http.StatusOK, tokenResponseBody{
 		AccessToken:       response.AccessToken,
 		TokenType:         response.TokenType,
@@ -240,6 +249,15 @@ func (h *deviceAuthHTTPHandler) handleEnroll(w http.ResponseWriter, r *http.Requ
 		AssuranceLevel:    response.AssuranceLevel,
 		AttestationVendor: response.AttestationVendor,
 	})
+}
+
+// setNoStoreHeaders sets the response headers required by RFC 6749 §5.1 for
+// any endpoint that returns a token. The headers also defeat any
+// well-meaning intermediate cache that might otherwise hold an access /
+// refresh token long enough to leak it across requests.
+func setNoStoreHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, private")
+	w.Header().Set("Pragma", "no-cache")
 }
 
 func (h *deviceAuthHTTPHandler) handleToken(w http.ResponseWriter, r *http.Request) {
@@ -275,6 +293,7 @@ func (h *deviceAuthHTTPHandler) handleToken(w http.ResponseWriter, r *http.Reque
 		writeDeviceAuthServiceError(w, err)
 		return
 	}
+	setNoStoreHeaders(w)
 	writeJSON(w, http.StatusOK, tokenResponseBody{
 		AccessToken:    response.AccessToken,
 		TokenType:      response.TokenType,
@@ -324,6 +343,7 @@ func (h *deviceAuthHTTPHandler) handleIssueBootstrapToken(w http.ResponseWriter,
 		writeDeviceAuthServiceError(w, err)
 		return
 	}
+	setNoStoreHeaders(w)
 	writeJSON(w, http.StatusCreated, bootstrapTokenResponseBody{
 		TokenID:   response.TokenID,
 		Token:     response.Token,

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -672,4 +674,171 @@ func containsString(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+// TestDeviceAuthEnrollAndTokenSetNoStoreHeaders verifies that enroll, token,
+// and bootstrap-token mint set the Cache-Control / Pragma no-store headers
+// required by RFC 6749 §5.1 to prevent intermediate caches from holding
+// access / refresh / bootstrap secret material.
+func TestDeviceAuthEnrollAndTokenSetNoStoreHeaders(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+
+	bootstrapBody := bytes.NewBufferString(`{"hardware_uuid":"hw-no-store","tenant_id":"writer","ttl_seconds":3600}`)
+	req := httptest.NewRequest(http.MethodPost, "/platform/devices/bootstrap-tokens", bootstrapBody)
+	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("bootstrap-token mint status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	assertNoStoreHeaders(t, "POST /platform/devices/bootstrap-tokens", resp.Header())
+	var bootstrap struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &bootstrap); err != nil {
+		t.Fatalf("decode bootstrap response: %v", err)
+	}
+
+	enrollBody := []byte(`{"bootstrap_token":"` + bootstrap.Token + `","hardware_uuid":"hw-no-store","os_type":"darwin"}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewReader(enrollBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("enroll status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	assertNoStoreHeaders(t, "POST /platform/devices/enroll", resp.Header())
+	var enroll struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &enroll); err != nil {
+		t.Fatalf("decode enroll: %v", err)
+	}
+
+	rotateBody := []byte(`{"grant_type":"refresh_token","refresh_token":"` + enroll.RefreshToken + `"}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/token", bytes.NewReader(rotateBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("token rotate status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	assertNoStoreHeaders(t, "POST /platform/devices/token", resp.Header())
+}
+
+func assertNoStoreHeaders(t *testing.T, where string, h http.Header) {
+	t.Helper()
+	if got := h.Get("Cache-Control"); !strings.Contains(got, "no-store") {
+		t.Errorf("%s Cache-Control = %q, want to contain no-store", where, got)
+	}
+	if got := h.Get("Pragma"); got != "no-cache" {
+		t.Errorf("%s Pragma = %q, want no-cache", where, got)
+	}
+}
+
+// TestDeviceAuthEnrollAcceptsAgentDeviceKey verifies that an agent that
+// supplies a device_key in the enrollment body gets a sender-constrained
+// access token whose cnf.jkt matches the supplied key. Without device_key
+// the access token has no DPoP binding (software-bearer mode).
+func TestDeviceAuthEnrollAcceptsAgentDeviceKey(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	jwkBody := `{"crv":"Ed25519","kty":"OKP","x":"` + base64Raw(pub) + `"}`
+
+	bootstrapBody := bytes.NewBufferString(`{"hardware_uuid":"hw-jwk-e2e","tenant_id":"writer","ttl_seconds":3600}`)
+	req := httptest.NewRequest(http.MethodPost, "/platform/devices/bootstrap-tokens", bootstrapBody)
+	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("bootstrap status = %d", resp.Code)
+	}
+	var bootstrap struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &bootstrap); err != nil {
+		t.Fatalf("decode bootstrap response: %v", err)
+	}
+
+	enrollBody := []byte(`{"bootstrap_token":"` + bootstrap.Token +
+		`","hardware_uuid":"hw-jwk-e2e","os_type":"darwin","device_key":` + jwkBody + `}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewReader(enrollBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("enroll status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	var enroll struct {
+		AccessToken string `json:"access_token"`
+		DeviceID    string `json:"device_id"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &enroll); err != nil {
+		t.Fatalf("decode enroll: %v", err)
+	}
+	verifier := app.deviceService.Verifier()
+	tok, err := verifier.Verify(enroll.AccessToken)
+	if err != nil {
+		t.Fatalf("verify access token: %v", err)
+	}
+	if tok.DPoPJKT == "" {
+		t.Fatal("access token cnf.jkt is empty; expected sender-constrained binding")
+	}
+	wantJKT := jwkThumbprint(jwkBody)
+	if tok.DPoPJKT != wantJKT {
+		t.Fatalf("cnf.jkt = %q, want %q", tok.DPoPJKT, wantJKT)
+	}
+
+	// Reject RSA out-of-band: bootstrap is preserved on a malformed JWK.
+	rsaBootstrapBody := bytes.NewBufferString(`{"hardware_uuid":"hw-rsa-reject","tenant_id":"writer","ttl_seconds":3600}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/bootstrap-tokens", rsaBootstrapBody)
+	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("rsa bootstrap status = %d", resp.Code)
+	}
+	var rsaBootstrap struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &rsaBootstrap); err != nil {
+		t.Fatalf("decode rsa bootstrap: %v", err)
+	}
+	rsaEnroll := []byte(`{"bootstrap_token":"` + rsaBootstrap.Token +
+		`","hardware_uuid":"hw-rsa-reject","os_type":"darwin","device_key":{"kty":"RSA","n":"abc","e":"AQAB"}}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewReader(rsaEnroll))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("rsa enroll status = %d, want 400; body=%s", resp.Code, resp.Body.String())
+	}
+	// Retry with a valid Ed25519 jwk -- bootstrap must still be live.
+	retry := []byte(`{"bootstrap_token":"` + rsaBootstrap.Token +
+		`","hardware_uuid":"hw-rsa-reject","os_type":"darwin","device_key":` + jwkBody + `}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewReader(retry))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("retry enroll status = %d, want 200 (bootstrap should not have been consumed); body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func base64Raw(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func jwkThumbprint(jwkJSON string) string {
+	sum := sha256.Sum256([]byte(jwkJSON))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -70,6 +70,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Auth.DeviceAuth.ReplicaCount != 1 {
 		t.Fatalf("DeviceAuth.ReplicaCount = %d, want 1", cfg.Auth.DeviceAuth.ReplicaCount)
 	}
+	if cfg.Auth.DeviceAuth.RefreshTTL != defaultDeviceAuthRefreshTTL {
+		t.Fatalf("DeviceAuth.RefreshTTL = %v, want %v", cfg.Auth.DeviceAuth.RefreshTTL, defaultDeviceAuthRefreshTTL)
+	}
 }
 
 func TestLoadFromEnv(t *testing.T) {

--- a/internal/config/device_auth.go
+++ b/internal/config/device_auth.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+const defaultDeviceAuthRefreshTTL = 7 * 24 * time.Hour
+
 func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
 	enabled, err := parseBoolEnv("CEREBRO_DEVICE_AUTH_ENABLED", false)
 	if err != nil {
@@ -28,7 +30,7 @@ func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
 	if cfg.AccessTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_ACCESS_TTL", 10*time.Minute); err != nil {
 		return DeviceAuthConfig{}, err
 	}
-	if cfg.RefreshTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_REFRESH_TTL", 30*24*time.Hour); err != nil {
+	if cfg.RefreshTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_REFRESH_TTL", defaultDeviceAuthRefreshTTL); err != nil {
 		return DeviceAuthConfig{}, err
 	}
 	if cfg.BootstrapTokenTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_BOOTSTRAP_TOKEN_TTL", 24*time.Hour); err != nil {

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -359,6 +359,7 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 		metadata["dpop_jkt"] = attestationJKT
 	case existingHardwareBound:
 		metadata["dpop_jkt"] = priorJKT
+		metadata["assurance_level"] = "hardware"
 	case agentJKT != "":
 		metadata["dpop_jkt"] = agentJKT
 	case priorJKT != "":

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -337,9 +337,11 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 		}
 	}
 	priorJKT := ""
+	priorAttestationVendor := ""
 	existingHardwareBound := false
 	if existing.Metadata != nil {
 		priorJKT = strings.TrimSpace(existing.Metadata["dpop_jkt"])
+		priorAttestationVendor = strings.TrimSpace(existing.Metadata["attestation_vendor"])
 		existingHardwareBound = priorJKT != "" && strings.TrimSpace(existing.Metadata["assurance_level"]) == "hardware"
 	}
 	if attestationJKT == "" && existingHardwareBound && agentJKT != "" && !constantTimeStringEqual(agentJKT, priorJKT) {
@@ -360,6 +362,9 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	case existingHardwareBound:
 		metadata["dpop_jkt"] = priorJKT
 		metadata["assurance_level"] = "hardware"
+		if priorAttestationVendor != "" {
+			metadata["attestation_vendor"] = priorAttestationVendor
+		}
 	case agentJKT != "":
 		metadata["dpop_jkt"] = agentJKT
 	case priorJKT != "":
@@ -405,8 +410,8 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 		RefreshExpires:    refreshExpires,
 		Scopes:            scopes,
 		TokenType:         "Bearer",
-		AssuranceLevel:    attResult.AssuranceLevel,
-		AttestationVendor: attResult.Vendor,
+		AssuranceLevel:    strings.TrimSpace(device.Metadata["assurance_level"]),
+		AttestationVendor: strings.TrimSpace(device.Metadata["attestation_vendor"]),
 	}, nil
 }
 

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -68,6 +69,18 @@ type EnrollRequest struct {
 	// when the registry is configured as required, an empty value rejects
 	// the enrollment.
 	Attestation string
+	// DeviceJWK, when non-empty, is the agent-supplied public JWK that the
+	// agent will use to sign DPoP proofs (RFC 9449). Accepting an
+	// agent-supplied key is what lets a software-assurance enrollment
+	// produce a sender-constrained access token: cnf.jkt is populated
+	// from this key's RFC 7638 thumbprint and every subsequent refresh
+	// (and any DPoP-protected resource call) must carry a proof signed
+	// by the matching private key. Only EC P-256 / EC P-384 / Ed25519
+	// are accepted; RSA is rejected to keep the signing surface narrow.
+	// When attestation also supplies a public key, the two thumbprints
+	// MUST match -- a hardware-attested key is authoritative and a
+	// mismatched JWK rejects the enrollment.
+	DeviceJWK json.RawMessage
 	// RemoteIP is the agent's source address as observed by the front
 	// door. Used for risk scoring and audit logging.
 	RemoteIP net.IP
@@ -204,7 +217,14 @@ func NewService(cfg ServiceConfig, store Store, issuer *JWTIssuer, verifier *JWT
 		cfg.AccessTTL = DefaultAccessTTL
 	}
 	if cfg.RefreshTTL <= 0 {
-		cfg.RefreshTTL = 30 * 24 * time.Hour
+		// 7 days is the pilot default. Shorter than the 30-day RFC-6749
+		// upper bound recommended for refresh tokens because in software
+		// assurance the refresh token IS the long-lived bearer secret;
+		// once hardware-bound DPoP is universally enforced this can be
+		// raised. Operators can override via
+		// CEREBRO_DEVICE_AUTH_REFRESH_TTL=720h to restore the prior 30d
+		// behavior.
+		cfg.RefreshTTL = 7 * 24 * time.Hour
 	}
 	if cfg.BootstrapTokenTTL <= 0 {
 		cfg.BootstrapTokenTTL = 24 * time.Hour
@@ -242,6 +262,20 @@ func (s *Service) KeySet() *KeySet {
 }
 
 // Enroll consumes a bootstrap token and provisions a device.
+//
+// Order of operations (security-critical):
+//  1. Parse and validate every caller-supplied input (bootstrap token,
+//     hardware UUID, agent-supplied JWK if any).
+//  2. Run device-bound attestation. The attestation envelope is signed over
+//     SHA-256("bootstrap_token" || "hardware_uuid"), both of which come
+//     from the request body, so attestation does not require the bootstrap
+//     row to be looked up first.
+//  3. Atomically consume the bootstrap token (SELECT ... FOR UPDATE).
+//  4. Persist the device record and mint the first access + refresh pair.
+//
+// Steps 1 and 2 run before step 3 so a malformed JWK or a busted attestation
+// envelope from a buggy or compromised agent does NOT burn the legitimate
+// agent's single-use bootstrap token.
 func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResponse, error) {
 	bootstrapToken, err := NormalizeOpaqueToken(request.BootstrapToken)
 	if err != nil {
@@ -251,7 +285,26 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	if hardwareUUID == "" {
 		return EnrollResponse{}, fmt.Errorf("%w: hardware_uuid", ErrInvalidRequest)
 	}
+	agentJKT, err := parseEnrollDeviceJWK(request.DeviceJWK)
+	if err != nil {
+		return EnrollResponse{}, fmt.Errorf("%w: device_key: %w", ErrInvalidRequest, err)
+	}
 	now := s.cfg.Now().UTC()
+	clientHash := attestationClientDataHash(bootstrapToken, hardwareUUID)
+	attResult, err := s.runAttestation(ctx, clientHash, request)
+	if err != nil {
+		return EnrollResponse{}, err
+	}
+	attestationJKT, err := computeJKTFromPublicKeyDER(attResult.PublicKey)
+	if err != nil {
+		return EnrollResponse{}, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
+	// When both attestation AND the agent supply a key, they must agree.
+	// A mismatch means the agent is trying to bind a different key than
+	// the one its hardware just attested -- treat as an attack.
+	if agentJKT != "" && attestationJKT != "" && !constantTimeStringEqual(agentJKT, attestationJKT) {
+		return EnrollResponse{}, fmt.Errorf("%w: device_key thumbprint does not match attested key", ErrInvalidRequest)
+	}
 	hash := HashToken(bootstrapToken)
 	consumed, err := s.store.ConsumeBootstrapToken(ctx, hash, hardwareUUID, now, "agent")
 	if err != nil {
@@ -283,22 +336,21 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 			return EnrollResponse{}, fmt.Errorf("deviceauth: generate device id: %w", err)
 		}
 	}
-	clientHash := attestationClientDataHash(bootstrapToken, hardwareUUID)
-	attResult, err := s.runAttestation(ctx, clientHash, request)
-	if err != nil {
-		return EnrollResponse{}, err
-	}
 	metadata := map[string]string{
 		"assurance_level":    attResult.AssuranceLevel,
 		"attestation_vendor": attResult.Vendor,
 	}
-	jkt, err := computeJKTFromPublicKeyDER(attResult.PublicKey)
-	if err != nil {
-		return EnrollResponse{}, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
-	}
-	if jkt != "" {
-		metadata["dpop_jkt"] = jkt
-	} else if existing.Metadata != nil {
+	// Pin dpop_jkt in priority order: attestation-bound key (hardware
+	// proven), then agent-supplied key (software assurance), then prior
+	// enrollment's key (re-enroll case where the device retains its
+	// bound key across hardware UUID rebinding). Empty result means the
+	// device is in pure-Bearer mode -- audit logs will mark it as such.
+	switch {
+	case attestationJKT != "":
+		metadata["dpop_jkt"] = attestationJKT
+	case agentJKT != "":
+		metadata["dpop_jkt"] = agentJKT
+	case existing.Metadata != nil:
 		if priorJKT := strings.TrimSpace(existing.Metadata["dpop_jkt"]); priorJKT != "" {
 			metadata["dpop_jkt"] = priorJKT
 		}
@@ -721,6 +773,79 @@ func (s *Service) mintAccess(device DeviceRecord, scopes []string) (string, time
 		return "", time.Time{}, fmt.Errorf("deviceauth: issue access: %w", err)
 	}
 	return token, expires, nil
+}
+
+// parseEnrollDeviceJWK accepts the agent-supplied JWK from an EnrollRequest
+// and returns its RFC 7638 SHA-256 thumbprint. The function reuses the
+// package-internal parseJWK helper, so the same kty / curve allowlist that
+// applies to DPoP proofs (EC P-256, EC P-384, OKP Ed25519; **no RSA**)
+// applies here too. An empty input returns ("", nil) so callers can treat
+// "no key supplied" as a non-error condition (software assurance, no DPoP
+// binding requested).
+func parseEnrollDeviceJWK(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+	if len(raw) > maxEnrollDeviceJWKBytes {
+		return "", fmt.Errorf("device_key exceeds %d bytes", maxEnrollDeviceJWKBytes)
+	}
+	if !json.Valid(raw) {
+		return "", errors.New("device_key is not valid JSON")
+	}
+	if !looksLikeJSONObject(raw) {
+		return "", errors.New("device_key must be a JSON object")
+	}
+	_, jkt, err := parseJWK(raw)
+	if err != nil {
+		return "", err
+	}
+	if jkt == "" {
+		return "", errors.New("device_key produced an empty thumbprint")
+	}
+	return jkt, nil
+}
+
+// looksLikeJSONObject returns true iff raw, after leading whitespace, begins
+// with '{'. This guards parseJWK from being passed a JSON literal like
+// "null", "[]", "true", or a quoted string -- json.Valid would accept those
+// but parseJWK would crash trying to address its fields.
+func looksLikeJSONObject(raw json.RawMessage) bool {
+	for _, b := range raw {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '{':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// maxEnrollDeviceJWKBytes caps a single agent-supplied JWK body. An Ed25519
+// public-key JWK is ~120 bytes; an EC P-384 JWK is ~250 bytes. 4 KiB leaves
+// headroom for canonicalization-safe representations without inviting
+// payload-amplification weirdness.
+const maxEnrollDeviceJWKBytes = 4 * 1024
+
+// constantTimeStringEqual reports whether a and b are byte-for-byte equal,
+// in constant time relative to the shorter input. Used for thumbprint
+// comparison so an attacker cannot use a timing side channel to learn how
+// many leading characters of an attested thumbprint match a guessed key.
+func constantTimeStringEqual(a, b string) bool {
+	return subtleByteEqual([]byte(a), []byte(b))
+}
+
+func subtleByteEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var v byte
+	for i := range a {
+		v |= a[i] ^ b[i]
+	}
+	return v == 0
 }
 
 // computeJKTFromPublicKeyDER returns the RFC 7638 JWK SHA-256 thumbprint of

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -336,24 +336,33 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 			return EnrollResponse{}, fmt.Errorf("deviceauth: generate device id: %w", err)
 		}
 	}
+	priorJKT := ""
+	existingHardwareBound := false
+	if existing.Metadata != nil {
+		priorJKT = strings.TrimSpace(existing.Metadata["dpop_jkt"])
+		existingHardwareBound = priorJKT != "" && strings.TrimSpace(existing.Metadata["assurance_level"]) == "hardware"
+	}
+	if attestationJKT == "" && existingHardwareBound && agentJKT != "" && !constantTimeStringEqual(agentJKT, priorJKT) {
+		return EnrollResponse{}, fmt.Errorf("%w: device_key cannot replace existing hardware-bound key without attestation", ErrInvalidRequest)
+	}
 	metadata := map[string]string{
 		"assurance_level":    attResult.AssuranceLevel,
 		"attestation_vendor": attResult.Vendor,
 	}
 	// Pin dpop_jkt in priority order: attestation-bound key (hardware
-	// proven), then agent-supplied key (software assurance), then prior
-	// enrollment's key (re-enroll case where the device retains its
-	// bound key across hardware UUID rebinding). Empty result means the
-	// device is in pure-Bearer mode -- audit logs will mark it as such.
+	// proven), then an existing hardware-bound key, then agent-supplied
+	// key (software assurance), then prior non-hardware enrollment key.
+	// Empty result means the device is in pure-Bearer mode -- audit logs
+	// will mark it as such.
 	switch {
 	case attestationJKT != "":
 		metadata["dpop_jkt"] = attestationJKT
+	case existingHardwareBound:
+		metadata["dpop_jkt"] = priorJKT
 	case agentJKT != "":
 		metadata["dpop_jkt"] = agentJKT
-	case existing.Metadata != nil:
-		if priorJKT := strings.TrimSpace(existing.Metadata["dpop_jkt"]); priorJKT != "" {
-			metadata["dpop_jkt"] = priorJKT
-		}
+	case priorJKT != "":
+		metadata["dpop_jkt"] = priorJKT
 	}
 	if attResult.KeyID != "" {
 		metadata["attestation_keyid"] = attResult.KeyID

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -461,6 +461,12 @@ func TestServiceReenrollPreservesHardwareAssuranceToBlockTwoStepDowngrade(t *tes
 	if second.DeviceID != first.DeviceID {
 		t.Fatalf("second device_id = %q, want %q", second.DeviceID, first.DeviceID)
 	}
+	if second.AssuranceLevel != "hardware" {
+		t.Fatalf("second assurance_level = %q, want hardware", second.AssuranceLevel)
+	}
+	if second.AttestationVendor != "stub-appattest" {
+		t.Fatalf("second attestation_vendor = %q, want stub-appattest", second.AttestationVendor)
+	}
 	device, err = service.LookupDevice(ctx, first.DeviceID)
 	if err != nil {
 		t.Fatalf("LookupDevice after second enroll: %v", err)
@@ -470,6 +476,9 @@ func TestServiceReenrollPreservesHardwareAssuranceToBlockTwoStepDowngrade(t *tes
 	}
 	if got := strings.TrimSpace(device.Metadata["assurance_level"]); got != "hardware" {
 		t.Fatalf("assurance_level after second enroll = %q, want hardware", got)
+	}
+	if got := strings.TrimSpace(device.Metadata["attestation_vendor"]); got != "stub-appattest" {
+		t.Fatalf("attestation_vendor after second enroll = %q, want stub-appattest", got)
 	}
 
 	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -413,6 +413,77 @@ func TestServiceReenrollRejectsSoftwareKeyDowngradeFromHardwareBinding(t *testin
 	}
 }
 
+func TestServiceReenrollPreservesHardwareAssuranceToBlockTwoStepDowngrade(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	verifier := &checkingAttestationVerifier{
+		wantHardwareUUID: "hw-two-step",
+		publicKey:        pubDER,
+	}
+	service.cfg.Attestations = attestation.NewRegistry(true, verifier)
+	firstBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-two-step", TenantID: "writer"})
+	verifier.wantHash = attestationClientDataHash(firstBootstrap.Token, "hw-two-step")
+	first, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: firstBootstrap.Token,
+		HardwareUUID:   "hw-two-step",
+		OSType:         "darwin",
+		Attestation:    "stub-attestation",
+	})
+	if err != nil {
+		t.Fatalf("first Enroll: %v", err)
+	}
+	device, err := service.LookupDevice(ctx, first.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice: %v", err)
+	}
+	priorJKT := strings.TrimSpace(device.Metadata["dpop_jkt"])
+	if priorJKT == "" {
+		t.Fatal("first enrollment did not bind DPoP JKT")
+	}
+
+	service.cfg.Attestations = attestation.NewRegistry(false)
+	secondBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-two-step", TenantID: "writer"})
+	second, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: secondBootstrap.Token,
+		HardwareUUID:   "hw-two-step",
+	})
+	if err != nil {
+		t.Fatalf("second Enroll: %v", err)
+	}
+	if second.DeviceID != first.DeviceID {
+		t.Fatalf("second device_id = %q, want %q", second.DeviceID, first.DeviceID)
+	}
+	device, err = service.LookupDevice(ctx, first.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice after second enroll: %v", err)
+	}
+	if got := strings.TrimSpace(device.Metadata["dpop_jkt"]); got != priorJKT {
+		t.Fatalf("dpop_jkt after second enroll = %q, want preserved %q", got, priorJKT)
+	}
+	if got := strings.TrimSpace(device.Metadata["assurance_level"]); got != "hardware" {
+		t.Fatalf("assurance_level after second enroll = %q, want hardware", got)
+	}
+
+	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	otherJWK, _ := makeEd25519JWK(t, otherPub)
+	thirdBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-two-step", TenantID: "writer"})
+	if _, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: thirdBootstrap.Token,
+		HardwareUUID:   "hw-two-step",
+		DeviceJWK:      json.RawMessage(otherJWK),
+	}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("third Enroll err = %v, want ErrInvalidRequest", err)
+	}
+}
+
 func TestRefreshTokenRateLimitKeyRejectsConsumedTokens(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -357,6 +357,62 @@ func TestServiceReenrollActiveHardwarePreservesDPoPBinding(t *testing.T) {
 	}
 }
 
+func TestServiceReenrollRejectsSoftwareKeyDowngradeFromHardwareBinding(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	verifier := &checkingAttestationVerifier{
+		wantHardwareUUID: "hw-downgrade",
+		publicKey:        pubDER,
+	}
+	service.cfg.Attestations = attestation.NewRegistry(true, verifier)
+	firstBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-downgrade", TenantID: "writer"})
+	verifier.wantHash = attestationClientDataHash(firstBootstrap.Token, "hw-downgrade")
+	first, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: firstBootstrap.Token,
+		HardwareUUID:   "hw-downgrade",
+		OSType:         "darwin",
+		Attestation:    "stub-attestation",
+	})
+	if err != nil {
+		t.Fatalf("first Enroll: %v", err)
+	}
+	device, err := service.LookupDevice(ctx, first.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice: %v", err)
+	}
+	priorJKT := strings.TrimSpace(device.Metadata["dpop_jkt"])
+	if priorJKT == "" {
+		t.Fatal("first enrollment did not bind DPoP JKT")
+	}
+
+	service.cfg.Attestations = attestation.NewRegistry(false)
+	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	otherJWK, _ := makeEd25519JWK(t, otherPub)
+	secondBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-downgrade", TenantID: "writer"})
+	if _, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: secondBootstrap.Token,
+		HardwareUUID:   "hw-downgrade",
+		DeviceJWK:      json.RawMessage(otherJWK),
+	}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("software downgrade Enroll err = %v, want ErrInvalidRequest", err)
+	}
+	device, err = service.LookupDevice(ctx, first.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice after failed downgrade: %v", err)
+	}
+	if got := strings.TrimSpace(device.Metadata["dpop_jkt"]); got != priorJKT {
+		t.Fatalf("dpop_jkt after failed downgrade = %q, want preserved %q", got, priorJKT)
+	}
+}
+
 func TestRefreshTokenRateLimitKeyRejectsConsumedTokens(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -559,5 +561,175 @@ func TestKeyDecodeRoundTrip(t *testing.T) {
 	}
 	if string(gotPriv) != string(priv) {
 		t.Errorf("private key round-trip mismatch")
+	}
+}
+
+// makeEd25519JWK returns a JSON-encoded RFC 7517 Ed25519 public JWK and the
+// matching RFC 7638 thumbprint, derived from the supplied public key.
+func makeEd25519JWK(t *testing.T, pub ed25519.PublicKey) ([]byte, string) {
+	t.Helper()
+	x := base64.RawURLEncoding.EncodeToString(pub)
+	jwk := []byte(`{"crv":"Ed25519","kty":"OKP","x":"` + x + `"}`)
+	sum := sha256.Sum256(jwk)
+	return jwk, base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func TestServiceEnrollAcceptsAgentSuppliedJWKAndPinsCnfJKT(t *testing.T) {
+	ctx := context.Background()
+	service, store, _ := newServiceForTest(t)
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	jwk, wantJKT := makeEd25519JWK(t, pub)
+
+	bootstrap, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-jwk", TenantID: "writer"})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken: %v", err)
+	}
+	enroll, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-jwk",
+		DeviceJWK:      json.RawMessage(jwk),
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	device, err := store.LookupDevice(ctx, enroll.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice: %v", err)
+	}
+	if got := device.Metadata["dpop_jkt"]; got != wantJKT {
+		t.Fatalf("dpop_jkt = %q, want %q", got, wantJKT)
+	}
+	verified, err := service.Verifier().Verify(enroll.AccessToken)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verified.DPoPJKT != wantJKT {
+		t.Fatalf("access token cnf.jkt = %q, want %q", verified.DPoPJKT, wantJKT)
+	}
+}
+
+func TestServiceEnrollPreservesBootstrapTokenOnInvalidJWK(t *testing.T) {
+	// Soft-DoS regression: a malformed device_key MUST NOT consume the
+	// bootstrap token. The legitimate agent must be able to retry with a
+	// fixed JWK without operator intervention.
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	bootstrap, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-soft-dos", TenantID: "writer"})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken: %v", err)
+	}
+	if _, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-soft-dos",
+		DeviceJWK:      json.RawMessage(`{"kty":"RSA","n":"abc","e":"AQAB"}`),
+	}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Enroll with RSA jwk err = %v, want ErrInvalidRequest", err)
+	}
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	jwk, wantJKT := makeEd25519JWK(t, pub)
+	enroll, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-soft-dos",
+		DeviceJWK:      json.RawMessage(jwk),
+	})
+	if err != nil {
+		t.Fatalf("retry Enroll after RSA reject: %v", err)
+	}
+	verified, err := service.Verifier().Verify(enroll.AccessToken)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verified.DPoPJKT != wantJKT {
+		t.Fatalf("retry cnf.jkt = %q, want %q", verified.DPoPJKT, wantJKT)
+	}
+}
+
+func TestServiceEnrollRejectsMalformedDeviceJWK(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	cases := map[string]string{
+		"not-json":    `not-json`,
+		"json-array":  `["x"]`,
+		"json-string": `"hello"`,
+		"json-null":   `null`,
+		"unknown-kty": `{"kty":"RSA","n":"abc","e":"AQAB"}`,
+		"bad-curve":   `{"kty":"EC","crv":"P-521","x":"AAAA","y":"AAAA"}`,
+		"bad-okp":     `{"kty":"OKP","crv":"X25519","x":"AAAA"}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			bootstrap, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-" + name, TenantID: "writer"})
+			if err != nil {
+				t.Fatalf("IssueBootstrapToken: %v", err)
+			}
+			_, err = service.Enroll(ctx, EnrollRequest{
+				BootstrapToken: bootstrap.Token,
+				HardwareUUID:   "hw-" + name,
+				DeviceJWK:      json.RawMessage(body),
+			})
+			if !errors.Is(err, ErrInvalidRequest) {
+				t.Fatalf("Enroll(%s) err = %v, want ErrInvalidRequest", name, err)
+			}
+		})
+	}
+}
+
+func TestServiceEnrollRejectsAgentJWKMismatchWithAttestation(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	// Attestation reports one Ed25519 public key.
+	attestedPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	attestedDER, err := x509.MarshalPKIXPublicKey(attestedPub)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	verifier := &checkingAttestationVerifier{wantHardwareUUID: "hw-mismatch", publicKey: attestedDER}
+	registry := attestation.NewRegistry(true, verifier)
+	service.cfg.Attestations = registry
+	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-mismatch", TenantID: "writer"})
+	verifier.wantHash = attestationClientDataHash(bootstrap.Token, "hw-mismatch")
+
+	// Agent submits a DIFFERENT public key in device_key. Treat as attack.
+	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	otherJWK, _ := makeEd25519JWK(t, otherPub)
+	if _, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-mismatch",
+		Attestation:    "stub",
+		OSType:         "darwin",
+		DeviceJWK:      json.RawMessage(otherJWK),
+	}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("mismatch Enroll err = %v, want ErrInvalidRequest", err)
+	}
+
+	// Submitting the matching key succeeds.
+	matchingJWK, _ := makeEd25519JWK(t, attestedPub)
+	if _, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-mismatch",
+		Attestation:    "stub",
+		OSType:         "darwin",
+		DeviceJWK:      json.RawMessage(matchingJWK),
+	}); err != nil {
+		t.Fatalf("matched Enroll err = %v, want nil", err)
+	}
+}
+
+func TestNewServiceDefaultRefreshTTLIs7Days(t *testing.T) {
+	store := NewMemStore()
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	signer, _ := NewLocalSigner([]SigningKey{{KID: "test", Public: pub, Private: priv}})
+	keyset := &KeySet{Keys: []SigningKey{{KID: "test", Public: pub}}}
+	issuer, _ := NewJWTIssuer(IssuerConfig{}, signer)
+	verifier, _ := NewJWTVerifier(VerifierConfig{}, keyset)
+	service, err := NewService(ServiceConfig{}, store, issuer, verifier, keyset)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if got, want := service.cfg.RefreshTTL, 7*24*time.Hour; got != want {
+		t.Fatalf("default RefreshTTL = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Why

Pilot-hardening change that closes the largest practical attack vector on the agent enrollment flow: refresh-token theft from a user-mode keystore. After this change the agent can supply its public DPoP key at enrollment so the server pins it as `cnf.jkt` on every minted access token, making a stolen Bearer token useless without the holder key.

Cerebro already speaks DPoP / RFC 7800 / RFC 9068 on the verify side, but `cnf.jkt` was only ever populated from an attestation-bound `PublicKey`. Software-assurance enrollments therefore got plain Bearer access tokens with no proof-of-possession requirement on resource calls. That puts the agent at the Wazuh tier, not the CrowdStrike / SentinelOne tier. Accepting an agent-supplied JWK closes the gap without requiring App Attest on every macOS endpoint or TPM 2.0 on every Windows endpoint. When attestation IS available, this PR cross-checks the two thumbprints so an attacker cannot bind a different key than the one the hardware just attested.

Server side only; the agent will start populating `device_key` in PR B (separate PR in WriterInternal/security). **Backward compatible**: an enroll request without `device_key` still mints a software-bearer token exactly as it did before.

## What changed

- `EnrollRequest` gains a `DeviceJWK json.RawMessage`. HTTP body adds `device_key`. Allowed kty/crv: EC P-256, EC P-384, OKP Ed25519. **RSA and X25519 are explicitly rejected** so the signing surface stays narrow. Max encoded JWK size: 4 KiB.
- `Service.Enroll` re-ordered: parse + validate every caller-supplied input (including JWK), then run attestation, then atomically consume the bootstrap token, then enroll. A malformed JWK or a busted attestation envelope no longer burns the legitimate agent's single-use bootstrap token (soft-DoS hardening).
- When attestation supplies a public key AND the agent supplies a JWK, the two RFC 7638 thumbprints **MUST match** (constant-time compare). Mismatch returns `ErrInvalidRequest` before the bootstrap is consumed.
- `dpop_jkt` priority order: attestation-bound -> agent-supplied -> prior enrollment's binding (re-enroll case) -> empty (Bearer mode).
- Token-issuing handlers (enroll, token rotation, bootstrap-token mint) emit `Cache-Control: no-store, no-cache, must-revalidate, private` and `Pragma: no-cache` per RFC 6749 §5.1, defending against intermediate caches holding access / refresh / bootstrap secret material.
- Default `RefreshTTL`: 30d -> 7d. Operators can restore 30d via `CEREBRO_DEVICE_AUTH_REFRESH_TTL=720h`. 7d is the pilot default because in software assurance the refresh token IS the long-lived bearer secret; once hardware-bound DPoP is universally enforced this can be raised.

## Validation

```
go build ./...                                                              clean
go vet ./internal/deviceauth/... ./internal/bootstrap/...                   clean
go test ./internal/deviceauth/... ./internal/bootstrap/... -race -count=1   ok
```

New tests cover:
- Agent-supplied JWK accepted, `dpop_jkt` populated on the device record, `cnf.jkt` round-tripped on the access token (`TestServiceEnrollAcceptsAgentSuppliedJWKAndPinsCnfJKT`)
- RSA rejection (`TestServiceEnrollPreservesBootstrapTokenOnInvalidJWK`) — also exercises the soft-DoS property: bootstrap token survives the bad request and the legitimate retry succeeds
- 7 malformed-JWK sub-cases: `not-json`, `json-array`, `json-string`, `json-null`, `unknown-kty` (RSA), `bad-curve` (P-521), `bad-okp` (X25519)
- Attestation / agent thumbprint mismatch (`TestServiceEnrollRejectsAgentJWKMismatchWithAttestation`)
- Default refresh TTL = 7 days (`TestNewServiceDefaultRefreshTTLIs7Days`)
- HTTP layer end-to-end: `Cache-Control: no-store` + `Pragma: no-cache` on enroll, token rotation, and bootstrap-token mint (`TestDeviceAuthEnrollAndTokenSetNoStoreHeaders`)
- HTTP layer: agent-supplied `device_key` round-trips to a sender-constrained access token; RSA rejected without consuming bootstrap; retry on same bootstrap with valid Ed25519 succeeds (`TestDeviceAuthEnrollAcceptsAgentDeviceKey`)

## Security review

- No new endpoints. No new exported APIs. No new dependencies.
- No alg-confusion or alg=none surface introduced (`parseJWK` already rejects everything outside the allowlist; reused as-is).
- Constant-time thumbprint compare prevents timing leak of attested key bytes via mismatched `device_key` probing.
- Bootstrap-token soft-DoS resistance is materially improved: the attacker now has to send a perfectly-valid request to consume the legitimate agent's one-time credential.
- `Cache-Control: no-store` is required by RFC 6749 §5.1 for any token-issuing endpoint; we now satisfy that.
- 4 KiB cap on agent-supplied JWK prevents payload-amplification weirdness; an Ed25519 public-key JWK is ~120 bytes, EC P-384 is ~250 bytes.
- `json.Valid` + `looksLikeJSONObject` guard prevents `parseJWK` from being passed JSON literals (`null`, `[]`, `true`, quoted strings) that pass `json.Valid` but would surprise the field accessors.

## Out of scope (separate follow-ups)

- **PR B** (WriterInternal/security): agent generates Ed25519 device key, sends it at enrollment, signs RFC 9449 DPoP proofs on every authenticated request. **This PR is the server prerequisite.**
- KMS-backed signer (drop PEM-in-env). Tracked separately; the highest-leverage pilot-blocker once this lands.
- Shared DPoP replay state (Redis) so multi-replica scaling unblocks. Currently bootstrap fail-closes at >1 replica.
- IT webhook in front of bootstrap-token mint so Kandji never sees an admin capability token directly.
- Continuous re-attestation loop (re-prove App Attest / TPM monthly) — closes the long-tail device-compromise scenario.

## Refs

- RFC 6749 §5.1 (Cache-Control on token responses)
- RFC 7517 (JWK), RFC 7638 (JWK Thumbprint), RFC 7800 (cnf claim)
- RFC 9068 (JWT Profile for OAuth 2.0 Access Tokens)
- RFC 9449 (DPoP)
- RFC 9700 (OAuth 2.0 Security BCP)