### PR TITLE
fix: report deploy preflight close failures

### DIFF
--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -13,6 +13,9 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/bootstrap"
+	appconfig "github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -59,6 +62,32 @@ func TestWritePreflightReceiptJSONRedactsToBoundedDetail(t *testing.T) {
 	}
 	if decoded.Status != "fail" || len(decoded.Checks) != 1 {
 		t.Fatalf("decoded receipt = %#v", decoded)
+	}
+}
+
+func TestExecuteDeployPreflightReportsDependencyCloseFailure(t *testing.T) {
+	closeErr := errors.New("close failed")
+	receipt := executeDeployPreflightWith(context.Background(), preflightRuntime{
+		loadConfig: func() (appconfig.Config, error) {
+			return appconfig.Config{}, nil
+		},
+		openDependencies: func(context.Context, appconfig.Config) (bootstrap.Dependencies, func() error, error) {
+			return bootstrap.Dependencies{}, func() error { return closeErr }, nil
+		},
+		probeLLM: func(context.Context, graphagent.LLMClient) error {
+			return nil
+		},
+	})
+
+	if receipt.Status != "fail" {
+		t.Fatalf("receipt status = %q, want fail", receipt.Status)
+	}
+	if got := len(receipt.Checks); got != 4 {
+		t.Fatalf("check count = %d, want 4: %#v", got, receipt.Checks)
+	}
+	closeCheck := receipt.Checks[3]
+	if closeCheck.Name != "dependencies.close" || closeCheck.Status != "fail" || closeCheck.Detail == "" {
+		t.Fatalf("close check = %#v, want failed dependencies.close detail", closeCheck)
 	}
 }
 

--- a/cmd/cerebro/preflight.go
+++ b/cmd/cerebro/preflight.go
@@ -33,6 +33,12 @@ type preflightOptions struct {
 	Stdout io.Writer
 }
 
+type preflightRuntime struct {
+	loadConfig       func() (appconfig.Config, error)
+	openDependencies func(context.Context, appconfig.Config) (bootstrap.Dependencies, func() error, error)
+	probeLLM         func(context.Context, graphagent.LLMClient) error
+}
+
 func runDeploy(args []string) error {
 	if len(args) == 0 {
 		return usageError("usage: cerebro deploy [preflight]")
@@ -70,7 +76,15 @@ func runDeployPreflight(args []string, opts preflightOptions) error {
 }
 
 func executeDeployPreflight(ctx context.Context) preflightReceipt {
-	receipt := preflightReceipt{
+	return executeDeployPreflightWith(ctx, preflightRuntime{
+		loadConfig:       appconfig.Load,
+		openDependencies: bootstrap.OpenDependencies,
+		probeLLM:         graphagent.ProbeLLM,
+	})
+}
+
+func executeDeployPreflightWith(ctx context.Context, runtime preflightRuntime) (receipt preflightReceipt) {
+	receipt = preflightReceipt{
 		Kind:        "cerebro.deploy_preflight",
 		Status:      "pass",
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano),
@@ -85,12 +99,12 @@ func executeDeployPreflight(ctx context.Context) preflightReceipt {
 		receipt.Checks = append(receipt.Checks, check)
 	}
 
-	cfg, err := appconfig.Load()
+	cfg, err := runtime.loadConfig()
 	addCheck("config.load", err)
 	if err != nil {
 		return receipt
 	}
-	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+	deps, closeDeps, err := runtime.openDependencies(ctx, cfg)
 	addCheck("dependencies.open", err)
 	if err != nil {
 		return receipt
@@ -98,7 +112,7 @@ func executeDeployPreflight(ctx context.Context) preflightReceipt {
 	defer func() {
 		addCheck("dependencies.close", closeDeps())
 	}()
-	addCheck("graph_agent_llm.probe", graphagent.ProbeLLM(ctx, deps.GraphAgentLLM))
+	addCheck("graph_agent_llm.probe", runtime.probeLLM(ctx, deps.GraphAgentLLM))
 	return receipt
 }
 


### PR DESCRIPTION
## Summary

- report dependency close failures in deploy preflight receipts
- keep the preflight status failed when dependency teardown fails
- add regression coverage for the returned close check

## Test Plan

- go test ./cmd/cerebro -run 'TestExecuteDeployPreflightReportsDependencyCloseFailure|TestRunDeploy|TestWritePreflight' -count=1\n- make check-structural check-structural-test check-arch\n- go test ./cmd/cerebro ./internal/graphagent ./internal/bootstrap ./internal/config -count=1\n- make lint readme-check oss-audit\n\n## Known Invariants\n\n- Source connectors use `internal/sourcehttp` for outbound HTTP safety.\n- Production body reads are bounded with `io.LimitReader` or streamed.\n- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.\n- Ask deterministic post-processing is not applied to LLM fallback rows.\n- Candidate finding lifecycle writes remain atomic and idempotent.\n- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.\n\n## Droid Review Context\n\n- Fast local preflight: `make droid-review-preflight`.\n- Focus review on deploy preflight receipt close-error behavior.\n- Follow-up to PR #923 review feedback.