### PR TITLE
feat: add source runtime orchestration job

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2050,6 +2050,7 @@ components:
           type: string
           enum:
             - source_runtime_sync
+            - source_runtime_orchestrate
             - graph_ingest_runtime
             - finding_rules_evaluate
             - findings_evaluate

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -44,6 +44,7 @@ type jobEventListResponse struct {
 func (a *App) jobService() *platformjobs.Service {
 	service := platformjobs.New(jobStore(a.deps.StateStore))
 	service.WithRunner(platformjobs.KindSourceRuntimeSync, a.runSourceRuntimeSyncJob)
+	service.WithRunner(platformjobs.KindSourceRuntimeOrchestrate, a.runSourceRuntimeOrchestrateJob)
 	service.WithRunner(platformjobs.KindGraphIngestRuntime, a.runGraphIngestRuntimeJob)
 	service.WithRunner(platformjobs.KindFindingRulesEvaluate, a.runFindingRulesEvaluateJob)
 	service.WithRunner(platformjobs.KindFindingsEvaluate, a.runFindingsEvaluateJob)
@@ -189,6 +190,58 @@ func (a *App) runSourceRuntimeSyncJob(ctx context.Context, job *ports.Job, _ *pl
 		return nil, nil, err
 	}
 	return protoToMap(response), nil, nil
+}
+
+func (a *App) runSourceRuntimeOrchestrateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+	if runtimeID == "" {
+		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
+	}
+	syncResponse, err := a.runtimeService().SyncWithLease(ctx, &cerebrov1.SyncSourceRuntimeRequest{
+		Id:        runtimeID,
+		PageLimit: uint32Payload(job.Payload, "page_limit"),
+	}, sourceruntime.SyncWithLeaseOptions{LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore)})
+	if err != nil {
+		return nil, nil, err
+	}
+	graphResult, err := a.graphIngestService().RunRuntime(ctx, graphingest.RuntimeRequest{
+		RuntimeID: runtimeID,
+		PageLimit: uint32Payload(job.Payload, "graph_page_limit"),
+		Trigger:   "platform_orchestration_job",
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	ruleResult, err := a.findingService().EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
+		RuntimeID:  runtimeID,
+		RuleIDs:    stringSlicePayload(job.Payload, "rule_ids"),
+		EventLimit: uint32Payload(job.Payload, "event_limit"),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	graphPayload, err := json.Marshal(graphResult)
+	if err != nil {
+		return nil, nil, err
+	}
+	graphOut := map[string]any{}
+	_ = json.Unmarshal(graphPayload, &graphOut)
+	rulePayload, err := json.Marshal(ruleResult)
+	if err != nil {
+		return nil, nil, err
+	}
+	ruleOut := map[string]any{}
+	_ = json.Unmarshal(rulePayload, &ruleOut)
+	result := map[string]any{
+		"sync":          protoToMap(syncResponse),
+		"graph_ingest":  graphOut,
+		"finding_rules": ruleOut,
+	}
+	refs := map[string]string{}
+	if graphResult.Run.ID != "" {
+		refs["graph_ingest_run_id"] = graphResult.Run.ID
+	}
+	return result, refs, nil
 }
 
 func (a *App) runGraphIngestRuntimeJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -333,7 +333,7 @@ func authorizeJobCreate(ctx context.Context, store ports.StateStore, request cre
 		return "", err
 	}
 	switch strings.TrimSpace(request.Kind) {
-	case platformjobs.KindSourceRuntimeSync, platformjobs.KindGraphIngestRuntime, platformjobs.KindFindingRulesEvaluate, platformjobs.KindFindingsEvaluate:
+	case platformjobs.KindSourceRuntimeSync, platformjobs.KindSourceRuntimeOrchestrate, platformjobs.KindGraphIngestRuntime, platformjobs.KindFindingRulesEvaluate, platformjobs.KindFindingsEvaluate:
 		runtimeID := stringPayload(request.Payload, "runtime_id", request.SubjectID)
 		runtimeTenantID, err := sourceRuntimeTenantID(ctx, sourceRuntimeStore(store), runtimeID, false)
 		if err != nil {

--- a/internal/bootstrap/jobs_test.go
+++ b/internal/bootstrap/jobs_test.go
@@ -1,0 +1,26 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	platformjobs "github.com/writer/cerebro/internal/jobs"
+)
+
+func TestAuthorizeJobCreateAllowsSourceRuntimeOrchestrate(t *testing.T) {
+	store := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-1": {Id: "runtime-1", SourceId: "github", TenantId: "writer"},
+	}}
+	tenantID, err := authorizeJobCreate(context.Background(), store, createJobHTTPRequest{
+		Kind:     platformjobs.KindSourceRuntimeOrchestrate,
+		TenantID: "writer",
+		Payload:  map[string]any{"runtime_id": "runtime-1"},
+	})
+	if err != nil {
+		t.Fatalf("authorizeJobCreate() error = %v", err)
+	}
+	if tenantID != "writer" {
+		t.Fatalf("authorizeJobCreate() tenantID = %q, want writer", tenantID)
+	}
+}

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -20,6 +20,7 @@ var (
 
 const (
 	KindSourceRuntimeSync         = "source_runtime_sync"
+	KindSourceRuntimeOrchestrate  = "source_runtime_orchestrate"
 	KindGraphIngestRuntime        = "graph_ingest_runtime"
 	KindFindingRulesEvaluate      = "finding_rules_evaluate"
 	KindFindingCandidatesEvaluate = "finding_candidates_evaluate"


### PR DESCRIPTION
## Summary

- adds a `source_runtime_orchestrate` platform job kind
- runs source runtime sync, graph ingest, and finding-rule evaluation as one durable job
- returns combined phase results and the graph ingest run reference for downstream timelines/ops

## Test Plan

- `go test ./internal/jobs ./internal/bootstrap -count=1`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on orchestration phase ordering, job result shape, and existing lease behavior.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
