### PR TITLE
feat(auth): add resource-bound NHI token flow

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1584,8 +1584,8 @@ paths:
           description: Authenticated human is not authorized for MCP access.
   /oauth/token:
     post:
-      summary: Exchange MCP OAuth token grants
-      description: Issues a resource-bound bearer capability token for MCP after PKCE verification, refresh-token rotation, or confidential client_credentials authentication.
+      summary: Exchange OAuth token grants
+      description: Issues a resource-bound bearer capability token for MCP after PKCE verification, refresh-token rotation, confidential MCP client_credentials authentication, or hashed Cerebro API client_credentials authentication.
       tags:
         - OAuth
       security: []

--- a/internal/bootstrap/api_client_credentials_test.go
+++ b/internal/bootstrap/api_client_credentials_test.go
@@ -1,0 +1,201 @@
+package bootstrap
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/mcpoauth"
+)
+
+func TestAPIClientCredentialsIssuesAPIResourceBoundCapabilityToken(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	cfg := apiClientCredentialsTestConfig()
+	app, err := NewWithError(cfg, Dependencies{}, registry)
+	if err != nil {
+		t.Fatalf("NewWithError: %v", err)
+	}
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	tokenResp := exchangeAPIClientCredentialsToken(t, server, "ci-client", "client-secret", url.Values{
+		"grant_type": {"client_credentials"},
+		"resource":   {"https://cerebro.example"},
+		"scope":      {scopeCosmoSecurityRead},
+	})
+	if tokenResp.AccessToken == "" || tokenResp.RefreshToken != "" || tokenResp.TokenType != "Bearer" {
+		t.Fatalf("token response = %#v", tokenResp)
+	}
+
+	staticSecretReq, err := http.NewRequest(http.MethodGet, server.URL+"/sources?tenant_id=writer", nil)
+	if err != nil {
+		t.Fatalf("NewRequest static secret sources: %v", err)
+	}
+	staticSecretReq.Header.Set("Authorization", "Bearer client-secret")
+	staticSecretResp, err := server.Client().Do(staticSecretReq)
+	if err != nil {
+		t.Fatalf("GET /sources with static client secret: %v", err)
+	}
+	_ = staticSecretResp.Body.Close()
+	if staticSecretResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("GET /sources with static client secret status = %d, want 401", staticSecretResp.StatusCode)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/sources?tenant_id=writer", nil)
+	if err != nil {
+		t.Fatalf("NewRequest sources: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /sources with API capability token: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /sources status = %d, want 200", resp.StatusCode)
+	}
+
+	mcpReq, err := http.NewRequest(http.MethodPost, server.URL+mcpEndpointPath, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	if err != nil {
+		t.Fatalf("NewRequest MCP: %v", err)
+	}
+	mcpReq.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
+	mcpReq.Header.Set("Content-Type", "application/json")
+	mcpResp, err := server.Client().Do(mcpReq)
+	if err != nil {
+		t.Fatalf("POST MCP with API capability token: %v", err)
+	}
+	_ = mcpResp.Body.Close()
+	if mcpResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("MCP status with API capability token = %d, want 401", mcpResp.StatusCode)
+	}
+}
+
+func TestAPIClientCredentialsRejectsWrongSecret(t *testing.T) {
+	app, err := NewWithError(apiClientCredentialsTestConfig(), Dependencies{}, nil)
+	if err != nil {
+		t.Fatalf("NewWithError: %v", err)
+	}
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp := exchangeAPIClientCredentialsTokenRaw(t, server, "ci-client", "wrong-secret", url.Values{
+		"grant_type": {"client_credentials"},
+		"resource":   {"https://cerebro.example"},
+		"scope":      {scopeCosmoSecurityRead},
+	})
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("wrong-secret token status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestResourceBoundCapabilityTokenCannotCrossSurfaces(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	cfg := apiClientCredentialsTestConfig()
+	app, err := NewWithError(cfg, Dependencies{}, registry)
+	if err != nil {
+		t.Fatalf("NewWithError: %v", err)
+	}
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	token, err := issueCapabilityToken(cfg.Auth, capabilityClaims{
+		Audience:     cfg.Auth.CapabilityTokenAudience,
+		Subject:      "service:mcp-client",
+		Resource:     mcpCapabilityTokenResource,
+		TenantID:     "writer",
+		Scopes:       []string{scopeCosmoSecurityRead},
+		Groups:       []string{"security"},
+		CredentialID: "test-mcp-client",
+		ClientID:     "mcp-client",
+	}, time.Minute, time.Now())
+	if err != nil {
+		t.Fatalf("issueCapabilityToken: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/sources?tenant_id=writer", nil)
+	if err != nil {
+		t.Fatalf("NewRequest sources: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /sources with MCP-bound token: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("API status with MCP-bound token = %d, want 401", resp.StatusCode)
+	}
+}
+
+func apiClientCredentialsTestConfig() config.Config {
+	return config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled:                 true,
+			CapabilityTokenSecrets:  []string{"capability-secret"},
+			CapabilityTokenAudience: "cerebro-api",
+			APICredentials: []config.APICredential{{
+				ID:        "ci-credential",
+				ClientID:  "ci-client",
+				Kind:      "oauth_client",
+				KeySHA256: sha256Hex("client-secret"),
+				Principal: "ci",
+				TenantID:  "writer",
+				Scopes:    []string{scopeCosmoSecurityRead},
+			}},
+			RequestOrigin: config.RequestOriginConfig{PublicOrigin: "https://cerebro.example"},
+		},
+	}
+}
+
+func exchangeAPIClientCredentialsToken(t *testing.T, server *httptest.Server, clientID string, secret string, form url.Values) mcpoauth.TokenResponse {
+	t.Helper()
+	resp := exchangeAPIClientCredentialsTokenRaw(t, server, clientID, secret, form)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("token status = %d body=%s", resp.StatusCode, body)
+	}
+	var decoded mcpoauth.TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	return decoded
+}
+
+func exchangeAPIClientCredentialsTokenRaw(t *testing.T, server *httptest.Server, clientID string, secret string, form url.Values) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, server.URL+oauthTokenPath, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("NewRequest token: %v", err)
+	}
+	req.SetBasicAuth(clientID, secret)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST token: %v", err)
+	}
+	return resp
+}
+
+func sha256Hex(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -69,7 +69,7 @@ type App struct {
 	observationStore      risk.ObservationStore
 	mcpOAuthService       *mcpoauth.Service
 	mcpOAuthRegisterLimit *deviceauth.TokenBucket
-	mcpOAuthEndpointLimit *deviceauth.TokenBucket
+	oauthEndpointLimit    *deviceauth.TokenBucket
 }
 
 type bootstrapService struct {
@@ -156,9 +156,14 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 			app.deviceHandler = newDeviceAuthHTTPHandler(service, cfg.Auth.DeviceAuth, cfg.Auth.RequestOrigin)
 		}
 	}
+	if cfg.Auth.Enabled && len(cfg.Auth.APICredentials) > 0 && len(cfg.Auth.CapabilityTokenSecrets) > 0 {
+		app.oauthEndpointLimit = deviceauth.NewTokenBucket(oauthEndpointRatePerSecond, oauthEndpointBurst)
+	}
 	if cfg.Auth.MCPOAuth.Enabled {
 		app.mcpOAuthRegisterLimit = deviceauth.NewTokenBucket(oauthRegisterRatePerSecond, oauthRegisterBurst)
-		app.mcpOAuthEndpointLimit = deviceauth.NewTokenBucket(oauthEndpointRatePerSecond, oauthEndpointBurst)
+		if app.oauthEndpointLimit == nil {
+			app.oauthEndpointLimit = deviceauth.NewTokenBucket(oauthEndpointRatePerSecond, oauthEndpointBurst)
+		}
 		service, err := mcpoauth.NewService(cfg.Auth.MCPOAuth, oauthStore, func(ctx context.Context, grant mcpoauth.AccessGrant, ttl time.Duration, now time.Time) (string, error) {
 			return issueCapabilityToken(cfg.Auth, capabilityClaims{
 				Audience:       cfg.Auth.CapabilityTokenAudience,

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -146,7 +146,7 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 			principal.RiskScore = decision.Score
 			principal.RiskLevel = decision.Level
 		}
-		if err := authorizeMCPTokenResource(cfg, principal, r); err != nil {
+		if err := authorizeTokenResource(cfg, principal, r); err != nil {
 			denialReason = "resource_forbidden"
 			writeAuthErrorForRequest(recorder, r, cfg, http.StatusUnauthorized, "unauthorized")
 			return
@@ -255,6 +255,9 @@ func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVe
 		return authPrincipal{}, "", "", false
 	}
 	for _, credential := range cfg.APICredentials {
+		if !apiCredentialAcceptsBearer(credential) {
+			continue
+		}
 		if apiCredentialMatches(token, credential) {
 			return authPrincipal{
 				Name:           credential.Principal,
@@ -279,6 +282,15 @@ func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVe
 		return principal, jkt, token, true
 	}
 	return authPrincipal{}, "", "", false
+}
+
+func apiCredentialAcceptsBearer(credential config.APICredential) bool {
+	switch strings.TrimSpace(credential.Kind) {
+	case "oauth_client", "client_credentials":
+		return false
+	default:
+		return true
+	}
 }
 
 // authenticateDeviceToken verifies an EdDSA device JWT issued by the
@@ -580,29 +592,6 @@ const (
 	scopeRuntimeResponseWrite    = "cerebro.runtime_response.write"
 )
 
-func scopeForDeviceRoute(method string, path string) string {
-	switch {
-	case method == http.MethodPost && path == "/platform/devices/enroll":
-		return deviceauth.ScopeDevicesEnroll
-	case method == http.MethodPost && path == "/platform/devices/token":
-		return deviceauth.ScopeDevicesToken
-	case method == http.MethodPost && path == "/platform/devices/bootstrap-tokens":
-		return deviceauth.ScopeDevicesBootstrapWrite
-	case method == http.MethodPost && strings.HasPrefix(path, "/platform/devices/") && strings.HasSuffix(path, "/revoke"):
-		return deviceauth.ScopeDevicesRevoke
-	case method == http.MethodGet && path == "/platform/devices":
-		return deviceauth.ScopeDevicesRead
-	case method == http.MethodGet && strings.HasPrefix(path, "/platform/devices/") && !strings.HasSuffix(path, "/revoke"):
-		return deviceauth.ScopeDevicesRead
-	case method == http.MethodPost && path == "/platform/telemetry/ingest":
-		return deviceauth.ScopeTelemetryIngest
-	case method == http.MethodGet && path == "/.well-known/device-jwks.json":
-		return ""
-	default:
-		return ""
-	}
-}
-
 func authorizeHTTPRequestScope(auth authContext, r *http.Request) error {
 	if !principalScopeRestricted(auth.principal) || isConnectProcedurePath(r.URL.Path) {
 		return nil
@@ -611,17 +600,11 @@ func authorizeHTTPRequestScope(auth authContext, r *http.Request) error {
 	return authorizePrincipalScope(auth.principal, scope)
 }
 
-func authorizeMCPTokenResource(cfg config.AuthConfig, principal authPrincipal, r *http.Request) error {
-	if principal.CredentialID != "mcp-oauth" {
+func authorizeTokenResource(cfg config.AuthConfig, principal authPrincipal, r *http.Request) error {
+	if strings.TrimSpace(principal.TokenResource) == "" {
 		return nil
 	}
-	if !cfg.MCPOAuth.Enabled {
-		return errScopeForbidden
-	}
-	if strings.TrimSpace(principal.TokenResource) != strings.TrimSpace(cfg.MCPOAuth.Resource) {
-		return errScopeForbidden
-	}
-	if r == nil || r.URL == nil || r.URL.Path != mcpEndpointPath {
+	if !tokenResourceAllowedForRequest(cfg, r, principal.TokenResource) {
 		return errScopeForbidden
 	}
 	return nil
@@ -662,62 +645,7 @@ func isConnectProcedurePath(path string) bool {
 }
 
 func scopeForHTTPRequest(r *http.Request) string {
-	path := strings.TrimSpace(r.URL.Path)
-	if path == "/api/v1/mcp" {
-		return scopeCosmoSecurityRead
-	}
-	if r.Method == http.MethodPost && path == "/grc/ask" {
-		return scopeCosmoSecurityRead
-	}
-	if scope := scopeForDeviceRoute(r.Method, path); scope != "" {
-		return scope
-	}
-	if r.Method != http.MethodGet {
-		if r.Method == http.MethodPost && strings.HasPrefix(path, "/finding-candidates/") && (strings.HasSuffix(path, "/promote") || strings.HasSuffix(path, "/reject")) {
-			return scopeFindingCandidatePromote
-		}
-		if r.Method == http.MethodPost && (path == "/platform/runtime-response/actions" || (strings.HasPrefix(path, "/platform/runtime-response/blocklist/") && strings.HasSuffix(path, "/revoke"))) {
-			return scopeRuntimeResponseWrite
-		}
-		return ""
-	}
-	switch {
-	case path == "/sources", path == "/reports", path == "/finding-rules", path == "/endpoint-vulnerability-findings":
-		return scopeCosmoSecurityRead
-	case path == "/source-runtimes" || strings.HasPrefix(path, "/source-runtimes/"):
-		return scopeCosmoSecurityRead
-	case strings.HasPrefix(path, "/findings/"):
-		return scopeCosmoSecurityRead
-	case strings.HasPrefix(path, "/finding-candidates/"):
-		return scopeCosmoSecurityRead
-	case strings.HasPrefix(path, "/finding-evaluation-runs/"), strings.HasPrefix(path, "/finding-evidence/"):
-		return scopeCosmoSecurityRead
-	case strings.HasPrefix(path, "/grc/"):
-		return scopeCosmoSecurityRead
-	case path == "/platform/graph/neighborhood":
-		return scopeCosmoSecurityRead
-	case strings.HasPrefix(path, "/platform/graph/impact/"):
-		return scopeCosmoSecurityRead
-	case path == "/platform/graph/attack-paths",
-		path == "/platform/graph/person-access-paths",
-		path == "/platform/graph/aws-public-endpoint-insights",
-		path == "/platform/graph/crown-jewel-rankings":
-		return scopeCosmoSecurityRead
-	case strings.HasPrefix(path, "/platform/endpoints/") && strings.HasSuffix(path, "/vulnerability-findings"):
-		return scopeCosmoSecurityRead
-	case path == "/platform/graph/ingest-health":
-		return scopeCosmoSecurityRead
-	case path == "/platform/graph/ingest-runs", strings.HasPrefix(path, "/platform/graph/ingest-runs/"):
-		return scopeCosmoSecurityRead
-	case strings.HasPrefix(path, "/report-runs/"):
-		return scopeCosmoSecurityRead
-	case path == "/platform/jobs", strings.HasPrefix(path, "/platform/jobs/"):
-		return scopeCosmoSecurityRead
-	case path == "/platform/runtime-response/capabilities", path == "/platform/runtime-response/blocklist":
-		return scopeCosmoSecurityRead
-	default:
-		return ""
-	}
+	return httpRoutePolicyForRequest(r).Scope
 }
 
 func scopeForConnectProcedure(procedure string) string {
@@ -1585,31 +1513,7 @@ func fallbackFindingCandidateRoute(path string) string {
 }
 
 func isKnownStaticAccessPath(path string) bool {
-	switch path {
-	case "/platform/knowledge/decisions",
-		"/platform/knowledge/actions",
-		"/platform/knowledge/actions/recommendation",
-		"/platform/knowledge/outcomes",
-		"/platform/workflow/replay",
-		"/platform/graph/neighborhood",
-		"/platform/graph/impact/package",
-		"/platform/graph/impact/asset",
-		"/platform/graph/attack-paths",
-		"/platform/graph/person-access-paths",
-		"/platform/graph/aws-public-endpoint-insights",
-		"/platform/graph/crown-jewel-rankings",
-		"/platform/graph/ingest-health",
-		"/platform/graph/ingest-runs",
-		"/platform/devices",
-		"/platform/devices/enroll",
-		"/platform/devices/token",
-		"/platform/devices/bootstrap-tokens",
-		"/platform/telemetry/ingest",
-		"/.well-known/device-jwks.json":
-		return true
-	default:
-		return false
-	}
+	return httpRouteStaticAccessPathKnown(path)
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/bootstrap/auth_api_client_credentials.go
+++ b/internal/bootstrap/auth_api_client_credentials.go
@@ -1,0 +1,153 @@
+package bootstrap
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/mcpoauth"
+)
+
+const defaultAPICapabilityTokenTTL = 10 * time.Minute
+
+func (app *App) shouldHandleAPIClientCredentialsToken(r *http.Request) bool {
+	if r == nil || r.Form == nil || strings.TrimSpace(r.Form.Get("grant_type")) != "client_credentials" {
+		return false
+	}
+	resource := strings.TrimSpace(r.Form.Get("resource"))
+	if tokenResourceMatchesAny(resource, apiCapabilityTokenResources(app.cfg.Auth, r)) {
+		return true
+	}
+	return app.mcpOAuthService == nil
+}
+
+func (app *App) exchangeAPIClientCredentialsToken(_ context.Context, r *http.Request) (mcpoauth.TokenResponse, error) {
+	if !app.cfg.Auth.Enabled || len(app.cfg.Auth.APICredentials) == 0 || len(app.cfg.Auth.CapabilityTokenSecrets) == 0 {
+		return mcpoauth.TokenResponse{}, mcpoauthOAuthError("server_error", "Cerebro API client credentials are not configured", http.StatusServiceUnavailable)
+	}
+	resource := strings.TrimSpace(r.Form.Get("resource"))
+	if resource == "" {
+		return mcpoauth.TokenResponse{}, mcpoauthOAuthError("invalid_target", "resource is required", http.StatusBadRequest)
+	}
+	if !tokenResourceMatchesAny(resource, apiCapabilityTokenResources(app.cfg.Auth, r)) {
+		return mcpoauth.TokenResponse{}, mcpoauthOAuthError("invalid_target", "resource is not this Cerebro API", http.StatusBadRequest)
+	}
+	clientID, secret, ok := oauthClientSecret(r)
+	if !ok {
+		return mcpoauth.TokenResponse{}, mcpoauthOAuthError("invalid_client", "confidential client authentication is required", http.StatusUnauthorized)
+	}
+	credential, ok := app.apiClientCredential(clientID, secret)
+	if !ok {
+		return mcpoauth.TokenResponse{}, mcpoauthOAuthError("invalid_client", "client authentication failed", http.StatusUnauthorized)
+	}
+	scopes, err := requestedAPICredentialScopes(r.Form, credential)
+	if err != nil {
+		return mcpoauth.TokenResponse{}, err
+	}
+	if strings.TrimSpace(credential.TenantID) == "" && len(credential.AllowedTenants) == 0 {
+		return mcpoauth.TokenResponse{}, mcpoauthOAuthError("invalid_client", "client_credentials credential has no tenant grant", http.StatusUnauthorized)
+	}
+	now := time.Now().UTC()
+	ttl := defaultAPICapabilityTokenTTL
+	if app.cfg.Auth.MCPOAuth.AccessTTL > 0 {
+		ttl = app.cfg.Auth.MCPOAuth.AccessTTL
+	}
+	access, err := issueCapabilityToken(app.cfg.Auth, capabilityClaims{
+		Audience:       app.cfg.Auth.CapabilityTokenAudience,
+		Subject:        "service:" + clientID,
+		IssuedAt:       now.Unix(),
+		CredentialID:   apiCredentialIdentifier(credential),
+		ClientID:       clientID,
+		Resource:       resource,
+		TenantID:       credential.TenantID,
+		AllowedTenants: cloneAuthValues(credential.AllowedTenants),
+		Scopes:         scopes,
+		Groups:         []string{"security"},
+	}, ttl, now)
+	if err != nil {
+		return mcpoauth.TokenResponse{}, err
+	}
+	return mcpoauth.TokenResponse{
+		AccessToken: access,
+		TokenType:   "Bearer",
+		ExpiresIn:   int64(ttl.Seconds()),
+		Scope:       strings.Join(scopes, " "),
+	}, nil
+}
+
+func oauthClientSecret(r *http.Request) (string, string, bool) {
+	if r == nil {
+		return "", "", false
+	}
+	if clientID, secret, ok := r.BasicAuth(); ok {
+		return strings.TrimSpace(clientID), strings.TrimSpace(secret), strings.TrimSpace(clientID) != "" && strings.TrimSpace(secret) != ""
+	}
+	if r.Form == nil {
+		return "", "", false
+	}
+	clientID := strings.TrimSpace(r.Form.Get("client_id"))
+	secret := strings.TrimSpace(r.Form.Get("client_secret"))
+	return clientID, secret, clientID != "" && secret != ""
+}
+
+func (app *App) apiClientCredential(clientID string, secret string) (config.APICredential, bool) {
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" || strings.TrimSpace(secret) == "" {
+		return config.APICredential{}, false
+	}
+	for _, credential := range app.cfg.Auth.APICredentials {
+		if strings.TrimSpace(credential.ClientID) != clientID {
+			continue
+		}
+		if apiCredentialMatches(secret, credential) {
+			return credential, true
+		}
+	}
+	return config.APICredential{}, false
+}
+
+func requestedAPICredentialScopes(form url.Values, credential config.APICredential) ([]string, error) {
+	allowed := normalizeAuthList(credential.Scopes)
+	if len(allowed) == 0 {
+		return nil, mcpoauthOAuthError("invalid_client", "client_credentials credential has no scopes", http.StatusUnauthorized)
+	}
+	requested := normalizeAuthList(strings.Fields(form.Get("scope")))
+	if len(requested) == 0 {
+		return cloneAuthValues(allowed), nil
+	}
+	for _, scope := range requested {
+		if !containsAuthValue(allowed, scope) {
+			return nil, mcpoauthOAuthError("invalid_scope", "requested scope is not allowed for client", http.StatusBadRequest)
+		}
+	}
+	return requested, nil
+}
+
+func tokenResourceMatchesAny(resource string, allowed []string) bool {
+	resource = strings.TrimSpace(resource)
+	if resource == "" {
+		return false
+	}
+	for _, candidate := range allowed {
+		if resource == strings.TrimSpace(candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func apiCredentialIdentifier(credential config.APICredential) string {
+	return firstNonEmpty(credential.ID, credential.ClientID, credential.Name, credential.Principal)
+}
+
+func cloneAuthValues(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, len(values))
+	copy(out, values)
+	return out
+}

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -1,0 +1,157 @@
+package bootstrap
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/deviceauth"
+)
+
+const (
+	apiCapabilityTokenResource = "cerebro-api"
+	mcpCapabilityTokenResource = "cerebro-mcp"
+)
+
+type httpAuthRoutePolicy struct {
+	Method string
+	Exact  string
+	Prefix string
+	Suffix string
+	Scope  string
+	Static bool
+}
+
+var httpAuthRoutePolicies = []httpAuthRoutePolicy{
+	{Exact: "/api/v1/mcp", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Exact: "/platform/knowledge/decisions", Static: true},
+	{Method: http.MethodPost, Exact: "/platform/knowledge/actions", Static: true},
+	{Method: http.MethodPost, Exact: "/platform/knowledge/actions/recommendation", Static: true},
+	{Method: http.MethodPost, Exact: "/platform/knowledge/outcomes", Static: true},
+	{Method: http.MethodPost, Exact: "/platform/workflow/replay", Static: true},
+	{Method: http.MethodGet, Exact: "/sources", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Exact: "/reports", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Exact: "/finding-rules", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Exact: "/endpoint-vulnerability-findings", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Exact: "/source-runtimes", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Prefix: "/source-runtimes/", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Prefix: "/findings/", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Prefix: "/finding-candidates/", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodPost, Prefix: "/finding-candidates/", Suffix: "/promote", Scope: scopeFindingCandidatePromote},
+	{Method: http.MethodPost, Prefix: "/finding-candidates/", Suffix: "/reject", Scope: scopeFindingCandidatePromote},
+	{Method: http.MethodGet, Prefix: "/finding-evaluation-runs/", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Prefix: "/finding-evidence/", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Prefix: "/grc/", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodPost, Exact: "/grc/ask", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/platform/graph/neighborhood", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/platform/graph/impact/package", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/platform/graph/impact/asset", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Prefix: "/platform/graph/impact/", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Exact: "/platform/graph/attack-paths", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/platform/graph/person-access-paths", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/platform/graph/aws-public-endpoint-insights", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/platform/graph/crown-jewel-rankings", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/platform/graph/ingest-health", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/platform/graph/ingest-runs", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Prefix: "/platform/graph/ingest-runs/", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Prefix: "/platform/endpoints/", Suffix: "/vulnerability-findings", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Prefix: "/report-runs/", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Exact: "/platform/jobs", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Prefix: "/platform/jobs/", Scope: scopeCosmoSecurityRead},
+	{Method: http.MethodGet, Exact: "/platform/runtime-response/capabilities", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/platform/runtime-response/blocklist", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Exact: "/platform/runtime-response/actions", Scope: scopeRuntimeResponseWrite, Static: true},
+	{Method: http.MethodPost, Prefix: "/platform/runtime-response/blocklist/", Suffix: "/revoke", Scope: scopeRuntimeResponseWrite},
+	{Method: http.MethodPost, Exact: "/platform/devices/enroll", Scope: deviceauth.ScopeDevicesEnroll, Static: true},
+	{Method: http.MethodPost, Exact: "/platform/devices/token", Scope: deviceauth.ScopeDevicesToken, Static: true},
+	{Method: http.MethodPost, Exact: "/platform/devices/bootstrap-tokens", Scope: deviceauth.ScopeDevicesBootstrapWrite, Static: true},
+	{Method: http.MethodPost, Prefix: "/platform/devices/", Suffix: "/revoke", Scope: deviceauth.ScopeDevicesRevoke},
+	{Method: http.MethodGet, Exact: "/platform/devices", Scope: deviceauth.ScopeDevicesRead, Static: true},
+	{Method: http.MethodGet, Prefix: "/platform/devices/", Scope: deviceauth.ScopeDevicesRead},
+	{Method: http.MethodPost, Exact: "/platform/telemetry/ingest", Scope: deviceauth.ScopeTelemetryIngest, Static: true},
+	{Method: http.MethodGet, Exact: "/.well-known/device-jwks.json", Static: true},
+}
+
+func httpRoutePolicyForRequest(r *http.Request) httpAuthRoutePolicy {
+	if r == nil || r.URL == nil {
+		return httpAuthRoutePolicy{}
+	}
+	return httpRoutePolicyFor(r.Method, r.URL.Path)
+}
+
+func httpRoutePolicyFor(method string, path string) httpAuthRoutePolicy {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	path = strings.TrimSpace(path)
+	for _, policy := range httpAuthRoutePolicies {
+		if policy.Method != "" && policy.Method != method {
+			continue
+		}
+		if !routePolicyPathMatches(policy, path) {
+			continue
+		}
+		return policy
+	}
+	return httpAuthRoutePolicy{}
+}
+
+func routePolicyPathMatches(policy httpAuthRoutePolicy, path string) bool {
+	if policy.Exact != "" && path != policy.Exact {
+		return false
+	}
+	if policy.Prefix != "" && !strings.HasPrefix(path, policy.Prefix) {
+		return false
+	}
+	if policy.Suffix != "" && !strings.HasSuffix(path, policy.Suffix) {
+		return false
+	}
+	return policy.Exact != "" || policy.Prefix != "" || policy.Suffix != ""
+}
+
+func httpRouteStaticAccessPathKnown(path string) bool {
+	for _, policy := range httpAuthRoutePolicies {
+		if policy.Static && routePolicyPathMatches(policy, strings.TrimSpace(path)) {
+			return true
+		}
+	}
+	return false
+}
+
+func tokenResourceAllowedForRequest(cfg config.AuthConfig, r *http.Request, resource string) bool {
+	resource = strings.TrimSpace(resource)
+	if resource == "" {
+		return true
+	}
+	for _, allowed := range tokenResourcesForRequest(cfg, r) {
+		if resource == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func tokenResourcesForRequest(cfg config.AuthConfig, r *http.Request) []string {
+	if r != nil && r.URL != nil && r.URL.Path == mcpEndpointPath {
+		return mcpCapabilityTokenResources(cfg, r)
+	}
+	return apiCapabilityTokenResources(cfg, r)
+}
+
+func apiCapabilityTokenResources(cfg config.AuthConfig, r *http.Request) []string {
+	resources := []string{apiCapabilityTokenResource}
+	if origin := strings.TrimRight(strings.TrimSpace(cfg.RequestOrigin.PublicOrigin), "/"); origin != "" {
+		resources = append(resources, origin)
+	} else if r != nil {
+		resources = append(resources, strings.TrimRight(externalOrigin(r, cfg.RequestOrigin), "/"))
+	}
+	return normalizeAuthList(resources)
+}
+
+func mcpCapabilityTokenResources(cfg config.AuthConfig, r *http.Request) []string {
+	resources := []string{mcpCapabilityTokenResource}
+	if resource := strings.TrimSpace(cfg.MCPOAuth.Resource); resource != "" {
+		resources = append(resources, resource)
+	} else if r != nil {
+		resources = append(resources, strings.TrimRight(externalOrigin(r, cfg.RequestOrigin), "/")+mcpEndpointPath)
+	}
+	return normalizeAuthList(resources)
+}

--- a/internal/bootstrap/oauth_handlers.go
+++ b/internal/bootstrap/oauth_handlers.go
@@ -131,11 +131,6 @@ func (app *App) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 		app.emitOAuthAuditEvent(r, "token", http.StatusMethodNotAllowed, "rejected", "method_not_allowed", "", started)
 		return
 	}
-	if app.mcpOAuthService == nil {
-		writeOAuthError(w, mcpoauthOAuthError("server_error", "MCP OAuth is not configured", http.StatusServiceUnavailable))
-		app.emitOAuthAuditEvent(r, "token", http.StatusServiceUnavailable, "error", "not_configured", "", started)
-		return
-	}
 	if !app.allowOAuthEndpoint(w, r, "token", "", started) {
 		return
 	}
@@ -146,6 +141,22 @@ func (app *App) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	clientID := r.Form.Get("client_id")
+	if app.shouldHandleAPIClientCredentialsToken(r) {
+		response, err := app.exchangeAPIClientCredentialsToken(r.Context(), r)
+		if err != nil {
+			writeOAuthError(w, err)
+			app.emitOAuthAuditEvent(r, "token", oauthErrorStatus(err), oauthAuditOutcome(err), oauthErrorCode(err), clientID, started)
+			return
+		}
+		app.emitOAuthAuditEvent(r, "token", http.StatusOK, "success", "", clientID, started)
+		writeOAuthJSON(w, http.StatusOK, response)
+		return
+	}
+	if app.mcpOAuthService == nil {
+		writeOAuthError(w, mcpoauthOAuthError("server_error", "OAuth token service is not configured", http.StatusServiceUnavailable))
+		app.emitOAuthAuditEvent(r, "token", http.StatusServiceUnavailable, "error", "not_configured", clientID, started)
+		return
+	}
 	response, err := app.mcpOAuthService.Token(r.Context(), r.Header.Get("Authorization"), r.Form)
 	if err != nil {
 		writeOAuthError(w, err)
@@ -251,12 +262,12 @@ func writeOAuthError(w http.ResponseWriter, err error) {
 }
 
 func (app *App) allowOAuthEndpoint(w http.ResponseWriter, r *http.Request, operation string, clientID string, started time.Time) bool {
-	if app.mcpOAuthEndpointLimit == nil {
+	if app.oauthEndpointLimit == nil {
 		return true
 	}
 	origin := resolveRequestOrigin(r, app.cfg.Auth.RequestOrigin)
 	key := operation + ":" + firstNonEmpty(origin.ClientIP, "unknown")
-	if !app.mcpOAuthEndpointLimit.Allow(key) {
+	if !app.oauthEndpointLimit.Allow(key) {
 		writeOAuthError(w, mcpoauthOAuthError("rate_limited", "too many OAuth requests", http.StatusTooManyRequests))
 		app.emitOAuthAuditEvent(r, operation, http.StatusTooManyRequests, "rejected", "rate_limited", clientID, started)
 		return false


### PR DESCRIPTION
## Summary

- Add hashed API client-credentials exchange through the existing OAuth token endpoint, issuing short-lived resource-bound capability tokens for Cerebro API callers.
- Generalize capability-token resource enforcement so API-bound and MCP-bound tokens cannot cross surfaces.
- Move HTTP auth scope/resource matching into a table-driven policy and keep MCP OAuth client-credentials behavior intact.
- Add regression coverage for API client-credentials issuance, direct static-secret rejection for `oauth_client` credentials, and cross-surface resource denial.

## Test Plan

- `go test ./internal/bootstrap -run 'Test(APIClientCredentials|ResourceBoundCapability|AuthenticateRequestPrefers)' -count=1`
- `go test ./internal/bootstrap -count=1`
- `make lint-bootstrap`
- `make openapi-check openapi-lint`
- `make test`
- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed auth behavior, resource isolation, tenant scoping, and OAuth token exchange.
- Escalate to a deep manual Droid tag review for broad auth review.
