### PR TITLE
feat: expand CorpSec source coverage

### DIFF
--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -164,7 +164,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 74 rules across cloud, identity, GitHub, GRC, runtime, endpoint, and vulnerability domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 76 rules across cloud, identity, GitHub, GRC, runtime, endpoint, and vulnerability domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/internal/findings/identity_okta_deprovisioned_active_cloud_rule.go
+++ b/internal/findings/identity_okta_deprovisioned_active_cloud_rule.go
@@ -1,0 +1,316 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var _ GraphRule = (*deprovisionedOktaActiveCloudAccessRule)(nil)
+
+const (
+	identityDeprovisionedOktaActiveCloudAccessRuleID = "identity-okta-deprovisioned-active-cloud-access"
+	identityDeprovisionedOktaActiveCloudAccessKind   = "finding.identity_okta_deprovisioned_active_cloud_access"
+	identityDeprovisionedOktaActiveCloudQueryLimit   = 500
+)
+
+var identityDeprovisionedOktaActiveCloudPrincipalTypes = []string{
+	grcOverlayEntityTypeAWSUser,
+	grcOverlayEntityTypeGCPUser,
+	grcOverlayEntityTypeAzureUser,
+	grcOverlayEntityTypeGoogleWorkspaceUser,
+}
+
+type deprovisionedOktaActiveCloudAccessRule struct {
+	definition RuleDefinition
+}
+
+func newDeprovisionedOktaActiveCloudAccessRule() Rule {
+	return &deprovisionedOktaActiveCloudAccessRule{
+		definition: RuleDefinition{
+			ID:          identityDeprovisionedOktaActiveCloudAccessRuleID,
+			Name:        "Deprovisioned Okta Identity Still Has Cloud Access",
+			Description: "Detect Okta identities marked deprovisioned, suspended, or inactive whose email-backed cloud/SaaS principal still has recent activity or privileged access.",
+			SourceID:    "okta",
+			EventKinds: []string{
+				"okta.user",
+				"aws.cloudtrail",
+				"aws.iam_role_assignment",
+				"aws.effective_permission",
+				"google_workspace.audit",
+				"google_workspace.role_assignment",
+				"gcp.audit",
+				"gcp.iam_role_assignment",
+				"gcp.effective_permission",
+				"azure.activity_log",
+				"azure.directory_role_assignment",
+				"azure.iam_role_assignment",
+				"azure.effective_permission",
+			},
+			OutputKind: identityDeprovisionedOktaActiveCloudAccessKind,
+			Severity:   "CRITICAL",
+			Status:     findingStatusOpen,
+			Maturity:   "test",
+			Tags: []string{
+				"identity",
+				"offboarding",
+				"cloud",
+				"graph-rule",
+				"attack.t1078",
+			},
+			References: []string{
+				"https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-user-lifecycle.htm",
+				"https://attack.mitre.org/techniques/T1078/",
+			},
+			FalsePositives: []string{
+				"Break-glass account intentionally retained during offboarding with a documented, time-bound exception.",
+				"Identity-provider or cloud-inventory sync lag immediately after a lifecycle transition.",
+			},
+			Runbook: "Confirm the Okta identity is offboarded, revoke the linked cloud/SaaS principal or its privileged grants, rotate credentials created by the account, and document any approved exception.",
+			FingerprintFields: []string{
+				"okta_user_urn",
+				"principal_urn",
+			},
+			ControlRefs: []ports.FindingControlRef{
+				{FrameworkName: "SOC 2", ControlID: "CC6.2"},
+				{FrameworkName: "SOC 2", ControlID: "CC6.6"},
+				{FrameworkName: "ISO 27001:2022", ControlID: "A.5.16"},
+				{FrameworkName: "ISO 27001:2022", ControlID: "A.5.18"},
+			},
+			Lifecycle: Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorGraphAnchored},
+		},
+	}
+}
+
+func (r *deprovisionedOktaActiveCloudAccessRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return proto.Clone(r.definition.RuleSpec()).(*cerebrov1.RuleSpec)
+}
+
+func (r *deprovisionedOktaActiveCloudAccessRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	sourceID := strings.ToLower(strings.TrimSpace(runtime.GetSourceId()))
+	family := strings.ToLower(strings.TrimSpace(runtime.GetConfig()["family"]))
+	switch sourceID {
+	case "okta":
+		return family == "user"
+	case "aws":
+		switch family {
+		case "cloudtrail", "access_key", "iam_role_assignment", "iam_role_trust", "effective_permission":
+			return true
+		}
+	case "google_workspace":
+		switch family {
+		case "audit", "role_assignment", "user":
+			return true
+		}
+	case "gcp":
+		switch family {
+		case "audit", "iam_role_assignment", "effective_permission", "service_account_impersonation":
+			return true
+		}
+	case "azure":
+		switch family {
+		case "activity_log", "directory_role_assignment", "iam_role_assignment", "effective_permission":
+			return true
+		}
+	}
+	return false
+}
+
+func (r *deprovisionedOktaActiveCloudAccessRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (r *deprovisionedOktaActiveCloudAccessRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
+	if runtime == nil {
+		return ports.CypherQueryRequest{}
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return ports.CypherQueryRequest{}
+	}
+	return ports.CypherQueryRequest{
+		Query: `MATCH (o:Entity {entity_type: 'okta.user', tenant_id: $tenant_id})
+      -[okta_identity:RELATION {relation: 'represents_identity'}]->(identity:Entity)
+      <-[principal_identity:RELATION {relation: 'represents_identity'}]-(principal:Entity {tenant_id: $tenant_id})
+WHERE principal.entity_type IN $principal_types
+  AND (toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"DEPROVISIONED"'
+    OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"SUSPENDED"'
+    OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"INACTIVE"')
+WITH o, okta_identity, identity, principal, principal_identity
+OPTIONAL MATCH (principal)-[access:RELATION]->(resource:Entity)
+WHERE access.relation IN $access_relations
+WITH o, okta_identity, identity, principal, principal_identity,
+     collect(DISTINCT {
+       relation: coalesce(access.relation, ''),
+       resource_urn: coalesce(resource.urn, ''),
+       resource_type: coalesce(resource.entity_type, ''),
+       resource_label: coalesce(resource.label, ''),
+       attributes_json: coalesce(access.attributes_json, '')
+     }) AS access_edges
+RETURN o.urn AS okta_user_urn,
+       o.label AS okta_user_label,
+       coalesce(o.attributes_json, '') AS okta_attributes_json,
+       identity.urn AS identity_urn,
+       identity.label AS identity_label,
+       principal.urn AS principal_urn,
+       principal.label AS principal_label,
+       principal.entity_type AS principal_entity_type,
+       coalesce(principal.attributes_json, '') AS principal_attributes_json,
+       coalesce(okta_identity.attributes_json, '') AS okta_identity_attributes_json,
+       coalesce(principal_identity.attributes_json, '') AS principal_identity_attributes_json,
+       access_edges
+LIMIT $row_limit`,
+		Params: map[string]any{
+			"tenant_id":        tenantID,
+			"principal_types":  identityDeprovisionedOktaActiveCloudPrincipalTypes,
+			"access_relations": grcOverlayActiveAccessRelations,
+			"row_limit":        int64(identityDeprovisionedOktaActiveCloudQueryLimit),
+		},
+		RowLimit: identityDeprovisionedOktaActiveCloudQueryLimit,
+	}
+}
+
+func (r *deprovisionedOktaActiveCloudAccessRule) EvaluateRows(_ context.Context, runtime *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {
+	if r == nil || runtime == nil || len(rows) == 0 {
+		return nil, nil
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return nil, nil
+	}
+	now := time.Now().UTC()
+	groups := map[string]*deprovisionedOktaActiveCloudGroup{}
+	keys := []string{}
+	for _, row := range rows {
+		oktaURN := cypherRowString(row, "okta_user_urn")
+		principalURN := cypherRowString(row, "principal_urn")
+		if oktaURN == "" || principalURN == "" {
+			continue
+		}
+		oktaStatus := extractOktaStatus(cypherRowString(row, "okta_attributes_json"))
+		if oktaStatus == "" {
+			continue
+		}
+		if !grcOverlayFreshEmailBridge(cypherRowString(row, "okta_identity_attributes_json"), cypherRowString(row, "principal_identity_attributes_json"), now) {
+			continue
+		}
+		accesses := grcOverlayAccessesFromRow(row, now, false)
+		if len(accesses) == 0 {
+			continue
+		}
+		key := oktaURN + "\x00" + principalURN
+		group, ok := groups[key]
+		if !ok {
+			group = &deprovisionedOktaActiveCloudGroup{
+				oktaUserURN:        oktaURN,
+				oktaUserLabel:      cypherRowString(row, "okta_user_label"),
+				oktaStatus:         oktaStatus,
+				identityURNs:       map[string]struct{}{},
+				identityLabels:     map[string]struct{}{},
+				principalURN:       principalURN,
+				principalLabel:     cypherRowString(row, "principal_label"),
+				principalType:      cypherRowString(row, "principal_entity_type"),
+				principalAttrsJSON: cypherRowString(row, "principal_attributes_json"),
+				accesses:           map[string]grcOverlayAccess{},
+			}
+			groups[key] = group
+			keys = append(keys, key)
+		}
+		if identityURN := cypherRowString(row, "identity_urn"); identityURN != "" {
+			group.identityURNs[identityURN] = struct{}{}
+		}
+		if identityLabel := cypherRowString(row, "identity_label"); identityLabel != "" {
+			group.identityLabels[identityLabel] = struct{}{}
+		}
+		for _, access := range accesses {
+			group.accesses[access.resourceURN+"|"+access.relation] = access
+		}
+	}
+	sort.Strings(keys)
+	findings := make([]*ports.FindingRecord, 0, len(keys))
+	for _, key := range keys {
+		group := groups[key]
+		if group == nil || len(group.accesses) == 0 {
+			continue
+		}
+		findings = append(findings, r.buildFinding(runtime, tenantID, group, now))
+	}
+	return findings, nil
+}
+
+type deprovisionedOktaActiveCloudGroup struct {
+	oktaUserURN        string
+	oktaUserLabel      string
+	oktaStatus         string
+	identityURNs       map[string]struct{}
+	identityLabels     map[string]struct{}
+	principalURN       string
+	principalLabel     string
+	principalType      string
+	principalAttrsJSON string
+	accesses           map[string]grcOverlayAccess
+}
+
+func (r *deprovisionedOktaActiveCloudAccessRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, group *deprovisionedOktaActiveCloudGroup, now time.Time) *ports.FindingRecord {
+	accessURNs, accessLabels, accessTypes, accessRelations := grcOverlayAccessTelemetry(group.accesses)
+	identityURNs := sortedKeys(group.identityURNs)
+	identityLabels := sortedKeys(group.identityLabels)
+	resourceURNs := deduplicateStrings(append(append([]string{group.oktaUserURN, group.principalURN}, identityURNs...), accessURNs...))
+	fingerprint := hashFindingFingerprint(r.definition.ID, tenantID, group.oktaUserURN, group.principalURN)
+	oktaLabel := firstNonEmpty(group.oktaUserLabel, group.oktaUserURN)
+	principalLabel := firstNonEmpty(group.principalLabel, group.principalURN)
+	summary := fmt.Sprintf("Deprovisioned Okta identity %s is still linked to %s principal %s with %d active access path(s)", oktaLabel, firstNonEmpty(group.principalType, "cloud"), principalLabel, len(group.accesses))
+	attributes := map[string]string{
+		"primary_resource_urn":   group.oktaUserURN,
+		"okta_user_urn":          group.oktaUserURN,
+		"okta_user_label":        group.oktaUserLabel,
+		"okta_status":            group.oktaStatus,
+		"identity_urns":          strings.Join(identityURNs, ","),
+		"identity_labels":        strings.Join(identityLabels, ","),
+		"principal_urn":          group.principalURN,
+		"principal_label":        group.principalLabel,
+		"principal_entity_type":  group.principalType,
+		"access_count":           fmt.Sprintf("%d", len(group.accesses)),
+		"access_resource_urns":   strings.Join(accessURNs, ","),
+		"access_resource_labels": strings.Join(accessLabels, ","),
+		"access_resource_types":  strings.Join(accessTypes, ","),
+		"access_relations":       strings.Join(accessRelations, ","),
+		"source_runtime_id":      strings.TrimSpace(runtime.GetId()),
+		"source_runtime_tenant":  tenantID,
+	}
+	for key, value := range r.definition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       strings.TrimSpace(runtime.GetId()),
+		RuleID:          r.definition.ID,
+		Title:           r.definition.Name,
+		Severity:        r.definition.Severity,
+		Status:          r.definition.Status,
+		Summary:         summary,
+		ResourceURNs:    resourceURNs,
+		ControlRefs:     cloneFindingControlRefs(r.definition.ControlRefs),
+		Attributes:      attributes,
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+		CheckID:         r.definition.ID,
+		CheckName:       r.definition.Name,
+	}
+}

--- a/internal/findings/identity_okta_deprovisioned_active_cloud_rule_test.go
+++ b/internal/findings/identity_okta_deprovisioned_active_cloud_rule_test.go
@@ -1,0 +1,145 @@
+package findings
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestDeprovisionedOktaActiveCloudAccessRuleQueryScopesByTenant(t *testing.T) {
+	rule := newDeprovisionedOktaActiveCloudAccessRule().(*deprovisionedOktaActiveCloudAccessRule)
+	request := rule.QueryFor(&cerebrov1.SourceRuntime{Id: "writer-okta-user", SourceId: "okta", TenantId: "writer"})
+	if request.Query == "" {
+		t.Fatal("QueryFor() returned empty query for fully-populated runtime")
+	}
+	if got := request.Params["tenant_id"]; got != "writer" {
+		t.Fatalf("Params[tenant_id] = %v, want writer", got)
+	}
+	if request.RowLimit != identityDeprovisionedOktaActiveCloudQueryLimit {
+		t.Fatalf("RowLimit = %d, want %d", request.RowLimit, identityDeprovisionedOktaActiveCloudQueryLimit)
+	}
+	if !strings.Contains(request.Query, "principal.entity_type IN $principal_types") {
+		t.Fatalf("Query does not scope joined principals to cloud/SaaS types:\n%s", request.Query)
+	}
+}
+
+func TestDeprovisionedOktaActiveCloudAccessRuleSupportsRelevantRuntimes(t *testing.T) {
+	rule := newDeprovisionedOktaActiveCloudAccessRule().(*deprovisionedOktaActiveCloudAccessRule)
+	withFamily := func(sourceID, family string) *cerebrov1.SourceRuntime {
+		return &cerebrov1.SourceRuntime{SourceId: sourceID, Config: map[string]string{"family": family}}
+	}
+	cases := map[string]struct {
+		runtime *cerebrov1.SourceRuntime
+		want    bool
+	}{
+		"okta user":                          {withFamily("okta", "user"), true},
+		"aws cloudtrail":                     {withFamily("aws", "cloudtrail"), true},
+		"aws effective permission":           {withFamily("aws", "effective_permission"), true},
+		"google workspace role assignment":   {withFamily("google_workspace", "role_assignment"), true},
+		"gcp iam role assignment":            {withFamily("gcp", "iam_role_assignment"), true},
+		"azure directory role assignment":    {withFamily("azure", "directory_role_assignment"), true},
+		"okta audit":                         {withFamily("okta", "audit"), false},
+		"github audit covered by other rule": {withFamily("github", "audit"), false},
+		"unrelated":                          {withFamily("sentinelone", "agent"), false},
+		"nil runtime":                        {nil, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := rule.SupportsRuntime(tc.runtime); got != tc.want {
+				t.Fatalf("SupportsRuntime() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeprovisionedOktaActiveCloudAccessRuleEvaluateRowsBuildsFinding(t *testing.T) {
+	rule := newDeprovisionedOktaActiveCloudAccessRule().(*deprovisionedOktaActiveCloudAccessRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-aws-cloudtrail", SourceId: "aws", TenantId: "writer"}
+	now := time.Now().UTC()
+	row := deprovisionedOktaActiveCloudRow(now)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if got := len(findings); got != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1", got)
+	}
+	finding := findings[0]
+	if finding.RuleID != identityDeprovisionedOktaActiveCloudAccessRuleID {
+		t.Fatalf("RuleID = %q, want %q", finding.RuleID, identityDeprovisionedOktaActiveCloudAccessRuleID)
+	}
+	if finding.Severity != "CRITICAL" {
+		t.Fatalf("Severity = %q, want CRITICAL", finding.Severity)
+	}
+	if got := finding.Attributes["okta_status"]; got != "DEPROVISIONED" {
+		t.Fatalf("okta_status = %q, want DEPROVISIONED", got)
+	}
+	if got := finding.Attributes["access_relations"]; got != grcOverlayAccessEdgeRelationCanAdmin {
+		t.Fatalf("access_relations = %q, want %q", got, grcOverlayAccessEdgeRelationCanAdmin)
+	}
+}
+
+func TestDeprovisionedOktaActiveCloudAccessRuleRequiresFreshEmailBridgeAndAccess(t *testing.T) {
+	rule := newDeprovisionedOktaActiveCloudAccessRule().(*deprovisionedOktaActiveCloudAccessRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-aws-cloudtrail", SourceId: "aws", TenantId: "writer"}
+	now := time.Now().UTC()
+
+	staleIdentity := deprovisionedOktaActiveCloudRow(now)
+	staleIdentity.Values["principal_identity_attributes_json"] = deprovisionedOktaRuleEmailIdentityAttrs(now.Add(-90 * 24 * time.Hour))
+
+	loginOnlyIdentity := deprovisionedOktaActiveCloudRow(now)
+	loginOnlyIdentity.Values["principal_identity_attributes_json"] = deprovisionedOktaRuleLoginIdentityAttrs(now)
+
+	noActionableAccess := deprovisionedOktaActiveCloudRow(now)
+	noActionableAccess.Values["access_edges"] = []any{map[string]any{
+		"relation":        grcOverlayAccessEdgeRelationActedOn,
+		"resource_urn":    "urn:cerebro:writer:aws_bucket:prod",
+		"resource_type":   "aws.s3.bucket",
+		"resource_label":  "prod",
+		"attributes_json": deprovisionedOktaActiveCloudJSON(map[string]string{"at": now.Add(-90 * 24 * time.Hour).Format(time.RFC3339)}),
+	}}
+
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{staleIdentity, loginOnlyIdentity, noActionableAccess})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 0: %#v", len(findings), findings)
+	}
+}
+
+func deprovisionedOktaActiveCloudRow(now time.Time) ports.CypherRow {
+	return ports.CypherRow{Values: map[string]any{
+		"okta_user_urn":                      "urn:cerebro:writer:okta.user:alice",
+		"okta_user_label":                    "alice@writer.com",
+		"okta_attributes_json":               `{"status":"DEPROVISIONED"}`,
+		"identity_urn":                       "urn:cerebro:writer:identity:email:alice@writer.com",
+		"identity_label":                     "alice@writer.com",
+		"principal_urn":                      "urn:cerebro:writer:aws.user:alice",
+		"principal_label":                    "alice",
+		"principal_entity_type":              grcOverlayEntityTypeAWSUser,
+		"principal_attributes_json":          `{"email":"alice@writer.com"}`,
+		"okta_identity_attributes_json":      deprovisionedOktaRuleEmailIdentityAttrs(now),
+		"principal_identity_attributes_json": deprovisionedOktaRuleEmailIdentityAttrs(now),
+		"access_edges": []any{map[string]any{
+			"relation":        grcOverlayAccessEdgeRelationCanAdmin,
+			"resource_urn":    "urn:cerebro:writer:aws_admin_role:admin",
+			"resource_type":   "aws.admin_role",
+			"resource_label":  "AdministratorAccess",
+			"attributes_json": "{}",
+		}},
+	}}
+}
+
+func deprovisionedOktaActiveCloudJSON(payload map[string]string) string {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -2752,6 +2752,72 @@
       ]
     },
     {
+      "id": "identity-okta-deprovisioned-active-cloud-access",
+      "pack_id": "identity",
+      "pack_name": "Identity",
+      "name": "Deprovisioned Okta Identity Still Has Cloud Access",
+      "description": "Detect Okta identities marked deprovisioned, suspended, or inactive whose email-backed cloud/SaaS principal still has recent activity or privileged access.",
+      "source_id": "okta",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "aws.cloudtrail",
+        "aws.effective_permission",
+        "aws.iam_role_assignment",
+        "azure.activity_log",
+        "azure.directory_role_assignment",
+        "azure.effective_permission",
+        "azure.iam_role_assignment",
+        "gcp.audit",
+        "gcp.effective_permission",
+        "gcp.iam_role_assignment",
+        "google_workspace.audit",
+        "google_workspace.role_assignment",
+        "okta.user"
+      ],
+      "output_kind": "finding.identity_okta_deprovisioned_active_cloud_access",
+      "severity": "CRITICAL",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "attack.t1078",
+        "cloud",
+        "graph-rule",
+        "identity",
+        "offboarding"
+      ],
+      "references": [
+        "https://attack.mitre.org/techniques/T1078/",
+        "https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-user-lifecycle.htm"
+      ],
+      "false_positives": [
+        "Break-glass account intentionally retained during offboarding with a documented, time-bound exception.",
+        "Identity-provider or cloud-inventory sync lag immediately after a lifecycle transition."
+      ],
+      "runbook": "Confirm the Okta identity is offboarded, revoke the linked cloud/SaaS principal or its privileged grants, rotate credentials created by the account, and document any approved exception.",
+      "fingerprint_fields": [
+        "okta_user_urn",
+        "principal_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC6.2"
+        },
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC6.6"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.5.16"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.5.18"
+        }
+      ]
+    },
+    {
       "id": "identity-okta-deprovisioned-active-in-github",
       "pack_id": "identity",
       "pack_name": "Identity",
@@ -3344,6 +3410,72 @@
         "Approved security testing, decommissioned endpoint, documented exception, or SentinelOne false positive reviewed by security."
       ],
       "runbook": "Review SentinelOne endpoint state, linked threat/activity evidence, policy scope, and documented exceptions before remediation or closure."
+    },
+    {
+      "id": "sentinelone-infected-endpoint-privileged-owner",
+      "pack_id": "sentinelone",
+      "pack_name": "SentinelOne",
+      "name": "Infected SentinelOne Endpoint Owned By Privileged Identity",
+      "description": "Detect active SentinelOne endpoint infection evidence where the endpoint owner resolves to a privileged identity in a connected control plane.",
+      "source_id": "sentinelone",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "aws.effective_permission",
+        "aws.iam_role_assignment",
+        "azure.directory_role_assignment",
+        "azure.effective_permission",
+        "azure.iam_role_assignment",
+        "gcp.effective_permission",
+        "gcp.iam_role_assignment",
+        "github.audit",
+        "google_workspace.role_assignment",
+        "okta.admin_role",
+        "sentinelone.agent",
+        "sentinelone.threat"
+      ],
+      "output_kind": "finding.sentinelone_infected_endpoint_privileged_owner",
+      "severity": "CRITICAL",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "attack.t1078",
+        "endpoint",
+        "graph-rule",
+        "identity",
+        "privilege",
+        "sentinelone"
+      ],
+      "references": [
+        "https://attack.mitre.org/techniques/T1078/",
+        "https://attack.mitre.org/techniques/T1566/"
+      ],
+      "false_positives": [
+        "Endpoint owner metadata is stale and no longer represents the current assignee.",
+        "Privileged role is break-glass only and disabled by compensating controls with documented exception."
+      ],
+      "runbook": "Prioritize containment of the infected endpoint, validate the owner identity's privileged grants, revoke or constrain active sessions, and rotate credentials used from the host.",
+      "fingerprint_fields": [
+        "agent_urn",
+        "principal_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC6.6"
+        },
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC7.2"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.5.16"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.8.7"
+        }
+      ]
     },
     {
       "id": "sentinelone-malicious-or-fileless-threat",

--- a/internal/findings/rule_metadata.go
+++ b/internal/findings/rule_metadata.go
@@ -150,6 +150,13 @@ func (r *deprovisionedOktaActiveGitHubRule) RuleMetadata() RuleDefinition {
 	return cloneRuleDefinition(r.definition)
 }
 
+func (r *deprovisionedOktaActiveCloudAccessRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
 func (r *githubActiveWithoutOktaLinkRule) RuleMetadata() RuleDefinition {
 	if r == nil {
 		return RuleDefinition{}
@@ -193,6 +200,13 @@ func (r *grcFailingControlOpenOperationalFindingsRule) RuleMetadata() RuleDefini
 }
 
 func (r *sentinelOneEndpointActiveInfectionGraphRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
+func (r *sentinelOneInfectedPrivilegedOwnerRule) RuleMetadata() RuleDefinition {
 	if r == nil {
 		return RuleDefinition{}
 	}

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -46,6 +46,7 @@ func builtinRulePacks() []RulePack {
 			Rules: append([]Rule{
 				newOktaPolicyRuleLifecycleTamperingRule(),
 				newDeprovisionedOktaActiveGitHubRule(),
+				newDeprovisionedOktaActiveCloudAccessRule(),
 				newGitHubActiveWithoutOktaLinkRule(),
 				newOktaOAuthPublicClientReviewRule(),
 				newOktaAuthenticatorWeakFactorRule(),
@@ -85,6 +86,7 @@ func builtinRulePacks() []RulePack {
 			Description: "SentinelOne endpoint posture, response, and protection-control findings.",
 			Rules: []Rule{
 				newSentinelOneEndpointActiveInfectionRule(),
+				newSentinelOneInfectedPrivilegedOwnerRule(),
 				newSentinelOneMitigationFailedRule(),
 				newSentinelOneAgentStaleRule(),
 				newSentinelOneAgentNotUpToDateRule(),

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -942,7 +942,7 @@ func TestNetNewRetiredRulesNoEmit(t *testing.T) {
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 36; got != want {
+	if got, want := len(keepRules), 38; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1203,6 +1203,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "identity-github-active-without-okta-link", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},
 		{RuleID: "identity-mfa-factor-reset-or-disabled", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "identity"},
 		{RuleID: "identity-okta-authenticator-weak-factor-enabled", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "identity"},
+		{RuleID: "identity-okta-deprovisioned-active-cloud-access", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "okta"},
 		{RuleID: "identity-okta-oauth-public-client-review-needed", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "identity"},
 		{RuleID: "identity-okta-threat-insight-not-blocking", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "identity"},
 		{RuleID: "identity-okta-deprovisioned-active-in-github", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "okta"},
@@ -1219,6 +1220,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "sentinelone-agent-not-up-to-date", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "sentinelone"},
 		{RuleID: "sentinelone-agent-stale", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "sentinelone"},
 		{RuleID: "sentinelone-endpoint-active-infection", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "sentinelone"},
+		{RuleID: "sentinelone-infected-endpoint-privileged-owner", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "sentinelone"},
 		{RuleID: "sentinelone-infected-endpoint", Classification: "RETIRE", BulkCloseoutThreshold: ">7d", Source: "sentinelone"},
 		{RuleID: "sentinelone-malicious-or-fileless-threat", Classification: "RETIRE", BulkCloseoutThreshold: ">7d", Source: "sentinelone"},
 		{RuleID: "sentinelone-mitigation-failed", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "sentinelone"},

--- a/internal/findings/sentinelone_privileged_owner_graph_rule.go
+++ b/internal/findings/sentinelone_privileged_owner_graph_rule.go
@@ -1,0 +1,338 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var _ GraphRule = (*sentinelOneInfectedPrivilegedOwnerRule)(nil)
+
+const (
+	sentinelOneInfectedPrivilegedOwnerRuleID = "sentinelone-infected-endpoint-privileged-owner"
+	sentinelOneInfectedPrivilegedOwnerKind   = "finding.sentinelone_infected_endpoint_privileged_owner"
+)
+
+var sentinelOnePrivilegedOwnerPrincipalTypes = []string{
+	grcOverlayEntityTypeOktaUser,
+	grcOverlayEntityTypeGitHubUser,
+	grcOverlayEntityTypeGoogleWorkspaceUser,
+	grcOverlayEntityTypeAWSUser,
+	grcOverlayEntityTypeGCPUser,
+	grcOverlayEntityTypeAzureUser,
+}
+
+type sentinelOneInfectedPrivilegedOwnerRule struct {
+	definition RuleDefinition
+}
+
+func newSentinelOneInfectedPrivilegedOwnerRule() Rule {
+	return &sentinelOneInfectedPrivilegedOwnerRule{
+		definition: RuleDefinition{
+			ID:          sentinelOneInfectedPrivilegedOwnerRuleID,
+			Name:        "Infected SentinelOne Endpoint Owned By Privileged Identity",
+			Description: "Detect active SentinelOne endpoint infection evidence where the endpoint owner resolves to a privileged identity in a connected control plane.",
+			SourceID:    "sentinelone",
+			EventKinds: []string{
+				"sentinelone.agent",
+				"sentinelone.threat",
+				"okta.admin_role",
+				"github.audit",
+				"google_workspace.role_assignment",
+				"aws.iam_role_assignment",
+				"aws.effective_permission",
+				"gcp.iam_role_assignment",
+				"gcp.effective_permission",
+				"azure.directory_role_assignment",
+				"azure.iam_role_assignment",
+				"azure.effective_permission",
+			},
+			OutputKind: sentinelOneInfectedPrivilegedOwnerKind,
+			Severity:   "CRITICAL",
+			Status:     findingStatusOpen,
+			Maturity:   "test",
+			Tags: []string{
+				"sentinelone",
+				"endpoint",
+				"identity",
+				"privilege",
+				"graph-rule",
+				"attack.t1078",
+			},
+			References: []string{
+				"https://attack.mitre.org/techniques/T1078/",
+				"https://attack.mitre.org/techniques/T1566/",
+			},
+			FalsePositives: []string{
+				"Endpoint owner metadata is stale and no longer represents the current assignee.",
+				"Privileged role is break-glass only and disabled by compensating controls with documented exception.",
+			},
+			Runbook: "Prioritize containment of the infected endpoint, validate the owner identity's privileged grants, revoke or constrain active sessions, and rotate credentials used from the host.",
+			FingerprintFields: []string{
+				"agent_urn",
+				"principal_urn",
+			},
+			ControlRefs: []ports.FindingControlRef{
+				{FrameworkName: "SOC 2", ControlID: "CC6.6"},
+				{FrameworkName: "SOC 2", ControlID: "CC7.2"},
+				{FrameworkName: "ISO 27001:2022", ControlID: "A.5.16"},
+				{FrameworkName: "ISO 27001:2022", ControlID: "A.8.7"},
+			},
+			Lifecycle: Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorGraphAnchored},
+		},
+	}
+}
+
+func (r *sentinelOneInfectedPrivilegedOwnerRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return proto.Clone(r.definition.RuleSpec()).(*cerebrov1.RuleSpec)
+}
+
+func (r *sentinelOneInfectedPrivilegedOwnerRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	sourceID := strings.ToLower(strings.TrimSpace(runtime.GetSourceId()))
+	family := strings.ToLower(strings.TrimSpace(runtime.GetConfig()["family"]))
+	switch sourceID {
+	case "sentinelone":
+		return family == "agent" || family == "threat"
+	case "okta":
+		return family == "admin_role" || family == "user"
+	case "github":
+		return family == "audit"
+	case "google_workspace":
+		return family == "role_assignment" || family == "user"
+	case "aws":
+		return family == "iam_role_assignment" || family == "effective_permission"
+	case "gcp":
+		return family == "iam_role_assignment" || family == "effective_permission"
+	case "azure":
+		return family == "directory_role_assignment" || family == "iam_role_assignment" || family == "effective_permission"
+	default:
+		return false
+	}
+}
+
+func (r *sentinelOneInfectedPrivilegedOwnerRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (r *sentinelOneInfectedPrivilegedOwnerRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
+	if runtime == nil {
+		return ports.CypherQueryRequest{}
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return ports.CypherQueryRequest{}
+	}
+	return ports.CypherQueryRequest{
+		Query: `MATCH (agent:Entity {entity_type: 'sentinelone.agent', tenant_id: $tenant_id})
+OPTIONAL MATCH (agent)-[affected:RELATION {relation: 'affected_by'}]->(threat:Entity {entity_type: 'sentinelone.threat', tenant_id: $tenant_id})
+WITH agent, collect({
+       urn: threat.urn,
+       label: coalesce(threat.label, ''),
+       entity_type: coalesce(threat.entity_type, ''),
+       attributes_json: coalesce(threat.attributes_json, ''),
+       affected_attributes_json: coalesce(affected.attributes_json, '')
+     }) AS threats
+MATCH (agent)-[owned:RELATION {relation: 'owned_by'}]->(identity:Entity)
+      <-[principal_identity:RELATION {relation: 'represents_identity'}]-(principal:Entity {tenant_id: $tenant_id})
+WHERE principal.entity_type IN $principal_types
+MATCH (principal)-[privilege:RELATION]->(privileged_resource:Entity)
+WHERE privilege.relation IN $privilege_relations
+WITH agent, threats, owned, identity, principal, principal_identity,
+     collect(DISTINCT {
+       relation: coalesce(privilege.relation, ''),
+       resource_urn: coalesce(privileged_resource.urn, ''),
+       resource_type: coalesce(privileged_resource.entity_type, ''),
+       resource_label: coalesce(privileged_resource.label, ''),
+       attributes_json: coalesce(privilege.attributes_json, '')
+     }) AS privilege_edges
+RETURN agent.urn AS agent_urn,
+       agent.label AS agent_label,
+       coalesce(agent.attributes_json, '') AS agent_attributes_json,
+       threats,
+       coalesce(owned.attributes_json, '') AS owned_attributes_json,
+       identity.urn AS identity_urn,
+       identity.label AS identity_label,
+       principal.urn AS principal_urn,
+       principal.label AS principal_label,
+       principal.entity_type AS principal_entity_type,
+       coalesce(principal_identity.attributes_json, '') AS principal_identity_attributes_json,
+       privilege_edges
+LIMIT $row_limit`,
+		Params: map[string]any{
+			"tenant_id":           tenantID,
+			"principal_types":     sentinelOnePrivilegedOwnerPrincipalTypes,
+			"privilege_relations": grcOverlayPrivilegedRelations,
+			"row_limit":           int64(sentinelOneGraphQueryRowLimit),
+		},
+		RowLimit: sentinelOneGraphQueryRowLimit,
+	}
+}
+
+func (r *sentinelOneInfectedPrivilegedOwnerRule) EvaluateRows(_ context.Context, runtime *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {
+	if r == nil || runtime == nil || len(rows) == 0 {
+		return nil, nil
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return nil, nil
+	}
+	now := time.Now().UTC()
+	groups := map[string]*sentinelOnePrivilegedOwnerGroup{}
+	keys := []string{}
+	for _, row := range rows {
+		agentURN := cypherRowString(row, "agent_urn")
+		principalURN := cypherRowString(row, "principal_urn")
+		if agentURN == "" || principalURN == "" {
+			continue
+		}
+		agentAttrs := edgeStringAttributes(cypherRowString(row, "agent_attributes_json"))
+		activeThreats := sentinelOneActiveThreatsFromRow(row)
+		agentInfected := findingAttributeBool(agentAttrs, "is_infected", "infected") || sentinelOneIntAttribute(agentAttrs, "active_threats") > 0
+		if !agentInfected && !sentinelOneGraphThreatsHaveInfectionEvidence(activeThreats) {
+			continue
+		}
+		if !edgeIsRecent(cypherRowString(row, "owned_attributes_json"), now, grcOverlayIdentityRecencyWindow) {
+			continue
+		}
+		principalIdentityJSON := cypherRowString(row, "principal_identity_attributes_json")
+		if !edgeIsRecent(principalIdentityJSON, now, grcOverlayIdentityRecencyWindow) || !identifierMatchIsEmail(principalIdentityJSON) {
+			continue
+		}
+		privileges := grcOverlayAccessesFromRowKey(row, "privilege_edges", now, true)
+		if len(privileges) == 0 {
+			continue
+		}
+		key := agentURN + "\x00" + principalURN
+		group, ok := groups[key]
+		if !ok {
+			group = &sentinelOnePrivilegedOwnerGroup{
+				agentURN:        agentURN,
+				agentLabel:      cypherRowString(row, "agent_label"),
+				agentAttrs:      agentAttrs,
+				identityURNs:    map[string]struct{}{},
+				identityLabels:  map[string]struct{}{},
+				principalURN:    principalURN,
+				principalLabel:  cypherRowString(row, "principal_label"),
+				principalType:   cypherRowString(row, "principal_entity_type"),
+				threats:         map[string]sentinelOneGraphThreat{},
+				privilegedEdges: map[string]grcOverlayAccess{},
+			}
+			groups[key] = group
+			keys = append(keys, key)
+		}
+		if identityURN := cypherRowString(row, "identity_urn"); identityURN != "" {
+			group.identityURNs[identityURN] = struct{}{}
+		}
+		if identityLabel := cypherRowString(row, "identity_label"); identityLabel != "" {
+			group.identityLabels[identityLabel] = struct{}{}
+		}
+		for _, threat := range activeThreats {
+			group.threats[threat.URN] = threat
+		}
+		for _, privilege := range privileges {
+			group.privilegedEdges[privilege.resourceURN+"|"+privilege.relation] = privilege
+		}
+	}
+	sort.Strings(keys)
+	findings := make([]*ports.FindingRecord, 0, len(keys))
+	for _, key := range keys {
+		group := groups[key]
+		if group == nil || len(group.privilegedEdges) == 0 {
+			continue
+		}
+		findings = append(findings, r.buildFinding(runtime, tenantID, group, now))
+	}
+	return findings, nil
+}
+
+type sentinelOnePrivilegedOwnerGroup struct {
+	agentURN        string
+	agentLabel      string
+	agentAttrs      map[string]string
+	identityURNs    map[string]struct{}
+	identityLabels  map[string]struct{}
+	principalURN    string
+	principalLabel  string
+	principalType   string
+	threats         map[string]sentinelOneGraphThreat
+	privilegedEdges map[string]grcOverlayAccess
+}
+
+func (r *sentinelOneInfectedPrivilegedOwnerRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, group *sentinelOnePrivilegedOwnerGroup, now time.Time) *ports.FindingRecord {
+	threatURNs := sortedKeysFromThreatMap(group.threats)
+	identityURNs := sortedKeys(group.identityURNs)
+	identityLabels := sortedKeys(group.identityLabels)
+	privilegeURNs, privilegeLabels, privilegeTypes, privilegeRelations := grcOverlayAccessTelemetry(group.privilegedEdges)
+	resourceURNs := deduplicateStrings(append(append(append([]string{group.agentURN, group.principalURN}, identityURNs...), threatURNs...), privilegeURNs...))
+	fingerprint := hashFindingFingerprint(r.definition.ID, tenantID, group.agentURN, group.principalURN)
+	agentLabel := firstNonEmpty(group.agentLabel, group.agentAttrs["computer_name"], group.agentURN)
+	principalLabel := firstNonEmpty(group.principalLabel, group.principalURN)
+	attributes := map[string]string{
+		"primary_resource_urn":       group.agentURN,
+		"agent_urn":                  group.agentURN,
+		"agent_label":                group.agentLabel,
+		"agent_id":                   group.agentAttrs["agent_id"],
+		"computer_name":              group.agentAttrs["computer_name"],
+		"is_infected":                group.agentAttrs["is_infected"],
+		"active_threats":             firstNonEmpty(group.agentAttrs["active_threats"], fmt.Sprintf("%d", len(group.threats))),
+		"active_threat_count":        fmt.Sprintf("%d", len(group.threats)),
+		"active_threat_urns":         strings.Join(threatURNs, ","),
+		"identity_urns":              strings.Join(identityURNs, ","),
+		"identity_labels":            strings.Join(identityLabels, ","),
+		"principal_urn":              group.principalURN,
+		"principal_label":            group.principalLabel,
+		"principal_entity_type":      group.principalType,
+		"privileged_resource_urns":   strings.Join(privilegeURNs, ","),
+		"privileged_resource_labels": strings.Join(privilegeLabels, ","),
+		"privileged_resource_types":  strings.Join(privilegeTypes, ","),
+		"privileged_relations":       strings.Join(privilegeRelations, ","),
+		"source_runtime_id":          strings.TrimSpace(runtime.GetId()),
+		"source_runtime_tenant":      tenantID,
+	}
+	for key, value := range r.definition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       strings.TrimSpace(runtime.GetId()),
+		RuleID:          r.definition.ID,
+		Title:           r.definition.Name,
+		Severity:        r.definition.Severity,
+		Status:          r.definition.Status,
+		Summary:         fmt.Sprintf("Infected SentinelOne endpoint %s is owned by privileged %s identity %s", agentLabel, firstNonEmpty(group.principalType, "external"), principalLabel),
+		ResourceURNs:    resourceURNs,
+		ControlRefs:     cloneFindingControlRefs(r.definition.ControlRefs),
+		Attributes:      attributes,
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+		CheckID:         r.definition.ID,
+		CheckName:       r.definition.Name,
+	}
+}
+
+func sortedKeysFromThreatMap(values map[string]sentinelOneGraphThreat) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if strings.TrimSpace(key) != "" {
+			keys = append(keys, strings.TrimSpace(key))
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/findings/sentinelone_privileged_owner_graph_rule_test.go
+++ b/internal/findings/sentinelone_privileged_owner_graph_rule_test.go
@@ -1,0 +1,121 @@
+package findings
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestSentinelOneInfectedPrivilegedOwnerRuleEvaluateRowsBuildsFinding(t *testing.T) {
+	rule := newSentinelOneInfectedPrivilegedOwnerRule().(*sentinelOneInfectedPrivilegedOwnerRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-threat", SourceId: "sentinelone", TenantId: "writer", Config: map[string]string{"family": "threat"}}
+	row := sentinelOnePrivilegedOwnerRow(time.Now().UTC())
+
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if got := len(findings); got != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1", got)
+	}
+	finding := findings[0]
+	if finding.RuleID != sentinelOneInfectedPrivilegedOwnerRuleID {
+		t.Fatalf("RuleID = %q, want %q", finding.RuleID, sentinelOneInfectedPrivilegedOwnerRuleID)
+	}
+	if finding.Severity != "CRITICAL" {
+		t.Fatalf("Severity = %q, want CRITICAL", finding.Severity)
+	}
+	if got := finding.Attributes["principal_urn"]; got != "urn:cerebro:writer:okta.user:alice" {
+		t.Fatalf("principal_urn = %q", got)
+	}
+	if got := finding.Attributes["privileged_relations"]; got != grcOverlayAccessEdgeRelationCanAdmin {
+		t.Fatalf("privileged_relations = %q, want %q", got, grcOverlayAccessEdgeRelationCanAdmin)
+	}
+}
+
+func TestSentinelOneInfectedPrivilegedOwnerRuleRequiresInfectionFreshOwnerAndPrivilege(t *testing.T) {
+	rule := newSentinelOneInfectedPrivilegedOwnerRule().(*sentinelOneInfectedPrivilegedOwnerRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-threat", SourceId: "sentinelone", TenantId: "writer", Config: map[string]string{"family": "threat"}}
+	now := time.Now().UTC()
+
+	clean := sentinelOnePrivilegedOwnerRow(now)
+	clean.Values["agent_attributes_json"] = sentinelOneTestJSON(map[string]string{"agent_id": "agent-1", "computer_name": "mac-1", "is_infected": "false", "active_threats": "0"})
+	clean.Values["threats"] = []any{}
+
+	staleOwner := sentinelOnePrivilegedOwnerRow(now)
+	staleOwner.Values["owned_attributes_json"] = sentinelOneTestJSON(map[string]string{"at": now.Add(-90 * 24 * time.Hour).Format(time.RFC3339), "match_type": "sentinelone_owner_email"})
+
+	noPrivilege := sentinelOnePrivilegedOwnerRow(now)
+	noPrivilege.Values["privilege_edges"] = []any{map[string]any{
+		"relation":        grcOverlayAccessEdgeRelationCanPerform,
+		"resource_urn":    "urn:cerebro:writer:cloud_resource:read-only",
+		"resource_type":   "cloud.resource",
+		"resource_label":  "ReadOnly",
+		"attributes_json": sentinelOneTestJSON(map[string]string{"permission": "read"}),
+	}}
+
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{clean, staleOwner, noPrivilege})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 0: %#v", len(findings), findings)
+	}
+}
+
+func TestSentinelOneInfectedPrivilegedOwnerRuleSupportsRelevantRuntimes(t *testing.T) {
+	rule := newSentinelOneInfectedPrivilegedOwnerRule().(*sentinelOneInfectedPrivilegedOwnerRule)
+	withFamily := func(sourceID, family string) *cerebrov1.SourceRuntime {
+		return &cerebrov1.SourceRuntime{SourceId: sourceID, Config: map[string]string{"family": family}}
+	}
+	cases := map[string]struct {
+		runtime *cerebrov1.SourceRuntime
+		want    bool
+	}{
+		"sentinelone agent":                {withFamily("sentinelone", "agent"), true},
+		"sentinelone threat":               {withFamily("sentinelone", "threat"), true},
+		"okta admin role":                  {withFamily("okta", "admin_role"), true},
+		"google workspace role assignment": {withFamily("google_workspace", "role_assignment"), true},
+		"aws effective permission":         {withFamily("aws", "effective_permission"), true},
+		"azure directory role assignment":  {withFamily("azure", "directory_role_assignment"), true},
+		"sentinelone application":          {withFamily("sentinelone", "application"), false},
+		"github dependabot":                {withFamily("github", "dependabot_alert"), false},
+		"nil runtime":                      {nil, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := rule.SupportsRuntime(tc.runtime); got != tc.want {
+				t.Fatalf("SupportsRuntime() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func sentinelOnePrivilegedOwnerRow(now time.Time) ports.CypherRow {
+	row := sentinelOneInfectionRow("agent-1", "mac-1", map[string]string{
+		"agent_id":       "agent-1",
+		"computer_name":  "mac-1",
+		"is_infected":    "true",
+		"active_threats": "1",
+	}, []map[string]string{
+		{"threat_id": "threat-1", "threat_name": "malware-a", "incident_status": "unresolved", "mitigation_status": "not_mitigated", "classification": "Malware"},
+	})
+	row.Values["owned_attributes_json"] = sentinelOneTestJSON(map[string]string{"at": now.Format(time.RFC3339), "match_type": "sentinelone_owner_email"})
+	row.Values["identity_urn"] = "urn:cerebro:writer:identity:email:alice@writer.com"
+	row.Values["identity_label"] = "alice@writer.com"
+	row.Values["principal_urn"] = "urn:cerebro:writer:okta.user:alice"
+	row.Values["principal_label"] = "alice@writer.com"
+	row.Values["principal_entity_type"] = grcOverlayEntityTypeOktaUser
+	row.Values["principal_identity_attributes_json"] = deprovisionedOktaRuleEmailIdentityAttrs(now)
+	row.Values["privilege_edges"] = []any{map[string]any{
+		"relation":        grcOverlayAccessEdgeRelationCanAdmin,
+		"resource_urn":    "urn:cerebro:writer:okta_admin_role:super-admin",
+		"resource_type":   "okta.admin_role",
+		"resource_label":  "Super Admin",
+		"attributes_json": "{}",
+	}}
+	return row
+}

--- a/sources/azure/deploy.yaml
+++ b/sources/azure/deploy.yaml
@@ -1,0 +1,168 @@
+sourceId: azure
+secretKeys:
+  - AZURE_ARM_TOKEN
+  - AZURE_GRAPH_TOKEN
+  - AZURE_SUBSCRIPTION_ID
+  - AZURE_TENANT_ID
+runtimes:
+  - localId: activity-log
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: activity_log
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: aks-cluster
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: aks_cluster
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: app-service
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: app_service
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: application
+    config:
+      family: application
+      graph_token: env:AZURE_GRAPH_TOKEN
+      per_page: "100"
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: asset-metadata
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: asset_metadata
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: container-registry
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: container_registry
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: cosmos-account
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: cosmos_account
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: credential
+    config:
+      family: credential
+      graph_token: env:AZURE_GRAPH_TOKEN
+      per_page: "100"
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: directory-audit
+    config:
+      family: directory_audit
+      graph_token: env:AZURE_GRAPH_TOKEN
+      per_page: "100"
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: directory-role-assignment
+    config:
+      family: directory_role_assignment
+      graph_token: env:AZURE_GRAPH_TOKEN
+      per_page: "100"
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: effective-permission
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: effective_permission
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: function-app
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: function_app
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: group
+    config:
+      family: group
+      graph_token: env:AZURE_GRAPH_TOKEN
+      per_page: "100"
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: iam-role-assignment
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: iam_role_assignment
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: key-vault
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: key_vault
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: key-vault-key
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: key_vault_key
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: key-vault-secret
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: key_vault_secret
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: resource-exposure
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: resource_exposure
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: service-principal
+    config:
+      family: service_principal
+      graph_token: env:AZURE_GRAPH_TOKEN
+      per_page: "100"
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: sql-database
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: sql_database
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: sql-server
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: sql_server
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: storage-account
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: storage_account
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: user
+    config:
+      family: user
+      graph_token: env:AZURE_GRAPH_TOKEN
+      per_page: "100"
+      tenant_id: env:AZURE_TENANT_ID
+  - localId: virtual-machine
+    config:
+      arm_token: env:AZURE_ARM_TOKEN
+      family: virtual_machine
+      per_page: "100"
+      subscription_id: env:AZURE_SUBSCRIPTION_ID
+      tenant_id: env:AZURE_TENANT_ID

--- a/sources/gcp/deploy.yaml
+++ b/sources/gcp/deploy.yaml
@@ -1,0 +1,136 @@
+sourceId: gcp
+secretKeys:
+  - GCP_ARTIFACT_REPOSITORY
+  - GCP_CUSTOMER_ID
+  - GCP_GROUP_KEY
+  - GCP_KEY_RING
+  - GCP_KMS_LOCATION
+  - GCP_PROJECT_ID
+  - GCP_SERVICE_ACCOUNT_EMAIL
+  - GCP_TOKEN
+runtimes:
+  - localId: asset-metadata
+    config:
+      family: asset_metadata
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: artifact-registry-image
+    config:
+      artifact_repository: env:GCP_ARTIFACT_REPOSITORY
+      family: artifact_registry_image
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: artifact-registry-repository
+    config:
+      family: artifact_registry_repository
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: audit
+    config:
+      family: audit
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: cloud-function
+    config:
+      family: cloud_function
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: cloud-run-service
+    config:
+      family: cloud_run_service
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: cloud-sql-instance
+    config:
+      family: cloud_sql_instance
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: compute-instance
+    config:
+      family: compute_instance
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: effective-permission
+    config:
+      family: effective_permission
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: gcs-bucket
+    config:
+      family: gcs_bucket
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: gke-cluster
+    config:
+      family: gke_cluster
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: group
+    config:
+      customer_id: env:GCP_CUSTOMER_ID
+      family: group
+      per_page: "100"
+      token: env:GCP_TOKEN
+  - localId: group-membership
+    config:
+      family: group_membership
+      group_key: env:GCP_GROUP_KEY
+      per_page: "100"
+      token: env:GCP_TOKEN
+  - localId: iam-role-assignment
+    config:
+      family: iam_role_assignment
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: kms-key
+    config:
+      family: kms_key
+      key_ring: env:GCP_KEY_RING
+      location: env:GCP_KMS_LOCATION
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: resource-exposure
+    config:
+      family: resource_exposure
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: secret-manager-secret
+    config:
+      family: secret_manager_secret
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: service-account
+    config:
+      family: service_account
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      token: env:GCP_TOKEN
+  - localId: service-account-impersonation
+    config:
+      family: service_account_impersonation
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      service_account_email: env:GCP_SERVICE_ACCOUNT_EMAIL
+      token: env:GCP_TOKEN
+  - localId: service-account-key
+    config:
+      family: service_account_key
+      per_page: "100"
+      project_id: env:GCP_PROJECT_ID
+      service_account_email: env:GCP_SERVICE_ACCOUNT_EMAIL
+      token: env:GCP_TOKEN

--- a/sources/github/deploy.yaml
+++ b/sources/github/deploy.yaml
@@ -8,3 +8,22 @@ runtimes:
       owner: writer
       per_page: "100"
       token: env:GITHUB_TOKEN
+  - localId: repository
+    config:
+      family: repository
+      owner: writer
+      per_page: "100"
+      token: env:GITHUB_TOKEN
+  - localId: org-inventory
+    config:
+      family: org_inventory
+      owner: writer
+      per_page: "100"
+      token: env:GITHUB_TOKEN
+  - localId: secret-scanning-alert
+    config:
+      family: secret_scanning_alert
+      owner: writer
+      per_page: "100"
+      state: open
+      token: env:GITHUB_TOKEN

--- a/sources/googleworkspace/deploy.yaml
+++ b/sources/googleworkspace/deploy.yaml
@@ -1,0 +1,43 @@
+sourceId: google_workspace
+secretKeys:
+  - GOOGLE_WORKSPACE_CUSTOMER_ID
+  - GOOGLE_WORKSPACE_DOMAIN
+  - GOOGLE_WORKSPACE_GROUP_KEY
+  - GOOGLE_WORKSPACE_TOKEN
+runtimes:
+  - localId: audit
+    config:
+      customer_id: env:GOOGLE_WORKSPACE_CUSTOMER_ID
+      domain: env:GOOGLE_WORKSPACE_DOMAIN
+      family: audit
+      per_page: "100"
+      token: env:GOOGLE_WORKSPACE_TOKEN
+  - localId: group
+    config:
+      customer_id: env:GOOGLE_WORKSPACE_CUSTOMER_ID
+      domain: env:GOOGLE_WORKSPACE_DOMAIN
+      family: group
+      per_page: "100"
+      token: env:GOOGLE_WORKSPACE_TOKEN
+  - localId: group-member
+    config:
+      customer_id: env:GOOGLE_WORKSPACE_CUSTOMER_ID
+      domain: env:GOOGLE_WORKSPACE_DOMAIN
+      family: group_member
+      group_key: env:GOOGLE_WORKSPACE_GROUP_KEY
+      per_page: "100"
+      token: env:GOOGLE_WORKSPACE_TOKEN
+  - localId: role-assignment
+    config:
+      customer_id: env:GOOGLE_WORKSPACE_CUSTOMER_ID
+      domain: env:GOOGLE_WORKSPACE_DOMAIN
+      family: role_assignment
+      per_page: "100"
+      token: env:GOOGLE_WORKSPACE_TOKEN
+  - localId: user
+    config:
+      customer_id: env:GOOGLE_WORKSPACE_CUSTOMER_ID
+      domain: env:GOOGLE_WORKSPACE_DOMAIN
+      family: user
+      per_page: "100"
+      token: env:GOOGLE_WORKSPACE_TOKEN

--- a/sources/kolide/deploy.yaml
+++ b/sources/kolide/deploy.yaml
@@ -21,6 +21,12 @@ runtimes:
       family: vulnerability
       per_page: "100"
       token: env:KOLIDE_API_TOKEN
+  - localId: user-device
+    config:
+      base_url: env:KOLIDE_BASE_URL
+      family: user_device
+      per_page: "100"
+      token: env:KOLIDE_API_TOKEN
   - localId: check
     config:
       base_url: env:KOLIDE_BASE_URL

--- a/sources/sentinelone/deploy.yaml
+++ b/sources/sentinelone/deploy.yaml
@@ -21,3 +21,27 @@ runtimes:
       family: application
       per_page: "50"
       token: env:SENTINELONE_API_TOKEN
+  - localId: exclusion
+    config:
+      base_url: env:SENTINELONE_BASE_URL
+      family: exclusion
+      per_page: "200"
+      token: env:SENTINELONE_API_TOKEN
+  - localId: group
+    config:
+      base_url: env:SENTINELONE_BASE_URL
+      family: group
+      per_page: "200"
+      token: env:SENTINELONE_API_TOKEN
+  - localId: site
+    config:
+      base_url: env:SENTINELONE_BASE_URL
+      family: site
+      per_page: "200"
+      token: env:SENTINELONE_API_TOKEN
+  - localId: activity
+    config:
+      base_url: env:SENTINELONE_BASE_URL
+      family: activity
+      per_page: "200"
+      token: env:SENTINELONE_API_TOKEN

--- a/sources/trustedendpoint/deploy.yaml
+++ b/sources/trustedendpoint/deploy.yaml
@@ -1,0 +1,5 @@
+sourceId: trusted_endpoint
+runtimes:
+  - localId: telemetry
+    config:
+      integration: trusted_endpoint

--- a/tools/archtests/source_deploy_test.go
+++ b/tools/archtests/source_deploy_test.go
@@ -15,9 +15,15 @@ import (
 // not own runtimes (e.g. push-only SDK adapters, infrastructure scanners
 // driven by the orchestrator default command) are exempt by being absent.
 var requireDeployManifest = map[string]struct{}{
-	"github":      {},
-	"okta":        {},
-	"sentinelone": {},
+	"azure":            {},
+	"gcp":              {},
+	"github":           {},
+	"google_workspace": {},
+	"kandji":           {},
+	"kolide":           {},
+	"okta":             {},
+	"sentinelone":      {},
+	"trusted_endpoint": {},
 }
 
 func TestSourceDeployManifestsAreValid(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add source deploy manifests for additional CorpSec integrations and expand existing runtime manifests.
- Add graph findings for deprovisioned identity cloud access and infected endpoints owned by privileged identities.
- Update rule metadata, rulepack audit coverage, and the public detection catalog.

## Validation
- make test
- make lint
- make catalog-check detection-catalog-check check-arch