### PR TITLE
chore: align SDK metadata guardrails

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "cerebro-sdk"
 version = "0.1.0"
-description = "Generated Python SDK for the Cerebro Agent SDK and report runtime"
+description = "Python helpers for the Cerebro bootstrap API"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 dependencies = [

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@writer/cerebro-sdk",
   "version": "0.1.0",
-  "description": "TypeScript SDK for the Cerebro Agent SDK and report runtime",
+  "description": "TypeScript helpers for the Cerebro bootstrap API",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.js",

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -107,6 +107,20 @@ func TestSDKHTTPRoutesExistInOpenAPI(t *testing.T) {
 			}
 		}
 	}
+	for _, rel := range []string{
+		filepath.Join("sdk", "python", "pyproject.toml"),
+		filepath.Join("sdk", "typescript", "package.json"),
+	} {
+		body, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		for _, stale := range []string{"Agent SDK", "report runtime"} {
+			if bytes.Contains(body, []byte(stale)) {
+				t.Fatalf("%s contains retired SDK marker %q", rel, stale)
+			}
+		}
+	}
 }
 
 func TestBootstrapPublicHTTPRoutesStayMethodScopedAndDocumented(t *testing.T) {


### PR DESCRIPTION
## Summary

- updates Python and TypeScript SDK package descriptions to reflect current bootstrap API helpers
- adds an arch guardrail preventing retired Agent SDK/report-runtime wording from reappearing in SDK package metadata
- keeps existing SDK route parity coverage in place

## Test Plan

- `go test ./tools/archtests -run 'TestSDKHTTPRoutesExistInOpenAPI' -count=1`
- `make sdk-test`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on SDK packaging metadata and guardrail scope.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
