### PR TITLE
feat(source): add Panopticon API source mode

### DIFF
--- a/sources/panopticon/api.go
+++ b/sources/panopticon/api.go
@@ -111,19 +111,19 @@ func (s *Source) readAPIFamily(ctx context.Context, st settings, cursor *cerebro
 	if nextCursor != "" {
 		opaque := encodeAPICursor(panopticonAPICursor{
 			Cursor:    nextCursor,
-			Watermark: watermarkString(watermark, cursorWatermark(panopticonCursor{Watermark: cursorState.Watermark})),
+			Watermark: watermarkString(watermark, parseAPIWatermark(cursorState.Watermark)),
 		})
 		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: opaque}
 		pull.Checkpoint = &cerebrov1.SourceCheckpoint{CursorOpaque: opaque}
 	} else if !watermark.IsZero() || cursor != nil {
 		opaque := encodeAPICursor(panopticonAPICursor{
 			Cursor:    cursorState.Cursor,
-			Watermark: watermarkString(watermark, cursorWatermark(panopticonCursor{Watermark: cursorState.Watermark})),
+			Watermark: watermarkString(watermark, parseAPIWatermark(cursorState.Watermark)),
 		})
 		pull.Checkpoint = &cerebrov1.SourceCheckpoint{CursorOpaque: opaque}
 	}
 	if pull.Checkpoint != nil {
-		if checkpointWatermark := cursorWatermark(panopticonCursor{Watermark: decodeAPICursor(&cerebrov1.SourceCursor{Opaque: pull.Checkpoint.CursorOpaque}).Watermark}); !checkpointWatermark.IsZero() {
+		if checkpointWatermark := parseAPIWatermark(decodeAPICursor(&cerebrov1.SourceCursor{Opaque: pull.Checkpoint.CursorOpaque}).Watermark); !checkpointWatermark.IsZero() {
 			pull.Checkpoint.Watermark = timestamppb.New(checkpointWatermark.UTC())
 		}
 	}

--- a/sources/panopticon/api.go
+++ b/sources/panopticon/api.go
@@ -1,0 +1,246 @@
+package panopticon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehttp"
+)
+
+const maxAPIResponseBytes = 8 << 20
+
+type panopticonAPICursor struct {
+	Source              string `json:"source,omitempty"`
+	ResumableCheckpoint bool   `json:"resumable_checkpoint,omitempty"`
+	Cursor              string `json:"cursor,omitempty"`
+	Watermark           string `json:"watermark,omitempty"`
+}
+
+type panopticonAPIResponse struct {
+	Records    []panopticonRecord `json:"records"`
+	Events     []panopticonRecord `json:"events"`
+	NextCursor string             `json:"next_cursor"`
+	Watermark  string             `json:"watermark"`
+}
+
+func apiPathForFamily(family string) string {
+	switch family {
+	case familyAlert:
+		return "/api/cerebro/alerts"
+	case familyCase:
+		return "/api/cerebro/cases"
+	case familyIOC:
+		return "/api/cerebro/iocs"
+	default:
+		return "/api/cerebro/events"
+	}
+}
+
+func discoverAPIFamily(st settings, urnPrefix string) ([]sourcecdk.URN, error) {
+	urnRaw := urnPrefix + url.PathEscape(st.baseURL+st.apiPath)
+	urn, err := sourcecdk.ParseURN(urnRaw)
+	if err != nil {
+		return nil, fmt.Errorf("build panopticon api urn: %w", err)
+	}
+	return []sourcecdk.URN{urn}, nil
+}
+
+func (s *Source) checkAPI(ctx context.Context, st settings) error {
+	_, err := s.readAPIPage(ctx, st, "")
+	return err
+}
+
+func (s *Source) readAPIFamily(ctx context.Context, st settings, cursor *cerebrov1.SourceCursor, kind, schemaRef string) (sourcecdk.Pull, error) {
+	cursorState := decodeAPICursor(cursor)
+	response, err := s.readAPIPage(ctx, st, cursorState.Cursor)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	records := response.apiRecords()
+	if len(records) > maxEventsPerPull {
+		return sourcecdk.Pull{}, fmt.Errorf("panopticon api returned %d records, max %d", len(records), maxEventsPerPull)
+	}
+	events := make([]*cerebrov1.EventEnvelope, 0, len(records))
+	var watermark time.Time
+	for _, rec := range records {
+		recordTenant := strings.TrimSpace(rec.TenantID)
+		if recordTenant == "" {
+			return sourcecdk.Pull{}, fmt.Errorf("invalid panopticon api event: tenant_id is required")
+		}
+		if recordTenant != rec.TenantID {
+			return sourcecdk.Pull{}, fmt.Errorf("invalid panopticon api event: tenant_id must not have leading or trailing whitespace")
+		}
+		if recordTenant != st.tenantID {
+			return sourcecdk.Pull{}, fmt.Errorf("invalid panopticon api event: tenant_id %q does not match runtime tenant", recordTenant)
+		}
+		if st.runtimeID != "" && strings.TrimSpace(rec.Attributes["runtime_id"]) != "" && strings.TrimSpace(rec.Attributes["runtime_id"]) != st.runtimeID {
+			continue
+		}
+		event, err := buildEvent(rec, kind, schemaRef)
+		if err != nil {
+			return sourcecdk.Pull{}, fmt.Errorf("convert panopticon api event: %w", err)
+		}
+		if err := sourcecdk.ValidateEventEnvelopeWithContracts(event, sourcecdkEventContracts()); err != nil {
+			return sourcecdk.Pull{}, fmt.Errorf("invalid panopticon api event: %w", err)
+		}
+		if err := validateFamilyContract(event); err != nil {
+			return sourcecdk.Pull{}, fmt.Errorf("invalid panopticon api event: %w", err)
+		}
+		events = append(events, event)
+		if rec.OccurredAt.After(watermark) {
+			watermark = rec.OccurredAt
+		}
+	}
+	if parsed := parseAPIWatermark(response.Watermark); parsed.After(watermark) {
+		watermark = parsed
+	}
+
+	pull := sourcecdk.Pull{Events: events}
+	nextCursor := strings.TrimSpace(response.NextCursor)
+	if nextCursor != "" {
+		opaque := encodeAPICursor(panopticonAPICursor{
+			Cursor:    nextCursor,
+			Watermark: watermarkString(watermark, cursorWatermark(panopticonCursor{Watermark: cursorState.Watermark})),
+		})
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: opaque}
+		pull.Checkpoint = &cerebrov1.SourceCheckpoint{CursorOpaque: opaque}
+	} else if !watermark.IsZero() || cursor != nil {
+		opaque := encodeAPICursor(panopticonAPICursor{
+			Cursor:    cursorState.Cursor,
+			Watermark: watermarkString(watermark, cursorWatermark(panopticonCursor{Watermark: cursorState.Watermark})),
+		})
+		pull.Checkpoint = &cerebrov1.SourceCheckpoint{CursorOpaque: opaque}
+	}
+	if pull.Checkpoint != nil {
+		if checkpointWatermark := cursorWatermark(panopticonCursor{Watermark: decodeAPICursor(&cerebrov1.SourceCursor{Opaque: pull.Checkpoint.CursorOpaque}).Watermark}); !checkpointWatermark.IsZero() {
+			pull.Checkpoint.Watermark = timestamppb.New(checkpointWatermark.UTC())
+		}
+	}
+	return pull, nil
+}
+
+func (s *Source) readAPIPage(ctx context.Context, st settings, cursor string) (panopticonAPIResponse, error) {
+	query := url.Values{}
+	query.Set("tenant_id", st.tenantID)
+	query.Set("family", st.family)
+	query.Set("limit", strconv.Itoa(int(st.perPage)))
+	if st.runtimeID != "" {
+		query.Set("runtime_id", st.runtimeID)
+	}
+	if cursor = strings.TrimSpace(cursor); cursor != "" {
+		query.Set("cursor", cursor)
+	}
+	endpoint := st.baseURL + st.apiPath
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return panopticonAPIResponse{}, fmt.Errorf("build panopticon api request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+st.token)
+
+	resp, err := sourceHTTPClient(s).Do(req)
+	if err != nil {
+		return panopticonAPIResponse{}, fmt.Errorf("request panopticon api: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	payload, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxAPIResponseBytes)
+	if err != nil {
+		return panopticonAPIResponse{}, fmt.Errorf("read panopticon api response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return panopticonAPIResponse{}, apiResponseError(resp.StatusCode, payload)
+	}
+	var response panopticonAPIResponse
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return panopticonAPIResponse{}, fmt.Errorf("decode panopticon api response: %w", err)
+	}
+	return response, nil
+}
+
+func sourceHTTPClient(s *Source) *http.Client {
+	if s == nil {
+		return sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: sourceID})
+	}
+	return sourcehttp.HardenClient(s.client, sourcehttp.ClientOptions{
+		SourceID:      sourceID,
+		AllowLoopback: s.allowLoopbackBaseURL,
+		LookupIPAddrs: lookupIPAddrs(s),
+	})
+}
+
+func lookupIPAddrs(s *Source) func(context.Context, string) ([]net.IPAddr, error) {
+	if s == nil || s.lookupIPAddrs == nil {
+		return net.DefaultResolver.LookupIPAddr
+	}
+	return s.lookupIPAddrs
+}
+
+func (r panopticonAPIResponse) apiRecords() []panopticonRecord {
+	if r.Records != nil {
+		return r.Records
+	}
+	return r.Events
+}
+
+func decodeAPICursor(cursor *cerebrov1.SourceCursor) panopticonAPICursor {
+	opaque := strings.TrimSpace(cursor.GetOpaque())
+	if opaque == "" {
+		return panopticonAPICursor{}
+	}
+	var decoded panopticonAPICursor
+	if err := json.Unmarshal([]byte(opaque), &decoded); err == nil && decoded.Source == cursorSourceAPI {
+		decoded.Cursor = strings.TrimSpace(decoded.Cursor)
+		decoded.Watermark = strings.TrimSpace(decoded.Watermark)
+		return decoded
+	}
+	return panopticonAPICursor{Cursor: opaque}
+}
+
+func encodeAPICursor(cursor panopticonAPICursor) string {
+	cursor.Source = cursorSourceAPI
+	cursor.ResumableCheckpoint = true
+	cursor.Cursor = strings.TrimSpace(cursor.Cursor)
+	cursor.Watermark = strings.TrimSpace(cursor.Watermark)
+	raw, err := json.Marshal(cursor)
+	if err != nil {
+		return cursor.Cursor
+	}
+	return string(raw)
+}
+
+func parseAPIWatermark(raw string) time.Time {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
+}
+
+func apiResponseError(statusCode int, payload []byte) error {
+	message := strings.TrimSpace(string(payload))
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+	if len(message) > 512 {
+		message = message[:512]
+	}
+	return fmt.Errorf("panopticon api returned status %d: %s", statusCode, message)
+}

--- a/sources/panopticon/catalog.yaml
+++ b/sources/panopticon/catalog.yaml
@@ -1,6 +1,6 @@
 id: panopticon
 name: Panopticon
-description: Panopticon security operations source. Reads canonical alert, case, and IOC event NDJSON archives written to S3 by the Panopticon export pipeline.
+description: Panopticon security operations source. Reads canonical alert, case, and IOC events from the Panopticon API.
 emitted_kinds:
   - panopticon.alert
   - panopticon.case

--- a/sources/panopticon/source.go
+++ b/sources/panopticon/source.go
@@ -1,33 +1,19 @@
 // Package panopticon implements the Cerebro source for Panopticon security
-// operations exports. Panopticon writes canonical Cerebro event envelopes as
-// NDJSON archives to S3, one prefix per event family. This source lists those
-// prefixes incrementally, reads new archives since the last cursor, and emits
-// validated panopticon.* events.
+// operations events exposed by the Panopticon API.
 package panopticon
 
 import (
-	"bufio"
-	"bytes"
-	"compress/gzip"
 	"context"
 	"embed"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
-	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -40,21 +26,14 @@ import (
 //go:embed catalog.yaml
 var catalogFS embed.FS
 
-var awsRoleARNPattern = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):iam::([0-9]{12}):role/[A-Za-z0-9+=,.@_/-]+$`)
-
 const (
 	sourceID = "panopticon"
 
-	defaultPageSize       = 100
-	maxPageSize           = 1000
-	defaultRegion         = "us-east-1"
-	assumeRoleSessionName = "cerebro-panopticon-source"
-	maxObjectBytes        = 64 << 20
-	maxLineBytes          = 1 << 20
-	maxEventsPerPull      = 1000
-	cursorSource          = "panopticon/s3-ndjson/v1"
-	cursorSourceAPI       = "panopticon/api/v1"
-	modeAPI               = "api"
+	defaultPageSize  = 100
+	maxPageSize      = 1000
+	maxEventsPerPull = 1000
+	cursorSourceAPI  = "panopticon/api/v1"
+	modeAPI          = "api"
 
 	familyAlert = "alert"
 	familyCase  = "case"
@@ -74,59 +53,37 @@ const (
 )
 
 var (
-	// ErrBucketRequired is returned when no S3 bucket is configured.
-	ErrBucketRequired = errors.New("bucket is required")
-	// ErrPrefixRequired is returned when no S3 key prefix is configured.
-	ErrPrefixRequired = errors.New("prefix is required")
 	// ErrInvalidPageSize is returned when page_size is not a positive integer.
 	ErrInvalidPageSize = errors.New("invalid page_size")
 	// ErrTenantIDRequired is returned when no explicit tenant scope is configured.
 	ErrTenantIDRequired = errors.New("tenant_id is required")
-	// ErrDecompressedObjectTooLarge is returned when a compressed archive expands past the configured limit.
-	ErrDecompressedObjectTooLarge = errors.New("decompressed object exceeds limit")
 	// ErrUnsupportedFamily is returned when the family is not one of the known kinds.
 	ErrUnsupportedFamily = errors.New("unsupported family")
-	// ErrInvalidBucket is returned when the bucket name contains illegal characters.
-	ErrInvalidBucket = errors.New("invalid bucket")
-	// ErrBaseURLRequired is returned when API mode has no configured base URL.
+	// ErrBaseURLRequired is returned when no API base URL is configured.
 	ErrBaseURLRequired = errors.New("base_url is required")
-	// ErrTokenRequired is returned when API mode has no bearer token.
+	// ErrTokenRequired is returned when no API bearer token is configured.
 	ErrTokenRequired = errors.New("token is required")
-	// ErrUnsupportedMode is returned when mode is not one of the known transports.
+	// ErrUnsupportedMode is returned when mode is not the API transport.
 	ErrUnsupportedMode = errors.New("unsupported mode")
 )
 
-// s3API is the narrow surface of *s3.Client this source uses, exposed for testing.
-type s3API interface {
-	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
-	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
-}
-
-// Source emits panopticon.* events from NDJSON archives stored in S3.
+// Source emits panopticon.* events from the Panopticon API.
 type Source struct {
 	spec                 *cerebrov1.SourceSpec
 	client               *http.Client
 	families             *sourcecdk.FamilyEngine[settings]
-	newClient            func(context.Context, settings) (s3API, error)
 	allowLoopbackBaseURL bool
 	lookupIPAddrs        func(context.Context, string) ([]net.IPAddr, error)
 }
 
 type settings struct {
-	mode           string
-	family         string
-	bucket         string
-	prefix         string
-	region         string
-	baseURL        string
-	apiPath        string
-	token          string
-	tenantID       string
-	runtimeID      string
-	roleARN        string
-	externalID     string
-	assumeRoleARNs string
-	perPage        int32
+	family    string
+	baseURL   string
+	apiPath   string
+	token     string
+	tenantID  string
+	runtimeID string
+	perPage   int32
 }
 
 type panopticonRecord struct {
@@ -140,16 +97,7 @@ type panopticonRecord struct {
 	Attributes map[string]string      `json:"attributes"`
 }
 
-type panopticonCursor struct {
-	Source              string `json:"source,omitempty"`
-	ResumableCheckpoint bool   `json:"resumable_checkpoint,omitempty"`
-	LastKey             string `json:"last_key,omitempty"`
-	PartialKey          string `json:"partial_key,omitempty"`
-	RecordOffset        int    `json:"record_offset,omitempty"`
-	Watermark           string `json:"watermark,omitempty"`
-}
-
-// New constructs the Panopticon source backed by an S3-NDJSON archive.
+// New constructs the Panopticon API source.
 func New() (*Source, error) {
 	spec, err := loadSpec()
 	if err != nil {
@@ -157,7 +105,6 @@ func New() (*Source, error) {
 	}
 	source := &Source{
 		spec:          spec,
-		newClient:     defaultClientFactory,
 		lookupIPAddrs: net.DefaultResolver.LookupIPAddr,
 	}
 	source.families, err = source.newFamilyEngine()
@@ -170,7 +117,7 @@ func New() (*Source, error) {
 // Spec returns the static metadata for the Panopticon source.
 func (s *Source) Spec() *cerebrov1.SourceSpec { return s.spec }
 
-// Check verifies that the configured S3 bucket/prefix is reachable.
+// Check verifies that the configured Panopticon API family is reachable.
 func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 	return s.families.Check(ctx, cfg)
 }
@@ -180,7 +127,7 @@ func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecd
 	return s.families.Discover(ctx, cfg)
 }
 
-// Read pages new NDJSON archives since the cursor and emits panopticon.* events.
+// Read pages Panopticon API events since the cursor.
 func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	return s.families.Read(ctx, cfg, cursor)
 }
@@ -197,27 +144,6 @@ func loadSpec() (*cerebrov1.SourceSpec, error) {
 	return spec, nil
 }
 
-func defaultClientFactory(ctx context.Context, st settings) (s3API, error) {
-	region := st.region
-	if strings.TrimSpace(region) == "" {
-		region = defaultRegion
-	}
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
-	if err != nil {
-		return nil, fmt.Errorf("load aws config: %w", err)
-	}
-	if st.roleARN != "" {
-		provider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), st.roleARN, func(options *stscreds.AssumeRoleOptions) {
-			options.RoleSessionName = assumeRoleSessionName
-			if st.externalID != "" {
-				options.ExternalID = awssdk.String(st.externalID)
-			}
-		})
-		cfg.Credentials = awssdk.NewCredentialsCache(provider)
-	}
-	return s3.NewFromConfig(cfg), nil
-}
-
 func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 	families := []sourcecdk.Family[settings]{
 		s.familyFor(familyAlert, kindAlert, schemaRefAlert, urnPrefixAlert),
@@ -226,7 +152,10 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 	}
 	return sourcecdk.NewFamilyEngine[settings](
 		func(cfg sourcecdk.Config) (settings, error) {
-			return parseSettingsWithLoopback(cfg, s != nil && s.allowLoopbackBaseURL)
+			if s != nil && s.allowLoopbackBaseURL {
+				return parseSettingsWithLoopback(cfg, true)
+			}
+			return parseSettings(cfg)
 		},
 		func(st settings) string { return st.family },
 		families...,
@@ -237,22 +166,13 @@ func (s *Source) familyFor(family, kind, schemaRef, urnPrefix string) sourcecdk.
 	return sourcecdk.Family[settings]{
 		Name: family,
 		Check: func(ctx context.Context, st settings) error {
-			if st.mode == modeAPI {
-				return s.checkAPI(ctx, st)
-			}
-			return s.check(ctx, st)
+			return s.checkAPI(ctx, st)
 		},
 		Discover: func(ctx context.Context, st settings) ([]sourcecdk.URN, error) {
-			if st.mode == modeAPI {
-				return discoverAPIFamily(st, urnPrefix)
-			}
-			return discoverFamily(st, urnPrefix)
+			return discoverAPIFamily(st, urnPrefix)
 		},
 		Read: func(ctx context.Context, st settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-			if st.mode == modeAPI {
-				return s.readAPIFamily(ctx, st, cursor, kind, schemaRef)
-			}
-			return s.readFamily(ctx, st, cursor, kind, schemaRef)
+			return s.readAPIFamily(ctx, st, cursor, kind, schemaRef)
 		},
 	}
 }
@@ -262,37 +182,22 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 }
 
 func parseSettingsWithLoopback(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
+	mode := strings.ToLower(strings.TrimSpace(configValue(cfg, "mode")))
+	if mode != "" && mode != modeAPI {
+		return settings{}, fmt.Errorf("%w: %q", ErrUnsupportedMode, mode)
+	}
 	tenantID := strings.TrimSpace(configValue(cfg, "tenant_id"))
 	if runtimeTenantID := strings.TrimSpace(configValue(cfg, sourceconfig.RuntimeTenantIDKey)); runtimeTenantID != "" {
 		tenantID = runtimeTenantID
 	}
-	mode := strings.ToLower(strings.TrimSpace(configValue(cfg, "mode")))
-	baseURL := strings.TrimSpace(configValue(cfg, "base_url"))
-	token := strings.TrimSpace(firstConfigValue(cfg, "token", "api_key"))
-	if mode == "" && (baseURL != "" || token != "") {
-		mode = modeAPI
-	}
-	if mode == "s3" {
-		mode = ""
-	}
-	if mode != "" && mode != modeAPI {
-		return settings{}, fmt.Errorf("%w: %q", ErrUnsupportedMode, mode)
-	}
 	st := settings{
-		mode:           mode,
-		family:         strings.TrimSpace(configValue(cfg, "family")),
-		bucket:         strings.TrimSpace(configValue(cfg, "bucket")),
-		prefix:         strings.TrimSpace(configValue(cfg, "prefix")),
-		region:         strings.TrimSpace(configValue(cfg, "region")),
-		baseURL:        baseURL,
-		apiPath:        strings.TrimSpace(configValue(cfg, "path")),
-		token:          token,
-		tenantID:       tenantID,
-		runtimeID:      strings.TrimSpace(firstConfigValue(cfg, "runtime_id", "source_runtime_id")),
-		roleARN:        strings.TrimSpace(configValue(cfg, "role_arn")),
-		externalID:     strings.TrimSpace(configValue(cfg, "external_id")),
-		assumeRoleARNs: strings.TrimSpace(configValue(cfg, sourceconfig.AWSAssumeRoleAllowlistKey)),
-		perPage:        defaultPageSize,
+		family:    strings.TrimSpace(configValue(cfg, "family")),
+		baseURL:   strings.TrimSpace(configValue(cfg, "base_url")),
+		apiPath:   strings.TrimSpace(configValue(cfg, "path")),
+		token:     strings.TrimSpace(firstConfigValue(cfg, "token", "api_key")),
+		tenantID:  tenantID,
+		runtimeID: strings.TrimSpace(firstConfigValue(cfg, "runtime_id", "source_runtime_id")),
+		perPage:   defaultPageSize,
 	}
 	if st.family == "" {
 		st.family = familyAlert
@@ -300,12 +205,8 @@ func parseSettingsWithLoopback(cfg sourcecdk.Config, allowLoopback bool) (settin
 	if st.tenantID == "" {
 		return settings{}, ErrTenantIDRequired
 	}
-	rawPageSize, ok := cfg.Lookup("per_page")
-	if !ok || strings.TrimSpace(rawPageSize) == "" {
-		rawPageSize, ok = cfg.Lookup("page_size")
-	}
-	if ok && strings.TrimSpace(rawPageSize) != "" {
-		size, err := strconv.ParseInt(strings.TrimSpace(rawPageSize), 10, 32)
+	if rawPageSize := strings.TrimSpace(firstConfigValue(cfg, "per_page", "page_size")); rawPageSize != "" {
+		size, err := strconv.ParseInt(rawPageSize, 10, 32)
 		if err != nil {
 			return settings{}, fmt.Errorf("%w: %w", ErrInvalidPageSize, err)
 		}
@@ -320,84 +221,26 @@ func parseSettingsWithLoopback(cfg sourcecdk.Config, allowLoopback bool) (settin
 	if !isKnownFamily(st.family) {
 		return settings{}, fmt.Errorf("%w: %q", ErrUnsupportedFamily, st.family)
 	}
-	if st.mode == modeAPI {
-		if st.baseURL == "" {
-			return settings{}, ErrBaseURLRequired
-		}
-		if st.token == "" {
-			return settings{}, ErrTokenRequired
-		}
-		baseURL, _, err := sourcehttp.NormalizeBaseURL(sourceID, st.baseURL, allowLoopback)
-		if err != nil {
-			return settings{}, err
-		}
-		st.baseURL = baseURL
-		if st.apiPath == "" {
-			st.apiPath = apiPathForFamily(st.family)
-		}
-		apiPath, err := sourcehttp.NormalizeRequestPath(sourceID, st.apiPath)
-		if err != nil {
-			return settings{}, err
-		}
-		st.apiPath = apiPath
-		return st, nil
+	if st.baseURL == "" {
+		return settings{}, ErrBaseURLRequired
 	}
-	if st.bucket == "" {
-		return settings{}, ErrBucketRequired
+	if st.token == "" {
+		return settings{}, ErrTokenRequired
 	}
-	if st.prefix == "" {
-		return settings{}, ErrPrefixRequired
+	baseURL, _, err := sourcehttp.NormalizeBaseURL(sourceID, st.baseURL, allowLoopback)
+	if err != nil {
+		return settings{}, err
 	}
-	if !strings.HasSuffix(st.prefix, "/") {
-		st.prefix += "/"
+	st.baseURL = baseURL
+	if st.apiPath == "" {
+		st.apiPath = apiPathForFamily(st.family)
 	}
-	if st.region == "" {
-		st.region = defaultRegion
+	apiPath, err := sourcehttp.NormalizeRequestPath(sourceID, st.apiPath)
+	if err != nil {
+		return settings{}, err
 	}
-	if st.roleARN != "" {
-		if err := validateAssumeRoleConfig(st); err != nil {
-			return settings{}, err
-		}
-	} else if st.externalID != "" {
-		return settings{}, fmt.Errorf("panopticon external_id requires role_arn")
-	}
-	if strings.ContainsRune(st.bucket, '/') {
-		return settings{}, fmt.Errorf("%w: %q must not contain slashes", ErrInvalidBucket, st.bucket)
-	}
+	st.apiPath = apiPath
 	return st, nil
-}
-
-func validateAssumeRoleConfig(st settings) error {
-	if len(awsRoleARNPattern.FindStringSubmatch(st.roleARN)) != 3 {
-		return fmt.Errorf("panopticon role_arn must be an IAM role ARN")
-	}
-	if st.tenantID == "" {
-		return fmt.Errorf("panopticon role_arn requires runtime tenant_id")
-	}
-	if !assumeRoleARNAllowed(st.tenantID, st.roleARN, st.assumeRoleARNs) {
-		return fmt.Errorf("panopticon role_arn is not allowed")
-	}
-	return nil
-}
-
-func assumeRoleARNAllowed(tenantID string, roleARN string, allowlist string) bool {
-	tenantID = strings.TrimSpace(tenantID)
-	roleARN = strings.TrimSpace(roleARN)
-	if tenantID == "" || roleARN == "" {
-		return false
-	}
-	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
-		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
-	}) {
-		tenant, arn, ok := strings.Cut(strings.TrimSpace(value), "=")
-		if !ok {
-			continue
-		}
-		if strings.TrimSpace(tenant) == tenantID && strings.TrimSpace(arn) == roleARN {
-			return true
-		}
-	}
-	return false
 }
 
 func isKnownFamily(name string) bool {
@@ -422,51 +265,6 @@ func firstConfigValue(cfg sourcecdk.Config, keys ...string) string {
 	return ""
 }
 
-func decodeCursor(cursor *cerebrov1.SourceCursor) panopticonCursor {
-	opaque := strings.TrimSpace(cursor.GetOpaque())
-	if opaque == "" {
-		return panopticonCursor{}
-	}
-	var decoded panopticonCursor
-	if err := json.Unmarshal([]byte(opaque), &decoded); err == nil && decoded.Source == cursorSource {
-		decoded.LastKey = strings.TrimSpace(decoded.LastKey)
-		decoded.PartialKey = strings.TrimSpace(decoded.PartialKey)
-		decoded.Watermark = strings.TrimSpace(decoded.Watermark)
-		if decoded.PartialKey == "" || decoded.RecordOffset < 0 {
-			decoded.RecordOffset = 0
-		}
-		return decoded
-	}
-	return panopticonCursor{LastKey: opaque}
-}
-
-func encodeCursor(cursor panopticonCursor) string {
-	cursor.Source = cursorSource
-	cursor.ResumableCheckpoint = true
-	cursor.LastKey = strings.TrimSpace(cursor.LastKey)
-	cursor.PartialKey = strings.TrimSpace(cursor.PartialKey)
-	cursor.Watermark = strings.TrimSpace(cursor.Watermark)
-	if cursor.PartialKey == "" || cursor.RecordOffset < 0 {
-		cursor.RecordOffset = 0
-	}
-	raw, err := json.Marshal(cursor)
-	if err != nil {
-		return cursor.LastKey
-	}
-	return string(raw)
-}
-
-func cursorWatermark(cursor panopticonCursor) time.Time {
-	if cursor.Watermark == "" {
-		return time.Time{}
-	}
-	value, err := time.Parse(time.RFC3339Nano, cursor.Watermark)
-	if err != nil {
-		return time.Time{}
-	}
-	return value.UTC()
-}
-
 func watermarkString(watermark time.Time, fallback time.Time) string {
 	if !watermark.IsZero() && !fallback.IsZero() && fallback.After(watermark) {
 		watermark = fallback
@@ -477,241 +275,6 @@ func watermarkString(watermark time.Time, fallback time.Time) string {
 		return ""
 	}
 	return watermark.UTC().Format(time.RFC3339Nano)
-}
-
-func discoverFamily(st settings, urnPrefix string) ([]sourcecdk.URN, error) {
-	urnRaw := urnPrefix + url.PathEscape(st.bucket+"/"+strings.TrimSuffix(st.prefix, "/"))
-	urn, err := sourcecdk.ParseURN(urnRaw)
-	if err != nil {
-		return nil, fmt.Errorf("build panopticon urn: %w", err)
-	}
-	return []sourcecdk.URN{urn}, nil
-}
-
-func (s *Source) check(ctx context.Context, st settings) error {
-	client, err := s.newClient(ctx, st)
-	if err != nil {
-		return err
-	}
-	_, err = client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket:  awssdk.String(st.bucket),
-		Prefix:  awssdk.String(st.prefix),
-		MaxKeys: awssdk.Int32(1),
-	})
-	if err != nil {
-		return fmt.Errorf("list objects in s3://%s/%s: %w", st.bucket, st.prefix, err)
-	}
-	return nil
-}
-
-func (s *Source) readFamily(ctx context.Context, st settings, cursor *cerebrov1.SourceCursor, kind, schemaRef string) (sourcecdk.Pull, error) {
-	client, err := s.newClient(ctx, st)
-	if err != nil {
-		return sourcecdk.Pull{}, err
-	}
-	cursorState := decodeCursor(cursor)
-	startAfter := cursorState.LastKey
-	input := &s3.ListObjectsV2Input{
-		Bucket:  awssdk.String(st.bucket),
-		Prefix:  awssdk.String(st.prefix),
-		MaxKeys: awssdk.Int32(st.perPage),
-	}
-	if startAfter != "" {
-		input.StartAfter = awssdk.String(startAfter)
-	}
-	listing, err := client.ListObjectsV2(ctx, input)
-	if err != nil {
-		return sourcecdk.Pull{}, fmt.Errorf("list objects in s3://%s/%s: %w", st.bucket, st.prefix, err)
-	}
-	events := make([]*primitives.Event, 0, st.perPage)
-	var watermark time.Time
-	priorWatermark := cursorWatermark(cursorState)
-	lastKey := startAfter
-	nextCursor := ""
-	for objectIndex, object := range listing.Contents {
-		key := awssdk.ToString(object.Key)
-		if key == "" {
-			continue
-		}
-		if strings.HasSuffix(key, "/") {
-			lastKey = key
-			continue
-		}
-		if !isArchiveKey(key) {
-			lastKey = key
-			continue
-		}
-		recs, err := s.readArchive(ctx, client, st.bucket, key)
-		if err != nil {
-			return sourcecdk.Pull{}, fmt.Errorf("read s3://%s/%s: %w", st.bucket, key, err)
-		}
-		startRecord := 0
-		if key == cursorState.PartialKey {
-			startRecord = cursorState.RecordOffset
-			if startRecord > len(recs) {
-				startRecord = len(recs)
-			}
-		}
-		for recordIndex := startRecord; recordIndex < len(recs); recordIndex++ {
-			rec := recs[recordIndex]
-			recordTenant := strings.TrimSpace(rec.TenantID)
-			if recordTenant == "" {
-				return sourcecdk.Pull{}, fmt.Errorf("invalid event in s3://%s/%s: tenant_id is required", st.bucket, key)
-			}
-			if recordTenant != rec.TenantID {
-				return sourcecdk.Pull{}, fmt.Errorf("invalid event in s3://%s/%s: tenant_id must not have leading or trailing whitespace", st.bucket, key)
-			}
-			if recordTenant != st.tenantID {
-				continue
-			}
-			if st.runtimeID != "" && strings.TrimSpace(rec.Attributes["runtime_id"]) != "" && strings.TrimSpace(rec.Attributes["runtime_id"]) != st.runtimeID {
-				continue
-			}
-			event, err := buildEvent(rec, kind, schemaRef)
-			if err != nil {
-				return sourcecdk.Pull{}, fmt.Errorf("convert event in s3://%s/%s: %w", st.bucket, key, err)
-			}
-			if err := sourcecdk.ValidateEventEnvelopeWithContracts(event, sourcecdkEventContracts()); err != nil {
-				return sourcecdk.Pull{}, fmt.Errorf("invalid event in s3://%s/%s: %w", st.bucket, key, err)
-			}
-			if err := validateFamilyContract(event); err != nil {
-				return sourcecdk.Pull{}, fmt.Errorf("invalid event in s3://%s/%s: %w", st.bucket, key, err)
-			}
-			events = append(events, event)
-			if rec.OccurredAt.After(watermark) {
-				watermark = rec.OccurredAt
-			}
-			if len(events) >= maxEventsPerPull {
-				nextRecord := recordIndex + 1
-				if nextRecord < len(recs) {
-					nextCursor = encodeCursor(panopticonCursor{
-						LastKey:      lastKey,
-						PartialKey:   key,
-						RecordOffset: nextRecord,
-						Watermark:    watermarkString(watermark, priorWatermark),
-					})
-				} else {
-					lastKey = key
-					if objectIndex < len(listing.Contents)-1 || awssdk.ToBool(listing.IsTruncated) {
-						nextCursor = encodeCursor(panopticonCursor{LastKey: lastKey, Watermark: watermarkString(watermark, priorWatermark)})
-					}
-				}
-				break
-			}
-		}
-		if nextCursor != "" {
-			break
-		}
-		lastKey = key
-	}
-	pull := sourcecdk.Pull{Events: events}
-	if nextCursor == "" && awssdk.ToBool(listing.IsTruncated) && lastKey != "" {
-		nextCursor = encodeCursor(panopticonCursor{LastKey: lastKey, Watermark: watermarkString(watermark, priorWatermark)})
-	}
-	if nextCursor != "" {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextCursor}
-	}
-	checkpointCursor := nextCursor
-	if checkpointCursor == "" && lastKey != "" {
-		checkpointCursor = encodeCursor(panopticonCursor{LastKey: lastKey, Watermark: watermarkString(watermark, priorWatermark)})
-	}
-	madeProgress := lastKey != "" && lastKey != startAfter
-	if checkpointCursor != "" && (!watermark.IsZero() || cursor != nil || nextCursor != "" || madeProgress) {
-		pull.Checkpoint = &cerebrov1.SourceCheckpoint{
-			CursorOpaque: checkpointCursor,
-		}
-		checkpointWatermark := watermark
-		if priorWatermark.After(checkpointWatermark) {
-			checkpointWatermark = priorWatermark
-		}
-		if !checkpointWatermark.IsZero() {
-			pull.Checkpoint.Watermark = timestamppb.New(checkpointWatermark.UTC())
-		}
-	}
-	return pull, nil
-}
-
-func isArchiveKey(key string) bool {
-	switch {
-	case strings.HasSuffix(key, ".ndjson"):
-		return true
-	case strings.HasSuffix(key, ".ndjson.gz"):
-		return true
-	}
-	return false
-}
-
-func (s *Source) readArchive(ctx context.Context, client s3API, bucket, key string) ([]panopticonRecord, error) {
-	out, err := client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: awssdk.String(bucket),
-		Key:    awssdk.String(key),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("get object: %w", err)
-	}
-	defer func() { _ = out.Body.Close() }()
-	body := io.LimitReader(out.Body, maxObjectBytes+1)
-	raw, err := io.ReadAll(body)
-	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
-	}
-	if len(raw) > maxObjectBytes {
-		return nil, fmt.Errorf("object exceeds %d bytes", maxObjectBytes)
-	}
-	records, err := readArchiveRecords(bytes.NewReader(raw), key, maxObjectBytes)
-	if err != nil {
-		return nil, err
-	}
-	return records, nil
-}
-
-func readArchiveRecords(reader io.Reader, key string, decompressedLimitBytes int64) ([]panopticonRecord, error) {
-	if strings.HasSuffix(key, ".gz") {
-		gz, err := gzip.NewReader(reader)
-		if err != nil {
-			return nil, fmt.Errorf("gunzip: %w", err)
-		}
-		defer func() { _ = gz.Close() }()
-		reader = gz
-	}
-	counter := &countingReader{reader: io.LimitReader(reader, decompressedLimitBytes+1)}
-	scanner := bufio.NewScanner(counter)
-	scanner.Buffer(make([]byte, 0, 64<<10), maxLineBytes)
-	records := make([]panopticonRecord, 0, 64)
-	line := 0
-	for scanner.Scan() {
-		if counter.bytesRead > decompressedLimitBytes {
-			return nil, fmt.Errorf("%w: %d bytes", ErrDecompressedObjectTooLarge, decompressedLimitBytes)
-		}
-		line++
-		text := bytes.TrimSpace(scanner.Bytes())
-		if len(text) == 0 {
-			continue
-		}
-		var rec panopticonRecord
-		if err := json.Unmarshal(text, &rec); err != nil {
-			return nil, fmt.Errorf("decode line %d: %w", line, err)
-		}
-		records = append(records, rec)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan archive: %w", err)
-	}
-	if counter.bytesRead > decompressedLimitBytes {
-		return nil, fmt.Errorf("%w: %d bytes", ErrDecompressedObjectTooLarge, decompressedLimitBytes)
-	}
-	return records, nil
-}
-
-type countingReader struct {
-	reader    io.Reader
-	bytesRead int64
-}
-
-func (r *countingReader) Read(p []byte) (int, error) {
-	n, err := r.reader.Read(p)
-	r.bytesRead += int64(n)
-	return n, err
 }
 
 func buildEvent(rec panopticonRecord, kind, schemaRef string) (*primitives.Event, error) {

--- a/sources/panopticon/source.go
+++ b/sources/panopticon/source.go
@@ -15,6 +15,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -32,6 +34,7 @@ import (
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
 //go:embed catalog.yaml
@@ -50,6 +53,8 @@ const (
 	maxLineBytes          = 1 << 20
 	maxEventsPerPull      = 1000
 	cursorSource          = "panopticon/s3-ndjson/v1"
+	cursorSourceAPI       = "panopticon/api/v1"
+	modeAPI               = "api"
 
 	familyAlert = "alert"
 	familyCase  = "case"
@@ -83,6 +88,12 @@ var (
 	ErrUnsupportedFamily = errors.New("unsupported family")
 	// ErrInvalidBucket is returned when the bucket name contains illegal characters.
 	ErrInvalidBucket = errors.New("invalid bucket")
+	// ErrBaseURLRequired is returned when API mode has no configured base URL.
+	ErrBaseURLRequired = errors.New("base_url is required")
+	// ErrTokenRequired is returned when API mode has no bearer token.
+	ErrTokenRequired = errors.New("token is required")
+	// ErrUnsupportedMode is returned when mode is not one of the known transports.
+	ErrUnsupportedMode = errors.New("unsupported mode")
 )
 
 // s3API is the narrow surface of *s3.Client this source uses, exposed for testing.
@@ -93,16 +104,23 @@ type s3API interface {
 
 // Source emits panopticon.* events from NDJSON archives stored in S3.
 type Source struct {
-	spec      *cerebrov1.SourceSpec
-	families  *sourcecdk.FamilyEngine[settings]
-	newClient func(context.Context, settings) (s3API, error)
+	spec                 *cerebrov1.SourceSpec
+	client               *http.Client
+	families             *sourcecdk.FamilyEngine[settings]
+	newClient            func(context.Context, settings) (s3API, error)
+	allowLoopbackBaseURL bool
+	lookupIPAddrs        func(context.Context, string) ([]net.IPAddr, error)
 }
 
 type settings struct {
+	mode           string
 	family         string
 	bucket         string
 	prefix         string
 	region         string
+	baseURL        string
+	apiPath        string
+	token          string
 	tenantID       string
 	runtimeID      string
 	roleARN        string
@@ -138,8 +156,9 @@ func New() (*Source, error) {
 		return nil, err
 	}
 	source := &Source{
-		spec:      spec,
-		newClient: defaultClientFactory,
+		spec:          spec,
+		newClient:     defaultClientFactory,
+		lookupIPAddrs: net.DefaultResolver.LookupIPAddr,
 	}
 	source.families, err = source.newFamilyEngine()
 	if err != nil {
@@ -205,34 +224,69 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 		s.familyFor(familyCase, kindCase, schemaRefCase, urnPrefixCase),
 		s.familyFor(familyIOC, kindIOC, schemaRefIOC, urnPrefixIOC),
 	}
-	return sourcecdk.NewFamilyEngine[settings](parseSettings, func(st settings) string { return st.family }, families...)
+	return sourcecdk.NewFamilyEngine[settings](
+		func(cfg sourcecdk.Config) (settings, error) {
+			return parseSettingsWithLoopback(cfg, s != nil && s.allowLoopbackBaseURL)
+		},
+		func(st settings) string { return st.family },
+		families...,
+	)
 }
 
 func (s *Source) familyFor(family, kind, schemaRef, urnPrefix string) sourcecdk.Family[settings] {
 	return sourcecdk.Family[settings]{
 		Name: family,
 		Check: func(ctx context.Context, st settings) error {
+			if st.mode == modeAPI {
+				return s.checkAPI(ctx, st)
+			}
 			return s.check(ctx, st)
 		},
 		Discover: func(ctx context.Context, st settings) ([]sourcecdk.URN, error) {
+			if st.mode == modeAPI {
+				return discoverAPIFamily(st, urnPrefix)
+			}
 			return discoverFamily(st, urnPrefix)
 		},
 		Read: func(ctx context.Context, st settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+			if st.mode == modeAPI {
+				return s.readAPIFamily(ctx, st, cursor, kind, schemaRef)
+			}
 			return s.readFamily(ctx, st, cursor, kind, schemaRef)
 		},
 	}
 }
 
 func parseSettings(cfg sourcecdk.Config) (settings, error) {
+	return parseSettingsWithLoopback(cfg, false)
+}
+
+func parseSettingsWithLoopback(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 	tenantID := strings.TrimSpace(configValue(cfg, "tenant_id"))
 	if runtimeTenantID := strings.TrimSpace(configValue(cfg, sourceconfig.RuntimeTenantIDKey)); runtimeTenantID != "" {
 		tenantID = runtimeTenantID
 	}
+	mode := strings.ToLower(strings.TrimSpace(configValue(cfg, "mode")))
+	baseURL := strings.TrimSpace(configValue(cfg, "base_url"))
+	token := strings.TrimSpace(firstConfigValue(cfg, "token", "api_key"))
+	if mode == "" && (baseURL != "" || token != "") {
+		mode = modeAPI
+	}
+	if mode == "s3" {
+		mode = ""
+	}
+	if mode != "" && mode != modeAPI {
+		return settings{}, fmt.Errorf("%w: %q", ErrUnsupportedMode, mode)
+	}
 	st := settings{
+		mode:           mode,
 		family:         strings.TrimSpace(configValue(cfg, "family")),
 		bucket:         strings.TrimSpace(configValue(cfg, "bucket")),
 		prefix:         strings.TrimSpace(configValue(cfg, "prefix")),
 		region:         strings.TrimSpace(configValue(cfg, "region")),
+		baseURL:        baseURL,
+		apiPath:        strings.TrimSpace(configValue(cfg, "path")),
+		token:          token,
 		tenantID:       tenantID,
 		runtimeID:      strings.TrimSpace(firstConfigValue(cfg, "runtime_id", "source_runtime_id")),
 		roleARN:        strings.TrimSpace(configValue(cfg, "role_arn")),
@@ -243,27 +297,8 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if st.family == "" {
 		st.family = familyAlert
 	}
-	if st.bucket == "" {
-		return settings{}, ErrBucketRequired
-	}
-	if st.prefix == "" {
-		return settings{}, ErrPrefixRequired
-	}
-	if !strings.HasSuffix(st.prefix, "/") {
-		st.prefix += "/"
-	}
-	if st.region == "" {
-		st.region = defaultRegion
-	}
 	if st.tenantID == "" {
 		return settings{}, ErrTenantIDRequired
-	}
-	if st.roleARN != "" {
-		if err := validateAssumeRoleConfig(st); err != nil {
-			return settings{}, err
-		}
-	} else if st.externalID != "" {
-		return settings{}, fmt.Errorf("panopticon external_id requires role_arn")
 	}
 	rawPageSize, ok := cfg.Lookup("per_page")
 	if !ok || strings.TrimSpace(rawPageSize) == "" {
@@ -284,6 +319,47 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 	}
 	if !isKnownFamily(st.family) {
 		return settings{}, fmt.Errorf("%w: %q", ErrUnsupportedFamily, st.family)
+	}
+	if st.mode == modeAPI {
+		if st.baseURL == "" {
+			return settings{}, ErrBaseURLRequired
+		}
+		if st.token == "" {
+			return settings{}, ErrTokenRequired
+		}
+		baseURL, _, err := sourcehttp.NormalizeBaseURL(sourceID, st.baseURL, allowLoopback)
+		if err != nil {
+			return settings{}, err
+		}
+		st.baseURL = baseURL
+		if st.apiPath == "" {
+			st.apiPath = apiPathForFamily(st.family)
+		}
+		apiPath, err := sourcehttp.NormalizeRequestPath(sourceID, st.apiPath)
+		if err != nil {
+			return settings{}, err
+		}
+		st.apiPath = apiPath
+		return st, nil
+	}
+	if st.bucket == "" {
+		return settings{}, ErrBucketRequired
+	}
+	if st.prefix == "" {
+		return settings{}, ErrPrefixRequired
+	}
+	if !strings.HasSuffix(st.prefix, "/") {
+		st.prefix += "/"
+	}
+	if st.region == "" {
+		st.region = defaultRegion
+	}
+	if st.roleARN != "" {
+		if err := validateAssumeRoleConfig(st); err != nil {
+			return settings{}, err
+		}
+	} else if st.externalID != "" {
+		return settings{}, fmt.Errorf("panopticon external_id requires role_arn")
 	}
 	if strings.ContainsRune(st.bucket, '/') {
 		return settings{}, fmt.Errorf("%w: %q must not contain slashes", ErrInvalidBucket, st.bucket)

--- a/sources/panopticon/source_test.go
+++ b/sources/panopticon/source_test.go
@@ -1,26 +1,15 @@
 package panopticon
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 	"time"
-
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -56,77 +45,87 @@ func TestParseSettings(t *testing.T) {
 	tests := []struct {
 		name      string
 		values    map[string]string
+		loopback  bool
 		wantErrIs error
 		want      settings
 	}{
 		{
-			name:   "defaults",
-			values: map[string]string{"bucket": "writer-panopticon-exports", "prefix": "alerts", "tenant_id": "writer"},
-			want:   settings{family: familyAlert, bucket: "writer-panopticon-exports", prefix: "alerts/", region: defaultRegion, tenantID: "writer", perPage: defaultPageSize},
+			name:     "defaults",
+			values:   map[string]string{"base_url": "http://127.0.0.1", "token": "token", "tenant_id": "writer"},
+			loopback: true,
+			want:     settings{family: familyAlert, baseURL: "http://127.0.0.1", apiPath: "/api/cerebro/alerts", token: "token", tenantID: "writer", perPage: defaultPageSize},
 		},
 		{
-			name:   "case-family-runtime-and-page",
-			values: map[string]string{"family": familyCase, "bucket": "writer-panopticon-exports", "prefix": "cases/", "region": "us-west-2", "per_page": "25", "tenant_id": "writer", "runtime_id": "writer-panopticon-cases"},
-			want:   settings{family: familyCase, bucket: "writer-panopticon-exports", prefix: "cases/", region: "us-west-2", tenantID: "writer", runtimeID: "writer-panopticon-cases", perPage: 25},
+			name:     "case-family-runtime-page-and-api-key",
+			values:   map[string]string{"mode": modeAPI, "family": familyCase, "base_url": "http://127.0.0.1", "api_key": "token", "per_page": "25", "tenant_id": "writer", "runtime_id": "writer-panopticon-cases"},
+			loopback: true,
+			want:     settings{family: familyCase, baseURL: "http://127.0.0.1", apiPath: "/api/cerebro/cases", token: "token", tenantID: "writer", runtimeID: "writer-panopticon-cases", perPage: 25},
 		},
 		{
-			name:   "runtime-tenant",
-			values: map[string]string{"bucket": "writer-panopticon-exports", "prefix": "alerts", sourceconfig.RuntimeTenantIDKey: "writer"},
-			want:   settings{family: familyAlert, bucket: "writer-panopticon-exports", prefix: "alerts/", region: defaultRegion, tenantID: "writer", perPage: defaultPageSize},
+			name:     "runtime-tenant",
+			values:   map[string]string{"base_url": "http://127.0.0.1", "token": "token", sourceconfig.RuntimeTenantIDKey: "writer"},
+			loopback: true,
+			want:     settings{family: familyAlert, baseURL: "http://127.0.0.1", apiPath: "/api/cerebro/alerts", token: "token", tenantID: "writer", perPage: defaultPageSize},
 		},
-		{name: "missing-bucket", values: map[string]string{"prefix": "alerts/", "tenant_id": "writer"}, wantErrIs: ErrBucketRequired},
-		{name: "missing-prefix", values: map[string]string{"bucket": "writer-panopticon-exports", "tenant_id": "writer"}, wantErrIs: ErrPrefixRequired},
-		{name: "missing-tenant", values: map[string]string{"bucket": "writer-panopticon-exports", "prefix": "alerts/"}, wantErrIs: ErrTenantIDRequired},
-		{name: "unknown-family", values: map[string]string{"family": "garbage", "bucket": "writer-panopticon-exports", "prefix": "x/", "tenant_id": "writer"}, wantErrIs: ErrUnsupportedFamily},
-		{name: "invalid-page-size", values: map[string]string{"bucket": "writer-panopticon-exports", "prefix": "x/", "page_size": "0", "tenant_id": "writer"}, wantErrIs: ErrInvalidPageSize},
-		{name: "bucket-with-slash-rejected", values: map[string]string{"bucket": "writer/panopticon", "prefix": "x/", "tenant_id": "writer"}, wantErrIs: ErrInvalidBucket},
+		{name: "missing-base-url", values: map[string]string{"token": "token", "tenant_id": "writer"}, wantErrIs: ErrBaseURLRequired},
+		{name: "missing-token", values: map[string]string{"base_url": "https://panopticon.example.com", "tenant_id": "writer"}, wantErrIs: ErrTokenRequired},
+		{name: "missing-tenant", values: map[string]string{"base_url": "https://panopticon.example.com", "token": "token"}, wantErrIs: ErrTenantIDRequired},
+		{name: "unknown-family", values: map[string]string{"family": "garbage", "base_url": "https://panopticon.example.com", "token": "token", "tenant_id": "writer"}, wantErrIs: ErrUnsupportedFamily},
+		{name: "invalid-page-size", values: map[string]string{"base_url": "https://panopticon.example.com", "token": "token", "page_size": "0", "tenant_id": "writer"}, wantErrIs: ErrInvalidPageSize},
+		{name: "s3-mode-rejected", values: map[string]string{"mode": "s3", "base_url": "https://panopticon.example.com", "token": "token", "tenant_id": "writer"}, wantErrIs: ErrUnsupportedMode},
+		{name: "unsafe-base-url", values: map[string]string{"base_url": "http://169.254.169.254", "token": "token", "tenant_id": "writer"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseSettings(sourcecdk.NewConfig(tc.values))
-			if tc.wantErrIs != nil {
-				if !errors.Is(err, tc.wantErrIs) {
-					t.Fatalf("parseSettings() error = %v, want errors.Is %v", err, tc.wantErrIs)
+			got, err := parseSettingsWithLoopback(sourcecdk.NewConfig(tc.values), tc.loopback)
+			if tc.wantErrIs != nil || tc.name == "unsafe-base-url" {
+				if err == nil {
+					t.Fatal("parseSettingsWithLoopback() error = nil, want non-nil")
+				}
+				if tc.wantErrIs != nil && !errors.Is(err, tc.wantErrIs) {
+					t.Fatalf("parseSettingsWithLoopback() error = %v, want errors.Is %v", err, tc.wantErrIs)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("parseSettings() error = %v", err)
+				t.Fatalf("parseSettingsWithLoopback() error = %v", err)
 			}
 			if got != tc.want {
-				t.Fatalf("parseSettings() = %+v, want %+v", got, tc.want)
+				t.Fatalf("parseSettingsWithLoopback() = %+v, want %+v", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestParseSettingsAPIMode(t *testing.T) {
-	_, err := parseSettings(sourcecdk.NewConfig(map[string]string{
-		"mode":      modeAPI,
-		"tenant_id": "writer",
-		"base_url":  "http://169.254.169.254",
-		"token":     "token",
+func TestCheckAndDiscoverUseAPIEndpoint(t *testing.T) {
+	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/cerebro/alerts" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("limit"); got != "1" {
+			t.Fatalf("check limit = %q, want 1", got)
+		}
+		_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Records: []panopticonRecord{validAlert("alert-1", fixed)}})
 	}))
-	if err == nil {
-		t.Fatal("parseSettings() unsafe api base_url error = nil, want non-nil")
-	}
+	defer server.Close()
 
-	got, err := parseSettingsWithLoopback(sourcecdk.NewConfig(map[string]string{
-		"mode":      modeAPI,
-		"family":    familyCase,
-		"tenant_id": "writer",
-		"base_url":  "http://127.0.0.1",
-		"token":     "token",
-	}), true)
-	if err != nil {
-		t.Fatalf("parseSettingsWithLoopback() error = %v", err)
+	src := newTestSource(t)
+	cfg := apiConfig(server.URL, map[string]string{"per_page": "1"})
+	if err := src.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check() error = %v", err)
 	}
-	if got.mode != modeAPI || got.apiPath != "/api/cerebro/cases" || got.baseURL != "http://127.0.0.1" {
-		t.Fatalf("api settings = %+v, want api mode with default cases path", got)
+	urns, err := src.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(urns) != 1 || !strings.Contains(urns[0].String(), "panopticon") {
+		t.Fatalf("Discover() urns = %v, want Panopticon URN", urns)
 	}
 }
 
-func TestReadAPIModePaginatesAndValidatesEvents(t *testing.T) {
+func TestReadAPIPaginatesAndValidatesEvents(t *testing.T) {
 	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -165,17 +164,8 @@ func TestReadAPIModePaginatesAndValidatesEvents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	src := newTestSource(t, nil)
-	src.allowLoopbackBaseURL = true
-	cfg := sourcecdk.NewConfig(map[string]string{
-		"mode":      modeAPI,
-		"family":    familyAlert,
-		"tenant_id": "writer",
-		"base_url":  server.URL,
-		"token":     "api-token",
-		"per_page":  "1",
-	})
-
+	src := newTestSource(t)
+	cfg := apiConfig(server.URL, map[string]string{"per_page": "1"})
 	first, err := src.Read(context.Background(), cfg, nil)
 	if err != nil {
 		t.Fatalf("Read(first) error = %v", err)
@@ -203,148 +193,78 @@ func TestReadAPIModePaginatesAndValidatesEvents(t *testing.T) {
 	}
 }
 
-func TestReadAPIModeRejectsCrossTenantEvents(t *testing.T) {
+func TestReadAPIAcceptsEventsResponseAndAllFamilies(t *testing.T) {
 	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(panopticonAPIResponse{
-			Records: []panopticonRecord{withTenant(validAlert("alert-1", fixed), "other")},
-		})
-	}))
-	defer server.Close()
-
-	src := newTestSource(t, nil)
-	src.allowLoopbackBaseURL = true
-	_, err := src.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
-		"mode":      modeAPI,
-		"tenant_id": "writer",
-		"base_url":  server.URL,
-		"token":     "api-token",
-	}), nil)
-	if err == nil || !errorContains(err, "does not match runtime tenant") {
-		t.Fatalf("Read() error = %v, want cross-tenant rejection", err)
-	}
-}
-
-func TestReadPlainAndGzipArchivesForAllFamilies(t *testing.T) {
-	src := newTestSource(t, nil)
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	client := newFakeS3([]fakeObject{
-		{key: "alerts/2026/06/08/plain.ndjson", records: []panopticonRecord{validAlert("alert-1", fixed)}},
-		{key: "alerts/2026/06/08/compressed.ndjson.gz", records: []panopticonRecord{validAlert("alert-2", fixed.Add(time.Minute))}, gzip: true},
-		{key: "cases/2026/06/08/plain.ndjson", records: []panopticonRecord{validCase("case-1", fixed)}},
-		{key: "cases/2026/06/08/compressed.ndjson.gz", records: []panopticonRecord{validCase("case-2", fixed.Add(time.Minute))}, gzip: true},
-		{key: "iocs/2026/06/08/plain.ndjson", records: []panopticonRecord{validIOC("ioc-1", fixed)}},
-		{key: "iocs/2026/06/08/compressed.ndjson.gz", records: []panopticonRecord{validIOC("ioc-2", fixed.Add(time.Minute))}, gzip: true},
-	})
-	src.newClient = func(context.Context, settings) (s3API, error) { return client, nil }
-
 	for _, tc := range []struct {
 		family string
-		prefix string
+		path   string
+		record panopticonRecord
 		kind   string
-		ids    []string
 	}{
-		{familyAlert, "alerts/", kindAlert, []string{"alert-2", "alert-1"}},
-		{familyCase, "cases/", kindCase, []string{"case-2", "case-1"}},
-		{familyIOC, "iocs/", kindIOC, []string{"ioc-2", "ioc-1"}},
+		{familyAlert, "/api/cerebro/alerts", validAlert("alert-1", fixed), kindAlert},
+		{familyCase, "/api/cerebro/cases", validCase("case-1", fixed), kindCase},
+		{familyIOC, "/api/cerebro/iocs", validIOC("ioc-1", fixed), kindIOC},
 	} {
 		t.Run(tc.family, func(t *testing.T) {
-			pull, err := src.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"family": tc.family, "bucket": "writer-panopticon-exports", "prefix": tc.prefix, "tenant_id": "writer"}), nil)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tc.path {
+					http.NotFound(w, r)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Events: []panopticonRecord{tc.record}})
+			}))
+			defer server.Close()
+
+			src := newTestSource(t)
+			pull, err := src.Read(context.Background(), apiConfig(server.URL, map[string]string{"family": tc.family}), nil)
 			if err != nil {
 				t.Fatalf("Read() error = %v", err)
 			}
-			if got := eventIDs(pull.Events); strings.Join(got, ",") != strings.Join(tc.ids, ",") {
-				t.Fatalf("event ids = %v, want %v", got, tc.ids)
-			}
-			for _, ev := range pull.Events {
-				if ev.GetSourceId() != sourceID || ev.GetKind() != tc.kind || ev.GetTenantId() != "writer" {
-					t.Fatalf("event scope = source %q kind %q tenant %q", ev.GetSourceId(), ev.GetKind(), ev.GetTenantId())
-				}
-				if err := sourcecdk.ValidateEventEnvelopeWithContracts(ev, sourcecdkEventContracts()); err != nil {
-					t.Fatalf("ValidateEventEnvelopeWithContracts() error = %v", err)
-				}
+			if len(pull.Events) != 1 || pull.Events[0].GetKind() != tc.kind {
+				t.Fatalf("events = %v, want one %s event", pull.Events, tc.kind)
 			}
 		})
 	}
 }
 
-func TestReadPanopticonGeneratedArchivesForAllFamilies(t *testing.T) {
-	manifest := generateCrossRepoPanopticonArchives(t)
-	objects := make([]fakeObject, 0, len(manifest.Archives))
-	for _, archive := range manifest.Archives {
-		raw, err := os.ReadFile(archive.Path)
-		if err != nil {
-			t.Fatalf("read generated archive %s: %v", archive.Path, err)
-		}
-		objects = append(objects, fakeObject{key: archive.Key, rawBody: raw})
-	}
-	src := newTestSource(t, newFakeS3(objects))
-
-	for _, tc := range []struct {
-		family string
-		prefix string
-		kind   string
-	}{
-		{familyAlert, "exports/alerts/", kindAlert},
-		{familyCase, "exports/cases/", kindCase},
-		{familyIOC, "exports/iocs/", kindIOC},
-	} {
-		t.Run(tc.family, func(t *testing.T) {
-			pull, err := src.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"family": tc.family, "bucket": "panopticon-cross-repo-contract", "prefix": tc.prefix, "tenant_id": "writer"}), nil)
-			if err != nil {
-				t.Fatalf("Read(generated Panopticon %s archives) error = %v", tc.family, err)
-			}
-			if len(pull.Events) != 2 {
-				t.Fatalf("generated Panopticon %s events = %d, want 2 (.ndjson and .ndjson.gz)", tc.family, len(pull.Events))
-			}
-			for _, ev := range pull.Events {
-				if ev.GetTenantId() != "writer" || ev.GetSourceId() != sourceID || ev.GetKind() != tc.kind {
-					t.Fatalf("generated event scope = tenant %q source %q kind %q", ev.GetTenantId(), ev.GetSourceId(), ev.GetKind())
-				}
-				if err := sourcecdk.ValidateEventEnvelopeWithContracts(ev, sourcecdkEventContracts()); err != nil {
-					t.Fatalf("generated event failed source contract validation: %v", err)
-				}
-				payloadText := string(ev.GetPayload())
-				for _, forbidden := range []string{"DO-NOT-EXPORT-CONTENTS", "DO-NOT-EXPORT-BYTES", "DO-NOT-EXPORT-INLINE", "DO-NOT-EXPORT-RAW"} {
-					if strings.Contains(payloadText, forbidden) {
-						t.Fatalf("generated event payload included inline evidence marker %q", forbidden)
-					}
-				}
-				if tc.family == familyCase && !strings.Contains(payloadText, "evidencecas://cases/42/evidence/triage.tar") {
-					t.Fatalf("generated case payload did not preserve EvidenceCAS pointer: %s", payloadText)
-				}
-			}
-		})
-	}
-}
-
-func TestReadScopesObjectsAndRecords(t *testing.T) {
+func TestReadAPIFiltersRuntimeID(t *testing.T) {
 	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	client := newFakeS3([]fakeObject{
-		{key: "alerts/", rawBody: []byte{}},
-		{key: "alerts/ignored.txt", rawBody: []byte(`ignored`)},
-		{key: "alerts/tmp/upload.tmp", rawBody: []byte(`ignored`)},
-		{key: "alerts/batch.ndjson", records: []panopticonRecord{
-			withTenant(validAlert("other-tenant", fixed), "other"),
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("runtime_id"); got != "writer-panopticon-alerts" {
+			t.Fatalf("runtime_id query = %q, want writer-panopticon-alerts", got)
+		}
+		_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Records: []panopticonRecord{
 			withRuntime(validAlert("other-runtime", fixed), "writer-panopticon-cases"),
 			withRuntime(validAlert("accepted", fixed), "writer-panopticon-alerts"),
-		}},
-		{key: "cases/not-listed.ndjson", records: []panopticonRecord{validCase("case-should-not-read", fixed)}},
-	})
-	src := newTestSource(t, client)
-	pull, err := src.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"family": familyAlert, "bucket": "writer-panopticon-exports", "prefix": "alerts/", "tenant_id": "writer", "runtime_id": "writer-panopticon-alerts"}), nil)
+		}})
+	}))
+	defer server.Close()
+
+	src := newTestSource(t)
+	pull, err := src.Read(context.Background(), apiConfig(server.URL, map[string]string{"runtime_id": "writer-panopticon-alerts"}), nil)
 	if err != nil {
 		t.Fatalf("Read() error = %v", err)
 	}
 	if got := eventIDs(pull.Events); len(got) != 1 || got[0] != "accepted" {
 		t.Fatalf("events = %v, want [accepted]", got)
 	}
-	if client.getCalls["alerts/ignored.txt"] != 0 || client.getCalls["alerts/tmp/upload.tmp"] != 0 || client.getCalls["cases/not-listed.ndjson"] != 0 {
-		t.Fatalf("unsupported or out-of-prefix objects were read: %#v", client.getCalls)
+}
+
+func TestReadAPIRejectsCrossTenantEvents(t *testing.T) {
+	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Records: []panopticonRecord{withTenant(validAlert("alert-1", fixed), "other")}})
+	}))
+	defer server.Close()
+
+	src := newTestSource(t)
+	_, err := src.Read(context.Background(), apiConfig(server.URL, nil), nil)
+	if err == nil || !errorContains(err, "does not match runtime tenant") {
+		t.Fatalf("Read() error = %v, want cross-tenant rejection", err)
 	}
 }
 
-func TestReadRejectsInvalidEnvelopesAndFamilyContracts(t *testing.T) {
+func TestReadAPIRejectsInvalidEnvelopesAndFamilyContracts(t *testing.T) {
 	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name   string
@@ -363,8 +283,13 @@ func TestReadRejectsInvalidEnvelopesAndFamilyContracts(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			src := newTestSource(t, newFakeS3([]fakeObject{{key: "alerts/bad.ndjson", records: []panopticonRecord{tc.record}}}))
-			_, err := src.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"family": familyAlert, "bucket": "writer-panopticon-exports", "prefix": "alerts/", "tenant_id": "writer"}), nil)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Records: []panopticonRecord{tc.record}})
+			}))
+			defer server.Close()
+
+			src := newTestSource(t)
+			_, err := src.Read(context.Background(), apiConfig(server.URL, nil), nil)
 			if err == nil || !errorContains(err, tc.want) {
 				t.Fatalf("Read() error = %v, want containing %q", err, tc.want)
 			}
@@ -372,254 +297,53 @@ func TestReadRejectsInvalidEnvelopesAndFamilyContracts(t *testing.T) {
 	}
 }
 
-func TestReadRejectsPayloadSynthesizedRequiredAttributesForAllFamilies(t *testing.T) {
+func TestReadAPIRejectsTooManyRecordsAndHTTPError(t *testing.T) {
 	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	tests := []struct {
-		name      string
-		family    string
-		prefix    string
-		record    panopticonRecord
-		missing   string
-		wantError string
-	}{
-		{name: "alert", family: familyAlert, prefix: "alerts/", record: validAlert("alert-1", fixed), missing: "severity", wantError: "severity"},
-		{name: "case", family: familyCase, prefix: "cases/", record: validCase("case-1", fixed), missing: "status", wantError: "status"},
-		{name: "ioc", family: familyIOC, prefix: "iocs/", record: validIOC("ioc-1", fixed), missing: "value", wantError: "value"},
+	tooMany := make([]panopticonRecord, maxEventsPerPull+1)
+	for i := range tooMany {
+		tooMany[i] = validAlert(fmt.Sprintf("alert-%04d", i), fixed)
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			record := withoutAttribute(tc.record, tc.missing)
-			src := newTestSource(t, newFakeS3([]fakeObject{{key: tc.prefix + "bad.ndjson", records: []panopticonRecord{record}}}))
-			_, err := src.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"family": tc.family, "bucket": "writer-panopticon-exports", "prefix": tc.prefix, "tenant_id": "writer"}), nil)
-			if err == nil || !errorContains(err, tc.wantError) {
-				t.Fatalf("Read() error = %v, want containing %q", err, tc.wantError)
-			}
-		})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Records: tooMany})
+	}))
+	defer server.Close()
+
+	src := newTestSource(t)
+	_, err := src.Read(context.Background(), apiConfig(server.URL, nil), nil)
+	if err == nil || !errorContains(err, "max") {
+		t.Fatalf("Read() error = %v, want max records rejection", err)
+	}
+
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+	_, err = src.Read(context.Background(), apiConfig(server.URL, nil), nil)
+	if err == nil || !errorContains(err, "status 401") {
+		t.Fatalf("Read() error = %v, want HTTP status error", err)
 	}
 }
 
-func TestFamilyValidationFailureDoesNotAdvanceCheckpoint(t *testing.T) {
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	client := newFakeS3([]fakeObject{
-		{key: "alerts/001-good.ndjson", records: []panopticonRecord{validAlert("good", fixed)}},
-		{key: "alerts/002-bad.ndjson", records: []panopticonRecord{withoutAttribute(validAlert("bad", fixed.Add(time.Minute)), "status")}},
-	})
-	src := newTestSource(t, client)
-	cfg := sourcecdk.NewConfig(map[string]string{"family": familyAlert, "bucket": "writer-panopticon-exports", "prefix": "alerts/", "tenant_id": "writer"})
-
-	pull, err := src.Read(context.Background(), cfg, nil)
-	if err == nil || !errorContains(err, "status") {
-		t.Fatalf("Read() error = %v, want required status failure", err)
-	}
-	if len(pull.Events) != 0 || pull.Checkpoint != nil || pull.NextCursor != nil {
-		t.Fatalf("failed pull advanced state: events=%d checkpoint=%v next=%v", len(pull.Events), pull.Checkpoint, pull.NextCursor)
-	}
-
-	retry, err := src.Read(context.Background(), cfg, nil)
-	if err == nil || !errorContains(err, "status") {
-		t.Fatalf("Read(retry) error = %v, want same required status failure", err)
-	}
-	if len(retry.Events) != 0 || retry.Checkpoint != nil || retry.NextCursor != nil {
-		t.Fatalf("failed retry advanced state: events=%d checkpoint=%v next=%v", len(retry.Events), retry.Checkpoint, retry.NextCursor)
-	}
-}
-
-func TestReadRejectsMalformedArchivesDeterministically(t *testing.T) {
-	badJSON := newFakeS3([]fakeObject{{key: "alerts/bad-json.ndjson", rawBody: []byte("{not json}\n")}})
-	src := newTestSource(t, badJSON)
-	cfg := sourcecdk.NewConfig(map[string]string{"family": familyAlert, "bucket": "writer-panopticon-exports", "prefix": "alerts/", "tenant_id": "writer"})
-	for i := 0; i < 2; i++ {
-		_, err := src.Read(context.Background(), cfg, nil)
-		if err == nil || !errorContains(err, "decode line 1") {
-			t.Fatalf("Read() retry %d error = %v, want decode line 1", i, err)
-		}
-	}
-	if badJSON.getCalls["alerts/bad-json.ndjson"] != 2 {
-		t.Fatalf("retry get calls = %d, want 2", badJSON.getCalls["alerts/bad-json.ndjson"])
-	}
-
-	badGzip := newFakeS3([]fakeObject{{key: "alerts/bad-gzip.ndjson.gz", rawBody: []byte("not gzip")}})
-	src = newTestSource(t, badGzip)
-	_, err := src.Read(context.Background(), cfg, nil)
-	if err == nil || !errorContains(err, "gunzip") {
-		t.Fatalf("Read() invalid gzip error = %v, want gunzip", err)
-	}
-}
-
-func TestReadEnforcesRawAndGzipDecompressedObjectSizeLimits(t *testing.T) {
-	rawTooLarge := newFakeS3([]fakeObject{{key: "alerts/too-large.ndjson", rawBody: bytes.Repeat([]byte{'x'}, maxObjectBytes+1)}})
-	src := newTestSource(t, rawTooLarge)
-	cfg := sourcecdk.NewConfig(map[string]string{"family": familyAlert, "bucket": "writer-panopticon-exports", "prefix": "alerts/", "tenant_id": "writer"})
-	_, err := src.Read(context.Background(), cfg, nil)
-	if err == nil || !errorContains(err, "object exceeds") {
-		t.Fatalf("Read() oversized raw object error = %v, want object exceeds", err)
-	}
-
-	compressed := &bytes.Buffer{}
-	gz := gzip.NewWriter(compressed)
-	if _, err := gz.Write(bytes.Repeat([]byte{'a'}, 128)); err != nil {
-		t.Fatalf("gzip write: %v", err)
-	}
-	if err := gz.Close(); err != nil {
-		t.Fatalf("gzip close: %v", err)
-	}
-	_, err = readArchiveRecords(bytes.NewReader(compressed.Bytes()), "oversized.ndjson.gz", 64)
-	if !errors.Is(err, ErrDecompressedObjectTooLarge) {
-		t.Fatalf("readArchiveRecords() decompressed size error = %v, want ErrDecompressedObjectTooLarge", err)
-	}
-}
-
-func TestReadRejectsNonStringAttributesAndOversizedLines(t *testing.T) {
-	nonString := newFakeS3([]fakeObject{{key: "alerts/non-string.ndjson", rawBody: []byte(`{"id":"alert-1","tenant_id":"writer","source_id":"panopticon","kind":"panopticon.alert","occurred_at":"2026-06-08T12:00:00Z","schema_ref":"panopticon/alert/v1","payload":{"alert_id":"a-1","severity":"high","status":"open","title":"Alert"},"attributes":{"alert_id":"a-1","severity":"high","status":42}}` + "\n")}})
-	src := newTestSource(t, nonString)
-	cfg := sourcecdk.NewConfig(map[string]string{"family": familyAlert, "bucket": "writer-panopticon-exports", "prefix": "alerts/", "tenant_id": "writer"})
-	_, err := src.Read(context.Background(), cfg, nil)
-	if err == nil || !errorContains(err, "cannot unmarshal") {
-		t.Fatalf("Read() non-string attributes error = %v, want cannot unmarshal", err)
-	}
-
-	_, err = readArchiveRecords(bytes.NewReader(append(bytes.Repeat([]byte{'a'}, maxLineBytes+1), '\n')), "oversized.ndjson", int64(maxLineBytes+2))
-	if err == nil || !errorContains(err, "token too long") {
-		t.Fatalf("readArchiveRecords() oversized line error = %v, want token too long", err)
-	}
-}
-
-func TestReadCursorSafetyAcrossPaginationAndPartialArchive(t *testing.T) {
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	records := make([]panopticonRecord, 0, maxEventsPerPull+1)
-	for i := 0; i < maxEventsPerPull+1; i++ {
-		records = append(records, validAlert(fmt.Sprintf("alert-%04d", i), fixed.Add(time.Duration(i)*time.Second)))
-	}
-	client := newFakeS3([]fakeObject{
-		{key: "alerts/001.ndjson", records: []panopticonRecord{validAlert("first-page", fixed)}},
-		{key: "alerts/002.ndjson", records: records},
-		{key: "alerts/003.ndjson", records: []panopticonRecord{validAlert("final-page", fixed)}},
-	})
-	src := newTestSource(t, client)
-	cfg := sourcecdk.NewConfig(map[string]string{"family": familyAlert, "bucket": "writer-panopticon-exports", "prefix": "alerts/", "tenant_id": "writer", "page_size": "1"})
-
-	first, err := src.Read(context.Background(), cfg, nil)
-	if err != nil {
-		t.Fatalf("Read(first) error = %v", err)
-	}
-	if got := eventIDs(first.Events); len(got) != 1 || got[0] != "first-page" || first.NextCursor == nil {
-		t.Fatalf("first events/cursor = %v/%v, want first-page with cursor", got, first.NextCursor)
-	}
-
-	second, err := src.Read(context.Background(), cfg, first.NextCursor)
-	if err != nil {
-		t.Fatalf("Read(second) error = %v", err)
-	}
-	if len(second.Events) != maxEventsPerPull || second.NextCursor == nil {
-		t.Fatalf("second events/cursor = %d/%v, want max events with partial cursor", len(second.Events), second.NextCursor)
-	}
-	secondCursor := mustDecodePanopticonCursor(t, second.NextCursor.GetOpaque())
-	if secondCursor.LastKey == "alerts/002.ndjson" || secondCursor.PartialKey != "alerts/002.ndjson" || secondCursor.RecordOffset != maxEventsPerPull {
-		t.Fatalf("second cursor = %+v, want partial archive at offset %d", secondCursor, maxEventsPerPull)
-	}
-
-	third, err := src.Read(context.Background(), cfg, second.NextCursor)
-	if err != nil {
-		t.Fatalf("Read(third) error = %v", err)
-	}
-	if got := eventIDs(third.Events); len(got) != 1 || got[0] != "alert-1000" {
-		t.Fatalf("third events = %v, want remaining partial record only", got)
-	}
-	if third.NextCursor == nil {
-		t.Fatal("third NextCursor = nil, want cursor for remaining S3 page")
-	}
-
-	fourth, err := src.Read(context.Background(), cfg, third.NextCursor)
-	if err != nil {
-		t.Fatalf("Read(fourth) error = %v", err)
-	}
-	if got := eventIDs(fourth.Events); len(got) != 1 || got[0] != "final-page" || fourth.NextCursor != nil {
-		t.Fatalf("fourth events/cursor = %v/%v, want final-page without cursor", got, fourth.NextCursor)
-	}
-}
-
-func TestMalformedArchiveDoesNotAdvanceCheckpointPastPriorCursor(t *testing.T) {
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	client := newFakeS3([]fakeObject{
-		{key: "alerts/001-good.ndjson", records: []panopticonRecord{validAlert("good", fixed)}},
-		{key: "alerts/002-bad.ndjson", rawBody: []byte("{bad json}\n")},
-	})
-	src := newTestSource(t, client)
-	cfg := sourcecdk.NewConfig(map[string]string{"family": familyAlert, "bucket": "writer-panopticon-exports", "prefix": "alerts/", "tenant_id": "writer"})
-
-	first, err := src.Read(context.Background(), cfg, nil)
-	if err == nil || !errorContains(err, "decode line 1") {
-		t.Fatalf("Read(first) error = %v, want deterministic malformed JSON failure", err)
-	}
-	if first.Checkpoint != nil || first.NextCursor != nil || len(first.Events) != 0 {
-		t.Fatalf("failed pull advanced state: events=%d checkpoint=%v next=%v", len(first.Events), first.Checkpoint, first.NextCursor)
-	}
-
-	cursor := &cerebrov1.SourceCursor{Opaque: encodeCursor(panopticonCursor{LastKey: "alerts/001-good.ndjson"})}
-	retry, err := src.Read(context.Background(), cfg, cursor)
-	if err == nil || !errorContains(err, "decode line 1") {
-		t.Fatalf("Read(retry) error = %v, want same malformed JSON failure", err)
-	}
-	if retry.Checkpoint != nil || retry.NextCursor != nil || len(retry.Events) != 0 {
-		t.Fatalf("failed retry advanced state: events=%d checkpoint=%v next=%v", len(retry.Events), retry.Checkpoint, retry.NextCursor)
-	}
-}
-
-func newTestSource(t *testing.T, client *fakeS3) *Source {
+func newTestSource(t *testing.T) *Source {
 	t.Helper()
 	src, err := New()
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
-	if client != nil {
-		src.newClient = func(context.Context, settings) (s3API, error) { return client, nil }
-	}
+	src.allowLoopbackBaseURL = true
 	return src
+}
+
+func apiConfig(baseURL string, overrides map[string]string) sourcecdk.Config {
+	values := map[string]string{"base_url": baseURL, "token": "api-token", "tenant_id": "writer"}
+	for key, value := range overrides {
+		values[key] = value
+	}
+	return sourcecdk.NewConfig(values)
 }
 
 func errorContains(err error, want string) bool {
 	return strings.Contains(fmt.Sprint(err), want)
-}
-
-type crossRepoPanopticonArchiveManifest struct {
-	Archives []struct {
-		Family string `json:"family"`
-		Gzip   bool   `json:"gzip"`
-		Key    string `json:"key"`
-		Path   string `json:"path"`
-	} `json:"archives"`
-}
-
-func generateCrossRepoPanopticonArchives(t *testing.T) crossRepoPanopticonArchiveManifest {
-	t.Helper()
-	panopticonRepo := os.Getenv("PANOPTICON_REPO")
-	if panopticonRepo == "" {
-		panopticonRepo = filepath.Clean("../../../panopticon")
-	}
-	script := filepath.Join(panopticonRepo, "scripts", "generate_cerebro_contract_archives.py")
-	// #nosec G703 -- test-only optional local cross-repo fixture path.
-	if _, err := os.Stat(script); err != nil {
-		t.Skipf("Panopticon cross-repo archive generator not available at %s: %v", script, err)
-	}
-	outputDir := t.TempDir()
-	// #nosec G204 G702 -- test-only optional local cross-repo fixture generator.
-	cmd := exec.Command("python3", script, "--output-dir", outputDir)
-	cmd.Env = append(os.Environ(), "PYTHONDONTWRITEBYTECODE=1")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("generate Panopticon cross-repo archives: %v\n%s", err, out)
-	}
-	manifestPath := filepath.Join(outputDir, "manifest.json")
-	// #nosec G304 -- manifest is read from this test's temporary output directory.
-	raw, err := os.ReadFile(manifestPath)
-	if err != nil {
-		t.Fatalf("read generated Panopticon manifest: %v", err)
-	}
-	var manifest crossRepoPanopticonArchiveManifest
-	if err := json.Unmarshal(raw, &manifest); err != nil {
-		t.Fatalf("decode generated Panopticon manifest: %v", err)
-	}
-	return manifest
 }
 
 func validAlert(id string, occurredAt time.Time) panopticonRecord {
@@ -662,10 +386,6 @@ func withoutPayloadField(rec panopticonRecord, key string) panopticonRecord {
 	delete(rec.Payload, key)
 	return rec
 }
-func withoutAttribute(rec panopticonRecord, key string) panopticonRecord {
-	delete(rec.Attributes, key)
-	return rec
-}
 
 func eventIDs(events []*cerebrov1.EventEnvelope) []string {
 	ids := make([]string, 0, len(events))
@@ -673,101 +393,4 @@ func eventIDs(events []*cerebrov1.EventEnvelope) []string {
 		ids = append(ids, ev.GetId())
 	}
 	return ids
-}
-
-type fakeObject struct {
-	key     string
-	records []panopticonRecord
-	gzip    bool
-	rawBody []byte
-}
-
-func (o fakeObject) body() (io.ReadCloser, error) {
-	if o.rawBody != nil {
-		return io.NopCloser(bytes.NewReader(o.rawBody)), nil
-	}
-	buf := &bytes.Buffer{}
-	for _, rec := range o.records {
-		raw, err := json.Marshal(rec)
-		if err != nil {
-			return nil, err
-		}
-		buf.Write(raw)
-		buf.WriteByte('\n')
-	}
-	if o.gzip {
-		compressed := &bytes.Buffer{}
-		gz := gzip.NewWriter(compressed)
-		if _, err := gz.Write(buf.Bytes()); err != nil {
-			return nil, err
-		}
-		if err := gz.Close(); err != nil {
-			return nil, err
-		}
-		return io.NopCloser(compressed), nil
-	}
-	return io.NopCloser(buf), nil
-}
-
-type fakeS3 struct {
-	objects  map[string]fakeObject
-	keys     []string
-	getCalls map[string]int
-}
-
-func newFakeS3(objects []fakeObject) *fakeS3 {
-	m := make(map[string]fakeObject, len(objects))
-	keys := make([]string, 0, len(objects))
-	for _, obj := range objects {
-		m[obj.key] = obj
-		keys = append(keys, obj.key)
-	}
-	sort.Strings(keys)
-	return &fakeS3{objects: m, keys: keys, getCalls: map[string]int{}}
-}
-
-func (f *fakeS3) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
-	prefix := awssdk.ToString(in.Prefix)
-	startAfter := awssdk.ToString(in.StartAfter)
-	maxKeys := int32(1000)
-	if in.MaxKeys != nil {
-		maxKeys = *in.MaxKeys
-	}
-	out := &s3.ListObjectsV2Output{}
-	matched := int32(0)
-	for _, key := range f.keys {
-		if !strings.HasPrefix(key, prefix) || (startAfter != "" && key <= startAfter) {
-			continue
-		}
-		matched++
-		if matched > maxKeys {
-			out.IsTruncated = awssdk.Bool(true)
-			break
-		}
-		out.Contents = append(out.Contents, s3types.Object{Key: awssdk.String(key)})
-	}
-	return out, nil
-}
-
-func (f *fakeS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-	key := awssdk.ToString(in.Key)
-	f.getCalls[key]++
-	obj, ok := f.objects[key]
-	if !ok {
-		return nil, errors.New("not found: " + key)
-	}
-	body, err := obj.body()
-	if err != nil {
-		return nil, err
-	}
-	return &s3.GetObjectOutput{Body: body}, nil
-}
-
-func mustDecodePanopticonCursor(t *testing.T, opaque string) panopticonCursor {
-	t.Helper()
-	cursor := decodeCursor(&cerebrov1.SourceCursor{Opaque: opaque})
-	if cursor.Source != cursorSource {
-		t.Fatalf("cursor source = %q, want %q (opaque %q)", cursor.Source, cursorSource, opaque)
-	}
-	return cursor
 }

--- a/sources/panopticon/source_test.go
+++ b/sources/panopticon/source_test.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -95,6 +97,131 @@ func TestParseSettings(t *testing.T) {
 				t.Fatalf("parseSettings() = %+v, want %+v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseSettingsAPIMode(t *testing.T) {
+	_, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"mode":      modeAPI,
+		"tenant_id": "writer",
+		"base_url":  "http://169.254.169.254",
+		"token":     "token",
+	}))
+	if err == nil {
+		t.Fatal("parseSettings() unsafe api base_url error = nil, want non-nil")
+	}
+
+	got, err := parseSettingsWithLoopback(sourcecdk.NewConfig(map[string]string{
+		"mode":      modeAPI,
+		"family":    familyCase,
+		"tenant_id": "writer",
+		"base_url":  "http://127.0.0.1",
+		"token":     "token",
+	}), true)
+	if err != nil {
+		t.Fatalf("parseSettingsWithLoopback() error = %v", err)
+	}
+	if got.mode != modeAPI || got.apiPath != "/api/cerebro/cases" || got.baseURL != "http://127.0.0.1" {
+		t.Fatalf("api settings = %+v, want api mode with default cases path", got)
+	}
+}
+
+func TestReadAPIModePaginatesAndValidatesEvents(t *testing.T) {
+	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/cerebro/alerts" {
+			http.NotFound(w, r)
+			return
+		}
+		requests++
+		if got := r.Header.Get("Authorization"); got != "Bearer api-token" {
+			t.Fatalf("Authorization = %q, want bearer token", got)
+		}
+		if got := r.URL.Query().Get("tenant_id"); got != "writer" {
+			t.Fatalf("tenant_id = %q, want writer", got)
+		}
+		if got := r.URL.Query().Get("family"); got != familyAlert {
+			t.Fatalf("family = %q, want %q", got, familyAlert)
+		}
+		if got := r.URL.Query().Get("limit"); got != "1" {
+			t.Fatalf("limit = %q, want 1", got)
+		}
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			_ = json.NewEncoder(w).Encode(panopticonAPIResponse{
+				Records:    []panopticonRecord{validAlert("alert-1", fixed)},
+				NextCursor: "page-2",
+				Watermark:  fixed.Format(time.RFC3339Nano),
+			})
+		case "page-2":
+			_ = json.NewEncoder(w).Encode(panopticonAPIResponse{
+				Records:   []panopticonRecord{validAlert("alert-2", fixed.Add(time.Minute))},
+				Watermark: fixed.Add(time.Minute).Format(time.RFC3339Nano),
+			})
+		default:
+			t.Fatalf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+		}
+	}))
+	defer server.Close()
+
+	src := newTestSource(t, nil)
+	src.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"mode":      modeAPI,
+		"family":    familyAlert,
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"token":     "api-token",
+		"per_page":  "1",
+	})
+
+	first, err := src.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if got := eventIDs(first.Events); len(got) != 1 || got[0] != "alert-1" || first.NextCursor == nil {
+		t.Fatalf("first events/cursor = %v/%v, want alert-1 and cursor", got, first.NextCursor)
+	}
+	firstCursor := decodeAPICursor(first.NextCursor)
+	if firstCursor.Source != cursorSourceAPI || firstCursor.Cursor != "page-2" {
+		t.Fatalf("first cursor = %+v, want api cursor page-2", firstCursor)
+	}
+
+	second, err := src.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if got := eventIDs(second.Events); len(got) != 1 || got[0] != "alert-2" || second.NextCursor != nil {
+		t.Fatalf("second events/cursor = %v/%v, want alert-2 without cursor", got, second.NextCursor)
+	}
+	if second.Checkpoint == nil || second.Checkpoint.GetWatermark().AsTime() != fixed.Add(time.Minute) {
+		t.Fatalf("second checkpoint = %+v, want watermark", second.Checkpoint)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
+func TestReadAPIModeRejectsCrossTenantEvents(t *testing.T) {
+	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(panopticonAPIResponse{
+			Records: []panopticonRecord{withTenant(validAlert("alert-1", fixed), "other")},
+		})
+	}))
+	defer server.Close()
+
+	src := newTestSource(t, nil)
+	src.allowLoopbackBaseURL = true
+	_, err := src.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"mode":      modeAPI,
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"token":     "api-token",
+	}), nil)
+	if err == nil || !errorContains(err, "does not match runtime tenant") {
+		t.Fatalf("Read() error = %v, want cross-tenant rejection", err)
 	}
 }
 

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -22,7 +22,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2454,
-	"panopticon":      753,
+	"panopticon":      1054,
 	"sentinelone":     2181,
 	"vulnview":        1064,
 }

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -22,7 +22,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2454,
-	"panopticon":      1054,
+	"panopticon":      634,
 	"sentinelone":     2181,
 	"vulnview":        1064,
 }


### PR DESCRIPTION
## Summary

- Replaces the Panopticon source transport with API-only ingestion.
- Reads paginated canonical Panopticon alert, case, and IOC events over bearer-authenticated HTTP.
- Preserves event validation, tenant scoping, cursor checkpoints, bounded response reads, and source HTTP safety.

## Test Plan

- `go test ./sources/panopticon -count=1 -v`
- `go test ./sources/... -count=1`
- `make test`
- `make lint`
- `make catalog-check`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
