### PR TITLE
fix(source): set Panopticon API user agent

### DIFF
--- a/sources/panopticon/api.go
+++ b/sources/panopticon/api.go
@@ -19,6 +19,7 @@ import (
 )
 
 const maxAPIResponseBytes = 8 << 20
+const panopticonUserAgent = "cerebro-panopticon-source/1.0"
 
 type panopticonAPICursor struct {
 	Source              string `json:"source,omitempty"`
@@ -177,8 +178,7 @@ func (s *Source) readNativeAPIPage(ctx context.Context, st settings, path string
 	if err != nil {
 		return nativeAPIPage{}, fmt.Errorf("build panopticon api request: %w", err)
 	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "Bearer "+st.token)
+	req.Header = http.Header{"Accept": {"application/json"}, "User-Agent": {panopticonUserAgent}, "Authorization": {"Bearer " + st.token}}
 
 	resp, err := sourceHTTPClient(s, st.privateEndpointAllowlist).Do(req)
 	if err != nil {

--- a/sources/panopticon/source_test.go
+++ b/sources/panopticon/source_test.go
@@ -185,6 +185,9 @@ func TestReadExistingAlertsAPIPaginatesAndMapsNativeFields(t *testing.T) {
 		if got := r.Header.Get("Authorization"); got != "Bearer api-token" {
 			t.Fatalf("Authorization = %q, want bearer token", got)
 		}
+		if got := r.Header.Get("User-Agent"); got != panopticonUserAgent {
+			t.Fatalf("User-Agent = %q, want %q", got, panopticonUserAgent)
+		}
 		if got := r.URL.Query().Get("per_page"); got != "1" {
 			t.Fatalf("per_page = %q, want 1", got)
 		}


### PR DESCRIPTION
## Summary

- Sets an explicit Panopticon API source `User-Agent` so Cloudflare does not block requests using Go's default user agent.
- Keeps requests on the existing `sourcehttp` hardened client path, preserving SSRF and private endpoint checks.
- Adds a test assertion for the outbound `User-Agent` header.

## Test Plan

- `go test ./sources/panopticon -run 'Test(ReadExistingAlertsAPIPaginatesAndMapsNativeFields|CheckAndDiscoverUseExistingAlertsEndpoint|PrivateEndpointAllowlistPermitsResolvedPrivatePanopticonHost)' -count=1 -v`
- `go test ./internal/sourcehttp -run 'Test(NormalizeBaseURLAllowsExactPrivateEndpointHostsOnly|SafeResolvedHostAddrsAllowsPrivateOnlyForExactAllowlistedHost|SafeResolvedHostAddrsRejectsLoopbackAndLinkLocalEvenWhenAllowlisted)' -count=1 -v`
- `go test ./sources/panopticon ./internal/sourcehttp -count=1`
- `make test`
- `make lint`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
