### PR TITLE
fix: address aws network substrate feedback

### DIFF
--- a/internal/sourceprojection/aws_network.go
+++ b/internal/sourceprojection/aws_network.go
@@ -7,6 +7,10 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
+type awsNetworkSubstrateContext func(map[string]*ports.ProjectedEntity, map[string]*ports.ProjectedLink, string, string, *cerebrov1.EventEnvelope, string, map[string]string)
+
+type awsNetworkSubstrateExtra func(map[string]*ports.ProjectedEntity, map[string]*ports.ProjectedLink, string, string, *cerebrov1.EventEnvelope, map[string]string)
+
 func awsGlobalAcceleratorAcceleratorProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return awsCloudResourceProjections(event)
 }
@@ -24,7 +28,7 @@ func awsSecurityGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 }
 
 func awsRouteTableProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return awsNetworkSubstrateProjections(event, func(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, resourceURN string, event *cerebrov1.EventEnvelope, attributes map[string]string) {
+	return awsNetworkSubstrateProjectionsWithContext(event, addAWSNetworkVPCContextLink, func(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, resourceURN string, event *cerebrov1.EventEnvelope, attributes map[string]string) {
 		sourceID := event.GetSourceId()
 		accountID := strings.TrimSpace(attributes["domain"])
 		for _, subnetID := range splitCloudAttributeList(attributes["subnet_ids"]) {
@@ -65,7 +69,11 @@ func awsVPCEndpointProjections(event *cerebrov1.EventEnvelope) ([]*ports.Project
 	})
 }
 
-func awsNetworkSubstrateProjections(event *cerebrov1.EventEnvelope, extra func(map[string]*ports.ProjectedEntity, map[string]*ports.ProjectedLink, string, string, *cerebrov1.EventEnvelope, map[string]string)) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+func awsNetworkSubstrateProjections(event *cerebrov1.EventEnvelope, extra awsNetworkSubstrateExtra) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return awsNetworkSubstrateProjectionsWithContext(event, addAWSNetworkContextLinks, extra)
+}
+
+func awsNetworkSubstrateProjectionsWithContext(event *cerebrov1.EventEnvelope, contextLinks awsNetworkSubstrateContext, extra awsNetworkSubstrateExtra) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	entities, links, err := awsCloudResourceProjections(event)
 	if err != nil {
 		return nil, nil, err
@@ -82,11 +90,22 @@ func awsNetworkSubstrateProjections(event *cerebrov1.EventEnvelope, extra func(m
 	if resourceURN == "" {
 		return identityProjectionResult(entityMap, linkMap)
 	}
-	addAWSNetworkContextLinks(entityMap, linkMap, tenantID, event.GetSourceId(), event, resourceURN, attributes)
+	if contextLinks != nil {
+		contextLinks(entityMap, linkMap, tenantID, event.GetSourceId(), event, resourceURN, attributes)
+	}
 	if extra != nil {
 		extra(entityMap, linkMap, tenantID, resourceURN, event, attributes)
 	}
 	return identityProjectionResult(entityMap, linkMap)
+}
+
+func addAWSNetworkVPCContextLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, resourceURN string, attributes map[string]string) {
+	accountID := strings.TrimSpace(attributes["domain"])
+	vpcURN := addAWSNetworkNode(entities, tenantID, sourceID, "aws_vpc", "aws.vpc", firstNonEmpty(attributes["vpc_id"], attributes["vpc"]), accountID)
+	if vpcURN != "" {
+		addLink(links, projectedLink(tenantID, sourceID, resourceURN, vpcURN, relationBelongsTo, map[string]string{"event_id": event.GetId(), "match_type": "aws_compute_vpc"}))
+		addCloudAccountLink(entities, links, tenantID, sourceID, event, vpcURN, accountID, "aws")
+	}
 }
 
 func awsNetworkSubstrateVPCOnlyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/aws_network_test.go
+++ b/internal/sourceprojection/aws_network_test.go
@@ -223,6 +223,7 @@ func TestProjectAWSNetworkSubstrateRelationships(t *testing.T) {
 	assertProjectedLink(t, state, securityGroupURN, relationBelongsTo, vpcURN)
 	assertProjectedLink(t, state, routeTableURN, relationBelongsTo, vpcURN)
 	assertProjectedLink(t, state, routeTableURN, relationAssociatedWith, subnetURN)
+	assertProjectedLinkMissing(t, state, routeTableURN, relationBelongsTo, subnetURN)
 	assertProjectedLink(t, state, routeTableURN, relationDependsOn, "urn:cerebro:writer:aws_internet_gateway:igw-123")
 	assertProjectedLink(t, state, routeTableURN, relationDependsOn, "urn:cerebro:writer:aws_nat_gateway:nat-123")
 	assertProjectedLink(t, state, vpcEndpointURN, relationBelongsTo, vpcURN)

--- a/sources/aws/network_substrate.go
+++ b/sources/aws/network_substrate.go
@@ -50,7 +50,7 @@ func listSecurityGroups(ctx context.Context, clients awsClients, _ settings, cur
 
 func listRouteTables(ctx context.Context, clients awsClients, _ settings, cursor string, limit int) ([]ec2types.RouteTable, string, error) {
 	out, err := clients.ec2.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
-		MaxResults: awssdk.Int32(int32(boundedAWSPageSize(limit, 5, 1000))),
+		MaxResults: awssdk.Int32(int32(boundedAWSPageSize(limit, 5, 100))),
 		NextToken:  stringPtr(cursor),
 	})
 	if err != nil {

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -3342,6 +3342,22 @@ func TestExpandedAWSGraphFamiliesUseExpectedAPIs(t *testing.T) {
 	}
 }
 
+func TestListRouteTablesCapsMaxResultsAtAWSLimit(t *testing.T) {
+	fake := &recordingAWS{}
+	_, _, err := listRouteTables(context.Background(), awsClients{
+		awsPlatformClients: awsPlatformClients{ec2: fake},
+	}, settings{}, "", 200)
+	if err != nil {
+		t.Fatalf("listRouteTables() error = %v", err)
+	}
+	if len(fake.routeTableMaxResults) != 1 {
+		t.Fatalf("DescribeRouteTables calls = %d, want 1", len(fake.routeTableMaxResults))
+	}
+	if got := fake.routeTableMaxResults[0]; got != 100 {
+		t.Fatalf("DescribeRouteTables MaxResults = %d, want 100", got)
+	}
+}
+
 func TestReadAWSNetworkInterfacePublicEndpointIncludesAttachedInstance(t *testing.T) {
 	endpoints, _, err := listNetworkInterfacePublicEndpoints(context.Background(), awsClients{
 		awsPlatformClients: awsPlatformClients{
@@ -4087,7 +4103,8 @@ type fakeAWSCompute struct {
 
 type recordingAWS struct {
 	fakeAWS
-	calls []string
+	calls                []string
+	routeTableMaxResults []int32
 }
 
 func (f *recordingAWS) record(action string) {
@@ -4311,6 +4328,7 @@ func (f *recordingAWS) DescribeSubnets(ctx context.Context, input *ec2.DescribeS
 
 func (f *recordingAWS) DescribeRouteTables(ctx context.Context, input *ec2.DescribeRouteTablesInput, options ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
 	f.record("ec2:DescribeRouteTables")
+	f.routeTableMaxResults = append(f.routeTableMaxResults, awssdk.ToInt32(input.MaxResults))
 	return f.fakeAWS.DescribeRouteTables(ctx, input, options...)
 }
 


### PR DESCRIPTION
## Summary
- cap route table pagination at the EC2 DescribeRouteTables limit
- avoid emitting conflicting route-table subnet projection edges
- add regression coverage for both review findings

## Validation
- go test ./sources/aws ./internal/sourceprojection/...
- make lint check-structural check-arch catalog-check