### PR TITLE
Persist trusted endpoint telemetry context

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -934,6 +934,70 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetEntityNeighborhoodResponse'
+  /platform/graph/trust-context:
+    post:
+      summary: Hydrate endpoint trust context
+      tags:
+        - Graph
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - tenant_id
+              properties:
+                tenant_id:
+                  type: string
+                runtime_id:
+                  type: string
+                agent_id:
+                  type: string
+                device_id:
+                  type: string
+                hardware_uuid:
+                  type: string
+                serial_number:
+                  type: string
+                hostname:
+                  type: string
+                max_allowed_severity:
+                  type: string
+                graph_root_urns:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Trust context result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  graph_neighborhood_loaded:
+                    type: boolean
+                  active_finding_count:
+                    type: integer
+                  max_finding_severity:
+                    type: string
+                  risk_score:
+                    type: integer
+                  stale_evidence_count:
+                    type: integer
+                  graph_root_urns:
+                    type: array
+                    items:
+                      type: string
+                  resolved_device_id:
+                    type: string
+                  candidate_device_ids:
+                    type: array
+                    items:
+                      type: string
+                  ambiguous_identity:
+                    type: boolean
   /platform/graph/impact/vulnerability/{id}:
     get:
       summary: Query vulnerability impact graph

--- a/docs/ENDPOINT_SECURITY_PLATFORM_INTEGRATION.md
+++ b/docs/ENDPOINT_SECURITY_PLATFORM_INTEGRATION.md
@@ -35,6 +35,11 @@ the device has enrolled. Before enrollment, use the tuple:
 tenant_id + hardware_uuid + serial_number + hostname
 ```
 
+Cerebro persists endpoint aliases in `endpoint_identity_aliases` and resolves
+lookups by tenant-scoped alias type/value. Strong identifiers (`device_id`,
+`hardware_uuid`, `serial_number`) should win over hostname, and hostname matches
+may be marked ambiguous when multiple enrolled devices share the same name.
+
 ## Source Runtime Contract
 
 Trusted Endpoint has a first-class Cerebro source ID:
@@ -81,6 +86,10 @@ event envelopes:
 
 This keeps endpoint telemetry compatible with source-runtime replay and graph
 projection without writing high-volume raw telemetry directly into the graph.
+On the first accepted request for an idempotency key, Cerebro appends those
+events to the append log, runs source projection, upserts endpoint aliases, and
+emits `endpoint_telemetry.accepted` observability. Idempotent replays return the
+cached receipt without re-appending or re-projecting events.
 
 ## Trust-Gate Loop
 
@@ -98,6 +107,19 @@ Trust gates should be bidirectional:
    targeted Trusted Endpoint refresh rather than approving from stale context.
 5. Every trust-gate decision and downstream action outcome should be emitted
    back as evidence so future policy and agent decisions can learn from it.
+
+Trusted Endpoint can hydrate Cerebro context with:
+
+```text
+POST /platform/graph/trust-context
+```
+
+The request supplies tenant and endpoint identifiers (`agent_id`, `device_id`,
+`hardware_uuid`, `serial_number`, `hostname`, and optional `graph_root_urns`).
+Cerebro resolves the endpoint identity, returns candidate root URNs, and
+summarizes graph-linked active findings into the existing trust-gate context
+fields (`graph_neighborhood_loaded`, `active_finding_count`,
+`max_finding_severity`, `risk_score`, and `stale_evidence_count`).
 
 ## Security/Kairos Agent Loop
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -151,7 +151,14 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 			app.dpopVerifier = dpop
 			app.riskScorer = riskScorer
 			app.observationStore = obsStore
-			app.deviceHandler = newDeviceAuthHTTPHandler(service, cfg.Auth.DeviceAuth, cfg.Auth.RequestOrigin)
+			app.deviceHandler = newDeviceAuthHTTPHandler(
+				service,
+				cfg.Auth.DeviceAuth,
+				cfg.Auth.RequestOrigin,
+				deps.AppendLog,
+				sourceProjector(deps.StateStore, deps.GraphStore),
+				endpointIdentityStore(deps.StateStore),
+			)
 		}
 	}
 	if cfg.Auth.MCPOAuth.Enabled {
@@ -3304,6 +3311,14 @@ func deviceRiskObservationStore(store ports.StateStore) risk.ObservationStore {
 		return nil
 	}
 	return observationStore
+}
+
+func endpointIdentityStore(store ports.StateStore) ports.EndpointIdentityStore {
+	identityStore, ok := store.(ports.EndpointIdentityStore)
+	if !ok || isNilInterface(identityStore) {
+		return nil
+	}
+	return identityStore
 }
 
 type startupJobLeaseProvider interface {

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/json"
 	"errors"
@@ -11,11 +12,15 @@ import (
 	"strings"
 	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/deviceauth"
 	"github.com/writer/cerebro/internal/deviceauth/attestation"
 	"github.com/writer/cerebro/internal/deviceauth/risk"
+	"github.com/writer/cerebro/internal/endpointidentity"
 	"github.com/writer/cerebro/internal/endpointtelemetry"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 // buildDeviceAuthService wires the deviceauth.Service against the configured
@@ -137,15 +142,21 @@ type deviceAuthHTTPHandler struct {
 	tokenLimit   *deviceauth.TokenBucket
 	originConfig config.RequestOriginConfig
 	now          func() time.Time
+	appendLog    ports.AppendLog
+	projector    ports.SourceProjector
+	identity     ports.EndpointIdentityStore
 }
 
-func newDeviceAuthHTTPHandler(service *deviceauth.Service, cfg config.DeviceAuthConfig, originConfig config.RequestOriginConfig) *deviceAuthHTTPHandler {
+func newDeviceAuthHTTPHandler(service *deviceauth.Service, cfg config.DeviceAuthConfig, originConfig config.RequestOriginConfig, appendLog ports.AppendLog, projector ports.SourceProjector, identity ports.EndpointIdentityStore) *deviceAuthHTTPHandler {
 	return &deviceAuthHTTPHandler{
 		service:      service,
 		enrollLimit:  deviceauth.NewTokenBucket(cfg.EnrollPerIPRatePerSecond, cfg.EnrollPerIPBurst),
 		tokenLimit:   deviceauth.NewTokenBucket(cfg.TokenPerDeviceRatePerSecond, cfg.TokenPerDeviceBurst),
 		originConfig: originConfig,
 		now:          time.Now,
+		appendLog:    appendLog,
+		projector:    projector,
+		identity:     identity,
 	}
 }
 
@@ -229,6 +240,25 @@ func (h *deviceAuthHTTPHandler) handleEnroll(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		writeDeviceAuthServiceError(w, err)
 		return
+	}
+	if h.identity != nil {
+		device, err := h.service.LookupDevice(r.Context(), response.DeviceID)
+		if err != nil {
+			writeDeviceAuthServiceError(w, err)
+			return
+		}
+		aliases := endpointidentity.AliasesFromDevice(
+			device.TenantID,
+			response.DeviceID,
+			body.HardwareUUID,
+			body.SerialNumber,
+			body.Hostname,
+			h.now(),
+		)
+		if err := h.identity.UpsertEndpointIdentityAliases(r.Context(), aliases); err != nil {
+			writeDeviceAuthError(w, http.StatusServiceUnavailable, "identity_unavailable", err.Error())
+			return
+		}
 	}
 	writeJSON(w, http.StatusOK, tokenResponseBody{
 		AccessToken:       response.AccessToken,
@@ -388,11 +418,20 @@ func (h *deviceAuthHTTPHandler) handleIngestTelemetry(w http.ResponseWriter, r *
 		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
-	if _, err := endpointtelemetry.Normalize(body, endpointtelemetry.Principal{
-		TenantID:     auth.principal.TenantID,
-		DeviceID:     auth.principal.DeviceID,
-		HardwareUUID: auth.principal.HardwareUUID,
-	}, time.Now()); err != nil {
+	device, err := h.service.LookupDevice(r.Context(), auth.principal.DeviceID)
+	if err != nil {
+		writeDeviceAuthServiceError(w, err)
+		return
+	}
+	observedAt := h.now()
+	events, err := endpointtelemetry.Normalize(body, endpointtelemetry.Principal{
+		TenantID:     device.TenantID,
+		DeviceID:     device.DeviceID,
+		HardwareUUID: firstNonEmpty(device.HardwareUUID, auth.principal.HardwareUUID),
+		SerialNumber: device.SerialNumber,
+		Hostname:     device.Hostname,
+	}, observedAt)
+	if err != nil {
 		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_telemetry", err.Error())
 		return
 	}
@@ -401,6 +440,9 @@ func (h *deviceAuthHTTPHandler) handleIngestTelemetry(w http.ResponseWriter, r *
 		DeviceID:       auth.principal.DeviceID,
 		IdempotencyKey: idempotencyKey,
 		Body:           body,
+		OnAccepted: func(ctx context.Context, accepted deviceauth.TelemetryAccepted) error {
+			return h.publishEndpointTelemetry(ctx, accepted, events)
+		},
 	})
 	if err != nil {
 		writeDeviceAuthServiceError(w, err)
@@ -412,6 +454,54 @@ func (h *deviceAuthHTTPHandler) handleIngestTelemetry(w http.ResponseWriter, r *
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(result.Status)
 	_, _ = w.Write(result.Body)
+}
+
+func (h *deviceAuthHTTPHandler) publishEndpointTelemetry(ctx context.Context, accepted deviceauth.TelemetryAccepted, events []*cerebrov1.EventEnvelope) error {
+	if h.identity != nil {
+		aliases := endpointidentity.AliasesFromTrustedEndpoint(
+			accepted.Device.TenantID,
+			accepted.Device.DeviceID,
+			accepted.Device.DeviceID,
+			accepted.Device.HardwareUUID,
+			accepted.Device.SerialNumber,
+			accepted.Device.Hostname,
+			accepted.ReceivedAt,
+		)
+		if err := h.identity.UpsertEndpointIdentityAliases(ctx, aliases); err != nil {
+			return fmt.Errorf("endpoint telemetry identity: %w", err)
+		}
+	}
+	appended := 0
+	projectedEntities := uint32(0)
+	projectedLinks := uint32(0)
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		if h.appendLog != nil {
+			if err := h.appendLog.Append(ctx, event); err != nil {
+				return fmt.Errorf("append endpoint telemetry event: %w", err)
+			}
+			appended++
+		}
+		if h.projector != nil {
+			result, err := h.projector.Project(ctx, event)
+			if err != nil {
+				return fmt.Errorf("project endpoint telemetry event: %w", err)
+			}
+			projectedEntities += result.EntitiesProjected
+			projectedLinks += result.LinksProjected
+		}
+	}
+	telemetry.Event(ctx, "endpoint_telemetry.accepted", telemetry.Attrs(
+		telemetry.Field{Key: "tenant_id", Value: accepted.Device.TenantID},
+		telemetry.Field{Key: "device_id", Value: accepted.Device.DeviceID},
+		telemetry.Field{Key: "normalized_events", Value: len(events)},
+		telemetry.Field{Key: "appended_events", Value: appended},
+		telemetry.Field{Key: "projected_entities", Value: projectedEntities},
+		telemetry.Field{Key: "projected_links", Value: projectedLinks},
+	))
+	return nil
 }
 
 func validateTelemetryBody(body []byte) error {

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -72,6 +72,7 @@ type deviceAuthMemStore struct {
 	identity *endpointidentity.MemoryStore
 	entities map[string]*ports.ProjectedEntity
 	links    []*ports.ProjectedLink
+	findings []*ports.FindingRecord
 }
 
 func newDeviceAuthMemStore() *deviceAuthMemStore {
@@ -90,6 +91,7 @@ var (
 	_ deviceauth.Store            = (*deviceAuthMemStore)(nil)
 	_ ports.ProjectionStateStore  = (*deviceAuthMemStore)(nil)
 	_ ports.EndpointIdentityStore = (*deviceAuthMemStore)(nil)
+	_ ports.FindingStore          = (*deviceAuthMemStore)(nil)
 )
 
 func (s *deviceAuthMemStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
@@ -123,6 +125,66 @@ func (s *deviceAuthMemStore) ResolveEndpointIdentity(ctx context.Context, reques
 	return s.identity.ResolveEndpointIdentity(ctx, request)
 }
 
+func (s *deviceAuthMemStore) UpsertFinding(_ context.Context, finding *ports.FindingRecord) (*ports.FindingRecord, error) {
+	if finding == nil {
+		return nil, nil
+	}
+	clone := *finding
+	s.findings = append(s.findings, &clone)
+	return &clone, nil
+}
+
+func (s *deviceAuthMemStore) GetFinding(_ context.Context, id string) (*ports.FindingRecord, error) {
+	for _, finding := range s.findings {
+		if finding.ID == id {
+			clone := *finding
+			return &clone, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *deviceAuthMemStore) ListFindings(_ context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	var out []*ports.FindingRecord
+	for _, finding := range s.findings {
+		if request.TenantID != "" && finding.TenantID != request.TenantID {
+			continue
+		}
+		if request.RuntimeID != "" && finding.RuntimeID != request.RuntimeID {
+			continue
+		}
+		if request.Status != "" && finding.Status != request.Status {
+			continue
+		}
+		if request.ResourceURN != "" && !stringSliceContains(finding.ResourceURNs, request.ResourceURN) {
+			continue
+		}
+		clone := *finding
+		out = append(out, &clone)
+	}
+	return out, nil
+}
+
+func (s *deviceAuthMemStore) UpdateFindingStatus(_ context.Context, request ports.FindingStatusUpdate) (*ports.FindingRecord, error) {
+	return s.GetFinding(context.Background(), request.FindingID)
+}
+
+func (s *deviceAuthMemStore) UpdateFindingAssignee(_ context.Context, request ports.FindingAssigneeUpdate) (*ports.FindingRecord, error) {
+	return s.GetFinding(context.Background(), request.FindingID)
+}
+
+func (s *deviceAuthMemStore) UpdateFindingDueDate(_ context.Context, request ports.FindingDueDateUpdate) (*ports.FindingRecord, error) {
+	return s.GetFinding(context.Background(), request.FindingID)
+}
+
+func (s *deviceAuthMemStore) AddFindingNote(_ context.Context, request ports.FindingNoteCreate) (*ports.FindingRecord, error) {
+	return s.GetFinding(context.Background(), request.FindingID)
+}
+
+func (s *deviceAuthMemStore) LinkFindingTicket(_ context.Context, request ports.FindingTicketLink) (*ports.FindingRecord, error) {
+	return s.GetFinding(context.Background(), request.FindingID)
+}
+
 func cloneStringMapForDeviceTest(values map[string]string) map[string]string {
 	if values == nil {
 		return nil
@@ -132,6 +194,15 @@ func cloneStringMapForDeviceTest(values map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func encodePEMPublic(t *testing.T, pub ed25519.PublicKey) string {
@@ -357,6 +428,19 @@ func TestTrustContextResolvesEndpointIdentity(t *testing.T) {
 	if err := store.UpsertEndpointIdentityAliases(ctx, endpointidentity.AliasesFromDevice("writer", enroll.DeviceID, "hw-trust", "", "trust-laptop", time.Now())); err != nil {
 		t.Fatalf("UpsertEndpointIdentityAliases: %v", err)
 	}
+	deviceURN := trustEndpointAgentURN("writer", enroll.DeviceID)
+	if _, err := store.UpsertFinding(ctx, &ports.FindingRecord{
+		ID:             "finding-open",
+		TenantID:       "writer",
+		RuntimeID:      "trusted-endpoint",
+		Severity:       "high",
+		Status:         "open",
+		ResourceURNs:   []string{deviceURN},
+		FindingRisk:    ports.FindingRisk{RiskScore: 87},
+		LastObservedAt: time.Now().Add(-25 * time.Hour),
+	}); err != nil {
+		t.Fatalf("UpsertFinding: %v", err)
+	}
 	req := httptest.NewRequest(http.MethodPost, "/platform/graph/trust-context", strings.NewReader(`{"tenant_id":"writer","hardware_uuid":"hw-trust"}`))
 	req.Header.Set("Authorization", "Bearer operator-key")
 	req.Header.Set("Content-Type", "application/json")
@@ -366,13 +450,20 @@ func TestTrustContextResolvesEndpointIdentity(t *testing.T) {
 		t.Fatalf("trust-context status = %d, body=%s", resp.Code, resp.Body.String())
 	}
 	var body struct {
-		ResolvedDeviceID string `json:"resolved_device_id"`
+		ResolvedDeviceID   string `json:"resolved_device_id"`
+		ActiveFindingCount uint64 `json:"active_finding_count"`
+		MaxFindingSeverity string `json:"max_finding_severity"`
+		RiskScore          uint64 `json:"risk_score"`
+		StaleEvidenceCount uint64 `json:"stale_evidence_count"`
 	}
 	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode trust context: %v", err)
 	}
 	if body.ResolvedDeviceID != enroll.DeviceID {
 		t.Fatalf("resolved_device_id = %q, want %q", body.ResolvedDeviceID, enroll.DeviceID)
+	}
+	if body.ActiveFindingCount != 1 || body.MaxFindingSeverity != "high" || body.RiskScore != 87 || body.StaleEvidenceCount != 1 {
+		t.Fatalf("finding summary = %#v, want one stale high-risk open finding", body)
 	}
 }
 

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/deviceauth"
 	"github.com/writer/cerebro/internal/deviceauth/attestation"
+	"github.com/writer/cerebro/internal/endpointidentity"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -57,7 +58,7 @@ func newAppForDeviceTest(t *testing.T) (*App, []byte, []byte) {
 		},
 	}
 	store := newDeviceAuthMemStore()
-	app := New(cfg, Dependencies{StateStore: store}, nil)
+	app := New(cfg, Dependencies{StateStore: store, AppendLog: &recordingAppendLog{}}, nil)
 	if app.deviceService == nil {
 		t.Fatal("device service was not wired")
 	}
@@ -68,19 +69,70 @@ func newAppForDeviceTest(t *testing.T) (*App, []byte, []byte) {
 // (Ping) so it can be passed via Dependencies.
 type deviceAuthMemStore struct {
 	*deviceauth.MemStore
+	identity *endpointidentity.MemoryStore
+	entities map[string]*ports.ProjectedEntity
+	links    []*ports.ProjectedLink
 }
 
 func newDeviceAuthMemStore() *deviceAuthMemStore {
-	return &deviceAuthMemStore{MemStore: deviceauth.NewMemStore()}
+	return &deviceAuthMemStore{
+		MemStore: deviceauth.NewMemStore(),
+		identity: endpointidentity.NewMemoryStore(),
+		entities: map[string]*ports.ProjectedEntity{},
+	}
 }
 
 // Ping satisfies ports.StateStore.
 func (s *deviceAuthMemStore) Ping(_ context.Context) error { return nil }
 
 var (
-	_ ports.StateStore = (*deviceAuthMemStore)(nil)
-	_ deviceauth.Store = (*deviceAuthMemStore)(nil)
+	_ ports.StateStore            = (*deviceAuthMemStore)(nil)
+	_ deviceauth.Store            = (*deviceAuthMemStore)(nil)
+	_ ports.ProjectionStateStore  = (*deviceAuthMemStore)(nil)
+	_ ports.EndpointIdentityStore = (*deviceAuthMemStore)(nil)
 )
+
+func (s *deviceAuthMemStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if entity == nil {
+		return nil
+	}
+	if s.entities == nil {
+		s.entities = map[string]*ports.ProjectedEntity{}
+	}
+	clone := *entity
+	clone.Attributes = cloneStringMapForDeviceTest(entity.Attributes)
+	s.entities[entity.URN] = &clone
+	return nil
+}
+
+func (s *deviceAuthMemStore) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	clone := *link
+	clone.Attributes = cloneStringMapForDeviceTest(link.Attributes)
+	s.links = append(s.links, &clone)
+	return nil
+}
+
+func (s *deviceAuthMemStore) UpsertEndpointIdentityAliases(ctx context.Context, aliases []ports.EndpointIdentityAlias) error {
+	return s.identity.UpsertEndpointIdentityAliases(ctx, aliases)
+}
+
+func (s *deviceAuthMemStore) ResolveEndpointIdentity(ctx context.Context, request ports.EndpointIdentityResolveRequest) (ports.EndpointIdentityResolution, error) {
+	return s.identity.ResolveEndpointIdentity(ctx, request)
+}
+
+func cloneStringMapForDeviceTest(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
 
 func encodePEMPublic(t *testing.T, pub ed25519.PublicKey) string {
 	t.Helper()
@@ -162,6 +214,31 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 		t.Fatalf("ingest status = %d, body=%s", resp.Code, resp.Body.String())
 	}
 	firstBody := resp.Body.String()
+	appendLog := app.deps.AppendLog.(*recordingAppendLog)
+	if len(appendLog.events) != 1 {
+		t.Fatalf("appended telemetry events = %d, want 1", len(appendLog.events))
+	}
+	if appendLog.events[0].GetKind() != "trusted_endpoint.action_outcome" {
+		t.Fatalf("appended kind = %q, want trusted_endpoint.action_outcome", appendLog.events[0].GetKind())
+	}
+	store := app.deps.StateStore.(*deviceAuthMemStore)
+	if len(store.entities) == 0 || len(store.links) == 0 {
+		t.Fatalf("expected projected telemetry entities and links, got entities=%d links=%d", len(store.entities), len(store.links))
+	}
+	resolution, err := store.ResolveEndpointIdentity(context.Background(), ports.EndpointIdentityResolveRequest{
+		TenantID: "writer",
+		Aliases: []ports.EndpointIdentityAlias{{
+			TenantID:   "writer",
+			AliasType:  endpointidentity.AliasHardwareUUID,
+			AliasValue: "hw-1",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveEndpointIdentity: %v", err)
+	}
+	if resolution.CanonicalDeviceID != enroll.DeviceID {
+		t.Fatalf("resolved device = %q, want %q", resolution.CanonicalDeviceID, enroll.DeviceID)
+	}
 
 	resp = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/platform/telemetry/ingest", bytes.NewReader(telemetry))
@@ -177,6 +254,9 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 	}
 	if resp.Body.String() != firstBody {
 		t.Errorf("idempotent body mismatch")
+	}
+	if len(appendLog.events) != 1 {
+		t.Fatalf("replay appended events = %d, want still 1", len(appendLog.events))
 	}
 
 	// Conflicting body with the same idempotency key returns 409.
@@ -251,6 +331,48 @@ func TestDeviceAuthRevokeAuthorizesTargetDeviceTenant(t *testing.T) {
 	}
 	if device.Status == "revoked" {
 		t.Fatal("cross-tenant revoke changed target device status")
+	}
+}
+
+func TestTrustContextResolvesEndpointIdentity(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+	ctx := context.Background()
+	bootstrap, err := app.deviceService.IssueBootstrapToken(ctx, deviceauth.IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-trust",
+		TenantID:     "writer",
+	})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken: %v", err)
+	}
+	enroll, err := app.deviceService.Enroll(ctx, deviceauth.EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-trust",
+		Hostname:       "trust-laptop",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	store := app.deps.StateStore.(*deviceAuthMemStore)
+	if err := store.UpsertEndpointIdentityAliases(ctx, endpointidentity.AliasesFromDevice("writer", enroll.DeviceID, "hw-trust", "", "trust-laptop", time.Now())); err != nil {
+		t.Fatalf("UpsertEndpointIdentityAliases: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/platform/graph/trust-context", strings.NewReader(`{"tenant_id":"writer","hardware_uuid":"hw-trust"}`))
+	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("trust-context status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		ResolvedDeviceID string `json:"resolved_device_id"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode trust context: %v", err)
+	}
+	if body.ResolvedDeviceID != enroll.DeviceID {
+		t.Fatalf("resolved_device_id = %q, want %q", body.ResolvedDeviceID, enroll.DeviceID)
 	}
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -108,6 +108,7 @@ func (app *App) registerKnowledgeRoutes(mux *http.ServeMux) {
 
 func (app *App) registerGraphRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /platform/graph/neighborhood", routeSurfacePlatformHTTP, app.handleGetEntityNeighborhood)
+	registerHTTPRoute(mux, "POST /platform/graph/trust-context", routeSurfacePlatformHTTP, app.handleGetTrustContext)
 	registerHTTPRoute(mux, "GET /platform/graph/impact/vulnerability/{id}", routeSurfacePlatformHTTP, app.handleGetVulnerabilityImpact)
 	registerHTTPRoute(mux, "GET /platform/graph/impact/package", routeSurfacePlatformHTTP, app.handleGetPackageImpact)
 	registerHTTPRoute(mux, "GET /platform/graph/impact/asset", routeSurfacePlatformHTTP, app.handleGetAssetImpact)

--- a/internal/bootstrap/trust_context_handlers.go
+++ b/internal/bootstrap/trust_context_handlers.go
@@ -110,7 +110,7 @@ func applyTrustContextFindings(r *http.Request, store ports.FindingStore, tenant
 		findings, err := store.ListFindings(r.Context(), ports.ListFindingsRequest{
 			TenantID:    tenantID,
 			RuntimeID:   runtimeID,
-			Status:      "active",
+			Status:      "open",
 			ResourceURN: root,
 			Limit:       100,
 		})

--- a/internal/bootstrap/trust_context_handlers.go
+++ b/internal/bootstrap/trust_context_handlers.go
@@ -1,0 +1,171 @@
+package bootstrap
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/endpointidentity"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type trustContextRequest struct {
+	TenantID           string   `json:"tenant_id"`
+	RuntimeID          string   `json:"runtime_id,omitempty"`
+	AgentID            string   `json:"agent_id,omitempty"`
+	DeviceID           string   `json:"device_id,omitempty"`
+	HardwareUUID       string   `json:"hardware_uuid,omitempty"`
+	SerialNumber       string   `json:"serial_number,omitempty"`
+	Hostname           string   `json:"hostname,omitempty"`
+	MaxAllowedSeverity string   `json:"max_allowed_severity,omitempty"`
+	GraphRootURNs      []string `json:"graph_root_urns,omitempty"`
+}
+
+type trustContextResponse struct {
+	GraphNeighborhoodLoaded bool     `json:"graph_neighborhood_loaded"`
+	ActiveFindingCount      uint64   `json:"active_finding_count"`
+	MaxFindingSeverity      string   `json:"max_finding_severity,omitempty"`
+	RiskScore               uint64   `json:"risk_score,omitempty"`
+	StaleEvidenceCount      uint64   `json:"stale_evidence_count"`
+	GraphRootURNs           []string `json:"graph_root_urns"`
+	ResolvedDeviceID        string   `json:"resolved_device_id,omitempty"`
+	CandidateDeviceIDs      []string `json:"candidate_device_ids,omitempty"`
+	AmbiguousIdentity       bool     `json:"ambiguous_identity,omitempty"`
+}
+
+func (app *App) handleGetTrustContext(w http.ResponseWriter, r *http.Request) {
+	var request trustContextRequest
+	if err := readJSONRequest(r, &request); err != nil {
+		writeGraphQueryError(w, errInvalidHTTPRequest)
+		return
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", "tenant_id is required")
+		return
+	}
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		writeDeviceAuthError(w, http.StatusForbidden, "tenant_forbidden", err.Error())
+		return
+	}
+	response := trustContextResponse{
+		GraphNeighborhoodLoaded: true,
+		GraphRootURNs:           trustContextRootURNs(tenantID, request),
+	}
+	if identity := endpointIdentityStore(app.deps.StateStore); identity != nil {
+		resolution, err := identity.ResolveEndpointIdentity(r.Context(), ports.EndpointIdentityResolveRequest{
+			TenantID: tenantID,
+			Aliases:  trustContextAliases(request),
+			Limit:    20,
+		})
+		if err != nil {
+			writeDeviceAuthError(w, http.StatusServiceUnavailable, "identity_unavailable", err.Error())
+			return
+		}
+		response.ResolvedDeviceID = resolution.CanonicalDeviceID
+		response.CandidateDeviceIDs = resolution.CandidateDeviceIDs
+		response.AmbiguousIdentity = resolution.Ambiguous
+		if resolution.CanonicalDeviceID != "" {
+			response.GraphRootURNs = append(response.GraphRootURNs, trustEndpointAgentURN(tenantID, resolution.CanonicalDeviceID))
+		}
+	}
+	response.GraphRootURNs = uniqueStrings(response.GraphRootURNs)
+	if findings := findingStore(app.deps.StateStore); findings != nil {
+		applyTrustContextFindings(r, findings, tenantID, strings.TrimSpace(firstNonEmpty(request.RuntimeID, "trusted-endpoint")), &response)
+	} else {
+		response.GraphNeighborhoodLoaded = false
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func trustContextAliases(request trustContextRequest) []ports.EndpointIdentityAlias {
+	tenantID := strings.TrimSpace(request.TenantID)
+	now := time.Now().UTC()
+	return []ports.EndpointIdentityAlias{
+		{TenantID: tenantID, AliasType: endpointidentity.AliasDeviceID, AliasValue: request.DeviceID, ObservedAt: now},
+		{TenantID: tenantID, AliasType: endpointidentity.AliasTrustedEndpointAgentID, AliasValue: request.AgentID, ObservedAt: now},
+		{TenantID: tenantID, AliasType: endpointidentity.AliasHardwareUUID, AliasValue: request.HardwareUUID, ObservedAt: now},
+		{TenantID: tenantID, AliasType: endpointidentity.AliasSerialNumber, AliasValue: request.SerialNumber, ObservedAt: now},
+		{TenantID: tenantID, AliasType: endpointidentity.AliasHostname, AliasValue: request.Hostname, ObservedAt: now},
+	}
+}
+
+func trustContextRootURNs(tenantID string, request trustContextRequest) []string {
+	roots := append([]string(nil), request.GraphRootURNs...)
+	if strings.TrimSpace(request.AgentID) != "" {
+		roots = append(roots, trustEndpointAgentURN(tenantID, request.AgentID))
+	}
+	if strings.TrimSpace(request.DeviceID) != "" {
+		roots = append(roots, trustEndpointAgentURN(tenantID, request.DeviceID))
+	}
+	return uniqueStrings(roots)
+}
+
+func applyTrustContextFindings(r *http.Request, store ports.FindingStore, tenantID string, runtimeID string, response *trustContextResponse) {
+	seen := map[string]struct{}{}
+	maxSeverity := ""
+	var maxRisk uint64
+	var stale uint64
+	for _, root := range response.GraphRootURNs {
+		findings, err := store.ListFindings(r.Context(), ports.ListFindingsRequest{
+			TenantID:    tenantID,
+			RuntimeID:   runtimeID,
+			Status:      "active",
+			ResourceURN: root,
+			Limit:       100,
+		})
+		if err != nil {
+			continue
+		}
+		for _, finding := range findings {
+			if finding == nil {
+				continue
+			}
+			if _, ok := seen[finding.ID]; ok {
+				continue
+			}
+			seen[finding.ID] = struct{}{}
+			response.ActiveFindingCount++
+			if maxSeverity == "" || severityRank(finding.Severity) < severityRank(maxSeverity) {
+				maxSeverity = finding.Severity
+			}
+			if finding.RiskScore > int(maxRisk) {
+				maxRisk = uint64(finding.RiskScore)
+			}
+			if !finding.LastObservedAt.IsZero() && time.Since(finding.LastObservedAt) > 24*time.Hour {
+				stale++
+			}
+		}
+	}
+	response.MaxFindingSeverity = maxSeverity
+	response.RiskScore = maxRisk
+	response.StaleEvidenceCount = stale
+}
+
+func trustEndpointAgentURN(tenantID string, agentID string) string {
+	values := []string{"urn", "cerebro", strings.TrimSpace(tenantID), "trusted_endpoint_agent", strings.TrimSpace(agentID)}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, strings.TrimSpace(value))
+		}
+	}
+	return strings.Join(out, ":")
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -645,6 +645,7 @@ type IngestPayload struct {
 	DeviceID       string
 	IdempotencyKey string
 	Body           []byte
+	OnAccepted     func(context.Context, TelemetryAccepted) error
 }
 
 // IngestResult is the outcome of [Service.IngestTelemetry].
@@ -653,6 +654,16 @@ type IngestResult struct {
 	Body       []byte
 	Cached     bool
 	ReceivedAt time.Time
+}
+
+// TelemetryAccepted is passed to the optional IngestPayload.OnAccepted hook
+// after device validation and idempotency conflict checks, but before the
+// successful idempotency response is cached.
+type TelemetryAccepted struct {
+	Device         DeviceRecord
+	IdempotencyKey string
+	Body           []byte
+	ReceivedAt     time.Time
 }
 
 // IngestTelemetry validates the device, enforces the Idempotency-Key
@@ -693,6 +704,16 @@ func (s *Service) IngestTelemetry(ctx context.Context, payload IngestPayload) (I
 	}
 	if err := s.store.MarkSeen(ctx, deviceID, now); err != nil {
 		return IngestResult{}, fmt.Errorf("deviceauth: mark seen: %w", err)
+	}
+	if payload.OnAccepted != nil {
+		if err := payload.OnAccepted(ctx, TelemetryAccepted{
+			Device:         device,
+			IdempotencyKey: idempotencyKey,
+			Body:           append([]byte(nil), payload.Body...),
+			ReceivedAt:     now,
+		}); err != nil {
+			return IngestResult{}, err
+		}
 	}
 	receipt := fmt.Sprintf(`{"status":"accepted","device_id":%q,"received_at":%q,"bytes":%d}`, deviceID, now.Format(time.RFC3339Nano), len(payload.Body))
 	body := []byte(receipt)

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -416,6 +416,64 @@ func TestServiceIngestTelemetryIdempotent(t *testing.T) {
 	}
 }
 
+func TestServiceIngestTelemetryRunsAcceptedHookOnce(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+
+	calls := 0
+	payload := IngestPayload{
+		DeviceID:       enroll.DeviceID,
+		IdempotencyKey: "accepted-hook",
+		Body:           []byte(`{"events":[{"type":"login"}]}`),
+		OnAccepted: func(_ context.Context, accepted TelemetryAccepted) error {
+			calls++
+			if accepted.Device.DeviceID != enroll.DeviceID {
+				t.Fatalf("accepted device = %q, want %q", accepted.Device.DeviceID, enroll.DeviceID)
+			}
+			return nil
+		},
+	}
+	if _, err := service.IngestTelemetry(ctx, payload); err != nil {
+		t.Fatalf("first IngestTelemetry: %v", err)
+	}
+	if _, err := service.IngestTelemetry(ctx, payload); err != nil {
+		t.Fatalf("second IngestTelemetry: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("OnAccepted calls = %d, want 1", calls)
+	}
+}
+
+func TestServiceIngestTelemetryDoesNotCacheFailedAcceptedHook(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+
+	hookErr := errors.New("publish failed")
+	payload := IngestPayload{
+		DeviceID:       enroll.DeviceID,
+		IdempotencyKey: "failed-hook",
+		Body:           []byte(`{"events":[{"type":"login"}]}`),
+		OnAccepted: func(context.Context, TelemetryAccepted) error {
+			return hookErr
+		},
+	}
+	if _, err := service.IngestTelemetry(ctx, payload); !errors.Is(err, hookErr) {
+		t.Fatalf("first IngestTelemetry err = %v, want hookErr", err)
+	}
+	payload.OnAccepted = nil
+	result, err := service.IngestTelemetry(ctx, payload)
+	if err != nil {
+		t.Fatalf("retry IngestTelemetry: %v", err)
+	}
+	if result.Cached {
+		t.Fatalf("retry after hook failure was cached")
+	}
+}
+
 func TestServiceIngestTelemetryIdempotencyPreservesBodyWhitespace(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)

--- a/internal/endpointidentity/identity.go
+++ b/internal/endpointidentity/identity.go
@@ -1,0 +1,175 @@
+package endpointidentity
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	AliasDeviceID               = "device_id"
+	AliasHardwareUUID           = "hardware_uuid"
+	AliasSerialNumber           = "serial_number"
+	AliasHostname               = "hostname"
+	AliasTrustedEndpointAgentID = "trusted_endpoint_agent_id"
+)
+
+// AliasesFromDevice builds durable aliases from device-auth enrollment state.
+func AliasesFromDevice(tenantID string, deviceID string, hardwareUUID string, serialNumber string, hostname string, observedAt time.Time) []ports.EndpointIdentityAlias {
+	return compactAliases([]ports.EndpointIdentityAlias{
+		alias(tenantID, deviceID, AliasDeviceID, deviceID, "deviceauth", 1.0, observedAt),
+		alias(tenantID, deviceID, AliasHardwareUUID, hardwareUUID, "deviceauth", 0.98, observedAt),
+		alias(tenantID, deviceID, AliasSerialNumber, serialNumber, "deviceauth", 0.95, observedAt),
+		alias(tenantID, deviceID, AliasHostname, hostname, "deviceauth", 0.60, observedAt),
+	})
+}
+
+// AliasesFromTrustedEndpoint builds aliases observed through Trusted Endpoint telemetry.
+func AliasesFromTrustedEndpoint(tenantID string, canonicalDeviceID string, agentID string, hardwareUUID string, serialNumber string, hostname string, observedAt time.Time) []ports.EndpointIdentityAlias {
+	if strings.TrimSpace(canonicalDeviceID) == "" {
+		canonicalDeviceID = firstNonEmpty(agentID, hardwareUUID, serialNumber, hostname)
+	}
+	return compactAliases([]ports.EndpointIdentityAlias{
+		alias(tenantID, canonicalDeviceID, AliasDeviceID, canonicalDeviceID, "trusted_endpoint", 1.0, observedAt),
+		alias(tenantID, canonicalDeviceID, AliasTrustedEndpointAgentID, agentID, "trusted_endpoint", 0.90, observedAt),
+		alias(tenantID, canonicalDeviceID, AliasHardwareUUID, hardwareUUID, "trusted_endpoint", 0.98, observedAt),
+		alias(tenantID, canonicalDeviceID, AliasSerialNumber, serialNumber, "trusted_endpoint", 0.95, observedAt),
+		alias(tenantID, canonicalDeviceID, AliasHostname, hostname, "trusted_endpoint", 0.60, observedAt),
+	})
+}
+
+func alias(tenantID string, deviceID string, aliasType string, value string, sourceID string, confidence float64, observedAt time.Time) ports.EndpointIdentityAlias {
+	return ports.EndpointIdentityAlias{
+		TenantID:          strings.TrimSpace(tenantID),
+		CanonicalDeviceID: strings.TrimSpace(deviceID),
+		AliasType:         strings.TrimSpace(aliasType),
+		AliasValue:        strings.TrimSpace(value),
+		SourceID:          strings.TrimSpace(sourceID),
+		Confidence:        confidence,
+		ObservedAt:        observedAt.UTC(),
+	}
+}
+
+func compactAliases(aliases []ports.EndpointIdentityAlias) []ports.EndpointIdentityAlias {
+	out := make([]ports.EndpointIdentityAlias, 0, len(aliases))
+	seen := map[string]struct{}{}
+	for _, candidate := range aliases {
+		candidate.TenantID = strings.TrimSpace(candidate.TenantID)
+		candidate.CanonicalDeviceID = strings.TrimSpace(candidate.CanonicalDeviceID)
+		candidate.AliasType = strings.TrimSpace(candidate.AliasType)
+		candidate.AliasValue = strings.TrimSpace(candidate.AliasValue)
+		if candidate.TenantID == "" || candidate.CanonicalDeviceID == "" || candidate.AliasType == "" || candidate.AliasValue == "" {
+			continue
+		}
+		key := candidate.TenantID + "\x00" + candidate.AliasType + "\x00" + strings.ToLower(candidate.AliasValue)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// MemoryStore is a test implementation of ports.EndpointIdentityStore.
+type MemoryStore struct {
+	mu      sync.Mutex
+	aliases map[string]ports.EndpointIdentityAlias
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{aliases: map[string]ports.EndpointIdentityAlias{}}
+}
+
+func (s *MemoryStore) UpsertEndpointIdentityAliases(_ context.Context, aliases []ports.EndpointIdentityAlias) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.aliases == nil {
+		s.aliases = map[string]ports.EndpointIdentityAlias{}
+	}
+	for _, candidate := range compactAliases(aliases) {
+		key := aliasKey(candidate)
+		if existing, ok := s.aliases[key]; ok {
+			if existing.ObservedAt.After(candidate.ObservedAt) {
+				candidate.ObservedAt = existing.ObservedAt
+			}
+			if existing.Confidence > candidate.Confidence {
+				candidate.Confidence = existing.Confidence
+			}
+		}
+		s.aliases[key] = candidate
+	}
+	return nil
+}
+
+func (s *MemoryStore) ResolveEndpointIdentity(_ context.Context, request ports.EndpointIdentityResolveRequest) (ports.EndpointIdentityResolution, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	matches := []ports.EndpointIdentityAlias{}
+	for _, candidate := range request.Aliases {
+		candidate.TenantID = strings.TrimSpace(candidate.TenantID)
+		candidate.AliasType = strings.TrimSpace(candidate.AliasType)
+		candidate.AliasValue = strings.TrimSpace(candidate.AliasValue)
+		if candidate.TenantID == "" || candidate.AliasType == "" || candidate.AliasValue == "" {
+			continue
+		}
+		for _, stored := range s.aliases {
+			if stored.TenantID == candidate.TenantID && stored.AliasType == candidate.AliasType && strings.EqualFold(stored.AliasValue, candidate.AliasValue) {
+				matches = append(matches, stored)
+			}
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Confidence != matches[j].Confidence {
+			return matches[i].Confidence > matches[j].Confidence
+		}
+		return matches[i].ObservedAt.After(matches[j].ObservedAt)
+	})
+	candidates := candidateDeviceIDs(matches)
+	resolution := ports.EndpointIdentityResolution{
+		TenantID:           strings.TrimSpace(request.TenantID),
+		MatchedAliases:     matches,
+		CandidateDeviceIDs: candidates,
+		Ambiguous:          len(candidates) > 1,
+	}
+	if len(candidates) > 0 {
+		resolution.CanonicalDeviceID = candidates[0]
+	}
+	return resolution, nil
+}
+
+func aliasKey(alias ports.EndpointIdentityAlias) string {
+	return alias.TenantID + "\x00" + alias.AliasType + "\x00" + strings.ToLower(strings.TrimSpace(alias.AliasValue)) + "\x00" + alias.CanonicalDeviceID
+}
+
+func candidateDeviceIDs(matches []ports.EndpointIdentityAlias) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, match := range matches {
+		id := strings.TrimSpace(match.CanonicalDeviceID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+var _ ports.EndpointIdentityStore = (*MemoryStore)(nil)

--- a/internal/endpointidentity/identity_test.go
+++ b/internal/endpointidentity/identity_test.go
@@ -1,0 +1,59 @@
+package endpointidentity
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestMemoryStoreResolvesDeviceByHardwareUUID(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	aliases := AliasesFromDevice("writer", "dev-1", "hw-1", "serial-1", "host-1", now)
+	if err := store.UpsertEndpointIdentityAliases(context.Background(), aliases); err != nil {
+		t.Fatalf("UpsertEndpointIdentityAliases: %v", err)
+	}
+	resolution, err := store.ResolveEndpointIdentity(context.Background(), ports.EndpointIdentityResolveRequest{
+		TenantID: "writer",
+		Aliases: []ports.EndpointIdentityAlias{{
+			TenantID:   "writer",
+			AliasType:  AliasHardwareUUID,
+			AliasValue: "HW-1",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveEndpointIdentity: %v", err)
+	}
+	if resolution.CanonicalDeviceID != "dev-1" {
+		t.Fatalf("CanonicalDeviceID = %q, want dev-1", resolution.CanonicalDeviceID)
+	}
+	if resolution.Ambiguous {
+		t.Fatal("resolution is ambiguous")
+	}
+}
+
+func TestMemoryStoreMarksHostnameCollisionAmbiguous(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	_ = store.UpsertEndpointIdentityAliases(context.Background(), AliasesFromDevice("writer", "dev-1", "hw-1", "serial-1", "shared-host", now))
+	_ = store.UpsertEndpointIdentityAliases(context.Background(), AliasesFromDevice("writer", "dev-2", "hw-2", "serial-2", "shared-host", now.Add(time.Minute)))
+	resolution, err := store.ResolveEndpointIdentity(context.Background(), ports.EndpointIdentityResolveRequest{
+		TenantID: "writer",
+		Aliases: []ports.EndpointIdentityAlias{{
+			TenantID:   "writer",
+			AliasType:  AliasHostname,
+			AliasValue: "shared-host",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveEndpointIdentity: %v", err)
+	}
+	if !resolution.Ambiguous {
+		t.Fatal("hostname collision should be ambiguous")
+	}
+	if len(resolution.CandidateDeviceIDs) != 2 {
+		t.Fatalf("candidate count = %d, want 2", len(resolution.CandidateDeviceIDs))
+	}
+}

--- a/internal/endpointtelemetry/normalizer.go
+++ b/internal/endpointtelemetry/normalizer.go
@@ -14,12 +14,14 @@ import (
 )
 
 const sourceID = "trusted_endpoint"
+const runtimeID = "trusted-endpoint"
 
 // Principal identifies the authenticated device that submitted telemetry.
 type Principal struct {
 	TenantID     string
 	DeviceID     string
 	HardwareUUID string
+	SerialNumber string
 	Hostname     string
 }
 
@@ -50,6 +52,7 @@ func Normalize(body []byte, principal Principal, observedAt time.Time) ([]*cereb
 			"agent_id":          agentID,
 			"device_id":         principal.DeviceID,
 			"hardware_uuid":     principal.HardwareUUID,
+			"serial_number":     principal.SerialNumber,
 			"hostname":          principal.Hostname,
 			"observation_table": observationTable(payload.Posture),
 			"summary":           payload.Posture,
@@ -60,6 +63,7 @@ func Normalize(body []byte, principal Principal, observedAt time.Time) ([]*cereb
 			"hardware_key":      firstNonEmpty(principal.HardwareUUID, principal.DeviceID, principal.Hostname),
 			"hostname":          principal.Hostname,
 			"observation_table": observationTable(payload.Posture),
+			"serial_number":     principal.SerialNumber,
 		}, observedAt, len(envelopes))
 		if err != nil {
 			return nil, err
@@ -90,30 +94,34 @@ func normalizeEvent(raw map[string]any, principal Principal, agentID string) (st
 		findingID := firstString(raw, "finding_id", "findingId")
 		severity := firstNonEmpty(firstString(raw, "severity"), "unknown")
 		payload := map[string]any{
-			"agent_id":   agentID,
-			"device_id":  principal.DeviceID,
-			"finding_id": findingID,
-			"severity":   severity,
-			"source":     "endpoint_telemetry",
-			"raw":        raw,
+			"agent_id":      agentID,
+			"device_id":     principal.DeviceID,
+			"serial_number": principal.SerialNumber,
+			"finding_id":    findingID,
+			"severity":      severity,
+			"source":        "endpoint_telemetry",
+			"raw":           raw,
 		}
 		return "trusted_endpoint.security_finding", "trusted_endpoint/security_finding/v1", payload, map[string]string{
-			"agent_id":   agentID,
-			"device_id":  principal.DeviceID,
-			"finding_id": findingID,
-			"severity":   severity,
+			"agent_id":      agentID,
+			"device_id":     principal.DeviceID,
+			"serial_number": principal.SerialNumber,
+			"finding_id":    findingID,
+			"severity":      severity,
 		}
 	}
 	payload := map[string]any{
-		"agent_id":  agentID,
-		"device_id": principal.DeviceID,
-		"action":    action,
-		"outcome":   outcome,
-		"raw":       raw,
+		"agent_id":      agentID,
+		"device_id":     principal.DeviceID,
+		"serial_number": principal.SerialNumber,
+		"action":        action,
+		"outcome":       outcome,
+		"raw":           raw,
 	}
 	return "trusted_endpoint.action_outcome", "trusted_endpoint/action_outcome/v1", payload, map[string]string{
 		"agent_id":       agentID,
 		"device_id":      principal.DeviceID,
+		"serial_number":  principal.SerialNumber,
 		"action":         action,
 		"outcome_result": outcome,
 	}
@@ -199,6 +207,7 @@ func firstNonEmpty(values ...string) string {
 
 func trimAttrs(attrs map[string]string) map[string]string {
 	out := make(map[string]string, len(attrs))
+	out["source_runtime_id"] = runtimeID
 	for key, value := range attrs {
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)

--- a/internal/ports/endpoint_identity.go
+++ b/internal/ports/endpoint_identity.go
@@ -1,0 +1,44 @@
+package ports
+
+import (
+	"context"
+	"time"
+)
+
+// EndpointIdentityAlias is one observed identifier for a canonical endpoint.
+// Implementations should treat hostname aliases as weaker evidence than device
+// IDs, hardware UUIDs, serial numbers, and provider-native IDs.
+type EndpointIdentityAlias struct {
+	TenantID          string
+	CanonicalDeviceID string
+	AliasType         string
+	AliasValue        string
+	SourceID          string
+	Confidence        float64
+	ObservedAt        time.Time
+	Attributes        map[string]string
+}
+
+// EndpointIdentityResolveRequest asks for the canonical endpoint associated
+// with any of the supplied aliases.
+type EndpointIdentityResolveRequest struct {
+	TenantID string
+	Aliases  []EndpointIdentityAlias
+	Limit    uint32
+}
+
+// EndpointIdentityResolution returns all candidate canonical endpoint IDs
+// matched by the supplied aliases, ordered by confidence and recency.
+type EndpointIdentityResolution struct {
+	TenantID           string
+	CanonicalDeviceID  string
+	MatchedAliases     []EndpointIdentityAlias
+	CandidateDeviceIDs []string
+	Ambiguous          bool
+}
+
+// EndpointIdentityStore persists and resolves endpoint identity aliases.
+type EndpointIdentityStore interface {
+	UpsertEndpointIdentityAliases(context.Context, []EndpointIdentityAlias) error
+	ResolveEndpointIdentity(context.Context, EndpointIdentityResolveRequest) (EndpointIdentityResolution, error)
+}

--- a/internal/sourceprojection/trusted_endpoint.go
+++ b/internal/sourceprojection/trusted_endpoint.go
@@ -41,6 +41,7 @@ func trustedEndpointProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 			"source_product": "trusted_endpoint",
 		},
 	})
+	endpointURN := trustedEndpointDeviceProjection(entities, links, tenantID, event, attrs, payload, agentURN, agentID)
 
 	eventURN := projectionURN(tenantID, "trusted_endpoint_event", event.GetKind(), event.GetId())
 	eventAttrs := map[string]string{
@@ -73,8 +74,111 @@ func trustedEndpointProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 		"kind":     event.GetKind(),
 		"at":       eventObservedAt(event),
 	}))
+	trustedEndpointSpecificProjection(entities, links, tenantID, event, attrs, payload, eventURN, endpointURN)
 	entitiesOut, linksOut := entitiesAndLinks(entities, links)
 	return entitiesOut, linksOut, nil
+}
+
+func trustedEndpointDeviceProjection(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, attrs map[string]string, payload map[string]any, agentURN string, agentID string) string {
+	endpointID := firstNonEmpty(attrs["device_id"], stringValue(payload, "device_id"), attrs["hardware_key"], agentID)
+	endpointURN := projectionURN(tenantID, "trusted_endpoint_device", endpointID)
+	if endpointURN == "" {
+		return ""
+	}
+	endpointAttrs := map[string]string{
+		"agent_id":       agentID,
+		"device_id":      endpointID,
+		"hardware_uuid":  firstNonEmpty(attrs["hardware_key"], stringValue(payload, "hardware_uuid")),
+		"hostname":       firstNonEmpty(attrs["hostname"], stringValue(payload, "hostname")),
+		"serial_number":  firstNonEmpty(attrs["serial_number"], stringValue(payload, "serial_number")),
+		"source_product": "trusted_endpoint",
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        endpointURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "trusted_endpoint.device",
+		Label:      firstNonEmpty(endpointAttrs["hostname"], endpointID),
+		Attributes: endpointAttrs,
+	})
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), agentURN, endpointURN, relationRepresents, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+	addEndpointIdentifierLink(entities, links, tenantID, event.GetSourceId(), event, endpointURN, "device_id", endpointID, "1.00")
+	addEndpointIdentifierLink(entities, links, tenantID, event.GetSourceId(), event, endpointURN, "hardware_uuid", endpointAttrs["hardware_uuid"], "0.98")
+	addEndpointIdentifierLink(entities, links, tenantID, event.GetSourceId(), event, endpointURN, "serial_number", endpointAttrs["serial_number"], "0.95")
+	addEndpointIdentifierLink(entities, links, tenantID, event.GetSourceId(), event, endpointURN, "hostname", endpointAttrs["hostname"], "0.60")
+	addEndpointIdentifierLink(entities, links, tenantID, event.GetSourceId(), event, endpointURN, "trusted_endpoint_agent_id", agentID, "0.90")
+	return endpointURN
+}
+
+func trustedEndpointSpecificProjection(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, attrs map[string]string, payload map[string]any, eventURN string, endpointURN string) {
+	switch event.GetKind() {
+	case "trusted_endpoint.security_finding":
+		findingID := firstNonEmpty(attrs["finding_id"], stringValue(payload, "finding_id"), event.GetId())
+		findingURN := projectionURN(tenantID, "finding", findingID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        findingURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "finding",
+			Label:      findingID,
+			Attributes: map[string]string{
+				"finding_id": findingID,
+				"severity":   firstNonEmpty(attrs["severity"], stringValue(payload, "severity")),
+				"source":     "trusted_endpoint",
+			},
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), eventURN, findingURN, relationSupports, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+		if endpointURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, endpointURN, relationObservedOn, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+		}
+	case "trusted_endpoint.grc_evidence":
+		controlID := firstNonEmpty(attrs["control_id"], stringValue(payload, "control_id"))
+		controlURN := projectionURN(tenantID, "grc_control", controlID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        controlURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "grc.control",
+			Label:      controlID,
+			Attributes: map[string]string{"control_id": controlID, "source": "trusted_endpoint"},
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), eventURN, controlURN, relationSupports, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+	case "trusted_endpoint.repo_worktree_context", "trusted_endpoint.ai_workflow_risk":
+		repoID := firstNonEmpty(attrs["repo_path_hash"], stringValue(payload, "repo_path_hash"), stringValue(payload, "repository"))
+		repoURN := projectionURN(tenantID, "trusted_endpoint_repo", repoID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        repoURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "trusted_endpoint.repo",
+			Label:      repoID,
+			Attributes: map[string]string{"repo_path_hash": repoID, "source": "trusted_endpoint"},
+		})
+		if endpointURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), endpointURN, repoURN, relationContains, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+		}
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), eventURN, repoURN, relationObservedOn, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+	case "trusted_endpoint.action_outcome", "trusted_endpoint.trust_gate_decision":
+		action := firstNonEmpty(attrs["action"], stringValue(payload, "action"), event.GetKind())
+		actionURN := projectionURN(tenantID, "trusted_endpoint_action", action, event.GetId())
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        actionURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "trusted_endpoint.action",
+			Label:      action,
+			Attributes: map[string]string{
+				"action":         action,
+				"decision":       firstNonEmpty(attrs["decision"], stringValue(payload, "decision")),
+				"outcome_result": firstNonEmpty(attrs["outcome_result"], stringValue(payload, "outcome")),
+				"source":         "trusted_endpoint",
+			},
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), actionURN, eventURN, relationHasEvidence, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+		if endpointURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), actionURN, endpointURN, relationTargeted, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+		}
+	}
 }
 
 func trustedEndpointEventEntityType(kind string) string {

--- a/internal/sourceprojection/trusted_endpoint_test.go
+++ b/internal/sourceprojection/trusted_endpoint_test.go
@@ -1,0 +1,61 @@
+package sourceprojection
+
+import (
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestTrustedEndpointSecurityFindingProjectsEndpointAndFinding(t *testing.T) {
+	event := &cerebrov1.EventEnvelope{
+		Id:         "evt-1",
+		TenantId:   "writer",
+		SourceId:   "trusted_endpoint",
+		Kind:       "trusted_endpoint.security_finding",
+		SchemaRef:  "trusted_endpoint/security_finding/v1",
+		OccurredAt: timestamppb.New(time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)),
+		Attributes: map[string]string{
+			"agent_id":      "agent-1",
+			"device_id":     "dev-1",
+			"hardware_key":  "hw-1",
+			"hostname":      "laptop-1",
+			"serial_number": "serial-1",
+			"finding_id":    "finding-1",
+			"severity":      "high",
+		},
+	}
+	entities, links, err := trustedEndpointProjections(event)
+	if err != nil {
+		t.Fatalf("trustedEndpointProjections: %v", err)
+	}
+	if !hasEntityType(entities, "trusted_endpoint.device") {
+		t.Fatalf("missing trusted_endpoint.device entity: %#v", entities)
+	}
+	if !hasEntityType(entities, "finding") {
+		t.Fatalf("missing finding entity: %#v", entities)
+	}
+	if !hasRelation(links, relationObservedOn) {
+		t.Fatalf("missing observed_on link: %#v", links)
+	}
+}
+
+func hasEntityType(entities []*ports.ProjectedEntity, entityType string) bool {
+	for _, entity := range entities {
+		if entity.EntityType == entityType {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRelation(links []*ports.ProjectedLink, relation string) bool {
+	for _, link := range links {
+		if link.Relation == relation {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/statestore/postgres/endpoint_identity.go
+++ b/internal/statestore/postgres/endpoint_identity.go
@@ -1,0 +1,253 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureEndpointIdentityStatements = []string{
+	`CREATE TABLE IF NOT EXISTS endpoint_identity_aliases (
+  tenant_id TEXT NOT NULL,
+  alias_type TEXT NOT NULL,
+  alias_value TEXT NOT NULL,
+  alias_value_normalized TEXT NOT NULL,
+  canonical_device_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  confidence DOUBLE PRECISION NOT NULL DEFAULT 0,
+  attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  first_seen_at TIMESTAMPTZ NOT NULL,
+  last_seen_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, alias_type, alias_value_normalized, canonical_device_id)
+)`,
+	`CREATE INDEX IF NOT EXISTS endpoint_identity_alias_lookup_idx
+        ON endpoint_identity_aliases (tenant_id, alias_type, alias_value_normalized)`,
+	`CREATE INDEX IF NOT EXISTS endpoint_identity_alias_device_idx
+        ON endpoint_identity_aliases (tenant_id, canonical_device_id)`,
+	`CREATE INDEX IF NOT EXISTS endpoint_identity_alias_last_seen_idx
+        ON endpoint_identity_aliases (tenant_id, last_seen_at DESC)`,
+}
+
+func (s *Store) UpsertEndpointIdentityAliases(ctx context.Context, aliases []ports.EndpointIdentityAlias) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureEndpointIdentityTables(ctx); err != nil {
+		return err
+	}
+	for _, alias := range aliases {
+		alias = normalizeEndpointAlias(alias)
+		if alias.TenantID == "" || alias.CanonicalDeviceID == "" || alias.AliasType == "" || alias.AliasValue == "" {
+			continue
+		}
+		attrs, err := json.Marshal(alias.Attributes)
+		if err != nil {
+			return fmt.Errorf("marshal endpoint identity attributes: %w", err)
+		}
+		observedAt := alias.ObservedAt.UTC()
+		if observedAt.IsZero() {
+			observedAt = time.Now().UTC()
+		}
+		if _, err := s.db.ExecContext(ctx, `
+INSERT INTO endpoint_identity_aliases (
+  tenant_id, alias_type, alias_value, alias_value_normalized, canonical_device_id,
+  source_id, confidence, attributes_json, first_seen_at, last_seen_at
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$9)
+ON CONFLICT (tenant_id, alias_type, alias_value_normalized, canonical_device_id)
+DO UPDATE SET
+  alias_value = EXCLUDED.alias_value,
+  source_id = EXCLUDED.source_id,
+  confidence = GREATEST(endpoint_identity_aliases.confidence, EXCLUDED.confidence),
+  attributes_json = endpoint_identity_aliases.attributes_json || EXCLUDED.attributes_json,
+  first_seen_at = LEAST(endpoint_identity_aliases.first_seen_at, EXCLUDED.first_seen_at),
+  last_seen_at = GREATEST(endpoint_identity_aliases.last_seen_at, EXCLUDED.last_seen_at),
+  updated_at = NOW()`,
+			alias.TenantID,
+			alias.AliasType,
+			alias.AliasValue,
+			normalizeEndpointAliasValue(alias.AliasValue),
+			alias.CanonicalDeviceID,
+			alias.SourceID,
+			alias.Confidence,
+			string(attrs),
+			observedAt,
+		); err != nil {
+			return fmt.Errorf("upsert endpoint identity alias %s/%s: %w", alias.AliasType, alias.AliasValue, err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) ResolveEndpointIdentity(ctx context.Context, request ports.EndpointIdentityResolveRequest) (ports.EndpointIdentityResolution, error) {
+	if s == nil || s.db == nil {
+		return ports.EndpointIdentityResolution{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureEndpointIdentityTables(ctx); err != nil {
+		return ports.EndpointIdentityResolution{}, err
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return ports.EndpointIdentityResolution{}, errors.New("endpoint identity tenant id is required")
+	}
+	aliases := normalizeEndpointAliases(request.Aliases)
+	if len(aliases) == 0 {
+		return ports.EndpointIdentityResolution{TenantID: tenantID}, nil
+	}
+	clauses := make([]string, 0, len(aliases))
+	args := []any{tenantID}
+	for _, alias := range aliases {
+		args = append(args, alias.AliasType, normalizeEndpointAliasValue(alias.AliasValue))
+		clauses = append(clauses, fmt.Sprintf("(alias_type = $%d AND alias_value_normalized = $%d)", len(args)-1, len(args)))
+	}
+	limit := request.Limit
+	if limit == 0 {
+		limit = 50
+	}
+	args = append(args, limit)
+	query := `
+SELECT tenant_id, alias_type, alias_value, canonical_device_id, source_id, confidence,
+       attributes_json::text, first_seen_at, last_seen_at
+  FROM endpoint_identity_aliases
+ WHERE tenant_id = $1 AND (` + strings.Join(clauses, " OR ") + `)
+ ORDER BY confidence DESC, last_seen_at DESC
+ LIMIT $` + fmt.Sprint(len(args))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return ports.EndpointIdentityResolution{}, fmt.Errorf("resolve endpoint identity: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	matches := []ports.EndpointIdentityAlias{}
+	for rows.Next() {
+		alias, err := scanEndpointAlias(rows)
+		if err != nil {
+			return ports.EndpointIdentityResolution{}, err
+		}
+		matches = append(matches, alias)
+	}
+	if err := rows.Err(); err != nil {
+		return ports.EndpointIdentityResolution{}, err
+	}
+	candidates := endpointIdentityCandidateIDs(matches)
+	resolution := ports.EndpointIdentityResolution{
+		TenantID:           tenantID,
+		MatchedAliases:     matches,
+		CandidateDeviceIDs: candidates,
+		Ambiguous:          len(candidates) > 1,
+	}
+	if len(candidates) > 0 {
+		resolution.CanonicalDeviceID = candidates[0]
+	}
+	return resolution, nil
+}
+
+func scanEndpointAlias(scanner interface {
+	Scan(dest ...any) error
+}) (ports.EndpointIdentityAlias, error) {
+	var alias ports.EndpointIdentityAlias
+	var attrsJSON string
+	var firstSeen time.Time
+	if err := scanner.Scan(
+		&alias.TenantID,
+		&alias.AliasType,
+		&alias.AliasValue,
+		&alias.CanonicalDeviceID,
+		&alias.SourceID,
+		&alias.Confidence,
+		&attrsJSON,
+		&firstSeen,
+		&alias.ObservedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ports.EndpointIdentityAlias{}, err
+		}
+		return ports.EndpointIdentityAlias{}, fmt.Errorf("scan endpoint identity alias: %w", err)
+	}
+	alias.Attributes = map[string]string{}
+	if strings.TrimSpace(attrsJSON) != "" {
+		if err := json.Unmarshal([]byte(attrsJSON), &alias.Attributes); err != nil {
+			return ports.EndpointIdentityAlias{}, fmt.Errorf("decode endpoint identity attributes: %w", err)
+		}
+	}
+	return alias, nil
+}
+
+func normalizeEndpointAliases(aliases []ports.EndpointIdentityAlias) []ports.EndpointIdentityAlias {
+	out := make([]ports.EndpointIdentityAlias, 0, len(aliases))
+	for _, alias := range aliases {
+		alias = normalizeEndpointAlias(alias)
+		if alias.AliasType != "" && alias.AliasValue != "" {
+			out = append(out, alias)
+		}
+	}
+	return out
+}
+
+func normalizeEndpointAlias(alias ports.EndpointIdentityAlias) ports.EndpointIdentityAlias {
+	alias.TenantID = strings.TrimSpace(alias.TenantID)
+	alias.CanonicalDeviceID = strings.TrimSpace(alias.CanonicalDeviceID)
+	alias.AliasType = strings.TrimSpace(alias.AliasType)
+	alias.AliasValue = strings.TrimSpace(alias.AliasValue)
+	alias.SourceID = strings.TrimSpace(alias.SourceID)
+	if alias.Attributes == nil {
+		alias.Attributes = map[string]string{}
+	}
+	if alias.Confidence < 0 {
+		alias.Confidence = 0
+	}
+	if alias.Confidence > 1 {
+		alias.Confidence = 1
+	}
+	return alias
+}
+
+func normalizeEndpointAliasValue(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func endpointIdentityCandidateIDs(matches []ports.EndpointIdentityAlias) []string {
+	type score struct {
+		deviceID   string
+		confidence float64
+		observedAt time.Time
+	}
+	byDevice := map[string]score{}
+	for _, match := range matches {
+		deviceID := strings.TrimSpace(match.CanonicalDeviceID)
+		if deviceID == "" {
+			continue
+		}
+		current := byDevice[deviceID]
+		if current.deviceID == "" || match.Confidence > current.confidence || (match.Confidence == current.confidence && match.ObservedAt.After(current.observedAt)) {
+			byDevice[deviceID] = score{deviceID: deviceID, confidence: match.Confidence, observedAt: match.ObservedAt}
+		}
+	}
+	scores := make([]score, 0, len(byDevice))
+	for _, score := range byDevice {
+		scores = append(scores, score)
+	}
+	sort.Slice(scores, func(i, j int) bool {
+		if scores[i].confidence != scores[j].confidence {
+			return scores[i].confidence > scores[j].confidence
+		}
+		return scores[i].observedAt.After(scores[j].observedAt)
+	})
+	out := make([]string, 0, len(scores))
+	for _, score := range scores {
+		out = append(out, score.deviceID)
+	}
+	return out
+}
+
+func (s *Store) ensureEndpointIdentityTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.endpointIdentityReady, "endpoint identity", ensureEndpointIdentityStatements)
+}
+
+var _ ports.EndpointIdentityStore = (*Store)(nil)

--- a/internal/statestore/postgres/endpoint_identity_test.go
+++ b/internal/statestore/postgres/endpoint_identity_test.go
@@ -1,0 +1,20 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEndpointIdentitySchemaSupportsAliasResolution(t *testing.T) {
+	joined := strings.Join(ensureEndpointIdentityStatements, "\n")
+	for _, want := range []string{
+		"CREATE TABLE IF NOT EXISTS endpoint_identity_aliases",
+		"PRIMARY KEY (tenant_id, alias_type, alias_value_normalized, canonical_device_id)",
+		"endpoint_identity_alias_lookup_idx",
+		"endpoint_identity_alias_device_idx",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("endpoint identity schema missing %q:\n%s", want, joined)
+		}
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -27,6 +27,7 @@ type Store struct {
 	findingCandidateReady     bool
 	vulnDBTablesReady         bool
 	deviceAuthTablesReady     bool
+	endpointIdentityReady     bool
 	mcpOAuthTablesReady       bool
 	startupLeaseTableReady    bool
 	askTrajectoryReady        bool


### PR DESCRIPTION
## Summary
- Persist endpoint identity aliases and normalize device telemetry into durable trusted_endpoint events on first accepted ingest.
- Add a trust-context graph endpoint and deepen Trusted Endpoint projections for devices, findings, GRC, repos, and actions.
- Document the durable endpoint identity and trust-context contract.

## Test plan
- go test ./...
- pre-commit hook: go build, go test ./..., SDK tests/typecheck, MCP checks, golangci-lint


Made with [Cursor](https://cursor.com)