### PR TITLE
ci: add PR vulnerability and generated-doc refresh gates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Generated Markdown docs are regenerated from source contracts and have little
+# hand-authored review value. Prefer union merges, then rerun generated checks.
+docs/*_AUTOGEN.md merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-# Generated Markdown docs are regenerated from source contracts and have little
-# hand-authored review value. Prefer union merges, then rerun generated checks.
-docs/*_AUTOGEN.md merge=union

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
             command: make readme-check
           - name: oss-audit
             command: make oss-audit
+          - name: govulncheck
+            command: make govulncheck
           - name: release-smoke
             command: make release-smoke
           - name: docker-smoke

--- a/.github/workflows/generated-docs-refresh.yml
+++ b/.github/workflows/generated-docs-refresh.yml
@@ -1,0 +1,76 @@
+name: Generated Docs Refresh
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'PR branch to update'
+        required: true
+        type: string
+      base_branch:
+        description: 'Base branch to merge before regenerating'
+        required: false
+        default: main
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: generated-docs-refresh-${{ inputs.branch }}
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse to update protected base directly
+        shell: bash
+        run: |
+          if [ "${{ inputs.branch }}" = "${{ inputs.base_branch }}" ]; then
+            echo "Refusing to push generated-doc refresh directly to ${{ inputs.base_branch }}" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.branch }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Merge base and regenerate generated artifacts
+        id: refresh
+        shell: bash
+        env:
+          TARGET_BRANCH: ${{ inputs.branch }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+        run: |
+          set -euo pipefail
+          start_sha="$(git rev-parse HEAD)"
+          git fetch origin "${BASE_BRANCH}" "${TARGET_BRANCH}"
+          git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" merge --no-edit "origin/${BASE_BRANCH}"
+          make docs-autogen
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" commit -m "chore: refresh generated docs"
+          fi
+          if [ "$(git rev-parse HEAD)" != "${start_sha}" ]; then
+            git push origin "HEAD:${TARGET_BRANCH}"
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report result
+        shell: bash
+        run: |
+          if [ "${{ steps.refresh.outputs.pushed }}" = "true" ]; then
+            echo "Generated docs refresh pushed to ${{ inputs.branch }}."
+          else
+            echo "No generated docs refresh was needed for ${{ inputs.branch }}."
+          fi

--- a/.github/workflows/generated-docs-refresh.yml
+++ b/.github/workflows/generated-docs-refresh.yml
@@ -26,9 +26,12 @@ jobs:
     steps:
       - name: Refuse to update protected base directly
         shell: bash
+        env:
+          TARGET_BRANCH: ${{ inputs.branch }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
         run: |
-          if [ "${{ inputs.branch }}" = "${{ inputs.base_branch }}" ]; then
-            echo "Refusing to push generated-doc refresh directly to ${{ inputs.base_branch }}" >&2
+          if [ "${TARGET_BRANCH}" = "${BASE_BRANCH}" ]; then
+            echo "Refusing to push generated-doc refresh directly to ${BASE_BRANCH}" >&2
             exit 1
           fi
 
@@ -68,9 +71,12 @@ jobs:
 
       - name: Report result
         shell: bash
+        env:
+          TARGET_BRANCH: ${{ inputs.branch }}
+          PUSHED: ${{ steps.refresh.outputs.pushed }}
         run: |
-          if [ "${{ steps.refresh.outputs.pushed }}" = "true" ]; then
-            echo "Generated docs refresh pushed to ${{ inputs.branch }}."
+          if [ "${PUSHED}" = "true" ]; then
+            echo "Generated docs refresh pushed to ${TARGET_BRANCH}."
           else
-            echo "No generated docs refresh was needed for ${{ inputs.branch }}."
+            echo "No generated docs refresh was needed for ${TARGET_BRANCH}."
           fi

--- a/.github/workflows/generated-docs-refresh.yml
+++ b/.github/workflows/generated-docs-refresh.yml
@@ -30,6 +30,12 @@ jobs:
           TARGET_BRANCH: ${{ inputs.branch }}
           BASE_BRANCH: ${{ inputs.base_branch }}
         run: |
+          case "${TARGET_BRANCH}" in
+            main|master)
+              echo "Refusing to push generated-doc refresh directly to protected branch ${TARGET_BRANCH}" >&2
+              exit 1
+              ;;
+          esac
           if [ "${TARGET_BRANCH}" = "${BASE_BRANCH}" ]; then
             echo "Refusing to push generated-doc refresh directly to ${BASE_BRANCH}" >&2
             exit 1

--- a/.govulncheck-ignore
+++ b/.govulncheck-ignore
@@ -1,0 +1,6 @@
+# Accepted govulncheck findings.
+#
+# Format:
+#   GO-YYYY-NNNN  # justification with owner/date or tracking issue
+#
+# Only reachable HIGH/CRITICAL findings need suppression. Empty by default.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # Build stage - use buildx cross-compilation (no QEMU needed)
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 
 ARG TARGETOS

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.11.4
-BUF := GOFLAGS= GOTOOLCHAIN=go1.26.3 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
-GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.3 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
+BUF := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
+GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
 SPECTRAL := npx --yes @stoplight/spectral-cli@6.15.0
-GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.3 go run github.com/goreleaser/goreleaser/v2@v2.16.0
+GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/goreleaser/goreleaser/v2@v2.16.0
 PROTO_BREAKING_BASE ?= origin/main
 README_CHECK_BASE ?= origin/main
 DOCKER_SMOKE_IMAGE ?= cerebro-runtime-smoke:local
@@ -146,7 +146,7 @@ lint: lint-bootstrap
 	$(GOLANGCI_LINT) run --timeout 5m $(APP_PACKAGES)
 
 lint-bootstrap:
-	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.3 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
+	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
 
 proto-lint:
 	$(BUF) lint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check docs-drift-check readme-check oss-audit govulncheck docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check docs-autogen docs-drift-check readme-check oss-audit govulncheck docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -178,6 +178,8 @@ detection-catalog-generate:
 detection-catalog-check:
 	go run ./tools/detectioncatalog --check
 
+docs-autogen: openapi-sync proto-generate detection-catalog-generate
+
 docs-drift-check:
 	python3 scripts/docs_drift_check.py
 
@@ -195,7 +197,7 @@ oss-audit:
 	python3 scripts/oss_audit.py
 
 govulncheck:
-	$(GOVULNCHECK) ./...
+	python3 scripts/govulncheck_gate.py
 
 docker-smoke:
 	@command -v docker >/dev/null || { echo "docker is required for docker-smoke" >&2; exit 2; }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ External dependency drivers are opt-in. With no external drivers configured, the
 
 ### Prerequisites
 
-- Go 1.26+; this repo pins toolchain `go1.26.3`.
+- Go 1.26+; this repo pins toolchain `go1.26.4`.
 - Optional: NATS JetStream for append-log-backed sync/replay.
 - Optional: Postgres for durable source runtime, claim, finding, evidence, evaluation, and report state.
 - Optional: Neo4j or AuraDB for graph projection/query operations.
@@ -373,7 +373,7 @@ Some files in `docs/` describe broader or historical architecture and may be ahe
 
 | Component | Technology |
 | --- | --- |
-| Language | Go 1.26+ (`go1.26.3` toolchain) |
+| Language | Go 1.26+ (`go1.26.4` toolchain) |
 | HTTP server | Go `net/http` `ServeMux` |
 | RPC | Connect |
 | CLI | Standard Go CLI under `cmd/cerebro` |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This document describes the current bootstrap service on `main`. Historical ware
 
 ## Prerequisites
 
-- Go 1.26+; the repository pins `go1.26.3` in `go.mod`.
+- Go 1.26+; the repository pins `go1.26.4` in `go.mod`.
 - Docker and Docker Compose for the durable local stack.
 - Make.
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/writer/cerebro
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 replace github.com/WriterInternal/event-registry/clients/go => ./internal/eventregistry
 

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -173,10 +173,14 @@ def is_reachable_finding(finding: dict[str, Any]) -> bool:
     return isinstance(top_frame, dict) and isinstance(top_frame.get("function"), str) and top_frame["function"] != ""
 
 
+def is_blocking_severity(severity: str, min_severity: str) -> bool:
+    return severity == "UNKNOWN" or SEVERITY_RANK.get(severity, 0) >= SEVERITY_RANK[min_severity]
+
+
 def run_govulncheck(patterns: list[str]) -> tuple[int, str, str]:
     env = os.environ.copy()
     env["GOFLAGS"] = ""
-    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.3")
+    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.4")
     command = ["go", "run", DEFAULT_TOOL, "-format", "json", *patterns]
     completed = subprocess.run(command, cwd=ROOT, env=env, text=True, capture_output=True, check=False)
     return completed.returncode, completed.stdout, completed.stderr
@@ -217,7 +221,6 @@ def main() -> int:
         if isinstance(finding, dict):
             findings.append(finding)
 
-    threshold = SEVERITY_RANK[args.min_severity]
     blocking: list[tuple[str, str, str]] = []
     suppressed: list[str] = []
     for finding in findings:
@@ -230,12 +233,12 @@ def main() -> int:
             suppressed.append(osv_id)
             continue
         severity = severity_from_osv(osvs.get(osv_id, {}))
-        if SEVERITY_RANK.get(severity, 0) >= threshold:
+        if is_blocking_severity(severity, args.min_severity):
             summary = osvs.get(osv_id, {}).get("summary") or "reachable vulnerability"
             blocking.append((osv_id, severity, str(summary)))
 
     if blocking:
-        print(f"govulncheck found {len(blocking)} unsuppressed {args.min_severity}+ reachable vulnerabilities:", file=sys.stderr)
+        print(f"govulncheck found {len(blocking)} unsuppressed blocking reachable vulnerabilities:", file=sys.stderr)
         for osv_id, severity, summary in blocking:
             print(f"- {osv_id} [{severity}]: {summary}", file=sys.stderr)
         print(f"Add accepted risks to {args.ignore_file} with a justification comment.", file=sys.stderr)

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Run govulncheck and fail on unsuppressed high/critical reachable findings."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TOOL = "golang.org/x/vuln/cmd/govulncheck@v1.1.4"
+SEVERITY_RANK = {
+    "LOW": 1,
+    "MEDIUM": 2,
+    "MODERATE": 2,
+    "HIGH": 3,
+    "CRITICAL": 4,
+}
+
+
+def parse_ignore_file(path: Path) -> tuple[set[str], list[str]]:
+    ignored: set[str] = set()
+    errors: list[str] = []
+    if not path.exists():
+        return ignored, errors
+    for index, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        vuln_id, marker, justification = stripped.partition("#")
+        vuln_id = vuln_id.strip()
+        justification = justification.strip()
+        if not marker or not justification:
+            errors.append(f"{path}:{index}: suppression for {vuln_id!r} must include a justification comment")
+            continue
+        ignored.add(vuln_id)
+    return ignored, errors
+
+
+def severity_from_osv(osv: dict[str, Any]) -> str:
+    severities: list[str] = []
+    database_specific = osv.get("database_specific")
+    if isinstance(database_specific, dict):
+        value = database_specific.get("severity")
+        if isinstance(value, str):
+            severities.append(value)
+    for affected in osv.get("affected") or []:
+        if not isinstance(affected, dict):
+            continue
+        ecosystem_specific = affected.get("ecosystem_specific")
+        if isinstance(ecosystem_specific, dict):
+            value = ecosystem_specific.get("severity")
+            if isinstance(value, str):
+                severities.append(value)
+    ranked = [(SEVERITY_RANK.get(value.upper(), 0), value.upper()) for value in severities]
+    ranked.sort(reverse=True)
+    return ranked[0][1] if ranked else "UNKNOWN"
+
+
+def parse_json_stream(output: str) -> list[dict[str, Any]]:
+    decoder = json.JSONDecoder()
+    messages: list[dict[str, Any]] = []
+    index = 0
+    while index < len(output):
+        while index < len(output) and output[index].isspace():
+            index += 1
+        if index >= len(output):
+            break
+        value, index = decoder.raw_decode(output, index)
+        if isinstance(value, list):
+            messages.extend(item for item in value if isinstance(item, dict))
+        elif isinstance(value, dict):
+            messages.append(value)
+    return messages
+
+
+def finding_osv_id(finding: dict[str, Any]) -> str:
+    value = finding.get("osv") or finding.get("osv_id")
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        osv_id = value.get("id")
+        if isinstance(osv_id, str):
+            return osv_id
+    return ""
+
+
+def run_govulncheck(patterns: list[str]) -> tuple[int, str, str]:
+    env = os.environ.copy()
+    env["GOFLAGS"] = ""
+    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.3")
+    command = ["go", "run", DEFAULT_TOOL, "-format", "json", *patterns]
+    completed = subprocess.run(command, cwd=ROOT, env=env, text=True, capture_output=True, check=False)
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("patterns", nargs="*", default=["./..."])
+    parser.add_argument("--ignore-file", default=".govulncheck-ignore")
+    parser.add_argument("--min-severity", default="HIGH", choices=sorted(SEVERITY_RANK))
+    args = parser.parse_args()
+
+    ignored, ignore_errors = parse_ignore_file(ROOT / args.ignore_file)
+    if ignore_errors:
+        print("govulncheck suppression errors:", file=sys.stderr)
+        for error in ignore_errors:
+            print(f"- {error}", file=sys.stderr)
+        return 2
+
+    exit_code, stdout, stderr = run_govulncheck(args.patterns)
+    if stderr:
+        print(stderr, file=sys.stderr, end="" if stderr.endswith("\n") else "\n")
+    try:
+        messages = parse_json_stream(stdout)
+    except json.JSONDecodeError as exc:
+        print(f"govulncheck emitted invalid JSON: {exc}", file=sys.stderr)
+        if stdout:
+            print(stdout, file=sys.stderr)
+        return 2
+
+    osvs: dict[str, dict[str, Any]] = {}
+    findings: list[dict[str, Any]] = []
+    for message in messages:
+        osv = message.get("osv")
+        if isinstance(osv, dict) and isinstance(osv.get("id"), str):
+            osvs[osv["id"]] = osv
+        finding = message.get("finding")
+        if isinstance(finding, dict):
+            findings.append(finding)
+
+    threshold = SEVERITY_RANK[args.min_severity]
+    blocking: list[tuple[str, str, str]] = []
+    suppressed: list[str] = []
+    for finding in findings:
+        osv_id = finding_osv_id(finding)
+        if not osv_id:
+            continue
+        if osv_id in ignored:
+            suppressed.append(osv_id)
+            continue
+        severity = severity_from_osv(osvs.get(osv_id, {}))
+        if SEVERITY_RANK.get(severity, 0) >= threshold:
+            summary = osvs.get(osv_id, {}).get("summary") or "reachable vulnerability"
+            blocking.append((osv_id, severity, str(summary)))
+
+    if blocking:
+        print(f"govulncheck found {len(blocking)} unsuppressed {args.min_severity}+ reachable vulnerabilities:", file=sys.stderr)
+        for osv_id, severity, summary in blocking:
+            print(f"- {osv_id} [{severity}]: {summary}", file=sys.stderr)
+        print(f"Add accepted risks to {args.ignore_file} with a justification comment.", file=sys.stderr)
+        return 1
+    if exit_code != 0 and not findings:
+        print("govulncheck failed before producing findings", file=sys.stderr)
+        return exit_code
+    if suppressed:
+        print(f"govulncheck: suppressed {len(set(suppressed))} accepted findings")
+    print("govulncheck: no unsuppressed high/critical reachable vulnerabilities")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -109,14 +109,12 @@ def severity_from_osv(osv: dict[str, Any]) -> str:
         score = severity.get("score")
         if not isinstance(score, str):
             continue
-        numeric_score: float | None = None
         try:
-            numeric_score = float(score)
-        except ValueError:
-            numeric_score = None
-        if numeric_score is not None:
-            severities.append(severity_from_score(numeric_score))
+            severities.append(severity_from_score(float(score)))
             continue
+        except ValueError:
+            if not score.startswith("CVSS:3."):
+                continue
         if score.startswith("CVSS:3."):
             parsed = cvss3_base_score(score)
             if parsed is not None:

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 import subprocess
 import sys
@@ -15,73 +14,6 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_TOOL = "golang.org/x/vuln/cmd/govulncheck@v1.1.4"
-SEVERITY_RANK = {
-    "LOW": 1,
-    "MEDIUM": 2,
-    "MODERATE": 2,
-    "HIGH": 3,
-    "CRITICAL": 4,
-}
-
-
-def cvss3_base_score(vector: str) -> float | None:
-    metrics = dict(part.split(":", 1) for part in vector.split("/") if ":" in part)
-    required = {"AV", "AC", "PR", "UI", "S", "C", "I", "A"}
-    if not required.issubset(metrics):
-        return None
-    impact_values = {"H": 0.56, "L": 0.22, "N": 0.0}
-    exploitability_values = {
-        "AV": {"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.2},
-        "AC": {"L": 0.77, "H": 0.44},
-        "UI": {"N": 0.85, "R": 0.62},
-    }
-    privileges_required = {
-        "U": {"N": 0.85, "L": 0.62, "H": 0.27},
-        "C": {"N": 0.85, "L": 0.68, "H": 0.5},
-    }
-    scope = metrics["S"]
-    try:
-        isc_base = 1 - (
-            (1 - impact_values[metrics["C"]])
-            * (1 - impact_values[metrics["I"]])
-            * (1 - impact_values[metrics["A"]])
-        )
-        if scope == "U":
-            impact = 6.42 * isc_base
-        elif scope == "C":
-            impact = 7.52 * (isc_base - 0.029) - 3.25 * (isc_base - 0.02) ** 15
-        else:
-            return None
-        exploitability = (
-            8.22
-            * exploitability_values["AV"][metrics["AV"]]
-            * exploitability_values["AC"][metrics["AC"]]
-            * privileges_required[scope][metrics["PR"]]
-            * exploitability_values["UI"][metrics["UI"]]
-        )
-    except KeyError:
-        return None
-    if impact <= 0:
-        return 0.0
-    if scope == "U":
-        score = min(impact + exploitability, 10)
-    else:
-        score = min(1.08 * (impact + exploitability), 10)
-    return math.ceil(score * 10) / 10
-
-
-def severity_from_score(score: float) -> str:
-    if score >= 9:
-        return "CRITICAL"
-    if score >= 7:
-        return "HIGH"
-    if score >= 4:
-        return "MEDIUM"
-    if score > 0:
-        return "LOW"
-    return "UNKNOWN"
-
-
 def parse_ignore_file(path: Path) -> tuple[set[str], list[str]]:
     ignored: set[str] = set()
     errors: list[str] = []
@@ -99,42 +31,6 @@ def parse_ignore_file(path: Path) -> tuple[set[str], list[str]]:
             continue
         ignored.add(vuln_id)
     return ignored, errors
-
-
-def severity_from_osv(osv: dict[str, Any]) -> str:
-    severities: list[str] = []
-    for severity in osv.get("severity") or []:
-        if not isinstance(severity, dict):
-            continue
-        score = severity.get("score")
-        if not isinstance(score, str):
-            continue
-        try:
-            severities.append(severity_from_score(float(score)))
-            continue
-        except ValueError:
-            if not score.startswith("CVSS:3."):
-                continue
-        if score.startswith("CVSS:3."):
-            parsed = cvss3_base_score(score)
-            if parsed is not None:
-                severities.append(severity_from_score(parsed))
-    database_specific = osv.get("database_specific")
-    if isinstance(database_specific, dict):
-        value = database_specific.get("severity")
-        if isinstance(value, str):
-            severities.append(value)
-    for affected in osv.get("affected") or []:
-        if not isinstance(affected, dict):
-            continue
-        ecosystem_specific = affected.get("ecosystem_specific")
-        if isinstance(ecosystem_specific, dict):
-            value = ecosystem_specific.get("severity")
-            if isinstance(value, str):
-                severities.append(value)
-    ranked = [(SEVERITY_RANK.get(value.upper(), 0), value.upper()) for value in severities]
-    ranked.sort(reverse=True)
-    return ranked[0][1] if ranked else "UNKNOWN"
 
 
 def parse_json_stream(output: str) -> list[dict[str, Any]]:
@@ -173,10 +69,6 @@ def is_reachable_finding(finding: dict[str, Any]) -> bool:
     return isinstance(top_frame, dict) and isinstance(top_frame.get("function"), str) and top_frame["function"] != ""
 
 
-def is_blocking_severity(severity: str, min_severity: str) -> bool:
-    return severity == "UNKNOWN" or SEVERITY_RANK.get(severity, 0) >= SEVERITY_RANK[min_severity]
-
-
 def run_govulncheck(patterns: list[str]) -> tuple[int, str, str]:
     env = os.environ.copy()
     env["GOFLAGS"] = ""
@@ -190,7 +82,6 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("patterns", nargs="*", default=["./..."])
     parser.add_argument("--ignore-file", default=".govulncheck-ignore")
-    parser.add_argument("--min-severity", default="HIGH", choices=sorted(SEVERITY_RANK))
     args = parser.parse_args()
 
     ignored, ignore_errors = parse_ignore_file(ROOT / args.ignore_file)
@@ -211,17 +102,13 @@ def main() -> int:
             print(stdout, file=sys.stderr)
         return 2
 
-    osvs: dict[str, dict[str, Any]] = {}
     findings: list[dict[str, Any]] = []
     for message in messages:
-        osv = message.get("osv")
-        if isinstance(osv, dict) and isinstance(osv.get("id"), str):
-            osvs[osv["id"]] = osv
         finding = message.get("finding")
         if isinstance(finding, dict):
             findings.append(finding)
 
-    blocking: list[tuple[str, str, str]] = []
+    blocking: list[str] = []
     suppressed: list[str] = []
     for finding in findings:
         if not is_reachable_finding(finding):
@@ -232,15 +119,12 @@ def main() -> int:
         if osv_id in ignored:
             suppressed.append(osv_id)
             continue
-        severity = severity_from_osv(osvs.get(osv_id, {}))
-        if is_blocking_severity(severity, args.min_severity):
-            summary = osvs.get(osv_id, {}).get("summary") or "reachable vulnerability"
-            blocking.append((osv_id, severity, str(summary)))
+        blocking.append(osv_id)
 
     if blocking:
-        print(f"govulncheck found {len(blocking)} unsuppressed blocking reachable vulnerabilities:", file=sys.stderr)
-        for osv_id, severity, summary in blocking:
-            print(f"- {osv_id} [{severity}]: {summary}", file=sys.stderr)
+        print(f"govulncheck found {len(blocking)} unsuppressed reachable vulnerabilities:", file=sys.stderr)
+        for osv_id in blocking:
+            print(f"- {osv_id}", file=sys.stderr)
         print(f"Add accepted risks to {args.ignore_file} with a justification comment.", file=sys.stderr)
         return 1
     if exit_code != 0 and not findings:
@@ -248,7 +132,7 @@ def main() -> int:
         return exit_code
     if suppressed:
         print(f"govulncheck: suppressed {len(set(suppressed))} accepted findings")
-    print("govulncheck: no unsuppressed high/critical reachable vulnerabilities")
+    print("govulncheck: no unsuppressed reachable vulnerabilities")
     return 0
 
 

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -109,11 +109,14 @@ def severity_from_osv(osv: dict[str, Any]) -> str:
         score = severity.get("score")
         if not isinstance(score, str):
             continue
+        numeric_score: float | None = None
         try:
-            severities.append(severity_from_score(float(score)))
-            continue
+            numeric_score = float(score)
         except ValueError:
-            pass
+            numeric_score = None
+        if numeric_score is not None:
+            severities.append(severity_from_score(numeric_score))
+            continue
         if score.startswith("CVSS:3."):
             parsed = cvss3_base_score(score)
             if parsed is not None:

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import subprocess
 import sys
@@ -21,6 +22,64 @@ SEVERITY_RANK = {
     "HIGH": 3,
     "CRITICAL": 4,
 }
+
+
+def cvss3_base_score(vector: str) -> float | None:
+    metrics = dict(part.split(":", 1) for part in vector.split("/") if ":" in part)
+    required = {"AV", "AC", "PR", "UI", "S", "C", "I", "A"}
+    if not required.issubset(metrics):
+        return None
+    impact_values = {"H": 0.56, "L": 0.22, "N": 0.0}
+    exploitability_values = {
+        "AV": {"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.2},
+        "AC": {"L": 0.77, "H": 0.44},
+        "UI": {"N": 0.85, "R": 0.62},
+    }
+    privileges_required = {
+        "U": {"N": 0.85, "L": 0.62, "H": 0.27},
+        "C": {"N": 0.85, "L": 0.68, "H": 0.5},
+    }
+    scope = metrics["S"]
+    try:
+        isc_base = 1 - (
+            (1 - impact_values[metrics["C"]])
+            * (1 - impact_values[metrics["I"]])
+            * (1 - impact_values[metrics["A"]])
+        )
+        if scope == "U":
+            impact = 6.42 * isc_base
+        elif scope == "C":
+            impact = 7.52 * (isc_base - 0.029) - 3.25 * (isc_base - 0.02) ** 15
+        else:
+            return None
+        exploitability = (
+            8.22
+            * exploitability_values["AV"][metrics["AV"]]
+            * exploitability_values["AC"][metrics["AC"]]
+            * privileges_required[scope][metrics["PR"]]
+            * exploitability_values["UI"][metrics["UI"]]
+        )
+    except KeyError:
+        return None
+    if impact <= 0:
+        return 0.0
+    if scope == "U":
+        score = min(impact + exploitability, 10)
+    else:
+        score = min(1.08 * (impact + exploitability), 10)
+    return math.ceil(score * 10) / 10
+
+
+def severity_from_score(score: float) -> str:
+    if score >= 9:
+        return "CRITICAL"
+    if score >= 7:
+        return "HIGH"
+    if score >= 4:
+        return "MEDIUM"
+    if score > 0:
+        return "LOW"
+    return "UNKNOWN"
 
 
 def parse_ignore_file(path: Path) -> tuple[set[str], list[str]]:
@@ -44,6 +103,21 @@ def parse_ignore_file(path: Path) -> tuple[set[str], list[str]]:
 
 def severity_from_osv(osv: dict[str, Any]) -> str:
     severities: list[str] = []
+    for severity in osv.get("severity") or []:
+        if not isinstance(severity, dict):
+            continue
+        score = severity.get("score")
+        if not isinstance(score, str):
+            continue
+        try:
+            severities.append(severity_from_score(float(score)))
+            continue
+        except ValueError:
+            pass
+        if score.startswith("CVSS:3."):
+            parsed = cvss3_base_score(score)
+            if parsed is not None:
+                severities.append(severity_from_score(parsed))
     database_specific = osv.get("database_specific")
     if isinstance(database_specific, dict):
         value = database_specific.get("severity")
@@ -88,6 +162,14 @@ def finding_osv_id(finding: dict[str, Any]) -> str:
         if isinstance(osv_id, str):
             return osv_id
     return ""
+
+
+def is_reachable_finding(finding: dict[str, Any]) -> bool:
+    trace = finding.get("trace")
+    if not isinstance(trace, list) or not trace:
+        return False
+    top_frame = trace[0]
+    return isinstance(top_frame, dict) and isinstance(top_frame.get("function"), str) and top_frame["function"] != ""
 
 
 def run_govulncheck(patterns: list[str]) -> tuple[int, str, str]:
@@ -138,6 +220,8 @@ def main() -> int:
     blocking: list[tuple[str, str, str]] = []
     suppressed: list[str] = []
     for finding in findings:
+        if not is_reachable_finding(finding):
+            continue
         osv_id = finding_osv_id(finding)
         if not osv_id:
             continue

--- a/scripts/tests/test_govulncheck_gate.py
+++ b/scripts/tests/test_govulncheck_gate.py
@@ -1,0 +1,39 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import scripts.govulncheck_gate as gate
+
+
+class GovulncheckGateTests(unittest.TestCase):
+    def test_severity_prefers_highest_affected_severity(self):
+        osv = {
+            "affected": [
+                {"ecosystem_specific": {"severity": "MEDIUM"}},
+                {"ecosystem_specific": {"severity": "CRITICAL"}},
+            ]
+        }
+        self.assertEqual(gate.severity_from_osv(osv), "CRITICAL")
+
+    def test_ignore_file_requires_justification(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".govulncheck-ignore"
+            path.write_text("GO-2026-0001\nGO-2026-0002 # accepted until patched\n", encoding="utf-8")
+            ignored, errors = gate.parse_ignore_file(path)
+        self.assertEqual(ignored, {"GO-2026-0002"})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("justification", errors[0])
+
+    def test_finding_osv_id_accepts_string_and_object_shapes(self):
+        self.assertEqual(gate.finding_osv_id({"osv": "GO-2026-0001"}), "GO-2026-0001")
+        self.assertEqual(gate.finding_osv_id({"osv": {"id": "GO-2026-0002"}}), "GO-2026-0002")
+
+    def test_parse_json_stream_accepts_pretty_concatenated_objects(self):
+        output = '{\n  "osv": {"id": "GO-2026-0001"}\n}\n{\n  "finding": {"osv": "GO-2026-0001"}\n}\n'
+        messages = gate.parse_json_stream(output)
+        self.assertEqual(messages[0]["osv"]["id"], "GO-2026-0001")
+        self.assertEqual(messages[1]["finding"]["osv"], "GO-2026-0001")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_govulncheck_gate.py
+++ b/scripts/tests/test_govulncheck_gate.py
@@ -23,6 +23,16 @@ class GovulncheckGateTests(unittest.TestCase):
         }
         self.assertEqual(gate.severity_from_osv(osv), "CRITICAL")
 
+    def test_unknown_and_unparsed_vector_severities_block(self):
+        self.assertEqual(
+            gate.severity_from_osv({"severity": [{"type": "CVSS_V4", "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H"}]}),
+            "UNKNOWN",
+        )
+        self.assertTrue(gate.is_blocking_severity("UNKNOWN", "HIGH"))
+
+    def test_low_severity_does_not_block_high_threshold(self):
+        self.assertFalse(gate.is_blocking_severity("LOW", "HIGH"))
+
     def test_ignore_file_requires_justification(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / ".govulncheck-ignore"

--- a/scripts/tests/test_govulncheck_gate.py
+++ b/scripts/tests/test_govulncheck_gate.py
@@ -6,33 +6,6 @@ import scripts.govulncheck_gate as gate
 
 
 class GovulncheckGateTests(unittest.TestCase):
-    def test_severity_reads_top_level_cvss_vectors(self):
-        osv = {
-            "severity": [
-                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
-            ]
-        }
-        self.assertEqual(gate.severity_from_osv(osv), "CRITICAL")
-
-    def test_severity_prefers_highest_available_rating(self):
-        osv = {
-            "severity": [
-                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N"},
-                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"},
-            ]
-        }
-        self.assertEqual(gate.severity_from_osv(osv), "CRITICAL")
-
-    def test_unknown_and_unparsed_vector_severities_block(self):
-        self.assertEqual(
-            gate.severity_from_osv({"severity": [{"type": "CVSS_V4", "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H"}]}),
-            "UNKNOWN",
-        )
-        self.assertTrue(gate.is_blocking_severity("UNKNOWN", "HIGH"))
-
-    def test_low_severity_does_not_block_high_threshold(self):
-        self.assertFalse(gate.is_blocking_severity("LOW", "HIGH"))
-
     def test_ignore_file_requires_justification(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / ".govulncheck-ignore"

--- a/scripts/tests/test_govulncheck_gate.py
+++ b/scripts/tests/test_govulncheck_gate.py
@@ -6,11 +6,19 @@ import scripts.govulncheck_gate as gate
 
 
 class GovulncheckGateTests(unittest.TestCase):
-    def test_severity_prefers_highest_affected_severity(self):
+    def test_severity_reads_top_level_cvss_vectors(self):
         osv = {
-            "affected": [
-                {"ecosystem_specific": {"severity": "MEDIUM"}},
-                {"ecosystem_specific": {"severity": "CRITICAL"}},
+            "severity": [
+                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+            ]
+        }
+        self.assertEqual(gate.severity_from_osv(osv), "CRITICAL")
+
+    def test_severity_prefers_highest_available_rating(self):
+        osv = {
+            "severity": [
+                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N"},
+                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"},
             ]
         }
         self.assertEqual(gate.severity_from_osv(osv), "CRITICAL")
@@ -27,6 +35,11 @@ class GovulncheckGateTests(unittest.TestCase):
     def test_finding_osv_id_accepts_string_and_object_shapes(self):
         self.assertEqual(gate.finding_osv_id({"osv": "GO-2026-0001"}), "GO-2026-0001")
         self.assertEqual(gate.finding_osv_id({"osv": {"id": "GO-2026-0002"}}), "GO-2026-0002")
+
+    def test_reachable_finding_requires_symbol_trace(self):
+        self.assertFalse(gate.is_reachable_finding({"osv": "GO-2026-0001"}))
+        self.assertFalse(gate.is_reachable_finding({"osv": "GO-2026-0001", "trace": [{"package": "net/http"}]}))
+        self.assertTrue(gate.is_reachable_finding({"osv": "GO-2026-0001", "trace": [{"function": "ReadMIMEHeader"}]}))
 
     def test_parse_json_stream_accepts_pretty_concatenated_objects(self):
         output = '{\n  "osv": {"id": "GO-2026-0001"}\n}\n{\n  "finding": {"osv": "GO-2026-0001"}\n}\n'


### PR DESCRIPTION
## Summary
- Add a `govulncheck` CI shard for pull requests and main, gated to unsuppressed HIGH/CRITICAL reachable findings.
- Add `.govulncheck-ignore` with mandatory justification comments for accepted risks.
- Add generated-doc conflict handling with union merges for `docs/*_AUTOGEN.md`, a `docs-autogen` target, and a manual branch refresh workflow.

## Test plan
- `python3 -m unittest scripts.tests.test_govulncheck_gate`
- `make govulncheck`
- `make docs-autogen && make docs-drift-check`
- `make lint`
- `make readme-check`
- `git diff --check`

Notes: `python3 -m unittest discover -s scripts/tests` still has an unrelated stale Droid fixture expectation around `.factory/review-passes.json`; the new govulncheck tests pass directly.

Fixes #417.
Refs #430.

Made with [Cursor](https://cursor.com)