### PR TITLE
Add connector operations detail endpoints

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -153,6 +153,44 @@ paths:
       responses:
         '200':
           description: Connector catalog with runtime counts and credential capability state.
+  /connectors/{sourceID}:
+    get:
+      summary: Get connector operations summary
+      tags:
+        - Connectors
+      parameters:
+        - $ref: '#/components/parameters/sourceID'
+        - name: tenant_id
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Connector catalog entry, runtime health summary, safe connection summaries, and recent activity.
+        '404':
+          description: Connector source was not found.
+  /connectors/{sourceID}/activity:
+    get:
+      summary: List connector activity
+      tags:
+        - Connectors
+      parameters:
+        - $ref: '#/components/parameters/sourceID'
+        - name: tenant_id
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+      responses:
+        '200':
+          description: Safe sync and graph activity derived from connector runtime health.
+        '404':
+          description: Connector source was not found.
   /connectors/credential-key:
     get:
       summary: Get connector credential transit key

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -662,6 +662,7 @@ func matchesReplayAttributes(event *cerebrov1.EventEnvelope, expected map[string
 type stubRuntimeStore struct {
 	err                             error
 	runtimes                        map[string]*cerebrov1.SourceRuntime
+	sourceRuntimeListFilter         ports.SourceRuntimeFilter
 	entities                        map[string]*ports.ProjectedEntity
 	links                           map[string]*ports.ProjectedLink
 	claims                          map[string]*ports.ClaimRecord
@@ -743,6 +744,7 @@ func (s *stubRuntimeStore) ListSourceRuntimes(_ context.Context, filter ports.So
 	if s.err != nil {
 		return nil, s.err
 	}
+	s.sourceRuntimeListFilter = filter
 	var ids []string
 	for id := range s.runtimes {
 		ids = append(ids, id)

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -1408,8 +1408,12 @@ func fallbackAccessAuditRoute(method string, path string) string {
 		return prefix + "/connectors"
 	case path == "/connectors/credential-key":
 		return prefix + "/connectors/credential-key"
+	case strings.HasPrefix(path, "/connectors/") && strings.HasSuffix(path, "/activity"):
+		return prefix + "/connectors/{sourceID}/activity"
 	case strings.HasPrefix(path, "/connectors/") && strings.HasSuffix(path, "/connections"):
 		return prefix + "/connectors/{sourceID}/connections"
+	case strings.HasPrefix(path, "/connectors/"):
+		return prefix + "/connectors/{sourceID}"
 	case path == "/source-runtimes":
 		return prefix + "/source-runtimes"
 	case strings.HasPrefix(path, "/source-runtimes/"):

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -36,6 +36,8 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodGet, Prefix: "/sources/", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Exact: "/connectors", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/connectors/credential-key", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Prefix: "/connectors/", Suffix: "/activity", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Prefix: "/connectors/", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Prefix: "/connectors/", Suffix: "/connections", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Exact: "/reports", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodGet, Exact: "/finding-rules", Scope: scopeCosmoSecurityRead},

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -61,6 +62,74 @@ type connectorLibraryResponse struct {
 	CredentialTransport connectorTransportView  `json:"credential_transport"`
 	CredentialVault     connectorVaultView      `json:"credential_vault"`
 	CredentialStores    []connectorStoreView    `json:"credential_stores,omitempty"`
+}
+
+type connectorDetailResponse struct {
+	GeneratedAt string                     `json:"generated_at"`
+	TenantID    string                     `json:"tenant_id,omitempty"`
+	Connector   connectorCatalogEntry      `json:"connector"`
+	Summary     connectorOperationsSummary `json:"summary"`
+	Connections []connectorConnectionView  `json:"connections"`
+	Activity    []connectorActivityView    `json:"activity"`
+}
+
+type connectorActivityResponse struct {
+	GeneratedAt string                  `json:"generated_at"`
+	TenantID    string                  `json:"tenant_id,omitempty"`
+	SourceID    string                  `json:"source_id"`
+	Activity    []connectorActivityView `json:"activity"`
+}
+
+type connectorOperationsSummary struct {
+	Status               string `json:"status"`
+	StatusReason         string `json:"status_reason"`
+	TopIssue             string `json:"top_issue,omitempty"`
+	TotalConnections     int    `json:"total_connections"`
+	HealthyConnections   int    `json:"healthy_connections"`
+	NeedsAttention       int    `json:"needs_attention"`
+	LastActivityAt       string `json:"last_activity_at,omitempty"`
+	SyncFrequencySeconds *int64 `json:"sync_frequency_seconds,omitempty"`
+	ResourceTypes        int    `json:"resource_types"`
+	EmittedKinds         int    `json:"emitted_kinds"`
+}
+
+type connectorConnectionView struct {
+	RuntimeID               string `json:"runtime_id"`
+	SourceID                string `json:"source_id"`
+	TenantID                string `json:"tenant_id,omitempty"`
+	Family                  string `json:"family,omitempty"`
+	Status                  string `json:"status"`
+	GraphStatus             string `json:"graph_status"`
+	ContractProbeState      string `json:"contract_probe_state"`
+	LastActivityAt          string `json:"last_activity_at,omitempty"`
+	CheckpointWatermark     string `json:"checkpoint_watermark,omitempty"`
+	WatermarkLagSeconds     *int64 `json:"watermark_lag_seconds,omitempty"`
+	RecordsAccepted         uint32 `json:"records_accepted"`
+	RecordsRejected         uint32 `json:"records_rejected"`
+	EntitiesProjected       uint32 `json:"entities_projected"`
+	LinksProjected          uint32 `json:"links_projected"`
+	CursorPending           bool   `json:"cursor_pending"`
+	CheckpointCursorPresent bool   `json:"checkpoint_cursor_present"`
+	NextAction              string `json:"next_action"`
+}
+
+type connectorActivityView struct {
+	ID                string `json:"id"`
+	RuntimeID         string `json:"runtime_id"`
+	SourceID          string `json:"source_id"`
+	TenantID          string `json:"tenant_id,omitempty"`
+	Family            string `json:"family,omitempty"`
+	Type              string `json:"type"`
+	Status            string `json:"status"`
+	Title             string `json:"title"`
+	Description       string `json:"description,omitempty"`
+	OccurredAt        string `json:"occurred_at,omitempty"`
+	DurationSeconds   *int64 `json:"duration_seconds,omitempty"`
+	RecordsAccepted   uint32 `json:"records_accepted,omitempty"`
+	RecordsRejected   uint32 `json:"records_rejected,omitempty"`
+	EntitiesProjected int64  `json:"entities_projected,omitempty"`
+	LinksProjected    int64  `json:"links_projected,omitempty"`
+	FailureClass      string `json:"failure_class,omitempty"`
 }
 
 type connectorTransportView struct {
@@ -143,6 +212,11 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 		writeConnectorError(w, err)
 		return
 	}
+	response := a.connectorLibrary(r, tenantID)
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibraryResponse {
 	runtimes, runtimeStoreStatus := a.connectorRuntimeCatalog(r, tenantID)
 	counts := connectorRuntimeCounts(runtimes)
 	sources := a.sourceService().List().GetSources()
@@ -184,13 +258,77 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 	sort.Slice(entries, func(i, j int) bool {
 		return strings.ToLower(entries[i].Name) < strings.ToLower(entries[j].Name)
 	})
-	writeJSON(w, http.StatusOK, connectorLibraryResponse{
+	return connectorLibraryResponse{
 		Connectors:          entries,
 		TenantID:            tenantID,
 		RuntimeStore:        runtimeStoreStatus,
 		CredentialTransport: transport,
 		CredentialVault:     vaultStatus,
 		CredentialStores:    stores,
+	}
+}
+
+func (a *App) handleGetConnector(w http.ResponseWriter, r *http.Request) {
+	sourceID := strings.TrimSpace(r.PathValue("sourceID"))
+	if sourceID == "" {
+		writeConnectorError(w, fmt.Errorf("%w: source_id is required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	tenantID, err := effectiveTenantFilter(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	library := a.connectorLibrary(r, tenantID)
+	entry, ok := connectorEntryBySourceID(library.Connectors, sourceID)
+	if !ok {
+		writeConnectorError(w, fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, sourceID))
+		return
+	}
+	health, err := a.connectorHealthForSource(r, entry.SourceID, tenantID)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	connections := connectorConnectionsFromHealth(health.Runtimes)
+	activity := connectorActivityFromHealth(health.Runtimes)
+	writeJSON(w, http.StatusOK, connectorDetailResponse{
+		GeneratedAt: health.GeneratedAt,
+		TenantID:    tenantID,
+		Connector:   entry,
+		Summary:     connectorOperationsSummaryFromHealth(entry, health.Runtimes),
+		Connections: connections,
+		Activity:    activity,
+	})
+}
+
+func (a *App) handleListConnectorActivity(w http.ResponseWriter, r *http.Request) {
+	sourceID := strings.TrimSpace(r.PathValue("sourceID"))
+	if sourceID == "" {
+		writeConnectorError(w, fmt.Errorf("%w: source_id is required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	tenantID, err := effectiveTenantFilter(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	library := a.connectorLibrary(r, tenantID)
+	entry, ok := connectorEntryBySourceID(library.Connectors, sourceID)
+	if !ok {
+		writeConnectorError(w, fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, sourceID))
+		return
+	}
+	health, err := a.connectorHealthForSource(r, entry.SourceID, tenantID)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, connectorActivityResponse{
+		GeneratedAt: health.GeneratedAt,
+		TenantID:    tenantID,
+		SourceID:    entry.SourceID,
+		Activity:    connectorActivityFromHealth(health.Runtimes),
 	})
 }
 
@@ -431,6 +569,352 @@ func connectorRuntimeCounts(runtimes []*cerebrov1.SourceRuntime) map[string]conn
 		counts[sourceID] = count
 	}
 	return counts
+}
+
+func connectorEntryBySourceID(entries []connectorCatalogEntry, sourceID string) (connectorCatalogEntry, bool) {
+	normalized := strings.TrimSpace(sourceID)
+	for _, entry := range entries {
+		if entry.SourceID == normalized {
+			return entry, true
+		}
+	}
+	return connectorCatalogEntry{}, false
+}
+
+func (a *App) connectorHealthForSource(r *http.Request, sourceID string, tenantID string) (sourceRuntimeHealthResponse, error) {
+	clone := r.Clone(r.Context())
+	clonedURL := *r.URL
+	query := clonedURL.Query()
+	query.Set("source_id", strings.TrimSpace(sourceID))
+	if strings.TrimSpace(tenantID) != "" {
+		query.Set("tenant_id", strings.TrimSpace(tenantID))
+	}
+	if strings.TrimSpace(query.Get("limit")) == "" {
+		query.Set("limit", "500")
+	}
+	clonedURL.RawQuery = query.Encode()
+	clone.URL = &clonedURL
+	health, err := a.listSourceRuntimeHealth(clone)
+	if errors.Is(err, sourceruntime.ErrRuntimeUnavailable) {
+		return emptySourceRuntimeHealthResponse(), nil
+	}
+	return health, err
+}
+
+func connectorOperationsSummaryFromHealth(entry connectorCatalogEntry, records []sourceRuntimeHealthRecord) connectorOperationsSummary {
+	total := len(records)
+	healthy := 0
+	needsAttention := 0
+	var syncFrequency *int64
+	var lastActivity time.Time
+	status := "not_configured"
+	reason := "No active connection is configured."
+	topIssue := reason
+	for _, record := range records {
+		if strings.EqualFold(record.Status, "healthy") && sourceRuntimeGraphState(record) == "current" {
+			healthy++
+		} else {
+			needsAttention++
+		}
+		if record.ExpectedCadenceSeconds != nil && (syncFrequency == nil || *record.ExpectedCadenceSeconds < *syncFrequency) {
+			value := *record.ExpectedCadenceSeconds
+			syncFrequency = &value
+		}
+		if observedAt, ok := connectorRecordLastActivityTime(record); ok && observedAt.After(lastActivity) {
+			lastActivity = observedAt
+		}
+	}
+	if total > 0 {
+		switch {
+		case connectorAnyRecordFailing(records):
+			status = "bad"
+			reason = "At least one connection has a failing sync, graph, or probe signal."
+			topIssue = "Fix failing connection signal."
+		case connectorAnyRecordRefreshNeeded(records):
+			status = "needs_refresh"
+			reason = "At least one connection is stale or missing graph freshness."
+			topIssue = "Refresh sync or graph projection."
+		case needsAttention > 0:
+			status = "poor"
+			reason = "Connection telemetry is incomplete."
+			topIssue = "Inspect incomplete connection telemetry."
+		default:
+			status = "healthy"
+			reason = "Sync and graph signals are current."
+			topIssue = ""
+		}
+	}
+	lastActivityAt := ""
+	if !lastActivity.IsZero() {
+		lastActivityAt = lastActivity.UTC().Format(time.RFC3339Nano)
+	}
+	return connectorOperationsSummary{
+		Status:               status,
+		StatusReason:         reason,
+		TopIssue:             topIssue,
+		TotalConnections:     total,
+		HealthyConnections:   healthy,
+		NeedsAttention:       needsAttention,
+		LastActivityAt:       lastActivityAt,
+		SyncFrequencySeconds: syncFrequency,
+		ResourceTypes:        len(entry.EmittedKinds),
+		EmittedKinds:         len(entry.EmittedKinds),
+	}
+}
+
+func connectorConnectionsFromHealth(records []sourceRuntimeHealthRecord) []connectorConnectionView {
+	connections := make([]connectorConnectionView, 0, len(records))
+	for _, record := range records {
+		status := connectorConnectionReadiness(record)
+		connections = append(connections, connectorConnectionView{
+			RuntimeID:               record.RuntimeID,
+			SourceID:                record.SourceID,
+			TenantID:                record.TenantID,
+			Family:                  record.Family,
+			Status:                  status,
+			GraphStatus:             sourceRuntimeGraphState(record),
+			ContractProbeState:      record.ContractProbeState,
+			LastActivityAt:          connectorRecordLastActivity(record),
+			CheckpointWatermark:     record.CheckpointWatermark,
+			WatermarkLagSeconds:     record.WatermarkLagSeconds,
+			RecordsAccepted:         record.RecentSync.RecordsAccepted,
+			RecordsRejected:         record.RecentSync.RecordsRejected,
+			EntitiesProjected:       record.RecentSync.EntitiesProjected,
+			LinksProjected:          record.RecentSync.LinksProjected,
+			CursorPending:           record.CursorPending,
+			CheckpointCursorPresent: record.CheckpointCursorPresent,
+			NextAction:              connectorConnectionNextAction(status, record),
+		})
+	}
+	sort.Slice(connections, func(i, j int) bool {
+		return connections[i].LastActivityAt > connections[j].LastActivityAt
+	})
+	return connections
+}
+
+func connectorActivityFromHealth(records []sourceRuntimeHealthRecord) []connectorActivityView {
+	activity := make([]connectorActivityView, 0, len(records)*2)
+	for _, record := range records {
+		syncStatus := connectorSyncActivityStatus(record)
+		activity = append(activity, connectorActivityView{
+			ID:              connectorActivityID(record.RuntimeID, "sync", connectorRecordLastActivity(record)),
+			RuntimeID:       record.RuntimeID,
+			SourceID:        record.SourceID,
+			TenantID:        record.TenantID,
+			Family:          record.Family,
+			Type:            "sync",
+			Status:          syncStatus,
+			Title:           connectorSyncActivityTitle(syncStatus),
+			Description:     connectorSyncActivityDescription(record),
+			OccurredAt:      connectorRecordLastActivity(record),
+			RecordsAccepted: record.RecentSync.RecordsAccepted,
+			RecordsRejected: record.RecentSync.RecordsRejected,
+			FailureClass:    connectorFailureClass(record),
+		})
+		if record.LatestGraphRun != nil {
+			graphStatus := connectorGraphActivityStatus(record.LatestGraphRun.Status)
+			activity = append(activity, connectorActivityView{
+				ID:                connectorActivityID(record.RuntimeID, "graph", connectorGraphActivityTime(record.LatestGraphRun)),
+				RuntimeID:         record.RuntimeID,
+				SourceID:          record.SourceID,
+				TenantID:          record.TenantID,
+				Family:            record.Family,
+				Type:              "graph",
+				Status:            graphStatus,
+				Title:             connectorGraphActivityTitle(graphStatus),
+				Description:       "Graph projection activity for this connection.",
+				OccurredAt:        connectorGraphActivityTime(record.LatestGraphRun),
+				DurationSeconds:   record.LatestGraphRun.DurationSeconds,
+				EntitiesProjected: record.LatestGraphRun.EntitiesProjected,
+				LinksProjected:    record.LatestGraphRun.LinksProjected,
+				FailureClass:      connectorGraphFailureClass(record.LatestGraphRun.Status),
+			})
+		}
+	}
+	sort.Slice(activity, func(i, j int) bool {
+		return activity[i].OccurredAt > activity[j].OccurredAt
+	})
+	return activity
+}
+
+func connectorAnyRecordFailing(records []sourceRuntimeHealthRecord) bool {
+	for _, record := range records {
+		if strings.EqualFold(record.Status, "failing") || sourceRuntimeGraphState(record) == "failed" || strings.EqualFold(record.ContractProbeState, "failure") {
+			return true
+		}
+	}
+	return false
+}
+
+func connectorAnyRecordRefreshNeeded(records []sourceRuntimeHealthRecord) bool {
+	for _, record := range records {
+		if strings.EqualFold(record.Status, "stale") || record.CursorPending {
+			return true
+		}
+		switch sourceRuntimeGraphState(record) {
+		case "behind", "not_observed":
+			return true
+		}
+	}
+	return false
+}
+
+func connectorConnectionReadiness(record sourceRuntimeHealthRecord) string {
+	if strings.EqualFold(record.Status, "failing") || sourceRuntimeGraphState(record) == "failed" || strings.EqualFold(record.ContractProbeState, "failure") {
+		return "bad"
+	}
+	if strings.EqualFold(record.Status, "stale") || record.CursorPending || sourceRuntimeGraphState(record) == "behind" || sourceRuntimeGraphState(record) == "not_observed" {
+		return "needs_refresh"
+	}
+	if strings.EqualFold(record.Status, "healthy") && sourceRuntimeGraphState(record) == "current" {
+		return "healthy"
+	}
+	return "poor"
+}
+
+func connectorConnectionNextAction(status string, record sourceRuntimeHealthRecord) string {
+	switch status {
+	case "bad":
+		return "fix_connection"
+	case "needs_refresh":
+		if sourceRuntimeGraphState(record) == "not_observed" || sourceRuntimeGraphState(record) == "behind" {
+			return "run_graph_ingest"
+		}
+		return "run_sync"
+	case "healthy":
+		return "monitor"
+	default:
+		return "inspect_connection"
+	}
+}
+
+func connectorRecordLastActivity(record sourceRuntimeHealthRecord) string {
+	if observedAt, ok := connectorRecordLastActivityTime(record); ok {
+		return observedAt.UTC().Format(time.RFC3339Nano)
+	}
+	return ""
+}
+
+func connectorRecordLastActivityTime(record sourceRuntimeHealthRecord) (time.Time, bool) {
+	var latest time.Time
+	for _, value := range []string{
+		record.LastSyncedAt,
+		record.CheckpointWatermark,
+		connectorGraphActivityTime(record.LatestGraphRun),
+	} {
+		parsed, ok := parseRFC3339(value)
+		if !ok {
+			continue
+		}
+		if parsed.After(latest) {
+			latest = parsed
+		}
+	}
+	if latest.IsZero() {
+		return time.Time{}, false
+	}
+	return latest, true
+}
+
+func connectorSyncActivityStatus(record sourceRuntimeHealthRecord) string {
+	switch connectorConnectionReadiness(record) {
+	case "healthy":
+		return "success"
+	case "bad":
+		return "failed"
+	case "needs_refresh":
+		return "needs_refresh"
+	default:
+		return "incomplete"
+	}
+}
+
+func connectorSyncActivityTitle(status string) string {
+	switch status {
+	case "success":
+		return "Successful sync"
+	case "failed":
+		return "Sync needs attention"
+	case "needs_refresh":
+		return "Sync refresh needed"
+	default:
+		return "Sync signal incomplete"
+	}
+}
+
+func connectorSyncActivityDescription(record sourceRuntimeHealthRecord) string {
+	switch connectorSyncActivityStatus(record) {
+	case "success":
+		return "Runtime sync completed with current source telemetry."
+	case "failed":
+		return "Runtime sync or validation is failing."
+	case "needs_refresh":
+		return "Runtime sync, cursor, or graph projection is behind."
+	default:
+		return "Runtime telemetry has not produced enough signal yet."
+	}
+}
+
+func connectorGraphActivityStatus(status string) string {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	if strings.Contains(normalized, "fail") || strings.Contains(normalized, "error") || strings.Contains(normalized, "cancel") {
+		return "failed"
+	}
+	if strings.Contains(normalized, "running") || strings.Contains(normalized, "pending") {
+		return "running"
+	}
+	if normalized == "" {
+		return "not_observed"
+	}
+	return "success"
+}
+
+func connectorGraphActivityTitle(status string) string {
+	switch status {
+	case "success":
+		return "Graph projection complete"
+	case "failed":
+		return "Graph projection failed"
+	case "running":
+		return "Graph projection running"
+	default:
+		return "Graph projection not observed"
+	}
+}
+
+func connectorGraphActivityTime(run *sourceRuntimeHealthGraphRun) string {
+	if run == nil {
+		return ""
+	}
+	if strings.TrimSpace(run.FinishedAt) != "" {
+		return strings.TrimSpace(run.FinishedAt)
+	}
+	return strings.TrimSpace(run.StartedAt)
+}
+
+func connectorFailureClass(record sourceRuntimeHealthRecord) string {
+	if value := strings.TrimSpace(record.LastFailureCategory); value != "" {
+		return value
+	}
+	if strings.EqualFold(record.ContractProbeState, "failure") {
+		return "contract_probe_failure"
+	}
+	if connectorConnectionReadiness(record) == "needs_refresh" {
+		return "freshness"
+	}
+	return ""
+}
+
+func connectorGraphFailureClass(status string) string {
+	if connectorGraphActivityStatus(status) == "failed" {
+		return "graph_ingest_failed"
+	}
+	return ""
+}
+
+func connectorActivityID(runtimeID string, kind string, occurredAt string) string {
+	parts := []string{strings.TrimSpace(runtimeID), strings.TrimSpace(kind), strings.TrimSpace(occurredAt)}
+	return strings.Trim(strings.Join(parts, ":"), ":")
 }
 
 func connectorRuntimeHealthy(runtime *cerebrov1.SourceRuntime) bool {

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +28,8 @@ import (
 const (
 	defaultConnectorCredentialStoreID = "cerebro_vault"
 	connectorStoreEnvironmentManaged  = "environment_managed"
+	connectorActivityDefaultLimit     = 500
+	connectorActivityMaxLimit         = 500
 
 	connectorAuthMethodEncryptedSubmission = "encrypted_submission"
 	connectorAuthMethodAWSSSOProfile       = "aws_sso_profile"
@@ -319,16 +322,22 @@ func (a *App) handleListConnectorActivity(w http.ResponseWriter, r *http.Request
 		writeConnectorError(w, fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, sourceID))
 		return
 	}
+	activityLimit, err := connectorActivityLimit(r)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
 	health, err := a.connectorHealthForSource(r, entry.SourceID, tenantID)
 	if err != nil {
 		writeConnectorError(w, err)
 		return
 	}
+	activity := connectorActivityFromHealth(health.Runtimes)
 	writeJSON(w, http.StatusOK, connectorActivityResponse{
 		GeneratedAt: health.GeneratedAt,
 		TenantID:    tenantID,
 		SourceID:    entry.SourceID,
-		Activity:    connectorActivityFromHealth(health.Runtimes),
+		Activity:    limitConnectorActivity(activity, activityLimit),
 	})
 }
 
@@ -589,9 +598,7 @@ func (a *App) connectorHealthForSource(r *http.Request, sourceID string, tenantI
 	if strings.TrimSpace(tenantID) != "" {
 		query.Set("tenant_id", strings.TrimSpace(tenantID))
 	}
-	if strings.TrimSpace(query.Get("limit")) == "" {
-		query.Set("limit", "500")
-	}
+	query.Set("limit", strconv.Itoa(connectorActivityMaxLimit))
 	clonedURL.RawQuery = query.Encode()
 	clone.URL = &clonedURL
 	health, err := a.listSourceRuntimeHealth(clone)
@@ -599,6 +606,21 @@ func (a *App) connectorHealthForSource(r *http.Request, sourceID string, tenantI
 		return emptySourceRuntimeHealthResponse(), nil
 	}
 	return health, err
+}
+
+func connectorActivityLimit(r *http.Request) (int, error) {
+	value := strings.TrimSpace(r.URL.Query().Get("limit"))
+	if value == "" {
+		return connectorActivityDefaultLimit, nil
+	}
+	parsed, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid limit", connectorcredentials.ErrInvalidRequest)
+	}
+	if parsed == 0 || parsed > connectorActivityMaxLimit {
+		return 0, fmt.Errorf("%w: limit must be between 1 and %d", connectorcredentials.ErrInvalidRequest, connectorActivityMaxLimit)
+	}
+	return int(parsed), nil
 }
 
 func connectorOperationsSummaryFromHealth(entry connectorCatalogEntry, records []sourceRuntimeHealthRecord) connectorOperationsSummary {
@@ -735,6 +757,13 @@ func connectorActivityFromHealth(records []sourceRuntimeHealthRecord) []connecto
 		return activity[i].OccurredAt > activity[j].OccurredAt
 	})
 	return activity
+}
+
+func limitConnectorActivity(activity []connectorActivityView, limit int) []connectorActivityView {
+	if limit <= 0 || len(activity) <= limit {
+		return activity
+	}
+	return activity[:limit]
 }
 
 func connectorAnyRecordFailing(records []sourceRuntimeHealthRecord) bool {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -22,6 +22,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/connectorcredentials"
+	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -505,6 +506,103 @@ func TestConnectorActivityRejectsUnknownSource(t *testing.T) {
 	}()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("GET /connectors/{sourceID}/activity status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestConnectorActivityRejectsLimitAboveContract(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors/bootstrap_token/activity?limit=501")
+	if err != nil {
+		t.Fatalf("GET /connectors/{sourceID}/activity error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("GET /connectors/{sourceID}/activity status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestConnectorActivityLimitTruncatesActivityRows(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	now := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-a": {
+			Id:           "runtime-a",
+			SourceId:     "bootstrap_token",
+			TenantId:     "tenant-a",
+			LastSyncedAt: timestamppb.New(now.Add(-time.Hour)),
+			Config: map[string]string{
+				"family":                        "audit",
+				runtimeRecordsAcceptedConfigKey: "10",
+			},
+		},
+	}}}
+	graph := &stubGraphStore{ingestRuns: map[string]graphstore.IngestRun{
+		"graph-a": {
+			ID:         "graph-a",
+			RuntimeID:  "runtime-a",
+			Status:     "completed",
+			StartedAt:  now.Add(-30 * time.Minute).Format(time.RFC3339Nano),
+			FinishedAt: now.Add(-25 * time.Minute).Format(time.RFC3339Nano),
+		},
+	}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: store, GraphStore: graph}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors/bootstrap_token/activity?tenant_id=tenant-a&limit=1")
+	if err != nil {
+		t.Fatalf("GET /connectors/{sourceID}/activity error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /connectors/{sourceID}/activity status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		Activity []struct {
+			Type      string `json:"type"`
+			RuntimeID string `json:"runtime_id"`
+		} `json:"activity"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.Activity) != 1 {
+		t.Fatalf("activity length = %d, want 1: %#v", len(payload.Activity), payload.Activity)
+	}
+	if got := payload.Activity[0].RuntimeID; got != "runtime-a" {
+		t.Fatalf("activity[0].runtime_id = %q, want runtime-a", got)
+	}
+	if got := store.sourceRuntimeListFilter.Limit; got != connectorActivityMaxLimit {
+		t.Fatalf("runtime list limit = %d, want connector fetch limit %d", got, connectorActivityMaxLimit)
+	}
+	if got := graph.ingestRunListFilter.Limit; got != 1 {
+		t.Fatalf("graph ingest run list limit = %d, want latest run lookup limit", got)
 	}
 }
 

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -19,10 +19,12 @@ import (
 	"testing"
 	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/connectorcredentials"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type connectorTestStore struct {
@@ -328,6 +330,181 @@ func TestConnectorCatalogAdvertisesConnectionMethods(t *testing.T) {
 	}
 	if !stores[connectorStoreEnvironmentManaged] {
 		t.Fatalf("environment-managed store not advertised available: %#v", stores)
+	}
+}
+
+func TestConnectorDetailSummarizesOperationsWithoutConfig(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	now := time.Date(2026, 6, 15, 16, 0, 0, 0, time.UTC)
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-a": {
+			Id:           "runtime-a",
+			SourceId:     "bootstrap_token",
+			TenantId:     "tenant-a",
+			LastSyncedAt: timestamppb.New(now),
+			Config: map[string]string{
+				"family":                           "audit",
+				"token":                            "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN",
+				runtimeRecordsAcceptedConfigKey:    "42",
+				runtimeRecordsRejectedConfigKey:    "1",
+				runtimeEntitiesProjectedConfigKey:  "40",
+				runtimeLinksProjectedConfigKey:     "8",
+				runtimeContractProbeStateConfigKey: "passing",
+				"expected_cadence_seconds":         "14400",
+			},
+		},
+	}}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: store}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors/bootstrap_token?tenant_id=tenant-a")
+	if err != nil {
+		t.Fatalf("GET /connectors/{sourceID} error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /connectors/{sourceID} status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		Connector struct {
+			SourceID string `json:"source_id"`
+		} `json:"connector"`
+		Summary struct {
+			Status               string `json:"status"`
+			TotalConnections     int    `json:"total_connections"`
+			NeedsAttention       int    `json:"needs_attention"`
+			SyncFrequencySeconds *int64 `json:"sync_frequency_seconds"`
+		} `json:"summary"`
+		Connections []struct {
+			RuntimeID       string `json:"runtime_id"`
+			RecordsAccepted uint32 `json:"records_accepted"`
+			NextAction      string `json:"next_action"`
+		} `json:"connections"`
+		Activity []struct {
+			Type            string `json:"type"`
+			Status          string `json:"status"`
+			RecordsAccepted uint32 `json:"records_accepted"`
+		} `json:"activity"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload.Connector.SourceID; got != "bootstrap_token" {
+		t.Fatalf("connector source_id = %q, want bootstrap_token", got)
+	}
+	if got := payload.Summary.TotalConnections; got != 1 {
+		t.Fatalf("summary total_connections = %d, want 1", got)
+	}
+	if got := payload.Summary.Status; got != "needs_refresh" {
+		t.Fatalf("summary status = %q, want needs_refresh because graph ingest is not observed", got)
+	}
+	if payload.Summary.SyncFrequencySeconds == nil || *payload.Summary.SyncFrequencySeconds != 14400 {
+		t.Fatalf("summary sync_frequency_seconds = %#v, want 14400", payload.Summary.SyncFrequencySeconds)
+	}
+	if len(payload.Connections) != 1 || payload.Connections[0].RuntimeID != "runtime-a" {
+		t.Fatalf("connections = %#v, want runtime-a", payload.Connections)
+	}
+	if got := payload.Connections[0].RecordsAccepted; got != 42 {
+		t.Fatalf("records_accepted = %d, want 42", got)
+	}
+	if got := payload.Connections[0].NextAction; got != "run_graph_ingest" {
+		t.Fatalf("next_action = %q, want run_graph_ingest", got)
+	}
+	if len(payload.Activity) == 0 || payload.Activity[0].Type != "sync" {
+		t.Fatalf("activity = %#v, want sync activity", payload.Activity)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal decoded payload: %v", err)
+	}
+	if strings.Contains(string(encoded), "CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN") || strings.Contains(string(encoded), "env:") {
+		t.Fatalf("connector detail leaked credential reference: %s", encoded)
+	}
+}
+
+func TestConnectorDetailToleratesUnavailableRuntimeStore(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors/bootstrap_token")
+	if err != nil {
+		t.Fatalf("GET /connectors/{sourceID} error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /connectors/{sourceID} status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		Summary struct {
+			Status           string `json:"status"`
+			TotalConnections int    `json:"total_connections"`
+		} `json:"summary"`
+		Connections []struct{} `json:"connections"`
+		Activity    []struct{} `json:"activity"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload.Summary.Status; got != "not_configured" {
+		t.Fatalf("summary status = %q, want not_configured", got)
+	}
+	if got := payload.Summary.TotalConnections; got != 0 {
+		t.Fatalf("summary total_connections = %d, want 0", got)
+	}
+	if len(payload.Connections) != 0 || len(payload.Activity) != 0 {
+		t.Fatalf("connections/activity = %d/%d, want empty", len(payload.Connections), len(payload.Activity))
+	}
+}
+
+func TestConnectorActivityRejectsUnknownSource(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors/missing/activity")
+	if err != nil {
+		t.Fatalf("GET /connectors/{sourceID}/activity error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET /connectors/{sourceID}/activity status = %d, want 404", resp.StatusCode)
 	}
 }
 

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -348,7 +348,7 @@ func TestConnectorDetailSummarizesOperationsWithoutConfig(t *testing.T) {
 			LastSyncedAt: timestamppb.New(now),
 			Config: map[string]string{
 				"family":                           "audit",
-				"token":                            "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN",
+				"internal_marker":                  "runtime-config-marker",
 				runtimeRecordsAcceptedConfigKey:    "42",
 				runtimeRecordsRejectedConfigKey:    "1",
 				runtimeEntitiesProjectedConfigKey:  "40",
@@ -429,8 +429,8 @@ func TestConnectorDetailSummarizesOperationsWithoutConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal decoded payload: %v", err)
 	}
-	if strings.Contains(string(encoded), "CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN") || strings.Contains(string(encoded), "env:") {
-		t.Fatalf("connector detail leaked credential reference: %s", encoded)
+	if strings.Contains(string(encoded), "runtime-config-marker") {
+		t.Fatalf("connector detail leaked runtime config: %s", encoded)
 	}
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -114,6 +114,8 @@ func (app *App) registerSourceRoutes(mux *http.ServeMux) {
 func (app *App) registerConnectorRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /connectors", routeSurfacePlatformHTTP, app.handleListConnectors)
 	registerHTTPRoute(mux, "GET /connectors/credential-key", routeSurfacePlatformHTTP, app.handleConnectorCredentialKey)
+	registerHTTPRoute(mux, "GET /connectors/{sourceID}", routeSurfacePlatformHTTP, app.handleGetConnector)
+	registerHTTPRoute(mux, "GET /connectors/{sourceID}/activity", routeSurfacePlatformHTTP, app.handleListConnectorActivity)
 	registerHTTPRoute(mux, "POST /connectors/{sourceID}/connections", routeSurfacePlatformHTTP, app.handleCreateConnectorConnection)
 }
 

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -268,11 +268,11 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 	}
 	store := sourceRuntimeStore(a.deps.StateStore)
 	if store == nil {
-		return sourceRuntimeHealthResponse{}, sourceruntime.ErrRuntimeUnavailable
+		return emptySourceRuntimeHealthResponse(), nil
 	}
 	lister, ok := store.(ports.SourceRuntimeListStore)
 	if !ok {
-		return sourceRuntimeHealthResponse{}, sourceruntime.ErrRuntimeUnavailable
+		return emptySourceRuntimeHealthResponse(), nil
 	}
 	if filter.Limit == 0 {
 		filter.Limit = 100
@@ -306,6 +306,14 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 		Coverage:        coverage,
 		CoverageSummary: sourcecoverage.Summaries(coverage),
 	}, nil
+}
+
+func emptySourceRuntimeHealthResponse() sourceRuntimeHealthResponse {
+	return sourceRuntimeHealthResponse{
+		GeneratedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+		Runtimes:        []sourceRuntimeHealthRecord{},
+		SourceSummaries: []sourceRuntimeHealthSummary{},
+	}
 }
 
 func runtimeFreshnessFromHealth(health sourceRuntimeHealthResponse) runtimeFreshnessResponse {

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -268,11 +268,11 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 	}
 	store := sourceRuntimeStore(a.deps.StateStore)
 	if store == nil {
-		return emptySourceRuntimeHealthResponse(), nil
+		return sourceRuntimeHealthResponse{}, sourceruntime.ErrRuntimeUnavailable
 	}
 	lister, ok := store.(ports.SourceRuntimeListStore)
 	if !ok {
-		return emptySourceRuntimeHealthResponse(), nil
+		return sourceRuntimeHealthResponse{}, sourceruntime.ErrRuntimeUnavailable
 	}
 	if filter.Limit == 0 {
 		filter.Limit = 100

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -407,6 +407,25 @@ func TestListSourceRuntimeHealthFiltersCoverageByAllowedTenant(t *testing.T) {
 	}
 }
 
+func TestListSourceRuntimeHealthToleratesUnavailableStore(t *testing.T) {
+	app := &App{}
+	req := httptest.NewRequest("GET", "/source-runtimes/health?source_id=aws", nil)
+
+	response, err := app.listSourceRuntimeHealth(req)
+	if err != nil {
+		t.Fatalf("listSourceRuntimeHealth() error = %v", err)
+	}
+	if strings.TrimSpace(response.GeneratedAt) == "" {
+		t.Fatalf("GeneratedAt is empty")
+	}
+	if len(response.Runtimes) != 0 {
+		t.Fatalf("Runtimes = %#v, want empty", response.Runtimes)
+	}
+	if len(response.SourceSummaries) != 0 {
+		t.Fatalf("SourceSummaries = %#v, want empty", response.SourceSummaries)
+	}
+}
+
 func TestRuntimeFreshnessIncludesCoverageBlindSpots(t *testing.T) {
 	health := sourceRuntimeHealthResponse{
 		GeneratedAt: "2026-06-15T00:00:00Z",

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcecoverage"
+	"github.com/writer/cerebro/internal/sourceruntime"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -407,22 +409,12 @@ func TestListSourceRuntimeHealthFiltersCoverageByAllowedTenant(t *testing.T) {
 	}
 }
 
-func TestListSourceRuntimeHealthToleratesUnavailableStore(t *testing.T) {
+func TestListSourceRuntimeHealthFailsClosedWithoutRuntimeStore(t *testing.T) {
 	app := &App{}
 	req := httptest.NewRequest("GET", "/source-runtimes/health?source_id=aws", nil)
 
-	response, err := app.listSourceRuntimeHealth(req)
-	if err != nil {
-		t.Fatalf("listSourceRuntimeHealth() error = %v", err)
-	}
-	if strings.TrimSpace(response.GeneratedAt) == "" {
-		t.Fatalf("GeneratedAt is empty")
-	}
-	if len(response.Runtimes) != 0 {
-		t.Fatalf("Runtimes = %#v, want empty", response.Runtimes)
-	}
-	if len(response.SourceSummaries) != 0 {
-		t.Fatalf("SourceSummaries = %#v, want empty", response.SourceSummaries)
+	if _, err := app.listSourceRuntimeHealth(req); !errors.Is(err, sourceruntime.ErrRuntimeUnavailable) {
+		t.Fatalf("listSourceRuntimeHealth() error = %v, want runtime unavailable", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds read-only connector detail and activity endpoints backed by runtime health summaries.
- Returns safe connection and activity telemetry without runtime config or credential material.
- Lets lightweight deployments return empty source-runtime health instead of a hard service error.
- Updates OpenAPI route coverage, auth route policy, and focused backend tests.

## Companion
- Frontend: https://github.com/writer/cerebro-web/pull/11

## Validation
- `go test ./internal/bootstrap -timeout 30s -count=1`
- `make contracts-check`

## Compatibility
- Additive HTTP endpoints only.
- Connector detail responses intentionally expose summary/status metadata, not secret or runtime config material.