### PR TITLE
feat: add inventory asset reports

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1029,6 +1029,105 @@ paths:
       responses:
         '200':
           description: Updated GRC purview state for one inventory asset.
+  /grc/inventory/asset-reports:
+    get:
+      summary: Inventory asset reports
+      tags:
+        - GRC
+      parameters:
+        - $ref: '#/components/parameters/tenantIDQuery'
+        - $ref: '#/components/parameters/sourceIDQuery'
+        - $ref: '#/components/parameters/limitQuery'
+        - name: asset_urn
+          in: query
+          schema:
+            type: string
+        - name: triage_status
+          in: query
+          schema:
+            type: string
+            enum: [submitted, in_triage, accepted, rejected, resolved]
+      responses:
+        '200':
+          description: Reported inventory asset data quality and curation items.
+    post:
+      summary: Report an inventory asset
+      tags:
+        - GRC
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [asset_urn, reason]
+              properties:
+                tenant_id:
+                  type: string
+                asset_urn:
+                  type: string
+                source_id:
+                  type: string
+                reason:
+                  type: string
+                reporter:
+                  type: string
+                triage_status:
+                  type: string
+                  enum: [submitted, in_triage, accepted, rejected, resolved]
+                attributes:
+                  type: object
+                  additionalProperties:
+                    type: string
+      responses:
+        '201':
+          description: Captured inventory asset report.
+  /grc/inventory/asset-reports/{reportID}:
+    get:
+      summary: Inventory asset report
+      tags:
+        - GRC
+      parameters:
+        - name: reportID
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/tenantIDQuery'
+      responses:
+        '200':
+          description: One reported inventory asset data quality and curation item.
+  /grc/inventory/asset-reports/{reportID}/triage:
+    patch:
+      summary: Update inventory asset report triage
+      tags:
+        - GRC
+      parameters:
+        - name: reportID
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [triage_status]
+              properties:
+                tenant_id:
+                  type: string
+                triage_status:
+                  type: string
+                  enum: [submitted, in_triage, accepted, rejected, resolved]
+                triage_reason:
+                  type: string
+                triaged_by:
+                  type: string
+      responses:
+        '200':
+          description: Updated inventory asset report triage state.
   /grc/entities/{entityID}/impact:
     get:
       summary: GRC entity impact map

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -3454,6 +3454,14 @@ func grcInventoryScopeStore(store ports.StateStore) ports.GRCInventoryScopeStore
 	return scopeStore
 }
 
+func grcInventoryAssetReportStore(store ports.StateStore) ports.GRCInventoryAssetReportStore {
+	reportStore, ok := store.(ports.GRCInventoryAssetReportStore)
+	if !ok || isNilInterface(reportStore) {
+		return nil
+	}
+	return reportStore
+}
+
 func eventReplayer(appendLog ports.AppendLog) ports.EventReplayer {
 	replayer, ok := appendLog.(ports.EventReplayer)
 	if !ok || isNilInterface(replayer) {

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -53,6 +53,8 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodGet, Prefix: "/grc/", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodPost, Exact: "/grc/ask", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/inventory/resource-scope", Scope: scopeGRCInventoryWrite, Static: true},
+	{Method: http.MethodPost, Exact: "/grc/inventory/asset-reports", Scope: scopeGRCInventoryWrite, Static: true},
+	{Method: http.MethodPatch, Prefix: "/grc/inventory/asset-reports/", Suffix: "/triage", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodGet, Exact: "/platform/runtime-freshness", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/platform/graph/neighborhood", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/platform/graph/impact/package", Scope: scopeCosmoSecurityRead, Static: true},

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -583,7 +583,8 @@ func grcTelemetryErrorKind(err error) string {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound),
 		errors.Is(err, ports.ErrFindingNotFound),
 		errors.Is(err, ports.ErrFindingEvidenceNotFound),
-		errors.Is(err, ports.ErrGraphEntityNotFound):
+		errors.Is(err, ports.ErrGraphEntityNotFound),
+		errors.Is(err, ports.ErrGRCInventoryAssetReportNotFound):
 		return "not_found"
 	case errors.Is(err, graphagent.ErrLLMAuthenticationFailed):
 		return "llm_authentication_failed"
@@ -1449,7 +1450,8 @@ func grcHTTPStatusCode(err error) int {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound),
 		errors.Is(err, ports.ErrFindingNotFound),
 		errors.Is(err, ports.ErrFindingEvidenceNotFound),
-		errors.Is(err, ports.ErrGraphEntityNotFound):
+		errors.Is(err, ports.ErrGraphEntityNotFound),
+		errors.Is(err, ports.ErrGRCInventoryAssetReportNotFound):
 		statusCode = http.StatusNotFound
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable),
 		errors.Is(err, findings.ErrRuntimeUnavailable),

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -1,6 +1,8 @@
 package bootstrap
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,10 +15,11 @@ import (
 )
 
 const (
-	grcRuntimeStatusConfigKey      = "__cerebro_runtime_status"
-	maxGRCInventoryScopeBodyBytes  = 32 << 10
-	grcInventoryScopeStateInScope  = ports.GRCInventoryScopeStateIn
-	grcInventoryScopeStateOutScope = ports.GRCInventoryScopeStateOut
+	grcRuntimeStatusConfigKey           = "__cerebro_runtime_status"
+	maxGRCInventoryScopeBodyBytes       = 32 << 10
+	maxGRCInventoryAssetReportBodyBytes = 32 << 10
+	grcInventoryScopeStateInScope       = ports.GRCInventoryScopeStateIn
+	grcInventoryScopeStateOutScope      = ports.GRCInventoryScopeStateOut
 )
 
 type grcInventoryCategoriesResponse struct {
@@ -31,16 +34,17 @@ type grcInventoryAssetsResponse struct {
 }
 
 type grcInventoryAssetDetailResponse struct {
-	Asset           graphquery.InventoryAsset   `json:"asset"`
-	Graph           any                         `json:"graph,omitempty"`
-	Findings        []grcFindingItem            `json:"findings"`
-	Evidence        []grcEvidenceItem           `json:"evidence"`
-	Controls        []grcControlItem            `json:"controls"`
-	Tests           []grcInventoryTestItem      `json:"tests"`
-	Vulnerabilities []grcInventoryVulnerability `json:"vulnerabilities"`
-	Timeline        []grcInventoryTimelineEvent `json:"timeline"`
-	Actions         []grcInventoryAction        `json:"actions"`
-	GeneratedAt     time.Time                   `json:"generated_at"`
+	Asset           graphquery.InventoryAsset              `json:"asset"`
+	Graph           any                                    `json:"graph,omitempty"`
+	Findings        []grcFindingItem                       `json:"findings"`
+	Evidence        []grcEvidenceItem                      `json:"evidence"`
+	Controls        []grcControlItem                       `json:"controls"`
+	Tests           []grcInventoryTestItem                 `json:"tests"`
+	Vulnerabilities []grcInventoryVulnerability            `json:"vulnerabilities"`
+	AssetReports    []*ports.GRCInventoryAssetReportRecord `json:"asset_reports,omitempty"`
+	Timeline        []grcInventoryTimelineEvent            `json:"timeline"`
+	Actions         []grcInventoryAction                   `json:"actions"`
+	GeneratedAt     time.Time                              `json:"generated_at"`
 }
 
 type grcInventorySummary struct {
@@ -110,6 +114,33 @@ type grcInventoryScopeUpdateRequest struct {
 type grcInventoryScopeUpdateResponse struct {
 	Scope       *ports.GRCInventoryScopeRecord `json:"scope"`
 	GeneratedAt time.Time                      `json:"generated_at"`
+}
+
+type grcInventoryAssetReportCreateRequest struct {
+	TenantID     string            `json:"tenant_id,omitempty"`
+	AssetURN     string            `json:"asset_urn"`
+	SourceID     string            `json:"source_id,omitempty"`
+	Reason       string            `json:"reason"`
+	Reporter     string            `json:"reporter,omitempty"`
+	TriageStatus string            `json:"triage_status,omitempty"`
+	Attributes   map[string]string `json:"attributes,omitempty"`
+}
+
+type grcInventoryAssetReportTriageRequest struct {
+	TenantID     string `json:"tenant_id,omitempty"`
+	TriageStatus string `json:"triage_status"`
+	TriageReason string `json:"triage_reason,omitempty"`
+	TriagedBy    string `json:"triaged_by,omitempty"`
+}
+
+type grcInventoryAssetReportResponse struct {
+	Report      *ports.GRCInventoryAssetReportRecord `json:"report"`
+	GeneratedAt time.Time                            `json:"generated_at"`
+}
+
+type grcInventoryAssetReportsResponse struct {
+	Reports     []*ports.GRCInventoryAssetReportRecord `json:"reports"`
+	GeneratedAt time.Time                              `json:"generated_at"`
 }
 
 type grcResourceScopeRuntime struct {
@@ -220,6 +251,11 @@ func (a *App) handleGRCInventoryAssetDetail(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	asset = applyFindingRiskToInventoryAsset(asset, findingItems, tests, vulnerabilities)
+	reports, err := a.listGRCInventoryAssetReportsForAsset(r, scope, asset.URN, scope.Limit)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, grcInventoryAssetDetailResponse{
 		Asset:           asset,
 		Graph:           detail.Graph,
@@ -228,7 +264,8 @@ func (a *App) handleGRCInventoryAssetDetail(w http.ResponseWriter, r *http.Reque
 		Controls:        controls,
 		Tests:           tests,
 		Vulnerabilities: vulnerabilities,
-		Timeline:        grcInventoryTimeline(asset, findingItems, evidenceItems, tests),
+		AssetReports:    reports,
+		Timeline:        grcInventoryTimeline(asset, findingItems, evidenceItems, tests, reports),
 		Actions:         grcInventoryActions(asset, findingItems, controls, tests, vulnerabilities),
 		GeneratedAt:     time.Now().UTC(),
 	})
@@ -342,6 +379,190 @@ func (a *App) handleUpdateGRCResourceScope(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, grcInventoryScopeUpdateResponse{Scope: record, GeneratedAt: time.Now().UTC()})
 }
 
+func (a *App) handleCreateGRCInventoryAssetReport(w http.ResponseWriter, r *http.Request) {
+	var request grcInventoryAssetReportCreateRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxGRCInventoryAssetReportBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeGRCError(w, fmt.Errorf("%w: decode inventory asset report request: %w", errInvalidHTTPRequest, err))
+		return
+	}
+	request.AssetURN = strings.TrimSpace(request.AssetURN)
+	request.Reason = strings.TrimSpace(request.Reason)
+	if request.AssetURN == "" {
+		writeGRCError(w, fmt.Errorf("%w: asset_urn is required", errInvalidHTTPRequest))
+		return
+	}
+	if request.Reason == "" {
+		writeGRCError(w, fmt.Errorf("%w: reason is required", errInvalidHTTPRequest))
+		return
+	}
+	if err := authorizeCerebroURNTenant(r.Context(), request.AssetURN); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		tenantID = tenantIDFromCerebroURN(request.AssetURN)
+	}
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	status := strings.TrimSpace(request.TriageStatus)
+	if status == "" {
+		status = ports.GRCInventoryAssetReportStatusSubmitted
+	}
+	if !ports.IsGRCInventoryAssetReportStatus(status) {
+		writeGRCError(w, fmt.Errorf("%w: triage_status is invalid", errInvalidHTTPRequest))
+		return
+	}
+	store := grcInventoryAssetReportStore(a.deps.StateStore)
+	if store == nil {
+		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
+		return
+	}
+	reporter := strings.TrimSpace(request.Reporter)
+	if reporter == "" {
+		reporter = grcInventoryUpdatedBy(r)
+	}
+	record, err := store.CreateGRCInventoryAssetReport(r.Context(), ports.GRCInventoryAssetReportRecord{
+		ID:           newGRCInventoryAssetReportID(),
+		TenantID:     tenantID,
+		AssetURN:     request.AssetURN,
+		SourceID:     strings.TrimSpace(request.SourceID),
+		Reason:       request.Reason,
+		Reporter:     reporter,
+		TriageStatus: status,
+		Attributes:   request.Attributes,
+	})
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, grcInventoryAssetReportResponse{Report: record, GeneratedAt: time.Now().UTC()})
+}
+
+func (a *App) handleListGRCInventoryAssetReports(w http.ResponseWriter, r *http.Request) {
+	scope, err := grcScopeFromRequest(r)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	assetURN := strings.TrimSpace(r.URL.Query().Get("asset_urn"))
+	if assetURN != "" {
+		if err := authorizeCerebroURNTenant(r.Context(), assetURN); err != nil {
+			writeGRCError(w, err)
+			return
+		}
+		if scope.TenantID == "" {
+			scope.TenantID = tenantIDFromCerebroURN(assetURN)
+		}
+	}
+	if err := authorizeTenantID(r.Context(), scope.TenantID); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	status := strings.TrimSpace(r.URL.Query().Get("triage_status"))
+	if status != "" && !ports.IsGRCInventoryAssetReportStatus(status) {
+		writeGRCError(w, fmt.Errorf("%w: triage_status is invalid", errInvalidHTTPRequest))
+		return
+	}
+	store := grcInventoryAssetReportStore(a.deps.StateStore)
+	if store == nil {
+		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
+		return
+	}
+	var urns []string
+	if assetURN != "" {
+		urns = []string{assetURN}
+	}
+	records, err := store.ListGRCInventoryAssetReports(r.Context(), ports.GRCInventoryAssetReportFilter{
+		TenantID:     scope.TenantID,
+		AssetURNs:    urns,
+		SourceID:     scope.SourceID,
+		TriageStatus: status,
+		Limit:        scope.Limit,
+	})
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, grcInventoryAssetReportsResponse{Reports: records, GeneratedAt: time.Now().UTC()})
+}
+
+func (a *App) handleGetGRCInventoryAssetReport(w http.ResponseWriter, r *http.Request) {
+	store := grcInventoryAssetReportStore(a.deps.StateStore)
+	if store == nil {
+		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
+		return
+	}
+	record, err := store.GetGRCInventoryAssetReport(r.Context(), strings.TrimSpace(r.PathValue("reportID")), strings.TrimSpace(r.URL.Query().Get("tenant_id")))
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	if err := authorizeTenantID(r.Context(), record.TenantID); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	if err := authorizeCerebroURNTenant(r.Context(), record.AssetURN); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, grcInventoryAssetReportResponse{Report: record, GeneratedAt: time.Now().UTC()})
+}
+
+func (a *App) handleUpdateGRCInventoryAssetReportTriage(w http.ResponseWriter, r *http.Request) {
+	var request grcInventoryAssetReportTriageRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxGRCInventoryAssetReportBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeGRCError(w, fmt.Errorf("%w: decode inventory asset report triage request: %w", errInvalidHTTPRequest, err))
+		return
+	}
+	status := strings.TrimSpace(request.TriageStatus)
+	if !ports.IsGRCInventoryAssetReportStatus(status) {
+		writeGRCError(w, fmt.Errorf("%w: triage_status is invalid", errInvalidHTTPRequest))
+		return
+	}
+	reportID := strings.TrimSpace(r.PathValue("reportID"))
+	store := grcInventoryAssetReportStore(a.deps.StateStore)
+	if store == nil {
+		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
+		return
+	}
+	record, err := store.GetGRCInventoryAssetReport(r.Context(), reportID, strings.TrimSpace(request.TenantID))
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	if err := authorizeTenantID(r.Context(), record.TenantID); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	if err := authorizeCerebroURNTenant(r.Context(), record.AssetURN); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	triagedBy := strings.TrimSpace(request.TriagedBy)
+	if triagedBy == "" {
+		triagedBy = grcInventoryUpdatedBy(r)
+	}
+	record, err = store.UpdateGRCInventoryAssetReportTriage(r.Context(), ports.GRCInventoryAssetReportTriageUpdate{
+		ID:           reportID,
+		TenantID:     record.TenantID,
+		TriageStatus: status,
+		TriageReason: strings.TrimSpace(request.TriageReason),
+		TriagedBy:    triagedBy,
+	})
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, grcInventoryAssetReportResponse{Report: record, GeneratedAt: time.Now().UTC()})
+}
+
 func grcInventoryTests(findings []grcFindingItem, controls []grcControlItem) []grcInventoryTestItem {
 	tests := []grcInventoryTestItem{}
 	seen := map[string]struct{}{}
@@ -424,7 +645,48 @@ func grcInventoryVulnerabilities(findings []grcFindingItem) []grcInventoryVulner
 }
 
 func (a *App) enrichGRCInventoryAssets(r *http.Request, scope grcScope, assets []graphquery.InventoryAsset) ([]graphquery.InventoryAsset, error) {
+	if len(assets) == 0 {
+		return assets, nil
+	}
 	store := grcInventoryScopeStore(a.deps.StateStore)
+	if store != nil {
+		urns := make([]string, 0, len(assets))
+		for _, asset := range assets {
+			if strings.TrimSpace(asset.URN) != "" {
+				urns = append(urns, asset.URN)
+			}
+		}
+		records, err := store.ListGRCInventoryScopes(r.Context(), ports.GRCInventoryScopeFilter{
+			TenantID:  scope.TenantID,
+			AssetURNs: urns,
+			Limit:     boundedUint32(len(urns)),
+		})
+		if err != nil {
+			return nil, err
+		}
+		byURN := map[string]*ports.GRCInventoryScopeRecord{}
+		for _, record := range records {
+			if record != nil {
+				byURN[record.AssetURN] = record
+			}
+		}
+		for index := range assets {
+			applyGRCInventoryScope(&assets[index], byURN[assets[index].URN])
+		}
+	}
+	return a.enrichGRCInventoryAssetsWithReports(r, scope, assets)
+}
+
+func (a *App) enrichGRCInventoryAsset(r *http.Request, scope grcScope, asset graphquery.InventoryAsset) (graphquery.InventoryAsset, error) {
+	assets, err := a.enrichGRCInventoryAssets(r, scope, []graphquery.InventoryAsset{asset})
+	if err != nil || len(assets) == 0 {
+		return asset, err
+	}
+	return assets[0], nil
+}
+
+func (a *App) enrichGRCInventoryAssetsWithReports(r *http.Request, scope grcScope, assets []graphquery.InventoryAsset) ([]graphquery.InventoryAsset, error) {
+	store := grcInventoryAssetReportStore(a.deps.StateStore)
 	if store == nil || len(assets) == 0 {
 		return assets, nil
 	}
@@ -434,32 +696,38 @@ func (a *App) enrichGRCInventoryAssets(r *http.Request, scope grcScope, assets [
 			urns = append(urns, asset.URN)
 		}
 	}
-	records, err := store.ListGRCInventoryScopes(r.Context(), ports.GRCInventoryScopeFilter{
+	reports, err := store.ListGRCInventoryAssetReports(r.Context(), ports.GRCInventoryAssetReportFilter{
 		TenantID:  scope.TenantID,
 		AssetURNs: urns,
-		Limit:     boundedUint32(len(urns)),
+		Limit:     boundedUint32(len(urns) * 5),
 	})
 	if err != nil {
 		return nil, err
 	}
-	byURN := map[string]*ports.GRCInventoryScopeRecord{}
-	for _, record := range records {
-		if record != nil {
-			byURN[record.AssetURN] = record
+	byURN := map[string][]*ports.GRCInventoryAssetReportRecord{}
+	for _, report := range reports {
+		if report == nil {
+			continue
 		}
+		byURN[report.AssetURN] = append(byURN[report.AssetURN], report)
 	}
 	for index := range assets {
-		applyGRCInventoryScope(&assets[index], byURN[assets[index].URN])
+		applyGRCInventoryAssetReports(&assets[index], byURN[assets[index].URN])
 	}
 	return assets, nil
 }
 
-func (a *App) enrichGRCInventoryAsset(r *http.Request, scope grcScope, asset graphquery.InventoryAsset) (graphquery.InventoryAsset, error) {
-	assets, err := a.enrichGRCInventoryAssets(r, scope, []graphquery.InventoryAsset{asset})
-	if err != nil || len(assets) == 0 {
-		return asset, err
+func (a *App) listGRCInventoryAssetReportsForAsset(r *http.Request, scope grcScope, assetURN string, limit uint32) ([]*ports.GRCInventoryAssetReportRecord, error) {
+	store := grcInventoryAssetReportStore(a.deps.StateStore)
+	if store == nil || strings.TrimSpace(assetURN) == "" {
+		return []*ports.GRCInventoryAssetReportRecord{}, nil
 	}
-	return assets[0], nil
+	return store.ListGRCInventoryAssetReports(r.Context(), ports.GRCInventoryAssetReportFilter{
+		TenantID:  fallbackString(scope.TenantID, tenantIDFromCerebroURN(assetURN)),
+		AssetURNs: []string{assetURN},
+		SourceID:  scope.SourceID,
+		Limit:     limit,
+	})
 }
 
 func applyGRCInventoryScope(asset *graphquery.InventoryAsset, record *ports.GRCInventoryScopeRecord) {
@@ -476,6 +744,30 @@ func applyGRCInventoryScope(asset *graphquery.InventoryAsset, record *ports.GRCI
 	asset.ScopeReason = record.Reason
 	if !record.UpdatedAt.IsZero() {
 		asset.ScopeUpdatedAt = record.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+}
+
+func applyGRCInventoryAssetReports(asset *graphquery.InventoryAsset, reports []*ports.GRCInventoryAssetReportRecord) {
+	if asset == nil || len(reports) == 0 {
+		return
+	}
+	asset.AssetReportCount = len(reports)
+	latest := reports[0]
+	for _, report := range reports[1:] {
+		if report == nil {
+			continue
+		}
+		if latest == nil || report.UpdatedAt.After(latest.UpdatedAt) {
+			latest = report
+		}
+	}
+	if latest == nil {
+		return
+	}
+	asset.LatestAssetReportStatus = latest.TriageStatus
+	asset.LatestAssetReportReason = latest.Reason
+	if !latest.UpdatedAt.IsZero() {
+		asset.LatestAssetReportUpdatedAt = latest.UpdatedAt.UTC().Format(time.RFC3339)
 	}
 }
 
@@ -557,7 +849,7 @@ func applyFindingRiskToInventoryAsset(asset graphquery.InventoryAsset, findings 
 	return asset
 }
 
-func grcInventoryTimeline(asset graphquery.InventoryAsset, findings []grcFindingItem, evidence []grcEvidenceItem, tests []grcInventoryTestItem) []grcInventoryTimelineEvent {
+func grcInventoryTimeline(asset graphquery.InventoryAsset, findings []grcFindingItem, evidence []grcEvidenceItem, tests []grcInventoryTestItem, reports []*ports.GRCInventoryAssetReportRecord) []grcInventoryTimelineEvent {
 	events := []grcInventoryTimelineEvent{}
 	for _, key := range []string{"created_at", "first_seen_at"} {
 		if at := parseGRCInventoryTime(asset.Attributes[key]); at != nil {
@@ -573,6 +865,16 @@ func grcInventoryTimeline(asset graphquery.InventoryAsset, findings []grcFinding
 	}
 	if asset.ScopeUpdatedAt != "" {
 		events = append(events, grcInventoryTimelineEvent{At: parseGRCInventoryTime(asset.ScopeUpdatedAt), Kind: "scope", Title: "GRC purview updated", Description: asset.ScopeReason, Status: asset.ScopeState})
+	}
+	for _, report := range reports {
+		if report == nil {
+			continue
+		}
+		createdAt := report.CreatedAt.UTC()
+		events = append(events, grcInventoryTimelineEvent{At: &createdAt, Kind: "asset_report", Title: "Asset reported for curation", Description: report.Reason, Status: report.TriageStatus})
+		if report.TriagedAt != nil {
+			events = append(events, grcInventoryTimelineEvent{At: report.TriagedAt, Kind: "asset_report", Title: "Asset report triaged", Description: report.TriageReason, Status: report.TriageStatus})
+		}
 	}
 	for _, finding := range findings {
 		events = append(events, grcInventoryTimelineEvent{At: finding.LastObservedAt, Kind: "finding", Title: finding.Title, Description: finding.ID, Status: finding.Status})
@@ -729,6 +1031,14 @@ func grcInventoryUpdatedBy(r *http.Request) string {
 		return strings.TrimSpace(auth.principal.Name)
 	}
 	return ""
+}
+
+func newGRCInventoryAssetReportID() string {
+	var random [8]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return fmt.Sprintf("asset-report-%d", time.Now().UnixNano())
+	}
+	return "asset-report-" + hex.EncodeToString(random[:])
 }
 
 func runtimeConfigValue(config map[string]string, key string) string {

--- a/internal/bootstrap/grc_inventory_reports_test.go
+++ b/internal/bootstrap/grc_inventory_reports_test.go
@@ -1,0 +1,172 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type memoryGRCInventoryAssetReportStore struct {
+	reports map[string]*ports.GRCInventoryAssetReportRecord
+}
+
+func (s *memoryGRCInventoryAssetReportStore) Ping(context.Context) error { return nil }
+
+func (s *memoryGRCInventoryAssetReportStore) CreateGRCInventoryAssetReport(_ context.Context, record ports.GRCInventoryAssetReportRecord) (*ports.GRCInventoryAssetReportRecord, error) {
+	if s.reports == nil {
+		s.reports = map[string]*ports.GRCInventoryAssetReportRecord{}
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	record.CreatedAt = now
+	record.UpdatedAt = now
+	s.reports[record.ID] = cloneGRCInventoryAssetReport(record)
+	return cloneGRCInventoryAssetReport(record), nil
+}
+
+func (s *memoryGRCInventoryAssetReportStore) GetGRCInventoryAssetReport(_ context.Context, id string, tenantID string) (*ports.GRCInventoryAssetReportRecord, error) {
+	report, ok := s.reports[strings.TrimSpace(id)]
+	if !ok || (tenantID != "" && report.TenantID != tenantID) {
+		return nil, ports.ErrGRCInventoryAssetReportNotFound
+	}
+	return cloneGRCInventoryAssetReportValue(report), nil
+}
+
+func (s *memoryGRCInventoryAssetReportStore) ListGRCInventoryAssetReports(_ context.Context, filter ports.GRCInventoryAssetReportFilter) ([]*ports.GRCInventoryAssetReportRecord, error) {
+	urns := map[string]struct{}{}
+	for _, urn := range filter.AssetURNs {
+		urn = strings.TrimSpace(urn)
+		if urn != "" {
+			urns[urn] = struct{}{}
+		}
+	}
+	reports := []*ports.GRCInventoryAssetReportRecord{}
+	for _, report := range s.reports {
+		if filter.TenantID != "" && report.TenantID != filter.TenantID {
+			continue
+		}
+		if filter.SourceID != "" && report.SourceID != filter.SourceID {
+			continue
+		}
+		if filter.TriageStatus != "" && report.TriageStatus != filter.TriageStatus {
+			continue
+		}
+		if len(urns) > 0 {
+			if _, ok := urns[report.AssetURN]; !ok {
+				continue
+			}
+		}
+		reports = append(reports, cloneGRCInventoryAssetReportValue(report))
+	}
+	sort.Slice(reports, func(i, j int) bool { return reports[i].UpdatedAt.After(reports[j].UpdatedAt) })
+	return reports, nil
+}
+
+func (s *memoryGRCInventoryAssetReportStore) UpdateGRCInventoryAssetReportTriage(_ context.Context, update ports.GRCInventoryAssetReportTriageUpdate) (*ports.GRCInventoryAssetReportRecord, error) {
+	report, ok := s.reports[strings.TrimSpace(update.ID)]
+	if !ok || (update.TenantID != "" && report.TenantID != update.TenantID) {
+		return nil, ports.ErrGRCInventoryAssetReportNotFound
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	report.TriageStatus = update.TriageStatus
+	report.TriageReason = update.TriageReason
+	report.TriagedBy = update.TriagedBy
+	report.TriagedAt = &now
+	report.UpdatedAt = now
+	return cloneGRCInventoryAssetReportValue(report), nil
+}
+
+func TestGRCInventoryAssetReportSubmitAndTriage(t *testing.T) {
+	store := &memoryGRCInventoryAssetReportStore{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	createBody := bytes.NewBufferString(`{"asset_urn":"urn:cerebro:writer:github_code_repository:writer/app","source_id":"github","reason":"Owner metadata is stale"}`)
+	createResp, err := server.Client().Post(server.URL+"/grc/inventory/asset-reports", "application/json", createBody)
+	if err != nil {
+		t.Fatalf("POST /grc/inventory/asset-reports error = %v", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST status = %d, want %d", createResp.StatusCode, http.StatusCreated)
+	}
+	var created grcInventoryAssetReportResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Report == nil || created.Report.TriageStatus != ports.GRCInventoryAssetReportStatusSubmitted {
+		t.Fatalf("created report = %#v, want submitted report", created.Report)
+	}
+
+	patchBody := bytes.NewBufferString(`{"triage_status":"accepted","triage_reason":"Confirmed bad owner data"}`)
+	patchReq, err := http.NewRequest(http.MethodPatch, server.URL+"/grc/inventory/asset-reports/"+created.Report.ID+"/triage", patchBody)
+	if err != nil {
+		t.Fatalf("NewRequest error = %v", err)
+	}
+	patchReq.Header.Set("Content-Type", "application/json")
+	patchResp, err := server.Client().Do(patchReq)
+	if err != nil {
+		t.Fatalf("PATCH /grc/inventory/asset-reports/{id}/triage error = %v", err)
+	}
+	defer func() { _ = patchResp.Body.Close() }()
+	if patchResp.StatusCode != http.StatusOK {
+		t.Fatalf("PATCH status = %d, want %d", patchResp.StatusCode, http.StatusOK)
+	}
+	var triaged grcInventoryAssetReportResponse
+	if err := json.NewDecoder(patchResp.Body).Decode(&triaged); err != nil {
+		t.Fatalf("decode triage response: %v", err)
+	}
+	if triaged.Report == nil || triaged.Report.TriageStatus != ports.GRCInventoryAssetReportStatusAccepted || triaged.Report.TriageReason != "Confirmed bad owner data" {
+		t.Fatalf("triaged report = %#v, want accepted with reason", triaged.Report)
+	}
+}
+
+func TestGRCInventoryAssetReportRejectsInvalidStatus(t *testing.T) {
+	store := &memoryGRCInventoryAssetReportStore{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"asset_urn":"urn:cerebro:writer:github_code_repository:writer/app","reason":"bad","triage_status":"unknown"}`)
+	resp, err := server.Client().Post(server.URL+"/grc/inventory/asset-reports", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /grc/inventory/asset-reports error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("POST status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func cloneGRCInventoryAssetReport(record ports.GRCInventoryAssetReportRecord) *ports.GRCInventoryAssetReportRecord {
+	cloned := record
+	if record.Attributes != nil {
+		cloned.Attributes = map[string]string{}
+		for key, value := range record.Attributes {
+			cloned.Attributes[key] = value
+		}
+	}
+	if record.TriagedAt != nil {
+		triagedAt := *record.TriagedAt
+		cloned.TriagedAt = &triagedAt
+	}
+	return &cloned
+}
+
+func cloneGRCInventoryAssetReportValue(record *ports.GRCInventoryAssetReportRecord) *ports.GRCInventoryAssetReportRecord {
+	if record == nil {
+		return nil
+	}
+	return cloneGRCInventoryAssetReport(*record)
+}
+
+var _ ports.GRCInventoryAssetReportStore = (*memoryGRCInventoryAssetReportStore)(nil)

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -77,6 +77,10 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /grc/inventory/assets/detail", routeSurfacePlatformHTTP, app.handleGRCInventoryAssetDetail)
 	registerHTTPRoute(mux, "GET /grc/inventory/resource-scope", routeSurfacePlatformHTTP, app.handleGRCResourceScope)
 	registerHTTPRoute(mux, "POST /grc/inventory/resource-scope", routeSurfacePlatformHTTP, app.handleUpdateGRCResourceScope)
+	registerHTTPRoute(mux, "GET /grc/inventory/asset-reports", routeSurfacePlatformHTTP, app.handleListGRCInventoryAssetReports)
+	registerHTTPRoute(mux, "POST /grc/inventory/asset-reports", routeSurfacePlatformHTTP, app.handleCreateGRCInventoryAssetReport)
+	registerHTTPRoute(mux, "GET /grc/inventory/asset-reports/{reportID}", routeSurfacePlatformHTTP, app.handleGetGRCInventoryAssetReport)
+	registerHTTPRoute(mux, "PATCH /grc/inventory/asset-reports/{reportID}/triage", routeSurfacePlatformHTTP, app.handleUpdateGRCInventoryAssetReportTriage)
 	registerHTTPRoute(mux, "GET /grc/entities/{entityID}/impact", routeSurfacePlatformHTTP, app.handleGRCEntityImpact)
 	registerHTTPRoute(mux, "GET /grc/audit-packets/{packetID}", routeSurfacePlatformHTTP, app.handleGRCAuditPacket)
 }

--- a/internal/bootstrap/tenant_filter_test.go
+++ b/internal/bootstrap/tenant_filter_test.go
@@ -92,12 +92,21 @@ func TestRuntimeResponseTrustedScopeIsServerDerived(t *testing.T) {
 }
 
 func TestGRCInventoryScopeMutationRequiresWriteScope(t *testing.T) {
-	request, err := http.NewRequest(http.MethodPost, "/grc/inventory/resource-scope", nil)
-	if err != nil {
-		t.Fatalf("NewRequest error = %v", err)
-	}
-	if got := scopeForHTTPRequest(request); got != scopeGRCInventoryWrite {
-		t.Fatalf("scopeForHTTPRequest(grc inventory scope update) = %q, want %q", got, scopeGRCInventoryWrite)
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodPost, path: "/grc/inventory/resource-scope"},
+		{method: http.MethodPost, path: "/grc/inventory/asset-reports"},
+		{method: http.MethodPatch, path: "/grc/inventory/asset-reports/report-1/triage"},
+	} {
+		request, err := http.NewRequest(tc.method, tc.path, nil)
+		if err != nil {
+			t.Fatalf("NewRequest error = %v", err)
+		}
+		if got := scopeForHTTPRequest(request); got != scopeGRCInventoryWrite {
+			t.Fatalf("scopeForHTTPRequest(%s %s) = %q, want %q", tc.method, tc.path, got, scopeGRCInventoryWrite)
+		}
 	}
 
 	readOnly := authPrincipal{Scopes: []string{scopeCosmoSecurityRead}}

--- a/internal/graphquery/inventory.go
+++ b/internal/graphquery/inventory.go
@@ -43,18 +43,22 @@ type InventoryCategory struct {
 }
 
 type InventoryAsset struct {
-	URN            string            `json:"urn"`
-	EntityType     string            `json:"entity_type"`
-	Label          string            `json:"label"`
-	SourceID       string            `json:"source_id,omitempty"`
-	RuntimeID      string            `json:"runtime_id,omitempty"`
-	RiskScore      int               `json:"risk_score,omitempty"`
-	RiskLevel      string            `json:"risk_level,omitempty"`
-	RiskReasons    []string          `json:"risk_reasons,omitempty"`
-	ScopeState     string            `json:"scope_state,omitempty"`
-	ScopeReason    string            `json:"scope_reason,omitempty"`
-	ScopeUpdatedAt string            `json:"scope_updated_at,omitempty"`
-	Attributes     map[string]string `json:"attributes,omitempty"`
+	URN                        string            `json:"urn"`
+	EntityType                 string            `json:"entity_type"`
+	Label                      string            `json:"label"`
+	SourceID                   string            `json:"source_id,omitempty"`
+	RuntimeID                  string            `json:"runtime_id,omitempty"`
+	RiskScore                  int               `json:"risk_score,omitempty"`
+	RiskLevel                  string            `json:"risk_level,omitempty"`
+	RiskReasons                []string          `json:"risk_reasons,omitempty"`
+	ScopeState                 string            `json:"scope_state,omitempty"`
+	ScopeReason                string            `json:"scope_reason,omitempty"`
+	ScopeUpdatedAt             string            `json:"scope_updated_at,omitempty"`
+	AssetReportCount           int               `json:"asset_report_count,omitempty"`
+	LatestAssetReportStatus    string            `json:"latest_asset_report_status,omitempty"`
+	LatestAssetReportReason    string            `json:"latest_asset_report_reason,omitempty"`
+	LatestAssetReportUpdatedAt string            `json:"latest_asset_report_updated_at,omitempty"`
+	Attributes                 map[string]string `json:"attributes,omitempty"`
 }
 
 type InventoryAssetDetail struct {

--- a/internal/ports/grc_inventory.go
+++ b/internal/ports/grc_inventory.go
@@ -2,13 +2,23 @@ package ports
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"time"
 )
 
 const (
 	GRCInventoryScopeStateIn  = "in_scope"
 	GRCInventoryScopeStateOut = "out_of_scope"
+
+	GRCInventoryAssetReportStatusSubmitted = "submitted"
+	GRCInventoryAssetReportStatusInTriage  = "in_triage"
+	GRCInventoryAssetReportStatusAccepted  = "accepted"
+	GRCInventoryAssetReportStatusRejected  = "rejected"
+	GRCInventoryAssetReportStatusResolved  = "resolved"
 )
+
+var ErrGRCInventoryAssetReportNotFound = errors.New("grc inventory asset report not found")
 
 type GRCInventoryScopeRecord struct {
 	TenantID   string            `json:"tenant_id"`
@@ -34,4 +44,57 @@ type GRCInventoryScopeStore interface {
 	StateStore
 	UpsertGRCInventoryScope(context.Context, GRCInventoryScopeRecord) (*GRCInventoryScopeRecord, error)
 	ListGRCInventoryScopes(context.Context, GRCInventoryScopeFilter) ([]*GRCInventoryScopeRecord, error)
+}
+
+type GRCInventoryAssetReportRecord struct {
+	ID           string            `json:"id"`
+	TenantID     string            `json:"tenant_id"`
+	AssetURN     string            `json:"asset_urn"`
+	SourceID     string            `json:"source_id,omitempty"`
+	Reason       string            `json:"reason"`
+	Reporter     string            `json:"reporter,omitempty"`
+	TriageStatus string            `json:"triage_status"`
+	TriageReason string            `json:"triage_reason,omitempty"`
+	TriagedBy    string            `json:"triaged_by,omitempty"`
+	TriagedAt    *time.Time        `json:"triaged_at,omitempty"`
+	Attributes   map[string]string `json:"attributes,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+}
+
+type GRCInventoryAssetReportFilter struct {
+	TenantID     string
+	AssetURNs    []string
+	SourceID     string
+	TriageStatus string
+	Limit        uint32
+}
+
+type GRCInventoryAssetReportTriageUpdate struct {
+	ID           string
+	TenantID     string
+	TriageStatus string
+	TriageReason string
+	TriagedBy    string
+}
+
+type GRCInventoryAssetReportStore interface {
+	StateStore
+	CreateGRCInventoryAssetReport(context.Context, GRCInventoryAssetReportRecord) (*GRCInventoryAssetReportRecord, error)
+	GetGRCInventoryAssetReport(context.Context, string, string) (*GRCInventoryAssetReportRecord, error)
+	ListGRCInventoryAssetReports(context.Context, GRCInventoryAssetReportFilter) ([]*GRCInventoryAssetReportRecord, error)
+	UpdateGRCInventoryAssetReportTriage(context.Context, GRCInventoryAssetReportTriageUpdate) (*GRCInventoryAssetReportRecord, error)
+}
+
+func IsGRCInventoryAssetReportStatus(value string) bool {
+	switch strings.TrimSpace(value) {
+	case GRCInventoryAssetReportStatusSubmitted,
+		GRCInventoryAssetReportStatusInTriage,
+		GRCInventoryAssetReportStatusAccepted,
+		GRCInventoryAssetReportStatusRejected,
+		GRCInventoryAssetReportStatusResolved:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/statestore/postgres/grc_inventory.go
+++ b/internal/statestore/postgres/grc_inventory.go
@@ -27,6 +27,26 @@ var ensureGRCInventoryScopeStatements = []string{
 	`CREATE INDEX IF NOT EXISTS grc_inventory_scopes_tenant_source_state_idx ON grc_inventory_scopes (tenant_id, source_id, scope_state, updated_at DESC)`,
 }
 
+var ensureGRCInventoryAssetReportStatements = []string{
+	`CREATE TABLE IF NOT EXISTS grc_inventory_asset_reports (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  asset_urn TEXT NOT NULL,
+  source_id TEXT NOT NULL DEFAULT '',
+  reason TEXT NOT NULL,
+  reporter TEXT NOT NULL DEFAULT '',
+  triage_status TEXT NOT NULL,
+  triage_reason TEXT NOT NULL DEFAULT '',
+  triaged_by TEXT NOT NULL DEFAULT '',
+  triaged_at TIMESTAMPTZ,
+  attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS grc_inventory_asset_reports_tenant_asset_status_idx ON grc_inventory_asset_reports (tenant_id, asset_urn, triage_status, updated_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS grc_inventory_asset_reports_tenant_status_idx ON grc_inventory_asset_reports (tenant_id, triage_status, updated_at DESC)`,
+}
+
 func (s *Store) UpsertGRCInventoryScope(ctx context.Context, record ports.GRCInventoryScopeRecord) (*ports.GRCInventoryScopeRecord, error) {
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
@@ -110,6 +130,146 @@ func (s *Store) ensureGRCInventoryScopeTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.grcInventoryScopeReady, "grc inventory scope", ensureGRCInventoryScopeStatements)
 }
 
+func (s *Store) CreateGRCInventoryAssetReport(ctx context.Context, record ports.GRCInventoryAssetReportRecord) (*ports.GRCInventoryAssetReportRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCInventoryAssetReportTables(ctx); err != nil {
+		return nil, err
+	}
+	record.ID = strings.TrimSpace(record.ID)
+	record.TenantID = strings.TrimSpace(record.TenantID)
+	record.AssetURN = strings.TrimSpace(record.AssetURN)
+	record.SourceID = strings.TrimSpace(record.SourceID)
+	record.Reason = strings.TrimSpace(record.Reason)
+	record.Reporter = strings.TrimSpace(record.Reporter)
+	record.TriageStatus = strings.TrimSpace(record.TriageStatus)
+	if record.ID == "" || record.TenantID == "" || record.AssetURN == "" || record.Reason == "" || record.TriageStatus == "" {
+		return nil, errors.New("id, tenant_id, asset_urn, reason, and triage_status are required")
+	}
+	if !ports.IsGRCInventoryAssetReportStatus(record.TriageStatus) {
+		return nil, errors.New("triage_status is invalid")
+	}
+	attrs, err := json.Marshal(emptyStringMap(record.Attributes))
+	if err != nil {
+		return nil, fmt.Errorf("marshal inventory asset report attributes: %w", err)
+	}
+	row := s.db.QueryRowContext(ctx, `
+INSERT INTO grc_inventory_asset_reports (id, tenant_id, asset_urn, source_id, reason, reporter, triage_status, attributes_json)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+RETURNING id, tenant_id, asset_urn, source_id, reason, reporter, triage_status, triage_reason, triaged_by, triaged_at, attributes_json::text, created_at, updated_at`,
+		record.ID, record.TenantID, record.AssetURN, record.SourceID, record.Reason, record.Reporter, record.TriageStatus, string(attrs))
+	return scanGRCInventoryAssetReport(row)
+}
+
+func (s *Store) GetGRCInventoryAssetReport(ctx context.Context, id string, tenantID string) (*ports.GRCInventoryAssetReportRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCInventoryAssetReportTables(ctx); err != nil {
+		return nil, err
+	}
+	id = strings.TrimSpace(id)
+	tenantID = strings.TrimSpace(tenantID)
+	if id == "" {
+		return nil, errors.New("id is required")
+	}
+	clauses := []string{"id = $1"}
+	args := []any{id}
+	addTextFilter(&clauses, &args, "tenant_id", tenantID)
+	// #nosec G201 -- clauses are fixed column predicates and values remain parameterized.
+	query := fmt.Sprintf(`
+SELECT id, tenant_id, asset_urn, source_id, reason, reporter, triage_status, triage_reason, triaged_by, triaged_at, attributes_json::text, created_at, updated_at
+FROM grc_inventory_asset_reports
+WHERE %s
+LIMIT 1`, strings.Join(clauses, " AND "))
+	record, err := scanGRCInventoryAssetReport(s.db.QueryRowContext(ctx, query, args...))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %s", ports.ErrGRCInventoryAssetReportNotFound, id)
+	}
+	return record, err
+}
+
+func (s *Store) ListGRCInventoryAssetReports(ctx context.Context, filter ports.GRCInventoryAssetReportFilter) ([]*ports.GRCInventoryAssetReportRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCInventoryAssetReportTables(ctx); err != nil {
+		return nil, err
+	}
+	clauses := []string{"1=1"}
+	args := []any{}
+	addTextFilter(&clauses, &args, "tenant_id", filter.TenantID)
+	addTextFilter(&clauses, &args, "source_id", filter.SourceID)
+	addTextFilter(&clauses, &args, "triage_status", filter.TriageStatus)
+	addStringInFilter(&clauses, &args, "asset_urn", filter.AssetURNs)
+	limit := filter.Limit
+	if limit == 0 || limit > 500 {
+		limit = 500
+	}
+	args = append(args, limit)
+	// #nosec G201 -- clauses are assembled from fixed column predicates and values remain parameterized.
+	query := fmt.Sprintf(`
+SELECT id, tenant_id, asset_urn, source_id, reason, reporter, triage_status, triage_reason, triaged_by, triaged_at, attributes_json::text, created_at, updated_at
+FROM grc_inventory_asset_reports
+WHERE %s
+ORDER BY updated_at DESC, created_at DESC, id ASC
+LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list inventory asset reports: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := []*ports.GRCInventoryAssetReportRecord{}
+	for rows.Next() {
+		record, err := scanGRCInventoryAssetReport(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+func (s *Store) UpdateGRCInventoryAssetReportTriage(ctx context.Context, update ports.GRCInventoryAssetReportTriageUpdate) (*ports.GRCInventoryAssetReportRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCInventoryAssetReportTables(ctx); err != nil {
+		return nil, err
+	}
+	update.ID = strings.TrimSpace(update.ID)
+	update.TenantID = strings.TrimSpace(update.TenantID)
+	update.TriageStatus = strings.TrimSpace(update.TriageStatus)
+	update.TriageReason = strings.TrimSpace(update.TriageReason)
+	update.TriagedBy = strings.TrimSpace(update.TriagedBy)
+	if update.ID == "" || update.TriageStatus == "" {
+		return nil, errors.New("id and triage_status are required")
+	}
+	if !ports.IsGRCInventoryAssetReportStatus(update.TriageStatus) {
+		return nil, errors.New("triage_status is invalid")
+	}
+	row := s.db.QueryRowContext(ctx, `
+UPDATE grc_inventory_asset_reports
+SET triage_status = $1,
+    triage_reason = $2,
+    triaged_by = CASE WHEN $1 = 'submitted' THEN '' ELSE $3 END,
+    triaged_at = CASE WHEN $1 = 'submitted' THEN NULL ELSE NOW() END,
+    updated_at = NOW()
+WHERE id = $4 AND ($5 = '' OR tenant_id = $5)
+RETURNING id, tenant_id, asset_urn, source_id, reason, reporter, triage_status, triage_reason, triaged_by, triaged_at, attributes_json::text, created_at, updated_at`,
+		update.TriageStatus, update.TriageReason, update.TriagedBy, update.ID, update.TenantID)
+	record, err := scanGRCInventoryAssetReport(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %s", ports.ErrGRCInventoryAssetReportNotFound, update.ID)
+	}
+	return record, err
+}
+
+func (s *Store) ensureGRCInventoryAssetReportTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.grcInventoryAssetReportReady, "grc inventory asset report", ensureGRCInventoryAssetReportStatements)
+}
+
 func scanGRCInventoryScope(row scanner) (*ports.GRCInventoryScopeRecord, error) {
 	record := &ports.GRCInventoryScopeRecord{}
 	var attrs string
@@ -122,4 +282,27 @@ func scanGRCInventoryScope(row scanner) (*ports.GRCInventoryScopeRecord, error) 
 	record.Attributes = map[string]string{}
 	_ = json.Unmarshal([]byte(attrs), &record.Attributes)
 	return record, nil
+}
+
+func scanGRCInventoryAssetReport(row scanner) (*ports.GRCInventoryAssetReportRecord, error) {
+	record := &ports.GRCInventoryAssetReportRecord{}
+	var attrs string
+	var triagedAt sql.NullTime
+	if err := row.Scan(&record.ID, &record.TenantID, &record.AssetURN, &record.SourceID, &record.Reason, &record.Reporter, &record.TriageStatus, &record.TriageReason, &record.TriagedBy, &triagedAt, &attrs, &record.CreatedAt, &record.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if triagedAt.Valid {
+		value := triagedAt.Time
+		record.TriagedAt = &value
+	}
+	record.Attributes = map[string]string{}
+	_ = json.Unmarshal([]byte(attrs), &record.Attributes)
+	return record, nil
+}
+
+func emptyStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return map[string]string{}
+	}
+	return values
 }

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -15,24 +15,25 @@ import (
 
 // Store is the Postgres-backed current-state store implementation.
 type Store struct {
-	db                        *sql.DB
-	schemaMu                  sync.Mutex
-	claimTablesReady          bool
-	projectionTablesReady     bool
-	findingTablesReady        bool
-	reportRunTableReady       bool
-	sourceRuntimeTableReady   bool
-	findingEvidenceReady      bool
-	findingEvaluationRunReady bool
-	findingCandidateReady     bool
-	vulnDBTablesReady         bool
-	deviceAuthTablesReady     bool
-	mcpOAuthTablesReady       bool
-	startupLeaseTableReady    bool
-	askTrajectoryReady        bool
-	jobTablesReady            bool
-	runtimeBlocklistReady     bool
-	grcInventoryScopeReady    bool
+	db                           *sql.DB
+	schemaMu                     sync.Mutex
+	claimTablesReady             bool
+	projectionTablesReady        bool
+	findingTablesReady           bool
+	reportRunTableReady          bool
+	sourceRuntimeTableReady      bool
+	findingEvidenceReady         bool
+	findingEvaluationRunReady    bool
+	findingCandidateReady        bool
+	vulnDBTablesReady            bool
+	deviceAuthTablesReady        bool
+	mcpOAuthTablesReady          bool
+	startupLeaseTableReady       bool
+	askTrajectoryReady           bool
+	jobTablesReady               bool
+	runtimeBlocklistReady        bool
+	grcInventoryScopeReady       bool
+	grcInventoryAssetReportReady bool
 }
 
 // Open opens a Postgres-backed current-state store.


### PR DESCRIPTION
## Summary

- Adds persisted GRC inventory asset reports for data quality and curation signals.
- Adds submit/list/get/triage APIs with tenant authorization, write-scope routing, OpenAPI coverage, and asset list/detail enrichment.
- Adds focused coverage for report submit and triage behavior.

## Test Plan

- `go test ./internal/bootstrap ./internal/statestore/postgres ./internal/ports ./internal/graphquery`
- `go test ./...`
- `make lint`
- `make openapi-check`
- `make openapi-lint`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Local validation completed with focused tests, full Go tests, lint, and OpenAPI checks.
- Changed behavior is limited to GRC inventory asset report persistence, HTTP handlers, auth route policy, and inventory response enrichment.
