### PR TITLE
feat: add source coverage catalog

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2729,6 +2729,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SourceRuntimeHealthSummary'
+        coverage:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageRecord'
+        coverage_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageSummary'
     SourceRuntimeHealthSummary:
       type: object
       properties:
@@ -2796,6 +2804,95 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RuntimeFreshnessSummary'
+        coverage_blind_spots:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageRecord'
+        coverage_blind_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageSummary'
+    SourceCoverageSummary:
+      type: object
+      properties:
+        source_id:
+          type: string
+        total:
+          type: integer
+          minimum: 0
+        healthy:
+          type: integer
+          minimum: 0
+        partial:
+          type: integer
+          minimum: 0
+        unsupported:
+          type: integer
+          minimum: 0
+        unconfigured:
+          type: integer
+          minimum: 0
+        stale:
+          type: integer
+          minimum: 0
+        failed:
+          type: integer
+          minimum: 0
+        unknown:
+          type: integer
+          minimum: 0
+        blind_spots:
+          type: integer
+          minimum: 0
+    SourceCoverageRecord:
+      type: object
+      properties:
+        source_id:
+          type: string
+        tenant_id:
+          type: string
+        dimension_id:
+          type: string
+        dimension_type:
+          type: string
+          enum: [app_entitlement, audit_event, entity_family, incremental_sync, lifecycle_state, relationship, remediation_state]
+        title:
+          type: string
+        state:
+          type: string
+          enum: [healthy, partial, unsupported, unconfigured, stale, failed, unknown]
+        support_level:
+          type: string
+          enum: [supported, partial, unsupported, planned]
+        runtime_id:
+          type: string
+        family:
+          type: string
+        last_synced_at:
+          type: string
+          format: date-time
+        owner_domain:
+          type: string
+        authority_domain:
+          type: string
+        high_value:
+          type: boolean
+        blind_spot:
+          type: boolean
+        warning:
+          type: string
+        known_unsupported_fields:
+          type: array
+          items:
+            type: string
+        notes:
+          type: array
+          items:
+            type: string
+        supported_runtime_families:
+          type: array
+          items:
+            type: string
     RuntimeFreshnessSummary:
       type: object
       properties:

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -35,12 +36,14 @@ type grcScope struct {
 }
 
 type grcDashboardResponse struct {
-	Summary     grcSummary        `json:"summary"`
-	Findings    []grcFindingItem  `json:"findings"`
-	Controls    []grcControlItem  `json:"controls"`
-	Evidence    []grcEvidenceItem `json:"evidence"`
-	Connectors  []grcConnector    `json:"connectors"`
-	GeneratedAt time.Time         `json:"generated_at"`
+	Summary            grcSummary               `json:"summary"`
+	Findings           []grcFindingItem         `json:"findings"`
+	Controls           []grcControlItem         `json:"controls"`
+	Evidence           []grcEvidenceItem        `json:"evidence"`
+	Connectors         []grcConnector           `json:"connectors"`
+	CoverageBlindSpots []sourcecoverage.Record  `json:"coverage_blind_spots,omitempty"`
+	CoverageSummaries  []sourcecoverage.Summary `json:"coverage_summaries,omitempty"`
+	GeneratedAt        time.Time                `json:"generated_at"`
 }
 
 type grcSummary struct {
@@ -252,17 +255,21 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	findingItems := grcFindingItems(findings, runtimeSourceIDs, evidenceCounts)
 	evidenceItems := grcEvidenceItems(evidence, grcFindingTitleMap(findings))
 	controls := grcControlItems(findingItems, evidenceItems)
+	coverage := a.sourceCoverageRecords(runtimes, ports.SourceRuntimeFilter{TenantID: scope.TenantID, SourceID: scope.SourceID}, time.Now().UTC())
+	coverageBlindSpots := sourcecoverage.BlindSpots(coverage)
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "runtime_count", Value: len(runtimes)})
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "finding_count", Value: len(findingItems)})
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "evidence_count", Value: len(evidenceItems)})
 
 	writeJSON(w, http.StatusOK, grcDashboardResponse{
-		Summary:     grcBuildSummary(findingItems, controls, evidenceItems, runtimes, findingSummary, evidenceCount),
-		Findings:    grcLimitFindings(findingItems, 25),
-		Controls:    grcLimitControls(controls, 25),
-		Evidence:    grcLimitEvidence(evidenceItems, 25),
-		Connectors:  grcConnectorItems(runtimes),
-		GeneratedAt: time.Now().UTC(),
+		Summary:            grcBuildSummary(findingItems, controls, evidenceItems, runtimes, findingSummary, evidenceCount),
+		Findings:           grcLimitFindings(findingItems, 25),
+		Controls:           grcLimitControls(controls, 25),
+		Evidence:           grcLimitEvidence(evidenceItems, 25),
+		Connectors:         grcConnectorItems(runtimes),
+		CoverageBlindSpots: coverageBlindSpots,
+		CoverageSummaries:  sourcecoverage.Summaries(coverageBlindSpots),
+		GeneratedAt:        time.Now().UTC(),
 	})
 }
 

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -268,7 +268,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		Evidence:           grcLimitEvidence(evidenceItems, 25),
 		Connectors:         grcConnectorItems(runtimes),
 		CoverageBlindSpots: coverageBlindSpots,
-		CoverageSummaries:  sourcecoverage.Summaries(coverageBlindSpots),
+		CoverageSummaries:  sourcecoverage.Summaries(coverage),
 		GeneratedAt:        time.Now().UTC(),
 	})
 }

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -433,6 +434,7 @@ func TestGRCDashboardCapsPreviewWorkToRenderedLimit(t *testing.T) {
 				TenantId:     tenantID,
 				LastSyncedAt: timestamppb.New(now),
 				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)},
+				Config:       map[string]string{"family": "user"},
 			},
 		},
 		findings:        map[string]*ports.FindingRecord{},
@@ -457,7 +459,11 @@ func TestGRCDashboardCapsPreviewWorkToRenderedLimit(t *testing.T) {
 			CreatedAt: timestamppb.New(now.Add(-time.Duration(i) * time.Minute)),
 		}
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	registry, err := sourcecdk.NewRegistry(sourceCoverageHealthSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -493,6 +499,16 @@ func TestGRCDashboardCapsPreviewWorkToRenderedLimit(t *testing.T) {
 	}
 	if store.aggregateCalls != 1 {
 		t.Fatalf("aggregate calls = %d, want 1", store.aggregateCalls)
+	}
+	if got := len(payload.CoverageBlindSpots); got != 2 {
+		t.Fatalf("coverage blind spots = %d, want 2: %#v", got, payload.CoverageBlindSpots)
+	}
+	if got := len(payload.CoverageSummaries); got != 1 {
+		t.Fatalf("coverage summaries = %d, want 1: %#v", got, payload.CoverageSummaries)
+	}
+	summary := payload.CoverageSummaries[0]
+	if summary.Total != 3 || summary.Healthy != 1 || summary.BlindSpots != 2 {
+		t.Fatalf("coverage summary = %+v, want total=3 healthy=1 blind_spots=2", summary)
 	}
 }
 

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -283,6 +283,7 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 	}
 	generatedAt := time.Now().UTC()
 	records := make([]sourceRuntimeHealthRecord, 0, len(runtimes))
+	visibleRuntimes := make([]*cerebrov1.SourceRuntime, 0, len(runtimes))
 	for _, runtime := range runtimes {
 		if runtime == nil {
 			continue
@@ -290,13 +291,14 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 		if requiresTenantFilter(r.Context()) && !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
 			continue
 		}
+		visibleRuntimes = append(visibleRuntimes, runtime)
 		record, err := a.sourceRuntimeHealthRecord(r.Context(), runtime, generatedAt)
 		if err != nil {
 			return sourceRuntimeHealthResponse{}, err
 		}
 		records = append(records, record)
 	}
-	coverage := a.sourceCoverageRecords(runtimes, filter, generatedAt)
+	coverage := a.sourceCoverageRecords(visibleRuntimes, filter, generatedAt)
 	return sourceRuntimeHealthResponse{
 		GeneratedAt:     generatedAt.Format(time.RFC3339Nano),
 		Runtimes:        records,
@@ -319,9 +321,6 @@ func runtimeFreshnessFromHealth(health sourceRuntimeHealthResponse) runtimeFresh
 		}
 	}
 	blindSpots := sourcecoverage.BlindSpots(health.Coverage)
-	if len(blindSpots) > 0 {
-		status = "degraded"
-	}
 	return runtimeFreshnessResponse{
 		GeneratedAt:          health.GeneratedAt,
 		Status:               status,

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -14,6 +14,7 @@ import (
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -22,13 +23,17 @@ type sourceRuntimeHealthResponse struct {
 	GeneratedAt     string                       `json:"generated_at"`
 	Runtimes        []sourceRuntimeHealthRecord  `json:"runtimes"`
 	SourceSummaries []sourceRuntimeHealthSummary `json:"source_summaries"`
+	Coverage        []sourcecoverage.Record      `json:"coverage,omitempty"`
+	CoverageSummary []sourcecoverage.Summary     `json:"coverage_summaries,omitempty"`
 }
 
 type runtimeFreshnessResponse struct {
-	GeneratedAt string                    `json:"generated_at"`
-	Status      string                    `json:"status"`
-	Runtimes    []runtimeFreshnessRecord  `json:"runtimes"`
-	Summaries   []runtimeFreshnessSummary `json:"summaries"`
+	GeneratedAt          string                    `json:"generated_at"`
+	Status               string                    `json:"status"`
+	Runtimes             []runtimeFreshnessRecord  `json:"runtimes"`
+	Summaries            []runtimeFreshnessSummary `json:"summaries"`
+	CoverageBlindSpots   []sourcecoverage.Record   `json:"coverage_blind_spots,omitempty"`
+	CoverageBlindSummary []sourcecoverage.Summary  `json:"coverage_blind_summaries,omitempty"`
 }
 
 type runtimeFreshnessSummary struct {
@@ -291,10 +296,13 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 		}
 		records = append(records, record)
 	}
+	coverage := a.sourceCoverageRecords(runtimes, filter, generatedAt)
 	return sourceRuntimeHealthResponse{
 		GeneratedAt:     generatedAt.Format(time.RFC3339Nano),
 		Runtimes:        records,
 		SourceSummaries: sourceRuntimeHealthSummaries(records),
+		Coverage:        coverage,
+		CoverageSummary: sourcecoverage.Summaries(coverage),
 	}, nil
 }
 
@@ -310,12 +318,35 @@ func runtimeFreshnessFromHealth(health sourceRuntimeHealthResponse) runtimeFresh
 			break
 		}
 	}
-	return runtimeFreshnessResponse{
-		GeneratedAt: health.GeneratedAt,
-		Status:      status,
-		Runtimes:    records,
-		Summaries:   runtimeFreshnessSummaries(records),
+	blindSpots := sourcecoverage.BlindSpots(health.Coverage)
+	if len(blindSpots) > 0 {
+		status = "degraded"
 	}
+	return runtimeFreshnessResponse{
+		GeneratedAt:          health.GeneratedAt,
+		Status:               status,
+		Runtimes:             records,
+		Summaries:            runtimeFreshnessSummaries(records),
+		CoverageBlindSpots:   blindSpots,
+		CoverageBlindSummary: sourcecoverage.Summaries(blindSpots),
+	}
+}
+
+func (a *App) sourceCoverageRecords(runtimes []*cerebrov1.SourceRuntime, filter ports.SourceRuntimeFilter, generatedAt time.Time) []sourcecoverage.Record {
+	if a == nil || a.sources == nil {
+		return nil
+	}
+	contracts := sourcecoverage.ContractsFromRegistry(a.sources)
+	if len(contracts) == 0 {
+		return nil
+	}
+	observations := sourcecoverage.ObservationsFromRuntimes(runtimes, func(runtime *cerebrov1.SourceRuntime) string {
+		return runtimeHealthStatus(runtime, generatedAt)
+	})
+	return sourcecoverage.Evaluate(contracts, observations, sourcecoverage.Options{
+		TenantID: strings.TrimSpace(filter.TenantID),
+		SourceID: strings.TrimSpace(filter.SourceID),
+	})
 }
 
 func runtimeFreshnessRecordFromHealth(record sourceRuntimeHealthRecord) runtimeFreshnessRecord {

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -353,6 +354,59 @@ func TestSourceCoverageRecordsSurfacesBlindSpots(t *testing.T) {
 	}
 }
 
+func TestListSourceRuntimeHealthFiltersCoverageByAllowedTenant(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(sourceCoverageHealthSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	store := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-okta-user": {
+			Id:           "writer-okta-user",
+			SourceId:     "okta",
+			TenantId:     "writer",
+			LastSyncedAt: timestamppb.New(now),
+			Config:       map[string]string{"family": "user"},
+		},
+		"other-okta-application": {
+			Id:           "other-okta-application",
+			SourceId:     "okta",
+			TenantId:     "other",
+			LastSyncedAt: timestamppb.New(now),
+			Config:       map[string]string{"family": "application"},
+		},
+	}}
+	app := &App{deps: Dependencies{StateStore: store}, sources: registry}
+	req := httptest.NewRequest("GET", "/source-runtime-health?runtime_ids=writer-okta-user,other-okta-application", nil)
+	req = req.WithContext(context.WithValue(req.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{AllowedTenants: []string{"writer"}},
+	}))
+
+	response, err := app.listSourceRuntimeHealth(req)
+	if err != nil {
+		t.Fatalf("listSourceRuntimeHealth() error = %v", err)
+	}
+	if len(response.Runtimes) != 1 || response.Runtimes[0].RuntimeID != "writer-okta-user" {
+		t.Fatalf("Runtimes = %#v, want only writer-okta-user", response.Runtimes)
+	}
+	byDimension := map[string]sourcecoverage.Record{}
+	for _, record := range response.Coverage {
+		if record.RuntimeID == "other-okta-application" || record.TenantID == "other" {
+			t.Fatalf("coverage leaked forbidden tenant runtime: %#v", record)
+		}
+		byDimension[record.DimensionID] = record
+	}
+	if got := byDimension["users"].RuntimeID; got != "writer-okta-user" {
+		t.Fatalf("users coverage runtime_id = %q, want writer-okta-user", got)
+	}
+	if got := byDimension["applications"].State; got != sourcecoverage.StateUnconfigured {
+		t.Fatalf("applications state = %q, want unconfigured; coverage=%#v", got, response.Coverage)
+	}
+	if got := byDimension["applications"].RuntimeID; got != "" {
+		t.Fatalf("applications runtime_id = %q, want empty", got)
+	}
+}
+
 func TestRuntimeFreshnessIncludesCoverageBlindSpots(t *testing.T) {
 	health := sourceRuntimeHealthResponse{
 		GeneratedAt: "2026-06-15T00:00:00Z",
@@ -370,8 +424,8 @@ func TestRuntimeFreshnessIncludesCoverageBlindSpots(t *testing.T) {
 
 	response := runtimeFreshnessFromHealth(health)
 
-	if response.Status != "degraded" {
-		t.Fatalf("Status = %q, want degraded", response.Status)
+	if response.Status != "healthy" {
+		t.Fatalf("Status = %q, want healthy", response.Status)
 	}
 	if len(response.CoverageBlindSpots) != 1 || response.CoverageBlindSpots[0].DimensionID != "applications" {
 		t.Fatalf("CoverageBlindSpots = %#v", response.CoverageBlindSpots)

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -8,6 +8,9 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcecoverage"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -315,6 +318,69 @@ func TestRuntimeFreshnessFromHealthTreatsRunningGraphAsHealthy(t *testing.T) {
 	}
 }
 
+func TestSourceCoverageRecordsSurfacesBlindSpots(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(sourceCoverageHealthSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	app := &App{sources: registry}
+
+	records := app.sourceCoverageRecords([]*cerebrov1.SourceRuntime{{
+		Id:           "okta-user",
+		SourceId:     "okta",
+		TenantId:     "writer",
+		LastSyncedAt: timestamppb.New(now),
+		Config:       map[string]string{"family": "user"},
+	}}, ports.SourceRuntimeFilter{TenantID: "writer", SourceID: "okta"}, now)
+
+	byDimension := map[string]sourcecoverage.Record{}
+	for _, record := range records {
+		byDimension[record.DimensionID] = record
+	}
+	if got := byDimension["users"].State; got != sourcecoverage.StateHealthy {
+		t.Fatalf("users state = %q, want healthy; records=%#v", got, records)
+	}
+	if got := byDimension["applications"].State; got != sourcecoverage.StateUnconfigured {
+		t.Fatalf("applications state = %q, want unconfigured; records=%#v", got, records)
+	}
+	if got := byDimension["remediation"].State; got != sourcecoverage.StateUnsupported {
+		t.Fatalf("remediation state = %q, want unsupported; records=%#v", got, records)
+	}
+	blindSpots := sourcecoverage.BlindSpots(records)
+	if len(blindSpots) != 2 {
+		t.Fatalf("len(BlindSpots()) = %d, want 2: %#v", len(blindSpots), blindSpots)
+	}
+}
+
+func TestRuntimeFreshnessIncludesCoverageBlindSpots(t *testing.T) {
+	health := sourceRuntimeHealthResponse{
+		GeneratedAt: "2026-06-15T00:00:00Z",
+		Coverage: []sourcecoverage.Record{{
+			SourceID:      "okta",
+			DimensionID:   "applications",
+			DimensionType: "entity_family",
+			Title:         "Applications",
+			State:         sourcecoverage.StateUnconfigured,
+			SupportLevel:  sourcecdk.CoverageSupportSupported,
+			HighValue:     true,
+			BlindSpot:     true,
+		}},
+	}
+
+	response := runtimeFreshnessFromHealth(health)
+
+	if response.Status != "degraded" {
+		t.Fatalf("Status = %q, want degraded", response.Status)
+	}
+	if len(response.CoverageBlindSpots) != 1 || response.CoverageBlindSpots[0].DimensionID != "applications" {
+		t.Fatalf("CoverageBlindSpots = %#v", response.CoverageBlindSpots)
+	}
+	if len(response.CoverageBlindSummary) != 1 || response.CoverageBlindSummary[0].BlindSpots != 1 {
+		t.Fatalf("CoverageBlindSummary = %#v", response.CoverageBlindSummary)
+	}
+}
+
 func FuzzRuntimeHealthConfigParsing(f *testing.F) {
 	f.Add("", "", "")
 	f.Add("3600", "7200", "passing")
@@ -343,6 +409,37 @@ func FuzzRuntimeHealthConfigParsing(f *testing.F) {
 			t.Fatalf("runtimeContractProbeState() = %q, want trimmed probe", got)
 		}
 	})
+}
+
+type sourceCoverageHealthSource struct{}
+
+func (sourceCoverageHealthSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "okta", Name: "Okta"}
+}
+
+func (sourceCoverageHealthSource) CoverageContract() sourcecdk.CoverageContract {
+	return sourcecdk.CoverageContract{
+		SourceID:        "okta",
+		OwnerDomain:     "identity",
+		AuthorityDomain: "okta",
+		Dimensions: []sourcecdk.CoverageDimension{
+			{ID: "users", Type: "entity_family", Title: "Users", Families: []string{"user"}, Support: sourcecdk.CoverageSupportSupported, HighValue: true},
+			{ID: "applications", Type: "entity_family", Title: "Applications", Families: []string{"application"}, Support: sourcecdk.CoverageSupportSupported, HighValue: true},
+			{ID: "remediation", Type: "remediation_state", Title: "Remediation lifecycle", Support: sourcecdk.CoverageSupportUnsupported, HighValue: true},
+		},
+	}
+}
+
+func (sourceCoverageHealthSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (sourceCoverageHealthSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (sourceCoverageHealthSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{}, nil
 }
 
 func FuzzSourceRuntimeHealthSummaries(f *testing.F) {

--- a/internal/sourcecdk/catalog.go
+++ b/internal/sourcecdk/catalog.go
@@ -10,7 +10,10 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-var catalogEventContracts sync.Map
+var (
+	catalogEventContracts    sync.Map
+	catalogCoverageContracts sync.Map
+)
 
 type catalogFile struct {
 	ID             string                 `yaml:"id"`
@@ -19,6 +22,7 @@ type catalogFile struct {
 	EmittedKinds   []string               `yaml:"emitted_kinds"`
 	KindLifecycle  []catalogKindLifecycle `yaml:"kind_lifecycle"`
 	EventContracts []EventContract        `yaml:"event_contracts"`
+	Coverage       CoverageContract       `yaml:"coverage_contract"`
 }
 
 type catalogKindLifecycle struct {
@@ -28,8 +32,9 @@ type catalogKindLifecycle struct {
 }
 
 type SourceCatalog struct {
-	Spec           *cerebrov1.SourceSpec
-	EventContracts []EventContract
+	Spec             *cerebrov1.SourceSpec
+	EventContracts   []EventContract
+	CoverageContract *CoverageContract
 }
 
 // LoadCatalog parses a source catalog.yaml file into a source spec.
@@ -67,13 +72,23 @@ func LoadSourceCatalog(data []byte) (*SourceCatalog, error) {
 	if err != nil {
 		return nil, err
 	}
+	coverageContract, err := NormalizeCoverageContract(catalog.ID, catalog.Coverage)
+	if err != nil {
+		return nil, err
+	}
 	registerCatalogEventContracts(catalog.ID, eventContracts)
+	registerCatalogCoverageContract(catalog.ID, coverageContract)
+	var coverage *CoverageContract
+	if len(coverageContract.Dimensions) > 0 {
+		cloned := cloneCoverageContract(coverageContract)
+		coverage = &cloned
+	}
 	return &SourceCatalog{Spec: &cerebrov1.SourceSpec{
 		Id:           catalog.ID,
 		Name:         catalog.Name,
 		Description:  catalog.Description,
 		EmittedKinds: emittedKinds,
-	}, EventContracts: eventContracts}, nil
+	}, EventContracts: eventContracts, CoverageContract: coverage}, nil
 }
 
 func registerCatalogEventContracts(sourceID string, contracts []EventContract) {
@@ -98,6 +113,31 @@ func catalogEventContractsForSource(sourceID string) []EventContract {
 		return nil
 	}
 	return cloneEventContracts(contracts)
+}
+
+func registerCatalogCoverageContract(sourceID string, contract CoverageContract) {
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return
+	}
+	if len(contract.Dimensions) == 0 {
+		catalogCoverageContracts.Delete(sourceID)
+		return
+	}
+	catalogCoverageContracts.Store(sourceID, cloneCoverageContract(contract))
+}
+
+func catalogCoverageContractForSource(sourceID string) *CoverageContract {
+	value, ok := catalogCoverageContracts.Load(strings.TrimSpace(sourceID))
+	if !ok {
+		return nil
+	}
+	contract, ok := value.(CoverageContract)
+	if !ok {
+		return nil
+	}
+	cloned := cloneCoverageContract(contract)
+	return &cloned
 }
 
 func normalizeCatalogKinds(values []string) ([]string, error) {

--- a/internal/sourcecdk/catalog_test.go
+++ b/internal/sourcecdk/catalog_test.go
@@ -92,6 +92,45 @@ event_contracts:
 	}
 }
 
+func TestLoadSourceCatalogParsesCoverageContract(t *testing.T) {
+	catalog, err := LoadSourceCatalog([]byte(`
+id: okta
+name: Okta
+emitted_kinds:
+  - okta.audit
+coverage_contract:
+  owner_domain: identity
+  authority_domain: okta
+  dimensions:
+    - id: users
+      type: entity_family
+      title: Users
+      families: [user]
+      support: supported
+      high_value: true
+    - id: remediation
+      type: remediation_state
+      title: Remediation lifecycle
+      support: unsupported
+      known_unsupported_fields: [app remediation state]
+`))
+	if err != nil {
+		t.Fatalf("LoadSourceCatalog() error = %v", err)
+	}
+	if catalog.CoverageContract == nil {
+		t.Fatal("CoverageContract = nil, want parsed contract")
+	}
+	if catalog.CoverageContract.SourceID != "okta" || catalog.CoverageContract.AuthorityDomain != "okta" {
+		t.Fatalf("CoverageContract = %#v", catalog.CoverageContract)
+	}
+	if len(catalog.CoverageContract.Dimensions) != 2 {
+		t.Fatalf("len(Dimensions) = %d, want 2", len(catalog.CoverageContract.Dimensions))
+	}
+	if got := catalog.CoverageContract.Dimensions[1].Support; got != CoverageSupportUnsupported {
+		t.Fatalf("Dimensions[1].Support = %q, want unsupported", got)
+	}
+}
+
 func TestNewRegistryPreservesCatalogEventContracts(t *testing.T) {
 	_, err := LoadSourceCatalog([]byte(`
 id: contract_source
@@ -124,6 +163,46 @@ event_contracts:
 	}
 }
 
+func TestNewRegistryPreservesCatalogCoverageContracts(t *testing.T) {
+	_, err := LoadSourceCatalog([]byte(`
+id: coverage_source
+name: Coverage Source
+emitted_kinds:
+  - coverage_source.user
+coverage_contract:
+  owner_domain: identity
+  dimensions:
+    - id: users
+      type: entity_family
+      title: Users
+      families: [user]
+      support: supported
+      high_value: true
+`))
+	if err != nil {
+		t.Fatalf("LoadSourceCatalog() error = %v", err)
+	}
+	registry, err := NewRegistry(catalogTestSource{id: "coverage_source"})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	registered, ok := registry.Get("coverage_source")
+	if !ok {
+		t.Fatal("registry missing coverage_source")
+	}
+	provider, ok := registered.(CoverageContractProvider)
+	if !ok {
+		t.Fatalf("registered source does not implement CoverageContractProvider")
+	}
+	if got := provider.CoverageContract(); got.SourceID != "coverage_source" || len(got.Dimensions) != 1 {
+		t.Fatalf("CoverageContract() = %#v, want coverage_source contract", got)
+	}
+	contracts := registry.CoverageContracts()
+	if len(contracts) != 1 || contracts[0].SourceID != "coverage_source" {
+		t.Fatalf("CoverageContracts() = %#v, want coverage_source", contracts)
+	}
+}
+
 type catalogTestSource struct {
 	id string
 }
@@ -153,5 +232,20 @@ kind_lifecycle:
     status: maybe
 `)); err == nil {
 		t.Fatal("LoadCatalog() error = nil, want invalid lifecycle status error")
+	}
+}
+
+func TestLoadCatalogRejectsInvalidCoverageContract(t *testing.T) {
+	if _, err := LoadCatalog([]byte(`
+id: okta
+name: Okta
+coverage_contract:
+  dimensions:
+    - id: users
+      type: entity_family
+      title: Users
+      support: maybe
+`)); err == nil {
+		t.Fatal("LoadCatalog() error = nil, want invalid coverage support error")
 	}
 }

--- a/internal/sourcecdk/coverage_contract.go
+++ b/internal/sourcecdk/coverage_contract.go
@@ -1,0 +1,131 @@
+package sourcecdk
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	CoverageSupportSupported   = "supported"
+	CoverageSupportPartial     = "partial"
+	CoverageSupportUnsupported = "unsupported"
+	CoverageSupportPlanned     = "planned"
+)
+
+// CoverageContract describes the source-backed coverage a connector can claim.
+type CoverageContract struct {
+	SourceID        string              `json:"source_id" yaml:"source_id"`
+	OwnerDomain     string              `json:"owner_domain,omitempty" yaml:"owner_domain"`
+	AuthorityDomain string              `json:"authority_domain,omitempty" yaml:"authority_domain"`
+	Dimensions      []CoverageDimension `json:"dimensions,omitempty" yaml:"dimensions"`
+}
+
+// CoverageDimension is one machine-readable coverage claim or explicit gap.
+type CoverageDimension struct {
+	ID                     string   `json:"id" yaml:"id"`
+	Type                   string   `json:"type" yaml:"type"`
+	Title                  string   `json:"title" yaml:"title"`
+	Families               []string `json:"families,omitempty" yaml:"families"`
+	Support                string   `json:"support" yaml:"support"`
+	HighValue              bool     `json:"high_value,omitempty" yaml:"high_value"`
+	KnownUnsupportedFields []string `json:"known_unsupported_fields,omitempty" yaml:"known_unsupported_fields"`
+	Notes                  []string `json:"notes,omitempty" yaml:"notes"`
+}
+
+func NormalizeCoverageContract(sourceID string, contract CoverageContract) (CoverageContract, error) {
+	normalized := CoverageContract{
+		SourceID:        strings.TrimSpace(contract.SourceID),
+		OwnerDomain:     strings.TrimSpace(contract.OwnerDomain),
+		AuthorityDomain: strings.TrimSpace(contract.AuthorityDomain),
+	}
+	sourceID = strings.TrimSpace(sourceID)
+	if normalized.SourceID == "" {
+		normalized.SourceID = sourceID
+	}
+	if normalized.SourceID == "" {
+		return CoverageContract{}, fmt.Errorf("coverage_contract source_id is required")
+	}
+	if sourceID != "" && normalized.SourceID != sourceID {
+		return CoverageContract{}, fmt.Errorf("coverage_contract source_id %q does not match catalog %q", normalized.SourceID, sourceID)
+	}
+	seen := map[string]struct{}{}
+	for _, dimension := range contract.Dimensions {
+		next, err := normalizeCoverageDimension(dimension)
+		if err != nil {
+			return CoverageContract{}, err
+		}
+		if _, ok := seen[next.ID]; ok {
+			return CoverageContract{}, fmt.Errorf("duplicate coverage_contract dimension %q", next.ID)
+		}
+		seen[next.ID] = struct{}{}
+		normalized.Dimensions = append(normalized.Dimensions, next)
+	}
+	sort.Slice(normalized.Dimensions, func(i int, j int) bool {
+		if normalized.Dimensions[i].Type != normalized.Dimensions[j].Type {
+			return normalized.Dimensions[i].Type < normalized.Dimensions[j].Type
+		}
+		return normalized.Dimensions[i].ID < normalized.Dimensions[j].ID
+	})
+	return normalized, nil
+}
+
+func normalizeCoverageDimension(dimension CoverageDimension) (CoverageDimension, error) {
+	normalized := CoverageDimension{
+		ID:                     strings.TrimSpace(dimension.ID),
+		Type:                   strings.TrimSpace(dimension.Type),
+		Title:                  strings.TrimSpace(dimension.Title),
+		Families:               uniqueTrimmedStrings(dimension.Families),
+		Support:                strings.ToLower(strings.TrimSpace(dimension.Support)),
+		HighValue:              dimension.HighValue,
+		KnownUnsupportedFields: uniqueTrimmedStrings(dimension.KnownUnsupportedFields),
+		Notes:                  uniqueTrimmedStrings(dimension.Notes),
+	}
+	if normalized.ID == "" {
+		return CoverageDimension{}, fmt.Errorf("coverage_contract dimension id is required")
+	}
+	if !validIdentifierPart(normalized.ID) {
+		return CoverageDimension{}, fmt.Errorf("coverage_contract dimension id %q must use lowercase identifier syntax", normalized.ID)
+	}
+	switch normalized.Type {
+	case "app_entitlement", "audit_event", "entity_family", "incremental_sync", "lifecycle_state", "relationship", "remediation_state":
+	default:
+		return CoverageDimension{}, fmt.Errorf("coverage_contract dimension %q has invalid type %q", normalized.ID, dimension.Type)
+	}
+	if normalized.Title == "" {
+		return CoverageDimension{}, fmt.Errorf("coverage_contract dimension %q title is required", normalized.ID)
+	}
+	switch normalized.Support {
+	case CoverageSupportSupported, CoverageSupportPartial, CoverageSupportUnsupported, CoverageSupportPlanned:
+	default:
+		return CoverageDimension{}, fmt.Errorf("coverage_contract dimension %q has invalid support %q", normalized.ID, dimension.Support)
+	}
+	for _, family := range normalized.Families {
+		if !validIdentifierPart(family) {
+			return CoverageDimension{}, fmt.Errorf("coverage_contract dimension %q family %q must use lowercase identifier syntax", normalized.ID, family)
+		}
+	}
+	return normalized, nil
+}
+
+func cloneCoverageContract(contract CoverageContract) CoverageContract {
+	cloned := CoverageContract{
+		SourceID:        contract.SourceID,
+		OwnerDomain:     contract.OwnerDomain,
+		AuthorityDomain: contract.AuthorityDomain,
+		Dimensions:      make([]CoverageDimension, len(contract.Dimensions)),
+	}
+	for i, dimension := range contract.Dimensions {
+		cloned.Dimensions[i] = CoverageDimension{
+			ID:                     dimension.ID,
+			Type:                   dimension.Type,
+			Title:                  dimension.Title,
+			Families:               append([]string(nil), dimension.Families...),
+			Support:                dimension.Support,
+			HighValue:              dimension.HighValue,
+			KnownUnsupportedFields: append([]string(nil), dimension.KnownUnsupportedFields...),
+			Notes:                  append([]string(nil), dimension.Notes...),
+		}
+	}
+	return cloned
+}

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -94,6 +94,11 @@ type EventContractProvider interface {
 	EventContracts() []EventContract
 }
 
+// CoverageContractProvider lets sources expose machine-readable collection coverage.
+type CoverageContractProvider interface {
+	CoverageContract() CoverageContract
+}
+
 // Registry indexes sources by their stable identifier.
 type Registry struct {
 	sources map[string]Source
@@ -122,6 +127,7 @@ func NewRegistry(sources ...Source) (*Registry, error) {
 			return nil, fmt.Errorf("duplicate source id %q", id)
 		}
 		source = sourceWithCatalogEventContracts(source, id)
+		source = sourceWithCatalogCoverageContract(source, id)
 		indexed[id] = source
 	}
 	return &Registry{sources: indexed}, nil
@@ -148,6 +154,29 @@ func sourceWithCatalogEventContracts(source Source, sourceID string) Source {
 		return source
 	}
 	return &catalogContractSource{Source: source, contracts: contracts}
+}
+
+type catalogCoverageSource struct {
+	Source
+	coverage CoverageContract
+}
+
+func (s *catalogCoverageSource) CoverageContract() CoverageContract {
+	if s == nil {
+		return CoverageContract{}
+	}
+	return cloneCoverageContract(s.coverage)
+}
+
+func sourceWithCatalogCoverageContract(source Source, sourceID string) Source {
+	if _, ok := source.(CoverageContractProvider); ok {
+		return source
+	}
+	contract := catalogCoverageContractForSource(sourceID)
+	if contract == nil {
+		return source
+	}
+	return &catalogCoverageSource{Source: source, coverage: cloneCoverageContract(*contract)}
 }
 
 func sourceIsNil(source Source) bool {
@@ -187,4 +216,29 @@ func (r *Registry) List() []*cerebrov1.SourceSpec {
 		specs = append(specs, r.sources[id].Spec())
 	}
 	return specs
+}
+
+// CoverageContracts returns source coverage contracts sorted by source ID.
+func (r *Registry) CoverageContracts() []CoverageContract {
+	if r == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(r.sources))
+	for id := range r.sources {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	contracts := make([]CoverageContract, 0, len(ids))
+	for _, id := range ids {
+		provider, ok := r.sources[id].(CoverageContractProvider)
+		if !ok {
+			continue
+		}
+		contract := provider.CoverageContract()
+		if len(contract.Dimensions) == 0 {
+			continue
+		}
+		contracts = append(contracts, cloneCoverageContract(contract))
+	}
+	return contracts
 }

--- a/internal/sourcecoverage/coverage.go
+++ b/internal/sourcecoverage/coverage.go
@@ -1,0 +1,358 @@
+package sourcecoverage
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	StateHealthy      = "healthy"
+	StatePartial      = "partial"
+	StateUnsupported  = "unsupported"
+	StateUnconfigured = "unconfigured"
+	StateStale        = "stale"
+	StateFailed       = "failed"
+	StateUnknown      = "unknown"
+)
+
+type Options struct {
+	TenantID string
+	SourceID string
+}
+
+type RuntimeObservation struct {
+	RuntimeID           string
+	SourceID            string
+	TenantID            string
+	Family              string
+	Status              string
+	LastFailureCategory string
+	LastSyncedAt        string
+}
+
+type Record struct {
+	SourceID                 string   `json:"source_id"`
+	TenantID                 string   `json:"tenant_id,omitempty"`
+	DimensionID              string   `json:"dimension_id"`
+	DimensionType            string   `json:"dimension_type"`
+	Title                    string   `json:"title"`
+	State                    string   `json:"state"`
+	SupportLevel             string   `json:"support_level"`
+	RuntimeID                string   `json:"runtime_id,omitempty"`
+	Family                   string   `json:"family,omitempty"`
+	LastSyncedAt             string   `json:"last_synced_at,omitempty"`
+	OwnerDomain              string   `json:"owner_domain,omitempty"`
+	AuthorityDomain          string   `json:"authority_domain,omitempty"`
+	HighValue                bool     `json:"high_value,omitempty"`
+	BlindSpot                bool     `json:"blind_spot"`
+	Warning                  string   `json:"warning,omitempty"`
+	KnownUnsupportedFields   []string `json:"known_unsupported_fields,omitempty"`
+	Notes                    []string `json:"notes,omitempty"`
+	SupportedRuntimeFamilies []string `json:"supported_runtime_families,omitempty"`
+}
+
+type Summary struct {
+	SourceID     string `json:"source_id"`
+	Total        int    `json:"total"`
+	Healthy      int    `json:"healthy"`
+	Partial      int    `json:"partial"`
+	Unsupported  int    `json:"unsupported"`
+	Unconfigured int    `json:"unconfigured"`
+	Stale        int    `json:"stale"`
+	Failed       int    `json:"failed"`
+	Unknown      int    `json:"unknown"`
+	BlindSpots   int    `json:"blind_spots"`
+}
+
+func ContractsFromRegistry(registry *sourcecdk.Registry) []sourcecdk.CoverageContract {
+	if registry == nil {
+		return nil
+	}
+	return registry.CoverageContracts()
+}
+
+func ObservationsFromRuntimes(runtimes []*cerebrov1.SourceRuntime, status func(*cerebrov1.SourceRuntime) string) []RuntimeObservation {
+	observations := make([]RuntimeObservation, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		lastSyncedAt := ""
+		if ts := timestampValue(runtime.GetLastSyncedAt()); !ts.IsZero() {
+			lastSyncedAt = ts.UTC().Format(time.RFC3339Nano)
+		}
+		observations = append(observations, RuntimeObservation{
+			RuntimeID:           strings.TrimSpace(runtime.GetId()),
+			SourceID:            strings.TrimSpace(runtime.GetSourceId()),
+			TenantID:            strings.TrimSpace(runtime.GetTenantId()),
+			Family:              strings.TrimSpace(runtime.GetConfig()["family"]),
+			Status:              strings.TrimSpace(status(runtime)),
+			LastFailureCategory: strings.TrimSpace(runtime.GetConfig()["__cerebro_runtime_last_failure_category"]),
+			LastSyncedAt:        lastSyncedAt,
+		})
+	}
+	return observations
+}
+
+func Evaluate(contracts []sourcecdk.CoverageContract, observations []RuntimeObservation, options Options) []Record {
+	options.TenantID = strings.TrimSpace(options.TenantID)
+	options.SourceID = strings.TrimSpace(options.SourceID)
+	bySource := observationsBySource(observations)
+	records := make([]Record, 0)
+	for _, contract := range contracts {
+		contract.SourceID = strings.TrimSpace(contract.SourceID)
+		if contract.SourceID == "" || (options.SourceID != "" && contract.SourceID != options.SourceID) {
+			continue
+		}
+		for _, dimension := range contract.Dimensions {
+			record := coverageRecord(contract, dimension, bySource[contract.SourceID], options)
+			if record.DimensionID != "" {
+				records = append(records, record)
+			}
+		}
+	}
+	sort.Slice(records, func(i int, j int) bool {
+		if records[i].SourceID != records[j].SourceID {
+			return records[i].SourceID < records[j].SourceID
+		}
+		if records[i].BlindSpot != records[j].BlindSpot {
+			return records[i].BlindSpot
+		}
+		if stateRank(records[i].State) != stateRank(records[j].State) {
+			return stateRank(records[i].State) < stateRank(records[j].State)
+		}
+		return records[i].DimensionID < records[j].DimensionID
+	})
+	return records
+}
+
+func BlindSpots(records []Record) []Record {
+	out := make([]Record, 0)
+	for _, record := range records {
+		if record.BlindSpot {
+			out = append(out, record)
+		}
+	}
+	return out
+}
+
+func Summaries(records []Record) []Summary {
+	bySource := map[string]*Summary{}
+	for _, record := range records {
+		sourceID := strings.TrimSpace(record.SourceID)
+		if sourceID == "" {
+			sourceID = "unknown"
+		}
+		summary := bySource[sourceID]
+		if summary == nil {
+			summary = &Summary{SourceID: sourceID}
+			bySource[sourceID] = summary
+		}
+		summary.Total++
+		switch record.State {
+		case StateHealthy:
+			summary.Healthy++
+		case StatePartial:
+			summary.Partial++
+		case StateUnsupported:
+			summary.Unsupported++
+		case StateUnconfigured:
+			summary.Unconfigured++
+		case StateStale:
+			summary.Stale++
+		case StateFailed:
+			summary.Failed++
+		default:
+			summary.Unknown++
+		}
+		if record.BlindSpot {
+			summary.BlindSpots++
+		}
+	}
+	summaries := make([]Summary, 0, len(bySource))
+	for _, summary := range bySource {
+		summaries = append(summaries, *summary)
+	}
+	sort.Slice(summaries, func(i int, j int) bool {
+		if summaries[i].BlindSpots != summaries[j].BlindSpots {
+			return summaries[i].BlindSpots > summaries[j].BlindSpots
+		}
+		if summaries[i].Total != summaries[j].Total {
+			return summaries[i].Total > summaries[j].Total
+		}
+		return summaries[i].SourceID < summaries[j].SourceID
+	})
+	return summaries
+}
+
+func coverageRecord(contract sourcecdk.CoverageContract, dimension sourcecdk.CoverageDimension, observations []RuntimeObservation, options Options) Record {
+	dimension.ID = strings.TrimSpace(dimension.ID)
+	dimension.Type = strings.TrimSpace(dimension.Type)
+	dimension.Title = strings.TrimSpace(dimension.Title)
+	dimension.Support = strings.ToLower(strings.TrimSpace(dimension.Support))
+	if dimension.ID == "" || dimension.Type == "" || dimension.Title == "" {
+		return Record{}
+	}
+	record := Record{
+		SourceID:                 contract.SourceID,
+		TenantID:                 options.TenantID,
+		DimensionID:              dimension.ID,
+		DimensionType:            dimension.Type,
+		Title:                    dimension.Title,
+		SupportLevel:             dimension.Support,
+		OwnerDomain:              strings.TrimSpace(contract.OwnerDomain),
+		AuthorityDomain:          strings.TrimSpace(contract.AuthorityDomain),
+		HighValue:                dimension.HighValue,
+		KnownUnsupportedFields:   append([]string(nil), dimension.KnownUnsupportedFields...),
+		Notes:                    append([]string(nil), dimension.Notes...),
+		SupportedRuntimeFamilies: append([]string(nil), dimension.Families...),
+	}
+	if dimension.Support == sourcecdk.CoverageSupportUnsupported || dimension.Support == sourcecdk.CoverageSupportPlanned {
+		record.State = StateUnsupported
+		return withBlindSpot(record)
+	}
+	matches := matchingObservations(observations, dimension.Families, options.TenantID)
+	if len(matches) == 0 {
+		record.State = StateUnconfigured
+		return withBlindSpot(record)
+	}
+	best := mostConcerningObservation(matches)
+	record.RuntimeID = best.RuntimeID
+	record.Family = best.Family
+	record.LastSyncedAt = best.LastSyncedAt
+	record.State = observationState(best)
+	if record.State == StateHealthy && dimension.Support == sourcecdk.CoverageSupportPartial {
+		record.State = StatePartial
+	}
+	return withBlindSpot(record)
+}
+
+func withBlindSpot(record Record) Record {
+	record.BlindSpot = record.HighValue && record.State != StateHealthy
+	if record.BlindSpot {
+		record.Warning = coverageWarning(record)
+	}
+	return record
+}
+
+func coverageWarning(record Record) string {
+	subject := strings.TrimSpace(record.Title)
+	if subject == "" {
+		subject = record.DimensionID
+	}
+	sourceID := strings.TrimSpace(record.SourceID)
+	switch record.State {
+	case StateUnsupported:
+		return fmt.Sprintf("%s coverage is unsupported by %s", subject, sourceID)
+	case StateUnconfigured:
+		if record.TenantID != "" {
+			return fmt.Sprintf("%s coverage is unconfigured for tenant %s", subject, record.TenantID)
+		}
+		return fmt.Sprintf("%s coverage is unconfigured", subject)
+	case StateStale:
+		return fmt.Sprintf("%s coverage is stale for %s", subject, sourceID)
+	case StateFailed:
+		return fmt.Sprintf("%s coverage is failing for %s", subject, sourceID)
+	case StatePartial:
+		return fmt.Sprintf("%s coverage is partial for %s", subject, sourceID)
+	default:
+		return fmt.Sprintf("%s coverage state is %s for %s", subject, record.State, sourceID)
+	}
+}
+
+func observationsBySource(observations []RuntimeObservation) map[string][]RuntimeObservation {
+	bySource := map[string][]RuntimeObservation{}
+	for _, observation := range observations {
+		sourceID := strings.TrimSpace(observation.SourceID)
+		if sourceID == "" {
+			continue
+		}
+		bySource[sourceID] = append(bySource[sourceID], observation)
+	}
+	return bySource
+}
+
+func matchingObservations(observations []RuntimeObservation, families []string, tenantID string) []RuntimeObservation {
+	familySet := map[string]struct{}{}
+	for _, family := range families {
+		family = strings.TrimSpace(family)
+		if family != "" {
+			familySet[family] = struct{}{}
+		}
+	}
+	matches := make([]RuntimeObservation, 0, len(observations))
+	for _, observation := range observations {
+		if tenantID != "" && strings.TrimSpace(observation.TenantID) != tenantID {
+			continue
+		}
+		if len(familySet) != 0 {
+			if _, ok := familySet[strings.TrimSpace(observation.Family)]; !ok {
+				continue
+			}
+		}
+		matches = append(matches, observation)
+	}
+	return matches
+}
+
+func mostConcerningObservation(observations []RuntimeObservation) RuntimeObservation {
+	best := observations[0]
+	for _, observation := range observations[1:] {
+		if stateRank(observationState(observation)) < stateRank(observationState(best)) {
+			best = observation
+		}
+	}
+	return best
+}
+
+func observationState(observation RuntimeObservation) string {
+	if strings.TrimSpace(observation.LastFailureCategory) != "" {
+		return StateFailed
+	}
+	switch strings.ToLower(strings.TrimSpace(observation.Status)) {
+	case "failing", "failed":
+		return StateFailed
+	case "stale":
+		return StateStale
+	case "healthy", "current":
+		return StateHealthy
+	case "partial":
+		return StatePartial
+	default:
+		return StateUnknown
+	}
+}
+
+func stateRank(state string) int {
+	switch state {
+	case StateFailed:
+		return 0
+	case StateStale:
+		return 1
+	case StateUnconfigured:
+		return 2
+	case StateUnsupported:
+		return 3
+	case StatePartial:
+		return 4
+	case StateUnknown:
+		return 5
+	case StateHealthy:
+		return 6
+	default:
+		return 7
+	}
+}
+
+func timestampValue(ts *timestamppb.Timestamp) time.Time {
+	if ts == nil || !ts.IsValid() {
+		return time.Time{}
+	}
+	return ts.AsTime()
+}

--- a/internal/sourcecoverage/coverage_test.go
+++ b/internal/sourcecoverage/coverage_test.go
@@ -1,0 +1,81 @@
+package sourcecoverage
+
+import (
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestEvaluateDistinguishesCoverageStates(t *testing.T) {
+	contracts := []sourcecdk.CoverageContract{{
+		SourceID:        "okta",
+		OwnerDomain:     "identity",
+		AuthorityDomain: "okta",
+		Dimensions: []sourcecdk.CoverageDimension{
+			{ID: "users", Type: "entity_family", Title: "Users", Families: []string{"user"}, Support: sourcecdk.CoverageSupportSupported, HighValue: true},
+			{ID: "apps", Type: "entity_family", Title: "Applications", Families: []string{"application"}, Support: sourcecdk.CoverageSupportSupported, HighValue: true},
+			{ID: "audit", Type: "audit_event", Title: "Audit events", Families: []string{"audit"}, Support: sourcecdk.CoverageSupportSupported, HighValue: true},
+			{ID: "remediation", Type: "remediation_state", Title: "Remediation lifecycle", Support: sourcecdk.CoverageSupportUnsupported, HighValue: true},
+			{ID: "entitlements", Type: "app_entitlement", Title: "App entitlements", Families: []string{"app_assignment"}, Support: sourcecdk.CoverageSupportPartial, HighValue: true},
+		},
+	}}
+	records := Evaluate(contracts, []RuntimeObservation{
+		{RuntimeID: "okta-user", SourceID: "okta", TenantID: "writer", Family: "user", Status: "healthy"},
+		{RuntimeID: "okta-audit", SourceID: "okta", TenantID: "writer", Family: "audit", Status: "failing"},
+		{RuntimeID: "okta-app-assignment", SourceID: "okta", TenantID: "writer", Family: "app_assignment", Status: "healthy"},
+	}, Options{TenantID: "writer"})
+
+	byDimension := map[string]Record{}
+	for _, record := range records {
+		byDimension[record.DimensionID] = record
+	}
+	for dimension, want := range map[string]string{
+		"users":        StateHealthy,
+		"apps":         StateUnconfigured,
+		"audit":        StateFailed,
+		"remediation":  StateUnsupported,
+		"entitlements": StatePartial,
+	} {
+		if got := byDimension[dimension].State; got != want {
+			t.Fatalf("%s state = %q, want %q; records=%#v", dimension, got, want, records)
+		}
+	}
+	blindSpots := BlindSpots(records)
+	if len(blindSpots) != 4 {
+		t.Fatalf("len(BlindSpots()) = %d, want 4: %#v", len(blindSpots), blindSpots)
+	}
+	summaries := Summaries(records)
+	if len(summaries) != 1 || summaries[0].BlindSpots != 4 || summaries[0].Unconfigured != 1 || summaries[0].Failed != 1 {
+		t.Fatalf("Summaries() = %#v", summaries)
+	}
+}
+
+func TestObservationsFromRuntimesPreservesFamilyStatusAndLastSync(t *testing.T) {
+	lastSync := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	runtimes := []*cerebrov1.SourceRuntime{{
+		Id:           "runtime-1",
+		SourceId:     "okta",
+		TenantId:     "writer",
+		LastSyncedAt: timestamppb.New(lastSync),
+		Config: map[string]string{
+			"family": "audit",
+			"__cerebro_runtime_last_failure_category": "auth_error",
+		},
+	}}
+
+	observations := ObservationsFromRuntimes(runtimes, func(*cerebrov1.SourceRuntime) string { return "healthy" })
+
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+	got := observations[0]
+	if got.RuntimeID != "runtime-1" || got.Family != "audit" || got.LastFailureCategory != "auth_error" {
+		t.Fatalf("observation = %#v", got)
+	}
+	if got.LastSyncedAt != lastSync.Format(time.RFC3339Nano) {
+		t.Fatalf("LastSyncedAt = %q, want %q", got.LastSyncedAt, lastSync.Format(time.RFC3339Nano))
+	}
+}

--- a/sources/github/catalog.yaml
+++ b/sources/github/catalog.yaml
@@ -9,6 +9,62 @@ emitted_kinds:
   - github.org_member
   - github.pull_request
   - github.secret_scanning_alert
+coverage_contract:
+  owner_domain: source_control
+  authority_domain: github
+  dimensions:
+    - id: audit_events
+      type: audit_event
+      title: Organization audit events
+      families: [audit]
+      support: supported
+      high_value: true
+    - id: code_security_alerts
+      type: entity_family
+      title: Code security alerts
+      families: [dependabot_alert, secret_scanning_alert]
+      support: supported
+      high_value: true
+    - id: fine_grained_permissions
+      type: app_entitlement
+      title: Fine-grained repository permissions
+      families: [org_inventory]
+      support: partial
+      high_value: true
+      known_unsupported_fields:
+        - branch-protection bypass actors
+        - repository rulesets
+    - id: incremental_sync
+      type: incremental_sync
+      title: Incremental cursor sync
+      support: partial
+      high_value: true
+      known_unsupported_fields:
+        - org inventory snapshot deltas
+    - id: organization_members
+      type: entity_family
+      title: Organization members
+      families: [org_inventory]
+      support: supported
+      high_value: true
+    - id: pull_requests
+      type: lifecycle_state
+      title: Pull request lifecycle
+      families: [pull_request]
+      support: supported
+    - id: remediation_state
+      type: remediation_state
+      title: Remediation lifecycle state
+      support: unsupported
+      high_value: true
+      known_unsupported_fields:
+        - remediation workflow state
+    - id: repositories
+      type: entity_family
+      title: Repositories
+      families: [repository]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: github.audit
     schema_ref: github/audit/v1

--- a/sources/googleworkspace/catalog.yaml
+++ b/sources/googleworkspace/catalog.yaml
@@ -7,3 +7,51 @@ emitted_kinds:
   - google_workspace.group_member
   - google_workspace.role_assignment
   - google_workspace.user
+coverage_contract:
+  owner_domain: identity
+  authority_domain: google_workspace
+  dimensions:
+    - id: audit_events
+      type: audit_event
+      title: Admin audit events
+      families: [audit]
+      support: supported
+      high_value: true
+    - id: groups
+      type: entity_family
+      title: Groups
+      families: [group]
+      support: supported
+      high_value: true
+    - id: group_memberships
+      type: relationship
+      title: Group memberships
+      families: [group_member]
+      support: supported
+      high_value: true
+    - id: incremental_sync
+      type: incremental_sync
+      title: Incremental cursor sync
+      support: partial
+      high_value: true
+      known_unsupported_fields:
+        - full Directory API deletion tombstones
+    - id: remediation_state
+      type: remediation_state
+      title: Remediation lifecycle state
+      support: unsupported
+      high_value: true
+      known_unsupported_fields:
+        - remediation workflow state
+    - id: role_assignments
+      type: app_entitlement
+      title: Role assignments
+      families: [role_assignment]
+      support: partial
+      high_value: true
+    - id: users
+      type: entity_family
+      title: Users
+      families: [user]
+      support: supported
+      high_value: true

--- a/sources/okta/catalog.yaml
+++ b/sources/okta/catalog.yaml
@@ -12,3 +12,65 @@ emitted_kinds:
   - okta.policy_rule
   - okta.threat_insight
   - okta.user
+coverage_contract:
+  owner_domain: identity
+  authority_domain: okta
+  dimensions:
+    - id: admin_roles
+      type: relationship
+      title: Admin role grants
+      families: [admin_role]
+      support: partial
+      high_value: true
+      known_unsupported_fields:
+        - full custom admin permission expansion
+    - id: app_assignments
+      type: app_entitlement
+      title: App assignments and entitlements
+      families: [app_assignment]
+      support: partial
+      high_value: true
+      known_unsupported_fields:
+        - app-specific fine-grained entitlement payloads
+    - id: applications
+      type: entity_family
+      title: Applications
+      families: [application]
+      support: supported
+      high_value: true
+    - id: audit_events
+      type: audit_event
+      title: Audit events
+      families: [audit]
+      support: supported
+      high_value: true
+    - id: groups
+      type: entity_family
+      title: Groups
+      families: [group]
+      support: supported
+      high_value: true
+    - id: group_memberships
+      type: relationship
+      title: Group memberships
+      families: [group_membership]
+      support: supported
+      high_value: true
+    - id: incremental_sync
+      type: incremental_sync
+      title: Incremental cursor sync
+      support: supported
+      high_value: true
+    - id: remediation_state
+      type: remediation_state
+      title: Remediation lifecycle state
+      support: unsupported
+      high_value: true
+      known_unsupported_fields:
+        - remediation workflow state
+    - id: users
+      type: entity_family
+      title: Users
+      families: [user]
+      support: supported
+      high_value: true

--- a/tools/sourcedeploy/contract.go
+++ b/tools/sourcedeploy/contract.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/writer/cerebro/internal/sourcecdk"
 	"gopkg.in/yaml.v3"
 )
 
@@ -30,13 +31,14 @@ type Contract struct {
 }
 
 type ContractSource struct {
-	SourceID                 string            `json:"source_id"`
-	EmittedKinds             []string          `json:"emitted_kinds,omitempty"`
-	SupportedFamilies        []string          `json:"supported_families,omitempty"`
-	RequiredSecrets          []string          `json:"required_secrets,omitempty"`
-	RoleAssumptionConfigKeys []string          `json:"role_assumption_config_keys,omitempty"`
-	SourceHealthReceipt      map[string]any    `json:"source_health_receipt,omitempty"`
-	Runtimes                 []ContractRuntime `json:"runtimes,omitempty"`
+	SourceID                 string                      `json:"source_id"`
+	EmittedKinds             []string                    `json:"emitted_kinds,omitempty"`
+	SupportedFamilies        []string                    `json:"supported_families,omitempty"`
+	RequiredSecrets          []string                    `json:"required_secrets,omitempty"`
+	RoleAssumptionConfigKeys []string                    `json:"role_assumption_config_keys,omitempty"`
+	SourceHealthReceipt      map[string]any              `json:"source_health_receipt,omitempty"`
+	CoverageContract         *sourcecdk.CoverageContract `json:"coverage_contract,omitempty"`
+	Runtimes                 []ContractRuntime           `json:"runtimes,omitempty"`
 }
 
 type ContractRuntime struct {
@@ -55,9 +57,10 @@ type RoleAssumption struct {
 }
 
 type contractCatalog struct {
-	ID              string   `yaml:"id"`
-	EmittedKinds    []string `yaml:"emitted_kinds"`
-	RuntimeFamilies []string `yaml:"runtime_families"`
+	ID              string                     `yaml:"id"`
+	EmittedKinds    []string                   `yaml:"emitted_kinds"`
+	RuntimeFamilies []string                   `yaml:"runtime_families"`
+	Coverage        sourcecdk.CoverageContract `yaml:"coverage_contract"`
 }
 
 func RenderContract(sourcesRoot string, manifests []Manifest, opts ContractOptions) (Contract, error) {
@@ -95,6 +98,10 @@ func RenderContract(sourcesRoot string, manifests []Manifest, opts ContractOptio
 		if err != nil {
 			return Contract{}, err
 		}
+		coverage, err := sourceCoverageContract(catalog)
+		if err != nil {
+			return Contract{}, err
+		}
 		sources = append(sources, ContractSource{
 			SourceID:                 catalog.ID,
 			EmittedKinds:             sortedStrings(catalog.EmittedKinds),
@@ -102,6 +109,7 @@ func RenderContract(sourcesRoot string, manifests []Manifest, opts ContractOptio
 			RequiredSecrets:          sortedStrings(manifest.SecretKeys),
 			RoleAssumptionConfigKeys: roleAssumptionConfigKeys(catalog.ID),
 			SourceHealthReceipt:      receipt,
+			CoverageContract:         coverage,
 			Runtimes:                 runtimesBySource[catalog.ID],
 		})
 	}
@@ -145,6 +153,17 @@ func sourceHealthReceipt(sourcesRoot string, sourceID string) (map[string]any, e
 	}
 	receipt["source_id"] = sourceID
 	return receipt, nil
+}
+
+func sourceCoverageContract(catalog contractCatalog) (*sourcecdk.CoverageContract, error) {
+	contract, err := sourcecdk.NormalizeCoverageContract(catalog.ID, catalog.Coverage)
+	if err != nil {
+		return nil, err
+	}
+	if len(contract.Dimensions) == 0 {
+		return nil, nil
+	}
+	return &contract, nil
 }
 
 func discoverCatalogs(sourcesRoot string) ([]contractCatalog, error) {

--- a/tools/sourcedeploy/contract_test.go
+++ b/tools/sourcedeploy/contract_test.go
@@ -11,7 +11,26 @@ func TestRenderContractIncludesCatalogsSecretsFamiliesAndRoles(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	mkSource(t, root, "aws", "id: aws\nemitted_kinds:\n  - aws.public_endpoint\n  - aws.iam_role\n", "")
-	mkSource(t, root, "okta", "id: okta\nemitted_kinds:\n  - okta.audit\n  - okta.user\n", `
+	mkSource(t, root, "okta", `id: okta
+emitted_kinds:
+  - okta.audit
+  - okta.user
+coverage_contract:
+  owner_domain: identity
+  authority_domain: okta
+  dimensions:
+    - id: users
+      type: entity_family
+      title: Users
+      families: [user]
+      support: supported
+      high_value: true
+    - id: remediation
+      type: remediation_state
+      title: Remediation lifecycle
+      support: unsupported
+      known_unsupported_fields: [inline remediation state]
+`, `
 sourceId: okta
 secretKeys:
   - OKTA_API_TOKEN
@@ -81,6 +100,12 @@ runtimes:
 	}
 	if got := okta.SourceHealthReceipt["expected_cadence_seconds"]; got != float64(3600) {
 		t.Fatalf("source health receipt cadence = %v", got)
+	}
+	if okta.CoverageContract == nil || okta.CoverageContract.OwnerDomain != "identity" {
+		t.Fatalf("coverage contract = %#v, want identity coverage", okta.CoverageContract)
+	}
+	if len(okta.CoverageContract.Dimensions) != 2 || okta.CoverageContract.Dimensions[1].Support != "unsupported" {
+		t.Fatalf("coverage dimensions = %#v", okta.CoverageContract.Dimensions)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a machine-readable `coverage_contract` to source catalogs and exposes it through the in-process registry and runtime deploy contract.
- Adds source coverage evaluation that distinguishes `unsupported`, `unconfigured`, `stale`, `failed`, `partial`, and `healthy` coverage states.
- Surfaces high-value blind spots in source runtime health, runtime freshness, and GRC dashboard responses, with initial Okta/GitHub/Google Workspace identity coverage contracts.

Refs #899.

## Test Plan

- `go test ./internal/sourcecoverage ./internal/sourcecdk ./internal/bootstrap ./tools/sourcedeploy ./tools/archtests -count=1`
- `go test ./sources/okta ./sources/github ./sources/googleworkspace -run Test -count=1`
- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
