### PR TITLE
fix(source): allow private Panopticon API endpoints

### DIFF
--- a/sources/panopticon/api.go
+++ b/sources/panopticon/api.go
@@ -180,7 +180,7 @@ func (s *Source) readNativeAPIPage(ctx context.Context, st settings, path string
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Bearer "+st.token)
 
-	resp, err := sourceHTTPClient(s).Do(req)
+	resp, err := sourceHTTPClient(s, st.privateEndpointAllowlist).Do(req)
 	if err != nil {
 		return nativeAPIPage{}, fmt.Errorf("request panopticon api: %w", err)
 	}
@@ -297,14 +297,18 @@ func canonicalRecord(st settings, item map[string]interface{}, kind, schemaRef, 
 	return panopticonRecord{ID: id, TenantID: st.tenantID, SourceID: sourceID, Kind: kind, OccurredAt: occurredAt, SchemaRef: schemaRef, Attributes: attributes, Payload: payload}, nil
 }
 
-func sourceHTTPClient(s *Source) *http.Client {
+func sourceHTTPClient(s *Source, privateEndpointAllowlist []string) *http.Client {
 	if s == nil {
-		return sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: sourceID})
+		return sourcehttp.NewClient(sourcehttp.ClientOptions{
+			SourceID:                 sourceID,
+			PrivateEndpointAllowlist: privateEndpointAllowlist,
+		})
 	}
 	return sourcehttp.HardenClient(s.client, sourcehttp.ClientOptions{
-		SourceID:      sourceID,
-		AllowLoopback: s.allowLoopbackBaseURL,
-		LookupIPAddrs: lookupIPAddrs(s),
+		SourceID:                 sourceID,
+		AllowLoopback:            s.allowLoopbackBaseURL,
+		PrivateEndpointAllowlist: privateEndpointAllowlist,
+		LookupIPAddrs:            lookupIPAddrs(s),
 	})
 }
 

--- a/sources/panopticon/source.go
+++ b/sources/panopticon/source.go
@@ -1,5 +1,4 @@
-// Package panopticon implements the Cerebro source for Panopticon security
-// operations events exposed by the Panopticon API.
+// Package panopticon implements the Cerebro source for Panopticon events.
 package panopticon
 
 import (
@@ -53,21 +52,14 @@ const (
 )
 
 var (
-	// ErrInvalidPageSize is returned when page_size is not a positive integer.
-	ErrInvalidPageSize = errors.New("invalid page_size")
-	// ErrTenantIDRequired is returned when no explicit tenant scope is configured.
-	ErrTenantIDRequired = errors.New("tenant_id is required")
-	// ErrUnsupportedFamily is returned when the family is not one of the known kinds.
+	ErrInvalidPageSize   = errors.New("invalid page_size")
+	ErrTenantIDRequired  = errors.New("tenant_id is required")
 	ErrUnsupportedFamily = errors.New("unsupported family")
-	// ErrBaseURLRequired is returned when no API base URL is configured.
-	ErrBaseURLRequired = errors.New("base_url is required")
-	// ErrTokenRequired is returned when no API bearer token is configured.
-	ErrTokenRequired = errors.New("token is required")
-	// ErrUnsupportedMode is returned when mode is not the API transport.
-	ErrUnsupportedMode = errors.New("unsupported mode")
+	ErrBaseURLRequired   = errors.New("base_url is required")
+	ErrTokenRequired     = errors.New("token is required")
+	ErrUnsupportedMode   = errors.New("unsupported mode")
 )
 
-// Source emits panopticon.* events from the Panopticon API.
 type Source struct {
 	spec                 *cerebrov1.SourceSpec
 	client               *http.Client
@@ -77,13 +69,14 @@ type Source struct {
 }
 
 type settings struct {
-	family    string
-	baseURL   string
-	apiPath   string
-	token     string
-	tenantID  string
-	runtimeID string
-	perPage   int32
+	family                   string
+	baseURL                  string
+	apiPath                  string
+	token                    string
+	tenantID                 string
+	runtimeID                string
+	privateEndpointAllowlist []string
+	perPage                  int32
 }
 
 type panopticonRecord struct {
@@ -97,7 +90,6 @@ type panopticonRecord struct {
 	Attributes map[string]string      `json:"attributes"`
 }
 
-// New constructs the Panopticon API source.
 func New() (*Source, error) {
 	spec, err := loadSpec()
 	if err != nil {
@@ -114,20 +106,16 @@ func New() (*Source, error) {
 	return source, nil
 }
 
-// Spec returns the static metadata for the Panopticon source.
 func (s *Source) Spec() *cerebrov1.SourceSpec { return s.spec }
 
-// Check verifies that the configured Panopticon API family is reachable.
 func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 	return s.families.Check(ctx, cfg)
 }
 
-// Discover returns the URN for the configured family runtime instance.
 func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
 	return s.families.Discover(ctx, cfg)
 }
 
-// Read pages Panopticon API events since the cursor.
 func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	return s.families.Read(ctx, cfg, cursor)
 }
@@ -227,11 +215,19 @@ func parseSettingsWithLoopback(cfg sourcecdk.Config, allowLoopback bool) (settin
 	if st.token == "" {
 		return settings{}, ErrTokenRequired
 	}
-	baseURL, _, err := sourcehttp.NormalizeBaseURL(sourceID, st.baseURL, allowLoopback)
+	privateEndpointAllowlist, err := sourcehttp.ParsePrivateEndpointAllowlist(sourceID, configValue(cfg, "private_endpoint_allowlist"))
+	if err != nil {
+		return settings{}, err
+	}
+	baseURL, _, err := sourcehttp.NormalizeBaseURLWithOptions(sourceID, st.baseURL, sourcehttp.URLValidationOptions{
+		AllowLoopback:            allowLoopback,
+		PrivateEndpointAllowlist: privateEndpointAllowlist,
+	})
 	if err != nil {
 		return settings{}, err
 	}
 	st.baseURL = baseURL
+	st.privateEndpointAllowlist = privateEndpointAllowlist
 	if st.apiPath == "" {
 		st.apiPath = apiPathForFamily(st.family)
 	}

--- a/sources/panopticon/source_test.go
+++ b/sources/panopticon/source_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -73,6 +75,19 @@ func TestParseSettings(t *testing.T) {
 			loopback: true,
 			want:     settings{family: familyAlert, baseURL: "http://127.0.0.1", apiPath: "/api/v2/alerts", token: "token", tenantID: "writer", perPage: defaultPageSize},
 		},
+		{
+			name:   "private-endpoint-allowlist",
+			values: map[string]string{"base_url": "https://panopticon.internal.example", "token": "token", "tenant_id": "writer", "private_endpoint_allowlist": "panopticon.internal.example"},
+			want: settings{
+				family:                   familyAlert,
+				baseURL:                  "https://panopticon.internal.example",
+				apiPath:                  "/api/v2/alerts",
+				token:                    "token",
+				tenantID:                 "writer",
+				privateEndpointAllowlist: []string{"panopticon.internal.example"},
+				perPage:                  defaultPageSize,
+			},
+		},
 		{name: "missing-base-url", values: map[string]string{"token": "token", "tenant_id": "writer"}, wantErrIs: ErrBaseURLRequired},
 		{name: "missing-token", values: map[string]string{"base_url": "https://panopticon.example.com", "tenant_id": "writer"}, wantErrIs: ErrTokenRequired},
 		{name: "missing-tenant", values: map[string]string{"base_url": "https://panopticon.example.com", "token": "token"}, wantErrIs: ErrTenantIDRequired},
@@ -96,10 +111,38 @@ func TestParseSettings(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parseSettingsWithLoopback() error = %v", err)
 			}
-			if got != tc.want {
+			if !reflect.DeepEqual(got, tc.want) {
 				t.Fatalf("parseSettingsWithLoopback() = %+v, want %+v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestPrivateEndpointAllowlistPermitsResolvedPrivatePanopticonHost(t *testing.T) {
+	src := &Source{
+		lookupIPAddrs: func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("10.20.0.10")}}, nil
+		},
+		client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Hostname() != "panopticon.internal.example" {
+				t.Fatalf("host = %q, want panopticon.internal.example", req.URL.Hostname())
+			}
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody, Request: req}, nil
+		})},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://panopticon.internal.example/api/v2/alerts", nil)
+	resp, err := sourceHTTPClient(src, []string{"panopticon.internal.example"}).Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v, want private endpoint allowed", err)
+	}
+	_ = resp.Body.Close()
+	req, _ = http.NewRequest(http.MethodGet, "https://panopticon.internal.example/api/v2/alerts", nil)
+	resp, err = sourceHTTPClient(src, nil).Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil || !errorContains(err, "must not resolve to loopback, private, or link-local") {
+		t.Fatalf("Do() error = %v, want private endpoint rejection without allowlist", err)
 	}
 }
 
@@ -314,4 +357,10 @@ func eventIDs(events []*cerebrov1.EventEnvelope) []string {
 		ids = append(ids, ev.GetId())
 	}
 	return ids
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }


### PR DESCRIPTION
## Summary
- add private_endpoint_allowlist support to the Panopticon source
- pass the allowlist into the hardened HTTP client for private DNS resolutions
- cover private endpoint allowlist parsing and resolved-private-IP behavior

## Validation
- go test ./sources/panopticon -count=1 -v
- go test ./sources/... -count=1
- go test ./... -count=1