### PR TITLE
feat: support mounted secret config files

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ const (
 	defaultPostgresMaxIdleConns    = 5
 	defaultPostgresConnMaxLifetime = 5 * time.Minute
 	defaultPostgresConnMaxIdleTime = time.Minute
+	maxConfigFileBytes             = 4 << 20
 )
 
 const (
@@ -30,7 +31,10 @@ const (
 	GraphStoreDriverNeo4j    = "neo4j"
 )
 
-var errLegacyKuzuPath = errors.New("CEREBRO_KUZU_PATH is no longer supported")
+var (
+	errConfigValueConflict = errors.New("config value and file are both set")
+	errLegacyKuzuPath      = errors.New("CEREBRO_KUZU_PATH is no longer supported")
+)
 
 // Config is the minimal bootstrap configuration for the rewrite skeleton.
 type Config struct {
@@ -278,7 +282,19 @@ func Load() (Config, error) {
 	if strings.TrimSpace(os.Getenv("CEREBRO_KUZU_PATH")) != "" {
 		return Config{}, fmt.Errorf("%w; configure Neo4j with CEREBRO_NEO4J_URI, CEREBRO_NEO4J_USERNAME, and CEREBRO_NEO4J_PASSWORD", errLegacyKuzuPath)
 	}
-	apiCredentials, err := parseAPICredentials(os.Getenv("CEREBRO_API_CREDENTIALS_JSON"))
+	apiCredentialsRaw, err := readConfigValue("CEREBRO_API_CREDENTIALS_JSON")
+	if err != nil {
+		return Config{}, err
+	}
+	apiCredentials, err := parseAPICredentials(apiCredentialsRaw)
+	if err != nil {
+		return Config{}, err
+	}
+	apiKeysRaw, err := readConfigValue("CEREBRO_API_KEYS")
+	if err != nil {
+		return Config{}, err
+	}
+	capabilityTokenSecretsRaw, err := readConfigValue("CEREBRO_CAPABILITY_TOKEN_SECRETS")
 	if err != nil {
 		return Config{}, err
 	}
@@ -330,9 +346,9 @@ func Load() (Config, error) {
 			MetricsEndpoint: strings.TrimSpace(os.Getenv("CEREBRO_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")),
 		},
 		Auth: AuthConfig{
-			APIKeys:                 parseAPIKeys(os.Getenv("CEREBRO_API_KEYS")),
+			APIKeys:                 parseAPIKeys(apiKeysRaw),
 			APICredentials:          apiCredentials,
-			CapabilityTokenSecrets:  parseCSV(os.Getenv("CEREBRO_CAPABILITY_TOKEN_SECRETS")),
+			CapabilityTokenSecrets:  parseCSV(capabilityTokenSecretsRaw),
 			CapabilityTokenAudience: strings.TrimSpace(os.Getenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE")),
 			AllowedTenants:          parseCSV(os.Getenv("CEREBRO_ALLOWED_TENANTS")),
 			RequestOrigin: RequestOriginConfig{
@@ -543,6 +559,26 @@ func ApplyPostgresPoolDefaults(cfg StateStoreConfig) StateStoreConfig {
 
 func (cfg AuthConfig) HasCredentialMaterial() bool {
 	return len(cfg.APIKeys) > 0 || len(cfg.APICredentials) > 0 || len(cfg.CapabilityTokenSecrets) > 0
+}
+
+func readConfigValue(name string) (string, error) {
+	value := strings.TrimSpace(os.Getenv(name))
+	filePath := strings.TrimSpace(os.Getenv(name + "_FILE"))
+	if value != "" && filePath != "" {
+		return "", fmt.Errorf("%w: %s and %s_FILE", errConfigValueConflict, name, name)
+	}
+	if filePath == "" {
+		return value, nil
+	}
+	// #nosec G304 G703 -- file path is an operator-configured mounted secret path.
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("read %s_FILE: %w", name, err)
+	}
+	if len(data) > maxConfigFileBytes {
+		return "", fmt.Errorf("%s_FILE exceeds %d bytes", name, maxConfigFileBytes)
+	}
+	return strings.TrimSpace(string(data)), nil
 }
 
 func validateRequestOriginConfig(cfg RequestOriginConfig) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -36,8 +38,11 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "")
 	t.Setenv("CEREBRO_API_KEYS", "")
+	t.Setenv("CEREBRO_API_KEYS_FILE", "")
 	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", "")
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON_FILE", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS_FILE", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "")
 	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "")
@@ -137,8 +142,11 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
 	t.Setenv("CEREBRO_API_KEYS", "token-1:ci:writer,token-2:ops:security")
+	t.Setenv("CEREBRO_API_KEYS_FILE", "")
 	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", "")
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON_FILE", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS_FILE", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "security,writer,writer")
 	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "https://api.writer.com")
@@ -238,6 +246,85 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 }
 
+func TestLoadParsesMountedAPISecretFiles(t *testing.T) {
+	clearDependencyEnv(t)
+	sum := sha256.Sum256([]byte("scoped-token"))
+	t.Setenv("CEREBRO_API_KEYS_FILE", writeConfigTestFile(t, "api-keys", "mounted-token:mounted:writer\n"))
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON_FILE", writeConfigTestFile(t, "api-credentials.json", `[
+		{
+			"credential_id": "mounted-credential",
+			"client_id": "mounted-client",
+			"key_sha256": "`+hex.EncodeToString(sum[:])+`",
+			"allowed_tenants": ["writer"],
+			"scopes": ["cerebro.cosmo.security.read"]
+		}
+	]`))
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS_FILE", writeConfigTestFile(t, "capability-secrets", "secret-2,secret-1\n"))
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(cfg.Auth.APIKeys) != 1 || cfg.Auth.APIKeys[0].Key != "mounted-token" || cfg.Auth.APIKeys[0].Principal != "mounted" {
+		t.Fatalf("Auth.APIKeys = %#v", cfg.Auth.APIKeys)
+	}
+	if len(cfg.Auth.APICredentials) != 1 || cfg.Auth.APICredentials[0].ID != "mounted-credential" {
+		t.Fatalf("Auth.APICredentials = %#v", cfg.Auth.APICredentials)
+	}
+	if got := cfg.Auth.CapabilityTokenSecrets; len(got) != 2 || got[0] != "secret-1" || got[1] != "secret-2" {
+		t.Fatalf("CapabilityTokenSecrets = %#v, want sorted mounted secrets", got)
+	}
+}
+
+func TestLoadRejectsConflictingMountedConfigValue(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", `[]`)
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON_FILE", writeConfigTestFile(t, "api-credentials.json", `[]`))
+
+	_, err := Load()
+	if !errors.Is(err, errConfigValueConflict) {
+		t.Fatalf("Load() error = %v, want errConfigValueConflict", err)
+	}
+}
+
+func TestLoadParsesDeviceAuthSigningKeysFile(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_DEVICE_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_DEVICE_AUTH_CURRENT_KID", "k1")
+	t.Setenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON_FILE", writeConfigTestFile(t, "device-keys.json", `[{"kid":"k1","public_pem":"public","private_pem":"private"}]`))
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(cfg.Auth.DeviceAuth.SigningKeys) != 1 || cfg.Auth.DeviceAuth.SigningKeys[0].KID != "k1" {
+		t.Fatalf("DeviceAuth.SigningKeys = %#v", cfg.Auth.DeviceAuth.SigningKeys)
+	}
+}
+
+func TestLoadParsesMCPOAuthJSONFiles(t *testing.T) {
+	setValidMCPOAuthEnv(t)
+	t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON_FILE", writeConfigTestFile(t, "mcp-clients.json", `[
+		{"client_id":"droid","redirect_uris":["http://127.0.0.1/callback"],"public":true}
+	]`))
+	t.Setenv("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON_FILE", writeConfigTestFile(t, "mcp-entitlements.json", `[
+		{"groups":["secops"],"allowed_tenants":["writer"],"scopes":["cerebro.cosmo.security.read"]}
+	]`))
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(cfg.Auth.MCPOAuth.Clients) != 1 || cfg.Auth.MCPOAuth.Clients[0].ClientID != "droid" {
+		t.Fatalf("MCPOAuth.Clients = %#v", cfg.Auth.MCPOAuth.Clients)
+	}
+	if len(cfg.Auth.MCPOAuth.Entitlements) != 1 || cfg.Auth.MCPOAuth.Entitlements[0].Groups[0] != "secops" {
+		t.Fatalf("MCPOAuth.Entitlements = %#v", cfg.Auth.MCPOAuth.Entitlements)
+	}
+}
+
 func TestLoadEnablesOTELWhenEndpointConfigured(t *testing.T) {
 	clearDependencyEnv(t)
 	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
@@ -249,6 +336,15 @@ func TestLoadEnablesOTELWhenEndpointConfigured(t *testing.T) {
 	if !cfg.OTEL.Enabled {
 		t.Fatal("OTEL.Enabled = false, want true when endpoint is configured")
 	}
+}
+
+func writeConfigTestFile(t *testing.T, name string, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config test file: %v", err)
+	}
+	return path
 }
 
 func clearDependencyEnv(t *testing.T) {
@@ -280,8 +376,11 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "")
 	t.Setenv("CEREBRO_API_KEYS", "")
+	t.Setenv("CEREBRO_API_KEYS_FILE", "")
 	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", "")
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON_FILE", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS_FILE", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "")
 	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "")
@@ -346,6 +445,7 @@ func clearDeviceAuthEnv(t *testing.T) {
 	t.Setenv("CEREBRO_DEVICE_AUTH_APPLE_TEAM_ID", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_APPLE_BUNDLE_IDS", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON_FILE", "")
 }
 
 func clearMCPOAuthEnv(t *testing.T) {
@@ -354,8 +454,10 @@ func clearMCPOAuthEnv(t *testing.T) {
 	t.Setenv("CEREBRO_MCP_OAUTH_ISSUER", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_RESOURCE", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON_FILE", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_DYNAMIC_CLIENT_REGISTRATION_ENABLED", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON", "")
+	t.Setenv("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON_FILE", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_ACCESS_TTL", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_REFRESH_TTL", "")
 	t.Setenv("CEREBRO_MCP_OAUTH_CODE_TTL", "")

--- a/internal/config/device_auth.go
+++ b/internal/config/device_auth.go
@@ -87,7 +87,11 @@ func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
 	if cfg.Enabled && cfg.ReplicaCount > 1 {
 		return DeviceAuthConfig{}, fmt.Errorf("CEREBRO_DEVICE_AUTH_REPLICA_COUNT=%d is unsupported with in-process DPoP replay protection; configure one replica or wire shared DPoP replay state", cfg.ReplicaCount)
 	}
-	keys, err := parseDeviceAuthSigningKeys(os.Getenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON"))
+	signingKeysRaw, err := readConfigValue("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON")
+	if err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	keys, err := parseDeviceAuthSigningKeys(signingKeysRaw)
 	if err != nil {
 		return DeviceAuthConfig{}, err
 	}

--- a/internal/config/mcp_oauth.go
+++ b/internal/config/mcp_oauth.go
@@ -68,12 +68,20 @@ func loadMCPOAuthConfig(publicOrigin string) (MCPOAuthConfig, error) {
 	if cfg.DynamicClientRegistration, err = parseBoolEnv("CEREBRO_MCP_OAUTH_DYNAMIC_CLIENT_REGISTRATION_ENABLED"); err != nil {
 		return MCPOAuthConfig{}, err
 	}
-	clients, err := parseMCPOAuthClients(os.Getenv("CEREBRO_MCP_OAUTH_CLIENTS_JSON"))
+	clientsRaw, err := readConfigValue("CEREBRO_MCP_OAUTH_CLIENTS_JSON")
+	if err != nil {
+		return MCPOAuthConfig{}, err
+	}
+	clients, err := parseMCPOAuthClients(clientsRaw)
 	if err != nil {
 		return MCPOAuthConfig{}, err
 	}
 	cfg.Clients = clients
-	entitlements, err := parseMCPOAuthEntitlements(os.Getenv("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON"))
+	entitlementsRaw, err := readConfigValue("CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON")
+	if err != nil {
+		return MCPOAuthConfig{}, err
+	}
+	entitlements, err := parseMCPOAuthEntitlements(entitlementsRaw)
 	if err != nil {
 		return MCPOAuthConfig{}, err
 	}


### PR DESCRIPTION
## Summary

- Adds `*_FILE` mounted-file alternatives for large auth and device/MCP JSON configuration.
- Supports mounted API keys, API credentials JSON, capability token secrets, device-auth signing keys JSON, MCP OAuth clients JSON, and MCP OAuth entitlements JSON.
- Rejects ambiguous direct env plus file env configuration for the same value.

Closes #696.

## Test Plan

- `go test ./internal/config -run 'TestLoadParsesMountedAPISecretFiles|TestLoadRejectsConflictingMountedConfigValue|TestLoadParsesDeviceAuthSigningKeysFile|TestLoadParsesMCPOAuthJSONFiles' -count=1 -v`
- `go test ./internal/config -count=1 -v`
- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
