### PR TITLE
fix: split AWS assumed-role session actors

### DIFF
--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -570,7 +570,13 @@ func identityAuditProjections(event *cerebrov1.EventEnvelope, profile identityPr
 	links := map[string]*ports.ProjectedLink{}
 	actorEmail := firstNonEmpty(attributes["actor_email"], attributes["email"])
 	actorIdentifier := firstNonEmpty(actorEmail, attributes["actor_alternate_id"])
-	actorURN := identityUserURN(tenantID, provider, firstNonEmpty(attributes["actor_id"], actorIdentifier), actorIdentifier)
+	actorID := firstNonEmpty(attributes["actor_id"], actorIdentifier)
+	actorURN := identityUserURN(tenantID, provider, actorID, actorIdentifier)
+	actorEntityType := profile.entityType("user")
+	if isAWSAssumedRoleActor(profile, attributes["actor_type"], actorID) {
+		actorURN = projectionURN(tenantID, "aws_assumed_role_session", actorID)
+		actorEntityType = profile.entityType("assumed_role_session")
+	}
 	resourceID := firstNonEmpty(attributes["resource_id"], attributes["target_id"], attributes["app_id"], attributes["group_id"], attributes["role_id"])
 	resourceEmail := firstNonEmpty(attributes["resource_email"], attributes["target_email"])
 	if resourceID == "" && extractEmailIdentifier(attributes["target_alternate_id"]) != "" {
@@ -584,7 +590,7 @@ func identityAuditProjections(event *cerebrov1.EventEnvelope, profile identityPr
 			URN:        actorURN,
 			TenantID:   tenantID,
 			SourceID:   event.GetSourceId(),
-			EntityType: profile.entityType("user"),
+			EntityType: actorEntityType,
 			Label:      firstNonEmpty(attributes["actor_name"], actorEmail, attributes["actor_alternate_id"], attributes["actor_id"]),
 			Attributes: map[string]string{"email": actorEmail, "actor_id": strings.TrimSpace(attributes["actor_id"])},
 		})
@@ -619,6 +625,18 @@ func identityAuditProjections(event *cerebrov1.EventEnvelope, profile identityPr
 	}
 	addAzureResourceGroupLinks(entities, links, tenantID, event.GetSourceId(), event, profile, attributes, resourceURN)
 	return identityProjectionResult(entities, links)
+}
+
+func isAWSAssumedRoleActor(profile identityProjectionProfile, actorType string, actorID string) bool {
+	if profile.Provider != "aws" {
+		return false
+	}
+	normalizedType := normalizeIdentifier(actorType)
+	trimmedID := strings.TrimSpace(actorID)
+	return normalizedType == "assumedrole" ||
+		normalizedType == "assumed_role" ||
+		strings.Contains(trimmedID, ":assumed-role/") ||
+		(strings.HasPrefix(trimmedID, "ARO") && strings.Contains(trimmedID, ":"))
 }
 
 func identityProjectionResult(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -2371,7 +2371,13 @@ func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
 	if _, ok := state.links["urn:cerebro:writer:okta_user:00u1|"+relationRepresentsIdentity+"|"+canonicalIdentityURN]; !ok {
 		t.Fatalf("okta canonical identity link missing for %q", canonicalIdentityURN)
 	}
-	awsActorURN := "urn:cerebro:writer:aws_user:arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_admin/alice@writer.com"
+	awsActorURN := "urn:cerebro:writer:aws_assumed_role_session:arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_admin/alice@writer.com"
+	if entity := state.entities[awsActorURN]; entity == nil || entity.EntityType != "aws.assumed_role_session" {
+		t.Fatalf("aws assumed-role session entity = %#v, want aws.assumed_role_session", entity)
+	}
+	if _, ok := state.entities["urn:cerebro:writer:aws_user:arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_admin/alice@writer.com"]; ok {
+		t.Fatalf("aws assumed-role CloudTrail actor must not be projected as aws.user")
+	}
 	if _, ok := state.links[awsActorURN+"|"+relationRepresentsIdentity+"|"+canonicalIdentityURN]; !ok {
 		t.Fatalf("aws canonical identity link missing for %q", canonicalIdentityURN)
 	}
@@ -2467,7 +2473,13 @@ func TestProjectAWSCloudTrailActorEmailPreservesAlternateIdentifier(t *testing.T
 		t.Fatalf("Project() error = %v", err)
 	}
 
-	actorURN := "urn:cerebro:writer:aws_user:arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_admin/alice"
+	actorURN := "urn:cerebro:writer:aws_assumed_role_session:arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_admin/alice"
+	if entity := state.entities[actorURN]; entity == nil || entity.EntityType != "aws.assumed_role_session" {
+		t.Fatalf("aws assumed-role session entity = %#v, want aws.assumed_role_session", entity)
+	}
+	if _, ok := state.entities["urn:cerebro:writer:aws_user:arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_admin/alice"]; ok {
+		t.Fatalf("aws assumed-role CloudTrail actor must not be projected as aws.user")
+	}
 	emailIdentityURN := "urn:cerebro:writer:identity:email:alice@writer.com"
 	alternateIdentifierURN := "urn:cerebro:writer:identifier:login:awsreservedsso_admin/alice"
 	if _, ok := state.links[actorURN+"|"+relationRepresentsIdentity+"|"+emailIdentityURN]; !ok {


### PR DESCRIPTION
## Summary
- classify AWS CloudTrail assumed-role actors as session entities instead of durable user entities
- preserve identity and identifier links for assumed-role actor traversal
- add regression coverage to prevent assumed-role actors from projecting as user entities

## Tests
- go -C /Users/jonathan/writer-cerebro-full-improvements test ./internal/sourceprojection -count=1