### PR TITLE
fix(security): resolve CodeQL code scanning findings

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -34,6 +34,10 @@ func (e usageError) Error() string {
 	return string(e)
 }
 
+func sanitizeLogValue(value string) string {
+	return strings.NewReplacer("\n", " ", "\r", " ").Replace(value)
+}
+
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		var usage usageError
@@ -41,7 +45,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(2)
 		}
-		log.Print(err)
+		log.Print(sanitizeLogValue(fmt.Sprint(err)))
 		os.Exit(1)
 	}
 }

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -1036,8 +1036,10 @@ func (app *App) mcpInvestigationContext(r *http.Request, args map[string]any) (a
 	assetLimit := 5
 	if rawLimit, err := mcpUint32Arg(args, "asset_limit"); err != nil {
 		return nil, err
+	} else if rawLimit > uint32(maxMCPAssetLimit) {
+		assetLimit = maxMCPAssetLimit
 	} else if rawLimit != 0 {
-		assetLimit = int(min(rawLimit, uint32(maxMCPAssetLimit)))
+		assetLimit = int(rawLimit)
 	}
 	assets := []mcpAssetSearchResult{}
 	neighborhoods := []any{}

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"sort"
@@ -2045,10 +2046,14 @@ func mcpBoundedLimit(args map[string]any, key string, defaultLimit int, maxLimit
 	if err != nil {
 		return 0, err
 	}
+	bound := uint32(math.MaxInt32)
+	if maxLimit >= 0 && maxLimit < math.MaxInt32 {
+		bound = uint32(maxLimit)
+	}
 	switch {
 	case limit == 0:
 		return defaultLimit, nil
-	case limit > uint32(maxLimit):
+	case limit > bound:
 		return maxLimit, nil
 	default:
 		return int(limit), nil
@@ -2411,10 +2416,14 @@ func mcpMetadataLimit(args map[string]any, key string, defaultLimit int, maxLimi
 }
 
 func mcpNormalizeLimitValue(limit uint32, defaultLimit int, maxLimit int) int {
+	bound := uint32(math.MaxInt32)
+	if maxLimit >= 0 && maxLimit < math.MaxInt32 {
+		bound = uint32(maxLimit)
+	}
 	switch {
 	case limit == 0:
 		return defaultLimit
-	case limit > uint32(maxLimit):
+	case limit > bound:
 		return maxLimit
 	default:
 		return int(limit)

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -1037,7 +1037,7 @@ func (app *App) mcpInvestigationContext(r *http.Request, args map[string]any) (a
 	if rawLimit, err := mcpUint32Arg(args, "asset_limit"); err != nil {
 		return nil, err
 	} else if rawLimit != 0 {
-		assetLimit = min(int(rawLimit), maxMCPAssetLimit)
+		assetLimit = int(min(rawLimit, uint32(maxMCPAssetLimit)))
 	}
 	assets := []mcpAssetSearchResult{}
 	neighborhoods := []any{}
@@ -2046,7 +2046,7 @@ func mcpBoundedLimit(args map[string]any, key string, defaultLimit int, maxLimit
 	switch {
 	case limit == 0:
 		return defaultLimit, nil
-	case int(limit) > maxLimit:
+	case limit > uint32(maxLimit):
 		return maxLimit, nil
 	default:
 		return int(limit), nil
@@ -2412,7 +2412,7 @@ func mcpNormalizeLimitValue(limit uint32, defaultLimit int, maxLimit int) int {
 	switch {
 	case limit == 0:
 		return defaultLimit
-	case int(limit) > maxLimit:
+	case limit > uint32(maxLimit):
 		return maxLimit
 	default:
 		return int(limit)

--- a/internal/bootstrap/mcp_limit_test.go
+++ b/internal/bootstrap/mcp_limit_test.go
@@ -1,0 +1,56 @@
+package bootstrap
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMCPNormalizeLimitValueClampsLargeUnsignedValues(t *testing.T) {
+	cases := []struct {
+		name         string
+		limit        uint32
+		defaultLimit int
+		maxLimit     int
+		want         int
+	}{
+		{name: "zero returns default", limit: 0, defaultLimit: 25, maxLimit: 100, want: 25},
+		{name: "within bound preserved", limit: 10, defaultLimit: 25, maxLimit: 100, want: 10},
+		{name: "above bound clamped", limit: 1000, defaultLimit: 25, maxLimit: 100, want: 100},
+		{name: "max uint32 clamped", limit: math.MaxUint32, defaultLimit: 25, maxLimit: 100, want: 100},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mcpNormalizeLimitValue(tc.limit, tc.defaultLimit, tc.maxLimit); got != tc.want {
+				t.Fatalf("mcpNormalizeLimitValue(%d) = %d, want %d", tc.limit, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMCPBoundedLimitClampsLargeUnsignedValues(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  int
+	}{
+		{name: "missing returns default", value: nil, want: 25},
+		{name: "within bound preserved", value: "10", want: 10},
+		{name: "above bound clamped", value: "1000", want: 100},
+		{name: "max uint32 clamped", value: "4294967295", want: 100},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := map[string]any{}
+			if tc.value != nil {
+				args["limit"] = tc.value
+			}
+			got, err := mcpBoundedLimit(args, "limit", 25, 100)
+			if err != nil {
+				t.Fatalf("mcpBoundedLimit: unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("mcpBoundedLimit(%v) = %d, want %d", tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/findings/endpoint_vulnerability.go
+++ b/internal/findings/endpoint_vulnerability.go
@@ -158,7 +158,7 @@ func ListEndpointVulnerabilityFindings(ctx context.Context, store ports.Endpoint
 		}
 		return findings[i].ID < findings[j].ID
 	})
-	if request.Limit > 0 && len(findings) > int(request.Limit) {
+	if request.Limit > 0 && uint64(len(findings)) > uint64(request.Limit) {
 		findings = findings[:request.Limit]
 	}
 	return EndpointVulnerabilityResponse{

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -177,7 +177,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	rowMaps = postProcessAskRows(conversion, rowMaps)
 	sanitizeInternalRowFields(rowMaps)
 	if s.options.EnableRecovery {
-		recoveredRows, recoveredCypher, recoveredValidation, ok, terminal, err := s.recoverWeakRows(ctx, traceID, started, timings, conversion, rowMaps, params, emit)
+		recoveredRows, recoveredCypher, _, ok, terminal, err := s.recoverWeakRows(ctx, traceID, started, timings, conversion, rowMaps, params, emit)
 		if err != nil {
 			return err
 		}
@@ -188,7 +188,6 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		if ok {
 			rowMaps = recoveredRows
 			cypher = recoveredCypher
-			validation = recoveredValidation
 		}
 	}
 	rowsEvent := RowsEvent{

--- a/internal/graphingest/log_sanitize_test.go
+++ b/internal/graphingest/log_sanitize_test.go
@@ -1,0 +1,22 @@
+package graphingest
+
+import "testing"
+
+func TestSanitizeLogValueStripsNewlines(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "plain value unchanged", input: "run-123", want: "run-123"},
+		{name: "newline forgery neutralized", input: "run-123\nFAKE level=error injected", want: "run-123 FAKE level=error injected"},
+		{name: "carriage return neutralized", input: "run-123\r\nmalicious", want: "run-123  malicious"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeLogValue(tc.input); got != tc.want {
+				t.Fatalf("sanitizeLogValue(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -491,7 +491,7 @@ func (s *Service) runStore() (RunStore, error) {
 func (s *Service) failRun(ctx context.Context, runStore RunStore, run graphstore.IngestRun, result *RunResult, ingest *IngestResult, runErr error) (*RunResult, error) {
 	failed := finishRun(run, ingest, graphstore.IngestRunStatusFailed, runErr)
 	result.Run = failed
-	log.Printf("graph ingest runtime failed run_id=%q runtime_id=%q error=%v", failed.ID, failed.RuntimeID, runErr)
+	log.Printf("graph ingest runtime failed run_id=%q runtime_id=%q error=%q", sanitizeLogValue(failed.ID), sanitizeLogValue(failed.RuntimeID), sanitizeLogValue(fmt.Sprint(runErr)))
 	return result, errors.Join(runErr, s.putTerminalIngestRun(ctx, runStore, failed))
 }
 
@@ -1209,6 +1209,10 @@ func ingestEvent(event *cerebrov1.EventEnvelope, tenantID string, runtimeID stri
 		cloned.Attributes[ports.EventAttributeSourceRuntimeID] = normalized
 	}
 	return cloned
+}
+
+func sanitizeLogValue(value string) string {
+	return strings.NewReplacer("\n", " ", "\r", " ").Replace(value)
 }
 
 func sanitizeIDPart(value string) string {

--- a/scripts/candidate_smoke.py
+++ b/scripts/candidate_smoke.py
@@ -9,6 +9,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from typing import NoReturn
 
 
 def env(name: str, default: str = "") -> str:
@@ -23,7 +24,7 @@ EVENT_LIMIT = env("CEREBRO_CANDIDATE_SMOKE_EVENT_LIMIT", "25")
 ALLOW_EMPTY = env("CEREBRO_CANDIDATE_SMOKE_ALLOW_EMPTY", "false").lower() in {"1", "true", "yes"}
 
 
-def fail(message: str) -> None:
+def fail(message: str) -> NoReturn:
     print(f"candidate-smoke: {message}", file=sys.stderr)
     raise SystemExit(1)
 

--- a/scripts/droid_sast_context.py
+++ b/scripts/droid_sast_context.py
@@ -8,7 +8,6 @@ import json
 import os
 import re
 import subprocess
-import sys
 import tempfile
 import urllib.request
 from dataclasses import dataclass

--- a/sdk/python/tests/test_jira.py
+++ b/sdk/python/tests/test_jira.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 import cerebro_sdk.jira as jira
 from cerebro_sdk.client import Client
-from cerebro_sdk.jira import build_jira_workspace_claims
 
 
 class JiraPostureTests(unittest.TestCase):
@@ -13,13 +12,13 @@ class JiraPostureTests(unittest.TestCase):
 
     def test_build_jira_workspace_claims_rejects_object_coerced_identifiers(self) -> None:
         with self.assertRaisesRegex(ValueError, "workspace_key is required"):
-            build_jira_workspace_claims(self.integration, {"workspace_key": {"id": "writer"}})
+            jira.build_jira_workspace_claims(self.integration, {"workspace_key": {"id": "writer"}})
 
         with self.assertRaisesRegex(ValueError, "workspace_key is required"):
-            build_jira_workspace_claims(self.integration, {"workspace_key": ["writer"]})
+            jira.build_jira_workspace_claims(self.integration, {"workspace_key": ["writer"]})
 
         with self.assertRaisesRegex(ValueError, r"projects\[\]\.key is required"):
-            build_jira_workspace_claims(
+            jira.build_jira_workspace_claims(
                 self.integration,
                 {
                     "workspace_key": "writer",
@@ -28,7 +27,7 @@ class JiraPostureTests(unittest.TestCase):
             )
 
         with self.assertRaisesRegex(ValueError, r"apps\[\]\.key is required"):
-            build_jira_workspace_claims(
+            jira.build_jira_workspace_claims(
                 self.integration,
                 {
                     "workspace_key": "writer",
@@ -38,28 +37,28 @@ class JiraPostureTests(unittest.TestCase):
 
     def test_build_jira_workspace_claims_rejects_boolean_identifiers(self) -> None:
         with self.assertRaisesRegex(ValueError, "workspace_key is required"):
-            build_jira_workspace_claims(self.integration, {"workspace_key": True})
+            jira.build_jira_workspace_claims(self.integration, {"workspace_key": True})
 
     def test_build_jira_workspace_claims_rejects_malformed_array_entries(self) -> None:
         with self.assertRaisesRegex(ValueError, r"admins\[0\] must be an object"):
-            build_jira_workspace_claims(self.integration, {"workspace_key": "writer", "admins": ["alice@writer.com"]})
+            jira.build_jira_workspace_claims(self.integration, {"workspace_key": "writer", "admins": ["alice@writer.com"]})
 
         with self.assertRaisesRegex(ValueError, r"projects\[1\] must be an object"):
-            build_jira_workspace_claims(
+            jira.build_jira_workspace_claims(
                 self.integration,
                 {"workspace_key": "writer", "projects": [{"key": "ENG"}, "SEC"]},
             )
 
     def test_build_jira_workspace_claims_rejects_unknown_boolean_strings(self) -> None:
         with self.assertRaisesRegex(ValueError, "invalid boolean string"):
-            build_jira_workspace_claims(
+            jira.build_jira_workspace_claims(
                 self.integration,
                 {"workspace_key": "writer", "public_signup_enabled": "falsee"},
             )
 
     def test_build_jira_workspace_claims_rejects_non_boolean_flag_values(self) -> None:
         with self.assertRaisesRegex(ValueError, "invalid boolean value"):
-            build_jira_workspace_claims(
+            jira.build_jira_workspace_claims(
                 self.integration,
                 {"workspace_key": "writer", "public_signup_enabled": {"bad": 1}},
             )
@@ -132,7 +131,7 @@ class JiraPostureTests(unittest.TestCase):
         self.assertFalse(any(finding["id"] == "jira_workspace_admin_sprawl" for finding in findings))
 
     def test_build_jira_workspace_claims_normalizes_admin_email_identity(self) -> None:
-        claims = build_jira_workspace_claims(
+        claims = jira.build_jira_workspace_claims(
             self.integration,
             {"workspace_key": "writer", "admins": [{"email": "ADMIN@writer.com"}, {"email": "admin@writer.com"}]},
         )

--- a/tools/droidreview/main.go
+++ b/tools/droidreview/main.go
@@ -440,12 +440,16 @@ func writeGitHubMetadata(result preflightResult, duration time.Duration, runErr 
 	}
 }
 
-func appendFile(path string, body []byte) error {
+func appendFile(path string, body []byte) (err error) {
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 	_, err = file.Write(body)
 	return err
 }


### PR DESCRIPTION
## Summary

Resolves the true-positive GitHub code scanning (CodeQL) alerts. False-positive and generated-code alerts are dismissed separately with documented reasons rather than code changes.

### Fixes (true positives)
- **Log injection** (CodeQL `go/log-injection`): strip CR/LF from interpolated values before logging in the CLI fatal-error path and the graph-ingest failure log, so untrusted values cannot forge log records.
- **Incorrect integer conversion** (`go/incorrect-integer-conversion`): perform unsigned limit comparisons in unsigned space before narrowing to `int` (MCP asset/bounded/normalized limits and the endpoint vulnerability list limit), preventing negative/garbage limits from a narrowing conversion.
- **Unhandled writable file close** (`go/unhandled-writable-file-close`): handle the `Close` error on a writable append file to avoid silent data loss.
- **Useless assignment** (`go/useless-assignment-to-local`): remove a dead store of the recovered validation result.
- **Python quality notes**: remove an unused import, annotate an always-raising helper as `NoReturn`, and consolidate a module that was imported both ways in a test.

### Tests
- Added regression tests for limit clamping (large `uint32` values clamp to the configured max) and for log-value sanitization (CR/LF neutralized).
- Ran focused `go test` for all changed packages and the Python SDK Jira tests; all pass.

### Notes
- Allocation-size-overflow and one integer-conversion alert are dismissed as false positives (capacities derive from in-memory map lengths / values already clamped to small constants).
- Unused-import / unused-global alerts in generated `*_pb2.py` protobuf stubs are dismissed as won't-fix per the repo policy of not hand-editing generated code.