### PR TITLE
ci: serialize goreleaser builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: v2.16.0
-          args: release --clean
+          args: release --clean --parallelism 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Run GoReleaser with parallelism 1 so release builds do not exhaust runner disk while compiling multi-platform artifacts.

## Validation
- make release-smoke
- git diff --check