### PR TITLE
Skip Droid execution for Dependabot PRs

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -244,7 +244,9 @@ jobs:
 
   droid-review:
     needs: droid-review-preflight
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && needs.droid-review-preflight.outputs.run_droid_review == 'true'
+    # Dependabot pull_request runs cannot access FACTORY_API_KEY, so keep the
+    # preflight context but skip the secret-dependent Droid execution job.
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && needs.droid-review-preflight.outputs.run_droid_review == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Skip the secret-dependent Droid execution job when `pull_request` runs are authored by Dependabot.
- Keep Droid preflight/context generation so bot PRs still get deterministic checks without requiring unavailable secrets.

## Test plan
- `git diff --check`

Made with [Cursor](https://cursor.com)