### PR TITLE
Harden async jobs and coordination rule coverage

### DIFF
--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -32,6 +32,7 @@ import (
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/graphstore"
+	platformjobs "github.com/writer/cerebro/internal/jobs"
 	"github.com/writer/cerebro/internal/knowledge"
 	"github.com/writer/cerebro/internal/mcpoauth"
 	"github.com/writer/cerebro/internal/observability"
@@ -67,9 +68,23 @@ type App struct {
 	dpopVerifier          *deviceauth.DPoPVerifier
 	riskScorer            *risk.Scorer
 	observationStore      risk.ObservationStore
+	services              appServices
 	mcpOAuthService       *mcpoauth.Service
 	mcpOAuthRegisterLimit *deviceauth.TokenBucket
 	oauthEndpointLimit    *deviceauth.TokenBucket
+}
+
+type appServices struct {
+	sourceOps      *sourceops.Service
+	reports        *reports.Service
+	runtimeOps     *sourceruntime.Service
+	claims         *claims.Service
+	findings       *findings.Service
+	knowledgeOps   *knowledge.Service
+	graphQueries   *graphquery.Service
+	graphIngestOps *graphingest.Service
+	workflowReplay *workflowprojection.Replayer
+	jobs           *platformjobs.Service
 }
 
 type bootstrapService struct {
@@ -183,6 +198,16 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 		}
 		app.mcpOAuthService = service
 	}
+	app.services.sourceOps = newSourceService(app.sources)
+	app.services.reports = app.newReportService()
+	app.services.runtimeOps = newRuntimeService(app.deps, app.sources)
+	app.services.claims = app.newClaimService()
+	app.services.findings = app.newFindingService()
+	app.services.knowledgeOps = app.newKnowledgeService()
+	app.services.graphQueries = app.newGraphQueryService()
+	app.services.graphIngestOps = newGraphIngestService(app.deps, app.sources)
+	app.services.workflowReplay = app.newWorkflowReplayService()
+	app.services.jobs = app.newJobService()
 	mux := http.NewServeMux()
 	app.mux = mux
 	app.registerRoutes(mux, cfg, deps, sources)
@@ -218,7 +243,13 @@ func (a *App) ListenAndServe() error {
 
 // Shutdown gracefully stops the bootstrap HTTP server.
 func (a *App) Shutdown(ctx context.Context) error {
-	return a.server.Shutdown(ctx)
+	if err := a.server.Shutdown(ctx); err != nil {
+		return err
+	}
+	if a.services.jobs != nil {
+		return a.services.jobs.Wait(ctx)
+	}
+	return nil
 }
 
 func (a *App) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -2722,10 +2753,20 @@ func boolQueryParam(r *http.Request, key string) (bool, error) {
 }
 
 func (a *App) sourceService() *sourceops.Service {
+	if a != nil && a.services.sourceOps != nil {
+		return a.services.sourceOps
+	}
 	return newSourceService(a.sources)
 }
 
 func (a *App) reportService() *reports.Service {
+	if a != nil && a.services.reports != nil {
+		return a.services.reports
+	}
+	return a.newReportService()
+}
+
+func (a *App) newReportService() *reports.Service {
 	return reports.New(
 		findingStore(a.deps.StateStore),
 		graphQueryStore(a.deps.GraphStore),
@@ -2734,6 +2775,9 @@ func (a *App) reportService() *reports.Service {
 }
 
 func (a *App) runtimeService() *sourceruntime.Service {
+	if a != nil && a.services.runtimeOps != nil {
+		return a.services.runtimeOps
+	}
 	return newRuntimeService(a.deps, a.sources)
 }
 
@@ -2782,6 +2826,13 @@ func authorizeRuntimeConfigEnvReferences(ctx context.Context, sourceID string, v
 }
 
 func (a *App) claimService() *claims.Service {
+	if a != nil && a.services.claims != nil {
+		return a.services.claims
+	}
+	return a.newClaimService()
+}
+
+func (a *App) newClaimService() *claims.Service {
 	return claims.New(
 		sourceRuntimeStore(a.deps.StateStore),
 		claimStore(a.deps.StateStore),
@@ -2791,6 +2842,13 @@ func (a *App) claimService() *claims.Service {
 }
 
 func (a *App) findingService() *findings.Service {
+	if a != nil && a.services.findings != nil {
+		return a.services.findings
+	}
+	return a.newFindingService()
+}
+
+func (a *App) newFindingService() *findings.Service {
 	return findings.New(
 		sourceRuntimeStore(a.deps.StateStore),
 		eventReplayer(a.deps.AppendLog),
@@ -2830,6 +2888,13 @@ func (a *App) BackfillFindingRisk(ctx context.Context) error {
 }
 
 func (a *App) knowledgeService() *knowledge.Service {
+	if a != nil && a.services.knowledgeOps != nil {
+		return a.services.knowledgeOps
+	}
+	return a.newKnowledgeService()
+}
+
+func (a *App) newKnowledgeService() *knowledge.Service {
 	return knowledge.New(
 		graphQueryStore(a.deps.GraphStore),
 		sourceProjectionGraphStore(a.deps.GraphStore),
@@ -2837,14 +2902,31 @@ func (a *App) knowledgeService() *knowledge.Service {
 }
 
 func (a *App) graphQueryService() *graphquery.Service {
+	if a != nil && a.services.graphQueries != nil {
+		return a.services.graphQueries
+	}
+	return a.newGraphQueryService()
+}
+
+func (a *App) newGraphQueryService() *graphquery.Service {
 	return graphquery.New(graphQueryStore(a.deps.GraphStore))
 }
 
 func (a *App) graphIngestService() *graphingest.Service {
+	if a != nil && a.services.graphIngestOps != nil {
+		return a.services.graphIngestOps
+	}
 	return newGraphIngestService(a.deps, a.sources)
 }
 
 func (a *App) workflowReplayService() *workflowprojection.Replayer {
+	if a != nil && a.services.workflowReplay != nil {
+		return a.services.workflowReplay
+	}
+	return a.newWorkflowReplayService()
+}
+
+func (a *App) newWorkflowReplayService() *workflowprojection.Replayer {
 	return workflowprojection.NewReplayer(
 		eventReplayer(a.deps.AppendLog),
 		sourceProjectionGraphStore(a.deps.GraphStore),

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -42,6 +42,13 @@ type jobEventListResponse struct {
 }
 
 func (a *App) jobService() *platformjobs.Service {
+	if a != nil && a.services.jobs != nil {
+		return a.services.jobs
+	}
+	return a.newJobService()
+}
+
+func (a *App) newJobService() *platformjobs.Service {
 	service := platformjobs.New(jobStore(a.deps.StateStore))
 	service.WithRunner(platformjobs.KindSourceRuntimeSync, a.runSourceRuntimeSyncJob)
 	service.WithRunner(platformjobs.KindSourceRuntimeOrchestrate, a.runSourceRuntimeOrchestrateJob)

--- a/internal/bootstrap/jobs_test.go
+++ b/internal/bootstrap/jobs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
 	platformjobs "github.com/writer/cerebro/internal/jobs"
 )
 
@@ -22,5 +23,17 @@ func TestAuthorizeJobCreateAllowsSourceRuntimeOrchestrate(t *testing.T) {
 	}
 	if tenantID != "writer" {
 		t.Fatalf("authorizeJobCreate() tenantID = %q, want writer", tenantID)
+	}
+}
+
+func TestNewCachesJobServiceForAsyncLifecycle(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0"}, Dependencies{StateStore: &stubRuntimeStore{}}, nil)
+	if app.services.jobs == nil {
+		t.Fatal("jobsService = nil, want cached service")
+	}
+	first := app.jobService()
+	second := app.jobService()
+	if first != second {
+		t.Fatal("jobService() returned different instances")
 	}
 }

--- a/internal/findings/coordination_graph_rule_test.go
+++ b/internal/findings/coordination_graph_rule_test.go
@@ -69,6 +69,78 @@ func TestCoordinationGraphRuleQueryOrdersFindingsBeforeSlice(t *testing.T) {
 	}
 }
 
+func TestReviewCoordinationGraphRulesHaveDirectCoverage(t *testing.T) {
+	tests := []struct {
+		name         string
+		rule         Rule
+		sourceID     string
+		family       string
+		querySnippet string
+	}{
+		{name: "github org owner", rule: newGitHubOrgOwnerConcentrationRule(), sourceID: "github", family: "org_inventory", querySnippet: `"role":"admin"`},
+		{name: "github programmatic credential", rule: newGitHubProgrammaticCredentialReviewRule(), sourceID: "github", family: "audit", querySnippet: `"resource_type":"personal_access_token"`},
+		{name: "github self-hosted runner", rule: newGitHubSelfHostedRunnerReviewRule(), sourceID: "github", family: "audit", querySnippet: `"runner_ephemeral":"true"`},
+		{name: "okta oauth public client", rule: newOktaOAuthPublicClientReviewRule(), sourceID: "okta", family: "application", querySnippet: `"oauth_public_client":"true"`},
+		{name: "okta weak authenticator", rule: newOktaAuthenticatorWeakFactorRule(), sourceID: "okta", family: "authenticator", querySnippet: `"key":"sms"`},
+		{name: "okta threat insight", rule: newOktaThreatInsightNotBlockingRule(), sourceID: "okta", family: "threat_insight", querySnippet: `"action":"block"`},
+		{name: "sentinelone stale agent", rule: newSentinelOneAgentNotUpToDateRule(), sourceID: "sentinelone", family: "agent", querySnippet: `"is_up_to_date":"false"`},
+		{name: "sentinelone unmitigated threat", rule: newSentinelOneUnmitigatedThreatRule(), sourceID: "sentinelone", family: "threat", querySnippet: `"mitigation_status":"not_mitigated"`},
+		{name: "cloud current public exposure", rule: newCloudPublicResourceExposureGraphRule(), sourceID: "aws", family: "resource_exposure", querySnippet: `"internet_exposed":"true"`},
+		{name: "graph aws eni link missing", rule: newGraphAWSEC2ENILinkMissingRule(), sourceID: "graph", querySnippet: "attached_instance_id"},
+		{name: "graph orphan node", rule: newGraphOrphanNonFindingNodeRule(), sourceID: "graph", querySnippet: "entity.entity_type <> 'finding'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			graphRule, ok := tt.rule.(GraphRule)
+			if !ok {
+				t.Fatalf("rule %T is not a GraphRule", tt.rule)
+			}
+			runtime := &cerebrov1.SourceRuntime{Id: "runtime-1", TenantId: "writer", SourceId: tt.sourceID, Config: map[string]string{"family": tt.family}}
+			if !tt.rule.SupportsRuntime(runtime) {
+				t.Fatalf("SupportsRuntime(%s/%s) = false, want true", tt.sourceID, tt.family)
+			}
+			query := graphRule.QueryFor(runtime)
+			if query.Query == "" {
+				t.Fatal("QueryFor() returned empty query")
+			}
+			if query.Params["tenant_id"] != "writer" {
+				t.Fatalf("tenant_id param = %#v, want writer", query.Params["tenant_id"])
+			}
+			if query.Params["row_limit"] != int64(coordinationGraphRowLimit) || query.RowLimit != coordinationGraphRowLimit {
+				t.Fatalf("row limit = params:%#v request:%d, want %d", query.Params["row_limit"], query.RowLimit, coordinationGraphRowLimit)
+			}
+			if !strings.Contains(query.Query, "LIMIT $row_limit") {
+				t.Fatalf("query missing LIMIT $row_limit: %s", query.Query)
+			}
+			if !strings.Contains(query.Query, tt.querySnippet) {
+				t.Fatalf("query missing critical predicate %q: %s", tt.querySnippet, query.Query)
+			}
+			findings, err := graphRule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{{Values: map[string]any{
+				"primary_urn":     "urn:cerebro:writer:resource:one",
+				"primary_label":   "Resource One",
+				"primary_type":    "resource",
+				"fingerprint_key": "urn:cerebro:writer:resource:one",
+				"summary":         "review finding",
+				"resource_urns":   []any{"urn:cerebro:writer:resource:one"},
+				"evidence":        []any{},
+			}}})
+			if err != nil {
+				t.Fatalf("EvaluateRows() error = %v", err)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("len(findings) = %d, want 1", len(findings))
+			}
+			if findings[0].RuleID != tt.rule.Spec().GetId() {
+				t.Fatalf("RuleID = %q, want %q", findings[0].RuleID, tt.rule.Spec().GetId())
+			}
+			if findings[0].TenantID != "writer" || findings[0].RuntimeID != "runtime-1" {
+				t.Fatalf("finding scope = tenant %q runtime %q", findings[0].TenantID, findings[0].RuntimeID)
+			}
+		})
+	}
+}
+
 func TestCoordinationGraphRuleEvaluateRowsBuildsFinding(t *testing.T) {
 	rule := newGRCSourceConcentratedOpenFindingsRule().(GraphRule)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-grc-integration", TenantId: "writer", SourceId: "grc", Config: map[string]string{"family": "integration"}}

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -33,13 +34,17 @@ const (
 type Runner func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error)
 
 type Service struct {
-	store   ports.JobStore
-	runners map[string]Runner
-	now     func() time.Time
+	store        ports.JobStore
+	runners      map[string]Runner
+	now          func() time.Time
+	nextAsyncID  uint64
+	asyncCancels map[uint64]context.CancelFunc
+	wg           sync.WaitGroup
+	mu           sync.Mutex
 }
 
 func New(store ports.JobStore) *Service {
-	return &Service{store: store, runners: map[string]Runner{}, now: func() time.Time { return time.Now().UTC() }}
+	return &Service{store: store, runners: map[string]Runner{}, now: func() time.Time { return time.Now().UTC() }, asyncCancels: map[uint64]context.CancelFunc{}}
 }
 
 func (s *Service) WithRunner(kind string, runner Runner) *Service {
@@ -82,7 +87,7 @@ func (s *Service) Create(ctx context.Context, request ports.CreateJobRequest) (*
 	return job, created, nil
 }
 
-func (s *Service) StartAsync(parent context.Context, job *ports.Job) {
+func (s *Service) StartAsync(ctx context.Context, job *ports.Job) { //nolint:contextcheck // Async jobs intentionally outlive request cancellation while preserving context values.
 	if s == nil || job == nil {
 		return
 	}
@@ -90,10 +95,59 @@ func (s *Service) StartAsync(parent context.Context, job *ports.Job) {
 	if runner == nil {
 		return
 	}
-	ctx := context.WithoutCancel(parent)
+	if ctx == nil {
+		return
+	}
+	runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	s.mu.Lock()
+	s.nextAsyncID++
+	asyncID := s.nextAsyncID
+	if s.asyncCancels == nil {
+		s.asyncCancels = map[uint64]context.CancelFunc{}
+	}
+	s.asyncCancels[asyncID] = cancel
+	s.wg.Add(1)
+	s.mu.Unlock()
 	go func() {
-		_ = s.Run(ctx, job.ID)
+		defer func() {
+			cancel()
+			s.mu.Lock()
+			delete(s.asyncCancels, asyncID)
+			s.mu.Unlock()
+			s.wg.Done()
+		}()
+		_ = s.Run(runCtx, job.ID)
 	}()
+}
+
+func (s *Service) Wait(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(s.asyncCancels))
+	for _, cancel := range s.asyncCancels {
+		cancels = append(cancels, cancel)
+	}
+	s.mu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	var ctxDone <-chan struct{}
+	if ctx != nil {
+		ctxDone = ctx.Done()
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctxDone:
+		return ctx.Err()
+	}
 }
 
 func (s *Service) Run(ctx context.Context, jobID string) (err error) {

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -83,6 +84,44 @@ func TestRunRecoversRunnerPanicAndMarksJobFailed(t *testing.T) {
 	}
 	if len(store.events) < 2 || store.events[len(store.events)-1].Type != "failed" {
 		t.Fatalf("events = %#v, want final failed event", store.events)
+	}
+}
+
+func TestStartAsyncDetachesFromRequestAndWaitCancelsJob(t *testing.T) {
+	store := newMemoryJobStore()
+	service := New(store)
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	service.WithRunner(KindReportRun, func(ctx context.Context, _ *ports.Job, _ *Service) (map[string]any, map[string]string, error) {
+		close(started)
+		<-ctx.Done()
+		close(cancelled)
+		return nil, nil, ctx.Err()
+	})
+	job, created, err := service.Create(context.Background(), ports.CreateJobRequest{Kind: KindReportRun})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if !created {
+		t.Fatal("created = false, want true")
+	}
+	requestCtx, requestCancel := context.WithCancel(context.Background())
+	requestCancel()
+	service.StartAsync(requestCtx, job)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("async job did not start after request context cancellation")
+	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+	defer waitCancel()
+	if err := service.Wait(waitCtx); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	select {
+	case <-cancelled:
+	default:
+		t.Fatal("runner did not observe service cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary
- cache bootstrap services, including jobs, instead of rebuilding them per request
- detach async jobs from request cancellation while making shutdown cancel and wait for in-flight jobs
- add direct coverage for coordination graph rules and their critical query predicates

## Validation
- make verify

## Closing issues
Closes #933.
Closes #939.
Closes #940.
