### PR TITLE
fix(security): clear remaining CodeQL int-conversion alerts on MCP limits

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -2046,18 +2046,17 @@ func mcpBoundedLimit(args map[string]any, key string, defaultLimit int, maxLimit
 	if err != nil {
 		return 0, err
 	}
-	bound := uint32(math.MaxInt32)
-	if maxLimit >= 0 && maxLimit < math.MaxInt32 {
-		bound = uint32(maxLimit)
-	}
-	switch {
-	case limit == 0:
+	if limit == 0 {
 		return defaultLimit, nil
-	case limit > bound:
-		return maxLimit, nil
-	default:
-		return int(limit), nil
 	}
+	if limit > math.MaxInt32 {
+		return maxLimit, nil
+	}
+	value := int(limit)
+	if value > maxLimit {
+		return maxLimit, nil
+	}
+	return value, nil
 }
 
 func mcpAssetSearchResultFromRow(row ports.CypherRow) (mcpAssetSearchResult, error) {
@@ -2416,18 +2415,17 @@ func mcpMetadataLimit(args map[string]any, key string, defaultLimit int, maxLimi
 }
 
 func mcpNormalizeLimitValue(limit uint32, defaultLimit int, maxLimit int) int {
-	bound := uint32(math.MaxInt32)
-	if maxLimit >= 0 && maxLimit < math.MaxInt32 {
-		bound = uint32(maxLimit)
-	}
-	switch {
-	case limit == 0:
+	if limit == 0 {
 		return defaultLimit
-	case limit > bound:
-		return maxLimit
-	default:
-		return int(limit)
 	}
+	if limit > math.MaxInt32 {
+		return maxLimit
+	}
+	value := int(limit)
+	if value > maxLimit {
+		return maxLimit
+	}
+	return value
 }
 
 func mcpNeighborhoodResultCount(neighborhood *ports.EntityNeighborhood) int {


### PR DESCRIPTION
## Summary

Follow-up to #882. After that PR merged and CodeQL re-scanned `main`, two `go/incorrect-integer-conversion` alerts remained open in `internal/bootstrap/mcp.go` (the default-branch `int(limit)` conversions in `mcpBoundedLimit` and `mcpNormalizeLimitValue`).

CodeQL only treats a `uint32 -> int` conversion as safe when it is guarded by a **constant** upper bound; a runtime-variable bound (even one capped at `MaxInt32`) was not sufficient. This change checks `limit > math.MaxInt32` (a constant) before the conversion and then clamps in `int` space, which clears both CodeQL and gosec G115.

### Tests
- Existing regression tests for limit clamping still pass and exercise both the `<= MaxInt32` (clamp-in-int) and `> MaxInt32` paths.
- gosec G115 reports 0 issues for `internal/bootstrap`; build and package tests pass.