### PR TITLE
feat: harden security defaults and identity access graph

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,21 @@
 CEREBRO_HTTP_ADDR=:8080
 CEREBRO_SHUTDOWN_TIMEOUT=10s
 
-# API auth. Enable in any shared or production deployment.
-CEREBRO_API_AUTH_ENABLED=false
+# Local development opt-out. Keep unset outside local debugging.
+CEREBRO_DEV_MODE=
+CEREBRO_DEV_MODE_ACK=
+
+# API auth is enabled by default. Set credentials before serving traffic.
+CEREBRO_API_AUTH_ENABLED=true
 # Comma-separated key[:principal[:tenant_id]] entries. Example only; replace with random secrets.
 CEREBRO_API_KEYS=
 # Optional tenant allowlist for unscoped API keys.
 CEREBRO_ALLOWED_TENANTS=
+
+# Global API rate limiting is enabled by default.
+CEREBRO_RATE_LIMIT_ENABLED=true
+CEREBRO_RATE_LIMIT_RPS=100
+CEREBRO_RATE_LIMIT_BURST=150
 
 # Append log: NATS JetStream
 CEREBRO_APPEND_LOG_DRIVER=

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -35,6 +35,12 @@ func (e usageError) Error() string {
 	return string(e)
 }
 
+var (
+	errServeAuthDisabled         = errors.New("api authentication disabled")
+	errServeAuthMaterialRequired = errors.New("api authentication material required")
+	errServeRateLimitDisabled    = errors.New("api rate limiting disabled")
+)
+
 func sanitizeLogValue(value string) string {
 	return strings.NewReplacer("\n", " ", "\r", " ").Replace(value)
 }
@@ -87,6 +93,12 @@ func serve() error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+	if err := validateServeConfig(cfg); err != nil {
+		return err
+	}
+	if cfg.DevMode {
+		log.Print("WARN DEV MODE: API authentication and rate limiting are disabled")
+	}
 	closeTelemetry, err := configureOpenTelemetry(context.Background(), cfg)
 	if err != nil {
 		return fmt.Errorf("configure telemetry: %w", err)
@@ -138,6 +150,22 @@ func serve() error {
 		waitForStartupJobs(shutdownCtx, grcWarmupDone, riskBackfillDone)
 		return nil
 	}
+}
+
+func validateServeConfig(cfg appconfig.Config) error {
+	if cfg.DevMode {
+		return nil
+	}
+	if !cfg.Auth.Enabled {
+		return fmt.Errorf("%w; set CEREBRO_DEV_MODE=1 and CEREBRO_DEV_MODE_ACK=1 only for local development", errServeAuthDisabled)
+	}
+	if !cfg.Auth.HasCredentialMaterial() {
+		return fmt.Errorf("%w; configure CEREBRO_API_KEYS, CEREBRO_API_CREDENTIALS_JSON, or CEREBRO_CAPABILITY_TOKEN_SECRETS, or set CEREBRO_DEV_MODE=1 and CEREBRO_DEV_MODE_ACK=1 only for local development", errServeAuthMaterialRequired)
+	}
+	if !cfg.RateLimit.Enabled {
+		return fmt.Errorf("%w; set CEREBRO_DEV_MODE=1 and CEREBRO_DEV_MODE_ACK=1 only for local development", errServeRateLimitDisabled)
+	}
+	return nil
 }
 
 func configureOpenTelemetry(ctx context.Context, cfg appconfig.Config) (telemetry.ShutdownFunc, error) {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -39,6 +39,40 @@ func TestRunDeployRejectsUnsupportedSubcommand(t *testing.T) {
 	}
 }
 
+func TestValidateServeConfigRequiresAuthMaterial(t *testing.T) {
+	err := validateServeConfig(appconfig.Config{
+		Auth:      appconfig.AuthConfig{Enabled: true},
+		RateLimit: appconfig.RateLimitConfig{Enabled: true},
+	})
+	if !errors.Is(err, errServeAuthMaterialRequired) {
+		t.Fatalf("validateServeConfig() error = %v, want errServeAuthMaterialRequired", err)
+	}
+}
+
+func TestValidateServeConfigRejectsDisabledRateLimitOutsideDevMode(t *testing.T) {
+	err := validateServeConfig(appconfig.Config{
+		Auth: appconfig.AuthConfig{
+			Enabled: true,
+			APIKeys: []appconfig.APIKey{{
+				Key:       "token",
+				Principal: "ci",
+				TenantID:  "writer",
+			}},
+		},
+		RateLimit: appconfig.RateLimitConfig{Enabled: false},
+	})
+	if !errors.Is(err, errServeRateLimitDisabled) {
+		t.Fatalf("validateServeConfig() error = %v, want errServeRateLimitDisabled", err)
+	}
+}
+
+func TestValidateServeConfigAllowsDevModeOptOut(t *testing.T) {
+	err := validateServeConfig(appconfig.Config{DevMode: true})
+	if err != nil {
+		t.Fatalf("validateServeConfig(dev mode) error = %v", err)
+	}
+}
+
 func TestWritePreflightReceiptJSONRedactsToBoundedDetail(t *testing.T) {
 	receipt := preflightReceipt{
 		Kind:   "cerebro.deploy_preflight",

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -649,7 +649,21 @@ func scopeForHTTPRequest(r *http.Request) string {
 	return httpRoutePolicyForRequest(r).Scope
 }
 
+type connectProcedureAuthPolicy struct {
+	Scope     string
+	AdminOnly bool
+}
+
 func scopeForConnectProcedure(procedure string) string {
+	return connectProcedurePolicyFor(procedure).Scope
+}
+
+func connectProcedurePolicyKnown(procedure string) bool {
+	policy := connectProcedurePolicyFor(procedure)
+	return policy.Scope != "" || policy.AdminOnly
+}
+
+func connectProcedurePolicyFor(procedure string) connectProcedureAuthPolicy {
 	switch procedure {
 	case cerebrov1connect.BootstrapServiceGetVersionProcedure,
 		cerebrov1connect.BootstrapServiceCheckHealthProcedure,
@@ -671,63 +685,34 @@ func scopeForConnectProcedure(procedure string) string {
 		cerebrov1connect.BootstrapServiceGetGraphIngestRunProcedure,
 		cerebrov1connect.BootstrapServiceListGraphIngestRunsProcedure,
 		cerebrov1connect.BootstrapServiceCheckGraphIngestHealthProcedure:
-		return scopeCosmoSecurityRead
+		return connectProcedureAuthPolicy{Scope: scopeCosmoSecurityRead}
 	case cerebrov1connect.BootstrapServicePromoteFindingCandidateProcedure,
 		cerebrov1connect.BootstrapServiceRejectFindingCandidateProcedure:
-		return scopeFindingCandidatePromote
-	default:
-		return ""
-	}
-}
-
-func connectProcedurePolicyKnown(procedure string) bool {
-	switch procedure {
-	case cerebrov1connect.BootstrapServiceGetVersionProcedure,
-		cerebrov1connect.BootstrapServiceCheckHealthProcedure,
-		cerebrov1connect.BootstrapServiceListReportDefinitionsProcedure,
-		cerebrov1connect.BootstrapServiceListFindingRulesProcedure,
-		cerebrov1connect.BootstrapServiceRunReportProcedure,
-		cerebrov1connect.BootstrapServiceGetReportRunProcedure,
-		cerebrov1connect.BootstrapServiceListSourcesProcedure,
+		return connectProcedureAuthPolicy{Scope: scopeFindingCandidatePromote}
+	case cerebrov1connect.BootstrapServiceRunReportProcedure,
 		cerebrov1connect.BootstrapServiceCheckSourceProcedure,
 		cerebrov1connect.BootstrapServiceDiscoverSourceProcedure,
 		cerebrov1connect.BootstrapServiceReadSourceProcedure,
 		cerebrov1connect.BootstrapServicePutSourceRuntimeProcedure,
-		cerebrov1connect.BootstrapServiceGetSourceRuntimeProcedure,
 		cerebrov1connect.BootstrapServiceSyncSourceRuntimeProcedure,
 		cerebrov1connect.BootstrapServiceWriteClaimsProcedure,
-		cerebrov1connect.BootstrapServiceListClaimsProcedure,
-		cerebrov1connect.BootstrapServiceListFindingsProcedure,
-		cerebrov1connect.BootstrapServiceGetFindingProcedure,
-		cerebrov1connect.BootstrapServiceListFindingCandidatesProcedure,
-		cerebrov1connect.BootstrapServiceGetFindingCandidateProcedure,
 		cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingCandidatesProcedure,
-		cerebrov1connect.BootstrapServicePromoteFindingCandidateProcedure,
-		cerebrov1connect.BootstrapServiceRejectFindingCandidateProcedure,
 		cerebrov1connect.BootstrapServiceResolveFindingProcedure,
 		cerebrov1connect.BootstrapServiceSuppressFindingProcedure,
 		cerebrov1connect.BootstrapServiceAssignFindingProcedure,
 		cerebrov1connect.BootstrapServiceSetFindingDueDateProcedure,
 		cerebrov1connect.BootstrapServiceAddFindingNoteProcedure,
 		cerebrov1connect.BootstrapServiceLinkFindingTicketProcedure,
-		cerebrov1connect.BootstrapServiceListFindingEvaluationRunsProcedure,
-		cerebrov1connect.BootstrapServiceGetFindingEvaluationRunProcedure,
-		cerebrov1connect.BootstrapServiceListFindingEvidenceProcedure,
-		cerebrov1connect.BootstrapServiceGetFindingEvidenceProcedure,
 		cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingRulesProcedure,
 		cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
 		cerebrov1connect.BootstrapServiceWriteDecisionProcedure,
 		cerebrov1connect.BootstrapServiceWriteActionProcedure,
 		cerebrov1connect.BootstrapServiceWriteOutcomeProcedure,
 		cerebrov1connect.BootstrapServiceReplayWorkflowEventsProcedure,
-		cerebrov1connect.BootstrapServiceGetEntityNeighborhoodProcedure,
-		cerebrov1connect.BootstrapServiceRunGraphIngestRuntimeProcedure,
-		cerebrov1connect.BootstrapServiceGetGraphIngestRunProcedure,
-		cerebrov1connect.BootstrapServiceListGraphIngestRunsProcedure,
-		cerebrov1connect.BootstrapServiceCheckGraphIngestHealthProcedure:
-		return true
+		cerebrov1connect.BootstrapServiceRunGraphIngestRuntimeProcedure:
+		return connectProcedureAuthPolicy{AdminOnly: true}
 	default:
-		return false
+		return connectProcedureAuthPolicy{}
 	}
 }
 
@@ -1065,6 +1050,9 @@ func emitAccessAuditEvent(r *http.Request, origin requestOrigin, principal authP
 	if principal.AuthMode != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "auth_mode", Value: principal.AuthMode})
 	}
+	if tier := accessAuditCredentialTier(principal); tier != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "credential_tier", Value: tier})
+	}
 	if principal.CredentialID != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "credential_id", Value: principal.CredentialID})
 	}
@@ -1268,6 +1256,19 @@ func accessAuditOperation(r *http.Request, route string) accessAuditOperationInf
 		Family:          accessAuditRouteFamily(route),
 		Type:            operationType,
 		SensitiveAction: operationType == "write" || accessAuditRouteUsesSourceSecret(route),
+	}
+}
+
+func accessAuditCredentialTier(principal authPrincipal) string {
+	switch {
+	case principal.AuthMode == "device_jwt":
+		return "device"
+	case principalScopeRestricted(principal):
+		return "scoped"
+	case strings.TrimSpace(principal.AuthMode) != "":
+		return "admin"
+	default:
+		return ""
 	}
 }
 

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -14,37 +14,38 @@ const (
 )
 
 type httpAuthRoutePolicy struct {
-	Method string
-	Exact  string
-	Prefix string
-	Suffix string
-	Scope  string
-	Static bool
+	Method    string
+	Exact     string
+	Prefix    string
+	Suffix    string
+	Scope     string
+	Static    bool
+	AdminOnly bool
 }
 
 var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Exact: "/api/v1/mcp", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/metrics", Scope: scopeCosmoSecurityRead, Static: true},
-	{Method: http.MethodPost, Prefix: "/reports/", Suffix: "/runs", Static: true},
-	{Method: http.MethodPost, Exact: "/platform/knowledge/decisions", Static: true},
-	{Method: http.MethodPost, Exact: "/platform/knowledge/actions", Static: true},
-	{Method: http.MethodPost, Exact: "/platform/knowledge/actions/recommendation", Static: true},
-	{Method: http.MethodPost, Exact: "/platform/knowledge/outcomes", Static: true},
-	{Method: http.MethodPost, Exact: "/platform/workflow/replay", Static: true},
+	{Method: http.MethodPost, Prefix: "/reports/", Suffix: "/runs", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Exact: "/platform/knowledge/decisions", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Exact: "/platform/knowledge/actions", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Exact: "/platform/knowledge/actions/recommendation", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Exact: "/platform/knowledge/outcomes", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Exact: "/platform/workflow/replay", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Exact: "/sources", Scope: scopeCosmoSecurityRead},
-	{Method: http.MethodGet, Prefix: "/sources/", Static: true},
+	{Method: http.MethodGet, Prefix: "/sources/", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Exact: "/reports", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodGet, Exact: "/finding-rules", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodGet, Exact: "/endpoint-vulnerability-findings", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodGet, Exact: "/source-runtimes", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodGet, Prefix: "/source-runtimes/", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodGet, Prefix: "/findings/", Scope: scopeCosmoSecurityRead},
-	{Method: http.MethodPost, Prefix: "/findings/", Suffix: "/resolve", Static: true},
-	{Method: http.MethodPost, Prefix: "/findings/", Suffix: "/suppress", Static: true},
-	{Method: http.MethodPut, Prefix: "/findings/", Suffix: "/assign", Static: true},
-	{Method: http.MethodPut, Prefix: "/findings/", Suffix: "/due", Static: true},
-	{Method: http.MethodPost, Prefix: "/findings/", Suffix: "/notes", Static: true},
-	{Method: http.MethodPost, Prefix: "/findings/", Suffix: "/tickets", Static: true},
+	{Method: http.MethodPost, Prefix: "/findings/", Suffix: "/resolve", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Prefix: "/findings/", Suffix: "/suppress", Static: true, AdminOnly: true},
+	{Method: http.MethodPut, Prefix: "/findings/", Suffix: "/assign", Static: true, AdminOnly: true},
+	{Method: http.MethodPut, Prefix: "/findings/", Suffix: "/due", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Prefix: "/findings/", Suffix: "/notes", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Prefix: "/findings/", Suffix: "/tickets", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Prefix: "/finding-candidates/", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodPost, Prefix: "/finding-candidates/", Suffix: "/promote", Scope: scopeFindingCandidatePromote},
 	{Method: http.MethodPost, Prefix: "/finding-candidates/", Suffix: "/reject", Scope: scopeFindingCandidatePromote},
@@ -69,21 +70,21 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodGet, Prefix: "/platform/graph/ingest-runs/", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodGet, Prefix: "/platform/endpoints/", Suffix: "/vulnerability-findings", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodGet, Prefix: "/report-runs/", Scope: scopeCosmoSecurityRead},
-	{Method: http.MethodPost, Exact: "/platform/jobs", Static: true},
+	{Method: http.MethodPost, Exact: "/platform/jobs", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Exact: "/platform/jobs", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Prefix: "/platform/jobs/", Scope: scopeCosmoSecurityRead},
-	{Method: http.MethodPost, Prefix: "/platform/jobs/", Suffix: "/cancel", Static: true},
+	{Method: http.MethodPost, Prefix: "/platform/jobs/", Suffix: "/cancel", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Exact: "/platform/runtime-response/capabilities", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/platform/runtime-response/blocklist", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/platform/runtime-response/actions", Scope: scopeRuntimeResponseWrite, Static: true},
 	{Method: http.MethodPost, Prefix: "/platform/runtime-response/blocklist/", Suffix: "/revoke", Scope: scopeRuntimeResponseWrite},
-	{Method: http.MethodPut, Prefix: "/source-runtimes/", Static: true},
-	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/sync", Static: true},
-	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/graph-ingest-runs", Static: true},
-	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/claims", Static: true},
-	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/finding-candidates/evaluate", Static: true},
-	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/finding-rules/evaluate", Static: true},
-	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/findings/evaluate", Static: true},
+	{Method: http.MethodPut, Prefix: "/source-runtimes/", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/sync", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/graph-ingest-runs", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/claims", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/finding-candidates/evaluate", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/finding-rules/evaluate", Static: true, AdminOnly: true},
+	{Method: http.MethodPost, Prefix: "/source-runtimes/", Suffix: "/findings/evaluate", Static: true, AdminOnly: true},
 	{Method: http.MethodPost, Exact: "/platform/devices/enroll", Scope: deviceauth.ScopeDevicesEnroll, Static: true},
 	{Method: http.MethodPost, Exact: "/platform/devices/token", Scope: deviceauth.ScopeDevicesToken, Static: true},
 	{Method: http.MethodPost, Exact: "/platform/devices/bootstrap-tokens", Scope: deviceauth.ScopeDevicesBootstrapWrite, Static: true},

--- a/internal/bootstrap/auth_route_policy_test.go
+++ b/internal/bootstrap/auth_route_policy_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	cerebrov1connect "github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 )
 
 func TestPlatformHTTPRoutesHaveAuthPolicies(t *testing.T) {
@@ -29,8 +31,8 @@ func TestPlatformHTTPRoutesHaveAuthPolicies(t *testing.T) {
 		if !routePolicyPathMatches(policy, path) {
 			t.Fatalf("%s %s has no matching auth route policy", method, route)
 		}
-		if policy.Scope == "" && !policy.Static {
-			t.Fatalf("%s %s auth policy must declare a scope or be explicitly static", method, route)
+		if policy.Scope == "" && !policy.AdminOnly {
+			t.Fatalf("%s %s auth policy must declare a scope or be explicitly admin-only", method, route)
 		}
 	}
 }
@@ -48,6 +50,20 @@ func TestConnectProceduresHaveAuthPolicies(t *testing.T) {
 		if !connectProcedurePolicyKnown(procedure) {
 			t.Fatalf("%s has no explicit Connect auth policy", procedure)
 		}
+	}
+}
+
+func TestWriteHTTPRoutePolicyIsExplicitAdminOnly(t *testing.T) {
+	policy := httpRoutePolicyFor("POST", "/findings/finding-1/resolve")
+	if !policy.AdminOnly || policy.Scope != "" {
+		t.Fatalf("resolve finding policy = %#v, want explicit admin-only decision", policy)
+	}
+}
+
+func TestWriteConnectProcedurePolicyIsExplicitAdminOnly(t *testing.T) {
+	policy := connectProcedurePolicyFor(cerebrov1connect.BootstrapServiceResolveFindingProcedure)
+	if !policy.AdminOnly || policy.Scope != "" {
+		t.Fatalf("ResolveFinding policy = %#v, want explicit admin-only decision", policy)
 	}
 }
 

--- a/internal/bootstrap/auth_test.go
+++ b/internal/bootstrap/auth_test.go
@@ -23,3 +23,22 @@ func TestTenantAllowedUsesExplicitGlobalAllowlistForUnscopedPrincipal(t *testing
 		t.Fatal("tenantAllowed() = true for tenant outside global allowlist, want false")
 	}
 }
+
+func TestAccessAuditCredentialTier(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		principal authPrincipal
+		want      string
+	}{
+		{name: "admin api key", principal: authPrincipal{AuthMode: "api_key"}, want: "admin"},
+		{name: "scoped token", principal: authPrincipal{AuthMode: "api_key", Scopes: []string{scopeCosmoSecurityRead}}, want: "scoped"},
+		{name: "device", principal: authPrincipal{AuthMode: "device_jwt", Scopes: []string{scopeCosmoSecurityRead}}, want: "device"},
+		{name: "anonymous", principal: authPrincipal{}, want: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := accessAuditCredentialTier(tt.principal); got != tt.want {
+				t.Fatalf("accessAuditCredentialTier() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/bootstrap/http_errors.go
+++ b/internal/bootstrap/http_errors.go
@@ -1,0 +1,20 @@
+package bootstrap
+
+import (
+	"net/http"
+	"strings"
+)
+
+func safeHTTPErrorMessage(status int, err error) string {
+	if status >= http.StatusInternalServerError {
+		message := strings.ToLower(http.StatusText(status))
+		if message == "" {
+			return "internal server error"
+		}
+		return message
+	}
+	if err == nil {
+		return strings.ToLower(http.StatusText(status))
+	}
+	return err.Error()
+}

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -389,7 +389,7 @@ func writeJobError(w http.ResponseWriter, err error) {
 	case errors.Is(err, errTenantForbidden):
 		status = http.StatusForbidden
 	}
-	writeJSON(w, status, map[string]string{"error": err.Error()})
+	writeJSON(w, status, map[string]string{"error": safeHTTPErrorMessage(status, err)})
 }
 
 func protoToMap(message proto.Message) map[string]any {

--- a/internal/bootstrap/jobs_test.go
+++ b/internal/bootstrap/jobs_test.go
@@ -2,6 +2,11 @@ package bootstrap
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -35,5 +40,37 @@ func TestNewCachesJobServiceForAsyncLifecycle(t *testing.T) {
 	second := app.jobService()
 	if first != second {
 		t.Fatal("jobService() returned different instances")
+	}
+}
+
+func TestWriteJobErrorSanitizesInternalErrors(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writeJobError(recorder, errors.New("postgres query failed: secret DSN"))
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", recorder.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] != "internal server error" {
+		t.Fatalf("error body = %q, want sanitized internal server error", body["error"])
+	}
+}
+
+func TestWriteJobErrorKeepsClientErrorsActionable(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writeJobError(recorder, fmt.Errorf("%w: missing tenant_id", platformjobs.ErrInvalidRequest))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", recorder.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] == "" || body["error"] == "bad request" {
+		t.Fatalf("error body = %q, want actionable client error", body["error"])
 	}
 }

--- a/internal/bootstrap/runtime_response.go
+++ b/internal/bootstrap/runtime_response.go
@@ -157,5 +157,5 @@ func writeRuntimeResponseError(w http.ResponseWriter, err error) {
 	case errors.Is(err, errTenantForbidden):
 		status = http.StatusForbidden
 	}
-	writeJSON(w, status, map[string]string{"error": err.Error()})
+	writeJSON(w, status, map[string]string{"error": safeHTTPErrorMessage(status, err)})
 }

--- a/internal/bootstrap/runtime_response_test.go
+++ b/internal/bootstrap/runtime_response_test.go
@@ -2,6 +2,10 @@ package bootstrap
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -66,5 +70,21 @@ func TestRecordRuntimeResponseWorkflowAppendsActionEvent(t *testing.T) {
 	}
 	if payload.Metadata["source_job_id"] != entry.SourceJobID {
 		t.Fatalf("source_job_id metadata = %v, want %q", payload.Metadata["source_job_id"], entry.SourceJobID)
+	}
+}
+
+func TestWriteRuntimeResponseErrorSanitizesRuntimeUnavailable(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writeRuntimeResponseError(recorder, fmt.Errorf("%w: endpoint token secret leaked", runtimeresponse.ErrRuntimeUnavailable))
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", recorder.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] != "service unavailable" {
+		t.Fatalf("error body = %q, want sanitized service unavailable", body["error"])
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -290,8 +290,8 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	if devMode && !devModeAck && !strings.EqualFold(strings.TrimSpace(os.Getenv("LOG_LEVEL")), "debug") {
-		return Config{}, fmt.Errorf("CEREBRO_DEV_MODE requires LOG_LEVEL=debug or CEREBRO_DEV_MODE_ACK=1")
+	if devMode && !devModeAck {
+		return Config{}, fmt.Errorf("CEREBRO_DEV_MODE requires CEREBRO_DEV_MODE_ACK=1")
 	}
 	cfg := Config{
 		HTTPAddr:        strings.TrimSpace(os.Getenv("CEREBRO_HTTP_ADDR")),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,13 @@ const defaultShutdownTimeout = 10 * time.Second
 const defaultJetStreamSubjectPrefix = "events"
 
 const (
+	defaultPostgresMaxOpenConns    = 25
+	defaultPostgresMaxIdleConns    = 5
+	defaultPostgresConnMaxLifetime = 5 * time.Minute
+	defaultPostgresConnMaxIdleTime = time.Minute
+)
+
+const (
 	AppendLogDriverJetStream = "jetstream"
 	StateStoreDriverPostgres = "postgres"
 	GraphStoreDriverNeo4j    = "neo4j"
@@ -30,6 +37,7 @@ type Config struct {
 	HTTPAddr        string
 	ShutdownTimeout time.Duration
 	ImageTag        string
+	DevMode         bool
 	AppendLog       AppendLogConfig
 	StateStore      StateStoreConfig
 	GraphStore      GraphStoreConfig
@@ -274,10 +282,22 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	devMode, err := parseBoolEnv("CEREBRO_DEV_MODE")
+	if err != nil {
+		return Config{}, err
+	}
+	devModeAck, err := parseBoolEnv("CEREBRO_DEV_MODE_ACK")
+	if err != nil {
+		return Config{}, err
+	}
+	if devMode && !devModeAck && !strings.EqualFold(strings.TrimSpace(os.Getenv("LOG_LEVEL")), "debug") {
+		return Config{}, fmt.Errorf("CEREBRO_DEV_MODE requires LOG_LEVEL=debug or CEREBRO_DEV_MODE_ACK=1")
+	}
 	cfg := Config{
 		HTTPAddr:        strings.TrimSpace(os.Getenv("CEREBRO_HTTP_ADDR")),
 		ShutdownTimeout: defaultShutdownTimeout,
 		ImageTag:        strings.TrimSpace(os.Getenv("CEREBRO_IMAGE_TAG")),
+		DevMode:         devMode,
 		AppendLog: AppendLogConfig{
 			Driver:                 strings.TrimSpace(os.Getenv("CEREBRO_APPEND_LOG_DRIVER")),
 			JetStreamURL:           strings.TrimSpace(os.Getenv("CEREBRO_JETSTREAM_URL")),
@@ -321,11 +341,14 @@ func Load() (Config, error) {
 			},
 		},
 	}
-	authEnabled, err := parseBoolEnv("CEREBRO_API_AUTH_ENABLED")
+	authEnabled, err := parseBoolEnvDefault("CEREBRO_API_AUTH_ENABLED", !cfg.DevMode)
 	if err != nil {
 		return Config{}, err
 	}
 	cfg.Auth.Enabled = authEnabled
+	if cfg.DevMode {
+		cfg.Auth.Enabled = false
+	}
 	otelEnabled, err := parseBoolEnv("CEREBRO_OTEL_ENABLED")
 	if err != nil {
 		return Config{}, err
@@ -403,6 +426,7 @@ func Load() (Config, error) {
 	if cfg.StateStore.PostgresConnMaxIdleTime, err = parseDurationEnv("CEREBRO_POSTGRES_CONN_MAX_IDLE_TIME", 0); err != nil {
 		return Config{}, err
 	}
+	cfg.StateStore = ApplyPostgresPoolDefaults(cfg.StateStore)
 	if cfg.GraphStore.Neo4jQueryTimeout, err = parseDurationEnv("CEREBRO_NEO4J_QUERY_TIMEOUT", 0); err != nil {
 		return Config{}, err
 	}
@@ -462,9 +486,6 @@ func Load() (Config, error) {
 	default:
 		return Config{}, fmt.Errorf("unsupported CEREBRO_GRAPH_STORE_DRIVER %q", cfg.GraphStore.Driver)
 	}
-	if cfg.Auth.Enabled && len(cfg.Auth.APIKeys) == 0 && len(cfg.Auth.APICredentials) == 0 && len(cfg.Auth.CapabilityTokenSecrets) == 0 {
-		return Config{}, fmt.Errorf("CEREBRO_API_KEYS, CEREBRO_API_CREDENTIALS_JSON, or CEREBRO_CAPABILITY_TOKEN_SECRETS is required when CEREBRO_API_AUTH_ENABLED=true")
-	}
 	if cfg.Auth.MCPOAuth.Enabled {
 		if !cfg.Auth.Enabled {
 			return Config{}, fmt.Errorf("CEREBRO_API_AUTH_ENABLED=true is required when CEREBRO_MCP_OAUTH_ENABLED=true")
@@ -481,8 +502,11 @@ func Load() (Config, error) {
 	}
 
 	// Rate limiting configuration
-	if cfg.RateLimit.Enabled, err = parseBoolEnv("CEREBRO_RATE_LIMIT_ENABLED"); err != nil {
+	if cfg.RateLimit.Enabled, err = parseBoolEnvDefault("CEREBRO_RATE_LIMIT_ENABLED", !cfg.DevMode); err != nil {
 		return Config{}, err
+	}
+	if cfg.DevMode {
+		cfg.RateLimit.Enabled = false
 	}
 	if cfg.RateLimit.RequestsPerSecond, err = parseFloatEnv("CEREBRO_RATE_LIMIT_RPS", 100); err != nil {
 		return Config{}, err
@@ -496,6 +520,29 @@ func Load() (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func ApplyPostgresPoolDefaults(cfg StateStoreConfig) StateStoreConfig {
+	if cfg.PostgresMaxOpenConns == 0 {
+		cfg.PostgresMaxOpenConns = defaultPostgresMaxOpenConns
+	}
+	if cfg.PostgresMaxIdleConns == 0 {
+		cfg.PostgresMaxIdleConns = defaultPostgresMaxIdleConns
+	}
+	if cfg.PostgresMaxIdleConns > cfg.PostgresMaxOpenConns {
+		cfg.PostgresMaxIdleConns = cfg.PostgresMaxOpenConns
+	}
+	if cfg.PostgresConnMaxLifetime == 0 {
+		cfg.PostgresConnMaxLifetime = defaultPostgresConnMaxLifetime
+	}
+	if cfg.PostgresConnMaxIdleTime == 0 {
+		cfg.PostgresConnMaxIdleTime = defaultPostgresConnMaxIdleTime
+	}
+	return cfg
+}
+
+func (cfg AuthConfig) HasCredentialMaterial() bool {
+	return len(cfg.APIKeys) > 0 || len(cfg.APICredentials) > 0 || len(cfg.CapabilityTokenSecrets) > 0
 }
 
 func validateRequestOriginConfig(cfg RequestOriginConfig) error {
@@ -541,6 +588,13 @@ func parseBoolEnv(name string) (bool, error) {
 	default:
 		return false, fmt.Errorf("%s must be a boolean", name)
 	}
+}
+
+func parseBoolEnvDefault(name string, defaultValue bool) (bool, error) {
+	if !envHasValue(name) {
+		return defaultValue, nil
+	}
+	return parseBoolEnv(name)
 }
 
 func parseIntEnv(name string, defaultValue int) (int, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,9 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_HTTP_ADDR", "")
 	t.Setenv("CEREBRO_SHUTDOWN_TIMEOUT", "")
 	t.Setenv("CEREBRO_IMAGE_TAG", "")
+	t.Setenv("CEREBRO_DEV_MODE", "")
+	t.Setenv("CEREBRO_DEV_MODE_ACK", "")
+	t.Setenv("LOG_LEVEL", "")
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", "")
 	t.Setenv("CEREBRO_JETSTREAM_URL", "")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
@@ -40,6 +43,10 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_CIDRS", "")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_COUNT", "")
+	t.Setenv("CEREBRO_RATE_LIMIT_ENABLED", "")
+	t.Setenv("CEREBRO_RATE_LIMIT_RPS", "")
+	t.Setenv("CEREBRO_RATE_LIMIT_BURST", "")
+	t.Setenv("CEREBRO_RATE_LIMIT_EXEMPT_PATHS", "")
 	clearMCPOAuthEnv(t)
 	clearDeviceAuthEnv(t)
 
@@ -68,8 +75,14 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.OTEL.Enabled || cfg.OTEL.Protocol != "http/protobuf" || cfg.OTEL.TraceSampleRate != 1 || cfg.OTEL.MetricInterval != time.Minute {
 		t.Fatalf("OTEL defaults = %#v", cfg.OTEL)
 	}
-	if cfg.Auth.Enabled {
-		t.Fatal("Auth.Enabled = true, want false")
+	if !cfg.Auth.Enabled {
+		t.Fatal("Auth.Enabled = false, want true safe default")
+	}
+	if !cfg.RateLimit.Enabled {
+		t.Fatal("RateLimit.Enabled = false, want true safe default")
+	}
+	if cfg.StateStore.PostgresMaxOpenConns != defaultPostgresMaxOpenConns || cfg.StateStore.PostgresMaxIdleConns != defaultPostgresMaxIdleConns || cfg.StateStore.PostgresConnMaxLifetime != defaultPostgresConnMaxLifetime || cfg.StateStore.PostgresConnMaxIdleTime != defaultPostgresConnMaxIdleTime {
+		t.Fatalf("StateStore Postgres pool defaults = %#v", cfg.StateStore)
 	}
 	if cfg.Auth.DeviceAuth.ReplicaCount != 1 {
 		t.Fatalf("DeviceAuth.ReplicaCount = %d, want 1", cfg.Auth.DeviceAuth.ReplicaCount)
@@ -83,6 +96,9 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_HTTP_ADDR", "127.0.0.1:9000")
 	t.Setenv("CEREBRO_SHUTDOWN_TIMEOUT", "3s")
 	t.Setenv("CEREBRO_IMAGE_TAG", "v9.9.9")
+	t.Setenv("CEREBRO_DEV_MODE", "")
+	t.Setenv("CEREBRO_DEV_MODE_ACK", "")
+	t.Setenv("LOG_LEVEL", "")
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", AppendLogDriverJetStream)
 	t.Setenv("CEREBRO_JETSTREAM_URL", "nats://127.0.0.1:4222")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "cerebro.events")
@@ -128,6 +144,10 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "https://api.writer.com")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_CIDRS", "10.0.0.0/8, 192.168.0.0/16")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_COUNT", "1")
+	t.Setenv("CEREBRO_RATE_LIMIT_ENABLED", "true")
+	t.Setenv("CEREBRO_RATE_LIMIT_RPS", "42.5")
+	t.Setenv("CEREBRO_RATE_LIMIT_BURST", "60")
+	t.Setenv("CEREBRO_RATE_LIMIT_EXEMPT_PATHS", "/health,/ready")
 	clearMCPOAuthEnv(t)
 	clearDeviceAuthEnv(t)
 
@@ -192,6 +212,12 @@ func TestLoadFromEnv(t *testing.T) {
 	if !cfg.Auth.Enabled {
 		t.Fatal("Auth.Enabled = false, want true")
 	}
+	if !cfg.RateLimit.Enabled || cfg.RateLimit.RequestsPerSecond != 42.5 || cfg.RateLimit.BurstSize != 60 {
+		t.Fatalf("RateLimit = %#v", cfg.RateLimit)
+	}
+	if got := cfg.RateLimit.ExemptPaths; len(got) != 2 || got[0] != "/health" || got[1] != "/ready" {
+		t.Fatalf("RateLimit.ExemptPaths = %#v", got)
+	}
 	if got := cfg.Auth.RequestOrigin.PublicOrigin; got != "https://api.writer.com" {
 		t.Fatalf("PublicOrigin = %q, want https://api.writer.com", got)
 	}
@@ -230,6 +256,9 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_HTTP_ADDR", "")
 	t.Setenv("CEREBRO_SHUTDOWN_TIMEOUT", "")
 	t.Setenv("CEREBRO_IMAGE_TAG", "")
+	t.Setenv("CEREBRO_DEV_MODE", "")
+	t.Setenv("CEREBRO_DEV_MODE_ACK", "")
+	t.Setenv("LOG_LEVEL", "")
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", "")
 	t.Setenv("CEREBRO_JETSTREAM_URL", "")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
@@ -258,6 +287,10 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_CIDRS", "")
 	t.Setenv("CEREBRO_TRUSTED_PROXY_COUNT", "")
+	t.Setenv("CEREBRO_RATE_LIMIT_ENABLED", "")
+	t.Setenv("CEREBRO_RATE_LIMIT_RPS", "")
+	t.Setenv("CEREBRO_RATE_LIMIT_BURST", "")
+	t.Setenv("CEREBRO_RATE_LIMIT_EXEMPT_PATHS", "")
 	clearMCPOAuthEnv(t)
 	clearDeviceAuthEnv(t)
 }
@@ -385,13 +418,34 @@ func TestLoadRejectsDeviceAuthEnabledWithoutCurrentKID(t *testing.T) {
 	}
 }
 
-func TestLoadRejectsAuthEnabledWithoutKeys(t *testing.T) {
+func TestLoadDevModeRequiresExplicitAckOutsideDebug(t *testing.T) {
 	clearDependencyEnv(t)
-	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
-	t.Setenv("CEREBRO_API_KEYS", "")
+	t.Setenv("CEREBRO_DEV_MODE", "true")
 
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadDevModeDisablesAuthAndRateLimit(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_DEV_MODE", "true")
+	t.Setenv("CEREBRO_DEV_MODE_ACK", "true")
+	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_RATE_LIMIT_ENABLED", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !cfg.DevMode {
+		t.Fatal("DevMode = false, want true")
+	}
+	if cfg.Auth.Enabled {
+		t.Fatal("Auth.Enabled = true, want false in dev mode")
+	}
+	if cfg.RateLimit.Enabled {
+		t.Fatal("RateLimit.Enabled = true, want false in dev mode")
 	}
 }
 
@@ -601,8 +655,9 @@ func TestLoadRejectsMCPOAuthWithoutProductionRequirements(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
 		unset string
+		value string
 	}{
-		{name: "api auth", unset: "CEREBRO_API_AUTH_ENABLED"},
+		{name: "api auth", unset: "CEREBRO_API_AUTH_ENABLED", value: "false"},
 		{name: "public origin", unset: "CEREBRO_PUBLIC_ORIGIN"},
 		{name: "state store", unset: "CEREBRO_POSTGRES_DSN"},
 		{name: "capability secret", unset: "CEREBRO_CAPABILITY_TOKEN_SECRETS"},
@@ -622,7 +677,7 @@ func TestLoadRejectsMCPOAuthWithoutProductionRequirements(t *testing.T) {
 			t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", "writer-secret")
 			t.Setenv("CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI", "https://cerebro.example/oauth/callback")
 			t.Setenv("CEREBRO_MCP_OAUTH_SECURITY_GROUPS", "secops")
-			t.Setenv(tt.unset, "")
+			t.Setenv(tt.unset, tt.value)
 
 			if _, err := Load(); err == nil {
 				t.Fatal("Load() error = nil, want MCP OAuth production requirement error")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -418,7 +418,7 @@ func TestLoadRejectsDeviceAuthEnabledWithoutCurrentKID(t *testing.T) {
 	}
 }
 
-func TestLoadDevModeRequiresExplicitAckOutsideDebug(t *testing.T) {
+func TestLoadDevModeRequiresExplicitAck(t *testing.T) {
 	clearDependencyEnv(t)
 	t.Setenv("CEREBRO_DEV_MODE", "true")
 

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -2,6 +2,7 @@ package sourceprojection
 
 import (
 	"strings"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
@@ -459,9 +460,134 @@ func identityAppAssignmentProjections(event *cerebrov1.EventEnvelope, profile id
 		})
 	}
 	if subjectURN != "" && appURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, appURN, relationAssignedTo, map[string]string{"event_id": event.GetId()}))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, appURN, relationAssignedTo, identityEventLinkAttributes(event)))
+	}
+	entitlementURN, capabilityURN := addIdentityAppEntitlement(entities, links, tenantID, event, profile, appURN, attributes)
+	if capabilityURN != "" && entitlementURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), entitlementURN, capabilityURN, relationConfersCapability, identityEventLinkAttributes(event)))
 	}
 	return identityProjectionResult(entities, links)
+}
+
+func addIdentityAppEntitlement(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, profile identityProjectionProfile, appURN string, attributes map[string]string) (string, string) {
+	appID := firstNonEmpty(attributes["app_id"], attributes["application_id"], attributes["client_id"])
+	if appURN == "" || appID == "" {
+		return "", ""
+	}
+	entitlementID := firstNonEmpty(attributes["entitlement_id"], attributes["entitlement"], attributes["scope"], "app_assignment:"+appID)
+	entitlementURN := projectionURN(tenantID, profile.Provider+"_entitlement", entitlementID)
+	if entitlementURN == "" {
+		return "", ""
+	}
+	appName := firstNonEmpty(attributes["app_name"], attributes["app_label"], attributes["client_id"], appID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        entitlementURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: profile.entityType("entitlement"),
+		Label:      firstNonEmpty(attributes["entitlement_name"], attributes["scope"], appName+" access", entitlementID),
+		Attributes: map[string]string{
+			"app_id":         appID,
+			"entitlement_id": entitlementID,
+			"scope":          strings.TrimSpace(attributes["scope"]),
+			"status":         strings.TrimSpace(attributes["status"]),
+		},
+	})
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), appURN, entitlementURN, relationGrantsEntitlement, identityEventLinkAttributes(event)))
+	capabilityID := identityAppCapabilityID(attributes, appName, entitlementID)
+	capabilityURN := addIdentityCapability(entities, tenantID, event.GetSourceId(), capabilityID, identityCapabilityLabel(capabilityID), map[string]string{"source": profile.Provider})
+	return entitlementURN, capabilityURN
+}
+
+func addIdentityRoleEntitlement(entities map[string]*ports.ProjectedEntity, tenantID string, event *cerebrov1.EventEnvelope, profile identityProjectionProfile, roleURN string, roleID string, privileged bool, attributes map[string]string) (string, string) {
+	if roleURN == "" || roleID == "" {
+		return "", ""
+	}
+	entitlementID := firstNonEmpty(attributes["entitlement_id"], attributes["entitlement"], "admin_role:"+roleID)
+	entitlementURN := projectionURN(tenantID, profile.Provider+"_entitlement", entitlementID)
+	if entitlementURN == "" {
+		return "", ""
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        entitlementURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: profile.entityType("entitlement"),
+		Label:      firstNonEmpty(attributes["entitlement_name"], attributes["role_name"], attributes["role_type"], roleID),
+		Attributes: map[string]string{
+			"entitlement_id": entitlementID,
+			"is_admin":       boolString(privileged),
+			"role_id":        roleID,
+			"role_type":      strings.TrimSpace(attributes["role_type"]),
+		},
+	})
+	capabilityID := firstNonEmpty(attributes["capability"], "identity_admin")
+	if !privileged {
+		capabilityID = firstNonEmpty(attributes["capability"], "identity_role")
+	}
+	capabilityURN := addIdentityCapability(entities, tenantID, event.GetSourceId(), capabilityID, identityCapabilityLabel(capabilityID), map[string]string{"source": profile.Provider})
+	return entitlementURN, capabilityURN
+}
+
+func addIdentityCapability(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, capabilityID string, label string, attributes map[string]string) string {
+	capabilityID = normalizeIdentityCapabilityID(capabilityID)
+	if capabilityID == "" {
+		return ""
+	}
+	capabilityURN := projectionURN(tenantID, "privileged_capability", capabilityID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        capabilityURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "privileged.capability",
+		Label:      firstNonEmpty(label, capabilityID),
+		Attributes: attributes,
+	})
+	return capabilityURN
+}
+
+func identityAppCapabilityID(attributes map[string]string, appName string, entitlementID string) string {
+	if explicit := strings.TrimSpace(attributes["capability"]); explicit != "" {
+		return explicit
+	}
+	text := strings.ToLower(appName + " " + entitlementID)
+	if strings.Contains(text, "admin") || strings.Contains(text, "administrator") || strings.Contains(text, "root") {
+		return "cloud_admin"
+	}
+	return "app_access"
+}
+
+func normalizeIdentityCapabilityID(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, " ", "_")
+	value = strings.ReplaceAll(value, "-", "_")
+	for strings.Contains(value, "__") {
+		value = strings.ReplaceAll(value, "__", "_")
+	}
+	return strings.Trim(value, "_")
+}
+
+func identityCapabilityLabel(capabilityID string) string {
+	switch normalizeIdentityCapabilityID(capabilityID) {
+	case "app_access":
+		return "Application access"
+	case "cloud_admin":
+		return "Cloud administrator"
+	case "identity_admin":
+		return "Identity administrator"
+	case "identity_role":
+		return "Identity role"
+	default:
+		return strings.TrimSpace(capabilityID)
+	}
+}
+
+func identityEventLinkAttributes(event *cerebrov1.EventEnvelope) map[string]string {
+	attributes := map[string]string{"event_id": event.GetId()}
+	if occurred := event.GetOccurredAt().AsTime(); !occurred.IsZero() {
+		attributes["at"] = occurred.UTC().Format(time.RFC3339Nano)
+	}
+	return attributes
 }
 
 func identityRoleAssignmentProjections(event *cerebrov1.EventEnvelope, profile identityProjectionProfile) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -515,7 +641,14 @@ func identityRoleAssignmentProjections(event *cerebrov1.EventEnvelope, profile i
 		addCloudIdentityAccountLink(entities, links, tenantID, event.GetSourceId(), event, roleURN, profile, attributes, roleKind, roleID)
 	}
 	if subjectURN != "" && roleURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, roleURN, relation, map[string]string{"event_id": event.GetId()}))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, roleURN, relation, identityEventLinkAttributes(event)))
+	}
+	entitlementURN, capabilityURN := addIdentityRoleEntitlement(entities, tenantID, event, profile, roleURN, roleID, privileged, attributes)
+	if roleURN != "" && entitlementURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), roleURN, entitlementURN, relationGrantsEntitlement, identityEventLinkAttributes(event)))
+	}
+	if entitlementURN != "" && capabilityURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), entitlementURN, capabilityURN, relationConfersCapability, identityEventLinkAttributes(event)))
 	}
 	return identityProjectionResult(entities, links)
 }

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -494,7 +494,7 @@ func addIdentityAppEntitlement(entities map[string]*ports.ProjectedEntity, links
 		},
 	})
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), appURN, entitlementURN, relationGrantsEntitlement, identityEventLinkAttributes(event)))
-	capabilityID := identityAppCapabilityID(attributes, appName, entitlementID)
+	capabilityID := identityAppCapabilityID(attributes, entitlementID)
 	capabilityURN := addIdentityCapability(entities, tenantID, event.GetSourceId(), capabilityID, identityCapabilityLabel(capabilityID), map[string]string{"source": profile.Provider})
 	return entitlementURN, capabilityURN
 }
@@ -546,12 +546,12 @@ func addIdentityCapability(entities map[string]*ports.ProjectedEntity, tenantID 
 	return capabilityURN
 }
 
-func identityAppCapabilityID(attributes map[string]string, appName string, entitlementID string) string {
+func identityAppCapabilityID(attributes map[string]string, entitlementID string) string {
 	if explicit := strings.TrimSpace(attributes["capability"]); explicit != "" {
 		return explicit
 	}
-	text := strings.ToLower(appName + " " + entitlementID)
-	if strings.Contains(text, "admin") || strings.Contains(text, "administrator") || strings.Contains(text, "root") {
+	switch normalizeIdentifier(entitlementID) {
+	case "admin", "administrator", "administratoraccess", "owner", "root", "superadmin", "globaladmin", "globaladministrator":
 		return "cloud_admin"
 	}
 	return "app_access"
@@ -584,7 +584,8 @@ func identityCapabilityLabel(capabilityID string) string {
 
 func identityEventLinkAttributes(event *cerebrov1.EventEnvelope) map[string]string {
 	attributes := map[string]string{"event_id": event.GetId()}
-	if occurred := event.GetOccurredAt().AsTime(); !occurred.IsZero() {
+	if occurredAt := event.GetOccurredAt(); occurredAt != nil && occurredAt.IsValid() {
+		occurred := occurredAt.AsTime()
 		attributes["at"] = occurred.UTC().Format(time.RFC3339Nano)
 	}
 	return attributes

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -35,6 +35,8 @@ const (
 	relationCanImpersonate     = "can_impersonate"
 	relationCanReach           = "can_reach"
 	relationContains           = "contains"
+	relationConfersCapability  = "confers_capability"
+	relationGrantsEntitlement  = "grants_entitlement"
 	relationHasClassification  = "has_classification"
 	relationHasDNSRecord       = "has_dns_record"
 	relationHasEvidence        = "has_evidence"

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -2861,6 +2861,76 @@ func TestProjectIdentityProviderJoinEdges(t *testing.T) {
 	assertProjectedLinkMissing(t, state, gcpUserURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
 }
 
+func TestProjectOktaEffectiveEntitlementGraph(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	occurred := time.Date(2026, time.June, 14, 12, 0, 0, 0, time.UTC)
+	events := []*cerebrov1.EventEnvelope{
+		{
+			Id:         "okta-group-app-assignment",
+			TenantId:   "writer",
+			SourceId:   "okta",
+			Kind:       "okta.app_assignment",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"app_id":       "app-admin",
+				"app_name":     "AWS Admin Console",
+				"scope":        "AdministratorAccess",
+				"status":       "ACTIVE",
+				"subject_id":   "grp-security",
+				"subject_name": "Security Engineering",
+				"subject_type": "group",
+			},
+		},
+		{
+			Id:         "okta-admin-role",
+			TenantId:   "writer",
+			SourceId:   "okta",
+			Kind:       "okta.admin_role",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"role_id":       "SUPER_ADMIN",
+				"role_name":     "Super Administrator",
+				"role_type":     "SUPER_ADMIN",
+				"subject_email": "admin@writer.com",
+				"subject_id":    "00u-admin",
+				"subject_type":  "user",
+			},
+		},
+	}
+	for _, event := range events {
+		if _, err := service.Project(context.Background(), event); err != nil {
+			t.Fatalf("Project(%q) error = %v", event.GetId(), err)
+		}
+	}
+
+	groupURN := "urn:cerebro:writer:okta_group:grp-security"
+	appURN := "urn:cerebro:writer:okta_application:app-admin"
+	appEntitlementURN := "urn:cerebro:writer:okta_entitlement:AdministratorAccess"
+	cloudAdminCapabilityURN := "urn:cerebro:writer:privileged_capability:cloud_admin"
+	assertProjectedLink(t, state, groupURN, relationAssignedTo, appURN)
+	assertProjectedLink(t, state, appURN, relationGrantsEntitlement, appEntitlementURN)
+	assertProjectedLink(t, state, appEntitlementURN, relationConfersCapability, cloudAdminCapabilityURN)
+	link := state.links[appURN+"|"+relationGrantsEntitlement+"|"+appEntitlementURN]
+	if link.Attributes["event_id"] != "okta-group-app-assignment" || link.Attributes["at"] != occurred.Format(time.RFC3339Nano) {
+		t.Fatalf("entitlement link attributes = %#v, want source event context", link.Attributes)
+	}
+
+	userURN := "urn:cerebro:writer:okta_user:00u-admin"
+	roleURN := "urn:cerebro:writer:okta_admin_role:SUPER_ADMIN"
+	roleEntitlementURN := "urn:cerebro:writer:okta_entitlement:admin_role:SUPER_ADMIN"
+	identityAdminCapabilityURN := "urn:cerebro:writer:privileged_capability:identity_admin"
+	assertProjectedLink(t, state, userURN, relationCanAdmin, roleURN)
+	assertProjectedLink(t, state, roleURN, relationGrantsEntitlement, roleEntitlementURN)
+	assertProjectedLink(t, state, roleEntitlementURN, relationConfersCapability, identityAdminCapabilityURN)
+	if entity := state.entities[appEntitlementURN]; entity == nil || entity.EntityType != "okta.entitlement" {
+		t.Fatalf("app entitlement entity missing or wrong type: %#v", entity)
+	}
+	if entity := state.entities[cloudAdminCapabilityURN]; entity == nil || entity.EntityType != "privileged.capability" {
+		t.Fatalf("capability entity missing or wrong type: %#v", entity)
+	}
+}
+
 func TestProjectCloudReadOnlyRoleAssignmentsAvoidAdminEdges(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -2931,6 +2931,57 @@ func TestProjectOktaEffectiveEntitlementGraph(t *testing.T) {
 	}
 }
 
+func TestProjectOktaEntitlementOmitsAtWhenOccurredAtUnset(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	event := &cerebrov1.EventEnvelope{
+		Id:       "okta-app-assignment-no-time",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.app_assignment",
+		Attributes: map[string]string{
+			"app_id":       "app-prod",
+			"app_name":     "Production Console",
+			"subject_id":   "00u-admin",
+			"subject_type": "user",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	link := state.links["urn:cerebro:writer:okta_application:app-prod|"+relationGrantsEntitlement+"|urn:cerebro:writer:okta_entitlement:app_assignment:app-prod"]
+	if link == nil {
+		t.Fatal("app entitlement link missing")
+	}
+	if _, ok := link.Attributes["at"]; ok {
+		t.Fatalf("link at attribute = %q, want omitted for unset OccurredAt", link.Attributes["at"])
+	}
+}
+
+func TestProjectOktaReadOnlyAdminNamedAppDoesNotInferCloudAdmin(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	event := &cerebrov1.EventEnvelope{
+		Id:       "okta-readonly-admin-app",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.app_assignment",
+		Attributes: map[string]string{
+			"app_id":       "app-view",
+			"app_name":     "Admin View",
+			"scope":        "read_only",
+			"subject_id":   "00u-analyst",
+			"subject_type": "user",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	entitlementURN := "urn:cerebro:writer:okta_entitlement:read_only"
+	assertProjectedLink(t, state, entitlementURN, relationConfersCapability, "urn:cerebro:writer:privileged_capability:app_access")
+	assertProjectedLinkMissing(t, state, entitlementURN, relationConfersCapability, "urn:cerebro:writer:privileged_capability:cloud_admin")
+}
+
 func TestProjectCloudReadOnlyRoleAssignmentsAvoidAdminEdges(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -2,7 +2,9 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,6 +31,7 @@ type Store struct {
 	deviceAuthTablesReady        bool
 	mcpOAuthTablesReady          bool
 	startupLeaseTableReady       bool
+	schemaMigrationsReady        bool
 	askTrajectoryReady           bool
 	jobTablesReady               bool
 	runtimeBlocklistReady        bool
@@ -38,6 +41,7 @@ type Store struct {
 
 // Open opens a Postgres-backed current-state store.
 func Open(cfg config.StateStoreConfig) (*Store, error) {
+	cfg = config.ApplyPostgresPoolDefaults(cfg)
 	dsn := strings.TrimSpace(cfg.PostgresDSN)
 	if dsn == "" {
 		return nil, errors.New("postgres dsn is required")
@@ -86,13 +90,80 @@ func (s *Store) ensureStatements(ctx context.Context, ready *bool, label string,
 	if *ready {
 		return nil
 	}
+	if err := s.ensureSchemaMigrationsLocked(ctx); err != nil {
+		return err
+	}
+	version, checksum, err := s.validateSchemaMigrationLocked(ctx, label, statements)
+	if err != nil {
+		return err
+	}
 	for _, statement := range statements {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {
 			return fmt.Errorf("ensure %s tables: %w", label, err)
 		}
 	}
+	if err := s.markSchemaMigrationLocked(ctx, version, checksum); err != nil {
+		return err
+	}
 	*ready = true
 	return nil
+}
+
+const schemaMigrationsDDL = `
+CREATE TABLE IF NOT EXISTS schema_migrations (
+	version text PRIMARY KEY,
+	checksum text NOT NULL,
+	applied_at timestamptz NOT NULL DEFAULT now()
+)`
+
+func (s *Store) ensureSchemaMigrationsLocked(ctx context.Context) error {
+	if s.schemaMigrationsReady {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, schemaMigrationsDDL); err != nil {
+		return fmt.Errorf("ensure schema migrations table: %w", err)
+	}
+	s.schemaMigrationsReady = true
+	return nil
+}
+
+func (s *Store) validateSchemaMigrationLocked(ctx context.Context, label string, statements []string) (string, string, error) {
+	version := "ensure:" + strings.TrimSpace(label)
+	checksum := schemaStatementsChecksum(statements)
+	var existing string
+	err := s.db.QueryRowContext(ctx, `SELECT checksum FROM schema_migrations WHERE version = $1`, version).Scan(&existing)
+	switch {
+	case err == nil:
+		if existing != checksum {
+			return "", "", fmt.Errorf("schema migration %q checksum changed; add a new migration instead of mutating applied DDL", version)
+		}
+	case errors.Is(err, sql.ErrNoRows):
+	default:
+		return "", "", fmt.Errorf("read schema migration %q: %w", version, err)
+	}
+	return version, checksum, nil
+}
+
+func (s *Store) markSchemaMigrationLocked(ctx context.Context, version string, checksum string) error {
+	if strings.TrimSpace(version) == "" || strings.TrimSpace(checksum) == "" {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO schema_migrations (version, checksum)
+VALUES ($1, $2)
+ON CONFLICT (version) DO NOTHING`, version, checksum); err != nil {
+		return fmt.Errorf("record schema migration %q: %w", version, err)
+	}
+	return nil
+}
+
+func schemaStatementsChecksum(statements []string) string {
+	hash := sha256.New()
+	for _, statement := range statements {
+		_, _ = hash.Write([]byte(strings.TrimSpace(statement)))
+		_, _ = hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 func normalizedNonEmptyStrings(values []string) []string {

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -93,10 +93,7 @@ func (s *Store) ensureStatements(ctx context.Context, ready *bool, label string,
 	if err := s.ensureSchemaMigrationsLocked(ctx); err != nil {
 		return err
 	}
-	version, checksum, err := s.validateSchemaMigrationLocked(ctx, label, statements)
-	if err != nil {
-		return err
-	}
+	version, checksum := schemaMigrationRecord(label, statements)
 	for _, statement := range statements {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {
 			return fmt.Errorf("ensure %s tables: %w", label, err)
@@ -127,21 +124,10 @@ func (s *Store) ensureSchemaMigrationsLocked(ctx context.Context) error {
 	return nil
 }
 
-func (s *Store) validateSchemaMigrationLocked(ctx context.Context, label string, statements []string) (string, string, error) {
+func schemaMigrationRecord(label string, statements []string) (string, string) {
 	version := "ensure:" + strings.TrimSpace(label)
 	checksum := schemaStatementsChecksum(statements)
-	var existing string
-	err := s.db.QueryRowContext(ctx, `SELECT checksum FROM schema_migrations WHERE version = $1`, version).Scan(&existing)
-	switch {
-	case err == nil:
-		if existing != checksum {
-			return "", "", fmt.Errorf("schema migration %q checksum changed; add a new migration instead of mutating applied DDL", version)
-		}
-	case errors.Is(err, sql.ErrNoRows):
-	default:
-		return "", "", fmt.Errorf("read schema migration %q: %w", version, err)
-	}
-	return version, checksum, nil
+	return version, checksum
 }
 
 func (s *Store) markSchemaMigrationLocked(ctx context.Context, version string, checksum string) error {
@@ -151,7 +137,10 @@ func (s *Store) markSchemaMigrationLocked(ctx context.Context, version string, c
 	if _, err := s.db.ExecContext(ctx, `
 INSERT INTO schema_migrations (version, checksum)
 VALUES ($1, $2)
-ON CONFLICT (version) DO NOTHING`, version, checksum); err != nil {
+ON CONFLICT (version) DO UPDATE
+SET checksum = EXCLUDED.checksum,
+	applied_at = now()
+WHERE schema_migrations.checksum <> EXCLUDED.checksum`, version, checksum); err != nil {
 		return fmt.Errorf("record schema migration %q: %w", version, err)
 	}
 	return nil

--- a/internal/statestore/postgres/postgres_test.go
+++ b/internal/statestore/postgres/postgres_test.go
@@ -32,3 +32,14 @@ func TestSchemaStatementsChecksumChangesWithDDL(t *testing.T) {
 		t.Fatalf("schemaStatementsChecksum() = %q, want stable whitespace-normalized checksum %q", got, first)
 	}
 }
+
+func TestSchemaMigrationRecordUsesStableLabelVersion(t *testing.T) {
+	version, first := schemaMigrationRecord("projection", []string{"CREATE TABLE example (id text)"})
+	againVersion, second := schemaMigrationRecord("projection", []string{"CREATE TABLE example (id text, name text)"})
+	if version != "ensure:projection" || againVersion != version {
+		t.Fatalf("schemaMigrationRecord versions = %q, %q", version, againVersion)
+	}
+	if first == second {
+		t.Fatal("schemaMigrationRecord checksum did not change after additive DDL changed")
+	}
+}

--- a/internal/statestore/postgres/postgres_test.go
+++ b/internal/statestore/postgres/postgres_test.go
@@ -18,3 +18,17 @@ func TestCloseNilStore(t *testing.T) {
 		t.Fatalf("Close() error = %v", err)
 	}
 }
+
+func TestSchemaStatementsChecksumChangesWithDDL(t *testing.T) {
+	first := schemaStatementsChecksum([]string{"CREATE TABLE example (id text)"})
+	second := schemaStatementsChecksum([]string{"CREATE TABLE example (id text, name text)"})
+	if first == "" {
+		t.Fatal("schemaStatementsChecksum() returned empty checksum")
+	}
+	if first == second {
+		t.Fatal("schemaStatementsChecksum() did not change after DDL changed")
+	}
+	if got := schemaStatementsChecksum([]string{"  CREATE TABLE example (id text)  "}); got != first {
+		t.Fatalf("schemaStatementsChecksum() = %q, want stable whitespace-normalized checksum %q", got, first)
+	}
+}


### PR DESCRIPTION
## Summary

- Flips API auth and global rate limiting to safe defaults, adds explicit `CEREBRO_DEV_MODE` acknowledgement, and makes `serve` fail closed when credentials or rate limits are missing.
- Sanitizes job/runtime-response 5xx HTTP errors, makes route/RPC auth decisions explicitly scoped or admin-only, and tags access audit telemetry with credential tiers.
- Adds conservative Postgres pool defaults plus a schema migration checksum ledger, and projects Okta app/admin-role entitlement paths into capability graph edges.

Refs #386, #267, #274, #289, #689, #237, #894.

## Test Plan

- `go test ./internal/config -count=1 -v`
- `go test ./internal/bootstrap -count=1 -v`
- `go test ./internal/statestore/postgres -count=1 -v`
- `go test ./internal/sourceprojection -run 'TestProjectOktaEffectiveEntitlementGraph|TestProjectCrossProviderIdentityProjection|TestProjectCloudReadOnlyRoleAssignmentsAvoidAdminEdges' -count=1 -v`
- `go test ./cmd/cerebro -run TestValidateServeConfig -count=1 -v`
- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
