### PR TITLE
feat: add operator investigation brief

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -561,6 +561,49 @@ paths:
                 properties:
                   finding:
                     $ref: '#/components/schemas/Finding'
+  /findings/{findingID}/investigation-brief:
+    get:
+      summary: Get an operator investigation brief for one finding
+      tags:
+        - Findings
+      parameters:
+        - $ref: '#/components/parameters/findingID'
+        - $ref: '#/components/parameters/limitQuery'
+        - name: skip_graph
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Deterministic finding brief with evidence, trust gaps, graph context, next pivots, and Markdown handoff.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  kind:
+                    type: string
+                  finding:
+                    type: object
+                  evidence:
+                    type: array
+                    items:
+                      type: object
+                  trust:
+                    type: object
+                  next_pivots:
+                    type: array
+                    items:
+                      type: object
+                  recommended_action:
+                    type: string
+                  markdown:
+                    type: string
+                  generated_at:
+                    type: string
+                    format: date-time
   /finding-candidates/{candidateID}:
     get:
       summary: Get candidate finding

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -351,6 +351,8 @@ func runGraph(args []string) error {
 		return runGraphInspect(args)
 	case "cve-impact", "package-exposure", "asset-vulns":
 		return runGraphImpact(args)
+	case "investigation-brief":
+		return runInvestigationBrief(args[1:])
 	case "inspect":
 		if len(args) < 2 {
 			return usageError(graphInspectUsage())
@@ -402,7 +404,7 @@ func runGraph(args []string) error {
 }
 
 func graphUsage() string {
-	return fmt.Sprintf("usage: %s graph [health|counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|cleanup-endpoint-owner-id-links|cleanup-projected-entities|repair-open-finding-primary-links|rebuild|inspect] ...", os.Args[0])
+	return fmt.Sprintf("usage: %s graph [health|counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|investigation-brief|ingest|ingest-runtime|ingest-run|ingest-runs|cleanup-endpoint-owner-id-links|cleanup-projected-entities|repair-open-finding-primary-links|rebuild|inspect] ...", os.Args[0])
 }
 
 func graphIngestUsage() string {

--- a/cmd/cerebro/investigation_brief.go
+++ b/cmd/cerebro/investigation_brief.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/writer/cerebro/internal/bootstrap"
+)
+
+const investigationBriefUsage = "usage: %s graph investigation-brief <finding-id> [base_url=<url>] [api_key=<key>] [limit=N] [skip_graph=true] [format=json|markdown]"
+
+type investigationBriefOptions struct {
+	FindingID string
+	BaseURL   string
+	APIKey    string
+	Limit     int
+	SkipGraph bool
+	Format    string
+}
+
+func runInvestigationBrief(args []string) error {
+	options, err := parseInvestigationBriefOptions(args)
+	if err != nil {
+		return err
+	}
+	body, err := bootstrap.FetchInvestigationBrief(context.Background(), bootstrap.InvestigationBriefClientRequest{
+		BaseURL:   options.BaseURL,
+		APIKey:    options.APIKey,
+		FindingID: options.FindingID,
+		Limit:     options.Limit,
+		SkipGraph: options.SkipGraph,
+	})
+	if err != nil {
+		return err
+	}
+	if options.Format == "markdown" {
+		var payload struct {
+			Markdown string `json:"markdown"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return fmt.Errorf("decode investigation brief markdown: %w", err)
+		}
+		fmt.Println(payload.Markdown)
+		return nil
+	}
+	var decoded any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return fmt.Errorf("decode investigation brief response: %w", err)
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(decoded); err != nil {
+		return fmt.Errorf("print investigation brief: %w", err)
+	}
+	return nil
+}
+
+func parseInvestigationBriefOptions(args []string) (investigationBriefOptions, error) {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return investigationBriefOptions{}, usageError(fmt.Sprintf(investigationBriefUsage, os.Args[0]))
+	}
+	options := investigationBriefOptions{
+		FindingID: strings.TrimSpace(args[0]),
+		BaseURL:   strings.TrimSpace(os.Getenv("CEREBRO_BASE_URL")),
+		APIKey:    strings.TrimSpace(os.Getenv("CEREBRO_API_KEY")),
+		Limit:     int(investigationBriefDefaultLimitForCLI()),
+		Format:    "json",
+	}
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return investigationBriefOptions{}, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		switch key {
+		case "base_url":
+			options.BaseURL = value
+		case "api_key":
+			options.APIKey = value
+		case "limit":
+			limit, err := strconv.Atoi(value)
+			if err != nil || limit <= 0 {
+				return investigationBriefOptions{}, usageError("limit must be a positive integer")
+			}
+			options.Limit = limit
+		case "skip_graph":
+			options.SkipGraph = strings.EqualFold(value, "true") || value == "1" || strings.EqualFold(value, "yes")
+		case "format":
+			if value != "json" && value != "markdown" {
+				return investigationBriefOptions{}, usageError("format must be json or markdown")
+			}
+			options.Format = value
+		default:
+			return investigationBriefOptions{}, usageError(fmt.Sprintf("unsupported investigation-brief argument %q", key))
+		}
+	}
+	if options.BaseURL == "" {
+		return investigationBriefOptions{}, usageError("base_url or CEREBRO_BASE_URL is required")
+	}
+	return options, nil
+}
+
+func investigationBriefDefaultLimitForCLI() uint32 {
+	return 25
+}

--- a/cmd/cerebro/investigation_brief_test.go
+++ b/cmd/cerebro/investigation_brief_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseInvestigationBriefOptions(t *testing.T) {
+	t.Setenv("CEREBRO_BASE_URL", "https://cerebro.example")
+	t.Setenv("CEREBRO_API_KEY", "test-key")
+
+	options, err := parseInvestigationBriefOptions([]string{"finding-1", "limit=10", "skip_graph=true", "format=markdown"})
+	if err != nil {
+		t.Fatalf("parseInvestigationBriefOptions error = %v", err)
+	}
+	if options.FindingID != "finding-1" || options.BaseURL != "https://cerebro.example" || options.APIKey != "test-key" {
+		t.Fatalf("options identity = %#v", options)
+	}
+	if options.Limit != 10 || !options.SkipGraph || options.Format != "markdown" {
+		t.Fatalf("options flags = %#v", options)
+	}
+}
+
+func TestParseInvestigationBriefOptionsRequiresBaseURL(t *testing.T) {
+	t.Setenv("CEREBRO_BASE_URL", "")
+	_, err := parseInvestigationBriefOptions([]string{"finding-1"})
+	var usage usageError
+	if !errors.As(err, &usage) {
+		t.Fatalf("parseInvestigationBriefOptions error = %v, want usageError", err)
+	}
+}

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -1563,7 +1563,7 @@ func fallbackFindingRoute(path string) string {
 	}
 	parts := strings.SplitN(suffix, "/", 2)
 	switch parts[1] {
-	case "resolve", "suppress", "assign", "due", "notes", "tickets":
+	case "resolve", "suppress", "assign", "due", "notes", "tickets", "investigation-brief":
 		return "/findings/{findingID}/" + parts[1]
 	default:
 		return "/findings/{findingID}/{subresource}"

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -142,6 +142,13 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleGRCAskInvestigationBrief(w http.ResponseWriter, r *http.Request, findingID string, started time.Time, evt *askWideEvent) {
+	brief, err := a.buildInvestigationBrief(r, findingID, investigationBriefDefaultLimit, false)
+	if err != nil {
+		evt.failureStage = "investigation_brief"
+		evt.finish(r, started, grcHTTPStatusCode(err), err)
+		writeGRCError(w, err)
+		return
+	}
 	clearStreamingWriteDeadline(w)
 	flusher, _ := w.(http.Flusher)
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -167,18 +174,6 @@ func (a *App) handleGRCAskInvestigationBrief(w http.ResponseWriter, r *http.Requ
 		ElapsedMS: time.Since(started).Milliseconds(),
 	}}); err != nil {
 		evt.failureStage = "brief_stream"
-		evt.sseEvents = eventCount
-		evt.finish(r, started, http.StatusOK, err)
-		return
-	}
-	brief, err := a.buildInvestigationBrief(r, findingID, investigationBriefDefaultLimit, false)
-	if err != nil {
-		errorEvent := graphagent.Event{Name: graphagent.EventError, Data: graphagent.ErrorEvent{
-			Code:    "investigation_brief_failed",
-			Message: err.Error(),
-		}}
-		_ = emit(errorEvent)
-		evt.failureStage = "investigation_brief"
 		evt.sseEvents = eventCount
 		evt.finish(r, started, http.StatusOK, err)
 		return

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -50,6 +50,10 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
+	if findingID, ok := askInvestigationBriefFindingID(request); ok {
+		a.handleGRCAskInvestigationBrief(w, r, findingID, started, &evt)
+		return
+	}
 	graphStore := graphQueryStore(a.deps.GraphStore)
 	if graphStore == nil {
 		evt.failureStage = "graph_store_nil"
@@ -133,6 +137,72 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 		evt.finish(r, started, http.StatusOK, err)
 		return
 	}
+	evt.sseEvents = eventCount
+	evt.finish(r, started, http.StatusOK, nil)
+}
+
+func (a *App) handleGRCAskInvestigationBrief(w http.ResponseWriter, r *http.Request, findingID string, started time.Time, evt *askWideEvent) {
+	clearStreamingWriteDeadline(w)
+	flusher, _ := w.(http.Flusher)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	eventCount := 0
+	emit := func(event graphagent.Event) error {
+		eventCount++
+		if err := graphagent.WriteSSEEvent(w, event); err != nil {
+			return err
+		}
+		evt.observe(event)
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return nil
+	}
+	if err := emit(graphagent.Event{Name: graphagent.EventProgress, Data: graphagent.ProgressEvent{
+		Stage:     "assembling_investigation_brief",
+		Message:   "Assembling a deterministic Cerebro investigation brief.",
+		ElapsedMS: time.Since(started).Milliseconds(),
+	}}); err != nil {
+		evt.failureStage = "brief_stream"
+		evt.sseEvents = eventCount
+		evt.finish(r, started, http.StatusOK, err)
+		return
+	}
+	brief, err := a.buildInvestigationBrief(r, findingID, investigationBriefDefaultLimit, false)
+	if err != nil {
+		errorEvent := graphagent.Event{Name: graphagent.EventError, Data: graphagent.ErrorEvent{
+			Code:    "investigation_brief_failed",
+			Message: err.Error(),
+		}}
+		_ = emit(errorEvent)
+		evt.failureStage = "investigation_brief"
+		evt.sseEvents = eventCount
+		evt.finish(r, started, http.StatusOK, err)
+		return
+	}
+	if err := emit(graphagent.Event{Name: graphagent.EventSummary, Data: graphagent.SummaryEvent{
+		Markdown: brief.Markdown,
+	}}); err != nil {
+		evt.failureStage = "brief_stream"
+		evt.sseEvents = eventCount
+		evt.finish(r, started, http.StatusOK, err)
+		return
+	}
+	if err := emit(graphagent.Event{Name: graphagent.EventDone, Data: graphagent.DoneEvent{
+		TraceID: "investigation-brief:" + brief.ID,
+		TotalMS: time.Since(started).Milliseconds(),
+	}}); err != nil {
+		evt.failureStage = "brief_stream"
+		evt.sseEvents = eventCount
+		evt.finish(r, started, http.StatusOK, err)
+		return
+	}
+	evt.queryPlan.intent = "investigation_brief"
+	evt.queryPlan.source = "deterministic"
+	evt.queryPlan.deterministic = true
 	evt.sseEvents = eventCount
 	evt.finish(r, started, http.StatusOK, nil)
 }

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -192,6 +192,24 @@ func TestGRCAskInvestigationBriefFastPath(t *testing.T) {
 	}
 }
 
+func TestGRCAskInvestigationBriefFastPathReturnsLookupStatusBeforeStreaming(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: &stubRuntimeStore{}}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Post(server.URL+"/grc/ask", "application/json", strings.NewReader(`{"tenant_id":"writer","question":"Brief investigation finding-missing"}`))
+	if err != nil {
+		t.Fatalf("POST /grc/ask error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("POST /grc/ask missing finding status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+	if got := resp.Header.Get("Content-Type"); strings.Contains(got, "text/event-stream") {
+		t.Fatalf("content-type = %q, want non-SSE error response", got)
+	}
+}
+
 func TestGRCAskMissingStartupLLMReturnsUnavailable(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: &stubGraphStore{}}, nil)
 	server := httptest.NewServer(app.Handler())

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -11,9 +11,11 @@ import (
 	"testing"
 	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestGRCAskStreamsSSE(t *testing.T) {
@@ -145,6 +147,48 @@ func TestGRCAskMissingTenantReturnsBadRequest(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestGRCAskInvestigationBriefFastPath(t *testing.T) {
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"runtime-1": {Id: "runtime-1", SourceId: "okta", TenantId: "writer"},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				TenantID:       "writer",
+				RuntimeID:      "runtime-1",
+				Title:          "Privileged identity drift",
+				Severity:       "HIGH",
+				Status:         "open",
+				Summary:        "A privileged identity needs review.",
+				FindingRisk:    ports.FindingRisk{RiskReasons: []string{"privileged access"}},
+				LastObservedAt: now,
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-1": {Id: "evidence-1", RuntimeId: "runtime-1", FindingId: "finding-1", CreatedAt: timestamppb.New(now)},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Post(server.URL+"/grc/ask", "application/json", strings.NewReader(`{"tenant_id":"writer","question":"Brief this investigation","scope_urn":"finding-1"}`))
+	if err != nil {
+		t.Fatalf("POST /grc/ask error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /grc/ask status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	events := readSSEEvents(t, resp)
+	assertSSEEventNames(t, events, []string{"progress", "summary", "done"})
+	if !strings.Contains(string(events[1].Data), "Investigation Brief") {
+		t.Fatalf("summary event = %s, want investigation brief markdown", events[1].Data)
 	}
 }
 

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -863,6 +863,31 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 	if packet.RecommendedAction == "" {
 		t.Fatalf("packet recommended action is empty")
 	}
+
+	briefResp, err := server.Client().Get(server.URL + "/findings/finding-high/investigation-brief?limit=10")
+	if err != nil {
+		t.Fatalf("GET /findings investigation-brief error = %v", err)
+	}
+	defer func() { _ = briefResp.Body.Close() }()
+	if briefResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /findings investigation-brief status = %d, want %d", briefResp.StatusCode, http.StatusOK)
+	}
+	var brief investigationBriefResponse
+	if err := json.NewDecoder(briefResp.Body).Decode(&brief); err != nil {
+		t.Fatalf("decode investigation brief: %v", err)
+	}
+	if brief.ID != "finding-high" || brief.Kind != "finding" {
+		t.Fatalf("brief identity = %#v, want finding-high finding", brief)
+	}
+	if brief.Trust.GraphStatus != "available" || brief.Trust.EvidenceCount != 1 {
+		t.Fatalf("brief trust = %#v", brief.Trust)
+	}
+	if !strings.Contains(brief.Markdown, "Investigation Brief") {
+		t.Fatalf("brief markdown = %q", brief.Markdown)
+	}
+	if len(brief.NextPivots) < 3 {
+		t.Fatalf("brief pivots = %#v, want operator pivots", brief.NextPivots)
+	}
 }
 
 type stubGRCAggregateStore struct {

--- a/internal/bootstrap/investigation_brief.go
+++ b/internal/bootstrap/investigation_brief.go
@@ -1,0 +1,332 @@
+package bootstrap
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphagent"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const investigationBriefDefaultLimit = uint32(25)
+
+var askFindingIDPattern = regexp.MustCompile(`(?i)\bfinding[-_][a-z0-9_.:-]+\b`)
+
+type investigationBriefResponse struct {
+	ID                string                    `json:"id"`
+	Kind              string                    `json:"kind"`
+	Finding           grcFindingItem            `json:"finding"`
+	Evidence          []grcEvidenceItem         `json:"evidence"`
+	Graph             *ports.EntityNeighborhood `json:"graph,omitempty"`
+	Controls          []grcControlRef           `json:"controls,omitempty"`
+	Trust             investigationBriefTrust   `json:"trust"`
+	NextPivots        []investigationBriefPivot `json:"next_pivots"`
+	RecommendedAction string                    `json:"recommended_action"`
+	Markdown          string                    `json:"markdown"`
+	GeneratedAt       time.Time                 `json:"generated_at"`
+}
+
+type investigationBriefTrust struct {
+	RuntimeID        string     `json:"runtime_id,omitempty"`
+	SourceID         string     `json:"source_id,omitempty"`
+	RuntimeStatus    string     `json:"runtime_status,omitempty"`
+	RuntimeFreshness string     `json:"runtime_freshness,omitempty"`
+	LastSyncedAt     *time.Time `json:"last_synced_at,omitempty"`
+	SyncLagSeconds   *int64     `json:"sync_lag_seconds,omitempty"`
+	GraphStatus      string     `json:"graph_status"`
+	GraphRootURN     string     `json:"graph_root_urn,omitempty"`
+	EvidenceCount    int        `json:"evidence_count"`
+	LimitApplied     uint32     `json:"limit_applied"`
+	DataGaps         []string   `json:"data_gaps,omitempty"`
+}
+
+type investigationBriefPivot struct {
+	Label string `json:"label"`
+	Kind  string `json:"kind"`
+	ID    string `json:"id,omitempty"`
+	URN   string `json:"urn,omitempty"`
+	Route string `json:"route,omitempty"`
+}
+
+func (a *App) handleGetInvestigationBrief(w http.ResponseWriter, r *http.Request) {
+	limit, err := investigationBriefLimitFromRequest(r)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	brief, err := a.buildInvestigationBrief(r, strings.TrimSpace(r.PathValue("findingID")), limit, boolQueryParamDefault(r, "skip_graph", false))
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, brief)
+}
+
+func (a *App) buildInvestigationBrief(r *http.Request, findingID string, limit uint32, skipGraph bool) (investigationBriefResponse, error) {
+	if findingID == "" {
+		return investigationBriefResponse{}, fmt.Errorf("%w: finding id is required", errInvalidHTTPRequest)
+	}
+	if limit == 0 {
+		limit = investigationBriefDefaultLimit
+	}
+	store := findingStore(a.deps.StateStore)
+	if store == nil {
+		return investigationBriefResponse{}, findings.ErrRuntimeUnavailable
+	}
+	if err := authorizeFindingIDTenant(r.Context(), store, findingID); err != nil {
+		return investigationBriefResponse{}, err
+	}
+	finding, err := a.findingService().GetFinding(r.Context(), findingID)
+	if err != nil {
+		return investigationBriefResponse{}, err
+	}
+	runtimes, err := a.grcListRuntimes(r, grcScope{TenantID: finding.TenantID, RuntimeID: finding.RuntimeID, Limit: limit})
+	if err != nil {
+		return investigationBriefResponse{}, err
+	}
+	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingID: finding.ID, Limit: limit})
+	if err != nil {
+		return investigationBriefResponse{}, err
+	}
+	gaps := []string{}
+	var graph *ports.EntityNeighborhood
+	graphStatus := "unavailable"
+	graphRootURN := firstNonEmptyBriefString(finding.ResourceURNs...)
+	if skipGraph {
+		graphStatus = "skipped"
+	} else if graphRootURN == "" {
+		gaps = append(gaps, "finding has no resource URN for graph context")
+	} else if graphStore := graphQueryStore(a.deps.GraphStore); graphStore != nil {
+		graph, err = graphStore.GetEntityNeighborhood(r.Context(), graphRootURN, int(limit))
+		if err != nil {
+			gaps = append(gaps, "graph neighborhood unavailable")
+			graphStatus = "error"
+		} else {
+			graphStatus = "available"
+		}
+	} else {
+		gaps = append(gaps, "graph store is not configured")
+	}
+	items := grcFindingItems([]*ports.FindingRecord{finding}, grcRuntimeSourceIDs(runtimes), grcEvidenceCounts(evidence))
+	if len(items) == 0 {
+		return investigationBriefResponse{}, ports.ErrFindingNotFound
+	}
+	if len(evidence) == 0 {
+		gaps = append(gaps, "no finding evidence matched this brief scope")
+	}
+	runtime := firstRuntimeByID(runtimes, finding.RuntimeID)
+	if runtime == nil {
+		gaps = append(gaps, "source runtime metadata was not found")
+	}
+	trust := investigationBriefTrust{
+		RuntimeID:      finding.RuntimeID,
+		GraphStatus:    graphStatus,
+		GraphRootURN:   graphRootURN,
+		EvidenceCount:  len(evidence),
+		LimitApplied:   limit,
+		DataGaps:       gaps,
+		SyncLagSeconds: nil,
+	}
+	if runtime != nil {
+		lastSyncedAt := timestampPtr(runtime.GetLastSyncedAt())
+		trust.SourceID = runtime.GetSourceId()
+		trust.RuntimeStatus = connectorStatus(lastSyncedAt)
+		trust.RuntimeFreshness = connectorFreshness(lastSyncedAt)
+		trust.LastSyncedAt = lastSyncedAt
+		trust.SyncLagSeconds = timestampLagSeconds(lastSyncedAt)
+	}
+	brief := investigationBriefResponse{
+		ID:                finding.ID,
+		Kind:              "finding",
+		Finding:           items[0],
+		Evidence:          grcEvidenceItems(evidence, map[string]string{finding.ID: finding.Title}),
+		Graph:             graph,
+		Controls:          grcControlRefs(finding.ControlRefs),
+		Trust:             trust,
+		NextPivots:        investigationBriefPivots(finding, graphRootURN),
+		RecommendedAction: grcRecommendedAction(items[0]),
+		GeneratedAt:       time.Now().UTC(),
+	}
+	brief.Markdown = investigationBriefMarkdown(brief)
+	return brief, nil
+}
+
+func investigationBriefLimitFromRequest(r *http.Request) (uint32, error) {
+	limit, err := uint32QueryParam(r, "limit")
+	if err != nil {
+		return 0, err
+	}
+	if limit == 0 {
+		return investigationBriefDefaultLimit, nil
+	}
+	if limit > grcMaxLimit {
+		return 0, fmt.Errorf("%w: limit must be <= %d", errInvalidHTTPRequest, grcMaxLimit)
+	}
+	return limit, nil
+}
+
+func boolQueryParamDefault(r *http.Request, key string, fallback bool) bool {
+	raw := strings.TrimSpace(r.URL.Query().Get(key))
+	if raw == "" {
+		return fallback
+	}
+	return strings.EqualFold(raw, "true") || raw == "1" || strings.EqualFold(raw, "yes")
+}
+
+func firstRuntimeByID(runtimes []*cerebrov1.SourceRuntime, id string) *cerebrov1.SourceRuntime {
+	for _, runtime := range runtimes {
+		if runtime != nil && runtime.GetId() == id {
+			return runtime
+		}
+	}
+	return nil
+}
+
+func firstNonEmptyBriefString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func investigationBriefPivots(finding *ports.FindingRecord, graphRootURN string) []investigationBriefPivot {
+	if finding == nil {
+		return nil
+	}
+	pivots := []investigationBriefPivot{{
+		Label: "Open finding record",
+		Kind:  "finding",
+		ID:    finding.ID,
+		Route: "/findings/" + url.PathEscape(finding.ID),
+	}}
+	if finding.RuntimeID != "" {
+		pivots = append(pivots, investigationBriefPivot{
+			Label: "Review supporting evidence",
+			Kind:  "evidence",
+			ID:    finding.ID,
+			Route: "/source-runtimes/" + url.PathEscape(finding.RuntimeID) + "/finding-evidence?finding_id=" + url.QueryEscape(finding.ID),
+		}, investigationBriefPivot{
+			Label: "Check source runtime freshness",
+			Kind:  "runtime",
+			ID:    finding.RuntimeID,
+			Route: "/source-runtimes/" + url.PathEscape(finding.RuntimeID),
+		})
+	}
+	if graphRootURN != "" {
+		pivots = append(pivots, investigationBriefPivot{
+			Label: "Inspect graph neighborhood",
+			Kind:  "graph",
+			URN:   graphRootURN,
+			Route: "/platform/graph/neighborhood?root_urn=" + url.QueryEscape(graphRootURN),
+		})
+	}
+	if finding.RuleID != "" && finding.RuntimeID != "" {
+		pivots = append(pivots, investigationBriefPivot{
+			Label: "Compare candidate snapshots",
+			Kind:  "candidate",
+			ID:    finding.RuleID,
+			Route: "/source-runtimes/" + url.PathEscape(finding.RuntimeID) + "/finding-candidates?rule_id=" + url.QueryEscape(finding.RuleID),
+		})
+	}
+	return pivots
+}
+
+func investigationBriefMarkdown(brief investigationBriefResponse) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Investigation Brief: %s\n\n", brief.Finding.Title)
+	fmt.Fprintf(&b, "- Finding: `%s` (%s, %s)\n", brief.Finding.ID, brief.Finding.Severity, brief.Finding.Status)
+	if brief.Finding.RiskScore != 0 {
+		fmt.Fprintf(&b, "- Risk score: `%d`\n", brief.Finding.RiskScore)
+	}
+	if brief.Finding.Owner != "" {
+		fmt.Fprintf(&b, "- Owner: `%s`\n", brief.Finding.Owner)
+	}
+	if brief.Trust.RuntimeID != "" {
+		fmt.Fprintf(&b, "- Runtime: `%s` (%s, %s)\n", brief.Trust.RuntimeID, fallbackString(brief.Trust.RuntimeStatus, "unknown"), fallbackString(brief.Trust.RuntimeFreshness, "unknown"))
+	}
+	fmt.Fprintf(&b, "- Evidence records returned: `%d`\n", brief.Trust.EvidenceCount)
+	fmt.Fprintf(&b, "- Graph context: `%s`\n\n", brief.Trust.GraphStatus)
+	if brief.Finding.Summary != "" {
+		fmt.Fprintf(&b, "## What matters\n\n%s\n\n", brief.Finding.Summary)
+	}
+	if len(brief.Finding.RiskReasons) > 0 {
+		b.WriteString("## Risk reasons\n\n")
+		for _, reason := range brief.Finding.RiskReasons {
+			fmt.Fprintf(&b, "- %s\n", reason)
+		}
+		b.WriteString("\n")
+	}
+	if len(brief.Trust.DataGaps) > 0 {
+		b.WriteString("## Trust gaps\n\n")
+		for _, gap := range brief.Trust.DataGaps {
+			fmt.Fprintf(&b, "- %s\n", gap)
+		}
+		b.WriteString("\n")
+	}
+	if brief.RecommendedAction != "" {
+		fmt.Fprintf(&b, "## Recommended next action\n\n%s\n", brief.RecommendedAction)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func (a *App) mcpInvestigationBrief(r *http.Request, args map[string]any) (any, error) {
+	findingID := mcpStringArg(args, "finding_id")
+	if findingID == "" {
+		return nil, fmt.Errorf("%w: finding_id is required", findings.ErrInvalidRequest)
+	}
+	limit, err := mcpBoundedLimit(args, "limit", int(investigationBriefDefaultLimit), int(grcMaxLimit))
+	if err != nil {
+		return nil, err
+	}
+	brief, err := a.buildInvestigationBrief(r, findingID, boundedUint32(limit), mcpBoolArg(args, "skip_graph"))
+	if err != nil {
+		return nil, mcpNormalizeIDLookupError(err, ports.ErrFindingNotFound)
+	}
+	value, err := jsonValue(brief)
+	if err != nil {
+		return nil, err
+	}
+	return mcpAddResponseMetadata(value, mcpResponseMetadata(limit, len(brief.Evidence), brief.Trust.DataGaps)), nil
+}
+
+func askInvestigationBriefFindingID(request graphagent.AskRequest) (string, bool) {
+	question := strings.ToLower(strings.TrimSpace(request.Question))
+	if !strings.Contains(question, "brief") && !strings.Contains(question, "investigat") {
+		return "", false
+	}
+	if id := findingIDFromAskValue(request.ScopeURN); id != "" {
+		return id, true
+	}
+	if match := askFindingIDPattern.FindString(request.Question); match != "" {
+		return match, true
+	}
+	return "", false
+}
+
+func findingIDFromAskValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(value), "finding-") || strings.HasPrefix(strings.ToLower(value), "finding_") {
+		return value
+	}
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ':' || r == '/' || r == '#'
+	})
+	for i := len(parts) - 1; i >= 0; i-- {
+		part := strings.TrimSpace(parts[i])
+		if strings.HasPrefix(strings.ToLower(part), "finding-") || strings.HasPrefix(strings.ToLower(part), "finding_") {
+			return part
+		}
+	}
+	return ""
+}

--- a/internal/bootstrap/investigation_brief_client.go
+++ b/internal/bootstrap/investigation_brief_client.go
@@ -1,0 +1,56 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type InvestigationBriefClientRequest struct {
+	BaseURL   string
+	APIKey    string
+	FindingID string
+	Limit     int
+	SkipGraph bool
+}
+
+func FetchInvestigationBrief(ctx context.Context, request InvestigationBriefClientRequest) ([]byte, error) {
+	endpoint, err := url.Parse(strings.TrimRight(request.BaseURL, "/") + "/findings/" + url.PathEscape(request.FindingID) + "/investigation-brief")
+	if err != nil {
+		return nil, fmt.Errorf("build investigation brief URL: %w", err)
+	}
+	query := endpoint.Query()
+	if request.Limit > 0 {
+		query.Set("limit", strconv.Itoa(request.Limit))
+	}
+	if request.SkipGraph {
+		query.Set("skip_graph", "true")
+	}
+	endpoint.RawQuery = query.Encode()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create investigation brief request: %w", err)
+	}
+	if strings.TrimSpace(request.APIKey) != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+strings.TrimSpace(request.APIKey))
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("fetch investigation brief: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read investigation brief response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch investigation brief: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -452,6 +452,8 @@ func (app *App) mcpToolStructuredContent(r *http.Request, name string, args map[
 		return app.mcpGraphPaths(r, args)
 	case "cerebro.investigation.context":
 		return app.mcpInvestigationContext(r, args)
+	case "cerebro.investigation.brief":
+		return app.mcpInvestigationBrief(r, args)
 	case "cerebro.findings.action.propose":
 		return app.mcpProposeFindingAction(r, args)
 	case "cerebro.source_runtimes.refresh.propose":
@@ -1403,6 +1405,18 @@ func mcpTools() []mcpTool {
 			Annotations:  mcpReadOnlyAnnotations("Investigation Context"),
 		},
 		{
+			Name:        "cerebro.investigation.brief",
+			Title:       "Investigation Brief",
+			Description: "Return a deterministic operator brief for one finding with risk narrative, trust gaps, evidence, graph context, and next pivots.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"finding_id": map[string]any{"type": "string"},
+				"limit":      mcpLimitSchema(int(grcMaxLimit), "evidence and graph rows"),
+				"skip_graph": map[string]any{"type": "boolean"},
+			}, []string{"finding_id"}),
+			OutputSchema: mcpOutputSchema(nil),
+			Annotations:  mcpReadOnlyAnnotations("Investigation Brief"),
+		},
+		{
 			Name:        "cerebro.findings.action.propose",
 			Title:       "Propose Finding Action",
 			Description: "Validate and describe a finding workflow action without applying it. Requires dry_run=true and never mutates state.",
@@ -1827,6 +1841,7 @@ func mcpResourceTemplates() []mcpResourceTemplate {
 		{URITemplate: "cerebro://asset/{asset_urn}", Name: "asset", Title: "Asset", Description: "Read one graph asset by URL-encoded Cerebro URN.", MimeType: mcpResourceMIMEJSON, Annotations: annotations},
 		{URITemplate: "cerebro://runtime/{runtime_id}", Name: "runtime", Title: "Runtime", Description: "Read one source runtime status bundle.", MimeType: mcpResourceMIMEJSON, Annotations: annotations},
 		{URITemplate: "cerebro://investigation/finding/{finding_id}", Name: "finding_investigation", Title: "Finding Investigation", Description: "Read a bounded investigation context bundle for one finding.", MimeType: mcpResourceMIMEJSON, Annotations: annotations},
+		{URITemplate: "cerebro://investigation/brief/finding/{finding_id}", Name: "finding_investigation_brief", Title: "Finding Investigation Brief", Description: "Read a deterministic operator brief for one finding.", MimeType: mcpResourceMIMEJSON, Annotations: annotations},
 	}
 }
 
@@ -1918,12 +1933,22 @@ func (app *App) mcpReadResource(r *http.Request, rawParams json.RawMessage) (mcp
 		value, err = app.mcpRuntimeStatus(r, map[string]any{"runtime_id": pathValue})
 	case "investigation":
 		parts := strings.SplitN(pathValue, "/", 2)
-		if len(parts) != 2 || parts[0] != "finding" {
-			err = ports.ErrGraphEntityNotFound
+		if len(parts) == 2 && parts[0] == "finding" {
+			args["finding_id"] = parts[1]
+			value, err = app.mcpInvestigationContext(r, args)
 			break
 		}
-		args["finding_id"] = parts[1]
-		value, err = app.mcpInvestigationContext(r, args)
+		if len(parts) == 2 && parts[0] == "brief" {
+			briefParts := strings.SplitN(parts[1], "/", 2)
+			if len(briefParts) == 2 && briefParts[0] == "finding" {
+				args["finding_id"] = briefParts[1]
+				value, err = app.mcpInvestigationBrief(r, args)
+				break
+			}
+		}
+		if value == nil && err == nil {
+			err = ports.ErrGraphEntityNotFound
+		}
 	default:
 		err = ports.ErrGraphEntityNotFound
 	}
@@ -1960,7 +1985,7 @@ func (app *App) mcpGetPrompt(_ *http.Request, rawParams json.RawMessage) (map[st
 		if findingID == "" {
 			return nil, fmt.Errorf("%w: finding_id is required", errInvalidHTTPRequest)
 		}
-		text = "Investigate Cerebro finding " + findingID + ". First read cerebro://investigation/finding/" + url.PathEscape(findingID) + ", then use cerebro.evidence.list, cerebro.assets.get, cerebro.graph.neighborhood, cerebro.graph.impact, and cerebro.findings.action.propose with dry_run=true for recommended next steps. Never infer data from inaccessible IDs, never reveal redacted values, and treat tenant-forbidden or not-found tool results as a hard boundary."
+		text = "Investigate Cerebro finding " + findingID + ". First read cerebro://investigation/brief/finding/" + url.PathEscape(findingID) + " for the operator brief, then use cerebro://investigation/finding/" + url.PathEscape(findingID) + ", cerebro.evidence.list, cerebro.assets.get, cerebro.graph.neighborhood, cerebro.graph.impact, and cerebro.findings.action.propose with dry_run=true for deeper next steps. Never infer data from inaccessible IDs, never reveal redacted values, and treat tenant-forbidden or not-found tool results as a hard boundary."
 	case "investigate_asset":
 		assetURN := mcpStringArg(args, "asset_urn")
 		if assetURN == "" {

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -131,6 +131,7 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 		"cerebro.graph.impact",
 		"cerebro.graph.paths",
 		"cerebro.investigation.context",
+		"cerebro.investigation.brief",
 		"cerebro.findings.action.propose",
 		"cerebro.source_runtimes.refresh.propose",
 	} {
@@ -885,6 +886,29 @@ func TestMCPFindingSearchRuntimeStatusEvidenceAndInvestigation(t *testing.T) {
 	}
 	if context["metadata"].(map[string]any)["stateless"] != true {
 		t.Fatalf("investigation metadata = %#v", context["metadata"])
+	}
+
+	briefResp, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      8,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.investigation.brief",
+			"arguments": map[string]any{
+				"finding_id": "finding-1",
+				"skip_graph": true,
+			},
+		},
+	})
+	if briefResp["error"] != nil {
+		t.Fatalf("investigation.brief error = %#v", briefResp["error"])
+	}
+	brief := briefResp["result"].(map[string]any)["structuredContent"].(map[string]any)
+	if brief["id"] != "finding-1" || !strings.Contains(brief["markdown"].(string), "Investigation Brief") {
+		t.Fatalf("investigation brief = %#v", brief)
+	}
+	if brief["metadata"].(map[string]any)["stateless"] != true {
+		t.Fatalf("investigation brief metadata = %#v", brief["metadata"])
 	}
 
 	resourceResp, _ := postMCP(t, server, "", map[string]any{

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -79,6 +79,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 func (app *App) registerFindingRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /finding-rules", routeSurfacePlatformHTTP, app.handleListFindingRules)
 	registerHTTPRoute(mux, "GET /findings/{findingID}", routeSurfacePlatformHTTP, app.handleGetFinding)
+	registerHTTPRoute(mux, "GET /findings/{findingID}/investigation-brief", routeSurfacePlatformHTTP, app.handleGetInvestigationBrief)
 	registerHTTPRoute(mux, "POST /findings/{findingID}/resolve", routeSurfacePlatformHTTP, app.handleResolveFinding)
 	registerHTTPRoute(mux, "POST /findings/{findingID}/suppress", routeSurfacePlatformHTTP, app.handleSuppressFinding)
 	registerHTTPRoute(mux, "PUT /findings/{findingID}/assign", routeSurfacePlatformHTTP, app.handleAssignFinding)

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -241,6 +241,8 @@ func dynamicRouteLabel(parts []string) (string, bool) {
 		return "/grc/entities/{entityID}/impact", true
 	case match(parts, "grc", "audit-packets", "*"):
 		return "/grc/audit-packets/{packetID}", true
+	case match(parts, "findings", "*", "investigation-brief"):
+		return "/findings/{findingID}/investigation-brief", true
 	case match(parts, "findings", "*"):
 		return "/findings/{findingID}", true
 	case match(parts, "findings", "*", "resolve"):


### PR DESCRIPTION
## Summary

- Add a deterministic operator investigation brief for findings with risk narrative, evidence, trust gaps, graph context, next pivots, and Markdown handoff.
- Surface the brief through HTTP, MCP, Ask Cerebro, and the existing graph CLI namespace.
- Add route labeling, OpenAPI coverage, and focused tests for the new surfaces.

## Test Plan

- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on the new investigation brief assembly, route authorization, MCP tool/resource behavior, and Ask Cerebro deterministic fast path.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
