### PR TITLE
feat(source): support GitHub App auth

### DIFF
--- a/internal/sourcehttp/github.go
+++ b/internal/sourcehttp/github.go
@@ -1,0 +1,146 @@
+package sourcehttp
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+var ErrUnsafeGitHubBaseURLHost = errors.New("github base_url must not target loopback, private, or link-local hosts")
+
+func NormalizeGitHubBaseURL(raw string, allowLoopback bool) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse github base_url: %w", err)
+	}
+	host := parsed.Hostname()
+	allowInsecureLoopback := allowLoopback && parsed.Scheme == "http" && isGitHubLoopbackHost(host)
+	if parsed.Scheme != "https" && !allowInsecureLoopback {
+		return "", fmt.Errorf("github base_url must use https")
+	}
+	if strings.TrimSpace(host) == "" {
+		return "", fmt.Errorf("github base_url must include a host")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", fmt.Errorf("github base_url must not include user info, query, or fragment")
+	}
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	if (path != "" && path != "/api/v3") || parsed.RawPath != "" {
+		return "", fmt.Errorf("github base_url must be an origin URL")
+	}
+	if isUnsafeGitHubHost(host) && (!allowLoopback || !isGitHubLoopbackHost(host)) {
+		return "", ErrUnsafeGitHubBaseURLHost
+	}
+	if path == "/api/v3" && IsGitHubAPIHost(host) {
+		parsed.Path = "/api/v3"
+	} else {
+		parsed.Path = ""
+	}
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func IsGitHubAPIHost(host string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(host))
+	return strings.HasPrefix(normalized, "api.") || strings.Contains(normalized, ".api.")
+}
+
+func isUnsafeGitHubHost(host string) bool {
+	value := normalizedGitHubIPHost(host)
+	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(value)
+	if ip == nil {
+		ip = parseNumericGitHubIPv4Host(value)
+	}
+	if ip == nil {
+		return false
+	}
+	return isUnsafeGitHubIP(ip)
+}
+
+func isGitHubLoopbackHost(host string) bool {
+	value := normalizedGitHubIPHost(host)
+	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(value)
+	if ip == nil {
+		ip = parseNumericGitHubIPv4Host(value)
+	}
+	return ip != nil && ip.IsLoopback()
+}
+
+func isUnsafeGitHubIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast()
+}
+
+func normalizedGitHubIPHost(host string) string {
+	value := strings.TrimRight(strings.ToLower(strings.TrimSpace(host)), ".")
+	value = strings.Trim(value, "[]")
+	if address, _, ok := strings.Cut(value, "%"); ok {
+		value = address
+	}
+	return value
+}
+
+func parseNumericGitHubIPv4Host(host string) net.IP {
+	if strings.Contains(host, ":") {
+		return nil
+	}
+	parts := strings.Split(host, ".")
+	if len(parts) == 0 || len(parts) > 4 {
+		return nil
+	}
+	values := make([]uint64, len(parts))
+	for i, part := range parts {
+		if part == "" {
+			return nil
+		}
+		value, err := strconv.ParseUint(part, 0, 32)
+		if err != nil {
+			return nil
+		}
+		values[i] = value
+	}
+	var ipv4 uint32
+	switch len(values) {
+	case 1:
+		ipv4 = uint32FromUint64(values[0])
+	case 2:
+		if values[0] > 0xff || values[1] > 0xffffff {
+			return nil
+		}
+		ipv4 = uint32FromUint64(values[0]<<24 | values[1])
+	case 3:
+		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xffff {
+			return nil
+		}
+		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2])
+	case 4:
+		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xff || values[3] > 0xff {
+			return nil
+		}
+		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2]<<8 | values[3])
+	}
+	return net.IPv4(byte(ipv4>>24), byte(ipv4>>16), byte(ipv4>>8), byte(ipv4))
+}
+
+func uint32FromUint64(value uint64) uint32 {
+	if value > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(value)
+}

--- a/internal/sourcehttp/github_app_auth.go
+++ b/internal/sourcehttp/github_app_auth.go
@@ -1,0 +1,218 @@
+package sourcehttp
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const githubAppTokenRefreshSkew = time.Minute
+
+type GitHubAppAuthConfig struct {
+	AppID            string
+	InstallationID   string
+	PrivateKey       string
+	PrivateKeyBase64 string
+	BaseURL          string
+}
+
+type githubAppTokenTransport struct {
+	base           http.RoundTripper
+	appID          string
+	installationID string
+	privateKey     *rsa.PrivateKey
+	tokenURL       string
+
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+}
+
+type githubAppInstallationTokenResponse struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func (cfg GitHubAppAuthConfig) Configured() bool {
+	return cfg.AppID != "" && cfg.InstallationID != "" && (cfg.PrivateKey != "" || cfg.PrivateKeyBase64 != "")
+}
+
+func (cfg GitHubAppAuthConfig) Validate() error {
+	appFields := 0
+	for _, value := range []string{cfg.AppID, cfg.InstallationID, cfg.PrivateKey, cfg.PrivateKeyBase64} {
+		if strings.TrimSpace(value) != "" {
+			appFields++
+		}
+	}
+	if appFields == 0 {
+		return nil
+	}
+	if cfg.PrivateKey != "" && cfg.PrivateKeyBase64 != "" {
+		return fmt.Errorf("github app private_key and private_key_base64 are mutually exclusive")
+	}
+	if cfg.AppID == "" || cfg.InstallationID == "" || (cfg.PrivateKey == "" && cfg.PrivateKeyBase64 == "") {
+		return fmt.Errorf("github app auth requires app_id, installation_id, and private_key")
+	}
+	if _, err := strconv.ParseInt(cfg.AppID, 10, 64); err != nil {
+		return fmt.Errorf("parse github app_id: %w", err)
+	}
+	if _, err := strconv.ParseInt(cfg.InstallationID, 10, 64); err != nil {
+		return fmt.Errorf("parse github installation_id: %w", err)
+	}
+	return nil
+}
+
+func WithGitHubAppAuth(client *http.Client, cfg GitHubAppAuthConfig) (*http.Client, error) {
+	key, err := parseGitHubAppPrivateKey(cfg)
+	if err != nil {
+		return nil, err
+	}
+	cloned := *client
+	base := cloned.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	cloned.Transport = &githubAppTokenTransport{
+		base:           base,
+		appID:          cfg.AppID,
+		installationID: cfg.InstallationID,
+		privateKey:     key,
+		tokenURL:       githubAppInstallationTokenURL(cfg.BaseURL, cfg.InstallationID),
+	}
+	return &cloned, nil
+}
+
+func (rt *githubAppTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := rt.installationToken(req.Context())
+	if err != nil {
+		return nil, err
+	}
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	cloned.Header.Set("Authorization", "Bearer "+token)
+	return rt.base.RoundTrip(cloned)
+}
+
+func (rt *githubAppTokenTransport) installationToken(ctx context.Context) (string, error) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if rt.token != "" && time.Until(rt.expiresAt) > githubAppTokenRefreshSkew {
+		return rt.token, nil
+	}
+	jwt, err := signGitHubAppJWT(rt.appID, rt.privateKey, time.Now)
+	if err != nil {
+		return "", err
+	}
+	// #nosec G704 -- tokenURL is derived from NormalizeGitHubBaseURL output plus GitHub's fixed app-token path.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rt.tokenURL, bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		return "", fmt.Errorf("build github app installation token request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := rt.base.RoundTrip(req)
+	if err != nil {
+		return "", fmt.Errorf("github app installation token request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("github app installation token request returned HTTP %d", resp.StatusCode)
+	}
+	if readErr != nil {
+		return "", fmt.Errorf("read github app installation token response: %w", readErr)
+	}
+	var parsed githubAppInstallationTokenResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("decode github app installation token response: %w", err)
+	}
+	if strings.TrimSpace(parsed.Token) == "" {
+		return "", fmt.Errorf("github app installation token response did not include token")
+	}
+	rt.token = parsed.Token
+	rt.expiresAt = parsed.ExpiresAt
+	if rt.expiresAt.IsZero() {
+		rt.expiresAt = time.Now().Add(time.Hour)
+	}
+	return rt.token, nil
+}
+
+func githubAppInstallationTokenURL(baseURL string, installationID string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		base = "https://api.github.com"
+	} else if parsed, err := url.Parse(base); err == nil && strings.TrimRight(parsed.EscapedPath(), "/") == "" && !IsGitHubAPIHost(parsed.Hostname()) {
+		base += "/api/v3"
+	}
+	return fmt.Sprintf("%s/app/installations/%s/access_tokens", base, installationID)
+}
+
+func signGitHubAppJWT(appID string, privateKey *rsa.PrivateKey, now func() time.Time) (string, error) {
+	if now == nil {
+		now = time.Now
+	}
+	issuedAt := now().Add(-time.Minute).Unix()
+	expiresAt := now().Add(9 * time.Minute).Unix()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims, err := json.Marshal(map[string]any{
+		"iat": issuedAt,
+		"exp": expiresAt,
+		"iss": appID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal github app jwt claims: %w", err)
+	}
+	payload := base64.RawURLEncoding.EncodeToString(claims)
+	unsigned := header + "." + payload
+	digest := sha256.Sum256([]byte(unsigned))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("sign github app jwt: %w", err)
+	}
+	return unsigned + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func parseGitHubAppPrivateKey(cfg GitHubAppAuthConfig) (*rsa.PrivateKey, error) {
+	raw := strings.TrimSpace(cfg.PrivateKey)
+	if raw == "" && strings.TrimSpace(cfg.PrivateKeyBase64) != "" {
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(cfg.PrivateKeyBase64))
+		if err != nil {
+			return nil, fmt.Errorf("decode github app private_key_base64: %w", err)
+		}
+		raw = string(decoded)
+	}
+	raw = strings.ReplaceAll(raw, `\n`, "\n")
+	block, _ := pem.Decode([]byte(raw))
+	if block == nil {
+		return nil, fmt.Errorf("github app private key must be PEM encoded")
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse github app private key: %w", err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("github app private key must be RSA")
+	}
+	return key, nil
+}

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -6,10 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -40,8 +38,6 @@ const (
 	familyPullRequest   = "pull_request"
 )
 
-var errUnsafeBaseURLHost = errors.New("github base_url must not target loopback, private, or link-local hosts")
-
 // Source is the live GitHub source preview used by the builtin registry.
 type Source struct {
 	spec                 *cerebrov1.SourceSpec
@@ -51,16 +47,20 @@ type Source struct {
 }
 
 type settings struct {
-	family       string
-	owner        string
-	repo         string
-	token        string
-	baseURL      string
-	state        string
-	auditInclude string
-	auditPhrase  string
-	auditOrder   string
-	perPage      int
+	family              string
+	owner               string
+	repo                string
+	token               string
+	appID               string
+	appInstallationID   string
+	appPrivateKey       string
+	appPrivateKeyBase64 string
+	baseURL             string
+	state               string
+	auditInclude        string
+	auditPhrase         string
+	auditOrder          string
+	perPage             int
 }
 
 type pullRequestPayload struct {
@@ -340,8 +340,14 @@ func (s *Source) newClient(cfg sourcecdk.Config, requireRepo bool) (*gogithub.Cl
 		httpClient = s.client
 	}
 	httpClient = sourceHTTPClientNoRedirect(httpClient, allowLoopbackBaseURL, lookupIPAddrs)
+	if settings.usesGitHubAppAuth() {
+		httpClient, err = sourcehttp.WithGitHubAppAuth(httpClient, settings.githubAppAuthConfig())
+		if err != nil {
+			return nil, settings, fmt.Errorf("%w: %w", sourcecdk.ErrInvalidConfig, err)
+		}
+	}
 	client := gogithub.NewClient(httpClient)
-	if settings.token != "" {
+	if settings.token != "" && !settings.usesGitHubAppAuth() {
 		client = client.WithAuthToken(settings.token)
 	}
 	if settings.baseURL != "" {
@@ -370,10 +376,23 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL 
 		}
 	}()
 	settings := settings{
-		family:       configValue(cfg, "family"),
-		owner:        configValue(cfg, "owner"),
-		repo:         configValue(cfg, "repo"),
-		token:        configValue(cfg, "token"),
+		family: configValue(cfg, "family"),
+		owner:  configValue(cfg, "owner"),
+		repo:   configValue(cfg, "repo"),
+		token:  configValue(cfg, "token"),
+		appID:  configValue(cfg, "app_id"),
+		appInstallationID: firstNonEmptyString(
+			configValue(cfg, "app_installation_id"),
+			configValue(cfg, "installation_id"),
+		),
+		appPrivateKey: firstNonEmptyString(
+			configValue(cfg, "app_private_key"),
+			configValue(cfg, "private_key"),
+		),
+		appPrivateKeyBase64: firstNonEmptyString(
+			configValue(cfg, "app_private_key_base64"),
+			configValue(cfg, "private_key_base64"),
+		),
 		baseURL:      configValue(cfg, "base_url"),
 		state:        configValue(cfg, "state"),
 		auditInclude: configValue(cfg, "include"),
@@ -382,7 +401,7 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL 
 		perPage:      defaultPageSize,
 	}
 	if settings.baseURL != "" {
-		baseURL, err := normalizeBaseURL(settings.baseURL, allowLoopbackBaseURL)
+		baseURL, err := sourcehttp.NormalizeGitHubBaseURL(settings.baseURL, allowLoopbackBaseURL)
 		if err != nil {
 			return settings, err
 		}
@@ -390,6 +409,9 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL 
 	}
 	if settings.owner == "" {
 		return settings, fmt.Errorf("github owner is required")
+	}
+	if err := settings.validateAuth(); err != nil {
+		return settings, err
 	}
 	if settings.family == "" {
 		settings.family = defaultFamily
@@ -426,8 +448,8 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL 
 			return settings, fmt.Errorf("github include, order, and phrase are only supported when family=%q", familyAudit)
 		}
 	case familyDependabot:
-		if settings.token == "" {
-			return settings, fmt.Errorf("github token is required when family=%q", familyDependabot)
+		if !settings.hasAuth() {
+			return settings, fmt.Errorf("github token or app auth is required when family=%q", familyDependabot)
 		}
 		if settings.repo == "" {
 			return settings, fmt.Errorf("github repo is required when family=%q", familyDependabot)
@@ -444,8 +466,8 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL 
 			return settings, fmt.Errorf("github include, order, and phrase are only supported when family=%q", familyAudit)
 		}
 	case familyOrgInventory:
-		if settings.token == "" {
-			return settings, fmt.Errorf("github token is required when family=%q", familyOrgInventory)
+		if !settings.hasAuth() {
+			return settings, fmt.Errorf("github token or app auth is required when family=%q", familyOrgInventory)
 		}
 		if settings.repo != "" {
 			return settings, fmt.Errorf("github repo is not supported when family=%q", familyOrgInventory)
@@ -457,8 +479,8 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL 
 			return settings, fmt.Errorf("github include, order, and phrase are only supported when family=%q", familyAudit)
 		}
 	case familySecretScanning:
-		if settings.token == "" {
-			return settings, fmt.Errorf("github token is required when family=%q", familySecretScanning)
+		if !settings.hasAuth() {
+			return settings, fmt.Errorf("github token or app auth is required when family=%q", familySecretScanning)
 		}
 		if settings.repo != "" {
 			return settings, fmt.Errorf("github repo is not supported when family=%q (org-level scan)", familySecretScanning)
@@ -482,8 +504,8 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL 
 			return settings, fmt.Errorf("github include, order, and phrase are only supported when family=%q", familyAudit)
 		}
 	case familyAudit:
-		if settings.token == "" {
-			return settings, fmt.Errorf("github token is required when family=%q", familyAudit)
+		if !settings.hasAuth() {
+			return settings, fmt.Errorf("github token or app auth is required when family=%q", familyAudit)
 		}
 		if settings.repo != "" {
 			return settings, fmt.Errorf("github repo is not supported when family=%q", familyAudit)
@@ -509,139 +531,6 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL 
 		}
 	}
 	return settings, nil
-}
-
-func normalizeBaseURL(raw string, allowLoopback bool) (string, error) {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil {
-		return "", fmt.Errorf("parse github base_url: %w", err)
-	}
-	host := parsed.Hostname()
-	allowInsecureLoopback := allowLoopback && parsed.Scheme == "http" && isLoopbackHost(host)
-	if parsed.Scheme != "https" && !allowInsecureLoopback {
-		return "", fmt.Errorf("github base_url must use https")
-	}
-	if strings.TrimSpace(host) == "" {
-		return "", fmt.Errorf("github base_url must include a host")
-	}
-	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", fmt.Errorf("github base_url must not include user info, query, or fragment")
-	}
-	path := strings.TrimRight(parsed.EscapedPath(), "/")
-	if (path != "" && path != "/api/v3") || parsed.RawPath != "" {
-		return "", fmt.Errorf("github base_url must be an origin URL")
-	}
-	if isUnsafeHost(host) && (!allowLoopback || !isLoopbackHost(host)) {
-		return "", errUnsafeBaseURLHost
-	}
-	if path == "/api/v3" && isGitHubAPIHost(host) {
-		parsed.Path = "/api/v3"
-	} else {
-		parsed.Path = ""
-	}
-	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func isGitHubAPIHost(host string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(host))
-	return strings.HasPrefix(normalized, "api.") || strings.Contains(normalized, ".api.")
-}
-
-func isUnsafeHost(host string) bool {
-	value := normalizedIPHost(host)
-	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
-		return true
-	}
-	ip := net.ParseIP(value)
-	if ip == nil {
-		ip = parseNumericIPv4Host(value)
-	}
-	if ip == nil {
-		return false
-	}
-	return isUnsafeIP(ip)
-}
-
-func isLoopbackHost(host string) bool {
-	value := normalizedIPHost(host)
-	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
-		return true
-	}
-	ip := net.ParseIP(value)
-	if ip == nil {
-		ip = parseNumericIPv4Host(value)
-	}
-	return ip != nil && ip.IsLoopback()
-}
-
-func isUnsafeIP(ip net.IP) bool {
-	if ip == nil {
-		return false
-	}
-	return ip.IsLoopback() ||
-		ip.IsPrivate() ||
-		ip.IsLinkLocalUnicast() ||
-		ip.IsLinkLocalMulticast() ||
-		ip.IsUnspecified() ||
-		ip.IsMulticast()
-}
-
-func normalizedIPHost(host string) string {
-	value := strings.TrimRight(strings.ToLower(strings.TrimSpace(host)), ".")
-	value = strings.Trim(value, "[]")
-	if address, _, ok := strings.Cut(value, "%"); ok {
-		value = address
-	}
-	return value
-}
-
-func parseNumericIPv4Host(host string) net.IP {
-	if strings.Contains(host, ":") {
-		return nil
-	}
-	parts := strings.Split(host, ".")
-	if len(parts) == 0 || len(parts) > 4 {
-		return nil
-	}
-	values := make([]uint64, len(parts))
-	for i, part := range parts {
-		if part == "" {
-			return nil
-		}
-		value, err := strconv.ParseUint(part, 0, 32)
-		if err != nil {
-			return nil
-		}
-		values[i] = value
-	}
-	var ipv4 uint32
-	switch len(values) {
-	case 1:
-		ipv4 = uint32FromUint64(values[0])
-	case 2:
-		if values[0] > 0xff || values[1] > 0xffffff {
-			return nil
-		}
-		ipv4 = uint32FromUint64(values[0]<<24 | values[1])
-	case 3:
-		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xffff {
-			return nil
-		}
-		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2])
-	case 4:
-		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xff || values[3] > 0xff {
-			return nil
-		}
-		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2]<<8 | values[3])
-	}
-	return net.IPv4(byte(ipv4>>24), byte(ipv4>>16), byte(ipv4>>8), byte(ipv4))
-}
-
-func uint32FromUint64(value uint64) uint32 {
-	if value > math.MaxUint32 {
-		return math.MaxUint32
-	}
-	return uint32(value)
 }
 
 func getRepo(ctx context.Context, client *gogithub.Client, owner string, repo string) (*gogithub.Repository, error) {
@@ -923,6 +812,31 @@ func normalizeRepositoryEventID(value string) string {
 func configValue(cfg sourcecdk.Config, key string) string {
 	value, _ := cfg.Lookup(key)
 	return strings.TrimSpace(value)
+}
+
+func (st settings) githubAppAuthConfig() sourcehttp.GitHubAppAuthConfig {
+	return sourcehttp.GitHubAppAuthConfig{
+		AppID:            st.appID,
+		InstallationID:   st.appInstallationID,
+		PrivateKey:       st.appPrivateKey,
+		PrivateKeyBase64: st.appPrivateKeyBase64,
+		BaseURL:          st.baseURL,
+	}
+}
+
+func (st settings) hasAuth() bool {
+	return st.token != "" || st.usesGitHubAppAuth()
+}
+
+func (st settings) usesGitHubAppAuth() bool {
+	return st.githubAppAuthConfig().Configured()
+}
+
+func (st settings) validateAuth() error {
+	if err := st.githubAppAuthConfig().Validate(); err != nil {
+		return fmt.Errorf("%w: %w", sourcecdk.ErrInvalidConfig, err)
+	}
+	return nil
 }
 
 func branchLabel(branch *gogithub.PullRequestBranch) string {

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -2,7 +2,11 @@ package github
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"io"
 	"net"
@@ -62,6 +66,65 @@ func TestAuditRequiresToken(t *testing.T) {
 	}
 }
 
+func TestAuditSupportsGitHubAppAuth(t *testing.T) {
+	privateKey := testGitHubAppPrivateKeyPEM(t)
+	tokenRequests := 0
+	apiHandler := newGitHubAPIHandler(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v3/app/installations/123/access_tokens" {
+			tokenRequests++
+			if got := r.Header.Get("Authorization"); !strings.HasPrefix(got, "Bearer ") {
+				t.Fatalf("app token Authorization = %q, want bearer JWT", got)
+			}
+			if err := json.NewEncoder(w).Encode(map[string]string{
+				"token":      "installation-token",
+				"expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			}); err != nil {
+				t.Fatalf("encode installation token response: %v", err)
+			}
+			return
+		}
+		if r.URL.Path == "/api/v3/orgs/writer/audit-log" {
+			if got := r.Header.Get("Authorization"); got != "Bearer installation-token" {
+				t.Fatalf("audit Authorization = %q, want installation token", got)
+			}
+		}
+		apiHandler.ServeHTTP(w, r)
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"app_id":          "42",
+		"base_url":        server.URL,
+		"family":          familyAudit,
+		"installation_id": "123",
+		"owner":           "writer",
+		"private_key":     privateKey,
+	})
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check(audit app auth) error = %v", err)
+	}
+	if tokenRequests != 1 {
+		t.Fatalf("installation token requests = %d, want 1", tokenRequests)
+	}
+}
+
+func TestGitHubAppAuthRejectsPartialCredentials(t *testing.T) {
+	if _, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"app_id": "42",
+		"family": familyAudit,
+		"owner":  "writer",
+	}), false, false); err == nil {
+		t.Fatal("parseSettings() error = nil, want partial app auth error")
+	}
+}
+
 func TestNewFixtureReturnsFixtureURNs(t *testing.T) {
 	source, err := NewFixture()
 	if err != nil {
@@ -74,6 +137,18 @@ func TestNewFixtureReturnsFixtureURNs(t *testing.T) {
 	if len(urns) != 2 {
 		t.Fatalf("len(Discover()) = %d, want 2", len(urns))
 	}
+}
+
+func testGitHubAppPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
 }
 
 func TestNewFixtureReplaysFixturePages(t *testing.T) {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -18,7 +18,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"azure":           2599,
 	"cosmo":           1112,
 	"gcp":             2142,
-	"github":          2275,
+	"github":          2194,
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2454,


### PR DESCRIPTION
## Summary
- add GitHub App installation-token authentication for GitHub source requests
- keep existing token authentication behavior
- move GitHub URL/auth helpers into shared source HTTP utilities

## Validation
- go test ./sources/github ./internal/sourcehttp -count=1
- go test ./sources/...
- make catalog-check
- go test ./...