### PR TITLE
feat: add source runtime health endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -165,6 +165,32 @@ paths:
       responses:
         '200':
           description: Source runtime list.
+  /source-runtimes/health:
+    get:
+      summary: List consolidated source runtime health
+      tags:
+        - Sources
+      parameters:
+        - name: runtime_id
+          in: query
+          schema:
+            type: string
+        - name: tenant_id
+          in: query
+          schema:
+            type: string
+        - name: source_id
+          in: query
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limitQuery'
+      responses:
+        '200':
+          description: Consolidated runtime freshness, graph ingest, and finding evaluation health.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SourceRuntimeHealthResponse'
   /source-runtimes/{runtimeID}:
     put:
       summary: Store source runtime configuration
@@ -1895,6 +1921,141 @@ components:
         last_synced_at:
           type: string
           format: date-time
+    SourceRuntimeHealthResponse:
+      type: object
+      properties:
+        generated_at:
+          type: string
+          format: date-time
+        runtimes:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceRuntimeHealthRecord'
+    SourceRuntimeHealthRecord:
+      type: object
+      properties:
+        runtime_id:
+          type: string
+        source_id:
+          type: string
+        tenant_id:
+          type: string
+        family:
+          type: string
+        last_synced_at:
+          type: string
+          format: date-time
+        sync_lag_seconds:
+          type: integer
+          minimum: 0
+        checkpoint_watermark:
+          type: string
+          format: date-time
+        watermark_lag_seconds:
+          type: integer
+          minimum: 0
+        cursor_pending:
+          type: boolean
+        checkpoint_cursor_present:
+          type: boolean
+        latest_graph_run:
+          $ref: '#/components/schemas/SourceRuntimeHealthGraphRun'
+        graph_lag_seconds:
+          type: integer
+          minimum: 0
+        latest_finding_evaluation:
+          $ref: '#/components/schemas/SourceRuntimeHealthFindingEvaluation'
+        expected_cadence_seconds:
+          type: integer
+          minimum: 0
+        stale_after_seconds:
+          type: integer
+          minimum: 0
+        schedule_context_configured:
+          type: boolean
+        generated_at:
+          type: string
+          format: date-time
+    SourceRuntimeHealthGraphRun:
+      type: object
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        finished_at:
+          type: string
+          format: date-time
+        error:
+          type: string
+        pages_read:
+          type: integer
+        events_read:
+          type: integer
+        entities_projected:
+          type: integer
+        links_projected:
+          type: integer
+        graph_nodes_before:
+          type: integer
+        graph_links_before:
+          type: integer
+        graph_nodes_after:
+          type: integer
+        graph_links_after:
+          type: integer
+        graph_node_delta:
+          type: integer
+        graph_link_delta:
+          type: integer
+        duration_seconds:
+          type: integer
+          minimum: 0
+    SourceRuntimeHealthFindingEvaluation:
+      type: object
+      properties:
+        id:
+          type: string
+        runtime_id:
+          type: string
+        rule_id:
+          type: string
+        status:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        finished_at:
+          type: string
+          format: date-time
+        error:
+          type: string
+        events_evaluated:
+          type: integer
+          minimum: 0
+        events_processed:
+          type: integer
+          minimum: 0
+        events_matched:
+          type: integer
+          minimum: 0
+        findings_upserted:
+          type: integer
+          minimum: 0
+        findings_emitted:
+          type: integer
+          minimum: 0
+        graph_rule:
+          type: boolean
+        graph_rows_read:
+          type: integer
+          minimum: 0
+        duration_seconds:
+          type: integer
+          minimum: 0
     EntityRef:
       type: object
       required: [urn, entity_type]

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -4258,6 +4258,131 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	}
 }
 
+func TestSourceRuntimeHealthEndpointIncludesRuntimeGraphAndFindingState(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	started := now.Add(-10 * time.Minute)
+	finished := now.Add(-9 * time.Minute)
+	runtimeStore := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-users": {
+				Id:       "writer-okta-users",
+				SourceId: "okta",
+				TenantId: "writer",
+				Config:   map[string]string{"family": "user"},
+				Checkpoint: &cerebrov1.SourceCheckpoint{
+					Watermark:    timestamppb.New(now.Add(-2 * time.Hour)),
+					CursorOpaque: "checkpoint-secret",
+				},
+				NextCursor:   &cerebrov1.SourceCursor{Opaque: "next-secret"},
+				LastSyncedAt: timestamppb.New(now.Add(-30 * time.Minute)),
+			},
+		},
+		findingEvaluationRuns: map[string]*cerebrov1.FindingEvaluationRun{
+			"finding-run-1": {
+				Id:               "finding-run-1",
+				RuntimeId:        "writer-okta-users",
+				RuleId:           "okta.user.mfa",
+				Status:           "completed",
+				EventsEvaluated:  7,
+				EventsProcessed:  9,
+				EventsMatched:    3,
+				FindingsUpserted: 2,
+				FindingsEmitted:  1,
+				StartedAt:        timestamppb.New(started),
+				FinishedAt:       timestamppb.New(finished),
+			},
+		},
+	}
+	graphStore := &stubGraphStore{
+		ingestRuns: map[string]graphstore.IngestRun{
+			"graph-run-1": {
+				ID:                "graph-run-1",
+				RuntimeID:         "writer-okta-users",
+				Status:            graphstore.IngestRunStatusCompleted,
+				StartedAt:         started.Format(time.RFC3339Nano),
+				FinishedAt:        finished.Format(time.RFC3339Nano),
+				PagesRead:         4,
+				EventsRead:        8,
+				EntitiesProjected: 12,
+				LinksProjected:    16,
+				GraphNodesBefore:  100,
+				GraphNodesAfter:   109,
+				GraphLinksBefore:  200,
+				GraphLinksAfter:   211,
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		StateStore: runtimeStore,
+		GraphStore: graphStore,
+	}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/source-runtimes/health?tenant_id=writer")
+	if err != nil {
+		t.Fatalf("GET /source-runtimes/health error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close health response body: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /source-runtimes/health status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode source runtime health response: %v", err)
+	}
+	runtimes, ok := payload["runtimes"].([]any)
+	if !ok || len(runtimes) != 1 {
+		t.Fatalf("health runtimes = %#v, want one runtime", payload["runtimes"])
+	}
+	record, ok := runtimes[0].(map[string]any)
+	if !ok {
+		t.Fatalf("health runtime = %#v, want object", runtimes[0])
+	}
+	if got := record["runtime_id"]; got != "writer-okta-users" {
+		t.Fatalf("runtime_id = %#v, want writer-okta-users", got)
+	}
+	if got := record["family"]; got != "user" {
+		t.Fatalf("family = %#v, want user", got)
+	}
+	if got := record["cursor_pending"]; got != true {
+		t.Fatalf("cursor_pending = %#v, want true", got)
+	}
+	if got := record["checkpoint_cursor_present"]; got != true {
+		t.Fatalf("checkpoint_cursor_present = %#v, want true", got)
+	}
+	if _, ok := record["next_cursor"]; ok {
+		t.Fatalf("health record leaked next_cursor: %#v", record["next_cursor"])
+	}
+	graphRun, ok := record["latest_graph_run"].(map[string]any)
+	if !ok {
+		t.Fatalf("latest_graph_run = %#v, want object", record["latest_graph_run"])
+	}
+	if got := graphRun["graph_node_delta"]; got != float64(9) {
+		t.Fatalf("graph_node_delta = %#v, want 9", got)
+	}
+	if got := graphRun["graph_link_delta"]; got != float64(11) {
+		t.Fatalf("graph_link_delta = %#v, want 11", got)
+	}
+	if got := graphRun["duration_seconds"]; got != float64(60) {
+		t.Fatalf("graph duration_seconds = %#v, want 60", got)
+	}
+	findingRun, ok := record["latest_finding_evaluation"].(map[string]any)
+	if !ok {
+		t.Fatalf("latest_finding_evaluation = %#v, want object", record["latest_finding_evaluation"])
+	}
+	if got := findingRun["events_processed"]; got != float64(9) {
+		t.Fatalf("finding events_processed = %#v, want 9", got)
+	}
+	if got := findingRun["duration_seconds"]; got != float64(60) {
+		t.Fatalf("finding duration_seconds = %#v, want 60", got)
+	}
+}
+
 func TestConnectSourceRuntimeEndpointsResolveEnvReferences(t *testing.T) {
 	source := &bootstrapTokenSource{id: "runtime_token"}
 	registry, err := sourcecdk.NewRegistry(source)

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -121,6 +121,7 @@ func (app *App) registerGraphRoutes(mux *http.ServeMux) {
 
 func (app *App) registerSourceRuntimeRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /source-runtimes", routeSurfacePlatformHTTP, app.handleListSourceRuntimes)
+	registerHTTPRoute(mux, "GET /source-runtimes/health", routeSurfacePlatformHTTP, app.handleListSourceRuntimeHealth)
 	registerHTTPRoute(mux, "PUT /source-runtimes/{runtimeID}", routeSurfacePlatformHTTP, app.handlePutSourceRuntime)
 	registerHTTPRoute(mux, "GET /source-runtimes/{runtimeID}", routeSurfacePlatformHTTP, app.handleGetSourceRuntime)
 	registerHTTPRoute(mux, "POST /source-runtimes/{runtimeID}/sync", routeSurfacePlatformHTTP, app.handleSyncSourceRuntime)

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -1,0 +1,349 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphingest"
+	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceruntime"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type sourceRuntimeHealthResponse struct {
+	GeneratedAt string                      `json:"generated_at"`
+	Runtimes    []sourceRuntimeHealthRecord `json:"runtimes"`
+}
+
+type sourceRuntimeHealthRecord struct {
+	RuntimeID                 string                                `json:"runtime_id"`
+	SourceID                  string                                `json:"source_id"`
+	TenantID                  string                                `json:"tenant_id"`
+	Family                    string                                `json:"family,omitempty"`
+	LastSyncedAt              string                                `json:"last_synced_at,omitempty"`
+	SyncLagSeconds            *int64                                `json:"sync_lag_seconds,omitempty"`
+	CheckpointWatermark       string                                `json:"checkpoint_watermark,omitempty"`
+	WatermarkLagSeconds       *int64                                `json:"watermark_lag_seconds,omitempty"`
+	CursorPending             bool                                  `json:"cursor_pending"`
+	CheckpointCursorPresent   bool                                  `json:"checkpoint_cursor_present"`
+	LatestGraphRun            *sourceRuntimeHealthGraphRun          `json:"latest_graph_run,omitempty"`
+	GraphLagSeconds           *int64                                `json:"graph_lag_seconds,omitempty"`
+	LatestFindingEvaluation   *sourceRuntimeHealthFindingEvaluation `json:"latest_finding_evaluation,omitempty"`
+	ExpectedCadenceSeconds    *int64                                `json:"expected_cadence_seconds,omitempty"`
+	StaleAfterSeconds         *int64                                `json:"stale_after_seconds,omitempty"`
+	ScheduleContextConfigured bool                                  `json:"schedule_context_configured"`
+	GeneratedAt               string                                `json:"generated_at"`
+}
+
+type sourceRuntimeHealthGraphRun struct {
+	ID                string `json:"id"`
+	Status            string `json:"status"`
+	StartedAt         string `json:"started_at,omitempty"`
+	FinishedAt        string `json:"finished_at,omitempty"`
+	Error             string `json:"error,omitempty"`
+	PagesRead         int64  `json:"pages_read"`
+	EventsRead        int64  `json:"events_read"`
+	EntitiesProjected int64  `json:"entities_projected"`
+	LinksProjected    int64  `json:"links_projected"`
+	GraphNodesBefore  int64  `json:"graph_nodes_before"`
+	GraphLinksBefore  int64  `json:"graph_links_before"`
+	GraphNodesAfter   int64  `json:"graph_nodes_after"`
+	GraphLinksAfter   int64  `json:"graph_links_after"`
+	GraphNodeDelta    int64  `json:"graph_node_delta"`
+	GraphLinkDelta    int64  `json:"graph_link_delta"`
+	DurationSeconds   *int64 `json:"duration_seconds,omitempty"`
+}
+
+type sourceRuntimeHealthFindingEvaluation struct {
+	ID               string `json:"id"`
+	RuntimeID        string `json:"runtime_id"`
+	RuleID           string `json:"rule_id,omitempty"`
+	Status           string `json:"status"`
+	StartedAt        string `json:"started_at,omitempty"`
+	FinishedAt       string `json:"finished_at,omitempty"`
+	Error            string `json:"error,omitempty"`
+	EventsEvaluated  uint32 `json:"events_evaluated"`
+	EventsProcessed  uint32 `json:"events_processed"`
+	EventsMatched    uint32 `json:"events_matched"`
+	FindingsUpserted uint32 `json:"findings_upserted"`
+	FindingsEmitted  uint32 `json:"findings_emitted"`
+	GraphRule        *bool  `json:"graph_rule,omitempty"`
+	GraphRowsRead    uint32 `json:"graph_rows_read,omitempty"`
+	DurationSeconds  *int64 `json:"duration_seconds,omitempty"`
+}
+
+func (a *App) handleListSourceRuntimeHealth(w http.ResponseWriter, r *http.Request) {
+	limit, err := uint32QueryParam(r, "limit")
+	if err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	filter := ports.SourceRuntimeFilter{
+		RuntimeID: strings.TrimSpace(r.URL.Query().Get("runtime_id")),
+		TenantID:  strings.TrimSpace(r.URL.Query().Get("tenant_id")),
+		SourceID:  strings.TrimSpace(r.URL.Query().Get("source_id")),
+		Limit:     limit,
+	}
+	if filter.TenantID == "" {
+		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok && strings.TrimSpace(auth.principal.TenantID) != "" {
+			filter.TenantID = strings.TrimSpace(auth.principal.TenantID)
+		}
+	}
+	if filter.TenantID == "" {
+		filter.TenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
+	}
+	if filter.TenantID == "" && filter.RuntimeID != "" && requiresTenantFilter(r.Context()) {
+		store := sourceRuntimeStore(a.deps.StateStore)
+		if store == nil {
+			writeSourceRuntimeError(w, sourceruntime.ErrRuntimeUnavailable)
+			return
+		}
+		runtime, err := store.GetSourceRuntime(r.Context(), filter.RuntimeID)
+		if errors.Is(err, ports.ErrSourceRuntimeNotFound) {
+			writeJSON(w, http.StatusOK, sourceRuntimeHealthResponse{GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano)})
+			return
+		}
+		if err != nil {
+			writeSourceRuntimeError(w, err)
+			return
+		}
+		if !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
+			writeJSON(w, http.StatusOK, sourceRuntimeHealthResponse{GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano)})
+			return
+		}
+		filter.TenantID = strings.TrimSpace(runtime.GetTenantId())
+	}
+	if filter.TenantID == "" && filter.RuntimeID == "" && requiresTenantFilter(r.Context()) {
+		writeSourceRuntimeError(w, errTenantForbidden)
+		return
+	}
+	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	runtimes, err := a.runtimeService().List(r.Context(), filter)
+	if err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	generatedAt := time.Now().UTC()
+	records := make([]sourceRuntimeHealthRecord, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		if requiresTenantFilter(r.Context()) && !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
+			continue
+		}
+		record, err := a.sourceRuntimeHealthRecord(r.Context(), runtime, generatedAt)
+		if err != nil {
+			writeSourceRuntimeError(w, err)
+			return
+		}
+		records = append(records, record)
+	}
+	writeJSON(w, http.StatusOK, sourceRuntimeHealthResponse{
+		GeneratedAt: generatedAt.Format(time.RFC3339Nano),
+		Runtimes:    records,
+	})
+}
+
+func (a *App) sourceRuntimeHealthRecord(ctx context.Context, runtime *cerebrov1.SourceRuntime, generatedAt time.Time) (sourceRuntimeHealthRecord, error) {
+	record := sourceRuntimeHealthRecord{
+		RuntimeID:               strings.TrimSpace(runtime.GetId()),
+		SourceID:                strings.TrimSpace(runtime.GetSourceId()),
+		TenantID:                strings.TrimSpace(runtime.GetTenantId()),
+		Family:                  strings.TrimSpace(runtime.GetConfig()["family"]),
+		CursorPending:           strings.TrimSpace(runtime.GetNextCursor().GetOpaque()) != "",
+		CheckpointCursorPresent: strings.TrimSpace(runtime.GetCheckpoint().GetCursorOpaque()) != "",
+		// Schedule cadence/SLA is currently deployment configuration, not runtime state.
+		ScheduleContextConfigured: false,
+		GeneratedAt:               generatedAt.Format(time.RFC3339Nano),
+	}
+	if lastSynced := timestampValue(runtime.GetLastSyncedAt()); !lastSynced.IsZero() {
+		lastSynced = lastSynced.UTC()
+		record.LastSyncedAt = lastSynced.Format(time.RFC3339Nano)
+		record.SyncLagSeconds = secondsSince(generatedAt, lastSynced)
+	}
+	if watermark := timestampValue(runtime.GetCheckpoint().GetWatermark()); !watermark.IsZero() {
+		watermark = watermark.UTC()
+		record.CheckpointWatermark = watermark.Format(time.RFC3339Nano)
+		record.WatermarkLagSeconds = secondsSince(generatedAt, watermark)
+	}
+	graphRun, err := a.latestGraphIngestRun(ctx, record.RuntimeID)
+	if err != nil {
+		return record, err
+	}
+	if graphRun != nil {
+		record.LatestGraphRun = sourceRuntimeGraphRunHealth(*graphRun)
+		record.GraphLagSeconds = graphRunLagSeconds(generatedAt, *graphRun)
+	}
+	findingRun, err := a.latestFindingEvaluationRun(ctx, record.RuntimeID)
+	if err != nil {
+		return record, err
+	}
+	if findingRun != nil {
+		record.LatestFindingEvaluation = sourceRuntimeFindingEvaluationHealth(findingRun)
+	}
+	return record, nil
+}
+
+func (a *App) latestGraphIngestRun(ctx context.Context, runtimeID string) (*graphstore.IngestRun, error) {
+	runStore, ok := a.deps.GraphStore.(graphingest.RunStore)
+	if !ok || isNilInterface(runStore) {
+		return nil, nil
+	}
+	runs, err := runStore.ListIngestRuns(ctx, graphstore.IngestRunFilter{RuntimeID: runtimeID, Limit: 1})
+	if err != nil {
+		return nil, err
+	}
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	return &runs[0], nil
+}
+
+func (a *App) latestFindingEvaluationRun(ctx context.Context, runtimeID string) (*cerebrov1.FindingEvaluationRun, error) {
+	runStore := findingEvaluationRunStore(a.deps.StateStore)
+	if runStore == nil {
+		return nil, nil
+	}
+	runs, err := runStore.ListFindingEvaluationRuns(ctx, ports.ListFindingEvaluationRunsRequest{RuntimeID: runtimeID, Limit: 1})
+	if err != nil {
+		if errors.Is(err, findings.ErrRuntimeUnavailable) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	return runs[0], nil
+}
+
+func sourceRuntimeGraphRunHealth(run graphstore.IngestRun) *sourceRuntimeHealthGraphRun {
+	return &sourceRuntimeHealthGraphRun{
+		ID:                run.ID,
+		Status:            run.Status,
+		StartedAt:         run.StartedAt,
+		FinishedAt:        run.FinishedAt,
+		Error:             run.Error,
+		PagesRead:         run.PagesRead,
+		EventsRead:        run.EventsRead,
+		EntitiesProjected: run.EntitiesProjected,
+		LinksProjected:    run.LinksProjected,
+		GraphNodesBefore:  run.GraphNodesBefore,
+		GraphLinksBefore:  run.GraphLinksBefore,
+		GraphNodesAfter:   run.GraphNodesAfter,
+		GraphLinksAfter:   run.GraphLinksAfter,
+		GraphNodeDelta:    run.GraphNodesAfter - run.GraphNodesBefore,
+		GraphLinkDelta:    run.GraphLinksAfter - run.GraphLinksBefore,
+		DurationSeconds:   durationSeconds(run.StartedAt, run.FinishedAt),
+	}
+}
+
+func sourceRuntimeFindingEvaluationHealth(run *cerebrov1.FindingEvaluationRun) *sourceRuntimeHealthFindingEvaluation {
+	if run == nil {
+		return nil
+	}
+	var graphRowsRead uint32
+	if run.GraphRowsRead != nil {
+		graphRowsRead = run.GetGraphRowsRead()
+	}
+	return &sourceRuntimeHealthFindingEvaluation{
+		ID:               run.GetId(),
+		RuntimeID:        run.GetRuntimeId(),
+		RuleID:           run.GetRuleId(),
+		Status:           run.GetStatus(),
+		StartedAt:        timestampString(run.GetStartedAt()),
+		FinishedAt:       timestampString(run.GetFinishedAt()),
+		Error:            run.GetError(),
+		EventsEvaluated:  run.GetEventsEvaluated(),
+		EventsProcessed:  run.GetEventsProcessed(),
+		EventsMatched:    run.GetEventsMatched(),
+		FindingsUpserted: run.GetFindingsUpserted(),
+		FindingsEmitted:  run.GetFindingsEmitted(),
+		GraphRule:        run.GraphRule,
+		GraphRowsRead:    graphRowsRead,
+		DurationSeconds:  timestampDurationSeconds(run.GetStartedAt(), run.GetFinishedAt()),
+	}
+}
+
+func timestampString(value *timestamppb.Timestamp) string {
+	if value == nil {
+		return ""
+	}
+	timestamp := value.AsTime()
+	if timestamp.IsZero() {
+		return ""
+	}
+	return timestamp.UTC().Format(time.RFC3339Nano)
+}
+
+func secondsSince(now time.Time, then time.Time) *int64 {
+	seconds := int64(now.UTC().Sub(then.UTC()).Seconds())
+	if seconds < 0 {
+		seconds = 0
+	}
+	return &seconds
+}
+
+func graphRunLagSeconds(now time.Time, run graphstore.IngestRun) *int64 {
+	if finished, ok := parseRFC3339(run.FinishedAt); ok {
+		return secondsSince(now, finished)
+	}
+	if started, ok := parseRFC3339(run.StartedAt); ok {
+		return secondsSince(now, started)
+	}
+	return nil
+}
+
+func durationSeconds(startedAt string, finishedAt string) *int64 {
+	started, ok := parseRFC3339(startedAt)
+	if !ok {
+		return nil
+	}
+	finished, ok := parseRFC3339(finishedAt)
+	if !ok {
+		return nil
+	}
+	seconds := int64(finished.Sub(started).Seconds())
+	if seconds < 0 {
+		seconds = 0
+	}
+	return &seconds
+}
+
+func timestampDurationSeconds(startedAt *timestamppb.Timestamp, finishedAt *timestamppb.Timestamp) *int64 {
+	if startedAt == nil || finishedAt == nil {
+		return nil
+	}
+	started := startedAt.AsTime()
+	finished := finishedAt.AsTime()
+	if started.IsZero() || finished.IsZero() {
+		return nil
+	}
+	seconds := int64(finished.UTC().Sub(started.UTC()).Seconds())
+	if seconds < 0 {
+		seconds = 0
+	}
+	return &seconds
+}
+
+func parseRFC3339(value string) (time.Time, bool) {
+	text := strings.TrimSpace(value)
+	if text == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, text)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed.UTC(), true
+}


### PR DESCRIPTION
## Summary\n- add a consolidated source runtime health endpoint\n- include runtime freshness, graph ingest, and finding-evaluation rollups\n- document the response shape in OpenAPI\n\n## Tests\n- go test ./internal/bootstrap -count=1\n- make openapi-check