### PR TITLE
Speed up Cerebro Ask responses

### DIFF
--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -74,12 +74,13 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 	clearStreamingWriteDeadline(w)
 	flusher, _ := w.(http.Flusher)
 	service := graphagent.NewServiceWithOptions(graphStore, llm, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
-		TrajectoryStore:   askTrajectoryStore(a.deps.StateStore),
-		EnableGraphProbes: true,
-		EnableRecovery:    true,
-		EnableMapReduce:   true,
-		MaxDepth:          2,
-		MaxChildren:       2,
+		TrajectoryStore:             askTrajectoryStore(a.deps.StateStore),
+		EnableGraphProbes:           true,
+		EnableDeterministicFastPath: true,
+		EnableRecovery:              true,
+		EnableMapReduce:             true,
+		MaxDepth:                    2,
+		MaxChildren:                 2,
 	})
 	var eventCount int
 	streamStarted := false

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -52,6 +53,8 @@ const (
 	mcpResourceMIMEJSON         = "application/json"
 )
 
+const mcpMaxConcurrentGraphFetches = 4
+
 const (
 	mcpGraphEvidenceIncluded     = "included"
 	mcpGraphEvidenceUnconfigured = "unconfigured"
@@ -76,6 +79,103 @@ type mcpJSONRPCResponse struct {
 type mcpError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+}
+
+type mcpGraphStoreNeighborhoodResult struct {
+	urn          string
+	neighborhood *ports.EntityNeighborhood
+	err          error
+}
+
+func fetchMCPGraphStoreNeighborhoods(ctx context.Context, graphStore ports.GraphQueryStore, roots []string, limit int) []mcpGraphStoreNeighborhoodResult {
+	if graphStore == nil || len(roots) == 0 {
+		return nil
+	}
+	results := make([]mcpGraphStoreNeighborhoodResult, len(roots))
+	sem := make(chan struct{}, mcpMaxConcurrentGraphFetches)
+	var wg sync.WaitGroup
+	for index, rootURN := range roots {
+		index, rootURN := index, rootURN
+		results[index].urn = rootURN
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				results[index].err = ctx.Err()
+				return
+			}
+			neighborhood, err := graphStore.GetEntityNeighborhood(ctx, rootURN, limit)
+			results[index].neighborhood = neighborhood
+			results[index].err = err
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+type mcpInvestigationResourceResult struct {
+	asset            *mcpAssetSearchResult
+	assetErr         error
+	neighborhood     any
+	graphErr         error
+	graphEncodingErr bool
+}
+
+func (app *App) fetchMCPInvestigationResources(ctx context.Context, r *http.Request, resourceURNs []string, includeGraph bool) []mcpInvestigationResourceResult {
+	if app == nil || r == nil || len(resourceURNs) == 0 {
+		return nil
+	}
+	results := make([]mcpInvestigationResourceResult, len(resourceURNs))
+	sem := make(chan struct{}, mcpMaxConcurrentGraphFetches)
+	var wg sync.WaitGroup
+	graphService := app.graphQueryService()
+	for index, resourceURN := range resourceURNs {
+		index, resourceURN := index, resourceURN
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				results[index].assetErr = ctx.Err()
+				return
+			}
+
+			found, err := app.mcpAssetSearchResults(r.Clone(ctx), map[string]any{"urn": resourceURN, "limit": 1})
+			if err == nil && len(found) > 0 {
+				asset := found[0]
+				results[index].asset = &asset
+			} else if err != nil {
+				results[index].assetErr = err
+			}
+			if !includeGraph || graphService == nil {
+				return
+			}
+			neighborhood, err := graphService.GetEntityNeighborhood(ctx, graphquery.NeighborhoodRequest{
+				RootURN: resourceURN,
+				Limit:   uint32(defaultMCPGraphLimit),
+			})
+			if err != nil {
+				results[index].graphErr = err
+				return
+			}
+			if neighborhood == nil {
+				return
+			}
+			value, err := protoJSONValue(graphNeighborhoodResponse(neighborhood))
+			if err != nil {
+				results[index].graphEncodingErr = true
+				return
+			}
+			results[index].neighborhood = mcpAddResponseMetadata(value, mcpResponseMetadata(defaultMCPGraphLimit, mcpNeighborhoodResultCount(neighborhood), nil))
+		}()
+	}
+	wg.Wait()
+	return results
 }
 
 type mcpTool struct {
@@ -1092,6 +1192,7 @@ func (app *App) mcpBuildRiskActionPlan(r *http.Request, args map[string]any) (mc
 			IncludeUnscored: mcpBoolArg(args, "include_unscored"),
 		})
 		seen := map[string]struct{}{}
+		roots := []string{}
 		for _, targetURN := range targetURNs {
 			if len(seen) >= rootLimit {
 				break
@@ -1104,17 +1205,20 @@ func (app *App) mcpBuildRiskActionPlan(r *http.Request, args map[string]any) (mc
 				continue
 			}
 			seen[targetURN] = struct{}{}
-			neighborhood, err := graphStore.GetEntityNeighborhood(r.Context(), targetURN, graphLimit)
+			roots = append(roots, targetURN)
+		}
+		for _, result := range fetchMCPGraphStoreNeighborhoods(r.Context(), graphStore, roots, graphLimit) {
 			switch {
-			case err == nil:
+			case result.err == nil:
+				neighborhood := result.neighborhood
 				if neighborhood == nil {
 					neighborhood = &ports.EntityNeighborhood{}
 				}
-				graphNeighborhoods[targetURN] = neighborhood
-			case errors.Is(err, ports.ErrGraphEntityNotFound):
+				graphNeighborhoods[result.urn] = neighborhood
+			case errors.Is(result.err, ports.ErrGraphEntityNotFound):
 				continue
 			default:
-				partialErrors = append(partialErrors, "graph neighborhood failed for "+targetURN+": "+safeMCPToolError(err))
+				partialErrors = append(partialErrors, "graph neighborhood failed for "+result.urn+": "+safeMCPToolError(result.err))
 			}
 		}
 	}
@@ -1292,34 +1396,34 @@ func (app *App) mcpInvestigationContext(r *http.Request, args map[string]any) (a
 	neighborhoods := []any{}
 	partialErrors := []string{}
 	includeGraph := !mcpBoolArg(args, "skip_graph")
+	resourceURNs := make([]string, 0, assetLimit)
+	seenResourceURNs := map[string]struct{}{}
 	for _, resourceURN := range finding.ResourceURNs {
-		if len(assets) >= assetLimit {
+		if len(resourceURNs) >= assetLimit {
 			break
 		}
-		if strings.TrimSpace(resourceURN) == "" {
+		resourceURN = strings.TrimSpace(resourceURN)
+		if resourceURN == "" {
 			continue
 		}
-		found, err := app.mcpAssetSearchResults(r, map[string]any{"urn": resourceURN, "limit": 1})
-		if err == nil && len(found) > 0 {
-			assets = append(assets, found[0])
-		} else if err != nil {
-			partialErrors = append(partialErrors, "asset lookup failed: "+safeMCPToolError(err))
+		if _, ok := seenResourceURNs[resourceURN]; ok {
+			continue
 		}
-		if includeGraph {
-			neighborhood, err := app.graphQueryService().GetEntityNeighborhood(r.Context(), graphquery.NeighborhoodRequest{
-				RootURN: resourceURN,
-				Limit:   uint32(defaultMCPGraphLimit),
-			})
-			if err == nil && neighborhood != nil {
-				value, err := protoJSONValue(graphNeighborhoodResponse(neighborhood))
-				if err == nil {
-					neighborhoods = append(neighborhoods, mcpAddResponseMetadata(value, mcpResponseMetadata(defaultMCPGraphLimit, mcpNeighborhoodResultCount(neighborhood), nil)))
-				} else {
-					partialErrors = append(partialErrors, "graph neighborhood encoding failed")
-				}
-			} else if err != nil {
-				partialErrors = append(partialErrors, "graph neighborhood failed: "+safeMCPToolError(err))
-			}
+		seenResourceURNs[resourceURN] = struct{}{}
+		resourceURNs = append(resourceURNs, resourceURN)
+	}
+	for _, result := range app.fetchMCPInvestigationResources(r.Context(), r, resourceURNs, includeGraph) {
+		if result.asset != nil {
+			assets = append(assets, *result.asset)
+		} else if result.assetErr != nil {
+			partialErrors = append(partialErrors, "asset lookup failed: "+safeMCPToolError(result.assetErr))
+		}
+		if result.neighborhood != nil {
+			neighborhoods = append(neighborhoods, result.neighborhood)
+		} else if result.graphErr != nil {
+			partialErrors = append(partialErrors, "graph neighborhood failed: "+safeMCPToolError(result.graphErr))
+		} else if result.graphEncodingErr {
+			partialErrors = append(partialErrors, "graph neighborhood encoding failed")
 		}
 	}
 	result := map[string]any{

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -98,39 +98,53 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 			return err
 		}
 	}
-	if err := emitProgress(emit, started, "drafting_query", "Drafting a read-only graph query."); err != nil {
-		return err
-	}
-	draftStarted := time.Now()
-	draft, err := s.llm.DraftCypher(ctx, DraftRequest{
-		TenantID:  strings.TrimSpace(request.TenantID),
-		Question:  strings.TrimSpace(request.Question),
-		ScopeURN:  strings.TrimSpace(request.ScopeURN),
-		Model:     model,
-		History:   history,
-		MaxRows:   defaultMaxRows,
-		Schema:    graphAgentSchemaHint,
-		Guardrail: graphAgentGuardrail,
-		Probe:     probe,
-	})
-	timings.DraftMS = time.Since(draftStarted).Milliseconds()
-	if err != nil {
-		return streamErrorf(traceID, timings, "%w: draft cypher: %w", ErrRuntimeUnavailable, err)
-	}
-	if draft == nil {
-		return streamErrorf(traceID, timings, "%w: LLM returned no draft", ErrRuntimeUnavailable)
-	}
-	rationale := strings.TrimSpace(draft.Rationale)
-	if rationale == "" {
-		rationale = "Drafting a bounded read-only Cypher query for the requested graph question."
+	var draft *DraftResponse
+	var conversion conversionResult
+	var rationale string
+	if fastConversion, fastRationale, ok := deterministicFastPathConversion(request, s.options.EnableDeterministicFastPath); ok {
+		if err := emitProgress(emit, started, "planning_query", "Selecting a deterministic read-only graph query template."); err != nil {
+			return err
+		}
+		conversionStarted := time.Now()
+		conversion = fastConversion
+		timings.ConversionMS = time.Since(conversionStarted).Milliseconds()
+		rationale = fastRationale
+	} else {
+		if err := emitProgress(emit, started, "drafting_query", "Drafting a read-only graph query."); err != nil {
+			return err
+		}
+		draftStarted := time.Now()
+		var err error
+		draft, err = s.llm.DraftCypher(ctx, DraftRequest{
+			TenantID:  strings.TrimSpace(request.TenantID),
+			Question:  strings.TrimSpace(request.Question),
+			ScopeURN:  strings.TrimSpace(request.ScopeURN),
+			Model:     model,
+			History:   history,
+			MaxRows:   defaultMaxRows,
+			Schema:    graphAgentSchemaHint,
+			Guardrail: graphAgentGuardrail,
+			Probe:     probe,
+		})
+		timings.DraftMS = time.Since(draftStarted).Milliseconds()
+		if err != nil {
+			return streamErrorf(traceID, timings, "%w: draft cypher: %w", ErrRuntimeUnavailable, err)
+		}
+		if draft == nil {
+			return streamErrorf(traceID, timings, "%w: LLM returned no draft", ErrRuntimeUnavailable)
+		}
+		rationale = strings.TrimSpace(draft.Rationale)
+		if rationale == "" {
+			rationale = "Drafting a bounded read-only Cypher query for the requested graph question."
+		}
+
+		conversionStarted := time.Now()
+		conversion = convertDraftToQuery(request, draft)
+		timings.ConversionMS = time.Since(conversionStarted).Milliseconds()
 	}
 	if err := emit(Event{Name: EventRationale, Data: RationaleEvent{Text: rationale}}); err != nil {
 		return err
 	}
-
-	conversionStarted := time.Now()
-	conversion := convertDraftToQuery(request, draft)
-	timings.ConversionMS = time.Since(conversionStarted).Milliseconds()
 	cypher := strings.TrimSpace(conversion.Cypher)
 	if err := emitQueryPlan(emit, conversion); err != nil {
 		return err

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -83,6 +83,83 @@ LIMIT 25`,
 	}
 }
 
+func TestServiceUsesDeterministicFastPathForCommonTopRiskAsk(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"finding_urn":                       "urn:cerebro:writer:finding:open-repo",
+				"finding_label":                     "Open repository finding",
+				"resource_urn":                      "urn:cerebro:writer:repo:alpha",
+				"resource_label":                    "repo-alpha",
+				"resource_type":                     "github.code.repository",
+				"relation_attributes_json_internal": `{"risk_score":88,"status":"open"}`,
+				"finding_attributes_json_internal":  `{"severity":"HIGH"}`,
+			},
+		}},
+	}
+	llm := &StubLLMClient{
+		DraftErr: errors.New("draft should be skipped"),
+		Summary:  "One open repository finding remains.",
+	}
+	service := NewServiceWithOptions(store, llm, ValidatorOptions{}, ServiceOptions{EnableDeterministicFastPath: true})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "Show open high-risk repository findings",
+	}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventProgress, EventCypher, EventProgress, EventRows, EventProgress, EventSummary, EventDone})
+	progressEvent := events[0].Data.(ProgressEvent)
+	if progressEvent.Stage != "planning_query" {
+		t.Fatalf("first progress stage = %q, want planning_query", progressEvent.Stage)
+	}
+	if len(llm.DraftRequests) != 0 {
+		t.Fatalf("DraftCypher called %#v, want deterministic fast path to skip drafting", llm.DraftRequests)
+	}
+	planEvent := events[2].Data.(QueryPlanEvent)
+	if planEvent.Source != "deterministic_fast_path" || !planEvent.Deterministic || planEvent.Plan.Intent != IntentTopRiskFindings {
+		t.Fatalf("query plan event = %#v, want deterministic fast path top-risk plan", planEvent)
+	}
+	if !strings.Contains(store.requests[0].Query, "toLower(filter_status) = 'open'") || !strings.Contains(store.requests[0].Query, "resource.entity_type = 'github.code.repository'") {
+		t.Fatalf("store request should push supported filters into Cypher:\n%s", store.requests[0].Query)
+	}
+}
+
+func TestCollectGraphProbeCachesTenantCounts(t *testing.T) {
+	resetGraphProbeCountsCacheForTest()
+	defer resetGraphProbeCountsCacheForTest()
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"name":  "source",
+				"count": int64(3),
+			},
+		}},
+	}
+	request := AskRequest{TenantID: "writer", Question: "What is risky?"}
+
+	first := collectGraphProbe(context.Background(), store, request, askParams(request))
+	if first.SourceCount != 3 {
+		t.Fatalf("first probe source count = %d, want 3", first.SourceCount)
+	}
+	if len(store.requests) != 2 {
+		t.Fatalf("store requests after first probe = %d, want 2", len(store.requests))
+	}
+	second := collectGraphProbe(context.Background(), store, request, askParams(request))
+	if second.SourceCount != 3 {
+		t.Fatalf("second probe source count = %d, want cached 3", second.SourceCount)
+	}
+	if len(store.requests) != 2 {
+		t.Fatalf("store requests after second probe = %d, want tenant count cache hit", len(store.requests))
+	}
+}
+
 func TestServiceRefusesValidatorRejectedCypher(t *testing.T) {
 	store := &askStore{}
 	llm := &StubLLMClient{DraftResponse: &DraftResponse{

--- a/internal/graphagent/llm_stub.go
+++ b/internal/graphagent/llm_stub.go
@@ -8,6 +8,7 @@ import (
 type StubLLMClient struct {
 	DraftResponse    *DraftResponse
 	Summary          string
+	DraftRequests    []DraftRequest
 	SummaryResponses []string
 	SummaryRequests  []SummarizeRequest
 	DraftErr         error
@@ -21,6 +22,9 @@ func NewStubLLMClient() *StubLLMClient {
 func (c *StubLLMClient) DraftCypher(_ context.Context, req DraftRequest) (*DraftResponse, error) {
 	if c != nil && c.DraftErr != nil {
 		return nil, c.DraftErr
+	}
+	if c != nil {
+		c.DraftRequests = append(c.DraftRequests, req)
 	}
 	if c != nil && c.DraftResponse != nil {
 		copy := *c.DraftResponse

--- a/internal/graphagent/options.go
+++ b/internal/graphagent/options.go
@@ -4,14 +4,15 @@ import "github.com/writer/cerebro/internal/ports"
 
 // ServiceOptions controls optional orchestration features for Ask.
 type ServiceOptions struct {
-	TrajectoryStore        ports.AskTrajectoryStore
-	EnableGraphProbes      bool
-	EnableRecovery         bool
-	EnableMapReduce        bool
-	MaxDepth               int
-	MaxChildren            int
-	MapReduceRowThreshold  int
-	MapReduceByteThreshold int
+	TrajectoryStore             ports.AskTrajectoryStore
+	EnableGraphProbes           bool
+	EnableDeterministicFastPath bool
+	EnableRecovery              bool
+	EnableMapReduce             bool
+	MaxDepth                    int
+	MaxChildren                 int
+	MapReduceRowThreshold       int
+	MapReduceByteThreshold      int
 }
 
 // AskExecutionContext bounds one root or child Ask execution.

--- a/internal/graphagent/probe.go
+++ b/internal/graphagent/probe.go
@@ -6,9 +6,28 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/writer/cerebro/internal/ports"
 )
+
+const graphProbeCountsCacheTTL = 2 * time.Minute
+
+var graphProbeCountsCache = struct {
+	sync.Mutex
+	entries map[string]graphProbeCountsCacheEntry
+}{
+	entries: map[string]graphProbeCountsCacheEntry{},
+}
+
+type graphProbeCountsCacheEntry struct {
+	ExpiresAt    time.Time
+	EntityTypes  []GraphProbeCount
+	Relations    []GraphProbeCount
+	SourceCount  int64
+	FindingCount int64
+}
 
 type GraphProbe struct {
 	ScopeURN     string            `json:"scope_urn,omitempty"`
@@ -43,6 +62,14 @@ func collectGraphProbe(ctx context.Context, store ports.GraphQueryStore, request
 			probe.ScopeLabel = neighborhood.Root.Label
 		}
 	}
+	if cached, ok := cachedGraphProbeCounts(request.TenantID); ok {
+		probe.EntityTypes = cached.EntityTypes
+		probe.Relations = cached.Relations
+		probe.SourceCount = cached.SourceCount
+		probe.FindingCount = cached.FindingCount
+		return probe
+	}
+	warningsBeforeCounts := len(probe.Warnings)
 	probe.EntityTypes = probeCounts(ctx, store, params, `MATCH (n:Entity {tenant_id: $tenant_id})
 RETURN n.entity_type AS name, count(n) AS count
 ORDER BY count DESC, name
@@ -53,7 +80,57 @@ ORDER BY count DESC, name
 LIMIT 20`, &probe)
 	probe.SourceCount = countForName(probe.EntityTypes, "source")
 	probe.FindingCount = countForName(probe.EntityTypes, "finding")
+	if len(probe.Warnings) == warningsBeforeCounts {
+		storeGraphProbeCounts(request.TenantID, probe)
+	}
 	return probe
+}
+
+func cachedGraphProbeCounts(tenantID string) (graphProbeCountsCacheEntry, bool) {
+	key := strings.TrimSpace(tenantID)
+	if key == "" {
+		return graphProbeCountsCacheEntry{}, false
+	}
+	now := time.Now()
+	graphProbeCountsCache.Lock()
+	defer graphProbeCountsCache.Unlock()
+	entry, ok := graphProbeCountsCache.entries[key]
+	if !ok || now.After(entry.ExpiresAt) {
+		delete(graphProbeCountsCache.entries, key)
+		return graphProbeCountsCacheEntry{}, false
+	}
+	entry.EntityTypes = copyGraphProbeCounts(entry.EntityTypes)
+	entry.Relations = copyGraphProbeCounts(entry.Relations)
+	return entry, true
+}
+
+func storeGraphProbeCounts(tenantID string, probe GraphProbe) {
+	key := strings.TrimSpace(tenantID)
+	if key == "" {
+		return
+	}
+	graphProbeCountsCache.Lock()
+	defer graphProbeCountsCache.Unlock()
+	graphProbeCountsCache.entries[key] = graphProbeCountsCacheEntry{
+		ExpiresAt:    time.Now().Add(graphProbeCountsCacheTTL),
+		EntityTypes:  copyGraphProbeCounts(probe.EntityTypes),
+		Relations:    copyGraphProbeCounts(probe.Relations),
+		SourceCount:  probe.SourceCount,
+		FindingCount: probe.FindingCount,
+	}
+}
+
+func copyGraphProbeCounts(counts []GraphProbeCount) []GraphProbeCount {
+	if len(counts) == 0 {
+		return nil
+	}
+	return append([]GraphProbeCount(nil), counts...)
+}
+
+func resetGraphProbeCountsCacheForTest() {
+	graphProbeCountsCache.Lock()
+	defer graphProbeCountsCache.Unlock()
+	graphProbeCountsCache.entries = map[string]graphProbeCountsCacheEntry{}
 }
 
 func probeCounts(ctx context.Context, store ports.GraphQueryStore, params map[string]any, query string, probe *GraphProbe) []GraphProbeCount {

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -162,6 +162,98 @@ func convertDraftToQuery(request AskRequest, draft *DraftResponse) conversionRes
 	return result
 }
 
+func deterministicFastPathConversion(request AskRequest, enabled bool) (conversionResult, string, bool) {
+	if !enabled {
+		return conversionResult{}, "", false
+	}
+	plan, ok := deterministicFastPathPlan(request)
+	if !ok {
+		return conversionResult{}, "", false
+	}
+	cypher, ok := renderDeterministicPlan(plan, defaultMaxRows)
+	if !ok || strings.TrimSpace(cypher) == "" {
+		return conversionResult{}, "", false
+	}
+	result := conversionResult{
+		Plan:          plan,
+		Cypher:        cypher,
+		Source:        "deterministic_fast_path",
+		Deterministic: true,
+		Diagnostics: []ConversionDiagnostic{{
+			Level:   "info",
+			Code:    "deterministic_query_plan",
+			Message: "Graph access used a deterministic Cerebro query template and skipped LLM Cypher drafting.",
+		}},
+	}
+	return result, "Using a deterministic Cerebro query template for this common read-only graph question.", true
+}
+
+func deterministicFastPathPlan(request AskRequest) (AskQueryPlan, bool) {
+	question := strings.TrimSpace(request.Question)
+	if question == "" || questionLooksUnsafe(question) {
+		return AskQueryPlan{}, false
+	}
+	intent := inferIntent(strings.ReplaceAll(question, "-", " "), "")
+	if intent == IntentRawCypher {
+		return AskQueryPlan{}, false
+	}
+	plan := AskQueryPlan{
+		Intent:     intent,
+		Confidence: 0.95,
+		ScopeURN:   strings.TrimSpace(request.ScopeURN),
+		Limit:      25,
+	}
+	switch intent {
+	case IntentTopRiskFindings:
+		plan.Filters = fastPathTopRiskFilters(question)
+	case IntentAggregateFindingsBySource, IntentConnectorHealth, IntentIdentityBridge:
+		plan.Filters = map[string]string{}
+	case IntentExplainFinding:
+		if plan.ScopeURN == "" {
+			return AskQueryPlan{}, false
+		}
+		plan.Filters = map[string]string{}
+	default:
+		return AskQueryPlan{}, false
+	}
+	return normalizePlan(&plan, request, "", defaultMaxRows), true
+}
+
+func questionLooksUnsafe(question string) bool {
+	lower := strings.ToLower(question)
+	for _, token := range []string{"delete", "drop", "detach", "remove", "write", "update", "merge ", "create "} {
+		if strings.Contains(lower, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func fastPathTopRiskFilters(question string) map[string]string {
+	lower := strings.ToLower(question)
+	filters := map[string]string{}
+	switch {
+	case containsWord(lower, "open"):
+		filters["status"] = "open"
+	case containsWord(lower, "resolved"):
+		filters["status"] = "resolved"
+	case containsWord(lower, "suppressed"):
+		filters["status"] = "suppressed"
+	}
+	if strings.Contains(lower, "repository") || containsWord(lower, "repo") || strings.Contains(lower, "code repo") {
+		filters["resource_type"] = "repository"
+	}
+	return filters
+}
+
+func containsWord(haystack string, needle string) bool {
+	if strings.TrimSpace(needle) == "" {
+		return false
+	}
+	pattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(strings.ToLower(needle)) + `\b`)
+	return pattern.MatchString(strings.ToLower(haystack))
+}
+
 func normalizePlan(plan *AskQueryPlan, request AskRequest, cypher string, defaultMaxRows int) AskQueryPlan {
 	var out AskQueryPlan
 	if plan != nil {


### PR DESCRIPTION
## Summary
- add a guarded deterministic fast path for common read-only Ask graph questions
- cache tenant graph probe counts while keeping scoped neighborhoods live
- parallelize MCP graph fanout for risk action plans and investigation context

## Tests
- go test ./internal/graphagent ./internal/bootstrap
- make mcp-contract-check mcp-sdk-compat

Cross-repo web companion: writer/cerebro-web#31