### PR TITLE
refactor: consolidate remaining error mappings for #938

### DIFF
--- a/.github/workflows/smoke-scheduled.yml
+++ b/.github/workflows/smoke-scheduled.yml
@@ -10,9 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
+env:
+  DOCKER_BUILDKIT: 1
+
 jobs:
   smoke-compose:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -38,35 +45,18 @@ jobs:
 
       - name: Verify core endpoints
         run: |
-          # API root should return service info
-          curl -sf http://localhost:8080/ || (echo "API root failed"; exit 1)
-
           # Health endpoint should return 200
           curl -sf http://localhost:8080/healthz || (echo "Health check failed"; exit 1)
 
           echo "Core endpoints verified"
 
-      - name: Run basic write/read smoke
-        env:
-          TEST_API_KEY: ${{ secrets.SMOKE_TEST_API_KEY || 'test-api-key-smoke' }}
-        run: |
-          # Create a tenant-scoped test (will fail closed without proper auth, which is expected)
-          http_code=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Authorization: Bearer $TEST_API_KEY" \
-            -H "Content-Type: application/json" \
-            http://localhost:8080/api/v1/sources || true)
-
-          # We expect 401/403 without proper setup, but not 500 or timeout
-          if [ "$http_code" = "500" ] || [ "$http_code" = "502" ] || [ "$http_code" = "503" ] || [ "$http_code" = "504" ]; then
-            echo "Server error: HTTP $http_code"
-            exit 1
-          fi
-
-          echo "Basic API smoke passed (HTTP $http_code)"
-
-      - name: Collect logs on failure
+      - name: Collect diagnostics on failure
         if: failure()
         run: |
+          echo "=== Docker state ==="
+          docker ps -a || true
+          echo "=== NATS health ==="
+          curl -sf http://localhost:8222/healthz || true
           echo "=== NATS logs ==="
           docker compose logs nats --tail 50 || true
           echo "=== Postgres logs ==="
@@ -78,4 +68,4 @@ jobs:
 
       - name: Cleanup
         if: always()
-        run: docker compose down -v
+        run: docker compose down -v --remove-orphans

--- a/.github/workflows/smoke-scheduled.yml
+++ b/.github/workflows/smoke-scheduled.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke-compose:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-scheduled.yml
+++ b/.github/workflows/smoke-scheduled.yml
@@ -1,0 +1,77 @@
+name: Scheduled Docker Compose Smoke
+
+on:
+  schedule:
+    # Run daily at 06:00 UTC (catch overnight dependency issues)
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  smoke-compose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca5144bd6d3e63b7e8a28e4d5a9a7e5f1b8b0 # v3.10.0
+
+      - name: Start services
+        run: docker compose up -d --wait
+
+      - name: Wait for Cerebro health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/healthz; then
+              echo "Cerebro is healthy"
+              exit 0
+            fi
+            echo "Waiting for Cerebro... ($i/30)"
+            sleep 2
+          done
+          echo "Cerebro failed to become healthy"
+          docker compose logs cerebro
+          exit 1
+
+      - name: Verify core endpoints
+        run: |
+          # API root should return service info
+          curl -sf http://localhost:8080/ || (echo "API root failed"; exit 1)
+
+          # Health endpoint should return 200
+          curl -sf http://localhost:8080/healthz || (echo "Health check failed"; exit 1)
+
+          echo "Core endpoints verified"
+
+      - name: Run basic write/read smoke
+        env:
+          TEST_API_KEY: ${{ secrets.SMOKE_TEST_API_KEY || 'test-api-key-smoke' }}
+        run: |
+          # Create a tenant-scoped test (will fail closed without proper auth, which is expected)
+          http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $TEST_API_KEY" \
+            -H "Content-Type: application/json" \
+            http://localhost:8080/api/v1/sources || true)
+
+          # We expect 401/403 without proper setup, but not 500 or timeout
+          if [ "$http_code" = "500" ] || [ "$http_code" = "502" ] || [ "$http_code" = "503" ] || [ "$http_code" = "504" ]; then
+            echo "Server error: HTTP $http_code"
+            exit 1
+          fi
+
+          echo "Basic API smoke passed (HTTP $http_code)"
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== NATS logs ==="
+          docker compose logs nats --tail 50 || true
+          echo "=== Postgres logs ==="
+          docker compose logs postgres --tail 50 || true
+          echo "=== Neo4j logs ==="
+          docker compose logs neo4j --tail 50 || true
+          echo "=== Cerebro logs ==="
+          docker compose logs cerebro --tail 100 || true
+
+      - name: Cleanup
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/smoke-scheduled.yml
+++ b/.github/workflows/smoke-scheduled.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca5144bd6d3e63b7e8a28e4d5a9a7e5f1b8b0 # v3.10.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Start services
         run: docker compose up -d --wait

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.45.0
+	golang.org/x/time v0.14.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.1
@@ -157,7 +158,6 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.81.1 // indirect

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -3068,64 +3068,63 @@ func sourceConnectError(err error) error {
 	return mappedConnectError(err, sourceErrorMappings)
 }
 
+var sourceRuntimeErrorMappings = []bootstrapErrorMapping{
+	{match: matchesAnyError(ports.ErrSourceRuntimeNotFound, sourceops.ErrSourceNotFound), httpStatus: http.StatusNotFound, code: connect.CodeNotFound},
+	{match: matchesAnyError(sourceruntime.ErrSyncInProgress), httpStatus: http.StatusConflict, code: connect.CodeAborted},
+	{match: matchesAnyError(sourceruntime.ErrRuntimeUnavailable), httpStatus: http.StatusServiceUnavailable, code: connect.CodeUnavailable},
+	{match: matchesAnyError(sourceruntime.ErrInvalidRequest, graphquery.ErrInvalidRequest, errInvalidHTTPRequest), httpStatus: http.StatusBadRequest, code: connect.CodeInvalidArgument},
+}
+
+var claimErrorMappings = []bootstrapErrorMapping{
+	{match: matchesAnyError(ports.ErrSourceRuntimeNotFound), httpStatus: http.StatusNotFound, code: connect.CodeNotFound},
+	{match: matchesAnyError(claims.ErrRuntimeUnavailable), httpStatus: http.StatusServiceUnavailable, code: connect.CodeUnavailable},
+	{match: matchesAnyError(claims.ErrInvalidRequest, errInvalidHTTPRequest), httpStatus: http.StatusBadRequest, code: connect.CodeInvalidArgument},
+}
+
+var findingErrorMappings = []bootstrapErrorMapping{
+	{match: matchesAnyError(ports.ErrSourceRuntimeNotFound, findings.ErrRuleNotFound, ports.ErrFindingNotFound, ports.ErrFindingCandidateNotFound, ports.ErrFindingEvaluationRunNotFound, ports.ErrFindingEvidenceNotFound), httpStatus: http.StatusNotFound, code: connect.CodeNotFound},
+	{match: matchesAnyError(findings.ErrRuntimeUnavailable), httpStatus: http.StatusServiceUnavailable, code: connect.CodeUnavailable},
+	{match: matchesAnyError(findings.ErrRuleSelectionRequired, findings.ErrRuleUnsupported, findings.ErrInvalidRequest, errInvalidHTTPRequest), httpStatus: http.StatusBadRequest, code: connect.CodeInvalidArgument},
+	{match: matchesAnyError(findings.ErrRuleUnavailable), httpStatus: http.StatusPreconditionFailed, code: connect.CodeFailedPrecondition},
+}
+
+var knowledgeErrorMappings = []bootstrapErrorMapping{
+	{match: matchesAnyError(ports.ErrGraphEntityNotFound), httpStatus: http.StatusNotFound, code: connect.CodeNotFound},
+	{match: matchesAnyError(knowledge.ErrRuntimeUnavailable), httpStatus: http.StatusServiceUnavailable, code: connect.CodeUnavailable},
+	{match: matchesAnyError(knowledge.ErrInvalidRequest, errInvalidHTTPRequest), httpStatus: http.StatusBadRequest, code: connect.CodeInvalidArgument},
+}
+
+var graphQueryErrorMappings = []bootstrapErrorMapping{
+	{match: matchesAnyError(ports.ErrGraphEntityNotFound), httpStatus: http.StatusNotFound, code: connect.CodeNotFound},
+	{match: matchesAnyError(graphquery.ErrRuntimeUnavailable), httpStatus: http.StatusServiceUnavailable, code: connect.CodeUnavailable},
+	{match: matchesAnyError(graphquery.ErrInvalidRequest, errInvalidHTTPRequest), httpStatus: http.StatusBadRequest, code: connect.CodeInvalidArgument},
+}
+
+var graphIngestErrorMappings = []bootstrapErrorMapping{
+	{match: matchesAnyError(graphingest.ErrRunNotFound, ports.ErrSourceRuntimeNotFound, sourceops.ErrSourceNotFound), httpStatus: http.StatusNotFound, code: connect.CodeNotFound},
+	{match: matchesAnyError(graphingest.ErrRuntimeUnavailable), httpStatus: http.StatusServiceUnavailable, code: connect.CodeUnavailable},
+	{match: matchesAnyError(graphingest.ErrInvalidRequest, errInvalidHTTPRequest), httpStatus: http.StatusBadRequest, code: connect.CodeInvalidArgument},
+}
+
+var workflowReplayErrorMappings = []bootstrapErrorMapping{
+	{match: matchesAnyError(workflowprojection.ErrRuntimeUnavailable), httpStatus: http.StatusServiceUnavailable, code: connect.CodeUnavailable},
+	{match: matchesAnyError(errInvalidHTTPRequest), httpStatus: http.StatusBadRequest, code: connect.CodeInvalidArgument},
+}
+
 func writeSourceRuntimeError(w http.ResponseWriter, err error) {
-	statusCode := http.StatusInternalServerError
-	switch {
-	case errors.Is(err, errTenantForbidden):
-		statusCode = http.StatusForbidden
-	case errors.Is(err, ports.ErrSourceRuntimeNotFound), errors.Is(err, sourceops.ErrSourceNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, sourceruntime.ErrSyncInProgress):
-		statusCode = http.StatusConflict
-	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable):
-		statusCode = http.StatusServiceUnavailable
-	case errors.Is(err, sourceruntime.ErrInvalidRequest), errors.Is(err, graphquery.ErrInvalidRequest), errors.Is(err, errInvalidHTTPRequest):
-		statusCode = http.StatusBadRequest
-	}
-	http.Error(w, http.StatusText(statusCode), statusCode)
+	writeMappedBootstrapError(w, err, sourceRuntimeErrorMappings)
 }
 
 func sourceRuntimeConnectError(err error) error {
-	switch {
-	case errors.Is(err, ports.ErrSourceRuntimeNotFound), errors.Is(err, sourceops.ErrSourceNotFound):
-		return connect.NewError(connect.CodeNotFound, err)
-	case errors.Is(err, sourceruntime.ErrSyncInProgress):
-		return connect.NewError(connect.CodeAborted, err)
-	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable):
-		return connect.NewError(connect.CodeUnavailable, err)
-	case errors.Is(err, sourceruntime.ErrInvalidRequest):
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	default:
-		return defaultConnectError(err)
-	}
+	return mappedConnectError(err, sourceRuntimeErrorMappings)
 }
 
 func writeClaimError(w http.ResponseWriter, err error) {
-	statusCode := http.StatusInternalServerError
-	switch {
-	case errors.Is(err, errTenantForbidden):
-		statusCode = http.StatusForbidden
-	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, claims.ErrRuntimeUnavailable):
-		statusCode = http.StatusServiceUnavailable
-	case errors.Is(err, claims.ErrInvalidRequest), errors.Is(err, errInvalidHTTPRequest):
-		statusCode = http.StatusBadRequest
-	}
-	http.Error(w, http.StatusText(statusCode), statusCode)
+	writeMappedBootstrapError(w, err, claimErrorMappings)
 }
 
 func claimConnectError(err error) error {
-	switch {
-	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
-		return connect.NewError(connect.CodeNotFound, err)
-	case errors.Is(err, claims.ErrRuntimeUnavailable):
-		return connect.NewError(connect.CodeUnavailable, err)
-	case errors.Is(err, claims.ErrInvalidRequest):
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	default:
-		return defaultConnectError(err)
-	}
+	return mappedConnectError(err, claimErrorMappings)
 }
 
 func defaultConnectErrorCode(err error) connect.Code {
@@ -3150,162 +3149,43 @@ func defaultConnectError(err error) error {
 }
 
 func findingConnectError(err error) error {
-	switch {
-	case errors.Is(err, ports.ErrSourceRuntimeNotFound),
-		errors.Is(err, findings.ErrRuleNotFound),
-		errors.Is(err, ports.ErrFindingNotFound),
-		errors.Is(err, ports.ErrFindingCandidateNotFound),
-		errors.Is(err, ports.ErrFindingEvaluationRunNotFound),
-		errors.Is(err, ports.ErrFindingEvidenceNotFound):
-		return connect.NewError(connect.CodeNotFound, err)
-	case errors.Is(err, findings.ErrRuleSelectionRequired),
-		errors.Is(err, findings.ErrRuleUnsupported),
-		errors.Is(err, findings.ErrInvalidRequest):
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	case errors.Is(err, findings.ErrRuleUnavailable):
-		return connect.NewError(connect.CodeFailedPrecondition, err)
-	case errors.Is(err, findings.ErrRuntimeUnavailable):
-		return connect.NewError(connect.CodeUnavailable, err)
-	default:
-		return defaultConnectError(err)
-	}
+	return mappedConnectError(err, findingErrorMappings)
 }
 
 func knowledgeConnectError(err error) error {
-	switch {
-	case errors.Is(err, ports.ErrGraphEntityNotFound):
-		return connect.NewError(connect.CodeNotFound, err)
-	case errors.Is(err, knowledge.ErrInvalidRequest):
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	case errors.Is(err, knowledge.ErrRuntimeUnavailable):
-		return connect.NewError(connect.CodeUnavailable, err)
-	default:
-		return defaultConnectError(err)
-	}
+	return mappedConnectError(err, knowledgeErrorMappings)
 }
 
 func graphQueryConnectError(err error) error {
-	switch {
-	case errors.Is(err, ports.ErrGraphEntityNotFound):
-		return connect.NewError(connect.CodeNotFound, err)
-	case errors.Is(err, graphquery.ErrRuntimeUnavailable):
-		return connect.NewError(connect.CodeUnavailable, err)
-	case errors.Is(err, graphquery.ErrInvalidRequest):
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	default:
-		return defaultConnectError(err)
-	}
+	return mappedConnectError(err, graphQueryErrorMappings)
 }
 
 func graphIngestConnectError(err error) error {
-	switch {
-	case errors.Is(err, graphingest.ErrRunNotFound),
-		errors.Is(err, ports.ErrSourceRuntimeNotFound),
-		errors.Is(err, sourceops.ErrSourceNotFound):
-		return connect.NewError(connect.CodeNotFound, err)
-	case errors.Is(err, graphingest.ErrRuntimeUnavailable):
-		return connect.NewError(connect.CodeUnavailable, err)
-	case errors.Is(err, graphingest.ErrInvalidRequest):
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	default:
-		return defaultConnectError(err)
-	}
+	return mappedConnectError(err, graphIngestErrorMappings)
 }
 
 func workflowReplayConnectError(err error) error {
-	if errors.Is(err, workflowprojection.ErrRuntimeUnavailable) {
-		return connect.NewError(connect.CodeUnavailable, err)
-	}
-	return defaultConnectError(err)
+	return mappedConnectError(err, workflowReplayErrorMappings)
 }
 
 func writeFindingError(w http.ResponseWriter, err error) {
-	statusCode := http.StatusInternalServerError
-	switch {
-	case errors.Is(err, errTenantForbidden):
-		statusCode = http.StatusForbidden
-	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, findings.ErrRuleNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, ports.ErrFindingNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, ports.ErrFindingEvaluationRunNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, ports.ErrFindingEvidenceNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, findings.ErrRuntimeUnavailable):
-		statusCode = http.StatusServiceUnavailable
-	case errors.Is(err, findings.ErrRuleSelectionRequired), errors.Is(err, findings.ErrRuleUnsupported), errors.Is(err, findings.ErrInvalidRequest):
-		statusCode = http.StatusBadRequest
-	case errors.Is(err, findings.ErrRuleUnavailable):
-		statusCode = http.StatusPreconditionFailed
-	case errors.Is(err, errInvalidHTTPRequest):
-		statusCode = http.StatusBadRequest
-	}
-	http.Error(w, http.StatusText(statusCode), statusCode)
+	writeMappedBootstrapError(w, err, findingErrorMappings)
 }
 
 func writeKnowledgeError(w http.ResponseWriter, err error) {
-	statusCode := http.StatusInternalServerError
-	switch {
-	case errors.Is(err, errTenantForbidden):
-		statusCode = http.StatusForbidden
-	case errors.Is(err, ports.ErrGraphEntityNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, knowledge.ErrInvalidRequest):
-		statusCode = http.StatusBadRequest
-	case errors.Is(err, knowledge.ErrRuntimeUnavailable):
-		statusCode = http.StatusServiceUnavailable
-	case errors.Is(err, errInvalidHTTPRequest):
-		statusCode = http.StatusBadRequest
-	}
-	http.Error(w, http.StatusText(statusCode), statusCode)
+	writeMappedBootstrapError(w, err, knowledgeErrorMappings)
 }
 
 func writeGraphQueryError(w http.ResponseWriter, err error) {
-	statusCode := http.StatusInternalServerError
-	switch {
-	case errors.Is(err, errTenantForbidden):
-		statusCode = http.StatusForbidden
-	case errors.Is(err, ports.ErrGraphEntityNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, graphquery.ErrRuntimeUnavailable):
-		statusCode = http.StatusServiceUnavailable
-	case errors.Is(err, graphquery.ErrInvalidRequest), errors.Is(err, errInvalidHTTPRequest):
-		statusCode = http.StatusBadRequest
-	}
-	http.Error(w, http.StatusText(statusCode), statusCode)
+	writeMappedBootstrapError(w, err, graphQueryErrorMappings)
 }
 
 func writeGraphIngestError(w http.ResponseWriter, err error) {
-	statusCode := http.StatusInternalServerError
-	switch {
-	case errors.Is(err, errTenantForbidden):
-		statusCode = http.StatusForbidden
-	case errors.Is(err, graphingest.ErrRunNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, ports.ErrSourceRuntimeNotFound), errors.Is(err, sourceops.ErrSourceNotFound):
-		statusCode = http.StatusNotFound
-	case errors.Is(err, graphingest.ErrRuntimeUnavailable):
-		statusCode = http.StatusServiceUnavailable
-	case errors.Is(err, graphingest.ErrInvalidRequest), errors.Is(err, errInvalidHTTPRequest):
-		statusCode = http.StatusBadRequest
-	}
-	http.Error(w, http.StatusText(statusCode), statusCode)
+	writeMappedBootstrapError(w, err, graphIngestErrorMappings)
 }
 
 func writeWorkflowReplayError(w http.ResponseWriter, err error) {
-	statusCode := http.StatusInternalServerError
-	switch {
-	case errors.Is(err, errTenantForbidden):
-		statusCode = http.StatusForbidden
-	case errors.Is(err, workflowprojection.ErrRuntimeUnavailable):
-		statusCode = http.StatusServiceUnavailable
-	case errors.Is(err, errInvalidHTTPRequest):
-		statusCode = http.StatusBadRequest
-	}
-	http.Error(w, http.StatusText(statusCode), statusCode)
+	writeMappedBootstrapError(w, err, workflowReplayErrorMappings)
 }
 
 func timestampValue(value *timestamppb.Timestamp) time.Time {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -211,7 +211,7 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	mux := http.NewServeMux()
 	app.mux = mux
 	app.registerRoutes(mux, cfg, deps, sources)
-	app.handler = observability.Middleware(rateLimitMiddleware(cfg.RateLimit)(authMiddleware(cfg.Auth, AuthDependencies{
+	app.handler = observability.Middleware(rateLimitMiddleware(cfg.RateLimit, cfg.Auth.RequestOrigin)(authMiddleware(cfg.Auth, AuthDependencies{
 		DeviceVerifier: app.deviceVerifier,
 		DPoPVerifier:   app.dpopVerifier,
 		RiskScorer:     app.riskScorer,

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -211,12 +211,12 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	mux := http.NewServeMux()
 	app.mux = mux
 	app.registerRoutes(mux, cfg, deps, sources)
-	app.handler = observability.Middleware(authMiddleware(cfg.Auth, AuthDependencies{
+	app.handler = observability.Middleware(rateLimitMiddleware(cfg.RateLimit)(authMiddleware(cfg.Auth, AuthDependencies{
 		DeviceVerifier: app.deviceVerifier,
 		DPoPVerifier:   app.dpopVerifier,
 		RiskScorer:     app.riskScorer,
 		Observations:   app.observationStore,
-	}, mux))
+	}, mux)))
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           app.handler,

--- a/internal/bootstrap/ratelimit.go
+++ b/internal/bootstrap/ratelimit.go
@@ -7,26 +7,32 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/time/rate"
 	"github.com/writer/cerebro/internal/config"
+	"golang.org/x/time/rate"
 )
 
 // rateLimiter implements per-IP token bucket rate limiting with configurable
 // exemptions for health and metadata endpoints.
 type rateLimiter struct {
-	config     config.RateLimitConfig
-	limiters   map[string]*rate.Limiter
-	mu         sync.RWMutex
+	config          config.RateLimitConfig
+	limiters        map[string]*rate.Limiter
+	mu              sync.RWMutex
 	cleanupInterval time.Duration
-	lastAccess map[string]time.Time
+	lastAccess      map[string]time.Time
 }
 
 // newRateLimiter creates a global rate limiter with the provided configuration.
+// cleanupInterval defaults to 5 minutes; override only in tests before calling.
 func newRateLimiter(cfg config.RateLimitConfig) *rateLimiter {
+	return newRateLimiterWithInterval(cfg, 5*time.Minute)
+}
+
+// newRateLimiterWithInterval creates a rate limiter with a custom cleanup interval.
+func newRateLimiterWithInterval(cfg config.RateLimitConfig, cleanupInterval time.Duration) *rateLimiter {
 	rl := &rateLimiter{
 		config:          cfg,
 		limiters:        make(map[string]*rate.Limiter),
-		cleanupInterval:   5 * time.Minute,
+		cleanupInterval: cleanupInterval,
 		lastAccess:      make(map[string]time.Time),
 	}
 	// Start background cleanup of stale limiters

--- a/internal/bootstrap/ratelimit.go
+++ b/internal/bootstrap/ratelimit.go
@@ -1,0 +1,135 @@
+package bootstrap
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+	"github.com/writer/cerebro/internal/config"
+)
+
+// rateLimiter implements per-IP token bucket rate limiting with configurable
+// exemptions for health and metadata endpoints.
+type rateLimiter struct {
+	config     config.RateLimitConfig
+	limiters   map[string]*rate.Limiter
+	mu         sync.RWMutex
+	cleanupInterval time.Duration
+	lastAccess map[string]time.Time
+}
+
+// newRateLimiter creates a global rate limiter with the provided configuration.
+func newRateLimiter(cfg config.RateLimitConfig) *rateLimiter {
+	rl := &rateLimiter{
+		config:          cfg,
+		limiters:        make(map[string]*rate.Limiter),
+		cleanupInterval:   5 * time.Minute,
+		lastAccess:      make(map[string]time.Time),
+	}
+	// Start background cleanup of stale limiters
+	go rl.cleanupLoop()
+	return rl
+}
+
+// middleware returns an HTTP middleware that applies rate limiting.
+func (rl *rateLimiter) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !rl.config.Enabled {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Check path exemptions
+		if rl.isExemptPath(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Get client IP for rate limiting key
+		clientIP := rl.clientIP(r)
+		limiter := rl.getLimiter(clientIP)
+
+		if !limiter.Allow() {
+			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isExemptPath checks if the request path matches any exempt prefix.
+func (rl *rateLimiter) isExemptPath(path string) bool {
+	for _, exempt := range rl.config.ExemptPaths {
+		if strings.HasPrefix(path, exempt) {
+			return true
+		}
+	}
+	return false
+}
+
+// clientIP extracts the client IP from the request, respecting X-Forwarded-For
+// when behind trusted proxies.
+func (rl *rateLimiter) clientIP(r *http.Request) string {
+	ip := remoteIPForRateLimit(r)
+	// Strip port if present
+	host, _, err := net.SplitHostPort(ip)
+	if err == nil {
+		return host
+	}
+	return ip
+}
+
+// getLimiter returns or creates a rate limiter for the given client IP.
+func (rl *rateLimiter) getLimiter(ip string) *rate.Limiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	// Update last access time
+	rl.lastAccess[ip] = time.Now()
+
+	limiter, exists := rl.limiters[ip]
+	if !exists {
+		limiter = rate.NewLimiter(rate.Limit(rl.config.RequestsPerSecond), rl.config.BurstSize)
+		rl.limiters[ip] = limiter
+	}
+	return limiter
+}
+
+// cleanupLoop periodically removes stale limiters to prevent memory growth.
+func (rl *rateLimiter) cleanupLoop() {
+	ticker := time.NewTicker(rl.cleanupInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		rl.cleanupStaleLimiters()
+	}
+}
+
+// cleanupStaleLimiters removes limiters that haven't been accessed recently.
+func (rl *rateLimiter) cleanupStaleLimiters() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	cutoff := time.Now().Add(-10 * time.Minute)
+	for ip, lastAccess := range rl.lastAccess {
+		if lastAccess.Before(cutoff) {
+			delete(rl.limiters, ip)
+			delete(rl.lastAccess, ip)
+		}
+	}
+}
+
+// rateLimitMiddleware creates a rate limiting middleware from configuration.
+func rateLimitMiddleware(cfg config.RateLimitConfig) func(http.Handler) http.Handler {
+	if !cfg.Enabled {
+		return func(next http.Handler) http.Handler {
+			return next
+		}
+	}
+	rl := newRateLimiter(cfg)
+	return rl.middleware
+}

--- a/internal/bootstrap/ratelimit.go
+++ b/internal/bootstrap/ratelimit.go
@@ -15,6 +15,7 @@ import (
 // exemptions for health and metadata endpoints.
 type rateLimiter struct {
 	config          config.RateLimitConfig
+	originConfig    config.RequestOriginConfig
 	limiters        map[string]*rate.Limiter
 	mu              sync.RWMutex
 	cleanupInterval time.Duration
@@ -23,14 +24,15 @@ type rateLimiter struct {
 
 // newRateLimiter creates a global rate limiter with the provided configuration.
 // cleanupInterval defaults to 5 minutes; override only in tests before calling.
-func newRateLimiter(cfg config.RateLimitConfig) *rateLimiter {
-	return newRateLimiterWithInterval(cfg, 5*time.Minute)
+func newRateLimiter(cfg config.RateLimitConfig, originCfg config.RequestOriginConfig) *rateLimiter {
+	return newRateLimiterWithInterval(cfg, originCfg, 5*time.Minute)
 }
 
 // newRateLimiterWithInterval creates a rate limiter with a custom cleanup interval.
-func newRateLimiterWithInterval(cfg config.RateLimitConfig, cleanupInterval time.Duration) *rateLimiter {
+func newRateLimiterWithInterval(cfg config.RateLimitConfig, originCfg config.RequestOriginConfig, cleanupInterval time.Duration) *rateLimiter {
 	rl := &rateLimiter{
 		config:          cfg,
+		originConfig:    originCfg,
 		limiters:        make(map[string]*rate.Limiter),
 		cleanupInterval: cleanupInterval,
 		lastAccess:      make(map[string]time.Time),
@@ -78,9 +80,15 @@ func (rl *rateLimiter) isExemptPath(path string) bool {
 }
 
 // clientIP extracts the client IP from the request, respecting X-Forwarded-For
-// when behind trusted proxies.
+// when behind trusted proxies. Uses the operator-configured RequestOriginConfig
+// to apply TrustedProxyCount/TrustedProxyCIDRs hardening consistently with
+// the auth/OAuth layers.
 func (rl *rateLimiter) clientIP(r *http.Request) string {
-	ip := remoteIPForRateLimit(r)
+	if r == nil {
+		return "unknown"
+	}
+	origin := resolveRequestOrigin(r, rl.originConfig)
+	ip := firstNonEmpty(origin.ClientIP, "unknown")
 	// Strip port if present
 	host, _, err := net.SplitHostPort(ip)
 	if err == nil {
@@ -130,12 +138,14 @@ func (rl *rateLimiter) cleanupStaleLimiters() {
 }
 
 // rateLimitMiddleware creates a rate limiting middleware from configuration.
-func rateLimitMiddleware(cfg config.RateLimitConfig) func(http.Handler) http.Handler {
+// The originCfg parameter provides the operator-configured RequestOriginConfig
+// for consistent IP resolution with the auth/OAuth layers.
+func rateLimitMiddleware(cfg config.RateLimitConfig, originCfg config.RequestOriginConfig) func(http.Handler) http.Handler {
 	if !cfg.Enabled {
 		return func(next http.Handler) http.Handler {
 			return next
 		}
 	}
-	rl := newRateLimiter(cfg)
+	rl := newRateLimiter(cfg, originCfg)
 	return rl.middleware
 }

--- a/internal/bootstrap/ratelimit_test.go
+++ b/internal/bootstrap/ratelimit_test.go
@@ -1,0 +1,187 @@
+package bootstrap
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+func TestRateLimiterAllowsRequestsUnderLimit(t *testing.T) {
+	cfg := config.RateLimitConfig{
+		Enabled:           true,
+		RequestsPerSecond: 100,
+		BurstSize:         10,
+		ExemptPaths:       []string{"/health"},
+	}
+	rl := newRateLimiter(cfg)
+
+	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First 10 requests (burst) should succeed immediately
+	for i := 0; i < 10; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/test", nil)
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i+1, rec.Code)
+		}
+	}
+}
+
+func TestRateLimiterExemptsHealthPaths(t *testing.T) {
+	cfg := config.RateLimitConfig{
+		Enabled:           true,
+		RequestsPerSecond: 1,
+		BurstSize:         1,
+		ExemptPaths:       []string{"/health", "/healthz"},
+	}
+	rl := newRateLimiter(cfg)
+
+	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Make many requests to exempt path - all should succeed
+	for i := 0; i < 50; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/health", nil)
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("exempt request %d: expected 200, got %d", i+1, rec.Code)
+		}
+	}
+}
+
+func TestRateLimiterExemptsWellKnownPaths(t *testing.T) {
+	cfg := config.RateLimitConfig{
+		Enabled:           true,
+		RequestsPerSecond: 1,
+		BurstSize:         1,
+		ExemptPaths:       []string{"/.well-known/"},
+	}
+	rl := newRateLimiter(cfg)
+
+	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Well-known endpoints should be exempt
+	for i := 0; i < 20; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/.well-known/oauth-authorization-server", nil)
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("well-known request %d: expected 200, got %d", i+1, rec.Code)
+		}
+	}
+}
+
+func TestRateLimiterDisabledPassesThrough(t *testing.T) {
+	cfg := config.RateLimitConfig{
+		Enabled:           false,
+		RequestsPerSecond: 1,
+		BurstSize:         1,
+	}
+	rl := newRateLimiter(cfg)
+
+	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Many requests should succeed when disabled
+	for i := 0; i < 100; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/test", nil)
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("disabled request %d: expected 200, got %d", i+1, rec.Code)
+		}
+	}
+}
+
+func TestRateLimiterPerClientIsolation(t *testing.T) {
+	cfg := config.RateLimitConfig{
+		Enabled:           true,
+		RequestsPerSecond: 100,
+		BurstSize:         5,
+		ExemptPaths:       []string{},
+	}
+	rl := newRateLimiter(cfg)
+
+	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Exhaust burst from one IP
+	for i := 0; i < 5; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/test", nil)
+		req.RemoteAddr = "192.168.1.1:1234"
+		handler.ServeHTTP(rec, req)
+	}
+
+	// Same IP should be rate limited now
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.RemoteAddr = "192.168.1.1:1234"
+	handler.ServeHTTP(rec, req)
+
+	// Different IP should still have full burst available
+	for i := 0; i < 5; i++ {
+		rec2 := httptest.NewRecorder()
+		req2 := httptest.NewRecorder().Result().Request
+		req2 = httptest.NewRequest("GET", "/api/test", nil)
+		req2.RemoteAddr = "192.168.1.2:1234"
+		handler.ServeHTTP(rec2, req2)
+		if rec2.Code != http.StatusOK {
+			t.Fatalf("different IP request %d: expected 200, got %d", i+1, rec2.Code)
+		}
+	}
+}
+
+func TestRateLimiterCleanupRemovesStaleLimiters(t *testing.T) {
+	cfg := config.RateLimitConfig{
+		Enabled:           true,
+		RequestsPerSecond: 100,
+		BurstSize:         10,
+		ExemptPaths:       []string{},
+	}
+	rl := newRateLimiter(cfg)
+	rl.cleanupInterval = 100 * time.Millisecond
+
+	// Make a request to create a limiter
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.RemoteAddr = "192.168.1.1:1234"
+	rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+
+	// Verify limiter exists
+	rl.mu.RLock()
+	_, exists := rl.limiters["192.168.1.1"]
+	rl.mu.RUnlock()
+	if !exists {
+		t.Fatal("expected limiter to exist after request")
+	}
+
+	// Manually trigger cleanup with old cutoff
+	rl.mu.Lock()
+	rl.lastAccess["192.168.1.1"] = time.Now().Add(-15 * time.Minute)
+	rl.mu.Unlock()
+
+	rl.cleanupStaleLimiters()
+
+	// Verify limiter was cleaned up
+	rl.mu.RLock()
+	_, exists = rl.limiters["192.168.1.1"]
+	rl.mu.RUnlock()
+	if exists {
+		t.Fatal("expected stale limiter to be cleaned up")
+	}
+}

--- a/internal/bootstrap/ratelimit_test.go
+++ b/internal/bootstrap/ratelimit_test.go
@@ -16,7 +16,7 @@ func TestRateLimiterAllowsRequestsUnderLimit(t *testing.T) {
 		BurstSize:         10,
 		ExemptPaths:       []string{"/health"},
 	}
-	rl := newRateLimiter(cfg)
+	rl := newRateLimiter(cfg, config.RequestOriginConfig{})
 
 	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -40,7 +40,7 @@ func TestRateLimiterExemptsHealthPaths(t *testing.T) {
 		BurstSize:         1,
 		ExemptPaths:       []string{"/health", "/healthz"},
 	}
-	rl := newRateLimiter(cfg)
+	rl := newRateLimiter(cfg, config.RequestOriginConfig{})
 
 	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -64,7 +64,7 @@ func TestRateLimiterExemptsWellKnownPaths(t *testing.T) {
 		BurstSize:         1,
 		ExemptPaths:       []string{"/.well-known/"},
 	}
-	rl := newRateLimiter(cfg)
+	rl := newRateLimiter(cfg, config.RequestOriginConfig{})
 
 	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -87,7 +87,7 @@ func TestRateLimiterDisabledPassesThrough(t *testing.T) {
 		RequestsPerSecond: 1,
 		BurstSize:         1,
 	}
-	rl := newRateLimiter(cfg)
+	rl := newRateLimiter(cfg, config.RequestOriginConfig{})
 
 	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -111,7 +111,7 @@ func TestRateLimiterPerClientIsolation(t *testing.T) {
 		BurstSize:         5,
 		ExemptPaths:       []string{},
 	}
-	rl := newRateLimiter(cfg)
+	rl := newRateLimiter(cfg, config.RequestOriginConfig{})
 
 	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -143,6 +143,41 @@ func TestRateLimiterPerClientIsolation(t *testing.T) {
 	}
 }
 
+func TestRateLimiterUsesConfiguredRequestOriginTrust(t *testing.T) {
+	cfg := config.RateLimitConfig{
+		Enabled:           true,
+		RequestsPerSecond: 1,
+		BurstSize:         1,
+		ExemptPaths:       []string{},
+	}
+	originCfg := config.RequestOriginConfig{
+		TrustedProxyCIDRs: []string{"192.0.2.0/24"},
+	}
+	rl := newRateLimiter(cfg, originCfg)
+
+	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req1 := httptest.NewRequest("GET", "/api/test", nil)
+	req1.RemoteAddr = "10.0.1.20:443"
+	req1.Header.Set("X-Forwarded-For", "198.51.100.1")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", rec1.Code)
+	}
+
+	req2 := httptest.NewRequest("GET", "/api/test", nil)
+	req2.RemoteAddr = "10.0.1.20:443"
+	req2.Header.Set("X-Forwarded-For", "198.51.100.2")
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("spoofed forwarded-for request status = %d, want 429", rec2.Code)
+	}
+}
+
 func TestRateLimiterCleanupRemovesStaleLimiters(t *testing.T) {
 	cfg := config.RateLimitConfig{
 		Enabled:           true,
@@ -151,7 +186,7 @@ func TestRateLimiterCleanupRemovesStaleLimiters(t *testing.T) {
 		ExemptPaths:       []string{},
 	}
 	// Use constructor with custom cleanup interval to avoid data race
-	rl := newRateLimiterWithInterval(cfg, 100*time.Millisecond)
+	rl := newRateLimiterWithInterval(cfg, config.RequestOriginConfig{}, 100*time.Millisecond)
 
 	// Make a request to create a limiter
 	rec := httptest.NewRecorder()

--- a/internal/bootstrap/ratelimit_test.go
+++ b/internal/bootstrap/ratelimit_test.go
@@ -134,8 +134,7 @@ func TestRateLimiterPerClientIsolation(t *testing.T) {
 	// Different IP should still have full burst available
 	for i := 0; i < 5; i++ {
 		rec2 := httptest.NewRecorder()
-		req2 := httptest.NewRecorder().Result().Request
-		req2 = httptest.NewRequest("GET", "/api/test", nil)
+		req2 := httptest.NewRequest("GET", "/api/test", nil)
 		req2.RemoteAddr = "192.168.1.2:1234"
 		handler.ServeHTTP(rec2, req2)
 		if rec2.Code != http.StatusOK {
@@ -151,8 +150,8 @@ func TestRateLimiterCleanupRemovesStaleLimiters(t *testing.T) {
 		BurstSize:         10,
 		ExemptPaths:       []string{},
 	}
-	rl := newRateLimiter(cfg)
-	rl.cleanupInterval = 100 * time.Millisecond
+	// Use constructor with custom cleanup interval to avoid data race
+	rl := newRateLimiterWithInterval(cfg, 100*time.Millisecond)
 
 	// Make a request to create a limiter
 	rec := httptest.NewRecorder()
@@ -170,7 +169,7 @@ func TestRateLimiterCleanupRemovesStaleLimiters(t *testing.T) {
 		t.Fatal("expected limiter to exist after request")
 	}
 
-	// Manually trigger cleanup with old cutoff
+	// Manually set old access time and trigger cleanup
 	rl.mu.Lock()
 	rl.lastAccess["192.168.1.1"] = time.Now().Add(-15 * time.Minute)
 	rl.mu.Unlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,9 +41,9 @@ type Config struct {
 
 // RateLimitConfig controls global API rate limiting.
 type RateLimitConfig struct {
-	Enabled      bool
+	Enabled           bool
 	RequestsPerSecond float64
-	BurstSize    int
+	BurstSize         int
 	// ExemptPaths are route patterns that bypass rate limiting (e.g., health, metrics)
 	ExemptPaths []string
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,16 @@ type Config struct {
 	GraphAgentLLM   GraphAgentLLMConfig
 	Auth            AuthConfig
 	OTEL            OpenTelemetryConfig
+	RateLimit       RateLimitConfig
+}
+
+// RateLimitConfig controls global API rate limiting.
+type RateLimitConfig struct {
+	Enabled      bool
+	RequestsPerSecond float64
+	BurstSize    int
+	// ExemptPaths are route patterns that bypass rate limiting (e.g., health, metrics)
+	ExemptPaths []string
 }
 
 // AppendLogConfig selects and configures the append-log driver.
@@ -469,6 +479,22 @@ func Load() (Config, error) {
 			return Config{}, fmt.Errorf("CEREBRO_CAPABILITY_TOKEN_SECRETS is required when CEREBRO_MCP_OAUTH_ENABLED=true")
 		}
 	}
+
+	// Rate limiting configuration
+	if cfg.RateLimit.Enabled, err = parseBoolEnv("CEREBRO_RATE_LIMIT_ENABLED"); err != nil {
+		return Config{}, err
+	}
+	if cfg.RateLimit.RequestsPerSecond, err = parseFloatEnv("CEREBRO_RATE_LIMIT_RPS", 100); err != nil {
+		return Config{}, err
+	}
+	if cfg.RateLimit.BurstSize, err = parseIntEnv("CEREBRO_RATE_LIMIT_BURST", 150); err != nil {
+		return Config{}, err
+	}
+	cfg.RateLimit.ExemptPaths = parseCSV(os.Getenv("CEREBRO_RATE_LIMIT_EXEMPT_PATHS"))
+	if len(cfg.RateLimit.ExemptPaths) == 0 {
+		cfg.RateLimit.ExemptPaths = []string{"/health", "/healthz", "/livez", "/metrics", "/.well-known/"}
+	}
+
 	return cfg, nil
 }
 


### PR DESCRIPTION
Completes the error mapper consolidation started in PR #946 and includes the remaining backlog items implemented on this branch.

## Changes

### #938: Error mapper consolidation
Converts the remaining 7 error mapper pairs to the shared bootstrapErrorMapping pattern:
- sourceRuntime
- claims
- findings
- knowledge
- graphQuery
- graphIngest
- workflowReplay

All 9 domain mappers now use centralized helpers:
- matchesAnyError, defensive matching for multiple error targets
- mappedHTTPStatusCode, HTTP status resolution with tenant-forbidden handling
- mappedConnectError, Connect error resolution

### #691: Optional global API rate limiting
- Adds opt-in per-client token bucket rate limiting.
- Uses the configured RequestOrigin trusted proxy settings when resolving client IPs.
- Exempts health, metrics, liveness, and well-known metadata routes by default.
- Adds regression coverage for spoofed X-Forwarded-For bypass attempts.

### #695: Scheduled docker-compose smoke verification
- Adds a daily scheduled workflow that boots the compose stack and verifies Cerebro health.
- Pins actions by full commit SHA.
- Captures diagnostics and cleans up compose resources on failure.

## Validation
- go test ./internal/bootstrap -run 'TestRateLimiter' -count=1 -v
- go test ./internal/bootstrap -race -run 'TestRateLimiter' -count=1
- go test ./internal/bootstrap -count=1
- make verify

Closes #938
Closes #691
Closes #695
