### PR TITLE
Add connector resource scope policies

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -152,7 +152,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Connector catalog with runtime counts and credential capability state.
+          description: Connector catalog with runtime counts, credential capability state, and source resource scope options.
   /connectors/{sourceID}:
     get:
       summary: Get connector operations summary
@@ -166,7 +166,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Connector catalog entry, runtime health summary, safe connection summaries, and recent activity.
+          description: Connector catalog entry, runtime health summary, safe connection summaries with typed scope policies, and recent activity.
         '404':
           description: Connector source was not found.
   /connectors/{sourceID}/activity:
@@ -255,6 +255,43 @@ paths:
                   description: Non-secret credential references for environment-managed or external-reference methods. Values must be server-resolvable references such as env:CEREBRO_SOURCE_<SOURCE>_<FIELD>; secret-store CLIs/controllers are expected to populate those environment values outside the browser.
                   additionalProperties:
                     type: string
+                scope_policy:
+                  type: object
+                  description: Non-secret connector scope policy. Excluded families are short-circuited before source reads; exact resources are filtered before downstream projection when the runtime can identify them.
+                  properties:
+                    mode:
+                      type: string
+                      enum:
+                        - exclude
+                    excluded_families:
+                      type: array
+                      items:
+                        type: string
+                    excluded_asset_classes:
+                      type: array
+                      items:
+                        type: string
+                    excluded_kinds:
+                      type: array
+                      items:
+                        type: string
+                    excluded_resource_urns:
+                      type: array
+                      items:
+                        type: string
+                    excluded_resources:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          urn:
+                            type: string
+                          type:
+                            type: string
+                          id:
+                            type: string
+                          reason:
+                            type: string
                 encrypted_credentials:
                   type: object
                   description: Required only when auth_method is encrypted_submission.
@@ -279,7 +316,7 @@ paths:
                       type: string
       responses:
         '200':
-          description: Stored runtime with sensitive config redacted and credential metadata.
+          description: Stored runtime with sensitive config redacted, credential metadata, and the applied typed scope policy when provided.
   /source-runtimes:
     get:
       summary: List source runtime configurations

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -39,6 +39,7 @@ import (
 	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/reports"
+	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
@@ -3572,7 +3573,7 @@ func redactSourceRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRunt
 	redacted := proto.Clone(runtime).(*cerebrov1.SourceRuntime)
 	config := make(map[string]string, len(redacted.GetConfig()))
 	for key, value := range redacted.GetConfig() {
-		if key == sourceRuntimeProgressConfigHashKey {
+		if sourceconfig.InternalKey(key) || key == resourcescope.ConfigKey {
 			continue
 		}
 		if sensitiveSourceConfigKey(key) {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -7046,13 +7046,14 @@ func TestFindingMessageIncludesRiskFactors(t *testing.T) {
 }
 
 type bootstrapTokenSource struct {
-	id         string
-	checkToken string
-	readToken  string
+	id           string
+	emittedKinds []string
+	checkToken   string
+	readToken    string
 }
 
 func (s *bootstrapTokenSource) Spec() *cerebrov1.SourceSpec {
-	return &cerebrov1.SourceSpec{Id: s.id, Name: "Bootstrap token source"}
+	return &cerebrov1.SourceSpec{Id: s.id, Name: "Bootstrap token source", EmittedKinds: append([]string{}, s.emittedKinds...)}
 }
 
 func (s *bootstrapTokenSource) Check(_ context.Context, config sourcecdk.Config) error {

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -19,6 +19,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/connectorcredentials"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
@@ -56,6 +57,7 @@ type connectorCatalogEntry struct {
 	HealthyRuntimes        int                             `json:"healthy_runtimes"`
 	NeedsAttentionRuntimes int                             `json:"needs_attention_runtimes"`
 	ConnectionMethods      []connectorConnectionMethodView `json:"connection_methods,omitempty"`
+	ScopeOptions           []connectorScopeOptionView      `json:"scope_options,omitempty"`
 }
 
 type connectorLibraryResponse struct {
@@ -97,23 +99,24 @@ type connectorOperationsSummary struct {
 }
 
 type connectorConnectionView struct {
-	RuntimeID               string `json:"runtime_id"`
-	SourceID                string `json:"source_id"`
-	TenantID                string `json:"tenant_id,omitempty"`
-	Family                  string `json:"family,omitempty"`
-	Status                  string `json:"status"`
-	GraphStatus             string `json:"graph_status"`
-	ContractProbeState      string `json:"contract_probe_state"`
-	LastActivityAt          string `json:"last_activity_at,omitempty"`
-	CheckpointWatermark     string `json:"checkpoint_watermark,omitempty"`
-	WatermarkLagSeconds     *int64 `json:"watermark_lag_seconds,omitempty"`
-	RecordsAccepted         uint32 `json:"records_accepted"`
-	RecordsRejected         uint32 `json:"records_rejected"`
-	EntitiesProjected       uint32 `json:"entities_projected"`
-	LinksProjected          uint32 `json:"links_projected"`
-	CursorPending           bool   `json:"cursor_pending"`
-	CheckpointCursorPresent bool   `json:"checkpoint_cursor_present"`
-	NextAction              string `json:"next_action"`
+	RuntimeID               string                `json:"runtime_id"`
+	SourceID                string                `json:"source_id"`
+	TenantID                string                `json:"tenant_id,omitempty"`
+	Family                  string                `json:"family,omitempty"`
+	Status                  string                `json:"status"`
+	GraphStatus             string                `json:"graph_status"`
+	ContractProbeState      string                `json:"contract_probe_state"`
+	LastActivityAt          string                `json:"last_activity_at,omitempty"`
+	CheckpointWatermark     string                `json:"checkpoint_watermark,omitempty"`
+	WatermarkLagSeconds     *int64                `json:"watermark_lag_seconds,omitempty"`
+	RecordsAccepted         uint32                `json:"records_accepted"`
+	RecordsRejected         uint32                `json:"records_rejected"`
+	EntitiesProjected       uint32                `json:"entities_projected"`
+	LinksProjected          uint32                `json:"links_projected"`
+	CursorPending           bool                  `json:"cursor_pending"`
+	CheckpointCursorPresent bool                  `json:"checkpoint_cursor_present"`
+	NextAction              string                `json:"next_action"`
+	ScopePolicy             *resourcescope.Policy `json:"scope_policy,omitempty"`
 }
 
 type connectorActivityView struct {
@@ -178,6 +181,15 @@ type connectorConnectionMethodView struct {
 	UnavailableReason string               `json:"unavailable_reason,omitempty"`
 }
 
+type connectorScopeOptionView struct {
+	ID        string   `json:"id"`
+	Label     string   `json:"label"`
+	Type      string   `json:"type"`
+	Families  []string `json:"families,omitempty"`
+	Support   string   `json:"support,omitempty"`
+	HighValue bool     `json:"high_value,omitempty"`
+}
+
 type connectorConnectionRequest struct {
 	RuntimeID            string                                `json:"runtime_id"`
 	TenantID             string                                `json:"tenant_id"`
@@ -185,15 +197,17 @@ type connectorConnectionRequest struct {
 	AuthMethod           string                                `json:"auth_method,omitempty"`
 	CredentialStoreID    string                                `json:"credential_store_id,omitempty"`
 	Config               map[string]string                     `json:"config"`
+	ScopePolicy          resourcescope.Policy                  `json:"scope_policy,omitempty"`
 	CredentialReferences map[string]string                     `json:"credential_references,omitempty"`
 	EncryptedCredentials connectorcredentials.EncryptedPayload `json:"encrypted_credentials"`
 }
 
 type connectorConnectionResponse struct {
-	SourceID   string                  `json:"source_id"`
-	Runtime    json.RawMessage         `json:"runtime"`
-	Credential connectorCredentialView `json:"credential"`
-	Status     string                  `json:"status,omitempty"`
+	SourceID    string                  `json:"source_id"`
+	Runtime     json.RawMessage         `json:"runtime"`
+	Credential  connectorCredentialView `json:"credential"`
+	ScopePolicy *resourcescope.Policy   `json:"scope_policy,omitempty"`
+	Status      string                  `json:"status,omitempty"`
 }
 
 type connectorCredentialView struct {
@@ -242,6 +256,7 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 			EmittedKinds:      append([]string{}, source.GetEmittedKinds()...),
 			Status:            "available",
 			ConnectionMethods: connectorConnectionMethods(source.GetId(), stores),
+			ScopeOptions:      a.connectorScopeOptions(source.GetId(), source.GetEmittedKinds()),
 		}
 		if count := counts[source.GetId()]; count.total > 0 {
 			entry.ConfiguredRuntimes = count.total
@@ -385,6 +400,20 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 		writeConnectorError(w, err)
 		return
 	}
+	scopePolicy, err := connectorScopePolicy(request.ScopePolicy)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	scopeConfigValue := ""
+	if !scopePolicy.Empty() {
+		scopeConfigValue, err = resourcescope.ConfigValue(scopePolicy)
+		if err != nil {
+			writeConnectorError(w, err)
+			return
+		}
+		runtimeConfig[resourcescope.ConfigKey] = scopeConfigValue
+	}
 	if err := validateConnectorConnectionShape(sourceID, authMethod, credentialStoreID, runtimeConfig, request.CredentialReferences, request.EncryptedCredentials); err != nil {
 		writeConnectorError(w, err)
 		return
@@ -445,10 +474,11 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 			return
 		}
 		writeJSON(w, http.StatusOK, connectorConnectionResponse{
-			SourceID:   sourceID,
-			Runtime:    runtimePayload,
-			Credential: credential,
-			Status:     "checked",
+			SourceID:    sourceID,
+			Runtime:     runtimePayload,
+			Credential:  credential,
+			ScopePolicy: connectorScopePolicyPtr(scopePolicy),
+			Status:      "checked",
 		})
 		return
 	}
@@ -477,6 +507,9 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 		credential.CreatedAt = connectorcredentials.TimestampOrZero(record.CreatedAt)
 		credential.UpdatedAt = connectorcredentials.TimestampOrZero(record.UpdatedAt)
 	}
+	if scopeConfigValue != "" {
+		runtime.Config[resourcescope.ConfigKey] = scopeConfigValue
+	}
 	response, err := a.runtimeService().Put(r.Context(), &cerebrov1.PutSourceRuntimeRequest{Runtime: runtime})
 	if err != nil {
 		writeConnectorError(w, err)
@@ -488,9 +521,10 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 		return
 	}
 	writeJSON(w, http.StatusOK, connectorConnectionResponse{
-		SourceID:   sourceID,
-		Runtime:    json.RawMessage(runtimePayload),
-		Credential: credential,
+		SourceID:    sourceID,
+		Runtime:     json.RawMessage(runtimePayload),
+		Credential:  credential,
+		ScopePolicy: connectorScopePolicyPtr(scopePolicy),
 	})
 }
 
@@ -588,6 +622,83 @@ func connectorEntryBySourceID(entries []connectorCatalogEntry, sourceID string) 
 		}
 	}
 	return connectorCatalogEntry{}, false
+}
+
+func (a *App) connectorScopeOptions(sourceID string, emittedKinds []string) []connectorScopeOptionView {
+	sourceID = strings.TrimSpace(sourceID)
+	if a != nil && a.sources != nil {
+		if source, ok := a.sources.Get(sourceID); ok {
+			if provider, ok := source.(sourcecdk.CoverageContractProvider); ok {
+				options := connectorScopeOptionsFromCoverage(provider.CoverageContract())
+				if len(options) > 0 {
+					return options
+				}
+			}
+		}
+	}
+	return connectorScopeOptionsFromKinds(emittedKinds)
+}
+
+func connectorScopeOptionsFromCoverage(contract sourcecdk.CoverageContract) []connectorScopeOptionView {
+	options := make([]connectorScopeOptionView, 0, len(contract.Dimensions))
+	for _, dimension := range contract.Dimensions {
+		if len(dimension.Families) == 0 {
+			continue
+		}
+		if dimension.Support == sourcecdk.CoverageSupportUnsupported || dimension.Support == sourcecdk.CoverageSupportPlanned {
+			continue
+		}
+		options = append(options, connectorScopeOptionView{
+			ID:        dimension.ID,
+			Label:     dimension.Title,
+			Type:      dimension.Type,
+			Families:  append([]string{}, dimension.Families...),
+			Support:   dimension.Support,
+			HighValue: dimension.HighValue,
+		})
+	}
+	sort.Slice(options, func(i, j int) bool {
+		if options[i].HighValue != options[j].HighValue {
+			return options[i].HighValue
+		}
+		return strings.ToLower(options[i].Label) < strings.ToLower(options[j].Label)
+	})
+	return options
+}
+
+func connectorScopeOptionsFromKinds(kinds []string) []connectorScopeOptionView {
+	options := make([]connectorScopeOptionView, 0, len(kinds))
+	for _, kind := range kinds {
+		kind = strings.TrimSpace(kind)
+		if kind == "" {
+			continue
+		}
+		options = append(options, connectorScopeOptionView{
+			ID:       kind,
+			Label:    connectorFieldLabel(strings.ReplaceAll(kind, ".", "_")),
+			Type:     "emitted_kind",
+			Families: []string{kind},
+			Support:  sourcecdk.CoverageSupportSupported,
+		})
+	}
+	sort.Slice(options, func(i, j int) bool { return strings.ToLower(options[i].Label) < strings.ToLower(options[j].Label) })
+	return options
+}
+
+func connectorScopePolicy(policy resourcescope.Policy) (resourcescope.Policy, error) {
+	normalized, err := resourcescope.Normalize(policy)
+	if err != nil {
+		return resourcescope.Policy{}, fmt.Errorf("%w: %w", connectorcredentials.ErrInvalidRequest, err)
+	}
+	return normalized, nil
+}
+
+func connectorScopePolicyPtr(policy resourcescope.Policy) *resourcescope.Policy {
+	if policy.Empty() {
+		return nil
+	}
+	cloned := policy
+	return &cloned
 }
 
 func (a *App) connectorHealthForSource(r *http.Request, sourceID string, tenantID string) (sourceRuntimeHealthResponse, error) {
@@ -706,6 +817,7 @@ func connectorConnectionsFromHealth(records []sourceRuntimeHealthRecord) []conne
 			CursorPending:           record.CursorPending,
 			CheckpointCursorPresent: record.CheckpointCursorPresent,
 			NextAction:              connectorConnectionNextAction(status, record),
+			ScopePolicy:             record.ScopePolicy,
 		})
 	}
 	sort.Slice(connections, func(i, j int) bool {
@@ -1382,7 +1494,7 @@ func connectorRuntimeConfig(input map[string]string) (map[string]string, error) 
 		if trimmedKey == "" {
 			continue
 		}
-		if sourceconfig.InternalKey(trimmedKey) {
+		if sourceconfig.InternalKey(trimmedKey) || trimmedKey == resourcescope.ConfigKey {
 			return nil, fmt.Errorf("%w: internal config %q cannot be supplied by connector requests", connectorcredentials.ErrInvalidRequest, trimmedKey)
 		}
 		if sourceconfig.SensitiveKey(trimmedKey) && strings.TrimSpace(value) != "" && !sourceconfig.IsCredentialReference(value) {
@@ -1400,7 +1512,7 @@ func applyConnectorCredentialReferences(config map[string]string, references map
 		if trimmedKey == "" || trimmedValue == "" {
 			return fmt.Errorf("%w: credential reference key and value are required", connectorcredentials.ErrInvalidRequest)
 		}
-		if sourceconfig.InternalKey(trimmedKey) {
+		if sourceconfig.InternalKey(trimmedKey) || trimmedKey == resourcescope.ConfigKey {
 			return fmt.Errorf("%w: internal config %q cannot be supplied by connector references", connectorcredentials.ErrInvalidRequest, trimmedKey)
 		}
 		if !sourceconfig.IsSecretReference(trimmedValue) {
@@ -1474,6 +1586,9 @@ func validateConnectorConfigFields(sourceID string, authMethod string, config ma
 		return nil
 	}
 	for key := range config {
+		if sourceconfig.InternalKey(key) || key == resourcescope.ConfigKey {
+			continue
+		}
 		if authMethod == connectorAuthMethodAWSSSOProfile && key == "profile" {
 			continue
 		}

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/writer/cerebro/internal/connectorcredentials"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -138,6 +139,89 @@ func TestConnectorConnectionStoresCredentialReference(t *testing.T) {
 	}
 	if source.checkToken != "secret-token" {
 		t.Fatalf("source check token = %q, want decrypted secret", source.checkToken)
+	}
+}
+
+func TestConnectorConnectionStoresValidatedScopePolicy(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	key := app.connectorTransitKey.PublicKey()
+	encrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "secret-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-a", "runtime-a", defaultConnectorCredentialStoreID),
+	)
+	if err != nil {
+		t.Fatalf("encrypt credentials: %v", err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":          "runtime-a",
+		"tenant_id":           "tenant-a",
+		"credential_store_id": defaultConnectorCredentialStoreID,
+		"config":              map[string]string{"family": "audit"},
+		"scope_policy": map[string]any{
+			"excluded_families":      []string{"audit"},
+			"excluded_resource_urns": []string{"urn:cerebro:tenant-a:external_asset:test"},
+		},
+		"encrypted_credentials": encrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/connections", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /connectors/{sourceID}/connections error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /connectors status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		Runtime map[string]any `json:"runtime"`
+		Scope   struct {
+			ExcludedFamilies []string `json:"excluded_families"`
+		} `json:"scope_policy"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.Scope.ExcludedFamilies) != 1 || payload.Scope.ExcludedFamilies[0] != "audit" {
+		t.Fatalf("scope_policy excluded_families = %#v, want [audit]", payload.Scope.ExcludedFamilies)
+	}
+	if configPayload, ok := payload.Runtime["config"].(map[string]any); ok {
+		if _, leaked := configPayload[resourcescope.ConfigKey]; leaked {
+			t.Fatalf("runtime payload leaked internal scope config: %#v", configPayload)
+		}
+	}
+	runtime := store.runtimes["runtime-a"]
+	if runtime == nil {
+		t.Fatal("stored runtime missing")
+	}
+	storedPolicy, err := resourcescope.FromConfig(runtime.GetConfig())
+	if err != nil {
+		t.Fatalf("FromConfig(stored runtime) error = %v", err)
+	}
+	if !storedPolicy.ExcludesFamily("bootstrap_token", "audit") {
+		t.Fatalf("stored scope policy does not exclude audit: %#v", storedPolicy)
 	}
 }
 
@@ -264,7 +348,7 @@ func TestConnectorConnectionRejectsUnsupportedCredentialStore(t *testing.T) {
 }
 
 func TestConnectorCatalogAdvertisesConnectionMethods(t *testing.T) {
-	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	source := &bootstrapTokenSource{id: "bootstrap_token", emittedKinds: []string{"bootstrap.token"}}
 	registry, err := sourcecdk.NewRegistry(source)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
@@ -300,6 +384,10 @@ func TestConnectorCatalogAdvertisesConnectionMethods(t *testing.T) {
 				ID       string `json:"id"`
 				Saveable bool   `json:"saveable"`
 			} `json:"connection_methods"`
+			ScopeOptions []struct {
+				ID       string   `json:"id"`
+				Families []string `json:"families"`
+			} `json:"scope_options"`
 		} `json:"connectors"`
 		CredentialStores []struct {
 			ID        string `json:"id"`
@@ -314,6 +402,12 @@ func TestConnectorCatalogAdvertisesConnectionMethods(t *testing.T) {
 	}
 	if got := payload.Connectors[0].DisplayName; got != "Bootstrap token source" {
 		t.Fatalf("display_name = %q, want fallback source name", got)
+	}
+	if len(payload.Connectors[0].ScopeOptions) != 1 || payload.Connectors[0].ScopeOptions[0].ID != "bootstrap.token" {
+		t.Fatalf("scope_options = %#v, want bootstrap.token option", payload.Connectors[0].ScopeOptions)
+	}
+	if got := payload.Connectors[0].ScopeOptions[0].Families; len(got) != 1 || got[0] != "bootstrap.token" {
+		t.Fatalf("scope option families = %#v, want [bootstrap.token]", got)
 	}
 	methods := map[string]bool{}
 	for _, method := range payload.Connectors[0].ConnectionMethods {
@@ -341,6 +435,10 @@ func TestConnectorDetailSummarizesOperationsWithoutConfig(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 	now := time.Date(2026, 6, 15, 16, 0, 0, 0, time.UTC)
+	rawScopePolicy, err := resourcescope.ConfigValue(resourcescope.Policy{ExcludedFamilies: []string{"audit"}})
+	if err != nil {
+		t.Fatalf("ConfigValue() error = %v", err)
+	}
 	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
 		"runtime-a": {
 			Id:           "runtime-a",
@@ -356,6 +454,7 @@ func TestConnectorDetailSummarizesOperationsWithoutConfig(t *testing.T) {
 				runtimeLinksProjectedConfigKey:     "8",
 				runtimeContractProbeStateConfigKey: "passing",
 				"expected_cadence_seconds":         "14400",
+				resourcescope.ConfigKey:            rawScopePolicy,
 			},
 		},
 	}}}
@@ -392,6 +491,9 @@ func TestConnectorDetailSummarizesOperationsWithoutConfig(t *testing.T) {
 			RuntimeID       string `json:"runtime_id"`
 			RecordsAccepted uint32 `json:"records_accepted"`
 			NextAction      string `json:"next_action"`
+			ScopePolicy     struct {
+				ExcludedFamilies []string `json:"excluded_families"`
+			} `json:"scope_policy"`
 		} `json:"connections"`
 		Activity []struct {
 			Type            string `json:"type"`
@@ -422,6 +524,9 @@ func TestConnectorDetailSummarizesOperationsWithoutConfig(t *testing.T) {
 	}
 	if got := payload.Connections[0].NextAction; got != "run_graph_ingest" {
 		t.Fatalf("next_action = %q, want run_graph_ingest", got)
+	}
+	if len(payload.Connections[0].ScopePolicy.ExcludedFamilies) != 1 || payload.Connections[0].ScopePolicy.ExcludedFamilies[0] != "audit" {
+		t.Fatalf("connection scope policy = %#v, want audit exclusion", payload.Connections[0].ScopePolicy)
 	}
 	if len(payload.Activity) == 0 || payload.Activity[0].Type != "sync" {
 		t.Fatalf("activity = %#v, want sync activity", payload.Activity)

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -14,6 +14,7 @@ import (
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -122,6 +123,7 @@ type sourceRuntimeHealthRecord struct {
 	SourceID                  string                                `json:"source_id"`
 	TenantID                  string                                `json:"tenant_id"`
 	Family                    string                                `json:"family,omitempty"`
+	ScopePolicy               *resourcescope.Policy                 `json:"scope_policy,omitempty"`
 	EnabledState              string                                `json:"enabled_state"`
 	Status                    string                                `json:"status"`
 	LastSyncedAt              string                                `json:"last_synced_at,omitempty"`
@@ -641,6 +643,13 @@ func (a *App) sourceRuntimeHealthRecord(ctx context.Context, runtime *cerebrov1.
 		// Schedule cadence/SLA is currently deployment configuration, not runtime state.
 		ScheduleContextConfigured: false,
 		GeneratedAt:               generatedAt.Format(time.RFC3339Nano),
+	}
+	policy, err := resourcescope.FromConfig(runtime.GetConfig())
+	if err != nil {
+		return sourceRuntimeHealthRecord{}, err
+	}
+	if !policy.Empty() {
+		record.ScopePolicy = &policy
 	}
 	if lastSynced := timestampValue(runtime.GetLastSyncedAt()); !lastSynced.IsZero() {
 		lastSynced = lastSynced.UTC()

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -644,11 +644,7 @@ func (a *App) sourceRuntimeHealthRecord(ctx context.Context, runtime *cerebrov1.
 		ScheduleContextConfigured: false,
 		GeneratedAt:               generatedAt.Format(time.RFC3339Nano),
 	}
-	policy, err := resourcescope.FromConfig(runtime.GetConfig())
-	if err != nil {
-		return sourceRuntimeHealthRecord{}, err
-	}
-	if !policy.Empty() {
+	if policy, err := resourcescope.FromConfig(runtime.GetConfig()); err == nil && !policy.Empty() {
 		record.ScopePolicy = &policy
 	}
 	if lastSynced := timestampValue(runtime.GetLastSyncedAt()); !lastSynced.IsZero() {

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -11,6 +11,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourceruntime"
@@ -45,6 +46,26 @@ func TestSourceRuntimeHealthRecordIncludesScheduleReceipt(t *testing.T) {
 	}
 	if record.Status != "healthy" {
 		t.Fatalf("Status = %q, want healthy", record.Status)
+	}
+}
+
+func TestSourceRuntimeHealthRecordIgnoresMalformedStoredScopePolicy(t *testing.T) {
+	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "runtime-1",
+		SourceId: "generated",
+		TenantId: "tenant",
+		Config: map[string]string{
+			resourcescope.ConfigKey: "{not-json",
+		},
+	}
+
+	record, err := (&App{}).sourceRuntimeHealthRecord(context.Background(), runtime, now)
+	if err != nil {
+		t.Fatalf("sourceRuntimeHealthRecord() error = %v", err)
+	}
+	if record.ScopePolicy != nil {
+		t.Fatalf("ScopePolicy = %#v, want nil for malformed stored policy", record.ScopePolicy)
 	}
 }
 

--- a/internal/resourcescope/policy.go
+++ b/internal/resourcescope/policy.go
@@ -151,14 +151,17 @@ func (p Policy) ExcludesEvent(kind string, id string, attributes map[string]stri
 			return true
 		}
 	}
-	ids := eventIDs(id, attributes, urns)
-	types := eventTypes(kind, attributes)
+	pairs := eventResourcePairs(kind, id, attributes, urns)
 	for _, resource := range p.ExcludedResources {
 		if resource.URN != "" && urns[resource.URN] {
 			return true
 		}
-		if resource.Type != "" && resource.ID != "" && types[strings.ToLower(resource.Type)] && ids[resource.ID] {
-			return true
+		if resource.Type != "" && resource.ID != "" {
+			for _, key := range resourcePairKeys(resource.Type, resource.ID) {
+				if pairs[key] {
+					return true
+				}
+			}
 		}
 	}
 	return false
@@ -293,36 +296,72 @@ func eventURNs(attributes map[string]string) map[string]bool {
 	return urns
 }
 
-func eventIDs(id string, attributes map[string]string, urns map[string]bool) map[string]bool {
-	ids := map[string]bool{}
-	for _, value := range splitAttributeValues(id) {
-		ids[value] = true
-	}
-	for _, key := range []string{"id", "asset_id", "resource_id", "resource_name", "target_id", "entity_id"} {
-		for _, value := range splitAttributeValues(attributes[key]) {
-			ids[value] = true
+func eventResourcePairs(kind string, id string, attributes map[string]string, urns map[string]bool) map[string]bool {
+	pairs := map[string]bool{}
+	addPairs := func(types []string, ids []string) {
+		for _, typ := range types {
+			for _, id := range ids {
+				for _, key := range resourcePairKeys(typ, id) {
+					pairs[key] = true
+				}
+			}
 		}
 	}
+	addPairs(splitAttributeValues(kind), splitAttributeValues(id))
+	addPairs(splitAttributeValues(attributes["kind"]), splitAttributeValues(attributes["id"]))
+	addPairs(splitAttributeValues(attributes["asset_type"]), splitAttributeValues(attributes["asset_id"]))
+	addPairs(splitAttributeValues(attributes["resource_type"]), splitAttributeValues(attributes["resource_id"]))
+	addPairs(splitAttributeValues(attributes["resource_type"]), splitAttributeValues(attributes["resource_name"]))
+	addPairs(splitAttributeValues(attributes["target_type"]), splitAttributeValues(attributes["target_id"]))
+	addPairs(splitAttributeValues(attributes["entity_type"]), splitAttributeValues(attributes["entity_id"]))
 	for urn := range urns {
 		parts := strings.Split(urn, ":")
-		if len(parts) > 0 {
-			ids[parts[len(parts)-1]] = true
+		if len(parts) >= 2 {
+			addPairs([]string{parts[len(parts)-2]}, []string{parts[len(parts)-1]})
 		}
 	}
-	return ids
+	return pairs
 }
 
-func eventTypes(kind string, attributes map[string]string) map[string]bool {
-	types := map[string]bool{}
-	for _, value := range splitAttributeValues(kind) {
-		types[strings.ToLower(value)] = true
+func resourcePairKeys(resourceType string, id string) []string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil
 	}
-	for _, key := range []string{"kind", "asset_type", "resource_type", "entity_type", "target_type"} {
-		for _, value := range splitAttributeValues(attributes[key]) {
-			types[strings.ToLower(value)] = true
+	types := resourceTypeCandidates(resourceType)
+	keys := make([]string, 0, len(types))
+	for _, typ := range types {
+		keys = append(keys, typ+"\x00"+id)
+	}
+	return keys
+}
+
+func resourceTypeCandidates(resourceType string) []string {
+	normalized := strings.ToLower(strings.TrimSpace(resourceType))
+	if normalized == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := []string{}
+	add := func(value string) {
+		if value == "" {
+			return
 		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
 	}
-	return types
+	add(normalized)
+	if strings.Contains(normalized, ".") {
+		add(strings.ReplaceAll(normalized, ".", "_"))
+		return out
+	}
+	if index := strings.Index(normalized, "_"); index > 0 && index < len(normalized)-1 {
+		add(normalized[:index] + "." + normalized[index+1:])
+	}
+	return out
 }
 
 func splitAttributeValues(value string) []string {

--- a/internal/resourcescope/policy.go
+++ b/internal/resourcescope/policy.go
@@ -1,0 +1,342 @@
+package resourcescope
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	// ConfigKey stores the non-secret runtime resource-scope policy.
+	ConfigKey = "cerebro_resource_scope_policy"
+
+	ModeExclude = "exclude"
+)
+
+const (
+	maxScopeValues       = 500
+	maxScopeValueLength  = 1024
+	maxScopeReasonLength = 512
+)
+
+// Policy describes source-runtime resources that should be skipped when possible.
+type Policy struct {
+	Mode                 string             `json:"mode,omitempty"`
+	ExcludedFamilies     []string           `json:"excluded_families,omitempty"`
+	ExcludedAssetClasses []string           `json:"excluded_asset_classes,omitempty"`
+	ExcludedKinds        []string           `json:"excluded_kinds,omitempty"`
+	ExcludedResourceURNs []string           `json:"excluded_resource_urns,omitempty"`
+	ExcludedResources    []ResourceSelector `json:"excluded_resources,omitempty"`
+}
+
+// ResourceSelector identifies one concrete resource by URN or provider type/id.
+type ResourceSelector struct {
+	URN    string `json:"urn,omitempty"`
+	Type   string `json:"type,omitempty"`
+	ID     string `json:"id,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// FromConfig parses the policy stored on a source runtime config map.
+func FromConfig(values map[string]string) (Policy, error) {
+	raw := strings.TrimSpace(values[ConfigKey])
+	if raw == "" {
+		return Policy{}, nil
+	}
+	var policy Policy
+	if err := json.Unmarshal([]byte(raw), &policy); err != nil {
+		return Policy{}, fmt.Errorf("parse resource scope policy: %w", err)
+	}
+	return Normalize(policy)
+}
+
+// ConfigValue returns the canonical JSON value for storing this policy in runtime config.
+func ConfigValue(policy Policy) (string, error) {
+	normalized, err := Normalize(policy)
+	if err != nil {
+		return "", err
+	}
+	if normalized.Empty() {
+		return "", nil
+	}
+	payload, err := json.Marshal(normalized)
+	if err != nil {
+		return "", fmt.Errorf("marshal resource scope policy: %w", err)
+	}
+	return string(payload), nil
+}
+
+// Normalize trims, deduplicates, and validates policy values.
+func Normalize(policy Policy) (Policy, error) {
+	mode := strings.ToLower(strings.TrimSpace(policy.Mode))
+	if mode == "" {
+		mode = ModeExclude
+	}
+	if mode != ModeExclude {
+		return Policy{}, fmt.Errorf("resource scope mode must be %q", ModeExclude)
+	}
+	normalized := Policy{
+		Mode:                 mode,
+		ExcludedFamilies:     normalizeTokens(policy.ExcludedFamilies),
+		ExcludedAssetClasses: normalizeTokens(policy.ExcludedAssetClasses),
+		ExcludedKinds:        normalizeTokens(policy.ExcludedKinds),
+		ExcludedResourceURNs: normalizeLiteralValues(policy.ExcludedResourceURNs),
+	}
+	if err := validateValues("excluded_families", normalized.ExcludedFamilies); err != nil {
+		return Policy{}, err
+	}
+	if err := validateValues("excluded_asset_classes", normalized.ExcludedAssetClasses); err != nil {
+		return Policy{}, err
+	}
+	if err := validateValues("excluded_kinds", normalized.ExcludedKinds); err != nil {
+		return Policy{}, err
+	}
+	if err := validateValues("excluded_resource_urns", normalized.ExcludedResourceURNs); err != nil {
+		return Policy{}, err
+	}
+	resources, err := normalizeResources(policy.ExcludedResources)
+	if err != nil {
+		return Policy{}, err
+	}
+	normalized.ExcludedResources = resources
+	if normalized.Empty() {
+		normalized.Mode = ""
+	}
+	return normalized, nil
+}
+
+// Empty reports whether the policy has no exclusions.
+func (p Policy) Empty() bool {
+	return len(p.ExcludedFamilies) == 0 &&
+		len(p.ExcludedAssetClasses) == 0 &&
+		len(p.ExcludedKinds) == 0 &&
+		len(p.ExcludedResourceURNs) == 0 &&
+		len(p.ExcludedResources) == 0
+}
+
+// ExcludesFamily returns true when a runtime family should be skipped before source IO.
+func (p Policy) ExcludesFamily(sourceID string, family string) bool {
+	if p.Empty() {
+		return false
+	}
+	candidates := familyCandidates(sourceID, family)
+	for _, value := range append(append([]string{}, p.ExcludedFamilies...), p.ExcludedAssetClasses...) {
+		if candidates[scopeFamilyToken(sourceID, value)] {
+			return true
+		}
+	}
+	for _, kind := range p.ExcludedKinds {
+		if candidates[scopeFamilyToken(sourceID, kind)] {
+			return true
+		}
+	}
+	return false
+}
+
+// ExcludesEvent returns true when a concrete event should be dropped before projection.
+func (p Policy) ExcludesEvent(kind string, id string, attributes map[string]string) bool {
+	if p.Empty() {
+		return false
+	}
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	for _, excluded := range p.ExcludedKinds {
+		if strings.EqualFold(excluded, kind) {
+			return true
+		}
+	}
+	urns := eventURNs(attributes)
+	for _, excludedURN := range p.ExcludedResourceURNs {
+		if urns[excludedURN] {
+			return true
+		}
+	}
+	ids := eventIDs(id, attributes, urns)
+	types := eventTypes(kind, attributes)
+	for _, resource := range p.ExcludedResources {
+		if resource.URN != "" && urns[resource.URN] {
+			return true
+		}
+		if resource.Type != "" && resource.ID != "" && types[strings.ToLower(resource.Type)] && ids[resource.ID] {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeTokens(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.ToLower(strings.TrimSpace(value))
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeLiteralValues(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func validateValues(field string, values []string) error {
+	if len(values) > maxScopeValues {
+		return fmt.Errorf("resource scope %s has too many values", field)
+	}
+	for _, value := range values {
+		if len(value) > maxScopeValueLength {
+			return fmt.Errorf("resource scope %s value is too long", field)
+		}
+	}
+	return nil
+}
+
+func normalizeResources(values []ResourceSelector) ([]ResourceSelector, error) {
+	if len(values) > maxScopeValues {
+		return nil, fmt.Errorf("resource scope excluded_resources has too many values")
+	}
+	out := make([]ResourceSelector, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		next := ResourceSelector{
+			URN:    strings.TrimSpace(value.URN),
+			Type:   strings.ToLower(strings.TrimSpace(value.Type)),
+			ID:     strings.TrimSpace(value.ID),
+			Reason: strings.TrimSpace(value.Reason),
+		}
+		if next.URN == "" && next.Type == "" && next.ID == "" && next.Reason == "" {
+			continue
+		}
+		if len(next.URN) > maxScopeValueLength || len(next.Type) > maxScopeValueLength || len(next.ID) > maxScopeValueLength {
+			return nil, fmt.Errorf("resource scope excluded_resources value is too long")
+		}
+		if len(next.Reason) > maxScopeReasonLength {
+			return nil, fmt.Errorf("resource scope excluded_resources reason is too long")
+		}
+		if next.URN == "" && (next.Type == "" || next.ID == "") {
+			return nil, fmt.Errorf("resource scope excluded_resources entries require urn or type and id")
+		}
+		key := next.URN + "\x00" + next.Type + "\x00" + next.ID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, next)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := out[i].URN + out[i].Type + out[i].ID
+		right := out[j].URN + out[j].Type + out[j].ID
+		return left < right
+	})
+	return out, nil
+}
+
+func familyCandidates(sourceID string, family string) map[string]bool {
+	sourceID = strings.ToLower(strings.TrimSpace(sourceID))
+	family = strings.ToLower(strings.TrimSpace(family))
+	candidates := map[string]bool{}
+	if family == "" {
+		return candidates
+	}
+	candidates[family] = true
+	if sourceID != "" {
+		candidates[sourceID+"."+family] = true
+		candidates[sourceID+"_"+family] = true
+	}
+	return candidates
+}
+
+func scopeFamilyToken(sourceID string, value string) string {
+	token := strings.ToLower(strings.TrimSpace(value))
+	sourceID = strings.ToLower(strings.TrimSpace(sourceID))
+	if sourceID != "" {
+		token = strings.TrimPrefix(token, sourceID+".")
+		token = strings.TrimPrefix(token, sourceID+"_")
+	}
+	if index := strings.LastIndex(token, "."); index >= 0 && index < len(token)-1 {
+		token = token[index+1:]
+	}
+	return token
+}
+
+func eventURNs(attributes map[string]string) map[string]bool {
+	keys := []string{"urn", "asset_urn", "resource_urn", "primary_resource_urn", "target_urn", "entity_urn", "exposed_resource_urn", "graph_root_urn", "graph_path_urn"}
+	urns := map[string]bool{}
+	for _, key := range keys {
+		for _, value := range splitAttributeValues(attributes[key]) {
+			if strings.HasPrefix(value, "urn:cerebro:") {
+				urns[value] = true
+			}
+		}
+	}
+	return urns
+}
+
+func eventIDs(id string, attributes map[string]string, urns map[string]bool) map[string]bool {
+	ids := map[string]bool{}
+	for _, value := range splitAttributeValues(id) {
+		ids[value] = true
+	}
+	for _, key := range []string{"id", "asset_id", "resource_id", "resource_name", "target_id", "entity_id"} {
+		for _, value := range splitAttributeValues(attributes[key]) {
+			ids[value] = true
+		}
+	}
+	for urn := range urns {
+		parts := strings.Split(urn, ":")
+		if len(parts) > 0 {
+			ids[parts[len(parts)-1]] = true
+		}
+	}
+	return ids
+}
+
+func eventTypes(kind string, attributes map[string]string) map[string]bool {
+	types := map[string]bool{}
+	for _, value := range splitAttributeValues(kind) {
+		types[strings.ToLower(value)] = true
+	}
+	for _, key := range []string{"kind", "asset_type", "resource_type", "entity_type", "target_type"} {
+		for _, value := range splitAttributeValues(attributes[key]) {
+			types[strings.ToLower(value)] = true
+		}
+	}
+	return types
+}
+
+func splitAttributeValues(value string) []string {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == '\n' || r == '\t' })
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/internal/resourcescope/policy_test.go
+++ b/internal/resourcescope/policy_test.go
@@ -44,6 +44,37 @@ func TestPolicyRejectsMalformedResourceSelectors(t *testing.T) {
 	}
 }
 
+func TestPolicyDoesNotCrossMatchUnpairedResourceTypeAndID(t *testing.T) {
+	policy, err := Normalize(Policy{ExcludedResources: []ResourceSelector{{Type: "aws.s3_bucket", ID: "bucket-a"}}})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if policy.ExcludesEvent("aws.iam_role", "role-a", map[string]string{
+		"resource_type": "aws.s3_bucket",
+		"target_id":     "bucket-a",
+	}) {
+		t.Fatal("policy excluded event by combining unrelated resource_type and target_id attributes")
+	}
+	if !policy.ExcludesEvent("aws.iam_role", "role-a", map[string]string{
+		"resource_type": "aws.s3_bucket",
+		"resource_id":   "bucket-a",
+	}) {
+		t.Fatal("policy did not exclude paired resource_type/resource_id attributes")
+	}
+}
+
+func TestPolicyMatchesTypedResourceFromURNTypeVariant(t *testing.T) {
+	policy, err := Normalize(Policy{ExcludedResources: []ResourceSelector{{Type: "gcp.bigquery_dataset", ID: "dataset-a"}}})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if !policy.ExcludesEvent("gcp.audit", "event-1", map[string]string{
+		"resource_urn": "urn:cerebro:tenant:gcp_bigquery_dataset:dataset-a",
+	}) {
+		t.Fatal("policy did not match typed resource selector from URN source_type:id variant")
+	}
+}
+
 func TestEmptyPolicyDoesNotStoreConfigValue(t *testing.T) {
 	value, err := ConfigValue(Policy{ExcludedFamilies: []string{" "}})
 	if err != nil {

--- a/internal/resourcescope/policy_test.go
+++ b/internal/resourcescope/policy_test.go
@@ -1,0 +1,55 @@
+package resourcescope
+
+import "testing"
+
+func TestPolicyConfigValueRoundTripsCanonicalPolicy(t *testing.T) {
+	value, err := ConfigValue(Policy{
+		ExcludedFamilies:     []string{" S3_Bucket ", "s3_bucket"},
+		ExcludedAssetClasses: []string{"aws.EC2_Instance"},
+		ExcludedResourceURNs: []string{"urn:cerebro:tenant:aws_s3_bucket:bucket-a"},
+		ExcludedResources: []ResourceSelector{{
+			Type:   "AWS.S3_BUCKET",
+			ID:     "bucket-a",
+			Reason: "not monitored",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ConfigValue() error = %v", err)
+	}
+	policy, err := FromConfig(map[string]string{ConfigKey: value})
+	if err != nil {
+		t.Fatalf("FromConfig() error = %v", err)
+	}
+	if policy.Empty() {
+		t.Fatal("policy unexpectedly empty")
+	}
+	if !policy.ExcludesFamily("aws", "s3_bucket") {
+		t.Fatal("policy did not exclude aws s3_bucket family")
+	}
+	if !policy.ExcludesFamily("aws", "ec2_instance") {
+		t.Fatal("policy did not exclude aws ec2_instance asset class")
+	}
+	if !policy.ExcludesEvent("aws.s3_bucket", "event-1", map[string]string{"asset_urn": "urn:cerebro:tenant:aws_s3_bucket:bucket-a"}) {
+		t.Fatal("policy did not exclude exact resource urn")
+	}
+	if !policy.ExcludesEvent("aws.s3_bucket", "event-1", map[string]string{"resource_type": "aws.s3_bucket", "resource_id": "bucket-a"}) {
+		t.Fatal("policy did not exclude typed resource id")
+	}
+}
+
+func TestPolicyRejectsMalformedResourceSelectors(t *testing.T) {
+	_, err := Normalize(Policy{ExcludedResources: []ResourceSelector{{Type: "aws.s3_bucket"}}})
+	if err == nil {
+		t.Fatal("Normalize() succeeded for selector without urn or type/id")
+	}
+}
+
+func TestEmptyPolicyDoesNotStoreConfigValue(t *testing.T) {
+	value, err := ConfigValue(Policy{ExcludedFamilies: []string{" "}})
+	if err != nil {
+		t.Fatalf("ConfigValue() error = %v", err)
+	}
+	if value != "" {
+		t.Fatalf("ConfigValue() = %q, want empty", value)
+	}
+}

--- a/internal/sourcecdk/family.go
+++ b/internal/sourcecdk/family.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/resourcescope"
 )
 
 // Family groups source behavior for one configured event family.
@@ -19,6 +20,7 @@ type Family[S any] struct {
 
 // FamilyEngine dispatches source operations to table-driven families.
 type FamilyEngine[S any] struct {
+	sourceID string
 	parse    func(Config) (S, error)
 	family   func(S) string
 	families map[string]Family[S]
@@ -26,6 +28,11 @@ type FamilyEngine[S any] struct {
 
 // NewFamilyEngine constructs a source family dispatcher.
 func NewFamilyEngine[S any](parse func(Config) (S, error), family func(S) string, families ...Family[S]) (*FamilyEngine[S], error) {
+	return NewFamilyEngineWithSourceID("", parse, family, families...)
+}
+
+// NewFamilyEngineWithSourceID constructs a source family dispatcher with a source id for scope policy matching.
+func NewFamilyEngineWithSourceID[S any](sourceID string, parse func(Config) (S, error), family func(S) string, families ...Family[S]) (*FamilyEngine[S], error) {
 	if parse == nil {
 		return nil, fmt.Errorf("family settings parser is required")
 	}
@@ -33,6 +40,7 @@ func NewFamilyEngine[S any](parse func(Config) (S, error), family func(S) string
 		return nil, fmt.Errorf("family name resolver is required")
 	}
 	engine := &FamilyEngine[S]{
+		sourceID: strings.TrimSpace(sourceID),
 		parse:    parse,
 		family:   family,
 		families: make(map[string]Family[S], len(families)),
@@ -65,9 +73,12 @@ func (e *FamilyEngine[S]) Names() []string {
 
 // Check validates the configured family.
 func (e *FamilyEngine[S]) Check(ctx context.Context, cfg Config) error {
-	family, settings, err := e.resolve(cfg)
+	family, settings, policy, err := e.resolve(cfg)
 	if err != nil {
 		return err
+	}
+	if policy.ExcludesFamily(e.sourceID, family.Name) {
+		return nil
 	}
 	if family.Check == nil {
 		return nil
@@ -77,9 +88,12 @@ func (e *FamilyEngine[S]) Check(ctx context.Context, cfg Config) error {
 
 // Discover returns URNs for the configured family.
 func (e *FamilyEngine[S]) Discover(ctx context.Context, cfg Config) ([]URN, error) {
-	family, settings, err := e.resolve(cfg)
+	family, settings, policy, err := e.resolve(cfg)
 	if err != nil {
 		return nil, err
+	}
+	if policy.ExcludesFamily(e.sourceID, family.Name) {
+		return nil, nil
 	}
 	if family.Discover == nil {
 		return nil, nil
@@ -89,29 +103,40 @@ func (e *FamilyEngine[S]) Discover(ctx context.Context, cfg Config) ([]URN, erro
 
 // Read reads one page for the configured family.
 func (e *FamilyEngine[S]) Read(ctx context.Context, cfg Config, cursor *cerebrov1.SourceCursor) (Pull, error) {
-	family, settings, err := e.resolve(cfg)
+	family, settings, policy, err := e.resolve(cfg)
 	if err != nil {
 		return Pull{}, err
+	}
+	if policy.ExcludesFamily(e.sourceID, family.Name) {
+		return Pull{}, nil
 	}
 	if family.Read == nil {
 		return Pull{}, nil
 	}
-	return family.Read(ctx, settings, cursor)
+	pull, err := family.Read(ctx, settings, cursor)
+	if err != nil {
+		return Pull{}, err
+	}
+	return applyResourceScopePolicy(pull, policy), nil
 }
 
-func (e *FamilyEngine[S]) resolve(cfg Config) (Family[S], S, error) {
+func (e *FamilyEngine[S]) resolve(cfg Config) (Family[S], S, resourcescope.Policy, error) {
 	var zero S
 	if e == nil {
-		return Family[S]{}, zero, fmt.Errorf("family engine is required")
+		return Family[S]{}, zero, resourcescope.Policy{}, fmt.Errorf("family engine is required")
 	}
 	settings, err := e.parse(cfg)
 	if err != nil {
-		return Family[S]{}, zero, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+		return Family[S]{}, zero, resourcescope.Policy{}, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
 	}
 	name := strings.TrimSpace(e.family(settings))
 	family, ok := e.families[name]
 	if !ok {
-		return Family[S]{}, zero, fmt.Errorf("%w: unsupported family %q", ErrInvalidConfig, name)
+		return Family[S]{}, zero, resourcescope.Policy{}, fmt.Errorf("%w: unsupported family %q", ErrInvalidConfig, name)
 	}
-	return family, settings, nil
+	policy, err := resourcescope.FromConfig(cfg.Values())
+	if err != nil {
+		return Family[S]{}, zero, resourcescope.Policy{}, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+	return family, settings, policy, nil
 }

--- a/internal/sourcecdk/family_scope_test.go
+++ b/internal/sourcecdk/family_scope_test.go
@@ -1,0 +1,88 @@
+package sourcecdk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/resourcescope"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestFamilyEngineSkipsOutOfScopeFamilyBeforeRead(t *testing.T) {
+	called := false
+	engine, err := NewFamilyEngineWithSourceID("aws", func(cfg Config) (string, error) {
+		family, _ := cfg.Lookup("family")
+		return family, nil
+	}, func(settings string) string { return settings }, Family[string]{
+		Name: "s3_bucket",
+		Read: func(context.Context, string, *cerebrov1.SourceCursor) (Pull, error) {
+			called = true
+			return Pull{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFamilyEngineWithSourceID() error = %v", err)
+	}
+	rawPolicy, err := resourcescope.ConfigValue(resourcescope.Policy{ExcludedAssetClasses: []string{"aws.s3_bucket"}})
+	if err != nil {
+		t.Fatalf("ConfigValue() error = %v", err)
+	}
+	pull, err := engine.Read(context.Background(), NewConfig(map[string]string{
+		"family":                "s3_bucket",
+		resourcescope.ConfigKey: rawPolicy,
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if called {
+		t.Fatal("family Read was called for out-of-scope family")
+	}
+	if len(pull.Events) != 0 {
+		t.Fatalf("events len = %d, want 0", len(pull.Events))
+	}
+}
+
+func TestFamilyEngineFiltersOutOfScopeEvents(t *testing.T) {
+	engine, err := NewFamilyEngineWithSourceID("aws", func(cfg Config) (string, error) {
+		family, _ := cfg.Lookup("family")
+		return family, nil
+	}, func(settings string) string { return settings }, Family[string]{
+		Name: "cloudtrail",
+		Read: func(context.Context, string, *cerebrov1.SourceCursor) (Pull, error) {
+			return Pull{Events: []*primitives.Event{
+				{
+					Id:         "keep",
+					Kind:       "aws.cloudtrail",
+					OccurredAt: timestamppb.New(time.Now().UTC()),
+					Attributes: map[string]string{"resource_urn": "urn:cerebro:tenant:aws_s3_bucket:kept"},
+				},
+				{
+					Id:         "drop",
+					Kind:       "aws.cloudtrail",
+					OccurredAt: timestamppb.New(time.Now().UTC()),
+					Attributes: map[string]string{"resource_urn": "urn:cerebro:tenant:aws_s3_bucket:excluded"},
+				},
+			}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFamilyEngineWithSourceID() error = %v", err)
+	}
+	rawPolicy, err := resourcescope.ConfigValue(resourcescope.Policy{ExcludedResourceURNs: []string{"urn:cerebro:tenant:aws_s3_bucket:excluded"}})
+	if err != nil {
+		t.Fatalf("ConfigValue() error = %v", err)
+	}
+	pull, err := engine.Read(context.Background(), NewConfig(map[string]string{
+		"family":                "cloudtrail",
+		resourcescope.ConfigKey: rawPolicy,
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 || pull.Events[0].GetId() != "keep" {
+		t.Fatalf("events = %#v, want only keep", pull.Events)
+	}
+}

--- a/internal/sourcecdk/resource_scope.go
+++ b/internal/sourcecdk/resource_scope.go
@@ -1,0 +1,27 @@
+package sourcecdk
+
+import (
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/resourcescope"
+)
+
+func applyResourceScopePolicy(pull Pull, policy resourcescope.Policy) Pull {
+	if policy.Empty() || len(pull.Events) == 0 {
+		return pull
+	}
+	events := make([]*primitives.Event, 0, len(pull.Events))
+	for _, event := range pull.Events {
+		if event == nil {
+			continue
+		}
+		if policy.ExcludesEvent(event.GetKind(), event.GetId(), event.GetAttributes()) {
+			continue
+		}
+		events = append(events, event)
+	}
+	if len(events) == len(pull.Events) {
+		return pull
+	}
+	pull.Events = events
+	return pull
+}

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -734,11 +734,19 @@ func normalizedListFilterRuntimeIDs(filter ports.SourceRuntimeFilter) []string {
 }
 
 func restoreRedactedConfig(existing *cerebrov1.SourceRuntime, incoming *cerebrov1.SourceRuntime) {
-	if existing == nil || incoming == nil || len(incoming.GetConfig()) == 0 {
+	if existing == nil || incoming == nil {
 		return
 	}
 	if strings.TrimSpace(existing.GetSourceId()) != strings.TrimSpace(incoming.GetSourceId()) {
 		return
+	}
+	if incoming.Config == nil {
+		incoming.Config = map[string]string{}
+	}
+	if _, ok := incoming.GetConfig()[resourcescope.ConfigKey]; !ok {
+		if preserved, ok := existing.GetConfig()[resourcescope.ConfigKey]; ok {
+			incoming.Config[resourcescope.ConfigKey] = preserved
+		}
 	}
 	for key, value := range incoming.GetConfig() {
 		if strings.TrimSpace(value) != redactedValue || !sensitiveConfigKey(key) {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -17,6 +17,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
@@ -944,7 +945,7 @@ func redactRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {
 	}
 	redacted := make(map[string]string, len(cloned.GetConfig()))
 	for key, value := range cloned.GetConfig() {
-		if key == runtimeProgressConfigHashKey || sourceconfig.InternalKey(key) {
+		if key == runtimeProgressConfigHashKey || sourceconfig.InternalKey(key) || key == resourcescope.ConfigKey {
 			continue
 		}
 		if sensitiveConfigKey(key) {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -14,6 +14,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	githubsource "github.com/writer/cerebro/sources/github"
@@ -1088,6 +1089,55 @@ func TestPutRestoresRedactedSensitiveConfigBeforeMerge(t *testing.T) {
 		t.Fatalf("response token = %q, want redacted", got)
 	}
 	if got := store.runtimes["writer-github"].GetNextCursor().GetOpaque(); got != "1" {
+		t.Fatalf("stored next cursor = %q, want preserved cursor", got)
+	}
+}
+
+func TestPutPreservesOmittedResourceScopePolicyOnRedactedRoundTrip(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(emptyPageSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	scopeValue, err := resourcescope.ConfigValue(resourcescope.Policy{ExcludedFamilies: []string{"empty_page.event"}})
+	if err != nil {
+		t.Fatalf("scope ConfigValue() error = %v", err)
+	}
+	store := &runtimeStore{}
+	service := New(registry, store, nil, nil)
+
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-empty-page",
+			SourceId: "empty_page",
+			TenantId: "writer",
+			Config: map[string]string{
+				"owner":                 "platform",
+				resourcescope.ConfigKey: scopeValue,
+			},
+			Checkpoint: &cerebrov1.SourceCheckpoint{CursorOpaque: "1"},
+			NextCursor: &cerebrov1.SourceCursor{Opaque: "1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("initial Put() error = %v", err)
+	}
+	getResp, err := service.Get(context.Background(), &cerebrov1.GetSourceRuntimeRequest{Id: "writer-empty-page"})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if _, ok := getResp.GetRuntime().GetConfig()[resourcescope.ConfigKey]; ok {
+		t.Fatal("redacted Get() response exposed resource scope config")
+	}
+
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: getResp.GetRuntime()})
+	if err != nil {
+		t.Fatalf("round-trip Put() error = %v", err)
+	}
+	stored := store.runtimes["writer-empty-page"]
+	if got := stored.GetConfig()[resourcescope.ConfigKey]; got != scopeValue {
+		t.Fatalf("stored scope policy = %q, want preserved %q", got, scopeValue)
+	}
+	if got := stored.GetNextCursor().GetOpaque(); got != "1" {
 		t.Fatalf("stored next cursor = %q, want preserved cursor", got)
 	}
 }

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -2323,7 +2323,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 	}
 	families = append(families, awsSecurityFamilies(s.clients)...)
 	families = append(families, awsaccount.Families(s.clients, func(clients awsClients) any { return clients.iam }, func(settings settings) string { return settings.accountID })...)
-	return sourcecdk.NewFamilyEngine(parseSettings, func(settings settings) string { return settings.family }, families...)
+	return sourcecdk.NewFamilyEngineWithSourceID("aws", parseSettings, func(settings settings) string { return settings.family }, families...)
 }
 
 func awsFamily[T any](clientFactory awsClientFactory, options awsFamilyOptions[T]) sourcecdk.Family[settings] {

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -277,7 +277,7 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 }
 
 func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
-	return sourcecdk.NewFamilyEngine(parseSettings, func(settings settings) string { return settings.family },
+	return sourcecdk.NewFamilyEngineWithSourceID("gcp", parseSettings, func(settings settings) string { return settings.family },
 		gcpFamily(s, gcpFamilyOptions[assetMetadataRecord]{
 			Name:  familyAssetMetadata,
 			Label: "gcp asset metadata",


### PR DESCRIPTION
## Summary
- add a validated connector `scope_policy` contract stored on source runtimes
- advertise source resource scope options from coverage contracts or emitted kinds
- short-circuit excluded source families before source reads and filter exact excluded resources before projection when event identity is available
- return typed scope policies on connector health/detail responses while keeping raw runtime config redacted

## Validation
- `go test ./internal/connectorcredentials ./internal/sourceruntime ./internal/bootstrap ./internal/resourcescope ./internal/sourcecdk ./sources/aws ./sources/gcp`
- `make openapi-check`