### PR TITLE
feat(deviceauth): emit structured audit event on bootstrap-token issuance

### DIFF
--- a/internal/deviceauth/memstore.go
+++ b/internal/deviceauth/memstore.go
@@ -13,13 +13,14 @@ import (
 // production: the bootstrap binary is required to use a real driver per
 // docs/NON_GOALS.md.
 type MemStore struct {
-	mu              sync.Mutex
-	devices         map[string]DeviceRecord
-	bootstrapTokens map[[32]byte]BootstrapToken
-	refreshTokens   map[[32]byte]RefreshToken
-	refreshByFamily map[string]map[[32]byte]struct{}
-	idempotency     map[string]idempotencyEntry
-	now             func() time.Time
+	mu                        sync.Mutex
+	devices                   map[string]DeviceRecord
+	bootstrapTokens           map[[32]byte]BootstrapToken
+	refreshTokens             map[[32]byte]RefreshToken
+	refreshByFamily           map[string]map[[32]byte]struct{}
+	idempotency               map[string]idempotencyEntry
+	now                       func() time.Time
+	createBootstrapTokenFault error
 }
 
 type idempotencyEntry struct {
@@ -111,10 +112,23 @@ func (s *MemStore) RevokeDevice(_ context.Context, deviceID string, at time.Time
 	return nil
 }
 
+// SetCreateBootstrapTokenFault is a test seam: when set, the next
+// (and every subsequent) call to CreateBootstrapToken returns the
+// supplied error WITHOUT mutating the store. Used to assert callers
+// emit audit events only AFTER the durable write succeeds.
+func (s *MemStore) SetCreateBootstrapTokenFault(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.createBootstrapTokenFault = err
+}
+
 // CreateBootstrapToken inserts a new bootstrap token row.
 func (s *MemStore) CreateBootstrapToken(_ context.Context, token BootstrapToken) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.createBootstrapTokenFault != nil {
+		return s.createBootstrapTokenFault
+	}
 	s.bootstrapTokens[token.TokenHash] = token
 	return nil
 }

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -186,7 +187,45 @@ type ServiceConfig struct {
 	// Observations, if set, is the per-device geo/ASN observation store
 	// the risk pipeline reads from and writes to.
 	Observations risk.ObservationStore
+	// Audit, if set, is invoked once per business-level lifecycle event
+	// on the device-auth surface (currently: bootstrap-token issuance).
+	// Production wiring should publish the event to the AppendLog so
+	// SOC tooling can correlate mints to subsequent enrollments. The
+	// callback is invoked synchronously after the database write
+	// succeeds; implementations MUST be non-blocking and MUST NOT
+	// return errors that should fail the request -- a logged-but-not-
+	// emitted audit event is preferable to a denied legitimate mint.
+	Audit AuditEmitter
 }
+
+// AuditEvent describes a single device-auth business-level event.
+//
+// HardwareUUIDHash holds the SHA-256 (lower-hex) digest of the raw
+// hardware UUID rather than the UUID itself, so the audit pipeline
+// can correlate without storing the raw identifier in plain text in
+// long-term log retention.
+type AuditEvent struct {
+	Kind             string
+	OccurredAt       time.Time
+	TenantID         string
+	IssuedBy         string
+	TokenID          string
+	HardwareUUIDHash string
+	Scopes           []string
+	TTL              time.Duration
+	ExpiresAt        time.Time
+}
+
+// AuditEmitter is the optional callback invoked once per device-auth
+// lifecycle event. See [ServiceConfig.Audit] for invariants.
+type AuditEmitter func(ctx context.Context, event AuditEvent)
+
+// Audit kinds. These are the canonical strings the audit pipeline
+// matches on; do not rename without coordinating with downstream
+// consumers.
+const (
+	AuditKindBootstrapTokenIssued = "deviceauth.bootstrap_token.issued"
+)
 
 // Service is the device-auth orchestration layer. It owns the lifecycle of
 // devices, bootstrap tokens, and refresh tokens, and is the only entry point
@@ -671,6 +710,27 @@ func (s *Service) IssueBootstrapToken(ctx context.Context, request IssueBootstra
 	}
 	if err := s.store.CreateBootstrapToken(ctx, token); err != nil {
 		return IssueBootstrapTokenResponse{}, fmt.Errorf("deviceauth: create bootstrap token: %w", err)
+	}
+	// Emit the business-level audit event AFTER the durable write
+	// succeeds. Order matters: emitting before the write would create
+	// a forensic trail entry for a token that does not exist in the
+	// database, leaving SOC investigators chasing ghosts. The Audit
+	// callback is documented as non-failing; we deliberately ignore
+	// any side-channel errors it might surface so a log-pipeline
+	// outage cannot deny legitimate mints.
+	if s.cfg.Audit != nil {
+		hardwareHash := sha256.Sum256([]byte(hardwareUUID))
+		s.cfg.Audit(ctx, AuditEvent{
+			Kind:             AuditKindBootstrapTokenIssued,
+			OccurredAt:       now,
+			TenantID:         tenantID,
+			IssuedBy:         strings.TrimSpace(request.IssuedBy),
+			TokenID:          tokenID,
+			HardwareUUIDHash: hex.EncodeToString(hardwareHash[:]),
+			Scopes:           append([]string(nil), scopes...),
+			TTL:              ttl,
+			ExpiresAt:        token.ExpiresAt,
+		})
 	}
 	return IssueBootstrapTokenResponse{
 		TokenID:   tokenID,

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -868,4 +869,139 @@ func TestNewServiceDefaultRefreshTTLIs7Days(t *testing.T) {
 	if got, want := service.cfg.RefreshTTL, 7*24*time.Hour; got != want {
 		t.Fatalf("default RefreshTTL = %v, want %v", got, want)
 	}
+}
+
+// newServiceWithAuditForTest mirrors newServiceForTest but installs a
+// caller-supplied AuditEmitter so tests can assert on the emitted
+// payload shape.
+func newServiceWithAuditForTest(t *testing.T, audit AuditEmitter) (*Service, *MemStore, time.Time) {
+	t.Helper()
+	store := NewMemStore()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer, err := NewLocalSigner([]SigningKey{{KID: "test", Public: pub, Private: priv}})
+	if err != nil {
+		t.Fatalf("NewLocalSigner: %v", err)
+	}
+	keyset := &KeySet{Keys: []SigningKey{{KID: "test", Public: pub}}}
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	store.SetClock(clock)
+	issuer, _ := NewJWTIssuer(IssuerConfig{Now: clock}, signer)
+	verifier, _ := NewJWTVerifier(VerifierConfig{Now: clock}, keyset)
+	service, err := NewService(ServiceConfig{
+		AccessTTL:         5 * time.Minute,
+		RefreshTTL:        24 * time.Hour,
+		BootstrapTokenTTL: time.Hour,
+		IdempotencyTTL:    time.Hour,
+		Now:               clock,
+		Audit:             audit,
+	}, store, issuer, verifier, keyset)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return service, store, now
+}
+
+// TestIssueBootstrapTokenEmitsAuditEvent pins the forensic-trail
+// invariant: every successful mint MUST surface a structured audit
+// event downstream so SOC tooling can correlate "token id X was
+// minted by operator Y at time Z" with subsequent enrollments using
+// the same token id. Hardware UUID is hashed (SHA-256, lower-hex)
+// rather than logged in plaintext so long-term retention does not
+// hold a raw device-correlatable identifier.
+func TestIssueBootstrapTokenEmitsAuditEvent(t *testing.T) {
+	ctx := context.Background()
+	var captured []AuditEvent
+	emit := func(_ context.Context, event AuditEvent) {
+		captured = append(captured, event)
+	}
+	service, _, now := newServiceWithAuditForTest(t, emit)
+	resp, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-audit-1",
+		TenantID:     "writer",
+		Scopes:       []string{ScopeDevicesToken, ScopeTelemetryIngest},
+		TTL:          15 * time.Minute,
+		IssuedBy:     "operator:ben",
+	})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("audit emit count = %d, want 1", len(captured))
+	}
+	event := captured[0]
+	if event.Kind != AuditKindBootstrapTokenIssued {
+		t.Errorf("event.Kind = %q, want %q", event.Kind, AuditKindBootstrapTokenIssued)
+	}
+	if event.TokenID != resp.TokenID {
+		t.Errorf("event.TokenID = %q, want %q", event.TokenID, resp.TokenID)
+	}
+	if event.IssuedBy != "operator:ben" {
+		t.Errorf("event.IssuedBy = %q, want %q", event.IssuedBy, "operator:ben")
+	}
+	if event.TenantID != "writer" {
+		t.Errorf("event.TenantID = %q, want %q", event.TenantID, "writer")
+	}
+	wantHash := sha256Hex("hw-audit-1")
+	if event.HardwareUUIDHash != wantHash {
+		t.Errorf("event.HardwareUUIDHash = %q, want %q (SHA-256(hw-audit-1))", event.HardwareUUIDHash, wantHash)
+	}
+	if !event.OccurredAt.Equal(now) {
+		t.Errorf("event.OccurredAt = %v, want %v", event.OccurredAt, now)
+	}
+	if event.TTL != 15*time.Minute {
+		t.Errorf("event.TTL = %v, want %v", event.TTL, 15*time.Minute)
+	}
+	if !event.ExpiresAt.Equal(now.Add(15 * time.Minute)) {
+		t.Errorf("event.ExpiresAt = %v, want %v", event.ExpiresAt, now.Add(15*time.Minute))
+	}
+	if len(event.Scopes) != 2 || event.Scopes[0] != ScopeDevicesToken || event.Scopes[1] != ScopeTelemetryIngest {
+		t.Errorf("event.Scopes = %v, want [%s %s]", event.Scopes, ScopeDevicesToken, ScopeTelemetryIngest)
+	}
+}
+
+// TestIssueBootstrapTokenAuditEventNotEmittedOnStoreFailure pins the
+// ordering invariant: the audit event MUST be emitted AFTER the
+// durable store write succeeds. Otherwise SOC investigators would
+// chase token ids that never actually existed.
+func TestIssueBootstrapTokenAuditEventNotEmittedOnStoreFailure(t *testing.T) {
+	ctx := context.Background()
+	emitted := 0
+	emit := func(context.Context, AuditEvent) { emitted++ }
+	service, store, _ := newServiceWithAuditForTest(t, emit)
+	store.SetCreateBootstrapTokenFault(errors.New("forced failure"))
+	_, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-fail",
+		TenantID:     "writer",
+		Scopes:       []string{ScopeDevicesToken},
+	})
+	if err == nil {
+		t.Fatal("IssueBootstrapToken returned nil error despite store fault")
+	}
+	if emitted != 0 {
+		t.Errorf("audit emit count = %d on failed mint, want 0", emitted)
+	}
+}
+
+// TestIssueBootstrapTokenAuditEmitterOptional confirms backward
+// compatibility: services constructed without an Audit emitter
+// continue to work unchanged.
+func TestIssueBootstrapTokenAuditEmitterOptional(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	if _, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-no-audit",
+		TenantID:     "writer",
+		Scopes:       []string{ScopeDevicesToken},
+	}); err != nil {
+		t.Fatalf("IssueBootstrapToken without audit emitter: %v", err)
+	}
+}
+
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
 }


### PR DESCRIPTION
## Why

Pilot operability hardening for the secheck device-auth surface. The bootstrap token IS the long-lived enrollment credential before sender-constrained tokens take over -- if one is mis-issued or stolen the response window is short, and the audit trail must surface every mint in real time.

The API access audit pipeline already records the HTTP request shape (principal, IP, status, route, timestamp) for every `POST /platform/devices/bootstrap-tokens`, but no business-level event is emitted that lets an analyst correlate "token id X was minted by operator Y at time Z" with subsequent enrollments using the same token id. Without that link a stolen or mis-issued bootstrap token can only be triaged by joining HTTP-access logs against the deviceauth Postgres tables.

## What changed

- `ServiceConfig` gains an optional `Audit AuditEmitter` callback. When nil, behavior is unchanged (backward compatible).
- `AuditEvent` describes a single lifecycle event with `TokenID`, `HardwareUUIDHash`, `IssuedBy`, `TenantID`, `Scopes`, `TTL`, `OccurredAt`, `ExpiresAt`.
- `AuditKindBootstrapTokenIssued` is the canonical event kind.
- `IssueBootstrapToken` invokes the emitter **after** the durable store write succeeds. Order matters: emitting before the write would surface a forensic-trail entry for a token that does not exist, leaving SOC investigators chasing ghosts.
- `MemStore.SetCreateBootstrapTokenFault` is a test seam used by the regression test that pins the order-of-operations invariant.

## Privacy

Hardware UUID is hashed (SHA-256, lower-hex) before being placed in the audit event; long-term retention does not store a raw device-correlatable identifier. The plaintext UUID stays in the deviceauth Postgres row (already protected by the store's RLS / encryption posture); this PR does not widen access to it.

## Validation

```
go build ./...                          clean
go vet ./...                            clean
gofmt -l internal/deviceauth/           clean
go test ./... -race -count=1            ok (full suite, 60+ packages)
```

3 new tests in `internal/deviceauth/service_test.go`:

| Test | Asserts |
|---|---|
| `TestIssueBootstrapTokenEmitsAuditEvent` | Every field of `AuditEvent` matches expected values, including the SHA-256 hardware-uuid hash and a defensive copy of `Scopes`. |
| `TestIssueBootstrapTokenAuditEventNotEmittedOnStoreFailure` | A failed `CreateBootstrapToken` returns the error AND emits zero audit events. |
| `TestIssueBootstrapTokenAuditEmitterOptional` | A service constructed without an emitter continues to work (backward compat). |

## Security review

- `AuditEmitter` is documented as non-failing; no error path can deny a legitimate mint due to a downstream log-pipeline outage.
- Hardware UUID never appears in the audit event in plaintext; callers receive only its SHA-256 digest.
- The plaintext bootstrap token is **never** passed to the emitter.
- The `Audit` field is a func type so production wiring is opt-in (nil-safe). No new dependency surface.

## Pairs with

- WriterInternal/cerebro PR #851 (Pulumi: `CEREBRO_DEVICE_AUTH_*` env wiring + sec-dev `apiMaxInstances=1` pin).
- WriterInternal/security PRs #800 / #803 (agent side, both merged).