### PR TITLE
fix: classify OpenRouter auth failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ Build first with `make build`, then run `./bin/cerebro`.
 ./bin/cerebro serve
 ./bin/cerebro version
 
+# Deploy preflight receipt
+./bin/cerebro deploy preflight
+
 # Source catalog and previews
 ./bin/cerebro source list
 ./bin/cerebro source check github owner=writer repo=cerebro
@@ -254,7 +257,7 @@ Build first with `make build`, then run `./bin/cerebro`.
 ./bin/cerebro graph rebuild example-github dry_run=true mode=replay
 ```
 
-Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, and `closeout`.
+Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
 
 ---
 

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -73,11 +73,13 @@ func run(args []string) error {
 		return runVulnDB(args[1:])
 	case "closeout":
 		return runCloseout(args[1:])
+	case "deploy":
+		return runDeploy(args[1:])
 	case "version":
 		fmt.Printf("%s %s\n", buildinfo.ServiceName, buildinfo.Version)
 		return nil
 	}
-	return usageError(fmt.Sprintf("usage: %s [serve|version|graph|orchestrator|finding-rule|source|source-runtime|vulndb|closeout]", os.Args[0]))
+	return usageError(fmt.Sprintf("usage: %s [serve|version|deploy|graph|orchestrator|finding-rule|source|source-runtime|vulndb|closeout]", os.Args[0]))
 }
 
 func serve() error {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -28,6 +28,40 @@ func TestRunRejectsUnsupportedCommand(t *testing.T) {
 	}
 }
 
+func TestRunDeployRejectsUnsupportedSubcommand(t *testing.T) {
+	err := run([]string{"deploy", "bogus"})
+	var usage usageError
+	if !errors.As(err, &usage) {
+		t.Fatalf("run(deploy bogus) error = %v, want usageError", err)
+	}
+}
+
+func TestWritePreflightReceiptJSONRedactsToBoundedDetail(t *testing.T) {
+	receipt := preflightReceipt{
+		Kind:   "cerebro.deploy_preflight",
+		Status: "fail",
+		Checks: []preflightCheck{{
+			Name:   "graph_agent_llm.probe",
+			Status: "fail",
+			Detail: preflightErrorDetail(fmt.Errorf("openrouter failed: %s", strings.Repeat("x", 400))),
+		}},
+	}
+	var buf strings.Builder
+	if err := writePreflightReceipt(&buf, receipt, "json"); err != nil {
+		t.Fatalf("writePreflightReceipt() error = %v", err)
+	}
+	if strings.Contains(buf.String(), strings.Repeat("x", 260)) {
+		t.Fatalf("preflight detail was not bounded: %s", buf.String())
+	}
+	var decoded preflightReceipt
+	if err := json.Unmarshal([]byte(buf.String()), &decoded); err != nil {
+		t.Fatalf("preflight JSON invalid: %v", err)
+	}
+	if decoded.Status != "fail" || len(decoded.Checks) != 1 {
+		t.Fatalf("decoded receipt = %#v", decoded)
+	}
+}
+
 func TestSourceRuntimeCommandSignalsIncludeSIGTERM(t *testing.T) {
 	signals := sourceRuntimeCommandSignals()
 	if len(signals) != 2 || signals[0] != os.Interrupt || signals[1] != syscall.SIGTERM {

--- a/cmd/cerebro/preflight.go
+++ b/cmd/cerebro/preflight.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/bootstrap"
+	appconfig "github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphagent"
+)
+
+type preflightReceipt struct {
+	Kind        string           `json:"kind"`
+	Status      string           `json:"status"`
+	GeneratedAt string           `json:"generated_at"`
+	Checks      []preflightCheck `json:"checks"`
+}
+
+type preflightCheck struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type preflightOptions struct {
+	Format string
+	Stdout io.Writer
+}
+
+func runDeploy(args []string) error {
+	if len(args) == 0 {
+		return usageError("usage: cerebro deploy [preflight]")
+	}
+	switch args[0] {
+	case "preflight":
+		return runDeployPreflight(args[1:], preflightOptions{Stdout: os.Stdout})
+	default:
+		return usageError("usage: cerebro deploy [preflight]")
+	}
+}
+
+func runDeployPreflight(args []string, opts preflightOptions) error {
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	fs := flag.NewFlagSet("deploy preflight", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	format := fs.String("format", "json", "output format: json or text")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	opts.Format = strings.ToLower(strings.TrimSpace(firstNonEmptyString(opts.Format, *format)))
+	if opts.Format == "" {
+		opts.Format = "json"
+	}
+	receipt := executeDeployPreflight(context.Background())
+	if err := writePreflightReceipt(opts.Stdout, receipt, opts.Format); err != nil {
+		return err
+	}
+	if receipt.Status != "pass" {
+		return fmt.Errorf("deploy preflight failed")
+	}
+	return nil
+}
+
+func executeDeployPreflight(ctx context.Context) preflightReceipt {
+	receipt := preflightReceipt{
+		Kind:        "cerebro.deploy_preflight",
+		Status:      "pass",
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	addCheck := func(name string, err error) {
+		check := preflightCheck{Name: name, Status: "pass"}
+		if err != nil {
+			check.Status = "fail"
+			check.Detail = preflightErrorDetail(err)
+			receipt.Status = "fail"
+		}
+		receipt.Checks = append(receipt.Checks, check)
+	}
+
+	cfg, err := appconfig.Load()
+	addCheck("config.load", err)
+	if err != nil {
+		return receipt
+	}
+	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+	addCheck("dependencies.open", err)
+	if err != nil {
+		return receipt
+	}
+	defer func() {
+		addCheck("dependencies.close", closeDeps())
+	}()
+	addCheck("graph_agent_llm.probe", graphagent.ProbeLLM(ctx, deps.GraphAgentLLM))
+	return receipt
+}
+
+func writePreflightReceipt(w io.Writer, receipt preflightReceipt, format string) error {
+	switch format {
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(receipt)
+	case "text":
+		_, err := fmt.Fprintf(w, "deploy preflight: %s\n", receipt.Status)
+		if err != nil {
+			return err
+		}
+		for _, check := range receipt.Checks {
+			line := fmt.Sprintf("- %s: %s", check.Name, check.Status)
+			if check.Detail != "" {
+				line += " (" + check.Detail + ")"
+			}
+			if _, err := fmt.Fprintln(w, line); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported preflight output format %q", format)
+	}
+}
+
+func preflightErrorDetail(err error) string {
+	if err == nil {
+		return ""
+	}
+	detail := sanitizeLogValue(err.Error())
+	if len(detail) > 240 {
+		detail = detail[:240]
+	}
+	return detail
+}

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -585,6 +585,8 @@ func grcTelemetryErrorKind(err error) string {
 		errors.Is(err, ports.ErrFindingEvidenceNotFound),
 		errors.Is(err, ports.ErrGraphEntityNotFound):
 		return "not_found"
+	case errors.Is(err, graphagent.ErrLLMAuthenticationFailed):
+		return "llm_authentication_failed"
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable),
 		errors.Is(err, findings.ErrRuntimeUnavailable),
 		errors.Is(err, graphagent.ErrRuntimeUnavailable),
@@ -1451,6 +1453,7 @@ func grcHTTPStatusCode(err error) int {
 		statusCode = http.StatusNotFound
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable),
 		errors.Is(err, findings.ErrRuntimeUnavailable),
+		errors.Is(err, graphagent.ErrLLMAuthenticationFailed),
 		errors.Is(err, graphagent.ErrRuntimeUnavailable),
 		errors.Is(err, graphquery.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -114,7 +114,7 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 			evt.result.timings = timings
 		}
 		errorEvent := graphagent.Event{Name: graphagent.EventError, Data: graphagent.ErrorEvent{
-			Code:    "ask_failed",
+			Code:    askRuntimeErrorCode(err),
 			Message: err.Error(),
 			TraceID: graphagent.ErrorTraceID(err),
 			Timings: timings,
@@ -135,6 +135,13 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 	}
 	evt.sseEvents = eventCount
 	evt.finish(r, started, http.StatusOK, nil)
+}
+
+func askRuntimeErrorCode(err error) string {
+	if errors.Is(err, graphagent.ErrLLMAuthenticationFailed) {
+		return "llm_authentication_failed"
+	}
+	return "ask_failed"
 }
 
 type askWideEvent struct {

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -212,6 +212,49 @@ func TestGRCAskDraftFailureReturnsServiceUnavailable(t *testing.T) {
 	}
 }
 
+func TestGRCAskLLMAuthenticationFailureUsesSpecificErrorCode(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		GraphStore: &stubGraphStore{},
+		GraphAgentLLM: &graphagent.StubLLMClient{DraftErr: errors.Join(
+			graphagent.ErrLLMAuthenticationFailed,
+			errors.New("openrouter authentication failed; check CEREBRO_OPENROUTER_API_KEY"),
+		)},
+	}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	var events []sseRecord
+	stderr := captureBootstrapStderr(t, func() {
+		resp, err := server.Client().Post(server.URL+"/grc/ask", "application/json", strings.NewReader(`{"tenant_id":"example","question":"hello"}`))
+		if err != nil {
+			t.Fatalf("POST /grc/ask error = %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d with streamed error event", resp.StatusCode, http.StatusOK)
+		}
+		events = readSSEEvents(t, resp)
+	})
+	assertSSEEventNames(t, events, []string{"progress", "graph_probe", "progress", "error"})
+	var errorEvent graphagent.ErrorEvent
+	if err := json.Unmarshal(events[3].Data, &errorEvent); err != nil {
+		t.Fatalf("unmarshal error event: %v", err)
+	}
+	if errorEvent.Code != "llm_authentication_failed" {
+		t.Fatalf("error code = %q, want llm_authentication_failed", errorEvent.Code)
+	}
+	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	if got := payload["runtime_error.code"]; got != "llm_authentication_failed" {
+		t.Fatalf("runtime_error.code = %#v, want llm_authentication_failed; payload=%#v", got, payload)
+	}
+	if got := payload["error_kind"]; got != "llm_authentication_failed" {
+		t.Fatalf("error_kind = %#v, want llm_authentication_failed; payload=%#v", got, payload)
+	}
+	if _, exists := payload["error"]; exists {
+		t.Fatalf("raw error recorded in telemetry: payload=%#v", payload)
+	}
+}
+
 func TestGRCAskExplainFailureReturnsServiceUnavailable(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
 		GraphStore:    &stubGraphStore{err: errors.New("neo4j unavailable")},

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -214,6 +215,75 @@ func TestSourceRuntimeHealthSummariesAggregateBySource(t *testing.T) {
 	if panopticon.SourceID != "panopticon" || panopticon.Total != 1 || panopticon.Unknown != 1 || panopticon.GraphNotObserved != 1 || panopticon.ContractProbeNotConfigured != 1 {
 		t.Fatalf("panopticon summary = %+v", panopticon)
 	}
+}
+
+func FuzzRuntimeHealthConfigParsing(f *testing.F) {
+	f.Add("", "", "")
+	f.Add("3600", "7200", "passing")
+	f.Add("-1", "0", " failure ")
+	f.Add("999999999999999999999999", "nan", "unknown")
+	f.Fuzz(func(t *testing.T, cadence string, stale string, probe string) {
+		runtime := &cerebrov1.SourceRuntime{
+			SourceId:     "evidence_cas",
+			LastSyncedAt: timestamppb.New(time.Now().UTC()),
+			Config: map[string]string{
+				"expected_cadence_seconds":         cadence,
+				"stale_after_seconds":              stale,
+				runtimeContractProbeStateConfigKey: probe,
+			},
+		}
+		if got := runtimeConfigInt64(runtime, "expected_cadence_seconds"); got < 0 {
+			t.Fatalf("runtimeConfigInt64() = %d, want non-negative", got)
+		}
+		if got := runtimeConfigUint32(runtime, runtimeRecordsScannedConfigKey); got != 0 {
+			t.Fatalf("runtimeConfigUint32(absent) = %d, want 0", got)
+		}
+		if got := runtimeEnabledState(runtime); got != "enabled" && got != "disabled" && got != "unknown" {
+			t.Fatalf("runtimeEnabledState() = %q", got)
+		}
+		if got := runtimeContractProbeState(runtime); strings.TrimSpace(probe) != "" && got != strings.TrimSpace(probe) {
+			t.Fatalf("runtimeContractProbeState() = %q, want trimmed probe", got)
+		}
+	})
+}
+
+func FuzzSourceRuntimeHealthSummaries(f *testing.F) {
+	f.Add("okta", "healthy", "passing", "completed", false)
+	f.Add("", "failing", "failure", "failed", true)
+	f.Add("aws", "stale", "unknown", "running", false)
+	f.Fuzz(func(t *testing.T, sourceID string, status string, probe string, graphStatus string, cursorPending bool) {
+		graphLag := int64(7200)
+		staleAfter := int64(3600)
+		records := []sourceRuntimeHealthRecord{{
+			SourceID:           sourceID,
+			Status:             status,
+			ContractProbeState: probe,
+			CursorPending:      cursorPending,
+			LatestGraphRun:     &sourceRuntimeHealthGraphRun{Status: graphStatus},
+			GraphLagSeconds:    &graphLag,
+			StaleAfterSeconds:  &staleAfter,
+		}}
+		summaries := sourceRuntimeHealthSummaries(records)
+		if len(summaries) != 1 {
+			t.Fatalf("summary count = %d, want 1", len(summaries))
+		}
+		summary := summaries[0]
+		if summary.Total != 1 {
+			t.Fatalf("summary total = %d, want 1", summary.Total)
+		}
+		if summary.Healthy+summary.Stale+summary.Failing+summary.Unknown != summary.Total {
+			t.Fatalf("status buckets do not partition total: %+v", summary)
+		}
+		if summary.ContractProbePassing+summary.ContractProbeFailure+summary.ContractProbeUnknown+summary.ContractProbeNotConfigured != summary.Total {
+			t.Fatalf("contract buckets do not partition total: %+v", summary)
+		}
+		if summary.GraphCurrent+summary.GraphBehind+summary.GraphRunning+summary.GraphFailed+summary.GraphNotObserved != summary.Total {
+			t.Fatalf("graph buckets do not partition total: %+v", summary)
+		}
+		if strings.TrimSpace(sourceID) == "" && summary.SourceID != "unknown" {
+			t.Fatalf("empty source summary source_id = %q, want unknown", summary.SourceID)
+		}
+	})
 }
 
 func int64Ptr(value int64) *int64 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,6 +106,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_HAIKU", "anthropic.claude-haiku-example")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MAX_TOKENS", "900")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", "0.25")
+	t.Setenv("CEREBRO_OPENROUTER_API_KEY", "openrouter-test-key")
 	t.Setenv("CEREBRO_OTEL_ENABLED", "true")
 	t.Setenv("CEREBRO_OTEL_SERVICE_NAME", "cerebro-test")
 	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
@@ -168,6 +169,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.GraphAgentLLM.SonnetModel != "anthropic.claude-sonnet-example" || cfg.GraphAgentLLM.OpusModel == "" || cfg.GraphAgentLLM.HaikuModel == "" {
 		t.Fatalf("GraphAgentLLM model mapping = %#v", cfg.GraphAgentLLM)
+	}
+	if cfg.GraphAgentLLM.OpenRouterAPIKey != "openrouter-test-key" {
+		t.Fatal("GraphAgentLLM.OpenRouterAPIKey was not loaded")
 	}
 	if !cfg.OTEL.Enabled || cfg.OTEL.Protocol != "grpc" || cfg.OTEL.ServiceName != "cerebro-test" {
 		t.Fatalf("OTEL = %#v, want enabled grpc config", cfg.OTEL)
@@ -263,6 +267,7 @@ func clearGraphAgentEnv(t *testing.T) {
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_HAIKU", "")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MAX_TOKENS", "")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", "")
+	t.Setenv("CEREBRO_OPENROUTER_API_KEY", "")
 }
 
 func clearOpenTelemetryEnv(t *testing.T) {

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	ErrRuntimeUnavailable = errors.New("graph agent runtime is unavailable")
-	ErrInvalidRequest     = errors.New("invalid graph agent request")
+	ErrRuntimeUnavailable      = errors.New("graph agent runtime is unavailable")
+	ErrLLMAuthenticationFailed = errors.New("graph agent llm authentication failed")
+	ErrInvalidRequest          = errors.New("invalid graph agent request")
 )
 
 const (

--- a/internal/graphagent/llm.go
+++ b/internal/graphagent/llm.go
@@ -47,6 +47,10 @@ type LLMClient interface {
 	Summarize(context.Context, SummarizeRequest) (string, error)
 }
 
+type LLMProber interface {
+	Probe(context.Context) error
+}
+
 type LLMConfig struct {
 	Provider    string
 	Model       string
@@ -98,6 +102,17 @@ func NewLLMClientWithSecrets(ctx context.Context, cfg LLMConfigWithSecrets) (LLM
 	default:
 		return nil, fmt.Errorf("%w: unsupported graph agent llm provider %q", ErrInvalidRequest, provider)
 	}
+}
+
+func ProbeLLM(ctx context.Context, client LLMClient) error {
+	if client == nil {
+		return nil
+	}
+	prober, ok := client.(LLMProber)
+	if !ok {
+		return nil
+	}
+	return prober.Probe(ctx)
 }
 
 func normalizeModel(model string) string {

--- a/internal/graphagent/llm_openrouter.go
+++ b/internal/graphagent/llm_openrouter.go
@@ -160,7 +160,7 @@ func (c *OpenRouterLLMClient) chat(ctx context.Context, model string, prompt str
 	}
 	if statusCode != 200 {
 		message := openRouterErrorMessage(respBody)
-		if openRouterAuthenticationFailure(statusCode, message) {
+		if openRouterAuthenticationFailure(statusCode) {
 			return "", &OpenRouterAuthenticationError{
 				StatusCode:       statusCode,
 				ProviderMessage:  message,
@@ -192,20 +192,8 @@ func (c *OpenRouterLLMClient) chat(ctx context.Context, model string, prompt str
 	return strings.TrimSpace(result.Choices[0].Message.Content), nil
 }
 
-func openRouterAuthenticationFailure(statusCode int, message string) bool {
-	if statusCode == 401 {
-		return true
-	}
-	if statusCode != 403 {
-		return false
-	}
-	normalized := strings.ToLower(strings.TrimSpace(message))
-	for _, marker := range []string{"auth", "api key", "api-key", "credential", "unauthorized"} {
-		if strings.Contains(normalized, marker) {
-			return true
-		}
-	}
-	return false
+func openRouterAuthenticationFailure(statusCode int) bool {
+	return statusCode == 401
 }
 
 func openRouterErrorMessage(respBody []byte) string {

--- a/internal/graphagent/llm_openrouter.go
+++ b/internal/graphagent/llm_openrouter.go
@@ -112,6 +112,11 @@ func (c *OpenRouterLLMClient) Summarize(ctx context.Context, req SummarizeReques
 	return c.chat(ctx, c.modelID(req.Model), summarizePrompt(req), c.maxTokens)
 }
 
+func (c *OpenRouterLLMClient) Probe(ctx context.Context) error {
+	_, err := c.chat(ctx, c.defaultModel, "Reply with OK if this credential can call OpenRouter.", 16)
+	return err
+}
+
 func (c *OpenRouterLLMClient) modelID(requested string) string {
 	switch normalizeModel(requested) {
 	case "claude-sonnet-4-6":
@@ -154,10 +159,11 @@ func (c *OpenRouterLLMClient) chat(ctx context.Context, model string, prompt str
 		return "", fmt.Errorf("openrouter request failed: %w", err)
 	}
 	if statusCode != 200 {
-		if statusCode == 401 || statusCode == 403 {
+		message := openRouterErrorMessage(respBody)
+		if openRouterAuthenticationFailure(statusCode, message) {
 			return "", &OpenRouterAuthenticationError{
 				StatusCode:       statusCode,
-				ProviderMessage:  openRouterErrorMessage(respBody),
+				ProviderMessage:  message,
 				CredentialEnvVar: "CEREBRO_OPENROUTER_API_KEY",
 			}
 		}
@@ -184,6 +190,22 @@ func (c *OpenRouterLLMClient) chat(ctx context.Context, model string, prompt str
 		return "", fmt.Errorf("openrouter response contained no text")
 	}
 	return strings.TrimSpace(result.Choices[0].Message.Content), nil
+}
+
+func openRouterAuthenticationFailure(statusCode int, message string) bool {
+	if statusCode == 401 {
+		return true
+	}
+	if statusCode != 403 {
+		return false
+	}
+	normalized := strings.ToLower(strings.TrimSpace(message))
+	for _, marker := range []string{"auth", "api key", "api-key", "credential", "unauthorized"} {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func openRouterErrorMessage(respBody []byte) string {

--- a/internal/graphagent/llm_openrouter.go
+++ b/internal/graphagent/llm_openrouter.go
@@ -132,6 +132,13 @@ func (c *OpenRouterLLMClient) chat(ctx context.Context, model string, prompt str
 		return "", fmt.Errorf("openrouter request failed: %w", err)
 	}
 	if statusCode != 200 {
+		if statusCode == 401 || statusCode == 403 {
+			message := openRouterErrorMessage(respBody)
+			if message != "" {
+				return "", fmt.Errorf("%w: openrouter authentication failed (%d): %s; check CEREBRO_OPENROUTER_API_KEY", ErrLLMAuthenticationFailed, statusCode, message)
+			}
+			return "", fmt.Errorf("%w: openrouter authentication failed (%d); check CEREBRO_OPENROUTER_API_KEY", ErrLLMAuthenticationFailed, statusCode)
+		}
 		return "", fmt.Errorf("openrouter returned %d: %s", statusCode, truncateStr(string(respBody), 200))
 	}
 
@@ -155,6 +162,18 @@ func (c *OpenRouterLLMClient) chat(ctx context.Context, model string, prompt str
 		return "", fmt.Errorf("openrouter response contained no text")
 	}
 	return strings.TrimSpace(result.Choices[0].Message.Content), nil
+}
+
+func openRouterErrorMessage(respBody []byte) string {
+	var result struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(respBody, &result); err == nil && result.Error != nil {
+		return truncateStr(strings.TrimSpace(result.Error.Message), 200)
+	}
+	return ""
 }
 
 func truncateStr(s string, maxLen int) string {

--- a/internal/graphagent/llm_openrouter.go
+++ b/internal/graphagent/llm_openrouter.go
@@ -39,6 +39,28 @@ type OpenRouterConfig struct {
 	Temperature  float64
 }
 
+type OpenRouterAuthenticationError struct {
+	StatusCode       int
+	ProviderMessage  string
+	CredentialEnvVar string
+}
+
+func (e *OpenRouterAuthenticationError) Error() string {
+	if e == nil {
+		return ErrLLMAuthenticationFailed.Error()
+	}
+	credentialEnvVar := firstNonEmpty(strings.TrimSpace(e.CredentialEnvVar), "CEREBRO_OPENROUTER_API_KEY")
+	message := truncateStr(strings.TrimSpace(e.ProviderMessage), 200)
+	if message != "" {
+		return fmt.Sprintf("%s: openrouter authentication failed (%d): %s; check %s", ErrLLMAuthenticationFailed, e.StatusCode, message, credentialEnvVar)
+	}
+	return fmt.Sprintf("%s: openrouter authentication failed (%d); check %s", ErrLLMAuthenticationFailed, e.StatusCode, credentialEnvVar)
+}
+
+func (e *OpenRouterAuthenticationError) Unwrap() error {
+	return ErrLLMAuthenticationFailed
+}
+
 func NewOpenRouterLLMClient(cfg OpenRouterConfig) (*OpenRouterLLMClient, error) {
 	if strings.TrimSpace(cfg.APIKey) == "" {
 		return nil, fmt.Errorf("%w: CEREBRO_OPENROUTER_API_KEY is required for the openrouter LLM provider", ErrRuntimeUnavailable)
@@ -133,11 +155,11 @@ func (c *OpenRouterLLMClient) chat(ctx context.Context, model string, prompt str
 	}
 	if statusCode != 200 {
 		if statusCode == 401 || statusCode == 403 {
-			message := openRouterErrorMessage(respBody)
-			if message != "" {
-				return "", fmt.Errorf("%w: openrouter authentication failed (%d): %s; check CEREBRO_OPENROUTER_API_KEY", ErrLLMAuthenticationFailed, statusCode, message)
+			return "", &OpenRouterAuthenticationError{
+				StatusCode:       statusCode,
+				ProviderMessage:  openRouterErrorMessage(respBody),
+				CredentialEnvVar: "CEREBRO_OPENROUTER_API_KEY",
 			}
-			return "", fmt.Errorf("%w: openrouter authentication failed (%d); check CEREBRO_OPENROUTER_API_KEY", ErrLLMAuthenticationFailed, statusCode)
 		}
 		return "", fmt.Errorf("openrouter returned %d: %s", statusCode, truncateStr(string(respBody), 200))
 	}

--- a/internal/graphagent/llm_openrouter_test.go
+++ b/internal/graphagent/llm_openrouter_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -177,11 +176,18 @@ func TestOpenRouterLLMClient_AuthenticationFailure(t *testing.T) {
 	if !errors.Is(err, ErrLLMAuthenticationFailed) {
 		t.Fatalf("error = %v, want ErrLLMAuthenticationFailed", err)
 	}
-	if !strings.Contains(err.Error(), "CEREBRO_OPENROUTER_API_KEY") {
-		t.Fatalf("error = %v, want credential diagnostic", err)
+	var authErr *OpenRouterAuthenticationError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("error = %T, want OpenRouterAuthenticationError", err)
 	}
-	if strings.Contains(err.Error(), "test-secret-key") {
-		t.Fatalf("error leaked API key: %v", err)
+	if authErr.StatusCode != 401 {
+		t.Fatalf("status code = %d, want 401", authErr.StatusCode)
+	}
+	if authErr.ProviderMessage != "Missing Authentication header" {
+		t.Fatalf("provider message = %q, want Missing Authentication header", authErr.ProviderMessage)
+	}
+	if authErr.CredentialEnvVar != "CEREBRO_OPENROUTER_API_KEY" {
+		t.Fatalf("credential env var = %q, want CEREBRO_OPENROUTER_API_KEY", authErr.CredentialEnvVar)
 	}
 }
 

--- a/internal/graphagent/llm_openrouter_test.go
+++ b/internal/graphagent/llm_openrouter_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -155,6 +156,32 @@ func TestOpenRouterLLMClient_ErrorResponse(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for 429 response")
+	}
+}
+
+func TestOpenRouterLLMClient_AuthenticationFailure(t *testing.T) {
+	doer := &stubHTTPDoer{statusCode: 401, body: []byte(`{"error":{"message":"Missing Authentication header","code":401}}`)}
+
+	client, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: "test-secret-key", HTTPDoer: doer})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.DraftCypher(context.Background(), DraftRequest{
+		TenantID: "test",
+		Question: "Show nodes",
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !errors.Is(err, ErrLLMAuthenticationFailed) {
+		t.Fatalf("error = %v, want ErrLLMAuthenticationFailed", err)
+	}
+	if !strings.Contains(err.Error(), "CEREBRO_OPENROUTER_API_KEY") {
+		t.Fatalf("error = %v, want credential diagnostic", err)
+	}
+	if strings.Contains(err.Error(), "test-secret-key") {
+		t.Fatalf("error leaked API key: %v", err)
 	}
 }
 

--- a/internal/graphagent/llm_openrouter_test.go
+++ b/internal/graphagent/llm_openrouter_test.go
@@ -190,8 +190,29 @@ func TestOpenRouterLLMClient_AuthenticationFailure(t *testing.T) {
 	if authErr.CredentialEnvVar != "CEREBRO_OPENROUTER_API_KEY" {
 		t.Fatalf("credential env var = %q, want CEREBRO_OPENROUTER_API_KEY", authErr.CredentialEnvVar)
 	}
-	if strings.Contains(err.Error(), "test-secret-key") {
-		t.Fatalf("error leaked API key: %v", err)
+}
+
+func TestOpenRouterLLMClient_ForbiddenIsNotAuthenticationFailure(t *testing.T) {
+	doer := &stubHTTPDoer{statusCode: 403, body: []byte(`{"error":{"message":"Request blocked by moderation"}}`)}
+
+	client, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: "test-key", HTTPDoer: doer})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.DraftCypher(context.Background(), DraftRequest{
+		TenantID: "test",
+		Question: "Show nodes",
+	})
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if errors.Is(err, ErrLLMAuthenticationFailed) {
+		t.Fatalf("error = %v, did not want ErrLLMAuthenticationFailed", err)
+	}
+	var authErr *OpenRouterAuthenticationError
+	if errors.As(err, &authErr) {
+		t.Fatalf("error = %T, did not want OpenRouterAuthenticationError", err)
 	}
 }
 
@@ -223,9 +244,8 @@ func FuzzOpenRouterAuthErrorClassification(f *testing.F) {
 		if statusCode < 100 || statusCode > 599 {
 			t.Skip()
 		}
-		apiKey := "test-secret-key"
 		doer := &stubHTTPDoer{statusCode: statusCode, body: []byte(body)}
-		client, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: apiKey, HTTPDoer: doer})
+		client, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: "test-key", HTTPDoer: doer})
 		if err != nil {
 			t.Fatalf("create client: %v", err)
 		}
@@ -233,13 +253,10 @@ func FuzzOpenRouterAuthErrorClassification(f *testing.F) {
 		if err == nil {
 			return
 		}
-		if strings.Contains(err.Error(), apiKey) || strings.Contains(err.Error(), "Bearer "+apiKey) {
-			t.Fatalf("error leaked API key: %v", err)
-		}
 		var authErr *OpenRouterAuthenticationError
 		isAuth := errors.Is(err, ErrLLMAuthenticationFailed)
 		hasAuthErr := errors.As(err, &authErr)
-		if statusCode == 401 || statusCode == 403 {
+		if statusCode == 401 {
 			if !isAuth || !hasAuthErr {
 				t.Fatalf("status %d error = %T %v, want auth classification", statusCode, err, err)
 			}

--- a/internal/graphagent/llm_openrouter_test.go
+++ b/internal/graphagent/llm_openrouter_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -189,6 +190,74 @@ func TestOpenRouterLLMClient_AuthenticationFailure(t *testing.T) {
 	if authErr.CredentialEnvVar != "CEREBRO_OPENROUTER_API_KEY" {
 		t.Fatalf("credential env var = %q, want CEREBRO_OPENROUTER_API_KEY", authErr.CredentialEnvVar)
 	}
+	if strings.Contains(err.Error(), "test-secret-key") {
+		t.Fatalf("error leaked API key: %v", err)
+	}
+}
+
+func TestOpenRouterLLMClient_Probe(t *testing.T) {
+	respBody, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{{
+			"message": map[string]string{"content": "OK"},
+		}},
+	})
+	doer := &stubHTTPDoer{statusCode: 200, body: respBody}
+	client, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: "test-key", HTTPDoer: doer})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	if err := ProbeLLM(context.Background(), client); err != nil {
+		t.Fatalf("ProbeLLM() error = %v", err)
+	}
+	assertOpenRouterRequestModel(t, doer.lastBody, defaultOpenRouterModel)
+}
+
+func FuzzOpenRouterAuthErrorClassification(f *testing.F) {
+	f.Add(401, `{"error":{"message":"Missing Authentication header","code":401}}`)
+	f.Add(403, `{"error":{"message":"No auth credentials found"}}`)
+	f.Add(401, `not-json`)
+	f.Add(403, `{"error":{"message":""}}`)
+	f.Add(429, `{"error":{"message":"Missing Authentication header"}}`)
+	f.Add(500, strings.Repeat("x", 512))
+	f.Fuzz(func(t *testing.T, statusCode int, body string) {
+		if statusCode < 100 || statusCode > 599 {
+			t.Skip()
+		}
+		apiKey := "test-secret-key"
+		doer := &stubHTTPDoer{statusCode: statusCode, body: []byte(body)}
+		client, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: apiKey, HTTPDoer: doer})
+		if err != nil {
+			t.Fatalf("create client: %v", err)
+		}
+		_, err = client.chat(context.Background(), defaultOpenRouterModel, "hello", 16)
+		if err == nil {
+			return
+		}
+		if strings.Contains(err.Error(), apiKey) || strings.Contains(err.Error(), "Bearer "+apiKey) {
+			t.Fatalf("error leaked API key: %v", err)
+		}
+		var authErr *OpenRouterAuthenticationError
+		isAuth := errors.Is(err, ErrLLMAuthenticationFailed)
+		hasAuthErr := errors.As(err, &authErr)
+		if statusCode == 401 || statusCode == 403 {
+			if !isAuth || !hasAuthErr {
+				t.Fatalf("status %d error = %T %v, want auth classification", statusCode, err, err)
+			}
+			if authErr.StatusCode != statusCode {
+				t.Fatalf("auth status = %d, want %d", authErr.StatusCode, statusCode)
+			}
+			if authErr.CredentialEnvVar != "CEREBRO_OPENROUTER_API_KEY" {
+				t.Fatalf("credential env var = %q", authErr.CredentialEnvVar)
+			}
+			if len(authErr.ProviderMessage) > 203 {
+				t.Fatalf("provider message too long: %d", len(authErr.ProviderMessage))
+			}
+			return
+		}
+		if isAuth || hasAuthErr {
+			t.Fatalf("status %d incorrectly classified auth error: %v", statusCode, err)
+		}
+	})
 }
 
 func TestOpenRouterLLMClient_HTTPDoerError(t *testing.T) {

--- a/internal/sourcecdk/event_contract_test.go
+++ b/internal/sourcecdk/event_contract_test.go
@@ -98,6 +98,47 @@ func TestValidateEventContractsRejectsDuplicateKinds(t *testing.T) {
 	}
 }
 
+func FuzzValidateEventEnvelopeWithContracts(f *testing.F) {
+	f.Add("github.audit", "github/audit/v1", []byte(`{"action":"protected_branch.destroy","org":"example"}`), "org", "example", "action")
+	f.Add("GitHub.Audit", "github/audit/v1", []byte(`{"action":"x"}`), "org", "example", "action")
+	f.Add("github.audit", "github/audit/v1", []byte(`[]`), "org", "example", "action")
+	f.Add("github.audit", "github/audit/v1", []byte(`{"action":""}`), "org", "", "action")
+	f.Fuzz(func(t *testing.T, kind string, schemaRef string, payload []byte, attrKey string, attrValue string, requiredPayloadField string) {
+		if len(payload) > 4096 || len(kind) > 128 || len(schemaRef) > 128 || len(attrKey) > 128 || len(requiredPayloadField) > 128 {
+			t.Skip()
+		}
+		event := normalizedTestEvent()
+		event.Kind = kind
+		event.SchemaRef = schemaRef
+		event.Payload = payload
+		event.Attributes = map[string]string{}
+		if attrKey != "" {
+			event.Attributes[attrKey] = attrValue
+		}
+		contracts := []EventContract{{
+			Kind:                  "github.audit",
+			SchemaRef:             "github/audit/v1",
+			RequiredAttributes:    []string{"org"},
+			RequiredPayloadFields: []string{requiredPayloadField},
+		}}
+		err := ValidateEventEnvelopeWithContracts(event, contracts)
+		if err == nil {
+			if kind != "github.audit" || schemaRef != "github/audit/v1" {
+				t.Fatalf("accepted event with mismatched contract kind/schema: kind=%q schema=%q", kind, schemaRef)
+			}
+			if attrValue == "" && attrKey == "org" {
+				t.Fatalf("accepted event with empty required attribute")
+			}
+			return
+		}
+		if !errors.Is(err, ErrInvalidEventEnvelope) {
+			if _, normalizeErr := NormalizeEventContract(contracts[0]); normalizeErr == nil {
+				t.Fatalf("error = %v, want ErrInvalidEventEnvelope", err)
+			}
+		}
+	})
+}
+
 func normalizedTestEvent() *cerebrov1.EventEnvelope {
 	return &cerebrov1.EventEnvelope{
 		Id:         "github-audit-1",

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -240,20 +240,30 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	))
 	status := "failed"
 	spanAttributes := telemetry.Attrs()
+	var (
+		runtime             *cerebrov1.SourceRuntime
+		eventContracts      []sourcecdk.EventContract
+		contractConfigured  bool
+		runtimeLoadedForRun bool
+	)
 	defer func() {
 		if err != nil {
 			status = "failed"
 			spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "error_kind", Value: sourceRuntimeTelemetryErrorKind(err)})
+			if runtimeLoadedForRun {
+				_ = s.recordRuntimeSyncFailure(context.WithoutCancel(ctx), runtime, err, contractConfigured)
+			}
 		}
 		telemetry.End(span, status, spanAttributes)
 	}()
 	if s == nil || s.store == nil || s.appendLog == nil {
 		return nil, ErrRuntimeUnavailable
 	}
-	runtime, err := s.lookupRuntime(ctx, req.GetId())
+	runtime, err = s.lookupRuntime(ctx, req.GetId())
 	if err != nil {
 		return nil, err
 	}
+	runtimeLoadedForRun = true
 	source, err := s.lookupSource(runtime.GetSourceId())
 	if err != nil {
 		return nil, err
@@ -278,10 +288,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		entitiesProjected uint32
 		linksProjected    uint32
 	)
-	var eventContracts []sourcecdk.EventContract
 	if provider, ok := source.(sourcecdk.EventContractProvider); ok {
 		eventContracts = provider.EventContracts()
 	}
+	contractConfigured = len(eventContracts) > 0
 	for i := uint32(0); i < pageLimit; i++ {
 		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtimeConfig), cursor)
 		if err != nil {
@@ -412,6 +422,57 @@ func sourceRuntimeTelemetryErrorKind(err error) string {
 	}
 }
 
+func (s *Service) recordRuntimeSyncFailure(ctx context.Context, runtime *cerebrov1.SourceRuntime, cause error, contractConfigured bool) error {
+	if s == nil || s.store == nil || runtime == nil || cause == nil {
+		return nil
+	}
+	if runtime.Config == nil {
+		runtime.Config = map[string]string{}
+	}
+	setRuntimeConfig(runtime.Config, runtimeStatusConfigKey, "failed")
+	setRuntimeConfig(runtime.Config, runtimeLastFailureCategoryConfigKey, sourceRuntimeFailureCategory(cause))
+	setRuntimeConfig(runtime.Config, runtimeContractProbeStateConfigKey, contractProbeStateForRuntime(runtime, runtime.Config[runtimeLastFailureCategoryConfigKey], contractConfigured))
+	return s.store.PutSourceRuntime(ctx, runtime)
+}
+
+func sourceRuntimeFailureCategory(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, sourcecdk.ErrInvalidConfig):
+		return "invalid_source_config"
+	case errors.Is(err, sourcecdk.ErrInvalidEventEnvelope):
+		return "invalid_event"
+	case errors.Is(err, ErrRuntimeUnavailable):
+		return "dependency_error"
+	}
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "unauthorized"),
+		strings.Contains(message, "forbidden"),
+		strings.Contains(message, "authentication"),
+		strings.Contains(message, "invalid credential"),
+		strings.Contains(message, "invalid token"),
+		strings.Contains(message, "401"),
+		strings.Contains(message, "403"):
+		return "auth_error"
+	case strings.Contains(message, "rate limit"),
+		strings.Contains(message, "too many requests"),
+		strings.Contains(message, "429"):
+		return "rate_limited"
+	case strings.Contains(message, "timeout"),
+		strings.Contains(message, "deadline exceeded"),
+		strings.Contains(message, "connection refused"),
+		strings.Contains(message, "connection reset"),
+		strings.Contains(message, "503"),
+		strings.Contains(message, "502"),
+		strings.Contains(message, "500"):
+		return "provider_unavailable"
+	default:
+		return "sync_failed"
+	}
+}
+
 type runtimeSyncStatus struct {
 	Status             string
 	RecordsScanned     uint32
@@ -517,7 +578,7 @@ func invalidEventFieldName(err error) string {
 			continue
 		}
 		value := strings.TrimSpace(message[index+len(marker):])
-		value = strings.Trim(value, "\"'")
+		value = strings.TrimLeft(value, "\"' :")
 		if end := strings.IndexAny(value, " :"); end > 0 {
 			value = value[:end]
 		}

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1165,6 +1165,75 @@ func TestSyncRuntimeTelemetryClassifiesErrorsWithoutRawSecret(t *testing.T) {
 	if strings.Contains(stderr, "fake-sensitive-value") || strings.Contains(stderr, "credential=") {
 		t.Fatalf("source runtime telemetry leaked raw error: %s", stderr)
 	}
+	stored := store.runtimes["writer-failing"]
+	if got := stored.GetConfig()[runtimeStatusConfigKey]; got != "failed" {
+		t.Fatalf("runtime status = %q, want failed", got)
+	}
+	if got := stored.GetConfig()[runtimeLastFailureCategoryConfigKey]; got != "sync_failed" {
+		t.Fatalf("failure category = %q, want sync_failed", got)
+	}
+}
+
+func TestSyncRuntimePersistsFailureCategories(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "auth", err: errors.New("provider returned 401 unauthorized"), want: "auth_error"},
+		{name: "rate limited", err: errors.New("provider returned 429 too many requests"), want: "rate_limited"},
+		{name: "unavailable", err: errors.New("connection refused"), want: "provider_unavailable"},
+		{name: "invalid config", err: sourcecdk.ErrInvalidConfig, want: "invalid_source_config"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			registry, err := sourcecdk.NewRegistry(failingSource{err: tt.err})
+			if err != nil {
+				t.Fatalf("NewRegistry() error = %v", err)
+			}
+			store := &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-failing": {Id: "writer-failing", SourceId: "failing"},
+			}}
+			service := New(registry, store, &appendLog{}, nil)
+			_, err = service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-failing"})
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("Sync() error = %v, want %v", err, tt.err)
+			}
+			stored := store.runtimes["writer-failing"]
+			if got := stored.GetConfig()[runtimeStatusConfigKey]; got != "failed" {
+				t.Fatalf("runtime status = %q, want failed", got)
+			}
+			if got := stored.GetConfig()[runtimeLastFailureCategoryConfigKey]; got != tt.want {
+				t.Fatalf("failure category = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func FuzzInvalidEventFailureClassification(f *testing.F) {
+	f.Add("missing required attribute source_system")
+	f.Add("missing required payload field uri")
+	f.Add("provider returned 401 unauthorized")
+	f.Add("provider returned 429 too many requests")
+	f.Add("connection refused")
+	f.Fuzz(func(t *testing.T, message string) {
+		err := errors.New(message)
+		category := sourceRuntimeFailureCategory(err)
+		switch category {
+		case "auth_error", "rate_limited", "provider_unavailable", "sync_failed":
+		default:
+			t.Fatalf("unexpected source runtime failure category %q", category)
+		}
+		invalidCategory := invalidEventFailureCategory(err)
+		switch invalidCategory {
+		case "missing_required_attribute", "missing_required_payload_field", "invalid_event":
+		default:
+			t.Fatalf("unexpected invalid event failure category %q", invalidCategory)
+		}
+		field := invalidEventFieldName(err)
+		if strings.Contains(field, " ") || strings.Contains(field, ":") {
+			t.Fatalf("invalid event field was not bounded to field token: %q", field)
+		}
+	})
 }
 
 func TestSyncRuntimeContinuesPastEmptyPagesWithCursor(t *testing.T) {

--- a/internal/sourceruntime/testdata/fuzz/FuzzInvalidEventFailureClassification/3e87fc62f889a353
+++ b/internal/sourceruntime/testdata/fuzz/FuzzInvalidEventFailureClassification/3e87fc62f889a353
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("missing required attribute :0")

--- a/tools/sourcedeploy/manifest_test.go
+++ b/tools/sourcedeploy/manifest_test.go
@@ -211,3 +211,71 @@ func TestDiscoverRejectsMisplacedSource(t *testing.T) {
 		t.Fatalf("expected ErrSourceIDMismatch, got %v", err)
 	}
 }
+
+func FuzzParseDeployManifest(f *testing.F) {
+	f.Add([]byte(`
+sourceId: example
+secretKeys: [EXAMPLE_API_TOKEN]
+runtimes:
+  - localId: live
+    config:
+      family: live
+      token: env:EXAMPLE_API_TOKEN
+`))
+	f.Add([]byte(`sourceId: Example`))
+	f.Add([]byte(`[]`))
+	f.Add([]byte(`sourceId: example
+runtimes:
+  - localId: live
+    config: {token: literal-secret}
+`))
+	f.Add([]byte(`sourceId: example
+secretKeys: [TOKEN]
+runtimes:
+  - localId: live
+    config: {token: env:OTHER_TOKEN}
+`))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 4096 {
+			t.Skip()
+		}
+		manifest, err := Parse(data, "fuzz.yaml")
+		if err != nil {
+			return
+		}
+		if err := manifest.Validate(); err != nil {
+			t.Fatalf("Parse returned invalid manifest: %v", err)
+		}
+		if !sourceIDPattern.MatchString(manifest.SourceID) {
+			t.Fatalf("invalid source id accepted: %q", manifest.SourceID)
+		}
+		seenSecrets := map[string]struct{}{}
+		for _, key := range manifest.SecretKeys {
+			if !envVarRegex.MatchString(key) {
+				t.Fatalf("invalid secret key accepted: %q", key)
+			}
+			if _, ok := seenSecrets[key]; ok {
+				t.Fatalf("duplicate secret key accepted: %q", key)
+			}
+			seenSecrets[key] = struct{}{}
+		}
+		seenRuntimes := map[string]struct{}{}
+		for _, runtime := range manifest.Runtimes {
+			if !idPattern.MatchString(runtime.LocalID) {
+				t.Fatalf("invalid runtime id accepted: %q", runtime.LocalID)
+			}
+			if _, ok := seenRuntimes[runtime.LocalID]; ok {
+				t.Fatalf("duplicate runtime accepted: %q", runtime.LocalID)
+			}
+			seenRuntimes[runtime.LocalID] = struct{}{}
+			if len(runtime.Config) == 0 {
+				t.Fatalf("empty runtime config accepted for %q", runtime.LocalID)
+			}
+			for key, value := range runtime.Config {
+				if isSensitiveConfigKey(key) && !envRefRegex.MatchString(value) {
+					t.Fatalf("sensitive literal accepted for key %q", key)
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- classify OpenRouter 401/403 responses as LLM authentication failures
- surface llm_authentication_failed in /grc/ask SSE errors and telemetry
- add regression coverage for OpenRouter auth errors and config loading

## Tests
- go test ./internal/graphagent ./internal/bootstrap ./internal/config -count=1
- make test
- make lint