### PR TITLE
devex: add unified contracts check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 - Prefer repo `make` targets over ad-hoc commands.
 - Go dependencies are module-managed; avoid dependency changes unless explicitly requested and validate them through the relevant `make` targets.
-- Do not hand-edit generated or contract-governed outputs without running the matching `Makefile` check/sync target.
+- Do not hand-edit generated or contract-governed outputs without running `make contracts-check` or the matching focused `Makefile` check/sync target.
 - Public-facing config/example changes should run `make oss-audit`; generated docs changes should also run `make docs-drift-check`.
 
 ## Public PR Data Safety

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ If you touch these areas, expect generated artifacts and compatibility checks:
 - SDK helper docs/packages
 - DevEx codegen catalog
 
-Check the corresponding `Makefile` `*-check` / `*-compat` targets before finishing.
+Run `make contracts-check` before finishing broad contract changes, or the corresponding focused `Makefile` `*-check` / `*-compat` target for narrow changes.
 
 ## Runtime notes
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check docs-autogen docs-drift-check readme-check oss-audit govulncheck docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: help build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -214,6 +214,9 @@ oss-audit: ## Run repository OSS hygiene audit.
 
 govulncheck: ## Run govulncheck gate for reachable vulnerabilities.
 	python3 scripts/govulncheck_gate.py
+
+contracts-check: ## Run contract and compatibility checks with a final summary.
+	python3 scripts/contracts_check.py
 
 # ==== Release and Environment ====
 ##@ Release and Environment

--- a/scripts/contracts_check.py
+++ b/scripts/contracts_check.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Run contract-governed Make targets and summarize every result."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_TARGETS = [
+    "proto-lint",
+    "proto-generate-check",
+    "proto-breaking",
+    "openapi-check",
+    "openapi-lint",
+    "catalog-check",
+    "detection-catalog-check",
+    "docs-drift-check",
+    "readme-check",
+    "mcp-contract-check",
+    "mcp-sdk-compat",
+]
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    target: str
+    exit_code: int
+    duration_seconds: float
+
+
+def run_target(target: str) -> CheckResult:
+    print(f"\n==> make {target}", flush=True)
+    started = time.monotonic()
+    completed = subprocess.run(["make", target], cwd=ROOT, check=False)
+    return CheckResult(
+        target=target,
+        exit_code=completed.returncode,
+        duration_seconds=time.monotonic() - started,
+    )
+
+
+def print_summary(results: list[CheckResult]) -> None:
+    print("\nContract check summary:")
+    width = max(len(result.target) for result in results)
+    for result in results:
+        status = "PASS" if result.exit_code == 0 else "FAIL"
+        print(f"  {status:<4}  {result.target:<{width}}  {result.duration_seconds:6.1f}s")
+
+
+def main() -> int:
+    results = [run_target(target) for target in CONTRACT_TARGETS]
+    print_summary(results)
+    return 1 if any(result.exit_code != 0 for result in results) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `make contracts-check` to run contract-governed checks to completion and print a final PASS/FAIL table.
- Add `scripts/contracts_check.py` as the summary runner.
- Update agent guidance to point broad contract changes at the unified target.

Closes #427

## Test plan
- `python3 -m py_compile scripts/contracts_check.py`
- `make help`
- `git diff --check`
- `make contracts-check`

Made with [Cursor](https://cursor.com)