### PR TITLE
feat: improve source runtime health telemetry

### DIFF
--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -18,8 +19,28 @@ import (
 )
 
 type sourceRuntimeHealthResponse struct {
-	GeneratedAt string                      `json:"generated_at"`
-	Runtimes    []sourceRuntimeHealthRecord `json:"runtimes"`
+	GeneratedAt     string                       `json:"generated_at"`
+	Runtimes        []sourceRuntimeHealthRecord  `json:"runtimes"`
+	SourceSummaries []sourceRuntimeHealthSummary `json:"source_summaries"`
+}
+
+type sourceRuntimeHealthSummary struct {
+	SourceID                   string `json:"source_id"`
+	Total                      int    `json:"total"`
+	Healthy                    int    `json:"healthy"`
+	Stale                      int    `json:"stale"`
+	Failing                    int    `json:"failing"`
+	Unknown                    int    `json:"unknown"`
+	CursorPending              int    `json:"cursor_pending"`
+	GraphCurrent               int    `json:"graph_current"`
+	GraphBehind                int    `json:"graph_behind"`
+	GraphRunning               int    `json:"graph_running"`
+	GraphFailed                int    `json:"graph_failed"`
+	GraphNotObserved           int    `json:"graph_not_observed"`
+	ContractProbePassing       int    `json:"contract_probe_passing"`
+	ContractProbeFailure       int    `json:"contract_probe_failure"`
+	ContractProbeUnknown       int    `json:"contract_probe_unknown"`
+	ContractProbeNotConfigured int    `json:"contract_probe_not_configured"`
 }
 
 type sourceRuntimeHealthRecord struct {
@@ -194,9 +215,89 @@ func (a *App) handleListSourceRuntimeHealth(w http.ResponseWriter, r *http.Reque
 		records = append(records, record)
 	}
 	writeJSON(w, http.StatusOK, sourceRuntimeHealthResponse{
-		GeneratedAt: generatedAt.Format(time.RFC3339Nano),
-		Runtimes:    records,
+		GeneratedAt:     generatedAt.Format(time.RFC3339Nano),
+		Runtimes:        records,
+		SourceSummaries: sourceRuntimeHealthSummaries(records),
 	})
+}
+
+func sourceRuntimeHealthSummaries(records []sourceRuntimeHealthRecord) []sourceRuntimeHealthSummary {
+	bySource := map[string]*sourceRuntimeHealthSummary{}
+	for _, record := range records {
+		sourceID := strings.TrimSpace(record.SourceID)
+		if sourceID == "" {
+			sourceID = "unknown"
+		}
+		summary := bySource[sourceID]
+		if summary == nil {
+			summary = &sourceRuntimeHealthSummary{SourceID: sourceID}
+			bySource[sourceID] = summary
+		}
+		summary.Total++
+		switch strings.ToLower(strings.TrimSpace(record.Status)) {
+		case "healthy":
+			summary.Healthy++
+		case "stale":
+			summary.Stale++
+		case "failing":
+			summary.Failing++
+		default:
+			summary.Unknown++
+		}
+		if record.CursorPending {
+			summary.CursorPending++
+		}
+		switch sourceRuntimeGraphState(record) {
+		case "current":
+			summary.GraphCurrent++
+		case "behind":
+			summary.GraphBehind++
+		case "running":
+			summary.GraphRunning++
+		case "failed":
+			summary.GraphFailed++
+		default:
+			summary.GraphNotObserved++
+		}
+		switch strings.ToLower(strings.TrimSpace(record.ContractProbeState)) {
+		case "passing":
+			summary.ContractProbePassing++
+		case "failure":
+			summary.ContractProbeFailure++
+		case "unknown":
+			summary.ContractProbeUnknown++
+		default:
+			summary.ContractProbeNotConfigured++
+		}
+	}
+	summaries := make([]sourceRuntimeHealthSummary, 0, len(bySource))
+	for _, summary := range bySource {
+		summaries = append(summaries, *summary)
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].Total != summaries[j].Total {
+			return summaries[i].Total > summaries[j].Total
+		}
+		return summaries[i].SourceID < summaries[j].SourceID
+	})
+	return summaries
+}
+
+func sourceRuntimeGraphState(record sourceRuntimeHealthRecord) string {
+	if record.LatestGraphRun == nil {
+		return "not_observed"
+	}
+	status := strings.ToLower(strings.TrimSpace(record.LatestGraphRun.Status))
+	if strings.Contains(status, "fail") || strings.Contains(status, "error") || strings.Contains(status, "cancel") {
+		return "failed"
+	}
+	if strings.Contains(status, "running") || strings.Contains(status, "pending") {
+		return "running"
+	}
+	if record.GraphLagSeconds != nil && record.StaleAfterSeconds != nil && *record.GraphLagSeconds > *record.StaleAfterSeconds {
+		return "behind"
+	}
+	return "current"
 }
 
 func (a *App) sourceRuntimeHealthRecord(ctx context.Context, runtime *cerebrov1.SourceRuntime, generatedAt time.Time) (sourceRuntimeHealthRecord, error) {

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/graphstore"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -161,6 +162,57 @@ func TestRuntimeHealthStatusStaleBoundaryAndFailurePrecedence(t *testing.T) {
 				t.Fatalf("runtimeHealthStatus() = %q, want %q", got, test.want)
 			}
 		})
+	}
+}
+
+func TestSourceRuntimeHealthSummariesAggregateBySource(t *testing.T) {
+	graphLag := int64(7200)
+	staleAfter := int64(3600)
+	records := []sourceRuntimeHealthRecord{
+		{
+			RuntimeID:          "runtime-a",
+			SourceID:           "okta",
+			Status:             "healthy",
+			ContractProbeState: "passing",
+			LatestGraphRun:     sourceRuntimeGraphRunHealth(graphstore.IngestRun{Status: "completed"}),
+			GraphLagSeconds:    &graphLag,
+			StaleAfterSeconds:  &staleAfter,
+		},
+		{
+			RuntimeID:          "runtime-b",
+			SourceID:           "okta",
+			Status:             "failing",
+			CursorPending:      true,
+			ContractProbeState: "failure",
+			LatestGraphRun:     sourceRuntimeGraphRunHealth(graphstore.IngestRun{Status: "failed"}),
+			StaleAfterSeconds:  &staleAfter,
+		},
+		{
+			RuntimeID:          "runtime-c",
+			SourceID:           "panopticon",
+			Status:             "unknown",
+			ContractProbeState: "not_configured",
+		},
+	}
+
+	summaries := sourceRuntimeHealthSummaries(records)
+
+	if len(summaries) != 2 {
+		t.Fatalf("len(sourceRuntimeHealthSummaries()) = %d, want 2", len(summaries))
+	}
+	okta := summaries[0]
+	if okta.SourceID != "okta" || okta.Total != 2 || okta.Healthy != 1 || okta.Failing != 1 {
+		t.Fatalf("okta summary = %+v", okta)
+	}
+	if okta.CursorPending != 1 || okta.GraphBehind != 1 || okta.GraphFailed != 1 {
+		t.Fatalf("okta graph/cursor summary = %+v", okta)
+	}
+	if okta.ContractProbePassing != 1 || okta.ContractProbeFailure != 1 {
+		t.Fatalf("okta contract summary = %+v", okta)
+	}
+	panopticon := summaries[1]
+	if panopticon.SourceID != "panopticon" || panopticon.Total != 1 || panopticon.Unknown != 1 || panopticon.GraphNotObserved != 1 || panopticon.ContractProbeNotConfigured != 1 {
+		t.Fatalf("panopticon summary = %+v", panopticon)
 	}
 }
 

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -271,6 +271,8 @@ func dynamicRouteLabel(parts []string) (string, bool) {
 		return "/sources/{sourceID}/discover", true
 	case match(parts, "sources", "*", "read"):
 		return "/sources/{sourceID}/read", true
+	case match(parts, "source-runtimes", "health"):
+		return "/source-runtimes/health", true
 	case match(parts, "platform", "graph", "impact", "vulnerability", "*"):
 		return "/platform/graph/impact/vulnerability/{id}", true
 	case match(parts, "platform", "graph", "ingest-runs", "*"):

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -19,6 +19,9 @@ func TestNormalizeRouteLabelBoundsUnknownPaths(t *testing.T) {
 	if got := normalizeRouteLabel("/source-runtimes/runtime-123/" + strings.Repeat("x", 128)); got != "/source-runtimes/{runtimeID}/{subresource}" {
 		t.Fatalf("unknown source-runtime subresource label = %q", got)
 	}
+	if got := normalizeRouteLabel("/source-runtimes/health"); got != "/source-runtimes/health" {
+		t.Fatalf("source-runtime health route label = %q", got)
+	}
 }
 
 func TestNormalizeMethodLabelBoundsUnknownMethods(t *testing.T) {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -315,7 +315,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 				if quarantinableContractError(err) {
 					recordsRejected++
 					category := invalidEventFailureCategory(err)
-					recordRuntimeInvalidEvent(runtime, syncedEvent, category, err, time.Now().UTC())
+					recordRuntimeInvalidEvent(runtime, syncedEvent, category, err, time.Now().UTC(), len(eventContracts) > 0)
 					telemetry.Event(ctx, "source_runtime.invalid_event", telemetry.Attrs(
 						telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
 						telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()},
@@ -342,13 +342,14 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		}
 		runtime.LastSyncedAt = timestamppb.Now()
 		updateRuntimeSyncStatus(runtime, runtimeSyncStatus{
-			Status:            "completed",
-			RecordsScanned:    recordsScanned,
-			RecordsAccepted:   eventsAppended,
-			RecordsRejected:   recordsRejected,
-			EntitiesProjected: entitiesProjected,
-			LinksProjected:    linksProjected,
-			CompletedAt:       runtime.GetLastSyncedAt().AsTime().UTC(),
+			Status:             "completed",
+			RecordsScanned:     recordsScanned,
+			RecordsAccepted:    eventsAppended,
+			RecordsRejected:    recordsRejected,
+			EntitiesProjected:  entitiesProjected,
+			LinksProjected:     linksProjected,
+			CompletedAt:        runtime.GetLastSyncedAt().AsTime().UTC(),
+			ContractConfigured: len(eventContracts) > 0,
 		})
 		if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
 			return nil, err
@@ -412,13 +413,14 @@ func sourceRuntimeTelemetryErrorKind(err error) string {
 }
 
 type runtimeSyncStatus struct {
-	Status            string
-	RecordsScanned    uint32
-	RecordsAccepted   uint32
-	RecordsRejected   uint32
-	EntitiesProjected uint32
-	LinksProjected    uint32
-	CompletedAt       time.Time
+	Status             string
+	RecordsScanned     uint32
+	RecordsAccepted    uint32
+	RecordsRejected    uint32
+	EntitiesProjected  uint32
+	LinksProjected     uint32
+	CompletedAt        time.Time
+	ContractConfigured bool
 }
 
 func updateRuntimeSyncStatus(runtime *cerebrov1.SourceRuntime, status runtimeSyncStatus) {
@@ -444,10 +446,10 @@ func updateRuntimeSyncStatus(runtime *cerebrov1.SourceRuntime, status runtimeSyn
 		clearRuntimeInvalidEvent(runtime.Config)
 	}
 	if strings.TrimSpace(runtime.Config[runtimeLastFailureCategoryConfigKey]) == "" {
-		setRuntimeConfig(runtime.Config, runtimeContractProbeStateConfigKey, contractProbeStateForRuntime(runtime, ""))
+		setRuntimeConfig(runtime.Config, runtimeContractProbeStateConfigKey, contractProbeStateForRuntime(runtime, "", status.ContractConfigured))
 		return
 	}
-	setRuntimeConfig(runtime.Config, runtimeContractProbeStateConfigKey, contractProbeStateForRuntime(runtime, runtime.Config[runtimeLastFailureCategoryConfigKey]))
+	setRuntimeConfig(runtime.Config, runtimeContractProbeStateConfigKey, contractProbeStateForRuntime(runtime, runtime.Config[runtimeLastFailureCategoryConfigKey], status.ContractConfigured))
 }
 
 func clearRuntimeInvalidEvent(config map[string]string) {
@@ -482,7 +484,7 @@ func invalidEventFailureCategory(err error) string {
 	}
 }
 
-func recordRuntimeInvalidEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope, category string, cause error, observedAt time.Time) {
+func recordRuntimeInvalidEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope, category string, cause error, observedAt time.Time, contractConfigured bool) {
 	if runtime == nil || event == nil {
 		return
 	}
@@ -504,7 +506,7 @@ func recordRuntimeInvalidEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov
 	} else {
 		setRuntimeConfig(runtime.Config, runtimeLastInvalidDiagnosticConfigKey, "invalid source event")
 	}
-	setRuntimeConfig(runtime.Config, runtimeContractProbeStateConfigKey, contractProbeStateForRuntime(runtime, category))
+	setRuntimeConfig(runtime.Config, runtimeContractProbeStateConfigKey, contractProbeStateForRuntime(runtime, category, contractConfigured))
 }
 
 func invalidEventFieldName(err error) string {
@@ -524,8 +526,8 @@ func invalidEventFieldName(err error) string {
 	return ""
 }
 
-func contractProbeStateForRuntime(runtime *cerebrov1.SourceRuntime, failureCategory string) string {
-	if runtime == nil || strings.TrimSpace(runtime.GetSourceId()) != "evidence_cas" {
+func contractProbeStateForRuntime(runtime *cerebrov1.SourceRuntime, failureCategory string, contractConfigured bool) string {
+	if runtime == nil || !contractConfigured {
 		return "not_configured"
 	}
 	if strings.TrimSpace(failureCategory) != "" {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1349,6 +1349,7 @@ func TestSyncRuntimeRejectsEventsMissingCatalogContractFields(t *testing.T) {
 		runtimeLastFailureCategoryConfigKey: "missing_required_attribute",
 		runtimeLastInvalidFieldConfigKey:    "required_attribute",
 		runtimeLastInvalidStatusConfigKey:   "terminal",
+		runtimeContractProbeStateConfigKey:  "failure",
 	} {
 		if got := stored.GetConfig()[key]; got != want {
 			t.Fatalf("stored config[%s] = %q, want %q", key, got, want)


### PR DESCRIPTION
## Summary

- Add source-level summaries to the source runtime health response.
- Track contract probe state for all contract-backed source runtimes.
- Keep the source runtime health route distinct in HTTP metrics labels.

## Test Plan

- go test ./internal/sourceruntime ./internal/observability ./internal/bootstrap -count=1
- make lint-bootstrap
- make verify

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed runtime-health telemetry behavior.
- No broad auth, source HTTP, graph query, or state-machine behavior is changed.