### PR TITLE
fix: tighten graph health runtime freshness

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -547,11 +547,37 @@ func runGraphHealth(args []string) error {
 		return err
 	}
 	defer logClose(closeDeps)
+	if len(options.DeclaredRuntimeIDs) == 0 {
+		declaredRuntimeIDs, err := graphHealthDeclaredRuntimeIDs(ctx, deps)
+		if err != nil {
+			return err
+		}
+		options.DeclaredRuntimeIDs = declaredRuntimeIDs
+	}
 	result, err := checkGraphHealth(ctx, deps.GraphStore, options, time.Now().UTC())
 	if printErr := printJSON(result); printErr != nil {
 		return printErr
 	}
 	return err
+}
+
+func graphHealthDeclaredRuntimeIDs(ctx context.Context, deps bootstrap.Dependencies) ([]string, error) {
+	lister, ok := deps.StateStore.(ports.SourceRuntimeListStore)
+	if !ok {
+		return nil, nil
+	}
+	runtimes, err := lister.ListSourceRuntimes(ctx, ports.SourceRuntimeFilter{Limit: graphingest.MaxStatusLimit})
+	if err != nil {
+		return nil, fmt.Errorf("list declared source runtimes: %w", err)
+	}
+	runtimeIDs := make([]string, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtimeID := strings.TrimSpace(runtime.GetId()); runtimeID != "" {
+			runtimeIDs = append(runtimeIDs, runtimeID)
+		}
+	}
+	sort.Strings(runtimeIDs)
+	return runtimeIDs, nil
 }
 
 func checkGraphHealth(ctx context.Context, store ports.GraphStore, options graphHealthOptions, now time.Time) (graphHealthResult, error) {
@@ -670,7 +696,14 @@ func checkGraphHealth(ctx context.Context, store ports.GraphStore, options graph
 	if !ok {
 		addFailure("graph store does not support ingest run history")
 	} else {
-		runs, err := runStore.ListIngestRuns(ctx, graphstore.IngestRunFilter{Limit: options.IngestLimit})
+		ingestRunFilter := graphstore.IngestRunFilter{Limit: options.IngestLimit, LatestByRuntime: true}
+		if len(options.DeclaredRuntimeIDs) != 0 {
+			ingestRunFilter.RuntimeIDs = options.DeclaredRuntimeIDs
+			if len(options.DeclaredRuntimeIDs) > ingestRunFilter.Limit {
+				ingestRunFilter.Limit = len(options.DeclaredRuntimeIDs)
+			}
+		}
+		runs, err := runStore.ListIngestRuns(ctx, ingestRunFilter)
 		if err != nil {
 			addFailure("list graph ingest runs: %v", err)
 		} else {
@@ -680,6 +713,18 @@ func checkGraphHealth(ctx context.Context, store ports.GraphStore, options graph
 				addFailure("graph ingest run history is empty")
 			}
 			successfulRuntimeIDs := successfulGraphHealthRuntimeIDs(runs)
+			if options.AllowTransientSourceFailures {
+				historyFilter := graphstore.IngestRunFilter{Limit: graphingest.MaxStatusLimit}
+				if len(options.DeclaredRuntimeIDs) != 0 {
+					historyFilter.RuntimeIDs = options.DeclaredRuntimeIDs
+				}
+				history, err := runStore.ListIngestRuns(ctx, historyFilter)
+				if err != nil {
+					addWarning("list graph ingest run history for transient failures: %v", err)
+				} else {
+					successfulRuntimeIDs = successfulGraphHealthRuntimeIDs(history)
+				}
+			}
 			currentRuntimeIDs := make(map[string]struct{}, len(current))
 			for runtimeID, run := range current {
 				currentRuntimeIDs[runtimeID] = struct{}{}

--- a/cmd/cerebro/graph_health_test.go
+++ b/cmd/cerebro/graph_health_test.go
@@ -158,6 +158,38 @@ func TestCheckGraphHealthFailsZeroProjectionRun(t *testing.T) {
 	}
 }
 
+func TestCheckGraphHealthExpandsLimitForDeclaredRuntimeIDs(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	store := graphHealthFixtureStore(t, now)
+	if err := store.PutIngestRun(ctx, graphstore.IngestRun{
+		ID:                "run-azure",
+		RuntimeID:         "azure-runtime",
+		SourceID:          "azure",
+		Status:            graphstore.IngestRunStatusCompleted,
+		StartedAt:         now.Add(-2 * time.Minute).Format(time.RFC3339Nano),
+		FinishedAt:        now.Add(-time.Minute).Format(time.RFC3339Nano),
+		EventsRead:        1,
+		EntitiesProjected: 1,
+		LinksProjected:    1,
+	}); err != nil {
+		t.Fatalf("PutIngestRun(azure) error = %v", err)
+	}
+
+	result, err := checkGraphHealth(ctx, store, graphHealthOptions{
+		IngestLimit:        1,
+		MaxRunningMinutes:  60,
+		RequiredRelations:  []string{"belongs_to"},
+		DeclaredRuntimeIDs: []string{"aws-runtime", "azure-runtime"},
+	}, now)
+	if err != nil {
+		t.Fatalf("checkGraphHealth() error = %v", err)
+	}
+	if result.Ingest.CurrentRuntimeCount != 2 || len(result.Ingest.MissingRuntimeIDs) != 0 {
+		t.Fatalf("ingest = %#v, want both declared runtimes current", result.Ingest)
+	}
+}
+
 func TestParseGraphHealthArgs(t *testing.T) {
 	options, err := parseGraphHealthArgs([]string{
 		"ingest_limit=100",

--- a/cmd/cerebro/graph_test_store_test.go
+++ b/cmd/cerebro/graph_test_store_test.go
@@ -316,10 +316,29 @@ func (s *graphTestStore) ListIngestRuns(_ context.Context, filter graphstore.Ing
 		if filter.RuntimeID != "" && run.RuntimeID != filter.RuntimeID {
 			continue
 		}
+		if len(filter.RuntimeIDs) != 0 && !testStringInSlice(filter.RuntimeIDs, run.RuntimeID) {
+			continue
+		}
 		if filter.Status != "" && run.Status != filter.Status {
 			continue
 		}
 		runs = append(runs, run)
+	}
+	if filter.LatestByRuntime {
+		latestByRuntime := map[string]graphstore.IngestRun{}
+		for _, run := range runs {
+			key := strings.TrimSpace(run.RuntimeID)
+			if key == "" {
+				key = strings.TrimSpace(run.ID)
+			}
+			if current, ok := latestByRuntime[key]; !ok || run.StartedAt > current.StartedAt || (run.StartedAt == current.StartedAt && run.ID > current.ID) {
+				latestByRuntime[key] = run
+			}
+		}
+		runs = runs[:0]
+		for _, run := range latestByRuntime {
+			runs = append(runs, run)
+		}
 	}
 	sort.Slice(runs, func(i, j int) bool {
 		return runs[i].ID < runs[j].ID
@@ -328,6 +347,15 @@ func (s *graphTestStore) ListIngestRuns(_ context.Context, filter graphstore.Ing
 		runs = runs[:filter.Limit]
 	}
 	return runs, nil
+}
+
+func testStringInSlice(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func sortedTestLinks(links map[string]*ports.ProjectedLink) []*ports.ProjectedLink {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1228,10 +1228,11 @@ func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	filter := ports.SourceRuntimeFilter{
-		RuntimeID: strings.TrimSpace(r.URL.Query().Get("runtime_id")),
-		TenantID:  strings.TrimSpace(r.URL.Query().Get("tenant_id")),
-		SourceID:  strings.TrimSpace(r.URL.Query().Get("source_id")),
-		Limit:     limit,
+		RuntimeID:  strings.TrimSpace(r.URL.Query().Get("runtime_id")),
+		RuntimeIDs: csvQueryValues(r.URL.Query().Get("runtime_ids")),
+		TenantID:   strings.TrimSpace(r.URL.Query().Get("tenant_id")),
+		SourceID:   strings.TrimSpace(r.URL.Query().Get("source_id")),
+		Limit:      limit,
 	}
 	if filter.TenantID == "" {
 		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok && strings.TrimSpace(auth.principal.TenantID) != "" {
@@ -1241,28 +1242,45 @@ func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
 	if filter.TenantID == "" {
 		filter.TenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
 	}
-	if filter.TenantID == "" && filter.RuntimeID != "" && requiresTenantFilter(r.Context()) {
+	filterRuntimeIDs := append([]string{}, filter.RuntimeIDs...)
+	if strings.TrimSpace(filter.RuntimeID) != "" {
+		filterRuntimeIDs = append(filterRuntimeIDs, filter.RuntimeID)
+	}
+	filterRuntimeIDs = csvQueryValues(strings.Join(filterRuntimeIDs, ","))
+	if filter.TenantID == "" && len(filterRuntimeIDs) != 0 && requiresTenantFilter(r.Context()) {
 		store := sourceRuntimeStore(a.deps.StateStore)
 		if store == nil {
 			writeSourceRuntimeError(w, sourceruntime.ErrRuntimeUnavailable)
 			return
 		}
-		runtime, err := store.GetSourceRuntime(r.Context(), filter.RuntimeID)
-		if errors.Is(err, ports.ErrSourceRuntimeNotFound) {
-			writeSourceRuntimeListJSON(w, http.StatusOK, nil)
+		tenantIDs := map[string]struct{}{}
+		for _, runtimeID := range filterRuntimeIDs {
+			runtime, err := store.GetSourceRuntime(r.Context(), runtimeID)
+			if errors.Is(err, ports.ErrSourceRuntimeNotFound) {
+				writeSourceRuntimeListJSON(w, http.StatusOK, nil)
+				return
+			}
+			if err != nil {
+				writeSourceRuntimeError(w, err)
+				return
+			}
+			if !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
+				writeSourceRuntimeListJSON(w, http.StatusOK, nil)
+				return
+			}
+			if tenantID := strings.TrimSpace(runtime.GetTenantId()); tenantID != "" {
+				tenantIDs[tenantID] = struct{}{}
+			}
+		}
+		if len(tenantIDs) > 1 {
+			writeSourceRuntimeError(w, errTenantForbidden)
 			return
 		}
-		if err != nil {
-			writeSourceRuntimeError(w, err)
-			return
+		for tenantID := range tenantIDs {
+			filter.TenantID = tenantID
 		}
-		if !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
-			writeSourceRuntimeListJSON(w, http.StatusOK, nil)
-			return
-		}
-		filter.TenantID = strings.TrimSpace(runtime.GetTenantId())
 	}
-	if filter.TenantID == "" && filter.RuntimeID == "" && requiresTenantFilter(r.Context()) {
+	if filter.TenantID == "" && len(filterRuntimeIDs) == 0 && requiresTenantFilter(r.Context()) {
 		writeSourceRuntimeError(w, errTenantForbidden)
 		return
 	}

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -27,10 +27,11 @@ const (
 )
 
 type grcScope struct {
-	TenantID  string
-	RuntimeID string
-	SourceID  string
-	Limit     uint32
+	TenantID   string
+	RuntimeID  string
+	RuntimeIDs []string
+	SourceID   string
+	Limit      uint32
 }
 
 type grcDashboardResponse struct {
@@ -621,11 +622,29 @@ func grcScopeFromRequest(r *http.Request) (grcScope, error) {
 		return grcScope{}, err
 	}
 	return grcScope{
-		TenantID:  tenantID,
-		RuntimeID: strings.TrimSpace(r.URL.Query().Get("runtime_id")),
-		SourceID:  strings.TrimSpace(r.URL.Query().Get("source_id")),
-		Limit:     limit,
+		TenantID:   tenantID,
+		RuntimeID:  strings.TrimSpace(r.URL.Query().Get("runtime_id")),
+		RuntimeIDs: csvQueryValues(r.URL.Query().Get("runtime_ids")),
+		SourceID:   strings.TrimSpace(r.URL.Query().Get("source_id")),
+		Limit:      limit,
 	}, nil
+}
+
+func csvQueryValues(value string) []string {
+	seen := map[string]struct{}{}
+	values := []string{}
+	for _, part := range strings.Split(value, ",") {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		values = append(values, trimmed)
+	}
+	return values
 }
 
 func grcLimitFromRequest(r *http.Request) (uint32, error) {
@@ -644,10 +663,11 @@ func grcLimitFromRequest(r *http.Request) (uint32, error) {
 
 func (a *App) grcListRuntimes(r *http.Request, scope grcScope) ([]*cerebrov1.SourceRuntime, error) {
 	runtimes, err := a.runtimeService().List(r.Context(), ports.SourceRuntimeFilter{
-		RuntimeID: scope.RuntimeID,
-		TenantID:  scope.TenantID,
-		SourceID:  scope.SourceID,
-		Limit:     scope.Limit,
+		RuntimeID:  scope.RuntimeID,
+		RuntimeIDs: scope.RuntimeIDs,
+		TenantID:   scope.TenantID,
+		SourceID:   scope.SourceID,
+		Limit:      scope.Limit,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -391,7 +391,7 @@ func (s *Service) Health(ctx context.Context, limit uint32) (result *HealthResul
 	if err != nil {
 		return nil, err
 	}
-	recentRuns, err := runStore.ListIngestRuns(ctx, graphstore.IngestRunFilter{Limit: MaxStatusLimit})
+	recentRuns, err := runStore.ListIngestRuns(ctx, graphstore.IngestRunFilter{Limit: MaxStatusLimit, LatestByRuntime: true})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -44,15 +44,30 @@ func (s *stubRunStore) ListIngestRuns(_ context.Context, filter graphstore.Inges
 		if filter.RuntimeID != "" && run.RuntimeID != filter.RuntimeID {
 			continue
 		}
+		if len(filter.RuntimeIDs) != 0 && !graphIngestStringInSlice(filter.RuntimeIDs, run.RuntimeID) {
+			continue
+		}
 		if filter.Status != "" && run.Status != filter.Status {
 			continue
 		}
 		runs = append(runs, run)
 	}
+	if filter.LatestByRuntime {
+		runs = latestRunsByRuntime(runs)
+	}
 	if filter.Limit != 0 && len(runs) > filter.Limit {
 		runs = runs[:filter.Limit]
 	}
 	return runs, nil
+}
+
+func graphIngestStringInSlice(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }
 
 type recordProjectorFunc func(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error)

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1167,9 +1167,13 @@ func (s *Store) ListIngestRuns(ctx context.Context, filter IngestRunFilter) (_ [
 	}
 	where := make([]string, 0, 2)
 	params := map[string]any{}
-	if runtimeID := strings.TrimSpace(filter.RuntimeID); runtimeID != "" {
+	runtimeIDs := normalizedNonEmptyStrings(append(filter.RuntimeIDs, filter.RuntimeID))
+	if len(runtimeIDs) == 1 {
 		where = append(where, "r.runtime_id = $runtime_id")
-		params["runtime_id"] = runtimeID
+		params["runtime_id"] = runtimeIDs[0]
+	} else if len(runtimeIDs) > 1 {
+		where = append(where, "r.runtime_id IN $runtime_ids")
+		params["runtime_ids"] = runtimeIDs
 	}
 	if status := strings.TrimSpace(filter.Status); status != "" {
 		if !validIngestRunStatus(status) {
@@ -1183,6 +1187,13 @@ func (s *Store) ListIngestRuns(ctx context.Context, filter IngestRunFilter) (_ [
 		prefix += " WHERE " + strings.Join(where, " AND ")
 	}
 	query := ingestRunReturnQuery(prefix) + fmt.Sprintf(" ORDER BY coalesce(r.started_at, '') DESC, r.id DESC LIMIT %d", limit)
+	if filter.LatestByRuntime {
+		query = prefix + `
+WITH coalesce(r.runtime_id, r.id) AS runtime_key, r
+ORDER BY runtime_key ASC, coalesce(r.started_at, '') DESC, r.id DESC
+WITH runtime_key, collect(r)[0] AS r
+` + ingestRunReturnQuery("WITH r") + fmt.Sprintf(" ORDER BY coalesce(r.started_at, '') DESC, r.id DESC LIMIT %d", limit)
+	}
 	var runs []IngestRun
 	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		runs = runs[:0]
@@ -1202,6 +1213,23 @@ func (s *Store) ListIngestRuns(ctx context.Context, filter IngestRunFilter) (_ [
 		return nil, fmt.Errorf("list ingest runs: %w", err)
 	}
 	return runs, nil
+}
+
+func normalizedNonEmptyStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
 }
 
 func (s *Store) requireConfigured() error {

--- a/internal/graphstore/types.go
+++ b/internal/graphstore/types.go
@@ -104,7 +104,9 @@ type IngestRun struct {
 
 // IngestRunFilter scopes ingest run listing.
 type IngestRunFilter struct {
-	RuntimeID string
-	Status    string
-	Limit     int
+	RuntimeID       string
+	RuntimeIDs      []string
+	Status          string
+	Limit           int
+	LatestByRuntime bool
 }

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -26,10 +26,11 @@ type SourceRuntimeBatchStore interface {
 
 // SourceRuntimeFilter scopes persisted source runtime listing.
 type SourceRuntimeFilter struct {
-	RuntimeID string
-	TenantID  string
-	SourceID  string
-	Limit     uint32
+	RuntimeID  string
+	RuntimeIDs []string
+	TenantID   string
+	SourceID   string
+	Limit      uint32
 }
 
 // SourceRuntimeListStore lists persisted source runtime definitions.

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -639,10 +639,11 @@ func normalizePageLimit(pageLimit uint32) (uint32, error) {
 
 func normalizeListFilter(filter ports.SourceRuntimeFilter) (ports.SourceRuntimeFilter, error) {
 	normalized := ports.SourceRuntimeFilter{
-		RuntimeID: strings.TrimSpace(filter.RuntimeID),
-		TenantID:  strings.TrimSpace(filter.TenantID),
-		SourceID:  strings.TrimSpace(filter.SourceID),
-		Limit:     filter.Limit,
+		RuntimeID:  strings.TrimSpace(filter.RuntimeID),
+		RuntimeIDs: normalizedListFilterRuntimeIDs(filter),
+		TenantID:   strings.TrimSpace(filter.TenantID),
+		SourceID:   strings.TrimSpace(filter.SourceID),
+		Limit:      filter.Limit,
 	}
 	if normalized.Limit == 0 {
 		normalized.Limit = defaultListLimit
@@ -651,6 +652,27 @@ func normalizeListFilter(filter ports.SourceRuntimeFilter) (ports.SourceRuntimeF
 		return ports.SourceRuntimeFilter{}, fmt.Errorf("%w: limit must be between 1 and %d", ErrInvalidRequest, maxListLimit)
 	}
 	return normalized, nil
+}
+
+func normalizedListFilterRuntimeIDs(filter ports.SourceRuntimeFilter) []string {
+	values := append([]string{}, filter.RuntimeIDs...)
+	if strings.TrimSpace(filter.RuntimeID) != "" {
+		values = append(values, filter.RuntimeID)
+	}
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
 }
 
 func restoreRedactedConfig(existing *cerebrov1.SourceRuntime, incoming *cerebrov1.SourceRuntime) {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -84,6 +84,9 @@ func (s *runtimeStore) ListSourceRuntimes(_ context.Context, filter ports.Source
 		if filter.RuntimeID != "" && runtime.GetId() != filter.RuntimeID {
 			continue
 		}
+		if len(filter.RuntimeIDs) != 0 && !stringInSlice(filter.RuntimeIDs, runtime.GetId()) {
+			continue
+		}
 		if filter.TenantID != "" && runtime.GetTenantId() != filter.TenantID {
 			continue
 		}
@@ -96,6 +99,15 @@ func (s *runtimeStore) ListSourceRuntimes(_ context.Context, filter ports.Source
 		}
 	}
 	return runtimes, nil
+}
+
+func stringInSlice(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }
 
 type appendLog struct {
@@ -766,6 +778,27 @@ func TestListRedactsSensitiveConfigAndFilters(t *testing.T) {
 	}
 	if len(runtimes) != 1 || runtimes[0].GetId() != "other-token" {
 		t.Fatalf("List(runtime_id) returned %#v, want other-token", runtimes)
+	}
+}
+
+func TestListSupportsRuntimeIDsFilter(t *testing.T) {
+	service := New(nil, &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-a": {Id: "runtime-a", SourceId: "okta", TenantId: "writer"},
+		"runtime-b": {Id: "runtime-b", SourceId: "github", TenantId: "writer"},
+		"runtime-c": {Id: "runtime-c", SourceId: "aws", TenantId: "writer"},
+	}}, nil, nil)
+
+	runtimes, err := service.List(context.Background(), ports.SourceRuntimeFilter{RuntimeIDs: []string{"runtime-b", "runtime-a", "runtime-b"}})
+	if err != nil {
+		t.Fatalf("List(runtime_ids) error = %v", err)
+	}
+	got := []string{}
+	for _, runtime := range runtimes {
+		got = append(got, runtime.GetId())
+	}
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "runtime-a" || got[1] != "runtime-b" {
+		t.Fatalf("List(runtime_ids) ids = %#v, want runtime-a/runtime-b", got)
 	}
 }
 

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -131,9 +131,17 @@ func (s *Store) ListSourceRuntimes(ctx context.Context, filter ports.SourceRunti
 	}
 	clauses := []string{"1=1"}
 	args := []any{}
-	if runtimeID := strings.TrimSpace(filter.RuntimeID); runtimeID != "" {
-		args = append(args, runtimeID)
+	runtimeIDs := normalizedNonEmptyStrings(append(filter.RuntimeIDs, filter.RuntimeID))
+	if len(runtimeIDs) == 1 {
+		args = append(args, runtimeIDs[0])
 		clauses = append(clauses, fmt.Sprintf("id = $%d", len(args)))
+	} else if len(runtimeIDs) > 1 {
+		placeholders := make([]string, 0, len(runtimeIDs))
+		for _, runtimeID := range runtimeIDs {
+			args = append(args, runtimeID)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		clauses = append(clauses, fmt.Sprintf("id IN (%s)", strings.Join(placeholders, ", ")))
 	}
 	if tenantID := strings.TrimSpace(filter.TenantID); tenantID != "" {
 		args = append(args, tenantID)


### PR DESCRIPTION
## Summary

- Scope graph health ingest checks to the latest run for each declared runtime.
- Support comma-separated runtime ID filters across source runtime listing and graph health storage queries.
- Keep transient failure tolerance based on bounded run history while reporting current runtime freshness separately.

## Test Plan

- `go test ./cmd/cerebro ./internal/graphingest ./internal/sourceruntime ./internal/bootstrap ./internal/statestore/postgres ./internal/graphstore/neo4j`
- `make lint-bootstrap`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
