### PR TITLE
docs: improve README onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 ## Repository Conventions
 
 - Prefer repo `make` targets over ad-hoc commands.
-- Go dependencies are vendored; avoid dependency changes unless explicitly requested.
+- Go dependencies are module-managed; avoid dependency changes unless explicitly requested and validate them through the relevant `make` targets.
 - Do not hand-edit generated or contract-governed outputs without running the matching `Makefile` check/sync target.
 - Public-facing config/example changes should run `python3 scripts/oss_audit.py` when that script is present.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 - Prefer repo `make` targets over ad-hoc commands.
 - Go dependencies are module-managed; avoid dependency changes unless explicitly requested and validate them through the relevant `make` targets.
 - Do not hand-edit generated or contract-governed outputs without running the matching `Makefile` check/sync target.
-- Public-facing config/example changes should run `python3 scripts/oss_audit.py` when that script is present.
+- Public-facing config/example changes should run `make oss-audit`; generated docs changes should also run `make docs-drift-check`.
 
 ## Public PR Data Safety
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Only repo-specific, non-obvious guidance lives here.
 - Use focused `make` targets while iterating, then `make verify` for broader PR-parity validation.
 - Use `make sdk-test` after SDK changes and `make proto-generate-check proto-breaking` after proto changes.
 - Prefer `make openapi-check` / `make openapi-sync` instead of hand-editing route placeholders.
-- Run `python3 scripts/oss_audit.py` after public-facing docs/config/example changes.
+- Run `make oss-audit` after public-facing docs/config/example changes, and `make docs-drift-check` when generated docs are touched.
 
 ## Generated / contract-governed surfaces
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Only repo-specific, non-obvious guidance lives here.
 
 - This is Writer's original public `cerebro` repo. Do not describe it as a fork or downstream mirror.
 - The repo is Go, but many validations are repo-specific and should usually be run via `make`/DevEx wrappers rather than ad-hoc commands.
-- Go dependencies are vendored (`GOFLAGS=-mod=vendor`), so dependency changes should usually be checked with `make vendor-check`.
+- Go dependencies are module-managed; avoid dependency changes unless explicitly requested and validate them through the relevant `make` targets.
 
 ## Scope discipline
 
@@ -30,7 +30,7 @@ If you touch these areas, expect generated artifacts and compatibility checks:
 - CloudEvents docs/contracts
 - report contract docs/contracts
 - entity facet docs/contracts
-- Agent SDK docs/contracts/packages
+- SDK helper docs/packages
 - DevEx codegen catalog
 
 Check the corresponding `Makefile` `*-check` / `*-compat` targets before finishing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,11 @@ Thanks for contributing.
 
 1. Install Go 1.26+.
 2. Clone the repository.
-3. Download modules:
+3. Check and build the local toolchain:
 
 ```bash
-go mod download
+make doctor
+make build
 ```
 
 Run the lightweight server:
@@ -36,6 +37,14 @@ For CI-parity validation:
 
 ```bash
 make verify
+```
+
+For public docs, config, or example changes:
+
+```bash
+make readme-check
+make docs-drift-check
+make oss-audit
 ```
 
 ## Architecture Boundaries

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ sdk-typescript-check:
 	cd sdk/typescript && npm ci && npm run typecheck
 
 sdk-dependency-audit:
+	python3 -m unittest scripts.test_sdk_dependency_audit
 	python3 -m pip install --user pip-audit
 	python3 scripts/sdk_dependency_audit.py
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ The compose stack starts Cerebro with NATS JetStream, Postgres, and Neo4j using 
 | --- | --- | --- |
 | Run the lightweight server | `make serve` | Starts the API without external stores; useful for health, source catalog, and OpenAPI checks. |
 | Run the durable local stack | `docker compose up --build` | Starts Cerebro with NATS JetStream, Postgres, and Neo4j. |
+| Try a local end-to-end path | `docs/GETTING_STARTED.md` | Creates an SDK source runtime, writes a synthetic claim, and reads it back. |
 | Explore the API | `GET /openapi.yaml` or `api/openapi.yaml` | JSON HTTP routes are generated and checked against the OpenAPI contract. |
 | Call the Connect API | `proto/cerebro/v1/bootstrap.proto` and `gen/cerebro/v1` | Connect RPCs are served under `/cerebro.v1.BootstrapService/{Method}`. |
-| Use SDK helpers | `sdk/python`, `sdk/typescript`, and `sources/sdk` | Maintained helpers target current bootstrap routes; the historical Agent SDK gateway is retired. |
+| Use SDK helpers | `sdk/python/README.md`, `sdk/typescript/README.md`, and `sources/sdk` | Maintained helpers target current bootstrap routes; the historical Agent SDK gateway is retired. |
 | Preview a source | `./bin/cerebro source check/discover/read ...` | Source config is passed as `key=value` pairs or HTTP query parameters. |
 | Persist and sync a runtime | `source-runtime put/get/list/sync` | Requires Postgres; sync also requires JetStream. |
 | Work on graph behavior | `graph counts`, `graph health`, `graph ingest-runtime` | Requires Neo4j/Aura and, for runtime-backed operations, the configured runtime stores. |
@@ -380,6 +381,7 @@ Some files in `docs/` describe broader or historical architecture and may be ahe
 
 | Document | Notes |
 | --- | --- |
+| [Getting started](docs/GETTING_STARTED.md) | local durable stack plus SDK source runtime and claim-write walkthrough |
 | [API contracts](docs/API_CONTRACTS_AUTOGEN.md) | current bootstrap HTTP and Connect contract reference |
 | [API reference](docs/API_REFERENCE.md) | OpenAPI-oriented route reference |
 | [CloudEvents](docs/CLOUDEVENTS_AUTOGEN.md) | generated event contract reference |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Cerebro is Writer's original operations platform repository. The current `main` branch is centered on a Go bootstrap service with Connect and JSON HTTP APIs, built-in source integrations, source runtime sync, finding and report workflows, append-log replay, MCP access, device-authenticated telemetry, and optional graph projection/query tooling.
 
+In practical terms, Cerebro ingests source and runtime signals, turns them into claims, findings, reports, workflow events, and graph context, then exposes that substrate through the CLI, JSON HTTP, Connect RPC, SDK helpers, and MCP.
+
 [![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
@@ -17,7 +19,7 @@ Cerebro is Writer's original operations platform repository. The current `main` 
 - **Report runs** — report definitions can be listed and executed with durable run retrieval when a state store is configured.
 - **Workflow event replay** — knowledge decisions, actions, and outcomes can be written and replayed through append-log-backed projections.
 - **Graph operations** — Neo4j/Aura-backed graph counts, relation counts, neighborhoods, path summaries, impact queries, graph health, source/runtime ingest, ingest run status, repair/cleanup helpers, and isolated dry-run rebuilds.
-- **MCP and agent surfaces** — an authenticated MCP endpoint, optional OAuth 2.1 authorization-server flow for MCP clients, and an optional graph agent LLM adapter.
+- **MCP and graph-agent surfaces** — an authenticated MCP endpoint, optional OAuth 2.1 authorization-server flow for MCP clients, and an optional graph agent LLM adapter.
 - **Device telemetry surface** — optional first-party device enrollment, token, telemetry ingest, and device vulnerability finding routes.
 - **Policy catalog** — JSON policy definitions under `policies/` for cloud, identity, GitHub, Kubernetes, SaaS, runtime, vulnerability, compliance, and business-operation checks.
 
@@ -72,39 +74,40 @@ External dependency drivers are opt-in. With no external drivers configured, the
 - Optional: Postgres for durable source runtime, claim, finding, evidence, evaluation, and report state.
 - Optional: Neo4j or AuraDB for graph projection/query operations.
 
-### Build and verify
+### First run
 
 ```bash
 git clone https://github.com/writer/cerebro.git
 cd cerebro
 
+make doctor
 make build
-make test
-make verify
-```
-
-### Run locally
-
-```bash
 make serve
-# or
-./bin/cerebro serve
 ```
 
 By default, Cerebro listens on `:8080`.
+
+In another shell:
 
 ```bash
 curl -sS http://127.0.0.1:8080/health
 curl -sS http://127.0.0.1:8080/sources
 ```
 
-For a durable local stack that matches the bootstrap runtime dependencies, use Docker Compose:
+Run focused tests while iterating, then use CI-parity validation before broad PRs:
+
+```bash
+make test
+make verify
+```
+
+### Durable local stack
 
 ```bash
 docker compose up --build
 ```
 
-The compose stack starts Cerebro with NATS JetStream, Postgres, and Neo4j using the `CEREBRO_*` environment variables documented below.
+The compose stack starts Cerebro with NATS JetStream, Postgres, and Neo4j using service-local `CEREBRO_*` environment variables. For a standalone environment template, start from `.env.example`.
 
 ---
 
@@ -115,16 +118,21 @@ The compose stack starts Cerebro with NATS JetStream, Postgres, and Neo4j using 
 | Run the lightweight server | `make serve` | Starts the API without external stores; useful for health, source catalog, and OpenAPI checks. |
 | Run the durable local stack | `docker compose up --build` | Starts Cerebro with NATS JetStream, Postgres, and Neo4j. |
 | Explore the API | `GET /openapi.yaml` or `api/openapi.yaml` | JSON HTTP routes are generated and checked against the OpenAPI contract. |
+| Call the Connect API | `proto/cerebro/v1/bootstrap.proto` and `gen/cerebro/v1` | Connect RPCs are served under `/cerebro.v1.BootstrapService/{Method}`. |
+| Use SDK helpers | `sdk/python`, `sdk/typescript`, and `sources/sdk` | Maintained helpers target current bootstrap routes; the historical Agent SDK gateway is retired. |
 | Preview a source | `./bin/cerebro source check/discover/read ...` | Source config is passed as `key=value` pairs or HTTP query parameters. |
 | Persist and sync a runtime | `source-runtime put/get/list/sync` | Requires Postgres; sync also requires JetStream. |
 | Work on graph behavior | `graph counts`, `graph health`, `graph ingest-runtime` | Requires Neo4j/Aura and, for runtime-backed operations, the configured runtime stores. |
+| Integrate MCP clients | `docs/MCP_DROID_SETUP.md` and `/api/v1/mcp` | Covers stateless Streamable HTTP, OAuth discovery, and compatibility checks. |
+| Integrate endpoint telemetry | `docs/ENDPOINT_SECURITY_PLATFORM_INTEGRATION.md` | Covers device-authenticated telemetry, trusted endpoint claims, and trust-gate evidence. |
 | Author policies or finding rules | `policies/`, `internal/findings`, and catalog checks | Run the relevant catalog and finding-rule tests before opening a PR. |
+| Contribute code or docs | `docs/DEVELOPMENT.md`, `docs/NON_GOALS.md`, and the Makefile | Prefer focused `make` targets while iterating; use `make verify` for broad PR preflight. |
 
 ---
 
 ## Configuration
 
-The bootstrap binary currently reads core, auth, store, graph-agent, MCP OAuth, device-auth, and source-config environment variables through `internal/config`.
+The bootstrap binary currently reads core, auth, store, graph-agent, MCP OAuth, device-auth, and source-config environment variables through `internal/config`. Start from `.env.example` for a local template, and use `docs/CONFIG_ENV_VARS.md` as the expanded configuration reference.
 
 Core runtime and store variables:
 
@@ -286,6 +294,22 @@ When auth is enabled, only health/OpenAPI and OAuth/device metadata-style routes
 
 ---
 
+## SDK helpers
+
+Maintained SDK helpers live directly under `sdk/python` and `sdk/typescript`. They target the current bootstrap API surface for source runtime setup, claim writes, graph neighborhoods, and integration examples such as Jira posture onboarding.
+
+These helpers are separate from the retired historical Agent SDK gateway. Future SDK methods should start from the current HTTP/OpenAPI or Connect contracts, then add generated or hand-maintained helpers after the runtime route exists.
+
+Useful checks:
+
+```bash
+make sdk-test
+cd sdk/python && python3 -m unittest discover -s tests
+cd sdk/typescript && npm test
+```
+
+---
+
 ## Policies
 
 Policy definitions live under `policies/` as JSON files. The catalog includes cloud posture, identity governance, GitHub, Kubernetes, M365, Okta, runtime, vulnerability, compliance, and business-operation checks.
@@ -307,6 +331,8 @@ make verify         # CI-parity local verification
 make doctor         # check required local developer tools
 make release-smoke  # validate GoReleaser config
 make docker-smoke   # build the runtime Dockerfile locally
+make readme-check   # README drift checks
+make docs-drift-check  # generated docs drift checks
 make oss-audit      # public repository hygiene scan
 make clean          # remove bin/
 ```
@@ -316,19 +342,19 @@ Focused validation and utility targets include `make openapi-check`, `make opena
 Public-facing docs, config, or example changes should run:
 
 ```bash
-python3 scripts/oss_audit.py
+make oss-audit
 ```
 
 Choose validators by change type:
 
 | Change type | Minimum local validation |
 | --- | --- |
-| README-only | `git diff --check README.md` and `make oss-audit` |
+| README-only | `make readme-check` and `make oss-audit` |
 | Go runtime/API change | `make test` plus focused package tests |
 | OpenAPI route or handler change | `make openapi-check openapi-lint` |
 | Proto change | `make proto-lint` and generated contract checks when applicable |
 | Source catalog or policy change | `make catalog-check detection-catalog-check` |
-| Public docs/config/examples | `make oss-audit` |
+| Public docs/config/examples | `make docs-drift-check` when generated docs are touched, plus `make oss-audit` |
 | Broad PR preflight | `make verify` |
 
 ---
@@ -359,6 +385,7 @@ Some files in `docs/` describe broader or historical architecture and may be ahe
 | [CloudEvents](docs/CLOUDEVENTS_AUTOGEN.md) | generated event contract reference |
 | [Configuration](docs/CONFIGURATION.md) | configuration and deployment notes |
 | [MCP native Droid setup](docs/MCP_DROID_SETUP.md) | native Droid MCP setup, OAuth flow, transport compatibility, and troubleshooting |
+| [DevEx codegen catalog](docs/DEVEX_CODEGEN_AUTOGEN.md) | generated surface map for OpenAPI, proto, and detection catalog checks |
 | [Graph ontology](docs/GRAPH_ONTOLOGY_AUTOGEN.md) | generated graph ontology reference |
 | [Graph report contracts](docs/GRAPH_REPORT_CONTRACTS_AUTOGEN.md) | generated graph/report contract reference |
 | [Endpoint security platform integration](docs/ENDPOINT_SECURITY_PLATFORM_INTEGRATION.md) | trusted-endpoint, secheck, Security/Kairos, identity, telemetry, and trust-gate integration contract |
@@ -380,7 +407,7 @@ Some files in `docs/` describe broader or historical architecture and may be ahe
 | Append log | NATS JetStream |
 | State store | Postgres |
 | Graph store | Neo4j/Aura |
-| Source integrations | Aurelius, AWS, Azure, Backstage, Cosmo, GCP, GitHub, Google Workspace, GRC, Kandji, Kolide, Okta, SDK, SentinelOne, Security Tooling Map, VulnView |
+| Source integrations | Aurelius, AWS, Azure, Backstage, Cosmo, GCP, GitHub, Google Workspace, GRC, Kandji, Kolide, Okta, SDK, SentinelOne, Security Tooling Map, Trusted Endpoint, VulnView |
 | Validation | `go test`, `golangci-lint`, Buf, Spectral, catalog checks, OSS audit, custom structural linters, arch tests |
 
 ---

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,7 +13,8 @@ This document describes the current bootstrap service on `main`. Historical ware
 ```bash
 git clone https://github.com/writer/cerebro.git
 cd cerebro
-go mod download
+make doctor
+make build
 ```
 
 Run the lightweight server without durable stores:
@@ -28,7 +29,7 @@ Run the durable local stack with NATS JetStream, Postgres, Neo4j, and Cerebro:
 docker compose up --build
 ```
 
-The compose stack uses the same `CEREBRO_*` variables documented in `README.md`.
+The compose stack uses service-local `CEREBRO_*` variables. For a standalone local template, start from `.env.example`.
 
 ## Common Commands
 
@@ -39,6 +40,9 @@ make lint           # golangci-lint over app packages
 make proto-lint     # buf lint
 make check          # build, tests, lint, proto lint, structural checks, arch tests
 make verify         # CI-parity validation
+make readme-check   # README drift checks
+make docs-drift-check  # generated docs drift checks
+make oss-audit      # public repository hygiene scan
 make clean          # remove bin/
 ```
 
@@ -71,5 +75,11 @@ make check
 For public config, docs, or packaging changes, also run:
 
 ```bash
-python3 scripts/oss_audit.py
+make oss-audit
+```
+
+For generated docs changes, also run:
+
+```bash
+make docs-drift-check
 ```

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,106 @@
+# Getting Started
+
+This guide walks through a local, durable Cerebro run and a small SDK-style claim write. It uses the current bootstrap HTTP API and avoids provider credentials.
+
+## Start The Durable Stack
+
+```bash
+docker compose up --build
+```
+
+The stack exposes Cerebro on `http://127.0.0.1:8080` with NATS JetStream, Postgres, and Neo4j configured by the compose file.
+
+In another shell, check readiness and the source catalog:
+
+```bash
+curl -sS http://127.0.0.1:8080/health
+curl -sS http://127.0.0.1:8080/sources
+```
+
+## Create An SDK Source Runtime
+
+The `sdk` source is the generic push source for application-owned posture or inventory claims.
+
+```bash
+curl -sS -X PUT http://127.0.0.1:8080/source-runtimes/local-sdk-demo \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "runtime": {
+      "id": "local-sdk-demo",
+      "source_id": "sdk",
+      "tenant_id": "local",
+      "config": {
+        "integration": "demo"
+      }
+    }
+  }'
+```
+
+## Write A Synthetic Claim
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/source-runtimes/local-sdk-demo/claims \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "claims": [
+      {
+        "subject_urn": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api",
+        "subject_ref": {
+          "urn": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api",
+          "entity_type": "service",
+          "label": "Example API"
+        },
+        "predicate": "owner",
+        "object_value": "platform",
+        "claim_type": "attribute",
+        "source_event_id": "demo-claim-1"
+      }
+    ]
+  }'
+```
+
+Read the claim back:
+
+```bash
+curl -sS 'http://127.0.0.1:8080/source-runtimes/local-sdk-demo/claims?limit=10'
+```
+
+## Try The SDK Helpers
+
+Python:
+
+```bash
+cd sdk/python
+CEREBRO_BASE_URL=http://127.0.0.1:8080 \
+CEREBRO_TENANT_ID=local \
+CEREBRO_RUNTIME_ID=local-jira-posture \
+python3 examples/jira_posture_onboarding.py
+```
+
+TypeScript:
+
+```bash
+cd sdk/typescript
+npm ci
+npm test
+npm run typecheck
+```
+
+The TypeScript Jira posture example lives at `sdk/typescript/examples/jira_posture_onboarding.ts`. Run it with your preferred TypeScript runner, or use it as reference application code.
+
+## Validate Your Change
+
+For README or public docs changes:
+
+```bash
+make readme-check
+make docs-drift-check
+make oss-audit
+```
+
+For SDK helper changes:
+
+```bash
+make sdk-test
+make sdk-dependency-audit
+```

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -15,6 +15,8 @@ Durable local stack:
 docker compose up --build
 ```
 
+End-to-end local walkthrough: [`docs/GETTING_STARTED.md`](GETTING_STARTED.md).
+
 Health and source catalog:
 
 ```bash
@@ -75,6 +77,9 @@ Graph operations require Neo4j:
 make test
 make check
 make verify
+make readme-check
+make docs-drift-check
+make oss-audit
 ```
 
 Focused targets:

--- a/scripts/readme_check.py
+++ b/scripts/readme_check.py
@@ -104,6 +104,13 @@ def main() -> int:
             "This public repository is authoritative for runtime behavior",
             "Environment-specific deployment details",
             "cerebro-runtime-contract.json",
+            ".env.example",
+            "docs/CONFIG_ENV_VARS.md",
+            "docs/GETTING_STARTED.md",
+            "sdk/python/README.md",
+            "sdk/typescript/README.md",
+            "docs/MCP_DROID_SETUP.md",
+            "docs/ENDPOINT_SECURITY_PLATFORM_INTEGRATION.md",
         ],
     )
 

--- a/scripts/sdk_dependency_audit.py
+++ b/scripts/sdk_dependency_audit.py
@@ -6,7 +6,11 @@ from __future__ import annotations
 import pathlib
 import subprocess
 import tempfile
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 and earlier.
+    tomllib = None
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -18,8 +22,38 @@ def run(command: list[str], cwd: pathlib.Path | None = None) -> int:
 
 
 def python_requirements_from_pyproject(pyproject: pathlib.Path) -> list[str]:
-    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    text = pyproject.read_text(encoding="utf-8")
+    if tomllib is None:
+        return fallback_project_dependencies(text)
+    data = tomllib.loads(text)
     return list(data.get("project", {}).get("dependencies", []) or [])
+
+
+def fallback_project_dependencies(text: str) -> list[str]:
+    """Parse the simple [project].dependencies array used by sdk/python."""
+    in_project = False
+    in_dependencies = False
+    dependencies: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_project = line == "[project]"
+            in_dependencies = False
+            continue
+        if not in_project:
+            continue
+        if line.startswith("dependencies") and line.endswith("["):
+            in_dependencies = True
+            continue
+        if in_dependencies:
+            if line == "]":
+                return dependencies
+            value = line.rstrip(",").strip().strip('"').strip("'")
+            if value:
+                dependencies.append(value)
+    return dependencies
 
 
 def audit_python_sdk() -> int:

--- a/scripts/test_sdk_dependency_audit.py
+++ b/scripts/test_sdk_dependency_audit.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import sdk_dependency_audit
+
+
+class SDKDependencyAuditTest(unittest.TestCase):
+    def test_fallback_project_dependencies_reads_project_array(self) -> None:
+        pyproject = """
+[build-system]
+requires = ["setuptools"]
+
+[project]
+name = "example"
+dependencies = [
+  "protobuf>=5.29.5,<8",
+  "requests>=2.31",
+]
+
+[tool.example]
+dependencies = [
+  "ignored",
+]
+"""
+        self.assertEqual(
+            sdk_dependency_audit.fallback_project_dependencies(pyproject),
+            ["protobuf>=5.29.5,<8", "requests>=2.31"],
+        )
+
+    def test_python_requirements_uses_fallback_without_tomllib(self) -> None:
+        original_tomllib = sdk_dependency_audit.tomllib
+        try:
+            sdk_dependency_audit.tomllib = None
+            with tempfile.TemporaryDirectory() as tmpdir:
+                pyproject = Path(tmpdir) / "pyproject.toml"
+                pyproject.write_text(
+                    """
+[project]
+dependencies = [
+  "protobuf>=5.29.5,<8",
+]
+""",
+                    encoding="utf-8",
+                )
+                self.assertEqual(
+                    sdk_dependency_audit.python_requirements_from_pyproject(pyproject),
+                    ["protobuf>=5.29.5,<8"],
+                )
+        finally:
+            sdk_dependency_audit.tomllib = original_tomllib
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,66 @@
+# Cerebro Python SDK Helpers
+
+The Python helpers target the current Cerebro bootstrap API. They are maintained directly in this folder and are separate from the retired historical Agent SDK gateway.
+
+## Install For Local Development
+
+```bash
+cd sdk/python
+python3 -m pip install -e .
+```
+
+The package requires Python 3.10+ and currently depends on `protobuf`.
+
+## Client Basics
+
+```python
+from cerebro_sdk import Client
+
+client = Client(
+    base_url="http://127.0.0.1:8080",
+    api_key=None,  # Set when CEREBRO_API_AUTH_ENABLED=true.
+)
+
+integration = client.integration(
+    runtime_id="local-sdk-demo",
+    tenant_id="local",
+    integration="demo",
+)
+
+integration.ensure_runtime()
+claims = [
+    integration.attr(
+        integration.ref("service", "example-api", "Example API"),
+        "owner",
+        "platform",
+        source_event_id="demo-claim-1",
+    )
+]
+integration.write_claims(claims)
+```
+
+Useful environment variables for examples:
+
+```bash
+export CEREBRO_BASE_URL=http://127.0.0.1:8080
+export CEREBRO_API_KEY=
+export CEREBRO_TENANT_ID=local
+export CEREBRO_RUNTIME_ID=local-jira-posture
+```
+
+Run the Jira posture example against a local Cerebro stack:
+
+```bash
+python3 examples/jira_posture_onboarding.py
+```
+
+## Checks
+
+```bash
+python3 -m unittest discover -s tests
+# Or from the repository root:
+make sdk-python-test
+make sdk-dependency-audit
+```
+
+Use `make sdk-test` from the repository root when changes affect shared SDK behavior.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,0 +1,61 @@
+# Cerebro TypeScript SDK Helpers
+
+The TypeScript helpers target the current Cerebro bootstrap API. They are maintained directly in this folder and are separate from the retired historical Agent SDK gateway.
+
+## Install For Local Development
+
+```bash
+cd sdk/typescript
+npm ci
+```
+
+The package is ESM and exports the base client plus the Jira posture helper entrypoint.
+
+## Client Basics
+
+```typescript
+import { Client } from "@writer/cerebro-sdk";
+
+const client = new Client({
+  baseUrl: "http://127.0.0.1:8080",
+  apiKey: undefined, // Set when CEREBRO_API_AUTH_ENABLED=true.
+});
+
+const integration = client.integration({
+  runtimeId: "local-sdk-demo",
+  tenantId: "local",
+  integration: "demo",
+});
+
+await integration.ensureRuntime();
+const subject = integration.ref("service", "example-api", "Example API");
+await integration.writeClaims([
+  integration.attr(subject, "owner", "platform", {
+    source_event_id: "demo-claim-1",
+  }),
+]);
+```
+
+Useful environment variables for examples:
+
+```bash
+export CEREBRO_BASE_URL=http://127.0.0.1:8080
+export CEREBRO_API_KEY=
+export CEREBRO_TENANT_ID=local
+export CEREBRO_RUNTIME_ID=local-jira-posture
+```
+
+The Jira posture example lives at `examples/jira_posture_onboarding.ts`. Run it with your preferred TypeScript runner, or use the source as a reference for application onboarding.
+
+## Checks
+
+```bash
+npm test
+npm run typecheck
+# Or from the repository root:
+make sdk-typescript-test
+make sdk-typescript-check
+make sdk-dependency-audit
+```
+
+Use `make sdk-test` from the repository root when changes affect shared SDK behavior.


### PR DESCRIPTION
## Summary
- Clarify the README first-run path and durable local stack guidance.
- Route readers to current SDK, MCP, config, endpoint telemetry, and validation surfaces.
- Update agent guidance for module-managed dependencies and keep the SDK dependency audit compatible with hook Python versions.

## Test plan
- `make readme-check`
- `make docs-drift-check`
- `make oss-audit`
- `python3 scripts/sdk_dependency_audit.py`
- Pre-commit hooks


Made with [Cursor](https://cursor.com)