### PR TITLE
feat(source): add Cerebro access telemetry dogfood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ vendor/
 go.work
 tmp/
 
+# Node
+node_modules/
+
 # Environment
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-
 | `aws` | AWS IAM, cloud, workload, network exposure, and CloudTrail source | access keys, IAM users/groups/roles/trust, EC2, ECS, EKS, Lambda, public endpoints, resource exposure, CloudTrail |
 | `azure` | Azure Entra ID, RBAC, activity, and audit source | activity logs, directory audit, users, groups, role/app assignments, service principals, credentials, resource exposure |
 | `backstage` | Backstage catalog source | components |
+| `cerebro` | Cerebro product access telemetry source backed by structured NDJSON archives | API access audit events |
 | `cosmo` | Cosmo workflow and message source | messages, survey feedback, configured families |
 | `evidence_cas` | EvidenceCAS content-addressed evidence reference source | object manifests |
 | `gcp` | GCP IAM, Cloud Identity, service-account, and audit source | audit, groups, IAM role assignments, service accounts, resource exposure |

--- a/internal/sourceprojection/cerebro.go
+++ b/internal/sourceprojection/cerebro.go
@@ -1,0 +1,81 @@
+package sourceprojection
+
+import (
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func cerebroAPIAccessProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	serviceURN := projectionURN(tenantID, "service", "cerebro")
+	accessURN := projectionURN(tenantID, "cerebro_api_access", firstNonEmpty(attrs["request_id"], event.GetId()))
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        serviceURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "service",
+		Label:      "Cerebro",
+		Attributes: map[string]string{"service": "cerebro"},
+	})
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        accessURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "cerebro.api_access",
+		Label:      strings.TrimSpace(firstNonEmpty(attrs["route"], attrs["connect_procedure"], event.GetId())),
+		Attributes: cerebroAccessEntityAttributes(event, attrs),
+	})
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), serviceURN, accessURN, relationHasEvidence, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), accessURN, serviceURN, relationObservedOn, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+	if principalURN := cerebroPrincipalURN(tenantID, attrs); principalURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        principalURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "cerebro.principal",
+			Label:      cerebroPrincipalLabel(attrs),
+			Attributes: cerebroPrincipalAttributes(attrs),
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), principalURN, accessURN, relationHasEvidence, map[string]string{"event_id": event.GetId(), "outcome": strings.TrimSpace(attrs["outcome_result"]), "at": eventObservedAt(event)}))
+		if actor := strings.TrimSpace(firstNonEmpty(attrs["actor_user"], attrs["principal"])); actor != "" {
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), principalURN, actor, event.GetOccurredAt())
+		}
+	}
+	return identityProjectionResult(entities, links)
+}
+
+func cerebroAccessEntityAttributes(event *cerebrov1.EventEnvelope, attrs map[string]string) map[string]string {
+	out := map[string]string{"event_id": event.GetId(), "source_product": "cerebro", "at": eventObservedAt(event)}
+	for _, key := range []string{"auth_mode", "client_ip", "connect_code", "connect_procedure", "denial_reason", "device_id", "duration_ms", "effective_status_code", "method", "operation_family", "operation_type", "outcome_result", "remote_ip", "request_id", "risk_level", "risk_score", "route", "source_ip", "status_code", "tenant_mismatch"} {
+		addProjectedAttribute(out, key, attrs[key])
+	}
+	return out
+}
+
+func cerebroPrincipalURN(tenantID string, attrs map[string]string) string {
+	value := firstNonEmpty(attrs["principal"], attrs["device_id"], attrs["client_id"], attrs["credential_id"])
+	if value == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "cerebro_principal", normalizeIdentifier(value))
+}
+
+func cerebroPrincipalLabel(attrs map[string]string) string {
+	return firstNonEmpty(attrs["principal"], attrs["device_id"], attrs["client_id"], attrs["credential_id"])
+}
+
+func cerebroPrincipalAttributes(attrs map[string]string) map[string]string {
+	out := map[string]string{"source_product": "cerebro"}
+	for _, key := range []string{"auth_mode", "client_id", "credential_id", "device_id", "principal", "principal_tenant_id", "risk_level", "risk_score"} {
+		addProjectedAttribute(out, key, attrs[key])
+	}
+	return out
+}

--- a/internal/sourceprojection/cerebro_test.go
+++ b/internal/sourceprojection/cerebro_test.go
@@ -1,0 +1,50 @@
+package sourceprojection
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestProjectCerebroAPIAccessLinksPrincipalAndService(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	event := &cerebrov1.EventEnvelope{
+		Id:         "cerebro-api-access-audit-request-1",
+		TenantId:   "writer",
+		SourceId:   "cerebro",
+		Kind:       "cerebro.api_access",
+		OccurredAt: timestamppb.New(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)),
+		Attributes: map[string]string{
+			"actor_user":     "ci@example.com",
+			"auth_mode":      "api_key",
+			"method":         "GET",
+			"outcome_result": "allowed",
+			"principal":      "ci@example.com",
+			"request_id":     "audit-request-1",
+			"route":          "GET /sources",
+			"source_ip":      "198.51.100.7",
+			"status_code":    "200",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	serviceURN := "urn:cerebro:writer:service:cerebro"
+	accessURN := "urn:cerebro:writer:cerebro_api_access:audit-request-1"
+	principalURN := "urn:cerebro:writer:cerebro_principal:ci@example.com"
+	identityURN := "urn:cerebro:writer:identity:email:ci@example.com"
+	if entity := state.entities[serviceURN]; entity == nil || entity.EntityType != "service" {
+		t.Fatalf("service entity missing or wrong: %#v", entity)
+	}
+	if entity := state.entities[accessURN]; entity == nil || entity.EntityType != "cerebro.api_access" || entity.Attributes["route"] != "GET /sources" {
+		t.Fatalf("access entity missing or wrong: %#v", entity)
+	}
+	assertProjectedLink(t, state, serviceURN, relationHasEvidence, accessURN)
+	assertProjectedLink(t, state, accessURN, relationObservedOn, serviceURN)
+	assertProjectedLink(t, state, principalURN, relationHasEvidence, accessURN)
+	assertProjectedLink(t, state, principalURN, relationRepresentsIdentity, identityURN)
+}

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -48,6 +48,7 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"aurelius.finding":                          aureliusFindingProjections,
 	"aurelius.image_scan":                       aureliusImageScanProjections,
 	"aurelius.policy_exception":                 aureliusPolicyExceptionProjections,
+	"cerebro.api_access":                        cerebroAPIAccessProjections,
 	"aurelius.verdict":                          aureliusVerdictProjections,
 	"github.pull_request":                       githubPullRequestProjections,
 	"github.audit":                              githubAuditProjections,

--- a/internal/sourceregistry/registry.go
+++ b/internal/sourceregistry/registry.go
@@ -8,6 +8,7 @@ import (
 	awssource "github.com/writer/cerebro/sources/aws"
 	azuresource "github.com/writer/cerebro/sources/azure"
 	backstagesource "github.com/writer/cerebro/sources/backstage"
+	cerebrosource "github.com/writer/cerebro/sources/cerebro"
 	cosmosource "github.com/writer/cerebro/sources/cosmo"
 	evidencecassource "github.com/writer/cerebro/sources/evidencecas"
 	gcpsource "github.com/writer/cerebro/sources/gcp"
@@ -59,6 +60,12 @@ var builtinSourceLoaders = []builtinSourceLoader{
 		name: "backstage",
 		load: func() (sourcecdk.Source, error) {
 			return backstagesource.New()
+		},
+	},
+	{
+		name: "cerebro",
+		load: func() (sourcecdk.Source, error) {
+			return cerebrosource.New()
 		},
 	},
 	{

--- a/internal/sourceregistry/registry_test.go
+++ b/internal/sourceregistry/registry_test.go
@@ -35,6 +35,13 @@ func TestBuiltin(t *testing.T) {
 	if backstage.Spec().Name != "Backstage" {
 		t.Fatalf("backstage Spec().Name = %q, want %q", backstage.Spec().Name, "Backstage")
 	}
+	cerebro, ok := registry.Get("cerebro")
+	if !ok {
+		t.Fatal("Get(cerebro) = false, want true")
+	}
+	if cerebro.Spec().Name != "Cerebro" {
+		t.Fatalf("cerebro Spec().Name = %q, want %q", cerebro.Spec().Name, "Cerebro")
+	}
 	cosmo, ok := registry.Get("cosmo")
 	if !ok {
 		t.Fatal("Get(cosmo) = false, want true")

--- a/sources/cerebro/catalog.yaml
+++ b/sources/cerebro/catalog.yaml
@@ -1,0 +1,17 @@
+id: cerebro
+name: Cerebro
+description: Cerebro product telemetry source. Reads structured access audit telemetry exported as NDJSON archives.
+emitted_kinds:
+  - cerebro.api_access
+event_contracts:
+  - kind: cerebro.api_access
+    schema_ref: cerebro/api_access/v1
+    required_attributes:
+      - event_type
+      - outcome_result
+      - route
+      - method
+    required_payload_fields:
+      - name
+      - outcome
+      - route

--- a/sources/cerebro/source.go
+++ b/sources/cerebro/source.go
@@ -181,7 +181,6 @@ func ndjsonSettings(st settings) s3ndjson.Settings {
 		ExternalID:       st.externalID,
 		SessionName:      "cerebro-product-source",
 		PerPage:          st.perPage,
-		ResumableCursor:  true,
 		MarshalRawRecord: func(raw json.RawMessage) (*primitives.Event, error) { return accessEvent(st, raw) },
 	}
 }

--- a/sources/cerebro/source.go
+++ b/sources/cerebro/source.go
@@ -1,0 +1,286 @@
+package cerebro
+
+import (
+	"context"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/sources/internal/s3ndjson"
+)
+
+//go:embed catalog.yaml
+var catalogFS embed.FS
+
+var awsRoleARNPattern = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:role/[A-Za-z0-9+=,.@_/-]+$`)
+
+const (
+	sourceID       = "cerebro"
+	familyAccess   = "access"
+	defaultRegion  = "us-east-1"
+	defaultPerPage = 100
+	maxPerPage     = 1000
+	cursorSource   = "cerebro/access/s3-ndjson/v1"
+	kindAccess     = "cerebro.api_access"
+	schemaAccess   = "cerebro/api_access/v1"
+)
+
+var (
+	ErrBucketRequired  = errors.New("bucket is required")
+	ErrPrefixRequired  = errors.New("prefix is required")
+	ErrTenantRequired  = errors.New("tenant_id is required")
+	ErrInvalidBucket   = errors.New("invalid bucket")
+	ErrInvalidPrefix   = errors.New("invalid prefix")
+	ErrInvalidPageSize = errors.New("invalid page_size")
+	ErrRoleNotAllowed  = errors.New("role_arn is not allowed")
+	ErrTenantScope     = errors.New("tenant outside runtime tenant")
+)
+
+type Source struct {
+	spec      *cerebrov1.SourceSpec
+	families  *sourcecdk.FamilyEngine[settings]
+	newClient func(context.Context, settings) (s3ndjson.API, error)
+}
+
+type settings struct {
+	family         string
+	bucket         string
+	prefix         string
+	region         string
+	tenantID       string
+	runtimeID      string
+	roleARN        string
+	externalID     string
+	assumeRoleARNs string
+	perPage        int32
+}
+
+func New() (*Source, error) {
+	specBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		return nil, err
+	}
+	spec, err := sourcecdk.LoadCatalog(specBytes)
+	if err != nil {
+		return nil, err
+	}
+	source := &Source{spec: spec, newClient: defaultClientFactory}
+	source.families, err = sourcecdk.NewFamilyEngine[settings](parseSettings, func(st settings) string { return st.family },
+		sourcecdk.Family[settings]{
+			Name: familyAccess,
+			Check: func(ctx context.Context, st settings) error {
+				client, err := source.newClient(ctx, st)
+				if err != nil {
+					return err
+				}
+				return s3ndjson.Check(ctx, client, ndjsonSettings(st))
+			},
+			Discover: func(_ context.Context, st settings) ([]sourcecdk.URN, error) {
+				return s3ndjson.Discover(fmt.Sprintf("urn:cerebro:%s:cerebro_access:%s", st.tenantID, firstNonEmpty(st.runtimeID, familyAccess)))
+			},
+			Read: func(ctx context.Context, st settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+				client, err := source.newClient(ctx, st)
+				if err != nil {
+					return sourcecdk.Pull{}, err
+				}
+				return s3ndjson.Read(ctx, client, ndjsonSettings(st), cursor)
+			},
+		})
+	if err != nil {
+		return nil, err
+	}
+	return source, nil
+}
+
+func (s *Source) Spec() *cerebrov1.SourceSpec { return s.spec }
+func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
+	return s.families.Check(ctx, cfg)
+}
+func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return s.families.Discover(ctx, cfg)
+}
+func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return s.families.Read(ctx, cfg, cursor)
+}
+
+func parseSettings(cfg sourcecdk.Config) (settings, error) {
+	tenantID := strings.TrimSpace(configValue(cfg, "tenant_id"))
+	if runtimeTenant := strings.TrimSpace(configValue(cfg, sourceconfig.RuntimeTenantIDKey)); runtimeTenant != "" {
+		tenantID = runtimeTenant
+	}
+	perPage, err := s3ndjson.PositivePageSize(firstNonEmpty(configValue(cfg, "per_page"), configValue(cfg, "page_size")), defaultPerPage, maxPerPage)
+	if err != nil {
+		return settings{}, fmt.Errorf("%w: %w", ErrInvalidPageSize, err)
+	}
+	st := settings{
+		family:         firstNonEmpty(configValue(cfg, "family"), familyAccess),
+		bucket:         strings.TrimSpace(configValue(cfg, "bucket")),
+		prefix:         strings.TrimSpace(configValue(cfg, "prefix")),
+		region:         firstNonEmpty(configValue(cfg, "region"), defaultRegion),
+		tenantID:       tenantID,
+		runtimeID:      firstNonEmpty(configValue(cfg, "runtime_id"), configValue(cfg, "source_runtime_id")),
+		roleARN:        strings.TrimSpace(configValue(cfg, "role_arn")),
+		externalID:     strings.TrimSpace(configValue(cfg, "external_id")),
+		assumeRoleARNs: strings.TrimSpace(configValue(cfg, sourceconfig.AWSAssumeRoleAllowlistKey)),
+		perPage:        perPage,
+	}
+	if st.bucket == "" {
+		return settings{}, ErrBucketRequired
+	}
+	if !s3ndjson.SafeS3Bucket(st.bucket) {
+		return settings{}, ErrInvalidBucket
+	}
+	if st.prefix == "" {
+		return settings{}, ErrPrefixRequired
+	}
+	if !strings.HasSuffix(st.prefix, "/") {
+		st.prefix += "/"
+	}
+	if !s3ndjson.SafeS3Prefix(st.prefix) {
+		return settings{}, ErrInvalidPrefix
+	}
+	if st.tenantID == "" {
+		return settings{}, ErrTenantRequired
+	}
+	if st.family != familyAccess {
+		return settings{}, fmt.Errorf("%w: unsupported family %q", sourcecdk.ErrInvalidConfig, st.family)
+	}
+	if st.roleARN != "" && !roleAllowed(st) {
+		return settings{}, ErrRoleNotAllowed
+	}
+	if st.roleARN == "" && st.externalID != "" {
+		return settings{}, fmt.Errorf("cerebro external_id requires role_arn")
+	}
+	return st, nil
+}
+
+func defaultClientFactory(ctx context.Context, st settings) (s3ndjson.API, error) {
+	return s3ndjson.NewClient(ctx, ndjsonSettings(st))
+}
+
+func ndjsonSettings(st settings) s3ndjson.Settings {
+	return s3ndjson.Settings{
+		Source:           cursorSource,
+		Bucket:           st.bucket,
+		Prefix:           st.prefix,
+		Region:           st.region,
+		RoleARN:          st.roleARN,
+		ExternalID:       st.externalID,
+		SessionName:      "cerebro-product-source",
+		PerPage:          st.perPage,
+		ResumableCursor:  true,
+		MarshalRawRecord: func(raw json.RawMessage) (*primitives.Event, error) { return accessEvent(st, raw) },
+	}
+}
+
+func accessEvent(st settings, raw json.RawMessage) (*primitives.Event, error) {
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, err
+	}
+	if stringField(body, "name") != "cerebro.api.access" {
+		return nil, fmt.Errorf("not a cerebro.api.access telemetry event")
+	}
+	occurredAt, err := parseTelemetryTime(stringField(body, "ts"))
+	if err != nil {
+		return nil, err
+	}
+	attrs := accessAttributes(body)
+	event := &cerebrov1.EventEnvelope{
+		Id:         accessEventID(body, raw),
+		TenantId:   firstNonEmpty(attrs["tenant_id"], st.tenantID),
+		SourceId:   sourceID,
+		Kind:       kindAccess,
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  schemaAccess,
+		Payload:    []byte(raw),
+		Attributes: attrs,
+	}
+	if event.TenantId != st.tenantID {
+		return nil, fmt.Errorf("%w: %q != %q", ErrTenantScope, event.TenantId, st.tenantID)
+	}
+	return event, sourcecdk.ValidateEventEnvelope(event)
+}
+
+func accessAttributes(body map[string]any) map[string]string {
+	attrs := map[string]string{
+		"event_type":     firstNonEmpty(stringField(body, "route"), stringField(body, "connect_procedure"), "api_access"),
+		"outcome_result": stringField(body, "outcome"),
+		"route":          stringField(body, "route"),
+		"method":         stringField(body, "method"),
+		"source_ip":      firstNonEmpty(stringField(body, "client_ip"), stringField(body, "remote_ip")),
+		"actor_user":     stringField(body, "principal"),
+		"resource_type":  "cerebro_api_route",
+	}
+	for _, key := range []string{"auth_mode", "client_id", "connect_code", "connect_procedure", "credential_id", "denial_reason", "device_id", "duration_ms", "effective_status_code", "effective_tenant_id", "operation_family", "operation_type", "principal", "principal_tenant_id", "remote_ip", "request_id", "requested_tenant_id", "risk_level", "risk_score", "sensitive_action", "status", "status_code", "tenant_id", "tenant_mismatch"} {
+		if value := stringField(body, key); value != "" {
+			attrs[key] = value
+		}
+	}
+	return attrs
+}
+
+func accessEventID(body map[string]any, raw []byte) string {
+	hash := sha256.Sum256(raw)
+	return "cerebro-api-access-" + firstNonEmpty(stringField(body, "request_id"), hex.EncodeToString(hash[:8]))
+}
+
+func parseTelemetryTime(value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, fmt.Errorf("ts is required")
+	}
+	return time.Parse(time.RFC3339Nano, value)
+}
+
+func roleAllowed(st settings) bool {
+	if !awsRoleARNPattern.MatchString(st.roleARN) || st.tenantID == "" {
+		return false
+	}
+	for _, value := range strings.FieldsFunc(st.assumeRoleARNs, func(r rune) bool { return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' ' }) {
+		tenant, arn, ok := strings.Cut(strings.TrimSpace(value), "=")
+		if ok && strings.TrimSpace(tenant) == st.tenantID && strings.TrimSpace(arn) == st.roleARN {
+			return true
+		}
+	}
+	return false
+}
+
+func stringField(body map[string]any, key string) string {
+	switch value := body[key].(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case float64:
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(value)
+	default:
+		return ""
+	}
+}
+
+func configValue(cfg sourcecdk.Config, key string) string {
+	value, _ := cfg.Lookup(key)
+	return value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/sources/cerebro/source_test.go
+++ b/sources/cerebro/source_test.go
@@ -56,7 +56,6 @@ func TestParseSettings(t *testing.T) {
 		{name: "missing-tenant", values: map[string]string{"bucket": "example-cerebro-access-logs", "prefix": "access"}, wantErrIs: ErrTenantRequired},
 		{name: "invalid-page-size", values: map[string]string{"bucket": "example-cerebro-access-logs", "prefix": "access", "tenant_id": "writer", "page_size": "0"}, wantErrIs: ErrInvalidPageSize},
 		{name: "role-not-allowlisted", values: map[string]string{"bucket": "example-cerebro-access-logs", "prefix": "access", "tenant_id": "writer", "role_arn": roleARN}, wantErrIs: nil},
-		{name: "role-not-allowlisted", values: map[string]string{"bucket": "writer-cerebro-logs", "prefix": "access", "tenant_id": "writer", "role_arn": roleARN}, wantErrIs: nil},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/sources/cerebro/source_test.go
+++ b/sources/cerebro/source_test.go
@@ -1,0 +1,211 @@
+package cerebro
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/sources/internal/s3ndjson"
+)
+
+func TestSourceSpec(t *testing.T) {
+	src, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if src.Spec().Id != sourceID || src.Spec().Name != "Cerebro" {
+		t.Fatalf("Spec() = %#v", src.Spec())
+	}
+}
+
+func TestParseSettings(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/cerebro-access-export"
+	tests := []struct {
+		name      string
+		values    map[string]string
+		wantErrIs error
+		want      settings
+	}{
+		{
+			name:   "defaults",
+			values: map[string]string{"bucket": "example-cerebro-access-logs", "prefix": "access", "tenant_id": "writer"},
+			want:   settings{family: familyAccess, bucket: "example-cerebro-access-logs", prefix: "access/", region: defaultRegion, tenantID: "writer", perPage: defaultPerPage},
+		},
+		{
+			name: "runtime-tenant-role-and-page",
+			values: map[string]string{
+				"bucket": "example-cerebro-access-logs", "prefix": "access/", "region": "us-west-2", "per_page": "25", "role_arn": roleARN, "external_id": "external",
+				sourceconfig.RuntimeTenantIDKey: "writer", sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + roleARN,
+			},
+			want: settings{family: familyAccess, bucket: "example-cerebro-access-logs", prefix: "access/", region: "us-west-2", tenantID: "writer", roleARN: roleARN, externalID: "external", assumeRoleARNs: "writer=" + roleARN, perPage: 25},
+		},
+		{name: "missing-bucket", values: map[string]string{"prefix": "access", "tenant_id": "writer"}, wantErrIs: ErrBucketRequired},
+		{name: "missing-prefix", values: map[string]string{"bucket": "example-cerebro-access-logs", "tenant_id": "writer"}, wantErrIs: ErrPrefixRequired},
+		{name: "missing-tenant", values: map[string]string{"bucket": "example-cerebro-access-logs", "prefix": "access"}, wantErrIs: ErrTenantRequired},
+		{name: "invalid-page-size", values: map[string]string{"bucket": "example-cerebro-access-logs", "prefix": "access", "tenant_id": "writer", "page_size": "0"}, wantErrIs: ErrInvalidPageSize},
+		{name: "role-not-allowlisted", values: map[string]string{"bucket": "example-cerebro-access-logs", "prefix": "access", "tenant_id": "writer", "role_arn": roleARN}, wantErrIs: nil},
+		{name: "role-not-allowlisted", values: map[string]string{"bucket": "writer-cerebro-logs", "prefix": "access", "tenant_id": "writer", "role_arn": roleARN}, wantErrIs: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSettings(sourcecdk.NewConfig(tc.values))
+			if tc.name == "role-not-allowlisted" {
+				if !errors.Is(err, ErrRoleNotAllowed) {
+					t.Fatalf("parseSettings() error = %v, want role allowlist error", err)
+				}
+				return
+			}
+			if tc.wantErrIs != nil {
+				if !errors.Is(err, tc.wantErrIs) {
+					t.Fatalf("parseSettings() error = %v, want errors.Is %v", err, tc.wantErrIs)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSettings() error = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseSettings() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadAccessTelemetryArchives(t *testing.T) {
+	src, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	client := newFakeS3([]fakeObject{
+		{key: "access/2026-06-09.ndjson", records: []map[string]any{
+			accessTelemetry("audit-request-1", "writer", "allowed", "GET /sources", "ci@example.com"),
+		}},
+		{key: "access/2026-06-10.ndjson.gz", gzip: true, records: []map[string]any{
+			accessTelemetry("audit-request-2", "writer", "denied", "POST /source-runtimes/{runtimeID}/sync", "ops@example.com"),
+		}},
+	})
+	src.newClient = func(context.Context, settings) (s3ndjson.API, error) { return client, nil }
+	pull, err := src.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"bucket": "example-cerebro-access-logs", "prefix": "access/", "tenant_id": "writer"}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("events = %d, want 2", len(pull.Events))
+	}
+	for _, event := range pull.Events {
+		if event.GetSourceId() != sourceID || event.GetKind() != kindAccess || event.GetSchemaRef() != schemaAccess {
+			t.Fatalf("event scope = source %q kind %q schema %q", event.GetSourceId(), event.GetKind(), event.GetSchemaRef())
+		}
+		if err := sourcecdk.ValidateEventEnvelope(event); err != nil {
+			t.Fatalf("ValidateEventEnvelope() error = %v", err)
+		}
+	}
+	if pull.Events[0].GetAttributes()["actor_user"] != "ci@example.com" || pull.Events[0].GetAttributes()["source_ip"] != "198.51.100.7" {
+		t.Fatalf("first event attrs = %#v", pull.Events[0].GetAttributes())
+	}
+	if pull.Events[1].GetAttributes()["outcome_result"] != "denied" || pull.Events[1].GetAttributes()["sensitive_action"] != "true" {
+		t.Fatalf("second event attrs = %#v", pull.Events[1].GetAttributes())
+	}
+}
+
+func TestReadRejectsOutsideTenantTelemetry(t *testing.T) {
+	src, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	src.newClient = func(context.Context, settings) (s3ndjson.API, error) {
+		return newFakeS3([]fakeObject{{key: "access/outside.ndjson", records: []map[string]any{accessTelemetry("audit-request-3", "other", "allowed", "GET /sources", "ci@example.com")}}}), nil
+	}
+	_, err = src.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"bucket": "example-cerebro-access-logs", "prefix": "access/", "tenant_id": "writer"}), nil)
+	if !errors.Is(err, ErrTenantScope) {
+		t.Fatalf("Read() error = %v, want tenant rejection", err)
+	}
+}
+
+type fakeObject struct {
+	key     string
+	records []map[string]any
+	gzip    bool
+}
+
+type fakeS3 struct {
+	objects []fakeObject
+}
+
+func newFakeS3(objects []fakeObject) *fakeS3 {
+	return &fakeS3{objects: objects}
+}
+
+func (f *fakeS3) ListObjectsV2(_ context.Context, input *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	prefix := awssdk.ToString(input.Prefix)
+	out := &s3.ListObjectsV2Output{}
+	for _, object := range f.objects {
+		if strings.HasPrefix(object.key, prefix) {
+			out.Contents = append(out.Contents, s3types.Object{Key: awssdk.String(object.key)})
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeS3) GetObject(_ context.Context, input *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	key := awssdk.ToString(input.Key)
+	for _, object := range f.objects {
+		if object.key != key {
+			continue
+		}
+		body := encodeRecords(object.records)
+		if object.gzip {
+			var zipped bytes.Buffer
+			gz := gzip.NewWriter(&zipped)
+			_, _ = gz.Write(body)
+			_ = gz.Close()
+			body = zipped.Bytes()
+		}
+		return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(body))}, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func encodeRecords(records []map[string]any) []byte {
+	var buf bytes.Buffer
+	for _, record := range records {
+		_ = json.NewEncoder(&buf).Encode(record)
+	}
+	return buf.Bytes()
+}
+
+func accessTelemetry(requestID string, tenantID string, outcome string, route string, principal string) map[string]any {
+	return map[string]any{
+		"kind":                  "event",
+		"name":                  "cerebro.api.access",
+		"ts":                    time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+		"outcome":               outcome,
+		"status":                200,
+		"status_code":           200,
+		"effective_status_code": 200,
+		"method":                strings.Fields(route)[0],
+		"route":                 route,
+		"operation_family":      "source",
+		"operation_type":        "read",
+		"tenant_id":             tenantID,
+		"effective_tenant_id":   tenantID,
+		"requested_tenant_id":   tenantID,
+		"principal":             principal,
+		"auth_mode":             "api_key",
+		"client_ip":             "198.51.100.7",
+		"request_id":            requestID,
+		"sensitive_action":      strings.HasPrefix(route, "POST"),
+	}
+}

--- a/sources/cerebro/testdata/read_access.json
+++ b/sources/cerebro/testdata/read_access.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "cerebro-api-access-audit-request-1",
+    "tenant_id": "writer",
+    "source_id": "cerebro",
+    "kind": "cerebro.api_access",
+    "occurred_at": "2026-06-09T12:00:00Z",
+    "schema_ref": "cerebro/api_access/v1",
+    "payload": {
+      "kind": "event",
+      "name": "cerebro.api.access",
+      "ts": "2026-06-09T12:00:00Z",
+      "outcome": "allowed",
+      "route": "GET /sources",
+      "method": "GET"
+    },
+    "attributes": {
+      "event_type": "GET /sources",
+      "outcome_result": "allowed",
+      "route": "GET /sources",
+      "method": "GET"
+    }
+  }
+]

--- a/sources/github/deploy.yaml
+++ b/sources/github/deploy.yaml
@@ -14,6 +14,38 @@ runtimes:
       owner: writer
       per_page: "100"
       token: env:GITHUB_TOKEN
+  - localId: cerebro-repository
+    config:
+      family: repository
+      owner: writer
+      per_page: "100"
+      repo: cerebro
+      token: env:GITHUB_TOKEN
+  - localId: cerebro-pull-request
+    config:
+      family: pull_request
+      owner: writer
+      per_page: "100"
+      repo: cerebro
+      state: all
+      token: env:GITHUB_TOKEN
+  - localId: cerebro-dependabot-alert
+    config:
+      family: dependabot_alert
+      owner: writer
+      per_page: "100"
+      repo: cerebro
+      state: open
+      token: env:GITHUB_TOKEN
+  - localId: cerebro-audit
+    config:
+      family: audit
+      include: all
+      order: desc
+      owner: writer
+      per_page: "100"
+      phrase: repo:writer/cerebro
+      token: env:GITHUB_TOKEN
   - localId: org-inventory
     config:
       family: org_inventory

--- a/sources/internal/s3ndjson/s3ndjson.go
+++ b/sources/internal/s3ndjson/s3ndjson.go
@@ -47,7 +47,6 @@ type Settings struct {
 	ExternalID       string
 	SessionName      string
 	PerPage          int32
-	ResumableCursor  bool
 	MarshalRawRecord func(json.RawMessage) (*primitives.Event, error)
 }
 
@@ -105,82 +104,86 @@ func Read(ctx context.Context, client API, st Settings, cursor *cerebrov1.Source
 		return sourcecdk.Pull{}, err
 	}
 	events := []*primitives.Event{}
-	lastKey := ""
+	completedLastKey := state.LastKey
 	for _, object := range out.Contents {
 		key := awssdk.ToString(object.Key)
 		if key == "" {
 			continue
 		}
-		lastKey = key
 		if strings.HasSuffix(key, "/") {
+			completedLastKey = key
 			continue
 		}
 		offset := 0
 		if key == state.PartialKey {
 			offset = state.RecordOffset
 		}
-		next, complete, err := readObject(ctx, client, st, key, offset)
+		next, nextOffset, complete, err := readObject(ctx, client, st, key, offset)
 		if err != nil {
 			return sourcecdk.Pull{}, err
 		}
 		events = append(events, next...)
 		if !complete {
+			state.LastKey = completedLastKey
 			state.PartialKey = key
-			state.RecordOffset = offset + len(next)
+			state.RecordOffset = nextOffset
 			return sourcecdk.Pull{Events: events, NextCursor: encodeCursor(state, st.Source), Checkpoint: checkpoint(state)}, nil
 		}
 		state.PartialKey = ""
 		state.RecordOffset = 0
+		completedLastKey = key
 		if len(events) >= MaxEventsPerPull {
-			state.LastKey = key
+			state.LastKey = completedLastKey
 			return sourcecdk.Pull{Events: events, NextCursor: encodeCursor(state, st.Source), Checkpoint: checkpoint(state)}, nil
 		}
 	}
 	if awssdk.ToBool(out.IsTruncated) {
-		state.LastKey = lastKey
+		state.LastKey = completedLastKey
 		return sourcecdk.Pull{Events: events, NextCursor: encodeCursor(state, st.Source), Checkpoint: checkpoint(state)}, nil
 	}
-	state.LastKey = lastKey
+	state.LastKey = completedLastKey
 	return sourcecdk.Pull{Events: events, Checkpoint: checkpoint(state)}, nil
 }
 
-func readObject(ctx context.Context, client API, st Settings, key string, skip int) ([]*primitives.Event, bool, error) {
+func readObject(ctx context.Context, client API, st Settings, key string, skip int) ([]*primitives.Event, int, bool, error) {
 	out, err := client.GetObject(ctx, &s3.GetObjectInput{Bucket: awssdk.String(st.Bucket), Key: awssdk.String(key)})
 	if err != nil {
-		return nil, false, err
+		return nil, 0, false, err
 	}
 	defer func() { _ = out.Body.Close() }()
 	reader, err := objectReader(key, io.LimitReader(out.Body, MaxObjectBytes+1))
 	if err != nil {
-		return nil, false, err
+		return nil, 0, false, err
 	}
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 0, 64*1024), MaxLineBytes)
 	events := []*primitives.Event{}
 	line := 0
+	recordsSeen := 0
 	for scanner.Scan() {
-		if line < skip {
-			line++
+		line++
+		raw := bytes.TrimSpace(scanner.Bytes())
+		if len(raw) == 0 {
 			continue
 		}
-		raw := bytes.TrimSpace(scanner.Bytes())
-		line++
-		if len(raw) == 0 {
+		if recordsSeen < skip {
+			recordsSeen++
 			continue
 		}
 		event, err := decodeEvent(raw, st.MarshalRawRecord)
 		if err != nil {
-			return nil, false, fmt.Errorf("decode %s line %d: %w", key, line, err)
+			return nil, recordsSeen, false, fmt.Errorf("decode %s line %d: %w", key, line, err)
 		}
+		recordsSeen++
 		events = append(events, event)
 		if len(events) >= MaxEventsPerPull {
-			return events, false, nil
+			return events, recordsSeen, false, nil
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, false, err
+		return nil, recordsSeen, false, err
 	}
-	return events, true, nil
+	return events, recordsSeen, true, nil
 }
 
 func objectReader(key string, reader io.Reader) (io.Reader, error) {

--- a/sources/internal/s3ndjson/s3ndjson.go
+++ b/sources/internal/s3ndjson/s3ndjson.go
@@ -1,0 +1,297 @@
+package s3ndjson
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+	"strings"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+const (
+	MaxObjectBytes   = 64 << 20
+	MaxLineBytes     = 1 << 20
+	MaxEventsPerPull = 1000
+)
+
+var ErrDecompressedObjectTooLarge = errors.New("decompressed object exceeds limit")
+
+type API interface {
+	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
+type Settings struct {
+	Source           string
+	Bucket           string
+	Prefix           string
+	Region           string
+	RoleARN          string
+	ExternalID       string
+	SessionName      string
+	PerPage          int32
+	ResumableCursor  bool
+	MarshalRawRecord func(json.RawMessage) (*primitives.Event, error)
+}
+
+type Cursor struct {
+	Source              string `json:"source,omitempty"`
+	ResumableCheckpoint bool   `json:"resumable_checkpoint,omitempty"`
+	LastKey             string `json:"last_key,omitempty"`
+	PartialKey          string `json:"partial_key,omitempty"`
+	RecordOffset        int    `json:"record_offset,omitempty"`
+}
+
+func NewClient(ctx context.Context, st Settings) (API, error) {
+	region := strings.TrimSpace(st.Region)
+	if region == "" {
+		region = "us-east-1"
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+	if st.RoleARN != "" {
+		provider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), st.RoleARN, func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = firstNonEmpty(st.SessionName, "cerebro-s3ndjson-source")
+			if st.ExternalID != "" {
+				options.ExternalID = awssdk.String(st.ExternalID)
+			}
+		})
+		cfg.Credentials = awssdk.NewCredentialsCache(provider)
+	}
+	return s3.NewFromConfig(cfg), nil
+}
+
+func Check(ctx context.Context, client API, st Settings) error {
+	_, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{Bucket: awssdk.String(st.Bucket), Prefix: awssdk.String(st.Prefix), MaxKeys: awssdk.Int32(1)})
+	return err
+}
+
+func Discover(urn string) ([]sourcecdk.URN, error) {
+	parsed, err := sourcecdk.ParseURN(urn)
+	if err != nil {
+		return nil, err
+	}
+	return []sourcecdk.URN{parsed}, nil
+}
+
+func Read(ctx context.Context, client API, st Settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	state := decodeCursor(cursor, st.Source)
+	out, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket:     awssdk.String(st.Bucket),
+		Prefix:     awssdk.String(st.Prefix),
+		StartAfter: tokenPtr(state.LastKey),
+		MaxKeys:    awssdk.Int32(st.PerPage),
+	})
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	events := []*primitives.Event{}
+	lastKey := ""
+	for _, object := range out.Contents {
+		key := awssdk.ToString(object.Key)
+		if key == "" {
+			continue
+		}
+		lastKey = key
+		if strings.HasSuffix(key, "/") {
+			continue
+		}
+		offset := 0
+		if key == state.PartialKey {
+			offset = state.RecordOffset
+		}
+		next, complete, err := readObject(ctx, client, st, key, offset)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		events = append(events, next...)
+		if !complete {
+			state.PartialKey = key
+			state.RecordOffset = offset + len(next)
+			return sourcecdk.Pull{Events: events, NextCursor: encodeCursor(state, st.Source), Checkpoint: checkpoint(state)}, nil
+		}
+		state.PartialKey = ""
+		state.RecordOffset = 0
+		if len(events) >= MaxEventsPerPull {
+			state.LastKey = key
+			return sourcecdk.Pull{Events: events, NextCursor: encodeCursor(state, st.Source), Checkpoint: checkpoint(state)}, nil
+		}
+	}
+	if awssdk.ToBool(out.IsTruncated) {
+		state.LastKey = lastKey
+		return sourcecdk.Pull{Events: events, NextCursor: encodeCursor(state, st.Source), Checkpoint: checkpoint(state)}, nil
+	}
+	state.LastKey = lastKey
+	return sourcecdk.Pull{Events: events, Checkpoint: checkpoint(state)}, nil
+}
+
+func readObject(ctx context.Context, client API, st Settings, key string, skip int) ([]*primitives.Event, bool, error) {
+	out, err := client.GetObject(ctx, &s3.GetObjectInput{Bucket: awssdk.String(st.Bucket), Key: awssdk.String(key)})
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = out.Body.Close() }()
+	reader, err := objectReader(key, io.LimitReader(out.Body, MaxObjectBytes+1))
+	if err != nil {
+		return nil, false, err
+	}
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), MaxLineBytes)
+	events := []*primitives.Event{}
+	line := 0
+	for scanner.Scan() {
+		if line < skip {
+			line++
+			continue
+		}
+		raw := bytes.TrimSpace(scanner.Bytes())
+		line++
+		if len(raw) == 0 {
+			continue
+		}
+		event, err := decodeEvent(raw, st.MarshalRawRecord)
+		if err != nil {
+			return nil, false, fmt.Errorf("decode %s line %d: %w", key, line, err)
+		}
+		events = append(events, event)
+		if len(events) >= MaxEventsPerPull {
+			return events, false, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, false, err
+	}
+	return events, true, nil
+}
+
+func objectReader(key string, reader io.Reader) (io.Reader, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, MaxObjectBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > MaxObjectBytes {
+		return nil, ErrDecompressedObjectTooLarge
+	}
+	if strings.HasSuffix(strings.ToLower(key), ".gz") {
+		gz, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+		data, err = io.ReadAll(io.LimitReader(gz, MaxObjectBytes+1))
+		if err != nil {
+			_ = gz.Close()
+			return nil, err
+		}
+		if err := gz.Close(); err != nil {
+			return nil, err
+		}
+		if len(data) > MaxObjectBytes {
+			return nil, ErrDecompressedObjectTooLarge
+		}
+	}
+	return bytes.NewReader(data), nil
+}
+
+func decodeEvent(raw json.RawMessage, marshal func(json.RawMessage) (*primitives.Event, error)) (*primitives.Event, error) {
+	if marshal != nil {
+		return marshal(raw)
+	}
+	event := &cerebrov1.EventEnvelope{}
+	if err := protojson.Unmarshal(raw, event); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+func decodeCursor(cursor *cerebrov1.SourceCursor, source string) Cursor {
+	if cursor == nil || strings.TrimSpace(cursor.GetOpaque()) == "" {
+		return Cursor{Source: source}
+	}
+	var decoded Cursor
+	if err := json.Unmarshal([]byte(cursor.GetOpaque()), &decoded); err != nil || decoded.Source != source {
+		return Cursor{Source: source}
+	}
+	return decoded
+}
+
+func encodeCursor(cursor Cursor, source string) *cerebrov1.SourceCursor {
+	cursor.Source = source
+	cursor.ResumableCheckpoint = true
+	data, _ := json.Marshal(cursor)
+	return &cerebrov1.SourceCursor{Opaque: string(data)}
+}
+
+func checkpoint(cursor Cursor) *cerebrov1.SourceCheckpoint {
+	data, _ := json.Marshal(cursor)
+	return &cerebrov1.SourceCheckpoint{CursorOpaque: string(data)}
+}
+
+func tokenPtr(value string) *string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return awssdk.String(value)
+}
+
+func SafeS3Bucket(value string) bool {
+	if len(value) < 3 || len(value) > 63 || strings.Contains(value, "..") {
+		return false
+	}
+	for _, ch := range value {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '.' || ch == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func SafeS3Prefix(value string) bool {
+	if strings.TrimSpace(value) == "" || len(value) > 1024 {
+		return false
+	}
+	_, err := url.ParseRequestURI("/" + value)
+	return err == nil
+}
+
+func PositivePageSize(raw string, def int32, max int32) (int32, error) {
+	if strings.TrimSpace(raw) == "" {
+		return def, nil
+	}
+	value, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 32)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("invalid page_size")
+	}
+	if int32(value) > max { // #nosec G109 G115 -- ParseInt bitSize 32 bounds value before conversion.
+		return max, nil
+	}
+	return int32(value), nil // #nosec G109 G115 -- ParseInt bitSize 32 bounds value before conversion.
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/sources/internal/s3ndjson/s3ndjson_test.go
+++ b/sources/internal/s3ndjson/s3ndjson_test.go
@@ -1,0 +1,120 @@
+package s3ndjson
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+)
+
+func TestReadPartialCursorAdvancesCompletedKeyAndSkipsLogicalRecords(t *testing.T) {
+	lines := make([]string, 0, MaxEventsPerPull+2)
+	for i := 0; i < MaxEventsPerPull+1; i++ {
+		if i == 500 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, fmt.Sprintf(`{"id":"b-%04d"}`, i))
+	}
+	client := &fakeS3{
+		objects: map[string]string{
+			"access/a.ndjson": `{"id":"a"}` + "\n",
+			"access/b.ndjson": strings.Join(lines, "\n") + "\n",
+		},
+	}
+	settings := Settings{
+		Source:           "test/s3-ndjson/v1",
+		Bucket:           "example",
+		Prefix:           "access/",
+		PerPage:          100,
+		MarshalRawRecord: testEvent,
+	}
+
+	first, err := Read(context.Background(), client, settings, nil)
+	if err != nil {
+		t.Fatalf("first Read() error = %v", err)
+	}
+	if len(first.Events) != MaxEventsPerPull+1 {
+		t.Fatalf("first events = %d, want %d", len(first.Events), MaxEventsPerPull+1)
+	}
+	if first.Events[0].GetId() != "a" || first.Events[len(first.Events)-1].GetId() != "b-0999" {
+		t.Fatalf("first event bounds = %q..%q", first.Events[0].GetId(), first.Events[len(first.Events)-1].GetId())
+	}
+	cursor := decodeCursor(first.NextCursor, settings.Source)
+	if cursor.LastKey != "access/a.ndjson" || cursor.PartialKey != "access/b.ndjson" || cursor.RecordOffset != MaxEventsPerPull {
+		t.Fatalf("first cursor = %+v, want completed a and partial b at offset %d", cursor, MaxEventsPerPull)
+	}
+
+	second, err := Read(context.Background(), client, settings, first.NextCursor)
+	if err != nil {
+		t.Fatalf("second Read() error = %v", err)
+	}
+	if len(client.startAfter) != 2 || client.startAfter[1] != "access/a.ndjson" {
+		t.Fatalf("second listing StartAfter = %v, want access/a.ndjson", client.startAfter)
+	}
+	if len(second.Events) != 1 || second.Events[0].GetId() != "b-1000" {
+		t.Fatalf("second events = %v, want only b-1000", eventIDs(second.Events))
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second NextCursor = %#v, want nil after completing partial object", second.NextCursor)
+	}
+}
+
+type fakeS3 struct {
+	objects    map[string]string
+	startAfter []string
+}
+
+func (f *fakeS3) ListObjectsV2(_ context.Context, input *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	prefix := awssdk.ToString(input.Prefix)
+	startAfter := awssdk.ToString(input.StartAfter)
+	f.startAfter = append(f.startAfter, startAfter)
+	keys := make([]string, 0, len(f.objects))
+	for key := range f.objects {
+		if strings.HasPrefix(key, prefix) && key > startAfter {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	contents := make([]s3types.Object, 0, len(keys))
+	for _, key := range keys {
+		contents = append(contents, s3types.Object{Key: awssdk.String(key)})
+	}
+	return &s3.ListObjectsV2Output{Contents: contents}, nil
+}
+
+func (f *fakeS3) GetObject(_ context.Context, input *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	body, ok := f.objects[awssdk.ToString(input.Key)]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader([]byte(body)))}, nil
+}
+
+func testEvent(raw json.RawMessage) (*primitives.Event, error) {
+	var payload struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, err
+	}
+	return &cerebrov1.EventEnvelope{Id: payload.ID}, nil
+}
+
+func eventIDs(events []*primitives.Event) []string {
+	ids := make([]string, 0, len(events))
+	for _, event := range events {
+		ids = append(ids, event.GetId())
+	}
+	return ids
+}

--- a/tools/archtests/source_deploy_test.go
+++ b/tools/archtests/source_deploy_test.go
@@ -74,3 +74,84 @@ func TestSourceDeployManifestsRenderForKnownEnvironments(t *testing.T) {
 		}
 	}
 }
+
+func TestGitHubDeployManifestIncludesCerebroSelfRuntimes(t *testing.T) {
+	root := filepath.Join("..", "..", "sources")
+	manifests, err := sourcedeploy.Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	var githubManifest *sourcedeploy.Manifest
+	for i := range manifests {
+		if manifests[i].SourceID == "github" {
+			githubManifest = &manifests[i]
+			break
+		}
+	}
+	if githubManifest == nil {
+		t.Fatal("github deploy manifest not found")
+	}
+
+	want := map[string]map[string]string{
+		"cerebro-audit": {
+			"family":   "audit",
+			"include":  "all",
+			"order":    "desc",
+			"owner":    "writer",
+			"per_page": "100",
+			"phrase":   "repo:writer/cerebro",
+			"token":    "env:GITHUB_TOKEN",
+		},
+		"cerebro-dependabot-alert": {
+			"family":   "dependabot_alert",
+			"owner":    "writer",
+			"per_page": "100",
+			"repo":     "cerebro",
+			"state":    "open",
+			"token":    "env:GITHUB_TOKEN",
+		},
+		"cerebro-pull-request": {
+			"family":   "pull_request",
+			"owner":    "writer",
+			"per_page": "100",
+			"repo":     "cerebro",
+			"state":    "all",
+			"token":    "env:GITHUB_TOKEN",
+		},
+		"cerebro-repository": {
+			"family":   "repository",
+			"owner":    "writer",
+			"per_page": "100",
+			"repo":     "cerebro",
+			"token":    "env:GITHUB_TOKEN",
+		},
+	}
+
+	have := map[string]map[string]string{}
+	for _, runtime := range githubManifest.Runtimes {
+		if _, ok := want[runtime.LocalID]; ok {
+			have[runtime.LocalID] = runtime.Config
+		}
+	}
+
+	missing := make([]string, 0)
+	for id := range want {
+		if _, ok := have[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("github deploy manifest missing Cerebro self runtimes: %v", missing)
+	}
+
+	for id, wantConfig := range want {
+		gotConfig := have[id]
+		for key, wantValue := range wantConfig {
+			if got := gotConfig[key]; got != wantValue {
+				t.Fatalf("%s config %s = %q, want %q", id, key, got, wantValue)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a built-in Cerebro source for structured API access telemetry archives
- project access events into service, principal, and evidence graph anchors
- add self-dogfood runtime coverage and regression tests

## Validation
- make verify