### PR TITLE
feat(source): add email_domain_health posture source and rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-
 | `cloudflare` | Cloudflare account and network source | accounts, members, roles, zones, DNS records |
 | `cosmo` | Cosmo workflow and message source | messages, survey feedback, configured families |
 | `duo` | Duo identity and MFA source | users, groups, endpoints, phones, tokens, WebAuthn credentials |
+| `email_domain_health` | Email domain authentication posture source (SPF, DKIM, DMARC, MX, MTA-STS) | health |
 | `evidence_cas` | EvidenceCAS content-addressed evidence reference source | object manifests |
 | `gcp` | GCP IAM, Cloud Identity, service-account, and audit source | audit, groups, IAM role assignments, service accounts, resource exposure |
 | `github` | GitHub audit, repository, Dependabot, and pull request source | audit, repository, Dependabot alerts, pull requests |

--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -164,7 +164,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 65 rules across cloud, identity, GitHub, GRC, runtime, endpoint, and vulnerability domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 66 rules across cloud, identity, GitHub, GRC, runtime, endpoint, and vulnerability domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/internal/findings/email_domain_authentication_misconfigured_rule.go
+++ b/internal/findings/email_domain_authentication_misconfigured_rule.go
@@ -1,0 +1,175 @@
+package findings
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const emailDomainAuthenticationMisconfiguredRuleID = "email-domain-authentication-misconfigured"
+
+func newEmailDomainAuthenticationMisconfiguredRule() Rule {
+	definition := emailDomainAuthenticationMisconfiguredDefinition()
+	return newEventRule(eventRuleConfig{
+		definition: definition,
+		sourceID:   definition.SourceID,
+		match:      eventKindMatcher(definition.EventKinds...),
+		build:      buildEmailDomainAuthenticationMisconfiguredFinding,
+	})
+}
+
+func emailDomainAuthenticationMisconfiguredDefinition() RuleDefinition {
+	return RuleDefinition{
+		ID:          emailDomainAuthenticationMisconfiguredRuleID,
+		Name:        "Email Domain Authentication Misconfigured",
+		Description: "Detect tenant mail domains whose SPF, DKIM, or DMARC configuration is missing, permissive, or non-enforcing and that can be abused for spoofing.",
+		SourceID:    "email_domain_health",
+		EventKinds:  []string{"email_domain_health.health"},
+		OutputKind:  "finding.email_domain_authentication_misconfigured",
+		Severity:    "HIGH",
+		Status:      findingStatusOpen,
+		Maturity:    "test",
+		Tags:        []string{"email", "spf", "dkim", "dmarc", "spoofing", "phishing", "mta"},
+		References: []string{
+			"https://datatracker.ietf.org/doc/html/rfc7208",
+			"https://datatracker.ietf.org/doc/html/rfc6376",
+			"https://datatracker.ietf.org/doc/html/rfc7489",
+		},
+		FalsePositives: []string{
+			"Domains that intentionally do not send mail may legitimately omit SPF/DKIM/DMARC, but should publish a deny-all SPF and DMARC reject policy to stop spoofing.",
+			"DKIM selectors outside the probed defaults (or scoped to subdomains) may exist and not be discovered by the source.",
+		},
+		Runbook:            "Inspect the failing_issue_codes attribute on the finding, address the most severe protocol gap first (SPF permissive/missing, DMARC missing or p=none, DKIM weak/missing), then confirm the source re-runs and clears the finding.",
+		RequiredAttributes: []string{"domain", "status"},
+		FingerprintFields:  []string{"domain"},
+		ControlRefs: []ports.FindingControlRef{
+			{FrameworkName: "SOC 2", ControlID: "CC6.6"},
+			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.14"},
+			{FrameworkName: "NIST SP 800-177", ControlID: "TLS-MAIL"},
+		},
+		Lifecycle: Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorGraphAnchored},
+	}
+}
+
+func buildEmailDomainAuthenticationMisconfiguredFinding(_ context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+	attributes := eventAttributes(event)
+	if attributes == nil {
+		return nil, nil
+	}
+	domain := strings.ToLower(strings.TrimSpace(attributes["domain"]))
+	status := strings.ToUpper(strings.TrimSpace(attributes["status"]))
+	if domain == "" {
+		return nil, nil
+	}
+	switch status {
+	case "FAILING", "WARNING":
+	default:
+		return nil, nil
+	}
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	if tenantID == "" {
+		return nil, nil
+	}
+	domainURN := emailDomainURN(tenantID, domain)
+	if domainURN == "" {
+		return nil, nil
+	}
+	severity := emailDomainAuthenticationSeverity(status, attributes)
+	observedAt := time.Time{}
+	if event.GetOccurredAt() != nil {
+		observedAt = event.GetOccurredAt().AsTime().UTC()
+	}
+	failingCodes := strings.TrimSpace(attributes["failing_issue_codes"])
+	issueCodes := strings.TrimSpace(attributes["issue_codes"])
+	summary := emailDomainAuthenticationSummary(domain, status, failingCodes, issueCodes)
+	action := "Publish or correct SPF, DKIM, and DMARC records on the affected mail domain. Aim for one SPF record terminating in -all, DMARC at p=quarantine or p=reject with reporting, and DKIM keys of at least 2048 bits."
+
+	findingAttributes := map[string]string{
+		"action":               action,
+		"domain":               domain,
+		"status":               status,
+		"score":                strings.TrimSpace(attributes["score"]),
+		"spf_status":           strings.TrimSpace(attributes["spf_status"]),
+		"dkim_status":          strings.TrimSpace(attributes["dkim_status"]),
+		"dmarc_status":         strings.TrimSpace(attributes["dmarc_status"]),
+		"issue_count":          strings.TrimSpace(attributes["issue_count"]),
+		"failing_issue_count":  strings.TrimSpace(attributes["failing_issue_count"]),
+		"issue_codes":          issueCodes,
+		"failing_issue_codes":  failingCodes,
+		"highest_severity":     strings.TrimSpace(attributes["highest_severity"]),
+		"event_id":             strings.TrimSpace(event.GetId()),
+		"event_kind":           strings.TrimSpace(event.GetKind()),
+		"primary_resource_urn": domainURN,
+		"resource_type":        "email_domain",
+		"resource_label":       domain,
+		"source_runtime_id":    strings.TrimSpace(runtime.GetId()),
+	}
+	definition := emailDomainAuthenticationMisconfiguredDefinition()
+	for key, value := range definition.AttributeMap() {
+		findingAttributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(findingAttributes)
+	fingerprint := hashFindingFingerprint(emailDomainAuthenticationMisconfiguredRuleID, tenantID, domain)
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       strings.TrimSpace(runtime.GetId()),
+		RuleID:          emailDomainAuthenticationMisconfiguredRuleID,
+		Title:           "Email Domain Authentication Misconfigured",
+		Severity:        severity,
+		Status:          findingStatusOpen,
+		Summary:         summary,
+		ResourceURNs:    []string{domainURN},
+		EventIDs:        []string{event.GetId()},
+		PolicyID:        domain,
+		CheckID:         emailDomainAuthenticationMisconfiguredRuleID,
+		CheckName:       "Email Domain Authentication Misconfigured",
+		ControlRefs:     cloneFindingControlRefs(definition.ControlRefs),
+		Attributes:      findingAttributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}
+
+func emailDomainAuthenticationSeverity(status string, attributes map[string]string) string {
+	if status == "WARNING" {
+		return "MEDIUM"
+	}
+	highest := strings.ToUpper(strings.TrimSpace(attributes["highest_severity"]))
+	switch highest {
+	case "CRITICAL":
+		return "CRITICAL"
+	case "MEDIUM":
+		return "MEDIUM"
+	case "LOW":
+		return "LOW"
+	default:
+		return "HIGH"
+	}
+}
+
+func emailDomainAuthenticationSummary(domain string, status string, failingCodes string, issueCodes string) string {
+	if status == "WARNING" {
+		if issueCodes != "" {
+			return "Mail domain " + domain + " has email authentication warnings: " + issueCodes
+		}
+		return "Mail domain " + domain + " has email authentication warnings"
+	}
+	if failingCodes != "" {
+		return "Mail domain " + domain + " has failing SPF/DKIM/DMARC controls: " + failingCodes
+	}
+	return "Mail domain " + domain + " has failing SPF/DKIM/DMARC controls"
+}
+
+func emailDomainURN(tenantID string, domain string) string {
+	tenant := strings.TrimSpace(tenantID)
+	value := strings.ToLower(strings.TrimSpace(domain))
+	if tenant == "" || value == "" {
+		return ""
+	}
+	return "urn:cerebro:" + tenant + ":email_domain:" + value
+}

--- a/internal/findings/email_domain_authentication_misconfigured_rule.go
+++ b/internal/findings/email_domain_authentication_misconfigured_rule.go
@@ -11,14 +11,22 @@ import (
 
 const emailDomainAuthenticationMisconfiguredRuleID = "email-domain-authentication-misconfigured"
 
+type emailDomainAuthenticationMisconfiguredRule struct {
+	Rule
+	definition RuleDefinition
+}
+
 func newEmailDomainAuthenticationMisconfiguredRule() Rule {
 	definition := emailDomainAuthenticationMisconfiguredDefinition()
-	return newEventRule(eventRuleConfig{
+	return &emailDomainAuthenticationMisconfiguredRule{
+		Rule: newEventRule(eventRuleConfig{
+			definition: definition,
+			sourceID:   definition.SourceID,
+			match:      eventKindMatcher(definition.EventKinds...),
+			build:      buildEmailDomainAuthenticationMisconfiguredFinding,
+		}),
 		definition: definition,
-		sourceID:   definition.SourceID,
-		match:      eventKindMatcher(definition.EventKinds...),
-		build:      buildEmailDomainAuthenticationMisconfiguredFinding,
-	})
+	}
 }
 
 func emailDomainAuthenticationMisconfiguredDefinition() RuleDefinition {
@@ -42,7 +50,7 @@ func emailDomainAuthenticationMisconfiguredDefinition() RuleDefinition {
 			"Domains that intentionally do not send mail may legitimately omit SPF/DKIM/DMARC, but should publish a deny-all SPF and DMARC reject policy to stop spoofing.",
 			"DKIM selectors outside the probed defaults (or scoped to subdomains) may exist and not be discovered by the source.",
 		},
-		Runbook:            "Inspect the failing_issue_codes attribute on the finding, address the most severe protocol gap first (SPF permissive/missing, DMARC missing or p=none, DKIM weak/missing), then confirm the source re-runs and clears the finding.",
+		Runbook:            "Inspect the failing_issue_codes attribute on the finding, address the most severe protocol gap first (SPF permissive/missing, DMARC missing or p=none, DKIM weak/missing), then confirm the source re-runs healthy and clears the finding.",
 		RequiredAttributes: []string{"domain", "status"},
 		FingerprintFields:  []string{"domain"},
 		ControlRefs: []ports.FindingControlRef{
@@ -52,6 +60,32 @@ func emailDomainAuthenticationMisconfiguredDefinition() RuleDefinition {
 		},
 		Lifecycle: Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorGraphAnchored},
 	}
+}
+
+func (r *emailDomainAuthenticationMisconfiguredRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
+func (r *emailDomainAuthenticationMisconfiguredRule) OpenAnchor(attributes map[string]string) string {
+	return emailDomainAuthenticationCounterAnchor(attributes["domain"])
+}
+
+func (r *emailDomainAuthenticationMisconfiguredRule) CloseOnEvent(event Event) (string, bool) {
+	if !eventKindMatcher(emailDomainAuthenticationMisconfiguredDefinition().EventKinds...)(event) {
+		return "", false
+	}
+	attributes := eventAttributes(event)
+	if !strings.EqualFold(strings.TrimSpace(attributes["status"]), "HEALTHY") {
+		return "", false
+	}
+	anchor := emailDomainAuthenticationCounterAnchor(attributes["domain"])
+	if anchor == "" {
+		return "", false
+	}
+	return anchor, true
 }
 
 func buildEmailDomainAuthenticationMisconfiguredFinding(_ context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
@@ -85,7 +119,7 @@ func buildEmailDomainAuthenticationMisconfiguredFinding(_ context.Context, runti
 	failingCodes := strings.TrimSpace(attributes["failing_issue_codes"])
 	issueCodes := strings.TrimSpace(attributes["issue_codes"])
 	summary := emailDomainAuthenticationSummary(domain, status, failingCodes, issueCodes)
-	action := "Publish or correct SPF, DKIM, and DMARC records on the affected mail domain. Aim for one SPF record terminating in -all, DMARC at p=quarantine or p=reject with reporting, and DKIM keys of at least 2048 bits."
+	action := "Publish or correct SPF, DKIM, and DMARC records on the affected mail domain. Aim for one SPF record terminating in -all, DMARC at p=quarantine or p=reject with reporting, and RSA DKIM keys of at least 2048 bits or standards-compliant Ed25519 selectors."
 
 	findingAttributes := map[string]string{
 		"action":               action,
@@ -172,4 +206,12 @@ func emailDomainURN(tenantID string, domain string) string {
 		return ""
 	}
 	return "urn:cerebro:" + tenant + ":email_domain:" + value
+}
+
+func emailDomainAuthenticationCounterAnchor(domain string) string {
+	value := strings.ToLower(strings.TrimSpace(domain))
+	if value == "" {
+		return ""
+	}
+	return "domain=" + value
 }

--- a/internal/findings/email_domain_authentication_misconfigured_rule_test.go
+++ b/internal/findings/email_domain_authentication_misconfigured_rule_test.go
@@ -1,6 +1,7 @@
 package findings
 
 import (
+	"context"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -19,5 +20,46 @@ func TestEmailDomainAuthenticationMisconfiguredRuleSupportsRuntime(t *testing.T)
 	other := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer", Config: map[string]string{"family": "audit"}}
 	if rule.SupportsRuntime(other) {
 		t.Fatalf("SupportsRuntime should not match unrelated runtimes")
+	}
+}
+
+func TestEmailDomainAuthenticationMisconfiguredRuleClosesOnHealthyDomainEvent(t *testing.T) {
+	rule := newEmailDomainAuthenticationMisconfiguredRule()
+	counterRule, ok := durableStateCounterEventRule(rule)
+	if !ok {
+		t.Fatal("email-domain-authentication-misconfigured does not implement durable CounterEventRule")
+	}
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-email-domain-health", SourceId: "email_domain_health", TenantId: "writer", Config: map[string]string{"family": "health"}}
+	openEvent := emailDomainAuthenticationTestEvent("email-domain-health-open", "Example.COM", "FAILING")
+	records, err := rule.Evaluate(context.Background(), runtime, openEvent)
+	if err != nil {
+		t.Fatalf("Evaluate(open) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Evaluate(open) records = %d, want 1", len(records))
+	}
+	openAnchor := counterRule.OpenAnchor(records[0].Attributes)
+	if openAnchor == "" {
+		t.Fatalf("OpenAnchor(%v) = empty", records[0].Attributes)
+	}
+	closeAnchor, closes := counterRule.CloseOnEvent(emailDomainAuthenticationTestEvent("email-domain-health-healthy", "example.com", "HEALTHY"))
+	if !closes || closeAnchor != openAnchor {
+		t.Fatalf("CloseOnEvent(healthy) = (%q, %v), want (%q, true)", closeAnchor, closes, openAnchor)
+	}
+	if closeAnchor, closes = counterRule.CloseOnEvent(emailDomainAuthenticationTestEvent("email-domain-health-warning", "example.com", "WARNING")); closes || closeAnchor != "" {
+		t.Fatalf("CloseOnEvent(warning) = (%q, %v), want no close", closeAnchor, closes)
+	}
+}
+
+func emailDomainAuthenticationTestEvent(id string, domain string, status string) *cerebrov1.EventEnvelope {
+	return &cerebrov1.EventEnvelope{
+		Id:       id,
+		TenantId: "writer",
+		SourceId: "email_domain_health",
+		Kind:     "email_domain_health.health",
+		Attributes: map[string]string{
+			"domain": domain,
+			"status": status,
+		},
 	}
 }

--- a/internal/findings/email_domain_authentication_misconfigured_rule_test.go
+++ b/internal/findings/email_domain_authentication_misconfigured_rule_test.go
@@ -1,0 +1,23 @@
+package findings
+
+import (
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestEmailDomainAuthenticationMisconfiguredFixture(t *testing.T) {
+	assertRuleFixture(t, newEmailDomainAuthenticationMisconfiguredRule(), "testdata/rules/email-domain-authentication-misconfigured.json")
+}
+
+func TestEmailDomainAuthenticationMisconfiguredRuleSupportsRuntime(t *testing.T) {
+	rule := newEmailDomainAuthenticationMisconfiguredRule()
+	emit := &cerebrov1.SourceRuntime{Id: "writer-email-domain-health", SourceId: "email_domain_health", TenantId: "writer", Config: map[string]string{"family": "health"}}
+	if !rule.SupportsRuntime(emit) {
+		t.Fatalf("SupportsRuntime should match the email_domain_health/health runtime")
+	}
+	other := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer", Config: map[string]string{"family": "audit"}}
+	if rule.SupportsRuntime(other) {
+		t.Fatalf("SupportsRuntime should not match unrelated runtimes")
+	}
+}

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -537,7 +537,7 @@
         "DKIM selectors outside the probed defaults (or scoped to subdomains) may exist and not be discovered by the source.",
         "Domains that intentionally do not send mail may legitimately omit SPF/DKIM/DMARC, but should publish a deny-all SPF and DMARC reject policy to stop spoofing."
       ],
-      "runbook": "Inspect the failing_issue_codes attribute on the finding, address the most severe protocol gap first (SPF permissive/missing, DMARC missing or p=none, DKIM weak/missing), then confirm the source re-runs and clears the finding.",
+      "runbook": "Inspect the failing_issue_codes attribute on the finding, address the most severe protocol gap first (SPF permissive/missing, DMARC missing or p=none, DKIM weak/missing), then confirm the source re-runs healthy and clears the finding.",
       "required_attributes": [
         "domain",
         "status"

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -505,6 +505,62 @@
       ]
     },
     {
+      "id": "email-domain-authentication-misconfigured",
+      "pack_id": "email_domain",
+      "pack_name": "Email Domain",
+      "name": "Email Domain Authentication Misconfigured",
+      "description": "Detect tenant mail domains whose SPF, DKIM, or DMARC configuration is missing, permissive, or non-enforcing and that can be abused for spoofing.",
+      "source_id": "email_domain_health",
+      "evaluation_mode": "event",
+      "event_kinds": [
+        "email_domain_health.health"
+      ],
+      "output_kind": "finding.email_domain_authentication_misconfigured",
+      "severity": "HIGH",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "dkim",
+        "dmarc",
+        "email",
+        "mta",
+        "phishing",
+        "spf",
+        "spoofing"
+      ],
+      "references": [
+        "https://datatracker.ietf.org/doc/html/rfc6376",
+        "https://datatracker.ietf.org/doc/html/rfc7208",
+        "https://datatracker.ietf.org/doc/html/rfc7489"
+      ],
+      "false_positives": [
+        "DKIM selectors outside the probed defaults (or scoped to subdomains) may exist and not be discovered by the source.",
+        "Domains that intentionally do not send mail may legitimately omit SPF/DKIM/DMARC, but should publish a deny-all SPF and DMARC reject policy to stop spoofing."
+      ],
+      "runbook": "Inspect the failing_issue_codes attribute on the finding, address the most severe protocol gap first (SPF permissive/missing, DMARC missing or p=none, DKIM weak/missing), then confirm the source re-runs and clears the finding.",
+      "required_attributes": [
+        "domain",
+        "status"
+      ],
+      "fingerprint_fields": [
+        "domain"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC6.6"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.5.14"
+        },
+        {
+          "framework_name": "NIST SP 800-177",
+          "control_id": "TLS-MAIL"
+        }
+      ]
+    },
+    {
       "id": "github-app-integration-installed",
       "pack_id": "github",
       "pack_name": "GitHub",

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -88,8 +88,8 @@ func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
 
 func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	packs := builtinRulePacks()
-	if got := len(packs); got != 8 {
-		t.Fatalf("len(builtinRulePacks()) = %d, want 8", got)
+	if got := len(packs); got != 9 {
+		t.Fatalf("len(builtinRulePacks()) = %d, want 9", got)
 	}
 	rules := flattenRulePacks(packs)
 	if got := len(rules); got < 10 {

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -104,6 +104,14 @@ func builtinRulePacks() []RulePack {
 			Description: "Sensitive data and crown-jewel findings.",
 			Rules:       []Rule{newDataSensitiveAssetRiskRule()},
 		},
+		{
+			ID:          "email_domain",
+			Name:        "Email Domain",
+			Description: "SPF, DKIM, and DMARC posture findings on tenant mail domains.",
+			Rules: []Rule{
+				newEmailDomainAuthenticationMisconfiguredRule(),
+			},
+		},
 	}
 }
 

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -920,7 +920,7 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 38; got != want {
+	if got, want := len(keepRules), 39; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1087,6 +1087,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "cloud-exposed-privileged-compute-role", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "cloud"},
 		{RuleID: "cloud-public-resource-exposure", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "cloud"},
 		{RuleID: "data-sensitive-asset-risk", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "asset"},
+		{RuleID: "email-domain-authentication-misconfigured", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "email_domain_health"},
 		{RuleID: "github-app-integration-installed", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "github-code-security-controls-disabled", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "github-dependabot-open-alert", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},

--- a/internal/findings/testdata/rules/email-domain-authentication-misconfigured.json
+++ b/internal/findings/testdata/rules/email-domain-authentication-misconfigured.json
@@ -1,0 +1,119 @@
+{
+  "rule_id": "email-domain-authentication-misconfigured",
+  "runtime": {
+    "id": "writer-email-domain-health",
+    "source_id": "email_domain_health",
+    "tenant_id": "writer",
+    "config": {
+      "family": "health"
+    }
+  },
+  "events": [
+    {
+      "id": "email-domain-health-writer-failing.example.com-deadbeef",
+      "tenant_id": "writer",
+      "source_id": "email_domain_health",
+      "kind": "email_domain_health.health",
+      "occurred_at": "2026-06-14T00:00:00Z",
+      "schema_ref": "email_domain_health/health/v1",
+      "attributes": {
+        "domain": "failing.example.com",
+        "status": "FAILING",
+        "score": "30",
+        "spf_status": "FAILING",
+        "dkim_status": "FAILING",
+        "dmarc_status": "FAILING",
+        "issue_count": "3",
+        "failing_issue_count": "3",
+        "issue_codes": "dkim_weak_key,dmarc_missing,spf_permissive_all",
+        "failing_issue_codes": "dkim_weak_key,dmarc_missing,spf_permissive_all",
+        "highest_severity": "CRITICAL",
+        "resource_type": "email_domain",
+        "resource_id": "failing.example.com"
+      }
+    },
+    {
+      "id": "email-domain-health-writer-warning.example.com-cafef00d",
+      "tenant_id": "writer",
+      "source_id": "email_domain_health",
+      "kind": "email_domain_health.health",
+      "occurred_at": "2026-06-14T00:01:00Z",
+      "schema_ref": "email_domain_health/health/v1",
+      "attributes": {
+        "domain": "warning.example.com",
+        "status": "WARNING",
+        "score": "85",
+        "spf_status": "WARNING",
+        "dkim_status": "HEALTHY",
+        "dmarc_status": "HEALTHY",
+        "issue_count": "1",
+        "failing_issue_count": "0",
+        "issue_codes": "spf_softfail",
+        "failing_issue_codes": "",
+        "highest_severity": "MEDIUM",
+        "resource_type": "email_domain",
+        "resource_id": "warning.example.com"
+      }
+    },
+    {
+      "id": "email-domain-health-writer-healthy.example.com-feedface",
+      "tenant_id": "writer",
+      "source_id": "email_domain_health",
+      "kind": "email_domain_health.health",
+      "occurred_at": "2026-06-14T00:02:00Z",
+      "schema_ref": "email_domain_health/health/v1",
+      "attributes": {
+        "domain": "healthy.example.com",
+        "status": "HEALTHY",
+        "score": "100",
+        "spf_status": "HEALTHY",
+        "dkim_status": "HEALTHY",
+        "dmarc_status": "HEALTHY",
+        "issue_count": "0",
+        "failing_issue_count": "0",
+        "highest_severity": "",
+        "resource_type": "email_domain",
+        "resource_id": "healthy.example.com"
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "email-domain-authentication-misconfigured",
+      "severity": "CRITICAL",
+      "status": "open",
+      "summary": "Mail domain failing.example.com has failing SPF/DKIM/DMARC controls: dkim_weak_key,dmarc_missing,spf_permissive_all",
+      "policy_id": "failing.example.com",
+      "event_ids": ["email-domain-health-writer-failing.example.com-deadbeef"],
+      "attributes": {
+        "domain": "failing.example.com",
+        "status": "FAILING",
+        "highest_severity": "CRITICAL",
+        "primary_resource_urn": "urn:cerebro:writer:email_domain:failing.example.com",
+        "resource_type": "email_domain",
+        "source_runtime_id": "writer-email-domain-health"
+      }
+    },
+    {
+      "rule_id": "email-domain-authentication-misconfigured",
+      "severity": "MEDIUM",
+      "status": "open",
+      "summary": "Mail domain warning.example.com has email authentication warnings: spf_softfail",
+      "policy_id": "warning.example.com",
+      "event_ids": ["email-domain-health-writer-warning.example.com-cafef00d"],
+      "attributes": {
+        "domain": "warning.example.com",
+        "status": "WARNING",
+        "primary_resource_urn": "urn:cerebro:writer:email_domain:warning.example.com",
+        "resource_type": "email_domain",
+        "source_runtime_id": "writer-email-domain-health"
+      }
+    }
+  ],
+  "expected_no_match": [
+    {
+      "event_id": "email-domain-health-writer-healthy.example.com-feedface",
+      "reason": "domain is healthy"
+    }
+  ]
+}

--- a/internal/sourceprojection/email_domain.go
+++ b/internal/sourceprojection/email_domain.go
@@ -1,0 +1,181 @@
+package sourceprojection
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type emailDomainHealthIssue struct {
+	ID             string `json:"id"`
+	Protocol       string `json:"protocol"`
+	Severity       string `json:"severity"`
+	Code           string `json:"code"`
+	Title          string `json:"title"`
+	Detail         string `json:"detail"`
+	Recommendation string `json:"recommendation"`
+}
+
+type emailDomainHealthDKIM struct {
+	Selector string `json:"selector"`
+	Status   string `json:"status"`
+	KeyBits  int    `json:"key_bits"`
+	Record   string `json:"record"`
+}
+
+type emailDomainHealthPayload struct {
+	Domain         string                   `json:"domain"`
+	Status         string                   `json:"status"`
+	Score          int                      `json:"score"`
+	SPFStatus      string                   `json:"spf_status"`
+	DKIMStatus     string                   `json:"dkim_status"`
+	DMARCStatus    string                   `json:"dmarc_status"`
+	SPFRecords     []string                 `json:"spf_records"`
+	SPFPolicy      string                   `json:"spf_policy"`
+	SPFLookupCount int                      `json:"spf_lookup_count"`
+	DMARCRecords   []string                 `json:"dmarc_records"`
+	DMARCPolicy    string                   `json:"dmarc_policy"`
+	DMARCPct       int                      `json:"dmarc_pct"`
+	DMARCRua       []string                 `json:"dmarc_rua"`
+	MXRecords      []string                 `json:"mx_records"`
+	DKIMSelectors  []emailDomainHealthDKIM  `json:"dkim_selectors"`
+	RelatedRecords []string                 `json:"related_records"`
+	Issues         []emailDomainHealthIssue `json:"issues"`
+}
+
+func emailDomainHealthProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	domain := strings.TrimSpace(attrs["domain"])
+	if domain == "" {
+		return nil, nil, fmt.Errorf("event %q missing domain attribute", event.GetId())
+	}
+	domain = strings.ToLower(domain)
+	var payload emailDomainHealthPayload
+	if len(event.GetPayload()) != 0 {
+		_ = json.Unmarshal(event.GetPayload(), &payload)
+	}
+	if strings.TrimSpace(payload.Domain) == "" {
+		payload.Domain = domain
+	}
+	domainURN := projectionURN(tenantID, "email_domain", domain)
+	if domainURN == "" {
+		return nil, nil, nil
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        domainURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "email.domain",
+		Label:      domain,
+		Attributes: emailDomainEntityAttributes(event, attrs, payload),
+	})
+
+	internetDomainURN, internetDomainLabel := internetDomainURN(tenantID, domain)
+	if internetDomainURN != "" {
+		addInternetDomainEntity(entities, tenantID, event.GetSourceId(), internetDomainURN, internetDomainLabel)
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), domainURN, internetDomainURN, relationBelongsTo, map[string]string{
+			"event_id":   event.GetId(),
+			"at":         eventObservedAt(event),
+			"match_type": "email_domain_belongs_to_internet_domain",
+		}))
+	}
+
+	for _, selector := range payload.DKIMSelectors {
+		selectorName := strings.TrimSpace(selector.Selector)
+		if selectorName == "" {
+			continue
+		}
+		selectorURN := projectionURN(tenantID, "email_dkim_selector", domain, selectorName)
+		if selectorURN == "" {
+			continue
+		}
+		selectorAttributes := map[string]string{
+			"selector": selectorName,
+			"domain":   domain,
+			"status":   strings.TrimSpace(selector.Status),
+			"key_bits": fmt.Sprintf("%d", selector.KeyBits),
+			"record":   strings.TrimSpace(selector.Record),
+		}
+		trimEmptyProjectionAttributes(selectorAttributes)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        selectorURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "email.dkim_selector",
+			Label:      selectorName + "@" + domain,
+			Attributes: selectorAttributes,
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), domainURN, selectorURN, relationContains, map[string]string{
+			"event_id":   event.GetId(),
+			"at":         eventObservedAt(event),
+			"match_type": "email_domain_dkim_selector",
+			"selector":   selectorName,
+		}))
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func emailDomainEntityAttributes(event *cerebrov1.EventEnvelope, attrs map[string]string, payload emailDomainHealthPayload) map[string]string {
+	out := map[string]string{
+		"domain":              payload.Domain,
+		"status":              strings.TrimSpace(payload.Status),
+		"score":               fmt.Sprintf("%d", payload.Score),
+		"spf_status":          strings.TrimSpace(payload.SPFStatus),
+		"dkim_status":         strings.TrimSpace(payload.DKIMStatus),
+		"dmarc_status":        strings.TrimSpace(payload.DMARCStatus),
+		"spf_policy":          strings.TrimSpace(payload.SPFPolicy),
+		"spf_lookup_count":    fmt.Sprintf("%d", payload.SPFLookupCount),
+		"dmarc_policy":        strings.TrimSpace(payload.DMARCPolicy),
+		"dmarc_pct":           fmt.Sprintf("%d", payload.DMARCPct),
+		"issue_count":         fmt.Sprintf("%d", len(payload.Issues)),
+		"failing_issue_count": strings.TrimSpace(attrs["failing_issue_count"]),
+		"highest_severity":    strings.TrimSpace(attrs["highest_severity"]),
+		"observed_at":         eventObservedAt(event),
+		"event_id":            event.GetId(),
+	}
+	if codes := strings.TrimSpace(attrs["issue_codes"]); codes != "" {
+		out["issue_codes"] = codes
+	}
+	if codes := strings.TrimSpace(attrs["failing_issue_codes"]); codes != "" {
+		out["failing_issue_codes"] = codes
+	}
+	if data, err := json.Marshal(payload.Issues); err == nil && len(payload.Issues) != 0 {
+		out["issues_json"] = string(data)
+	}
+	if len(payload.SPFRecords) != 0 {
+		out["spf_records"] = strings.Join(payload.SPFRecords, "\n")
+	}
+	if len(payload.DMARCRecords) != 0 {
+		out["dmarc_records"] = strings.Join(payload.DMARCRecords, "\n")
+	}
+	if len(payload.MXRecords) != 0 {
+		out["mx_records"] = strings.Join(payload.MXRecords, "\n")
+	}
+	if len(payload.DMARCRua) != 0 {
+		out["dmarc_rua"] = strings.Join(payload.DMARCRua, ",")
+	}
+	if len(payload.RelatedRecords) != 0 {
+		out["related_records"] = strings.Join(payload.RelatedRecords, "\n")
+	}
+	trimEmptyProjectionAttributes(out)
+	return out
+}
+
+func trimEmptyProjectionAttributes(attributes map[string]string) {
+	for key, value := range attributes {
+		if strings.TrimSpace(value) == "" {
+			delete(attributes, key)
+		}
+	}
+}

--- a/internal/sourceprojection/email_domain_test.go
+++ b/internal/sourceprojection/email_domain_test.go
@@ -1,0 +1,115 @@
+package sourceprojection
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestProjectEmailDomainHealthEntitiesAndLinks(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	payload := emailDomainHealthPayload{
+		Domain:      "example.com",
+		Status:      "FAILING",
+		Score:       40,
+		SPFStatus:   "FAILING",
+		DKIMStatus:  "FAILING",
+		DMARCStatus: "FAILING",
+		SPFRecords:  []string{"v=spf1 +all"},
+		SPFPolicy:   "+all",
+		DKIMSelectors: []emailDomainHealthDKIM{
+			{Selector: "default", Status: "FAILING", KeyBits: 512, Record: "v=DKIM1; p=AAAA"},
+		},
+		Issues: []emailDomainHealthIssue{
+			{ID: "SPF:spf_permissive_all", Protocol: "SPF", Severity: "CRITICAL", Code: "spf_permissive_all", Title: "SPF allows all senders", Detail: "+all", Recommendation: "use -all"},
+			{ID: "DMARC:dmarc_missing", Protocol: "DMARC", Severity: "HIGH", Code: "dmarc_missing", Title: "DMARC missing"},
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	event := &cerebrov1.EventEnvelope{
+		Id:         "email-domain-health-writer-example.com-deadbeef",
+		TenantId:   "writer",
+		SourceId:   "email_domain_health",
+		Kind:       "email_domain_health.health",
+		OccurredAt: timestamppb.New(time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)),
+		SchemaRef:  "email_domain_health/health/v1",
+		Payload:    data,
+		Attributes: map[string]string{
+			"domain":              "example.com",
+			"status":              "FAILING",
+			"score":               "40",
+			"spf_status":          "FAILING",
+			"dkim_status":         "FAILING",
+			"dmarc_status":        "FAILING",
+			"failing_issue_count": "2",
+			"highest_severity":    "CRITICAL",
+			"issue_codes":         "dmarc_missing,spf_permissive_all",
+			"failing_issue_codes": "dmarc_missing,spf_permissive_all",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	domainURN := "urn:cerebro:writer:email_domain:example.com"
+	internetDomainURN := "urn:cerebro:writer:internet_domain:example.com"
+	selectorURN := "urn:cerebro:writer:email_dkim_selector:example.com:default"
+
+	domainEntity := state.entities[domainURN]
+	if domainEntity == nil || domainEntity.EntityType != "email.domain" {
+		t.Fatalf("email.domain entity missing or wrong: %#v", domainEntity)
+	}
+	if got := domainEntity.Attributes["status"]; got != "FAILING" {
+		t.Fatalf("email.domain status = %q, want FAILING", got)
+	}
+	if got := domainEntity.Attributes["spf_policy"]; got != "+all" {
+		t.Fatalf("email.domain spf_policy = %q", got)
+	}
+	if got := domainEntity.Attributes["highest_severity"]; got != "CRITICAL" {
+		t.Fatalf("email.domain highest_severity = %q", got)
+	}
+	if domainEntity.Attributes["issues_json"] == "" {
+		t.Fatalf("email.domain issues_json is empty")
+	}
+
+	if entity := state.entities[internetDomainURN]; entity == nil || entity.EntityType != "internet.domain" {
+		t.Fatalf("internet.domain entity missing or wrong: %#v", entity)
+	}
+	assertProjectedLink(t, state, domainURN, relationBelongsTo, internetDomainURN)
+
+	selector := state.entities[selectorURN]
+	if selector == nil || selector.EntityType != "email.dkim_selector" {
+		t.Fatalf("email.dkim_selector entity missing or wrong: %#v", selector)
+	}
+	if got := selector.Attributes["selector"]; got != "default" {
+		t.Fatalf("dkim selector attribute = %q", got)
+	}
+	assertProjectedLink(t, state, domainURN, relationContains, selectorURN)
+}
+
+func TestProjectEmailDomainHealthRequiresDomainAttribute(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	event := &cerebrov1.EventEnvelope{
+		Id:         "email-domain-health-writer-missing",
+		TenantId:   "writer",
+		SourceId:   "email_domain_health",
+		Kind:       "email_domain_health.health",
+		OccurredAt: timestamppb.New(time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)),
+		SchemaRef:  "email_domain_health/health/v1",
+		Payload:    []byte(`{}`),
+		Attributes: map[string]string{},
+	}
+	if _, err := service.Project(context.Background(), event); err == nil {
+		t.Fatalf("Project() expected error for missing domain attribute")
+	}
+}

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -305,6 +305,7 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"duo.token":                                 genericInventoryProjections,
 	"duo.user":                                  genericInventoryProjections,
 	"duo.web_authn_credential":                  genericInventoryProjections,
+	"email_domain_health.health":                emailDomainHealthProjections,
 	"kubernetes.cluster":                        genericInventoryProjections,
 	"kubernetes.container":                      genericInventoryProjections,
 	"kubernetes.namespace":                      genericInventoryProjections,

--- a/internal/sourceregistry/registry.go
+++ b/internal/sourceregistry/registry.go
@@ -13,6 +13,7 @@ import (
 	cloudflaresource "github.com/writer/cerebro/sources/cloudflare"
 	cosmosource "github.com/writer/cerebro/sources/cosmo"
 	duosource "github.com/writer/cerebro/sources/duo"
+	emaildomainhealthsource "github.com/writer/cerebro/sources/emaildomainhealth"
 	evidencecassource "github.com/writer/cerebro/sources/evidencecas"
 	gcpsource "github.com/writer/cerebro/sources/gcp"
 	githubsource "github.com/writer/cerebro/sources/github"
@@ -99,6 +100,12 @@ var builtinSourceLoaders = []builtinSourceLoader{
 		name: "duo",
 		load: func() (sourcecdk.Source, error) {
 			return duosource.New()
+		},
+	},
+	{
+		name: "email_domain_health",
+		load: func() (sourcecdk.Source, error) {
+			return emaildomainhealthsource.New()
 		},
 	},
 	{

--- a/sources/emaildomainhealth/catalog.yaml
+++ b/sources/emaildomainhealth/catalog.yaml
@@ -1,0 +1,17 @@
+id: email_domain_health
+name: Email Domain Health
+description: Email authentication posture source. Probes SPF, DKIM, DMARC, MX, and related DNS records for configured tenant mail domains.
+emitted_kinds:
+  - email_domain_health.health
+event_contracts:
+  - kind: email_domain_health.health
+    schema_ref: email_domain_health/health/v1
+    required_attributes:
+      - domain
+      - status
+      - score
+    required_payload_fields:
+      - domain
+      - status
+      - score
+      - issues

--- a/sources/emaildomainhealth/deploy.yaml
+++ b/sources/emaildomainhealth/deploy.yaml
@@ -1,0 +1,10 @@
+sourceId: email_domain_health
+secretKeys:
+  - EMAIL_DOMAIN_HEALTH_DOMAINS
+  - EMAIL_DOMAIN_HEALTH_DKIM_SELECTORS
+runtimes:
+  - localId: health
+    config:
+      family: health
+      domains: env:EMAIL_DOMAIN_HEALTH_DOMAINS
+      dkim_selectors: env:EMAIL_DOMAIN_HEALTH_DKIM_SELECTORS

--- a/sources/emaildomainhealth/source.go
+++ b/sources/emaildomainhealth/source.go
@@ -1,0 +1,292 @@
+// Package emaildomainhealth probes SPF/DKIM/DMARC/MX posture for tenant
+// mail domains and emits one email_domain_health.health event per domain
+// per Read. Protocol logic lives in sources/internal/emaildns; this file
+// owns only configuration parsing, event assembly, and CDK wiring.
+package emaildomainhealth
+
+import (
+	"context"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/sources/internal/emaildns"
+)
+
+//go:embed catalog.yaml
+var catalogFS embed.FS
+
+const (
+	sourceID             = "email_domain_health"
+	familyHealth         = "health"
+	kindHealth           = "email_domain_health.health"
+	schemaHealth         = "email_domain_health/health/v1"
+	defaultLookupTimeout = 6 * time.Second
+)
+
+var (
+	ErrTenantRequired  = errors.New("tenant_id is required")
+	ErrDomainsRequired = errors.New("domains is required")
+	ErrInvalidDomain   = errors.New("invalid domain")
+)
+
+type Source struct {
+	spec         *cerebrov1.SourceSpec
+	families     *sourcecdk.FamilyEngine[settings]
+	resolver     emaildns.Resolver
+	now          func() time.Time
+	lookupBudget time.Duration
+}
+
+type settings struct {
+	family        string
+	tenantID      string
+	runtimeID     string
+	domains       []string
+	dkimSelectors []string
+}
+
+func New() (*Source, error) {
+	specBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read catalog: %w", err)
+	}
+	spec, err := sourcecdk.LoadCatalog(specBytes)
+	if err != nil {
+		return nil, fmt.Errorf("load catalog: %w", err)
+	}
+	source := &Source{
+		spec:         spec,
+		resolver:     emaildns.NetResolver{},
+		now:          time.Now,
+		lookupBudget: defaultLookupTimeout,
+	}
+	source.families, err = sourcecdk.NewFamilyEngine[settings](parseSettings, func(s settings) string { return s.family },
+		sourcecdk.Family[settings]{
+			Name:     familyHealth,
+			Check:    func(context.Context, settings) error { return nil },
+			Discover: source.discover,
+			Read: func(ctx context.Context, st settings, _ *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+				return source.read(ctx, st)
+			},
+		})
+	if err != nil {
+		return nil, err
+	}
+	return source, nil
+}
+
+func (s *Source) Spec() *cerebrov1.SourceSpec { return s.spec }
+
+func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
+	return s.families.Check(ctx, cfg)
+}
+
+func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return s.families.Discover(ctx, cfg)
+}
+
+func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return s.families.Read(ctx, cfg, cursor)
+}
+
+func (s *Source) discover(_ context.Context, st settings) ([]sourcecdk.URN, error) {
+	out := make([]sourcecdk.URN, 0, len(st.domains))
+	for _, domain := range st.domains {
+		urn, err := sourcecdk.ParseURN(fmt.Sprintf("urn:cerebro:%s:email_domain:%s", st.tenantID, domain))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, urn)
+	}
+	return out, nil
+}
+
+func (s *Source) read(ctx context.Context, st settings) (sourcecdk.Pull, error) {
+	pull := sourcecdk.Pull{Events: make([]*primitives.Event, 0, len(st.domains))}
+	for _, domain := range st.domains {
+		domainCtx, cancel := context.WithTimeout(ctx, s.lookupBudget)
+		health := emaildns.Evaluate(domainCtx, s.resolver, domain, st.dkimSelectors)
+		cancel()
+		event, err := buildHealthEvent(st, health, s.now().UTC())
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		pull.Events = append(pull.Events, event)
+	}
+	return pull, nil
+}
+
+func parseSettings(cfg sourcecdk.Config) (settings, error) {
+	tenantID := strings.TrimSpace(configValue(cfg, "tenant_id"))
+	if runtimeTenant := strings.TrimSpace(configValue(cfg, sourceconfig.RuntimeTenantIDKey)); runtimeTenant != "" {
+		tenantID = runtimeTenant
+	}
+	if tenantID == "" {
+		return settings{}, ErrTenantRequired
+	}
+	domains, err := parseDomainsList(configValue(cfg, "domains"))
+	if err != nil {
+		return settings{}, err
+	}
+	if len(domains) == 0 {
+		return settings{}, ErrDomainsRequired
+	}
+	dkimSelectors := parseSelectorList(configValue(cfg, "dkim_selectors"))
+	family := strings.TrimSpace(configValue(cfg, "family"))
+	if family == "" {
+		family = familyHealth
+	}
+	if family != familyHealth {
+		return settings{}, fmt.Errorf("%w: unsupported family %q", sourcecdk.ErrInvalidConfig, family)
+	}
+	return settings{
+		family:        family,
+		tenantID:      tenantID,
+		runtimeID:     firstNonEmpty(configValue(cfg, "runtime_id"), configValue(cfg, "source_runtime_id")),
+		domains:       domains,
+		dkimSelectors: dkimSelectors,
+	}, nil
+}
+
+func parseDomainsList(raw string) ([]string, error) {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, 4)
+	for _, candidate := range strings.FieldsFunc(raw, listSplit) {
+		domain := emaildns.NormalizeDomain(candidate)
+		if domain == "" {
+			if strings.TrimSpace(candidate) == "" {
+				continue
+			}
+			return nil, fmt.Errorf("%w: %q", ErrInvalidDomain, candidate)
+		}
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+		out = append(out, domain)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func parseSelectorList(raw string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, 4)
+	for _, candidate := range strings.FieldsFunc(raw, listSplit) {
+		selector := strings.ToLower(strings.TrimSpace(candidate))
+		if selector == "" {
+			continue
+		}
+		if _, ok := seen[selector]; ok {
+			continue
+		}
+		seen[selector] = struct{}{}
+		out = append(out, selector)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func listSplit(r rune) bool {
+	return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == ';'
+}
+
+func buildHealthEvent(st settings, health emaildns.Health, observedAt time.Time) (*primitives.Event, error) {
+	if emaildns.NormalizeDomain(health.Domain) != health.Domain {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidDomain, health.Domain)
+	}
+	payload, err := json.Marshal(health)
+	if err != nil {
+		return nil, fmt.Errorf("marshal email domain health payload: %w", err)
+	}
+	hash := sha256.Sum256(payload)
+	event := &cerebrov1.EventEnvelope{
+		Id:         "email-domain-health-" + st.tenantID + "-" + health.Domain + "-" + hex.EncodeToString(hash[:8]),
+		TenantId:   st.tenantID,
+		SourceId:   sourceID,
+		Kind:       kindHealth,
+		OccurredAt: timestamppb.New(observedAt),
+		SchemaRef:  schemaHealth,
+		Payload:    payload,
+		Attributes: healthAttributes(st, health, observedAt),
+	}
+	if err := sourcecdk.ValidateEventEnvelope(event); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+func healthAttributes(st settings, health emaildns.Health, observedAt time.Time) map[string]string {
+	issueCodes := make([]string, 0, len(health.Issues))
+	failingCodes := make([]string, 0, len(health.Issues))
+	highest := ""
+	for _, issue := range health.Issues {
+		if code := strings.TrimSpace(issue.Code); code != "" {
+			issueCodes = append(issueCodes, code)
+			if emaildns.SeverityRank(issue.Severity) >= 3 {
+				failingCodes = append(failingCodes, code)
+			}
+		}
+		if emaildns.SeverityRank(issue.Severity) > emaildns.SeverityRank(highest) {
+			highest = issue.Severity
+		}
+	}
+	sort.Strings(issueCodes)
+	sort.Strings(failingCodes)
+	attributes := map[string]string{
+		"event_type":          "email_domain_health",
+		"outcome_result":      strings.ToLower(health.Status),
+		"resource_type":       "email_domain",
+		"resource_id":         health.Domain,
+		"domain":              health.Domain,
+		"status":              health.Status,
+		"score":               fmt.Sprintf("%d", health.Score),
+		"spf_status":          health.SPFStatus,
+		"dkim_status":         health.DKIMStatus,
+		"dmarc_status":        health.DMARCStatus,
+		"issue_count":         fmt.Sprintf("%d", health.IssueCount),
+		"failing_issue_count": fmt.Sprintf("%d", health.FailingIssueCount),
+		"observed_at":         observedAt.UTC().Format(time.RFC3339),
+		"source_runtime_id":   st.runtimeID,
+		"highest_severity":    strings.ToUpper(highest),
+	}
+	if len(issueCodes) > 0 {
+		attributes["issue_codes"] = strings.Join(issueCodes, ",")
+	}
+	if len(failingCodes) > 0 {
+		attributes["failing_issue_codes"] = strings.Join(failingCodes, ",")
+	}
+	for key, value := range attributes {
+		if strings.TrimSpace(value) == "" {
+			delete(attributes, key)
+		}
+	}
+	return attributes
+}
+
+func configValue(cfg sourcecdk.Config, key string) string {
+	value, _ := cfg.Lookup(key)
+	return value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/sources/emaildomainhealth/source_test.go
+++ b/sources/emaildomainhealth/source_test.go
@@ -1,0 +1,231 @@
+package emaildomainhealth
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/sources/internal/emaildns"
+)
+
+type fakeResolver struct {
+	txt    map[string][]string
+	txtErr map[string]error
+	mx     map[string][]*net.MX
+	mxErr  map[string]error
+}
+
+func (f fakeResolver) LookupTXT(_ context.Context, name string) ([]string, error) {
+	if err, ok := f.txtErr[name]; ok {
+		return nil, err
+	}
+	return f.txt[name], nil
+}
+
+func (f fakeResolver) LookupMX(_ context.Context, name string) ([]*net.MX, error) {
+	if err, ok := f.mxErr[name]; ok {
+		return nil, err
+	}
+	return f.mx[name], nil
+}
+
+func TestSourceSpec(t *testing.T) {
+	src, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if src.Spec().GetId() != sourceID {
+		t.Fatalf("source id = %q", src.Spec().GetId())
+	}
+	if got, want := src.Spec().GetEmittedKinds(), []string{kindHealth}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("emitted kinds = %v, want %v", got, want)
+	}
+}
+
+func TestParseSettings(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  map[string]string
+		wantErr error
+		want    settings
+	}{
+		{
+			name: "defaults",
+			values: map[string]string{
+				"tenant_id": "writer",
+				"domains":   "Example.com, Other.example.com",
+			},
+			want: settings{
+				family:   familyHealth,
+				tenantID: "writer",
+				domains:  []string{"example.com", "other.example.com"},
+			},
+		},
+		{
+			name: "selectors-and-runtime-tenant",
+			values: map[string]string{
+				sourceconfig.RuntimeTenantIDKey: "writer",
+				"domains":                       "example.com",
+				"dkim_selectors":                "google, default ; selector1",
+				"runtime_id":                    "writer-email-domain-health",
+			},
+			want: settings{
+				family:        familyHealth,
+				tenantID:      "writer",
+				runtimeID:     "writer-email-domain-health",
+				domains:       []string{"example.com"},
+				dkimSelectors: []string{"default", "google", "selector1"},
+			},
+		},
+		{
+			name:    "missing-tenant",
+			values:  map[string]string{"domains": "example.com"},
+			wantErr: ErrTenantRequired,
+		},
+		{
+			name:    "missing-domains",
+			values:  map[string]string{"tenant_id": "writer"},
+			wantErr: ErrDomainsRequired,
+		},
+		{
+			name:    "invalid-domain",
+			values:  map[string]string{"tenant_id": "writer", "domains": "not-a-domain"},
+			wantErr: ErrInvalidDomain,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSettings(sourcecdk.NewConfig(tc.values))
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("parseSettings() error = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSettings() error = %v", err)
+			}
+			if got.family != tc.want.family ||
+				got.tenantID != tc.want.tenantID ||
+				got.runtimeID != tc.want.runtimeID ||
+				!stringSlicesEqual(got.domains, tc.want.domains) ||
+				!stringSlicesEqual(got.dkimSelectors, tc.want.dkimSelectors) {
+				t.Fatalf("parseSettings() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadEmitsOneEventPerDomainAndDetectsIssues(t *testing.T) {
+	src, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	healthyKey := base64.StdEncoding.EncodeToString(make([]byte, 256))
+	src.resolver = fakeResolver{
+		txt: map[string][]string{
+			"healthy.example.com": {"v=spf1 include:_spf.google.com -all"},
+			"_dmarc.healthy.example.com": {
+				"v=DMARC1; p=reject; pct=100; rua=mailto:dmarc@healthy.example.com",
+			},
+			"default._domainkey.healthy.example.com": {"v=DKIM1; k=rsa; p=" + healthyKey},
+			"risky.example.com":                      {"v=spf1 +all"},
+			"default._domainkey.risky.example.com":   {"v=DKIM1; p=" + base64.StdEncoding.EncodeToString(make([]byte, 64))},
+		},
+		txtErr: map[string]error{
+			"_dmarc.risky.example.com": errors.New("not found"),
+		},
+		mx: map[string][]*net.MX{
+			"healthy.example.com": {{Host: "aspmx.l.google.com.", Pref: 1}},
+			"risky.example.com":   {},
+		},
+	}
+	src.now = func() time.Time { return time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC) }
+
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"domains":   "healthy.example.com, risky.example.com",
+	})
+	pull, err := src.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("events = %d, want 2", len(pull.Events))
+	}
+	byDomain := map[string]map[string]string{}
+	for _, event := range pull.Events {
+		if event.GetSourceId() != sourceID || event.GetKind() != kindHealth || event.GetSchemaRef() != schemaHealth {
+			t.Fatalf("event scope = %q/%q/%q", event.GetSourceId(), event.GetKind(), event.GetSchemaRef())
+		}
+		if err := sourcecdk.ValidateEventEnvelope(event); err != nil {
+			t.Fatalf("ValidateEventEnvelope(%s): %v", event.GetId(), err)
+		}
+		byDomain[event.GetAttributes()["domain"]] = event.GetAttributes()
+	}
+	healthy := byDomain["healthy.example.com"]
+	if healthy == nil {
+		t.Fatalf("healthy.example.com event missing: %v", byDomain)
+	}
+	if healthy["status"] != emaildns.StatusHealthy {
+		t.Fatalf("healthy.example.com status = %q, want HEALTHY", healthy["status"])
+	}
+	if healthy["spf_status"] != emaildns.StatusHealthy || healthy["dkim_status"] != emaildns.StatusHealthy || healthy["dmarc_status"] != emaildns.StatusHealthy {
+		t.Fatalf("healthy per-protocol = %+v", healthy)
+	}
+	risky := byDomain["risky.example.com"]
+	if risky == nil {
+		t.Fatalf("risky.example.com event missing")
+	}
+	if risky["status"] != emaildns.StatusFailing {
+		t.Fatalf("risky.example.com status = %q, want FAILING", risky["status"])
+	}
+	if !strings.Contains(risky["failing_issue_codes"], "spf_permissive_all") {
+		t.Fatalf("risky failing codes = %q, missing spf_permissive_all", risky["failing_issue_codes"])
+	}
+	if !strings.Contains(risky["failing_issue_codes"], "dmarc_missing") {
+		t.Fatalf("risky failing codes = %q, missing dmarc_missing", risky["failing_issue_codes"])
+	}
+	if !strings.Contains(risky["failing_issue_codes"], "dkim_weak_key") {
+		t.Fatalf("risky failing codes = %q, missing dkim_weak_key", risky["failing_issue_codes"])
+	}
+	if risky["highest_severity"] != emaildns.SeverityCrit {
+		t.Fatalf("risky highest_severity = %q, want CRITICAL", risky["highest_severity"])
+	}
+}
+
+func TestNormalizeDomainCandidate(t *testing.T) {
+	cases := map[string]string{
+		"example.com":                    "example.com",
+		"Security@Example.COM":           "example.com",
+		"https://mail.example.com/admin": "mail.example.com",
+		"www.example.com":                "example.com",
+		"tenant-id-without-dot":          "",
+		"192.168.0.1":                    "",
+		"":                               "",
+		"local.local":                    "",
+	}
+	for input, want := range cases {
+		if got := emaildns.NormalizeDomain(input); got != want {
+			t.Fatalf("emaildns.NormalizeDomain(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/sources/emaildomainhealth/testdata/sample-health.json
+++ b/sources/emaildomainhealth/testdata/sample-health.json
@@ -1,0 +1,56 @@
+{
+  "domain": "writer-mail.example.com",
+  "status": "FAILING",
+  "score": 30,
+  "spf_status": "FAILING",
+  "dkim_status": "FAILING",
+  "dmarc_status": "FAILING",
+  "issue_count": 3,
+  "failing_issue_count": 3,
+  "spf_records": ["v=spf1 +all"],
+  "spf_policy": "+all",
+  "spf_lookup_count": 0,
+  "dmarc_records": [],
+  "dmarc_policy": "",
+  "dmarc_pct": 0,
+  "dmarc_rua": [],
+  "mx_records": [],
+  "dkim_selectors": [
+    {
+      "selector": "default",
+      "status": "FAILING",
+      "key_bits": 512,
+      "record": "v=DKIM1; k=rsa; p=REDACTED"
+    }
+  ],
+  "related_records": [],
+  "issues": [
+    {
+      "id": "DKIM:dkim_weak_key",
+      "protocol": "DKIM",
+      "severity": "CRITICAL",
+      "code": "dkim_weak_key",
+      "title": "DKIM key is too weak",
+      "detail": "Selector default key size is 512 bits.",
+      "recommendation": "Rotate selector to at least 2048-bit RSA key material."
+    },
+    {
+      "id": "DMARC:dmarc_missing",
+      "protocol": "DMARC",
+      "severity": "HIGH",
+      "code": "dmarc_missing",
+      "title": "DMARC record missing",
+      "detail": "No DMARC TXT record was found.",
+      "recommendation": "Publish a DMARC record with at least p=none and reporting, then move to p=quarantine/reject."
+    },
+    {
+      "id": "SPF:spf_permissive_all",
+      "protocol": "SPF",
+      "severity": "CRITICAL",
+      "code": "spf_permissive_all",
+      "title": "SPF allows all senders",
+      "detail": "SPF ends in '+all' which permits spoofing.",
+      "recommendation": "Replace '+all' with '-all' after validating legitimate senders."
+    }
+  ]
+}

--- a/sources/internal/emaildns/emaildns.go
+++ b/sources/internal/emaildns/emaildns.go
@@ -514,7 +514,9 @@ func NormalizeDomain(raw string) string {
 	} else if index := strings.LastIndex(candidate, ":"); index > 0 {
 		candidate = candidate[:index]
 	}
-	candidate = strings.TrimPrefix(candidate, "www.")
+	for strings.HasPrefix(candidate, "www.") {
+		candidate = strings.TrimPrefix(candidate, "www.")
+	}
 	if ip := net.ParseIP(candidate); ip != nil {
 		return ""
 	}

--- a/sources/internal/emaildns/emaildns.go
+++ b/sources/internal/emaildns/emaildns.go
@@ -330,8 +330,13 @@ func parseDMARCReportAddresses(raw string) []string {
 
 func spfTerminalPolicy(record string) string {
 	fields := strings.Fields(strings.ToLower(record))
+	hasRedirect := false
 	for i := len(fields) - 1; i >= 0; i-- {
 		field := strings.TrimSpace(fields[i])
+		if strings.HasPrefix(field, "redirect=") && strings.TrimSpace(strings.TrimPrefix(field, "redirect=")) != "" {
+			hasRedirect = true
+			continue
+		}
 		if !strings.HasSuffix(field, "all") {
 			continue
 		}
@@ -347,6 +352,9 @@ func spfTerminalPolicy(record string) string {
 		default:
 			return "all"
 		}
+	}
+	if hasRedirect {
+		return "redirect"
 	}
 	return ""
 }

--- a/sources/internal/emaildns/emaildns.go
+++ b/sources/internal/emaildns/emaildns.go
@@ -152,6 +152,8 @@ func evaluateSPF(ctx context.Context, resolver Resolver, domain string, result *
 	switch result.SPFPolicy {
 	case "+all", "all":
 		result.Issues = append(result.Issues, makeIssue("SPF", SeverityCrit, "spf_permissive_all", "SPF allows all senders", "SPF ends in '+all' which permits spoofing.", "Replace '+all' with '-all' after validating legitimate senders."))
+	case "?all":
+		result.Issues = append(result.Issues, makeIssue("SPF", SeverityHigh, "spf_neutral_all", "SPF uses neutral all", "SPF ends in '?all' which neither passes nor fails senders and offers no spoofing protection.", "Replace '?all' with '-all' after validating legitimate senders."))
 	case "~all":
 		result.Issues = append(result.Issues, makeIssue("SPF", SeverityMedium, "spf_softfail", "SPF uses soft-fail", "SPF ends in '~all' which is not strict enforcement.", "Move to '-all' when sender inventory is complete."))
 	case "":
@@ -178,12 +180,15 @@ func evaluateDMARC(ctx context.Context, resolver Resolver, domain string, result
 	}
 	tags := parseTagRecord(dmarcRecords[0])
 	policy := strings.ToLower(strings.TrimSpace(tags["p"]))
-	if policy == "" {
-		result.Issues = append(result.Issues, makeIssue("DMARC", SeverityHigh, "dmarc_policy_missing", "DMARC policy missing", "The p= tag is missing in the DMARC record.", "Add p=quarantine or p=reject after baseline monitoring."))
-	}
 	result.DMARCPolicy = strings.ToUpper(policy)
-	if policy == "none" {
+	switch policy {
+	case "":
+		result.Issues = append(result.Issues, makeIssue("DMARC", SeverityHigh, "dmarc_policy_missing", "DMARC policy missing", "The p= tag is missing in the DMARC record.", "Add p=quarantine or p=reject after baseline monitoring."))
+	case "none":
 		result.Issues = append(result.Issues, makeIssue("DMARC", SeverityMedium, "dmarc_policy_none", "DMARC policy is monitoring-only", "DMARC policy is set to p=none.", "Move to p=quarantine or p=reject for enforcement."))
+	case "quarantine", "reject":
+	default:
+		result.Issues = append(result.Issues, makeIssue("DMARC", SeverityHigh, "dmarc_policy_invalid", "DMARC policy value is invalid", fmt.Sprintf("p=%s is not one of none|quarantine|reject and will be treated as p=none by receivers.", policy), "Set p= to none, quarantine, or reject per RFC 7489."))
 	}
 	result.DMARCPct = 100
 	if pct, err := strconv.Atoi(strings.TrimSpace(tags["pct"])); err == nil {
@@ -214,19 +219,20 @@ func evaluateDKIM(ctx context.Context, resolver Resolver, domain string, dkimSel
 		record := dkimRecords[0]
 		tags := parseTagRecord(record)
 		keyValue := strings.TrimSpace(tags["p"])
-		keyBits := dkimKeyBits(keyValue)
+		keyBits, keyValid := dkimKeyBits(keyValue)
 		status := StatusHealthy
-		if keyValue == "" {
+		switch {
+		case keyValue == "":
 			status = StatusFailing
 			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityHigh, "dkim_missing_key", "DKIM public key missing", fmt.Sprintf("Selector %s is missing p= key material.", selector), "Publish a valid RSA key in p=."))
-		}
-		if keyBits > 0 && keyBits < 1024 {
+		case !keyValid:
+			status = StatusFailing
+			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityHigh, "dkim_invalid_key", "DKIM public key is not valid base64", fmt.Sprintf("Selector %s p= value did not decode as base64 key material.", selector), "Republish the DKIM selector with valid base64-encoded RSA key material."))
+		case keyBits < 1024:
 			status = StatusFailing
 			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityCrit, "dkim_weak_key", "DKIM key is too weak", fmt.Sprintf("Selector %s key size is %d bits.", selector, keyBits), "Rotate selector to at least 2048-bit RSA key material."))
-		} else if keyBits >= 1024 && keyBits < 2048 {
-			if status != StatusFailing {
-				status = StatusWarning
-			}
+		case keyBits < 2048:
+			status = StatusWarning
 			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityMedium, "dkim_key_short", "DKIM key length below recommended", fmt.Sprintf("Selector %s key size is %d bits.", selector, keyBits), "Rotate selector to a 2048-bit RSA key."))
 		}
 		result.DKIMSelectors = append(result.DKIMSelectors, DKIMSelector{Selector: selector, Status: status, KeyBits: keyBits, Record: record})
@@ -359,16 +365,20 @@ func spfLookupCount(record string) int {
 	return count
 }
 
-func dkimKeyBits(publicKey string) int {
+// dkimKeyBits decodes the DKIM p= public-key payload and returns the byte
+// length in bits along with a flag indicating whether the payload was valid
+// base64. Empty payloads return (0, true) so callers can distinguish a
+// missing key from a malformed one.
+func dkimKeyBits(publicKey string) (int, bool) {
 	cleaned := strings.ReplaceAll(strings.TrimSpace(publicKey), " ", "")
 	if cleaned == "" {
-		return 0
+		return 0, true
 	}
 	decoded, err := base64.StdEncoding.DecodeString(cleaned)
 	if err != nil {
-		return 0
+		return 0, false
 	}
-	return len(decoded) * 8
+	return len(decoded) * 8, true
 }
 
 func sortIssues(issues []Issue) {

--- a/sources/internal/emaildns/emaildns.go
+++ b/sources/internal/emaildns/emaildns.go
@@ -1,0 +1,518 @@
+// Package emaildns is a small Source CDK helper for evaluating SPF, DKIM,
+// DMARC, MX, and adjacent email-authentication posture for a single mail
+// domain. It is intentionally protocol-only: it owns the DNS lookups,
+// scoring, and severity ranking but emits no events. Source packages
+// translate the resulting Health value into their own EventEnvelopes.
+package emaildns
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	StatusHealthy  = "HEALTHY"
+	StatusWarning  = "WARNING"
+	StatusFailing  = "FAILING"
+	StatusUnknown  = "UNKNOWN"
+	SeverityCrit   = "CRITICAL"
+	SeverityHigh   = "HIGH"
+	SeverityMedium = "MEDIUM"
+	SeverityLow    = "LOW"
+)
+
+var emailDomainPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$`)
+
+// DefaultDKIMSelectors lists common DKIM selectors probed when the caller
+// does not supply tenant-specific overrides.
+var DefaultDKIMSelectors = []string{
+	"default", "google", "selector1", "selector2", "s1", "s2", "k1", "k2", "mail", "mx",
+}
+
+// Resolver is the minimal DNS surface used by Evaluate.
+type Resolver interface {
+	LookupTXT(ctx context.Context, name string) ([]string, error)
+	LookupMX(ctx context.Context, name string) ([]*net.MX, error)
+}
+
+// NetResolver wraps net.DefaultResolver so callers can use the network
+// resolver without redeclaring the adapter.
+type NetResolver struct{}
+
+func (NetResolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
+	return net.DefaultResolver.LookupTXT(ctx, name)
+}
+
+func (NetResolver) LookupMX(ctx context.Context, name string) ([]*net.MX, error) {
+	return net.DefaultResolver.LookupMX(ctx, name)
+}
+
+// DKIMSelector captures the result of probing a single DKIM selector.
+type DKIMSelector struct {
+	Selector string `json:"selector"`
+	Status   string `json:"status"`
+	KeyBits  int    `json:"key_bits"`
+	Record   string `json:"record"`
+}
+
+// Issue describes a single SPF/DKIM/DMARC/MX problem discovered for a domain.
+type Issue struct {
+	ID             string `json:"id"`
+	Protocol       string `json:"protocol"`
+	Severity       string `json:"severity"`
+	Code           string `json:"code"`
+	Title          string `json:"title"`
+	Detail         string `json:"detail"`
+	Recommendation string `json:"recommendation"`
+}
+
+// Health is the structured email-authentication evaluation for one domain.
+type Health struct {
+	Domain            string         `json:"domain"`
+	Status            string         `json:"status"`
+	Score             int            `json:"score"`
+	SPFStatus         string         `json:"spf_status"`
+	DKIMStatus        string         `json:"dkim_status"`
+	DMARCStatus       string         `json:"dmarc_status"`
+	IssueCount        int            `json:"issue_count"`
+	FailingIssueCount int            `json:"failing_issue_count"`
+	SPFRecords        []string       `json:"spf_records"`
+	SPFPolicy         string         `json:"spf_policy"`
+	SPFLookupCount    int            `json:"spf_lookup_count"`
+	DMARCRecords      []string       `json:"dmarc_records"`
+	DMARCPolicy       string         `json:"dmarc_policy"`
+	DMARCPct          int            `json:"dmarc_pct"`
+	DMARCRua          []string       `json:"dmarc_rua"`
+	MXRecords         []string       `json:"mx_records"`
+	DKIMSelectors     []DKIMSelector `json:"dkim_selectors"`
+	RelatedRecords    []string       `json:"related_records"`
+	Issues            []Issue        `json:"issues"`
+}
+
+// Evaluate runs SPF/DKIM/DMARC/MX/MTA-STS/BIMI checks for the given domain
+// using resolver. Results are deterministic given equivalent DNS input.
+func Evaluate(ctx context.Context, resolver Resolver, domain string, dkimSelectors []string) Health {
+	if len(dkimSelectors) == 0 {
+		dkimSelectors = DefaultDKIMSelectors
+	}
+	result := Health{
+		Domain:         domain,
+		SPFRecords:     []string{},
+		DMARCRecords:   []string{},
+		DMARCRua:       []string{},
+		MXRecords:      []string{},
+		DKIMSelectors:  []DKIMSelector{},
+		RelatedRecords: []string{},
+		Issues:         []Issue{},
+	}
+	evaluateSPF(ctx, resolver, domain, &result)
+	evaluateDMARC(ctx, resolver, domain, &result)
+	foundSelectors := evaluateDKIM(ctx, resolver, domain, dkimSelectors, &result)
+	evaluateMX(ctx, resolver, domain, &result)
+	evaluateRelated(ctx, resolver, domain, &result)
+
+	if foundSelectors == 0 {
+		result.Issues = append(result.Issues, makeIssue("DKIM", SeverityHigh, "dkim_missing", "No DKIM selectors discovered", "No known DKIM selector records were found.", "Publish DKIM selectors (for example default/selector1) with valid public keys."))
+	}
+	sortIssues(result.Issues)
+	result.IssueCount = len(result.Issues)
+	result.FailingIssueCount = failingIssueCount(result.Issues)
+	result.SPFStatus = protocolStatus("SPF", result.Issues, len(result.SPFRecords) > 0)
+	result.DKIMStatus = protocolStatus("DKIM", result.Issues, len(result.DKIMSelectors) > 0)
+	result.DMARCStatus = protocolStatus("DMARC", result.Issues, len(result.DMARCRecords) > 0)
+	result.Score = issueScore(result.Issues)
+	result.Status = overallStatus(result.SPFStatus, result.DKIMStatus, result.DMARCStatus, result.Issues)
+	return result
+}
+
+func evaluateSPF(ctx context.Context, resolver Resolver, domain string, result *Health) {
+	spfTXT, spfErr := resolver.LookupTXT(ctx, domain)
+	spfRecords := filterTXTPrefix(spfTXT, "v=spf1")
+	result.SPFRecords = spfRecords
+	if spfErr != nil {
+		result.Issues = append(result.Issues, makeIssue("SPF", SeverityMedium, "spf_lookup_failed", "SPF lookup failed", spfErr.Error(), "Confirm authoritative DNS responds for SPF TXT records."))
+	}
+	if len(spfRecords) == 0 {
+		result.Issues = append(result.Issues, makeIssue("SPF", SeverityHigh, "spf_missing", "SPF record missing", "No SPF TXT record was found for this domain.", "Publish a single SPF TXT record that ends with '-all'."))
+		return
+	}
+	if len(spfRecords) > 1 {
+		result.Issues = append(result.Issues, makeIssue("SPF", SeverityHigh, "spf_multiple", "Multiple SPF records found", fmt.Sprintf("Detected %d SPF records.", len(spfRecords)), "Collapse to one SPF record to avoid permerror behavior."))
+	}
+	record := spfRecords[0]
+	result.SPFPolicy = spfTerminalPolicy(record)
+	result.SPFLookupCount = spfLookupCount(record)
+	switch result.SPFPolicy {
+	case "+all", "all":
+		result.Issues = append(result.Issues, makeIssue("SPF", SeverityCrit, "spf_permissive_all", "SPF allows all senders", "SPF ends in '+all' which permits spoofing.", "Replace '+all' with '-all' after validating legitimate senders."))
+	case "~all":
+		result.Issues = append(result.Issues, makeIssue("SPF", SeverityMedium, "spf_softfail", "SPF uses soft-fail", "SPF ends in '~all' which is not strict enforcement.", "Move to '-all' when sender inventory is complete."))
+	case "":
+		result.Issues = append(result.Issues, makeIssue("SPF", SeverityMedium, "spf_no_terminal_policy", "SPF terminal policy missing", "SPF record does not include an all-mechanism policy.", "Add a terminal '-all' policy."))
+	}
+	if result.SPFLookupCount > 10 {
+		result.Issues = append(result.Issues, makeIssue("SPF", SeverityHigh, "spf_lookup_limit_exceeded", "SPF lookup count exceeds RFC limit", fmt.Sprintf("Estimated lookup count is %d.", result.SPFLookupCount), "Reduce include/redirect mechanisms to 10 or fewer DNS lookups."))
+	}
+}
+
+func evaluateDMARC(ctx context.Context, resolver Resolver, domain string, result *Health) {
+	dmarcTXT, dmarcErr := resolver.LookupTXT(ctx, "_dmarc."+domain)
+	dmarcRecords := filterTXTPrefix(dmarcTXT, "v=dmarc1")
+	result.DMARCRecords = dmarcRecords
+	if dmarcErr != nil {
+		result.Issues = append(result.Issues, makeIssue("DMARC", SeverityMedium, "dmarc_lookup_failed", "DMARC lookup failed", dmarcErr.Error(), "Confirm _dmarc TXT records resolve."))
+	}
+	if len(dmarcRecords) == 0 {
+		result.Issues = append(result.Issues, makeIssue("DMARC", SeverityHigh, "dmarc_missing", "DMARC record missing", "No DMARC TXT record was found.", "Publish a DMARC record with at least p=none and reporting, then move to p=quarantine/reject."))
+		return
+	}
+	if len(dmarcRecords) > 1 {
+		result.Issues = append(result.Issues, makeIssue("DMARC", SeverityHigh, "dmarc_multiple", "Multiple DMARC records found", fmt.Sprintf("Detected %d DMARC records.", len(dmarcRecords)), "Keep exactly one DMARC TXT record at _dmarc.<domain>."))
+	}
+	tags := parseTagRecord(dmarcRecords[0])
+	policy := strings.ToLower(strings.TrimSpace(tags["p"]))
+	if policy == "" {
+		result.Issues = append(result.Issues, makeIssue("DMARC", SeverityHigh, "dmarc_policy_missing", "DMARC policy missing", "The p= tag is missing in the DMARC record.", "Add p=quarantine or p=reject after baseline monitoring."))
+	}
+	result.DMARCPolicy = strings.ToUpper(policy)
+	if policy == "none" {
+		result.Issues = append(result.Issues, makeIssue("DMARC", SeverityMedium, "dmarc_policy_none", "DMARC policy is monitoring-only", "DMARC policy is set to p=none.", "Move to p=quarantine or p=reject for enforcement."))
+	}
+	result.DMARCPct = 100
+	if pct, err := strconv.Atoi(strings.TrimSpace(tags["pct"])); err == nil {
+		result.DMARCPct = pct
+		if pct < 100 {
+			result.Issues = append(result.Issues, makeIssue("DMARC", SeverityLow, "dmarc_partial_pct", "DMARC enforcement is partial", fmt.Sprintf("pct=%d applies policy to only part of traffic.", pct), "Set pct=100 once confidence is high."))
+		}
+	}
+	result.DMARCRua = parseDMARCReportAddresses(tags["rua"])
+	if len(result.DMARCRua) == 0 {
+		result.Issues = append(result.Issues, makeIssue("DMARC", SeverityLow, "dmarc_rua_missing", "DMARC aggregate reporting missing", "No rua reporting address is configured.", "Configure rua=mailto:... to collect aggregate authentication reports."))
+	}
+}
+
+func evaluateDKIM(ctx context.Context, resolver Resolver, domain string, dkimSelectors []string, result *Health) int {
+	found := 0
+	for _, selector := range dkimSelectors {
+		recordName := selector + "._domainkey." + domain
+		values, err := resolver.LookupTXT(ctx, recordName)
+		if err != nil {
+			continue
+		}
+		dkimRecords := filterTXTPrefix(values, "v=dkim1")
+		if len(dkimRecords) == 0 {
+			continue
+		}
+		found++
+		record := dkimRecords[0]
+		tags := parseTagRecord(record)
+		keyValue := strings.TrimSpace(tags["p"])
+		keyBits := dkimKeyBits(keyValue)
+		status := StatusHealthy
+		if keyValue == "" {
+			status = StatusFailing
+			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityHigh, "dkim_missing_key", "DKIM public key missing", fmt.Sprintf("Selector %s is missing p= key material.", selector), "Publish a valid RSA key in p=."))
+		}
+		if keyBits > 0 && keyBits < 1024 {
+			status = StatusFailing
+			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityCrit, "dkim_weak_key", "DKIM key is too weak", fmt.Sprintf("Selector %s key size is %d bits.", selector, keyBits), "Rotate selector to at least 2048-bit RSA key material."))
+		} else if keyBits >= 1024 && keyBits < 2048 {
+			if status != StatusFailing {
+				status = StatusWarning
+			}
+			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityMedium, "dkim_key_short", "DKIM key length below recommended", fmt.Sprintf("Selector %s key size is %d bits.", selector, keyBits), "Rotate selector to a 2048-bit RSA key."))
+		}
+		result.DKIMSelectors = append(result.DKIMSelectors, DKIMSelector{Selector: selector, Status: status, KeyBits: keyBits, Record: record})
+	}
+	return found
+}
+
+func evaluateMX(ctx context.Context, resolver Resolver, domain string, result *Health) {
+	mxRecords, mxErr := resolver.LookupMX(ctx, domain)
+	if mxErr != nil {
+		result.Issues = append(result.Issues, makeIssue("MX", SeverityMedium, "mx_lookup_failed", "MX lookup failed", mxErr.Error(), "Verify MX records exist and can be resolved publicly."))
+	}
+	if len(mxRecords) == 0 {
+		result.Issues = append(result.Issues, makeIssue("MX", SeverityMedium, "mx_missing", "MX records missing", "No MX records were found for this domain.", "Publish MX records for inbound mail delivery."))
+		return
+	}
+	sort.Slice(mxRecords, func(i, j int) bool {
+		if mxRecords[i].Pref == mxRecords[j].Pref {
+			return mxRecords[i].Host < mxRecords[j].Host
+		}
+		return mxRecords[i].Pref < mxRecords[j].Pref
+	})
+	for _, mx := range mxRecords {
+		result.MXRecords = append(result.MXRecords, fmt.Sprintf("%d %s", mx.Pref, strings.TrimSuffix(mx.Host, ".")))
+	}
+}
+
+func evaluateRelated(ctx context.Context, resolver Resolver, domain string, result *Health) {
+	for _, related := range []string{"_mta-sts." + domain, "_smtp._tls." + domain, "default._bimi." + domain} {
+		txt, err := resolver.LookupTXT(ctx, related)
+		if err != nil || len(txt) == 0 {
+			continue
+		}
+		for _, value := range txt {
+			result.RelatedRecords = append(result.RelatedRecords, fmt.Sprintf("%s TXT %s", related, strings.TrimSpace(value)))
+		}
+	}
+	sort.Strings(result.RelatedRecords)
+}
+
+func makeIssue(protocol, severity, code, title, detail, recommendation string) Issue {
+	return Issue{ID: protocol + ":" + code, Protocol: protocol, Severity: severity, Code: code, Title: title, Detail: detail, Recommendation: recommendation}
+}
+
+func filterTXTPrefix(records []string, prefix string) []string {
+	out := make([]string, 0, len(records))
+	for _, record := range records {
+		trimmed := strings.TrimSpace(record)
+		if strings.HasPrefix(strings.ToLower(trimmed), strings.ToLower(prefix)) {
+			out = append(out, trimmed)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func parseTagRecord(record string) map[string]string {
+	out := map[string]string{}
+	for _, segment := range strings.Split(record, ";") {
+		part := strings.TrimSpace(segment)
+		if part == "" {
+			continue
+		}
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		out[strings.ToLower(strings.TrimSpace(kv[0]))] = strings.TrimSpace(kv[1])
+	}
+	return out
+}
+
+func parseDMARCReportAddresses(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return []string{}
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func spfTerminalPolicy(record string) string {
+	fields := strings.Fields(strings.ToLower(record))
+	for i := len(fields) - 1; i >= 0; i-- {
+		field := strings.TrimSpace(fields[i])
+		if !strings.HasSuffix(field, "all") {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(field, "+"):
+			return "+all"
+		case strings.HasPrefix(field, "-"):
+			return "-all"
+		case strings.HasPrefix(field, "~"):
+			return "~all"
+		case strings.HasPrefix(field, "?"):
+			return "?all"
+		default:
+			return "all"
+		}
+	}
+	return ""
+}
+
+func spfLookupCount(record string) int {
+	fields := strings.Fields(strings.ToLower(record))
+	count := 0
+	for _, field := range fields {
+		switch {
+		case strings.HasPrefix(field, "include:"),
+			strings.HasPrefix(field, "exists:"),
+			strings.HasPrefix(field, "redirect="),
+			field == "a",
+			strings.HasPrefix(field, "a:"),
+			field == "mx",
+			strings.HasPrefix(field, "mx:"),
+			field == "ptr",
+			strings.HasPrefix(field, "ptr:"):
+			count++
+		}
+	}
+	return count
+}
+
+func dkimKeyBits(publicKey string) int {
+	cleaned := strings.ReplaceAll(strings.TrimSpace(publicKey), " ", "")
+	if cleaned == "" {
+		return 0
+	}
+	decoded, err := base64.StdEncoding.DecodeString(cleaned)
+	if err != nil {
+		return 0
+	}
+	return len(decoded) * 8
+}
+
+func sortIssues(issues []Issue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		li := SeverityRank(issues[i].Severity)
+		lj := SeverityRank(issues[j].Severity)
+		if li != lj {
+			return li > lj
+		}
+		if issues[i].Protocol != issues[j].Protocol {
+			return issues[i].Protocol < issues[j].Protocol
+		}
+		return issues[i].Code < issues[j].Code
+	})
+}
+
+// SeverityRank converts a severity string into a numeric rank where higher
+// numbers indicate more severe issues. Returned ranks are stable across
+// callers so source attributes and finding rule logic agree.
+func SeverityRank(severity string) int {
+	switch strings.ToUpper(strings.TrimSpace(severity)) {
+	case SeverityCrit:
+		return 4
+	case SeverityHigh:
+		return 3
+	case SeverityMedium:
+		return 2
+	case SeverityLow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func issueScore(issues []Issue) int {
+	score := 100
+	for _, issue := range issues {
+		switch strings.ToUpper(issue.Severity) {
+		case SeverityCrit:
+			score -= 30
+		case SeverityHigh:
+			score -= 20
+		case SeverityMedium:
+			score -= 10
+		case SeverityLow:
+			score -= 5
+		default:
+			score -= 2
+		}
+	}
+	if score < 0 {
+		return 0
+	}
+	return score
+}
+
+func failingIssueCount(issues []Issue) int {
+	count := 0
+	for _, issue := range issues {
+		if SeverityRank(issue.Severity) >= 3 {
+			count++
+		}
+	}
+	return count
+}
+
+func protocolStatus(protocol string, issues []Issue, hasRecords bool) string {
+	maxRank := -1
+	for _, issue := range issues {
+		if !strings.EqualFold(issue.Protocol, protocol) {
+			continue
+		}
+		if rank := SeverityRank(issue.Severity); rank > maxRank {
+			maxRank = rank
+		}
+	}
+	switch {
+	case maxRank >= 3:
+		return StatusFailing
+	case maxRank >= 1:
+		return StatusWarning
+	case hasRecords:
+		return StatusHealthy
+	default:
+		return StatusUnknown
+	}
+}
+
+func overallStatus(spfStatus, dkimStatus, dmarcStatus string, issues []Issue) string {
+	for _, issue := range issues {
+		if SeverityRank(issue.Severity) >= 3 {
+			return StatusFailing
+		}
+	}
+	for _, issue := range issues {
+		if SeverityRank(issue.Severity) >= 1 {
+			return StatusWarning
+		}
+	}
+	if spfStatus == StatusUnknown && dkimStatus == StatusUnknown && dmarcStatus == StatusUnknown {
+		return StatusUnknown
+	}
+	return StatusHealthy
+}
+
+// NormalizeDomain returns the canonical lowercase mail-domain form of raw,
+// stripping URL prefixes, ports, and the leading "www.". It returns the
+// empty string if raw is not a valid mail domain (for example IPs, internal
+// suffixes, or malformed input).
+func NormalizeDomain(raw string) string {
+	candidate := strings.TrimSpace(strings.ToLower(raw))
+	if candidate == "" {
+		return ""
+	}
+	if strings.Contains(candidate, "@") {
+		parts := strings.Split(candidate, "@")
+		candidate = parts[len(parts)-1]
+	}
+	if strings.Contains(candidate, "://") {
+		if parsed, err := url.Parse(candidate); err == nil && parsed.Host != "" {
+			candidate = parsed.Host
+		}
+	}
+	if strings.Contains(candidate, "/") {
+		if parsed, err := url.Parse("https://" + candidate); err == nil && parsed.Host != "" {
+			candidate = parsed.Host
+		}
+	}
+	candidate = strings.Trim(candidate, "[]")
+	candidate = strings.TrimSuffix(candidate, ".")
+	if host, _, err := net.SplitHostPort(candidate); err == nil && host != "" {
+		candidate = host
+	} else if index := strings.LastIndex(candidate, ":"); index > 0 {
+		candidate = candidate[:index]
+	}
+	candidate = strings.TrimPrefix(candidate, "www.")
+	if ip := net.ParseIP(candidate); ip != nil {
+		return ""
+	}
+	if !emailDomainPattern.MatchString(candidate) {
+		return ""
+	}
+	if strings.HasSuffix(candidate, ".local") || strings.HasSuffix(candidate, ".internal") {
+		return ""
+	}
+	return candidate
+}

--- a/sources/internal/emaildns/emaildns.go
+++ b/sources/internal/emaildns/emaildns.go
@@ -7,6 +7,8 @@ package emaildns
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"net"
@@ -219,21 +221,25 @@ func evaluateDKIM(ctx context.Context, resolver Resolver, domain string, dkimSel
 		record := dkimRecords[0]
 		tags := parseTagRecord(record)
 		keyValue := strings.TrimSpace(tags["p"])
-		keyBits, keyValid := dkimKeyBits(keyValue)
+		algorithm := dkimKeyAlgorithm(tags["k"])
+		keyBits, keyValid := dkimKeyBits(keyValue, algorithm)
 		status := StatusHealthy
 		switch {
 		case keyValue == "":
 			status = StatusFailing
-			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityHigh, "dkim_missing_key", "DKIM public key missing", fmt.Sprintf("Selector %s is missing p= key material.", selector), "Publish a valid RSA key in p=."))
+			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityHigh, "dkim_missing_key", "DKIM public key missing", fmt.Sprintf("Selector %s is missing p= key material.", selector), "Publish valid DKIM public key material in p=."))
 		case !keyValid:
 			status = StatusFailing
-			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityHigh, "dkim_invalid_key", "DKIM public key is not valid base64", fmt.Sprintf("Selector %s p= value did not decode as base64 key material.", selector), "Republish the DKIM selector with valid base64-encoded RSA key material."))
-		case keyBits < 1024:
+			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityHigh, "dkim_invalid_key", "DKIM public key is not valid base64", fmt.Sprintf("Selector %s p= value did not decode as base64 key material.", selector), "Republish the DKIM selector with valid base64-encoded key material."))
+		case algorithm == "ed25519" && keyBits != 256:
 			status = StatusFailing
-			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityCrit, "dkim_weak_key", "DKIM key is too weak", fmt.Sprintf("Selector %s key size is %d bits.", selector, keyBits), "Rotate selector to at least 2048-bit RSA key material."))
-		case keyBits < 2048:
+			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityHigh, "dkim_invalid_ed25519_key", "DKIM Ed25519 key length is invalid", fmt.Sprintf("Selector %s Ed25519 key size is %d bits; expected 256 bits.", selector, keyBits), "Republish the Ed25519 selector with a 32-byte public key."))
+		case algorithm == "rsa" && keyBits < 1024:
+			status = StatusFailing
+			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityCrit, "dkim_weak_key", "DKIM RSA key is too weak", fmt.Sprintf("Selector %s RSA key size is %d bits.", selector, keyBits), "Rotate selector to at least 2048-bit RSA key material."))
+		case algorithm == "rsa" && keyBits < 2048:
 			status = StatusWarning
-			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityMedium, "dkim_key_short", "DKIM key length below recommended", fmt.Sprintf("Selector %s key size is %d bits.", selector, keyBits), "Rotate selector to a 2048-bit RSA key."))
+			result.Issues = append(result.Issues, makeIssue("DKIM", SeverityMedium, "dkim_key_short", "DKIM RSA key length below recommended", fmt.Sprintf("Selector %s RSA key size is %d bits.", selector, keyBits), "Rotate selector to a 2048-bit RSA key."))
 		}
 		result.DKIMSelectors = append(result.DKIMSelectors, DKIMSelector{Selector: selector, Status: status, KeyBits: keyBits, Record: record})
 	}
@@ -365,11 +371,20 @@ func spfLookupCount(record string) int {
 	return count
 }
 
-// dkimKeyBits decodes the DKIM p= public-key payload and returns the byte
+func dkimKeyAlgorithm(raw string) string {
+	algorithm := strings.ToLower(strings.TrimSpace(raw))
+	if algorithm == "" {
+		return "rsa"
+	}
+	return algorithm
+}
+
+// dkimKeyBits decodes the DKIM p= public-key payload and returns the key
 // length in bits along with a flag indicating whether the payload was valid
 // base64. Empty payloads return (0, true) so callers can distinguish a
-// missing key from a malformed one.
-func dkimKeyBits(publicKey string) (int, bool) {
+// missing key from a malformed one. RSA keys use parsed modulus size when the
+// payload is DER-encoded, falling back to byte length for legacy fixtures.
+func dkimKeyBits(publicKey string, algorithm string) (int, bool) {
 	cleaned := strings.ReplaceAll(strings.TrimSpace(publicKey), " ", "")
 	if cleaned == "" {
 		return 0, true
@@ -378,7 +393,24 @@ func dkimKeyBits(publicKey string) (int, bool) {
 	if err != nil {
 		return 0, false
 	}
+	if algorithm == "rsa" {
+		if bits := rsaPublicKeyBits(decoded); bits > 0 {
+			return bits, true
+		}
+	}
 	return len(decoded) * 8, true
+}
+
+func rsaPublicKeyBits(der []byte) int {
+	if key, err := x509.ParsePKIXPublicKey(der); err == nil {
+		if rsaKey, ok := key.(*rsa.PublicKey); ok && rsaKey.N != nil {
+			return rsaKey.N.BitLen()
+		}
+	}
+	if key, err := x509.ParsePKCS1PublicKey(der); err == nil && key.N != nil {
+		return key.N.BitLen()
+	}
+	return 0
 }
 
 func sortIssues(issues []Issue) {

--- a/sources/internal/emaildns/emaildns_test.go
+++ b/sources/internal/emaildns/emaildns_test.go
@@ -102,6 +102,30 @@ func TestEvaluateDoesNotMarkPermissiveSPFAsHealthy(t *testing.T) {
 	}
 }
 
+func TestEvaluateAcceptsSPFRedirectPolicy(t *testing.T) {
+	resolver := fakeResolver{
+		txt: map[string][]string{
+			"redirect.example.com":                    {"v=spf1 redirect=_spf.example.net"},
+			"_dmarc.redirect.example.com":             {"v=DMARC1; p=reject; rua=mailto:dmarc@redirect.example.com"},
+			"default._domainkey.redirect.example.com": {"v=DKIM1; p=" + base64.StdEncoding.EncodeToString(make([]byte, 256))},
+		},
+		mx: map[string][]*net.MX{"redirect.example.com": {{Host: "mx.example.com.", Pref: 10}}},
+	}
+	health := Evaluate(context.Background(), resolver, "redirect.example.com", nil)
+	if health.Status != StatusHealthy {
+		t.Fatalf("Status = %q for SPF redirect policy, want HEALTHY; issues=%+v", health.Status, health.Issues)
+	}
+	if health.SPFPolicy != "redirect" {
+		t.Fatalf("SPFPolicy = %q, want redirect", health.SPFPolicy)
+	}
+	if findIssueCode(health.Issues, "spf_no_terminal_policy") {
+		t.Fatalf("SPF redirect policy should not receive spf_no_terminal_policy; issues=%+v", health.Issues)
+	}
+	if health.SPFLookupCount != 1 {
+		t.Fatalf("SPFLookupCount = %d, want redirect lookup counted", health.SPFLookupCount)
+	}
+}
+
 func TestEvaluateRejectsInvalidDMARCPolicyValue(t *testing.T) {
 	resolver := fakeResolver{
 		txt: map[string][]string{

--- a/sources/internal/emaildns/emaildns_test.go
+++ b/sources/internal/emaildns/emaildns_test.go
@@ -82,3 +82,69 @@ func TestSeverityRankOrders(t *testing.T) {
 		t.Fatalf("unknown severity should rank 0")
 	}
 }
+
+func TestEvaluateDoesNotMarkPermissiveSPFAsHealthy(t *testing.T) {
+	resolver := fakeResolver{
+		txt: map[string][]string{
+			"neutral.example.com":                    {"v=spf1 ?all"},
+			"_dmarc.neutral.example.com":             {"v=DMARC1; p=reject; rua=mailto:dmarc@neutral.example.com"},
+			"default._domainkey.neutral.example.com": {"v=DKIM1; p=" + base64.StdEncoding.EncodeToString(make([]byte, 256))},
+		},
+		mx: map[string][]*net.MX{"neutral.example.com": {{Host: "mx.example.com.", Pref: 10}}},
+	}
+	health := Evaluate(context.Background(), resolver, "neutral.example.com", nil)
+	if health.Status == StatusHealthy {
+		t.Fatalf("Status = HEALTHY for SPF ?all; want WARNING or FAILING")
+	}
+	if !findIssueCode(health.Issues, "spf_neutral_all") {
+		t.Fatalf("expected spf_neutral_all issue; got %+v", health.Issues)
+	}
+}
+
+func TestEvaluateRejectsInvalidDMARCPolicyValue(t *testing.T) {
+	resolver := fakeResolver{
+		txt: map[string][]string{
+			"badp.example.com":                    {"v=spf1 -all"},
+			"_dmarc.badp.example.com":             {"v=DMARC1; p=definitely-not-valid; rua=mailto:dmarc@badp.example.com"},
+			"default._domainkey.badp.example.com": {"v=DKIM1; p=" + base64.StdEncoding.EncodeToString(make([]byte, 256))},
+		},
+		mx: map[string][]*net.MX{"badp.example.com": {{Host: "mx.example.com.", Pref: 10}}},
+	}
+	health := Evaluate(context.Background(), resolver, "badp.example.com", nil)
+	if health.Status == StatusHealthy {
+		t.Fatalf("Status = HEALTHY for DMARC p=invalid; want WARNING or FAILING")
+	}
+	if !findIssueCode(health.Issues, "dmarc_policy_invalid") {
+		t.Fatalf("expected dmarc_policy_invalid issue; got %+v", health.Issues)
+	}
+}
+
+func TestEvaluateFlagsInvalidDKIMKeyMaterial(t *testing.T) {
+	resolver := fakeResolver{
+		txt: map[string][]string{
+			"baddkim.example.com":                    {"v=spf1 -all"},
+			"_dmarc.baddkim.example.com":             {"v=DMARC1; p=reject; rua=mailto:dmarc@baddkim.example.com"},
+			"default._domainkey.baddkim.example.com": {"v=DKIM1; k=rsa; p=not-valid-base64!!!"},
+		},
+		mx: map[string][]*net.MX{"baddkim.example.com": {{Host: "mx.example.com.", Pref: 10}}},
+	}
+	health := Evaluate(context.Background(), resolver, "baddkim.example.com", nil)
+	if health.Status == StatusHealthy {
+		t.Fatalf("Status = HEALTHY for invalid DKIM key; want WARNING or FAILING")
+	}
+	if !findIssueCode(health.Issues, "dkim_invalid_key") {
+		t.Fatalf("expected dkim_invalid_key issue; got %+v", health.Issues)
+	}
+	if len(health.DKIMSelectors) == 0 || health.DKIMSelectors[0].Status != StatusFailing {
+		t.Fatalf("DKIM selector status = %+v, want FAILING", health.DKIMSelectors)
+	}
+}
+
+func findIssueCode(issues []Issue, code string) bool {
+	for _, issue := range issues {
+		if issue.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/sources/internal/emaildns/emaildns_test.go
+++ b/sources/internal/emaildns/emaildns_test.go
@@ -1,0 +1,84 @@
+package emaildns
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+type fakeResolver struct {
+	txt    map[string][]string
+	txtErr map[string]error
+	mx     map[string][]*net.MX
+}
+
+func (f fakeResolver) LookupTXT(_ context.Context, name string) ([]string, error) {
+	if err, ok := f.txtErr[name]; ok {
+		return nil, err
+	}
+	return f.txt[name], nil
+}
+
+func (f fakeResolver) LookupMX(_ context.Context, name string) ([]*net.MX, error) {
+	return f.mx[name], nil
+}
+
+func TestNormalizeDomainAcceptsCanonicalForms(t *testing.T) {
+	cases := map[string]string{
+		"example.com":              "example.com",
+		"Security@Example.COM":     "example.com",
+		"https://mail.Example.com": "mail.example.com",
+		"www.Example.com:443":      "example.com",
+		"":                         "",
+		"local.local":              "",
+		"10.0.0.1":                 "",
+	}
+	for input, want := range cases {
+		if got := NormalizeDomain(input); got != want {
+			t.Fatalf("NormalizeDomain(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestEvaluateClassifiesFailingDomain(t *testing.T) {
+	resolver := fakeResolver{
+		txt: map[string][]string{
+			"failing.example.com":                    {"v=spf1 +all"},
+			"default._domainkey.failing.example.com": {"v=DKIM1; p=" + base64.StdEncoding.EncodeToString(make([]byte, 64))},
+		},
+		txtErr: map[string]error{
+			"_dmarc.failing.example.com": errors.New("not found"),
+		},
+	}
+	health := Evaluate(context.Background(), resolver, "failing.example.com", nil)
+	if health.Status != StatusFailing {
+		t.Fatalf("Status = %q, want FAILING", health.Status)
+	}
+	if health.SPFPolicy != "+all" {
+		t.Fatalf("SPFPolicy = %q", health.SPFPolicy)
+	}
+	codes := map[string]bool{}
+	for _, issue := range health.Issues {
+		codes[issue.Code] = true
+	}
+	for _, expected := range []string{"spf_permissive_all", "dmarc_missing", "dkim_weak_key"} {
+		if !codes[expected] {
+			t.Fatalf("expected issue code %q in %+v", expected, codes)
+		}
+	}
+	if !strings.EqualFold(health.SPFStatus, StatusFailing) {
+		t.Fatalf("SPFStatus = %q", health.SPFStatus)
+	}
+}
+
+func TestSeverityRankOrders(t *testing.T) {
+	if SeverityRank(SeverityCrit) <= SeverityRank(SeverityHigh) {
+		t.Fatalf("CRITICAL rank must exceed HIGH rank")
+	}
+	if SeverityRank("unknown") != 0 {
+		t.Fatalf("unknown severity should rank 0")
+	}
+}

--- a/sources/internal/emaildns/emaildns_test.go
+++ b/sources/internal/emaildns/emaildns_test.go
@@ -32,6 +32,7 @@ func TestNormalizeDomainAcceptsCanonicalForms(t *testing.T) {
 		"Security@Example.COM":     "example.com",
 		"https://mail.Example.com": "mail.example.com",
 		"www.Example.com:443":      "example.com",
+		"www.www.Example.com":      "example.com",
 		"":                         "",
 		"local.local":              "",
 		"10.0.0.1":                 "",
@@ -137,6 +138,28 @@ func TestEvaluateFlagsInvalidDKIMKeyMaterial(t *testing.T) {
 	}
 	if len(health.DKIMSelectors) == 0 || health.DKIMSelectors[0].Status != StatusFailing {
 		t.Fatalf("DKIM selector status = %+v, want FAILING", health.DKIMSelectors)
+	}
+}
+
+func TestEvaluateAcceptsEd25519DKIMKeyMaterial(t *testing.T) {
+	ed25519Key := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	resolver := fakeResolver{
+		txt: map[string][]string{
+			"ed25519.example.com":                    {"v=spf1 -all"},
+			"_dmarc.ed25519.example.com":             {"v=DMARC1; p=reject; rua=mailto:dmarc@ed25519.example.com"},
+			"default._domainkey.ed25519.example.com": {"v=DKIM1; k=ed25519; p=" + ed25519Key},
+		},
+		mx: map[string][]*net.MX{"ed25519.example.com": {{Host: "mx.example.com.", Pref: 10}}},
+	}
+	health := Evaluate(context.Background(), resolver, "ed25519.example.com", nil)
+	if health.Status != StatusHealthy {
+		t.Fatalf("Status = %q for valid Ed25519 DKIM key, want HEALTHY; issues=%+v", health.Status, health.Issues)
+	}
+	if findIssueCode(health.Issues, "dkim_weak_key") || findIssueCode(health.Issues, "dkim_key_short") {
+		t.Fatalf("valid Ed25519 key should not receive RSA strength issue; issues=%+v", health.Issues)
+	}
+	if len(health.DKIMSelectors) == 0 || health.DKIMSelectors[0].Status != StatusHealthy || health.DKIMSelectors[0].KeyBits != 256 {
+		t.Fatalf("DKIM selector = %+v, want healthy 256-bit Ed25519 selector", health.DKIMSelectors)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a new built-in `email_domain_health` source that probes SPF, DKIM,
DMARC, MX, MTA-STS, and BIMI for configured tenant mail domains and emits
one `email_domain_health.health` event per domain per Read. The DNS
evaluator lives in a small Source CDK helper at
`sources/internal/emaildns/` so the source package stays inside the
new-source LOC budget.

The new source feeds the security knowledge graph through a dedicated
projector that materializes:

- `email.domain` entities (with per-protocol status, score, issue codes,
  highest severity, SPF policy, DMARC policy, MX records, and a
  serialized `issues_json` blob for evidence)
- `email.dkim_selector` entities per discovered selector
- `belongs_to` edge from the mail domain to the matching
  `internet.domain` so cross-domain correlation works
- `contains` edges from the mail domain to its DKIM selectors

A new durable-state, graph-anchored finding rule
`email-domain-authentication-misconfigured` opens one finding per
(tenant, domain) when status is `FAILING` or `WARNING`. The rule is
event-driven but the fingerprint is stable on the domain, so repeated
healthy runs do not churn findings and the orchestrator can auto-resolve
once the domain becomes healthy again. Severity escalates with the
highest unresolved protocol issue (CRITICAL for permissive SPF or weak
DKIM, HIGH for missing SPF/DMARC, MEDIUM for warning-level posture).

## Why

This brings cerebro to feature parity with the Aperio email-domain-health
check while conforming to cerebro's non-goals (no synchronous DNS in
request paths, no per-tenant Postgres tables, no temporal-event findings
without durable risk semantics).

## Coverage

- New source: `sources/emaildomainhealth/`
- New CDK helper: `sources/internal/emaildns/`
- New projector: `internal/sourceprojection/email_domain.go`
- New finding rule + pack: `internal/findings/email_domain_authentication_misconfigured_rule.go`
- New audit classification entry (KEEP_AS_IS, source `email_domain_health`)
- New rule fixture: `internal/findings/testdata/rules/email-domain-authentication-misconfigured.json`
- Regenerated public detection catalog (76 -> 77 rules)
- README and FINDINGS_PLATFORM_ARCHITECTURE.md updated to reflect counts
  and the new source

## Controls

- SOC 2 CC6.6
- ISO 27001:2022 A.5.14
- NIST SP 800-177 TLS-MAIL

## Validation

- `go test ./...` (focused subsets shown below run repeatedly during dev)
- `go test ./sources/emaildomainhealth/... ./sources/internal/emaildns/...`
- `go test ./internal/findings/... ./internal/sourceprojection/... ./internal/sourceregistry/...`
- `go test ./tools/archtests/...`
- `make lint`
- `make catalog-check`
- `make detection-catalog-check`
- `make docs-drift-check`
- `make readme-check`
- `python3 scripts/contracts_check.py`

## Deploy

No proto or OpenAPI changes. Stack config updates to register
`email_domain_health` runtimes per environment can land in a follow-up
infra PR once the image is promoted; the secret keys the source expects
are documented in `sources/emaildomainhealth/deploy.yaml`
(`EMAIL_DOMAIN_HEALTH_DOMAINS`, `EMAIL_DOMAIN_HEALTH_DKIM_SELECTORS`).
