### PR TITLE
fix(source): allow private EvidenceCAS endpoints

### DIFF
--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -21,17 +21,29 @@ const DefaultRetryBackoff = 250 * time.Millisecond
 const MaxRetryAfter = 5 * time.Second
 
 type ClientOptions struct {
-	SourceID      string
-	Timeout       time.Duration
-	BaseTransport http.RoundTripper
-	AllowLoopback bool
-	LookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)
+	SourceID                 string
+	Timeout                  time.Duration
+	BaseTransport            http.RoundTripper
+	AllowLoopback            bool
+	PrivateEndpointAllowlist []string
+	LookupIPAddrs            func(context.Context, string) ([]net.IPAddr, error)
 }
 
 type RetryOptions struct {
 	MaxAttempts  int
 	Backoff      time.Duration
 	MaxBodyBytes int
+}
+
+type URLValidationOptions struct {
+	AllowLoopback            bool
+	PrivateEndpointAllowlist []string
+}
+
+type HostResolutionOptions struct {
+	AllowLoopback            bool
+	PrivateEndpointAllowlist []string
+	LookupIPAddrs            func(context.Context, string) ([]net.IPAddr, error)
 }
 
 type ResponseBody struct {
@@ -63,10 +75,11 @@ func HardenClient(client *http.Client, options ClientOptions) *http.Client {
 		transport = http.DefaultTransport
 	}
 	cloned.Transport = SafeRoundTripper{
-		Base:          transport,
-		SourceID:      strings.TrimSpace(options.SourceID),
-		AllowLoopback: options.AllowLoopback,
-		LookupIPAddrs: options.LookupIPAddrs,
+		Base:                     transport,
+		SourceID:                 strings.TrimSpace(options.SourceID),
+		AllowLoopback:            options.AllowLoopback,
+		PrivateEndpointAllowlist: options.PrivateEndpointAllowlist,
+		LookupIPAddrs:            options.LookupIPAddrs,
 	}
 	return &cloned
 }
@@ -83,25 +96,42 @@ func firstDuration(values ...time.Duration) time.Duration {
 // NormalizeBaseURL validates source-configured API origins before credentials are
 // attached to requests.
 func NormalizeBaseURL(sourceID string, raw string, allowLoopback bool) (string, string, error) {
+	return NormalizeBaseURLWithOptions(sourceID, raw, URLValidationOptions{AllowLoopback: allowLoopback})
+}
+
+func NormalizeBaseURLWithOptions(sourceID string, raw string, options URLValidationOptions) (string, string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
 		return "", "", fmt.Errorf("parse %s base_url: %w", sourceID, err)
 	}
 	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
-	allowInsecureLoopback := allowLoopback && parsed.Scheme == "http" && IsLoopbackHost(host)
+	allowInsecureLoopback := options.AllowLoopback && parsed.Scheme == "http" && IsLoopbackHost(host)
 	if parsed.Scheme != "https" && !allowInsecureLoopback {
 		return "", "", fmt.Errorf("%s base_url must use https", sourceID)
 	}
 	if host == "" {
 		return "", "", fmt.Errorf("%s base_url must include a host", sourceID)
 	}
+	privateEndpointAllowed := privateEndpointHostAllowed(host, options.PrivateEndpointAllowlist)
+	if len(options.PrivateEndpointAllowlist) > 0 && !privateEndpointAllowed {
+		return "", "", fmt.Errorf("%s private endpoint host must exactly match the configured allowlist", sourceID)
+	}
 	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
 		return "", "", fmt.Errorf("%s base_url must not include user info, query, or fragment", sourceID)
 	}
-	if strings.TrimSpace(parsed.Port()) != "" && parsed.Port() != "443" && (!allowLoopback || !IsLoopbackHost(host)) {
+	if privateEndpointAllowed && strings.Trim(strings.TrimSpace(host), "[]") != host {
+		return "", "", fmt.Errorf("%s private endpoint allowlist must use DNS hostnames, not IP literals", sourceID)
+	}
+	if privateEndpointAllowed && net.ParseIP(strings.Trim(host, "[]")) != nil {
+		return "", "", fmt.Errorf("%s private endpoint allowlist must use DNS hostnames, not IP literals", sourceID)
+	}
+	if privateEndpointAllowed && strings.Trim(parsed.EscapedPath(), "/") != "" {
+		return "", "", fmt.Errorf("%s private endpoint base_url must be an HTTPS origin without a path", sourceID)
+	}
+	if strings.TrimSpace(parsed.Port()) != "" && parsed.Port() != "443" && (!options.AllowLoopback || !IsLoopbackHost(host)) {
 		return "", "", fmt.Errorf("%s base_url must not include a custom port", sourceID)
 	}
-	if IsUnsafeHost(host) && (!allowLoopback || !IsLoopbackHost(host)) {
+	if IsUnsafeHost(host) && (!options.AllowLoopback || !IsLoopbackHost(host)) {
 		return "", "", fmt.Errorf("%s base_url must not target loopback, private, or link-local hosts", sourceID)
 	}
 	return strings.TrimRight(parsed.String(), "/"), host, nil
@@ -147,10 +177,11 @@ func SameOriginAbsoluteURL(sourceID string, baseURL string, raw string) (string,
 }
 
 type SafeRoundTripper struct {
-	Base          http.RoundTripper
-	SourceID      string
-	AllowLoopback bool
-	LookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)
+	Base                     http.RoundTripper
+	SourceID                 string
+	AllowLoopback            bool
+	PrivateEndpointAllowlist []string
+	LookupIPAddrs            func(context.Context, string) ([]net.IPAddr, error)
 }
 
 func (rt SafeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -165,7 +196,19 @@ func (rt SafeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		}
 	}
 	if req != nil && req.URL != nil {
-		addrs, err := SafeResolvedHostAddrs(req.Context(), rt.SourceID, req.URL.Hostname(), rt.AllowLoopback, rt.LookupIPAddrs)
+		if privateEndpointHostAllowed(req.URL.Hostname(), rt.PrivateEndpointAllowlist) {
+			if req.URL.Scheme != "https" {
+				return nil, fmt.Errorf("%s private endpoint requests must use https", rt.SourceID)
+			}
+			if port := strings.TrimSpace(req.URL.Port()); port != "" && port != "443" {
+				return nil, fmt.Errorf("%s private endpoint requests must not use a custom port", rt.SourceID)
+			}
+		}
+		addrs, err := SafeResolvedHostAddrsWithOptions(req.Context(), rt.SourceID, req.URL.Hostname(), HostResolutionOptions{
+			AllowLoopback:            rt.AllowLoopback,
+			PrivateEndpointAllowlist: rt.PrivateEndpointAllowlist,
+			LookupIPAddrs:            rt.LookupIPAddrs,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -214,16 +257,21 @@ func pinnedHostTransport(base http.RoundTripper, host string, ip net.IP) (http.R
 }
 
 func SafeResolvedHostAddrs(ctx context.Context, sourceID string, host string, allowLoopback bool, lookup func(context.Context, string) ([]net.IPAddr, error)) ([]net.IPAddr, error) {
+	return SafeResolvedHostAddrsWithOptions(ctx, sourceID, host, HostResolutionOptions{AllowLoopback: allowLoopback, LookupIPAddrs: lookup})
+}
+
+func SafeResolvedHostAddrsWithOptions(ctx context.Context, sourceID string, host string, options HostResolutionOptions) ([]net.IPAddr, error) {
 	normalized := strings.ToLower(strings.TrimSpace(host))
 	if normalized == "" {
 		return nil, fmt.Errorf("%s host is required", sourceID)
 	}
 	if ip := net.ParseIP(strings.Trim(normalized, "[]")); ip != nil {
-		if unsafeIP(ip, allowLoopback) {
+		if unsafeIP(ip, options.AllowLoopback) {
 			return nil, fmt.Errorf("%s host must not target loopback, private, or link-local addresses", sourceID)
 		}
 		return nil, nil
 	}
+	lookup := options.LookupIPAddrs
 	if lookup == nil {
 		lookup = net.DefaultResolver.LookupIPAddr
 	}
@@ -234,12 +282,67 @@ func SafeResolvedHostAddrs(ctx context.Context, sourceID string, host string, al
 	if len(addrs) == 0 {
 		return nil, fmt.Errorf("resolve %s host %q: no addresses", sourceID, normalized)
 	}
+	allowPrivate := privateEndpointHostAllowed(normalized, options.PrivateEndpointAllowlist)
 	for _, addr := range addrs {
-		if unsafeIP(addr.IP, allowLoopback) {
+		if unsafeResolvedIP(addr.IP, options.AllowLoopback, allowPrivate) {
 			return nil, fmt.Errorf("%s host must not resolve to loopback, private, or link-local addresses", sourceID)
 		}
 	}
 	return addrs, nil
+}
+
+func ParsePrivateEndpointAllowlist(sourceID string, raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	seen := map[string]struct{}{}
+	hosts := []string{}
+	for _, entry := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
+	}) {
+		host := strings.ToLower(strings.TrimSpace(entry))
+		if host == "" {
+			continue
+		}
+		if strings.Contains(host, "://") {
+			parsed, err := url.Parse(host)
+			if err != nil {
+				return nil, fmt.Errorf("parse %s private endpoint allowlist entry: %w", sourceID, err)
+			}
+			if parsed.Scheme != "https" || parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || strings.Trim(parsed.EscapedPath(), "/") != "" {
+				return nil, fmt.Errorf("%s private endpoint allowlist URL entries must be HTTPS origins", sourceID)
+			}
+			if port := strings.TrimSpace(parsed.Port()); port != "" && port != "443" {
+				return nil, fmt.Errorf("%s private endpoint allowlist URL entries must not include a custom port", sourceID)
+			}
+			host = strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+		}
+		if strings.Contains(host, "://") || strings.Contains(host, "/") || strings.Contains(host, "?") || strings.Contains(host, "#") || strings.Contains(host, ":") {
+			return nil, fmt.Errorf("%s private endpoint allowlist entries must be exact DNS hostnames", sourceID)
+		}
+		if net.ParseIP(strings.Trim(host, "[]")) != nil || IsUnsafeHost(host) {
+			return nil, fmt.Errorf("%s private endpoint allowlist entries must be non-loopback DNS hostnames", sourceID)
+		}
+		if _, ok := seen[host]; ok {
+			continue
+		}
+		seen[host] = struct{}{}
+		hosts = append(hosts, host)
+	}
+	return hosts, nil
+}
+
+func privateEndpointHostAllowed(host string, allowlist []string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(host))
+	if normalized == "" {
+		return false
+	}
+	for _, allowed := range allowlist {
+		if normalized == strings.ToLower(strings.TrimSpace(allowed)) {
+			return true
+		}
+	}
+	return false
 }
 
 func IsUnsafeHost(host string) bool {
@@ -259,6 +362,22 @@ func unsafeIP(ip net.IP, allowLoopback bool) bool {
 		return false
 	}
 	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast()
+}
+
+func unsafeResolvedIP(ip net.IP, allowLoopback bool, allowPrivate bool) bool {
+	if ip == nil {
+		return true
+	}
+	if allowLoopback && ip.IsLoopback() {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
+		return true
+	}
+	if ip.IsPrivate() && !allowPrivate {
+		return true
+	}
+	return false
 }
 
 func IsLoopbackHost(host string) bool {

--- a/internal/sourcehttp/safe_test.go
+++ b/internal/sourcehttp/safe_test.go
@@ -26,6 +26,58 @@ func TestNormalizeBaseURLRejectsUnsafeHosts(t *testing.T) {
 	}
 }
 
+func TestNormalizeBaseURLAllowsExactPrivateEndpointHostsOnly(t *testing.T) {
+	allowlist, err := ParsePrivateEndpointAllowlist("evidence_cas", "cas.internal.example")
+	if err != nil {
+		t.Fatalf("ParsePrivateEndpointAllowlist() error = %v", err)
+	}
+	if got, host, err := NormalizeBaseURLWithOptions("evidence_cas", "https://cas.internal.example", URLValidationOptions{PrivateEndpointAllowlist: allowlist}); err != nil || got != "https://cas.internal.example" || host != "cas.internal.example" {
+		t.Fatalf("NormalizeBaseURLWithOptions() = %q, %q, %v; want exact origin", got, host, err)
+	}
+	for name, raw := range map[string]string{
+		"http scheme":     "http://cas.internal.example",
+		"custom port":     "https://cas.internal.example:8443",
+		"path":            "https://cas.internal.example/v1",
+		"allowlist miss":  "https://other.internal.example",
+		"private literal": "https://10.0.0.10",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := NormalizeBaseURLWithOptions("evidence_cas", raw, URLValidationOptions{PrivateEndpointAllowlist: allowlist})
+			if err == nil {
+				t.Fatal("NormalizeBaseURLWithOptions() error = nil, want rejection")
+			}
+		})
+	}
+}
+
+func TestParsePrivateEndpointAllowlistAcceptsHttpsOrigins(t *testing.T) {
+	hosts, err := ParsePrivateEndpointAllowlist("evidence_cas", "https://cas.internal.example/")
+	if err != nil {
+		t.Fatalf("ParsePrivateEndpointAllowlist() error = %v", err)
+	}
+	if len(hosts) != 1 || hosts[0] != "cas.internal.example" {
+		t.Fatalf("hosts = %#v, want extracted origin host", hosts)
+	}
+}
+
+func TestParsePrivateEndpointAllowlistRejectsUnsafeOrAmbiguousEntries(t *testing.T) {
+	for _, raw := range []string{
+		"http://cas.internal.example",
+		"https://cas.internal.example/path",
+		"https://cas.internal.example:8443",
+		"cas.internal.example:443",
+		"localhost",
+		"127.0.0.1",
+		"10.0.0.10",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := ParsePrivateEndpointAllowlist("evidence_cas", raw); err == nil {
+				t.Fatal("ParsePrivateEndpointAllowlist() error = nil, want invalid allowlist entry")
+			}
+		})
+	}
+}
+
 func TestSameOriginAbsoluteURLRejectsHostChanges(t *testing.T) {
 	if _, err := SameOriginAbsoluteURL("test_source", "https://api.example.com", "https://metadata.google.internal/latest"); err == nil {
 		t.Fatal("SameOriginAbsoluteURL() error = nil, want host mismatch")
@@ -156,5 +208,38 @@ func TestPinnedHostTransportDisablesKeepAlives(t *testing.T) {
 	}
 	if !transport.DisableKeepAlives {
 		t.Fatal("pinned transport must disable keep-alives")
+	}
+}
+
+func TestSafeResolvedHostAddrsAllowsPrivateOnlyForExactAllowlistedHost(t *testing.T) {
+	lookup := func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("10.0.0.10")}}, nil
+	}
+	allowlist := []string{"cas.internal.example"}
+	if _, err := SafeResolvedHostAddrsWithOptions(context.Background(), "evidence_cas", "cas.internal.example", HostResolutionOptions{PrivateEndpointAllowlist: allowlist, LookupIPAddrs: lookup}); err != nil {
+		t.Fatalf("SafeResolvedHostAddrsWithOptions() allowlisted private error = %v", err)
+	}
+	if _, err := SafeResolvedHostAddrsWithOptions(context.Background(), "evidence_cas", "other.internal.example", HostResolutionOptions{PrivateEndpointAllowlist: allowlist, LookupIPAddrs: lookup}); err == nil {
+		t.Fatal("SafeResolvedHostAddrsWithOptions() unallowlisted private error = nil, want rejection")
+	}
+}
+
+func TestSafeResolvedHostAddrsRejectsLoopbackAndLinkLocalEvenWhenAllowlisted(t *testing.T) {
+	for name, ip := range map[string]string{
+		"loopback":    "127.0.0.1",
+		"link local":  "169.254.169.254",
+		"metadata":    "169.254.169.254",
+		"unspecified": "0.0.0.0",
+		"multicast":   "224.0.0.1",
+	} {
+		t.Run(name, func(t *testing.T) {
+			lookup := func(context.Context, string) ([]net.IPAddr, error) {
+				return []net.IPAddr{{IP: net.ParseIP(ip)}}, nil
+			}
+			_, err := SafeResolvedHostAddrsWithOptions(context.Background(), "evidence_cas", "cas.internal.example", HostResolutionOptions{PrivateEndpointAllowlist: []string{"cas.internal.example"}, LookupIPAddrs: lookup})
+			if err == nil {
+				t.Fatal("SafeResolvedHostAddrsWithOptions() error = nil, want unsafe address rejection")
+			}
+		})
 	}
 }

--- a/sources/evidencecas/deploy.yaml
+++ b/sources/evidencecas/deploy.yaml
@@ -9,4 +9,5 @@ runtimes:
       bucket: cases
       family: object
       per_page: "100"
+      private_endpoint_allowlist: env:EVIDENCE_CAS_BASE_URL
       token: env:EVIDENCE_CAS_TOKEN

--- a/sources/evidencecas/source.go
+++ b/sources/evidencecas/source.go
@@ -37,10 +37,11 @@ func New() (*Source, error) {
 		return nil, err
 	}
 	inner, err := jsonapi.New(spec, jsonapi.Options{
-		SourceID:        sourceID,
-		DefaultFamily:   defaultFamily,
-		RequireTenantID: true,
-		TokenScheme:     "Bearer",
+		SourceID:                          sourceID,
+		DefaultFamily:                     defaultFamily,
+		RequireTenantID:                   true,
+		TokenScheme:                       "Bearer",
+		PrivateEndpointAllowlistConfigKey: "private_endpoint_allowlist",
 		Families: []jsonapi.Family{
 			{
 				Name:    familyObject,
@@ -209,7 +210,14 @@ func (s *Source) checkContract(ctx context.Context, cfg sourcecdk.Config) error 
 
 func (s *Source) getControlJSON(ctx context.Context, cfg sourcecdk.Config, path string, target any) error {
 	baseURL := strings.TrimSpace(configValue(cfg, "base_url"))
-	normalizedBaseURL, _, err := sourcehttp.NormalizeBaseURL(sourceID, baseURL, s != nil && s.allowLoopback)
+	privateEndpointAllowlist, err := sourcehttp.ParsePrivateEndpointAllowlist(sourceID, configValue(cfg, "private_endpoint_allowlist"))
+	if err != nil {
+		return err
+	}
+	normalizedBaseURL, _, err := sourcehttp.NormalizeBaseURLWithOptions(sourceID, baseURL, sourcehttp.URLValidationOptions{
+		AllowLoopback:            s != nil && s.allowLoopback,
+		PrivateEndpointAllowlist: privateEndpointAllowlist,
+	})
 	if err != nil {
 		return err
 	}
@@ -219,9 +227,10 @@ func (s *Source) getControlJSON(ctx context.Context, cfg sourcecdk.Config, path 
 	}
 	req.Header.Set("Accept", "application/json")
 	client := sourcehttp.NewClient(sourcehttp.ClientOptions{
-		SourceID:      sourceID,
-		AllowLoopback: s != nil && s.allowLoopback,
-		Timeout:       10 * time.Second,
+		SourceID:                 sourceID,
+		AllowLoopback:            s != nil && s.allowLoopback,
+		PrivateEndpointAllowlist: privateEndpointAllowlist,
+		Timeout:                  10 * time.Second,
 	})
 	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})
 	if err != nil {

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -45,13 +45,14 @@ type Family struct {
 
 // Options configures a JSON API-backed source adapter.
 type Options struct {
-	SourceID         string
-	DefaultBaseURL   string
-	DefaultFamily    string
-	RequireTenantID  bool
-	TokenScheme      string
-	DiscoverURNScope string
-	Families         []Family
+	SourceID                          string
+	DefaultBaseURL                    string
+	DefaultFamily                     string
+	RequireTenantID                   bool
+	TokenScheme                       string
+	DiscoverURNScope                  string
+	PrivateEndpointAllowlistConfigKey string
+	Families                          []Family
 }
 
 // Source is a small, safe JSON API source implementation used by endpoint
@@ -66,14 +67,15 @@ type Source struct {
 }
 
 type settings struct {
-	tenantID string
-	family   string
-	baseURL  string
-	host     string
-	token    string
-	path     string
-	query    url.Values
-	perPage  int
+	tenantID                 string
+	family                   string
+	baseURL                  string
+	host                     string
+	token                    string
+	path                     string
+	query                    url.Values
+	perPage                  int
+	privateEndpointAllowlist []string
 }
 
 type record struct {
@@ -181,7 +183,17 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if resolved.baseURL == "" {
 		return resolved, fmt.Errorf("%s base_url is required", s.options.SourceID)
 	}
-	baseURL, host, err := sourcehttp.NormalizeBaseURL(s.options.SourceID, resolved.baseURL, s.AllowLoopbackBaseURL)
+	if key := strings.TrimSpace(s.options.PrivateEndpointAllowlistConfigKey); key != "" {
+		allowlist, err := sourcehttp.ParsePrivateEndpointAllowlist(s.options.SourceID, configValue(cfg, key))
+		if err != nil {
+			return resolved, err
+		}
+		resolved.privateEndpointAllowlist = allowlist
+	}
+	baseURL, host, err := sourcehttp.NormalizeBaseURLWithOptions(s.options.SourceID, resolved.baseURL, sourcehttp.URLValidationOptions{
+		AllowLoopback:            s.AllowLoopbackBaseURL,
+		PrivateEndpointAllowlist: resolved.privateEndpointAllowlist,
+	})
 	if err != nil {
 		return resolved, err
 	}
@@ -300,9 +312,10 @@ func (s *Source) getJSON(ctx context.Context, settings settings, query url.Value
 	client := s.client
 	if client == nil {
 		client = sourcehttp.NewClient(sourcehttp.ClientOptions{
-			SourceID:      s.options.SourceID,
-			AllowLoopback: s.AllowLoopbackBaseURL,
-			LookupIPAddrs: lookupIPAddrs(s),
+			SourceID:                 s.options.SourceID,
+			AllowLoopback:            s.AllowLoopbackBaseURL,
+			PrivateEndpointAllowlist: settings.privateEndpointAllowlist,
+			LookupIPAddrs:            lookupIPAddrs(s),
 		})
 	}
 	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -298,6 +298,44 @@ func TestRejectsUnsafeBaseURL(t *testing.T) {
 	}
 }
 
+func TestPrivateEndpointAllowlistIsOptInPerSource(t *testing.T) {
+	source := newTestSource(t, "https://example.com")
+	source.AllowLoopbackBaseURL = false
+	source.lookupIPAddrs = func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("10.0.0.10")}}, nil
+	}
+	err := source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id":                  "writer",
+		"token":                      "token-1",
+		"base_url":                   "https://cas.internal.example",
+		"private_endpoint_allowlist": "cas.internal.example",
+	}))
+	if err == nil {
+		t.Fatal("parseSettings() error = nil, want non-EvidenceCAS source to ignore private_endpoint_allowlist and keep default SSRF protection")
+	}
+}
+
+func TestPrivateEndpointAllowlistAllowsConfiguredJSONAPISource(t *testing.T) {
+	source := newTestSource(t, "https://example.com")
+	source.options.PrivateEndpointAllowlistConfigKey = "private_endpoint_allowlist"
+	source.AllowLoopbackBaseURL = false
+	source.lookupIPAddrs = func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("10.0.0.10")}}, nil
+	}
+	settings, err := source.parseSettings(sourcecdk.NewConfig(map[string]string{
+		"tenant_id":                  "writer",
+		"token":                      "token-1",
+		"base_url":                   "https://cas.internal.example",
+		"private_endpoint_allowlist": "cas.internal.example",
+	}))
+	if err != nil {
+		t.Fatalf("parseSettings() error = %v, want allowlisted private endpoint accepted", err)
+	}
+	if settings.host != "cas.internal.example" {
+		t.Fatalf("host = %q, want cas.internal.example", settings.host)
+	}
+}
+
 func TestSafeRoundTripperPinsValidatedHostnameAddress(t *testing.T) {
 	var dialed string
 	rt := sourcehttp.SafeRoundTripper{


### PR DESCRIPTION
## Summary
- add an EvidenceCAS-only private endpoint allowlist option to source HTTP validation
- keep default SSRF protections for other sources and unsafe address classes
- wire EvidenceCAS deploy config to opt in via the configured base URL origin

## Tests
- make build
- make test
- go test ./internal/sourcehttp ./sources/internal/jsonapi ./sources/evidencecas ./internal/sourceprojection ./tools/sourcedeploy -count=1 -v
- make openapi-check openapi-lint
- make catalog-check detection-catalog-check
- make contracts-check