### PR TITLE
Add connector credential store selection contract

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -183,6 +183,10 @@ paths:
                   type: string
                 tenant_id:
                   type: string
+                credential_store_id:
+                  type: string
+                  description: Closed credential-store identifier selected from /connectors credential_stores metadata.
+                  default: cerebro_vault
                 config:
                   type: object
                   additionalProperties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -177,22 +177,49 @@ paths:
               required:
                 - runtime_id
                 - tenant_id
-                - encrypted_credentials
               properties:
                 runtime_id:
                   type: string
                 tenant_id:
                   type: string
+                check_only:
+                  type: boolean
+                  description: Validate the connector configuration and selected credential path without persisting a runtime or storing credentials.
+                  default: false
+                auth_method:
+                  type: string
+                  description: Backend-advertised connection method selected from /connectors connection_methods metadata.
+                  default: encrypted_submission
+                  enum:
+                    - encrypted_submission
+                    - aws_sso_profile
+                    - infisical_cli
+                    - environment_managed
+                    - external_reference
                 credential_store_id:
                   type: string
                   description: Closed credential-store identifier selected from /connectors credential_stores metadata.
                   default: cerebro_vault
+                  enum:
+                    - cerebro_vault
+                    - environment_managed
+                    - infisical
+                    - google_secret_manager
+                    - aws_secrets_manager
+                    - azure_key_vault
+                    - hashicorp_vault
                 config:
                   type: object
                   additionalProperties:
                     type: string
+                credential_references:
+                  type: object
+                  description: Non-secret credential references for environment-managed or external-reference methods. Values must be server-resolvable references such as env:CEREBRO_SOURCE_<SOURCE>_<FIELD>; secret-store CLIs/controllers are expected to populate those environment values outside the browser.
+                  additionalProperties:
+                    type: string
                 encrypted_credentials:
                   type: object
+                  description: Required only when auth_method is encrypted_submission.
                   required:
                     - key_id
                     - algorithm

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,22 +17,41 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/connectorcredentials"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceruntime"
 )
 
-const defaultConnectorCredentialStoreID = "cerebro_vault"
+const (
+	defaultConnectorCredentialStoreID = "cerebro_vault"
+	connectorStoreEnvironmentManaged  = "environment_managed"
+
+	connectorAuthMethodEncryptedSubmission = "encrypted_submission"
+	connectorAuthMethodAWSSSOProfile       = "aws_sso_profile"
+	connectorAuthMethodInfisicalCLI        = "infisical_cli"
+	connectorAuthMethodEnvironmentManaged  = "environment_managed"
+	connectorAuthMethodExternalReference   = "external_reference"
+
+	connectorStoreInfisical          = "infisical"
+	connectorStoreGoogleSecretMgr    = "google_secret_manager"
+	connectorStoreAWSSecretsManager  = "aws_secrets_manager"
+	connectorStoreAzureKeyVault      = "azure_key_vault"
+	connectorStoreHashiCorpVault     = "hashicorp_vault"
+	connectorCredentialStoreModeRefs = "reference"
+)
 
 type connectorCatalogEntry struct {
-	SourceID               string   `json:"source_id"`
-	Name                   string   `json:"name"`
-	Description            string   `json:"description"`
-	EmittedKinds           []string `json:"emitted_kinds"`
-	Status                 string   `json:"status"`
-	ConfiguredRuntimes     int      `json:"configured_runtimes"`
-	HealthyRuntimes        int      `json:"healthy_runtimes"`
-	NeedsAttentionRuntimes int      `json:"needs_attention_runtimes"`
+	SourceID               string                          `json:"source_id"`
+	Name                   string                          `json:"name"`
+	DisplayName            string                          `json:"display_name"`
+	Description            string                          `json:"description"`
+	EmittedKinds           []string                        `json:"emitted_kinds"`
+	Status                 string                          `json:"status"`
+	ConfiguredRuntimes     int                             `json:"configured_runtimes"`
+	HealthyRuntimes        int                             `json:"healthy_runtimes"`
+	NeedsAttentionRuntimes int                             `json:"needs_attention_runtimes"`
+	ConnectionMethods      []connectorConnectionMethodView `json:"connection_methods,omitempty"`
 }
 
 type connectorLibraryResponse struct {
@@ -64,11 +84,36 @@ type connectorStoreView struct {
 	Detail    string `json:"detail,omitempty"`
 }
 
+type connectorFieldView struct {
+	Key           string `json:"key"`
+	Label         string `json:"label"`
+	Required      bool   `json:"required,omitempty"`
+	Secret        bool   `json:"secret,omitempty"`
+	ReferenceOnly bool   `json:"reference_only,omitempty"`
+	Placeholder   string `json:"placeholder,omitempty"`
+	Help          string `json:"help,omitempty"`
+}
+
+type connectorConnectionMethodView struct {
+	ID                string               `json:"id"`
+	Label             string               `json:"label"`
+	Description       string               `json:"description"`
+	CredentialStores  []string             `json:"credential_stores,omitempty"`
+	ConfigFields      []connectorFieldView `json:"config_fields,omitempty"`
+	CredentialFields  []connectorFieldView `json:"credential_fields,omitempty"`
+	RequiresSecrets   bool                 `json:"requires_secrets"`
+	Saveable          bool                 `json:"saveable"`
+	UnavailableReason string               `json:"unavailable_reason,omitempty"`
+}
+
 type connectorConnectionRequest struct {
 	RuntimeID            string                                `json:"runtime_id"`
 	TenantID             string                                `json:"tenant_id"`
+	CheckOnly            bool                                  `json:"check_only,omitempty"`
+	AuthMethod           string                                `json:"auth_method,omitempty"`
 	CredentialStoreID    string                                `json:"credential_store_id,omitempty"`
 	Config               map[string]string                     `json:"config"`
+	CredentialReferences map[string]string                     `json:"credential_references,omitempty"`
 	EncryptedCredentials connectorcredentials.EncryptedPayload `json:"encrypted_credentials"`
 }
 
@@ -76,18 +121,20 @@ type connectorConnectionResponse struct {
 	SourceID   string                  `json:"source_id"`
 	Runtime    json.RawMessage         `json:"runtime"`
 	Credential connectorCredentialView `json:"credential"`
+	Status     string                  `json:"status,omitempty"`
 }
 
 type connectorCredentialView struct {
-	ID        string   `json:"id"`
-	TenantID  string   `json:"tenant_id"`
-	SourceID  string   `json:"source_id"`
-	RuntimeID string   `json:"runtime_id"`
-	StoreID   string   `json:"credential_store_id"`
-	KeyID     string   `json:"key_id"`
-	Fields    []string `json:"fields"`
-	CreatedAt string   `json:"created_at,omitempty"`
-	UpdatedAt string   `json:"updated_at,omitempty"`
+	ID         string   `json:"id"`
+	TenantID   string   `json:"tenant_id"`
+	SourceID   string   `json:"source_id"`
+	RuntimeID  string   `json:"runtime_id"`
+	StoreID    string   `json:"credential_store_id"`
+	AuthMethod string   `json:"auth_method"`
+	KeyID      string   `json:"key_id"`
+	Fields     []string `json:"fields"`
+	CreatedAt  string   `json:"created_at,omitempty"`
+	UpdatedAt  string   `json:"updated_at,omitempty"`
 }
 
 func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
@@ -99,14 +146,25 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 	runtimes, runtimeStoreStatus := a.connectorRuntimeCatalog(r, tenantID)
 	counts := connectorRuntimeCounts(runtimes)
 	sources := a.sourceService().List().GetSources()
+	transport := connectorTransportView{
+		Available: a.connectorTransitKey != nil,
+		KeyURL:    "/connectors/credential-key",
+	}
+	if a.connectorTransitKey != nil {
+		transport.Algorithm = a.connectorTransitKey.PublicKey().Algorithm
+	}
+	vaultStatus := connectorVaultStatus(a.cfg.ConnectorCredentials, a.deps.StateStore)
+	stores := connectorStoreViews(vaultStatus, transport)
 	entries := make([]connectorCatalogEntry, 0, len(sources))
 	for _, source := range sources {
 		entry := connectorCatalogEntry{
-			SourceID:     source.GetId(),
-			Name:         source.GetName(),
-			Description:  source.GetDescription(),
-			EmittedKinds: append([]string{}, source.GetEmittedKinds()...),
-			Status:       "available",
+			SourceID:          source.GetId(),
+			Name:              source.GetName(),
+			DisplayName:       connectorDisplayName(source.GetId(), source.GetName()),
+			Description:       source.GetDescription(),
+			EmittedKinds:      append([]string{}, source.GetEmittedKinds()...),
+			Status:            "available",
+			ConnectionMethods: connectorConnectionMethods(source.GetId(), stores),
 		}
 		if count := counts[source.GetId()]; count.total > 0 {
 			entry.ConfiguredRuntimes = count.total
@@ -126,21 +184,13 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 	sort.Slice(entries, func(i, j int) bool {
 		return strings.ToLower(entries[i].Name) < strings.ToLower(entries[j].Name)
 	})
-	transport := connectorTransportView{
-		Available: a.connectorTransitKey != nil,
-		KeyURL:    "/connectors/credential-key",
-	}
-	if a.connectorTransitKey != nil {
-		transport.Algorithm = a.connectorTransitKey.PublicKey().Algorithm
-	}
-	vaultStatus := connectorVaultStatus(a.cfg.ConnectorCredentials, a.deps.StateStore)
 	writeJSON(w, http.StatusOK, connectorLibraryResponse{
 		Connectors:          entries,
 		TenantID:            tenantID,
 		RuntimeStore:        runtimeStoreStatus,
 		CredentialTransport: transport,
 		CredentialVault:     vaultStatus,
-		CredentialStores:    connectorStoreViews(vaultStatus, transport),
+		CredentialStores:    stores,
 	})
 }
 
@@ -173,13 +223,22 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 		writeConnectorError(w, fmt.Errorf("%w: tenant_id is required", connectorcredentials.ErrInvalidRequest))
 		return
 	}
-	credentialStoreID, err := normalizeConnectorCredentialStoreID(request.CredentialStoreID)
+	authMethod := normalizeConnectorAuthMethod(request.AuthMethod)
+	credentialStoreID, err := normalizeConnectorCredentialStoreID(request.CredentialStoreID, authMethod)
 	if err != nil {
 		writeConnectorError(w, err)
 		return
 	}
 	runtimeConfig, err := connectorRuntimeConfig(request.Config)
 	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if err := applyConnectorCredentialReferences(runtimeConfig, request.CredentialReferences); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if err := validateConnectorConnectionShape(sourceID, authMethod, credentialStoreID, runtimeConfig, request.CredentialReferences, request.EncryptedCredentials); err != nil {
 		writeConnectorError(w, err)
 		return
 	}
@@ -193,40 +252,83 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 		writeConnectorError(w, err)
 		return
 	}
-	if a == nil || a.connectorTransitKey == nil {
-		writeConnectorError(w, connectorcredentials.ErrUnavailable)
-		return
+	credential := connectorCredentialView{
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		RuntimeID:  runtimeID,
+		StoreID:    credentialStoreID,
+		AuthMethod: authMethod,
 	}
-	decrypted, err := a.connectorTransitKey.DecryptWithAdditionalData(
-		request.EncryptedCredentials,
-		connectorCredentialAdditionalData(request.EncryptedCredentials.KeyID, sourceID, tenantID, runtimeID, credentialStoreID),
-	)
-	if err != nil {
+	var plaintextFields map[string]string
+	if authMethod == connectorAuthMethodEncryptedSubmission {
+		if a == nil || a.connectorTransitKey == nil {
+			writeConnectorError(w, connectorcredentials.ErrUnavailable)
+			return
+		}
+		decrypted, err := a.connectorTransitKey.DecryptWithAdditionalData(
+			request.EncryptedCredentials,
+			connectorCredentialAdditionalData(request.EncryptedCredentials.KeyID, sourceID, tenantID, runtimeID, credentialStoreID),
+		)
+		if err != nil {
+			writeConnectorError(w, err)
+			return
+		}
+		fields, err := connectorcredentials.ParseCredentialFields(decrypted)
+		if err != nil {
+			writeConnectorError(w, err)
+			return
+		}
+		if err := validateConnectorCredentialFields(sourceID, authMethod, fields); err != nil {
+			writeConnectorError(w, err)
+			return
+		}
+		plaintextFields = fields
+		credential.Fields = connectorcredentials.SortedFieldNames(fields)
+	} else {
+		credential.Fields = sortedStringKeys(request.CredentialReferences)
+	}
+	if err := a.checkConnectorRuntime(r.Context(), runtime, plaintextFields); err != nil {
 		writeConnectorError(w, err)
 		return
 	}
-	fields, err := connectorcredentials.ParseCredentialFields(decrypted)
-	if err != nil {
-		writeConnectorError(w, err)
+	if request.CheckOnly {
+		runtimePayload, err := connectorRuntimePayload(runtime)
+		if err != nil {
+			writeConnectorError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, connectorConnectionResponse{
+			SourceID:   sourceID,
+			Runtime:    runtimePayload,
+			Credential: credential,
+			Status:     "checked",
+		})
 		return
 	}
-	vault, err := connectorCredentialVault(a.cfg.ConnectorCredentials, a.deps.StateStore)
-	if err != nil {
-		writeConnectorError(w, err)
-		return
-	}
-	record, err := vault.Put(r.Context(), connectorcredentials.PlainCredential{
-		TenantID:  tenantID,
-		SourceID:  sourceID,
-		RuntimeID: runtimeID,
-		Fields:    fields,
-	})
-	if err != nil {
-		writeConnectorError(w, err)
-		return
-	}
-	for _, field := range connectorcredentials.SortedFieldNames(fields) {
-		runtime.Config[field] = connectorcredentials.Reference(record.ID, field)
+	if authMethod == connectorAuthMethodEncryptedSubmission {
+		vault, err := connectorCredentialVault(a.cfg.ConnectorCredentials, a.deps.StateStore)
+		if err != nil {
+			writeConnectorError(w, err)
+			return
+		}
+		record, err := vault.Put(r.Context(), connectorcredentials.PlainCredential{
+			TenantID:  tenantID,
+			SourceID:  sourceID,
+			RuntimeID: runtimeID,
+			Fields:    plaintextFields,
+		})
+		if err != nil {
+			writeConnectorError(w, err)
+			return
+		}
+		for _, field := range connectorcredentials.SortedFieldNames(plaintextFields) {
+			runtime.Config[field] = connectorcredentials.Reference(record.ID, field)
+		}
+		credential.ID = record.ID
+		credential.KeyID = record.KeyID
+		credential.Fields = connectorcredentials.SortedFieldNames(plaintextFields)
+		credential.CreatedAt = connectorcredentials.TimestampOrZero(record.CreatedAt)
+		credential.UpdatedAt = connectorcredentials.TimestampOrZero(record.UpdatedAt)
 	}
 	response, err := a.runtimeService().Put(r.Context(), &cerebrov1.PutSourceRuntimeRequest{Runtime: runtime})
 	if err != nil {
@@ -239,19 +341,9 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 		return
 	}
 	writeJSON(w, http.StatusOK, connectorConnectionResponse{
-		SourceID: sourceID,
-		Runtime:  json.RawMessage(runtimePayload),
-		Credential: connectorCredentialView{
-			ID:        record.ID,
-			TenantID:  record.TenantID,
-			SourceID:  record.SourceID,
-			RuntimeID: record.RuntimeID,
-			StoreID:   credentialStoreID,
-			KeyID:     record.KeyID,
-			Fields:    connectorcredentials.SortedFieldNames(fields),
-			CreatedAt: connectorcredentials.TimestampOrZero(record.CreatedAt),
-			UpdatedAt: connectorcredentials.TimestampOrZero(record.UpdatedAt),
-		},
+		SourceID:   sourceID,
+		Runtime:    json.RawMessage(runtimePayload),
+		Credential: credential,
 	})
 }
 
@@ -269,6 +361,59 @@ func (a *App) connectorRuntimeCatalog(r *http.Request, tenantID string) ([]*cere
 type connectorRuntimeCount struct {
 	total   int
 	healthy int
+}
+
+type connectorSchema struct {
+	ConfigKeys          map[string]struct{}
+	CredentialKeys      map[string]struct{}
+	RequiredConfig      []string
+	RequiredCredentials []string
+}
+
+var connectorSchemas = map[string]connectorSchema{
+	"anthropic": {
+		ConfigKeys:          stringSet("family"),
+		CredentialKeys:      stringSet("api_key"),
+		RequiredCredentials: []string{"api_key"},
+	},
+	"aws": {
+		ConfigKeys:          stringSet("account_id", "region", "family", "include_global", "role_arn", "external_id"),
+		CredentialKeys:      stringSet("access_key_id", "secret_access_key", "session_token"),
+		RequiredConfig:      []string{"account_id"},
+		RequiredCredentials: []string{"access_key_id", "secret_access_key"},
+	},
+	"gcp": {
+		ConfigKeys:     stringSet("project_id", "family", "wif_audience", "wif_service_account_email", "customer_id", "group_key", "service_account_email"),
+		CredentialKeys: stringSet("token"),
+		RequiredConfig: []string{"project_id"},
+	},
+	"github": {
+		ConfigKeys:          stringSet("owner", "repo", "family", "phrase"),
+		CredentialKeys:      stringSet("token"),
+		RequiredCredentials: []string{"token"},
+	},
+	"google_workspace": {
+		ConfigKeys:          stringSet("domain", "family", "customer_id", "group_key"),
+		CredentialKeys:      stringSet("token"),
+		RequiredConfig:      []string{"domain"},
+		RequiredCredentials: []string{"token"},
+	},
+	"okta": {
+		ConfigKeys:          stringSet("domain", "family"),
+		CredentialKeys:      stringSet("token"),
+		RequiredConfig:      []string{"domain"},
+		RequiredCredentials: []string{"token"},
+	},
+	"openai": {
+		ConfigKeys:          stringSet("family"),
+		CredentialKeys:      stringSet("api_key"),
+		RequiredCredentials: []string{"api_key"},
+	},
+	"bootstrap_token": {
+		ConfigKeys:          stringSet("family"),
+		CredentialKeys:      stringSet("token"),
+		RequiredCredentials: []string{"token"},
+	},
 }
 
 func connectorRuntimeCounts(runtimes []*cerebrov1.SourceRuntime) map[string]connectorRuntimeCount {
@@ -299,6 +444,209 @@ func connectorRuntimeHealthy(runtime *cerebrov1.SourceRuntime) bool {
 	return runtime.GetLastSyncedAt() != nil
 }
 
+func (a *App) checkConnectorRuntime(ctx context.Context, runtime *cerebrov1.SourceRuntime, plaintextFields map[string]string) error {
+	if runtime == nil {
+		return fmt.Errorf("%w: source runtime is required", connectorcredentials.ErrInvalidRequest)
+	}
+	source, err := a.connectorSource(runtime.GetSourceId())
+	if err != nil {
+		return err
+	}
+	values := copyStringMap(runtime.GetConfig())
+	for key, value := range plaintextFields {
+		values[key] = value
+	}
+	values = sourceconfig.WithRuntimeContext(values, runtime.GetTenantId(), runtime.GetId())
+	resolved, err := resolveRuntimeSourceConfigWithStore(ctx, a.cfg.ConnectorCredentials, a.deps.StateStore, runtime.GetSourceId(), values)
+	if err != nil {
+		return err
+	}
+	if err := source.Check(ctx, sourcecdk.NewConfig(resolved)); err != nil {
+		if errors.Is(err, sourcecdk.ErrInvalidConfig) {
+			return fmt.Errorf("%w: %w", sourceruntime.ErrInvalidRequest, err)
+		}
+		return err
+	}
+	return nil
+}
+
+func (a *App) connectorSource(sourceID string) (sourcecdk.Source, error) {
+	id := strings.TrimSpace(sourceID)
+	if id == "" {
+		return nil, fmt.Errorf("%w: source id is required", connectorcredentials.ErrInvalidRequest)
+	}
+	if a == nil || a.sources == nil {
+		return nil, fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, id)
+	}
+	source, ok := a.sources.Get(id)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, id)
+	}
+	return source, nil
+}
+
+func connectorRuntimePayload(runtime *cerebrov1.SourceRuntime) (json.RawMessage, error) {
+	payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(redactSourceRuntime(runtime))
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(payload), nil
+}
+
+func connectorDisplayName(sourceID string, fallback string) string {
+	switch strings.TrimSpace(sourceID) {
+	case "aws":
+		return "Amazon Web Services"
+	case "gcp":
+		return "Google Cloud Platform"
+	case "google_workspace":
+		return "Google Workspace"
+	case "github":
+		return "GitHub"
+	case "okta":
+		return "Okta"
+	case "openai":
+		return "OpenAI"
+	case "anthropic":
+		return "Anthropic"
+	case "azure":
+		return "Microsoft Azure"
+	default:
+		if name := strings.TrimSpace(fallback); name != "" {
+			return name
+		}
+		return strings.TrimSpace(sourceID)
+	}
+}
+
+func connectorConfigFields(sourceID string, authMethod string) []connectorFieldView {
+	schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]
+	if !ok {
+		return nil
+	}
+	keys := sortedSetKeys(schema.ConfigKeys)
+	if authMethod == connectorAuthMethodAWSSSOProfile && strings.TrimSpace(sourceID) == "aws" {
+		keys = append(keys, "profile")
+		sort.Strings(keys)
+	}
+	required := stringSet(schema.RequiredConfig...)
+	if authMethod == connectorAuthMethodAWSSSOProfile {
+		required["profile"] = struct{}{}
+	}
+	fields := make([]connectorFieldView, 0, len(keys))
+	for _, key := range keys {
+		if authMethod != connectorAuthMethodAWSSSOProfile && key == "profile" {
+			continue
+		}
+		field := connectorFieldView{
+			Key:         key,
+			Label:       connectorFieldLabel(key),
+			Required:    setContains(required, key),
+			Placeholder: connectorFieldPlaceholder(sourceID, key, false),
+			Help:        connectorFieldHelp(sourceID, authMethod, key),
+		}
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+func connectorCredentialFields(sourceID string, authMethod string) []connectorFieldView {
+	if authMethod == connectorAuthMethodAWSSSOProfile {
+		return nil
+	}
+	schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]
+	if !ok {
+		return nil
+	}
+	required := stringSet(schema.RequiredCredentials...)
+	keys := sortedSetKeys(schema.CredentialKeys)
+	fields := make([]connectorFieldView, 0, len(keys))
+	for _, key := range keys {
+		field := connectorFieldView{
+			Key:           key,
+			Label:         connectorFieldLabel(key),
+			Required:      setContains(required, key),
+			Secret:        authMethod == connectorAuthMethodEncryptedSubmission,
+			ReferenceOnly: authMethod != connectorAuthMethodEncryptedSubmission,
+			Placeholder:   connectorFieldPlaceholder(sourceID, key, authMethod != connectorAuthMethodEncryptedSubmission),
+			Help:          connectorFieldHelp(sourceID, authMethod, key),
+		}
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+func connectorFieldLabel(key string) string {
+	words := strings.Fields(strings.ReplaceAll(strings.TrimSpace(key), "_", " "))
+	for i, word := range words {
+		switch strings.ToLower(word) {
+		case "id", "iam", "sso", "api", "arn", "url", "wif", "gcp", "aws":
+			words[i] = strings.ToUpper(word)
+		default:
+			if word != "" {
+				words[i] = strings.ToUpper(word[:1]) + word[1:]
+			}
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func connectorFieldPlaceholder(sourceID string, key string, referenceOnly bool) string {
+	if referenceOnly {
+		return "env:" + connectorSuggestedEnvName(sourceID, key)
+	}
+	switch key {
+	case "profile":
+		return "cerebro-readonly"
+	case "region":
+		return "us-east-1"
+	case "family":
+		return "audit"
+	case "include_global":
+		return "true"
+	default:
+		return ""
+	}
+}
+
+func connectorFieldHelp(sourceID string, authMethod string, key string) string {
+	if authMethod == connectorAuthMethodAWSSSOProfile && key == "profile" {
+		return "AWS SDK shared config profile already authenticated on the server."
+	}
+	if authMethod != connectorAuthMethodEncryptedSubmission && sourceconfig.SensitiveKey(key) {
+		return "Server-resolvable reference; the browser never receives the secret value."
+	}
+	if strings.TrimSpace(sourceID) == "aws" && key == "role_arn" {
+		return "Optional IAM role; server-side allowlist validation still applies."
+	}
+	return ""
+}
+
+func connectorSuggestedEnvName(sourceID string, key string) string {
+	return "CEREBRO_SOURCE_" + connectorEnvComponent(sourceID) + "_" + connectorEnvComponent(key)
+}
+
+func connectorEnvComponent(value string) string {
+	var builder strings.Builder
+	for _, char := range strings.TrimSpace(value) {
+		switch {
+		case char >= 'a' && char <= 'z':
+			builder.WriteRune(char - 'a' + 'A')
+		case char >= 'A' && char <= 'Z':
+			builder.WriteRune(char)
+		case char >= '0' && char <= '9':
+			builder.WriteRune(char)
+		default:
+			builder.WriteByte('_')
+		}
+	}
+	component := strings.Trim(builder.String(), "_")
+	if component == "" {
+		return "CONFIG"
+	}
+	return component
+}
+
 func connectorStoreViews(vaultStatus connectorVaultView, transport connectorTransportView) []connectorStoreView {
 	available := vaultStatus.Available && transport.Available
 	detail := strings.TrimSpace(vaultStatus.Detail)
@@ -315,18 +663,190 @@ func connectorStoreViews(vaultStatus connectorVaultView, transport connectorTran
 			Mode:      "encrypted_submission",
 			Detail:    detail,
 		},
+		{
+			ID:        connectorStoreEnvironmentManaged,
+			Label:     "Environment managed",
+			Provider:  "Deployment",
+			Available: true,
+			Mode:      "environment_managed",
+			Detail:    "ready",
+		},
+		{
+			ID:        connectorStoreInfisical,
+			Label:     "Infisical",
+			Provider:  "Infisical",
+			Available: true,
+			Mode:      connectorCredentialStoreModeRefs,
+			Detail:    "reference-backed",
+		},
+		{
+			ID:        connectorStoreGoogleSecretMgr,
+			Label:     "Google Secret Manager",
+			Provider:  "Google Cloud Platform",
+			Available: true,
+			Mode:      connectorCredentialStoreModeRefs,
+			Detail:    "reference-backed",
+		},
+		{
+			ID:        connectorStoreAWSSecretsManager,
+			Label:     "AWS Secrets Manager",
+			Provider:  "Amazon Web Services",
+			Available: true,
+			Mode:      connectorCredentialStoreModeRefs,
+			Detail:    "reference-backed",
+		},
+		{
+			ID:        connectorStoreAzureKeyVault,
+			Label:     "Azure Key Vault",
+			Provider:  "Microsoft Azure",
+			Available: true,
+			Mode:      connectorCredentialStoreModeRefs,
+			Detail:    "reference-backed",
+		},
+		{
+			ID:        connectorStoreHashiCorpVault,
+			Label:     "HashiCorp Vault",
+			Provider:  "HashiCorp",
+			Available: true,
+			Mode:      connectorCredentialStoreModeRefs,
+			Detail:    "reference-backed",
+		},
 	}
 }
 
-func normalizeConnectorCredentialStoreID(value string) (string, error) {
+func connectorConnectionMethods(sourceID string, stores []connectorStoreView) []connectorConnectionMethodView {
+	vaultAvailable := connectorStoreAvailable(stores, defaultConnectorCredentialStoreID)
+	environmentAvailable := connectorStoreAvailable(stores, connectorStoreEnvironmentManaged)
+	externalStores := []string{connectorStoreInfisical, connectorStoreGoogleSecretMgr, connectorStoreAWSSecretsManager, connectorStoreAzureKeyVault, connectorStoreHashiCorpVault}
+	externalAvailable := connectorAnyStoreAvailable(stores, externalStores...)
+	methods := []connectorConnectionMethodView{
+		{
+			ID:                connectorAuthMethodEncryptedSubmission,
+			Label:             "Encrypted browser submission",
+			Description:       "Submit one encrypted credential payload to Cerebro Vault.",
+			CredentialStores:  []string{defaultConnectorCredentialStoreID},
+			ConfigFields:      connectorConfigFields(sourceID, connectorAuthMethodEncryptedSubmission),
+			CredentialFields:  connectorCredentialFields(sourceID, connectorAuthMethodEncryptedSubmission),
+			RequiresSecrets:   true,
+			Saveable:          vaultAvailable,
+			UnavailableReason: connectorUnavailableReason(vaultAvailable, "Cerebro Vault or the credential transit key is unavailable."),
+		},
+		{
+			ID:                connectorAuthMethodEnvironmentManaged,
+			Label:             "Environment-managed reference",
+			Description:       "Store env-backed credential references for deployment-side resolution.",
+			CredentialStores:  []string{connectorStoreEnvironmentManaged},
+			ConfigFields:      connectorConfigFields(sourceID, connectorAuthMethodEnvironmentManaged),
+			CredentialFields:  connectorCredentialFields(sourceID, connectorAuthMethodEnvironmentManaged),
+			Saveable:          environmentAvailable,
+			UnavailableReason: connectorUnavailableReason(environmentAvailable, "Environment-managed references are unavailable."),
+		},
+		{
+			ID:                connectorAuthMethodInfisicalCLI,
+			Label:             "Infisical CLI handoff",
+			Description:       "Use Infisical SSO/CLI to populate deployment env references consumed by Cerebro.",
+			CredentialStores:  []string{connectorStoreEnvironmentManaged},
+			ConfigFields:      connectorConfigFields(sourceID, connectorAuthMethodInfisicalCLI),
+			CredentialFields:  connectorCredentialFields(sourceID, connectorAuthMethodInfisicalCLI),
+			Saveable:          environmentAvailable,
+			UnavailableReason: connectorUnavailableReason(environmentAvailable, "Environment-managed references are unavailable."),
+		},
+		{
+			ID:                connectorAuthMethodExternalReference,
+			Label:             "External secret-store reference",
+			Description:       "Select an operator-managed secret store and save only server-resolvable references.",
+			CredentialStores:  externalStores,
+			ConfigFields:      connectorConfigFields(sourceID, connectorAuthMethodExternalReference),
+			CredentialFields:  connectorCredentialFields(sourceID, connectorAuthMethodExternalReference),
+			Saveable:          externalAvailable,
+			UnavailableReason: connectorUnavailableReason(externalAvailable, "External secret-store references are unavailable."),
+		},
+	}
+	if strings.TrimSpace(sourceID) == "aws" {
+		methods = append([]connectorConnectionMethodView{{
+			ID:                connectorAuthMethodAWSSSOProfile,
+			Label:             "AWS IAM Identity Center profile",
+			Description:       "Use AWS CLI SSO and save a deployment-managed profile/role runtime.",
+			CredentialStores:  []string{connectorStoreEnvironmentManaged},
+			ConfigFields:      connectorConfigFields(sourceID, connectorAuthMethodAWSSSOProfile),
+			Saveable:          environmentAvailable,
+			UnavailableReason: connectorUnavailableReason(environmentAvailable, "Environment-managed AWS profiles are unavailable."),
+		}}, methods...)
+	}
+	return methods
+}
+
+func connectorUnavailableReason(available bool, reason string) string {
+	if available {
+		return ""
+	}
+	return reason
+}
+
+func connectorStoreAvailable(stores []connectorStoreView, id string) bool {
+	for _, store := range stores {
+		if store.ID == id {
+			return store.Available
+		}
+	}
+	return false
+}
+
+func connectorAnyStoreAvailable(stores []connectorStoreView, ids ...string) bool {
+	for _, id := range ids {
+		if connectorStoreAvailable(stores, id) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeConnectorAuthMethod(value string) string {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
-		return defaultConnectorCredentialStoreID, nil
+		return connectorAuthMethodEncryptedSubmission
 	}
-	if trimmed != defaultConnectorCredentialStoreID {
+	return trimmed
+}
+
+func normalizeConnectorCredentialStoreID(value string, authMethod string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		switch authMethod {
+		case connectorAuthMethodEncryptedSubmission:
+			return defaultConnectorCredentialStoreID, nil
+		case connectorAuthMethodExternalReference:
+			return "", fmt.Errorf("%w: credential_store_id is required for external references", connectorcredentials.ErrInvalidRequest)
+		default:
+			return connectorStoreEnvironmentManaged, nil
+		}
+	}
+	switch authMethod {
+	case connectorAuthMethodEncryptedSubmission:
+		if trimmed != defaultConnectorCredentialStoreID {
+			return "", fmt.Errorf("%w: credential store is not available for encrypted submission", connectorcredentials.ErrInvalidRequest)
+		}
+	case connectorAuthMethodAWSSSOProfile, connectorAuthMethodInfisicalCLI, connectorAuthMethodEnvironmentManaged:
+		if trimmed != connectorStoreEnvironmentManaged {
+			return "", fmt.Errorf("%w: credential store is not available for environment-managed references", connectorcredentials.ErrInvalidRequest)
+		}
+	case connectorAuthMethodExternalReference:
+		if !connectorExternalReferenceStore(trimmed) {
+			return "", fmt.Errorf("%w: credential store is not available for external references", connectorcredentials.ErrInvalidRequest)
+		}
+	default:
 		return "", fmt.Errorf("%w: credential store is not available", connectorcredentials.ErrInvalidRequest)
 	}
 	return trimmed, nil
+}
+
+func connectorExternalReferenceStore(id string) bool {
+	switch strings.TrimSpace(id) {
+	case connectorStoreInfisical, connectorStoreGoogleSecretMgr, connectorStoreAWSSecretsManager, connectorStoreAzureKeyVault, connectorStoreHashiCorpVault:
+		return true
+	default:
+		return false
+	}
 }
 
 func connectorCredentialAdditionalData(keyID string, sourceID string, tenantID string, runtimeID string, credentialStoreID string) []byte {
@@ -349,12 +869,193 @@ func connectorRuntimeConfig(input map[string]string) (map[string]string, error) 
 		if trimmedKey == "" {
 			continue
 		}
+		if sourceconfig.InternalKey(trimmedKey) {
+			return nil, fmt.Errorf("%w: internal config %q cannot be supplied by connector requests", connectorcredentials.ErrInvalidRequest, trimmedKey)
+		}
 		if sourceconfig.SensitiveKey(trimmedKey) && strings.TrimSpace(value) != "" && !sourceconfig.IsCredentialReference(value) {
 			return nil, fmt.Errorf("%w: sensitive config %q must be supplied in encrypted_credentials", connectorcredentials.ErrInvalidRequest, trimmedKey)
 		}
 		config[trimmedKey] = value
 	}
 	return config, nil
+}
+
+func applyConnectorCredentialReferences(config map[string]string, references map[string]string) error {
+	for key, value := range references {
+		trimmedKey := strings.TrimSpace(key)
+		trimmedValue := strings.TrimSpace(value)
+		if trimmedKey == "" || trimmedValue == "" {
+			return fmt.Errorf("%w: credential reference key and value are required", connectorcredentials.ErrInvalidRequest)
+		}
+		if sourceconfig.InternalKey(trimmedKey) {
+			return fmt.Errorf("%w: internal config %q cannot be supplied by connector references", connectorcredentials.ErrInvalidRequest, trimmedKey)
+		}
+		if !sourceconfig.IsSecretReference(trimmedValue) {
+			return fmt.Errorf("%w: credential reference %q must use an env reference", connectorcredentials.ErrInvalidRequest, trimmedKey)
+		}
+		config[trimmedKey] = trimmedValue
+	}
+	return nil
+}
+
+func validateConnectorConnectionShape(sourceID string, authMethod string, credentialStoreID string, config map[string]string, references map[string]string, encrypted connectorcredentials.EncryptedPayload) error {
+	switch authMethod {
+	case connectorAuthMethodEncryptedSubmission:
+		if credentialStoreID != defaultConnectorCredentialStoreID {
+			return fmt.Errorf("%w: encrypted submission requires Cerebro Vault", connectorcredentials.ErrInvalidRequest)
+		}
+		if len(references) > 0 {
+			return fmt.Errorf("%w: encrypted submission cannot include credential references", connectorcredentials.ErrInvalidRequest)
+		}
+		if !connectorEncryptedPayloadPresent(encrypted) {
+			return fmt.Errorf("%w: encrypted_credentials is required", connectorcredentials.ErrInvalidRequest)
+		}
+	case connectorAuthMethodAWSSSOProfile:
+		if strings.TrimSpace(sourceID) != "aws" {
+			return fmt.Errorf("%w: aws_sso_profile is only available for aws", connectorcredentials.ErrInvalidRequest)
+		}
+		if credentialStoreID != connectorStoreEnvironmentManaged {
+			return fmt.Errorf("%w: aws_sso_profile requires environment-managed storage", connectorcredentials.ErrInvalidRequest)
+		}
+		if connectorEncryptedPayloadPresent(encrypted) {
+			return fmt.Errorf("%w: aws_sso_profile cannot include encrypted credentials", connectorcredentials.ErrInvalidRequest)
+		}
+		if len(references) > 0 {
+			return fmt.Errorf("%w: aws_sso_profile cannot include credential references", connectorcredentials.ErrInvalidRequest)
+		}
+		if strings.TrimSpace(config["profile"]) == "" {
+			return fmt.Errorf("%w: aws_sso_profile requires profile", connectorcredentials.ErrInvalidRequest)
+		}
+	case connectorAuthMethodInfisicalCLI, connectorAuthMethodEnvironmentManaged:
+		if credentialStoreID != connectorStoreEnvironmentManaged {
+			return fmt.Errorf("%w: environment-managed auth requires environment-managed storage", connectorcredentials.ErrInvalidRequest)
+		}
+		if connectorEncryptedPayloadPresent(encrypted) {
+			return fmt.Errorf("%w: environment-managed auth cannot include encrypted credentials", connectorcredentials.ErrInvalidRequest)
+		}
+		if authMethod == connectorAuthMethodInfisicalCLI && len(references) == 0 {
+			return fmt.Errorf("%w: infisical_cli requires credential references", connectorcredentials.ErrInvalidRequest)
+		}
+	case connectorAuthMethodExternalReference:
+		if !connectorExternalReferenceStore(credentialStoreID) {
+			return fmt.Errorf("%w: external_reference requires an external credential store", connectorcredentials.ErrInvalidRequest)
+		}
+		if connectorEncryptedPayloadPresent(encrypted) {
+			return fmt.Errorf("%w: external_reference cannot include encrypted credentials", connectorcredentials.ErrInvalidRequest)
+		}
+		if len(references) == 0 {
+			return fmt.Errorf("%w: external_reference requires credential references", connectorcredentials.ErrInvalidRequest)
+		}
+	default:
+		return fmt.Errorf("%w: unsupported auth method", connectorcredentials.ErrInvalidRequest)
+	}
+	if err := validateConnectorConfigFields(sourceID, authMethod, config, references); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateConnectorConfigFields(sourceID string, authMethod string, config map[string]string, references map[string]string) error {
+	schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]
+	if !ok {
+		return nil
+	}
+	for key := range config {
+		if authMethod == connectorAuthMethodAWSSSOProfile && key == "profile" {
+			continue
+		}
+		if _, ok := schema.ConfigKeys[key]; ok {
+			continue
+		}
+		if _, ok := references[key]; ok {
+			if _, credentialOK := schema.CredentialKeys[key]; credentialOK {
+				continue
+			}
+		}
+		return fmt.Errorf("%w: unsupported connector config %q", connectorcredentials.ErrInvalidRequest, key)
+	}
+	for _, key := range schema.RequiredConfig {
+		if strings.TrimSpace(config[key]) == "" {
+			return fmt.Errorf("%w: connector config %q is required", connectorcredentials.ErrInvalidRequest, key)
+		}
+	}
+	if authMethod == connectorAuthMethodEncryptedSubmission || authMethod == connectorAuthMethodAWSSSOProfile {
+		return nil
+	}
+	for _, key := range schema.RequiredCredentials {
+		if strings.TrimSpace(config[key]) == "" {
+			return fmt.Errorf("%w: credential reference %q is required", connectorcredentials.ErrInvalidRequest, key)
+		}
+	}
+	return nil
+}
+
+func validateConnectorCredentialFields(sourceID string, authMethod string, fields map[string]string) error {
+	if authMethod != connectorAuthMethodEncryptedSubmission {
+		return nil
+	}
+	schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]
+	if !ok {
+		return nil
+	}
+	for key := range fields {
+		if _, ok := schema.CredentialKeys[key]; !ok {
+			return fmt.Errorf("%w: unsupported credential field %q", connectorcredentials.ErrInvalidRequest, key)
+		}
+	}
+	for _, key := range schema.RequiredCredentials {
+		if strings.TrimSpace(fields[key]) == "" {
+			return fmt.Errorf("%w: credential field %q is required", connectorcredentials.ErrInvalidRequest, key)
+		}
+	}
+	return nil
+}
+
+func connectorEncryptedPayloadPresent(payload connectorcredentials.EncryptedPayload) bool {
+	return strings.TrimSpace(payload.KeyID) != "" ||
+		strings.TrimSpace(payload.Algorithm) != "" ||
+		strings.TrimSpace(payload.WrappedKey) != "" ||
+		strings.TrimSpace(payload.Nonce) != "" ||
+		strings.TrimSpace(payload.Ciphertext) != ""
+}
+
+func sortedStringKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func copyStringMap(values map[string]string) map[string]string {
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func stringSet(values ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
+}
+
+func sortedSetKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func setContains(values map[string]struct{}, key string) bool {
+	_, ok := values[key]
+	return ok
 }
 
 func connectorCredentialVault(credentialConfig config.ConnectorCredentialConfig, store ports.StateStore) (*connectorcredentials.Vault, error) {
@@ -410,6 +1111,7 @@ func writeConnectorError(w http.ResponseWriter, err error) {
 		errors.Is(err, sourceops.ErrSourceNotFound):
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 	case errors.Is(err, connectorcredentials.ErrInvalidRequest),
+		errors.Is(err, sourceops.ErrInvalidRequest),
 		errors.Is(err, sourceruntime.ErrInvalidRequest),
 		errors.Is(err, errInvalidHTTPRequest):
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -265,7 +265,7 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 			writeConnectorError(w, connectorcredentials.ErrUnavailable)
 			return
 		}
-		decrypted, err := a.connectorTransitKey.DecryptWithAdditionalData(
+		decrypted, err := a.connectorTransitKey.DecryptWithExactAdditionalData(
 			request.EncryptedCredentials,
 			connectorCredentialAdditionalData(request.EncryptedCredentials.KeyID, sourceID, tenantID, runtimeID, credentialStoreID),
 		)

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -21,6 +21,8 @@ import (
 	"github.com/writer/cerebro/internal/sourceruntime"
 )
 
+const defaultConnectorCredentialStoreID = "cerebro_vault"
+
 type connectorCatalogEntry struct {
 	SourceID               string   `json:"source_id"`
 	Name                   string   `json:"name"`
@@ -38,6 +40,7 @@ type connectorLibraryResponse struct {
 	RuntimeStore        string                  `json:"runtime_store"`
 	CredentialTransport connectorTransportView  `json:"credential_transport"`
 	CredentialVault     connectorVaultView      `json:"credential_vault"`
+	CredentialStores    []connectorStoreView    `json:"credential_stores,omitempty"`
 }
 
 type connectorTransportView struct {
@@ -51,9 +54,20 @@ type connectorVaultView struct {
 	Detail    string `json:"detail,omitempty"`
 }
 
+type connectorStoreView struct {
+	ID        string `json:"id"`
+	Label     string `json:"label"`
+	Provider  string `json:"provider"`
+	Available bool   `json:"available"`
+	Default   bool   `json:"default,omitempty"`
+	Mode      string `json:"mode"`
+	Detail    string `json:"detail,omitempty"`
+}
+
 type connectorConnectionRequest struct {
 	RuntimeID            string                                `json:"runtime_id"`
 	TenantID             string                                `json:"tenant_id"`
+	CredentialStoreID    string                                `json:"credential_store_id,omitempty"`
 	Config               map[string]string                     `json:"config"`
 	EncryptedCredentials connectorcredentials.EncryptedPayload `json:"encrypted_credentials"`
 }
@@ -69,6 +83,7 @@ type connectorCredentialView struct {
 	TenantID  string   `json:"tenant_id"`
 	SourceID  string   `json:"source_id"`
 	RuntimeID string   `json:"runtime_id"`
+	StoreID   string   `json:"credential_store_id"`
 	KeyID     string   `json:"key_id"`
 	Fields    []string `json:"fields"`
 	CreatedAt string   `json:"created_at,omitempty"`
@@ -118,12 +133,14 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 	if a.connectorTransitKey != nil {
 		transport.Algorithm = a.connectorTransitKey.PublicKey().Algorithm
 	}
+	vaultStatus := connectorVaultStatus(a.cfg.ConnectorCredentials, a.deps.StateStore)
 	writeJSON(w, http.StatusOK, connectorLibraryResponse{
 		Connectors:          entries,
 		TenantID:            tenantID,
 		RuntimeStore:        runtimeStoreStatus,
 		CredentialTransport: transport,
-		CredentialVault:     connectorVaultStatus(a.cfg.ConnectorCredentials, a.deps.StateStore),
+		CredentialVault:     vaultStatus,
+		CredentialStores:    connectorStoreViews(vaultStatus, transport),
 	})
 }
 
@@ -156,6 +173,11 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 		writeConnectorError(w, fmt.Errorf("%w: tenant_id is required", connectorcredentials.ErrInvalidRequest))
 		return
 	}
+	credentialStoreID, err := normalizeConnectorCredentialStoreID(request.CredentialStoreID)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
 	runtimeConfig, err := connectorRuntimeConfig(request.Config)
 	if err != nil {
 		writeConnectorError(w, err)
@@ -175,7 +197,10 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 		writeConnectorError(w, connectorcredentials.ErrUnavailable)
 		return
 	}
-	decrypted, err := a.connectorTransitKey.Decrypt(request.EncryptedCredentials)
+	decrypted, err := a.connectorTransitKey.DecryptWithAdditionalData(
+		request.EncryptedCredentials,
+		connectorCredentialAdditionalData(request.EncryptedCredentials.KeyID, sourceID, tenantID, runtimeID, credentialStoreID),
+	)
 	if err != nil {
 		writeConnectorError(w, err)
 		return
@@ -221,6 +246,7 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 			TenantID:  record.TenantID,
 			SourceID:  record.SourceID,
 			RuntimeID: record.RuntimeID,
+			StoreID:   credentialStoreID,
 			KeyID:     record.KeyID,
 			Fields:    connectorcredentials.SortedFieldNames(fields),
 			CreatedAt: connectorcredentials.TimestampOrZero(record.CreatedAt),
@@ -271,6 +297,49 @@ func connectorRuntimeHealthy(runtime *cerebrov1.SourceRuntime) bool {
 		return status == "completed" || status == "healthy"
 	}
 	return runtime.GetLastSyncedAt() != nil
+}
+
+func connectorStoreViews(vaultStatus connectorVaultView, transport connectorTransportView) []connectorStoreView {
+	available := vaultStatus.Available && transport.Available
+	detail := strings.TrimSpace(vaultStatus.Detail)
+	if available {
+		detail = "ready"
+	}
+	return []connectorStoreView{
+		{
+			ID:        defaultConnectorCredentialStoreID,
+			Label:     "Cerebro Vault",
+			Provider:  "Cerebro",
+			Available: available,
+			Default:   true,
+			Mode:      "encrypted_submission",
+			Detail:    detail,
+		},
+	}
+}
+
+func normalizeConnectorCredentialStoreID(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return defaultConnectorCredentialStoreID, nil
+	}
+	if trimmed != defaultConnectorCredentialStoreID {
+		return "", fmt.Errorf("%w: credential store is not available", connectorcredentials.ErrInvalidRequest)
+	}
+	return trimmed, nil
+}
+
+func connectorCredentialAdditionalData(keyID string, sourceID string, tenantID string, runtimeID string, credentialStoreID string) []byte {
+	parts := []string{
+		"connector-credential",
+		"v1",
+		strings.TrimSpace(keyID),
+		strings.TrimSpace(sourceID),
+		strings.TrimSpace(tenantID),
+		strings.TrimSpace(runtimeID),
+		strings.TrimSpace(credentialStoreID),
+	}
+	return []byte(strings.Join(parts, "\x00"))
 }
 
 func connectorRuntimeConfig(input map[string]string) (map[string]string, error) {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -203,6 +203,315 @@ func TestConnectorConnectionRejectsUnsupportedCredentialStore(t *testing.T) {
 	}
 }
 
+func TestConnectorCatalogAdvertisesConnectionMethods(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors")
+	if err != nil {
+		t.Fatalf("GET /connectors error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /connectors status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		Connectors []struct {
+			SourceID          string `json:"source_id"`
+			DisplayName       string `json:"display_name"`
+			ConnectionMethods []struct {
+				ID       string `json:"id"`
+				Saveable bool   `json:"saveable"`
+			} `json:"connection_methods"`
+		} `json:"connectors"`
+		CredentialStores []struct {
+			ID        string `json:"id"`
+			Available bool   `json:"available"`
+		} `json:"credential_stores"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.Connectors) != 1 {
+		t.Fatalf("connectors len = %d, want 1", len(payload.Connectors))
+	}
+	if got := payload.Connectors[0].DisplayName; got != "Bootstrap token source" {
+		t.Fatalf("display_name = %q, want fallback source name", got)
+	}
+	methods := map[string]bool{}
+	for _, method := range payload.Connectors[0].ConnectionMethods {
+		methods[method.ID] = method.Saveable
+	}
+	if !methods[connectorAuthMethodEncryptedSubmission] {
+		t.Fatalf("encrypted submission method not saveable: %#v", methods)
+	}
+	if !methods[connectorAuthMethodEnvironmentManaged] {
+		t.Fatalf("environment-managed method not saveable: %#v", methods)
+	}
+	stores := map[string]bool{}
+	for _, store := range payload.CredentialStores {
+		stores[store.ID] = store.Available
+	}
+	if !stores[connectorStoreEnvironmentManaged] {
+		t.Fatalf("environment-managed store not advertised available: %#v", stores)
+	}
+}
+
+func TestConnectorConnectionStoresEnvironmentManagedReference(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: store}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+	t.Setenv("CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN", "resolved-env-token")
+
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":          "runtime-env",
+		"tenant_id":           "tenant-a",
+		"auth_method":         connectorAuthMethodInfisicalCLI,
+		"credential_store_id": connectorStoreEnvironmentManaged,
+		"config":              map[string]string{"family": "audit"},
+		"credential_references": map[string]string{
+			"token": "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN", // #nosec G101 -- env reference string, not a secret value.
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/connections", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /connectors environment reference error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /connectors environment reference status = %d, want 200", resp.StatusCode)
+	}
+	if source.checkToken != "resolved-env-token" {
+		t.Fatalf("source check token = %q, want resolved-env-token", source.checkToken)
+	}
+	runtime := store.runtimes["runtime-env"]
+	if runtime == nil {
+		t.Fatal("stored runtime missing")
+	}
+	if got := runtime.GetConfig()["token"]; got != "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN" {
+		t.Fatalf("stored runtime token = %q, want env reference", got)
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	credentialPayload, ok := payload["credential"].(map[string]any)
+	if !ok {
+		t.Fatalf("credential payload = %#v", payload["credential"])
+	}
+	if got := credentialPayload["auth_method"]; got != connectorAuthMethodInfisicalCLI {
+		t.Fatalf("credential auth_method = %#v, want %q", got, connectorAuthMethodInfisicalCLI)
+	}
+	if got := credentialPayload["credential_store_id"]; got != connectorStoreEnvironmentManaged {
+		t.Fatalf("credential_store_id = %#v, want %q", got, connectorStoreEnvironmentManaged)
+	}
+}
+
+func TestConnectorConnectionCheckOnlyDoesNotPersistCredentialOrRuntime(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	key := app.connectorTransitKey.PublicKey()
+	encrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "secret-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-a", "runtime-check", defaultConnectorCredentialStoreID),
+	)
+	if err != nil {
+		t.Fatalf("encrypt credentials: %v", err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":            "runtime-check",
+		"tenant_id":             "tenant-a",
+		"check_only":            true,
+		"auth_method":           connectorAuthMethodEncryptedSubmission,
+		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"config":                map[string]string{"family": "audit"},
+		"encrypted_credentials": encrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/connections", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /connectors check-only error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /connectors check-only status = %d, want 200", resp.StatusCode)
+	}
+	if source.checkToken != "secret-token" {
+		t.Fatalf("source check token = %q, want decrypted secret", source.checkToken)
+	}
+	if len(store.runtimes) != 0 {
+		t.Fatalf("stored runtimes len = %d, want 0", len(store.runtimes))
+	}
+	if len(store.credentials) != 0 {
+		t.Fatalf("stored credentials len = %d, want 0", len(store.credentials))
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload["status"]; got != "checked" {
+		t.Fatalf("status = %#v, want checked", got)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal response payload: %v", err)
+	}
+	if strings.Contains(string(encoded), "secret-token") {
+		t.Fatalf("check-only response leaked secret: %s", encoded)
+	}
+}
+
+func TestConnectorConnectionStoresExternalStoreReference(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: store}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+	t.Setenv("CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN", "resolved-external-token")
+
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":          "runtime-external",
+		"tenant_id":           "tenant-a",
+		"auth_method":         connectorAuthMethodExternalReference,
+		"credential_store_id": connectorStoreInfisical,
+		"config":              map[string]string{"family": "audit"},
+		"credential_references": map[string]string{
+			"token": "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN", // #nosec G101 -- env reference string, not a secret value.
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/connections", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /connectors external reference error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /connectors external reference status = %d, want 200", resp.StatusCode)
+	}
+	if source.checkToken != "resolved-external-token" {
+		t.Fatalf("source check token = %q, want resolved-external-token", source.checkToken)
+	}
+	runtime := store.runtimes["runtime-external"]
+	if runtime == nil {
+		t.Fatal("stored runtime missing")
+	}
+	if got := runtime.GetConfig()["token"]; got != "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN" {
+		t.Fatalf("stored runtime token = %q, want env reference", got)
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	credentialPayload, ok := payload["credential"].(map[string]any)
+	if !ok {
+		t.Fatalf("credential payload = %#v", payload["credential"])
+	}
+	if got := credentialPayload["auth_method"]; got != connectorAuthMethodExternalReference {
+		t.Fatalf("credential auth_method = %#v, want %q", got, connectorAuthMethodExternalReference)
+	}
+	if got := credentialPayload["credential_store_id"]; got != connectorStoreInfisical {
+		t.Fatalf("credential_store_id = %#v, want %q", got, connectorStoreInfisical)
+	}
+}
+
+func TestConnectorConnectionRejectsInternalConfigAndUnsupportedAuth(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	for name, body := range map[string]string{
+		"internal_config": `{"runtime_id":"runtime-a","tenant_id":"tenant-a","auth_method":"environment_managed","credential_store_id":"environment_managed","config":{"__cerebro_aws_assume_role_arns":"caller-controlled"}}`,
+		"wrong_source":    `{"runtime_id":"runtime-a","tenant_id":"tenant-a","auth_method":"aws_sso_profile","credential_store_id":"environment_managed","config":{"account_id":"123456789012","profile":"cerebro"}}`,
+	} {
+		resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/connections", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("%s: POST /connectors error = %v", name, err)
+		}
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("%s: close response: %v", name, closeErr)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("%s: POST /connectors status = %d, want 400", name, resp.StatusCode)
+		}
+	}
+}
+
 func TestConnectorTransitKeyIsSharedAcrossReplicas(t *testing.T) {
 	source := &bootstrapTokenSource{id: "bootstrap_token"}
 	registry, err := sourcecdk.NewRegistry(source)

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -70,13 +70,19 @@ func TestConnectorConnectionStoresCredentialReference(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	encrypted, err := encryptConnectorCredentialsForTest(app.connectorTransitKey.PublicKey(), map[string]string{"token": "secret-token"})
+	key := app.connectorTransitKey.PublicKey()
+	encrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "secret-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-a", "runtime-a", defaultConnectorCredentialStoreID),
+	)
 	if err != nil {
 		t.Fatalf("encrypt credentials: %v", err)
 	}
 	body, err := json.Marshal(map[string]any{
 		"runtime_id":            "runtime-a",
 		"tenant_id":             "tenant-a",
+		"credential_store_id":   defaultConnectorCredentialStoreID,
 		"config":                map[string]string{"family": "audit"},
 		"encrypted_credentials": encrypted,
 	})
@@ -109,6 +115,13 @@ func TestConnectorConnectionStoresCredentialReference(t *testing.T) {
 	}
 	if got := configPayload["token"]; got != "[redacted]" {
 		t.Fatalf("response token = %#v, want [redacted]", got)
+	}
+	credentialPayload, ok := payload["credential"].(map[string]any)
+	if !ok {
+		t.Fatalf("credential payload = %#v", payload["credential"])
+	}
+	if got := credentialPayload["credential_store_id"]; got != defaultConnectorCredentialStoreID {
+		t.Fatalf("credential_store_id = %#v, want %q", got, defaultConnectorCredentialStoreID)
 	}
 	runtime := store.runtimes["runtime-a"]
 	if runtime == nil {
@@ -155,6 +168,38 @@ func TestConnectorConnectionRejectsPlaintextSensitiveConfig(t *testing.T) {
 	}()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("POST /connectors plaintext status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestConnectorConnectionRejectsUnsupportedCredentialStore(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := []byte(`{"runtime_id":"runtime-a","tenant_id":"tenant-a","credential_store_id":"google_secret_manager","encrypted_credentials":{"key_id":"ignored","algorithm":"RSA-OAEP-256+A256GCM"}}`)
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/connections", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /connectors unsupported credential store error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("POST /connectors unsupported credential store status = %d, want 400", resp.StatusCode)
 	}
 }
 
@@ -242,6 +287,10 @@ func testConnectorTransitPrivateKeyPEM(t *testing.T) string {
 }
 
 func encryptConnectorCredentialsForTest(key connectorcredentials.PublicKey, fields map[string]string) (connectorcredentials.EncryptedPayload, error) {
+	return encryptConnectorCredentialsForTestWithAAD(key, fields, []byte(key.KeyID))
+}
+
+func encryptConnectorCredentialsForTestWithAAD(key connectorcredentials.PublicKey, fields map[string]string, additionalData []byte) (connectorcredentials.EncryptedPayload, error) {
 	plaintext, err := json.Marshal(fields)
 	if err != nil {
 		return connectorcredentials.EncryptedPayload{}, err
@@ -275,7 +324,7 @@ func encryptConnectorCredentialsForTest(key connectorcredentials.PublicKey, fiel
 		Algorithm:  key.Algorithm,
 		WrappedKey: base64.StdEncoding.EncodeToString(wrapped),
 		Nonce:      base64.StdEncoding.EncodeToString(nonce),
-		Ciphertext: base64.StdEncoding.EncodeToString(gcm.Seal(nil, nonce, plaintext, []byte(key.KeyID))),
+		Ciphertext: base64.StdEncoding.EncodeToString(gcm.Seal(nil, nonce, plaintext, additionalData)),
 	}, nil
 }
 

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -171,6 +171,63 @@ func TestConnectorConnectionRejectsPlaintextSensitiveConfig(t *testing.T) {
 	}
 }
 
+func TestConnectorConnectionRejectsLegacyAADEncryptedSubmission(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	key := app.connectorTransitKey.PublicKey()
+	encrypted, err := encryptConnectorCredentialsForTest(key, map[string]string{"token": "secret-token"})
+	if err != nil {
+		t.Fatalf("encrypt credentials: %v", err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":            "runtime-a",
+		"tenant_id":             "tenant-a",
+		"auth_method":           connectorAuthMethodEncryptedSubmission,
+		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"config":                map[string]string{"family": "audit"},
+		"encrypted_credentials": encrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/connections", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /connectors legacy AAD error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("POST /connectors legacy AAD status = %d, want 400", resp.StatusCode)
+	}
+	if source.checkToken != "" {
+		t.Fatalf("source check token = %q, want no source check", source.checkToken)
+	}
+	if len(store.runtimes) != 0 {
+		t.Fatalf("stored runtimes len = %d, want 0", len(store.runtimes))
+	}
+	if len(store.credentials) != 0 {
+		t.Fatalf("stored credentials len = %d, want 0", len(store.credentials))
+	}
+}
+
 func TestConnectorConnectionRejectsUnsupportedCredentialStore(t *testing.T) {
 	source := &bootstrapTokenSource{id: "bootstrap_token"}
 	registry, err := sourcecdk.NewRegistry(source)
@@ -543,13 +600,14 @@ func TestConnectorTransitKeyIsSharedAcrossReplicas(t *testing.T) {
 	if keyA.KeyID == "" || keyA.KeyID != keyB.KeyID {
 		t.Fatalf("transit key IDs = %q and %q, want shared stable key ID", keyA.KeyID, keyB.KeyID)
 	}
-	encrypted, err := encryptConnectorCredentialsForTest(keyA, map[string]string{"token": "secret-token"})
+	additionalData := connectorCredentialAdditionalData(keyA.KeyID, "bootstrap_token", "tenant-a", "runtime-a", defaultConnectorCredentialStoreID)
+	encrypted, err := encryptConnectorCredentialsForTestWithAAD(keyA, map[string]string{"token": "secret-token"}, additionalData)
 	if err != nil {
 		t.Fatalf("encrypt credentials: %v", err)
 	}
-	decrypted, err := appB.connectorTransitKey.Decrypt(encrypted)
+	decrypted, err := appB.connectorTransitKey.DecryptWithExactAdditionalData(encrypted, additionalData)
 	if err != nil {
-		t.Fatalf("Decrypt() on second app error = %v", err)
+		t.Fatalf("DecryptWithExactAdditionalData() on second app error = %v", err)
 	}
 	var fields map[string]string
 	if err := json.Unmarshal(decrypted, &fields); err != nil {

--- a/internal/connectorcredentials/credentials.go
+++ b/internal/connectorcredentials/credentials.go
@@ -188,10 +188,21 @@ func (k *TransitKey) PublicKey() PublicKey {
 }
 
 func (k *TransitKey) Decrypt(payload EncryptedPayload) ([]byte, error) {
-	return k.DecryptWithAdditionalData(payload, []byte(payload.KeyID))
+	return k.DecryptWithAdditionalData(payload, nil)
 }
 
 func (k *TransitKey) DecryptWithAdditionalData(payload EncryptedPayload, additionalData []byte) ([]byte, error) {
+	return k.decryptWithAdditionalData(payload, additionalData)
+}
+
+func (k *TransitKey) DecryptWithExactAdditionalData(payload EncryptedPayload, additionalData []byte) ([]byte, error) {
+	if len(additionalData) == 0 {
+		return nil, fmt.Errorf("%w: credential payload context is required", ErrInvalidRequest)
+	}
+	return k.decryptWithAdditionalData(payload, additionalData)
+}
+
+func (k *TransitKey) decryptWithAdditionalData(payload EncryptedPayload, additionalData []byte) ([]byte, error) {
 	if k == nil || k.private == nil {
 		return nil, fmt.Errorf("%w: transit key is not configured", ErrUnavailable)
 	}
@@ -200,28 +211,12 @@ func (k *TransitKey) DecryptWithAdditionalData(payload EncryptedPayload, additio
 	}
 	algorithm := strings.TrimSpace(payload.Algorithm)
 	if strings.EqualFold(algorithm, transitAlgorithm) {
-		aad := additionalData
-		if len(aad) == 0 {
-			aad = []byte(payload.KeyID)
+		if len(additionalData) == 0 {
+			return nil, fmt.Errorf("%w: credential payload context is required", ErrInvalidRequest)
 		}
-		plaintext, err := k.decryptHybrid(payload, aad)
-		if err == nil || bytes.Equal(aad, []byte(payload.KeyID)) {
-			return plaintext, err
-		}
-		return k.decryptHybrid(payload, []byte(payload.KeyID))
+		return k.decryptHybrid(payload, additionalData)
 	}
-	if !strings.EqualFold(algorithm, rsaOAEPAlgorithm) {
-		return nil, fmt.Errorf("%w: unsupported credential transport algorithm", ErrInvalidRequest)
-	}
-	ciphertext, err := decodeBase64(payload.Ciphertext)
-	if err != nil {
-		return nil, fmt.Errorf("%w: decode credential ciphertext: %w", ErrInvalidRequest, err)
-	}
-	plaintext, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, k.private, ciphertext, nil)
-	if err != nil {
-		return nil, fmt.Errorf("%w: decrypt credential payload", ErrInvalidRequest)
-	}
-	return plaintext, nil
+	return nil, fmt.Errorf("%w: unsupported credential transport algorithm", ErrInvalidRequest)
 }
 
 func (k *TransitKey) decryptHybrid(payload EncryptedPayload, additionalData []byte) ([]byte, error) {

--- a/internal/connectorcredentials/credentials.go
+++ b/internal/connectorcredentials/credentials.go
@@ -188,6 +188,10 @@ func (k *TransitKey) PublicKey() PublicKey {
 }
 
 func (k *TransitKey) Decrypt(payload EncryptedPayload) ([]byte, error) {
+	return k.DecryptWithAdditionalData(payload, []byte(payload.KeyID))
+}
+
+func (k *TransitKey) DecryptWithAdditionalData(payload EncryptedPayload, additionalData []byte) ([]byte, error) {
 	if k == nil || k.private == nil {
 		return nil, fmt.Errorf("%w: transit key is not configured", ErrUnavailable)
 	}
@@ -196,7 +200,15 @@ func (k *TransitKey) Decrypt(payload EncryptedPayload) ([]byte, error) {
 	}
 	algorithm := strings.TrimSpace(payload.Algorithm)
 	if strings.EqualFold(algorithm, transitAlgorithm) {
-		return k.decryptHybrid(payload)
+		aad := additionalData
+		if len(aad) == 0 {
+			aad = []byte(payload.KeyID)
+		}
+		plaintext, err := k.decryptHybrid(payload, aad)
+		if err == nil || bytes.Equal(aad, []byte(payload.KeyID)) {
+			return plaintext, err
+		}
+		return k.decryptHybrid(payload, []byte(payload.KeyID))
 	}
 	if !strings.EqualFold(algorithm, rsaOAEPAlgorithm) {
 		return nil, fmt.Errorf("%w: unsupported credential transport algorithm", ErrInvalidRequest)
@@ -212,7 +224,7 @@ func (k *TransitKey) Decrypt(payload EncryptedPayload) ([]byte, error) {
 	return plaintext, nil
 }
 
-func (k *TransitKey) decryptHybrid(payload EncryptedPayload) ([]byte, error) {
+func (k *TransitKey) decryptHybrid(payload EncryptedPayload, additionalData []byte) ([]byte, error) {
 	wrappedKey, err := decodeBase64(payload.WrappedKey)
 	if err != nil {
 		return nil, fmt.Errorf("%w: decode wrapped credential key: %w", ErrInvalidRequest, err)
@@ -237,7 +249,7 @@ func (k *TransitKey) decryptHybrid(payload EncryptedPayload) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: initialize credential payload cipher: %w", ErrInvalidRequest, err)
 	}
-	plaintext, err := gcm.Open(nil, nonce, ciphertext, []byte(payload.KeyID))
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, additionalData)
 	if err != nil {
 		return nil, fmt.Errorf("%w: decrypt credential payload", ErrInvalidRequest)
 	}

--- a/internal/connectorcredentials/credentials_test.go
+++ b/internal/connectorcredentials/credentials_test.go
@@ -79,20 +79,24 @@ func TestTransitKeyDecryptsHybridPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewTransitKey() error = %v", err)
 	}
-	payload, err := encryptForTransit(transit, []byte(`{"token":"secret-token"}`))
+	additionalData := []byte("connector-credential-test-context")
+	payload, err := encryptForTransit(transit, []byte(`{"token":"secret-token"}`), additionalData)
 	if err != nil {
 		t.Fatalf("encryptForTransit() error = %v", err)
 	}
-	plaintext, err := transit.Decrypt(payload)
+	plaintext, err := transit.DecryptWithExactAdditionalData(payload, additionalData)
 	if err != nil {
-		t.Fatalf("Decrypt() error = %v", err)
+		t.Fatalf("DecryptWithExactAdditionalData() error = %v", err)
 	}
 	if string(plaintext) != `{"token":"secret-token"}` {
 		t.Fatalf("plaintext = %s", plaintext)
 	}
+	if _, err := transit.Decrypt(payload); err == nil {
+		t.Fatal("Decrypt() with implicit context error = nil, want error")
+	}
 }
 
-func encryptForTransit(transit *TransitKey, plaintext []byte) (EncryptedPayload, error) {
+func encryptForTransit(transit *TransitKey, plaintext []byte, additionalData []byte) (EncryptedPayload, error) {
 	aesKey := make([]byte, 32)
 	if _, err := rand.Read(aesKey); err != nil {
 		return EncryptedPayload{}, err
@@ -115,7 +119,7 @@ func encryptForTransit(transit *TransitKey, plaintext []byte) (EncryptedPayload,
 		return EncryptedPayload{}, err
 	}
 	key := transit.PublicKey()
-	ciphertext := gcm.Seal(nil, nonce, plaintext, []byte(key.KeyID))
+	ciphertext := gcm.Seal(nil, nonce, plaintext, additionalData)
 	return EncryptedPayload{
 		KeyID:      key.KeyID,
 		Algorithm:  key.Algorithm,


### PR DESCRIPTION
## Summary
- advertises connector display names, backend-supported auth methods, credential-store compatibility, config fields, and credential reference fields from the connector catalog
- validates connector connection requests by auth method and store, including AWS SSO/profile, environment-managed references, CLI handoff, external reference stores, and encrypted browser submission
- adds check-only connection validation so the UI can test source configuration without persisting runtime or credential metadata
- requires context-bound AAD for connector connection encrypted submissions, binding payloads to connector, tenant, runtime, and store before decrypt/preflight/persist
- updates the OpenAPI contract and adds backend coverage for catalog metadata, environment-managed references, external references, check-only behavior, and legacy-AAD rejection

## Validation
- `go test ./internal/bootstrap ./internal/connectorcredentials`
- `make contracts-check`

## Companion UI PR
- Frontend companion: writer/cerebro-web#10.

## Notes
- Public-safe metadata only. Deployment-specific store wiring, store paths, cloud account details, and secret values remain deploy-owned.