### PR TITLE
Add risk action plan report

### DIFF
--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -111,16 +111,21 @@ These reads stay generic and source-agnostic. Rules populate persisted findings;
 
 ### 6. Reporting
 
-Reports such as `finding-summary`, `risk-delta`, and `risk-action-plan` operate on persisted findings instead of on raw source logic. `risk-action-plan` ranks remediation candidates by reusing the bounded `risk-delta` simulation path; it recommends next-best actions without executing remediation or introducing a new store.
+Reports such as `finding-summary`, `risk-delta`, and `risk-action-plan` operate on persisted findings instead of on raw source logic. `risk-action-plan` is backed by the shared `internal/riskplan` engine, which ranks remediation candidates by reusing the bounded `risk-delta` simulation path and returns typed score breakdowns, expected reduction, effort, ownership, evidence quality, prior outcome signals, and optional plan diffs. It recommends next-best actions without executing remediation or introducing a new store.
 
 Why:
 
 - reporting should summarize durable state
 - rules should emit findings
 - reports should consume findings
-- action planning should remain an explainable report over current findings and graph evidence
+- action planning should remain an explainable, read-only plan over current findings and graph evidence
 
 That separation keeps the platform layered cleanly.
+
+The same planner engine is exposed to MCP clients through read-only tools:
+
+- `cerebro.risk.actions.list` returns a bounded ranked plan with the typed candidate contract.
+- `cerebro.risk.actions.explain` returns the full explanation for one candidate ID, including score breakdown, risk delta, effort, ownership, evidence quality, and outcome-learning signals.
 
 ## Public Platform Surfaces
 

--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -111,13 +111,14 @@ These reads stay generic and source-agnostic. Rules populate persisted findings;
 
 ### 6. Reporting
 
-Reports such as `finding-summary` operate on persisted findings instead of on raw source logic.
+Reports such as `finding-summary`, `risk-delta`, and `risk-action-plan` operate on persisted findings instead of on raw source logic. `risk-action-plan` ranks remediation candidates by reusing the bounded `risk-delta` simulation path; it recommends next-best actions without executing remediation or introducing a new store.
 
 Why:
 
 - reporting should summarize durable state
 - rules should emit findings
 - reports should consume findings
+- action planning should remain an explainable report over current findings and graph evidence
 
 That separation keeps the platform layered cleanly.
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -6809,8 +6809,8 @@ func TestReportEndpoints(t *testing.T) {
 		t.Fatalf("decode /reports response: %v", err)
 	}
 	reportsPayload, ok := listPayload["reports"].([]any)
-	if !ok || len(reportsPayload) != 2 {
-		t.Fatalf("/reports payload = %#v, want 2 entries", listPayload["reports"])
+	if !ok || len(reportsPayload) != 3 {
+		t.Fatalf("/reports payload = %#v, want 3 entries", listPayload["reports"])
 	}
 
 	runReq, err := http.NewRequest(http.MethodPost, server.URL+"/reports/finding-summary/runs?tenant_id=writer&runtime_ids=writer-okta-audit&graph_limit=2", nil)
@@ -6906,8 +6906,8 @@ func TestReportEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListReportDefinitions() error = %v", err)
 	}
-	if len(listReportsResp.Msg.GetReports()) != 2 {
-		t.Fatalf("len(ListReportDefinitions.Reports) = %d, want 2", len(listReportsResp.Msg.GetReports()))
+	if len(listReportsResp.Msg.GetReports()) != 3 {
+		t.Fatalf("len(ListReportDefinitions.Reports) = %d, want 3", len(listReportsResp.Msg.GetReports()))
 	}
 	runReportResp, err := client.RunReport(context.Background(), connect.NewRequest(&cerebrov1.RunReportRequest{
 		ReportId: "finding-summary",

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -27,31 +27,34 @@ import (
 )
 
 const (
-	mcpProtocolVersion           = "2025-11-25"
-	mcpEndpointPath              = "/api/v1/mcp"
-	mcpRedactedValue             = "[redacted]"
-	defaultMCPListLimit          = 25
-	maxMCPListLimit              = 100
-	defaultMCPAssetLimit         = 10
-	maxMCPAssetLimit             = 50
-	defaultMCPEvidenceLimit      = 25
-	maxMCPEvidenceLimit          = 100
-	defaultMCPNeighborhoodLimit  = 10
-	maxMCPNeighborhoodLimit      = 50
-	defaultMCPGraphLimit         = 25
-	maxMCPGraphLimit             = 100
-	defaultMCPImpactLimit        = 100
-	maxMCPImpactLimit            = 250
-	defaultMCPRiskLimit          = 100
-	maxMCPRiskLimit              = 500
-	defaultMCPRiskActionRoots    = 3
-	maxMCPRiskActionRoots        = 10
-	defaultMCPRiskActionGraph    = 3
-	maxMCPRiskActionGraph        = 10
+	mcpProtocolVersion          = "2025-11-25"
+	mcpEndpointPath             = "/api/v1/mcp"
+	mcpRedactedValue            = "[redacted]"
+	defaultMCPListLimit         = 25
+	maxMCPListLimit             = 100
+	defaultMCPAssetLimit        = 10
+	maxMCPAssetLimit            = 50
+	defaultMCPEvidenceLimit     = 25
+	maxMCPEvidenceLimit         = 100
+	defaultMCPNeighborhoodLimit = 10
+	maxMCPNeighborhoodLimit     = 50
+	defaultMCPGraphLimit        = 25
+	maxMCPGraphLimit            = 100
+	defaultMCPImpactLimit       = 100
+	maxMCPImpactLimit           = 250
+	defaultMCPRiskLimit         = 100
+	maxMCPRiskLimit             = 500
+	defaultMCPRiskActionRoots   = 3
+	maxMCPRiskActionRoots       = 10
+	defaultMCPRiskActionGraph   = 3
+	maxMCPRiskActionGraph       = 10
+	defaultMCPRecentRiskRows    = 10
+	mcpResourceMIMEJSON         = "application/json"
+)
+
+const (
 	mcpGraphEvidenceIncluded     = "included"
 	mcpGraphEvidenceUnconfigured = "unconfigured"
-	defaultMCPRecentRiskRows     = 10
-	mcpResourceMIMEJSON          = "application/json"
 )
 
 type mcpJSONRPCRequest struct {
@@ -2983,9 +2986,7 @@ func splitMCPStringList(value string) []string {
 		return r == ',' || r == ';' || r == '\n' || r == '\t'
 	})
 	values := make([]string, 0, len(parts))
-	for _, part := range parts {
-		values = append(values, part)
-	}
+	values = append(values, parts...)
 	return values
 }
 

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -19,6 +19,7 @@ import (
 	findingdomain "github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/riskplan"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -26,25 +27,31 @@ import (
 )
 
 const (
-	mcpProtocolVersion          = "2025-11-25"
-	mcpEndpointPath             = "/api/v1/mcp"
-	mcpRedactedValue            = "[redacted]"
-	defaultMCPListLimit         = 25
-	maxMCPListLimit             = 100
-	defaultMCPAssetLimit        = 10
-	maxMCPAssetLimit            = 50
-	defaultMCPEvidenceLimit     = 25
-	maxMCPEvidenceLimit         = 100
-	defaultMCPNeighborhoodLimit = 10
-	maxMCPNeighborhoodLimit     = 50
-	defaultMCPGraphLimit        = 25
-	maxMCPGraphLimit            = 100
-	defaultMCPImpactLimit       = 100
-	maxMCPImpactLimit           = 250
-	defaultMCPRiskLimit         = 100
-	maxMCPRiskLimit             = 500
-	defaultMCPRecentRiskRows    = 10
-	mcpResourceMIMEJSON         = "application/json"
+	mcpProtocolVersion           = "2025-11-25"
+	mcpEndpointPath              = "/api/v1/mcp"
+	mcpRedactedValue             = "[redacted]"
+	defaultMCPListLimit          = 25
+	maxMCPListLimit              = 100
+	defaultMCPAssetLimit         = 10
+	maxMCPAssetLimit             = 50
+	defaultMCPEvidenceLimit      = 25
+	maxMCPEvidenceLimit          = 100
+	defaultMCPNeighborhoodLimit  = 10
+	maxMCPNeighborhoodLimit      = 50
+	defaultMCPGraphLimit         = 25
+	maxMCPGraphLimit             = 100
+	defaultMCPImpactLimit        = 100
+	maxMCPImpactLimit            = 250
+	defaultMCPRiskLimit          = 100
+	maxMCPRiskLimit              = 500
+	defaultMCPRiskActionRoots    = 3
+	maxMCPRiskActionRoots        = 10
+	defaultMCPRiskActionGraph    = 3
+	maxMCPRiskActionGraph        = 10
+	mcpGraphEvidenceIncluded     = "included"
+	mcpGraphEvidenceUnconfigured = "unconfigured"
+	defaultMCPRecentRiskRows     = 10
+	mcpResourceMIMEJSON          = "application/json"
 )
 
 type mcpJSONRPCRequest struct {
@@ -444,6 +451,10 @@ func (app *App) mcpToolStructuredContent(r *http.Request, name string, args map[
 		return app.mcpGetAsset(r, args)
 	case "cerebro.risk.summary":
 		return app.mcpRiskSummary(r, args)
+	case "cerebro.risk.actions.list":
+		return app.mcpRiskActionsList(r, args)
+	case "cerebro.risk.actions.explain":
+		return app.mcpRiskActionsExplain(r, args)
 	case "cerebro.graph.neighborhood":
 		return app.mcpGraphNeighborhood(r, args)
 	case "cerebro.graph.impact":
@@ -913,6 +924,200 @@ func (app *App) mcpRiskSummary(r *http.Request, args map[string]any) (any, error
 	return summary, nil
 }
 
+type mcpRiskActionPlanResult struct {
+	Plan                   riskplan.Plan
+	Limit                  int
+	FindingLimit           int
+	GraphEvidenceStatus    string
+	GraphNeighborhoodCount int
+	PartialErrors          []string
+}
+
+func (app *App) mcpRiskActionsList(r *http.Request, args map[string]any) (any, error) {
+	result, err := app.mcpBuildRiskActionPlan(r, args)
+	if err != nil {
+		return nil, err
+	}
+	planValue, err := jsonValue(result.Plan)
+	if err != nil {
+		return nil, err
+	}
+	candidatesValue, err := jsonValue(result.Plan.ActionCandidates)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"plan":                     planValue,
+		"action_candidates":        candidatesValue,
+		"graph_evidence_status":    result.GraphEvidenceStatus,
+		"graph_neighborhood_count": result.GraphNeighborhoodCount,
+		"metadata":                 mcpResponseMetadata(result.Limit, len(result.Plan.ActionCandidates), result.PartialErrors),
+	}, nil
+}
+
+func (app *App) mcpRiskActionsExplain(r *http.Request, args map[string]any) (any, error) {
+	candidateID := mcpStringArg(args, "candidate_id")
+	if candidateID == "" {
+		return nil, fmt.Errorf("%w: candidate_id is required", findingdomain.ErrInvalidRequest)
+	}
+	result, err := app.mcpBuildRiskActionPlan(r, args)
+	if err != nil {
+		return nil, err
+	}
+	for _, candidate := range result.Plan.ActionCandidates {
+		if candidate.ID != candidateID {
+			continue
+		}
+		candidateValue, err := jsonValue(candidate)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"candidate":                candidateValue,
+			"score_breakdown":          candidate.ScoreBreakdown,
+			"expected_reduction":       candidate.ExpectedReduction,
+			"effort":                   candidate.Effort,
+			"ownership":                candidate.Ownership,
+			"evidence":                 candidate.Evidence,
+			"outcome_learning":         candidate.OutcomeLearning,
+			"risk_delta":               candidate.RiskDelta,
+			"plan_model_version":       result.Plan.ModelVersion,
+			"graph_evidence_status":    result.GraphEvidenceStatus,
+			"graph_neighborhood_count": result.GraphNeighborhoodCount,
+			"metadata":                 mcpResponseMetadata(result.Limit, 1, result.PartialErrors),
+		}, nil
+	}
+	return nil, fmt.Errorf("%w: risk action candidate %q not found", ports.ErrFindingNotFound, candidateID)
+}
+
+func (app *App) mcpBuildRiskActionPlan(r *http.Request, args map[string]any) (mcpRiskActionPlanResult, error) {
+	tenantID := mcpTenantArg(r, args)
+	runtimeIDs := mcpRuntimeIDsArg(args)
+	limit, err := mcpBoundedLimit(args, "limit", riskplan.DefaultCandidateLimit, riskplan.MaxCandidateLimit)
+	if err != nil {
+		return mcpRiskActionPlanResult{}, err
+	}
+	findingLimit, err := mcpBoundedLimit(args, "finding_limit", defaultMCPRiskLimit, maxMCPRiskLimit)
+	if err != nil {
+		return mcpRiskActionPlanResult{}, err
+	}
+	rootLimit, err := mcpBoundedLimit(args, "resource_limit", defaultMCPRiskActionRoots, maxMCPRiskActionRoots)
+	if err != nil {
+		return mcpRiskActionPlanResult{}, err
+	}
+	graphLimit, err := mcpBoundedLimit(args, "graph_limit", defaultMCPRiskActionGraph, maxMCPRiskActionGraph)
+	if err != nil {
+		return mcpRiskActionPlanResult{}, err
+	}
+	status := mcpStringArg(args, "status")
+	if status != "" {
+		parsed, err := parseFindingStatus(status)
+		if err != nil {
+			return mcpRiskActionPlanResult{}, err
+		}
+		status = findingStatusString(parsed)
+	}
+	if len(runtimeIDs) > 0 {
+		runtimeStore := sourceRuntimeStore(app.deps.StateStore)
+		for _, runtimeID := range runtimeIDs {
+			if err := authorizeSourceRuntimeIDTenant(r.Context(), runtimeStore, runtimeID); err != nil {
+				return mcpRiskActionPlanResult{}, mcpNormalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound)
+			}
+		}
+	}
+	if tenantID == "" && len(runtimeIDs) == 0 && requiresTenantFilter(r.Context()) {
+		return mcpRiskActionPlanResult{}, errTenantForbidden
+	}
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		return mcpRiskActionPlanResult{}, err
+	}
+	store := findingStore(app.deps.StateStore)
+	if store == nil {
+		return mcpRiskActionPlanResult{}, findingdomain.ErrRuntimeUnavailable
+	}
+	listRequest := ports.ListFindingsRequest{
+		TenantID: tenantID,
+		Status:   status,
+		Limit:    boundedUint32(findingLimit),
+		Order:    ports.FindingOrderRiskScore,
+	}
+	if len(runtimeIDs) == 1 {
+		listRequest.RuntimeID = runtimeIDs[0]
+	} else if len(runtimeIDs) > 1 {
+		listRequest.RuntimeIDs = runtimeIDs
+	}
+	findings, err := store.ListFindings(r.Context(), listRequest)
+	if err != nil {
+		return mcpRiskActionPlanResult{}, err
+	}
+	filtered := findings[:0]
+	for _, finding := range findings {
+		if finding == nil || !tenantAllowedByContext(r.Context(), finding.TenantID) {
+			continue
+		}
+		filtered = append(filtered, finding)
+	}
+	findings = filtered
+
+	graphEvidenceStatus := mcpGraphEvidenceUnconfigured
+	graphNeighborhoods := map[string]*ports.EntityNeighborhood{}
+	partialErrors := []string{}
+	now := time.Now().UTC()
+	if graphStore := graphQueryStore(app.deps.GraphStore); graphStore != nil {
+		graphEvidenceStatus = mcpGraphEvidenceIncluded
+		targetURNs := riskplan.TargetURNs(findings, riskplan.Options{
+			TenantID:        tenantID,
+			RuntimeIDs:      runtimeIDs,
+			SeedLimit:       riskplan.MaxSimulationSeedLimit,
+			Now:             now,
+			IncludeUnscored: mcpBoolArg(args, "include_unscored"),
+		})
+		seen := map[string]struct{}{}
+		for _, targetURN := range targetURNs {
+			if len(seen) >= rootLimit {
+				break
+			}
+			targetURN = strings.TrimSpace(targetURN)
+			if targetURN == "" {
+				continue
+			}
+			if _, ok := seen[targetURN]; ok {
+				continue
+			}
+			seen[targetURN] = struct{}{}
+			neighborhood, err := graphStore.GetEntityNeighborhood(r.Context(), targetURN, graphLimit)
+			switch {
+			case err == nil:
+				if neighborhood == nil {
+					neighborhood = &ports.EntityNeighborhood{}
+				}
+				graphNeighborhoods[targetURN] = neighborhood
+			case errors.Is(err, ports.ErrGraphEntityNotFound):
+				continue
+			default:
+				partialErrors = append(partialErrors, "graph neighborhood failed for "+targetURN+": "+safeMCPToolError(err))
+			}
+		}
+	}
+	plan := riskplan.Analyze(findings, riskplan.Options{
+		TenantID:           tenantID,
+		RuntimeIDs:         runtimeIDs,
+		CandidateLimit:     limit,
+		SeedLimit:          riskplan.MaxSimulationSeedLimit,
+		GraphNeighborhoods: graphNeighborhoods,
+		Now:                now,
+		IncludeUnscored:    mcpBoolArg(args, "include_unscored"),
+	})
+	return mcpRiskActionPlanResult{
+		Plan:                   plan,
+		Limit:                  limit,
+		FindingLimit:           findingLimit,
+		GraphEvidenceStatus:    graphEvidenceStatus,
+		GraphNeighborhoodCount: len(graphNeighborhoods),
+		PartialErrors:          partialErrors,
+	}, nil
+}
+
 func (app *App) mcpGraphNeighborhood(r *http.Request, args map[string]any) (any, error) {
 	rootURN := mcpStringArg(args, "root_urn")
 	limit, err := mcpUint32Arg(args, "limit")
@@ -1349,6 +1554,60 @@ func mcpTools() []mcpTool {
 			}, nil),
 			OutputSchema: mcpOutputSchema(nil),
 			Annotations:  mcpReadOnlyAnnotations("Risk Summary"),
+		},
+		{
+			Name:        "cerebro.risk.actions.list",
+			Title:       "List Risk Actions",
+			Description: "Rank next-best remediation and planning-blocker candidates from visible findings using bounded risk-delta simulations and graph context.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"tenant_id":        map[string]any{"type": "string"},
+				"runtime_id":       map[string]any{"type": "string"},
+				"runtime_ids":      map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				"status":           map[string]any{"type": "string", "enum": []string{"open", "resolved", "suppressed"}},
+				"limit":            mcpLimitSchema(riskplan.MaxCandidateLimit, "risk action candidates"),
+				"finding_limit":    mcpLimitSchema(maxMCPRiskLimit, "risk findings to seed the plan"),
+				"resource_limit":   mcpLimitSchema(maxMCPRiskActionRoots, "candidate target graph roots"),
+				"graph_limit":      mcpLimitSchema(maxMCPRiskActionGraph, "graph neighbors per candidate target"),
+				"include_unscored": map[string]any{"type": "boolean"},
+			}, nil),
+			OutputSchema: mcpOutputSchema(map[string]any{
+				"plan":                     map[string]any{"type": "object"},
+				"action_candidates":        map[string]any{"type": "array"},
+				"graph_evidence_status":    map[string]any{"type": "string"},
+				"graph_neighborhood_count": map[string]any{"type": "integer"},
+			}),
+			Annotations: mcpReadOnlyAnnotations("List Risk Actions"),
+		},
+		{
+			Name:        "cerebro.risk.actions.explain",
+			Title:       "Explain Risk Action",
+			Description: "Explain one ranked risk action candidate by id, including score breakdown, expected reduction, effort, ownership, evidence quality, outcome learning, and risk delta.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"candidate_id":     map[string]any{"type": "string"},
+				"tenant_id":        map[string]any{"type": "string"},
+				"runtime_id":       map[string]any{"type": "string"},
+				"runtime_ids":      map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				"status":           map[string]any{"type": "string", "enum": []string{"open", "resolved", "suppressed"}},
+				"limit":            mcpLimitSchema(riskplan.MaxCandidateLimit, "risk action candidates"),
+				"finding_limit":    mcpLimitSchema(maxMCPRiskLimit, "risk findings to seed the plan"),
+				"resource_limit":   mcpLimitSchema(maxMCPRiskActionRoots, "candidate target graph roots"),
+				"graph_limit":      mcpLimitSchema(maxMCPRiskActionGraph, "graph neighbors per candidate target"),
+				"include_unscored": map[string]any{"type": "boolean"},
+			}, []string{"candidate_id"}),
+			OutputSchema: mcpOutputSchema(map[string]any{
+				"candidate":                map[string]any{"type": "object"},
+				"score_breakdown":          map[string]any{"type": "object"},
+				"expected_reduction":       map[string]any{"type": "object"},
+				"effort":                   map[string]any{"type": "object"},
+				"ownership":                map[string]any{"type": "object"},
+				"evidence":                 map[string]any{"type": "object"},
+				"outcome_learning":         map[string]any{"type": "object"},
+				"risk_delta":               map[string]any{"type": "object"},
+				"plan_model_version":       map[string]any{"type": "string"},
+				"graph_evidence_status":    map[string]any{"type": "string"},
+				"graph_neighborhood_count": map[string]any{"type": "integer"},
+			}),
+			Annotations: mcpReadOnlyAnnotations("Explain Risk Action"),
 		},
 		{
 			Name:        "cerebro.graph.neighborhood",
@@ -2693,6 +2952,59 @@ func mcpStringArg(args map[string]any, key string) string {
 	default:
 		return strings.TrimSpace(fmt.Sprint(typed))
 	}
+}
+
+func mcpRuntimeIDsArg(args map[string]any) []string {
+	values := []string{}
+	if runtimeID := mcpStringArg(args, "runtime_id"); runtimeID != "" {
+		values = append(values, runtimeID)
+	}
+	raw, ok := args["runtime_ids"]
+	if !ok || raw == nil {
+		return normalizeMCPStringList(values)
+	}
+	switch typed := raw.(type) {
+	case []any:
+		for _, item := range typed {
+			values = append(values, mcpAnyString(item))
+		}
+	case []string:
+		values = append(values, typed...)
+	case string:
+		values = append(values, splitMCPStringList(typed)...)
+	default:
+		values = append(values, splitMCPStringList(mcpAnyString(typed))...)
+	}
+	return normalizeMCPStringList(values)
+}
+
+func splitMCPStringList(value string) []string {
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t'
+	})
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		values = append(values, part)
+	}
+	return values
+}
+
+func normalizeMCPStringList(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	sort.Strings(normalized)
+	return normalized
 }
 
 func mcpBoolArg(args map[string]any, key string) bool {

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -1022,10 +1022,26 @@ func (app *App) mcpBuildRiskActionPlan(r *http.Request, args map[string]any) (mc
 	}
 	if len(runtimeIDs) > 0 {
 		runtimeStore := sourceRuntimeStore(app.deps.StateStore)
+		runtimeTenantID := ""
+		mixedRuntimeTenants := false
 		for _, runtimeID := range runtimeIDs {
-			if err := authorizeSourceRuntimeIDTenant(r.Context(), runtimeStore, runtimeID); err != nil {
+			resolvedTenantID, err := sourceRuntimeTenantID(r.Context(), runtimeStore, runtimeID, false)
+			if err != nil {
 				return mcpRiskActionPlanResult{}, mcpNormalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound)
 			}
+			if tenantID != "" || resolvedTenantID == "" {
+				continue
+			}
+			if runtimeTenantID == "" {
+				runtimeTenantID = resolvedTenantID
+				continue
+			}
+			if runtimeTenantID != resolvedTenantID {
+				mixedRuntimeTenants = true
+			}
+		}
+		if tenantID == "" && !mixedRuntimeTenants {
+			tenantID = runtimeTenantID
 		}
 	}
 	if tenantID == "" && len(runtimeIDs) == 0 && requiresTenantFilter(r.Context()) {

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -127,6 +127,8 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 		"cerebro.assets.search",
 		"cerebro.assets.get",
 		"cerebro.risk.summary",
+		"cerebro.risk.actions.list",
+		"cerebro.risk.actions.explain",
 		"cerebro.graph.neighborhood",
 		"cerebro.graph.impact",
 		"cerebro.graph.paths",
@@ -1044,7 +1046,8 @@ func TestMCPAssetsSearchUsesTenantScopedCypher(t *testing.T) {
 func TestMCPAssetsGetGraphToolsAndDryRunProposals(t *testing.T) {
 	store := &stubRuntimeStore{
 		runtimes: map[string]*cerebrov1.SourceRuntime{
-			"writer-aws": {Id: "writer-aws", SourceId: "aws", TenantId: "writer"},
+			"writer-aws":    {Id: "writer-aws", SourceId: "aws", TenantId: "writer"},
+			"writer-github": {Id: "writer-github", SourceId: "github", TenantId: "writer"},
 		},
 		findings: map[string]*ports.FindingRecord{
 			"finding-1": {ID: "finding-1", RuntimeID: "writer-aws", TenantID: "writer", RuleID: "rule-1", Title: "Finding", Severity: "high", Status: "open"},
@@ -1365,6 +1368,144 @@ func TestMCPRiskSummaryAggregatesScopedRuntimeFindings(t *testing.T) {
 	recent := summary["recent_high_risk"].([]any)
 	if len(recent) == 0 || recent[0].(map[string]any)["id"] != "finding-critical" {
 		t.Fatalf("recent_high_risk = %#v", recent)
+	}
+}
+
+func TestMCPRiskActionsListAndExplain(t *testing.T) {
+	now := time.Now().UTC()
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-aws":    {Id: "writer-aws", SourceId: "aws", TenantId: "writer"},
+			"writer-github": {Id: "writer-github", SourceId: "github", TenantId: "writer"},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"cloud-public-prod-secrets": {
+				ID:           "cloud-public-prod-secrets",
+				TenantID:     "writer",
+				RuntimeID:    "writer-aws",
+				RuleID:       "cloud-public-resource-exposure",
+				Title:        "Cloud Public Resource Exposure",
+				Severity:     "HIGH",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:aws_secret_store:prod-secrets"},
+				EventIDs:     []string{"evt-public"},
+				FindingWorkflow: ports.FindingWorkflow{
+					Assignee: "cloud-platform",
+				},
+				FindingRisk: ports.FindingRisk{
+					RiskScore:       90,
+					ConfidenceScore: 92,
+					RiskReasons:     []string{"external_exposure", "crown_jewel"},
+					RiskFactors: []ports.FindingRiskFactor{
+						{FactorID: "external_exposure", Category: "likelihood", Weight: 35, SeverityContribution: "high", EvidenceRefs: []string{"attribute:internet_exposed"}},
+					},
+				},
+				Attributes: map[string]string{
+					"action":               "public_network_ingress",
+					"internet_exposed":     "true",
+					"primary_resource_urn": "urn:cerebro:writer:aws_secret_store:prod-secrets",
+					"resource_name":        "prod-secrets",
+				},
+				LastObservedAt: now,
+			},
+		},
+	}
+	graph := &stubGraphStore{
+		neighborhood: &ports.EntityNeighborhood{
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+			Neighbors: []*ports.NeighborhoodNode{
+				{URN: "urn:cerebro:writer:aws_public_principal:public_internet", EntityType: "aws.public_principal", Label: "public internet"},
+				{URN: "urn:cerebro:writer:finding:cloud-public-prod-secrets", EntityType: "finding", Label: "cloud-public-prod-secrets"},
+			},
+			Relations: []*ports.NeighborhoodRelation{
+				{FromURN: "urn:cerebro:writer:aws_public_principal:public_internet", Relation: "can_reach", ToURN: "urn:cerebro:writer:aws_secret_store:prod-secrets"},
+				{FromURN: "urn:cerebro:writer:aws_secret_store:prod-secrets", Relation: "has_finding", ToURN: "urn:cerebro:writer:finding:cloud-public-prod-secrets"},
+			},
+		},
+	}
+	server := newMCPTestServerWithGraph(t, store, graph)
+	defer server.Close()
+
+	listResp, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.risk.actions.list",
+			"arguments": map[string]any{
+				"runtime_ids": []string{"writer-aws", "writer-github"},
+				"status":      "open",
+				"limit":       5,
+				"graph_limit": 3,
+			},
+		},
+	})
+	if listResp["error"] != nil {
+		t.Fatalf("risk.actions.list error = %#v", listResp["error"])
+	}
+	if listResp["result"].(map[string]any)["isError"] == true {
+		t.Fatalf("risk.actions.list tool error = %#v", listResp["result"])
+	}
+	content := listResp["result"].(map[string]any)["structuredContent"].(map[string]any)
+	if content["graph_evidence_status"] != mcpGraphEvidenceIncluded || content["graph_neighborhood_count"] != float64(1) {
+		t.Fatalf("graph evidence content = %#v", content)
+	}
+	candidates := content["action_candidates"].([]any)
+	if len(candidates) != 1 {
+		t.Fatalf("action_candidates = %#v, want one candidate", candidates)
+	}
+	candidate := candidates[0].(map[string]any)
+	candidateID := "remove-public-exposure-urn-cerebro-writer-aws-secret-store-prod-secrets"
+	if candidate["id"] != candidateID || candidate["simulation_status"] != "simulated" {
+		t.Fatalf("candidate = %#v, want simulated public exposure candidate", candidate)
+	}
+	if candidate["owner"] != "cloud-platform" {
+		t.Fatalf("candidate owner = %#v, want cloud-platform", candidate["owner"])
+	}
+	scoreBreakdown := candidate["score_breakdown"].(map[string]any)
+	if scoreBreakdown["total"].(float64) <= 0 || scoreBreakdown["attack_path_count_reduction_points"].(float64) <= 0 {
+		t.Fatalf("score_breakdown = %#v, want positive attack-path contribution", scoreBreakdown)
+	}
+	if store.findingListRequest.RuntimeID != "" || len(store.findingListRequest.RuntimeIDs) != 2 || store.findingListRequest.RuntimeIDs[0] != "writer-aws" || store.findingListRequest.RuntimeIDs[1] != "writer-github" {
+		t.Fatalf("finding list request = %#v, want runtime_ids request", store.findingListRequest)
+	}
+	if graph.neighborhoodRootURN != "urn:cerebro:writer:aws_secret_store:prod-secrets" || graph.neighborhoodLimit != 3 {
+		t.Fatalf("graph request root=%q limit=%d, want prod-secrets limit 3", graph.neighborhoodRootURN, graph.neighborhoodLimit)
+	}
+
+	explainResp, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.risk.actions.explain",
+			"arguments": map[string]any{
+				"candidate_id": candidateID,
+				"runtime_ids":  []string{"writer-aws", "writer-github"},
+				"status":       "open",
+				"limit":        5,
+				"graph_limit":  3,
+			},
+		},
+	})
+	if explainResp["error"] != nil {
+		t.Fatalf("risk.actions.explain error = %#v", explainResp["error"])
+	}
+	if explainResp["result"].(map[string]any)["isError"] == true {
+		t.Fatalf("risk.actions.explain tool error = %#v", explainResp["result"])
+	}
+	explain := explainResp["result"].(map[string]any)["structuredContent"].(map[string]any)
+	if explain["plan_model_version"] != "risk-action-plan-v2" {
+		t.Fatalf("plan_model_version = %#v, want risk-action-plan-v2", explain["plan_model_version"])
+	}
+	if explain["candidate"].(map[string]any)["id"] != candidateID {
+		t.Fatalf("explain candidate = %#v, want %s", explain["candidate"], candidateID)
+	}
+	if explain["expected_reduction"].(map[string]any)["risk_score"].(float64) <= 0 {
+		t.Fatalf("expected_reduction = %#v, want positive risk score reduction", explain["expected_reduction"])
+	}
+	if explain["ownership"].(map[string]any)["owner"] != "cloud-platform" {
+		t.Fatalf("ownership = %#v, want cloud-platform", explain["ownership"])
 	}
 }
 

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -1509,6 +1509,88 @@ func TestMCPRiskActionsListAndExplain(t *testing.T) {
 	}
 }
 
+func TestMCPRiskActionsDerivesTenantFromRuntimeID(t *testing.T) {
+	now := time.Now().UTC()
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-aws": {Id: "writer-aws", SourceId: "aws", TenantId: "writer"},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"cloud-public-prod-secrets": {
+				ID:           "cloud-public-prod-secrets",
+				TenantID:     "writer",
+				RuntimeID:    "writer-aws",
+				RuleID:       "cloud-public-resource-exposure",
+				Title:        "Cloud Public Resource Exposure",
+				Severity:     "HIGH",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:aws_secret_store:prod-secrets"},
+				FindingRisk: ports.FindingRisk{
+					RiskScore:       90,
+					ConfidenceScore: 92,
+					RiskReasons:     []string{"external_exposure"},
+					RiskFactors: []ports.FindingRiskFactor{
+						{FactorID: "external_exposure", Category: "likelihood", Weight: 35, SeverityContribution: "high", EvidenceRefs: []string{"attribute:internet_exposed"}},
+					},
+				},
+				Attributes: map[string]string{
+					"action":               "public_network_ingress",
+					"internet_exposed":     "true",
+					"primary_resource_urn": "urn:cerebro:writer:aws_secret_store:prod-secrets",
+					"resource_name":        "prod-secrets",
+				},
+				LastObservedAt: now,
+			},
+		},
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled:        true,
+			AllowedTenants: []string{"writer"},
+			APIKeys: []config.APIKey{{
+				Key:       "test-key",
+				Principal: "tester",
+			}},
+		},
+	}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.risk.actions.list",
+			"arguments": map[string]any{
+				"runtime_id": "writer-aws",
+				"status":     "open",
+				"limit":      5,
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("risk.actions.list error = %#v", response["error"])
+	}
+	if response["result"].(map[string]any)["isError"] == true {
+		t.Fatalf("risk.actions.list tool error = %#v", response["result"])
+	}
+	content := response["result"].(map[string]any)["structuredContent"].(map[string]any)
+	plan := content["plan"].(map[string]any)
+	if plan["tenant_id"] != "writer" {
+		t.Fatalf("plan.tenant_id = %#v, want writer", plan["tenant_id"])
+	}
+	candidates := content["action_candidates"].([]any)
+	if len(candidates) != 1 {
+		t.Fatalf("action_candidates = %#v, want one candidate", candidates)
+	}
+	if store.findingListRequest.TenantID != "writer" || store.findingListRequest.RuntimeID != "writer-aws" {
+		t.Fatalf("finding list request = %#v, want tenant/runtime scoped request", store.findingListRequest)
+	}
+}
+
 func TestMCPRiskSummaryCountsAllMatchingFindingsBeyondReturnedLimit(t *testing.T) {
 	now := time.Now().UTC()
 	store := &stubRuntimeStore{

--- a/internal/reports/risk_action_plan.go
+++ b/internal/reports/risk_action_plan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -12,80 +11,15 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
-	findinganalysis "github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/riskplan"
 )
 
 const (
 	reportParameterCandidateLimit      = "candidate_limit"
-	defaultRiskActionCandidateLimit    = 10
-	maxRiskActionCandidateLimit        = 25
-	maxRiskActionSimulationSeedLimit   = 50
-	riskActionTypeRemovePublicExposure = "remove_public_exposure"
-	riskActionTypeRemovePrivilege      = "remove_privilege"
-	riskActionTypePatchVulnerability   = "patch_vulnerability"
+	reportParameterIncludeUnscored     = "include_unscored"
+	reportParameterPreviousReportRunID = "previous_report_run_id"
 )
-
-type riskActionCandidateSeed struct {
-	ID              string
-	Title           string
-	ActionType      string
-	ScenarioType    string
-	TargetURN       string
-	FindingIDs      map[string]struct{}
-	RuleIDs         map[string]struct{}
-	RuntimeIDs      map[string]struct{}
-	ResourceURNs    map[string]struct{}
-	Owners          map[string]struct{}
-	ControlRefs     map[string]struct{}
-	Reasons         map[string]struct{}
-	RiskFactors     map[string]*riskActionFactorSummary
-	MaxRiskScore    int
-	ConfidenceScore int
-}
-
-type riskActionFactorSummary struct {
-	FactorID             string
-	Category             string
-	SeverityContribution string
-	Count                int
-	WeightTotal          int
-	EvidenceRefs         map[string]struct{}
-}
-
-type riskActionCandidateOutput struct {
-	ID                               string                                    `json:"id"`
-	Title                            string                                    `json:"title"`
-	ActionType                       string                                    `json:"action_type"`
-	ScenarioType                     string                                    `json:"scenario_type"`
-	TargetURN                        string                                    `json:"target_urn"`
-	Owner                            string                                    `json:"owner,omitempty"`
-	PriorityScore                    int                                       `json:"priority_score"`
-	RiskLevel                        string                                    `json:"risk_level,omitempty"`
-	ConfidenceScore                  int                                       `json:"confidence_score,omitempty"`
-	ExpectedRiskScoreReduction       int                                       `json:"expected_risk_score_reduction"`
-	ExpectedAttackPathScoreReduction int                                       `json:"expected_attack_path_score_reduction"`
-	ExpectedAttackPathCountReduction int                                       `json:"expected_attack_path_count_reduction"`
-	BeforeRiskScore                  int                                       `json:"before_risk_score"`
-	AfterRiskScore                   int                                       `json:"after_risk_score"`
-	FindingIDs                       []string                                  `json:"finding_ids,omitempty"`
-	RuleIDs                          []string                                  `json:"rule_ids,omitempty"`
-	RuntimeIDs                       []string                                  `json:"runtime_ids,omitempty"`
-	ResourceURNs                     []string                                  `json:"resource_urns,omitempty"`
-	ControlRefs                      []string                                  `json:"control_refs,omitempty"`
-	RiskFactors                      []riskActionFactorOutput                  `json:"risk_factors,omitempty"`
-	Reasons                          []string                                  `json:"reasons,omitempty"`
-	RiskDelta                        findinganalysis.RiskDeltaSimulationReport `json:"risk_delta"`
-}
-
-type riskActionFactorOutput struct {
-	FactorID             string   `json:"factor_id"`
-	Category             string   `json:"category,omitempty"`
-	SeverityContribution string   `json:"severity_contribution,omitempty"`
-	Count                int      `json:"count"`
-	WeightTotal          int      `json:"weight_total"`
-	EvidenceRefs         []string `json:"evidence_refs,omitempty"`
-}
 
 func (s *Service) runRiskActionPlan(ctx context.Context, parameters map[string]string) (*structpb.Struct, error) {
 	tenantID := strings.TrimSpace(parameters[reportParameterTenantID])
@@ -96,7 +30,7 @@ func (s *Service) runRiskActionPlan(ctx context.Context, parameters map[string]s
 	if len(runtimeIDs) == 0 {
 		return nil, fmt.Errorf("%w: report parameter %q is required", ErrInvalidRequest, reportParameterRuntimeIDs)
 	}
-	candidateLimit, err := normalizePositiveLimit(parameters[reportParameterCandidateLimit], defaultRiskActionCandidateLimit, maxRiskActionCandidateLimit, reportParameterCandidateLimit)
+	candidateLimit, err := normalizePositiveLimit(parameters[reportParameterCandidateLimit], riskplan.DefaultCandidateLimit, riskplan.MaxCandidateLimit, reportParameterCandidateLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -108,11 +42,19 @@ func (s *Service) runRiskActionPlan(ctx context.Context, parameters map[string]s
 	if err != nil {
 		return nil, err
 	}
+	includeUnscored, err := normalizeBoolParameter(parameters[reportParameterIncludeUnscored], false, reportParameterIncludeUnscored)
+	if err != nil {
+		return nil, err
+	}
 	runtimeIDsCSV := strings.Join(runtimeIDs, ",")
 	parameters[reportParameterRuntimeIDs] = runtimeIDsCSV
 	parameters[reportParameterCandidateLimit] = strconv.Itoa(candidateLimit)
 	parameters[reportParameterResourceLimit] = strconv.Itoa(resourceLimit)
 	parameters[reportParameterGraphLimit] = strconv.Itoa(graphLimit)
+	if includeUnscored {
+		parameters[reportParameterIncludeUnscored] = "true"
+	}
+
 	listRequest := ports.ListFindingsRequest{TenantID: tenantID, Order: ports.FindingOrderRiskScore}
 	if len(runtimeIDs) == 1 {
 		listRequest.RuntimeID = runtimeIDs[0]
@@ -124,45 +66,147 @@ func (s *Service) runRiskActionPlan(ctx context.Context, parameters map[string]s
 		return nil, fmt.Errorf("list findings for tenant %q runtimes %q: %w", tenantID, runtimeIDsCSV, err)
 	}
 	now := time.Now().UTC()
-	seeds := riskActionPlanSeeds(tenantID, findings, now)
+	previousCandidates, err := s.previousRiskActionCandidates(ctx, strings.TrimSpace(parameters[reportParameterPreviousReportRunID]))
+	if err != nil {
+		return nil, err
+	}
+
 	graphEvidenceStatus := graphEvidenceStatusUnconfigured
 	graphNeighborhoods := map[string]*ports.EntityNeighborhood{}
 	if s.graphStore != nil {
 		graphEvidenceStatus = graphEvidenceStatusIncluded
-		graphNeighborhoods, err = s.riskActionPlanGraphNeighborhoods(ctx, seeds, resourceLimit, graphLimit)
+		targetURNs := riskplan.TargetURNs(findings, riskplan.Options{
+			TenantID:        tenantID,
+			RuntimeIDs:      runtimeIDs,
+			SeedLimit:       riskplan.MaxSimulationSeedLimit,
+			Now:             now,
+			IncludeUnscored: includeUnscored,
+		})
+		graphNeighborhoods, err = s.riskActionPlanGraphNeighborhoods(ctx, targetURNs, resourceLimit, graphLimit)
 		if err != nil {
 			return nil, err
 		}
 	}
-	candidates := riskActionPlanCandidates(findings, seeds, graphNeighborhoods, candidateLimit, now)
-	actionCandidates, err := jsonPayload(candidates)
+	plan := riskplan.Analyze(findings, riskplan.Options{
+		TenantID:           tenantID,
+		RuntimeIDs:         runtimeIDs,
+		CandidateLimit:     candidateLimit,
+		SeedLimit:          riskplan.MaxSimulationSeedLimit,
+		GraphNeighborhoods: graphNeighborhoods,
+		Now:                now,
+		PreviousCandidates: previousCandidates,
+		IncludeUnscored:    includeUnscored,
+	})
+	actionCandidates, err := jsonPayload(plan.ActionCandidates)
 	if err != nil {
 		return nil, fmt.Errorf("build risk action plan candidate payload: %w", err)
 	}
-	result, err := structpb.NewStruct(map[string]any{
-		reportParameterTenantID:       tenantID,
-		reportParameterRuntimeIDs:     reportStringValues(runtimeIDs),
-		reportParameterCandidateLimit: candidateLimit,
-		reportParameterResourceLimit:  resourceLimit,
-		reportParameterGraphLimit:     graphLimit,
-		"total_findings":              len(findings),
-		"candidate_seed_count":        len(seeds),
-		"total_candidates":            len(candidates),
-		"graph_evidence_status":       graphEvidenceStatus,
-		"graph_neighborhood_count":    len(graphNeighborhoods),
-		"action_candidates":           actionCandidates,
-	})
+	planPayload, err := jsonPayload(plan)
+	if err != nil {
+		return nil, fmt.Errorf("build risk action plan payload: %w", err)
+	}
+	resultValues := map[string]any{
+		reportParameterTenantID:        tenantID,
+		reportParameterRuntimeIDs:      reportStringValues(runtimeIDs),
+		reportParameterCandidateLimit:  candidateLimit,
+		reportParameterResourceLimit:   resourceLimit,
+		reportParameterGraphLimit:      graphLimit,
+		reportParameterIncludeUnscored: includeUnscored,
+		"model_version":                plan.ModelVersion,
+		"total_findings":               plan.TotalFindings,
+		"candidate_seed_count":         plan.CandidateSeedCount,
+		"total_candidates":             plan.TotalCandidates,
+		"simulated_candidate_count":    plan.SimulatedCandidateCount,
+		"unscored_candidate_count":     plan.UnscoredCandidateCount,
+		"graph_evidence_status":        graphEvidenceStatus,
+		"graph_neighborhood_count":     len(graphNeighborhoods),
+		"action_candidates":            actionCandidates,
+		"plan":                         planPayload,
+	}
+	if plan.Diff != nil {
+		planDiff, err := jsonPayload(plan.Diff)
+		if err != nil {
+			return nil, fmt.Errorf("build risk action plan diff payload: %w", err)
+		}
+		resultValues["plan_diff"] = planDiff
+	}
+	result, err := structpb.NewStruct(resultValues)
 	if err != nil {
 		return nil, fmt.Errorf("build risk action plan report result: %w", err)
 	}
 	return result, nil
 }
 
+func (s *Service) previousRiskActionCandidates(ctx context.Context, reportRunID string) ([]riskplan.Candidate, error) {
+	if reportRunID == "" {
+		return nil, nil
+	}
+	if s.reportStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	run, err := s.reportStore.GetReportRun(ctx, reportRunID)
+	if err != nil {
+		return nil, fmt.Errorf("load previous risk action plan report run %q: %w", reportRunID, err)
+	}
+	result := run.GetResult()
+	if result == nil {
+		return nil, nil
+	}
+	candidates, err := riskplan.DecodeCandidates(result.AsMap()["action_candidates"])
+	if err != nil {
+		return nil, fmt.Errorf("decode previous risk action plan candidates from %q: %w", reportRunID, err)
+	}
+	return candidates, nil
+}
+
+func normalizeBoolParameter(raw string, defaultValue bool, parameterID string) (bool, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return defaultValue, nil
+	}
+	value, err := strconv.ParseBool(trimmed)
+	if err != nil {
+		return false, fmt.Errorf("%w: report parameter %q must be a boolean", ErrInvalidRequest, parameterID)
+	}
+	return value, nil
+}
+
+func (s *Service) riskActionPlanGraphNeighborhoods(ctx context.Context, targetURNs []string, resourceLimit int, graphLimit int) (map[string]*ports.EntityNeighborhood, error) {
+	neighborhoods := map[string]*ports.EntityNeighborhood{}
+	seen := map[string]struct{}{}
+	for _, targetURN := range targetURNs {
+		if len(seen) >= resourceLimit {
+			break
+		}
+		targetURN = strings.TrimSpace(targetURN)
+		if targetURN == "" {
+			continue
+		}
+		if _, ok := seen[targetURN]; ok {
+			continue
+		}
+		seen[targetURN] = struct{}{}
+		neighborhood, err := s.graphStore.GetEntityNeighborhood(ctx, targetURN, graphLimit)
+		switch {
+		case err == nil:
+			if neighborhood == nil {
+				neighborhood = &ports.EntityNeighborhood{}
+			}
+			neighborhoods[targetURN] = neighborhood
+		case errors.Is(err, ports.ErrGraphEntityNotFound):
+			continue
+		default:
+			return nil, fmt.Errorf("load risk action plan graph neighborhood for %q: %w", targetURN, err)
+		}
+	}
+	return neighborhoods, nil
+}
+
 func riskActionPlanDefinition() *cerebrov1.ReportDefinition {
 	return &cerebrov1.ReportDefinition{
 		Id:          riskActionPlanReportID,
 		Name:        riskActionPlanReportName,
-		Description: "Rank next-best remediation actions by simulating expected risk and attack-path reduction from persisted findings and bounded graph neighborhoods without mutating stores.",
+		Description: "Rank next-best remediation actions with typed score breakdowns, effort, ownership, evidence quality, prior outcome learning, and optional plan diffs without mutating stores.",
 		Parameters: []*cerebrov1.ReportParameter{
 			{
 				Id:          reportParameterTenantID,
@@ -189,489 +233,16 @@ func riskActionPlanDefinition() *cerebrov1.ReportDefinition {
 				Description: "Optional maximum neighborhood size to read for each candidate target root.",
 				Required:    false,
 			},
+			{
+				Id:          reportParameterIncludeUnscored,
+				Description: "Optional boolean that includes planning blockers such as missing ownership or stale evidence even when no direct risk-delta simulation is available.",
+				Required:    false,
+			},
+			{
+				Id:          reportParameterPreviousReportRunID,
+				Description: "Optional prior risk-action-plan report run id used to return added, removed, and changed candidate diffs.",
+				Required:    false,
+			},
 		},
 	}
-}
-
-func riskActionPlanSeeds(tenantID string, findings []*ports.FindingRecord, now time.Time) []riskActionCandidateSeed {
-	byID := map[string]*riskActionCandidateSeed{}
-	for _, finding := range findings {
-		if finding == nil {
-			continue
-		}
-		context := findinganalysis.AnalyzeFindingRiskContext(finding, now)
-		for _, actionType := range []string{riskActionTypeRemovePublicExposure, riskActionTypeRemovePrivilege, riskActionTypePatchVulnerability} {
-			if !riskActionFindingSupportsAction(finding, context, actionType) {
-				continue
-			}
-			targetURN := riskActionTargetURN(tenantID, finding, actionType)
-			if targetURN == "" {
-				continue
-			}
-			id := actionType + "|" + targetURN
-			seed := byID[id]
-			if seed == nil {
-				seed = newRiskActionCandidateSeed(id, actionType, targetURN, finding)
-				byID[id] = seed
-			}
-			seed.addFinding(finding, context)
-		}
-	}
-	seeds := make([]riskActionCandidateSeed, 0, len(byID))
-	for _, seed := range byID {
-		seeds = append(seeds, *seed)
-	}
-	slices.SortFunc(seeds, compareRiskActionSeeds)
-	if len(seeds) > maxRiskActionSimulationSeedLimit {
-		seeds = seeds[:maxRiskActionSimulationSeedLimit]
-	}
-	return seeds
-}
-
-func newRiskActionCandidateSeed(id string, actionType string, targetURN string, finding *ports.FindingRecord) *riskActionCandidateSeed {
-	return &riskActionCandidateSeed{
-		ID:           id,
-		Title:        riskActionTitle(actionType, riskActionTargetLabel(finding, targetURN)),
-		ActionType:   actionType,
-		ScenarioType: actionType,
-		TargetURN:    targetURN,
-		FindingIDs:   map[string]struct{}{},
-		RuleIDs:      map[string]struct{}{},
-		RuntimeIDs:   map[string]struct{}{},
-		ResourceURNs: map[string]struct{}{},
-		Owners:       map[string]struct{}{},
-		ControlRefs:  map[string]struct{}{},
-		Reasons:      map[string]struct{}{},
-		RiskFactors:  map[string]*riskActionFactorSummary{},
-	}
-}
-
-func (s *riskActionCandidateSeed) addFinding(finding *ports.FindingRecord, context findinganalysis.FindingRiskContext) {
-	addStringSetValue(s.FindingIDs, finding.ID)
-	addStringSetValue(s.RuleIDs, finding.RuleID)
-	addStringSetValue(s.RuntimeIDs, finding.RuntimeID)
-	for _, resourceURN := range finding.ResourceURNs {
-		addStringSetValue(s.ResourceURNs, resourceURN)
-	}
-	if primary := primaryResourceURN(finding); primary != "" {
-		addStringSetValue(s.ResourceURNs, primary)
-	}
-	if owner := riskActionFindingOwner(finding); owner != "" {
-		addStringSetValue(s.Owners, owner)
-	}
-	for _, controlRef := range finding.ControlRefs {
-		normalized, key := normalizeControlRef(controlRef)
-		if key == "" {
-			continue
-		}
-		addStringSetValue(s.ControlRefs, normalized.FrameworkName+":"+normalized.ControlID)
-	}
-	for _, reason := range append(append([]string{}, finding.RiskReasons...), context.Reasons...) {
-		addStringSetValue(s.Reasons, reason)
-	}
-	for _, factor := range append(append([]ports.FindingRiskFactor{}, finding.RiskFactors...), context.Factors...) {
-		s.addRiskFactor(factor)
-	}
-	riskScore := finding.RiskScore
-	if riskScore == 0 {
-		riskScore = context.Score
-	}
-	if riskScore > s.MaxRiskScore {
-		s.MaxRiskScore = riskScore
-	}
-	confidenceScore := finding.ConfidenceScore
-	if confidenceScore == 0 {
-		confidenceScore = context.ConfidenceScore
-	}
-	if confidenceScore > s.ConfidenceScore {
-		s.ConfidenceScore = confidenceScore
-	}
-}
-
-func (s *riskActionCandidateSeed) addRiskFactor(factor ports.FindingRiskFactor) {
-	factorID := strings.TrimSpace(factor.FactorID)
-	if factorID == "" {
-		return
-	}
-	entry := s.RiskFactors[factorID]
-	if entry == nil {
-		entry = &riskActionFactorSummary{
-			FactorID:             factorID,
-			Category:             strings.TrimSpace(factor.Category),
-			SeverityContribution: strings.TrimSpace(factor.SeverityContribution),
-			EvidenceRefs:         map[string]struct{}{},
-		}
-		s.RiskFactors[factorID] = entry
-	}
-	entry.Count++
-	entry.WeightTotal += factor.Weight
-	for _, ref := range factor.EvidenceRefs {
-		addStringSetValue(entry.EvidenceRefs, ref)
-	}
-}
-
-func (s *Service) riskActionPlanGraphNeighborhoods(ctx context.Context, seeds []riskActionCandidateSeed, resourceLimit int, graphLimit int) (map[string]*ports.EntityNeighborhood, error) {
-	neighborhoods := map[string]*ports.EntityNeighborhood{}
-	seen := map[string]struct{}{}
-	for _, seed := range seeds {
-		if len(seen) >= resourceLimit {
-			break
-		}
-		targetURN := strings.TrimSpace(seed.TargetURN)
-		if targetURN == "" {
-			continue
-		}
-		if _, ok := seen[targetURN]; ok {
-			continue
-		}
-		seen[targetURN] = struct{}{}
-		neighborhood, err := s.graphStore.GetEntityNeighborhood(ctx, targetURN, graphLimit)
-		switch {
-		case err == nil:
-			if neighborhood == nil {
-				neighborhood = &ports.EntityNeighborhood{}
-			}
-			neighborhoods[targetURN] = neighborhood
-		case errors.Is(err, ports.ErrGraphEntityNotFound):
-			continue
-		default:
-			return nil, fmt.Errorf("load risk action plan graph neighborhood for %q: %w", targetURN, err)
-		}
-	}
-	return neighborhoods, nil
-}
-
-func riskActionPlanCandidates(findings []*ports.FindingRecord, seeds []riskActionCandidateSeed, graphNeighborhoods map[string]*ports.EntityNeighborhood, limit int, now time.Time) []riskActionCandidateOutput {
-	candidates := make([]riskActionCandidateOutput, 0, len(seeds))
-	for _, seed := range seeds {
-		report := findinganalysis.SimulateRiskDelta(findings, findinganalysis.RiskDeltaSimulationOptions{
-			ScenarioType:       seed.ScenarioType,
-			TargetURN:          seed.TargetURN,
-			Limit:              10,
-			GraphNeighborhoods: graphNeighborhoods,
-			Now:                now,
-		})
-		if report.RiskScoreReduction <= 0 && report.AttackPathScoreReduction <= 0 && report.AttackPathCountReduction <= 0 {
-			continue
-		}
-		candidates = append(candidates, riskActionCandidateOutput{
-			ID:                               riskActionCandidateID(seed),
-			Title:                            seed.Title,
-			ActionType:                       seed.ActionType,
-			ScenarioType:                     seed.ScenarioType,
-			TargetURN:                        seed.TargetURN,
-			Owner:                            firstSortedSetValue(seed.Owners),
-			PriorityScore:                    riskActionPriorityScore(seed, report),
-			RiskLevel:                        reportRiskLevel(seed.MaxRiskScore),
-			ConfidenceScore:                  seed.ConfidenceScore,
-			ExpectedRiskScoreReduction:       report.RiskScoreReduction,
-			ExpectedAttackPathScoreReduction: report.AttackPathScoreReduction,
-			ExpectedAttackPathCountReduction: report.AttackPathCountReduction,
-			BeforeRiskScore:                  report.Before.TotalRiskScore,
-			AfterRiskScore:                   report.After.TotalRiskScore,
-			FindingIDs:                       sortedStringSetValues(seed.FindingIDs),
-			RuleIDs:                          sortedStringSetValues(seed.RuleIDs),
-			RuntimeIDs:                       sortedStringSetValues(seed.RuntimeIDs),
-			ResourceURNs:                     sortedStringSetValues(seed.ResourceURNs),
-			ControlRefs:                      sortedStringSetValues(seed.ControlRefs),
-			RiskFactors:                      riskActionFactorOutputs(seed.RiskFactors),
-			Reasons:                          sortedStringSetValues(seed.Reasons),
-			RiskDelta:                        report,
-		})
-	}
-	slices.SortFunc(candidates, compareRiskActionCandidates)
-	if limit > 0 && len(candidates) > limit {
-		candidates = candidates[:limit]
-	}
-	return candidates
-}
-
-func riskActionFindingSupportsAction(finding *ports.FindingRecord, context findinganalysis.FindingRiskContext, actionType string) bool {
-	attributes := finding.Attributes
-	reasons := map[string]struct{}{}
-	for _, reason := range append(append([]string{}, finding.RiskReasons...), context.Reasons...) {
-		addStringSetValue(reasons, reason)
-	}
-	for _, factor := range append(append([]ports.FindingRiskFactor{}, finding.RiskFactors...), context.Factors...) {
-		addStringSetValue(reasons, factor.FactorID)
-	}
-	action := strings.ToLower(strings.TrimSpace(attributes["action"]))
-	switch actionType {
-	case riskActionTypeRemovePublicExposure:
-		return stringSetContains(reasons, "external_exposure") ||
-			riskActionAttributeBool(attributes, "internet_exposed", "public", "externally_exposed", "external_exposure", "is_public", "is_internet_facing", "reachable", "directly_reachable", "internet_reachable", "can_reach") ||
-			riskActionContainsAny(action, "public", "expose", "internet", "can_reach")
-	case riskActionTypeRemovePrivilege:
-		return stringSetContains(reasons, "privileged_actor") ||
-			stringSetContains(reasons, "privilege_or_control_plane") ||
-			riskActionAttributeBool(attributes, "privileged", "actor_privileged", "admin", "is_admin", "has_admin", "can_admin", "admin_reachable", "privileged_access", "has_admin_path") ||
-			riskActionContainsAny(action, "can_admin", "can_assume", "can_impersonate", "administratoraccess")
-	case riskActionTypePatchVulnerability:
-		return stringSetContains(reasons, "known_exploited") ||
-			stringSetContains(reasons, "epss_high") ||
-			stringSetContains(reasons, "epss_elevated") ||
-			stringSetContains(reasons, "exploit_available") ||
-			stringSetContains(reasons, "cvss_critical") ||
-			stringSetContains(reasons, "cvss_high") ||
-			riskActionSetContainsPrefix(reasons, "exploit_maturity:") ||
-			riskActionAttributePresent(attributes, "vulnerability_urn", "package_urn", "image_urn", "cve", "cve_id", "vulnerability_id", "package", "purl", "cvss_score", "cvss", "epss_score", "epss") ||
-			riskActionAttributeBool(attributes, "is_kev", "kev", "known_exploited", "known_exploited_vulnerability", "exploit_available", "public_exploit", "weaponized_exploit")
-	default:
-		return false
-	}
-}
-
-func riskActionTargetURN(tenantID string, finding *ports.FindingRecord, actionType string) string {
-	attributes := finding.Attributes
-	switch actionType {
-	case riskActionTypeRemovePublicExposure:
-		return firstTenantScopedURN(tenantID, attributes["exposed_resource_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
-	case riskActionTypeRemovePrivilege:
-		return firstTenantScopedURN(tenantID, attributes["principal_urn"], attributes["identity_urn"], attributes["actor_urn"], attributes["permission_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
-	case riskActionTypePatchVulnerability:
-		return firstTenantScopedURN(tenantID, attributes["vulnerability_urn"], attributes["package_urn"], attributes["image_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
-	default:
-		return ""
-	}
-}
-
-func firstTenantScopedURN(tenantID string, values ...string) string {
-	for _, value := range values {
-		trimmed := strings.TrimSpace(value)
-		if trimmed == "" {
-			continue
-		}
-		if tenantIDFromRiskDeltaTargetURN(trimmed) == strings.TrimSpace(tenantID) {
-			return trimmed
-		}
-	}
-	return ""
-}
-
-func riskActionTitle(actionType string, targetLabel string) string {
-	switch actionType {
-	case riskActionTypeRemovePublicExposure:
-		return "Remove public exposure from " + targetLabel
-	case riskActionTypeRemovePrivilege:
-		return "Remove excess privilege from " + targetLabel
-	case riskActionTypePatchVulnerability:
-		return "Patch exploitable vulnerability on " + targetLabel
-	default:
-		return "Reduce risk on " + targetLabel
-	}
-}
-
-func riskActionTargetLabel(finding *ports.FindingRecord, targetURN string) string {
-	for _, value := range []string{
-		finding.Attributes["resource_label"],
-		finding.Attributes["resource_name"],
-		finding.Attributes["asset_name"],
-		finding.Attributes["repository"],
-		finding.Attributes["package"],
-		finding.Title,
-	} {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	targetURN = strings.TrimSpace(targetURN)
-	if targetURN == "" {
-		return "target"
-	}
-	parts := strings.FieldsFunc(targetURN, func(r rune) bool {
-		return r == ':' || r == '/' || r == '#'
-	})
-	if len(parts) == 0 {
-		return targetURN
-	}
-	return parts[len(parts)-1]
-}
-
-func riskActionFindingOwner(finding *ports.FindingRecord) string {
-	for _, value := range []string{
-		finding.Assignee,
-		finding.Attributes["owner"],
-		finding.Attributes["team"],
-		finding.Attributes["service_owner"],
-		finding.Attributes["resource_owner"],
-		finding.Attributes["repo_owner"],
-	} {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
-}
-
-func riskActionPriorityScore(seed riskActionCandidateSeed, report findinganalysis.RiskDeltaSimulationReport) int {
-	return report.RiskScoreReduction*10 +
-		report.AttackPathScoreReduction*3 +
-		report.AttackPathCountReduction*25 +
-		seed.MaxRiskScore +
-		len(seed.FindingIDs)*5
-}
-
-func riskActionCandidateID(seed riskActionCandidateSeed) string {
-	value := strings.ToLower(seed.ActionType + "-" + seed.TargetURN)
-	value = strings.NewReplacer(":", "-", "/", "-", "#", "-", "_", "-").Replace(value)
-	value = strings.Trim(value, "-")
-	if value == "" {
-		return "risk-action"
-	}
-	return value
-}
-
-func riskActionFactorOutputs(factors map[string]*riskActionFactorSummary) []riskActionFactorOutput {
-	entries := make([]*riskActionFactorSummary, 0, len(factors))
-	for _, factor := range factors {
-		entries = append(entries, factor)
-	}
-	slices.SortFunc(entries, func(left *riskActionFactorSummary, right *riskActionFactorSummary) int {
-		switch {
-		case left.WeightTotal > right.WeightTotal:
-			return -1
-		case left.WeightTotal < right.WeightTotal:
-			return 1
-		case left.Count > right.Count:
-			return -1
-		case left.Count < right.Count:
-			return 1
-		case left.FactorID < right.FactorID:
-			return -1
-		case left.FactorID > right.FactorID:
-			return 1
-		default:
-			return 0
-		}
-	})
-	values := make([]riskActionFactorOutput, 0, len(entries))
-	for _, entry := range entries {
-		values = append(values, riskActionFactorOutput{
-			FactorID:             entry.FactorID,
-			Category:             entry.Category,
-			SeverityContribution: entry.SeverityContribution,
-			Count:                entry.Count,
-			WeightTotal:          entry.WeightTotal,
-			EvidenceRefs:         sortedStringSetValues(entry.EvidenceRefs),
-		})
-	}
-	return values
-}
-
-func compareRiskActionSeeds(left riskActionCandidateSeed, right riskActionCandidateSeed) int {
-	switch {
-	case left.MaxRiskScore > right.MaxRiskScore:
-		return -1
-	case left.MaxRiskScore < right.MaxRiskScore:
-		return 1
-	case len(left.FindingIDs) > len(right.FindingIDs):
-		return -1
-	case len(left.FindingIDs) < len(right.FindingIDs):
-		return 1
-	case left.ActionType < right.ActionType:
-		return -1
-	case left.ActionType > right.ActionType:
-		return 1
-	case left.TargetURN < right.TargetURN:
-		return -1
-	case left.TargetURN > right.TargetURN:
-		return 1
-	default:
-		return 0
-	}
-}
-
-func compareRiskActionCandidates(left riskActionCandidateOutput, right riskActionCandidateOutput) int {
-	switch {
-	case left.PriorityScore > right.PriorityScore:
-		return -1
-	case left.PriorityScore < right.PriorityScore:
-		return 1
-	case left.ExpectedRiskScoreReduction > right.ExpectedRiskScoreReduction:
-		return -1
-	case left.ExpectedRiskScoreReduction < right.ExpectedRiskScoreReduction:
-		return 1
-	case left.ExpectedAttackPathScoreReduction > right.ExpectedAttackPathScoreReduction:
-		return -1
-	case left.ExpectedAttackPathScoreReduction < right.ExpectedAttackPathScoreReduction:
-		return 1
-	case left.ID < right.ID:
-		return -1
-	case left.ID > right.ID:
-		return 1
-	default:
-		return 0
-	}
-}
-
-func riskActionAttributePresent(attributes map[string]string, keys ...string) bool {
-	for _, key := range keys {
-		if strings.TrimSpace(attributes[key]) != "" {
-			return true
-		}
-	}
-	return false
-}
-
-func riskActionAttributeBool(attributes map[string]string, keys ...string) bool {
-	for _, key := range keys {
-		switch strings.ToLower(strings.TrimSpace(attributes[key])) {
-		case "1", "true", "yes", "y", "enabled", "public", "external", "internet", "admin", "privileged":
-			return true
-		}
-	}
-	return false
-}
-
-func riskActionContainsAny(value string, needles ...string) bool {
-	value = strings.ToLower(strings.TrimSpace(value))
-	if value == "" {
-		return false
-	}
-	for _, needle := range needles {
-		if strings.Contains(value, strings.ToLower(strings.TrimSpace(needle))) {
-			return true
-		}
-	}
-	return false
-}
-
-func riskActionSetContainsPrefix(values map[string]struct{}, prefix string) bool {
-	for value := range values {
-		if strings.HasPrefix(strings.TrimSpace(value), prefix) {
-			return true
-		}
-	}
-	return false
-}
-
-func stringSetContains(values map[string]struct{}, value string) bool {
-	_, ok := values[strings.TrimSpace(value)]
-	return ok
-}
-
-func addStringSetValue(values map[string]struct{}, value string) {
-	if trimmed := strings.TrimSpace(value); trimmed != "" {
-		values[trimmed] = struct{}{}
-	}
-}
-
-func firstSortedSetValue(values map[string]struct{}) string {
-	sorted := sortedStringSetValues(values)
-	if len(sorted) == 0 {
-		return ""
-	}
-	return sorted[0]
-}
-
-func sortedStringSetValues(values map[string]struct{}) []string {
-	if len(values) == 0 {
-		return []string{}
-	}
-	sorted := make([]string, 0, len(values))
-	for value := range values {
-		sorted = append(sorted, value)
-	}
-	slices.Sort(sorted)
-	return sorted
 }

--- a/internal/reports/risk_action_plan.go
+++ b/internal/reports/risk_action_plan.go
@@ -67,7 +67,7 @@ func (s *Service) runRiskActionPlan(ctx context.Context, parameters map[string]s
 		return nil, fmt.Errorf("list findings for tenant %q runtimes %q: %w", tenantID, runtimeIDsCSV, err)
 	}
 	now := time.Now().UTC()
-	previousCandidates, err := s.previousRiskActionCandidates(ctx, strings.TrimSpace(parameters[reportParameterPreviousReportRunID]))
+	previousCandidates, err := s.previousRiskActionCandidates(ctx, tenantID, strings.TrimSpace(parameters[reportParameterPreviousReportRunID]))
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (s *Service) runRiskActionPlan(ctx context.Context, parameters map[string]s
 	return result, nil
 }
 
-func (s *Service) previousRiskActionCandidates(ctx context.Context, reportRunID string) ([]riskplan.Candidate, error) {
+func (s *Service) previousRiskActionCandidates(ctx context.Context, tenantID string, reportRunID string) ([]riskplan.Candidate, error) {
 	if reportRunID == "" {
 		return nil, nil
 	}
@@ -148,6 +148,9 @@ func (s *Service) previousRiskActionCandidates(ctx context.Context, reportRunID 
 	run, err := s.reportStore.GetReportRun(ctx, reportRunID)
 	if err != nil {
 		return nil, fmt.Errorf("load previous risk action plan report run %q: %w", reportRunID, err)
+	}
+	if runTenantID := strings.TrimSpace(run.GetParameters()[reportParameterTenantID]); runTenantID != strings.TrimSpace(tenantID) {
+		return nil, fmt.Errorf("%w: previous_report_run_id %q does not belong to tenant %q", ErrInvalidRequest, reportRunID, tenantID)
 	}
 	result := run.GetResult()
 	if result == nil {

--- a/internal/reports/risk_action_plan.go
+++ b/internal/reports/risk_action_plan.go
@@ -1,0 +1,677 @@
+package reports
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	findinganalysis "github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	reportParameterCandidateLimit      = "candidate_limit"
+	defaultRiskActionCandidateLimit    = 10
+	maxRiskActionCandidateLimit        = 25
+	maxRiskActionSimulationSeedLimit   = 50
+	riskActionTypeRemovePublicExposure = "remove_public_exposure"
+	riskActionTypeRemovePrivilege      = "remove_privilege"
+	riskActionTypePatchVulnerability   = "patch_vulnerability"
+)
+
+type riskActionCandidateSeed struct {
+	ID              string
+	Title           string
+	ActionType      string
+	ScenarioType    string
+	TargetURN       string
+	FindingIDs      map[string]struct{}
+	RuleIDs         map[string]struct{}
+	RuntimeIDs      map[string]struct{}
+	ResourceURNs    map[string]struct{}
+	Owners          map[string]struct{}
+	ControlRefs     map[string]struct{}
+	Reasons         map[string]struct{}
+	RiskFactors     map[string]*riskActionFactorSummary
+	MaxRiskScore    int
+	ConfidenceScore int
+}
+
+type riskActionFactorSummary struct {
+	FactorID             string
+	Category             string
+	SeverityContribution string
+	Count                int
+	WeightTotal          int
+	EvidenceRefs         map[string]struct{}
+}
+
+type riskActionCandidateOutput struct {
+	ID                               string                                    `json:"id"`
+	Title                            string                                    `json:"title"`
+	ActionType                       string                                    `json:"action_type"`
+	ScenarioType                     string                                    `json:"scenario_type"`
+	TargetURN                        string                                    `json:"target_urn"`
+	Owner                            string                                    `json:"owner,omitempty"`
+	PriorityScore                    int                                       `json:"priority_score"`
+	RiskLevel                        string                                    `json:"risk_level,omitempty"`
+	ConfidenceScore                  int                                       `json:"confidence_score,omitempty"`
+	ExpectedRiskScoreReduction       int                                       `json:"expected_risk_score_reduction"`
+	ExpectedAttackPathScoreReduction int                                       `json:"expected_attack_path_score_reduction"`
+	ExpectedAttackPathCountReduction int                                       `json:"expected_attack_path_count_reduction"`
+	BeforeRiskScore                  int                                       `json:"before_risk_score"`
+	AfterRiskScore                   int                                       `json:"after_risk_score"`
+	FindingIDs                       []string                                  `json:"finding_ids,omitempty"`
+	RuleIDs                          []string                                  `json:"rule_ids,omitempty"`
+	RuntimeIDs                       []string                                  `json:"runtime_ids,omitempty"`
+	ResourceURNs                     []string                                  `json:"resource_urns,omitempty"`
+	ControlRefs                      []string                                  `json:"control_refs,omitempty"`
+	RiskFactors                      []riskActionFactorOutput                  `json:"risk_factors,omitempty"`
+	Reasons                          []string                                  `json:"reasons,omitempty"`
+	RiskDelta                        findinganalysis.RiskDeltaSimulationReport `json:"risk_delta"`
+}
+
+type riskActionFactorOutput struct {
+	FactorID             string   `json:"factor_id"`
+	Category             string   `json:"category,omitempty"`
+	SeverityContribution string   `json:"severity_contribution,omitempty"`
+	Count                int      `json:"count"`
+	WeightTotal          int      `json:"weight_total"`
+	EvidenceRefs         []string `json:"evidence_refs,omitempty"`
+}
+
+func (s *Service) runRiskActionPlan(ctx context.Context, parameters map[string]string) (*structpb.Struct, error) {
+	tenantID := strings.TrimSpace(parameters[reportParameterTenantID])
+	if tenantID == "" {
+		return nil, fmt.Errorf("%w: report parameter %q is required", ErrInvalidRequest, reportParameterTenantID)
+	}
+	runtimeIDs := normalizeRuntimeIDs(parameters[reportParameterRuntimeIDs])
+	if len(runtimeIDs) == 0 {
+		return nil, fmt.Errorf("%w: report parameter %q is required", ErrInvalidRequest, reportParameterRuntimeIDs)
+	}
+	candidateLimit, err := normalizePositiveLimit(parameters[reportParameterCandidateLimit], defaultRiskActionCandidateLimit, maxRiskActionCandidateLimit, reportParameterCandidateLimit)
+	if err != nil {
+		return nil, err
+	}
+	resourceLimit, err := normalizePositiveLimit(parameters[reportParameterResourceLimit], defaultResourceEvidenceLimit, maxResourceEvidenceLimit, reportParameterResourceLimit)
+	if err != nil {
+		return nil, err
+	}
+	graphLimit, err := normalizePositiveLimit(parameters[reportParameterGraphLimit], defaultNeighborhoodEvidenceLimit, maxNeighborhoodEvidenceLimit, reportParameterGraphLimit)
+	if err != nil {
+		return nil, err
+	}
+	runtimeIDsCSV := strings.Join(runtimeIDs, ",")
+	parameters[reportParameterRuntimeIDs] = runtimeIDsCSV
+	parameters[reportParameterCandidateLimit] = strconv.Itoa(candidateLimit)
+	parameters[reportParameterResourceLimit] = strconv.Itoa(resourceLimit)
+	parameters[reportParameterGraphLimit] = strconv.Itoa(graphLimit)
+	listRequest := ports.ListFindingsRequest{TenantID: tenantID, Order: ports.FindingOrderRiskScore}
+	if len(runtimeIDs) == 1 {
+		listRequest.RuntimeID = runtimeIDs[0]
+	} else {
+		listRequest.RuntimeIDs = runtimeIDs
+	}
+	findings, err := s.findingStore.ListFindings(ctx, listRequest)
+	if err != nil {
+		return nil, fmt.Errorf("list findings for tenant %q runtimes %q: %w", tenantID, runtimeIDsCSV, err)
+	}
+	now := time.Now().UTC()
+	seeds := riskActionPlanSeeds(tenantID, findings, now)
+	graphEvidenceStatus := graphEvidenceStatusUnconfigured
+	graphNeighborhoods := map[string]*ports.EntityNeighborhood{}
+	if s.graphStore != nil {
+		graphEvidenceStatus = graphEvidenceStatusIncluded
+		graphNeighborhoods, err = s.riskActionPlanGraphNeighborhoods(ctx, seeds, resourceLimit, graphLimit)
+		if err != nil {
+			return nil, err
+		}
+	}
+	candidates := riskActionPlanCandidates(findings, seeds, graphNeighborhoods, candidateLimit, now)
+	actionCandidates, err := jsonPayload(candidates)
+	if err != nil {
+		return nil, fmt.Errorf("build risk action plan candidate payload: %w", err)
+	}
+	result, err := structpb.NewStruct(map[string]any{
+		reportParameterTenantID:       tenantID,
+		reportParameterRuntimeIDs:     reportStringValues(runtimeIDs),
+		reportParameterCandidateLimit: candidateLimit,
+		reportParameterResourceLimit:  resourceLimit,
+		reportParameterGraphLimit:     graphLimit,
+		"total_findings":              len(findings),
+		"candidate_seed_count":        len(seeds),
+		"total_candidates":            len(candidates),
+		"graph_evidence_status":       graphEvidenceStatus,
+		"graph_neighborhood_count":    len(graphNeighborhoods),
+		"action_candidates":           actionCandidates,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build risk action plan report result: %w", err)
+	}
+	return result, nil
+}
+
+func riskActionPlanDefinition() *cerebrov1.ReportDefinition {
+	return &cerebrov1.ReportDefinition{
+		Id:          riskActionPlanReportID,
+		Name:        riskActionPlanReportName,
+		Description: "Rank next-best remediation actions by simulating expected risk and attack-path reduction from persisted findings and bounded graph neighborhoods without mutating stores.",
+		Parameters: []*cerebrov1.ReportParameter{
+			{
+				Id:          reportParameterTenantID,
+				Description: "Tenant identifier whose persisted findings should be planned.",
+				Required:    true,
+			},
+			{
+				Id:          reportParameterRuntimeIDs,
+				Description: "Required comma-separated stored source runtime identifiers for action planning.",
+				Required:    true,
+			},
+			{
+				Id:          reportParameterCandidateLimit,
+				Description: "Optional maximum number of ranked remediation candidates to return.",
+				Required:    false,
+			},
+			{
+				Id:          reportParameterResourceLimit,
+				Description: "Optional maximum number of candidate target roots to include in simulation graph context.",
+				Required:    false,
+			},
+			{
+				Id:          reportParameterGraphLimit,
+				Description: "Optional maximum neighborhood size to read for each candidate target root.",
+				Required:    false,
+			},
+		},
+	}
+}
+
+func riskActionPlanSeeds(tenantID string, findings []*ports.FindingRecord, now time.Time) []riskActionCandidateSeed {
+	byID := map[string]*riskActionCandidateSeed{}
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		context := findinganalysis.AnalyzeFindingRiskContext(finding, now)
+		for _, actionType := range []string{riskActionTypeRemovePublicExposure, riskActionTypeRemovePrivilege, riskActionTypePatchVulnerability} {
+			if !riskActionFindingSupportsAction(finding, context, actionType) {
+				continue
+			}
+			targetURN := riskActionTargetURN(tenantID, finding, actionType)
+			if targetURN == "" {
+				continue
+			}
+			id := actionType + "|" + targetURN
+			seed := byID[id]
+			if seed == nil {
+				seed = newRiskActionCandidateSeed(id, actionType, targetURN, finding)
+				byID[id] = seed
+			}
+			seed.addFinding(finding, context)
+		}
+	}
+	seeds := make([]riskActionCandidateSeed, 0, len(byID))
+	for _, seed := range byID {
+		seeds = append(seeds, *seed)
+	}
+	slices.SortFunc(seeds, compareRiskActionSeeds)
+	if len(seeds) > maxRiskActionSimulationSeedLimit {
+		seeds = seeds[:maxRiskActionSimulationSeedLimit]
+	}
+	return seeds
+}
+
+func newRiskActionCandidateSeed(id string, actionType string, targetURN string, finding *ports.FindingRecord) *riskActionCandidateSeed {
+	return &riskActionCandidateSeed{
+		ID:           id,
+		Title:        riskActionTitle(actionType, riskActionTargetLabel(finding, targetURN)),
+		ActionType:   actionType,
+		ScenarioType: actionType,
+		TargetURN:    targetURN,
+		FindingIDs:   map[string]struct{}{},
+		RuleIDs:      map[string]struct{}{},
+		RuntimeIDs:   map[string]struct{}{},
+		ResourceURNs: map[string]struct{}{},
+		Owners:       map[string]struct{}{},
+		ControlRefs:  map[string]struct{}{},
+		Reasons:      map[string]struct{}{},
+		RiskFactors:  map[string]*riskActionFactorSummary{},
+	}
+}
+
+func (s *riskActionCandidateSeed) addFinding(finding *ports.FindingRecord, context findinganalysis.FindingRiskContext) {
+	addStringSetValue(s.FindingIDs, finding.ID)
+	addStringSetValue(s.RuleIDs, finding.RuleID)
+	addStringSetValue(s.RuntimeIDs, finding.RuntimeID)
+	for _, resourceURN := range finding.ResourceURNs {
+		addStringSetValue(s.ResourceURNs, resourceURN)
+	}
+	if primary := primaryResourceURN(finding); primary != "" {
+		addStringSetValue(s.ResourceURNs, primary)
+	}
+	if owner := riskActionFindingOwner(finding); owner != "" {
+		addStringSetValue(s.Owners, owner)
+	}
+	for _, controlRef := range finding.ControlRefs {
+		normalized, key := normalizeControlRef(controlRef)
+		if key == "" {
+			continue
+		}
+		addStringSetValue(s.ControlRefs, normalized.FrameworkName+":"+normalized.ControlID)
+	}
+	for _, reason := range append(append([]string{}, finding.RiskReasons...), context.Reasons...) {
+		addStringSetValue(s.Reasons, reason)
+	}
+	for _, factor := range append(append([]ports.FindingRiskFactor{}, finding.RiskFactors...), context.Factors...) {
+		s.addRiskFactor(factor)
+	}
+	riskScore := finding.RiskScore
+	if riskScore == 0 {
+		riskScore = context.Score
+	}
+	if riskScore > s.MaxRiskScore {
+		s.MaxRiskScore = riskScore
+	}
+	confidenceScore := finding.ConfidenceScore
+	if confidenceScore == 0 {
+		confidenceScore = context.ConfidenceScore
+	}
+	if confidenceScore > s.ConfidenceScore {
+		s.ConfidenceScore = confidenceScore
+	}
+}
+
+func (s *riskActionCandidateSeed) addRiskFactor(factor ports.FindingRiskFactor) {
+	factorID := strings.TrimSpace(factor.FactorID)
+	if factorID == "" {
+		return
+	}
+	entry := s.RiskFactors[factorID]
+	if entry == nil {
+		entry = &riskActionFactorSummary{
+			FactorID:             factorID,
+			Category:             strings.TrimSpace(factor.Category),
+			SeverityContribution: strings.TrimSpace(factor.SeverityContribution),
+			EvidenceRefs:         map[string]struct{}{},
+		}
+		s.RiskFactors[factorID] = entry
+	}
+	entry.Count++
+	entry.WeightTotal += factor.Weight
+	for _, ref := range factor.EvidenceRefs {
+		addStringSetValue(entry.EvidenceRefs, ref)
+	}
+}
+
+func (s *Service) riskActionPlanGraphNeighborhoods(ctx context.Context, seeds []riskActionCandidateSeed, resourceLimit int, graphLimit int) (map[string]*ports.EntityNeighborhood, error) {
+	neighborhoods := map[string]*ports.EntityNeighborhood{}
+	seen := map[string]struct{}{}
+	for _, seed := range seeds {
+		if len(seen) >= resourceLimit {
+			break
+		}
+		targetURN := strings.TrimSpace(seed.TargetURN)
+		if targetURN == "" {
+			continue
+		}
+		if _, ok := seen[targetURN]; ok {
+			continue
+		}
+		seen[targetURN] = struct{}{}
+		neighborhood, err := s.graphStore.GetEntityNeighborhood(ctx, targetURN, graphLimit)
+		switch {
+		case err == nil:
+			if neighborhood == nil {
+				neighborhood = &ports.EntityNeighborhood{}
+			}
+			neighborhoods[targetURN] = neighborhood
+		case errors.Is(err, ports.ErrGraphEntityNotFound):
+			continue
+		default:
+			return nil, fmt.Errorf("load risk action plan graph neighborhood for %q: %w", targetURN, err)
+		}
+	}
+	return neighborhoods, nil
+}
+
+func riskActionPlanCandidates(findings []*ports.FindingRecord, seeds []riskActionCandidateSeed, graphNeighborhoods map[string]*ports.EntityNeighborhood, limit int, now time.Time) []riskActionCandidateOutput {
+	candidates := make([]riskActionCandidateOutput, 0, len(seeds))
+	for _, seed := range seeds {
+		report := findinganalysis.SimulateRiskDelta(findings, findinganalysis.RiskDeltaSimulationOptions{
+			ScenarioType:       seed.ScenarioType,
+			TargetURN:          seed.TargetURN,
+			Limit:              10,
+			GraphNeighborhoods: graphNeighborhoods,
+			Now:                now,
+		})
+		if report.RiskScoreReduction <= 0 && report.AttackPathScoreReduction <= 0 && report.AttackPathCountReduction <= 0 {
+			continue
+		}
+		candidates = append(candidates, riskActionCandidateOutput{
+			ID:                               riskActionCandidateID(seed),
+			Title:                            seed.Title,
+			ActionType:                       seed.ActionType,
+			ScenarioType:                     seed.ScenarioType,
+			TargetURN:                        seed.TargetURN,
+			Owner:                            firstSortedSetValue(seed.Owners),
+			PriorityScore:                    riskActionPriorityScore(seed, report),
+			RiskLevel:                        reportRiskLevel(seed.MaxRiskScore),
+			ConfidenceScore:                  seed.ConfidenceScore,
+			ExpectedRiskScoreReduction:       report.RiskScoreReduction,
+			ExpectedAttackPathScoreReduction: report.AttackPathScoreReduction,
+			ExpectedAttackPathCountReduction: report.AttackPathCountReduction,
+			BeforeRiskScore:                  report.Before.TotalRiskScore,
+			AfterRiskScore:                   report.After.TotalRiskScore,
+			FindingIDs:                       sortedStringSetValues(seed.FindingIDs),
+			RuleIDs:                          sortedStringSetValues(seed.RuleIDs),
+			RuntimeIDs:                       sortedStringSetValues(seed.RuntimeIDs),
+			ResourceURNs:                     sortedStringSetValues(seed.ResourceURNs),
+			ControlRefs:                      sortedStringSetValues(seed.ControlRefs),
+			RiskFactors:                      riskActionFactorOutputs(seed.RiskFactors),
+			Reasons:                          sortedStringSetValues(seed.Reasons),
+			RiskDelta:                        report,
+		})
+	}
+	slices.SortFunc(candidates, compareRiskActionCandidates)
+	if limit > 0 && len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	return candidates
+}
+
+func riskActionFindingSupportsAction(finding *ports.FindingRecord, context findinganalysis.FindingRiskContext, actionType string) bool {
+	attributes := finding.Attributes
+	reasons := map[string]struct{}{}
+	for _, reason := range append(append([]string{}, finding.RiskReasons...), context.Reasons...) {
+		addStringSetValue(reasons, reason)
+	}
+	for _, factor := range append(append([]ports.FindingRiskFactor{}, finding.RiskFactors...), context.Factors...) {
+		addStringSetValue(reasons, factor.FactorID)
+	}
+	action := strings.ToLower(strings.TrimSpace(attributes["action"]))
+	switch actionType {
+	case riskActionTypeRemovePublicExposure:
+		return stringSetContains(reasons, "external_exposure") ||
+			riskActionAttributeBool(attributes, "internet_exposed", "public", "externally_exposed", "external_exposure", "is_public", "is_internet_facing", "reachable", "directly_reachable", "internet_reachable", "can_reach") ||
+			riskActionContainsAny(action, "public", "expose", "internet", "can_reach")
+	case riskActionTypeRemovePrivilege:
+		return stringSetContains(reasons, "privileged_actor") ||
+			stringSetContains(reasons, "privilege_or_control_plane") ||
+			riskActionAttributeBool(attributes, "privileged", "actor_privileged", "admin", "is_admin", "has_admin", "can_admin", "admin_reachable", "privileged_access", "has_admin_path") ||
+			riskActionContainsAny(action, "can_admin", "can_assume", "can_impersonate", "administratoraccess")
+	case riskActionTypePatchVulnerability:
+		return stringSetContains(reasons, "known_exploited") ||
+			stringSetContains(reasons, "epss_high") ||
+			stringSetContains(reasons, "epss_elevated") ||
+			stringSetContains(reasons, "exploit_available") ||
+			stringSetContains(reasons, "cvss_critical") ||
+			stringSetContains(reasons, "cvss_high") ||
+			riskActionSetContainsPrefix(reasons, "exploit_maturity:") ||
+			riskActionAttributePresent(attributes, "vulnerability_urn", "package_urn", "image_urn", "cve", "cve_id", "vulnerability_id", "package", "purl", "cvss_score", "cvss", "epss_score", "epss") ||
+			riskActionAttributeBool(attributes, "is_kev", "kev", "known_exploited", "known_exploited_vulnerability", "exploit_available", "public_exploit", "weaponized_exploit")
+	default:
+		return false
+	}
+}
+
+func riskActionTargetURN(tenantID string, finding *ports.FindingRecord, actionType string) string {
+	attributes := finding.Attributes
+	switch actionType {
+	case riskActionTypeRemovePublicExposure:
+		return firstTenantScopedURN(tenantID, attributes["exposed_resource_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
+	case riskActionTypeRemovePrivilege:
+		return firstTenantScopedURN(tenantID, attributes["principal_urn"], attributes["identity_urn"], attributes["actor_urn"], attributes["permission_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
+	case riskActionTypePatchVulnerability:
+		return firstTenantScopedURN(tenantID, attributes["vulnerability_urn"], attributes["package_urn"], attributes["image_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
+	default:
+		return ""
+	}
+}
+
+func firstTenantScopedURN(tenantID string, values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if tenantIDFromRiskDeltaTargetURN(trimmed) == strings.TrimSpace(tenantID) {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func riskActionTitle(actionType string, targetLabel string) string {
+	switch actionType {
+	case riskActionTypeRemovePublicExposure:
+		return "Remove public exposure from " + targetLabel
+	case riskActionTypeRemovePrivilege:
+		return "Remove excess privilege from " + targetLabel
+	case riskActionTypePatchVulnerability:
+		return "Patch exploitable vulnerability on " + targetLabel
+	default:
+		return "Reduce risk on " + targetLabel
+	}
+}
+
+func riskActionTargetLabel(finding *ports.FindingRecord, targetURN string) string {
+	for _, value := range []string{
+		finding.Attributes["resource_label"],
+		finding.Attributes["resource_name"],
+		finding.Attributes["asset_name"],
+		finding.Attributes["repository"],
+		finding.Attributes["package"],
+		finding.Title,
+	} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	targetURN = strings.TrimSpace(targetURN)
+	if targetURN == "" {
+		return "target"
+	}
+	parts := strings.FieldsFunc(targetURN, func(r rune) bool {
+		return r == ':' || r == '/' || r == '#'
+	})
+	if len(parts) == 0 {
+		return targetURN
+	}
+	return parts[len(parts)-1]
+}
+
+func riskActionFindingOwner(finding *ports.FindingRecord) string {
+	for _, value := range []string{
+		finding.Assignee,
+		finding.Attributes["owner"],
+		finding.Attributes["team"],
+		finding.Attributes["service_owner"],
+		finding.Attributes["resource_owner"],
+		finding.Attributes["repo_owner"],
+	} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func riskActionPriorityScore(seed riskActionCandidateSeed, report findinganalysis.RiskDeltaSimulationReport) int {
+	return report.RiskScoreReduction*10 +
+		report.AttackPathScoreReduction*3 +
+		report.AttackPathCountReduction*25 +
+		seed.MaxRiskScore +
+		len(seed.FindingIDs)*5
+}
+
+func riskActionCandidateID(seed riskActionCandidateSeed) string {
+	value := strings.ToLower(seed.ActionType + "-" + seed.TargetURN)
+	value = strings.NewReplacer(":", "-", "/", "-", "#", "-", "_", "-").Replace(value)
+	value = strings.Trim(value, "-")
+	if value == "" {
+		return "risk-action"
+	}
+	return value
+}
+
+func riskActionFactorOutputs(factors map[string]*riskActionFactorSummary) []riskActionFactorOutput {
+	entries := make([]*riskActionFactorSummary, 0, len(factors))
+	for _, factor := range factors {
+		entries = append(entries, factor)
+	}
+	slices.SortFunc(entries, func(left *riskActionFactorSummary, right *riskActionFactorSummary) int {
+		switch {
+		case left.WeightTotal > right.WeightTotal:
+			return -1
+		case left.WeightTotal < right.WeightTotal:
+			return 1
+		case left.Count > right.Count:
+			return -1
+		case left.Count < right.Count:
+			return 1
+		case left.FactorID < right.FactorID:
+			return -1
+		case left.FactorID > right.FactorID:
+			return 1
+		default:
+			return 0
+		}
+	})
+	values := make([]riskActionFactorOutput, 0, len(entries))
+	for _, entry := range entries {
+		values = append(values, riskActionFactorOutput{
+			FactorID:             entry.FactorID,
+			Category:             entry.Category,
+			SeverityContribution: entry.SeverityContribution,
+			Count:                entry.Count,
+			WeightTotal:          entry.WeightTotal,
+			EvidenceRefs:         sortedStringSetValues(entry.EvidenceRefs),
+		})
+	}
+	return values
+}
+
+func compareRiskActionSeeds(left riskActionCandidateSeed, right riskActionCandidateSeed) int {
+	switch {
+	case left.MaxRiskScore > right.MaxRiskScore:
+		return -1
+	case left.MaxRiskScore < right.MaxRiskScore:
+		return 1
+	case len(left.FindingIDs) > len(right.FindingIDs):
+		return -1
+	case len(left.FindingIDs) < len(right.FindingIDs):
+		return 1
+	case left.ActionType < right.ActionType:
+		return -1
+	case left.ActionType > right.ActionType:
+		return 1
+	case left.TargetURN < right.TargetURN:
+		return -1
+	case left.TargetURN > right.TargetURN:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func compareRiskActionCandidates(left riskActionCandidateOutput, right riskActionCandidateOutput) int {
+	switch {
+	case left.PriorityScore > right.PriorityScore:
+		return -1
+	case left.PriorityScore < right.PriorityScore:
+		return 1
+	case left.ExpectedRiskScoreReduction > right.ExpectedRiskScoreReduction:
+		return -1
+	case left.ExpectedRiskScoreReduction < right.ExpectedRiskScoreReduction:
+		return 1
+	case left.ExpectedAttackPathScoreReduction > right.ExpectedAttackPathScoreReduction:
+		return -1
+	case left.ExpectedAttackPathScoreReduction < right.ExpectedAttackPathScoreReduction:
+		return 1
+	case left.ID < right.ID:
+		return -1
+	case left.ID > right.ID:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func riskActionAttributePresent(attributes map[string]string, keys ...string) bool {
+	for _, key := range keys {
+		if strings.TrimSpace(attributes[key]) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func riskActionAttributeBool(attributes map[string]string, keys ...string) bool {
+	for _, key := range keys {
+		switch strings.ToLower(strings.TrimSpace(attributes[key])) {
+		case "1", "true", "yes", "y", "enabled", "public", "external", "internet", "admin", "privileged":
+			return true
+		}
+	}
+	return false
+}
+
+func riskActionContainsAny(value string, needles ...string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return false
+	}
+	for _, needle := range needles {
+		if strings.Contains(value, strings.ToLower(strings.TrimSpace(needle))) {
+			return true
+		}
+	}
+	return false
+}
+
+func riskActionSetContainsPrefix(values map[string]struct{}, prefix string) bool {
+	for value := range values {
+		if strings.HasPrefix(strings.TrimSpace(value), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSetContains(values map[string]struct{}, value string) bool {
+	_, ok := values[strings.TrimSpace(value)]
+	return ok
+}
+
+func addStringSetValue(values map[string]struct{}, value string) {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		values[trimmed] = struct{}{}
+	}
+}
+
+func firstSortedSetValue(values map[string]struct{}) string {
+	sorted := sortedStringSetValues(values)
+	if len(sorted) == 0 {
+		return ""
+	}
+	return sorted[0]
+}
+
+func sortedStringSetValues(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	sorted := make([]string, 0, len(values))
+	for value := range values {
+		sorted = append(sorted, value)
+	}
+	slices.Sort(sorted)
+	return sorted
+}

--- a/internal/reports/risk_action_plan.go
+++ b/internal/reports/risk_action_plan.go
@@ -2,6 +2,7 @@ package reports
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -152,7 +153,11 @@ func (s *Service) previousRiskActionCandidates(ctx context.Context, reportRunID 
 	if result == nil {
 		return nil, nil
 	}
-	candidates, err := riskplan.DecodeCandidates(result.AsMap()["action_candidates"])
+	content, err := json.Marshal(result.AsMap()["action_candidates"])
+	if err != nil {
+		return nil, fmt.Errorf("encode previous risk action plan candidates from %q: %w", reportRunID, err)
+	}
+	candidates, err := riskplan.DecodeCandidates(content)
 	if err != nil {
 		return nil, fmt.Errorf("decode previous risk action plan candidates from %q: %w", reportRunID, err)
 	}

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -25,6 +25,8 @@ const (
 	findingSummaryReportName         = "Finding Summary"
 	riskDeltaReportID                = "risk-delta"
 	riskDeltaReportName              = "Risk Delta"
+	riskActionPlanReportID           = "risk-action-plan"
+	riskActionPlanReportName         = "Risk Action Plan"
 	findingSummaryReportStatus       = "completed"
 	reportParameterTenantID          = "tenant_id"
 	reportParameterRuntimeIDs        = "runtime_ids"
@@ -75,6 +77,7 @@ func (s *Service) List() *cerebrov1.ListReportDefinitionsResponse {
 		Reports: []*cerebrov1.ReportDefinition{
 			findingSummaryDefinition(),
 			riskDeltaDefinition(),
+			riskActionPlanDefinition(),
 		},
 	}
 }
@@ -104,6 +107,8 @@ func (s *Service) Run(ctx context.Context, request *cerebrov1.RunReportRequest) 
 		result, err = s.runFindingSummary(ctx, parameters)
 	case riskDeltaReportID:
 		result, err = s.runRiskDelta(ctx, parameters)
+	case riskActionPlanReportID:
+		result, err = s.runRiskActionPlan(ctx, parameters)
 	default:
 		err = fmt.Errorf("%w: %s", ErrReportNotFound, reportID)
 	}
@@ -632,6 +637,8 @@ func reportDefinition(reportID string) (*cerebrov1.ReportDefinition, error) {
 		return findingSummaryDefinition(), nil
 	case riskDeltaReportID:
 		return riskDeltaDefinition(), nil
+	case riskActionPlanReportID:
+		return riskActionPlanDefinition(), nil
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrReportNotFound, reportID)
 	}

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -816,9 +816,10 @@ func TestRunRiskActionPlanReportIncludesUnscoredCandidatesAndDiff(t *testing.T) 
 		t.Fatalf("NewStruct(previousResult) error = %v", err)
 	}
 	reportStore := &stubReportStore{run: &cerebrov1.ReportRun{
-		Id:       "previous-plan",
-		ReportId: riskActionPlanReportID,
-		Result:   previousResult,
+		Id:         "previous-plan",
+		ReportId:   riskActionPlanReportID,
+		Parameters: map[string]string{reportParameterTenantID: "writer"},
+		Result:     previousResult,
 	}}
 	findingStore := &stubFindingStore{
 		findings: []*ports.FindingRecord{
@@ -887,6 +888,66 @@ func TestRunRiskActionPlanReportIncludesUnscoredCandidatesAndDiff(t *testing.T) 
 	plan := result["plan"].(map[string]any)
 	if plan["model_version"] != "risk-action-plan-v2" || plan["plan_diff"] == nil {
 		t.Fatalf("plan = %#v, want typed plan with diff", plan)
+	}
+}
+
+func TestRunRiskActionPlanReportRejectsCrossTenantPreviousRun(t *testing.T) {
+	previousResult, err := structpb.NewStruct(map[string]any{
+		"action_candidates": []any{
+			map[string]any{
+				"id":                "remove-public-exposure-urn-cerebro-other-service-billing",
+				"title":             "Remove public exposure from other tenant billing",
+				"target_urn":        "urn:cerebro:other:service:billing",
+				"priority_score":    100,
+				"simulation_status": "simulated",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewStruct(previousResult) error = %v", err)
+	}
+	reportStore := &stubReportStore{run: &cerebrov1.ReportRun{
+		Id:         "previous-plan",
+		ReportId:   riskActionPlanReportID,
+		Parameters: map[string]string{reportParameterTenantID: "other"},
+		Result:     previousResult,
+	}}
+	findingStore := &stubFindingStore{
+		findings: []*ports.FindingRecord{
+			{
+				ID:           "ownerless-control-gap",
+				TenantID:     "writer",
+				RuntimeID:    "writer-grc",
+				RuleID:       "control-owner-missing",
+				Title:        "High risk control gap",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:service:payments"},
+				FindingRisk: ports.FindingRisk{
+					RiskScore:       82,
+					ConfidenceScore: 42,
+					RiskReasons:     []string{"crown_jewel"},
+				},
+				Attributes: map[string]string{
+					"primary_resource_urn": "urn:cerebro:writer:service:payments",
+					"resource_name":        "payments",
+				},
+				LastObservedAt: time.Now().UTC().Add(-45 * 24 * time.Hour),
+			},
+		},
+	}
+	service := New(findingStore, nil, reportStore)
+
+	_, err = service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: riskActionPlanReportID,
+		Parameters: map[string]string{
+			reportParameterTenantID:            "writer",
+			reportParameterRuntimeIDs:          "writer-grc",
+			reportParameterIncludeUnscored:     "true",
+			reportParameterPreviousReportRunID: "previous-plan",
+		},
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Run() error = %v, want %v", err, ErrInvalidRequest)
 	}
 }
 

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -11,6 +11,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	findinganalysis "github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type stubFindingStore struct {
@@ -791,6 +792,101 @@ func TestRunRiskActionPlanReportWithoutGraphStoreUsesFindingSignals(t *testing.T
 	}
 	if got := candidate["expected_risk_score_reduction"]; got.(float64) <= 0 {
 		t.Fatalf("expected risk reduction = %#v, want positive", got)
+	}
+}
+
+func TestRunRiskActionPlanReportIncludesUnscoredCandidatesAndDiff(t *testing.T) {
+	previousResult, err := structpb.NewStruct(map[string]any{
+		"action_candidates": []any{
+			map[string]any{
+				"id":                            "assign-owner-urn-cerebro-writer-service-payments",
+				"title":                         "Assign owner for payments",
+				"priority_score":                1,
+				"expected_risk_score_reduction": 0,
+				"simulation_status":             "unsupported",
+			},
+			map[string]any{
+				"id":             "removed-candidate",
+				"title":          "Removed candidate",
+				"priority_score": 10,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewStruct(previousResult) error = %v", err)
+	}
+	reportStore := &stubReportStore{run: &cerebrov1.ReportRun{
+		Id:       "previous-plan",
+		ReportId: riskActionPlanReportID,
+		Result:   previousResult,
+	}}
+	findingStore := &stubFindingStore{
+		findings: []*ports.FindingRecord{
+			{
+				ID:           "ownerless-control-gap",
+				TenantID:     "writer",
+				RuntimeID:    "writer-grc",
+				RuleID:       "control-owner-missing",
+				Title:        "High risk control gap",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:service:payments"},
+				FindingRisk: ports.FindingRisk{
+					RiskScore:       82,
+					ConfidenceScore: 42,
+					RiskReasons:     []string{"crown_jewel"},
+				},
+				Attributes: map[string]string{
+					"primary_resource_urn": "urn:cerebro:writer:service:payments",
+					"resource_name":        "payments",
+				},
+				LastObservedAt: time.Now().UTC().Add(-45 * 24 * time.Hour),
+			},
+		},
+	}
+	service := New(findingStore, nil, reportStore)
+
+	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: riskActionPlanReportID,
+		Parameters: map[string]string{
+			reportParameterTenantID:            "writer",
+			reportParameterRuntimeIDs:          "writer-grc",
+			reportParameterIncludeUnscored:     "true",
+			reportParameterPreviousReportRunID: "previous-plan",
+			reportParameterCandidateLimit:      "5",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	result := response.GetRun().GetResult().AsMap()
+	if result[reportParameterIncludeUnscored] != true {
+		t.Fatalf("include_unscored = %#v, want true", result[reportParameterIncludeUnscored])
+	}
+	candidates, ok := result["action_candidates"].([]any)
+	if !ok || len(candidates) != 2 {
+		t.Fatalf("action_candidates = %#v, want two unscored candidates", result["action_candidates"])
+	}
+	types := map[string]bool{}
+	for _, raw := range candidates {
+		candidate := raw.(map[string]any)
+		if candidate["simulation_status"] != "unsupported" {
+			t.Fatalf("candidate = %#v, want unsupported status", candidate)
+		}
+		types[candidate["action_type"].(string)] = true
+	}
+	if !types["assign_owner"] || !types["refresh_evidence"] {
+		t.Fatalf("candidate types = %#v, want assign_owner and refresh_evidence", types)
+	}
+	planDiff, ok := result["plan_diff"].(map[string]any)
+	if !ok {
+		t.Fatalf("plan_diff = %#v, want object", result["plan_diff"])
+	}
+	if len(planDiff["added"].([]any)) != 1 || len(planDiff["changed"].([]any)) != 1 || len(planDiff["removed"].([]any)) != 1 {
+		t.Fatalf("plan_diff = %#v, want one added, changed, and removed candidate", planDiff)
+	}
+	plan := result["plan"].(map[string]any)
+	if plan["model_version"] != "risk-action-plan-v2" || plan["plan_diff"] == nil {
+		t.Fatalf("plan = %#v, want typed plan with diff", plan)
 	}
 }
 

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -606,6 +606,194 @@ func TestRunRiskDeltaReportRejectsCrossTenantTargetURN(t *testing.T) {
 	}
 }
 
+func TestRunRiskActionPlanReportRanksSimulatedRemediations(t *testing.T) {
+	findingStore := &stubFindingStore{
+		findings: []*ports.FindingRecord{
+			{
+				ID:           "cloud-public-prod-secrets",
+				TenantID:     "writer",
+				RuntimeID:    "writer-aws",
+				RuleID:       "cloud-public-resource-exposure",
+				Title:        "Cloud Public Resource Exposure",
+				Severity:     "HIGH",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:aws_secret_store:prod-secrets"},
+				FindingWorkflow: ports.FindingWorkflow{
+					Assignee: "cloud-platform",
+				},
+				FindingRisk: ports.FindingRisk{
+					RiskScore:       90,
+					ConfidenceScore: 92,
+					RiskReasons:     []string{"external_exposure", "crown_jewel"},
+					RiskFactors: []ports.FindingRiskFactor{
+						{FactorID: "external_exposure", Category: "likelihood", Weight: 35, SeverityContribution: "high", EvidenceRefs: []string{"attribute:internet_exposed"}},
+						{FactorID: "crown_jewel", Category: "impact", Weight: 35, SeverityContribution: "high", EvidenceRefs: []string{"attribute:crown_jewel"}},
+					},
+				},
+				Attributes: map[string]string{
+					"action":               "public_network_ingress",
+					"crown_jewel":          "true",
+					"internet_exposed":     "true",
+					"primary_resource_urn": "urn:cerebro:writer:aws_secret_store:prod-secrets",
+					"resource_name":        "prod-secrets",
+				},
+			},
+			{
+				ID:           "repo-kev-package",
+				TenantID:     "writer",
+				RuntimeID:    "writer-github",
+				RuleID:       "vulnerability-known-exploited",
+				Title:        "Known exploited dependency",
+				Severity:     "HIGH",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:github_repository:payments-api"},
+				FindingRisk: ports.FindingRisk{
+					RiskScore:       78,
+					ConfidenceScore: 88,
+					RiskReasons:     []string{"known_exploited", "cvss_high"},
+					RiskFactors: []ports.FindingRiskFactor{
+						{FactorID: "known_exploited", Category: "likelihood", Weight: 35, SeverityContribution: "high", EvidenceRefs: []string{"attribute:is_kev"}},
+					},
+				},
+				Attributes: map[string]string{
+					"cvss_score":           "8.7",
+					"is_kev":               "true",
+					"package":              "example-lib",
+					"primary_resource_urn": "urn:cerebro:writer:github_repository:payments-api",
+				},
+			},
+		},
+	}
+	graphStore := &stubGraphStore{
+		neighborhoods: map[string]*ports.EntityNeighborhood{
+			"urn:cerebro:writer:aws_secret_store:prod-secrets": {
+				Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+				Neighbors: []*ports.NeighborhoodNode{
+					{URN: "urn:cerebro:writer:aws_public_principal:public_internet", EntityType: "aws.public_principal", Label: "public internet"},
+					{URN: "urn:cerebro:writer:finding:cloud-public-prod-secrets", EntityType: "finding", Label: "cloud-public-prod-secrets"},
+				},
+				Relations: []*ports.NeighborhoodRelation{
+					{FromURN: "urn:cerebro:writer:aws_public_principal:public_internet", Relation: "can_reach", ToURN: "urn:cerebro:writer:aws_secret_store:prod-secrets"},
+					{FromURN: "urn:cerebro:writer:aws_secret_store:prod-secrets", Relation: "has_finding", ToURN: "urn:cerebro:writer:finding:cloud-public-prod-secrets"},
+				},
+			},
+			"urn:cerebro:writer:github_repository:payments-api": {
+				Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:github_repository:payments-api", EntityType: "github.repository", Label: "payments-api"},
+			},
+		},
+	}
+	service := New(findingStore, graphStore, &stubReportStore{})
+
+	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: riskActionPlanReportID,
+		Parameters: map[string]string{
+			reportParameterTenantID:       "writer",
+			reportParameterRuntimeIDs:     "writer-aws, writer-github",
+			reportParameterCandidateLimit: "2",
+			reportParameterResourceLimit:  "2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if findingStore.request.RuntimeID != "" {
+		t.Fatalf("ListFindings().RuntimeID = %q, want empty for multi-runtime request", findingStore.request.RuntimeID)
+	}
+	if got := findingStore.request.RuntimeIDs; len(got) != 2 || got[0] != "writer-aws" || got[1] != "writer-github" {
+		t.Fatalf("ListFindings().RuntimeIDs = %#v, want both runtimes", got)
+	}
+	result := response.GetRun().GetResult().AsMap()
+	if got := result["graph_evidence_status"]; got != graphEvidenceStatusIncluded {
+		t.Fatalf("graph_evidence_status = %#v, want included", got)
+	}
+	if got := result["graph_neighborhood_count"]; got != float64(2) {
+		t.Fatalf("graph_neighborhood_count = %#v, want 2", got)
+	}
+	candidates, ok := result["action_candidates"].([]any)
+	if !ok || len(candidates) != 2 {
+		t.Fatalf("action_candidates = %#v, want 2 entries", result["action_candidates"])
+	}
+	topCandidate, ok := candidates[0].(map[string]any)
+	if !ok {
+		t.Fatalf("top candidate = %#v, want object", candidates[0])
+	}
+	if got := topCandidate["scenario_type"]; got != findinganalysis.RiskDeltaScenarioRemovePublicExposure {
+		t.Fatalf("top scenario_type = %#v, want remove_public_exposure", got)
+	}
+	if got := topCandidate["target_urn"]; got != "urn:cerebro:writer:aws_secret_store:prod-secrets" {
+		t.Fatalf("top target_urn = %#v, want prod secrets", got)
+	}
+	if got := topCandidate["owner"]; got != "cloud-platform" {
+		t.Fatalf("top owner = %#v, want cloud-platform", got)
+	}
+	if got := topCandidate["expected_risk_score_reduction"]; got.(float64) <= 0 {
+		t.Fatalf("expected risk reduction = %#v, want positive", got)
+	}
+	if got := topCandidate["expected_attack_path_score_reduction"]; got.(float64) <= 0 {
+		t.Fatalf("expected attack path reduction = %#v, want positive", got)
+	}
+	riskDelta, ok := topCandidate["risk_delta"].(map[string]any)
+	if !ok {
+		t.Fatalf("risk_delta = %#v, want object", topCandidate["risk_delta"])
+	}
+	removedPaths, ok := riskDelta["removed_attack_paths"].([]any)
+	if !ok || len(removedPaths) == 0 {
+		t.Fatalf("risk_delta.removed_attack_paths = %#v, want removed public path", riskDelta["removed_attack_paths"])
+	}
+	if got := response.GetRun().GetParameters()[reportParameterCandidateLimit]; got != "2" {
+		t.Fatalf("stored candidate_limit = %q, want 2", got)
+	}
+}
+
+func TestRunRiskActionPlanReportWithoutGraphStoreUsesFindingSignals(t *testing.T) {
+	findingStore := &stubFindingStore{
+		findings: []*ports.FindingRecord{
+			{
+				ID:           "repo-kev-package",
+				TenantID:     "writer",
+				RuntimeID:    "writer-github",
+				RuleID:       "vulnerability-known-exploited",
+				Title:        "Known exploited dependency",
+				Severity:     "HIGH",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:github_repository:payments-api"},
+				Attributes: map[string]string{
+					"cvss_score":           "9.1",
+					"is_kev":               "true",
+					"primary_resource_urn": "urn:cerebro:writer:github_repository:payments-api",
+				},
+			},
+		},
+	}
+	service := New(findingStore, nil, &stubReportStore{})
+
+	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: riskActionPlanReportID,
+		Parameters: map[string]string{
+			reportParameterTenantID:   "writer",
+			reportParameterRuntimeIDs: "writer-github",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	result := response.GetRun().GetResult().AsMap()
+	if got := result["graph_evidence_status"]; got != graphEvidenceStatusUnconfigured {
+		t.Fatalf("graph_evidence_status = %#v, want unconfigured", got)
+	}
+	candidates, ok := result["action_candidates"].([]any)
+	if !ok || len(candidates) != 1 {
+		t.Fatalf("action_candidates = %#v, want one entry", result["action_candidates"])
+	}
+	candidate := candidates[0].(map[string]any)
+	if got := candidate["scenario_type"]; got != findinganalysis.RiskDeltaScenarioPatchVulnerability {
+		t.Fatalf("scenario_type = %#v, want patch_vulnerability", got)
+	}
+	if got := candidate["expected_risk_score_reduction"]; got.(float64) <= 0 {
+		t.Fatalf("expected risk reduction = %#v, want positive", got)
+	}
+}
+
 func TestGetReportRunRequiresAvailableStore(t *testing.T) {
 	service := New(nil, nil, nil)
 	if _, err := service.Get(context.Background(), &cerebrov1.GetReportRunRequest{Id: "report-run-1"}); !errors.Is(err, ErrRuntimeUnavailable) {
@@ -622,8 +810,8 @@ func TestRunReportValidationErrorsAreInvalidRequest(t *testing.T) {
 
 func TestListReportDefinitionsIncludesFindingSummary(t *testing.T) {
 	response := New(nil, nil, nil).List()
-	if len(response.GetReports()) != 2 {
-		t.Fatalf("len(List().Reports) = %d, want 2", len(response.GetReports()))
+	if len(response.GetReports()) != 3 {
+		t.Fatalf("len(List().Reports) = %d, want 3", len(response.GetReports()))
 	}
 	reportsByID := map[string]*cerebrov1.ReportDefinition{}
 	for _, report := range response.GetReports() {
@@ -635,6 +823,9 @@ func TestListReportDefinitionsIncludesFindingSummary(t *testing.T) {
 	if reportsByID[riskDeltaReportID] == nil {
 		t.Fatalf("List().Reports = %#v, want risk delta definition", response.GetReports())
 	}
+	if reportsByID[riskActionPlanReportID] == nil {
+		t.Fatalf("List().Reports = %#v, want risk action plan definition", response.GetReports())
+	}
 	parameters := reportParametersByID(reportsByID[findingSummaryReportID].GetParameters())
 	if !parameters[reportParameterRuntimeIDs].GetRequired() {
 		t.Fatalf("runtime_ids parameter Required = false, want true")
@@ -642,6 +833,10 @@ func TestListReportDefinitionsIncludesFindingSummary(t *testing.T) {
 	riskDeltaParameters := reportParametersByID(reportsByID[riskDeltaReportID].GetParameters())
 	if !riskDeltaParameters[reportParameterScenarioType].GetRequired() || !riskDeltaParameters[reportParameterTargetURN].GetRequired() {
 		t.Fatalf("risk delta parameters = %#v, want scenario_type and target_urn required", riskDeltaParameters)
+	}
+	riskActionPlanParameters := reportParametersByID(reportsByID[riskActionPlanReportID].GetParameters())
+	if !riskActionPlanParameters[reportParameterRuntimeIDs].GetRequired() || riskActionPlanParameters[reportParameterCandidateLimit].GetRequired() {
+		t.Fatalf("risk action plan parameters = %#v, want runtime_ids required and candidate_limit optional", riskActionPlanParameters)
 	}
 }
 

--- a/internal/riskplan/diff.go
+++ b/internal/riskplan/diff.go
@@ -1,0 +1,91 @@
+package riskplan
+
+import "slices"
+
+// DiffCandidates compares a previous plan candidate set with the current set.
+func DiffCandidates(previous []Candidate, current []Candidate) PlanDiff {
+	previousByID := map[string]Candidate{}
+	currentByID := map[string]Candidate{}
+	for _, candidate := range previous {
+		if candidate.ID != "" {
+			previousByID[candidate.ID] = candidate
+		}
+	}
+	for _, candidate := range current {
+		if candidate.ID != "" {
+			currentByID[candidate.ID] = candidate
+		}
+	}
+	diff := PlanDiff{}
+	for id, candidate := range currentByID {
+		previousCandidate, ok := previousByID[id]
+		if !ok {
+			diff.Added = append(diff.Added, candidateDiff("", Candidate{}, candidate))
+			continue
+		}
+		if candidateChanged(previousCandidate, candidate) {
+			diff.Changed = append(diff.Changed, candidateDiff("changed", previousCandidate, candidate))
+			continue
+		}
+		diff.UnchangedCount++
+	}
+	for id, candidate := range previousByID {
+		if _, ok := currentByID[id]; ok {
+			continue
+		}
+		diff.Removed = append(diff.Removed, candidateDiff("removed", candidate, Candidate{}))
+	}
+	sortCandidateDiffs(diff.Added)
+	sortCandidateDiffs(diff.Removed)
+	sortCandidateDiffs(diff.Changed)
+	return diff
+}
+
+func candidateChanged(previous Candidate, current Candidate) bool {
+	return previous.PriorityScore != current.PriorityScore ||
+		previous.ExpectedRiskScoreReduction != current.ExpectedRiskScoreReduction ||
+		previous.ExpectedAttackPathScoreReduction != current.ExpectedAttackPathScoreReduction ||
+		previous.ExpectedAttackPathCountReduction != current.ExpectedAttackPathCountReduction ||
+		previous.SimulationStatus != current.SimulationStatus ||
+		previous.Owner != current.Owner
+}
+
+func candidateDiff(changeType string, previous Candidate, current Candidate) CandidateDiff {
+	if changeType == "" {
+		changeType = "added"
+	}
+	id := current.ID
+	title := current.Title
+	if id == "" {
+		id = previous.ID
+	}
+	if title == "" {
+		title = previous.Title
+	}
+	return CandidateDiff{
+		ID:                                       id,
+		Title:                                    title,
+		ChangeType:                               changeType,
+		PreviousPriorityScore:                    previous.PriorityScore,
+		CurrentPriorityScore:                     current.PriorityScore,
+		PriorityScoreDelta:                       current.PriorityScore - previous.PriorityScore,
+		PreviousExpectedRiskScoreReduction:       previous.ExpectedRiskScoreReduction,
+		CurrentExpectedRiskScoreReduction:        current.ExpectedRiskScoreReduction,
+		ExpectedRiskScoreReductionDelta:          current.ExpectedRiskScoreReduction - previous.ExpectedRiskScoreReduction,
+		PreviousExpectedAttackPathCountReduction: previous.ExpectedAttackPathCountReduction,
+		CurrentExpectedAttackPathCountReduction:  current.ExpectedAttackPathCountReduction,
+	}
+}
+
+func sortCandidateDiffs(values []CandidateDiff) {
+	slices.SortFunc(values, func(left CandidateDiff, right CandidateDiff) int {
+		switch {
+		case left.ID < right.ID:
+			return -1
+		case left.ID > right.ID:
+			return 1
+		default:
+			return 0
+		}
+	})
+}

--- a/internal/riskplan/generators.go
+++ b/internal/riskplan/generators.go
@@ -1,0 +1,254 @@
+package riskplan
+
+import (
+	"strings"
+	"time"
+
+	findinganalysis "github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type publicExposureGenerator struct{}
+
+func (publicExposureGenerator) ID() string {
+	return "public_exposure"
+}
+
+func (publicExposureGenerator) Generate(input CandidateGeneratorInput) []CandidateSeed {
+	if !findingSupportsAction(input.Finding, input.RiskContext, findinganalysis.RiskDeltaScenarioRemovePublicExposure) {
+		return nil
+	}
+	targetURN := actionTargetURN(input.TenantID, input.Finding, findinganalysis.RiskDeltaScenarioRemovePublicExposure)
+	if targetURN == "" {
+		return nil
+	}
+	return []CandidateSeed{{
+		Title:               actionTitle(findinganalysis.RiskDeltaScenarioRemovePublicExposure, targetLabel(input.Finding, targetURN)),
+		ActionType:          findinganalysis.RiskDeltaScenarioRemovePublicExposure,
+		ScenarioType:        findinganalysis.RiskDeltaScenarioRemovePublicExposure,
+		TargetURN:           targetURN,
+		SimulationSupported: true,
+		Reasons:             []string{"candidate_generator:public_exposure"},
+	}}
+}
+
+type privilegeGenerator struct{}
+
+func (privilegeGenerator) ID() string {
+	return "privilege"
+}
+
+func (privilegeGenerator) Generate(input CandidateGeneratorInput) []CandidateSeed {
+	if !findingSupportsAction(input.Finding, input.RiskContext, findinganalysis.RiskDeltaScenarioRemovePrivilege) {
+		return nil
+	}
+	targetURN := actionTargetURN(input.TenantID, input.Finding, findinganalysis.RiskDeltaScenarioRemovePrivilege)
+	if targetURN == "" {
+		return nil
+	}
+	return []CandidateSeed{{
+		Title:               actionTitle(findinganalysis.RiskDeltaScenarioRemovePrivilege, targetLabel(input.Finding, targetURN)),
+		ActionType:          findinganalysis.RiskDeltaScenarioRemovePrivilege,
+		ScenarioType:        findinganalysis.RiskDeltaScenarioRemovePrivilege,
+		TargetURN:           targetURN,
+		SimulationSupported: true,
+		Reasons:             []string{"candidate_generator:privilege"},
+	}}
+}
+
+type vulnerabilityGenerator struct{}
+
+func (vulnerabilityGenerator) ID() string {
+	return "vulnerability"
+}
+
+func (vulnerabilityGenerator) Generate(input CandidateGeneratorInput) []CandidateSeed {
+	if !findingSupportsAction(input.Finding, input.RiskContext, findinganalysis.RiskDeltaScenarioPatchVulnerability) {
+		return nil
+	}
+	targetURN := actionTargetURN(input.TenantID, input.Finding, findinganalysis.RiskDeltaScenarioPatchVulnerability)
+	if targetURN == "" {
+		return nil
+	}
+	return []CandidateSeed{{
+		Title:               actionTitle(findinganalysis.RiskDeltaScenarioPatchVulnerability, targetLabel(input.Finding, targetURN)),
+		ActionType:          findinganalysis.RiskDeltaScenarioPatchVulnerability,
+		ScenarioType:        findinganalysis.RiskDeltaScenarioPatchVulnerability,
+		TargetURN:           targetURN,
+		SimulationSupported: true,
+		Reasons:             []string{"candidate_generator:vulnerability"},
+	}}
+}
+
+type ownerAssignmentGenerator struct{}
+
+func (ownerAssignmentGenerator) ID() string {
+	return "owner_assignment"
+}
+
+func (ownerAssignmentGenerator) Generate(input CandidateGeneratorInput) []CandidateSeed {
+	if input.Finding == nil {
+		return nil
+	}
+	if owner, _ := findingOwner(input.Finding); owner != "" {
+		return nil
+	}
+	if input.RiskContext.Score < 70 && input.Finding.RiskScore < 70 {
+		return nil
+	}
+	targetURN := actionTargetURN(input.TenantID, input.Finding, ActionTypeAssignOwner)
+	if targetURN == "" {
+		return nil
+	}
+	return []CandidateSeed{{
+		Title:               "Assign owner for " + targetLabel(input.Finding, targetURN),
+		ActionType:          ActionTypeAssignOwner,
+		TargetURN:           targetURN,
+		SimulationSupported: false,
+		Reasons:             []string{"candidate_generator:owner_assignment", "missing_owner"},
+	}}
+}
+
+type evidenceRefreshGenerator struct{}
+
+func (evidenceRefreshGenerator) ID() string {
+	return "evidence_refresh"
+}
+
+func (evidenceRefreshGenerator) Generate(input CandidateGeneratorInput) []CandidateSeed {
+	if input.Finding == nil {
+		return nil
+	}
+	if !findingNeedsEvidenceRefresh(input.Finding, input.RiskContext, input.Now) {
+		return nil
+	}
+	targetURN := actionTargetURN(input.TenantID, input.Finding, ActionTypeRefreshEvidence)
+	if targetURN == "" {
+		return nil
+	}
+	return []CandidateSeed{{
+		Title:               "Refresh evidence for " + targetLabel(input.Finding, targetURN),
+		ActionType:          ActionTypeRefreshEvidence,
+		TargetURN:           targetURN,
+		SimulationSupported: false,
+		Reasons:             []string{"candidate_generator:evidence_refresh", "limited_or_stale_evidence"},
+	}}
+}
+
+func findingSupportsAction(finding *ports.FindingRecord, context findinganalysis.FindingRiskContext, actionType string) bool {
+	if finding == nil {
+		return false
+	}
+	attributes := finding.Attributes
+	reasons := map[string]struct{}{}
+	for _, reason := range append(append([]string{}, finding.RiskReasons...), context.Reasons...) {
+		addStringSetValue(reasons, reason)
+	}
+	for _, factor := range append(append([]ports.FindingRiskFactor{}, finding.RiskFactors...), context.Factors...) {
+		addStringSetValue(reasons, factor.FactorID)
+	}
+	action := strings.ToLower(strings.TrimSpace(attributes["action"]))
+	switch actionType {
+	case findinganalysis.RiskDeltaScenarioRemovePublicExposure:
+		return stringSetContains(reasons, "external_exposure") ||
+			attributeBool(attributes, "internet_exposed", "public", "externally_exposed", "external_exposure", "is_public", "is_internet_facing", "reachable", "directly_reachable", "internet_reachable", "can_reach") ||
+			containsAny(action, "public", "expose", "internet", "can_reach")
+	case findinganalysis.RiskDeltaScenarioRemovePrivilege:
+		return stringSetContains(reasons, "privileged_actor") ||
+			stringSetContains(reasons, "privilege_or_control_plane") ||
+			attributeBool(attributes, "privileged", "actor_privileged", "admin", "is_admin", "has_admin", "can_admin", "admin_reachable", "privileged_access", "has_admin_path") ||
+			containsAny(action, "can_admin", "can_assume", "can_impersonate", "administratoraccess")
+	case findinganalysis.RiskDeltaScenarioPatchVulnerability:
+		return stringSetContains(reasons, "known_exploited") ||
+			stringSetContains(reasons, "epss_high") ||
+			stringSetContains(reasons, "epss_elevated") ||
+			stringSetContains(reasons, "exploit_available") ||
+			stringSetContains(reasons, "cvss_critical") ||
+			stringSetContains(reasons, "cvss_high") ||
+			stringSetContainsPrefix(reasons, "exploit_maturity:") ||
+			attributePresent(attributes, "vulnerability_urn", "package_urn", "image_urn", "cve", "cve_id", "vulnerability_id", "package", "purl", "cvss_score", "cvss", "epss_score", "epss") ||
+			attributeBool(attributes, "is_kev", "kev", "known_exploited", "known_exploited_vulnerability", "exploit_available", "public_exploit", "weaponized_exploit") ||
+			parseFloatAttribute(attributes, "cvss_score", "cvss") >= 7 ||
+			parseFloatAttribute(attributes, "epss_score", "epss") >= 0.5
+	default:
+		return false
+	}
+}
+
+func actionTargetURN(tenantID string, finding *ports.FindingRecord, actionType string) string {
+	if finding == nil {
+		return ""
+	}
+	attributes := finding.Attributes
+	switch actionType {
+	case findinganalysis.RiskDeltaScenarioRemovePublicExposure:
+		return firstTenantScopedURN(tenantID, attributes["exposed_resource_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
+	case findinganalysis.RiskDeltaScenarioRemovePrivilege:
+		return firstTenantScopedURN(tenantID, attributes["principal_urn"], attributes["identity_urn"], attributes["actor_urn"], attributes["permission_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
+	case findinganalysis.RiskDeltaScenarioPatchVulnerability:
+		return firstTenantScopedURN(tenantID, attributes["vulnerability_urn"], attributes["package_urn"], attributes["image_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
+	case ActionTypeAssignOwner, ActionTypeRefreshEvidence:
+		return firstTenantScopedURN(tenantID, attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
+	default:
+		return ""
+	}
+}
+
+func actionTitle(actionType string, targetLabel string) string {
+	switch actionType {
+	case findinganalysis.RiskDeltaScenarioRemovePublicExposure:
+		return "Remove public exposure from " + targetLabel
+	case findinganalysis.RiskDeltaScenarioRemovePrivilege:
+		return "Remove excess privilege from " + targetLabel
+	case findinganalysis.RiskDeltaScenarioPatchVulnerability:
+		return "Patch exploitable vulnerability on " + targetLabel
+	default:
+		return "Reduce risk on " + targetLabel
+	}
+}
+
+func targetLabel(finding *ports.FindingRecord, targetURN string) string {
+	if finding != nil {
+		for _, value := range []string{
+			finding.Attributes["resource_label"],
+			finding.Attributes["resource_name"],
+			finding.Attributes["asset_name"],
+			finding.Attributes["repository"],
+			finding.Attributes["package"],
+			finding.Title,
+		} {
+			if trimmed := strings.TrimSpace(value); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	targetURN = strings.TrimSpace(targetURN)
+	if targetURN == "" {
+		return "target"
+	}
+	parts := strings.FieldsFunc(targetURN, func(r rune) bool {
+		return r == ':' || r == '/' || r == '#'
+	})
+	if len(parts) == 0 {
+		return targetURN
+	}
+	return parts[len(parts)-1]
+}
+
+func findingNeedsEvidenceRefresh(finding *ports.FindingRecord, context findinganalysis.FindingRiskContext, now time.Time) bool {
+	confidence := finding.ConfidenceScore
+	if confidence == 0 {
+		confidence = context.ConfidenceScore
+	}
+	if confidence > 0 && confidence < 65 {
+		return true
+	}
+	if !finding.LastObservedAt.IsZero() && now.Sub(finding.LastObservedAt) > 30*24*time.Hour {
+		return true
+	}
+	evidenceRefs := 0
+	for _, factor := range append(append([]ports.FindingRiskFactor{}, finding.RiskFactors...), context.Factors...) {
+		evidenceRefs += len(factor.EvidenceRefs)
+	}
+	return evidenceRefs == 0 && len(finding.EventIDs) == 0 && len(finding.GraphEvidenceRows) == 0
+}

--- a/internal/riskplan/planner.go
+++ b/internal/riskplan/planner.go
@@ -103,14 +103,10 @@ func Analyze(findings []*ports.FindingRecord, options Options) Plan {
 	return plan
 }
 
-// DecodeCandidates decodes prior candidates from a JSON-compatible report result.
-func DecodeCandidates(value any) ([]Candidate, error) {
-	if value == nil {
+// DecodeCandidates decodes prior candidates from a JSON report payload.
+func DecodeCandidates(content []byte) ([]Candidate, error) {
+	if len(content) == 0 {
 		return nil, nil
-	}
-	content, err := json.Marshal(value)
-	if err != nil {
-		return nil, err
 	}
 	var candidates []Candidate
 	if err := json.Unmarshal(content, &candidates); err != nil {
@@ -323,39 +319,47 @@ func actionPlanCandidates(findings []*ports.FindingRecord, seeds []aggregatedCan
 		outcome := outcomeLearningForTarget(seed.TargetURN, options.GraphNeighborhoods)
 		breakdown := scoreBreakdown(seed, report, status, effort, ownership, outcome)
 		candidate := Candidate{
-			ID:                               actionCandidateID(seed),
-			Title:                            seed.Title,
-			ActionType:                       seed.ActionType,
-			ScenarioType:                     seed.ScenarioType,
-			TargetURN:                        seed.TargetURN,
-			Owner:                            ownership.Owner,
-			PriorityScore:                    breakdown.Total,
-			ScoreBreakdown:                   breakdown,
-			RiskLevel:                        riskLevel(seed.MaxRiskScore),
-			ConfidenceScore:                  seed.ConfidenceScore,
-			ExpectedRiskScoreReduction:       report.RiskScoreReduction,
-			ExpectedAttackPathScoreReduction: report.AttackPathScoreReduction,
-			ExpectedAttackPathCountReduction: report.AttackPathCountReduction,
-			ExpectedReduction: ExpectedReduction{
-				RiskScore:       report.RiskScoreReduction,
-				AttackPathScore: report.AttackPathScoreReduction,
-				AttackPathCount: report.AttackPathCountReduction,
+			CandidateIdentity: CandidateIdentity{
+				ID:               actionCandidateID(seed),
+				Title:            seed.Title,
+				ActionType:       seed.ActionType,
+				ScenarioType:     seed.ScenarioType,
+				TargetURN:        seed.TargetURN,
+				Owner:            ownership.Owner,
+				RiskLevel:        riskLevel(seed.MaxRiskScore),
+				SimulationStatus: status,
 			},
-			BeforeRiskScore:  report.Before.TotalRiskScore,
-			AfterRiskScore:   report.After.TotalRiskScore,
-			FindingIDs:       sortedStringSetValues(seed.FindingIDs),
-			RuleIDs:          sortedStringSetValues(seed.RuleIDs),
-			RuntimeIDs:       sortedStringSetValues(seed.RuntimeIDs),
-			ResourceURNs:     sortedStringSetValues(seed.ResourceURNs),
-			ControlRefs:      sortedStringSetValues(seed.ControlRefs),
-			RiskFactors:      riskFactorSummaries(seed.RiskFactors),
-			Reasons:          sortedStringSetValues(seed.Reasons),
-			SimulationStatus: status,
-			Effort:           effort,
-			Ownership:        ownership,
-			Evidence:         evidence,
-			OutcomeLearning:  outcome,
-			RiskDelta:        report,
+			CandidateScoring: CandidateScoring{
+				PriorityScore:                    breakdown.Total,
+				ScoreBreakdown:                   breakdown,
+				ConfidenceScore:                  seed.ConfidenceScore,
+				ExpectedRiskScoreReduction:       report.RiskScoreReduction,
+				ExpectedAttackPathScoreReduction: report.AttackPathScoreReduction,
+				ExpectedAttackPathCountReduction: report.AttackPathCountReduction,
+				ExpectedReduction: ExpectedReduction{
+					RiskScore:       report.RiskScoreReduction,
+					AttackPathScore: report.AttackPathScoreReduction,
+					AttackPathCount: report.AttackPathCountReduction,
+				},
+				BeforeRiskScore: report.Before.TotalRiskScore,
+				AfterRiskScore:  report.After.TotalRiskScore,
+			},
+			CandidateReferences: CandidateReferences{
+				FindingIDs:   sortedStringSetValues(seed.FindingIDs),
+				RuleIDs:      sortedStringSetValues(seed.RuleIDs),
+				RuntimeIDs:   sortedStringSetValues(seed.RuntimeIDs),
+				ResourceURNs: sortedStringSetValues(seed.ResourceURNs),
+				ControlRefs:  sortedStringSetValues(seed.ControlRefs),
+				RiskFactors:  riskFactorSummaries(seed.RiskFactors),
+				Reasons:      sortedStringSetValues(seed.Reasons),
+			},
+			CandidateExecution: CandidateExecution{
+				Effort:          effort,
+				Ownership:       ownership,
+				Evidence:        evidence,
+				OutcomeLearning: outcome,
+			},
+			RiskDelta: report,
 		}
 		candidates = append(candidates, candidate)
 	}

--- a/internal/riskplan/planner.go
+++ b/internal/riskplan/planner.go
@@ -512,6 +512,7 @@ func outcomeLearningForTarget(targetURN string, neighborhoods map[string]*ports.
 		return learning
 	}
 	seenActions := map[string]struct{}{}
+	seenRelations := map[string]struct{}{}
 	if neighborhood := neighborhoodForTarget(targetURN, neighborhoods); neighborhood != nil {
 		for _, node := range append(append([]*ports.NeighborhoodNode{}, neighborhood.Root), neighborhood.Neighbors...) {
 			if node == nil {
@@ -533,6 +534,11 @@ func outcomeLearningForTarget(targetURN string, neighborhoods map[string]*ports.
 			if relation == nil || !relationTouchesTarget(relation, targetURN) {
 				continue
 			}
+			relationKey := outcomeRelationKey(relation)
+			if _, ok := seenRelations[relationKey]; ok {
+				continue
+			}
+			seenRelations[relationKey] = struct{}{}
 			relationName := strings.ToLower(strings.TrimSpace(relation.Relation))
 			if strings.Contains(relationName, "action") || strings.Contains(relationName, "remediat") || strings.Contains(relationName, "ticket") {
 				addStringSetValue(seenActions, relation.FromURN)
@@ -552,6 +558,15 @@ func outcomeLearningForTarget(targetURN string, neighborhoods map[string]*ports.
 		learning.Status = "learned_from_prior_outcomes"
 	}
 	return learning
+}
+
+func outcomeRelationKey(relation *ports.NeighborhoodRelation) string {
+	if relation == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(relation.FromURN)) + "|" +
+		strings.ToLower(strings.TrimSpace(relation.Relation)) + "|" +
+		strings.ToLower(strings.TrimSpace(relation.ToURN))
 }
 
 func neighborhoodForTarget(targetURN string, neighborhoods map[string]*ports.EntityNeighborhood) *ports.EntityNeighborhood {

--- a/internal/riskplan/planner.go
+++ b/internal/riskplan/planner.go
@@ -240,9 +240,7 @@ func (s *aggregatedCandidateSeed) addFinding(finding *ports.FindingRecord, conte
 	for _, reason := range append(append([]string{}, finding.RiskReasons...), context.Reasons...) {
 		addStringSetValue(s.Reasons, reason)
 	}
-	for _, factor := range append(append([]ports.FindingRiskFactor{}, finding.RiskFactors...), context.Factors...) {
-		s.addRiskFactor(factor)
-	}
+	s.addRiskFactorsForFinding(finding.RiskFactors, context.Factors)
 	riskScore := finding.RiskScore
 	if riskScore == 0 {
 		riskScore = context.Score
@@ -286,6 +284,21 @@ func (s *aggregatedCandidateSeed) addRiskFactor(factor ports.FindingRiskFactor) 
 			entry.EvidenceRefs[strings.TrimSpace(ref)] = struct{}{}
 			s.EvidenceRefCount++
 		}
+	}
+}
+
+func (s *aggregatedCandidateSeed) addRiskFactorsForFinding(findingFactors []ports.FindingRiskFactor, contextFactors []ports.FindingRiskFactor) {
+	seen := map[string]struct{}{}
+	for _, factor := range append(append([]ports.FindingRiskFactor{}, findingFactors...), contextFactors...) {
+		factorID := strings.TrimSpace(factor.FactorID)
+		if factorID == "" {
+			continue
+		}
+		if _, ok := seen[factorID]; ok {
+			continue
+		}
+		seen[factorID] = struct{}{}
+		s.addRiskFactor(factor)
 	}
 }
 
@@ -639,14 +652,13 @@ func compareActionSeeds(left aggregatedCandidateSeed, right aggregatedCandidateS
 }
 
 func compareCandidates(left Candidate, right Candidate) int {
+	if left.SimulationStatus == SimulationStatusSimulated && right.SimulationStatus != SimulationStatusSimulated {
+		return -1
+	}
+	if right.SimulationStatus == SimulationStatusSimulated && left.SimulationStatus != SimulationStatusSimulated {
+		return 1
+	}
 	switch {
-	case left.SimulationStatus != right.SimulationStatus:
-		if left.SimulationStatus == SimulationStatusSimulated {
-			return -1
-		}
-		if right.SimulationStatus == SimulationStatusSimulated {
-			return 1
-		}
 	case left.PriorityScore > right.PriorityScore:
 		return -1
 	case left.PriorityScore < right.PriorityScore:
@@ -666,7 +678,6 @@ func compareCandidates(left Candidate, right Candidate) int {
 	default:
 		return 0
 	}
-	return 0
 }
 
 func actionCandidateID(seed aggregatedCandidateSeed) string {

--- a/internal/riskplan/planner.go
+++ b/internal/riskplan/planner.go
@@ -512,10 +512,7 @@ func outcomeLearningForTarget(targetURN string, neighborhoods map[string]*ports.
 		return learning
 	}
 	seenActions := map[string]struct{}{}
-	for _, neighborhood := range neighborhoods {
-		if neighborhood == nil {
-			continue
-		}
+	if neighborhood := neighborhoodForTarget(targetURN, neighborhoods); neighborhood != nil {
 		for _, node := range append(append([]*ports.NeighborhoodNode{}, neighborhood.Root), neighborhood.Neighbors...) {
 			if node == nil {
 				continue
@@ -526,6 +523,11 @@ func outcomeLearningForTarget(targetURN string, neighborhoods map[string]*ports.
 			if strings.Contains(strings.ToLower(node.EntityType), "outcome") {
 				learning.PositiveOutcomeCount++
 			}
+		}
+	}
+	for _, neighborhood := range neighborhoods {
+		if neighborhood == nil {
+			continue
 		}
 		for _, relation := range neighborhood.Relations {
 			if relation == nil || !relationTouchesTarget(relation, targetURN) {
@@ -550,6 +552,18 @@ func outcomeLearningForTarget(targetURN string, neighborhoods map[string]*ports.
 		learning.Status = "learned_from_prior_outcomes"
 	}
 	return learning
+}
+
+func neighborhoodForTarget(targetURN string, neighborhoods map[string]*ports.EntityNeighborhood) *ports.EntityNeighborhood {
+	if neighborhood := neighborhoods[targetURN]; neighborhood != nil {
+		return neighborhood
+	}
+	for key, neighborhood := range neighborhoods {
+		if strings.EqualFold(strings.TrimSpace(key), targetURN) {
+			return neighborhood
+		}
+	}
+	return nil
 }
 
 func relationTouchesTarget(relation *ports.NeighborhoodRelation, targetURN string) bool {

--- a/internal/riskplan/planner.go
+++ b/internal/riskplan/planner.go
@@ -1,0 +1,870 @@
+package riskplan
+
+import (
+	"encoding/json"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	findinganalysis "github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type aggregatedCandidateSeed struct {
+	CandidateSeed
+	FindingIDs        map[string]struct{}
+	RuleIDs           map[string]struct{}
+	RuntimeIDs        map[string]struct{}
+	ResourceURNs      map[string]struct{}
+	Owners            map[string]struct{}
+	OwnerSources      map[string]struct{}
+	ControlRefs       map[string]struct{}
+	Reasons           map[string]struct{}
+	RiskFactors       map[string]*riskFactorAggregate
+	MaxRiskScore      int
+	ConfidenceScore   int
+	LatestObservedAt  time.Time
+	EvidenceRefCount  int
+	EventCount        int
+	GraphEvidenceRows int
+}
+
+type riskFactorAggregate struct {
+	FactorID             string
+	Category             string
+	SeverityContribution string
+	Count                int
+	WeightTotal          int
+	EvidenceRefs         map[string]struct{}
+}
+
+// DefaultGenerators returns the built-in action proposal generators.
+func DefaultGenerators() []CandidateGenerator {
+	return []CandidateGenerator{
+		publicExposureGenerator{},
+		privilegeGenerator{},
+		vulnerabilityGenerator{},
+		ownerAssignmentGenerator{},
+		evidenceRefreshGenerator{},
+	}
+}
+
+// TargetURNs returns candidate graph roots in seed priority order.
+func TargetURNs(findings []*ports.FindingRecord, options Options) []string {
+	options = normalizeOptions(options)
+	seeds := actionPlanSeeds(options.TenantID, findings, options)
+	targets := make([]string, 0, len(seeds))
+	seen := map[string]struct{}{}
+	for _, seed := range seeds {
+		targetURN := strings.TrimSpace(seed.TargetURN)
+		if targetURN == "" {
+			continue
+		}
+		if _, ok := seen[targetURN]; ok {
+			continue
+		}
+		seen[targetURN] = struct{}{}
+		targets = append(targets, targetURN)
+	}
+	return targets
+}
+
+// Analyze builds a ranked plan from already-loaded finding and graph context.
+func Analyze(findings []*ports.FindingRecord, options Options) Plan {
+	options = normalizeOptions(options)
+	seeds := actionPlanSeeds(options.TenantID, findings, options)
+	candidates := actionPlanCandidates(findings, seeds, options)
+	simulatedCount := 0
+	unscoredCount := 0
+	for _, candidate := range candidates {
+		if candidate.SimulationStatus == SimulationStatusSimulated {
+			simulatedCount++
+		} else {
+			unscoredCount++
+		}
+	}
+	plan := Plan{
+		TenantID:                strings.TrimSpace(options.TenantID),
+		RuntimeIDs:              append([]string(nil), options.RuntimeIDs...),
+		GeneratedAt:             options.Now.UTC().Format(time.RFC3339Nano),
+		ModelVersion:            ModelVersion,
+		TotalFindings:           countFindings(findings),
+		CandidateSeedCount:      len(seeds),
+		TotalCandidates:         len(candidates),
+		SimulatedCandidateCount: simulatedCount,
+		UnscoredCandidateCount:  unscoredCount,
+		ActionCandidates:        candidates,
+	}
+	if len(options.PreviousCandidates) > 0 {
+		diff := DiffCandidates(options.PreviousCandidates, candidates)
+		plan.Diff = &diff
+	}
+	return plan
+}
+
+// DecodeCandidates decodes prior candidates from a JSON-compatible report result.
+func DecodeCandidates(value any) ([]Candidate, error) {
+	if value == nil {
+		return nil, nil
+	}
+	content, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var candidates []Candidate
+	if err := json.Unmarshal(content, &candidates); err != nil {
+		return nil, err
+	}
+	return candidates, nil
+}
+
+func normalizeOptions(options Options) Options {
+	if options.Now.IsZero() {
+		options.Now = time.Now().UTC()
+	}
+	if options.CandidateLimit <= 0 {
+		options.CandidateLimit = DefaultCandidateLimit
+	}
+	if options.CandidateLimit > MaxCandidateLimit {
+		options.CandidateLimit = MaxCandidateLimit
+	}
+	if options.SeedLimit <= 0 {
+		options.SeedLimit = MaxSimulationSeedLimit
+	}
+	if options.SeedLimit > MaxSimulationSeedLimit {
+		options.SeedLimit = MaxSimulationSeedLimit
+	}
+	options.TenantID = strings.TrimSpace(options.TenantID)
+	options.RuntimeIDs = normalizeStringSlice(options.RuntimeIDs)
+	if options.GraphNeighborhoods == nil {
+		options.GraphNeighborhoods = map[string]*ports.EntityNeighborhood{}
+	}
+	if len(options.Generators) == 0 {
+		options.Generators = DefaultGenerators()
+	}
+	return options
+}
+
+func actionPlanSeeds(tenantID string, findings []*ports.FindingRecord, options Options) []aggregatedCandidateSeed {
+	byID := map[string]*aggregatedCandidateSeed{}
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		context := findinganalysis.AnalyzeFindingRiskContext(finding, options.Now)
+		for _, generator := range options.Generators {
+			if generator == nil {
+				continue
+			}
+			for _, seed := range generator.Generate(CandidateGeneratorInput{
+				TenantID:    tenantID,
+				Finding:     finding,
+				RiskContext: context,
+				Now:         options.Now,
+			}) {
+				seed = normalizeCandidateSeed(seed)
+				if seed.TargetURN == "" {
+					continue
+				}
+				id := strings.TrimSpace(seed.ID)
+				if id == "" {
+					id = seed.ActionType + "|" + seed.TargetURN
+				}
+				entry := byID[id]
+				if entry == nil {
+					entry = newAggregatedSeed(id, seed)
+					byID[id] = entry
+				}
+				entry.addFinding(finding, context, seed)
+			}
+		}
+	}
+	seeds := make([]aggregatedCandidateSeed, 0, len(byID))
+	for _, seed := range byID {
+		seeds = append(seeds, *seed)
+	}
+	slices.SortFunc(seeds, compareActionSeeds)
+	if len(seeds) > options.SeedLimit {
+		seeds = seeds[:options.SeedLimit]
+	}
+	return seeds
+}
+
+func normalizeCandidateSeed(seed CandidateSeed) CandidateSeed {
+	seed.ID = strings.TrimSpace(seed.ID)
+	seed.Title = strings.TrimSpace(seed.Title)
+	seed.ActionType = strings.TrimSpace(seed.ActionType)
+	seed.ScenarioType = strings.TrimSpace(seed.ScenarioType)
+	seed.TargetURN = strings.TrimSpace(seed.TargetURN)
+	seed.Reasons = normalizeStringSlice(seed.Reasons)
+	return seed
+}
+
+func newAggregatedSeed(id string, seed CandidateSeed) *aggregatedCandidateSeed {
+	seed.ID = id
+	return &aggregatedCandidateSeed{
+		CandidateSeed: seed,
+		FindingIDs:    map[string]struct{}{},
+		RuleIDs:       map[string]struct{}{},
+		RuntimeIDs:    map[string]struct{}{},
+		ResourceURNs:  map[string]struct{}{},
+		Owners:        map[string]struct{}{},
+		OwnerSources:  map[string]struct{}{},
+		ControlRefs:   map[string]struct{}{},
+		Reasons:       map[string]struct{}{},
+		RiskFactors:   map[string]*riskFactorAggregate{},
+	}
+}
+
+func (s *aggregatedCandidateSeed) addFinding(finding *ports.FindingRecord, context findinganalysis.FindingRiskContext, seed CandidateSeed) {
+	addStringSetValue(s.FindingIDs, finding.ID)
+	addStringSetValue(s.RuleIDs, finding.RuleID)
+	addStringSetValue(s.RuntimeIDs, finding.RuntimeID)
+	for _, resourceURN := range finding.ResourceURNs {
+		addStringSetValue(s.ResourceURNs, resourceURN)
+	}
+	if primary := primaryResourceURN(finding); primary != "" {
+		addStringSetValue(s.ResourceURNs, primary)
+	}
+	if owner, source := findingOwner(finding); owner != "" {
+		addStringSetValue(s.Owners, owner)
+		addStringSetValue(s.OwnerSources, source)
+	}
+	for _, controlRef := range finding.ControlRefs {
+		normalized, key := normalizeControlRef(controlRef)
+		if key == "" {
+			continue
+		}
+		addStringSetValue(s.ControlRefs, normalized.FrameworkName+":"+normalized.ControlID)
+	}
+	for _, reason := range seed.Reasons {
+		addStringSetValue(s.Reasons, reason)
+	}
+	for _, reason := range append(append([]string{}, finding.RiskReasons...), context.Reasons...) {
+		addStringSetValue(s.Reasons, reason)
+	}
+	for _, factor := range append(append([]ports.FindingRiskFactor{}, finding.RiskFactors...), context.Factors...) {
+		s.addRiskFactor(factor)
+	}
+	riskScore := finding.RiskScore
+	if riskScore == 0 {
+		riskScore = context.Score
+	}
+	if riskScore > s.MaxRiskScore {
+		s.MaxRiskScore = riskScore
+	}
+	confidenceScore := finding.ConfidenceScore
+	if confidenceScore == 0 {
+		confidenceScore = context.ConfidenceScore
+	}
+	if confidenceScore > s.ConfidenceScore {
+		s.ConfidenceScore = confidenceScore
+	}
+	if finding.LastObservedAt.After(s.LatestObservedAt) {
+		s.LatestObservedAt = finding.LastObservedAt
+	}
+	s.EventCount += len(finding.EventIDs)
+	s.GraphEvidenceRows += len(finding.GraphEvidenceRows)
+}
+
+func (s *aggregatedCandidateSeed) addRiskFactor(factor ports.FindingRiskFactor) {
+	factorID := strings.TrimSpace(factor.FactorID)
+	if factorID == "" {
+		return
+	}
+	entry := s.RiskFactors[factorID]
+	if entry == nil {
+		entry = &riskFactorAggregate{
+			FactorID:             factorID,
+			Category:             strings.TrimSpace(factor.Category),
+			SeverityContribution: strings.TrimSpace(factor.SeverityContribution),
+			EvidenceRefs:         map[string]struct{}{},
+		}
+		s.RiskFactors[factorID] = entry
+	}
+	entry.Count++
+	entry.WeightTotal += factor.Weight
+	for _, ref := range factor.EvidenceRefs {
+		if strings.TrimSpace(ref) != "" {
+			entry.EvidenceRefs[strings.TrimSpace(ref)] = struct{}{}
+			s.EvidenceRefCount++
+		}
+	}
+}
+
+func actionPlanCandidates(findings []*ports.FindingRecord, seeds []aggregatedCandidateSeed, options Options) []Candidate {
+	candidates := make([]Candidate, 0, len(seeds))
+	for _, seed := range seeds {
+		report := findinganalysis.RiskDeltaSimulationReport{}
+		status := SimulationStatusUnsupported
+		if seed.SimulationSupported {
+			report = findinganalysis.SimulateRiskDelta(findings, findinganalysis.RiskDeltaSimulationOptions{
+				ScenarioType:       seed.ScenarioType,
+				TargetURN:          seed.TargetURN,
+				Limit:              10,
+				GraphNeighborhoods: options.GraphNeighborhoods,
+				Now:                options.Now,
+			})
+			if report.RiskScoreReduction <= 0 && report.AttackPathScoreReduction <= 0 && report.AttackPathCountReduction <= 0 {
+				status = SimulationStatusNoExpectedRisk
+				if !options.IncludeUnscored {
+					continue
+				}
+			} else {
+				status = SimulationStatusSimulated
+			}
+		} else if !options.IncludeUnscored {
+			continue
+		}
+		ownership := ownershipForSeed(seed)
+		effort := effortForAction(seed.ActionType)
+		evidence := evidenceForSeed(seed, options.Now)
+		outcome := outcomeLearningForTarget(seed.TargetURN, options.GraphNeighborhoods)
+		breakdown := scoreBreakdown(seed, report, status, effort, ownership, outcome)
+		candidate := Candidate{
+			ID:                               actionCandidateID(seed),
+			Title:                            seed.Title,
+			ActionType:                       seed.ActionType,
+			ScenarioType:                     seed.ScenarioType,
+			TargetURN:                        seed.TargetURN,
+			Owner:                            ownership.Owner,
+			PriorityScore:                    breakdown.Total,
+			ScoreBreakdown:                   breakdown,
+			RiskLevel:                        riskLevel(seed.MaxRiskScore),
+			ConfidenceScore:                  seed.ConfidenceScore,
+			ExpectedRiskScoreReduction:       report.RiskScoreReduction,
+			ExpectedAttackPathScoreReduction: report.AttackPathScoreReduction,
+			ExpectedAttackPathCountReduction: report.AttackPathCountReduction,
+			ExpectedReduction: ExpectedReduction{
+				RiskScore:       report.RiskScoreReduction,
+				AttackPathScore: report.AttackPathScoreReduction,
+				AttackPathCount: report.AttackPathCountReduction,
+			},
+			BeforeRiskScore:  report.Before.TotalRiskScore,
+			AfterRiskScore:   report.After.TotalRiskScore,
+			FindingIDs:       sortedStringSetValues(seed.FindingIDs),
+			RuleIDs:          sortedStringSetValues(seed.RuleIDs),
+			RuntimeIDs:       sortedStringSetValues(seed.RuntimeIDs),
+			ResourceURNs:     sortedStringSetValues(seed.ResourceURNs),
+			ControlRefs:      sortedStringSetValues(seed.ControlRefs),
+			RiskFactors:      riskFactorSummaries(seed.RiskFactors),
+			Reasons:          sortedStringSetValues(seed.Reasons),
+			SimulationStatus: status,
+			Effort:           effort,
+			Ownership:        ownership,
+			Evidence:         evidence,
+			OutcomeLearning:  outcome,
+			RiskDelta:        report,
+		}
+		candidates = append(candidates, candidate)
+	}
+	slices.SortFunc(candidates, compareCandidates)
+	if len(candidates) > options.CandidateLimit {
+		candidates = candidates[:options.CandidateLimit]
+	}
+	return candidates
+}
+
+func scoreBreakdown(seed aggregatedCandidateSeed, report findinganalysis.RiskDeltaSimulationReport, status string, effort Effort, ownership Ownership, outcome OutcomeLearning) ScoreBreakdown {
+	breakdown := ScoreBreakdown{
+		RiskReductionPoints:            report.RiskScoreReduction * 10,
+		AttackPathScoreReductionPoints: report.AttackPathScoreReduction * 3,
+		AttackPathCountReductionPoints: report.AttackPathCountReduction * 25,
+		RiskContextPoints:              seed.MaxRiskScore,
+		FindingCoveragePoints:          len(seed.FindingIDs) * 5,
+		ConfidencePoints:               seed.ConfidenceScore / 5,
+		OutcomePriorPoints:             outcome.PriorityAdjustment,
+		EffortCostPoints:               effort.CostPoints,
+	}
+	if ownership.Missing {
+		breakdown.OwnershipPenaltyPoints = 15
+	}
+	if status != SimulationStatusSimulated {
+		breakdown.SimulationPenaltyPoints = 40
+	}
+	breakdown.Total = breakdown.RiskReductionPoints +
+		breakdown.AttackPathScoreReductionPoints +
+		breakdown.AttackPathCountReductionPoints +
+		breakdown.RiskContextPoints +
+		breakdown.FindingCoveragePoints +
+		breakdown.ConfidencePoints +
+		breakdown.OutcomePriorPoints -
+		breakdown.EffortCostPoints -
+		breakdown.OwnershipPenaltyPoints -
+		breakdown.SimulationPenaltyPoints
+	if breakdown.Total < 0 {
+		breakdown.Total = 0
+	}
+	return breakdown
+}
+
+func effortForAction(actionType string) Effort {
+	switch actionType {
+	case findinganalysis.RiskDeltaScenarioRemovePublicExposure:
+		return Effort{
+			Level:             "medium",
+			Estimate:          "hours",
+			CostPoints:        20,
+			ApprovalRequired:  true,
+			ApprovalReason:    "network exposure changes can affect reachability",
+			Reversible:        true,
+			PrimaryConstraint: "change_window",
+		}
+	case findinganalysis.RiskDeltaScenarioRemovePrivilege:
+		return Effort{
+			Level:             "medium",
+			Estimate:          "hours",
+			CostPoints:        18,
+			ApprovalRequired:  true,
+			ApprovalReason:    "privilege changes can affect production access",
+			Reversible:        true,
+			PrimaryConstraint: "access_review",
+		}
+	case findinganalysis.RiskDeltaScenarioPatchVulnerability:
+		return Effort{
+			Level:             "medium",
+			Estimate:          "hours",
+			CostPoints:        15,
+			ApprovalRequired:  false,
+			Reversible:        true,
+			PrimaryConstraint: "release_cycle",
+		}
+	case ActionTypeAssignOwner:
+		return Effort{Level: "small", Estimate: "minutes", CostPoints: 5, ApprovalRequired: false, Reversible: true, PrimaryConstraint: "routing"}
+	case ActionTypeRefreshEvidence:
+		return Effort{Level: "small", Estimate: "minutes", CostPoints: 5, ApprovalRequired: false, Reversible: true, PrimaryConstraint: "connector_freshness"}
+	default:
+		return Effort{Level: "medium", Estimate: "hours", CostPoints: 15, ApprovalRequired: true, Reversible: true}
+	}
+}
+
+func ownershipForSeed(seed aggregatedCandidateSeed) Ownership {
+	owners := sortedStringSetValues(seed.Owners)
+	sources := sortedStringSetValues(seed.OwnerSources)
+	ownership := Ownership{
+		Candidates: owners,
+		Missing:    len(owners) == 0,
+	}
+	if len(owners) > 0 {
+		ownership.Owner = owners[0]
+	}
+	if len(sources) > 0 {
+		ownership.Source = sources[0]
+	}
+	return ownership
+}
+
+func evidenceForSeed(seed aggregatedCandidateSeed, now time.Time) EvidenceConfidence {
+	evidence := EvidenceConfidence{
+		ConfidenceScore: seed.ConfidenceScore,
+		EvidenceRefs:    seed.EvidenceRefCount + seed.EventCount + seed.GraphEvidenceRows,
+	}
+	switch {
+	case seed.LatestObservedAt.IsZero():
+		evidence.Freshness = "unknown"
+	case now.Sub(seed.LatestObservedAt) <= 7*24*time.Hour:
+		evidence.Freshness = "current"
+		evidence.LastObservedAt = seed.LatestObservedAt.UTC().Format(time.RFC3339Nano)
+	case now.Sub(seed.LatestObservedAt) <= 30*24*time.Hour:
+		evidence.Freshness = "aging"
+		evidence.LastObservedAt = seed.LatestObservedAt.UTC().Format(time.RFC3339Nano)
+	default:
+		evidence.Freshness = "stale"
+		evidence.LastObservedAt = seed.LatestObservedAt.UTC().Format(time.RFC3339Nano)
+	}
+	switch {
+	case evidence.EvidenceRefs == 0 || seed.ConfidenceScore < 50:
+		evidence.Status = "limited"
+	case evidence.Freshness == "stale":
+		evidence.Status = "stale"
+	default:
+		evidence.Status = "ready"
+	}
+	return evidence
+}
+
+func outcomeLearningForTarget(targetURN string, neighborhoods map[string]*ports.EntityNeighborhood) OutcomeLearning {
+	targetURN = strings.TrimSpace(targetURN)
+	learning := OutcomeLearning{Status: "no_prior_outcomes"}
+	if targetURN == "" || len(neighborhoods) == 0 {
+		return learning
+	}
+	seenActions := map[string]struct{}{}
+	for _, neighborhood := range neighborhoods {
+		if neighborhood == nil {
+			continue
+		}
+		for _, node := range append(append([]*ports.NeighborhoodNode{}, neighborhood.Root), neighborhood.Neighbors...) {
+			if node == nil {
+				continue
+			}
+			if !strings.EqualFold(strings.TrimSpace(node.URN), targetURN) && strings.Contains(strings.ToLower(node.EntityType), "action") {
+				seenActions[node.URN] = struct{}{}
+			}
+			if strings.Contains(strings.ToLower(node.EntityType), "outcome") {
+				learning.PositiveOutcomeCount++
+			}
+		}
+		for _, relation := range neighborhood.Relations {
+			if relation == nil || !relationTouchesTarget(relation, targetURN) {
+				continue
+			}
+			relationName := strings.ToLower(strings.TrimSpace(relation.Relation))
+			if strings.Contains(relationName, "action") || strings.Contains(relationName, "remediat") || strings.Contains(relationName, "ticket") {
+				addStringSetValue(seenActions, relation.FromURN)
+				addStringSetValue(seenActions, relation.ToURN)
+			}
+			if relationOutcomePositive(relation) {
+				learning.PositiveOutcomeCount++
+			}
+			if relationOutcomeNegative(relation) {
+				learning.NegativeOutcomeCount++
+			}
+		}
+	}
+	learning.PriorActionCount = len(seenActions)
+	learning.PriorityAdjustment = learning.PositiveOutcomeCount*10 - learning.NegativeOutcomeCount*15
+	if learning.PriorActionCount > 0 || learning.PositiveOutcomeCount > 0 || learning.NegativeOutcomeCount > 0 {
+		learning.Status = "learned_from_prior_outcomes"
+	}
+	return learning
+}
+
+func relationTouchesTarget(relation *ports.NeighborhoodRelation, targetURN string) bool {
+	return strings.EqualFold(strings.TrimSpace(relation.FromURN), targetURN) || strings.EqualFold(strings.TrimSpace(relation.ToURN), targetURN)
+}
+
+func relationOutcomePositive(relation *ports.NeighborhoodRelation) bool {
+	if relation == nil {
+		return false
+	}
+	value := strings.ToLower(strings.TrimSpace(relation.Relation))
+	if strings.Contains(value, "resolved") || strings.Contains(value, "completed") || strings.Contains(value, "succeeded") || strings.Contains(value, "effective") {
+		return true
+	}
+	for key, attr := range relation.Attributes {
+		combined := strings.ToLower(strings.TrimSpace(key + ":" + attr))
+		if strings.Contains(combined, "success") || strings.Contains(combined, "resolved") || strings.Contains(combined, "effective") || strings.Contains(combined, "complete") {
+			return true
+		}
+	}
+	return false
+}
+
+func relationOutcomeNegative(relation *ports.NeighborhoodRelation) bool {
+	if relation == nil {
+		return false
+	}
+	value := strings.ToLower(strings.TrimSpace(relation.Relation))
+	if strings.Contains(value, "failed") || strings.Contains(value, "reverted") || strings.Contains(value, "regressed") {
+		return true
+	}
+	for key, attr := range relation.Attributes {
+		combined := strings.ToLower(strings.TrimSpace(key + ":" + attr))
+		if strings.Contains(combined, "failed") || strings.Contains(combined, "reverted") || strings.Contains(combined, "regressed") {
+			return true
+		}
+	}
+	return false
+}
+
+func riskFactorSummaries(factors map[string]*riskFactorAggregate) []RiskFactorSummary {
+	entries := make([]*riskFactorAggregate, 0, len(factors))
+	for _, factor := range factors {
+		entries = append(entries, factor)
+	}
+	slices.SortFunc(entries, func(left *riskFactorAggregate, right *riskFactorAggregate) int {
+		switch {
+		case left.WeightTotal > right.WeightTotal:
+			return -1
+		case left.WeightTotal < right.WeightTotal:
+			return 1
+		case left.Count > right.Count:
+			return -1
+		case left.Count < right.Count:
+			return 1
+		case left.FactorID < right.FactorID:
+			return -1
+		case left.FactorID > right.FactorID:
+			return 1
+		default:
+			return 0
+		}
+	})
+	values := make([]RiskFactorSummary, 0, len(entries))
+	for _, entry := range entries {
+		values = append(values, RiskFactorSummary{
+			FactorID:             entry.FactorID,
+			Category:             entry.Category,
+			SeverityContribution: entry.SeverityContribution,
+			Count:                entry.Count,
+			WeightTotal:          entry.WeightTotal,
+			EvidenceRefs:         sortedStringSetValues(entry.EvidenceRefs),
+		})
+	}
+	return values
+}
+
+func compareActionSeeds(left aggregatedCandidateSeed, right aggregatedCandidateSeed) int {
+	switch {
+	case left.MaxRiskScore > right.MaxRiskScore:
+		return -1
+	case left.MaxRiskScore < right.MaxRiskScore:
+		return 1
+	case len(left.FindingIDs) > len(right.FindingIDs):
+		return -1
+	case len(left.FindingIDs) < len(right.FindingIDs):
+		return 1
+	case left.SimulationSupported != right.SimulationSupported:
+		if left.SimulationSupported {
+			return -1
+		}
+		return 1
+	case left.ActionType < right.ActionType:
+		return -1
+	case left.ActionType > right.ActionType:
+		return 1
+	case left.TargetURN < right.TargetURN:
+		return -1
+	case left.TargetURN > right.TargetURN:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func compareCandidates(left Candidate, right Candidate) int {
+	switch {
+	case left.SimulationStatus != right.SimulationStatus:
+		if left.SimulationStatus == SimulationStatusSimulated {
+			return -1
+		}
+		if right.SimulationStatus == SimulationStatusSimulated {
+			return 1
+		}
+	case left.PriorityScore > right.PriorityScore:
+		return -1
+	case left.PriorityScore < right.PriorityScore:
+		return 1
+	case left.ExpectedRiskScoreReduction > right.ExpectedRiskScoreReduction:
+		return -1
+	case left.ExpectedRiskScoreReduction < right.ExpectedRiskScoreReduction:
+		return 1
+	case left.ExpectedAttackPathScoreReduction > right.ExpectedAttackPathScoreReduction:
+		return -1
+	case left.ExpectedAttackPathScoreReduction < right.ExpectedAttackPathScoreReduction:
+		return 1
+	case left.ID < right.ID:
+		return -1
+	case left.ID > right.ID:
+		return 1
+	default:
+		return 0
+	}
+	return 0
+}
+
+func actionCandidateID(seed aggregatedCandidateSeed) string {
+	value := strings.ToLower(seed.ActionType + "-" + seed.TargetURN)
+	value = strings.NewReplacer(":", "-", "/", "-", "#", "-", "_", "-").Replace(value)
+	value = strings.Trim(value, "-")
+	if value == "" {
+		return "risk-action"
+	}
+	return value
+}
+
+func riskLevel(score int) string {
+	switch {
+	case score >= 85:
+		return "critical"
+	case score >= 70:
+		return "high"
+	case score >= 40:
+		return "medium"
+	case score > 0:
+		return "low"
+	default:
+		return "unknown"
+	}
+}
+
+func countFindings(findings []*ports.FindingRecord) int {
+	count := 0
+	for _, finding := range findings {
+		if finding != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func normalizeControlRef(value ports.FindingControlRef) (ports.FindingControlRef, string) {
+	normalized := ports.FindingControlRef{
+		FrameworkName: strings.TrimSpace(value.FrameworkName),
+		ControlID:     strings.TrimSpace(value.ControlID),
+	}
+	if normalized.FrameworkName == "" || normalized.ControlID == "" {
+		return ports.FindingControlRef{}, ""
+	}
+	return normalized, normalized.FrameworkName + "|" + normalized.ControlID
+}
+
+func primaryResourceURN(finding *ports.FindingRecord) string {
+	if finding == nil {
+		return ""
+	}
+	if value := strings.TrimSpace(finding.Attributes["primary_resource_urn"]); value != "" {
+		return value
+	}
+	primaryActorURN := strings.TrimSpace(finding.Attributes["primary_actor_urn"])
+	for _, resourceURN := range finding.ResourceURNs {
+		trimmed := strings.TrimSpace(resourceURN)
+		if trimmed == "" || trimmed == primaryActorURN {
+			continue
+		}
+		return trimmed
+	}
+	return ""
+}
+
+func findingOwner(finding *ports.FindingRecord) (string, string) {
+	if finding == nil {
+		return "", ""
+	}
+	if owner := strings.TrimSpace(finding.Assignee); owner != "" {
+		return owner, "finding_assignee"
+	}
+	for _, key := range []string{"owner", "team", "service_owner", "resource_owner", "repo_owner"} {
+		if owner := strings.TrimSpace(finding.Attributes[key]); owner != "" {
+			return owner, "attribute:" + key
+		}
+	}
+	return "", ""
+}
+
+func tenantIDFromURN(urn string) string {
+	parts := strings.SplitN(strings.TrimSpace(urn), ":", 5)
+	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
+		return ""
+	}
+	return strings.TrimSpace(parts[2])
+}
+
+func firstTenantScopedURN(tenantID string, values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if tenantIDFromURN(trimmed) == strings.TrimSpace(tenantID) {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func normalizeStringSlice(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	slices.Sort(normalized)
+	return normalized
+}
+
+func addStringSetValue(values map[string]struct{}, value string) {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		values[trimmed] = struct{}{}
+	}
+}
+
+func firstSortedSetValue(values map[string]struct{}) string {
+	sorted := sortedStringSetValues(values)
+	if len(sorted) == 0 {
+		return ""
+	}
+	return sorted[0]
+}
+
+func sortedStringSetValues(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	sorted := make([]string, 0, len(values))
+	for value := range values {
+		sorted = append(sorted, value)
+	}
+	slices.Sort(sorted)
+	return sorted
+}
+
+func stringSetContains(values map[string]struct{}, value string) bool {
+	_, ok := values[strings.TrimSpace(value)]
+	return ok
+}
+
+func stringSetContainsPrefix(values map[string]struct{}, prefix string) bool {
+	for value := range values {
+		if strings.HasPrefix(strings.TrimSpace(value), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func attributePresent(attributes map[string]string, keys ...string) bool {
+	for _, key := range keys {
+		if strings.TrimSpace(attributes[key]) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func attributeBool(attributes map[string]string, keys ...string) bool {
+	for _, key := range keys {
+		switch strings.ToLower(strings.TrimSpace(attributes[key])) {
+		case "1", "true", "yes", "y", "enabled", "public", "external", "internet", "admin", "privileged":
+			return true
+		}
+	}
+	return false
+}
+
+func containsAny(value string, needles ...string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return false
+	}
+	for _, needle := range needles {
+		if strings.Contains(value, strings.ToLower(strings.TrimSpace(needle))) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseFloatAttribute(attributes map[string]string, keys ...string) float64 {
+	for _, key := range keys {
+		raw := strings.TrimSpace(attributes[key])
+		if raw == "" {
+			continue
+		}
+		value, err := strconv.ParseFloat(raw, 64)
+		if err == nil {
+			return value
+		}
+	}
+	return 0
+}

--- a/internal/riskplan/planner.go
+++ b/internal/riskplan/planner.go
@@ -280,8 +280,12 @@ func (s *aggregatedCandidateSeed) addRiskFactor(factor ports.FindingRiskFactor) 
 	entry.Count++
 	entry.WeightTotal += factor.Weight
 	for _, ref := range factor.EvidenceRefs {
-		if strings.TrimSpace(ref) != "" {
-			entry.EvidenceRefs[strings.TrimSpace(ref)] = struct{}{}
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			continue
+		}
+		if _, ok := entry.EvidenceRefs[ref]; !ok {
+			entry.EvidenceRefs[ref] = struct{}{}
 			s.EvidenceRefCount++
 		}
 	}

--- a/internal/riskplan/planner.go
+++ b/internal/riskplan/planner.go
@@ -789,14 +789,6 @@ func addStringSetValue(values map[string]struct{}, value string) {
 	}
 }
 
-func firstSortedSetValue(values map[string]struct{}) string {
-	sorted := sortedStringSetValues(values)
-	if len(sorted) == 0 {
-		return ""
-	}
-	return sorted[0]
-}
-
 func sortedStringSetValues(values map[string]struct{}) []string {
 	if len(values) == 0 {
 		return []string{}

--- a/internal/riskplan/planner_test.go
+++ b/internal/riskplan/planner_test.go
@@ -128,6 +128,54 @@ func TestAnalyzeRanksSimulatedCandidatesWithFirstClassSignals(t *testing.T) {
 	}
 }
 
+func TestAnalyzeDeduplicatesStoredAndRecomputedRiskFactorsPerFinding(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	plan := Analyze([]*ports.FindingRecord{{
+		ID:           "cloud-public-prod-secrets",
+		TenantID:     "writer",
+		RuntimeID:    "writer-aws",
+		RuleID:       "cloud-public-resource-exposure",
+		Title:        "Cloud Public Resource Exposure",
+		Severity:     "HIGH",
+		Status:       "open",
+		ResourceURNs: []string{"urn:cerebro:writer:aws_secret_store:prod-secrets"},
+		FindingRisk: ports.FindingRisk{
+			RiskScore:       90,
+			ConfidenceScore: 92,
+			RiskReasons:     []string{"external_exposure"},
+			RiskFactors: []ports.FindingRiskFactor{
+				{FactorID: "external_exposure", Category: "likelihood", Weight: 35, SeverityContribution: "high", EvidenceRefs: []string{"attribute:internet_exposed"}},
+			},
+		},
+		Attributes: map[string]string{
+			"action":               "public_network_ingress",
+			"internet_exposed":     "true",
+			"primary_resource_urn": "urn:cerebro:writer:aws_secret_store:prod-secrets",
+			"resource_name":        "prod-secrets",
+		},
+		LastObservedAt: now.Add(-2 * time.Hour),
+	}}, Options{
+		TenantID:   "writer",
+		RuntimeIDs: []string{"writer-aws"},
+		Now:        now,
+	})
+
+	if len(plan.ActionCandidates) == 0 {
+		t.Fatalf("ActionCandidates = nil, want public exposure candidate")
+	}
+	factors := plan.ActionCandidates[0].RiskFactors
+	for _, factor := range factors {
+		if factor.FactorID != "external_exposure" {
+			continue
+		}
+		if factor.Count != 1 || factor.WeightTotal != 35 {
+			t.Fatalf("external_exposure factor = %#v, want one contribution from the finding", factor)
+		}
+		return
+	}
+	t.Fatalf("risk factors = %#v, want external_exposure factor", factors)
+}
+
 func TestAnalyzeCanIncludeUnscoredPlanningBlockers(t *testing.T) {
 	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
 	plan := Analyze([]*ports.FindingRecord{{
@@ -173,6 +221,23 @@ func TestAnalyzeCanIncludeUnscoredPlanningBlockers(t *testing.T) {
 	}
 	if evidence := byType[ActionTypeRefreshEvidence]; evidence.Evidence.Status != "limited" || evidence.Evidence.Freshness != "stale" {
 		t.Fatalf("refresh evidence candidate = %#v, want limited stale evidence", evidence)
+	}
+}
+
+func TestCompareCandidatesRanksNonSimulatedStatusesByScore(t *testing.T) {
+	unsupportedHigh := diffTestCandidate("unsupported-high", "Unsupported high", 100, 0, 0, SimulationStatusUnsupported)
+	noReductionLow := diffTestCandidate("no-reduction-low", "No reduction low", 10, 0, 0, SimulationStatusNoExpectedRisk)
+	unsupportedMid := diffTestCandidate("unsupported-mid", "Unsupported mid", 50, 0, 0, SimulationStatusUnsupported)
+	simulatedLow := diffTestCandidate("simulated-low", "Simulated low", 1, 0, 0, SimulationStatusSimulated)
+
+	if got := compareCandidates(unsupportedHigh, noReductionLow); got >= 0 {
+		t.Fatalf("compareCandidates(high unsupported, low no-reduction) = %d, want high priority first", got)
+	}
+	if got := compareCandidates(noReductionLow, unsupportedMid); got <= 0 {
+		t.Fatalf("compareCandidates(low no-reduction, mid unsupported) = %d, want priority tie-breaker across non-simulated statuses", got)
+	}
+	if got := compareCandidates(simulatedLow, unsupportedHigh); got >= 0 {
+		t.Fatalf("compareCandidates(simulated, unsupported) = %d, want simulated first", got)
 	}
 }
 

--- a/internal/riskplan/planner_test.go
+++ b/internal/riskplan/planner_test.go
@@ -126,6 +126,19 @@ func TestAnalyzeRanksSimulatedCandidatesWithFirstClassSignals(t *testing.T) {
 	if top.OutcomeLearning.Status != "learned_from_prior_outcomes" || top.OutcomeLearning.PositiveOutcomeCount == 0 {
 		t.Fatalf("outcome learning = %#v, want learned positive outcome", top.OutcomeLearning)
 	}
+	var payments Candidate
+	for _, candidate := range plan.ActionCandidates {
+		if candidate.TargetURN == "urn:cerebro:writer:github_repository:payments-api" {
+			payments = candidate
+			break
+		}
+	}
+	if payments.ID == "" {
+		t.Fatalf("action candidates = %#v, want payments-api candidate", plan.ActionCandidates)
+	}
+	if payments.OutcomeLearning.Status != "no_prior_outcomes" || payments.OutcomeLearning.PriorActionCount != 0 || payments.OutcomeLearning.PositiveOutcomeCount != 0 {
+		t.Fatalf("payments outcome learning = %#v, want no leaked prior outcomes", payments.OutcomeLearning)
+	}
 }
 
 func TestAnalyzeDeduplicatesStoredAndRecomputedRiskFactorsPerFinding(t *testing.T) {

--- a/internal/riskplan/planner_test.go
+++ b/internal/riskplan/planner_test.go
@@ -141,6 +141,45 @@ func TestAnalyzeRanksSimulatedCandidatesWithFirstClassSignals(t *testing.T) {
 	}
 }
 
+func TestOutcomeLearningDeduplicatesMirroredRelations(t *testing.T) {
+	targetURN := "urn:cerebro:writer:service:payments"
+	actionURN := "urn:cerebro:writer:workflow_action:patch-payments"
+	relation := &ports.NeighborhoodRelation{
+		FromURN:    actionURN,
+		Relation:   "completed_action",
+		ToURN:      targetURN,
+		Attributes: map[string]string{"outcome": "resolved"},
+	}
+	neighborhoods := map[string]*ports.EntityNeighborhood{
+		targetURN: {
+			Root: &ports.NeighborhoodNode{URN: targetURN, EntityType: "service", Label: "payments"},
+			Relations: []*ports.NeighborhoodRelation{
+				relation,
+			},
+		},
+		actionURN: {
+			Root: &ports.NeighborhoodNode{URN: actionURN, EntityType: "workflow_action", Label: "patch payments"},
+			Relations: []*ports.NeighborhoodRelation{
+				{
+					FromURN:    " " + actionURN + " ",
+					Relation:   " completed_action ",
+					ToURN:      " " + targetURN + " ",
+					Attributes: map[string]string{"outcome": "resolved"},
+				},
+			},
+		},
+	}
+
+	learning := outcomeLearningForTarget(targetURN, neighborhoods)
+
+	if learning.PositiveOutcomeCount != 1 {
+		t.Fatalf("PositiveOutcomeCount = %d, want mirrored relations counted once", learning.PositiveOutcomeCount)
+	}
+	if learning.NegativeOutcomeCount != 0 || learning.PriorityAdjustment != 10 {
+		t.Fatalf("outcome learning = %#v, want one positive outcome adjustment", learning)
+	}
+}
+
 func TestAnalyzeDeduplicatesStoredAndRecomputedRiskFactorsPerFinding(t *testing.T) {
 	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
 	plan := Analyze([]*ports.FindingRecord{{

--- a/internal/riskplan/planner_test.go
+++ b/internal/riskplan/planner_test.go
@@ -1,0 +1,203 @@
+package riskplan
+
+import (
+	"testing"
+	"time"
+
+	findinganalysis "github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestAnalyzeRanksSimulatedCandidatesWithFirstClassSignals(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	findings := []*ports.FindingRecord{
+		{
+			ID:           "cloud-public-prod-secrets",
+			TenantID:     "writer",
+			RuntimeID:    "writer-aws",
+			RuleID:       "cloud-public-resource-exposure",
+			Title:        "Cloud Public Resource Exposure",
+			Severity:     "HIGH",
+			Status:       "open",
+			ResourceURNs: []string{"urn:cerebro:writer:aws_secret_store:prod-secrets"},
+			EventIDs:     []string{"evt-public"},
+			FindingWorkflow: ports.FindingWorkflow{
+				Assignee: "cloud-platform",
+			},
+			FindingRisk: ports.FindingRisk{
+				RiskScore:       90,
+				ConfidenceScore: 92,
+				RiskReasons:     []string{"external_exposure", "crown_jewel"},
+				RiskFactors: []ports.FindingRiskFactor{
+					{FactorID: "external_exposure", Category: "likelihood", Weight: 35, SeverityContribution: "high", EvidenceRefs: []string{"attribute:internet_exposed"}},
+					{FactorID: "crown_jewel", Category: "impact", Weight: 35, SeverityContribution: "high", EvidenceRefs: []string{"attribute:crown_jewel"}},
+				},
+			},
+			Attributes: map[string]string{
+				"action":               "public_network_ingress",
+				"crown_jewel":          "true",
+				"internet_exposed":     "true",
+				"primary_resource_urn": "urn:cerebro:writer:aws_secret_store:prod-secrets",
+				"resource_name":        "prod-secrets",
+			},
+			LastObservedAt: now.Add(-2 * time.Hour),
+		},
+		{
+			ID:           "repo-kev-package",
+			TenantID:     "writer",
+			RuntimeID:    "writer-github",
+			RuleID:       "vulnerability-known-exploited",
+			Title:        "Known exploited dependency",
+			Severity:     "HIGH",
+			Status:       "open",
+			ResourceURNs: []string{"urn:cerebro:writer:github_repository:payments-api"},
+			FindingRisk: ports.FindingRisk{
+				RiskScore:       78,
+				ConfidenceScore: 88,
+				RiskReasons:     []string{"known_exploited", "cvss_high"},
+				RiskFactors: []ports.FindingRiskFactor{
+					{FactorID: "known_exploited", Category: "likelihood", Weight: 35, SeverityContribution: "high", EvidenceRefs: []string{"attribute:is_kev"}},
+				},
+			},
+			Attributes: map[string]string{
+				"cvss_score":           "8.7",
+				"is_kev":               "true",
+				"package":              "example-lib",
+				"primary_resource_urn": "urn:cerebro:writer:github_repository:payments-api",
+			},
+			LastObservedAt: now.Add(-24 * time.Hour),
+		},
+	}
+	graphNeighborhoods := map[string]*ports.EntityNeighborhood{
+		"urn:cerebro:writer:aws_secret_store:prod-secrets": {
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+			Neighbors: []*ports.NeighborhoodNode{
+				{URN: "urn:cerebro:writer:aws_public_principal:public_internet", EntityType: "aws.public_principal", Label: "public internet"},
+				{URN: "urn:cerebro:writer:finding:cloud-public-prod-secrets", EntityType: "finding", Label: "cloud-public-prod-secrets"},
+				{URN: "urn:cerebro:writer:action:block-public-prod-secrets", EntityType: "workflow_action", Label: "block public access"},
+			},
+			Relations: []*ports.NeighborhoodRelation{
+				{FromURN: "urn:cerebro:writer:aws_public_principal:public_internet", Relation: "can_reach", ToURN: "urn:cerebro:writer:aws_secret_store:prod-secrets"},
+				{FromURN: "urn:cerebro:writer:aws_secret_store:prod-secrets", Relation: "has_finding", ToURN: "urn:cerebro:writer:finding:cloud-public-prod-secrets"},
+				{FromURN: "urn:cerebro:writer:action:block-public-prod-secrets", Relation: "completed_action", ToURN: "urn:cerebro:writer:aws_secret_store:prod-secrets", Attributes: map[string]string{"outcome": "resolved"}},
+			},
+		},
+		"urn:cerebro:writer:github_repository:payments-api": {
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:github_repository:payments-api", EntityType: "github.repository", Label: "payments-api"},
+		},
+	}
+
+	plan := Analyze(findings, Options{
+		TenantID:           "writer",
+		RuntimeIDs:         []string{"writer-aws", "writer-github"},
+		CandidateLimit:     2,
+		GraphNeighborhoods: graphNeighborhoods,
+		Now:                now,
+	})
+
+	if plan.ModelVersion != ModelVersion {
+		t.Fatalf("ModelVersion = %q, want %q", plan.ModelVersion, ModelVersion)
+	}
+	if plan.TotalFindings != 2 || plan.TotalCandidates != 2 || plan.SimulatedCandidateCount != 2 {
+		t.Fatalf("plan counts = %#v, want two simulated candidates", plan)
+	}
+	top := plan.ActionCandidates[0]
+	if top.ScenarioType != findinganalysis.RiskDeltaScenarioRemovePublicExposure {
+		t.Fatalf("top scenario = %q, want remove public exposure", top.ScenarioType)
+	}
+	if top.TargetURN != "urn:cerebro:writer:aws_secret_store:prod-secrets" {
+		t.Fatalf("top target = %q, want prod secrets", top.TargetURN)
+	}
+	if top.PriorityScore != top.ScoreBreakdown.Total || top.ScoreBreakdown.AttackPathCountReductionPoints <= 0 {
+		t.Fatalf("score breakdown = %#v, priority = %d, want auditable attack-path contribution", top.ScoreBreakdown, top.PriorityScore)
+	}
+	if top.ExpectedReduction.RiskScore != top.ExpectedRiskScoreReduction || top.ExpectedAttackPathScoreReduction <= 0 {
+		t.Fatalf("expected reduction = %#v, legacy reduction = %d", top.ExpectedReduction, top.ExpectedRiskScoreReduction)
+	}
+	if top.Ownership.Owner != "cloud-platform" || top.Owner != "cloud-platform" || top.Ownership.Missing {
+		t.Fatalf("ownership = %#v, owner = %q, want cloud-platform", top.Ownership, top.Owner)
+	}
+	if top.Effort.Level == "" || !top.Effort.ApprovalRequired {
+		t.Fatalf("effort = %#v, want explicit approval-aware estimate", top.Effort)
+	}
+	if top.Evidence.Status != "ready" || top.Evidence.Freshness != "current" {
+		t.Fatalf("evidence = %#v, want current ready evidence", top.Evidence)
+	}
+	if top.OutcomeLearning.Status != "learned_from_prior_outcomes" || top.OutcomeLearning.PositiveOutcomeCount == 0 {
+		t.Fatalf("outcome learning = %#v, want learned positive outcome", top.OutcomeLearning)
+	}
+}
+
+func TestAnalyzeCanIncludeUnscoredPlanningBlockers(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	plan := Analyze([]*ports.FindingRecord{{
+		ID:           "ownerless-control-gap",
+		TenantID:     "writer",
+		RuntimeID:    "writer-grc",
+		RuleID:       "control-owner-missing",
+		Title:        "High risk control gap",
+		Status:       "open",
+		ResourceURNs: []string{"urn:cerebro:writer:service:payments"},
+		FindingRisk: ports.FindingRisk{
+			RiskScore:       82,
+			ConfidenceScore: 42,
+			RiskReasons:     []string{"crown_jewel"},
+		},
+		Attributes: map[string]string{
+			"primary_resource_urn": "urn:cerebro:writer:service:payments",
+			"resource_name":        "payments",
+		},
+		LastObservedAt: now.Add(-45 * 24 * time.Hour),
+	}}, Options{
+		TenantID:        "writer",
+		RuntimeIDs:      []string{"writer-grc"},
+		IncludeUnscored: true,
+		Now:             now,
+	})
+
+	if plan.SimulatedCandidateCount != 0 || plan.UnscoredCandidateCount != 2 {
+		t.Fatalf("candidate counts = simulated %d unscored %d, want two unscored blockers", plan.SimulatedCandidateCount, plan.UnscoredCandidateCount)
+	}
+	byType := map[string]Candidate{}
+	for _, candidate := range plan.ActionCandidates {
+		byType[candidate.ActionType] = candidate
+		if candidate.SimulationStatus != SimulationStatusUnsupported {
+			t.Fatalf("candidate %s status = %q, want unsupported", candidate.ActionType, candidate.SimulationStatus)
+		}
+		if candidate.ScoreBreakdown.SimulationPenaltyPoints == 0 {
+			t.Fatalf("candidate %s score breakdown = %#v, want simulation penalty", candidate.ActionType, candidate.ScoreBreakdown)
+		}
+	}
+	if owner := byType[ActionTypeAssignOwner]; !owner.Ownership.Missing || owner.Effort.PrimaryConstraint != "routing" {
+		t.Fatalf("assign owner candidate = %#v, want missing ownership routing blocker", owner)
+	}
+	if evidence := byType[ActionTypeRefreshEvidence]; evidence.Evidence.Status != "limited" || evidence.Evidence.Freshness != "stale" {
+		t.Fatalf("refresh evidence candidate = %#v, want limited stale evidence", evidence)
+	}
+}
+
+func TestDiffCandidatesReportsAddedRemovedAndChanged(t *testing.T) {
+	diff := DiffCandidates(
+		[]Candidate{
+			{ID: "a", Title: "A", PriorityScore: 100, ExpectedRiskScoreReduction: 5, ExpectedAttackPathCountReduction: 1, SimulationStatus: SimulationStatusSimulated},
+			{ID: "c", Title: "C", PriorityScore: 70},
+		},
+		[]Candidate{
+			{ID: "a", Title: "A", PriorityScore: 115, ExpectedRiskScoreReduction: 8, ExpectedAttackPathCountReduction: 2, SimulationStatus: SimulationStatusSimulated},
+			{ID: "b", Title: "B", PriorityScore: 20},
+		},
+	)
+
+	if len(diff.Added) != 1 || diff.Added[0].ID != "b" || diff.Added[0].ChangeType != "added" {
+		t.Fatalf("added diff = %#v, want b added", diff.Added)
+	}
+	if len(diff.Removed) != 1 || diff.Removed[0].ID != "c" || diff.Removed[0].ChangeType != "removed" {
+		t.Fatalf("removed diff = %#v, want c removed", diff.Removed)
+	}
+	if len(diff.Changed) != 1 || diff.Changed[0].ID != "a" || diff.Changed[0].PriorityScoreDelta != 15 || diff.Changed[0].ExpectedRiskScoreReductionDelta != 3 {
+		t.Fatalf("changed diff = %#v, want a changed with deltas", diff.Changed)
+	}
+	if diff.UnchangedCount != 0 {
+		t.Fatalf("UnchangedCount = %d, want 0", diff.UnchangedCount)
+	}
+}

--- a/internal/riskplan/planner_test.go
+++ b/internal/riskplan/planner_test.go
@@ -176,6 +176,22 @@ func TestAnalyzeDeduplicatesStoredAndRecomputedRiskFactorsPerFinding(t *testing.
 	t.Fatalf("risk factors = %#v, want external_exposure factor", factors)
 }
 
+func TestAddRiskFactorCountsUniqueEvidenceRefs(t *testing.T) {
+	seed := newAggregatedSeed("candidate", CandidateSeed{})
+	seed.addRiskFactor(ports.FindingRiskFactor{
+		FactorID:     "external_exposure",
+		EvidenceRefs: []string{"attribute:internet_exposed", " attribute:internet_exposed ", "attribute:public"},
+	})
+
+	if seed.EvidenceRefCount != 2 {
+		t.Fatalf("EvidenceRefCount = %d, want 2 unique evidence refs", seed.EvidenceRefCount)
+	}
+	factor := seed.RiskFactors["external_exposure"]
+	if factor == nil || len(factor.EvidenceRefs) != 2 {
+		t.Fatalf("factor evidence refs = %#v, want two unique refs", factor)
+	}
+}
+
 func TestAnalyzeCanIncludeUnscoredPlanningBlockers(t *testing.T) {
 	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
 	plan := Analyze([]*ports.FindingRecord{{

--- a/internal/riskplan/planner_test.go
+++ b/internal/riskplan/planner_test.go
@@ -179,12 +179,12 @@ func TestAnalyzeCanIncludeUnscoredPlanningBlockers(t *testing.T) {
 func TestDiffCandidatesReportsAddedRemovedAndChanged(t *testing.T) {
 	diff := DiffCandidates(
 		[]Candidate{
-			{ID: "a", Title: "A", PriorityScore: 100, ExpectedRiskScoreReduction: 5, ExpectedAttackPathCountReduction: 1, SimulationStatus: SimulationStatusSimulated},
-			{ID: "c", Title: "C", PriorityScore: 70},
+			diffTestCandidate("a", "A", 100, 5, 1, SimulationStatusSimulated),
+			diffTestCandidate("c", "C", 70, 0, 0, ""),
 		},
 		[]Candidate{
-			{ID: "a", Title: "A", PriorityScore: 115, ExpectedRiskScoreReduction: 8, ExpectedAttackPathCountReduction: 2, SimulationStatus: SimulationStatusSimulated},
-			{ID: "b", Title: "B", PriorityScore: 20},
+			diffTestCandidate("a", "A", 115, 8, 2, SimulationStatusSimulated),
+			diffTestCandidate("b", "B", 20, 0, 0, ""),
 		},
 	)
 
@@ -199,5 +199,20 @@ func TestDiffCandidatesReportsAddedRemovedAndChanged(t *testing.T) {
 	}
 	if diff.UnchangedCount != 0 {
 		t.Fatalf("UnchangedCount = %d, want 0", diff.UnchangedCount)
+	}
+}
+
+func diffTestCandidate(id string, title string, priorityScore int, riskReduction int, pathCountReduction int, simulationStatus string) Candidate {
+	return Candidate{
+		CandidateIdentity: CandidateIdentity{
+			ID:               id,
+			Title:            title,
+			SimulationStatus: simulationStatus,
+		},
+		CandidateScoring: CandidateScoring{
+			PriorityScore:                    priorityScore,
+			ExpectedRiskScoreReduction:       riskReduction,
+			ExpectedAttackPathCountReduction: pathCountReduction,
+		},
 	}
 }

--- a/internal/riskplan/types.go
+++ b/internal/riskplan/types.go
@@ -80,37 +80,58 @@ type CandidateSeed struct {
 	Reasons             []string
 }
 
-// Candidate is one ranked next-best action with compatibility fields kept at top level.
+// Candidate is one ranked next-best action. Embedded contracts keep the JSON
+// shape flat while keeping the Go type cohesive.
 type Candidate struct {
-	ID                               string                                    `json:"id"`
-	Title                            string                                    `json:"title"`
-	ActionType                       string                                    `json:"action_type"`
-	ScenarioType                     string                                    `json:"scenario_type,omitempty"`
-	TargetURN                        string                                    `json:"target_urn"`
-	Owner                            string                                    `json:"owner,omitempty"`
-	PriorityScore                    int                                       `json:"priority_score"`
-	ScoreBreakdown                   ScoreBreakdown                            `json:"score_breakdown"`
-	RiskLevel                        string                                    `json:"risk_level,omitempty"`
-	ConfidenceScore                  int                                       `json:"confidence_score,omitempty"`
-	ExpectedRiskScoreReduction       int                                       `json:"expected_risk_score_reduction"`
-	ExpectedAttackPathScoreReduction int                                       `json:"expected_attack_path_score_reduction"`
-	ExpectedAttackPathCountReduction int                                       `json:"expected_attack_path_count_reduction"`
-	ExpectedReduction                ExpectedReduction                         `json:"expected_reduction"`
-	BeforeRiskScore                  int                                       `json:"before_risk_score"`
-	AfterRiskScore                   int                                       `json:"after_risk_score"`
-	FindingIDs                       []string                                  `json:"finding_ids,omitempty"`
-	RuleIDs                          []string                                  `json:"rule_ids,omitempty"`
-	RuntimeIDs                       []string                                  `json:"runtime_ids,omitempty"`
-	ResourceURNs                     []string                                  `json:"resource_urns,omitempty"`
-	ControlRefs                      []string                                  `json:"control_refs,omitempty"`
-	RiskFactors                      []RiskFactorSummary                       `json:"risk_factors,omitempty"`
-	Reasons                          []string                                  `json:"reasons,omitempty"`
-	SimulationStatus                 string                                    `json:"simulation_status"`
-	Effort                           Effort                                    `json:"effort"`
-	Ownership                        Ownership                                 `json:"ownership"`
-	Evidence                         EvidenceConfidence                        `json:"evidence"`
-	OutcomeLearning                  OutcomeLearning                           `json:"outcome_learning"`
-	RiskDelta                        findinganalysis.RiskDeltaSimulationReport `json:"risk_delta"`
+	CandidateIdentity
+	CandidateScoring
+	CandidateReferences
+	CandidateExecution
+	RiskDelta findinganalysis.RiskDeltaSimulationReport `json:"risk_delta"`
+}
+
+// CandidateIdentity identifies the action target and simulation mode.
+type CandidateIdentity struct {
+	ID               string `json:"id"`
+	Title            string `json:"title"`
+	ActionType       string `json:"action_type"`
+	ScenarioType     string `json:"scenario_type,omitempty"`
+	TargetURN        string `json:"target_urn"`
+	Owner            string `json:"owner,omitempty"`
+	RiskLevel        string `json:"risk_level,omitempty"`
+	SimulationStatus string `json:"simulation_status"`
+}
+
+// CandidateScoring contains all ranking and expected-reduction fields.
+type CandidateScoring struct {
+	PriorityScore                    int               `json:"priority_score"`
+	ScoreBreakdown                   ScoreBreakdown    `json:"score_breakdown"`
+	ConfidenceScore                  int               `json:"confidence_score,omitempty"`
+	ExpectedRiskScoreReduction       int               `json:"expected_risk_score_reduction"`
+	ExpectedAttackPathScoreReduction int               `json:"expected_attack_path_score_reduction"`
+	ExpectedAttackPathCountReduction int               `json:"expected_attack_path_count_reduction"`
+	ExpectedReduction                ExpectedReduction `json:"expected_reduction"`
+	BeforeRiskScore                  int               `json:"before_risk_score"`
+	AfterRiskScore                   int               `json:"after_risk_score"`
+}
+
+// CandidateReferences links a candidate to the findings and evidence that produced it.
+type CandidateReferences struct {
+	FindingIDs   []string            `json:"finding_ids,omitempty"`
+	RuleIDs      []string            `json:"rule_ids,omitempty"`
+	RuntimeIDs   []string            `json:"runtime_ids,omitempty"`
+	ResourceURNs []string            `json:"resource_urns,omitempty"`
+	ControlRefs  []string            `json:"control_refs,omitempty"`
+	RiskFactors  []RiskFactorSummary `json:"risk_factors,omitempty"`
+	Reasons      []string            `json:"reasons,omitempty"`
+}
+
+// CandidateExecution describes operational readiness and learned outcomes.
+type CandidateExecution struct {
+	Effort          Effort             `json:"effort"`
+	Ownership       Ownership          `json:"ownership"`
+	Evidence        EvidenceConfidence `json:"evidence"`
+	OutcomeLearning OutcomeLearning    `json:"outcome_learning"`
 }
 
 // ExpectedReduction groups all expected impact fields for newer consumers.

--- a/internal/riskplan/types.go
+++ b/internal/riskplan/types.go
@@ -1,0 +1,206 @@
+package riskplan
+
+import (
+	"time"
+
+	findinganalysis "github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	// ModelVersion identifies the planner contract and scoring model.
+	ModelVersion = "risk-action-plan-v2"
+
+	// DefaultCandidateLimit is the report and MCP default for ranked actions.
+	DefaultCandidateLimit = 10
+
+	// MaxCandidateLimit caps action-plan output for agent-facing surfaces.
+	MaxCandidateLimit = 25
+
+	// MaxSimulationSeedLimit caps simulation work before final ranking.
+	MaxSimulationSeedLimit = 50
+
+	ActionTypeAssignOwner          = "assign_owner"
+	ActionTypeRefreshEvidence      = "refresh_evidence"
+	SimulationStatusSimulated      = "simulated"
+	SimulationStatusUnsupported    = "unsupported"
+	SimulationStatusNoExpectedRisk = "no_expected_reduction"
+)
+
+// Options controls deterministic risk action planning over already-scoped findings.
+type Options struct {
+	TenantID           string
+	RuntimeIDs         []string
+	CandidateLimit     int
+	SeedLimit          int
+	GraphNeighborhoods map[string]*ports.EntityNeighborhood
+	Now                time.Time
+	PreviousCandidates []Candidate
+	IncludeUnscored    bool
+	Generators         []CandidateGenerator
+}
+
+// Plan is the typed risk-action-plan contract shared by reports and MCP tools.
+type Plan struct {
+	TenantID                string      `json:"tenant_id"`
+	RuntimeIDs              []string    `json:"runtime_ids,omitempty"`
+	GeneratedAt             string      `json:"generated_at,omitempty"`
+	ModelVersion            string      `json:"model_version"`
+	TotalFindings           int         `json:"total_findings"`
+	CandidateSeedCount      int         `json:"candidate_seed_count"`
+	TotalCandidates         int         `json:"total_candidates"`
+	SimulatedCandidateCount int         `json:"simulated_candidate_count"`
+	UnscoredCandidateCount  int         `json:"unscored_candidate_count"`
+	ActionCandidates        []Candidate `json:"action_candidates"`
+	Diff                    *PlanDiff   `json:"plan_diff,omitempty"`
+}
+
+// CandidateGenerator is a pluggable source of candidate remediation seeds.
+type CandidateGenerator interface {
+	ID() string
+	Generate(CandidateGeneratorInput) []CandidateSeed
+}
+
+// CandidateGeneratorInput is the per-finding context passed to generators.
+type CandidateGeneratorInput struct {
+	TenantID    string
+	Finding     *ports.FindingRecord
+	RiskContext findinganalysis.FindingRiskContext
+	Now         time.Time
+}
+
+// CandidateSeed is the minimal typed proposal produced by a generator.
+type CandidateSeed struct {
+	ID                  string
+	Title               string
+	ActionType          string
+	ScenarioType        string
+	TargetURN           string
+	SimulationSupported bool
+	Reasons             []string
+}
+
+// Candidate is one ranked next-best action with compatibility fields kept at top level.
+type Candidate struct {
+	ID                               string                                    `json:"id"`
+	Title                            string                                    `json:"title"`
+	ActionType                       string                                    `json:"action_type"`
+	ScenarioType                     string                                    `json:"scenario_type,omitempty"`
+	TargetURN                        string                                    `json:"target_urn"`
+	Owner                            string                                    `json:"owner,omitempty"`
+	PriorityScore                    int                                       `json:"priority_score"`
+	ScoreBreakdown                   ScoreBreakdown                            `json:"score_breakdown"`
+	RiskLevel                        string                                    `json:"risk_level,omitempty"`
+	ConfidenceScore                  int                                       `json:"confidence_score,omitempty"`
+	ExpectedRiskScoreReduction       int                                       `json:"expected_risk_score_reduction"`
+	ExpectedAttackPathScoreReduction int                                       `json:"expected_attack_path_score_reduction"`
+	ExpectedAttackPathCountReduction int                                       `json:"expected_attack_path_count_reduction"`
+	ExpectedReduction                ExpectedReduction                         `json:"expected_reduction"`
+	BeforeRiskScore                  int                                       `json:"before_risk_score"`
+	AfterRiskScore                   int                                       `json:"after_risk_score"`
+	FindingIDs                       []string                                  `json:"finding_ids,omitempty"`
+	RuleIDs                          []string                                  `json:"rule_ids,omitempty"`
+	RuntimeIDs                       []string                                  `json:"runtime_ids,omitempty"`
+	ResourceURNs                     []string                                  `json:"resource_urns,omitempty"`
+	ControlRefs                      []string                                  `json:"control_refs,omitempty"`
+	RiskFactors                      []RiskFactorSummary                       `json:"risk_factors,omitempty"`
+	Reasons                          []string                                  `json:"reasons,omitempty"`
+	SimulationStatus                 string                                    `json:"simulation_status"`
+	Effort                           Effort                                    `json:"effort"`
+	Ownership                        Ownership                                 `json:"ownership"`
+	Evidence                         EvidenceConfidence                        `json:"evidence"`
+	OutcomeLearning                  OutcomeLearning                           `json:"outcome_learning"`
+	RiskDelta                        findinganalysis.RiskDeltaSimulationReport `json:"risk_delta"`
+}
+
+// ExpectedReduction groups all expected impact fields for newer consumers.
+type ExpectedReduction struct {
+	RiskScore       int `json:"risk_score"`
+	AttackPathScore int `json:"attack_path_score"`
+	AttackPathCount int `json:"attack_path_count"`
+}
+
+// ScoreBreakdown makes priority scoring auditable.
+type ScoreBreakdown struct {
+	RiskReductionPoints            int `json:"risk_reduction_points"`
+	AttackPathScoreReductionPoints int `json:"attack_path_score_reduction_points"`
+	AttackPathCountReductionPoints int `json:"attack_path_count_reduction_points"`
+	RiskContextPoints              int `json:"risk_context_points"`
+	FindingCoveragePoints          int `json:"finding_coverage_points"`
+	ConfidencePoints               int `json:"confidence_points"`
+	OutcomePriorPoints             int `json:"outcome_prior_points"`
+	EffortCostPoints               int `json:"effort_cost_points"`
+	OwnershipPenaltyPoints         int `json:"ownership_penalty_points"`
+	SimulationPenaltyPoints        int `json:"simulation_penalty_points"`
+	Total                          int `json:"total"`
+}
+
+// Effort estimates the operational cost and reversibility of a candidate.
+type Effort struct {
+	Level             string `json:"level"`
+	Estimate          string `json:"estimate"`
+	CostPoints        int    `json:"cost_points"`
+	ApprovalRequired  bool   `json:"approval_required"`
+	ApprovalReason    string `json:"approval_reason,omitempty"`
+	Reversible        bool   `json:"reversible"`
+	PrimaryConstraint string `json:"primary_constraint,omitempty"`
+}
+
+// Ownership captures likely ownership and whether routing is blocked.
+type Ownership struct {
+	Owner      string   `json:"owner,omitempty"`
+	Source     string   `json:"source,omitempty"`
+	Candidates []string `json:"candidates,omitempty"`
+	Missing    bool     `json:"missing"`
+}
+
+// EvidenceConfidence summarizes data quality behind a candidate.
+type EvidenceConfidence struct {
+	ConfidenceScore int    `json:"confidence_score"`
+	Status          string `json:"status"`
+	Freshness       string `json:"freshness,omitempty"`
+	LastObservedAt  string `json:"last_observed_at,omitempty"`
+	EvidenceRefs    int    `json:"evidence_refs"`
+}
+
+// OutcomeLearning records prior action/outcome signals connected to the target.
+type OutcomeLearning struct {
+	Status               string `json:"status"`
+	PriorActionCount     int    `json:"prior_action_count"`
+	PositiveOutcomeCount int    `json:"positive_outcome_count"`
+	NegativeOutcomeCount int    `json:"negative_outcome_count"`
+	PriorityAdjustment   int    `json:"priority_adjustment"`
+}
+
+// RiskFactorSummary is the aggregate risk-factor explanation for a candidate.
+type RiskFactorSummary struct {
+	FactorID             string   `json:"factor_id"`
+	Category             string   `json:"category,omitempty"`
+	SeverityContribution string   `json:"severity_contribution,omitempty"`
+	Count                int      `json:"count"`
+	WeightTotal          int      `json:"weight_total"`
+	EvidenceRefs         []string `json:"evidence_refs,omitempty"`
+}
+
+// PlanDiff describes how a candidate set changed relative to a previous run.
+type PlanDiff struct {
+	Added          []CandidateDiff `json:"added,omitempty"`
+	Removed        []CandidateDiff `json:"removed,omitempty"`
+	Changed        []CandidateDiff `json:"changed,omitempty"`
+	UnchangedCount int             `json:"unchanged_count"`
+}
+
+// CandidateDiff is one added, removed, or materially changed candidate.
+type CandidateDiff struct {
+	ID                                       string `json:"id"`
+	Title                                    string `json:"title,omitempty"`
+	ChangeType                               string `json:"change_type"`
+	PreviousPriorityScore                    int    `json:"previous_priority_score,omitempty"`
+	CurrentPriorityScore                     int    `json:"current_priority_score,omitempty"`
+	PriorityScoreDelta                       int    `json:"priority_score_delta,omitempty"`
+	PreviousExpectedRiskScoreReduction       int    `json:"previous_expected_risk_score_reduction,omitempty"`
+	CurrentExpectedRiskScoreReduction        int    `json:"current_expected_risk_score_reduction,omitempty"`
+	ExpectedRiskScoreReductionDelta          int    `json:"expected_risk_score_reduction_delta,omitempty"`
+	PreviousExpectedAttackPathCountReduction int    `json:"previous_expected_attack_path_count_reduction,omitempty"`
+	CurrentExpectedAttackPathCountReduction  int    `json:"current_expected_attack_path_count_reduction,omitempty"`
+}


### PR DESCRIPTION
## Summary
- add a shared `internal/riskplan` engine with typed action-plan contracts, pluggable generators, score breakdowns, effort/ownership/evidence signals, outcome-learning hints, and plan diffs
- keep the `risk-action-plan` report compatible while adding the full typed `plan`, `include_unscored`, and `previous_report_run_id` support
- expose read-only MCP tools: `cerebro.risk.actions.list` and `cerebro.risk.actions.explain`
- document the first-class risk action planning model and keep remediation strictly simulated/read-only

## Validation
- [x] `go test ./internal/riskplan ./internal/reports ./internal/bootstrap`
- [x] `go test ./...`
- [x] `make test-race`
- [x] `make mcp-contract-check mcp-sdk-compat lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check detection-catalog-check docs-drift-check readme-check oss-audit release-smoke check-structural check-structural-test check-arch`
- [x] Python SDK tests and `scripts/sdk_dependency_audit.py` in `tmp/sdk-python-venv` because local Homebrew Python rejects Makefile's global/user `pip install` with PEP 668

## Notes
Opened as a draft early per request and pushed in small reviewable commits. The planner remains read-only: it ranks and explains candidate actions but does not execute remediation or introduce a new persistent store.
