### PR TITLE
fix: replay canonical finding workflow events

### DIFF
--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -200,7 +200,7 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		return nil, errors.New("jetstream is not configured")
 	}
 	request := normalizeReplayRequest(req)
-	if request.RuntimeID == "" && request.KindPrefix == "" && request.TenantID == "" && len(request.AttributeEquals) == 0 {
+	if request.RuntimeID == "" && request.KindPrefix == "" && len(request.KindPrefixes) == 0 && request.TenantID == "" && len(request.AttributeEquals) == 0 {
 		return nil, errors.New("at least one replay filter is required")
 	}
 	stream, err := l.replayStream(ctx)
@@ -211,7 +211,7 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	if err != nil {
 		return nil, err
 	}
-	subjectPrefix := replaySubjectPrefix(prefix, request.KindPrefix)
+	subjectPrefixes := replaySubjectPrefixes(prefix, request)
 	limit := normalizeReplayLimit(request.Limit)
 	candidateLimit := normalizeReplayCandidateLimit(limit)
 	streamRef, err := l.replay.Stream(ctx, stream.Config.Name)
@@ -233,7 +233,7 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 			}
 			return nil, fmt.Errorf("get replay message %s:%d: %w", stream.Config.Name, seq, err)
 		}
-		if raw != nil && replaySubjectMatchesPrefix(raw.Subject, subjectPrefix) {
+		if raw != nil && replaySubjectMatchesAnyPrefix(raw.Subject, subjectPrefixes) {
 			event, err := decodeReplayEvent(raw)
 			if err != nil {
 				return nil, fmt.Errorf("decode replay message %s:%d: %w", stream.Config.Name, seq, err)
@@ -285,10 +285,31 @@ func replaySubjectPrefix(prefix string, kindPrefix string) string {
 	return normalized + "." + kindPrefix
 }
 
+func replaySubjectPrefixes(prefix string, request ports.ReplayRequest) []string {
+	kindPrefixes := replayKindPrefixes(request)
+	if len(kindPrefixes) == 0 {
+		return []string{replaySubjectPrefix(prefix, "")}
+	}
+	subjectPrefixes := make([]string, 0, len(kindPrefixes))
+	for _, kindPrefix := range kindPrefixes {
+		subjectPrefixes = append(subjectPrefixes, replaySubjectPrefix(prefix, kindPrefix))
+	}
+	return subjectPrefixes
+}
+
 func replaySubjectMatchesPrefix(subject string, prefix string) bool {
 	subject = strings.TrimSpace(subject)
 	prefix = strings.TrimSpace(prefix)
 	return subject == prefix || strings.HasPrefix(subject, prefix+".")
+}
+
+func replaySubjectMatchesAnyPrefix(subject string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if replaySubjectMatchesPrefix(subject, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func publishPayload(event *cerebrov1.EventEnvelope) ([]byte, error) {
@@ -447,6 +468,7 @@ func normalizeReplayRequest(req ports.ReplayRequest) ports.ReplayRequest {
 	normalized := ports.ReplayRequest{
 		RuntimeID:       strings.TrimSpace(req.RuntimeID),
 		KindPrefix:      strings.TrimSpace(req.KindPrefix),
+		KindPrefixes:    normalizeReplayKindPrefixes(req.KindPrefixes),
 		TenantID:        strings.TrimSpace(req.TenantID),
 		AttributeEquals: make(map[string]string, len(req.AttributeEquals)),
 		Limit:           req.Limit,
@@ -462,6 +484,44 @@ func normalizeReplayRequest(req ports.ReplayRequest) ports.ReplayRequest {
 	return normalized
 }
 
+func normalizeReplayKindPrefixes(kindPrefixes []string) []string {
+	normalized := make([]string, 0, len(kindPrefixes))
+	seen := map[string]struct{}{}
+	for _, kindPrefix := range kindPrefixes {
+		kindPrefix = strings.TrimSpace(kindPrefix)
+		if kindPrefix == "" {
+			continue
+		}
+		if _, ok := seen[kindPrefix]; ok {
+			continue
+		}
+		seen[kindPrefix] = struct{}{}
+		normalized = append(normalized, kindPrefix)
+	}
+	return normalized
+}
+
+func replayKindPrefixes(req ports.ReplayRequest) []string {
+	prefixes := make([]string, 0, 1+len(req.KindPrefixes))
+	seen := map[string]struct{}{}
+	add := func(kindPrefix string) {
+		kindPrefix = strings.TrimSpace(kindPrefix)
+		if kindPrefix == "" {
+			return
+		}
+		if _, ok := seen[kindPrefix]; ok {
+			return
+		}
+		seen[kindPrefix] = struct{}{}
+		prefixes = append(prefixes, kindPrefix)
+	}
+	add(req.KindPrefix)
+	for _, kindPrefix := range req.KindPrefixes {
+		add(kindPrefix)
+	}
+	return prefixes
+}
+
 func matchesReplayRequest(event *cerebrov1.EventEnvelope, req ports.ReplayRequest) bool {
 	if event == nil {
 		return false
@@ -469,8 +529,18 @@ func matchesReplayRequest(event *cerebrov1.EventEnvelope, req ports.ReplayReques
 	if req.RuntimeID != "" && strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID]) != req.RuntimeID {
 		return false
 	}
-	if req.KindPrefix != "" && !strings.HasPrefix(strings.TrimSpace(event.GetKind()), req.KindPrefix) {
-		return false
+	if kindPrefixes := replayKindPrefixes(req); len(kindPrefixes) > 0 {
+		eventKind := strings.TrimSpace(event.GetKind())
+		matched := false
+		for _, kindPrefix := range kindPrefixes {
+			if strings.HasPrefix(eventKind, kindPrefix) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
 	}
 	if req.TenantID != "" && strings.TrimSpace(event.GetTenantId()) != req.TenantID {
 		return false

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -412,6 +412,43 @@ func TestReplayFiltersCanonicalSecurityEventsByKindPrefix(t *testing.T) {
 	}
 }
 
+func TestReplayFiltersMultipleKindPrefixesInAppendOrder(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{
+					Name:     "CEREBRO_EVENTS",
+					Subjects: []string{"events.>", "sec.>"},
+				},
+				State: natsjetstream.StreamState{FirstSeq: 1, LastSeq: 4},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, securityevents.FindingRecorded, workflowReplayEvent("evt-1", securityevents.FindingRecorded, "writer", "")),
+				2: rawReplayMsg(t, "events.github.audit", replayEvent("evt-2", "github.audit", "writer-github")),
+				3: rawReplayMsg(t, "events.workflow.v1.finding.tombstoned", workflowReplayEvent("evt-3", "workflow.v1.finding.tombstoned", "writer", "")),
+				4: rawReplayMsg(t, securityevents.ToolRegistered, workflowReplayEvent("evt-4", securityevents.ToolRegistered, "writer", "")),
+			},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{
+		KindPrefixes: []string{"workflow.v1.", securityevents.FindingsV1Prefix + "."},
+		TenantID:     "writer",
+	})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if events[0].GetId() != "evt-1" || events[1].GetId() != "evt-3" {
+		t.Fatalf("replayed ids = [%q, %q], want [evt-1, evt-3]", events[0].GetId(), events[1].GetId())
+	}
+}
+
 func TestReplaySkipsDecodeForSubjectsOutsideKindPrefix(t *testing.T) {
 	replay := &fakeReplayManager{
 		streams: []*natsjetstream.StreamInfo{

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -617,7 +617,7 @@ func (s *recordingAppendLog) Replay(_ context.Context, request ports.ReplayReque
 		if request.RuntimeID != "" && event.GetAttributes()[ports.EventAttributeSourceRuntimeID] != request.RuntimeID {
 			continue
 		}
-		if request.KindPrefix != "" && !strings.HasPrefix(event.GetKind(), request.KindPrefix) {
+		if !replayEventMatchesKindPrefixes(event.GetKind(), request.KindPrefix, request.KindPrefixes) {
 			continue
 		}
 		if request.TenantID != "" && event.GetTenantId() != request.TenantID {
@@ -632,6 +632,21 @@ func (s *recordingAppendLog) Replay(_ context.Context, request ports.ReplayReque
 		}
 	}
 	return events, nil
+}
+
+func replayEventMatchesKindPrefixes(kind string, kindPrefix string, kindPrefixes []string) bool {
+	if strings.TrimSpace(kindPrefix) == "" && len(kindPrefixes) == 0 {
+		return true
+	}
+	if strings.TrimSpace(kindPrefix) != "" && strings.HasPrefix(kind, strings.TrimSpace(kindPrefix)) {
+		return true
+	}
+	for _, prefix := range kindPrefixes {
+		if strings.TrimSpace(prefix) != "" && strings.HasPrefix(kind, strings.TrimSpace(prefix)) {
+			return true
+		}
+	}
+	return false
 }
 
 func matchesReplayAttributes(event *cerebrov1.EventEnvelope, expected map[string]string) bool {
@@ -6289,14 +6304,14 @@ func TestWorkflowReplayEndpoint(t *testing.T) {
 	if _, ok := graphStore.links[decisionID+"|targets|"+targetURN]; !ok {
 		t.Fatal("decision target link missing after replay")
 	}
-	if len(appendLog.replayRequests) != 2 {
-		t.Fatalf("len(replayRequests) = %d, want 2", len(appendLog.replayRequests))
+	if len(appendLog.replayRequests) != 1 {
+		t.Fatalf("len(replayRequests) = %d, want 1", len(appendLog.replayRequests))
 	}
-	if got := appendLog.replayRequests[0].KindPrefix; got != "workflow.v1." {
-		t.Fatalf("HTTP replay kind prefix = %q, want workflow.v1.", got)
+	if got := appendLog.replayRequests[0].KindPrefix; got != "" {
+		t.Fatalf("HTTP replay kind prefix = %q, want empty multi-prefix request", got)
 	}
-	if got := appendLog.replayRequests[1].KindPrefix; got != "sec.findings.v1." {
-		t.Fatalf("HTTP replay canonical finding prefix = %q, want sec.findings.v1.", got)
+	if got := appendLog.replayRequests[0].KindPrefixes; len(got) != 2 || got[0] != "workflow.v1." || got[1] != "sec.findings.v1." {
+		t.Fatalf("HTTP replay kind prefixes = %v, want workflow and sec finding prefixes", got)
 	}
 	if got := appendLog.replayRequests[0].AttributeEquals["workflow_kind"]; got != "knowledge_decision" {
 		t.Fatalf("HTTP replay workflow_kind filter = %q, want knowledge_decision", got)
@@ -6314,10 +6329,10 @@ func TestWorkflowReplayEndpoint(t *testing.T) {
 	if got := connectResp.Msg.GetEntitiesProjected(); got != 1 {
 		t.Fatalf("ReplayWorkflowEvents().EntitiesProjected = %d, want 1", got)
 	}
-	if len(appendLog.replayRequests) != 3 {
-		t.Fatalf("len(replayRequests) = %d, want 3", len(appendLog.replayRequests))
+	if len(appendLog.replayRequests) != 2 {
+		t.Fatalf("len(replayRequests) = %d, want 2", len(appendLog.replayRequests))
 	}
-	if got := appendLog.replayRequests[2].KindPrefix; got != "workflow.v1.knowledge." {
+	if got := appendLog.replayRequests[1].KindPrefix; got != "workflow.v1.knowledge." {
 		t.Fatalf("Connect replay kind prefix = %q, want workflow.v1.knowledge.", got)
 	}
 }

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -6289,11 +6289,14 @@ func TestWorkflowReplayEndpoint(t *testing.T) {
 	if _, ok := graphStore.links[decisionID+"|targets|"+targetURN]; !ok {
 		t.Fatal("decision target link missing after replay")
 	}
-	if len(appendLog.replayRequests) != 1 {
-		t.Fatalf("len(replayRequests) = %d, want 1", len(appendLog.replayRequests))
+	if len(appendLog.replayRequests) != 2 {
+		t.Fatalf("len(replayRequests) = %d, want 2", len(appendLog.replayRequests))
 	}
 	if got := appendLog.replayRequests[0].KindPrefix; got != "workflow.v1." {
 		t.Fatalf("HTTP replay kind prefix = %q, want workflow.v1.", got)
+	}
+	if got := appendLog.replayRequests[1].KindPrefix; got != "sec.findings.v1." {
+		t.Fatalf("HTTP replay canonical finding prefix = %q, want sec.findings.v1.", got)
 	}
 	if got := appendLog.replayRequests[0].AttributeEquals["workflow_kind"]; got != "knowledge_decision" {
 		t.Fatalf("HTTP replay workflow_kind filter = %q, want knowledge_decision", got)
@@ -6311,10 +6314,10 @@ func TestWorkflowReplayEndpoint(t *testing.T) {
 	if got := connectResp.Msg.GetEntitiesProjected(); got != 1 {
 		t.Fatalf("ReplayWorkflowEvents().EntitiesProjected = %d, want 1", got)
 	}
-	if len(appendLog.replayRequests) != 2 {
-		t.Fatalf("len(replayRequests) = %d, want 2", len(appendLog.replayRequests))
+	if len(appendLog.replayRequests) != 3 {
+		t.Fatalf("len(replayRequests) = %d, want 3", len(appendLog.replayRequests))
 	}
-	if got := appendLog.replayRequests[1].KindPrefix; got != "workflow.v1.knowledge." {
+	if got := appendLog.replayRequests[2].KindPrefix; got != "workflow.v1.knowledge." {
 		t.Fatalf("Connect replay kind prefix = %q, want workflow.v1.knowledge.", got)
 	}
 }

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -18,6 +18,7 @@ type AppendLog interface {
 type ReplayRequest struct {
 	RuntimeID       string
 	KindPrefix      string
+	KindPrefixes    []string
 	TenantID        string
 	AttributeEquals map[string]string
 	Limit           uint32

--- a/internal/workflowprojection/dispatcher.go
+++ b/internal/workflowprojection/dispatcher.go
@@ -7,6 +7,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
@@ -18,7 +19,9 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 	if s == nil || s.graph == nil {
 		return ports.ProjectionResult{}, fmt.Errorf("workflow graph projection store is required")
 	}
-	switch strings.TrimSpace(event.GetKind()) {
+	kind := workflowProjectionKind(event.GetKind())
+	event = eventWithProjectionKind(event, kind)
+	switch kind {
 	case workflowevents.EventKindKnowledgeDecisionRecorded:
 		return s.projectDecision(ctx, event)
 	case workflowevents.EventKindKnowledgeActionRecorded:
@@ -38,4 +41,28 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 	default:
 		return ports.ProjectionResult{}, nil
 	}
+}
+
+func workflowProjectionKind(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case securityevents.FindingRecorded:
+		return workflowevents.EventKindFindingRecorded
+	case securityevents.FindingNoteAdded:
+		return workflowevents.EventKindFindingNoteAdded
+	case securityevents.FindingTicketLinked:
+		return workflowevents.EventKindFindingTicketLinked
+	case securityevents.FindingStatusChanged:
+		return workflowevents.EventKindFindingStatusChanged
+	default:
+		return strings.TrimSpace(kind)
+	}
+}
+
+func eventWithProjectionKind(event *cerebrov1.EventEnvelope, kind string) *cerebrov1.EventEnvelope {
+	if event == nil || strings.TrimSpace(event.GetKind()) == kind {
+		return event
+	}
+	clone := *event
+	clone.Kind = kind
+	return &clone
 }

--- a/internal/workflowprojection/dispatcher.go
+++ b/internal/workflowprojection/dispatcher.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"google.golang.org/protobuf/proto"
+
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/securityevents"
@@ -62,7 +64,10 @@ func eventWithProjectionKind(event *cerebrov1.EventEnvelope, kind string) *cereb
 	if event == nil || strings.TrimSpace(event.GetKind()) == kind {
 		return event
 	}
-	clone := *event
+	clone, ok := proto.Clone(event).(*cerebrov1.EventEnvelope)
+	if !ok {
+		return event
+	}
 	clone.Kind = kind
-	return &clone
+	return clone
 }

--- a/internal/workflowprojection/replay.go
+++ b/internal/workflowprojection/replay.go
@@ -48,33 +48,37 @@ func (r *Replayer) Replay(ctx context.Context, request ReplayRequest) (*ReplayRe
 	}
 	projector := New(r.graph)
 	result := &ReplayResult{}
-	for _, kindPrefix := range workflowReplayKindPrefixes(request.KindPrefix) {
-		events, err := r.replayer.Replay(ctx, ports.ReplayRequest{
-			KindPrefix:      kindPrefix,
-			TenantID:        strings.TrimSpace(request.TenantID),
-			AttributeEquals: request.AttributeEquals,
-			Limit:           request.Limit,
-		})
+	replayRequest := ports.ReplayRequest{
+		TenantID:        strings.TrimSpace(request.TenantID),
+		AttributeEquals: request.AttributeEquals,
+		Limit:           request.Limit,
+	}
+	kindPrefixes := workflowReplayKindPrefixes(request.KindPrefix)
+	if len(kindPrefixes) == 1 {
+		replayRequest.KindPrefix = kindPrefixes[0]
+	} else {
+		replayRequest.KindPrefixes = kindPrefixes
+	}
+	events, err := r.replayer.Replay(ctx, replayRequest)
+	if err != nil {
+		return nil, err
+	}
+	for _, event := range events {
+		result.EventsRead++
+		projection, err := projector.Project(ctx, event)
 		if err != nil {
 			return nil, err
 		}
-		for _, event := range events {
-			result.EventsRead++
-			projection, err := projector.Project(ctx, event)
-			if err != nil {
-				return nil, err
-			}
-			eventsProjected := projection.EventsProjected
-			if eventsProjected == 0 && (projection.EntitiesProjected != 0 || projection.LinksProjected != 0 || projection.EntitiesDeleted != 0 || projection.LinksDeleted != 0) {
-				eventsProjected = 1
-			}
-			if eventsProjected == 0 {
-				continue
-			}
-			result.EventsProjected += eventsProjected
-			result.EntitiesProjected += projection.EntitiesProjected
-			result.LinksProjected += projection.LinksProjected
+		eventsProjected := projection.EventsProjected
+		if eventsProjected == 0 && (projection.EntitiesProjected != 0 || projection.LinksProjected != 0 || projection.EntitiesDeleted != 0 || projection.LinksDeleted != 0) {
+			eventsProjected = 1
 		}
+		if eventsProjected == 0 {
+			continue
+		}
+		result.EventsProjected += eventsProjected
+		result.EntitiesProjected += projection.EntitiesProjected
+		result.LinksProjected += projection.LinksProjected
 	}
 	return result, nil
 }

--- a/internal/workflowprojection/replay.go
+++ b/internal/workflowprojection/replay.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/securityevents"
 )
 
 const defaultWorkflowKindPrefix = "workflow.v1."
@@ -45,37 +46,43 @@ func (r *Replayer) Replay(ctx context.Context, request ReplayRequest) (*ReplayRe
 	if r == nil || r.replayer == nil || r.graph == nil {
 		return nil, ErrRuntimeUnavailable
 	}
-	kindPrefix := strings.TrimSpace(request.KindPrefix)
-	if kindPrefix == "" {
-		kindPrefix = defaultWorkflowKindPrefix
-	}
-	events, err := r.replayer.Replay(ctx, ports.ReplayRequest{
-		KindPrefix:      kindPrefix,
-		TenantID:        strings.TrimSpace(request.TenantID),
-		AttributeEquals: request.AttributeEquals,
-		Limit:           request.Limit,
-	})
-	if err != nil {
-		return nil, err
-	}
 	projector := New(r.graph)
 	result := &ReplayResult{}
-	for _, event := range events {
-		result.EventsRead++
-		projection, err := projector.Project(ctx, event)
+	for _, kindPrefix := range workflowReplayKindPrefixes(request.KindPrefix) {
+		events, err := r.replayer.Replay(ctx, ports.ReplayRequest{
+			KindPrefix:      kindPrefix,
+			TenantID:        strings.TrimSpace(request.TenantID),
+			AttributeEquals: request.AttributeEquals,
+			Limit:           request.Limit,
+		})
 		if err != nil {
 			return nil, err
 		}
-		eventsProjected := projection.EventsProjected
-		if eventsProjected == 0 && (projection.EntitiesProjected != 0 || projection.LinksProjected != 0 || projection.EntitiesDeleted != 0 || projection.LinksDeleted != 0) {
-			eventsProjected = 1
+		for _, event := range events {
+			result.EventsRead++
+			projection, err := projector.Project(ctx, event)
+			if err != nil {
+				return nil, err
+			}
+			eventsProjected := projection.EventsProjected
+			if eventsProjected == 0 && (projection.EntitiesProjected != 0 || projection.LinksProjected != 0 || projection.EntitiesDeleted != 0 || projection.LinksDeleted != 0) {
+				eventsProjected = 1
+			}
+			if eventsProjected == 0 {
+				continue
+			}
+			result.EventsProjected += eventsProjected
+			result.EntitiesProjected += projection.EntitiesProjected
+			result.LinksProjected += projection.LinksProjected
 		}
-		if eventsProjected == 0 {
-			continue
-		}
-		result.EventsProjected += eventsProjected
-		result.EntitiesProjected += projection.EntitiesProjected
-		result.LinksProjected += projection.LinksProjected
 	}
 	return result, nil
+}
+
+func workflowReplayKindPrefixes(kindPrefix string) []string {
+	kindPrefix = strings.TrimSpace(kindPrefix)
+	if kindPrefix != "" {
+		return []string{kindPrefix}
+	}
+	return []string{defaultWorkflowKindPrefix, securityevents.FindingsV1Prefix + "."}
 }

--- a/internal/workflowprojection/replay_test.go
+++ b/internal/workflowprojection/replay_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"google.golang.org/protobuf/proto"
+
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/securityevents"
@@ -88,11 +90,11 @@ func TestReplayProjectsCanonicalFindingEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFindingRecordedEvent() error = %v", err)
 	}
-	canonical := *findingEvent
+	canonical := proto.Clone(findingEvent).(*cerebrov1.EventEnvelope)
 	canonical.Kind = securityevents.FindingRecorded
 	graph := &projectionRecorder{}
 	result, err := NewReplayer(&eventReplayer{eventsByPrefix: map[string][]*cerebrov1.EventEnvelope{
-		securityevents.FindingsV1Prefix + ".": {&canonical},
+		securityevents.FindingsV1Prefix + ".": {canonical},
 	}}, graph).Replay(context.Background(), ReplayRequest{TenantID: "writer"})
 	if err != nil {
 		t.Fatalf("Replay() error = %v", err)

--- a/internal/workflowprojection/replay_test.go
+++ b/internal/workflowprojection/replay_test.go
@@ -6,16 +6,21 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
 type eventReplayer struct {
-	request ports.ReplayRequest
-	events  []*cerebrov1.EventEnvelope
+	requests       []ports.ReplayRequest
+	events         []*cerebrov1.EventEnvelope
+	eventsByPrefix map[string][]*cerebrov1.EventEnvelope
 }
 
 func (r *eventReplayer) Replay(_ context.Context, request ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
-	r.request = request
+	r.requests = append(r.requests, request)
+	if r.eventsByPrefix != nil {
+		return append([]*cerebrov1.EventEnvelope(nil), r.eventsByPrefix[request.KindPrefix]...), nil
+	}
 	return append([]*cerebrov1.EventEnvelope(nil), r.events...), nil
 }
 
@@ -34,7 +39,9 @@ func TestReplayProjectsWorkflowEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDecisionRecordedEvent() error = %v", err)
 	}
-	replayer := &eventReplayer{events: []*cerebrov1.EventEnvelope{decisionEvent}}
+	replayer := &eventReplayer{eventsByPrefix: map[string][]*cerebrov1.EventEnvelope{
+		defaultWorkflowKindPrefix: {decisionEvent},
+	}}
 	graph := &projectionRecorder{}
 	result, err := NewReplayer(replayer, graph).Replay(context.Background(), ReplayRequest{
 		TenantID: "writer",
@@ -43,10 +50,16 @@ func TestReplayProjectsWorkflowEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Replay() error = %v", err)
 	}
-	if got := replayer.request.KindPrefix; got != defaultWorkflowKindPrefix {
-		t.Fatalf("ReplayRequest.KindPrefix = %q, want %q", got, defaultWorkflowKindPrefix)
+	if len(replayer.requests) != 2 {
+		t.Fatalf("Replay() requests = %d, want 2", len(replayer.requests))
 	}
-	if got := replayer.request.TenantID; got != "writer" {
+	if got := replayer.requests[0].KindPrefix; got != defaultWorkflowKindPrefix {
+		t.Fatalf("ReplayRequest[0].KindPrefix = %q, want %q", got, defaultWorkflowKindPrefix)
+	}
+	if got := replayer.requests[1].KindPrefix; got != securityevents.FindingsV1Prefix+"." {
+		t.Fatalf("ReplayRequest[1].KindPrefix = %q, want sec findings prefix", got)
+	}
+	if got := replayer.requests[0].TenantID; got != "writer" {
 		t.Fatalf("ReplayRequest.TenantID = %q, want writer", got)
 	}
 	if got := result.EventsRead; got != 1 {
@@ -57,5 +70,40 @@ func TestReplayProjectsWorkflowEvents(t *testing.T) {
 	}
 	if _, ok := graph.links["urn:cerebro:writer:decision:decision-1|targets|"+targetURN]; !ok {
 		t.Fatal("decision target link missing after replay")
+	}
+}
+
+func TestReplayProjectsCanonicalFindingEvents(t *testing.T) {
+	findingEvent, err := workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
+		Finding: workflowevents.FindingSnapshot{
+			TenantID:           "writer",
+			SourceSystem:       "findings",
+			FindingID:          "finding-1",
+			Title:              "Risky resource",
+			Status:             "open",
+			PrimaryResourceURN: "urn:cerebro:writer:asset:resource-1",
+		},
+		RecordedAt: "2026-04-27T12:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingRecordedEvent() error = %v", err)
+	}
+	canonical := *findingEvent
+	canonical.Kind = securityevents.FindingRecorded
+	graph := &projectionRecorder{}
+	result, err := NewReplayer(&eventReplayer{eventsByPrefix: map[string][]*cerebrov1.EventEnvelope{
+		securityevents.FindingsV1Prefix + ".": {&canonical},
+	}}, graph).Replay(context.Background(), ReplayRequest{TenantID: "writer"})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if got := result.EventsRead; got != 1 {
+		t.Fatalf("EventsRead = %d, want 1", got)
+	}
+	if got := result.EventsProjected; got != 1 {
+		t.Fatalf("EventsProjected = %d, want 1", got)
+	}
+	if len(graph.entities) == 0 {
+		t.Fatal("canonical finding replay did not project graph entities")
 	}
 }

--- a/internal/workflowprojection/replay_test.go
+++ b/internal/workflowprojection/replay_test.go
@@ -2,6 +2,7 @@ package workflowprojection
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/proto"
@@ -21,9 +22,34 @@ type eventReplayer struct {
 func (r *eventReplayer) Replay(_ context.Context, request ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
 	r.requests = append(r.requests, request)
 	if r.eventsByPrefix != nil {
-		return append([]*cerebrov1.EventEnvelope(nil), r.eventsByPrefix[request.KindPrefix]...), nil
+		events := append([]*cerebrov1.EventEnvelope(nil), r.eventsByPrefix[request.KindPrefix]...)
+		for _, kindPrefix := range request.KindPrefixes {
+			events = append(events, r.eventsByPrefix[kindPrefix]...)
+		}
+		return events, nil
 	}
-	return append([]*cerebrov1.EventEnvelope(nil), r.events...), nil
+	events := make([]*cerebrov1.EventEnvelope, 0, len(r.events))
+	for _, event := range r.events {
+		if replayTestMatchesPrefix(event.GetKind(), request.KindPrefix, request.KindPrefixes) {
+			events = append(events, event)
+		}
+	}
+	return events, nil
+}
+
+func replayTestMatchesPrefix(kind string, kindPrefix string, kindPrefixes []string) bool {
+	if strings.TrimSpace(kindPrefix) == "" && len(kindPrefixes) == 0 {
+		return true
+	}
+	if strings.TrimSpace(kindPrefix) != "" && strings.HasPrefix(kind, strings.TrimSpace(kindPrefix)) {
+		return true
+	}
+	for _, prefix := range kindPrefixes {
+		if strings.TrimSpace(prefix) != "" && strings.HasPrefix(kind, strings.TrimSpace(prefix)) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestReplayProjectsWorkflowEvents(t *testing.T) {
@@ -52,14 +78,14 @@ func TestReplayProjectsWorkflowEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Replay() error = %v", err)
 	}
-	if len(replayer.requests) != 2 {
-		t.Fatalf("Replay() requests = %d, want 2", len(replayer.requests))
+	if len(replayer.requests) != 1 {
+		t.Fatalf("Replay() requests = %d, want 1", len(replayer.requests))
 	}
-	if got := replayer.requests[0].KindPrefix; got != defaultWorkflowKindPrefix {
-		t.Fatalf("ReplayRequest[0].KindPrefix = %q, want %q", got, defaultWorkflowKindPrefix)
+	if got := replayer.requests[0].KindPrefixes; len(got) != 2 || got[0] != defaultWorkflowKindPrefix || got[1] != securityevents.FindingsV1Prefix+"." {
+		t.Fatalf("ReplayRequest.KindPrefixes = %v, want workflow and sec findings prefixes", got)
 	}
-	if got := replayer.requests[1].KindPrefix; got != securityevents.FindingsV1Prefix+"." {
-		t.Fatalf("ReplayRequest[1].KindPrefix = %q, want sec findings prefix", got)
+	if got := replayer.requests[0].KindPrefix; got != "" {
+		t.Fatalf("ReplayRequest.KindPrefix = %q, want empty multi-prefix request", got)
 	}
 	if got := replayer.requests[0].TenantID; got != "writer" {
 		t.Fatalf("ReplayRequest.TenantID = %q, want writer", got)
@@ -107,5 +133,58 @@ func TestReplayProjectsCanonicalFindingEvents(t *testing.T) {
 	}
 	if len(graph.entities) == 0 {
 		t.Fatal("canonical finding replay did not project graph entities")
+	}
+}
+
+func TestReplayDefaultPrefixesPreserveChronologyAcrossCanonicalAndWorkflowEvents(t *testing.T) {
+	findingID := "finding-1"
+	anchorURN := "urn:cerebro:writer:asset:resource-1"
+	recorded, err := workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
+		Finding: workflowevents.FindingSnapshot{
+			TenantID:           "writer",
+			SourceSystem:       "findings",
+			FindingID:          findingID,
+			Title:              "Risky resource",
+			Status:             "open",
+			PrimaryResourceURN: anchorURN,
+			ResourceURNs:       []string{anchorURN},
+		},
+		RecordedAt: "2026-04-27T11:59:00Z",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingRecordedEvent() error = %v", err)
+	}
+	recorded = proto.Clone(recorded).(*cerebrov1.EventEnvelope)
+	recorded.Kind = securityevents.FindingRecorded
+	tombstoned, err := workflowevents.NewFindingTombstonedEvent(workflowevents.FindingTombstoned{
+		Finding: workflowevents.FindingSnapshot{
+			TenantID:           "writer",
+			SourceSystem:       "findings",
+			FindingID:          findingID,
+			Title:              "Risky resource",
+			Status:             "tombstoned",
+			PrimaryResourceURN: anchorURN,
+			ResourceURNs:       []string{anchorURN},
+		},
+		PriorStatus:  "open",
+		Reason:       "bulk closeout",
+		Actor:        "operator",
+		RunID:        "run-1",
+		TombstonedAt: "2026-04-27T12:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingTombstonedEvent() error = %v", err)
+	}
+	graph := &projectionRecorder{}
+	result, err := NewReplayer(&eventReplayer{events: []*cerebrov1.EventEnvelope{recorded, tombstoned}}, graph).Replay(context.Background(), ReplayRequest{TenantID: "writer"})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if got := result.EventsRead; got != 2 {
+		t.Fatalf("EventsRead = %d, want 2", got)
+	}
+	linkKey := anchorURN + "|" + relationHasFinding + "|" + findingURN("writer", findingID)
+	if _, ok := graph.links[linkKey]; ok {
+		t.Fatalf("tombstoned finding link %q was resurrected", linkKey)
 	}
 }


### PR DESCRIPTION
## Summary

- teaches workflow projection to normalize canonical `sec.findings.v1.*` finding workflow events back to their workflow projection kinds
- makes default workflow replay scan both `workflow.v1.*` and canonical finding event prefixes
- adds coverage proving canonical finding events project during replay

## Test Plan

- `go test ./internal/workflowprojection -run 'TestReplay' -count=1`
- `go test ./internal/workflowevents ./internal/workflowprojection ./internal/findings -count=1`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on workflow replay prefix behavior and canonical finding-event projection.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
