### PR TITLE
fix: harden tenant and graph guardrails

### DIFF
--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -790,7 +790,7 @@ func tenantAllowed(cfg config.AuthConfig, principal authPrincipal, tenantID stri
 		return containsAuthValue(principal.AllowedTenants, tenantID)
 	}
 	if len(cfg.AllowedTenants) == 0 {
-		return true
+		return false
 	}
 	return containsAuthValue(cfg.AllowedTenants, tenantID)
 }

--- a/internal/bootstrap/auth_test.go
+++ b/internal/bootstrap/auth_test.go
@@ -1,0 +1,25 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+func TestTenantAllowedFailsClosedForUnscopedPrincipal(t *testing.T) {
+	principal := authPrincipal{AuthMode: "api_key"}
+	if tenantAllowed(config.AuthConfig{}, principal, "writer") {
+		t.Fatal("tenantAllowed() = true for unscoped principal and non-empty tenant, want false")
+	}
+}
+
+func TestTenantAllowedUsesExplicitGlobalAllowlistForUnscopedPrincipal(t *testing.T) {
+	principal := authPrincipal{AuthMode: "api_key"}
+	cfg := config.AuthConfig{AllowedTenants: []string{"writer"}}
+	if !tenantAllowed(cfg, principal, "writer") {
+		t.Fatal("tenantAllowed() = false for globally allowed tenant, want true")
+	}
+	if tenantAllowed(cfg, principal, "security") {
+		t.Fatal("tenantAllowed() = true for tenant outside global allowlist, want false")
+	}
+}

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -234,7 +234,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	}(r.Context())
 	wg.Wait()
 	close(errs)
-	if err := <-errs; err != nil {
+	if err := joinGRCErrors(errs); err != nil {
 		statusCode = grcHTTPStatusCode(err)
 		status, endAttrs = grcTelemetryError(endAttrs, err)
 		writeGRCError(w, err)
@@ -271,6 +271,14 @@ func grcDashboardPreviewLimitFor(limit uint32) uint32 {
 		return grcDashboardPreviewLimit
 	}
 	return limit
+}
+
+func joinGRCErrors(errs <-chan error) error {
+	var joined error
+	for err := range errs {
+		joined = errors.Join(joined, err)
+	}
+	return joined
 }
 
 func (a *App) handleGRCFindings(w http.ResponseWriter, r *http.Request) {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,9 +14,27 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestJoinGRCErrorsPreservesAllFailures(t *testing.T) {
+	errA := fmt.Errorf("%w: evidence", graphquery.ErrRuntimeUnavailable)
+	errB := fmt.Errorf("%w: aggregate", ports.ErrFindingNotFound)
+	errs := make(chan error, 2)
+	errs <- errA
+	errs <- errB
+	close(errs)
+
+	err := joinGRCErrors(errs)
+	if !errors.Is(err, graphquery.ErrRuntimeUnavailable) {
+		t.Fatalf("joined error = %v, want runtime unavailable", err)
+	}
+	if !errors.Is(err, ports.ErrFindingNotFound) {
+		t.Fatalf("joined error = %v, want finding not found", err)
+	}
+}
 
 func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -55,6 +55,7 @@ type ValidatorOptions struct {
 	MaxRows           int
 	AllNodesScanLimit int
 	Explain           bool
+	DisableExplain    bool
 }
 
 type Validator struct {
@@ -68,6 +69,13 @@ func NewValidator(store ports.GraphQueryStore, options ValidatorOptions) *Valida
 	}
 	if options.AllNodesScanLimit <= 0 {
 		options.AllNodesScanLimit = defaultAllNodesScanLimit
+	}
+	if !options.DisableExplain && store != nil {
+		if _, ok := store.(interface {
+			ExplainReadCypher(context.Context, ports.CypherQueryRequest) (*ports.CypherPlan, error)
+		}); ok {
+			options.Explain = true
+		}
 	}
 	return &Validator{store: store, options: options}
 }

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -400,6 +400,26 @@ LIMIT 25`, map[string]any{"tenant_id": "example"})
 	}
 }
 
+func TestValidatorDefaultsToExplainWhenStoreSupportsPlans(t *testing.T) {
+	store := &validatorStore{plan: &ports.CypherPlan{Root: &ports.CypherPlanNode{
+		Operator:  "AllNodesScan",
+		Arguments: map[string]any{"EstimatedRows": 2_000_001},
+	}}}
+	validator := NewValidator(store, ValidatorOptions{AllNodesScanLimit: 1_000_000})
+	result, _, err := validator.validate(context.Background(), `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS urn
+LIMIT 25`, map[string]any{"tenant_id": "example"})
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if result.OK {
+		t.Fatalf("Validate() ok = true, want false")
+	}
+	if len(store.requests) != 1 {
+		t.Fatalf("EXPLAIN requests = %d, want 1", len(store.requests))
+	}
+}
+
 type validatorStore struct {
 	requests []ports.CypherQueryRequest
 	rows     []ports.CypherRow

--- a/tools/archtests/import_boundaries_test.go
+++ b/tools/archtests/import_boundaries_test.go
@@ -90,6 +90,19 @@ func TestConcreteStoresStayAtWiringBoundary(t *testing.T) {
 	})
 }
 
+func TestPlatformSecurityNamespaceBoundary(t *testing.T) {
+	root := repoRoot(t)
+	routes, err := os.ReadFile(filepath.Join(root, "internal", "bootstrap", "routes.go"))
+	if err != nil {
+		t.Fatalf("read routes.go: %v", err)
+	}
+	for _, forbidden := range []string{"/platform/security", "/security/platform"} {
+		if strings.Contains(string(routes), forbidden) {
+			t.Fatalf("routes.go contains %q; platform and security namespaces must stay separate", forbidden)
+		}
+	}
+}
+
 func forEachProductionGoFile(t *testing.T, root string, visit func(path string, imports []string)) {
 	t.Helper()
 	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {


### PR DESCRIPTION
## Summary

- Fail closed for unscoped API-key tenant checks unless a global allowlist explicitly permits the tenant.
- Enable graph-agent EXPLAIN plan validation by default when the graph store supports plans.
- Preserve all GRC dashboard parallel sub-fetch errors and add a platform/security namespace arch guard.

## Closing issues
Closes #934.
Closes #935.
Refs #938.
Refs #940.

## Test Plan

- `go test ./internal/bootstrap ./internal/graphagent ./tools/archtests -count=1`
- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
