### PR TITLE
fix(source): preserve Okta app assignment contracts

### DIFF
--- a/sources/internal/oktaevent/attributes.go
+++ b/sources/internal/oktaevent/attributes.go
@@ -24,6 +24,20 @@ type SystemLogContext struct {
 	Transaction           map[string]any
 }
 
+func AppAssignmentAttributes(domain string, family string, appID string, subjectID string, subjectType string, status string) map[string]string {
+	return map[string]string{
+		"domain":         domain,
+		"family":         family,
+		"app_id":         appID,
+		"subject_id":     subjectID,
+		"subject_type":   subjectType,
+		"assignee_id":    subjectID,
+		"assignee_type":  subjectType,
+		"principal_type": subjectType,
+		"status":         status,
+	}
+}
+
 func AddSystemLogAttributes(attributes map[string]string, ctx SystemLogContext) {
 	auth := ctx.AuthenticationContext
 	addAttribute(attributes, "authentication_provider", stringMap(auth, "authenticationProvider"))

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -1291,8 +1291,12 @@ func appAssignmentEvent(settings settings, record appAssignmentRecord) (*primiti
 	if err != nil {
 		return nil, fmt.Errorf("marshal okta app assignment payload: %w", err)
 	}
+	eventID := fmt.Sprintf("okta-app-assignment-%s-%s-%d", appID, record.ID, occurredAt.UnixMilli())
+	if subjectType != "user" {
+		eventID = fmt.Sprintf("okta-app-assignment-%s-%s-%s-%d", appID, subjectType, record.ID, occurredAt.UnixMilli())
+	}
 	return &primitives.Event{
-		Id:         fmt.Sprintf("okta-app-assignment-%s-%s-%s-%d", appID, subjectType, record.ID, occurredAt.UnixMilli()),
+		Id:         eventID,
 		TenantId:   settings.domain,
 		SourceId:   "okta",
 		Kind:       "okta.app_assignment",
@@ -1554,15 +1558,7 @@ func appAssignmentAttributes(settings settings, record appAssignmentRecord) map[
 	subjectEmail := assignmentEmail(record)
 	subjectType := firstNonEmpty(record.SubjectType, "user")
 	appID := firstNonEmpty(record.AppID, settings.appID)
-	attributes := map[string]string{
-		"domain":         settings.domain,
-		"family":         familyAppAssign,
-		"app_id":         appID,
-		"subject_id":     record.ID,
-		"subject_type":   subjectType,
-		"principal_type": subjectType,
-		"status":         record.Status,
-	}
+	attributes := oktaevent.AppAssignmentAttributes(settings.domain, familyAppAssign, appID, record.ID, subjectType, record.Status)
 	addAttribute(attributes, "subject_email", subjectEmail)
 	addAttribute(attributes, "email", subjectEmail)
 	addAttribute(attributes, "subject_name", firstNonEmpty(stringMap(record.Profile, "displayName"), stringMap(record.Profile, "name"), subjectEmail, record.ID))

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -474,14 +474,27 @@ func TestReadOktaAppAssignmentsIncludesGroupAssignments(t *testing.T) {
 			if got := event.Attributes["subject_email"]; got != "admin@writer.com" {
 				t.Fatalf("user assignment subject_email = %q, want admin@writer.com", got)
 			}
+			for key, want := range map[string]string{
+				"assignee_id":   "00u1",
+				"assignee_type": "user",
+				"subject_id":    "00u1",
+				"subject_type":  "user",
+			} {
+				if got := event.Attributes[key]; got != want {
+					t.Fatalf("user assignment attribute %s = %q, want %q", key, got, want)
+				}
+			}
 		case "group":
 			sawGroup = true
 			for key, want := range map[string]string{
-				"subject_id":   "grp-security",
-				"subject_name": "Security",
-				"group_id":     "grp-security",
-				"group_name":   "Security",
-				"app_id":       "app-prod",
+				"assignee_id":   "grp-security",
+				"assignee_type": "group",
+				"subject_id":    "grp-security",
+				"subject_type":  "group",
+				"subject_name":  "Security",
+				"group_id":      "grp-security",
+				"group_name":    "Security",
+				"app_id":        "app-prod",
 			} {
 				if got := event.Attributes[key]; got != want {
 					t.Fatalf("group assignment attribute %s = %q, want %q", key, got, want)
@@ -493,6 +506,48 @@ func TestReadOktaAppAssignmentsIncludesGroupAssignments(t *testing.T) {
 	}
 	if !sawUser || !sawGroup {
 		t.Fatalf("sawUser=%v sawGroup=%v, want both", sawUser, sawGroup)
+	}
+}
+
+func TestAppAssignmentEventPreservesUserEventIDFormat(t *testing.T) {
+	created := mustTestTime(t)
+	for _, tt := range []struct {
+		name   string
+		record appAssignmentRecord
+		wantID string
+	}{
+		{
+			name: "user",
+			record: appAssignmentRecord{
+				ID:          "00u1",
+				AppID:       "app-prod",
+				SubjectType: "user",
+				Created:     &created,
+				raw:         json.RawMessage(`{"id":"00u1"}`),
+			},
+			wantID: "okta-app-assignment-app-prod-00u1-1778183686000",
+		},
+		{
+			name: "group",
+			record: appAssignmentRecord{
+				ID:          "grp-security",
+				AppID:       "app-prod",
+				SubjectType: "group",
+				Created:     &created,
+				raw:         json.RawMessage(`{"id":"grp-security"}`),
+			},
+			wantID: "okta-app-assignment-app-prod-group-grp-security-1778183686000",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			event, err := appAssignmentEvent(settings{domain: "writer.okta.com", appID: "app-prod"}, tt.record)
+			if err != nil {
+				t.Fatalf("appAssignmentEvent() error = %v", err)
+			}
+			if event.Id != tt.wantID {
+				t.Fatalf("event.Id = %q, want %q", event.Id, tt.wantID)
+			}
+		})
 	}
 }
 

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -21,7 +21,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"github":          2194,
 	"googleworkspace": 827,
 	"grc":             1378,
-	"okta":            2441,
+	"okta":            2437,
 	"panopticon":      820,
 	"sentinelone":     2181,
 	"vulnview":        1064,


### PR DESCRIPTION
## Summary

- Preserve historical Okta user app-assignment event IDs to avoid duplicate user assignment events after #905.
- Add `assignee_id` / `assignee_type` compatibility aliases for Okta app-assignment attributes while keeping `subject_*` attributes.
- Move base app-assignment attribute construction into `sources/internal/oktaevent` and ratchet the Okta source LOC budget down.

## Test Plan

- `go test ./sources/okta ./sources/internal/oktaevent ./tools/archtests -count=1`
- `make build`
- `make lint`
- `make test`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed Okta app-assignment event identity and attribute compatibility.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
