### PR TITLE
fix: correct MCP risk summary totals

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -922,43 +922,67 @@ func (s *stubRuntimeStore) SummarizeFindings(_ context.Context, request ports.Li
 	if s.err != nil {
 		return ports.FindingSummary{}, s.err
 	}
-	var summary ports.FindingSummary
+	summary := ports.FindingSummary{
+		BySeverity:       map[string]int{},
+		ByStatus:         map[string]int{},
+		RiskReasonCounts: map[string]int{},
+	}
 	controls := map[string]struct{}{}
 	now := time.Now().UTC()
 	for _, finding := range s.findings {
 		if !findingMatches(request, finding) {
 			continue
 		}
-		if !strings.EqualFold(strings.TrimSpace(finding.Status), "open") {
-			continue
+		summary.TotalFindings++
+		status := strings.ToLower(strings.TrimSpace(finding.Status))
+		if status == "" {
+			status = "unknown"
 		}
-		summary.OpenFindings++
-		if strings.EqualFold(strings.TrimSpace(finding.Severity), "critical") {
-			summary.CriticalFindings++
+		severity := strings.ToLower(strings.TrimSpace(finding.Severity))
+		if severity == "" {
+			severity = "unknown"
 		}
-		if strings.EqualFold(strings.TrimSpace(finding.Severity), "high") {
-			summary.HighFindings++
+		summary.ByStatus[status]++
+		summary.BySeverity[severity]++
+		if finding.RiskScore > summary.MaxRiskScore {
+			summary.MaxRiskScore = finding.RiskScore
 		}
-		if !finding.DueAt.IsZero() && now.After(finding.DueAt.UTC()) {
-			summary.OverdueFindings++
-		}
-		if strings.TrimSpace(finding.Assignee) == "" {
-			summary.Unassigned++
-		}
-		if len(finding.ControlRefs) == 0 {
-			controls["Unmapped\x00Needs mapping"] = struct{}{}
-			continue
-		}
-		for _, ref := range finding.ControlRefs {
-			framework := strings.TrimSpace(ref.FrameworkName)
-			controlID := strings.TrimSpace(ref.ControlID)
-			if framework == "" {
-				framework = "Unmapped"
+		summary.RiskScoreTotal += finding.RiskScore
+		for _, reason := range finding.RiskReasons {
+			reason = strings.TrimSpace(reason)
+			if reason != "" {
+				summary.RiskReasonCounts[reason]++
 			}
-			if controlID == "" {
-				controlID = "Needs mapping"
+		}
+		if status == "open" {
+			summary.OpenFindings++
+			if severity == "critical" {
+				summary.CriticalFindings++
 			}
-			controls[framework+"\x00"+controlID] = struct{}{}
+			if severity == "high" {
+				summary.HighFindings++
+			}
+			if !finding.DueAt.IsZero() && now.After(finding.DueAt.UTC()) {
+				summary.OverdueFindings++
+			}
+			if strings.TrimSpace(finding.Assignee) == "" {
+				summary.Unassigned++
+			}
+			if len(finding.ControlRefs) == 0 {
+				controls["Unmapped\x00Needs mapping"] = struct{}{}
+				continue
+			}
+			for _, ref := range finding.ControlRefs {
+				framework := strings.TrimSpace(ref.FrameworkName)
+				controlID := strings.TrimSpace(ref.ControlID)
+				if framework == "" {
+					framework = "Unmapped"
+				}
+				if controlID == "" {
+					controlID = "Needs mapping"
+				}
+				controls[framework+"\x00"+controlID] = struct{}{}
+			}
 		}
 	}
 	summary.ControlsFailing = len(controls)

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -165,6 +165,7 @@ type mcpRiskSummary struct {
 	TenantID             string               `json:"tenant_id,omitempty"`
 	RuntimeID            string               `json:"runtime_id,omitempty"`
 	TotalFindings        int                  `json:"total_findings"`
+	ReturnedFindings     int                  `json:"returned_findings"`
 	OpenFindings         int                  `json:"open_findings"`
 	CriticalOpenFindings int                  `json:"critical_open_findings"`
 	HighOpenFindings     int                  `json:"high_open_findings"`
@@ -176,6 +177,10 @@ type mcpRiskSummary struct {
 	RecentHighRisk       []any                `json:"recent_high_risk"`
 	LimitApplied         int                  `json:"limit_applied"`
 	Metadata             map[string]any       `json:"metadata,omitempty"`
+}
+
+type mcpFindingSummaryStore interface {
+	SummarizeFindings(context.Context, ports.ListFindingsRequest) (ports.FindingSummary, error)
 }
 
 type mcpRiskReasonCount struct {
@@ -678,9 +683,18 @@ func (app *App) mcpRuntimeStatus(r *http.Request, args map[string]any) (any, err
 	if err != nil {
 		return nil, err
 	}
+	summary, err := app.mcpBuildRiskSummaryForRequest(r, ports.ListFindingsRequest{
+		TenantID:  strings.TrimSpace(runtime.GetTenantId()),
+		RuntimeID: runtimeID,
+		Limit:     uint32(defaultMCPRiskLimit),
+		Order:     ports.FindingOrderRiskScore,
+	}, defaultMCPRiskLimit, findings)
+	if err != nil {
+		return nil, err
+	}
 	return map[string]any{
 		"runtime":      runtimeValue,
-		"risk_summary": mcpBuildRiskSummary(strings.TrimSpace(runtime.GetTenantId()), runtimeID, defaultMCPRiskLimit, findings),
+		"risk_summary": summary,
 		"metadata":     mcpResponseMetadata(defaultMCPRiskLimit, len(findings), nil),
 	}, nil
 }
@@ -886,8 +900,16 @@ func (app *App) mcpRiskSummary(r *http.Request, args map[string]any) (any, error
 	if err != nil {
 		return nil, err
 	}
-	summary := mcpBuildRiskSummary(tenantID, runtimeID, limit, findings)
-	summary.Metadata = mcpResponseMetadata(limit, len(findings), nil)
+	summary, err := app.mcpBuildRiskSummaryForRequest(r, ports.ListFindingsRequest{
+		TenantID:  tenantID,
+		RuntimeID: runtimeID,
+		Status:    mcpStringArg(args, "status"),
+		Limit:     boundedUint32(limit),
+		Order:     ports.FindingOrderRiskScore,
+	}, limit, findings)
+	if err != nil {
+		return nil, err
+	}
 	return summary, nil
 }
 
@@ -2126,6 +2148,102 @@ func (app *App) mcpListRiskFindings(r *http.Request, request ports.ListFindingsR
 	return findings, nil
 }
 
+func (app *App) mcpBuildRiskSummaryForRequest(r *http.Request, request ports.ListFindingsRequest, limit int, findings []*ports.FindingRecord) (mcpRiskSummary, error) {
+	summaryStore, ok := findingStore(app.deps.StateStore).(mcpFindingSummaryStore)
+	if !ok {
+		summary := mcpBuildRiskSummary(request.TenantID, request.RuntimeID, limit, findings)
+		summary.Metadata = mcpRiskSummaryMetadata(limit, len(findings), summary.TotalFindings)
+		return summary, nil
+	}
+	request.Limit = 0
+	if strings.TrimSpace(request.Status) != "" {
+		parsed, err := parseFindingStatus(request.Status)
+		if err != nil {
+			return mcpRiskSummary{}, err
+		}
+		request.Status = findingStatusString(parsed)
+	}
+	summary := mcpRiskSummary{
+		TenantID:         request.TenantID,
+		RuntimeID:        request.RuntimeID,
+		BySeverity:       map[string]int{},
+		ByStatus:         map[string]int{},
+		LimitApplied:     limit,
+		RecentHighRisk:   []any{},
+		ReturnedFindings: len(findings),
+	}
+	reasonCounts := map[string]int{}
+	riskScoreTotal := 0
+	merge := func(item ports.FindingSummary) {
+		summary.TotalFindings += item.TotalFindings
+		summary.OpenFindings += item.OpenFindings
+		summary.CriticalOpenFindings += item.CriticalFindings
+		summary.HighOpenFindings += item.HighFindings
+		if item.MaxRiskScore > summary.MaxRiskScore {
+			summary.MaxRiskScore = item.MaxRiskScore
+		}
+		riskScoreTotal += item.RiskScoreTotal
+		for severity, count := range item.BySeverity {
+			severity = strings.TrimSpace(severity)
+			if severity == "" {
+				severity = "unknown"
+			}
+			summary.BySeverity[severity] += count
+		}
+		for status, count := range item.ByStatus {
+			status = strings.TrimSpace(status)
+			if status == "" {
+				status = "unknown"
+			}
+			summary.ByStatus[status] += count
+		}
+		for reason, count := range item.RiskReasonCounts {
+			reason = strings.TrimSpace(reason)
+			if reason != "" {
+				reasonCounts[reason] += count
+			}
+		}
+	}
+	if strings.TrimSpace(request.RuntimeID) != "" {
+		item, err := summaryStore.SummarizeFindings(r.Context(), request)
+		if err != nil {
+			return mcpRiskSummary{}, err
+		}
+		merge(item)
+	} else {
+		runtimes, err := app.runtimeService().List(r.Context(), ports.SourceRuntimeFilter{
+			TenantID: request.TenantID,
+			Limit:    uint32(maxMCPRiskLimit),
+		})
+		if err != nil {
+			return mcpRiskSummary{}, err
+		}
+		for _, runtime := range runtimes {
+			if runtime == nil || strings.TrimSpace(runtime.GetId()) == "" {
+				continue
+			}
+			if !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
+				continue
+			}
+			scoped := request
+			scoped.TenantID = strings.TrimSpace(runtime.GetTenantId())
+			scoped.RuntimeID = strings.TrimSpace(runtime.GetId())
+			item, err := summaryStore.SummarizeFindings(r.Context(), scoped)
+			if err != nil {
+				return mcpRiskSummary{}, err
+			}
+			merge(item)
+		}
+	}
+	if summary.TotalFindings != 0 {
+		summary.AverageRiskScore = float64(riskScoreTotal) / float64(summary.TotalFindings)
+	}
+	summary.TopRiskReasons = mcpTopRiskReasons(reasonCounts, 10)
+	mcpAttachRecentHighRisk(&summary, findings)
+	summary.Metadata = mcpRiskSummaryMetadata(limit, len(findings), summary.TotalFindings)
+	return summary, nil
+}
+
 func mcpBuildRiskSummary(tenantID string, runtimeID string, limit int, findings []*ports.FindingRecord) mcpRiskSummary {
 	summary := mcpRiskSummary{
 		TenantID:       tenantID,
@@ -2142,6 +2260,7 @@ func mcpBuildRiskSummary(tenantID string, runtimeID string, limit int, findings 
 			continue
 		}
 		summary.TotalFindings++
+		summary.ReturnedFindings++
 		status := strings.ToLower(strings.TrimSpace(finding.Status))
 		if status == "" {
 			status = "unknown"
@@ -2176,6 +2295,11 @@ func mcpBuildRiskSummary(tenantID string, runtimeID string, limit int, findings 
 		summary.AverageRiskScore = float64(riskScoreTotal) / float64(summary.TotalFindings)
 	}
 	summary.TopRiskReasons = mcpTopRiskReasons(reasonCounts, 10)
+	mcpAttachRecentHighRisk(&summary, findings)
+	return summary
+}
+
+func mcpAttachRecentHighRisk(summary *mcpRiskSummary, findings []*ports.FindingRecord) {
 	recent := make([]*ports.FindingRecord, 0, len(findings))
 	for _, finding := range findings {
 		if finding != nil {
@@ -2202,7 +2326,6 @@ func mcpBuildRiskSummary(tenantID string, runtimeID string, limit int, findings 
 			summary.RecentHighRisk = append(summary.RecentHighRisk, value)
 		}
 	}
-	return summary
 }
 
 func mcpTopRiskReasons(counts map[string]int, limit int) []mcpRiskReasonCount {
@@ -2389,6 +2512,15 @@ func mcpResponseMetadata(limit int, returned int, partialErrors []string) map[st
 	}
 	if len(partialErrors) != 0 {
 		metadata["partial_errors"] = append([]string(nil), partialErrors...)
+	}
+	return metadata
+}
+
+func mcpRiskSummaryMetadata(limit int, returned int, total int) map[string]any {
+	metadata := mcpResponseMetadata(limit, returned, nil)
+	if total > returned {
+		metadata["more_results_possible"] = true
+		metadata["total_matching_findings"] = total
 	}
 	return metadata
 }

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -1368,6 +1368,81 @@ func TestMCPRiskSummaryAggregatesScopedRuntimeFindings(t *testing.T) {
 	}
 }
 
+func TestMCPRiskSummaryCountsAllMatchingFindingsBeyondReturnedLimit(t *testing.T) {
+	now := time.Now().UTC()
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-aws":    {Id: "writer-aws", SourceId: "aws", TenantId: "writer"},
+			"writer-github": {Id: "writer-github", SourceId: "github", TenantId: "writer"},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				RuntimeID:      "writer-aws",
+				TenantID:       "writer",
+				RuleID:         "rule-1",
+				Title:          "First",
+				Severity:       "high",
+				Status:         "open",
+				FindingRisk:    ports.FindingRisk{RiskScore: 90, RiskReasons: []string{"active"}},
+				LastObservedAt: now,
+			},
+			"finding-2": {
+				ID:             "finding-2",
+				RuntimeID:      "writer-aws",
+				TenantID:       "writer",
+				RuleID:         "rule-2",
+				Title:          "Second",
+				Severity:       "medium",
+				Status:         "open",
+				FindingRisk:    ports.FindingRisk{RiskScore: 80, RiskReasons: []string{"active"}},
+				LastObservedAt: now.Add(-time.Minute),
+			},
+			"finding-3": {
+				ID:             "finding-3",
+				RuntimeID:      "writer-github",
+				TenantID:       "writer",
+				RuleID:         "rule-3",
+				Title:          "Third",
+				Severity:       "low",
+				Status:         "open",
+				FindingRisk:    ports.FindingRisk{RiskScore: 70, RiskReasons: []string{"active"}},
+				LastObservedAt: now.Add(-2 * time.Minute),
+			},
+		},
+	}
+	server := newMCPTestServer(t, store)
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.risk.summary",
+			"arguments": map[string]any{
+				"limit":  2,
+				"status": "open",
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("tools/call error = %#v", response["error"])
+	}
+	summary := response["result"].(map[string]any)["structuredContent"].(map[string]any)
+	if summary["total_findings"] != float64(3) || summary["open_findings"] != float64(3) || summary["returned_findings"] != float64(2) {
+		t.Fatalf("summary counts = %#v", summary)
+	}
+	bySeverity := summary["by_severity"].(map[string]any)
+	if bySeverity["high"] != float64(1) || bySeverity["medium"] != float64(1) || bySeverity["low"] != float64(1) {
+		t.Fatalf("by_severity = %#v", bySeverity)
+	}
+	metadata := summary["metadata"].(map[string]any)
+	if metadata["total_matching_findings"] != float64(3) || metadata["more_results_possible"] != true {
+		t.Fatalf("metadata = %#v", metadata)
+	}
+}
+
 func TestMCPGraphNeighborhood(t *testing.T) {
 	store := &stubRuntimeStore{}
 	graph := &stubGraphStore{neighborhood: &ports.EntityNeighborhood{

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -119,11 +119,17 @@ const (
 // FindingSummary captures aggregate counts for one finding query without applying
 // pagination limits intended for UI rows.
 type FindingSummary struct {
+	TotalFindings      int
 	OpenFindings       int
 	CriticalFindings   int
 	HighFindings       int
 	OverdueFindings    int
 	Unassigned         int
+	MaxRiskScore       int
+	RiskScoreTotal     int
+	BySeverity         map[string]int
+	ByStatus           map[string]int
+	RiskReasonCounts   map[string]int
 	ControlsFailing    int
 	FailingControlKeys []string
 }

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -632,23 +632,57 @@ func (s *Store) SummarizeFindings(ctx context.Context, request ports.ListFinding
 	effectiveSeverity := findingEffectiveSeveritySQL()
 	query := `
 SELECT
+  COUNT(*),
   COUNT(*) FILTER (WHERE LOWER(status) = 'open'),
   COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND ` + effectiveSeverity + ` = 'CRITICAL'),
   COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND ` + effectiveSeverity + ` = 'HIGH'),
   COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND due_at IS NOT NULL AND due_at < NOW()),
-  COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND TRIM(assignee) = '')
+  COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND TRIM(assignee) = ''),
+  COALESCE(MAX(risk_score), 0),
+  COALESCE(SUM(risk_score), 0)
 FROM findings
 WHERE ` + where
 	var summary ports.FindingSummary
 	if err := s.db.QueryRowContext(ctx, query, args...).Scan(
+		&summary.TotalFindings,
 		&summary.OpenFindings,
 		&summary.CriticalFindings,
 		&summary.HighFindings,
 		&summary.OverdueFindings,
 		&summary.Unassigned,
+		&summary.MaxRiskScore,
+		&summary.RiskScoreTotal,
 	); err != nil {
 		return ports.FindingSummary{}, fmt.Errorf("summarize findings: %w", err)
 	}
+	severityCounts, err := s.findingSummaryCountMap(ctx, `
+SELECT COALESCE(NULLIF(LOWER(TRIM(`+effectiveSeverity+`)), ''), 'unknown') AS key, COUNT(*) AS count
+FROM findings
+WHERE `+where+`
+GROUP BY key`, args)
+	if err != nil {
+		return ports.FindingSummary{}, fmt.Errorf("summarize finding severities: %w", err)
+	}
+	summary.BySeverity = severityCounts
+	statusCounts, err := s.findingSummaryCountMap(ctx, `
+SELECT COALESCE(NULLIF(LOWER(TRIM(status)), ''), 'unknown') AS key, COUNT(*) AS count
+FROM findings
+WHERE `+where+`
+GROUP BY key`, args)
+	if err != nil {
+		return ports.FindingSummary{}, fmt.Errorf("summarize finding statuses: %w", err)
+	}
+	summary.ByStatus = statusCounts
+	reasonCounts, err := s.findingSummaryCountMap(ctx, `
+SELECT TRIM(reason.value) AS key, COUNT(*) AS count
+FROM findings
+CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(risk_reasons_json, '[]'::jsonb)) AS reason(value)
+WHERE `+where+` AND TRIM(reason.value) <> ''
+GROUP BY key`, args)
+	if err != nil {
+		return ports.FindingSummary{}, fmt.Errorf("summarize finding risk reasons: %w", err)
+	}
+	summary.RiskReasonCounts = reasonCounts
 	// #nosec G202 -- where is assembled from fixed predicates with parameterized values.
 	controlQuery := `
 SELECT framework_name, control_id
@@ -690,6 +724,31 @@ FROM (
 	sort.Strings(summary.FailingControlKeys)
 	summary.ControlsFailing = len(summary.FailingControlKeys)
 	return summary, nil
+}
+
+func (s *Store) findingSummaryCountMap(ctx context.Context, query string, args []any) (map[string]int, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	counts := map[string]int{}
+	for rows.Next() {
+		var key string
+		var count int
+		if err := rows.Scan(&key, &count); err != nil {
+			return nil, err
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			key = "unknown"
+		}
+		counts[key] += count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return counts, nil
 }
 
 // GetFinding loads one persisted finding by durable identifier.


### PR DESCRIPTION
## Summary

Fixes MCP risk summary totals so aggregate counts are computed independently from bounded rows returned for display. Adds explicit returned-row metadata so clients can tell page size apart from matching-result totals.

## Test Plan

- `go test ./internal/bootstrap -run 'TestMCPRiskSummary' -count=1 -v`
- `go test ./internal/statestore/postgres -run 'Test.*Finding|Test.*GRC|Test.*Summarize' -count=1 -v`
- `make test`
- `make lint`
- `make mcp-contract-check`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
