### PR TITLE
feat: add runtime freshness API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -149,6 +149,11 @@ paths:
           in: query
           schema:
             type: string
+        - name: runtime_ids
+          in: query
+          schema:
+            type: string
+          description: Comma-separated runtime IDs.
         - name: tenant_id
           in: query
           schema:
@@ -1358,6 +1363,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EndpointVulnerabilityFindingsResponse'
+  /platform/runtime-freshness:
+    get:
+      summary: List canonical runtime freshness
+      tags:
+        - Platform
+      parameters:
+        - name: runtime_id
+          in: query
+          schema:
+            type: string
+        - name: runtime_ids
+          in: query
+          schema:
+            type: string
+          description: Comma-separated runtime IDs.
+        - name: tenant_id
+          in: query
+          schema:
+            type: string
+        - name: source_id
+          in: query
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limitQuery'
+      responses:
+        '200':
+          description: Canonical source sync and graph freshness worklist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeFreshnessResponse'
   /platform/graph/ingest-health:
     get:
       summary: Check graph ingest health
@@ -2590,6 +2626,187 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SourceRuntimeHealthRecord'
+        source_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceRuntimeHealthSummary'
+    SourceRuntimeHealthSummary:
+      type: object
+      properties:
+        source_id:
+          type: string
+        total:
+          type: integer
+          minimum: 0
+        healthy:
+          type: integer
+          minimum: 0
+        stale:
+          type: integer
+          minimum: 0
+        failing:
+          type: integer
+          minimum: 0
+        unknown:
+          type: integer
+          minimum: 0
+        graph_current:
+          type: integer
+          minimum: 0
+        graph_behind:
+          type: integer
+          minimum: 0
+        graph_failed:
+          type: integer
+          minimum: 0
+        graph_running:
+          type: integer
+          minimum: 0
+        graph_not_observed:
+          type: integer
+          minimum: 0
+        contract_probe_passing:
+          type: integer
+          minimum: 0
+        contract_probe_failure:
+          type: integer
+          minimum: 0
+        contract_probe_unknown:
+          type: integer
+          minimum: 0
+        contract_probe_not_configured:
+          type: integer
+          minimum: 0
+        cursor_pending:
+          type: integer
+          minimum: 0
+    RuntimeFreshnessResponse:
+      type: object
+      properties:
+        generated_at:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [healthy, degraded]
+        runtimes:
+          type: array
+          items:
+            $ref: '#/components/schemas/RuntimeFreshnessRecord'
+        summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/RuntimeFreshnessSummary'
+    RuntimeFreshnessSummary:
+      type: object
+      properties:
+        source_id:
+          type: string
+        total:
+          type: integer
+          minimum: 0
+        healthy:
+          type: integer
+          minimum: 0
+        needs_attention:
+          type: integer
+          minimum: 0
+        source_failed:
+          type: integer
+          minimum: 0
+        source_stale:
+          type: integer
+          minimum: 0
+        graph_missing:
+          type: integer
+          minimum: 0
+        graph_failed:
+          type: integer
+          minimum: 0
+        graph_behind:
+          type: integer
+          minimum: 0
+        backfill_eligible:
+          type: integer
+          minimum: 0
+        quarantined_or_disabled:
+          type: integer
+          minimum: 0
+    RuntimeFreshnessRecord:
+      type: object
+      properties:
+        runtime_id:
+          type: string
+        source_id:
+          type: string
+        tenant_id:
+          type: string
+        family:
+          type: string
+        lifecycle_state:
+          type: string
+          enum: [active, disabled]
+        schedule_state:
+          type: string
+          enum: [configured, unknown]
+        freshness_state:
+          type: string
+          enum: [healthy, disabled, source_failed, source_stale, graph_missing, graph_failed, graph_behind, unknown]
+        source_sync_state:
+          type: string
+          enum: [current, stale, failed, unknown]
+        graph_ingest_state:
+          type: string
+          enum: [current, behind, failed, running, not_observed]
+        finding_evaluation_state:
+          type: string
+          enum: [current, failed, running, not_observed]
+        failure_class:
+          type: string
+        failure_reason:
+          type: string
+        last_synced_at:
+          type: string
+          format: date-time
+        sync_lag_seconds:
+          type: integer
+          minimum: 0
+        checkpoint_watermark:
+          type: string
+          format: date-time
+        watermark_lag_seconds:
+          type: integer
+          minimum: 0
+        latest_graph_run:
+          $ref: '#/components/schemas/SourceRuntimeHealthGraphRun'
+        graph_lag_seconds:
+          type: integer
+          minimum: 0
+        latest_finding_evaluation:
+          $ref: '#/components/schemas/SourceRuntimeHealthFindingEvaluation'
+        expected_cadence_seconds:
+          type: integer
+          minimum: 0
+        stale_after_seconds:
+          type: integer
+          minimum: 0
+        backfill_eligible:
+          type: boolean
+        backfill_eligibility_reason:
+          type: string
+        next_action:
+          type: string
+        recommended_workflow:
+          type: string
+        cursor_pending:
+          type: boolean
+        checkpoint_cursor_present:
+          type: boolean
+        schedule_context_configured:
+          type: boolean
+        generated_at:
+          type: string
+          format: date-time
     SourceRuntimeHealthRecord:
       type: object
       properties:

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -53,6 +53,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodGet, Prefix: "/grc/", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodPost, Exact: "/grc/ask", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/inventory/resource-scope", Scope: scopeGRCInventoryWrite, Static: true},
+	{Method: http.MethodGet, Exact: "/platform/runtime-freshness", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/platform/graph/neighborhood", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/platform/graph/impact/package", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/platform/graph/impact/asset", Scope: scopeCosmoSecurityRead, Static: true},

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -115,6 +115,7 @@ func (app *App) registerKnowledgeRoutes(mux *http.ServeMux) {
 }
 
 func (app *App) registerGraphRoutes(mux *http.ServeMux) {
+	registerHTTPRoute(mux, "GET /platform/runtime-freshness", routeSurfacePlatformHTTP, app.handleListRuntimeFreshness)
 	registerHTTPRoute(mux, "GET /platform/graph/neighborhood", routeSurfacePlatformHTTP, app.handleGetEntityNeighborhood)
 	registerHTTPRoute(mux, "GET /platform/graph/impact/vulnerability/{id}", routeSurfacePlatformHTTP, app.handleGetVulnerabilityImpact)
 	registerHTTPRoute(mux, "GET /platform/graph/impact/package", routeSurfacePlatformHTTP, app.handleGetPackageImpact)

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -46,35 +46,51 @@ type runtimeFreshnessSummary struct {
 }
 
 type runtimeFreshnessRecord struct {
-	RuntimeID                 string                                `json:"runtime_id"`
-	SourceID                  string                                `json:"source_id"`
-	TenantID                  string                                `json:"tenant_id,omitempty"`
-	Family                    string                                `json:"family,omitempty"`
-	LifecycleState            string                                `json:"lifecycle_state"`
-	ScheduleState             string                                `json:"schedule_state"`
-	FreshnessState            string                                `json:"freshness_state"`
-	SourceSyncState           string                                `json:"source_sync_state"`
-	GraphIngestState          string                                `json:"graph_ingest_state"`
-	FindingEvaluationState    string                                `json:"finding_evaluation_state"`
-	FailureClass              string                                `json:"failure_class,omitempty"`
-	FailureReason             string                                `json:"failure_reason,omitempty"`
-	LastSyncedAt              string                                `json:"last_synced_at,omitempty"`
-	SyncLagSeconds            *int64                                `json:"sync_lag_seconds,omitempty"`
-	CheckpointWatermark       string                                `json:"checkpoint_watermark,omitempty"`
-	WatermarkLagSeconds       *int64                                `json:"watermark_lag_seconds,omitempty"`
-	LatestGraphRun            *sourceRuntimeHealthGraphRun          `json:"latest_graph_run,omitempty"`
-	GraphLagSeconds           *int64                                `json:"graph_lag_seconds,omitempty"`
-	LatestFindingEvaluation   *sourceRuntimeHealthFindingEvaluation `json:"latest_finding_evaluation,omitempty"`
-	ExpectedCadenceSeconds    *int64                                `json:"expected_cadence_seconds,omitempty"`
-	StaleAfterSeconds         *int64                                `json:"stale_after_seconds,omitempty"`
-	BackfillEligible          bool                                  `json:"backfill_eligible"`
-	BackfillEligibilityReason string                                `json:"backfill_eligibility_reason,omitempty"`
-	NextAction                string                                `json:"next_action"`
-	RecommendedWorkflow       string                                `json:"recommended_workflow,omitempty"`
-	CursorPending             bool                                  `json:"cursor_pending"`
-	CheckpointCursorPresent   bool                                  `json:"checkpoint_cursor_present"`
-	ScheduleContextConfigured bool                                  `json:"schedule_context_configured"`
-	GeneratedAt               string                                `json:"generated_at"`
+	runtimeFreshnessIdentity
+	runtimeFreshnessStates
+	runtimeFreshnessObservations
+	runtimeFreshnessActions
+}
+
+type runtimeFreshnessIdentity struct {
+	RuntimeID string `json:"runtime_id"`
+	SourceID  string `json:"source_id"`
+	TenantID  string `json:"tenant_id,omitempty"`
+	Family    string `json:"family,omitempty"`
+}
+
+type runtimeFreshnessStates struct {
+	LifecycleState            string `json:"lifecycle_state"`
+	ScheduleState             string `json:"schedule_state"`
+	FreshnessState            string `json:"freshness_state"`
+	SourceSyncState           string `json:"source_sync_state"`
+	GraphIngestState          string `json:"graph_ingest_state"`
+	FindingEvaluationState    string `json:"finding_evaluation_state"`
+	FailureClass              string `json:"failure_class,omitempty"`
+	FailureReason             string `json:"failure_reason,omitempty"`
+	BackfillEligible          bool   `json:"backfill_eligible"`
+	BackfillEligibilityReason string `json:"backfill_eligibility_reason,omitempty"`
+}
+
+type runtimeFreshnessObservations struct {
+	LastSyncedAt            string                                `json:"last_synced_at,omitempty"`
+	SyncLagSeconds          *int64                                `json:"sync_lag_seconds,omitempty"`
+	CheckpointWatermark     string                                `json:"checkpoint_watermark,omitempty"`
+	WatermarkLagSeconds     *int64                                `json:"watermark_lag_seconds,omitempty"`
+	LatestGraphRun          *sourceRuntimeHealthGraphRun          `json:"latest_graph_run,omitempty"`
+	GraphLagSeconds         *int64                                `json:"graph_lag_seconds,omitempty"`
+	LatestFindingEvaluation *sourceRuntimeHealthFindingEvaluation `json:"latest_finding_evaluation,omitempty"`
+	ExpectedCadenceSeconds  *int64                                `json:"expected_cadence_seconds,omitempty"`
+	StaleAfterSeconds       *int64                                `json:"stale_after_seconds,omitempty"`
+	GeneratedAt             string                                `json:"generated_at"`
+}
+
+type runtimeFreshnessActions struct {
+	NextAction                string `json:"next_action"`
+	RecommendedWorkflow       string `json:"recommended_workflow,omitempty"`
+	CursorPending             bool   `json:"cursor_pending"`
+	CheckpointCursorPresent   bool   `json:"checkpoint_cursor_present"`
+	ScheduleContextConfigured bool   `json:"schedule_context_configured"`
 }
 
 type sourceRuntimeHealthSummary struct {
@@ -321,35 +337,43 @@ func runtimeFreshnessRecordFromHealth(record sourceRuntimeHealthRecord) runtimeF
 		workflow = "source-runtime-backfill"
 	}
 	return runtimeFreshnessRecord{
-		RuntimeID:                 record.RuntimeID,
-		SourceID:                  record.SourceID,
-		TenantID:                  record.TenantID,
-		Family:                    record.Family,
-		LifecycleState:            lifecycleState,
-		ScheduleState:             scheduleState,
-		FreshnessState:            freshnessState,
-		SourceSyncState:           sourceSyncState,
-		GraphIngestState:          graphIngestState,
-		FindingEvaluationState:    findingEvaluationState,
-		FailureClass:              failureClass,
-		FailureReason:             failureReason,
-		LastSyncedAt:              record.LastSyncedAt,
-		SyncLagSeconds:            record.SyncLagSeconds,
-		CheckpointWatermark:       record.CheckpointWatermark,
-		WatermarkLagSeconds:       record.WatermarkLagSeconds,
-		LatestGraphRun:            record.LatestGraphRun,
-		GraphLagSeconds:           record.GraphLagSeconds,
-		LatestFindingEvaluation:   record.LatestFindingEvaluation,
-		ExpectedCadenceSeconds:    record.ExpectedCadenceSeconds,
-		StaleAfterSeconds:         record.StaleAfterSeconds,
-		BackfillEligible:          backfillEligible,
-		BackfillEligibilityReason: backfillReason,
-		NextAction:                nextAction,
-		RecommendedWorkflow:       workflow,
-		CursorPending:             record.CursorPending,
-		CheckpointCursorPresent:   record.CheckpointCursorPresent,
-		ScheduleContextConfigured: record.ScheduleContextConfigured,
-		GeneratedAt:               record.GeneratedAt,
+		runtimeFreshnessIdentity: runtimeFreshnessIdentity{
+			RuntimeID: record.RuntimeID,
+			SourceID:  record.SourceID,
+			TenantID:  record.TenantID,
+			Family:    record.Family,
+		},
+		runtimeFreshnessStates: runtimeFreshnessStates{
+			LifecycleState:            lifecycleState,
+			ScheduleState:             scheduleState,
+			FreshnessState:            freshnessState,
+			SourceSyncState:           sourceSyncState,
+			GraphIngestState:          graphIngestState,
+			FindingEvaluationState:    findingEvaluationState,
+			FailureClass:              failureClass,
+			FailureReason:             failureReason,
+			BackfillEligible:          backfillEligible,
+			BackfillEligibilityReason: backfillReason,
+		},
+		runtimeFreshnessObservations: runtimeFreshnessObservations{
+			LastSyncedAt:            record.LastSyncedAt,
+			SyncLagSeconds:          record.SyncLagSeconds,
+			CheckpointWatermark:     record.CheckpointWatermark,
+			WatermarkLagSeconds:     record.WatermarkLagSeconds,
+			LatestGraphRun:          record.LatestGraphRun,
+			GraphLagSeconds:         record.GraphLagSeconds,
+			LatestFindingEvaluation: record.LatestFindingEvaluation,
+			ExpectedCadenceSeconds:  record.ExpectedCadenceSeconds,
+			StaleAfterSeconds:       record.StaleAfterSeconds,
+			GeneratedAt:             record.GeneratedAt,
+		},
+		runtimeFreshnessActions: runtimeFreshnessActions{
+			NextAction:                nextAction,
+			RecommendedWorkflow:       workflow,
+			CursorPending:             record.CursorPending,
+			CheckpointCursorPresent:   record.CheckpointCursorPresent,
+			ScheduleContextConfigured: record.ScheduleContextConfigured,
+		},
 	}
 }
 

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -429,7 +429,7 @@ func runtimeFreshnessState(record sourceRuntimeHealthRecord, lifecycleState stri
 	if sourceSyncState == "stale" {
 		return "source_stale", "source_sync_stale", "source runtime is older than the configured freshness window", "run_source_sync"
 	}
-	if sourceSyncState == "current" && graphIngestState == "current" {
+	if sourceSyncState == "current" && (graphIngestState == "current" || graphIngestState == "running") {
 		return "healthy", "", "", "monitor"
 	}
 	return "unknown", "insufficient_signal", "source or graph freshness signal is unavailable", "inspect_runtime"

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -24,6 +24,59 @@ type sourceRuntimeHealthResponse struct {
 	SourceSummaries []sourceRuntimeHealthSummary `json:"source_summaries"`
 }
 
+type runtimeFreshnessResponse struct {
+	GeneratedAt string                    `json:"generated_at"`
+	Status      string                    `json:"status"`
+	Runtimes    []runtimeFreshnessRecord  `json:"runtimes"`
+	Summaries   []runtimeFreshnessSummary `json:"summaries"`
+}
+
+type runtimeFreshnessSummary struct {
+	SourceID              string `json:"source_id"`
+	Total                 int    `json:"total"`
+	Healthy               int    `json:"healthy"`
+	NeedsAttention        int    `json:"needs_attention"`
+	SourceFailed          int    `json:"source_failed"`
+	SourceStale           int    `json:"source_stale"`
+	GraphMissing          int    `json:"graph_missing"`
+	GraphFailed           int    `json:"graph_failed"`
+	GraphBehind           int    `json:"graph_behind"`
+	BackfillEligible      int    `json:"backfill_eligible"`
+	QuarantinedOrDisabled int    `json:"quarantined_or_disabled"`
+}
+
+type runtimeFreshnessRecord struct {
+	RuntimeID                 string                                `json:"runtime_id"`
+	SourceID                  string                                `json:"source_id"`
+	TenantID                  string                                `json:"tenant_id,omitempty"`
+	Family                    string                                `json:"family,omitempty"`
+	LifecycleState            string                                `json:"lifecycle_state"`
+	ScheduleState             string                                `json:"schedule_state"`
+	FreshnessState            string                                `json:"freshness_state"`
+	SourceSyncState           string                                `json:"source_sync_state"`
+	GraphIngestState          string                                `json:"graph_ingest_state"`
+	FindingEvaluationState    string                                `json:"finding_evaluation_state"`
+	FailureClass              string                                `json:"failure_class,omitempty"`
+	FailureReason             string                                `json:"failure_reason,omitempty"`
+	LastSyncedAt              string                                `json:"last_synced_at,omitempty"`
+	SyncLagSeconds            *int64                                `json:"sync_lag_seconds,omitempty"`
+	CheckpointWatermark       string                                `json:"checkpoint_watermark,omitempty"`
+	WatermarkLagSeconds       *int64                                `json:"watermark_lag_seconds,omitempty"`
+	LatestGraphRun            *sourceRuntimeHealthGraphRun          `json:"latest_graph_run,omitempty"`
+	GraphLagSeconds           *int64                                `json:"graph_lag_seconds,omitempty"`
+	LatestFindingEvaluation   *sourceRuntimeHealthFindingEvaluation `json:"latest_finding_evaluation,omitempty"`
+	ExpectedCadenceSeconds    *int64                                `json:"expected_cadence_seconds,omitempty"`
+	StaleAfterSeconds         *int64                                `json:"stale_after_seconds,omitempty"`
+	BackfillEligible          bool                                  `json:"backfill_eligible"`
+	BackfillEligibilityReason string                                `json:"backfill_eligibility_reason,omitempty"`
+	NextAction                string                                `json:"next_action"`
+	RecommendedWorkflow       string                                `json:"recommended_workflow,omitempty"`
+	CursorPending             bool                                  `json:"cursor_pending"`
+	CheckpointCursorPresent   bool                                  `json:"checkpoint_cursor_present"`
+	ScheduleContextConfigured bool                                  `json:"schedule_context_configured"`
+	GeneratedAt               string                                `json:"generated_at"`
+}
+
 type sourceRuntimeHealthSummary struct {
 	SourceID                   string `json:"source_id"`
 	Total                      int    `json:"total"`
@@ -132,16 +185,34 @@ const (
 )
 
 func (a *App) handleListSourceRuntimeHealth(w http.ResponseWriter, r *http.Request) {
-	limit, err := uint32QueryParam(r, "limit")
+	response, err := a.listSourceRuntimeHealth(r)
 	if err != nil {
 		writeSourceRuntimeError(w, err)
 		return
 	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleListRuntimeFreshness(w http.ResponseWriter, r *http.Request) {
+	health, err := a.listSourceRuntimeHealth(r)
+	if err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, runtimeFreshnessFromHealth(health))
+}
+
+func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthResponse, error) {
+	limit, err := uint32QueryParam(r, "limit")
+	if err != nil {
+		return sourceRuntimeHealthResponse{}, err
+	}
 	filter := ports.SourceRuntimeFilter{
-		RuntimeID: strings.TrimSpace(r.URL.Query().Get("runtime_id")),
-		TenantID:  strings.TrimSpace(r.URL.Query().Get("tenant_id")),
-		SourceID:  strings.TrimSpace(r.URL.Query().Get("source_id")),
-		Limit:     limit,
+		RuntimeID:  strings.TrimSpace(r.URL.Query().Get("runtime_id")),
+		RuntimeIDs: csvQueryValues(r.URL.Query().Get("runtime_ids")),
+		TenantID:   strings.TrimSpace(r.URL.Query().Get("tenant_id")),
+		SourceID:   strings.TrimSpace(r.URL.Query().Get("source_id")),
+		Limit:      limit,
 	}
 	if filter.TenantID == "" {
 		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok && strings.TrimSpace(auth.principal.TenantID) != "" {
@@ -154,49 +225,40 @@ func (a *App) handleListSourceRuntimeHealth(w http.ResponseWriter, r *http.Reque
 	if filter.TenantID == "" && filter.RuntimeID != "" && requiresTenantFilter(r.Context()) {
 		store := sourceRuntimeStore(a.deps.StateStore)
 		if store == nil {
-			writeSourceRuntimeError(w, sourceruntime.ErrRuntimeUnavailable)
-			return
+			return sourceRuntimeHealthResponse{}, sourceruntime.ErrRuntimeUnavailable
 		}
 		runtime, err := store.GetSourceRuntime(r.Context(), filter.RuntimeID)
 		if errors.Is(err, ports.ErrSourceRuntimeNotFound) {
-			writeJSON(w, http.StatusOK, sourceRuntimeHealthResponse{GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano)})
-			return
+			return sourceRuntimeHealthResponse{GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano)}, nil
 		}
 		if err != nil {
-			writeSourceRuntimeError(w, err)
-			return
+			return sourceRuntimeHealthResponse{}, err
 		}
 		if !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
-			writeJSON(w, http.StatusOK, sourceRuntimeHealthResponse{GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano)})
-			return
+			return sourceRuntimeHealthResponse{GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano)}, nil
 		}
 		filter.TenantID = strings.TrimSpace(runtime.GetTenantId())
 	}
-	if filter.TenantID == "" && filter.RuntimeID == "" && requiresTenantFilter(r.Context()) {
-		writeSourceRuntimeError(w, errTenantForbidden)
-		return
+	if filter.TenantID == "" && filter.RuntimeID == "" && len(filter.RuntimeIDs) == 0 && requiresTenantFilter(r.Context()) {
+		return sourceRuntimeHealthResponse{}, errTenantForbidden
 	}
 	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
-		writeSourceRuntimeError(w, err)
-		return
+		return sourceRuntimeHealthResponse{}, err
 	}
 	store := sourceRuntimeStore(a.deps.StateStore)
 	if store == nil {
-		writeSourceRuntimeError(w, sourceruntime.ErrRuntimeUnavailable)
-		return
+		return sourceRuntimeHealthResponse{}, sourceruntime.ErrRuntimeUnavailable
 	}
 	lister, ok := store.(ports.SourceRuntimeListStore)
 	if !ok {
-		writeSourceRuntimeError(w, sourceruntime.ErrRuntimeUnavailable)
-		return
+		return sourceRuntimeHealthResponse{}, sourceruntime.ErrRuntimeUnavailable
 	}
 	if filter.Limit == 0 {
 		filter.Limit = 100
 	}
 	runtimes, err := lister.ListSourceRuntimes(r.Context(), filter)
 	if err != nil {
-		writeSourceRuntimeError(w, err)
-		return
+		return sourceRuntimeHealthResponse{}, err
 	}
 	generatedAt := time.Now().UTC()
 	records := make([]sourceRuntimeHealthRecord, 0, len(runtimes))
@@ -209,16 +271,211 @@ func (a *App) handleListSourceRuntimeHealth(w http.ResponseWriter, r *http.Reque
 		}
 		record, err := a.sourceRuntimeHealthRecord(r.Context(), runtime, generatedAt)
 		if err != nil {
-			writeSourceRuntimeError(w, err)
-			return
+			return sourceRuntimeHealthResponse{}, err
 		}
 		records = append(records, record)
 	}
-	writeJSON(w, http.StatusOK, sourceRuntimeHealthResponse{
+	return sourceRuntimeHealthResponse{
 		GeneratedAt:     generatedAt.Format(time.RFC3339Nano),
 		Runtimes:        records,
 		SourceSummaries: sourceRuntimeHealthSummaries(records),
+	}, nil
+}
+
+func runtimeFreshnessFromHealth(health sourceRuntimeHealthResponse) runtimeFreshnessResponse {
+	records := make([]runtimeFreshnessRecord, 0, len(health.Runtimes))
+	for _, record := range health.Runtimes {
+		records = append(records, runtimeFreshnessRecordFromHealth(record))
+	}
+	status := "healthy"
+	for _, record := range records {
+		if record.FreshnessState != "healthy" {
+			status = "degraded"
+			break
+		}
+	}
+	return runtimeFreshnessResponse{
+		GeneratedAt: health.GeneratedAt,
+		Status:      status,
+		Runtimes:    records,
+		Summaries:   runtimeFreshnessSummaries(records),
+	}
+}
+
+func runtimeFreshnessRecordFromHealth(record sourceRuntimeHealthRecord) runtimeFreshnessRecord {
+	lifecycleState := "active"
+	if strings.ToLower(strings.TrimSpace(record.EnabledState)) == "disabled" {
+		lifecycleState = "disabled"
+	}
+	sourceSyncState := runtimeFreshnessSourceSyncState(record)
+	graphIngestState := sourceRuntimeGraphState(record)
+	findingEvaluationState := runtimeFreshnessFindingEvaluationState(record)
+	scheduleState := "unknown"
+	if record.ScheduleContextConfigured {
+		scheduleState = "configured"
+	}
+	freshnessState, failureClass, failureReason, nextAction := runtimeFreshnessState(record, lifecycleState, sourceSyncState, graphIngestState)
+	backfillEligible, backfillReason := runtimeBackfillEligibility(lifecycleState, sourceSyncState, graphIngestState)
+	workflow := ""
+	if backfillEligible {
+		workflow = "source-runtime-backfill"
+	}
+	return runtimeFreshnessRecord{
+		RuntimeID:                 record.RuntimeID,
+		SourceID:                  record.SourceID,
+		TenantID:                  record.TenantID,
+		Family:                    record.Family,
+		LifecycleState:            lifecycleState,
+		ScheduleState:             scheduleState,
+		FreshnessState:            freshnessState,
+		SourceSyncState:           sourceSyncState,
+		GraphIngestState:          graphIngestState,
+		FindingEvaluationState:    findingEvaluationState,
+		FailureClass:              failureClass,
+		FailureReason:             failureReason,
+		LastSyncedAt:              record.LastSyncedAt,
+		SyncLagSeconds:            record.SyncLagSeconds,
+		CheckpointWatermark:       record.CheckpointWatermark,
+		WatermarkLagSeconds:       record.WatermarkLagSeconds,
+		LatestGraphRun:            record.LatestGraphRun,
+		GraphLagSeconds:           record.GraphLagSeconds,
+		LatestFindingEvaluation:   record.LatestFindingEvaluation,
+		ExpectedCadenceSeconds:    record.ExpectedCadenceSeconds,
+		StaleAfterSeconds:         record.StaleAfterSeconds,
+		BackfillEligible:          backfillEligible,
+		BackfillEligibilityReason: backfillReason,
+		NextAction:                nextAction,
+		RecommendedWorkflow:       workflow,
+		CursorPending:             record.CursorPending,
+		CheckpointCursorPresent:   record.CheckpointCursorPresent,
+		ScheduleContextConfigured: record.ScheduleContextConfigured,
+		GeneratedAt:               record.GeneratedAt,
+	}
+}
+
+func runtimeFreshnessSourceSyncState(record sourceRuntimeHealthRecord) string {
+	if strings.TrimSpace(record.LastFailureCategory) != "" {
+		return "failed"
+	}
+	switch strings.ToLower(strings.TrimSpace(record.Status)) {
+	case "failing":
+		return "failed"
+	case "stale":
+		return "stale"
+	case "healthy":
+		return "current"
+	default:
+		return "unknown"
+	}
+}
+
+func runtimeFreshnessFindingEvaluationState(record sourceRuntimeHealthRecord) string {
+	if record.LatestFindingEvaluation == nil {
+		return "not_observed"
+	}
+	status := strings.ToLower(strings.TrimSpace(record.LatestFindingEvaluation.Status))
+	if strings.Contains(status, "fail") || strings.Contains(status, "error") || strings.Contains(status, "cancel") {
+		return "failed"
+	}
+	if strings.Contains(status, "running") || strings.Contains(status, "pending") {
+		return "running"
+	}
+	return "current"
+}
+
+func runtimeFreshnessState(record sourceRuntimeHealthRecord, lifecycleState string, sourceSyncState string, graphIngestState string) (string, string, string, string) {
+	if lifecycleState != "active" {
+		return "disabled", "disabled", "runtime is disabled", "review_runtime_enablement"
+	}
+	if sourceSyncState == "failed" {
+		failureClass := strings.TrimSpace(record.LastFailureCategory)
+		if failureClass == "" {
+			failureClass = "source_sync_failed"
+		}
+		return "source_failed", failureClass, "source sync is failing", "fix_source_sync"
+	}
+	switch graphIngestState {
+	case "failed":
+		return "graph_failed", "graph_ingest_failed", "latest graph ingest failed", "inspect_graph_ingest"
+	case "not_observed":
+		return "graph_missing", "graph_ingest_missing", "no graph ingest run has been observed", "plan_backfill"
+	case "behind":
+		return "graph_behind", "graph_ingest_behind", "graph ingest is older than the configured freshness window", "plan_backfill"
+	}
+	if sourceSyncState == "stale" {
+		return "source_stale", "source_sync_stale", "source runtime is older than the configured freshness window", "run_source_sync"
+	}
+	if sourceSyncState == "current" && graphIngestState == "current" {
+		return "healthy", "", "", "monitor"
+	}
+	return "unknown", "insufficient_signal", "source or graph freshness signal is unavailable", "inspect_runtime"
+}
+
+func runtimeBackfillEligibility(lifecycleState string, sourceSyncState string, graphIngestState string) (bool, string) {
+	if lifecycleState != "active" {
+		return false, "runtime is disabled"
+	}
+	if sourceSyncState == "failed" {
+		return false, "source sync must succeed before graph backfill"
+	}
+	switch graphIngestState {
+	case "failed", "not_observed", "behind":
+		return true, "graph ingest is missing, failed, or behind"
+	default:
+		return false, "graph ingest backfill is not indicated"
+	}
+}
+
+func runtimeFreshnessSummaries(records []runtimeFreshnessRecord) []runtimeFreshnessSummary {
+	bySource := map[string]*runtimeFreshnessSummary{}
+	for _, record := range records {
+		sourceID := record.SourceID
+		if sourceID == "" {
+			sourceID = "unknown"
+		}
+		summary := bySource[sourceID]
+		if summary == nil {
+			summary = &runtimeFreshnessSummary{SourceID: sourceID}
+			bySource[sourceID] = summary
+		}
+		summary.Total++
+		if record.FreshnessState == "healthy" {
+			summary.Healthy++
+		} else {
+			summary.NeedsAttention++
+		}
+		switch record.FreshnessState {
+		case "source_failed":
+			summary.SourceFailed++
+		case "source_stale":
+			summary.SourceStale++
+		case "graph_missing":
+			summary.GraphMissing++
+		case "graph_failed":
+			summary.GraphFailed++
+		case "graph_behind":
+			summary.GraphBehind++
+		case "disabled":
+			summary.QuarantinedOrDisabled++
+		}
+		if record.BackfillEligible {
+			summary.BackfillEligible++
+		}
+	}
+	summaries := make([]runtimeFreshnessSummary, 0, len(bySource))
+	for _, summary := range bySource {
+		summaries = append(summaries, *summary)
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].NeedsAttention != summaries[j].NeedsAttention {
+			return summaries[i].NeedsAttention > summaries[j].NeedsAttention
+		}
+		if summaries[i].Total != summaries[j].Total {
+			return summaries[i].Total > summaries[j].Total
+		}
+		return summaries[i].SourceID < summaries[j].SourceID
 	})
+	return summaries
 }
 
 func sourceRuntimeHealthSummaries(records []sourceRuntimeHealthRecord) []sourceRuntimeHealthSummary {

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -217,6 +217,76 @@ func TestSourceRuntimeHealthSummariesAggregateBySource(t *testing.T) {
 	}
 }
 
+func TestRuntimeFreshnessFromHealthClassifiesBackfillWorklist(t *testing.T) {
+	graphLag := int64(7200)
+	staleAfter := int64(3600)
+	health := sourceRuntimeHealthResponse{
+		GeneratedAt: "2026-06-12T00:00:00Z",
+		Runtimes: []sourceRuntimeHealthRecord{
+			{
+				RuntimeID:         "runtime-current",
+				SourceID:          "okta",
+				EnabledState:      "enabled",
+				Status:            "healthy",
+				LatestGraphRun:    sourceRuntimeGraphRunHealth(graphstore.IngestRun{Status: "completed"}),
+				GraphLagSeconds:   int64Ptr(60),
+				StaleAfterSeconds: &staleAfter,
+			},
+			{
+				RuntimeID:         "runtime-missing-graph",
+				SourceID:          "okta",
+				EnabledState:      "enabled",
+				Status:            "healthy",
+				GraphLagSeconds:   &graphLag,
+				StaleAfterSeconds: &staleAfter,
+			},
+			{
+				RuntimeID:           "runtime-source-failed",
+				SourceID:            "gcp",
+				EnabledState:        "enabled",
+				Status:              "failing",
+				LastFailureCategory: "auth_error",
+				LatestGraphRun:      sourceRuntimeGraphRunHealth(graphstore.IngestRun{Status: "completed"}),
+				StaleAfterSeconds:   &staleAfter,
+			},
+			{
+				RuntimeID:    "runtime-disabled",
+				SourceID:     "cosmo",
+				EnabledState: "disabled",
+				Status:       "unknown",
+			},
+		},
+	}
+
+	response := runtimeFreshnessFromHealth(health)
+
+	if response.Status != "degraded" {
+		t.Fatalf("Status = %q, want degraded", response.Status)
+	}
+	byRuntime := map[string]runtimeFreshnessRecord{}
+	for _, record := range response.Runtimes {
+		byRuntime[record.RuntimeID] = record
+	}
+	if got := byRuntime["runtime-current"]; got.FreshnessState != "healthy" || got.BackfillEligible {
+		t.Fatalf("runtime-current freshness = %+v", got)
+	}
+	if got := byRuntime["runtime-missing-graph"]; got.FreshnessState != "graph_missing" || !got.BackfillEligible || got.RecommendedWorkflow != "source-runtime-backfill" {
+		t.Fatalf("runtime-missing-graph freshness = %+v", got)
+	}
+	if got := byRuntime["runtime-source-failed"]; got.FreshnessState != "source_failed" || got.FailureClass != "auth_error" || got.BackfillEligible {
+		t.Fatalf("runtime-source-failed freshness = %+v", got)
+	}
+	if got := byRuntime["runtime-disabled"]; got.FreshnessState != "disabled" || got.LifecycleState != "disabled" || got.BackfillEligible {
+		t.Fatalf("runtime-disabled freshness = %+v", got)
+	}
+	if len(response.Summaries) != 3 {
+		t.Fatalf("len(Summaries) = %d, want 3", len(response.Summaries))
+	}
+	if response.Summaries[0].SourceID != "okta" || response.Summaries[0].BackfillEligible != 1 || response.Summaries[0].GraphMissing != 1 {
+		t.Fatalf("okta summary = %+v", response.Summaries[0])
+	}
+}
+
 func FuzzRuntimeHealthConfigParsing(f *testing.F) {
 	f.Add("", "", "")
 	f.Add("3600", "7200", "passing")

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -287,6 +287,34 @@ func TestRuntimeFreshnessFromHealthClassifiesBackfillWorklist(t *testing.T) {
 	}
 }
 
+func TestRuntimeFreshnessFromHealthTreatsRunningGraphAsHealthy(t *testing.T) {
+	health := sourceRuntimeHealthResponse{
+		GeneratedAt: "2026-06-12T00:00:00Z",
+		Runtimes: []sourceRuntimeHealthRecord{
+			{
+				RuntimeID:      "runtime-graph-running",
+				SourceID:       "okta",
+				EnabledState:   "enabled",
+				Status:         "healthy",
+				LatestGraphRun: sourceRuntimeGraphRunHealth(graphstore.IngestRun{Status: "running"}),
+			},
+		},
+	}
+
+	response := runtimeFreshnessFromHealth(health)
+
+	if response.Status != "healthy" {
+		t.Fatalf("Status = %q, want healthy", response.Status)
+	}
+	record := response.Runtimes[0]
+	if record.GraphIngestState != "running" || record.FreshnessState != "healthy" || record.BackfillEligible || record.NextAction != "monitor" {
+		t.Fatalf("running graph freshness = %+v", record)
+	}
+	if response.Summaries[0].Healthy != 1 || response.Summaries[0].NeedsAttention != 0 {
+		t.Fatalf("summary = %+v", response.Summaries[0])
+	}
+}
+
 func FuzzRuntimeHealthConfigParsing(f *testing.F) {
 	f.Add("", "", "")
 	f.Add("3600", "7200", "passing")

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -228,6 +228,7 @@ var exactRouteLabels = map[string]struct{}{
 	"/platform/knowledge/actions/recommendation":                          {},
 	"/platform/knowledge/outcomes":                                        {},
 	"/platform/workflow/replay":                                           {},
+	"/platform/runtime-freshness":                                         {},
 	"/platform/graph/neighborhood":                                        {},
 	"/platform/graph/impact/package":                                      {},
 	"/platform/graph/impact/asset":                                        {},

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -25,6 +25,9 @@ func TestNormalizeRouteLabelBoundsUnknownPaths(t *testing.T) {
 	if got := normalizeRouteLabel("/source-runtimes/health"); got != "/source-runtimes/health" {
 		t.Fatalf("source-runtime health route label = %q", got)
 	}
+	if got := normalizeRouteLabel("/platform/runtime-freshness"); got != "/platform/runtime-freshness" {
+		t.Fatalf("runtime freshness route label = %q", got)
+	}
 }
 
 func TestNormalizeMethodLabelBoundsUnknownMethods(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add /platform/runtime-freshness as a canonical source-sync and graph-ingest freshness worklist API.
- Reuse source runtime health data, add source summaries, runtime_ids filtering, route auth, metrics, and OpenAPI coverage.

## Validation
- go test ./internal/bootstrap ./internal/observability
- make openapi-check
- go test ./...
- make openapi-lint