### PR TITLE
feat: harden Bedrock graph agent provider

### DIFF
--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -90,6 +90,7 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 				SonnetModel: cfg.GraphAgentLLM.SonnetModel,
 				OpusModel:   cfg.GraphAgentLLM.OpusModel,
 				HaikuModel:  cfg.GraphAgentLLM.HaikuModel,
+				Region:      cfg.GraphAgentLLM.BedrockRegion,
 				MaxTokens:   cfg.GraphAgentLLM.MaxTokens,
 				Temperature: cfg.GraphAgentLLM.Temperature,
 			},
@@ -110,6 +111,7 @@ func graphAgentLLMConfigured(cfg config.GraphAgentLLMConfig) bool {
 		cfg.SonnetModel != "" ||
 		cfg.OpusModel != "" ||
 		cfg.HaikuModel != "" ||
+		cfg.BedrockRegion != "" ||
 		cfg.OpenRouterAPIKey != "" ||
 		cfg.MaxTokens != 0 ||
 		cfg.Temperature != 0

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -588,6 +588,8 @@ func grcTelemetryErrorKind(err error) string {
 		return "not_found"
 	case errors.Is(err, graphagent.ErrLLMAuthenticationFailed):
 		return "llm_authentication_failed"
+	case errors.Is(err, graphagent.ErrLLMAccessDenied):
+		return "llm_access_denied"
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable),
 		errors.Is(err, findings.ErrRuntimeUnavailable),
 		errors.Is(err, graphagent.ErrRuntimeUnavailable),

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -141,6 +141,9 @@ func askRuntimeErrorCode(err error) string {
 	if errors.Is(err, graphagent.ErrLLMAuthenticationFailed) {
 		return "llm_authentication_failed"
 	}
+	if errors.Is(err, graphagent.ErrLLMAccessDenied) {
+		return "llm_access_denied"
+	}
 	return "ask_failed"
 }
 

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -255,6 +255,49 @@ func TestGRCAskLLMAuthenticationFailureUsesSpecificErrorCode(t *testing.T) {
 	}
 }
 
+func TestGRCAskLLMAccessDeniedUsesSpecificErrorCode(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		GraphStore: &stubGraphStore{},
+		GraphAgentLLM: &graphagent.StubLLMClient{DraftErr: errors.Join(
+			graphagent.ErrLLMAccessDenied,
+			errors.New("bedrock access denied; grant bedrock:InvokeModel"),
+		)},
+	}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	var events []sseRecord
+	stderr := captureBootstrapStderr(t, func() {
+		resp, err := server.Client().Post(server.URL+"/grc/ask", "application/json", strings.NewReader(`{"tenant_id":"example","question":"hello"}`))
+		if err != nil {
+			t.Fatalf("POST /grc/ask error = %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d with streamed error event", resp.StatusCode, http.StatusOK)
+		}
+		events = readSSEEvents(t, resp)
+	})
+	assertSSEEventNames(t, events, []string{"progress", "graph_probe", "progress", "error"})
+	var errorEvent graphagent.ErrorEvent
+	if err := json.Unmarshal(events[3].Data, &errorEvent); err != nil {
+		t.Fatalf("unmarshal error event: %v", err)
+	}
+	if errorEvent.Code != "llm_access_denied" {
+		t.Fatalf("error code = %q, want llm_access_denied", errorEvent.Code)
+	}
+	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	if got := payload["runtime_error.code"]; got != "llm_access_denied" {
+		t.Fatalf("runtime_error.code = %#v, want llm_access_denied; payload=%#v", got, payload)
+	}
+	if got := payload["error_kind"]; got != "llm_access_denied" {
+		t.Fatalf("error_kind = %#v, want llm_access_denied; payload=%#v", got, payload)
+	}
+	if _, exists := payload["error"]; exists {
+		t.Fatalf("raw error recorded in telemetry: payload=%#v", payload)
+	}
+}
+
 func TestGRCAskExplainFailureReturnsServiceUnavailable(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
 		GraphStore:    &stubGraphStore{err: errors.New("neo4j unavailable")},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,7 @@ type GraphAgentLLMConfig struct {
 	MaxTokens        int
 	Temperature      float64
 	OpenRouterAPIKey string
+	BedrockRegion    string
 }
 
 // OpenTelemetryConfig controls OTLP trace and metric export.
@@ -284,11 +285,12 @@ func Load() (Config, error) {
 			Neo4jDatabase: strings.TrimSpace(os.Getenv("CEREBRO_NEO4J_DATABASE")),
 		},
 		GraphAgentLLM: GraphAgentLLMConfig{
-			Provider:    strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_PROVIDER")),
-			Model:       strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL")),
-			SonnetModel: strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_SONNET")),
-			OpusModel:   strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_OPUS")),
-			HaikuModel:  strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_HAIKU")),
+			Provider:      strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_PROVIDER")),
+			Model:         strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL")),
+			SonnetModel:   strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_SONNET")),
+			OpusModel:     strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_OPUS")),
+			HaikuModel:    strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_HAIKU")),
+			BedrockRegion: strings.TrimSpace(os.Getenv("CEREBRO_BEDROCK_REGION")),
 		},
 		OTEL: OpenTelemetryConfig{
 			ServiceName:     strings.TrimSpace(os.Getenv("CEREBRO_OTEL_SERVICE_NAME")),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -107,6 +107,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MAX_TOKENS", "900")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", "0.25")
 	t.Setenv("CEREBRO_OPENROUTER_API_KEY", "openrouter-test-key")
+	t.Setenv("CEREBRO_BEDROCK_REGION", "us-east-1")
 	t.Setenv("CEREBRO_OTEL_ENABLED", "true")
 	t.Setenv("CEREBRO_OTEL_SERVICE_NAME", "cerebro-test")
 	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
@@ -172,6 +173,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.GraphAgentLLM.OpenRouterAPIKey != "openrouter-test-key" {
 		t.Fatal("GraphAgentLLM.OpenRouterAPIKey was not loaded")
+	}
+	if cfg.GraphAgentLLM.BedrockRegion != "us-east-1" {
+		t.Fatalf("GraphAgentLLM.BedrockRegion = %q, want us-east-1", cfg.GraphAgentLLM.BedrockRegion)
 	}
 	if !cfg.OTEL.Enabled || cfg.OTEL.Protocol != "grpc" || cfg.OTEL.ServiceName != "cerebro-test" {
 		t.Fatalf("OTEL = %#v, want enabled grpc config", cfg.OTEL)
@@ -268,6 +272,7 @@ func clearGraphAgentEnv(t *testing.T) {
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MAX_TOKENS", "")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", "")
 	t.Setenv("CEREBRO_OPENROUTER_API_KEY", "")
+	t.Setenv("CEREBRO_BEDROCK_REGION", "")
 }
 
 func clearOpenTelemetryEnv(t *testing.T) {

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -19,6 +19,7 @@ import (
 var (
 	ErrRuntimeUnavailable      = errors.New("graph agent runtime is unavailable")
 	ErrLLMAuthenticationFailed = errors.New("graph agent llm authentication failed")
+	ErrLLMAccessDenied         = errors.New("graph agent llm access denied")
 	ErrInvalidRequest          = errors.New("invalid graph agent request")
 )
 

--- a/internal/graphagent/llm.go
+++ b/internal/graphagent/llm.go
@@ -57,6 +57,7 @@ type LLMConfig struct {
 	SonnetModel string
 	OpusModel   string
 	HaikuModel  string
+	Region      string
 	MaxTokens   int
 	Temperature float64
 }
@@ -85,6 +86,7 @@ func NewLLMClientWithSecrets(ctx context.Context, cfg LLMConfigWithSecrets) (LLM
 			SonnetModel:  cfg.SonnetModel,
 			OpusModel:    cfg.OpusModel,
 			HaikuModel:   cfg.HaikuModel,
+			Region:       cfg.Region,
 			MaxTokens:    cfg.MaxTokens,
 			Temperature:  cfg.Temperature,
 		})

--- a/internal/graphagent/llm_bedrock.go
+++ b/internal/graphagent/llm_bedrock.go
@@ -4,16 +4,27 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/aws/smithy-go"
 )
 
+const maxBedrockConverseTokens int32 = 1<<31 - 1
+
+var errBedrockNoText = errors.New("bedrock response contained no text")
+
+type BedrockRuntimeInvoker interface {
+	Converse(context.Context, *bedrockruntime.ConverseInput, ...func(*bedrockruntime.Options)) (*bedrockruntime.ConverseOutput, error)
+}
+
 type BedrockLLMClient struct {
-	client       *bedrockruntime.Client
+	client       BedrockRuntimeInvoker
 	defaultModel string
 	sonnetModel  string
 	opusModel    string
@@ -27,14 +38,40 @@ type BedrockConfig struct {
 	SonnetModel  string
 	OpusModel    string
 	HaikuModel   string
+	Region       string
 	MaxTokens    int
 	Temperature  float64
+	Runtime      BedrockRuntimeInvoker
+}
+
+type BedrockAccessDeniedError struct {
+	Code string
+}
+
+func (e *BedrockAccessDeniedError) Error() string {
+	code := strings.TrimSpace(e.Code)
+	if code == "" {
+		code = "AccessDeniedException"
+	}
+	return fmt.Sprintf("%s: bedrock access denied (%s); grant bedrock:InvokeModel for the configured graph-agent model", ErrLLMAccessDenied, code)
+}
+
+func (e *BedrockAccessDeniedError) Unwrap() error {
+	return ErrLLMAccessDenied
 }
 
 func NewBedrockLLMClient(ctx context.Context, llmConfig BedrockConfig) (*BedrockLLMClient, error) {
-	awsConfig, err := awsconfig.LoadDefaultConfig(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("load AWS config for Bedrock: %w", err)
+	client := llmConfig.Runtime
+	if client == nil {
+		loadOptions := []func(*awsconfig.LoadOptions) error{}
+		if region := strings.TrimSpace(llmConfig.Region); region != "" {
+			loadOptions = append(loadOptions, awsconfig.WithRegion(region))
+		}
+		awsConfig, err := awsconfig.LoadDefaultConfig(ctx, loadOptions...)
+		if err != nil {
+			return nil, fmt.Errorf("load AWS config for Bedrock: %w", err)
+		}
+		client = bedrockruntime.NewFromConfig(awsConfig)
 	}
 	if llmConfig.DefaultModel == "" {
 		llmConfig.DefaultModel = DefaultModel
@@ -43,7 +80,7 @@ func NewBedrockLLMClient(ctx context.Context, llmConfig BedrockConfig) (*Bedrock
 		llmConfig.MaxTokens = 1200
 	}
 	return &BedrockLLMClient{
-		client:       bedrockruntime.NewFromConfig(awsConfig),
+		client:       client,
 		defaultModel: strings.TrimSpace(llmConfig.DefaultModel),
 		sonnetModel:  strings.TrimSpace(llmConfig.SonnetModel),
 		opusModel:    strings.TrimSpace(llmConfig.OpusModel),
@@ -79,6 +116,11 @@ func (c *BedrockLLMClient) Summarize(ctx context.Context, req SummarizeRequest) 
 	return c.invokeMessages(ctx, c.modelID(req.Model), summarizePrompt(req), c.maxTokens)
 }
 
+func (c *BedrockLLMClient) Probe(ctx context.Context) error {
+	_, err := c.invokeMessages(ctx, c.defaultModel, "Reply with OK if this Bedrock model is callable.", 16)
+	return err
+}
+
 func (c *BedrockLLMClient) modelID(requested string) string {
 	switch normalizeModel(requested) {
 	case "claude-sonnet-4-6":
@@ -96,53 +138,87 @@ func (c *BedrockLLMClient) modelID(requested string) string {
 }
 
 func (c *BedrockLLMClient) invokeMessages(ctx context.Context, modelID string, prompt string, maxTokens int) (string, error) {
-	body := map[string]any{
-		"anthropic_version": "bedrock-2023-05-31",
-		"max_tokens":        maxTokens,
-		"temperature":       c.temperature,
-		"messages": []map[string]any{{
-			"role": "user",
-			"content": []map[string]string{{
-				"type": "text",
-				"text": prompt,
-			}},
-		}},
-	}
-	payload, err := json.Marshal(body)
+	maxTokens32, err := bedrockConverseMaxTokens(maxTokens)
 	if err != nil {
 		return "", err
 	}
-	out, err := c.client.InvokeModel(ctx, &bedrockruntime.InvokeModelInput{
-		ModelId:     aws.String(modelID),
-		ContentType: aws.String("application/json"),
-		Accept:      aws.String("application/json"),
-		Body:        payload,
+	temperature32 := float32(c.temperature)
+	out, err := c.client.Converse(ctx, &bedrockruntime.ConverseInput{
+		ModelId: aws.String(modelID),
+		Messages: []bedrocktypes.Message{{
+			Role: bedrocktypes.ConversationRoleUser,
+			Content: []bedrocktypes.ContentBlock{
+				&bedrocktypes.ContentBlockMemberText{Value: prompt},
+			},
+		}},
+		InferenceConfig: &bedrocktypes.InferenceConfiguration{
+			MaxTokens:   &maxTokens32,
+			Temperature: &temperature32,
+		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("invoke Bedrock model: %w", err)
-	}
-	var response struct {
-		Content []struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		} `json:"content"`
-	}
-	if err := json.Unmarshal(out.Body, &response); err != nil {
-		return "", fmt.Errorf("parse Bedrock response: %w", err)
+		return "", classifyBedrockInvokeError(err)
 	}
 	var text strings.Builder
-	for _, part := range response.Content {
-		if part.Type == "text" && strings.TrimSpace(part.Text) != "" {
+	message, ok := out.Output.(*bedrocktypes.ConverseOutputMemberMessage)
+	if ok && message != nil {
+		for _, part := range message.Value.Content {
+			partText := bedrockContentText(part)
+			if strings.TrimSpace(partText) == "" {
+				continue
+			}
 			if text.Len() > 0 {
 				text.WriteString("\n")
 			}
-			text.WriteString(part.Text)
+			text.WriteString(partText)
 		}
 	}
 	if strings.TrimSpace(text.String()) == "" {
-		return "", fmt.Errorf("bedrock response contained no text")
+		return "", errBedrockNoText
 	}
 	return strings.TrimSpace(text.String()), nil
+}
+
+func bedrockConverseMaxTokens(maxTokens int) (int32, error) {
+	if maxTokens <= 0 {
+		return 0, fmt.Errorf("bedrock max tokens must be greater than zero")
+	}
+	if maxTokens > int(maxBedrockConverseTokens) {
+		return 0, fmt.Errorf("bedrock max tokens exceeds supported limit")
+	}
+	return int32(maxTokens), nil
+}
+
+func bedrockContentText(part bedrocktypes.ContentBlock) string {
+	switch typed := part.(type) {
+	case *bedrocktypes.ContentBlockMemberText:
+		if typed == nil {
+			return ""
+		}
+		return typed.Value
+	default:
+		return ""
+	}
+}
+
+func classifyBedrockInvokeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && bedrockAccessDeniedCode(apiErr.ErrorCode()) {
+		return &BedrockAccessDeniedError{Code: apiErr.ErrorCode()}
+	}
+	return fmt.Errorf("invoke Bedrock model: %w", err)
+}
+
+func bedrockAccessDeniedCode(code string) bool {
+	switch strings.TrimSpace(code) {
+	case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation":
+		return true
+	default:
+		return false
+	}
 }
 
 func draftPrompt(req DraftRequest) string {

--- a/internal/graphagent/llm_bedrock.go
+++ b/internal/graphagent/llm_bedrock.go
@@ -60,6 +60,18 @@ func (e *BedrockAccessDeniedError) Unwrap() error {
 	return ErrLLMAccessDenied
 }
 
+type BedrockInvocationError struct {
+	cause error
+}
+
+func (e *BedrockInvocationError) Error() string {
+	return ErrRuntimeUnavailable.Error() + ": bedrock invocation failed"
+}
+
+func (e *BedrockInvocationError) Unwrap() []error {
+	return []error{ErrRuntimeUnavailable, e.cause}
+}
+
 func NewBedrockLLMClient(ctx context.Context, llmConfig BedrockConfig) (*BedrockLLMClient, error) {
 	client := llmConfig.Runtime
 	if client == nil {
@@ -209,7 +221,7 @@ func classifyBedrockInvokeError(err error) error {
 	if errors.As(err, &apiErr) && bedrockAccessDeniedCode(apiErr.ErrorCode()) {
 		return &BedrockAccessDeniedError{Code: apiErr.ErrorCode()}
 	}
-	return fmt.Errorf("invoke Bedrock model: %w", err)
+	return &BedrockInvocationError{cause: err}
 }
 
 func bedrockAccessDeniedCode(code string) bool {

--- a/internal/graphagent/llm_bedrock_test.go
+++ b/internal/graphagent/llm_bedrock_test.go
@@ -32,11 +32,12 @@ func (s *stubBedrockRuntime) Converse(_ context.Context, input *bedrockruntime.C
 }
 
 type stubBedrockAPIError struct {
-	code string
+	code    string
+	message string
 }
 
 func (e stubBedrockAPIError) Error() string {
-	return e.code
+	return e.code + ": " + e.ErrorMessage()
 }
 
 func (e stubBedrockAPIError) ErrorCode() string {
@@ -44,6 +45,9 @@ func (e stubBedrockAPIError) ErrorCode() string {
 }
 
 func (e stubBedrockAPIError) ErrorMessage() string {
+	if strings.TrimSpace(e.message) != "" {
+		return e.message
+	}
 	return "denied"
 }
 
@@ -128,6 +132,34 @@ func TestBedrockLLMClient_AccessDeniedClassification(t *testing.T) {
 	}
 	if strings.Contains(fmt.Sprint(err), "arn:aws") {
 		t.Fatalf("access error leaked ARN: %v", err)
+	}
+}
+
+func TestBedrockLLMClient_SanitizesGenericProviderErrors(t *testing.T) {
+	runtime := &stubBedrockRuntime{err: stubBedrockAPIError{
+		code:    "ResourceNotFoundException",
+		message: "model arn:aws:bedrock:us-east-1:123456789012:inference-profile/private-model not found; RequestID: req-123",
+	}}
+	client, err := NewBedrockLLMClient(context.Background(), BedrockConfig{DefaultModel: "us.anthropic.claude-sonnet-4-6", Runtime: runtime})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.Summarize(context.Background(), SummarizeRequest{TenantID: "test", Question: "hello"})
+	if err == nil {
+		t.Fatal("expected provider error")
+	}
+	if !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("error = %v, want ErrRuntimeUnavailable", err)
+	}
+	var invocationErr *BedrockInvocationError
+	if !errors.As(err, &invocationErr) {
+		t.Fatalf("error = %T, want BedrockInvocationError", err)
+	}
+	for _, forbidden := range []string{"arn:aws", "req-123", "ResourceNotFoundException", "private-model"} {
+		if strings.Contains(err.Error(), forbidden) {
+			t.Fatalf("sanitized error leaked %q: %v", forbidden, err)
+		}
 	}
 }
 

--- a/internal/graphagent/llm_bedrock_test.go
+++ b/internal/graphagent/llm_bedrock_test.go
@@ -1,0 +1,148 @@
+package graphagent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/aws/smithy-go"
+)
+
+type stubBedrockRuntime struct {
+	text      string
+	err       error
+	lastInput *bedrockruntime.ConverseInput
+}
+
+func (s *stubBedrockRuntime) Converse(_ context.Context, input *bedrockruntime.ConverseInput, _ ...func(*bedrockruntime.Options)) (*bedrockruntime.ConverseOutput, error) {
+	s.lastInput = input
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &bedrockruntime.ConverseOutput{
+		Output: &bedrocktypes.ConverseOutputMemberMessage{Value: bedrocktypes.Message{
+			Content: []bedrocktypes.ContentBlock{&bedrocktypes.ContentBlockMemberText{Value: s.text}},
+		}},
+	}, nil
+}
+
+type stubBedrockAPIError struct {
+	code string
+}
+
+func (e stubBedrockAPIError) Error() string {
+	return e.code
+}
+
+func (e stubBedrockAPIError) ErrorCode() string {
+	return e.code
+}
+
+func (e stubBedrockAPIError) ErrorMessage() string {
+	return "denied"
+}
+
+func (e stubBedrockAPIError) ErrorFault() smithy.ErrorFault {
+	return smithy.FaultClient
+}
+
+func TestBedrockLLMClient_DraftCypherUsesInferenceProfile(t *testing.T) {
+	runtime := &stubBedrockRuntime{text: `{"rationale":"ok","cypher":"MATCH (n) RETURN n LIMIT 5","refusal":""}`}
+	client, err := NewBedrockLLMClient(context.Background(), BedrockConfig{
+		DefaultModel: "us.anthropic.claude-sonnet-4-6",
+		Runtime:      runtime,
+		MaxTokens:    100,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	resp, err := client.DraftCypher(context.Background(), DraftRequest{
+		TenantID: "test",
+		Question: "Show risky assets",
+		Model:    DefaultModel,
+	})
+	if err != nil {
+		t.Fatalf("draft cypher: %v", err)
+	}
+	if resp.Rationale != "ok" || resp.Cypher != "MATCH (n) RETURN n LIMIT 5" {
+		t.Fatalf("draft response = %#v", resp)
+	}
+	if got := aws.ToString(runtime.lastInput.ModelId); got != "us.anthropic.claude-sonnet-4-6" {
+		t.Fatalf("model id = %q, want inference profile", got)
+	}
+	if runtime.lastInput.InferenceConfig == nil || aws.ToInt32(runtime.lastInput.InferenceConfig.MaxTokens) != 100 {
+		t.Fatalf("max_tokens = %#v, want 100", runtime.lastInput.InferenceConfig)
+	}
+	if len(runtime.lastInput.Messages) != 1 || len(runtime.lastInput.Messages[0].Content) != 1 {
+		t.Fatalf("messages = %#v", runtime.lastInput.Messages)
+	}
+	if !strings.Contains(bedrockContentText(runtime.lastInput.Messages[0].Content[0]), "Show risky assets") {
+		t.Fatalf("request message did not include question: %#v", runtime.lastInput.Messages)
+	}
+}
+
+func TestBedrockLLMClient_Probe(t *testing.T) {
+	runtime := &stubBedrockRuntime{text: "OK"}
+	client, err := NewBedrockLLMClient(context.Background(), BedrockConfig{DefaultModel: "us.anthropic.claude-sonnet-4-6", Runtime: runtime})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	if err := ProbeLLM(context.Background(), client); err != nil {
+		t.Fatalf("ProbeLLM() error = %v", err)
+	}
+	if got := aws.ToString(runtime.lastInput.ModelId); got != "us.anthropic.claude-sonnet-4-6" {
+		t.Fatalf("probe model id = %q, want default model", got)
+	}
+	if !strings.Contains(bedrockContentText(runtime.lastInput.Messages[0].Content[0]), "Bedrock model is callable") {
+		t.Fatalf("probe message = %#v", runtime.lastInput.Messages)
+	}
+}
+
+func TestBedrockLLMClient_AccessDeniedClassification(t *testing.T) {
+	runtime := &stubBedrockRuntime{err: stubBedrockAPIError{code: "AccessDeniedException"}}
+	client, err := NewBedrockLLMClient(context.Background(), BedrockConfig{DefaultModel: "us.anthropic.claude-sonnet-4-6", Runtime: runtime})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.Summarize(context.Background(), SummarizeRequest{TenantID: "test", Question: "hello"})
+	if err == nil {
+		t.Fatal("expected access denied error")
+	}
+	if !errors.Is(err, ErrLLMAccessDenied) {
+		t.Fatalf("error = %v, want ErrLLMAccessDenied", err)
+	}
+	var denied *BedrockAccessDeniedError
+	if !errors.As(err, &denied) {
+		t.Fatalf("error = %T, want BedrockAccessDeniedError", err)
+	}
+	if denied.Code != "AccessDeniedException" {
+		t.Fatalf("access code = %q", denied.Code)
+	}
+	if strings.Contains(fmt.Sprint(err), "arn:aws") {
+		t.Fatalf("access error leaked ARN: %v", err)
+	}
+}
+
+func TestBedrockLLMClient_EmptyTextResponseFails(t *testing.T) {
+	runtime := &stubBedrockRuntime{text: " "}
+	client, err := NewBedrockLLMClient(context.Background(), BedrockConfig{DefaultModel: "us.anthropic.claude-sonnet-4-6", Runtime: runtime})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.Summarize(context.Background(), SummarizeRequest{TenantID: "test", Question: "hello"})
+	if err == nil {
+		t.Fatal("expected empty text response error")
+	}
+	if !errors.Is(err, errBedrockNoText) {
+		t.Fatalf("error = %v, want errBedrockNoText", err)
+	}
+}

--- a/internal/graphagent/llm_bedrock_test.go
+++ b/internal/graphagent/llm_bedrock_test.go
@@ -156,8 +156,9 @@ func TestBedrockLLMClient_SanitizesGenericProviderErrors(t *testing.T) {
 	if !errors.As(err, &invocationErr) {
 		t.Fatalf("error = %T, want BedrockInvocationError", err)
 	}
+	sanitized := fmt.Sprint(err)
 	for _, forbidden := range []string{"arn:aws", "req-123", "ResourceNotFoundException", "private-model"} {
-		if strings.Contains(err.Error(), forbidden) {
+		if strings.Contains(sanitized, forbidden) {
 			t.Fatalf("sanitized error leaked %q: %v", forbidden, err)
 		}
 	}


### PR DESCRIPTION
## Summary
- switch the Bedrock graph-agent adapter to the Bedrock Converse API
- add provider probing, explicit region config, and typed access-denied classification
- add focused Bedrock/provider telemetry tests

## Validation
- go test ./internal/graphagent ./internal/bootstrap ./internal/config ./cmd/cerebro
- make verify