### PR TITLE
Add source deploy contracts for additional runtimes

### DIFF
--- a/sources/grc/deploy.yaml
+++ b/sources/grc/deploy.yaml
@@ -1,0 +1,47 @@
+sourceId: grc
+secretKeys:
+  - GRC_CLIENT_ID
+  - GRC_CLIENT_SECRET
+runtimes:
+  - localId: person
+    config:
+      client_id: env:GRC_CLIENT_ID
+      client_secret: env:GRC_CLIENT_SECRET
+      family: person
+      per_page: "100"
+  - localId: user
+    config:
+      client_id: env:GRC_CLIENT_ID
+      client_secret: env:GRC_CLIENT_SECRET
+      family: user
+      per_page: "100"
+  - localId: control
+    config:
+      client_id: env:GRC_CLIENT_ID
+      client_secret: env:GRC_CLIENT_SECRET
+      family: control
+      per_page: "100"
+  - localId: control-test
+    config:
+      client_id: env:GRC_CLIENT_ID
+      client_secret: env:GRC_CLIENT_SECRET
+      family: control_test
+      per_page: "100"
+  - localId: integration
+    config:
+      client_id: env:GRC_CLIENT_ID
+      client_secret: env:GRC_CLIENT_SECRET
+      family: integration
+      per_page: "100"
+  - localId: vulnerability
+    config:
+      client_id: env:GRC_CLIENT_ID
+      client_secret: env:GRC_CLIENT_SECRET
+      family: vulnerability
+      per_page: "100"
+  - localId: vulnerable-asset
+    config:
+      client_id: env:GRC_CLIENT_ID
+      client_secret: env:GRC_CLIENT_SECRET
+      family: vulnerable_asset
+      per_page: "100"

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -221,7 +221,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 func parseSettings(cfg sourcecdk.Config, allowLoopbackBaseURL bool) (settings, error) {
 	resolved := settings{
 		provider:     configValue(cfg, "provider"),
-		tenantID:     configValue(cfg, "tenant_id"),
+		tenantID:     firstNonEmptyString(configValue(cfg, "tenant_id"), configValue(cfg, "__cerebro_runtime_tenant_id")),
 		family:       configValue(cfg, "family"),
 		baseURL:      configValue(cfg, "base_url"),
 		tokenURL:     configValue(cfg, "token_url"),

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 const (
@@ -42,6 +43,21 @@ func TestParseSettingsRequiresTenant(t *testing.T) {
 	}))
 	if err == nil {
 		t.Fatal("Check() error = nil, want tenant_id error")
+	}
+}
+
+func TestParseSettingsUsesRuntimeTenantFallback(t *testing.T) {
+	settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"client_id":                     testClientID,
+		"client_secret":                 testClientSecret,
+		"family":                        familyVendor,
+		sourceconfig.RuntimeTenantIDKey: "writer",
+	}), true)
+	if err != nil {
+		t.Fatalf("parseSettings() error = %v", err)
+	}
+	if settings.tenantID != "writer" {
+		t.Fatalf("tenantID = %q, want writer", settings.tenantID)
 	}
 }
 

--- a/sources/kubernetes/deploy.yaml
+++ b/sources/kubernetes/deploy.yaml
@@ -1,0 +1,39 @@
+sourceId: kubernetes
+secretKeys:
+  - KUBERNETES_KUBECONFIG_PATH
+runtimes:
+  - localId: cluster
+    config:
+      family: cluster
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: namespace
+    config:
+      family: namespace
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: pod
+    config:
+      family: pod
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: container
+    config:
+      family: container
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: service-account
+    config:
+      family: service_account
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: workload
+    config:
+      family: workload
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: workload-identity-binding
+    config:
+      family: workload_identity_binding
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"

--- a/sources/okta/deploy.yaml
+++ b/sources/okta/deploy.yaml
@@ -28,3 +28,21 @@ runtimes:
       family: application
       per_page: "200"
       token: env:OKTA_API_TOKEN
+  - localId: authenticator
+    config:
+      domain: env:OKTA_DOMAIN
+      family: authenticator
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: policy-rule
+    config:
+      domain: env:OKTA_DOMAIN
+      family: policy_rule
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: threat-insight
+    config:
+      domain: env:OKTA_DOMAIN
+      family: threat_insight
+      per_page: "200"
+      token: env:OKTA_API_TOKEN

--- a/sources/vulnview/deploy.yaml
+++ b/sources/vulnview/deploy.yaml
@@ -1,0 +1,41 @@
+sourceId: vulnview
+secretKeys:
+  - VULNVIEW_CLIENT_ID
+  - VULNVIEW_CLIENT_SECRET
+  - VULNVIEW_OKTA_ISSUER
+runtimes:
+  - localId: site
+    config:
+      client_id: env:VULNVIEW_CLIENT_ID
+      client_secret: env:VULNVIEW_CLIENT_SECRET
+      family: site
+      okta_issuer: env:VULNVIEW_OKTA_ISSUER
+      per_page: "100"
+  - localId: scan
+    config:
+      client_id: env:VULNVIEW_CLIENT_ID
+      client_secret: env:VULNVIEW_CLIENT_SECRET
+      family: scan
+      okta_issuer: env:VULNVIEW_OKTA_ISSUER
+      per_page: "100"
+  - localId: vulnerability
+    config:
+      client_id: env:VULNVIEW_CLIENT_ID
+      client_secret: env:VULNVIEW_CLIENT_SECRET
+      family: vulnerability
+      okta_issuer: env:VULNVIEW_OKTA_ISSUER
+      per_page: "100"
+  - localId: asset
+    config:
+      client_id: env:VULNVIEW_CLIENT_ID
+      client_secret: env:VULNVIEW_CLIENT_SECRET
+      family: asset
+      okta_issuer: env:VULNVIEW_OKTA_ISSUER
+      per_page: "100"
+  - localId: dns-alert
+    config:
+      client_id: env:VULNVIEW_CLIENT_ID
+      client_secret: env:VULNVIEW_CLIENT_SECRET
+      family: dns_alert
+      okta_issuer: env:VULNVIEW_OKTA_ISSUER
+      per_page: "100"

--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -232,7 +232,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 
 func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 	resolved := settings{
-		tenantID:     configValue(cfg, "tenant_id"),
+		tenantID:     firstNonEmpty(configValue(cfg, "tenant_id"), configValue(cfg, "__cerebro_runtime_tenant_id")),
 		family:       configValue(cfg, "family"),
 		baseURL:      configValue(cfg, "base_url"),
 		tokenURL:     configValue(cfg, "token_url"),

--- a/sources/vulnview/source_test.go
+++ b/sources/vulnview/source_test.go
@@ -8,7 +8,25 @@ import (
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
+
+func TestParseSettingsUsesRuntimeTenantFallback(t *testing.T) {
+	settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- config fixture uses placeholder secret text.
+		"base_url":                      "http://127.0.0.1/api",
+		"client_id":                     "client",
+		"client_secret":                 "secret",
+		"family":                        "asset",
+		"okta_issuer":                   "http://127.0.0.1/oauth2/default",
+		sourceconfig.RuntimeTenantIDKey: "writer",
+	}), true)
+	if err != nil {
+		t.Fatalf("parseSettings() error = %v", err)
+	}
+	if settings.tenantID != "writer" {
+		t.Fatalf("tenantID = %q, want writer", settings.tenantID)
+	}
+}
 
 func TestParseSettingsRejectsUnsafeBaseURL(t *testing.T) {
 	_, err := parseSettings(sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- invalid config fixture uses placeholder secret text.

--- a/tools/archtests/source_deploy_test.go
+++ b/tools/archtests/source_deploy_test.go
@@ -19,11 +19,14 @@ var requireDeployManifest = map[string]struct{}{
 	"gcp":              {},
 	"github":           {},
 	"google_workspace": {},
+	"grc":              {},
 	"kandji":           {},
 	"kolide":           {},
+	"kubernetes":       {},
 	"okta":             {},
 	"sentinelone":      {},
 	"trusted_endpoint": {},
+	"vulnview":         {},
 }
 
 func TestSourceDeployManifestsAreValid(t *testing.T) {


### PR DESCRIPTION
Summary:
- Add deploy manifests for GRC, Kubernetes, and VulnView sources.
- Let GRC and VulnView use runtime-provided context in deploy-driven runs.
- Add Okta control posture runtime families to the deploy manifest.

Validation:
- go test ./sources/grc ./sources/vulnview ./tools/sourcedeploy ./tools/archtests -count=1
- make contracts-check
- make oss-audit