### PR TITLE
fix(source): use existing Panopticon API

### DIFF
--- a/sources/panopticon/api.go
+++ b/sources/panopticon/api.go
@@ -23,32 +23,38 @@ const maxAPIResponseBytes = 8 << 20
 type panopticonAPICursor struct {
 	Source              string `json:"source,omitempty"`
 	ResumableCheckpoint bool   `json:"resumable_checkpoint,omitempty"`
-	Cursor              string `json:"cursor,omitempty"`
+	Page                int    `json:"page,omitempty"`
+	CasePage            int    `json:"case_page,omitempty"`
+	CaseIndex           int    `json:"case_index,omitempty"`
+	IOCPage             int    `json:"ioc_page,omitempty"`
 	Watermark           string `json:"watermark,omitempty"`
 }
 
-type panopticonAPIResponse struct {
-	Records    []panopticonRecord `json:"records"`
-	Events     []panopticonRecord `json:"events"`
-	NextCursor string             `json:"next_cursor"`
-	Watermark  string             `json:"watermark"`
+type nativeAPIPage struct {
+	Total       int                      `json:"total"`
+	Data        []map[string]interface{} `json:"data"`
+	LastPage    int                      `json:"last_page"`
+	CurrentPage int                      `json:"current_page"`
+	NextPage    json.RawMessage          `json:"next_page"`
 }
 
 func apiPathForFamily(family string) string {
 	switch family {
 	case familyAlert:
-		return "/api/cerebro/alerts"
-	case familyCase:
-		return "/api/cerebro/cases"
-	case familyIOC:
-		return "/api/cerebro/iocs"
+		return "/api/v2/alerts"
+	case familyCase, familyIOC:
+		return "/api/v2/cases"
 	default:
-		return "/api/cerebro/events"
+		return "/api/v2/alerts"
 	}
 }
 
 func discoverAPIFamily(st settings, urnPrefix string) ([]sourcecdk.URN, error) {
-	urnRaw := urnPrefix + url.PathEscape(st.baseURL+st.apiPath)
+	path := st.apiPath
+	if st.family == familyIOC {
+		path = strings.TrimRight(path, "/") + "/*/iocs"
+	}
+	urnRaw := urnPrefix + url.PathEscape(st.baseURL+path)
 	urn, err := sourcecdk.ParseURN(urnRaw)
 	if err != nil {
 		return nil, fmt.Errorf("build panopticon api urn: %w", err)
@@ -57,37 +63,150 @@ func discoverAPIFamily(st settings, urnPrefix string) ([]sourcecdk.URN, error) {
 }
 
 func (s *Source) checkAPI(ctx context.Context, st settings) error {
-	_, err := s.readAPIPage(ctx, st, "")
+	st.perPage = 1
+	_, err := s.readNativeAPIPage(ctx, st, st.apiPath, 1)
 	return err
 }
 
 func (s *Source) readAPIFamily(ctx context.Context, st settings, cursor *cerebrov1.SourceCursor, kind, schemaRef string) (sourcecdk.Pull, error) {
+	if st.family == familyIOC {
+		return s.readNativeIOCFamily(ctx, st, cursor)
+	}
 	cursorState := decodeAPICursor(cursor)
-	response, err := s.readAPIPage(ctx, st, cursorState.Cursor)
+	page := cursorState.Page
+	if page < 1 {
+		page = 1
+	}
+	response, err := s.readNativeAPIPage(ctx, st, st.apiPath, page)
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
-	records := response.apiRecords()
+	records, err := nativeRecords(st, response.Data, kind, schemaRef, time.Time{})
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	next := cursorState
+	if nextPage := response.nextPage(); nextPage > 0 {
+		next.Page = nextPage
+	} else {
+		next.Page = 0
+	}
+	return recordsPull(records, cursorState, next, cursor != nil)
+}
+
+func (s *Source) readNativeIOCFamily(ctx context.Context, st settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	state := decodeAPICursor(cursor)
+	if state.CasePage < 1 {
+		state.CasePage = 1
+	}
+	if state.IOCPage < 1 {
+		state.IOCPage = 1
+	}
+	current := state
+	for scanned := 0; scanned < int(st.perPage)+1; scanned++ {
+		cases, err := s.readNativeAPIPage(ctx, st, st.apiPath, current.CasePage)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		for current.CaseIndex < len(cases.Data) {
+			caseItem := cases.Data[current.CaseIndex]
+			caseID := nativeString(caseItem, "case_id")
+			if caseID == "" {
+				return sourcecdk.Pull{}, fmt.Errorf("panopticon case missing case_id")
+			}
+			caseOccurred := firstNativeTime(caseItem, "initial_date", "open_date", "close_date")
+			iocPath := strings.TrimRight(st.apiPath, "/") + "/" + url.PathEscape(caseID) + "/iocs"
+			iocs, err := s.readNativeAPIPage(ctx, st, iocPath, current.IOCPage)
+			if err != nil {
+				return sourcecdk.Pull{}, err
+			}
+			records, err := nativeRecords(st, iocs.Data, kindIOC, schemaRefIOC, caseOccurred)
+			if err != nil {
+				return sourcecdk.Pull{}, err
+			}
+			next := current
+			if nextIOCPage := iocs.nextPage(); nextIOCPage > 0 {
+				next.IOCPage = nextIOCPage
+				return recordsPull(records, state, next, cursor != nil)
+			}
+			next.CaseIndex++
+			next.IOCPage = 1
+			if len(records) > 0 {
+				if next.CaseIndex >= len(cases.Data) {
+					if nextCasePage := cases.nextPage(); nextCasePage > 0 {
+						next.CasePage = nextCasePage
+						next.CaseIndex = 0
+					} else {
+						next.CasePage = 0
+						next.IOCPage = 0
+					}
+				}
+				return recordsPull(records, state, next, cursor != nil)
+			}
+			current = next
+		}
+		if nextCasePage := cases.nextPage(); nextCasePage > 0 {
+			current.CasePage = nextCasePage
+			current.CaseIndex = 0
+			current.IOCPage = 1
+			continue
+		}
+		return recordsPull(nil, state, panopticonAPICursor{}, cursor != nil)
+	}
+	return sourcecdk.Pull{}, fmt.Errorf("panopticon ioc pagination did not make progress")
+}
+
+func (s *Source) readNativeAPIPage(ctx context.Context, st settings, path string, page int) (nativeAPIPage, error) {
+	if page < 1 {
+		page = 1
+	}
+	query := url.Values{}
+	query.Set("page", strconv.Itoa(page))
+	query.Set("per_page", strconv.Itoa(int(st.perPage)))
+	if st.family == familyAlert {
+		query.Set("sort", "asc")
+	} else {
+		query.Set("order_by", "case_id")
+		query.Set("sort_dir", "asc")
+	}
+	endpoint := st.baseURL + path
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nativeAPIPage{}, fmt.Errorf("build panopticon api request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+st.token)
+
+	resp, err := sourceHTTPClient(s).Do(req)
+	if err != nil {
+		return nativeAPIPage{}, fmt.Errorf("request panopticon api: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	payload, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxAPIResponseBytes)
+	if err != nil {
+		return nativeAPIPage{}, fmt.Errorf("read panopticon api response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return nativeAPIPage{}, apiResponseError(resp.StatusCode, payload)
+	}
+	var response nativeAPIPage
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return nativeAPIPage{}, fmt.Errorf("decode panopticon api response: %w", err)
+	}
+	return response, nil
+}
+
+func recordsPull(records []panopticonRecord, cursorState, next panopticonAPICursor, hadCursor bool) (sourcecdk.Pull, error) {
 	if len(records) > maxEventsPerPull {
 		return sourcecdk.Pull{}, fmt.Errorf("panopticon api returned %d records, max %d", len(records), maxEventsPerPull)
 	}
 	events := make([]*cerebrov1.EventEnvelope, 0, len(records))
 	var watermark time.Time
 	for _, rec := range records {
-		recordTenant := strings.TrimSpace(rec.TenantID)
-		if recordTenant == "" {
-			return sourcecdk.Pull{}, fmt.Errorf("invalid panopticon api event: tenant_id is required")
-		}
-		if recordTenant != rec.TenantID {
-			return sourcecdk.Pull{}, fmt.Errorf("invalid panopticon api event: tenant_id must not have leading or trailing whitespace")
-		}
-		if recordTenant != st.tenantID {
-			return sourcecdk.Pull{}, fmt.Errorf("invalid panopticon api event: tenant_id %q does not match runtime tenant", recordTenant)
-		}
-		if st.runtimeID != "" && strings.TrimSpace(rec.Attributes["runtime_id"]) != "" && strings.TrimSpace(rec.Attributes["runtime_id"]) != st.runtimeID {
-			continue
-		}
-		event, err := buildEvent(rec, kind, schemaRef)
+		event, err := buildEvent(rec, rec.Kind, rec.SchemaRef)
 		if err != nil {
 			return sourcecdk.Pull{}, fmt.Errorf("convert panopticon api event: %w", err)
 		}
@@ -102,24 +221,20 @@ func (s *Source) readAPIFamily(ctx context.Context, st settings, cursor *cerebro
 			watermark = rec.OccurredAt
 		}
 	}
-	if parsed := parseAPIWatermark(response.Watermark); parsed.After(watermark) {
-		watermark = parsed
-	}
-
 	pull := sourcecdk.Pull{Events: events}
-	nextCursor := strings.TrimSpace(response.NextCursor)
-	if nextCursor != "" {
-		opaque := encodeAPICursor(panopticonAPICursor{
-			Cursor:    nextCursor,
-			Watermark: watermarkString(watermark, parseAPIWatermark(cursorState.Watermark)),
-		})
+	watermarkValue := watermarkString(watermark, parseAPIWatermark(cursorState.Watermark))
+	if next.hasMore() {
+		next.Watermark = watermarkValue
+		opaque := encodeAPICursor(next)
 		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: opaque}
 		pull.Checkpoint = &cerebrov1.SourceCheckpoint{CursorOpaque: opaque}
-	} else if !watermark.IsZero() || cursor != nil {
-		opaque := encodeAPICursor(panopticonAPICursor{
-			Cursor:    cursorState.Cursor,
-			Watermark: watermarkString(watermark, parseAPIWatermark(cursorState.Watermark)),
-		})
+	} else if watermarkValue != "" || hadCursor {
+		cursorState.Watermark = watermarkValue
+		cursorState.Page = 0
+		cursorState.CasePage = 0
+		cursorState.CaseIndex = 0
+		cursorState.IOCPage = 0
+		opaque := encodeAPICursor(cursorState)
 		pull.Checkpoint = &cerebrov1.SourceCheckpoint{CursorOpaque: opaque}
 	}
 	if pull.Checkpoint != nil {
@@ -130,45 +245,56 @@ func (s *Source) readAPIFamily(ctx context.Context, st settings, cursor *cerebro
 	return pull, nil
 }
 
-func (s *Source) readAPIPage(ctx context.Context, st settings, cursor string) (panopticonAPIResponse, error) {
-	query := url.Values{}
-	query.Set("tenant_id", st.tenantID)
-	query.Set("family", st.family)
-	query.Set("limit", strconv.Itoa(int(st.perPage)))
-	if st.runtimeID != "" {
-		query.Set("runtime_id", st.runtimeID)
+func nativeRecords(st settings, items []map[string]interface{}, kind, schemaRef string, fallbackOccurredAt time.Time) ([]panopticonRecord, error) {
+	records := make([]panopticonRecord, 0, len(items))
+	for _, item := range items {
+		record, err := nativeRecord(st, item, kind, schemaRef, fallbackOccurredAt)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
 	}
-	if cursor = strings.TrimSpace(cursor); cursor != "" {
-		query.Set("cursor", cursor)
-	}
-	endpoint := st.baseURL + st.apiPath
-	if encoded := query.Encode(); encoded != "" {
-		endpoint += "?" + encoded
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return panopticonAPIResponse{}, fmt.Errorf("build panopticon api request: %w", err)
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "Bearer "+st.token)
+	return records, nil
+}
 
-	resp, err := sourceHTTPClient(s).Do(req)
-	if err != nil {
-		return panopticonAPIResponse{}, fmt.Errorf("request panopticon api: %w", err)
+func nativeRecord(st settings, item map[string]interface{}, kind, schemaRef string, fallbackOccurredAt time.Time) (panopticonRecord, error) {
+	switch kind {
+	case kindAlert:
+		alertID := nativeString(item, "alert_id")
+		severity := firstString(nestedString(item, "severity", "severity_name"), nativeString(item, "severity"), nativeString(item, "alert_severity_id"))
+		status := firstString(nestedString(item, "status", "status_name"), nativeString(item, "status"), nativeString(item, "alert_status_id"))
+		title := firstString(nativeString(item, "alert_title"), nativeString(item, "title"))
+		occurredAt := firstNativeTime(item, "alert_source_event_time", "alert_creation_time")
+		return canonicalRecord(st, item, kind, schemaRef, "alert-"+alertID, occurredAt, map[string]string{"alert_id": alertID, "severity": severity, "status": status}, map[string]interface{}{"alert_id": alertID, "severity": severity, "status": status, "title": title})
+	case kindCase:
+		caseID := nativeString(item, "case_id")
+		status := firstString(nestedString(item, "state", "state_name"), nativeString(item, "status"), nativeString(item, "status_id"))
+		title := firstString(nativeString(item, "case_name"), nativeString(item, "name"))
+		occurredAt := firstNativeTime(item, "initial_date", "open_date", "close_date")
+		return canonicalRecord(st, item, kind, schemaRef, "case-"+caseID, occurredAt, map[string]string{"case_id": caseID, "status": status}, map[string]interface{}{"case_id": caseID, "status": status, "title": title})
+	case kindIOC:
+		iocID := nativeString(item, "ioc_id")
+		iocType := firstString(nestedString(item, "ioc_type", "type_name"), nativeString(item, "ioc_type"), nativeString(item, "ioc_type_id"))
+		value := firstString(nativeString(item, "ioc_value"), nativeString(item, "value"))
+		occurredAt := fallbackOccurredAt
+		return canonicalRecord(st, item, kind, schemaRef, "ioc-"+iocID, occurredAt, map[string]string{"ioc_id": iocID, "ioc_type": iocType, "value": value}, map[string]interface{}{"ioc_id": iocID, "ioc_type": iocType, "value": value})
+	default:
+		return panopticonRecord{}, fmt.Errorf("unsupported kind %q", kind)
 	}
-	defer func() { _ = resp.Body.Close() }()
-	payload, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxAPIResponseBytes)
-	if err != nil {
-		return panopticonAPIResponse{}, fmt.Errorf("read panopticon api response: %w", err)
+}
+
+func canonicalRecord(st settings, item map[string]interface{}, kind, schemaRef, id string, occurredAt time.Time, attributes map[string]string, canonicalPayload map[string]interface{}) (panopticonRecord, error) {
+	payload := make(map[string]interface{}, len(item)+len(canonicalPayload))
+	for key, value := range item {
+		payload[key] = value
 	}
-	if resp.StatusCode >= http.StatusMultipleChoices {
-		return panopticonAPIResponse{}, apiResponseError(resp.StatusCode, payload)
+	for key, value := range canonicalPayload {
+		payload[key] = value
 	}
-	var response panopticonAPIResponse
-	if err := json.Unmarshal(payload, &response); err != nil {
-		return panopticonAPIResponse{}, fmt.Errorf("decode panopticon api response: %w", err)
+	if st.runtimeID != "" {
+		attributes["runtime_id"] = st.runtimeID
 	}
-	return response, nil
+	return panopticonRecord{ID: id, TenantID: st.tenantID, SourceID: sourceID, Kind: kind, OccurredAt: occurredAt, SchemaRef: schemaRef, Attributes: attributes, Payload: payload}, nil
 }
 
 func sourceHTTPClient(s *Source) *http.Client {
@@ -189,13 +315,6 @@ func lookupIPAddrs(s *Source) func(context.Context, string) ([]net.IPAddr, error
 	return s.lookupIPAddrs
 }
 
-func (r panopticonAPIResponse) apiRecords() []panopticonRecord {
-	if r.Records != nil {
-		return r.Records
-	}
-	return r.Events
-}
-
 func decodeAPICursor(cursor *cerebrov1.SourceCursor) panopticonAPICursor {
 	opaque := strings.TrimSpace(cursor.GetOpaque())
 	if opaque == "" {
@@ -203,21 +322,22 @@ func decodeAPICursor(cursor *cerebrov1.SourceCursor) panopticonAPICursor {
 	}
 	var decoded panopticonAPICursor
 	if err := json.Unmarshal([]byte(opaque), &decoded); err == nil && decoded.Source == cursorSourceAPI {
-		decoded.Cursor = strings.TrimSpace(decoded.Cursor)
 		decoded.Watermark = strings.TrimSpace(decoded.Watermark)
 		return decoded
 	}
-	return panopticonAPICursor{Cursor: opaque}
+	if page, err := strconv.Atoi(opaque); err == nil {
+		return panopticonAPICursor{Page: page}
+	}
+	return panopticonAPICursor{}
 }
 
 func encodeAPICursor(cursor panopticonAPICursor) string {
 	cursor.Source = cursorSourceAPI
 	cursor.ResumableCheckpoint = true
-	cursor.Cursor = strings.TrimSpace(cursor.Cursor)
 	cursor.Watermark = strings.TrimSpace(cursor.Watermark)
 	raw, err := json.Marshal(cursor)
 	if err != nil {
-		return cursor.Cursor
+		return ""
 	}
 	return string(raw)
 }
@@ -232,6 +352,83 @@ func parseAPIWatermark(raw string) time.Time {
 		return time.Time{}
 	}
 	return parsed.UTC()
+}
+
+func (c panopticonAPICursor) hasMore() bool {
+	return c.Page > 0 || c.CasePage > 0 || c.IOCPage > 0
+}
+
+func (p nativeAPIPage) nextPage() int {
+	raw := strings.TrimSpace(string(p.NextPage))
+	if raw == "" || raw == "null" || raw == "false" || raw == "0" {
+		return 0
+	}
+	if raw == "true" {
+		return p.CurrentPage + 1
+	}
+	var page int
+	if err := json.Unmarshal(p.NextPage, &page); err == nil && page > 0 {
+		return page
+	}
+	return 0
+}
+
+func firstNativeTime(item map[string]interface{}, keys ...string) time.Time {
+	for _, key := range keys {
+		if parsed := parseNativeTime(item[key]); !parsed.IsZero() {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+func parseNativeTime(value interface{}) time.Time {
+	raw := strings.TrimSpace(nativeValueString(value))
+	if raw == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, "2006-01-02T15:04:05.999999", "2006-01-02T15:04:05", "2006-01-02"} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func nativeString(item map[string]interface{}, key string) string {
+	return nativeValueString(item[key])
+}
+
+func nestedString(item map[string]interface{}, key, nestedKey string) string {
+	nested, ok := item[key].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	return nativeValueString(nested[nestedKey])
+}
+
+func firstString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func nativeValueString(value interface{}) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return strings.TrimSpace(typed.String())
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(typed)
+	default:
+		return ""
+	}
 }
 
 func apiResponseError(statusCode int, payload []byte) error {

--- a/sources/panopticon/source_test.go
+++ b/sources/panopticon/source_test.go
@@ -53,19 +53,25 @@ func TestParseSettings(t *testing.T) {
 			name:     "defaults",
 			values:   map[string]string{"base_url": "http://127.0.0.1", "token": "token", "tenant_id": "writer"},
 			loopback: true,
-			want:     settings{family: familyAlert, baseURL: "http://127.0.0.1", apiPath: "/api/cerebro/alerts", token: "token", tenantID: "writer", perPage: defaultPageSize},
+			want:     settings{family: familyAlert, baseURL: "http://127.0.0.1", apiPath: "/api/v2/alerts", token: "token", tenantID: "writer", perPage: defaultPageSize},
 		},
 		{
 			name:     "case-family-runtime-page-and-api-key",
 			values:   map[string]string{"mode": modeAPI, "family": familyCase, "base_url": "http://127.0.0.1", "api_key": "token", "per_page": "25", "tenant_id": "writer", "runtime_id": "writer-panopticon-cases"},
 			loopback: true,
-			want:     settings{family: familyCase, baseURL: "http://127.0.0.1", apiPath: "/api/cerebro/cases", token: "token", tenantID: "writer", runtimeID: "writer-panopticon-cases", perPage: 25},
+			want:     settings{family: familyCase, baseURL: "http://127.0.0.1", apiPath: "/api/v2/cases", token: "token", tenantID: "writer", runtimeID: "writer-panopticon-cases", perPage: 25},
+		},
+		{
+			name:     "ioc-family-uses-cases-api",
+			values:   map[string]string{"family": familyIOC, "base_url": "http://127.0.0.1", "token": "token", "tenant_id": "writer"},
+			loopback: true,
+			want:     settings{family: familyIOC, baseURL: "http://127.0.0.1", apiPath: "/api/v2/cases", token: "token", tenantID: "writer", perPage: defaultPageSize},
 		},
 		{
 			name:     "runtime-tenant",
 			values:   map[string]string{"base_url": "http://127.0.0.1", "token": "token", sourceconfig.RuntimeTenantIDKey: "writer"},
 			loopback: true,
-			want:     settings{family: familyAlert, baseURL: "http://127.0.0.1", apiPath: "/api/cerebro/alerts", token: "token", tenantID: "writer", perPage: defaultPageSize},
+			want:     settings{family: familyAlert, baseURL: "http://127.0.0.1", apiPath: "/api/v2/alerts", token: "token", tenantID: "writer", perPage: defaultPageSize},
 		},
 		{name: "missing-base-url", values: map[string]string{"token": "token", "tenant_id": "writer"}, wantErrIs: ErrBaseURLRequired},
 		{name: "missing-token", values: map[string]string{"base_url": "https://panopticon.example.com", "tenant_id": "writer"}, wantErrIs: ErrTokenRequired},
@@ -97,22 +103,21 @@ func TestParseSettings(t *testing.T) {
 	}
 }
 
-func TestCheckAndDiscoverUseAPIEndpoint(t *testing.T) {
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+func TestCheckAndDiscoverUseExistingAlertsEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/cerebro/alerts" {
+		if r.URL.Path != "/api/v2/alerts" {
 			http.NotFound(w, r)
 			return
 		}
-		if got := r.URL.Query().Get("limit"); got != "1" {
-			t.Fatalf("check limit = %q, want 1", got)
+		if got := r.URL.Query().Get("per_page"); got != "1" {
+			t.Fatalf("check per_page = %q, want 1", got)
 		}
-		_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Records: []panopticonRecord{validAlert("alert-1", fixed)}})
+		writePage(w, []map[string]interface{}{validNativeAlert("1", fixedTime())}, 1, 0)
 	}))
 	defer server.Close()
 
 	src := newTestSource(t)
-	cfg := apiConfig(server.URL, map[string]string{"per_page": "1"})
+	cfg := apiConfig(server.URL, map[string]string{"per_page": "25"})
 	if err := src.Check(context.Background(), cfg); err != nil {
 		t.Fatalf("Check() error = %v", err)
 	}
@@ -120,16 +125,16 @@ func TestCheckAndDiscoverUseAPIEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Discover() error = %v", err)
 	}
-	if len(urns) != 1 || !strings.Contains(urns[0].String(), "panopticon") {
-		t.Fatalf("Discover() urns = %v, want Panopticon URN", urns)
+	if len(urns) != 1 || !strings.Contains(urns[0].String(), "%2Fapi%2Fv2%2Falerts") {
+		t.Fatalf("Discover() urns = %v, want alerts URN", urns)
 	}
 }
 
-func TestReadAPIPaginatesAndValidatesEvents(t *testing.T) {
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+func TestReadExistingAlertsAPIPaginatesAndMapsNativeFields(t *testing.T) {
+	fixed := fixedTime()
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/cerebro/alerts" {
+		if r.URL.Path != "/api/v2/alerts" {
 			http.NotFound(w, r)
 			return
 		}
@@ -137,29 +142,16 @@ func TestReadAPIPaginatesAndValidatesEvents(t *testing.T) {
 		if got := r.Header.Get("Authorization"); got != "Bearer api-token" {
 			t.Fatalf("Authorization = %q, want bearer token", got)
 		}
-		if got := r.URL.Query().Get("tenant_id"); got != "writer" {
-			t.Fatalf("tenant_id = %q, want writer", got)
+		if got := r.URL.Query().Get("per_page"); got != "1" {
+			t.Fatalf("per_page = %q, want 1", got)
 		}
-		if got := r.URL.Query().Get("family"); got != familyAlert {
-			t.Fatalf("family = %q, want %q", got, familyAlert)
-		}
-		if got := r.URL.Query().Get("limit"); got != "1" {
-			t.Fatalf("limit = %q, want 1", got)
-		}
-		switch r.URL.Query().Get("cursor") {
-		case "":
-			_ = json.NewEncoder(w).Encode(panopticonAPIResponse{
-				Records:    []panopticonRecord{validAlert("alert-1", fixed)},
-				NextCursor: "page-2",
-				Watermark:  fixed.Format(time.RFC3339Nano),
-			})
-		case "page-2":
-			_ = json.NewEncoder(w).Encode(panopticonAPIResponse{
-				Records:   []panopticonRecord{validAlert("alert-2", fixed.Add(time.Minute))},
-				Watermark: fixed.Add(time.Minute).Format(time.RFC3339Nano),
-			})
+		switch r.URL.Query().Get("page") {
+		case "1":
+			writePage(w, []map[string]interface{}{validNativeAlert("1", fixed)}, 1, 2)
+		case "2":
+			writePage(w, []map[string]interface{}{validNativeAlert("2", fixed.Add(time.Minute))}, 2, 0)
 		default:
-			t.Fatalf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+			t.Fatalf("unexpected page %q", r.URL.Query().Get("page"))
 		}
 	}))
 	defer server.Close()
@@ -174,8 +166,8 @@ func TestReadAPIPaginatesAndValidatesEvents(t *testing.T) {
 		t.Fatalf("first events/cursor = %v/%v, want alert-1 and cursor", got, first.NextCursor)
 	}
 	firstCursor := decodeAPICursor(first.NextCursor)
-	if firstCursor.Source != cursorSourceAPI || firstCursor.Cursor != "page-2" {
-		t.Fatalf("first cursor = %+v, want api cursor page-2", firstCursor)
+	if firstCursor.Source != cursorSourceAPI || firstCursor.Page != 2 {
+		t.Fatalf("first cursor = %+v, want api page 2", firstCursor)
 	}
 
 	second, err := src.Read(context.Background(), cfg, first.NextCursor)
@@ -193,25 +185,25 @@ func TestReadAPIPaginatesAndValidatesEvents(t *testing.T) {
 	}
 }
 
-func TestReadAPIAcceptsEventsResponseAndAllFamilies(t *testing.T) {
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+func TestReadExistingCasesAndIOCsAPI(t *testing.T) {
+	fixed := fixedTime()
 	for _, tc := range []struct {
 		family string
-		path   string
-		record panopticonRecord
 		kind   string
 	}{
-		{familyAlert, "/api/cerebro/alerts", validAlert("alert-1", fixed), kindAlert},
-		{familyCase, "/api/cerebro/cases", validCase("case-1", fixed), kindCase},
-		{familyIOC, "/api/cerebro/iocs", validIOC("ioc-1", fixed), kindIOC},
+		{familyCase, kindCase},
+		{familyIOC, kindIOC},
 	} {
 		t.Run(tc.family, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != tc.path {
+				switch r.URL.Path {
+				case "/api/v2/cases":
+					writePage(w, []map[string]interface{}{validNativeCase("42", fixed)}, 1, 0)
+				case "/api/v2/cases/42/iocs":
+					writePage(w, []map[string]interface{}{validNativeIOC("7")}, 1, 0)
+				default:
 					http.NotFound(w, r)
-					return
 				}
-				_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Events: []panopticonRecord{tc.record}})
 			}))
 			defer server.Close()
 
@@ -227,91 +219,16 @@ func TestReadAPIAcceptsEventsResponseAndAllFamilies(t *testing.T) {
 	}
 }
 
-func TestReadAPIFiltersRuntimeID(t *testing.T) {
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+func TestReadAPIRejectsInvalidNativeRecordsAndHTTPError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.URL.Query().Get("runtime_id"); got != "writer-panopticon-alerts" {
-			t.Fatalf("runtime_id query = %q, want writer-panopticon-alerts", got)
-		}
-		_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Records: []panopticonRecord{
-			withRuntime(validAlert("other-runtime", fixed), "writer-panopticon-cases"),
-			withRuntime(validAlert("accepted", fixed), "writer-panopticon-alerts"),
-		}})
-	}))
-	defer server.Close()
-
-	src := newTestSource(t)
-	pull, err := src.Read(context.Background(), apiConfig(server.URL, map[string]string{"runtime_id": "writer-panopticon-alerts"}), nil)
-	if err != nil {
-		t.Fatalf("Read() error = %v", err)
-	}
-	if got := eventIDs(pull.Events); len(got) != 1 || got[0] != "accepted" {
-		t.Fatalf("events = %v, want [accepted]", got)
-	}
-}
-
-func TestReadAPIRejectsCrossTenantEvents(t *testing.T) {
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Records: []panopticonRecord{withTenant(validAlert("alert-1", fixed), "other")}})
+		writePage(w, []map[string]interface{}{{"alert_id": "1"}}, 1, 0)
 	}))
 	defer server.Close()
 
 	src := newTestSource(t)
 	_, err := src.Read(context.Background(), apiConfig(server.URL, nil), nil)
-	if err == nil || !errorContains(err, "does not match runtime tenant") {
-		t.Fatalf("Read() error = %v, want cross-tenant rejection", err)
-	}
-}
-
-func TestReadAPIRejectsInvalidEnvelopesAndFamilyContracts(t *testing.T) {
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	tests := []struct {
-		name   string
-		record panopticonRecord
-		want   string
-	}{
-		{"wrong-source", withSource(validAlert("alert-1", fixed), "other"), "source_id"},
-		{"unsupported-kind", withKind(validAlert("alert-1", fixed), kindCase, schemaRefCase), "kind"},
-		{"schema-mismatch", withKind(validAlert("alert-1", fixed), kindAlert, "panopticon/alert/v2"), "schema_ref"},
-		{"missing-tenant", withTenant(validAlert("alert-1", fixed), ""), "tenant_id"},
-		{"blank-tenant", withTenant(validAlert("alert-1", fixed), "  "), "tenant_id"},
-		{"missing-title", withoutPayloadField(validAlert("alert-1", fixed), "title"), "title"},
-		{"empty-required-attribute", withAttribute(validAlert("alert-1", fixed), "severity", ""), "severity"},
-		{"mismatched-attribute-payload", withAttribute(validAlert("alert-1", fixed), "status", "closed"), "does not match"},
-		{"missing-payload", panopticonRecord{ID: "alert-1", TenantID: "writer", SourceID: sourceID, Kind: kindAlert, OccurredAt: fixed, SchemaRef: schemaRefAlert, Attributes: map[string]string{"alert_id": "a-1", "severity": "high", "status": "open"}}, "payload"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Records: []panopticonRecord{tc.record}})
-			}))
-			defer server.Close()
-
-			src := newTestSource(t)
-			_, err := src.Read(context.Background(), apiConfig(server.URL, nil), nil)
-			if err == nil || !errorContains(err, tc.want) {
-				t.Fatalf("Read() error = %v, want containing %q", err, tc.want)
-			}
-		})
-	}
-}
-
-func TestReadAPIRejectsTooManyRecordsAndHTTPError(t *testing.T) {
-	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	tooMany := make([]panopticonRecord, maxEventsPerPull+1)
-	for i := range tooMany {
-		tooMany[i] = validAlert(fmt.Sprintf("alert-%04d", i), fixed)
-	}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(panopticonAPIResponse{Records: tooMany})
-	}))
-	defer server.Close()
-
-	src := newTestSource(t)
-	_, err := src.Read(context.Background(), apiConfig(server.URL, nil), nil)
-	if err == nil || !errorContains(err, "max") {
-		t.Fatalf("Read() error = %v, want max records rejection", err)
+	if err == nil || !errorContains(err, "occurred_at") {
+		t.Fatalf("Read() error = %v, want occurred_at validation", err)
 	}
 
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -342,49 +259,53 @@ func apiConfig(baseURL string, overrides map[string]string) sourcecdk.Config {
 	return sourcecdk.NewConfig(values)
 }
 
+func writePage(w http.ResponseWriter, data []map[string]interface{}, currentPage, nextPage int) {
+	payload := map[string]interface{}{
+		"total":        len(data),
+		"data":         data,
+		"last_page":    currentPage,
+		"current_page": currentPage,
+		"next_page":    nil,
+	}
+	if nextPage > 0 {
+		payload["next_page"] = nextPage
+	}
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func fixedTime() time.Time {
+	return time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+}
+
+func validNativeAlert(id string, occurredAt time.Time) map[string]interface{} {
+	return map[string]interface{}{
+		"alert_id":                id,
+		"alert_title":             "Suspicious activity",
+		"alert_source_event_time": occurredAt.Format(time.RFC3339Nano),
+		"severity":                map[string]interface{}{"severity_name": "high"},
+		"status":                  map[string]interface{}{"status_name": "open"},
+	}
+}
+
+func validNativeCase(id string, occurredAt time.Time) map[string]interface{} {
+	return map[string]interface{}{
+		"case_id":      id,
+		"case_name":    "Incident case",
+		"initial_date": occurredAt.Format(time.RFC3339Nano),
+		"state":        map[string]interface{}{"state_name": "investigating"},
+	}
+}
+
+func validNativeIOC(id string) map[string]interface{} {
+	return map[string]interface{}{
+		"ioc_id":    id,
+		"ioc_value": "evil.example",
+		"ioc_type":  map[string]interface{}{"type_name": "domain"},
+	}
+}
+
 func errorContains(err error, want string) bool {
 	return strings.Contains(fmt.Sprint(err), want)
-}
-
-func validAlert(id string, occurredAt time.Time) panopticonRecord {
-	alertID := strings.TrimPrefix(id, "alert-")
-	return panopticonRecord{ID: id, TenantID: "writer", SourceID: sourceID, Kind: kindAlert, OccurredAt: occurredAt, SchemaRef: schemaRefAlert, Attributes: map[string]string{"alert_id": alertID, "severity": "high", "status": "open"}, Payload: map[string]interface{}{"alert_id": alertID, "severity": "high", "status": "open", "title": "Suspicious activity"}}
-}
-
-func validCase(id string, occurredAt time.Time) panopticonRecord {
-	caseID := strings.TrimPrefix(id, "case-")
-	return panopticonRecord{ID: id, TenantID: "writer", SourceID: sourceID, Kind: kindCase, OccurredAt: occurredAt, SchemaRef: schemaRefCase, Attributes: map[string]string{"case_id": caseID, "status": "investigating"}, Payload: map[string]interface{}{"case_id": caseID, "status": "investigating", "title": "Incident case", "evidence": []interface{}{map[string]interface{}{"evidence_cas": "cas://object/abc", "sha256": "abc"}}}}
-}
-
-func validIOC(id string, occurredAt time.Time) panopticonRecord {
-	iocID := strings.TrimPrefix(id, "ioc-")
-	return panopticonRecord{ID: id, TenantID: "writer", SourceID: sourceID, Kind: kindIOC, OccurredAt: occurredAt, SchemaRef: schemaRefIOC, Attributes: map[string]string{"ioc_id": iocID, "ioc_type": "domain", "value": "evil.example"}, Payload: map[string]interface{}{"ioc_id": iocID, "ioc_type": "domain", "value": "evil.example"}}
-}
-
-func withTenant(rec panopticonRecord, tenant string) panopticonRecord {
-	rec.TenantID = tenant
-	return rec
-}
-func withSource(rec panopticonRecord, source string) panopticonRecord {
-	rec.SourceID = source
-	return rec
-}
-func withKind(rec panopticonRecord, kind, schemaRef string) panopticonRecord {
-	rec.Kind = kind
-	rec.SchemaRef = schemaRef
-	return rec
-}
-func withRuntime(rec panopticonRecord, runtimeID string) panopticonRecord {
-	rec.Attributes["runtime_id"] = runtimeID
-	return rec
-}
-func withAttribute(rec panopticonRecord, key, value string) panopticonRecord {
-	rec.Attributes[key] = value
-	return rec
-}
-func withoutPayloadField(rec panopticonRecord, key string) panopticonRecord {
-	delete(rec.Payload, key)
-	return rec
 }
 
 func eventIDs(events []*cerebrov1.EventEnvelope) []string {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -22,7 +22,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2454,
-	"panopticon":      634,
+	"panopticon":      820,
 	"sentinelone":     2181,
 	"vulnview":        1064,
 }


### PR DESCRIPTION
## Summary

- Replaces the invented `/api/cerebro/*` Panopticon paths with the existing Panopticon API surface: `/api/v2/alerts`, `/api/v2/cases`, and case-scoped `/api/v2/cases/{case_id}/iocs`.
- Maps native Panopticon alert, case, and IOC response fields into the existing Cerebro `panopticon.*` event contracts.
- Updates pagination/cursor handling for the Panopticon page-based API and refreshes source tests around native API envelopes.

## Test Plan

- `go test ./sources/panopticon -count=1`
- `go test ./sources/... -count=1`
- `make test`
- `GOLANGCI_LINT_CACHE="$(mktemp -d)" make lint`
- `make catalog-check`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
