### PR TITLE
fix: harden audit finding guardrails

### DIFF
--- a/cmd/cerebro/closeout.go
+++ b/cmd/cerebro/closeout.go
@@ -601,9 +601,13 @@ func parseCloseoutDuration(raw string) (time.Duration, error) {
 		return 0, errors.New("duration must be positive")
 	}
 	if strings.HasSuffix(raw, "d") {
-		days, err := strconv.Atoi(strings.TrimSuffix(raw, "d"))
+		const maxCloseoutDurationDays = int64(1<<63-1) / int64(24*time.Hour)
+		days, err := strconv.ParseInt(strings.TrimSuffix(raw, "d"), 10, 64)
 		if err != nil || days <= 0 {
 			return 0, fmt.Errorf("invalid day duration %q", raw)
+		}
+		if days > maxCloseoutDurationDays {
+			return 0, fmt.Errorf("day duration %q is too large", raw)
 		}
 		return time.Duration(days) * 24 * time.Hour, nil
 	}

--- a/cmd/cerebro/closeout_test.go
+++ b/cmd/cerebro/closeout_test.go
@@ -694,7 +694,7 @@ func TestCloseoutDryRunExitCode(t *testing.T) {
 }
 
 func TestCloseout_OlderThanRejectsInvalid(t *testing.T) {
-	cases := []string{"abc", "-3d", "0d"}
+	cases := []string{"abc", "-3d", "0d", "106752d"}
 	for _, raw := range cases {
 		t.Run(raw, func(t *testing.T) {
 			env, backend, _, _, _ := newCloseoutTestEnv(t)

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -1661,7 +1661,11 @@ func graphHealthRunStartedAfter(left, right graphstore.IngestRun) bool {
 
 func graphHealthRunIsStale(run graphstore.IngestRun, now time.Time, maxRunningMinutes int) bool {
 	startedAt, ok := parseGraphHealthRunTime(run.StartedAt)
-	return ok && now.UTC().Sub(startedAt) > time.Duration(maxRunningMinutes)*time.Minute
+	const maxDurationMinutes = int64(1<<63-1) / int64(time.Minute)
+	if !ok || maxRunningMinutes <= 0 || int64(maxRunningMinutes) > maxDurationMinutes {
+		return false
+	}
+	return now.UTC().Sub(startedAt) > time.Duration(maxRunningMinutes)*time.Minute
 }
 
 func parseGraphHealthRunTime(value string) (time.Time, bool) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -383,7 +383,7 @@ func (a *App) handleListFindingRules(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleGetFinding(w http.ResponseWriter, r *http.Request) {
 	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), r.PathValue("findingID")); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
 		return
 	}
 	finding, err := a.findingService().GetFinding(r.Context(), r.PathValue("findingID"))
@@ -407,7 +407,7 @@ func (a *App) handleResolveFinding(w http.ResponseWriter, r *http.Request) {
 		request.Reason = rawReason
 	}
 	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), request.GetId()); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
 		return
 	}
 	finding, err := a.findingService().ResolveFinding(r.Context(), request.GetId(), request.GetReason())
@@ -431,7 +431,7 @@ func (a *App) handleSuppressFinding(w http.ResponseWriter, r *http.Request) {
 		request.Reason = rawReason
 	}
 	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), request.GetId()); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
 		return
 	}
 	finding, err := a.findingService().SuppressFinding(r.Context(), request.GetId(), request.GetReason())
@@ -455,7 +455,7 @@ func (a *App) handleAssignFinding(w http.ResponseWriter, r *http.Request) {
 		request.Assignee = rawAssignee[len(rawAssignee)-1]
 	}
 	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), request.GetId()); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
 		return
 	}
 	finding, err := a.findingService().AssignFinding(r.Context(), request.GetId(), request.GetAssignee())
@@ -480,7 +480,7 @@ func (a *App) handleSetFindingDueDate(w http.ResponseWriter, r *http.Request) {
 		dueAt = request.GetDueAt().AsTime()
 	}
 	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), request.GetId()); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
 		return
 	}
 	finding, err := a.findingService().SetFindingDueDate(r.Context(), request.GetId(), dueAt)
@@ -501,7 +501,7 @@ func (a *App) handleAddFindingNote(w http.ResponseWriter, r *http.Request) {
 	}
 	request.Id = r.PathValue("findingID")
 	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), request.GetId()); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
 		return
 	}
 	finding, err := a.findingService().AddFindingNote(r.Context(), request.GetId(), request.GetNote())
@@ -522,7 +522,7 @@ func (a *App) handleLinkFindingTicket(w http.ResponseWriter, r *http.Request) {
 	}
 	request.Id = r.PathValue("findingID")
 	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), request.GetId()); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
 		return
 	}
 	finding, err := a.findingService().LinkFindingTicket(
@@ -595,7 +595,7 @@ func (a *App) handleGetFindingEvaluationRun(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), response.GetRuntimeId()); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingEvaluationRunNotFound))
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.GetFindingEvaluationRunResponse{
@@ -610,7 +610,7 @@ func (a *App) handleGetFindingEvidence(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), response.GetRuntimeId()); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingEvidenceNotFound))
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.GetFindingEvidenceResponse{
@@ -1239,7 +1239,7 @@ func (a *App) handlePutSourceRuntime(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleGetSourceRuntime(w http.ResponseWriter, r *http.Request) {
 	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), r.PathValue("runtimeID")); err != nil {
-		writeSourceRuntimeError(w, err)
+		writeSourceRuntimeError(w, normalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound))
 		return
 	}
 	response, err := a.runtimeService().Get(r.Context(), &cerebrov1.GetSourceRuntimeRequest{
@@ -1338,7 +1338,7 @@ func (a *App) handleSyncSourceRuntime(w http.ResponseWriter, r *http.Request) {
 	}
 	request.Id = r.PathValue("runtimeID")
 	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), request.GetId()); err != nil {
-		writeSourceRuntimeError(w, err)
+		writeSourceRuntimeError(w, normalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound))
 		return
 	}
 	response, err := a.runtimeService().SyncWithLease(r.Context(), request, sourceruntime.SyncWithLeaseOptions{
@@ -1658,7 +1658,7 @@ func (a *App) handleGetFindingCandidate(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), candidate.RuntimeID); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingCandidateNotFound))
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.GetFindingCandidateResponse{Candidate: findingCandidateMessage(candidate)})
@@ -1677,7 +1677,7 @@ func (a *App) handlePromoteFindingCandidate(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), candidate.RuntimeID); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingCandidateNotFound))
 		return
 	}
 	if err := authorizeFindingCandidatePromotion(r.Context()); err != nil {
@@ -1712,7 +1712,7 @@ func (a *App) handleRejectFindingCandidate(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), candidate.RuntimeID); err != nil {
-		writeFindingError(w, err)
+		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingCandidateNotFound))
 		return
 	}
 	if err := authorizeFindingCandidatePromotion(r.Context()); err != nil {
@@ -1923,7 +1923,7 @@ func (s *bootstrapService) PutSourceRuntime(ctx context.Context, req *connect.Re
 
 func (s *bootstrapService) GetSourceRuntime(ctx context.Context, req *connect.Request[cerebrov1.GetSourceRuntimeRequest]) (*connect.Response[cerebrov1.GetSourceRuntimeResponse], error) {
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, sourceRuntimeConnectError(err)
+		return nil, sourceRuntimeConnectError(normalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound))
 	}
 	response, err := newRuntimeService(s.deps, s.sources).Get(ctx, req.Msg)
 	if err != nil {
@@ -1934,7 +1934,7 @@ func (s *bootstrapService) GetSourceRuntime(ctx context.Context, req *connect.Re
 
 func (s *bootstrapService) SyncSourceRuntime(ctx context.Context, req *connect.Request[cerebrov1.SyncSourceRuntimeRequest]) (*connect.Response[cerebrov1.SyncSourceRuntimeResponse], error) {
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, sourceRuntimeConnectError(err)
+		return nil, sourceRuntimeConnectError(normalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound))
 	}
 	response, err := newRuntimeService(s.deps, s.sources).SyncWithLease(ctx, req.Msg, sourceruntime.SyncWithLeaseOptions{
 		LeaseStore: sourceRuntimeLeaseStore(s.deps.StateStore),
@@ -2030,7 +2030,7 @@ func (s *bootstrapService) ListFindings(ctx context.Context, req *connect.Reques
 
 func (s *bootstrapService) GetFinding(ctx context.Context, req *connect.Request[cerebrov1.GetFindingRequest]) (*connect.Response[cerebrov1.GetFindingResponse], error) {
 	if err := authorizeFindingIDTenant(ctx, findingStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingNotFound))
 	}
 	finding, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -2085,14 +2085,14 @@ func (s *bootstrapService) GetFindingCandidate(ctx context.Context, req *connect
 		return nil, findingConnectError(err)
 	}
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), candidate.RuntimeID); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingCandidateNotFound))
 	}
 	return connect.NewResponse(&cerebrov1.GetFindingCandidateResponse{Candidate: findingCandidateMessage(candidate)}), nil
 }
 
 func (s *bootstrapService) EvaluateSourceRuntimeFindingCandidates(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingCandidatesRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingCandidatesResponse], error) {
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound))
 	}
 	response, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -2126,7 +2126,7 @@ func (s *bootstrapService) PromoteFindingCandidate(ctx context.Context, req *con
 		return nil, findingConnectError(err)
 	}
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), candidate.RuntimeID); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingCandidateNotFound))
 	}
 	if err := authorizeFindingCandidatePromotion(ctx); err != nil {
 		return nil, findingConnectError(err)
@@ -2159,7 +2159,7 @@ func (s *bootstrapService) RejectFindingCandidate(ctx context.Context, req *conn
 		return nil, findingConnectError(err)
 	}
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), candidate.RuntimeID); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingCandidateNotFound))
 	}
 	if err := authorizeFindingCandidatePromotion(ctx); err != nil {
 		return nil, findingConnectError(err)
@@ -2177,7 +2177,7 @@ func (s *bootstrapService) RejectFindingCandidate(ctx context.Context, req *conn
 
 func (s *bootstrapService) ResolveFinding(ctx context.Context, req *connect.Request[cerebrov1.ResolveFindingRequest]) (*connect.Response[cerebrov1.ResolveFindingResponse], error) {
 	if err := authorizeFindingIDTenant(ctx, findingStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingNotFound))
 	}
 	finding, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -2195,7 +2195,7 @@ func (s *bootstrapService) ResolveFinding(ctx context.Context, req *connect.Requ
 
 func (s *bootstrapService) SuppressFinding(ctx context.Context, req *connect.Request[cerebrov1.SuppressFindingRequest]) (*connect.Response[cerebrov1.SuppressFindingResponse], error) {
 	if err := authorizeFindingIDTenant(ctx, findingStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingNotFound))
 	}
 	finding, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -2213,7 +2213,7 @@ func (s *bootstrapService) SuppressFinding(ctx context.Context, req *connect.Req
 
 func (s *bootstrapService) AssignFinding(ctx context.Context, req *connect.Request[cerebrov1.AssignFindingRequest]) (*connect.Response[cerebrov1.AssignFindingResponse], error) {
 	if err := authorizeFindingIDTenant(ctx, findingStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingNotFound))
 	}
 	finding, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -2231,7 +2231,7 @@ func (s *bootstrapService) AssignFinding(ctx context.Context, req *connect.Reque
 
 func (s *bootstrapService) SetFindingDueDate(ctx context.Context, req *connect.Request[cerebrov1.SetFindingDueDateRequest]) (*connect.Response[cerebrov1.SetFindingDueDateResponse], error) {
 	if err := authorizeFindingIDTenant(ctx, findingStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingNotFound))
 	}
 	var dueAt time.Time
 	if req.Msg.GetDueAt() != nil {
@@ -2253,7 +2253,7 @@ func (s *bootstrapService) SetFindingDueDate(ctx context.Context, req *connect.R
 
 func (s *bootstrapService) AddFindingNote(ctx context.Context, req *connect.Request[cerebrov1.AddFindingNoteRequest]) (*connect.Response[cerebrov1.AddFindingNoteResponse], error) {
 	if err := authorizeFindingIDTenant(ctx, findingStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingNotFound))
 	}
 	finding, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -2271,7 +2271,7 @@ func (s *bootstrapService) AddFindingNote(ctx context.Context, req *connect.Requ
 
 func (s *bootstrapService) LinkFindingTicket(ctx context.Context, req *connect.Request[cerebrov1.LinkFindingTicketRequest]) (*connect.Response[cerebrov1.LinkFindingTicketResponse], error) {
 	if err := authorizeFindingIDTenant(ctx, findingStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingNotFound))
 	}
 	finding, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -2361,7 +2361,7 @@ func (s *bootstrapService) GetFindingEvaluationRun(ctx context.Context, req *con
 		return nil, findingConnectError(err)
 	}
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), run.GetRuntimeId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingEvaluationRunNotFound))
 	}
 	return connect.NewResponse(&cerebrov1.GetFindingEvaluationRunResponse{Run: run}), nil
 }
@@ -2379,14 +2379,14 @@ func (s *bootstrapService) GetFindingEvidence(ctx context.Context, req *connect.
 		return nil, findingConnectError(err)
 	}
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), evidence.GetRuntimeId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingEvidenceNotFound))
 	}
 	return connect.NewResponse(&cerebrov1.GetFindingEvidenceResponse{Evidence: evidence}), nil
 }
 
 func (s *bootstrapService) EvaluateSourceRuntimeFindingRules(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingRulesRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingRulesResponse], error) {
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound))
 	}
 	response, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -2408,7 +2408,7 @@ func (s *bootstrapService) EvaluateSourceRuntimeFindingRules(ctx context.Context
 
 func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingsResponse], error) {
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetId()); err != nil {
-		return nil, findingConnectError(err)
+		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound))
 	}
 	response, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -3025,6 +3025,13 @@ func mappedHTTPStatusCode(err error, mappings []bootstrapErrorMapping) int {
 		}
 	}
 	return http.StatusInternalServerError
+}
+
+func normalizeIDLookupError(err error, normalized error) error {
+	if errors.Is(err, errTenantForbidden) {
+		return normalized
+	}
+	return err
 }
 
 func writeMappedBootstrapError(w http.ResponseWriter, err error, mappings []bootstrapErrorMapping) {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2913,8 +2913,8 @@ func TestAuthMiddlewareEnforcesTenantOnIDOnlyRoutes(t *testing.T) {
 				t.Fatalf("%s %s error = %v", tt.method, tt.path, err)
 			}
 			_ = resp.Body.Close()
-			if resp.StatusCode != http.StatusForbidden {
-				t.Fatalf("%s %s status = %d, want %d", tt.method, tt.path, resp.StatusCode, http.StatusForbidden)
+			if resp.StatusCode != http.StatusNotFound {
+				t.Fatalf("%s %s status = %d, want %d", tt.method, tt.path, resp.StatusCode, http.StatusNotFound)
 			}
 		})
 	}
@@ -2922,13 +2922,13 @@ func TestAuthMiddlewareEnforcesTenantOnIDOnlyRoutes(t *testing.T) {
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	getRuntimeReq := connect.NewRequest(&cerebrov1.GetSourceRuntimeRequest{Id: "other-runtime"})
 	getRuntimeReq.Header().Set("Authorization", "Bearer writer-key")
-	if _, err := client.GetSourceRuntime(context.Background(), getRuntimeReq); connect.CodeOf(err) != connect.CodePermissionDenied {
-		t.Fatalf("GetSourceRuntime(other) code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodePermissionDenied, err)
+	if _, err := client.GetSourceRuntime(context.Background(), getRuntimeReq); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("GetSourceRuntime(other) code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodeNotFound, err)
 	}
 	getFindingReq := connect.NewRequest(&cerebrov1.GetFindingRequest{Id: "other-finding"})
 	getFindingReq.Header().Set("Authorization", "Bearer writer-key")
-	if _, err := client.GetFinding(context.Background(), getFindingReq); connect.CodeOf(err) != connect.CodePermissionDenied {
-		t.Fatalf("GetFinding(other) code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodePermissionDenied, err)
+	if _, err := client.GetFinding(context.Background(), getFindingReq); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("GetFinding(other) code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodeNotFound, err)
 	}
 }
 
@@ -3389,8 +3389,8 @@ func TestAuthMiddlewareRejectsBlankTenantSourceRuntimesForScopedKeys(t *testing.
 		t.Fatalf("GET /source-runtimes blank tenant error = %v", err)
 	}
 	_ = getResp.Body.Close()
-	if getResp.StatusCode != http.StatusForbidden {
-		t.Fatalf("GET /source-runtimes blank tenant status = %d, want %d", getResp.StatusCode, http.StatusForbidden)
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET /source-runtimes blank tenant status = %d, want %d", getResp.StatusCode, http.StatusNotFound)
 	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
@@ -3403,8 +3403,8 @@ func TestAuthMiddlewareRejectsBlankTenantSourceRuntimesForScopedKeys(t *testing.
 	}
 	getRuntimeReq := connect.NewRequest(&cerebrov1.GetSourceRuntimeRequest{Id: "blank-runtime"})
 	getRuntimeReq.Header().Set("Authorization", "Bearer writer-key")
-	if _, err := client.GetSourceRuntime(context.Background(), getRuntimeReq); connect.CodeOf(err) != connect.CodePermissionDenied {
-		t.Fatalf("GetSourceRuntime(blank tenant) code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodePermissionDenied, err)
+	if _, err := client.GetSourceRuntime(context.Background(), getRuntimeReq); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("GetSourceRuntime(blank tenant) code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodeNotFound, err)
 	}
 }
 

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -2607,10 +2607,7 @@ func mcpMapArrayCount(value any, key string) int {
 }
 
 func mcpNormalizeIDLookupError(err error, normalized error) error {
-	if errors.Is(err, errTenantForbidden) {
-		return normalized
-	}
-	return err
+	return normalizeIDLookupError(err, normalized)
 }
 
 func mcpAnyString(value any) string {

--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -27,6 +27,8 @@ const (
 	claimStatusRefuted      = "refuted"
 	claimStatusSuperseded   = "superseded"
 
+	defaultListLimit                   uint32 = 500
+	maxListLimit                       uint32 = 500
 	supportingRelationClaimLookupLimit uint32 = 2
 )
 
@@ -261,7 +263,7 @@ func (s *Service) ListClaims(ctx context.Context, request ListRequest) (*ListRes
 		ClaimType:     strings.TrimSpace(request.ClaimType),
 		Status:        strings.TrimSpace(request.Status),
 		SourceEventID: strings.TrimSpace(request.SourceEventID),
-		Limit:         request.Limit,
+		Limit:         normalizeListLimit(request.Limit),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list claims for runtime %q: %w", runtimeID, err)
@@ -315,6 +317,17 @@ func (s *Service) retractMissingClaims(ctx context.Context, runtime *cerebrov1.S
 		retracted++
 	}
 	return retracted, nil
+}
+
+func normalizeListLimit(limit uint32) uint32 {
+	switch {
+	case limit == 0:
+		return defaultListLimit
+	case limit > maxListLimit:
+		return maxListLimit
+	default:
+		return limit
+	}
 }
 
 func (s *Service) deleteRelationIfUnsupported(ctx context.Context, runtime *cerebrov1.SourceRuntime, claim *cerebrov1.Claim, link *ports.ProjectedLink) error {

--- a/internal/claims/service_test.go
+++ b/internal/claims/service_test.go
@@ -484,6 +484,9 @@ func TestWriteClaimsReplaceExistingRetractsOmittedClaims(t *testing.T) {
 	if got := retractList.Status; got != claimStatusAsserted {
 		t.Fatalf("retract list status = %q, want %q", got, claimStatusAsserted)
 	}
+	if got := retractList.Limit; got != 0 {
+		t.Fatalf("retract list limit = %d, want unbounded 0", got)
+	}
 	retracted := store.claims[assigneeID]
 	if retracted == nil {
 		t.Fatal("retracted claim = nil, want non-nil")
@@ -1877,14 +1880,15 @@ func TestListClaimsReturnsFilteredProtoClaims(t *testing.T) {
 	}
 }
 
-func TestListClaimsPreservesUnboundedAndExplicitLimits(t *testing.T) {
+func TestListClaimsNormalizesUserFacingLimits(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
 		limit uint32
 		want  uint32
 	}{
-		{name: "unbounded", limit: 0, want: 0},
-		{name: "large explicit", limit: 5000, want: 5000},
+		{name: "zero defaults", limit: 0, want: defaultListLimit},
+		{name: "within limit preserved", limit: 25, want: 25},
+		{name: "above max clamped", limit: maxListLimit + 1, want: maxListLimit},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			store := &stubClaimStore{claims: map[string]*ports.ClaimRecord{}}

--- a/internal/findings/closeout_test.go
+++ b/internal/findings/closeout_test.go
@@ -352,6 +352,38 @@ func TestTombstoneFindingsBulk_DryRun_NoMutation(t *testing.T) {
 	}
 }
 
+func TestTombstoneFindingsBulk_CloseoutCandidatesRemainUnbounded(t *testing.T) {
+	fx := newCloseoutFixture(t)
+	now := time.Now().UTC()
+	for i := 0; i < 501; i++ {
+		fx.seedFinding(fmt.Sprintf("fresh-%03d", i), "open", now.Add(-time.Hour), nil)
+	}
+	stale := fx.seedFinding("stale-eligible", "open", now.Add(-72*time.Hour), nil)
+	request := fx.request("run-unbounded-1", true)
+	request.Selector.OlderThan = 24 * time.Hour
+
+	result, err := fx.service.TombstoneFindingsBulk(context.Background(), request)
+	if err != nil {
+		t.Fatalf("TombstoneFindingsBulk error = %v", err)
+	}
+	if result.ProposedCount != 1 {
+		t.Fatalf("ProposedCount = %d, want 1", result.ProposedCount)
+	}
+	if got := strings.TrimSpace(result.Proposed[0].ID); got != stale.ID {
+		t.Fatalf("Proposed[0].ID = %q, want %q", got, stale.ID)
+	}
+	var candidateList ports.ListFindingsRequest
+	for _, request := range fx.store.listFindingsRequests {
+		if request.RuleID == fx.ruleID && request.Status == findingStatusOpen {
+			candidateList = request
+			break
+		}
+	}
+	if got := candidateList.Limit; got != 0 {
+		t.Fatalf("closeout candidate list limit = %d, want unbounded 0", got)
+	}
+}
+
 func TestTombstoneFindingsBulk_Apply_PersistsAndEmits(t *testing.T) {
 	fx := newCloseoutFixture(t)
 	first := fx.seedFinding("f-1", "open", fx.now.Add(-48*time.Hour), nil)

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -25,6 +25,8 @@ import (
 const (
 	defaultEventLimit       = 100
 	maxEventLimit           = 1000
+	defaultListLimit        = uint32(500)
+	maxListLimit            = uint32(500)
 	defaultEvidenceClaimCap = 100
 	findingStatusOpen       = "open"
 	findingStatusResolved   = "resolved"
@@ -580,7 +582,7 @@ func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListR
 		ResourceURN: strings.TrimSpace(request.ResourceURN),
 		EventID:     strings.TrimSpace(request.EventID),
 		PolicyID:    strings.TrimSpace(request.PolicyID),
-		Limit:       request.Limit,
+		Limit:       normalizeListLimit(request.Limit),
 		Order:       request.Order,
 	})
 	if err != nil {
@@ -1598,6 +1600,17 @@ func normalizeEventLimit(limit uint32) uint32 {
 		return defaultEventLimit
 	case limit > maxEventLimit:
 		return maxEventLimit
+	default:
+		return limit
+	}
+}
+
+func normalizeListLimit(limit uint32) uint32 {
+	switch {
+	case limit == 0:
+		return defaultListLimit
+	case limit > maxListLimit:
+		return maxListLimit
 	default:
 		return limit
 	}

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -4024,6 +4024,44 @@ func TestListFindingsReturnsFilteredPersistedFindings(t *testing.T) {
 	}
 }
 
+func TestListFindingsNormalizesUserFacingLimits(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		limit uint32
+		want  uint32
+	}{
+		{name: "zero defaults", limit: 0, want: defaultListLimit},
+		{name: "within limit preserved", limit: 25, want: 25},
+		{name: "above max clamped", limit: maxListLimit + 1, want: maxListLimit},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &stubFindingStore{}
+			service := New(
+				&stubRuntimeStore{
+					runtimes: map[string]*cerebrov1.SourceRuntime{
+						"writer-okta-audit": {
+							Id:       "writer-okta-audit",
+							SourceId: "okta",
+							TenantId: "writer",
+						},
+					},
+				},
+				&stubReplayer{},
+				store,
+				store,
+				store,
+				store,
+			)
+			if _, err := service.ListFindings(context.Background(), ListRequest{RuntimeID: "writer-okta-audit", Limit: tt.limit}); err != nil {
+				t.Fatalf("ListFindings() error = %v", err)
+			}
+			if got := store.request.Limit; got != tt.want {
+				t.Fatalf("ListFindings().Limit = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestListFindingsRequiresAvailableDependencies(t *testing.T) {
 	service := New(nil, nil, nil, nil, nil, nil)
 	if _, err := service.ListFindings(context.Background(), ListRequest{RuntimeID: "writer-okta-audit"}); !errors.Is(err, ErrRuntimeUnavailable) {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -247,6 +247,12 @@ func (s *stubFindingStore) UpdateFindingStatus(_ context.Context, request ports.
 	if !ok {
 		return nil, ports.ErrFindingNotFound
 	}
+	if expected := strings.TrimSpace(request.ExpectedStatus); expected != "" && strings.TrimSpace(finding.Status) != expected {
+		return nil, ports.ErrFindingStatusPreconditionFailed
+	}
+	if cutoff := request.LastObservedBefore.UTC(); !cutoff.IsZero() && !finding.LastObservedAt.Before(cutoff) {
+		return nil, ports.ErrFindingStatusPreconditionFailed
+	}
 	s.updateStatusCallCount++
 	s.updateStatusCalls = append(s.updateStatusCalls, request)
 	cloned := cloneFinding(finding)
@@ -5587,6 +5593,9 @@ func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRec
 		return false
 	}
 	if request.PolicyID != "" && strings.TrimSpace(finding.PolicyID) != strings.TrimSpace(request.PolicyID) {
+		return false
+	}
+	if cutoff := request.LastObservedBefore.UTC(); !cutoff.IsZero() && !finding.LastObservedAt.Before(cutoff) {
 		return false
 	}
 	return true

--- a/internal/findings/ttl_resolver.go
+++ b/internal/findings/ttl_resolver.go
@@ -3,6 +3,7 @@ package findings
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,8 @@ import (
 const ttlResolveLogEvent = "ttl.resolve"
 
 const ttlResolutionReasonPrefix = workflowevents.FindingStatusReasonTTLExpired + ":"
+
+const ttlResolverListLimit = uint32(500)
 
 // ttlClock is the per-Service "now" boundary used by the TTL sweeper. Tests
 // inject a fixed clock via Service.WithTTLClock so the sweeper can be exercised
@@ -116,46 +119,60 @@ func (s *Service) resolveTTLOpenFindings(ctx context.Context, tenantID string, r
 	}
 	now := s.ttlClockNow()
 	cutoff := now.Add(-ttl)
-	candidates, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
-		TenantID: tenantID,
-		RuleID:   id,
-		Status:   findingStatusOpen,
-	})
-	if err != nil {
-		return fmt.Errorf("list ttl candidates for rule %q: %w", id, err)
-	}
 	ttlLabel := formatTTLDuration(ttl)
 	reason := ttlResolutionReasonPrefix + ttlLabel
 	sink := s.ttlSink()
-	for _, finding := range candidates {
-		if finding == nil {
-			continue
-		}
-		if finding.Tombstoned {
-			continue
-		}
-		if !finding.LastObservedAt.Before(cutoff) {
-			continue
-		}
-		updated, err := s.updateFindingStatusAndRisk(ctx, ports.FindingStatusUpdate{
-			FindingID: strings.TrimSpace(finding.ID),
-			Status:    findingStatusResolved,
-			Reason:    reason,
-			UpdatedAt: now,
+	for {
+		candidates, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
+			TenantID:           tenantID,
+			RuleID:             id,
+			Status:             findingStatusOpen,
+			LastObservedBefore: cutoff,
+			Limit:              ttlResolverListLimit,
 		})
 		if err != nil {
-			return fmt.Errorf("resolve ttl finding %q: %w", strings.TrimSpace(finding.ID), err)
+			return fmt.Errorf("list ttl candidates for rule %q: %w", id, err)
 		}
-		if err := s.recordFindingStatusWorkflow(ctx, updated, workflowevents.FindingStatusSourceStaleEvaluation); err != nil {
-			return fmt.Errorf("project ttl finding %q resolution: %w", strings.TrimSpace(finding.ID), err)
+		if len(candidates) == 0 {
+			return nil
 		}
-		resolvedAt := updated.StatusUpdatedAt
-		if resolvedAt.IsZero() {
-			resolvedAt = now
+		for _, finding := range candidates {
+			if finding == nil {
+				continue
+			}
+			if finding.Tombstoned {
+				continue
+			}
+			if !finding.LastObservedAt.Before(cutoff) {
+				continue
+			}
+			updated, err := s.updateFindingStatusAndRisk(ctx, ports.FindingStatusUpdate{
+				FindingID:          strings.TrimSpace(finding.ID),
+				Status:             findingStatusResolved,
+				Reason:             reason,
+				UpdatedAt:          now,
+				ExpectedStatus:     findingStatusOpen,
+				LastObservedBefore: cutoff,
+			})
+			if errors.Is(err, ports.ErrFindingStatusPreconditionFailed) {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("resolve ttl finding %q: %w", strings.TrimSpace(finding.ID), err)
+			}
+			if err := s.recordFindingStatusWorkflow(ctx, updated, workflowevents.FindingStatusSourceStaleEvaluation); err != nil {
+				return fmt.Errorf("project ttl finding %q resolution: %w", strings.TrimSpace(finding.ID), err)
+			}
+			resolvedAt := updated.StatusUpdatedAt
+			if resolvedAt.IsZero() {
+				resolvedAt = now
+			}
+			writeTTLResolveLog(sink, id, strings.TrimSpace(updated.ID), ttlLabel, resolvedAt)
 		}
-		writeTTLResolveLog(sink, id, strings.TrimSpace(updated.ID), ttlLabel, resolvedAt)
+		if len(candidates) < int(ttlResolverListLimit) {
+			return nil
+		}
 	}
-	return nil
 }
 
 func writeTTLResolveLog(sink io.Writer, ruleID, findingID, ttlLabel string, resolvedAt time.Time) {

--- a/internal/findings/ttl_resolver_test.go
+++ b/internal/findings/ttl_resolver_test.go
@@ -171,6 +171,32 @@ func TestResolveTTLOpenFindings_ResolvesStale(t *testing.T) {
 	}
 }
 
+func TestResolveTTLOpenFindings_SkipsConcurrentFreshObservation(t *testing.T) {
+	fx := newTTLResolverFixture(t, LifecycleTTLEvidence, 24*time.Hour)
+	fx.seedFinding("stale-race", findingStatusOpen, fx.now.Add(-48*time.Hour), nil)
+	racingStore := &ttlConcurrentObservationStore{
+		stubFindingStore: fx.store,
+		findingID:        "stale-race",
+		observedAt:       fx.now.Add(-time.Hour),
+	}
+	fx.service.store = racingStore
+
+	if err := fx.service.resolveTTLOpenFindings(context.Background(), fx.tenantID, fx.ruleID); err != nil {
+		t.Fatalf("resolveTTLOpenFindings: %v", err)
+	}
+
+	finding := fx.store.findings["stale-race"]
+	if finding.Status != findingStatusOpen {
+		t.Fatalf("finding status = %q, want open after concurrent fresh observation", finding.Status)
+	}
+	if !finding.LastObservedAt.Equal(fx.now.Add(-time.Hour)) {
+		t.Fatalf("last_observed_at = %v, want concurrent fresh observation", finding.LastObservedAt)
+	}
+	if fx.store.updateStatusCallCount != 0 {
+		t.Fatalf("UpdateFindingStatus calls = %d, want 0 because CAS precondition failed", fx.store.updateStatusCallCount)
+	}
+}
+
 func TestResolveTTLOpenFindings_EmitsStatusChangedWorkflowEvent(t *testing.T) {
 	fx := newTTLResolverFixture(t, LifecycleTTLEvidence, 24*time.Hour)
 	appendLog := &recordingAppendLog{}
@@ -462,6 +488,24 @@ func (s *tenantRequiredListFindingStore) ListFindings(ctx context.Context, reque
 		return nil, errors.New("finding tenant id is required")
 	}
 	return s.stubFindingStore.ListFindings(ctx, request)
+}
+
+type ttlConcurrentObservationStore struct {
+	*stubFindingStore
+	findingID  string
+	observedAt time.Time
+	mutated    bool
+}
+
+func (s *ttlConcurrentObservationStore) ListFindings(ctx context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	rows, err := s.stubFindingStore.ListFindings(ctx, request)
+	if err == nil && !s.mutated {
+		s.mutated = true
+		if finding := s.findings[strings.TrimSpace(s.findingID)]; finding != nil {
+			finding.LastObservedAt = s.observedAt.UTC()
+		}
+	}
+	return rows, err
 }
 
 func TestResolveTTLOpenFindings_Idempotent(t *testing.T) {

--- a/internal/mcpoauth/service.go
+++ b/internal/mcpoauth/service.go
@@ -82,9 +82,15 @@ const (
 	statusBadRequest          = 400
 	statusUnauthorized        = 401
 	statusForbidden           = 403
+	statusTooManyRequests     = 429
 	statusInternalServerError = 500
 	statusBadGateway          = 502
+	maxDynamicOAuthClients    = 10000
 )
+
+type oauthClientLimitStore interface {
+	SaveOAuthClientWithLimit(ctx context.Context, client OAuthClient, maxClients int) error
+}
 
 type OAuthError struct {
 	Code        string
@@ -185,7 +191,15 @@ func (s *Service) RegisterClient(ctx context.Context, request ClientRegistration
 		Public:       clientSecret == "",
 		CreatedAt:    s.now().UTC(),
 	}
-	if err := s.store.SaveOAuthClient(ctx, client); err != nil {
+	if limitedStore, ok := s.store.(oauthClientLimitStore); ok {
+		err = limitedStore.SaveOAuthClientWithLimit(ctx, client, maxDynamicOAuthClients)
+	} else {
+		err = s.store.SaveOAuthClient(ctx, client)
+	}
+	if errors.Is(err, ErrOAuthClientLimitExceeded) {
+		return ClientRegistrationResponse{}, oauthError("too_many_clients", "dynamic client registration limit exceeded", statusTooManyRequests)
+	}
+	if err != nil {
 		return ClientRegistrationResponse{}, fmt.Errorf("mcpoauth: save dynamic client: %w", err)
 	}
 	response := ClientRegistrationResponse{

--- a/internal/mcpoauth/service_test.go
+++ b/internal/mcpoauth/service_test.go
@@ -109,6 +109,30 @@ func TestClientCredentialsAcceptsHashedClientSecret(t *testing.T) {
 	}
 }
 
+func TestRegisterClientEnforcesDynamicClientLimit(t *testing.T) {
+	store := &limitedClientStore{err: ErrOAuthClientLimitExceeded}
+	service, err := NewService(config.MCPOAuthConfig{
+		Resource:                  "https://cerebro.example/api/v1/mcp",
+		DynamicClientRegistration: true,
+	}, store, func(context.Context, AccessGrant, time.Duration, time.Time) (string, error) {
+		return "access-token", nil
+	}, WithOIDCProvider(stubOIDCProvider{}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = service.RegisterClient(context.Background(), ClientRegistrationRequest{
+		RedirectURIs: []string{"http://127.0.0.1:9876/callback"},
+	})
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) || oauthErr.Code != "too_many_clients" || oauthErr.Status != statusTooManyRequests {
+		t.Fatalf("RegisterClient limit error = %v, want too_many_clients 429", err)
+	}
+	if store.maxClients != maxDynamicOAuthClients {
+		t.Fatalf("maxClients = %d, want %d", store.maxClients, maxDynamicOAuthClients)
+	}
+}
+
 func TestEntitlementForIdentityScopesTenantGrant(t *testing.T) {
 	service := &Service{cfg: config.MCPOAuthConfig{
 		Entitlements: []config.MCPOAuthEntitlement{{
@@ -163,6 +187,17 @@ func (s *replayRefreshStore) ConsumeOAuthRefreshToken(context.Context, [32]byte,
 func (s *replayRefreshStore) RevokeOAuthRefreshFamily(_ context.Context, familyID string) error {
 	s.revokedFamilies = append(s.revokedFamilies, familyID)
 	return nil
+}
+
+type limitedClientStore struct {
+	Store
+	err        error
+	maxClients int
+}
+
+func (s *limitedClientStore) SaveOAuthClientWithLimit(_ context.Context, _ OAuthClient, maxClients int) error {
+	s.maxClients = maxClients
+	return s.err
 }
 
 type stubOIDCProvider struct{}

--- a/internal/mcpoauth/store.go
+++ b/internal/mcpoauth/store.go
@@ -87,10 +87,11 @@ type RefreshToken struct {
 }
 
 var (
-	ErrNotFound = errors.New("mcpoauth: token not found")
-	ErrExpired  = errors.New("mcpoauth: token expired")
-	ErrConsumed = errors.New("mcpoauth: token already consumed")
-	ErrReplay   = errors.New("mcpoauth: refresh token replay detected")
+	ErrNotFound                 = errors.New("mcpoauth: token not found")
+	ErrExpired                  = errors.New("mcpoauth: token expired")
+	ErrConsumed                 = errors.New("mcpoauth: token already consumed")
+	ErrReplay                   = errors.New("mcpoauth: refresh token replay detected")
+	ErrOAuthClientLimitExceeded = errors.New("mcpoauth: oauth client registration limit exceeded")
 )
 
 func HashToken(token string) [32]byte {

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -92,19 +92,20 @@ type FindingRecord struct {
 
 // ListFindingsRequest scopes one finding query.
 type ListFindingsRequest struct {
-	TenantID      string
-	RuntimeID     string
-	RuntimeIDs    []string
-	FindingID     string
-	RuleID        string
-	Severity      string
-	Status        string
-	ResourceURN   string
-	EventID       string
-	PolicyID      string
-	Limit         uint32
-	PriorityOrder bool
-	Order         FindingOrder
+	TenantID           string
+	RuntimeID          string
+	RuntimeIDs         []string
+	FindingID          string
+	RuleID             string
+	Severity           string
+	Status             string
+	ResourceURN        string
+	EventID            string
+	PolicyID           string
+	LastObservedBefore time.Time
+	Limit              uint32
+	PriorityOrder      bool
+	Order              FindingOrder
 }
 
 // FindingOrder controls persisted finding list sort order.
@@ -139,6 +140,10 @@ var ErrFindingEvaluationRunNotFound = errors.New("finding evaluation run not fou
 
 // ErrFindingNotFound indicates that a persisted finding does not exist.
 var ErrFindingNotFound = errors.New("finding not found")
+
+// ErrFindingStatusPreconditionFailed indicates that a conditional lifecycle
+// status mutation did not match the live row state.
+var ErrFindingStatusPreconditionFailed = errors.New("finding status precondition failed")
 
 // ErrFindingEvidenceNotFound indicates that persisted finding evidence does not exist.
 var ErrFindingEvidenceNotFound = errors.New("finding evidence not found")
@@ -295,12 +300,14 @@ type FindingTombstoneApply struct {
 
 // FindingStatusUpdate scopes one persisted finding lifecycle mutation.
 type FindingStatusUpdate struct {
-	FindingID string
-	Status    string
-	Reason    string
-	UpdatedAt time.Time
-	EventIDs  []string
-	Tombstone *FindingTombstoneApply
+	FindingID          string
+	Status             string
+	Reason             string
+	UpdatedAt          time.Time
+	EventIDs           []string
+	ExpectedStatus     string
+	LastObservedBefore time.Time
+	Tombstone          *FindingTombstoneApply
 }
 
 // FindingAssigneeUpdate scopes one persisted finding assignee mutation.

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -2,6 +2,7 @@ package sourcehttp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -19,6 +20,8 @@ const DefaultTimeout = 30 * time.Second
 const DefaultRetryMaxAttempts = 3
 const DefaultRetryBackoff = 250 * time.Millisecond
 const MaxRetryAfter = 5 * time.Second
+
+var ErrTransportPinningUnsupported = errors.New("source transport must support pinned host dialing")
 
 type ClientOptions struct {
 	SourceID                 string
@@ -214,26 +217,19 @@ func (rt SafeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		}
 		if len(addrs) > 0 {
 			pinned, err := pinnedHostTransport(base, req.URL.Hostname(), addrs[0].IP)
-			if err != nil && isDefaultTransportShape(base) {
+			if err != nil {
 				return nil, err
 			}
-			if err == nil {
-				base = pinned
-			}
+			base = pinned
 		}
 	}
 	return base.RoundTrip(req)
 }
 
-func isDefaultTransportShape(base http.RoundTripper) bool {
-	_, ok := base.(*http.Transport)
-	return ok
-}
-
 func pinnedHostTransport(base http.RoundTripper, host string, ip net.IP) (http.RoundTripper, error) {
 	transport, ok := base.(*http.Transport)
 	if !ok {
-		return nil, fmt.Errorf("source transport must support pinned host dialing")
+		return nil, ErrTransportPinningUnsupported
 	}
 	clone := transport.Clone()
 	clone.Proxy = nil

--- a/internal/sourcehttp/safe_test.go
+++ b/internal/sourcehttp/safe_test.go
@@ -2,6 +2,7 @@ package sourcehttp
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -10,6 +11,12 @@ import (
 	"testing"
 	"time"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
 
 func TestNormalizeBaseURLRejectsUnsafeHosts(t *testing.T) {
 	for _, raw := range []string{
@@ -208,6 +215,29 @@ func TestPinnedHostTransportDisablesKeepAlives(t *testing.T) {
 	}
 	if !transport.DisableKeepAlives {
 		t.Fatal("pinned transport must disable keep-alives")
+	}
+}
+
+func TestSafeRoundTripperFailsClosedWhenBaseCannotBePinned(t *testing.T) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.example.com/v1", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+	resp, err := SafeRoundTripper{
+		SourceID: "test",
+		Base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatal("base RoundTrip should not be called when pinning fails")
+			return nil, nil
+		}),
+		LookupIPAddrs: func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("203.0.113.10")}}, nil
+		},
+	}.RoundTrip(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if !errors.Is(err, ErrTransportPinningUnsupported) {
+		t.Fatalf("SafeRoundTripper.RoundTrip() error = %v, want pinned host dialing error", err)
 	}
 }
 

--- a/internal/statestore/postgres/claims.go
+++ b/internal/statestore/postgres/claims.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	defaultClaimListLimit = uint32(500)
-	maxClaimListLimit     = uint32(500)
+	maxClaimListLimit = uint32(500)
 )
 
 var ensureClaimStatements = []string{
@@ -223,8 +222,10 @@ SELECT runtime_id, tenant_id, claim_json::text
 FROM claims
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY observed_at DESC NULLS LAST, updated_at DESC, id`
-	args = append(args, int64(claimListLimit(request.Limit)))
-	query += fmt.Sprintf(" LIMIT $%d", len(args))
+	if limit := claimListLimit(request.Limit); limit > 0 {
+		args = append(args, int64(limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query claims for scope %q/%q: %w", tenantID, runtimeID, err)
@@ -256,8 +257,8 @@ ORDER BY observed_at DESC NULLS LAST, updated_at DESC, id`
 }
 
 func claimListLimit(limit uint32) uint32 {
-	if limit == 0 || limit > maxClaimListLimit {
-		return defaultClaimListLimit
+	if limit > maxClaimListLimit {
+		return maxClaimListLimit
 	}
 	return limit
 }

--- a/internal/statestore/postgres/claims.go
+++ b/internal/statestore/postgres/claims.go
@@ -15,6 +15,11 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
+const (
+	defaultClaimListLimit = uint32(500)
+	maxClaimListLimit     = uint32(500)
+)
+
 var ensureClaimStatements = []string{
 	`CREATE TABLE IF NOT EXISTS claims (
   id TEXT NOT NULL,
@@ -218,10 +223,8 @@ SELECT runtime_id, tenant_id, claim_json::text
 FROM claims
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY observed_at DESC NULLS LAST, updated_at DESC, id`
-	if request.Limit != 0 {
-		args = append(args, int64(request.Limit))
-		query += fmt.Sprintf(" LIMIT $%d", len(args))
-	}
+	args = append(args, int64(claimListLimit(request.Limit)))
+	query += fmt.Sprintf(" LIMIT $%d", len(args))
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query claims for scope %q/%q: %w", tenantID, runtimeID, err)
@@ -250,6 +253,13 @@ ORDER BY observed_at DESC NULLS LAST, updated_at DESC, id`
 		return nil, fmt.Errorf("iterate claims rows: %w", err)
 	}
 	return claims, nil
+}
+
+func claimListLimit(limit uint32) uint32 {
+	if limit == 0 || limit > maxClaimListLimit {
+		return defaultClaimListLimit
+	}
+	return limit
 }
 
 func (s *Store) ensureClaimTables(ctx context.Context) error {

--- a/internal/statestore/postgres/claims_test.go
+++ b/internal/statestore/postgres/claims_test.go
@@ -71,6 +71,24 @@ func TestListClaimsRejectsUnconfiguredStore(t *testing.T) {
 	}
 }
 
+func TestClaimListLimitPreservesUnboundedAndClampsExplicitLimit(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		limit uint32
+		want  uint32
+	}{
+		{name: "zero remains unbounded", limit: 0, want: 0},
+		{name: "within limit preserved", limit: 25, want: 25},
+		{name: "above max clamped", limit: maxClaimListLimit + 1, want: maxClaimListLimit},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := claimListLimit(tt.limit); got != tt.want {
+				t.Fatalf("claimListLimit(%d) = %d, want %d", tt.limit, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClaimSchemaScopesPrimaryKeyByTenantAndRuntime(t *testing.T) {
 	create := ensureClaimStatements[0]
 	if !strings.Contains(create, "PRIMARY KEY (tenant_id, runtime_id, id)") {

--- a/internal/statestore/postgres/finding_candidates.go
+++ b/internal/statestore/postgres/finding_candidates.go
@@ -13,6 +13,11 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
+const (
+	defaultFindingCandidateListLimit = uint32(500)
+	maxFindingCandidateListLimit     = uint32(500)
+)
+
 var ensureFindingCandidateStatements = []string{
 	`CREATE TABLE IF NOT EXISTS finding_candidate_runs (
   id TEXT PRIMARY KEY,
@@ -579,10 +584,8 @@ SELECT id, tenant_id, runtime_id, rule_id, status, event_limit, events_evaluated
 FROM finding_candidate_runs
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY started_at DESC, id`
-	if request.Limit != 0 {
-		args = append(args, int64(request.Limit))
-		query += fmt.Sprintf(" LIMIT $%d", len(args))
-	}
+	args = append(args, int64(findingCandidateListLimit(request.Limit)))
+	query += fmt.Sprintf(" LIMIT $%d", len(args))
 	return query, args, nil
 }
 
@@ -608,11 +611,16 @@ func findingCandidateListQuery(request ports.ListFindingCandidatesRequest) (stri
 FROM finding_candidates
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY last_observed_at DESC, id`
-	if request.Limit != 0 {
-		args = append(args, int64(request.Limit))
-		query += fmt.Sprintf(" LIMIT $%d", len(args))
-	}
+	args = append(args, int64(findingCandidateListLimit(request.Limit)))
+	query += fmt.Sprintf(" LIMIT $%d", len(args))
 	return query, args, nil
+}
+
+func findingCandidateListLimit(limit uint32) uint32 {
+	if limit == 0 || limit > maxFindingCandidateListLimit {
+		return defaultFindingCandidateListLimit
+	}
+	return limit
 }
 
 func addFindingCandidateFilter(clauses *[]string, args *[]any, column string, value string) {

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -17,6 +17,11 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
+const (
+	defaultFindingEvidenceListLimit = uint32(500)
+	maxFindingEvidenceListLimit     = uint32(500)
+)
+
 var ensureFindingEvidenceStatements = []string{
 	`CREATE TABLE IF NOT EXISTS finding_evidence (
   id TEXT PRIMARY KEY,
@@ -397,10 +402,8 @@ SELECT finding_evidence_json::text
 FROM finding_evidence
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY ` + findingEvidenceListOrder(request)
-	if request.Limit != 0 {
-		args = append(args, int64(request.Limit))
-		query += fmt.Sprintf(" LIMIT $%d", len(args))
-	}
+	args = append(args, int64(findingEvidenceListLimit(request.Limit)))
+	query += fmt.Sprintf(" LIMIT $%d", len(args))
 	return query, args, nil
 }
 
@@ -414,11 +417,16 @@ SELECT id, runtime_id, rule_id, finding_id, run_id, claim_ids_json::text, event_
 FROM finding_evidence
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY ` + findingEvidenceListOrder(request)
-	if request.Limit != 0 {
-		args = append(args, int64(request.Limit))
-		query += fmt.Sprintf(" LIMIT $%d", len(args))
-	}
+	args = append(args, int64(findingEvidenceListLimit(request.Limit)))
+	query += fmt.Sprintf(" LIMIT $%d", len(args))
 	return query, args, nil
+}
+
+func findingEvidenceListLimit(limit uint32) uint32 {
+	if limit == 0 || limit > maxFindingEvidenceListLimit {
+		return defaultFindingEvidenceListLimit
+	}
+	return limit
 }
 
 func findingEvidenceCountByFindingIDQuery(request ports.ListFindingEvidenceRequest) (string, []any, error) {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -176,6 +176,8 @@ const findingStatusReasonBackfillCollision findingStatusReason = "backfill_colli
 const (
 	tenantScopedFingerprintBackfillActor = "tenant_scoped_fingerprint_backfill"
 	tenantScopedFingerprintBackfillRunID = "tenant_scoped_fingerprint_backfill"
+	defaultFindingListLimit              = uint32(500)
+	maxFindingListLimit                  = uint32(500)
 )
 
 var errTenantScopedFingerprintBackfillRetry = errors.New("retry tenant-scoped fingerprint backfill")
@@ -803,12 +805,27 @@ func (s *Store) UpdateFindingStatus(ctx context.Context, request ports.FindingSt
 	if err != nil {
 		return nil, fmt.Errorf("marshal finding status event ids: %w", err)
 	}
+	expectedStatus := strings.TrimSpace(request.ExpectedStatus)
+	lastObservedBefore := request.LastObservedBefore.UTC()
 	if request.Tombstone != nil {
 		t := request.Tombstone
 		tombstonedAt := t.TombstonedAt.UTC()
 		if tombstonedAt.IsZero() {
 			tombstonedAt = updatedAt
 		}
+		args := []any{
+			findingID,
+			status,
+			statusReason,
+			updatedAt,
+			tombstonedAt,
+			strings.TrimSpace(t.By),
+			strings.TrimSpace(t.Reason),
+			strings.TrimSpace(t.RunID),
+			strings.TrimSpace(t.PriorStatus),
+			eventIDsJSON,
+		}
+		whereClause, args, preconditioned := findingStatusWhereClause(args, expectedStatus, lastObservedBefore)
 		var row findingRow
 		if err := scanFindingRow(s.db.QueryRowContext(ctx, `
 UPDATE findings
@@ -833,26 +850,23 @@ SET status = $2,
       )
     END,
     updated_at = NOW()
-WHERE id = $1
-RETURNING `+findingSelectColumns,
-			findingID,
-			status,
-			statusReason,
-			updatedAt,
-			tombstonedAt,
-			strings.TrimSpace(t.By),
-			strings.TrimSpace(t.Reason),
-			strings.TrimSpace(t.RunID),
-			strings.TrimSpace(t.PriorStatus),
-			eventIDsJSON,
-		), &row); err != nil {
+`+whereClause+`
+RETURNING `+findingSelectColumns, args...), &row); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return nil, ports.ErrFindingNotFound
+				return nil, findingStatusNoRowsError(preconditioned)
 			}
 			return nil, fmt.Errorf("update finding %q tombstone status: %w", findingID, err)
 		}
 		return row.record()
 	}
+	args := []any{
+		findingID,
+		status,
+		statusReason,
+		updatedAt,
+		eventIDsJSON,
+	}
+	whereClause, args, preconditioned := findingStatusWhereClause(args, expectedStatus, lastObservedBefore)
 	var row findingRow
 	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
 UPDATE findings
@@ -871,20 +885,37 @@ SET status = $2,
       )
     END,
     updated_at = NOW()
-WHERE id = $1
-RETURNING `+findingSelectColumns,
-		findingID,
-		status,
-		statusReason,
-		updatedAt,
-		eventIDsJSON,
-	), &row); err != nil {
+`+whereClause+`
+RETURNING `+findingSelectColumns, args...), &row); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ports.ErrFindingNotFound
+			return nil, findingStatusNoRowsError(preconditioned)
 		}
 		return nil, fmt.Errorf("update finding %q status: %w", findingID, err)
 	}
 	return row.record()
+}
+
+func findingStatusWhereClause(args []any, expectedStatus string, lastObservedBefore time.Time) (string, []any, bool) {
+	where := "WHERE id = $1"
+	preconditioned := false
+	if expectedStatus = strings.TrimSpace(expectedStatus); expectedStatus != "" {
+		args = append(args, expectedStatus)
+		where += fmt.Sprintf("\n  AND status = $%d", len(args))
+		preconditioned = true
+	}
+	if !lastObservedBefore.IsZero() {
+		args = append(args, lastObservedBefore.UTC())
+		where += fmt.Sprintf("\n  AND last_observed_at < $%d", len(args))
+		preconditioned = true
+	}
+	return where, args, preconditioned
+}
+
+func findingStatusNoRowsError(preconditioned bool) error {
+	if preconditioned {
+		return ports.ErrFindingStatusPreconditionFailed
+	}
+	return ports.ErrFindingNotFound
 }
 
 // UpdateFindingAssignee updates or clears one persisted finding assignee.
@@ -1111,10 +1142,8 @@ SELECT ` + findingSelectColumns + `
 FROM findings
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY ` + findingOrderClause(request)
-	if request.Limit != 0 {
-		args = append(args, int64(request.Limit))
-		query += fmt.Sprintf(" LIMIT $%d", len(args))
-	}
+	args = append(args, int64(findingListLimit(request.Limit)))
+	query += fmt.Sprintf(" LIMIT $%d", len(args))
 	return query, args, nil
 }
 
@@ -1130,10 +1159,8 @@ SELECT id, tenant_id, runtime_id, rule_id, title, ` + findingEffectiveSeveritySQ
 FROM findings
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY ` + findingOrderClause(request)
-	if request.Limit != 0 {
-		args = append(args, int64(request.Limit))
-		query += fmt.Sprintf(" LIMIT $%d", len(args))
-	}
+	args = append(args, int64(findingListLimit(request.Limit)))
+	query += fmt.Sprintf(" LIMIT $%d", len(args))
 	return query, args, nil
 }
 
@@ -1156,6 +1183,10 @@ func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, e
 	addFindingSeverityFilter(&clauses, &args, request.Severity)
 	addFindingFilter(&clauses, &args, "status", request.Status)
 	addFindingFilter(&clauses, &args, "policy_id", request.PolicyID)
+	if !request.LastObservedBefore.IsZero() {
+		args = append(args, request.LastObservedBefore.UTC())
+		clauses = append(clauses, fmt.Sprintf("last_observed_at < $%d", len(args)))
+	}
 	if err := addFindingArrayContainsFilter(&clauses, &args, "resource_urns_json", request.ResourceURN); err != nil {
 		return nil, nil, err
 	}
@@ -1163,6 +1194,13 @@ func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, e
 		return nil, nil, err
 	}
 	return clauses, args, nil
+}
+
+func findingListLimit(limit uint32) uint32 {
+	if limit == 0 || limit > maxFindingListLimit {
+		return defaultFindingListLimit
+	}
+	return limit
 }
 
 // SupportsTombstones reports whether the tombstone schema has been applied to the

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -176,7 +176,6 @@ const findingStatusReasonBackfillCollision findingStatusReason = "backfill_colli
 const (
 	tenantScopedFingerprintBackfillActor = "tenant_scoped_fingerprint_backfill"
 	tenantScopedFingerprintBackfillRunID = "tenant_scoped_fingerprint_backfill"
-	defaultFindingListLimit              = uint32(500)
 	maxFindingListLimit                  = uint32(500)
 )
 
@@ -1142,8 +1141,10 @@ SELECT ` + findingSelectColumns + `
 FROM findings
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY ` + findingOrderClause(request)
-	args = append(args, int64(findingListLimit(request.Limit)))
-	query += fmt.Sprintf(" LIMIT $%d", len(args))
+	if limit := findingListLimit(request.Limit); limit > 0 {
+		args = append(args, int64(limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
 	return query, args, nil
 }
 
@@ -1159,8 +1160,10 @@ SELECT id, tenant_id, runtime_id, rule_id, title, ` + findingEffectiveSeveritySQ
 FROM findings
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY ` + findingOrderClause(request)
-	args = append(args, int64(findingListLimit(request.Limit)))
-	query += fmt.Sprintf(" LIMIT $%d", len(args))
+	if limit := findingListLimit(request.Limit); limit > 0 {
+		args = append(args, int64(limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
 	return query, args, nil
 }
 
@@ -1197,8 +1200,8 @@ func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, e
 }
 
 func findingListLimit(limit uint32) uint32 {
-	if limit == 0 || limit > maxFindingListLimit {
-		return defaultFindingListLimit
+	if limit > maxFindingListLimit {
+		return maxFindingListLimit
 	}
 	return limit
 }

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -201,7 +201,7 @@ func TestFindingRiskAttributesForUpdateIncludesEffectiveSeverity(t *testing.T) {
 	}
 }
 
-func TestFindingListQueryAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
+func TestFindingListQueryAcceptsTenantAndRuleWithoutRuntimeUnbounded(t *testing.T) {
 	query, args, err := findingListQuery(ports.ListFindingsRequest{
 		TenantID: "writer",
 		RuleID:   "identity-okta-deprovisioned-active-in-github",
@@ -222,17 +222,35 @@ func TestFindingListQueryAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
 	if !strings.Contains(query, "status = $3") {
 		t.Fatalf("findingListQuery() did not slot status at $3 when runtime is omitted: %s", query)
 	}
-	if !strings.Contains(query, "LIMIT $4") {
-		t.Fatalf("findingListQuery() did not apply default LIMIT at $4: %s", query)
+	if strings.Contains(query, "LIMIT") {
+		t.Fatalf("findingListQuery() applied LIMIT for unbounded internal request: %s", query)
 	}
-	if got := len(args); got != 4 {
-		t.Fatalf("len(findingListQuery().args) = %d, want 4", got)
+	if got := len(args); got != 3 {
+		t.Fatalf("len(findingListQuery().args) = %d, want 3", got)
 	}
 	if got := args[1]; got != "identity-okta-deprovisioned-active-in-github" {
 		t.Fatalf("findingListQuery().args[1] = %#v, want rule id", got)
 	}
-	if got := args[3]; got != int64(defaultFindingListLimit) {
-		t.Fatalf("findingListQuery().args[3] = %#v, want default limit", got)
+}
+
+func TestFindingListQueryClampsExplicitLimit(t *testing.T) {
+	query, args, err := findingListQuery(ports.ListFindingsRequest{
+		TenantID: "writer",
+		RuleID:   "identity-okta-deprovisioned-active-in-github",
+		Status:   "open",
+		Limit:    maxFindingListLimit + 1,
+	})
+	if err != nil {
+		t.Fatalf("findingListQuery() error = %v", err)
+	}
+	if !strings.Contains(query, "LIMIT $4") {
+		t.Fatalf("findingListQuery() did not apply LIMIT at $4: %s", query)
+	}
+	if got := len(args); got != 4 {
+		t.Fatalf("len(findingListQuery().args) = %d, want 4", got)
+	}
+	if got := args[3]; got != int64(maxFindingListLimit) {
+		t.Fatalf("findingListQuery().args[3] = %#v, want max limit", got)
 	}
 }
 

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -222,11 +222,17 @@ func TestFindingListQueryAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
 	if !strings.Contains(query, "status = $3") {
 		t.Fatalf("findingListQuery() did not slot status at $3 when runtime is omitted: %s", query)
 	}
-	if got := len(args); got != 3 {
-		t.Fatalf("len(findingListQuery().args) = %d, want 3", got)
+	if !strings.Contains(query, "LIMIT $4") {
+		t.Fatalf("findingListQuery() did not apply default LIMIT at $4: %s", query)
+	}
+	if got := len(args); got != 4 {
+		t.Fatalf("len(findingListQuery().args) = %d, want 4", got)
 	}
 	if got := args[1]; got != "identity-okta-deprovisioned-active-in-github" {
 		t.Fatalf("findingListQuery().args[1] = %#v, want rule id", got)
+	}
+	if got := args[3]; got != int64(defaultFindingListLimit) {
+		t.Fatalf("findingListQuery().args[3] = %#v, want default limit", got)
 	}
 }
 

--- a/internal/statestore/postgres/jobs.go
+++ b/internal/statestore/postgres/jobs.go
@@ -184,59 +184,53 @@ func (s *Store) UpdateJob(ctx context.Context, id string, update ports.JobUpdate
 	if err := s.ensureJobTables(ctx); err != nil {
 		return nil, err
 	}
-	job, err := s.GetJob(ctx, id)
-	if err != nil {
-		return nil, err
+	args := []any{id}
+	setClauses := []string{}
+	addSet := func(column string, value any) {
+		args = append(args, value)
+		setClauses = append(setClauses, fmt.Sprintf("%s = $%d", column, len(args)))
 	}
-	if strings.TrimSpace(update.Status) != "" {
-		job.Status = strings.TrimSpace(update.Status)
+	addJSONSet := func(column string, value string) {
+		args = append(args, value)
+		setClauses = append(setClauses, fmt.Sprintf("%s = $%d::jsonb", column, len(args)))
+	}
+	if status := strings.TrimSpace(update.Status); status != "" {
+		addSet("status", status)
 	}
 	if update.Progress != nil {
-		job.Progress = *update.Progress
+		addSet("progress_percent", *update.Progress)
 	}
 	if update.Message != "" {
-		job.Message = update.Message
+		addSet("message", update.Message)
 	}
 	if update.Error != "" {
-		job.Error = update.Error
+		addSet("error", update.Error)
 	}
 	if update.Result != nil {
-		job.Result = cloneMap(update.Result)
+		result, err := json.Marshal(cloneMap(update.Result))
+		if err != nil {
+			return nil, err
+		}
+		addJSONSet("result_json", string(result))
 	}
 	if update.ResultRefs != nil {
-		job.ResultRefs = cloneStringMap(update.ResultRefs)
+		refs, err := json.Marshal(cloneStringMap(update.ResultRefs))
+		if err != nil {
+			return nil, err
+		}
+		addJSONSet("result_refs_json", string(refs))
 	}
 	if update.StartedAt != nil {
-		job.StartedAt = update.StartedAt.UTC()
+		addSet("started_at", update.StartedAt.UTC())
 	}
 	if update.FinishedAt != nil {
-		job.FinishedAt = update.FinishedAt.UTC()
+		addSet("finished_at", update.FinishedAt.UTC())
 	}
 	if update.CancelRequested != nil {
-		job.CancelRequested = *update.CancelRequested
+		addSet("cancel_requested", *update.CancelRequested)
 	}
-	var cancelRequested any
-	if update.CancelRequested != nil {
-		cancelRequested = job.CancelRequested
-	}
-	result, err := json.Marshal(job.Result)
-	if err != nil {
-		return nil, err
-	}
-	refs, err := json.Marshal(job.ResultRefs)
-	if err != nil {
-		return nil, err
-	}
-	var started any
-	if !job.StartedAt.IsZero() {
-		started = job.StartedAt
-	}
-	var finished any
-	if !job.FinishedAt.IsZero() {
-		finished = job.FinishedAt
-	}
+	setClauses = append(setClauses, "updated_at = NOW()")
 	allowedStatuses := normalizeJobStatuses(update.AllowedStatuses)
-	args := []any{id, job.Status, job.Progress, job.Message, job.Error, string(result), string(refs), started, finished, cancelRequested}
 	clauses := []string{"id = $1"}
 	if len(allowedStatuses) > 0 {
 		placeholders := make([]string, 0, len(allowedStatuses))
@@ -248,11 +242,8 @@ func (s *Store) UpdateJob(ctx context.Context, id string, update ports.JobUpdate
 	}
 	resultExec, err := s.db.ExecContext(ctx, fmt.Sprintf(`
 UPDATE platform_jobs
-SET status = $2, progress_percent = $3, message = $4, error = $5,
-    result_json = $6::jsonb, result_refs_json = $7::jsonb,
-    started_at = COALESCE($8, started_at), finished_at = COALESCE($9, finished_at),
-    cancel_requested = COALESCE($10, cancel_requested), updated_at = NOW()
-WHERE %s`, strings.Join(clauses, " AND ")), args...)
+SET %s
+WHERE %s`, strings.Join(setClauses, ", "), strings.Join(clauses, " AND ")), args...)
 	if err != nil {
 		return nil, fmt.Errorf("update platform job %q: %w", id, err)
 	}

--- a/internal/statestore/postgres/mcp_oauth.go
+++ b/internal/statestore/postgres/mcp_oauth.go
@@ -75,6 +75,14 @@ var ensureMCPOAuthStatements = []string{
 }
 
 func (s *Store) SaveOAuthClient(ctx context.Context, client mcpoauth.OAuthClient) error {
+	return s.saveOAuthClient(ctx, client, 0)
+}
+
+func (s *Store) SaveOAuthClientWithLimit(ctx context.Context, client mcpoauth.OAuthClient, maxClients int) error {
+	return s.saveOAuthClient(ctx, client, maxClients)
+}
+
+func (s *Store) saveOAuthClient(ctx context.Context, client mcpoauth.OAuthClient, maxClients int) error {
 	if err := s.ensureMCPOAuthTables(ctx); err != nil {
 		return err
 	}
@@ -82,17 +90,51 @@ func (s *Store) SaveOAuthClient(ctx context.Context, client mcpoauth.OAuthClient
 	if err != nil {
 		return fmt.Errorf("marshal mcp oauth client redirect URIs: %w", err)
 	}
-	_, err = s.db.ExecContext(ctx, `
-INSERT INTO mcp_oauth_clients (
-  client_id, client_secret, client_name, redirect_uris_json, public, created_at
-) VALUES ($1,$2,$3,$4::jsonb,$5,$6)`,
+	args := []any{
 		strings.TrimSpace(client.ClientID),
 		strings.TrimSpace(client.ClientSecret),
 		strings.TrimSpace(client.Name),
 		redirectURIs,
 		client.Public,
 		nullableUTC(client.CreatedAt),
-	)
+	}
+	if maxClients > 0 {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin save mcp oauth client: %w", err)
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				_ = tx.Rollback()
+			}
+		}()
+		if _, err := tx.ExecContext(ctx, `LOCK TABLE mcp_oauth_clients IN SHARE ROW EXCLUSIVE MODE`); err != nil {
+			return fmt.Errorf("lock mcp oauth clients: %w", err)
+		}
+		var count int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM mcp_oauth_clients`).Scan(&count); err != nil {
+			return fmt.Errorf("count mcp oauth clients: %w", err)
+		}
+		if count >= maxClients {
+			return mcpoauth.ErrOAuthClientLimitExceeded
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO mcp_oauth_clients (
+  client_id, client_secret, client_name, redirect_uris_json, public, created_at
+) VALUES ($1,$2,$3,$4::jsonb,$5,$6)`, args...); err != nil {
+			return fmt.Errorf("save mcp oauth client: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit save mcp oauth client: %w", err)
+		}
+		committed = true
+		return nil
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO mcp_oauth_clients (
+  client_id, client_secret, client_name, redirect_uris_json, public, created_at
+) VALUES ($1,$2,$3,$4::jsonb,$5,$6)`, args...)
 	if err != nil {
 		return fmt.Errorf("save mcp oauth client: %w", err)
 	}

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -31,7 +31,7 @@ const (
 	defaultState        = "open"
 	defaultFamily       = familyPullRequest
 	defaultAuditInclude = "all"
-	defaultAuditOrder   = "desc"
+	defaultAuditOrder   = "asc"
 	familyAudit         = "audit"
 	familyRepository    = "repository"
 	familyDependabot    = "dependabot_alert"

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -20,6 +20,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
 func TestNewLoadsCatalog(t *testing.T) {
@@ -805,7 +806,7 @@ func TestSourceHTTPClientFailsClosedWhenHostResolutionFails(t *testing.T) {
 	}
 }
 
-func TestSourceHTTPClientAllowsHostsResolvingToPublicIPs(t *testing.T) {
+func TestSourceHTTPClientFailsClosedWhenCustomTransportCannotPinResolvedIP(t *testing.T) {
 	called := false
 	client := sourceHTTPClientNoRedirect(&http.Client{
 		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
@@ -823,17 +824,15 @@ func TestSourceHTTPClientAllowsHostsResolvingToPublicIPs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequestWithContext() error = %v", err)
 	}
-	response, err := client.Do(request)
-	if err != nil {
-		t.Fatalf("Do() error = %v", err)
+	resp, err := client.Do(request)
+	if resp != nil {
+		_ = resp.Body.Close()
 	}
-	defer func() {
-		if closeErr := response.Body.Close(); closeErr != nil {
-			t.Fatalf("response.Body.Close() error = %v", closeErr)
-		}
-	}()
-	if !called {
-		t.Fatal("Do() did not reach wrapped transport for public resolved host")
+	if !errors.Is(err, sourcehttp.ErrTransportPinningUnsupported) {
+		t.Fatalf("Do() error = %v, want pinned host dialing error", err)
+	}
+	if called {
+		t.Fatal("Do() reached wrapped transport after pinning failed")
 	}
 }
 
@@ -1054,6 +1053,9 @@ func newGitHubAPIHandler(t *testing.T) http.Handler {
 				t.Fatalf("encode users response: %v", err)
 			}
 		case "/api/v3/orgs/writer/audit-log":
+			if got := r.URL.Query().Get("order"); got != "asc" {
+				t.Fatalf("audit order = %q, want asc", got)
+			}
 			after := r.URL.Query().Get("after")
 			if after == "" {
 				w.Header().Set("Link", "</api/v3/orgs/writer/audit-log?after=cursor-2&before=>; rel=\"next\"")

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -33,7 +33,7 @@ const (
 	oktaHTTPTimeout   = 30 * time.Second
 	maxOktaBodyBytes  = 4 << 20
 	defaultFamily     = familyAudit
-	defaultAuditOrder = "DESCENDING"
+	defaultAuditOrder = "ASCENDING"
 	defaultUserOrder  = "asc"
 	familyAudit       = "audit"
 	familyApplication = "application"
@@ -772,10 +772,10 @@ func uint32FromUint64(value uint64) uint32 {
 
 func normalizeAuditSortOrder(raw string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "", "desc", "descending":
+	case "", "asc", "ascending":
 		return defaultAuditOrder, nil
-	case "asc", "ascending":
-		return "ASCENDING", nil
+	case "desc", "descending":
+		return "DESCENDING", nil
 	default:
 		return "", fmt.Errorf("okta sort_order must be one of asc, desc, ascending, or descending when family=%q", familyAudit)
 	}

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -1794,6 +1794,9 @@ func newOktaAPIHandler(t *testing.T) http.Handler {
 		}
 		switch r.URL.Path {
 		case "/api/v1/logs":
+			if got := r.URL.Query().Get("sortOrder"); got != "ASCENDING" {
+				t.Fatalf("audit sortOrder = %q, want ASCENDING", got)
+			}
 			after := r.URL.Query().Get("after")
 			if after == "" {
 				w.Header().Set("Link", "</api/v1/logs?after=cursor-2&limit=1>; rel=\"next\"")

--- a/sources/panopticon/source_test.go
+++ b/sources/panopticon/source_test.go
@@ -16,6 +16,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
 func TestSpecLoadsFromCatalog(t *testing.T) {
@@ -118,7 +119,7 @@ func TestParseSettings(t *testing.T) {
 	}
 }
 
-func TestPrivateEndpointAllowlistPermitsResolvedPrivatePanopticonHost(t *testing.T) {
+func TestPrivateEndpointAllowlistFailsClosedWhenCustomTransportCannotPin(t *testing.T) {
 	src := &Source{
 		lookupIPAddrs: func(context.Context, string) ([]net.IPAddr, error) {
 			return []net.IPAddr{{IP: net.ParseIP("10.20.0.10")}}, nil
@@ -132,10 +133,12 @@ func TestPrivateEndpointAllowlistPermitsResolvedPrivatePanopticonHost(t *testing
 	}
 	req, _ := http.NewRequest(http.MethodGet, "https://panopticon.internal.example/api/v2/alerts", nil)
 	resp, err := sourceHTTPClient(src, []string{"panopticon.internal.example"}).Do(req)
-	if err != nil {
-		t.Fatalf("Do() error = %v, want private endpoint allowed", err)
+	if resp != nil {
+		_ = resp.Body.Close()
 	}
-	_ = resp.Body.Close()
+	if !errors.Is(err, sourcehttp.ErrTransportPinningUnsupported) {
+		t.Fatalf("Do() error = %v, want pinned host dialing error", err)
+	}
 	req, _ = http.NewRequest(http.MethodGet, "https://panopticon.internal.example/api/v2/alerts", nil)
 	resp, err = sourceHTTPClient(src, nil).Do(req)
 	if resp != nil {


### PR DESCRIPTION
## Summary

- Make TTL finding auto-resolution conditional on the live open/stale row state and page stale candidates.
- Default GitHub and Okta audit polling to ascending order for forward-moving checkpoints.
- Normalize cross-tenant ID lookups to not-found and add guardrails for list limits, OAuth client growth, source HTTP pinning, and duration overflow.

## Test Plan

- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Full local validation: `make verify`.
- Focus review on finding lifecycle CAS behavior, source audit pagination defaults, and ID lookup error normalization.
