### PR TITLE
chore(source): add platform inventory deploy manifests

### DIFF
--- a/sources/anthropic/deploy.yaml
+++ b/sources/anthropic/deploy.yaml
@@ -1,0 +1,19 @@
+sourceId: anthropic
+secretKeys:
+  - ANTHROPIC_API_KEY
+runtimes:
+  - localId: user
+    config:
+      family: user
+      per_page: "100"
+      token: env:ANTHROPIC_API_KEY
+  - localId: workspace
+    config:
+      family: workspace
+      per_page: "100"
+      token: env:ANTHROPIC_API_KEY
+  - localId: api-key
+    config:
+      family: api_key
+      per_page: "100"
+      token: env:ANTHROPIC_API_KEY

--- a/sources/cloudflare/deploy.yaml
+++ b/sources/cloudflare/deploy.yaml
@@ -1,0 +1,35 @@
+sourceId: cloudflare
+secretKeys:
+  - CLOUDFLARE_API_TOKEN
+  - CLOUDFLARE_DNS_RECORD_PATH
+  - CLOUDFLARE_MEMBER_PATH
+  - CLOUDFLARE_ROLE_PATH
+runtimes:
+  - localId: account
+    config:
+      family: account
+      per_page: "100"
+      token: env:CLOUDFLARE_API_TOKEN
+  - localId: member
+    config:
+      family: member
+      member_path: env:CLOUDFLARE_MEMBER_PATH
+      per_page: "100"
+      token: env:CLOUDFLARE_API_TOKEN
+  - localId: role
+    config:
+      family: role
+      per_page: "100"
+      role_path: env:CLOUDFLARE_ROLE_PATH
+      token: env:CLOUDFLARE_API_TOKEN
+  - localId: zone
+    config:
+      family: zone
+      per_page: "100"
+      token: env:CLOUDFLARE_API_TOKEN
+  - localId: dns-record
+    config:
+      dns_record_path: env:CLOUDFLARE_DNS_RECORD_PATH
+      family: dns_record
+      per_page: "100"
+      token: env:CLOUDFLARE_API_TOKEN

--- a/sources/duo/deploy.yaml
+++ b/sources/duo/deploy.yaml
@@ -1,0 +1,41 @@
+sourceId: duo
+secretKeys:
+  - DUO_API_TOKEN
+  - DUO_BASE_URL
+runtimes:
+  - localId: user
+    config:
+      base_url: env:DUO_BASE_URL
+      family: user
+      per_page: "100"
+      token: env:DUO_API_TOKEN
+  - localId: group
+    config:
+      base_url: env:DUO_BASE_URL
+      family: group
+      per_page: "100"
+      token: env:DUO_API_TOKEN
+  - localId: endpoint
+    config:
+      base_url: env:DUO_BASE_URL
+      family: endpoint
+      per_page: "100"
+      token: env:DUO_API_TOKEN
+  - localId: phone
+    config:
+      base_url: env:DUO_BASE_URL
+      family: phone
+      per_page: "100"
+      token: env:DUO_API_TOKEN
+  - localId: token
+    config:
+      base_url: env:DUO_BASE_URL
+      family: token
+      per_page: "100"
+      token: env:DUO_API_TOKEN
+  - localId: web-authn-credential
+    config:
+      base_url: env:DUO_BASE_URL
+      family: web_authn_credential
+      per_page: "100"
+      token: env:DUO_API_TOKEN

--- a/sources/kubernetes/deploy.yaml
+++ b/sources/kubernetes/deploy.yaml
@@ -1,0 +1,39 @@
+sourceId: kubernetes
+secretKeys:
+  - KUBERNETES_KUBECONFIG_PATH
+runtimes:
+  - localId: cluster
+    config:
+      family: cluster
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: namespace
+    config:
+      family: namespace
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: pod
+    config:
+      family: pod
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: container
+    config:
+      family: container
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: service-account
+    config:
+      family: service_account
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: workload
+    config:
+      family: workload
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: workload-identity-binding
+    config:
+      family: workload_identity_binding
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"

--- a/sources/openai/deploy.yaml
+++ b/sources/openai/deploy.yaml
@@ -1,0 +1,33 @@
+sourceId: openai
+secretKeys:
+  - OPENAI_API_KEY
+  - OPENAI_API_KEY_PATH
+  - OPENAI_SERVICE_ACCOUNT_PATH
+runtimes:
+  - localId: user
+    config:
+      family: user
+      per_page: "100"
+      token: env:OPENAI_API_KEY
+  - localId: project
+    config:
+      family: project
+      per_page: "100"
+      token: env:OPENAI_API_KEY
+  - localId: service-account
+    config:
+      family: service_account
+      per_page: "100"
+      service_account_path: env:OPENAI_SERVICE_ACCOUNT_PATH
+      token: env:OPENAI_API_KEY
+  - localId: api-key
+    config:
+      api_key_path: env:OPENAI_API_KEY_PATH
+      family: api_key
+      per_page: "100"
+      token: env:OPENAI_API_KEY
+  - localId: admin-api-key
+    config:
+      family: admin_api_key
+      per_page: "100"
+      token: env:OPENAI_API_KEY

--- a/sources/pagerduty/deploy.yaml
+++ b/sources/pagerduty/deploy.yaml
@@ -1,0 +1,41 @@
+sourceId: pagerduty
+secretKeys:
+  - PAGERDUTY_API_TOKEN
+  - PAGERDUTY_INTEGRATION_PATH
+runtimes:
+  - localId: user
+    config:
+      family: user
+      per_page: "100"
+      token: env:PAGERDUTY_API_TOKEN
+  - localId: team
+    config:
+      family: team
+      per_page: "100"
+      token: env:PAGERDUTY_API_TOKEN
+  - localId: service
+    config:
+      family: service
+      per_page: "100"
+      token: env:PAGERDUTY_API_TOKEN
+  - localId: schedule
+    config:
+      family: schedule
+      per_page: "100"
+      token: env:PAGERDUTY_API_TOKEN
+  - localId: escalation-policy
+    config:
+      family: escalation_policy
+      per_page: "100"
+      token: env:PAGERDUTY_API_TOKEN
+  - localId: integration
+    config:
+      family: integration
+      path: env:PAGERDUTY_INTEGRATION_PATH
+      per_page: "100"
+      token: env:PAGERDUTY_API_TOKEN
+  - localId: vendor
+    config:
+      family: vendor
+      per_page: "100"
+      token: env:PAGERDUTY_API_TOKEN

--- a/sources/slack/deploy.yaml
+++ b/sources/slack/deploy.yaml
@@ -1,0 +1,24 @@
+sourceId: slack
+secretKeys:
+  - SLACK_TOKEN
+runtimes:
+  - localId: team
+    config:
+      family: team
+      per_page: "100"
+      token: env:SLACK_TOKEN
+  - localId: user
+    config:
+      family: user
+      per_page: "100"
+      token: env:SLACK_TOKEN
+  - localId: channel
+    config:
+      family: channel
+      per_page: "100"
+      token: env:SLACK_TOKEN
+  - localId: user-group
+    config:
+      family: user_group
+      per_page: "100"
+      token: env:SLACK_TOKEN

--- a/sources/tailscale/deploy.yaml
+++ b/sources/tailscale/deploy.yaml
@@ -1,0 +1,39 @@
+sourceId: tailscale
+secretKeys:
+  - TAILSCALE_API_TOKEN
+runtimes:
+  - localId: tailnet
+    config:
+      family: tailnet
+      per_page: "100"
+      token: env:TAILSCALE_API_TOKEN
+  - localId: user
+    config:
+      family: user
+      per_page: "100"
+      token: env:TAILSCALE_API_TOKEN
+  - localId: device
+    config:
+      family: device
+      per_page: "100"
+      token: env:TAILSCALE_API_TOKEN
+  - localId: group
+    config:
+      family: group
+      per_page: "100"
+      token: env:TAILSCALE_API_TOKEN
+  - localId: tag
+    config:
+      family: tag
+      per_page: "100"
+      token: env:TAILSCALE_API_TOKEN
+  - localId: service
+    config:
+      family: service
+      per_page: "100"
+      token: env:TAILSCALE_API_TOKEN
+  - localId: grant
+    config:
+      family: grant
+      per_page: "100"
+      token: env:TAILSCALE_API_TOKEN

--- a/sources/trivy/deploy.yaml
+++ b/sources/trivy/deploy.yaml
@@ -1,0 +1,20 @@
+sourceId: trivy
+secretKeys:
+  - TRIVY_REPORT_PATH
+runtimes:
+  - localId: image-scan
+    config:
+      family: image_scan
+      path: env:TRIVY_REPORT_PATH
+  - localId: image-package
+    config:
+      family: image_package
+      path: env:TRIVY_REPORT_PATH
+  - localId: image-vulnerability
+    config:
+      family: image_vulnerability
+      path: env:TRIVY_REPORT_PATH
+  - localId: fix
+    config:
+      family: fix
+      path: env:TRIVY_REPORT_PATH

--- a/tools/archtests/source_deploy_test.go
+++ b/tools/archtests/source_deploy_test.go
@@ -15,15 +15,24 @@ import (
 // not own runtimes (e.g. push-only SDK adapters, infrastructure scanners
 // driven by the orchestrator default command) are exempt by being absent.
 var requireDeployManifest = map[string]struct{}{
+	"anthropic":        {},
 	"azure":            {},
+	"cloudflare":       {},
+	"duo":              {},
 	"gcp":              {},
 	"github":           {},
 	"google_workspace": {},
 	"kandji":           {},
+	"kubernetes":       {},
 	"kolide":           {},
+	"openai":           {},
 	"okta":             {},
+	"pagerduty":        {},
 	"sentinelone":      {},
+	"slack":            {},
+	"tailscale":        {},
 	"trusted_endpoint": {},
+	"trivy":            {},
 }
 
 func TestSourceDeployManifestsAreValid(t *testing.T) {


### PR DESCRIPTION
## Summary
- add Infisical-compatible deploy manifests for Anthropic, Cloudflare, Duo, Kubernetes, OpenAI, PagerDuty, Slack, Tailscale, and Trivy
- declare required source secret keys and runtime configs for the source deploy renderer
- add these sources to the deploy manifest archtest coverage list

## Validation
- go test ./tools/sourcedeploy ./tools/archtests ./internal/sourcegen
- go run ./cmd/sourcedeploy -env sec-dev -tenant writer -format yaml
- go run ./cmd/sourcedeploy -env sec-dev -tenant writer -format contract-json -image-tag v0.0.0-test
- make test
- make lint
- make catalog-check