### PR TITLE
fix: tolerate disabled GCP optional services

### DIFF
--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -1220,7 +1220,7 @@ func listGKEClusters(ctx context.Context, source *Source, settings settings, pag
 	addQuery(query, pageToken)
 	var response pageResponse
 	path := "/v1/projects/" + url.PathEscape(settings.projectID) + "/locations/-/clusters"
-	if err := getJSON(ctx, source, settings, containerBaseURL, http.MethodGet, path, query, nil, &response); err != nil {
+	if err := optionalGCPServiceErr(getJSON(ctx, source, settings, containerBaseURL, http.MethodGet, path, query, nil, &response)); err != nil {
 		return nil, "", err
 	}
 	records, err := decodeRecords(response.Clusters, "gcp gke cluster", func(record *gkeClusterRecord, raw json.RawMessage) { record.raw = append(json.RawMessage(nil), raw...) })
@@ -1232,7 +1232,7 @@ func listCloudRunServices(ctx context.Context, source *Source, settings settings
 	addQuery(query, pageToken)
 	var response pageResponse
 	path := "/v2/projects/" + url.PathEscape(settings.projectID) + "/locations/-/services"
-	if err := getJSON(ctx, source, settings, runBaseURL, http.MethodGet, path, query, nil, &response); err != nil {
+	if err := optionalGCPServiceErr(getJSON(ctx, source, settings, runBaseURL, http.MethodGet, path, query, nil, &response)); err != nil {
 		return nil, "", err
 	}
 	records, err := decodeRecords(response.Services, "gcp cloud run service", func(record *cloudRunServiceRecord, raw json.RawMessage) {
@@ -1246,7 +1246,7 @@ func listCloudFunctions(ctx context.Context, source *Source, settings settings, 
 	addQuery(query, pageToken)
 	var response pageResponse
 	path := "/v2/projects/" + url.PathEscape(settings.projectID) + "/locations/-/functions"
-	if err := getJSON(ctx, source, settings, functionsBaseURL, http.MethodGet, path, query, nil, &response); err != nil {
+	if err := optionalGCPServiceErr(getJSON(ctx, source, settings, functionsBaseURL, http.MethodGet, path, query, nil, &response)); err != nil {
 		return nil, "", err
 	}
 	records, err := decodeRecords(response.Functions, "gcp cloud function", func(record *cloudFunctionRecord, raw json.RawMessage) {
@@ -1285,7 +1285,7 @@ func listSecrets(ctx context.Context, source *Source, settings settings, pageTok
 	addQuery(query, pageToken)
 	var response pageResponse
 	path := "/v1/projects/" + url.PathEscape(settings.projectID) + "/secrets"
-	if err := getJSON(ctx, source, settings, secretManagerBaseURL, http.MethodGet, path, query, nil, &response); err != nil {
+	if err := optionalGCPServiceErr(getJSON(ctx, source, settings, secretManagerBaseURL, http.MethodGet, path, query, nil, &response)); err != nil {
 		return nil, "", err
 	}
 	records, err := decodeRecords(response.Secrets, "gcp secret", func(record *secretRecord, raw json.RawMessage) { record.raw = append(json.RawMessage(nil), raw...) })
@@ -2160,9 +2160,6 @@ func artifactRepositoryName(value string) string {
 
 func artifactRegistryHost(value string) string {
 	parts := strings.Split(strings.TrimSpace(value), "/")
-	if len(parts) == 0 {
-		return ""
-	}
 	if strings.Contains(parts[0], ".pkg.dev") {
 		return parts[0]
 	}
@@ -2247,6 +2244,13 @@ func getJSON(ctx context.Context, source *Source, settings settings, defaultBase
 		return fmt.Errorf("decode %s response: %w", requestPath, err)
 	}
 	return nil
+}
+
+func optionalGCPServiceErr(err error) error {
+	if err != nil && (strings.Contains(fmt.Sprint(err), "SERVICE_DISABLED") || strings.Contains(fmt.Sprint(err), "has not been used")) {
+		return nil
+	}
+	return err
 }
 
 func gcpBearerToken(ctx context.Context, source *Source, settings settings) (string, error) {
@@ -2498,10 +2502,7 @@ func disabledStatus(disabled bool) string {
 }
 
 func boolString(value bool) string {
-	if value {
-		return "true"
-	}
-	return "false"
+	return strconv.FormatBool(value)
 }
 
 func tenantID(settings settings) string {

--- a/sources/gcp/source_test.go
+++ b/sources/gcp/source_test.go
@@ -332,6 +332,50 @@ func TestReadLiveGCPRegionalComputeDiskKeepsRegionOutOfZone(t *testing.T) {
 	}
 }
 
+func TestReadLiveGCPDisabledOptionalServicesReturnEmpty(t *testing.T) {
+	for _, tt := range []struct {
+		family string
+		path   string
+	}{
+		{family: familyGKECluster, path: "/v1/projects/writer-prod/locations/-/clusters"},
+		{family: familyCloudRunService, path: "/v2/projects/writer-prod/locations/-/services"},
+		{family: familyCloudFunction, path: "/v2/projects/writer-prod/locations/-/functions"},
+		{family: familySecret, path: "/v1/projects/writer-prod/secrets"},
+	} {
+		t.Run(tt.family, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tt.path {
+					http.NotFound(w, r)
+					return
+				}
+				w.WriteHeader(http.StatusForbidden)
+				writeJSON(t, w, map[string]any{"error": map[string]any{
+					"code":    403,
+					"message": "Example API has not been used in project before or it is disabled.",
+					"status":  "PERMISSION_DENIED",
+					"details": []map[string]any{{"reason": "SERVICE_DISABLED"}},
+				}})
+			}))
+			defer server.Close()
+			source, err := newLiveTestSource()
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			cfg := sourcecdk.NewConfig(map[string]string{"base_url": server.URL, "family": tt.family, "project_id": "writer-prod", "token": "test-token"})
+			if err := source.Check(context.Background(), cfg); err != nil {
+				t.Fatalf("Check(%s) error = %v", tt.family, err)
+			}
+			pull, err := source.Read(context.Background(), cfg, nil)
+			if err != nil {
+				t.Fatalf("Read(%s) error = %v", tt.family, err)
+			}
+			if len(pull.Events) != 0 {
+				t.Fatalf("len(events) = %d, want 0", len(pull.Events))
+			}
+		})
+	}
+}
+
 func TestReadLiveGCPServiceAccountKeyPreview(t *testing.T) {
 	server := httptest.NewServer(newGCPAPIHandler(t))
 	defer server.Close()


### PR DESCRIPTION
## Summary
- Treat disabled-service responses from optional GCP inventory APIs as empty reads.
- Add regression coverage for check and read behavior when those APIs are disabled.

## Tests
- go test ./sources/gcp -run 'TestReadLiveGCPDisabledOptionalServicesReturnEmpty|TestReadLiveGCPTypedCloudResourceFamiliesPreview' -count=1\n- go test ./sources/gcp -count=1\n- make verify