### PR TITLE
Honor generic replica count for DPoP guard

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -301,6 +301,7 @@ func clearDeviceAuthEnv(t *testing.T) {
 	t.Setenv("CEREBRO_DEVICE_AUTH_TOKEN_BURST", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_DPOP_PROOF_TTL", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_REPLICA_COUNT", "")
+	t.Setenv("CEREBRO_REPLICA_COUNT", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_RISK_ELEVATED", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_RISK_HIGH", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED", "")
@@ -349,6 +350,17 @@ func TestLoadRejectsDeviceAuthMultipleReplicasWithoutSharedDPoPReplay(t *testing
 	clearDependencyEnv(t)
 	t.Setenv("CEREBRO_DEVICE_AUTH_ENABLED", "true")
 	t.Setenv("CEREBRO_DEVICE_AUTH_REPLICA_COUNT", "2")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadRejectsDeviceAuthGenericMultipleReplicasWithoutSharedDPoPReplay(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_DEVICE_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_REPLICA_COUNT", "2")
 
 	_, err := Load()
 	if err == nil {

--- a/internal/config/device_auth.go
+++ b/internal/config/device_auth.go
@@ -61,11 +61,8 @@ func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
 	if cfg.DPoPProofTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_DPOP_PROOF_TTL", 60*time.Second); err != nil {
 		return DeviceAuthConfig{}, err
 	}
-	if cfg.ReplicaCount, err = parseIntEnv("CEREBRO_DEVICE_AUTH_REPLICA_COUNT", 1); err != nil {
+	if cfg.ReplicaCount, err = loadDeviceAuthReplicaCount(); err != nil {
 		return DeviceAuthConfig{}, err
-	}
-	if cfg.ReplicaCount <= 0 {
-		return DeviceAuthConfig{}, fmt.Errorf("CEREBRO_DEVICE_AUTH_REPLICA_COUNT must be greater than zero")
 	}
 	if cfg.RiskElevatedThreshold, err = parseIntEnv("CEREBRO_DEVICE_AUTH_RISK_ELEVATED", 30); err != nil {
 		return DeviceAuthConfig{}, err
@@ -110,6 +107,27 @@ func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
 		}
 	}
 	return cfg, nil
+}
+
+func loadDeviceAuthReplicaCount() (int, error) {
+	deviceAuthReplicas, err := parseIntEnv("CEREBRO_DEVICE_AUTH_REPLICA_COUNT", 1)
+	if err != nil {
+		return 0, err
+	}
+	if deviceAuthReplicas <= 0 {
+		return 0, fmt.Errorf("CEREBRO_DEVICE_AUTH_REPLICA_COUNT must be greater than zero")
+	}
+	replicas, err := parseIntEnv("CEREBRO_REPLICA_COUNT", 1)
+	if err != nil {
+		return 0, err
+	}
+	if replicas <= 0 {
+		return 0, fmt.Errorf("CEREBRO_REPLICA_COUNT must be greater than zero")
+	}
+	if replicas > deviceAuthReplicas {
+		return replicas, nil
+	}
+	return deviceAuthReplicas, nil
 }
 
 func parseDeviceAuthSigningKeys(raw string) ([]DeviceAuthSigningKey, error) {


### PR DESCRIPTION
## Summary
- treat CEREBRO_REPLICA_COUNT as a deployment-wide replica hint for device-auth DPoP safety
- reject device auth when either generic or device-auth-specific replica count exceeds one
- add regression coverage for the generic replica-count guard

## Validation
- go test ./internal/config -run 'TestLoadRejectsDeviceAuthMultipleReplicasWithoutSharedDPoPReplay|TestLoadRejectsDeviceAuthGenericMultipleReplicasWithoutSharedDPoPReplay|TestLoadDefaults' -count=1 -v
- make verify

## Closing issues
Closes #936.