### PR TITLE
Configure EvidenceCAS ref ingestion

### DIFF
--- a/sources/evidencecas/deploy.yaml
+++ b/sources/evidencecas/deploy.yaml
@@ -6,6 +6,7 @@ runtimes:
   - localId: object
     config:
       base_url: env:EVIDENCE_CAS_BASE_URL
+      bucket: cases
       family: object
       per_page: "100"
       token: env:EVIDENCE_CAS_TOKEN

--- a/sources/evidencecas/source.go
+++ b/sources/evidencecas/source.go
@@ -3,10 +3,15 @@ package evidencecas
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehttp"
 	"github.com/writer/cerebro/sources/internal/jsonapi"
 )
 
@@ -16,12 +21,14 @@ var catalogFS embed.FS
 const (
 	sourceID      = "evidence_cas"
 	defaultFamily = familyObject
+	defaultBucket = "cases"
 
 	familyObject = "object"
 )
 
 type Source struct {
-	inner *jsonapi.Source
+	inner         *jsonapi.Source
+	allowLoopback bool
 }
 
 func New() (*Source, error) {
@@ -62,6 +69,10 @@ func New() (*Source, error) {
 					"source_product": "evidence_cas",
 					"evidence_type":  "evidence_cas.artifact",
 				},
+				ConfigQuery: map[string]string{
+					"prefix": "prefix",
+					"tag":    "tag",
+				},
 			},
 		},
 	})
@@ -79,15 +90,135 @@ func (s *Source) Spec() *cerebrov1.SourceSpec {
 }
 
 func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
+	cfg, err := s.configForInner(cfg)
+	if err != nil {
+		return err
+	}
+	if err := s.checkReadiness(ctx, cfg); err != nil {
+		return err
+	}
+	if err := s.checkContract(ctx, cfg); err != nil {
+		return err
+	}
 	return s.inner.Check(ctx, cfg)
 }
 
 func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	cfg, err := s.configForInner(cfg)
+	if err != nil {
+		return nil, err
+	}
 	return s.inner.Discover(ctx, cfg)
 }
 
 func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	cfg, err := s.configForInner(cfg)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
 	return s.inner.Read(ctx, cfg, cursor)
+}
+
+func (s *Source) configForInner(cfg sourcecdk.Config) (sourcecdk.Config, error) {
+	values := cfg.Values()
+	if strings.TrimSpace(values["path"]) == "" && strings.TrimSpace(values[familyObject+"_path"]) == "" {
+		bucket := strings.TrimSpace(values["bucket"])
+		if bucket == "" {
+			bucket = defaultBucket
+		}
+		if err := validateBucket(bucket); err != nil {
+			return sourcecdk.Config{}, err
+		}
+		values["path"] = "/v1/b/" + bucket + "/refs"
+	}
+	return sourcecdk.NewConfig(values), nil
+}
+
+func validateBucket(bucket string) error {
+	if bucket == "" {
+		return fmt.Errorf("%s bucket is required", sourceID)
+	}
+	if len(bucket) > 128 {
+		return fmt.Errorf("%s bucket is too long", sourceID)
+	}
+	for index, char := range bucket {
+		if index == 0 && !isASCIIAlnum(char) {
+			return fmt.Errorf("%s bucket must start with an ASCII letter or digit", sourceID)
+		}
+		if isASCIIAlnum(char) || char == '-' || char == '_' || char == '.' {
+			continue
+		}
+		return fmt.Errorf("%s bucket contains unsupported character %q", sourceID, char)
+	}
+	return nil
+}
+
+func isASCIIAlnum(char rune) bool {
+	return (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9')
+}
+
+func (s *Source) checkReadiness(ctx context.Context, cfg sourcecdk.Config) error {
+	var body struct {
+		OK bool `json:"ok"`
+	}
+	if err := s.getControlJSON(ctx, cfg, "/readyz", &body); err != nil {
+		return err
+	}
+	if !body.OK {
+		return fmt.Errorf("%s readiness check failed", sourceID)
+	}
+	return nil
+}
+
+func (s *Source) checkContract(ctx context.Context, cfg sourcecdk.Config) error {
+	var body struct {
+		Service              string `json:"service"`
+		RouteContractVersion int    `json:"route_contract_version"`
+	}
+	if err := s.getControlJSON(ctx, cfg, "/v1/contract", &body); err != nil {
+		return err
+	}
+	if body.Service != "evidence-cas" {
+		return fmt.Errorf("%s contract service = %q, want evidence-cas", sourceID, body.Service)
+	}
+	if body.RouteContractVersion < 1 {
+		return fmt.Errorf("%s contract route_contract_version is required", sourceID)
+	}
+	return nil
+}
+
+func (s *Source) getControlJSON(ctx context.Context, cfg sourcecdk.Config, path string, target any) error {
+	baseURL := strings.TrimSpace(configValue(cfg, "base_url"))
+	normalizedBaseURL, _, err := sourcehttp.NormalizeBaseURL(sourceID, baseURL, s != nil && s.allowLoopback)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, normalizedBaseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("build %s control request: %w", sourceID, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	client := sourcehttp.NewClient(sourcehttp.ClientOptions{
+		SourceID:      sourceID,
+		AllowLoopback: s != nil && s.allowLoopback,
+		Timeout:       10 * time.Second,
+	})
+	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s control route %s returned HTTP %d", sourceID, path, resp.StatusCode)
+	}
+	if err := json.Unmarshal(resp.Body, target); err != nil {
+		return fmt.Errorf("decode %s control response: %w", sourceID, err)
+	}
+	return nil
+}
+
+func configValue(cfg sourcecdk.Config, key string) string {
+	value, _ := cfg.Lookup(key)
+	return value
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {
@@ -105,5 +236,6 @@ func loadSpec() (*cerebrov1.SourceSpec, error) {
 func (s *Source) allowLoopbackForTest() {
 	if s != nil && s.inner != nil {
 		s.inner.AllowLoopbackBaseURL = true
+		s.allowLoopback = true
 	}
 }

--- a/sources/evidencecas/source_test.go
+++ b/sources/evidencecas/source_test.go
@@ -86,3 +86,112 @@ func TestReadObjectRefs(t *testing.T) {
 		t.Fatalf("evidence_type = %q, want evidence_cas.artifact", event.Attributes["evidence_type"])
 	}
 }
+
+func TestReadObjectRefsWithBucketAndFilters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/b/trusted-endpoint/refs" {
+			t.Fatalf("request path = %q, want /v1/b/trusted-endpoint/refs", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("prefix"); got != "agents/" {
+			t.Fatalf("prefix query = %q, want agents/", got)
+		}
+		if got := r.URL.Query().Get("tag"); got != "endpoint" {
+			t.Fatalf("tag query = %q, want endpoint", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"objects": []map[string]any{{
+			"ref_type":         "evidencecas.manifest.v2",
+			"uri":              "evidencecas://trusted-endpoint/agents/agent-1.json",
+			"digest":           "sha256agent",
+			"size":             42,
+			"content_type":     "application/json",
+			"manifest_version": 2,
+			"blocks_count":     1,
+			"updated_at":       "2026-06-06T00:00:00Z",
+			"metadata": map[string]any{
+				"evidence_id":  "agent-1",
+				"resource_urn": "urn:cerebro:writer:endpoint:agent-1",
+			},
+		}}})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"token":     "cache-token",
+		"bucket":    "trusted-endpoint",
+		"prefix":    "agents/",
+		"tag":       "endpoint",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+	if pull.Events[0].Attributes["evidence_id"] != "agent-1" {
+		t.Fatalf("evidence_id = %q, want agent-1", pull.Events[0].Attributes["evidence_id"])
+	}
+}
+
+func TestCheckValidatesControlRoutes(t *testing.T) {
+	paths := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths[r.URL.Path]++
+		switch r.URL.Path {
+		case "/readyz":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		case "/v1/contract":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"service":                "evidence-cas",
+				"route_contract_version": 1,
+			})
+		case "/v1/b/cases/refs":
+			_ = json.NewEncoder(w).Encode(map[string]any{"objects": []map[string]any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	err = source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"token":     "cache-token",
+	}))
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	for _, path := range []string{"/readyz", "/v1/contract", "/v1/b/cases/refs"} {
+		if paths[path] != 1 {
+			t.Fatalf("%s request count = %d, want 1", path, paths[path])
+		}
+	}
+}
+
+func TestRejectsUnsafeBucket(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  "http://127.0.0.1",
+		"token":     "cache-token",
+		"bucket":    "../cases",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want invalid bucket error")
+	}
+}

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -38,6 +38,7 @@ type Family struct {
 	Attributes       map[string]string
 	StaticAttributes map[string]string
 	StaticQuery      map[string]string
+	ConfigQuery      map[string]string
 	PageSizeParams   []string
 	RequireID        bool
 }
@@ -71,6 +72,7 @@ type settings struct {
 	host     string
 	token    string
 	path     string
+	query    url.Values
 	perPage  int
 }
 
@@ -206,6 +208,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if err != nil {
 		return resolved, err
 	}
+	resolved.query = queryFromConfig(cfg, family.ConfigQuery)
 	return resolved, nil
 }
 
@@ -214,6 +217,11 @@ func (s *Source) list(ctx context.Context, family Family, settings settings, cur
 	for key, value := range family.StaticQuery {
 		if strings.TrimSpace(key) != "" && strings.TrimSpace(value) != "" {
 			query.Set(strings.TrimSpace(key), strings.TrimSpace(value))
+		}
+	}
+	for key, values := range settings.query {
+		for _, value := range values {
+			query.Add(key, value)
 		}
 	}
 	for _, param := range pageSizeParams(family) {
@@ -257,6 +265,21 @@ func pageSizeParams(family Family) []string {
 		return []string{"limit", "per_page"}
 	}
 	return params
+}
+
+func queryFromConfig(cfg sourcecdk.Config, configQuery map[string]string) url.Values {
+	query := url.Values{}
+	for queryKey, configKey := range configQuery {
+		queryKey = strings.TrimSpace(queryKey)
+		configKey = strings.TrimSpace(configKey)
+		if queryKey == "" || configKey == "" {
+			continue
+		}
+		if value := strings.TrimSpace(configValue(cfg, configKey)); value != "" {
+			query.Set(queryKey, value)
+		}
+	}
+	return query
 }
 
 func (s *Source) getJSON(ctx context.Context, settings settings, query url.Values, target any) error {


### PR DESCRIPTION
## Summary
- Allow the EvidenceCAS source to configure the ref bucket and optional list filters.
- Validate service readiness and route contract during source checks.
- Add a generic JSON API query-param mapping for source adapters.

## Testing
- go test ./sources/internal/jsonapi ./sources/evidencecas
- make catalog-check
- make contracts-check
- make test
- make lint