### PR TITLE
fix: summarize inventory asset reports

### DIFF
--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -696,23 +696,22 @@ func (a *App) enrichGRCInventoryAssetsWithReports(r *http.Request, scope grcScop
 			urns = append(urns, asset.URN)
 		}
 	}
-	reports, err := store.ListGRCInventoryAssetReports(r.Context(), ports.GRCInventoryAssetReportFilter{
+	summaries, err := store.SummarizeGRCInventoryAssetReports(r.Context(), ports.GRCInventoryAssetReportFilter{
 		TenantID:  scope.TenantID,
 		AssetURNs: urns,
-		Limit:     boundedUint32(len(urns) * 5),
 	})
 	if err != nil {
 		return nil, err
 	}
-	byURN := map[string][]*ports.GRCInventoryAssetReportRecord{}
-	for _, report := range reports {
-		if report == nil {
+	byURN := map[string]*ports.GRCInventoryAssetReportSummary{}
+	for _, summary := range summaries {
+		if summary == nil {
 			continue
 		}
-		byURN[report.AssetURN] = append(byURN[report.AssetURN], report)
+		byURN[summary.AssetURN] = summary
 	}
 	for index := range assets {
-		applyGRCInventoryAssetReports(&assets[index], byURN[assets[index].URN])
+		applyGRCInventoryAssetReportSummary(&assets[index], byURN[assets[index].URN])
 	}
 	return assets, nil
 }
@@ -747,27 +746,15 @@ func applyGRCInventoryScope(asset *graphquery.InventoryAsset, record *ports.GRCI
 	}
 }
 
-func applyGRCInventoryAssetReports(asset *graphquery.InventoryAsset, reports []*ports.GRCInventoryAssetReportRecord) {
-	if asset == nil || len(reports) == 0 {
+func applyGRCInventoryAssetReportSummary(asset *graphquery.InventoryAsset, summary *ports.GRCInventoryAssetReportSummary) {
+	if asset == nil || summary == nil {
 		return
 	}
-	asset.AssetReportCount = len(reports)
-	latest := reports[0]
-	for _, report := range reports[1:] {
-		if report == nil {
-			continue
-		}
-		if latest == nil || report.UpdatedAt.After(latest.UpdatedAt) {
-			latest = report
-		}
-	}
-	if latest == nil {
-		return
-	}
-	asset.LatestAssetReportStatus = latest.TriageStatus
-	asset.LatestAssetReportReason = latest.Reason
-	if !latest.UpdatedAt.IsZero() {
-		asset.LatestAssetReportUpdatedAt = latest.UpdatedAt.UTC().Format(time.RFC3339)
+	asset.AssetReportCount = summary.ReportCount
+	asset.LatestAssetReportStatus = summary.TriageStatus
+	asset.LatestAssetReportReason = summary.Reason
+	if !summary.UpdatedAt.IsZero() {
+		asset.LatestAssetReportUpdatedAt = summary.UpdatedAt.UTC().Format(time.RFC3339)
 	}
 }
 

--- a/internal/bootstrap/grc_inventory_reports_test.go
+++ b/internal/bootstrap/grc_inventory_reports_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -67,7 +68,51 @@ func (s *memoryGRCInventoryAssetReportStore) ListGRCInventoryAssetReports(_ cont
 		reports = append(reports, cloneGRCInventoryAssetReportValue(report))
 	}
 	sort.Slice(reports, func(i, j int) bool { return reports[i].UpdatedAt.After(reports[j].UpdatedAt) })
+	if filter.Limit > 0 && len(reports) > int(filter.Limit) {
+		reports = reports[:filter.Limit]
+	}
 	return reports, nil
+}
+
+func (s *memoryGRCInventoryAssetReportStore) SummarizeGRCInventoryAssetReports(ctx context.Context, filter ports.GRCInventoryAssetReportFilter) ([]*ports.GRCInventoryAssetReportSummary, error) {
+	reports, err := s.ListGRCInventoryAssetReports(ctx, ports.GRCInventoryAssetReportFilter{
+		TenantID:     filter.TenantID,
+		AssetURNs:    filter.AssetURNs,
+		SourceID:     filter.SourceID,
+		TriageStatus: filter.TriageStatus,
+	})
+	if err != nil {
+		return nil, err
+	}
+	byURN := map[string]*ports.GRCInventoryAssetReportSummary{}
+	for _, report := range reports {
+		if report == nil {
+			continue
+		}
+		summary := byURN[report.AssetURN]
+		if summary == nil {
+			byURN[report.AssetURN] = &ports.GRCInventoryAssetReportSummary{
+				AssetURN:     report.AssetURN,
+				ReportCount:  1,
+				TriageStatus: report.TriageStatus,
+				Reason:       report.Reason,
+				UpdatedAt:    report.UpdatedAt,
+			}
+			continue
+		}
+		summary.ReportCount++
+		if report.UpdatedAt.After(summary.UpdatedAt) {
+			summary.TriageStatus = report.TriageStatus
+			summary.Reason = report.Reason
+			summary.UpdatedAt = report.UpdatedAt
+		}
+	}
+	summaries := make([]*ports.GRCInventoryAssetReportSummary, 0, len(byURN))
+	for _, summary := range byURN {
+		summaries = append(summaries, summary)
+	}
+	sort.Slice(summaries, func(i, j int) bool { return summaries[i].UpdatedAt.After(summaries[j].UpdatedAt) })
+	return summaries, nil
 }
 
 func (s *memoryGRCInventoryAssetReportStore) UpdateGRCInventoryAssetReportTriage(_ context.Context, update ports.GRCInventoryAssetReportTriageUpdate) (*ports.GRCInventoryAssetReportRecord, error) {
@@ -144,6 +189,51 @@ func TestGRCInventoryAssetReportRejectsInvalidStatus(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("POST status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestGRCInventoryAssetReportSummaryPreservesCountsAcrossListCap(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	store := &memoryGRCInventoryAssetReportStore{reports: map[string]*ports.GRCInventoryAssetReportRecord{}}
+	for index := 0; index < 12; index++ {
+		id := "asset-a-report-" + string(rune('a'+index))
+		store.reports[id] = &ports.GRCInventoryAssetReportRecord{
+			ID:           id,
+			TenantID:     "writer",
+			AssetURN:     "urn:cerebro:writer:github_code_repository:writer/a",
+			Reason:       "asset a report",
+			TriageStatus: ports.GRCInventoryAssetReportStatusSubmitted,
+			CreatedAt:    now.Add(time.Duration(index) * time.Minute),
+			UpdatedAt:    now.Add(time.Duration(index) * time.Minute),
+		}
+	}
+	store.reports["asset-b-report"] = &ports.GRCInventoryAssetReportRecord{
+		ID:           "asset-b-report",
+		TenantID:     "writer",
+		AssetURN:     "urn:cerebro:writer:github_code_repository:writer/b",
+		Reason:       "asset b report",
+		TriageStatus: ports.GRCInventoryAssetReportStatusAccepted,
+		CreatedAt:    now.Add(-time.Hour),
+		UpdatedAt:    now.Add(-time.Hour),
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	req := httptest.NewRequest(http.MethodGet, "/grc/inventory/assets?tenant_id=writer", nil)
+
+	assets, err := app.enrichGRCInventoryAssetsWithReports(req, grcScope{TenantID: "writer"}, []graphquery.InventoryAsset{
+		{URN: "urn:cerebro:writer:github_code_repository:writer/a", Label: "A"},
+		{URN: "urn:cerebro:writer:github_code_repository:writer/b", Label: "B"},
+	})
+	if err != nil {
+		t.Fatalf("enrichGRCInventoryAssetsWithReports() error = %v", err)
+	}
+	if assets[0].AssetReportCount != 12 {
+		t.Fatalf("asset a report count = %d, want 12", assets[0].AssetReportCount)
+	}
+	if assets[1].AssetReportCount != 1 {
+		t.Fatalf("asset b report count = %d, want 1", assets[1].AssetReportCount)
+	}
+	if assets[1].LatestAssetReportStatus != ports.GRCInventoryAssetReportStatusAccepted {
+		t.Fatalf("asset b latest status = %q, want accepted", assets[1].LatestAssetReportStatus)
 	}
 }
 

--- a/internal/ports/grc_inventory.go
+++ b/internal/ports/grc_inventory.go
@@ -78,11 +78,20 @@ type GRCInventoryAssetReportTriageUpdate struct {
 	TriagedBy    string
 }
 
+type GRCInventoryAssetReportSummary struct {
+	AssetURN     string
+	ReportCount  int
+	TriageStatus string
+	Reason       string
+	UpdatedAt    time.Time
+}
+
 type GRCInventoryAssetReportStore interface {
 	StateStore
 	CreateGRCInventoryAssetReport(context.Context, GRCInventoryAssetReportRecord) (*GRCInventoryAssetReportRecord, error)
 	GetGRCInventoryAssetReport(context.Context, string, string) (*GRCInventoryAssetReportRecord, error)
 	ListGRCInventoryAssetReports(context.Context, GRCInventoryAssetReportFilter) ([]*GRCInventoryAssetReportRecord, error)
+	SummarizeGRCInventoryAssetReports(context.Context, GRCInventoryAssetReportFilter) ([]*GRCInventoryAssetReportSummary, error)
 	UpdateGRCInventoryAssetReportTriage(context.Context, GRCInventoryAssetReportTriageUpdate) (*GRCInventoryAssetReportRecord, error)
 }
 

--- a/internal/statestore/postgres/grc_inventory.go
+++ b/internal/statestore/postgres/grc_inventory.go
@@ -231,6 +231,54 @@ LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
 	return records, rows.Err()
 }
 
+func (s *Store) SummarizeGRCInventoryAssetReports(ctx context.Context, filter ports.GRCInventoryAssetReportFilter) ([]*ports.GRCInventoryAssetReportSummary, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCInventoryAssetReportTables(ctx); err != nil {
+		return nil, err
+	}
+	if len(normalizedNonEmptyStrings(filter.AssetURNs)) == 0 {
+		return []*ports.GRCInventoryAssetReportSummary{}, nil
+	}
+	clauses := []string{"1=1"}
+	args := []any{}
+	addTextFilter(&clauses, &args, "tenant_id", filter.TenantID)
+	addTextFilter(&clauses, &args, "source_id", filter.SourceID)
+	addTextFilter(&clauses, &args, "triage_status", filter.TriageStatus)
+	addStringInFilter(&clauses, &args, "asset_urn", filter.AssetURNs)
+	// #nosec G201 -- clauses are assembled from fixed column predicates and values remain parameterized.
+	query := fmt.Sprintf(`
+WITH ranked_reports AS (
+  SELECT asset_urn,
+         reason,
+         triage_status,
+         updated_at,
+         COUNT(*) OVER (PARTITION BY asset_urn) AS report_count,
+         ROW_NUMBER() OVER (PARTITION BY asset_urn ORDER BY updated_at DESC, created_at DESC, id ASC) AS report_rank
+  FROM grc_inventory_asset_reports
+  WHERE %s
+)
+SELECT asset_urn, report_count, triage_status, reason, updated_at
+FROM ranked_reports
+WHERE report_rank = 1
+ORDER BY updated_at DESC, asset_urn ASC`, strings.Join(clauses, " AND "))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("summarize inventory asset reports: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	summaries := []*ports.GRCInventoryAssetReportSummary{}
+	for rows.Next() {
+		summary, err := scanGRCInventoryAssetReportSummary(rows)
+		if err != nil {
+			return nil, err
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries, rows.Err()
+}
+
 func (s *Store) UpdateGRCInventoryAssetReportTriage(ctx context.Context, update ports.GRCInventoryAssetReportTriageUpdate) (*ports.GRCInventoryAssetReportRecord, error) {
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
@@ -298,6 +346,14 @@ func scanGRCInventoryAssetReport(row scanner) (*ports.GRCInventoryAssetReportRec
 	record.Attributes = map[string]string{}
 	_ = json.Unmarshal([]byte(attrs), &record.Attributes)
 	return record, nil
+}
+
+func scanGRCInventoryAssetReportSummary(row scanner) (*ports.GRCInventoryAssetReportSummary, error) {
+	summary := &ports.GRCInventoryAssetReportSummary{}
+	if err := row.Scan(&summary.AssetURN, &summary.ReportCount, &summary.TriageStatus, &summary.Reason, &summary.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return summary, nil
 }
 
 func emptyStringMap(values map[string]string) map[string]string {


### PR DESCRIPTION
## Summary

- Fixes missed PR #927 feedback by replacing global, capped asset-report list enrichment with a per-asset summary query.
- Preserves accurate `AssetReportCount` and latest report status/reason for every listed inventory asset, even when total report volume exceeds list caps.
- Adds regression coverage for report counts across a simulated global list cap.

## Test Plan

- `go test ./internal/bootstrap ./internal/statestore/postgres ./internal/ports ./internal/graphquery`
- `go test ./...`
- `make lint`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Addresses feedback from https://github.com/writer/cerebro/pull/927#discussion_r3405185918.
- Changed behavior is limited to GRC inventory asset report list enrichment and store summary helpers.
