### PR TITLE
test: harden governance safety guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
             command: make build
           - name: test
             command: make test
+          - name: coverage
+            command: make cover
           - name: sdk
             command: make sdk-test
           - name: sdk-dependency-audit

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build serve test sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: help build serve test cover sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -14,6 +14,8 @@ README_CHECK_BASE ?= origin/main
 DOCKER_SMOKE_IMAGE ?= cerebro-runtime-smoke:local
 DOCKER_SMOKE_GOARCH ?= amd64
 APP_PACKAGES := ./api/... ./cmd/... ./internal/... ./sources/...
+COVER_PACKAGES ?= ./internal/runtimeresponse ./internal/graphagent ./internal/deviceauth ./internal/sourceprojection ./internal/findings
+COVERAGE_OUT ?= tmp/coverage.out
 LINTER_MODULE := ./tools/linters
 LINTER_BIN := $(GO_BIN)/cerebrolint
 WORKFLOW_E2E_PACKAGES := ./internal/workflowevents ./internal/workflowprojection ./internal/knowledge ./internal/findings ./internal/bootstrap
@@ -69,6 +71,11 @@ serve: build ## Build and run the local HTTP server.
 
 test: ## Run all Go tests.
 	go test ./...
+
+cover: ## Run Go coverage for high-stakes packages.
+	mkdir -p "$(dir $(COVERAGE_OUT))"
+	go test -covermode=atomic -coverprofile="$(COVERAGE_OUT)" $(COVER_PACKAGES)
+	go tool cover -func="$(COVERAGE_OUT)"
 
 sdk-test: sdk-python-test sdk-typescript-test sdk-typescript-check ## Run all SDK tests and type checks.
 

--- a/docs/NON_GOALS.md
+++ b/docs/NON_GOALS.md
@@ -158,7 +158,7 @@ Each section lists what Cerebro will not do, why that boundary exists, where in 
 
 - The Agent primitive composes Events, Streams, Views, Rules, and Actions under a policy. It does not get a private path to mutate Postgres or Neo4j. It does not author Cypher writes. It does not call Actions without going through the typed Action contract, including approval gates and trusted actuation scope where required.
 - Why: autonomous remediation is the failure mode that justifies most of the safety surface in Cerebro. Letting an Agent route around any of it would erase the reason the safety surface exists.
-- Enforced in: Agent contract in [`PLAN.md`](../PLAN.md) §4; `internal/graphagent/validator.go`; trusted actuation scope checks in `internal/runtime`.
+- Enforced in: Agent contract in [`PLAN.md`](../PLAN.md) §4; `internal/graphagent/validator.go`; trusted runtime-response scope derivation in `internal/bootstrap/auth.go` and mutation gating in `internal/runtimeresponse`.
 - What would change this: nothing structural. Agent capabilities grow by adding typed Actions and Rules, not by widening Agent's direct surface.
 
 ## Runtime Response

--- a/internal/runtimeresponse/service_test.go
+++ b/internal/runtimeresponse/service_test.go
@@ -1,0 +1,180 @@
+package runtimeresponse
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type recordingRuntimeBlocklistStore struct {
+	putEntries []ports.RuntimeBlocklistEntry
+}
+
+func (s *recordingRuntimeBlocklistStore) Ping(context.Context) error {
+	return nil
+}
+
+func (s *recordingRuntimeBlocklistStore) PutRuntimeBlocklistEntry(_ context.Context, entry ports.RuntimeBlocklistEntry) (*ports.RuntimeBlocklistEntry, error) {
+	s.putEntries = append(s.putEntries, entry)
+	return &s.putEntries[len(s.putEntries)-1], nil
+}
+
+func (s *recordingRuntimeBlocklistStore) ListRuntimeBlocklistEntries(context.Context, ports.RuntimeBlocklistFilter) ([]*ports.RuntimeBlocklistEntry, error) {
+	return nil, nil
+}
+
+func (s *recordingRuntimeBlocklistStore) RevokeRuntimeBlocklistEntry(context.Context, string, string) (*ports.RuntimeBlocklistEntry, error) {
+	return nil, ports.ErrRuntimeBlocklistEntryNotFound
+}
+
+func TestExecuteRequiresTrustedScopeBeforeMutation(t *testing.T) {
+	store := &recordingRuntimeBlocklistStore{}
+	service := New(store)
+
+	_, err := service.Execute(context.Background(), ExecuteRequest{
+		TenantID: "writer",
+		Action:   ActionBlockIP,
+		Target:   "192.0.2.1",
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Execute() error = %v, want ErrInvalidRequest", err)
+	}
+	if len(store.putEntries) != 0 {
+		t.Fatalf("Execute() wrote %d blocklist entries without trusted scope", len(store.putEntries))
+	}
+}
+
+func TestExecutePersistsTrustedIPBlock(t *testing.T) {
+	store := &recordingRuntimeBlocklistStore{}
+	service := New(store)
+
+	entry, err := service.Execute(context.Background(), ExecuteRequest{
+		TenantID:     " writer ",
+		Action:       " " + ActionBlockIP + " ",
+		Target:       " 192.0.2.1 ",
+		Reason:       " suspicious traffic ",
+		Source:       " finding ",
+		SourceJobID:  " job-1 ",
+		TrustedScope: true,
+		Attributes:   map[string]string{"rule_id": "rule-1"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(store.putEntries) != 1 {
+		t.Fatalf("PutRuntimeBlocklistEntry calls = %d, want 1", len(store.putEntries))
+	}
+	if entry.ID == "" || !strings.HasPrefix(entry.ID, "rr-") {
+		t.Fatalf("entry ID = %q, want rr-*", entry.ID)
+	}
+	if entry.TenantID != "writer" || entry.Type != "ip" || entry.Value != "192.0.2.1" {
+		t.Fatalf("entry = %#v, want normalized writer ip 192.0.2.1", entry)
+	}
+	if entry.Reason != "suspicious traffic" || entry.Source != "finding" || entry.SourceJobID != "job-1" {
+		t.Fatalf("entry metadata was not trimmed: %#v", entry)
+	}
+}
+
+func TestExecutePersistsTrustedDomainBlock(t *testing.T) {
+	store := &recordingRuntimeBlocklistStore{}
+	service := New(store)
+
+	entry, err := service.Execute(context.Background(), ExecuteRequest{
+		TenantID:     "writer",
+		Action:       ActionBlockDomain,
+		Target:       " Example.COM. ",
+		TrustedScope: true,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if entry.Type != "domain" || entry.Value != "example.com" {
+		t.Fatalf("entry = %#v, want normalized domain example.com", entry)
+	}
+}
+
+func TestExecuteRejectsInvalidRequestsBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name    string
+		request ExecuteRequest
+		wantErr error
+	}{
+		{
+			name: "missing tenant",
+			request: ExecuteRequest{
+				Action:       ActionBlockIP,
+				Target:       "192.0.2.1",
+				TrustedScope: true,
+			},
+			wantErr: ErrInvalidRequest,
+		},
+		{
+			name: "missing target",
+			request: ExecuteRequest{
+				TenantID:     "writer",
+				Action:       ActionBlockIP,
+				TrustedScope: true,
+			},
+			wantErr: ErrInvalidRequest,
+		},
+		{
+			name: "invalid ip",
+			request: ExecuteRequest{
+				TenantID:     "writer",
+				Action:       ActionBlockIP,
+				Target:       "not-an-ip",
+				TrustedScope: true,
+			},
+			wantErr: ErrInvalidRequest,
+		},
+		{
+			name: "invalid domain",
+			request: ExecuteRequest{
+				TenantID:     "writer",
+				Action:       ActionBlockDomain,
+				Target:       "example..com",
+				TrustedScope: true,
+			},
+			wantErr: ErrInvalidRequest,
+		},
+		{
+			name: "unsupported action",
+			request: ExecuteRequest{
+				TenantID:     "writer",
+				Action:       "scale_down",
+				Target:       "runtime-1",
+				TrustedScope: true,
+			},
+			wantErr: ErrUnsupportedAction,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &recordingRuntimeBlocklistStore{}
+			service := New(store)
+			_, err := service.Execute(context.Background(), tt.request)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Execute() error = %v, want %v", err, tt.wantErr)
+			}
+			if len(store.putEntries) != 0 {
+				t.Fatalf("Execute() wrote %d blocklist entries for invalid request", len(store.putEntries))
+			}
+		})
+	}
+}
+
+func TestCapabilitiesRequireTrustedScope(t *testing.T) {
+	capabilities := New(&recordingRuntimeBlocklistStore{}).Capabilities()
+	if len(capabilities) == 0 {
+		t.Fatal("Capabilities() returned no capabilities")
+	}
+	for _, capability := range capabilities {
+		if !capability.RequiresScope {
+			t.Fatalf("capability %s does not require trusted scope", capability.Action)
+		}
+	}
+}

--- a/internal/sourceprojection/aws_network_test.go
+++ b/internal/sourceprojection/aws_network_test.go
@@ -219,15 +219,27 @@ func TestProjectAWSNetworkSubstrateRelationships(t *testing.T) {
 	routeTableURN := "urn:cerebro:writer:aws_route_table:rtb-123"
 	vpcEndpointURN := "urn:cerebro:writer:aws_vpc_endpoint:vpce-123"
 	vpcURN := "urn:cerebro:writer:aws_vpc:vpc-123"
-	assertProjectedLink(t, state, subnetURN, relationBelongsTo, vpcURN)
-	assertProjectedLink(t, state, securityGroupURN, relationBelongsTo, vpcURN)
-	assertProjectedLink(t, state, routeTableURN, relationBelongsTo, vpcURN)
-	assertProjectedLink(t, state, routeTableURN, relationAssociatedWith, subnetURN)
-	assertProjectedLinkMissing(t, state, routeTableURN, relationBelongsTo, subnetURN)
-	assertProjectedLink(t, state, routeTableURN, relationDependsOn, "urn:cerebro:writer:aws_internet_gateway:igw-123")
-	assertProjectedLink(t, state, routeTableURN, relationDependsOn, "urn:cerebro:writer:aws_nat_gateway:nat-123")
-	assertProjectedLink(t, state, vpcEndpointURN, relationBelongsTo, vpcURN)
-	assertProjectedLink(t, state, vpcEndpointURN, relationBelongsTo, subnetURN)
-	assertProjectedLink(t, state, vpcEndpointURN, relationMemberOf, securityGroupURN)
-	assertProjectedLink(t, state, vpcEndpointURN, relationAssociatedWith, routeTableURN)
+	accountURN := "urn:cerebro:writer:cloud_account:123456789012"
+	classificationURN := "urn:cerebro:writer:data_classification"
+	assertProjectedLinkSet(t, state,
+		wantProjectedLink(subnetURN, relationBelongsTo, accountURN),
+		wantProjectedLink(subnetURN, relationBelongsTo, vpcURN),
+		wantProjectedLink(subnetURN, relationHasClassification, classificationURN),
+		wantProjectedLink(securityGroupURN, relationBelongsTo, accountURN),
+		wantProjectedLink(securityGroupURN, relationBelongsTo, vpcURN),
+		wantProjectedLink(securityGroupURN, relationHasClassification, classificationURN),
+		wantProjectedLink(routeTableURN, relationBelongsTo, accountURN),
+		wantProjectedLink(routeTableURN, relationBelongsTo, vpcURN),
+		wantProjectedLink(routeTableURN, relationHasClassification, classificationURN),
+		wantProjectedLink(vpcURN, relationBelongsTo, accountURN),
+		wantProjectedLink(routeTableURN, relationAssociatedWith, subnetURN),
+		wantProjectedLink(routeTableURN, relationDependsOn, "urn:cerebro:writer:aws_internet_gateway:igw-123"),
+		wantProjectedLink(routeTableURN, relationDependsOn, "urn:cerebro:writer:aws_nat_gateway:nat-123"),
+		wantProjectedLink(vpcEndpointURN, relationBelongsTo, accountURN),
+		wantProjectedLink(vpcEndpointURN, relationBelongsTo, vpcURN),
+		wantProjectedLink(vpcEndpointURN, relationBelongsTo, subnetURN),
+		wantProjectedLink(vpcEndpointURN, relationHasClassification, classificationURN),
+		wantProjectedLink(vpcEndpointURN, relationMemberOf, securityGroupURN),
+		wantProjectedLink(vpcEndpointURN, relationAssociatedWith, routeTableURN),
+	)
 }

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -3,6 +3,7 @@ package sourceprojection
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -4324,6 +4325,71 @@ func assertProjectedLinkMissing(t *testing.T, recorder *projectionRecorder, from
 	if _, ok := recorder.links[key]; ok {
 		t.Fatalf("projected link %q unexpectedly present; links=%v", key, recorder.links)
 	}
+}
+
+type projectedLinkExpectation struct {
+	fromURN  string
+	relation string
+	toURN    string
+}
+
+func wantProjectedLink(fromURN string, relation string, toURN string) projectedLinkExpectation {
+	return projectedLinkExpectation{fromURN: fromURN, relation: relation, toURN: toURN}
+}
+
+func assertProjectedLinkSet(t *testing.T, recorder *projectionRecorder, want ...projectedLinkExpectation) {
+	t.Helper()
+	actualKeys := make([]string, 0, len(recorder.links))
+	for key := range recorder.links {
+		actualKeys = append(actualKeys, key)
+	}
+	wantKeys := make([]string, 0, len(want))
+	for _, link := range want {
+		wantKeys = append(wantKeys, link.fromURN+"|"+link.relation+"|"+link.toURN)
+	}
+	sort.Strings(actualKeys)
+	sort.Strings(wantKeys)
+	if stringSlicesEqual(actualKeys, wantKeys) {
+		return
+	}
+	t.Fatalf("projected link set mismatch\nmissing:\n%s\nunexpected:\n%s\nactual:\n%s",
+		formatProjectedLinkKeys(diffStringSlices(wantKeys, actualKeys)),
+		formatProjectedLinkKeys(diffStringSlices(actualKeys, wantKeys)),
+		formatProjectedLinkKeys(actualKeys),
+	)
+}
+
+func stringSlicesEqual(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func diffStringSlices(left []string, right []string) []string {
+	rightSet := map[string]struct{}{}
+	for _, value := range right {
+		rightSet[value] = struct{}{}
+	}
+	var diff []string
+	for _, value := range left {
+		if _, ok := rightSet[value]; !ok {
+			diff = append(diff, value)
+		}
+	}
+	return diff
+}
+
+func formatProjectedLinkKeys(keys []string) string {
+	if len(keys) == 0 {
+		return "(none)"
+	}
+	return strings.Join(keys, "\n")
 }
 
 func mustJSON(t *testing.T, value any) []byte {

--- a/tools/archtests/non_goals_test.go
+++ b/tools/archtests/non_goals_test.go
@@ -1,0 +1,106 @@
+package archtests
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+var (
+	nonGoalsMarkdownLinkRE = regexp.MustCompile(`\[[^\]]+\]\(([^)]+)\)`)
+	nonGoalsCodeSpanRE     = regexp.MustCompile("`([^`]+)`")
+)
+
+func TestNonGoalsEnforcedInPointersResolve(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "docs", "NON_GOALS.md"))
+	if err != nil {
+		t.Fatalf("read NON_GOALS.md: %v", err)
+	}
+	var missing []string
+	for lineNumber, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "- Enforced in:") {
+			continue
+		}
+		for _, ref := range nonGoalsEnforcedInRefs(line) {
+			path := nonGoalsPointerPath(root, ref)
+			if path == "" {
+				continue
+			}
+			if _, err := os.Stat(path); err != nil {
+				missing = append(missing, filepath.ToSlash(ref)+": line "+strconvLine(lineNumber+1))
+			}
+		}
+	}
+	if len(missing) != 0 {
+		sort.Strings(missing)
+		t.Fatalf("docs/NON_GOALS.md Enforced in pointers must resolve:\n%s", strings.Join(missing, "\n"))
+	}
+}
+
+func nonGoalsEnforcedInRefs(line string) []string {
+	seen := map[string]struct{}{}
+	var refs []string
+	add := func(ref string) {
+		ref = strings.TrimSpace(ref)
+		if ref == "" || !nonGoalsLooksLikeRepoPath(ref) {
+			return
+		}
+		if _, ok := seen[ref]; ok {
+			return
+		}
+		seen[ref] = struct{}{}
+		refs = append(refs, ref)
+	}
+	for _, match := range nonGoalsMarkdownLinkRE.FindAllStringSubmatch(line, -1) {
+		add(match[1])
+	}
+	for _, match := range nonGoalsCodeSpanRE.FindAllStringSubmatch(line, -1) {
+		add(match[1])
+	}
+	return refs
+}
+
+func nonGoalsLooksLikeRepoPath(ref string) bool {
+	ref = strings.TrimSpace(strings.Split(ref, "#")[0])
+	ref = strings.TrimPrefix(ref, "./")
+	ref = strings.TrimPrefix(ref, "../")
+	if ref == "" || strings.HasPrefix(ref, "/") || strings.Contains(ref, "*") {
+		return false
+	}
+	first := ref
+	if slash := strings.Index(first, "/"); slash >= 0 {
+		first = first[:slash]
+	}
+	switch first {
+	case "api", "cmd", "docs", "gen", "internal", "policies", "proto", "scripts", "sdk", "sources", "tools":
+		return true
+	}
+	switch ref {
+	case "AGENTS.md", "Makefile", "PLAN.md", "README.md":
+		return true
+	}
+	return false
+}
+
+func nonGoalsPointerPath(root string, ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") {
+		return ""
+	}
+	ref = strings.Split(ref, "#")[0]
+	ref = strings.TrimSpace(ref)
+	if strings.HasPrefix(ref, "./") || strings.HasPrefix(ref, "../") {
+		return filepath.Clean(filepath.Join(root, "docs", filepath.FromSlash(ref)))
+	}
+	return filepath.Join(root, filepath.FromSlash(ref))
+}
+
+func strconvLine(lineNumber int) string {
+	return strconv.Itoa(lineNumber)
+}

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -9,18 +9,21 @@ import (
 
 const newSourcePackageLOCBudget = 300
 
+// Grandfathered budgets are exact current nonblank Go LOC ceilings for legacy
+// sources. If a source shrinks, lower its ceiling in the same change; if a
+// source grows, move shared behavior into the Source CDK instead of raising it.
 var grandfatheredSourcePackageLOCBudgets = map[string]int{
-	"aurelius":        700,
+	"aurelius":        656,
 	"aws":             16212,
-	"azure":           2600,
-	"cosmo":           1300,
-	"gcp":             2200,
-	"github":          2300,
-	"googleworkspace": 900,
-	"grc":             1600,
-	"okta":            2600,
-	"sentinelone":     2400,
-	"vulnview":        1300,
+	"azure":           2599,
+	"cosmo":           1113,
+	"gcp":             2141,
+	"github":          2271,
+	"googleworkspace": 827,
+	"grc":             1382,
+	"okta":            2447,
+	"sentinelone":     2174,
+	"vulnview":        1068,
 }
 
 func TestSourcePackagesHaveCatalogFixturesAndTests(t *testing.T) {
@@ -83,7 +86,21 @@ func TestSourcePackagesStayWithinLOCBudget(t *testing.T) {
 			t.Fatalf("count source LOC for %s: %v", entry.Name(), err)
 		}
 		if lines > limit {
-			t.Fatalf("sources/%s has %d Go LOC, budget is %d; move shared I/O/pagination logic into sources/internal or raise the ratchet intentionally", entry.Name(), lines, limit)
+			t.Fatalf("sources/%s has %d Go LOC, budget is %d; move shared I/O/pagination logic into the Source CDK instead of raising the ratchet", entry.Name(), lines, limit)
+		}
+	}
+}
+
+func TestGrandfatheredSourceLOCBudgetsRatchetDownToCurrentSize(t *testing.T) {
+	root := repoRoot(t)
+	sourceRoot := filepath.Join(root, "sources")
+	for name, budget := range grandfatheredSourcePackageLOCBudgets {
+		lines, err := sourcePackageGoLines(filepath.Join(sourceRoot, name))
+		if err != nil {
+			t.Fatalf("count source LOC for %s: %v", name, err)
+		}
+		if lines != budget {
+			t.Fatalf("sources/%s has %d Go LOC but grandfathered budget is %d; keep legacy source budgets as exact no-growth ceilings", name, lines, budget)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add coverage reporting for high-signal safety packages
- enforce current Source CDK legacy LOC ceilings and NON_GOALS pointer validity
- add runtime response trust-gate tests and exact AWS network projection edge assertions

## Validation
- make cover
- make test
- make lint check-structural check-structural-test check-arch docs-drift-check oss-audit
- git diff --check