### PR TITLE
fix: tolerate unavailable AWS inventory APIs

### DIFF
--- a/sources/aws/cloud_assets.go
+++ b/sources/aws/cloud_assets.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -159,22 +160,21 @@ func listKMSKeys(ctx context.Context, clients awsClients, _ settings, cursor str
 			continue
 		}
 		describe, err := clients.kms.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: awssdk.String(keyID)})
-		if err != nil {
+		if err != nil && !optionalAWSError(err, "AccessDeniedException", "NotFoundException", "KMSInvalidStateException") {
 			return nil, "", fmt.Errorf("describe kms key %q: %w", keyID, err)
 		}
-		if describe.KeyMetadata == nil {
+		if err != nil || describe.KeyMetadata == nil {
 			continue
 		}
 		record := awsKMSKey{Metadata: *describe.KeyMetadata}
 		if tags, err := clients.kms.ListResourceTags(ctx, &kms.ListResourceTagsInput{KeyId: awssdk.String(keyID), Limit: awssdk.Int32(50)}); err == nil {
 			record.Tags = kmsTagMap(tags.Tags)
-		} else if !optionalAWSError(err, "NotFoundException") {
+		} else if !optionalAWSError(err, "AccessDeniedException", "NotFoundException") {
 			return nil, "", fmt.Errorf("list kms tags %q: %w", keyID, err)
 		}
 		if rotation, err := clients.kms.GetKeyRotationStatus(ctx, &kms.GetKeyRotationStatusInput{KeyId: awssdk.String(keyID)}); err == nil {
-			enabled := rotation.KeyRotationEnabled
-			record.RotationEnabled = &enabled
-		} else if !optionalAWSError(err, "UnsupportedOperationException", "KMSInvalidStateException", "NotFoundException") {
+			record.RotationEnabled = &rotation.KeyRotationEnabled
+		} else if !optionalAWSError(err, "AccessDeniedException", "UnsupportedOperationException", "KMSInvalidStateException", "NotFoundException") {
 			return nil, "", fmt.Errorf("get kms rotation %q: %w", keyID, err)
 		}
 		records = append(records, record)
@@ -673,17 +673,11 @@ func optionalAWSError(err error, codes ...string) bool {
 		return false
 	}
 	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) {
-		code := apiErr.ErrorCode()
-		for _, allowed := range codes {
-			if code == allowed {
-				return true
-			}
-		}
+	if errors.As(err, &apiErr) && slices.Contains(codes, apiErr.ErrorCode()) {
+		return true
 	}
-	message := err.Error()
 	for _, allowed := range codes {
-		if strings.Contains(message, allowed) {
+		if strings.Contains(fmt.Sprint(err), allowed) {
 			return true
 		}
 	}

--- a/sources/aws/governance.go
+++ b/sources/aws/governance.go
@@ -89,15 +89,15 @@ type awsIdentityStoreGroupMembership struct {
 	Membership      identitystoretypes.GroupMembership
 }
 
-func listOrganizationsAccounts(ctx context.Context, clients awsClients, _ settings, cursor string, limit int) ([]awsOrganizationsAccount, string, error) {
-	records, err := listAllOrganizationsAccounts(ctx, clients)
+func listOrganizationsAccounts(ctx context.Context, clients awsClients, settings settings, cursor string, limit int) ([]awsOrganizationsAccount, string, error) {
+	records, err := listAllOrganizationsAccounts(ctx, clients, settings)
 	if err != nil {
 		return nil, "", err
 	}
 	return governancePage(records, cursor, limit)
 }
 
-func listAllOrganizationsAccounts(ctx context.Context, clients awsClients) ([]awsOrganizationsAccount, error) {
+func listAllOrganizationsAccounts(ctx context.Context, clients awsClients, settings settings) ([]awsOrganizationsAccount, error) {
 	var records []awsOrganizationsAccount
 	var next *string
 	for {
@@ -105,6 +105,9 @@ func listAllOrganizationsAccounts(ctx context.Context, clients awsClients) ([]aw
 			MaxResults: awssdk.Int32(20),
 			NextToken:  next,
 		})
+		if err != nil && optionalAWSError(err, "AccessDeniedException") && settings.accountID != "" {
+			return []awsOrganizationsAccount{{ID: settings.accountID}}, nil
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/sources/aws/security_services.go
+++ b/sources/aws/security_services.go
@@ -340,6 +340,9 @@ func listSecurityHubFindings(ctx context.Context, clients awsClients, _ settings
 		MaxResults: awssdk.Int32(boundedAWSPageSizeInt32(limit, 1, 100)),
 		NextToken:  stringPtr(cursor),
 	})
+	if err != nil && optionalAWSError(err, "AccessDeniedException", "InvalidAccessException", "ResourceNotFoundException") {
+		return nil, "", nil
+	}
 	if err != nil {
 		return nil, "", err
 	}

--- a/sources/aws/security_services_test.go
+++ b/sources/aws/security_services_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -176,6 +177,20 @@ func TestReadAWSSecurityServiceEvents(t *testing.T) {
 	}
 }
 
+func TestReadAWSSecurityHubUnavailableReturnsEmpty(t *testing.T) {
+	source := newSecurityTestSource(t, &fakeAWSSecurityServices{
+		securityHubError: errors.New("InvalidAccessException: Security Hub is not enabled"),
+	})
+
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familySecurityHubFinding}), nil)
+	if err != nil {
+		t.Fatalf("Read(securityhub_finding) error = %v", err)
+	}
+	if len(pull.Events) != 0 {
+		t.Fatalf("len(Events) = %d, want 0", len(pull.Events))
+	}
+}
+
 func newSecurityTestSource(t *testing.T, fake *fakeAWSSecurityServices) *Source {
 	t.Helper()
 	spec, err := loadSpec()
@@ -210,6 +225,7 @@ type fakeAWSSecurityServices struct {
 	guardDutyFindingIDs  map[string][]string
 	guardDutyFindings    map[string]guarddutytypes.Finding
 	securityHubFindings  []securityhubtypes.AwsSecurityFinding
+	securityHubError     error
 	inspector2Findings   []inspector2types.Finding
 	macieFindingIDs      []string
 	macieFindings        []macie2types.Finding
@@ -259,6 +275,9 @@ type fakeSecurityHubSecurity struct {
 }
 
 func (f fakeSecurityHubSecurity) GetFindings(context.Context, *securityhub.GetFindingsInput, ...func(*securityhub.Options)) (*securityhub.GetFindingsOutput, error) {
+	if f.fake.securityHubError != nil {
+		return nil, f.fake.securityHubError
+	}
 	return &securityhub.GetFindingsOutput{Findings: f.fake.securityHubFindings}, nil
 }
 

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -1190,6 +1190,33 @@ func TestReadAWSCloudAssetInventoryEvents(t *testing.T) {
 	}
 }
 
+func TestReadAWSKMSKeysSkipsDeniedKeyDetails(t *testing.T) {
+	source := newTestSource(t, fakeAWS{
+		fakeAWSData: fakeAWSData{
+			fakeAWSCoreData: fakeAWSCoreData{
+				kmsKeys: []kmstypes.KeyMetadata{
+					{Arn: awssdk.String("arn:aws:kms:us-east-1:123456789012:key/denied"), KeyId: awssdk.String("denied")},
+					{Arn: awssdk.String("arn:aws:kms:us-east-1:123456789012:key/allowed"), KeyId: awssdk.String("allowed")},
+				},
+				kmsDescribeErrors: map[string]error{"denied": fmt.Errorf("AccessDeniedException: denied")},
+				kmsTagErrors:      map[string]error{"allowed": fmt.Errorf("AccessDeniedException: denied")},
+				kmsRotationErrors: map[string]error{"allowed": fmt.Errorf("AccessDeniedException: denied")},
+			},
+		},
+	})
+
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familyKMSKey}), nil)
+	if err != nil {
+		t.Fatalf("Read(kms_key) error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+	if got := pull.Events[0].Attributes["key_id"]; got != "allowed" {
+		t.Fatalf("key_id = %q, want allowed", got)
+	}
+}
+
 func TestReadAWSDataManagerInventoryEvents(t *testing.T) {
 	openSearchARN := "arn:aws:es:us-east-1:123456789012:domain/search-prod"
 	aossCollectionARN := "arn:aws:aoss:us-east-1:123456789012:collection/col-123"
@@ -2041,6 +2068,25 @@ func TestReadAWSGovernanceInventoryEvents(t *testing.T) {
 				t.Fatalf("%s = %q, want %q", tt.attr, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReadAWSOrganizationsAccountsFallsBackWhenListDenied(t *testing.T) {
+	source := newTestSource(t, fakeAWS{
+		fakeAWSGovernance: fakeAWSGovernance{
+			organizationAccountsError: fmt.Errorf("AccessDeniedException: denied"),
+		},
+	})
+
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familyOrganizationsAcct}), nil)
+	if err != nil {
+		t.Fatalf("Read(organizations_account) error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+	if got := pull.Events[0].Attributes["account_id"]; got != "123456789012" {
+		t.Fatalf("account_id = %q, want 123456789012", got)
 	}
 }
 
@@ -3891,6 +3937,9 @@ type fakeAWSCoreData struct {
 	s3OptionalError      error
 	rdsInstances         []rdstypes.DBInstance
 	kmsKeys              []kmstypes.KeyMetadata
+	kmsDescribeErrors    map[string]error
+	kmsTagErrors         map[string]error
+	kmsRotationErrors    map[string]error
 	kmsTags              map[string][]kmstypes.Tag
 	kmsRotation          map[string]bool
 	secrets              []secretsmanagertypes.SecretListEntry
@@ -4035,6 +4084,7 @@ type fakeAWSAnalytics struct {
 
 type fakeAWSGovernance struct {
 	organizationAccounts      []organizationstypes.Account
+	organizationAccountsError error
 	organizationRoots         []organizationstypes.Root
 	organizationOUs           map[string][]organizationstypes.OrganizationalUnit
 	organizationParents       map[string]organizationstypes.Parent
@@ -6010,6 +6060,9 @@ func (f fakeAWS) GetInstanceProfile(_ context.Context, input *iam.GetInstancePro
 }
 
 func (f fakeAWS) ListAccounts(context.Context, *organizations.ListAccountsInput, ...func(*organizations.Options)) (*organizations.ListAccountsOutput, error) {
+	if f.organizationAccountsError != nil {
+		return nil, f.organizationAccountsError
+	}
 	return &organizations.ListAccountsOutput{Accounts: f.organizationAccounts}, nil
 }
 
@@ -6652,6 +6705,9 @@ func (f fakeAWS) ListKeys(context.Context, *kms.ListKeysInput, ...func(*kms.Opti
 
 func (f fakeAWS) DescribeKey(_ context.Context, input *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
 	keyID := awssdk.ToString(input.KeyId)
+	if err := f.kmsDescribeErrors[keyID]; err != nil {
+		return nil, err
+	}
 	for _, key := range f.kmsKeys {
 		if awssdk.ToString(key.KeyId) == keyID || awssdk.ToString(key.Arn) == keyID {
 			copy := key
@@ -6662,11 +6718,19 @@ func (f fakeAWS) DescribeKey(_ context.Context, input *kms.DescribeKeyInput, _ .
 }
 
 func (f fakeAWS) ListResourceTags(_ context.Context, input *kms.ListResourceTagsInput, _ ...func(*kms.Options)) (*kms.ListResourceTagsOutput, error) {
-	return &kms.ListResourceTagsOutput{Tags: f.kmsTags[awssdk.ToString(input.KeyId)]}, nil
+	keyID := awssdk.ToString(input.KeyId)
+	if err := f.kmsTagErrors[keyID]; err != nil {
+		return nil, err
+	}
+	return &kms.ListResourceTagsOutput{Tags: f.kmsTags[keyID]}, nil
 }
 
 func (f fakeAWS) GetKeyRotationStatus(_ context.Context, input *kms.GetKeyRotationStatusInput, _ ...func(*kms.Options)) (*kms.GetKeyRotationStatusOutput, error) {
-	return &kms.GetKeyRotationStatusOutput{KeyRotationEnabled: f.kmsRotation[awssdk.ToString(input.KeyId)]}, nil
+	keyID := awssdk.ToString(input.KeyId)
+	if err := f.kmsRotationErrors[keyID]; err != nil {
+		return nil, err
+	}
+	return &kms.GetKeyRotationStatusOutput{KeyRotationEnabled: f.kmsRotation[keyID]}, nil
 }
 
 func (f fakeAWS) ListSecrets(context.Context, *secretsmanager.ListSecretsInput, ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {


### PR DESCRIPTION
## Summary
- tolerate unavailable or denied optional AWS inventory details without failing the whole source read
- keep partial inventory for AWS KMS and return empty reads for unavailable Security Hub findings
- add regression coverage for unavailable AWS inventory paths

## Tests
- `go test ./sources/aws -run 'TestReadAWS(KMSKeysSkipsDeniedKeyDetails|OrganizationsAccountsFallsBackWhenListDenied|SecurityHubUnavailableReturnsEmpty)' -count=1 -v`
- `go test ./sources/aws -count=1`
- `make verify`