### PR TITLE
feat: Add Kubernetes RBAC coverage

### DIFF
--- a/internal/sourceprojection/kubernetes.go
+++ b/internal/sourceprojection/kubernetes.go
@@ -138,6 +138,141 @@ func kubernetesWorkloadIdentityBindingProjections(event *cerebrov1.EventEnvelope
 	return identityProjectionResult(entities, links)
 }
 
+func kubernetesRBACRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	roleURN := kubernetesRBACRoleURN(tenantID, attributes)
+	namespaceURN := kubernetesExplicitNamespaceURN(tenantID, attributes)
+	clusterURN := kubernetesClusterURN(tenantID, attributes)
+	if roleURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        roleURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "kubernetes.rbac_role",
+			Label:      firstNonEmpty(attributes["role_name"], attributes["resource_name"], attributes["name"]),
+			Attributes: map[string]string{
+				"cluster_id":   strings.TrimSpace(attributes["cluster_id"]),
+				"cluster_name": strings.TrimSpace(attributes["cluster_name"]),
+				"namespace":    strings.TrimSpace(attributes["namespace"]),
+				"resources":    strings.TrimSpace(attributes["resources"]),
+				"role_kind":    strings.TrimSpace(attributes["role_kind"]),
+				"role_name":    firstNonEmpty(attributes["role_name"], attributes["resource_name"], attributes["name"]),
+				"role_scope":   kubernetesRBACScope(attributes),
+				"rules":        strings.TrimSpace(attributes["rules"]),
+				"verbs":        strings.TrimSpace(attributes["verbs"]),
+			},
+		})
+	}
+	addKubernetesCluster(entities, tenantID, event.GetSourceId(), attributes, clusterURN)
+	addKubernetesNamespace(entities, tenantID, event.GetSourceId(), attributes, namespaceURN)
+	if roleURN != "" {
+		if kubernetesRBACScope(attributes) == "namespace" && namespaceURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), roleURN, namespaceURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		} else if clusterURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), roleURN, clusterURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+	addKubernetesClusterLinks(entities, links, tenantID, event.GetSourceId(), event, attributes, namespaceURN, clusterURN)
+	return identityProjectionResult(entities, links)
+}
+
+func kubernetesRBACBindingProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	bindingURN := kubernetesRBACBindingURN(tenantID, attributes)
+	roleURN := kubernetesRBACBindingRoleURN(tenantID, attributes)
+	namespaceURN := kubernetesExplicitNamespaceURN(tenantID, attributes)
+	clusterURN := kubernetesClusterURN(tenantID, attributes)
+	if bindingURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        bindingURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "kubernetes.rbac_binding",
+			Label:      firstNonEmpty(attributes["binding_name"], attributes["resource_name"], attributes["name"]),
+			Attributes: map[string]string{
+				"binding_kind":  strings.TrimSpace(attributes["binding_kind"]),
+				"binding_name":  firstNonEmpty(attributes["binding_name"], attributes["resource_name"], attributes["name"]),
+				"binding_scope": kubernetesRBACScope(attributes),
+				"cluster_id":    strings.TrimSpace(attributes["cluster_id"]),
+				"cluster_name":  strings.TrimSpace(attributes["cluster_name"]),
+				"namespace":     strings.TrimSpace(attributes["namespace"]),
+				"role_kind":     strings.TrimSpace(attributes["role_kind"]),
+				"role_name":     strings.TrimSpace(attributes["role_name"]),
+				"subject_refs":  strings.TrimSpace(attributes["subject_refs"]),
+			},
+		})
+	}
+	if roleURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        roleURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "kubernetes.rbac_role",
+			Label:      strings.TrimSpace(attributes["role_name"]),
+			Attributes: map[string]string{
+				"cluster_id":   strings.TrimSpace(attributes["cluster_id"]),
+				"cluster_name": strings.TrimSpace(attributes["cluster_name"]),
+				"namespace":    kubernetesRBACRoleNamespace(attributes),
+				"role_kind":    strings.TrimSpace(attributes["role_kind"]),
+				"role_name":    strings.TrimSpace(attributes["role_name"]),
+			},
+		})
+	}
+	addKubernetesCluster(entities, tenantID, event.GetSourceId(), attributes, clusterURN)
+	addKubernetesNamespace(entities, tenantID, event.GetSourceId(), attributes, namespaceURN)
+	if bindingURN != "" && roleURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), bindingURN, roleURN, relationAttachedTo, map[string]string{"event_id": event.GetId(), "match_type": "kubernetes_rbac_binding_role"}))
+	}
+	if bindingURN != "" {
+		if kubernetesRBACScope(attributes) == "namespace" && namespaceURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), bindingURN, namespaceURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		} else if clusterURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), bindingURN, clusterURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+	for _, subject := range parseKubernetesRBACSubjectRefs(attributes["subject_refs"]) {
+		subjectURN := kubernetesRBACSubjectURN(tenantID, attributes, subject)
+		if subjectURN == "" {
+			continue
+		}
+		addKubernetesRBACSubjectEntity(entities, tenantID, event.GetSourceId(), attributes, subject, subjectURN)
+		if roleURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, roleURN, relationAssignedTo, map[string]string{
+				"binding_kind": strings.TrimSpace(attributes["binding_kind"]),
+				"binding_name": strings.TrimSpace(attributes["binding_name"]),
+				"event_id":     event.GetId(),
+				"match_type":   "kubernetes_rbac_binding_subject",
+			}))
+		}
+		if normalizeIdentifier(subject.Kind) == "serviceaccount" || normalizeIdentifier(subject.Kind) == "service_account" {
+			subjectNamespaceURN := kubernetesRBACSubjectNamespaceURN(tenantID, attributes, subject)
+			if subjectNamespaceURN != "" {
+				subjectNamespaceAttrs := cloneAttributes(attributes)
+				subjectNamespaceAttrs["namespace"] = kubernetesRBACSubjectNamespace(attributes, subject)
+				addKubernetesNamespace(entities, tenantID, event.GetSourceId(), subjectNamespaceAttrs, subjectNamespaceURN)
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, subjectNamespaceURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+				if clusterURN != "" {
+					addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectNamespaceURN, clusterURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+				}
+			}
+		}
+	}
+	addKubernetesClusterLinks(entities, links, tenantID, event.GetSourceId(), event, attributes, namespaceURN, clusterURN)
+	return identityProjectionResult(entities, links)
+}
+
 func addKubernetesCluster(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, attributes map[string]string, clusterURN string) {
 	if clusterURN == "" {
 		return
@@ -206,6 +341,13 @@ func kubernetesNamespaceURN(tenantID string, attributes map[string]string) strin
 	return projectionURN(tenantID, "kubernetes_namespace", clusterID, firstNonEmpty(attributes["namespace"], "default"))
 }
 
+func kubernetesExplicitNamespaceURN(tenantID string, attributes map[string]string) string {
+	if strings.TrimSpace(attributes["namespace"]) == "" {
+		return ""
+	}
+	return kubernetesNamespaceURN(tenantID, attributes)
+}
+
 func kubernetesWorkloadURN(tenantID string, attributes map[string]string) string {
 	clusterID := kubernetesClusterIdentity(attributes)
 	if clusterID == "" {
@@ -220,6 +362,42 @@ func kubernetesWorkloadURN(tenantID string, attributes map[string]string) string
 		return ""
 	}
 	return projectionURN(tenantID, "kubernetes_workload", clusterID, firstNonEmpty(attributes["namespace"], "default"), workloadID)
+}
+
+func kubernetesRBACRoleURN(tenantID string, attributes map[string]string) string {
+	clusterID := kubernetesClusterIdentity(attributes)
+	roleName := firstNonEmpty(attributes["role_name"], attributes["resource_name"], attributes["name"])
+	roleKind := firstNonEmpty(attributes["role_kind"], "Role")
+	if clusterID == "" || roleName == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "kubernetes_rbac_role", clusterID, roleKind, firstNonEmpty(kubernetesRBACRoleNamespace(attributes), "cluster"), roleName)
+}
+
+func kubernetesRBACBindingURN(tenantID string, attributes map[string]string) string {
+	clusterID := kubernetesClusterIdentity(attributes)
+	bindingName := firstNonEmpty(attributes["binding_name"], attributes["resource_name"], attributes["name"])
+	bindingKind := firstNonEmpty(attributes["binding_kind"], "RoleBinding")
+	if clusterID == "" || bindingName == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "kubernetes_rbac_binding", clusterID, bindingKind, firstNonEmpty(strings.TrimSpace(attributes["namespace"]), "cluster"), bindingName)
+}
+
+func kubernetesRBACBindingRoleURN(tenantID string, attributes map[string]string) string {
+	roleName := strings.TrimSpace(attributes["role_name"])
+	if roleName == "" {
+		return ""
+	}
+	roleAttrs := cloneAttributes(attributes)
+	roleAttrs["role_name"] = roleName
+	roleAttrs["role_kind"] = firstNonEmpty(attributes["role_kind"], "Role")
+	if !strings.EqualFold(roleAttrs["role_kind"], "ClusterRole") {
+		roleAttrs["namespace"] = firstNonEmpty(attributes["namespace"], "default")
+	} else {
+		roleAttrs["namespace"] = ""
+	}
+	return kubernetesRBACRoleURN(tenantID, roleAttrs)
 }
 
 func kubernetesClusterIdentity(attributes map[string]string) string {
@@ -269,4 +447,132 @@ func kubernetesCloudAccountID(attributes map[string]string) string {
 			attributes["project_id"],
 		)
 	}
+}
+
+type kubernetesRBACSubjectRef struct {
+	Kind      string
+	Namespace string
+	Name      string
+}
+
+func parseKubernetesRBACSubjectRefs(raw string) []kubernetesRBACSubjectRef {
+	refs := []kubernetesRBACSubjectRef{}
+	for _, part := range strings.Split(raw, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		kind, value, ok := strings.Cut(part, ":")
+		if !ok {
+			continue
+		}
+		namespace := ""
+		name := strings.TrimSpace(value)
+		if isKubernetesServiceAccountKind(kind) {
+			if before, after, found := strings.Cut(name, "/"); found {
+				namespace = strings.TrimSpace(before)
+				name = strings.TrimSpace(after)
+			}
+		}
+		if strings.TrimSpace(kind) == "" || name == "" {
+			continue
+		}
+		refs = append(refs, kubernetesRBACSubjectRef{Kind: strings.TrimSpace(kind), Namespace: namespace, Name: name})
+	}
+	return refs
+}
+
+func isKubernetesServiceAccountKind(kind string) bool {
+	normalized := normalizeIdentifier(kind)
+	return normalized == "serviceaccount" || normalized == "service_account"
+}
+
+func kubernetesRBACSubjectNamespace(attributes map[string]string, subject kubernetesRBACSubjectRef) string {
+	if !isKubernetesServiceAccountKind(subject.Kind) {
+		return ""
+	}
+	return firstNonEmpty(subject.Namespace, attributes["namespace"], "default")
+}
+
+func kubernetesRBACSubjectNamespaceURN(tenantID string, attributes map[string]string, subject kubernetesRBACSubjectRef) string {
+	namespace := kubernetesRBACSubjectNamespace(attributes, subject)
+	if namespace == "" {
+		return ""
+	}
+	subjectNamespaceAttrs := cloneAttributes(attributes)
+	subjectNamespaceAttrs["namespace"] = namespace
+	return kubernetesNamespaceURN(tenantID, subjectNamespaceAttrs)
+}
+
+func kubernetesRBACSubjectURN(tenantID string, attributes map[string]string, subject kubernetesRBACSubjectRef) string {
+	clusterID := kubernetesClusterIdentity(attributes)
+	if clusterID == "" || strings.TrimSpace(subject.Name) == "" {
+		return ""
+	}
+	switch normalizeIdentifier(subject.Kind) {
+	case "serviceaccount", "service_account":
+		return projectionURN(tenantID, "kubernetes_service_account", clusterID, kubernetesRBACSubjectNamespace(attributes, subject), subject.Name)
+	case "group":
+		return projectionURN(tenantID, "kubernetes_group", clusterID, subject.Name)
+	default:
+		return projectionURN(tenantID, "kubernetes_user", clusterID, subject.Name)
+	}
+}
+
+func addKubernetesRBACSubjectEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, attributes map[string]string, subject kubernetesRBACSubjectRef, subjectURN string) {
+	clusterID := kubernetesClusterIdentity(attributes)
+	switch normalizeIdentifier(subject.Kind) {
+	case "serviceaccount", "service_account":
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        subjectURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: "kubernetes.service_account",
+			Label:      subject.Name,
+			Attributes: map[string]string{
+				"cluster_id":           clusterID,
+				"cluster_name":         strings.TrimSpace(attributes["cluster_name"]),
+				"namespace":            kubernetesRBACSubjectNamespace(attributes, subject),
+				"service_account_name": subject.Name,
+			},
+		})
+	case "group":
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        subjectURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: "kubernetes.group",
+			Label:      subject.Name,
+			Attributes: map[string]string{"cluster_id": clusterID, "cluster_name": strings.TrimSpace(attributes["cluster_name"]), "group_name": subject.Name},
+		})
+	default:
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        subjectURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: "kubernetes.user",
+			Label:      subject.Name,
+			Attributes: map[string]string{"cluster_id": clusterID, "cluster_name": strings.TrimSpace(attributes["cluster_name"]), "user_name": subject.Name},
+		})
+	}
+}
+
+func kubernetesRBACRoleNamespace(attributes map[string]string) string {
+	if strings.EqualFold(firstNonEmpty(attributes["role_kind"], "Role"), "ClusterRole") {
+		return ""
+	}
+	return strings.TrimSpace(attributes["namespace"])
+}
+
+func kubernetesRBACScope(attributes map[string]string) string {
+	if bindingKind := strings.TrimSpace(attributes["binding_kind"]); bindingKind != "" {
+		if strings.EqualFold(bindingKind, "ClusterRoleBinding") || strings.TrimSpace(attributes["namespace"]) == "" {
+			return "cluster"
+		}
+		return "namespace"
+	}
+	if strings.TrimSpace(attributes["namespace"]) == "" || strings.EqualFold(firstNonEmpty(attributes["role_kind"], "Role"), "ClusterRole") {
+		return "cluster"
+	}
+	return "namespace"
 }

--- a/internal/sourceprojection/kubernetes.go
+++ b/internal/sourceprojection/kubernetes.go
@@ -1,6 +1,7 @@
 package sourceprojection
 
 import (
+	"encoding/json"
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -450,12 +451,22 @@ func kubernetesCloudAccountID(attributes map[string]string) string {
 }
 
 type kubernetesRBACSubjectRef struct {
-	Kind      string
-	Namespace string
-	Name      string
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
 }
 
 func parseKubernetesRBACSubjectRefs(raw string) []kubernetesRBACSubjectRef {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if strings.HasPrefix(raw, "[") {
+		var refs []kubernetesRBACSubjectRef
+		if err := json.Unmarshal([]byte(raw), &refs); err == nil {
+			return normalizeKubernetesRBACSubjectRefs(refs)
+		}
+	}
 	refs := []kubernetesRBACSubjectRef{}
 	for _, part := range strings.Split(raw, ";") {
 		part = strings.TrimSpace(part)
@@ -478,6 +489,22 @@ func parseKubernetesRBACSubjectRefs(raw string) []kubernetesRBACSubjectRef {
 			continue
 		}
 		refs = append(refs, kubernetesRBACSubjectRef{Kind: strings.TrimSpace(kind), Namespace: namespace, Name: name})
+	}
+	return refs
+}
+
+func normalizeKubernetesRBACSubjectRefs(values []kubernetesRBACSubjectRef) []kubernetesRBACSubjectRef {
+	refs := make([]kubernetesRBACSubjectRef, 0, len(values))
+	for _, value := range values {
+		ref := kubernetesRBACSubjectRef{
+			Kind:      strings.TrimSpace(value.Kind),
+			Namespace: strings.TrimSpace(value.Namespace),
+			Name:      strings.TrimSpace(value.Name),
+		}
+		if ref.Kind == "" || ref.Name == "" {
+			continue
+		}
+		refs = append(refs, ref)
 	}
 	return refs
 }

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -4702,6 +4702,41 @@ func TestProjectKubernetesRBACBindingLinksSubjectsToRole(t *testing.T) {
 	assertProjectedLinkMissing(t, state, crossNamespaceServiceAccountURN, relationBelongsTo, namespaceURN)
 }
 
+func TestProjectKubernetesRBACBindingJSONSubjectRefsDoNotInjectSubjects(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "k8s-rbac-binding-injection",
+		TenantId: "writer",
+		SourceId: "kubernetes",
+		Kind:     "kubernetes.rbac_binding",
+		Attributes: map[string]string{
+			"binding_kind": "RoleBinding",
+			"binding_name": "secret-reader-binding",
+			"cluster_id":   "prod-cluster",
+			"namespace":    "payments",
+			"role_kind":    "Role",
+			"role_name":    "secret-reader",
+			"subject_refs": `[{"kind":"User","name":"alice@example.com;ServiceAccount:payments/admin"},{"kind":"ServiceAccount","namespace":"payments","name":"api"}]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	roleURN := "urn:cerebro:writer:kubernetes_rbac_role:prod-cluster:Role:payments:secret-reader"
+	serviceAccountURN := "urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:api"
+	userURN := "urn:cerebro:writer:kubernetes_user:prod-cluster:alice@example.com;ServiceAccount:payments/admin"
+	injectedServiceAccountURN := "urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:admin"
+	assertProjectedLink(t, state, serviceAccountURN, relationAssignedTo, roleURN)
+	assertProjectedLink(t, state, userURN, relationAssignedTo, roleURN)
+	assertProjectedLinkMissing(t, state, injectedServiceAccountURN, relationAssignedTo, roleURN)
+	if entity := state.entities[injectedServiceAccountURN]; entity != nil {
+		t.Fatalf("injected service account entity should not be created: %#v", entity)
+	}
+}
+
 func TestProjectKubernetesRBACClusterRoleBindingStaysClusterScoped(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -4662,6 +4662,82 @@ func TestProjectKubernetesWorkloadIdentityBindingAddsContainmentLinks(t *testing
 	assertProjectedLink(t, state, "urn:cerebro:writer:identifier:email:payments-sa@writer-prod.iam.gserviceaccount.com", relationRepresentsIdentity, targetIdentityURN)
 }
 
+func TestProjectKubernetesRBACBindingLinksSubjectsToRole(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "k8s-rbac-binding",
+		TenantId: "writer",
+		SourceId: "kubernetes",
+		Kind:     "kubernetes.rbac_binding",
+		Attributes: map[string]string{
+			"binding_kind": "RoleBinding",
+			"binding_name": "secret-reader-binding",
+			"cluster_id":   "prod-cluster",
+			"namespace":    "payments",
+			"role_kind":    "Role",
+			"role_name":    "secret-reader",
+			"subject_refs": "ServiceAccount:payments/api;ServiceAccount:platform/deployer;User:arn:aws:sts::123456789012:assumed-role/Admin/alice@example.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	bindingURN := "urn:cerebro:writer:kubernetes_rbac_binding:prod-cluster:RoleBinding:payments:secret-reader-binding"
+	roleURN := "urn:cerebro:writer:kubernetes_rbac_role:prod-cluster:Role:payments:secret-reader"
+	serviceAccountURN := "urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:api"
+	crossNamespaceServiceAccountURN := "urn:cerebro:writer:kubernetes_service_account:prod-cluster:platform:deployer"
+	userURN := "urn:cerebro:writer:kubernetes_user:prod-cluster:arn:aws:sts::123456789012:assumed-role/Admin/alice@example.com"
+	namespaceURN := "urn:cerebro:writer:kubernetes_namespace:prod-cluster:payments"
+	crossNamespaceURN := "urn:cerebro:writer:kubernetes_namespace:prod-cluster:platform"
+	assertProjectedLink(t, state, bindingURN, relationAttachedTo, roleURN)
+	assertProjectedLink(t, state, bindingURN, relationBelongsTo, namespaceURN)
+	assertProjectedLink(t, state, serviceAccountURN, relationAssignedTo, roleURN)
+	assertProjectedLink(t, state, crossNamespaceServiceAccountURN, relationAssignedTo, roleURN)
+	assertProjectedLink(t, state, userURN, relationAssignedTo, roleURN)
+	assertProjectedLink(t, state, serviceAccountURN, relationBelongsTo, namespaceURN)
+	assertProjectedLink(t, state, crossNamespaceServiceAccountURN, relationBelongsTo, crossNamespaceURN)
+	assertProjectedLinkMissing(t, state, crossNamespaceServiceAccountURN, relationBelongsTo, namespaceURN)
+}
+
+func TestProjectKubernetesRBACClusterRoleBindingStaysClusterScoped(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "k8s-cluster-rbac-binding",
+		TenantId: "writer",
+		SourceId: "kubernetes",
+		Kind:     "kubernetes.rbac_binding",
+		Attributes: map[string]string{
+			"binding_kind": "ClusterRoleBinding",
+			"binding_name": "cluster-admin-binding",
+			"cluster_id":   "prod-cluster",
+			"role_kind":    "ClusterRole",
+			"role_name":    "cluster-admin",
+			"subject_refs": "Group:system:masters",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	bindingURN := "urn:cerebro:writer:kubernetes_rbac_binding:prod-cluster:ClusterRoleBinding:cluster:cluster-admin-binding"
+	roleURN := "urn:cerebro:writer:kubernetes_rbac_role:prod-cluster:ClusterRole:cluster:cluster-admin"
+	clusterURN := "urn:cerebro:writer:kubernetes_cluster:prod-cluster"
+	groupURN := "urn:cerebro:writer:kubernetes_group:prod-cluster:system:masters"
+	defaultNamespaceURN := "urn:cerebro:writer:kubernetes_namespace:prod-cluster:default"
+	assertProjectedLink(t, state, bindingURN, relationAttachedTo, roleURN)
+	assertProjectedLink(t, state, bindingURN, relationBelongsTo, clusterURN)
+	assertProjectedLink(t, state, groupURN, relationAssignedTo, roleURN)
+	assertProjectedLinkMissing(t, state, defaultNamespaceURN, relationBelongsTo, clusterURN)
+	if entity := state.entities[defaultNamespaceURN]; entity != nil {
+		t.Fatalf("default namespace entity should not be created for cluster-scoped RBAC: %#v", entity)
+	}
+}
+
 func TestProjectKubernetesWorkloadFallbackURNIncludesKind(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -369,6 +369,8 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"grc.user":                                      grcUserProjections,
 	"grc.integration":                               grcIntegrationProjections,
 	"kubernetes.service_account":                    kubernetesServiceAccountProjections,
+	"kubernetes.rbac_binding":                       kubernetesRBACBindingProjections,
+	"kubernetes.rbac_role":                          kubernetesRBACRoleProjections,
 	"kubernetes.workload":                           kubernetesWorkloadProjections,
 	"kubernetes.workload_identity_binding":          kubernetesWorkloadIdentityBindingProjections,
 	"anthropic.api_key":                             genericInventoryProjections,

--- a/sources/internal/kubernetes/catalog.internal.yaml
+++ b/sources/internal/kubernetes/catalog.internal.yaml
@@ -6,6 +6,8 @@ emitted_kinds:
   - kubernetes.namespace
   - kubernetes.pod
   - kubernetes.container
+  - kubernetes.rbac_binding
+  - kubernetes.rbac_role
   - kubernetes.service_account
   - kubernetes.workload
   - kubernetes.workload_identity_binding
@@ -45,6 +47,27 @@ event_contracts:
     required_payload_fields:
       - container_name
       - pod_uid
+  - kind: kubernetes.rbac_binding
+    schema_ref: kubernetes/rbac_binding/v1
+    required_attributes:
+      - cluster_id
+      - binding_name
+      - binding_kind
+      - role_name
+    required_payload_fields:
+      - name
+      - binding_kind
+      - role_ref
+  - kind: kubernetes.rbac_role
+    schema_ref: kubernetes/rbac_role/v1
+    required_attributes:
+      - cluster_id
+      - role_name
+      - role_kind
+    required_payload_fields:
+      - name
+      - role_kind
+      - rules
   - kind: kubernetes.service_account
     schema_ref: kubernetes/service_account/v1
     required_attributes:

--- a/sources/internal/kubernetes/source.go
+++ b/sources/internal/kubernetes/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"embed"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -19,10 +20,12 @@ import (
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -37,6 +40,8 @@ const (
 	familyNamespace               = "namespace"
 	familyPod                     = "pod"
 	familyContainer               = "container"
+	familyRBACBinding             = "rbac_binding"
+	familyRBACRole                = "rbac_role"
 	familyServiceAccount          = "service_account"
 	familyWorkload                = "workload"
 	familyWorkloadIdentityBinding = "workload_identity_binding"
@@ -49,6 +54,7 @@ const (
 type clientset interface {
 	Discovery() discovery.DiscoveryInterface
 	CoreV1() corev1client.CoreV1Interface
+	RbacV1() rbacv1client.RbacV1Interface
 }
 
 type settings struct {
@@ -109,6 +115,8 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 		sourcecdk.Family[settings]{Name: familyNamespace, Check: s.check, Discover: s.discoverNamespaces, Read: s.readNamespaces},
 		sourcecdk.Family[settings]{Name: familyPod, Check: s.check, Discover: s.discoverPods, Read: s.readPods},
 		sourcecdk.Family[settings]{Name: familyContainer, Check: s.check, Discover: s.discoverPods, Read: s.readContainers},
+		sourcecdk.Family[settings]{Name: familyRBACRole, Check: s.check, Discover: s.discoverRBACRoles, Read: s.readRBACRoles},
+		sourcecdk.Family[settings]{Name: familyRBACBinding, Check: s.check, Discover: s.discoverRBACBindings, Read: s.readRBACBindings},
 		sourcecdk.Family[settings]{Name: familyServiceAccount, Check: s.check, Discover: s.discoverServiceAccounts, Read: s.readServiceAccounts},
 		sourcecdk.Family[settings]{Name: familyWorkload, Check: s.check, Discover: s.discoverPods, Read: s.readWorkloads},
 		sourcecdk.Family[settings]{Name: familyWorkloadIdentityBinding, Check: s.check, Discover: s.discoverServiceAccounts, Read: s.readWorkloadIdentityBindings},
@@ -132,9 +140,9 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 		st.family = defaultFamily
 	}
 	switch st.family {
-	case familyCluster, familyNamespace, familyPod, familyContainer, familyServiceAccount, familyWorkload, familyWorkloadIdentityBinding:
+	case familyCluster, familyNamespace, familyPod, familyContainer, familyRBACBinding, familyRBACRole, familyServiceAccount, familyWorkload, familyWorkloadIdentityBinding:
 	default:
-		return st, fmt.Errorf("kubernetes family must be one of cluster, namespace, pod, container, service_account, workload, or workload_identity_binding")
+		return st, fmt.Errorf("kubernetes family must be one of cluster, namespace, pod, container, rbac_binding, rbac_role, service_account, workload, or workload_identity_binding")
 	}
 	if st.tenantID == "" {
 		return st, fmt.Errorf("kubernetes tenant_id is required")
@@ -243,6 +251,52 @@ func (s *Source) discoverServiceAccounts(ctx context.Context, st settings) ([]so
 	return parseURNs(urns...)
 }
 
+func (s *Source) discoverRBACRoles(ctx context.Context, st settings) ([]sourcecdk.URN, error) {
+	client, err := s.clientFactory(st)
+	if err != nil {
+		return nil, err
+	}
+	roles, _, err := listRBACRoles(ctx, client, st.perPage, "")
+	if err != nil {
+		return nil, err
+	}
+	clusterRoles, _, err := listRBACClusterRoles(ctx, client, st.perPage, "")
+	if err != nil {
+		return nil, err
+	}
+	urns := make([]string, 0, len(roles)+len(clusterRoles))
+	for _, item := range roles {
+		urns = append(urns, rbacRoleURN(st, "Role", item.Namespace, item.Name))
+	}
+	for _, item := range clusterRoles {
+		urns = append(urns, rbacRoleURN(st, "ClusterRole", "", item.Name))
+	}
+	return parseURNs(urns...)
+}
+
+func (s *Source) discoverRBACBindings(ctx context.Context, st settings) ([]sourcecdk.URN, error) {
+	client, err := s.clientFactory(st)
+	if err != nil {
+		return nil, err
+	}
+	bindings, _, err := listRBACRoleBindings(ctx, client, st.perPage, "")
+	if err != nil {
+		return nil, err
+	}
+	clusterBindings, _, err := listRBACClusterRoleBindings(ctx, client, st.perPage, "")
+	if err != nil {
+		return nil, err
+	}
+	urns := make([]string, 0, len(bindings)+len(clusterBindings))
+	for _, item := range bindings {
+		urns = append(urns, rbacBindingURN(st, "RoleBinding", item.Namespace, item.Name))
+	}
+	for _, item := range clusterBindings {
+		urns = append(urns, rbacBindingURN(st, "ClusterRoleBinding", "", item.Name))
+	}
+	return parseURNs(urns...)
+}
+
 func (s *Source) readCluster(ctx context.Context, st settings, _ *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	info, err := s.clusterInfo(ctx, st)
 	if err != nil {
@@ -334,6 +388,104 @@ func (s *Source) readContainers(ctx context.Context, st settings, cursor *cerebr
 		}
 	}
 	return pullWithCursor(events, next), nil
+}
+
+func (s *Source) readRBACRoles(ctx context.Context, st settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	client, err := s.clientFactory(st)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	state, err := parseKubernetesStageCursor(cursor.GetOpaque(), "role", "rbac_role")
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	events := []*primitives.Event{}
+	switch state.Stage {
+	case "role":
+		roles, next, err := listRBACRoles(ctx, client, st.perPage, state.Token)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		for _, role := range roles {
+			event, err := s.rbacRoleEvent(st, kubernetesRBACRole{Kind: "Role", Name: role.Name, Namespace: role.Namespace, UID: string(role.UID), Rules: role.Rules, Created: role.CreationTimestamp})
+			if err != nil {
+				return sourcecdk.Pull{}, err
+			}
+			events = append(events, event)
+		}
+		if next != "" {
+			return pullWithCursor(events, encodeKubernetesStageCursor(kubernetesStageCursor{Stage: "role", Token: next})), nil
+		}
+		state = kubernetesStageCursor{Stage: "cluster_role"}
+		fallthrough
+	case "cluster_role":
+		clusterRoles, next, err := listRBACClusterRoles(ctx, client, st.perPage, state.Token)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		for _, role := range clusterRoles {
+			event, err := s.rbacRoleEvent(st, kubernetesRBACRole{Kind: "ClusterRole", Name: role.Name, UID: string(role.UID), Rules: role.Rules, Created: role.CreationTimestamp})
+			if err != nil {
+				return sourcecdk.Pull{}, err
+			}
+			events = append(events, event)
+		}
+		if next != "" {
+			return pullWithCursor(events, encodeKubernetesStageCursor(kubernetesStageCursor{Stage: "cluster_role", Token: next})), nil
+		}
+	default:
+		return sourcecdk.Pull{}, fmt.Errorf("unknown kubernetes rbac_role cursor stage %q", state.Stage)
+	}
+	return sourcecdk.Pull{Events: events}, nil
+}
+
+func (s *Source) readRBACBindings(ctx context.Context, st settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	client, err := s.clientFactory(st)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	state, err := parseKubernetesStageCursor(cursor.GetOpaque(), "role_binding", "rbac_binding")
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	events := []*primitives.Event{}
+	switch state.Stage {
+	case "role_binding":
+		bindings, next, err := listRBACRoleBindings(ctx, client, st.perPage, state.Token)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		for _, binding := range bindings {
+			event, err := s.rbacBindingEvent(st, kubernetesRBACBinding{Kind: "RoleBinding", Name: binding.Name, Namespace: binding.Namespace, UID: string(binding.UID), RoleRef: binding.RoleRef, Subjects: binding.Subjects, Created: binding.CreationTimestamp})
+			if err != nil {
+				return sourcecdk.Pull{}, err
+			}
+			events = append(events, event)
+		}
+		if next != "" {
+			return pullWithCursor(events, encodeKubernetesStageCursor(kubernetesStageCursor{Stage: "role_binding", Token: next})), nil
+		}
+		state = kubernetesStageCursor{Stage: "cluster_role_binding"}
+		fallthrough
+	case "cluster_role_binding":
+		clusterBindings, next, err := listRBACClusterRoleBindings(ctx, client, st.perPage, state.Token)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		for _, binding := range clusterBindings {
+			event, err := s.rbacBindingEvent(st, kubernetesRBACBinding{Kind: "ClusterRoleBinding", Name: binding.Name, UID: string(binding.UID), RoleRef: binding.RoleRef, Subjects: binding.Subjects, Created: binding.CreationTimestamp})
+			if err != nil {
+				return sourcecdk.Pull{}, err
+			}
+			events = append(events, event)
+		}
+		if next != "" {
+			return pullWithCursor(events, encodeKubernetesStageCursor(kubernetesStageCursor{Stage: "cluster_role_binding", Token: next})), nil
+		}
+	default:
+		return sourcecdk.Pull{}, fmt.Errorf("unknown kubernetes rbac_binding cursor stage %q", state.Stage)
+	}
+	return sourcecdk.Pull{Events: events}, nil
 }
 
 func (s *Source) readServiceAccounts(ctx context.Context, st settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
@@ -434,6 +586,38 @@ func listServiceAccounts(ctx context.Context, client clientset, limit int64, cur
 	out, err := client.CoreV1().ServiceAccounts("").List(ctx, metav1.ListOptions{Limit: limit, Continue: strings.TrimSpace(cursor)})
 	if err != nil {
 		return nil, "", fmt.Errorf("list kubernetes service accounts: %w", err)
+	}
+	return out.Items, out.Continue, nil
+}
+
+func listRBACRoles(ctx context.Context, client clientset, limit int64, cursor string) ([]rbacv1.Role, string, error) {
+	out, err := client.RbacV1().Roles("").List(ctx, metav1.ListOptions{Limit: limit, Continue: strings.TrimSpace(cursor)})
+	if err != nil {
+		return nil, "", fmt.Errorf("list kubernetes roles: %w", err)
+	}
+	return out.Items, out.Continue, nil
+}
+
+func listRBACClusterRoles(ctx context.Context, client clientset, limit int64, cursor string) ([]rbacv1.ClusterRole, string, error) {
+	out, err := client.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{Limit: limit, Continue: strings.TrimSpace(cursor)})
+	if err != nil {
+		return nil, "", fmt.Errorf("list kubernetes cluster roles: %w", err)
+	}
+	return out.Items, out.Continue, nil
+}
+
+func listRBACRoleBindings(ctx context.Context, client clientset, limit int64, cursor string) ([]rbacv1.RoleBinding, string, error) {
+	out, err := client.RbacV1().RoleBindings("").List(ctx, metav1.ListOptions{Limit: limit, Continue: strings.TrimSpace(cursor)})
+	if err != nil {
+		return nil, "", fmt.Errorf("list kubernetes role bindings: %w", err)
+	}
+	return out.Items, out.Continue, nil
+}
+
+func listRBACClusterRoleBindings(ctx context.Context, client clientset, limit int64, cursor string) ([]rbacv1.ClusterRoleBinding, string, error) {
+	out, err := client.RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{Limit: limit, Continue: strings.TrimSpace(cursor)})
+	if err != nil {
+		return nil, "", fmt.Errorf("list kubernetes cluster role bindings: %w", err)
 	}
 	return out.Items, out.Continue, nil
 }
@@ -548,6 +732,85 @@ func serviceAccountAttributes(st settings, account v1.ServiceAccount) map[string
 	return attrs
 }
 
+type kubernetesRBACRole struct {
+	Kind      string
+	Name      string
+	Namespace string
+	UID       string
+	Rules     []rbacv1.PolicyRule
+	Created   metav1.Time
+}
+
+type kubernetesRBACBinding struct {
+	Kind      string
+	Name      string
+	Namespace string
+	UID       string
+	RoleRef   rbacv1.RoleRef
+	Subjects  []rbacv1.Subject
+	Created   metav1.Time
+}
+
+func (s *Source) rbacRoleEvent(st settings, role kubernetesRBACRole) (*primitives.Event, error) {
+	attrs := rbacRoleAttributes(st, role)
+	payload := map[string]any{
+		"uid":        role.UID,
+		"name":       role.Name,
+		"namespace":  role.Namespace,
+		"role_kind":  role.Kind,
+		"role_scope": rbacScope(role.Namespace),
+		"rules":      role.Rules,
+	}
+	id := "kubernetes-rbac-role-" + stableID(st.clusterIdentity()+"/"+role.Kind+"/"+role.Namespace+"/"+role.Name+"/"+role.UID)
+	return s.event(st, id, "kubernetes.rbac_role", "kubernetes/rbac_role/v1", payload, attrs, objectTime(role.Created, s.now()))
+}
+
+func (s *Source) rbacBindingEvent(st settings, binding kubernetesRBACBinding) (*primitives.Event, error) {
+	attrs := rbacBindingAttributes(st, binding)
+	payload := map[string]any{
+		"uid":           binding.UID,
+		"name":          binding.Name,
+		"namespace":     binding.Namespace,
+		"binding_kind":  binding.Kind,
+		"binding_scope": rbacScope(binding.Namespace),
+		"role_ref":      binding.RoleRef,
+		"subjects":      binding.Subjects,
+	}
+	id := "kubernetes-rbac-binding-" + stableID(st.clusterIdentity()+"/"+binding.Kind+"/"+binding.Namespace+"/"+binding.Name+"/"+binding.UID)
+	return s.event(st, id, "kubernetes.rbac_binding", "kubernetes/rbac_binding/v1", payload, attrs, objectTime(binding.Created, s.now()))
+}
+
+func rbacRoleAttributes(st settings, role kubernetesRBACRole) map[string]string {
+	attrs := resourceAttributes(st, "rbac_role", firstNonEmpty(role.UID, role.Kind+"/"+role.Namespace+"/"+role.Name), role.Name, role.Namespace)
+	attrs["uid"] = role.UID
+	attrs["role_kind"] = role.Kind
+	attrs["role_name"] = role.Name
+	attrs["role_scope"] = rbacScope(role.Namespace)
+	attrs["rules"] = strings.Join(rbacRuleSummaries(role.Rules), ";")
+	attrs["api_groups"] = strings.Join(rbacRuleValues(role.Rules, func(rule rbacv1.PolicyRule) []string { return rule.APIGroups }), ",")
+	attrs["resources"] = strings.Join(rbacRuleValues(role.Rules, func(rule rbacv1.PolicyRule) []string { return rule.Resources }), ",")
+	attrs["verbs"] = strings.Join(rbacRuleValues(role.Rules, func(rule rbacv1.PolicyRule) []string { return rule.Verbs }), ",")
+	return attrs
+}
+
+func rbacBindingAttributes(st settings, binding kubernetesRBACBinding) map[string]string {
+	attrs := resourceAttributes(st, "rbac_binding", firstNonEmpty(binding.UID, binding.Kind+"/"+binding.Namespace+"/"+binding.Name), binding.Name, binding.Namespace)
+	attrs["uid"] = binding.UID
+	attrs["binding_kind"] = binding.Kind
+	attrs["binding_name"] = binding.Name
+	attrs["binding_scope"] = rbacScope(binding.Namespace)
+	attrs["role_api_group"] = binding.RoleRef.APIGroup
+	attrs["role_kind"] = binding.RoleRef.Kind
+	attrs["role_name"] = binding.RoleRef.Name
+	attrs["subject_count"] = strconv.Itoa(len(binding.Subjects))
+	attrs["subject_refs"] = strings.Join(rbacSubjectRefs(binding.Subjects, binding.Namespace), ";")
+	attrs["subject_kinds"] = strings.Join(rbacSubjectValues(binding.Subjects, func(subject rbacv1.Subject) string { return subject.Kind }), ",")
+	attrs["subject_names"] = strings.Join(rbacSubjectValues(binding.Subjects, func(subject rbacv1.Subject) string {
+		return subject.Name
+	}), ",")
+	return attrs
+}
+
 func podPayload(pod v1.Pod) map[string]any {
 	return map[string]any{
 		"uid":                             string(pod.UID),
@@ -622,6 +885,38 @@ func workloadIdentityBindings(st settings, account v1.ServiceAccount) []map[stri
 	return bindings
 }
 
+type kubernetesStageCursor struct {
+	Stage string `json:"stage,omitempty"`
+	Token string `json:"token,omitempty"`
+}
+
+func parseKubernetesStageCursor(raw string, defaultStage string, label string) (kubernetesStageCursor, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return kubernetesStageCursor{Stage: defaultStage}, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return kubernetesStageCursor{}, fmt.Errorf("decode kubernetes %s cursor: %w", label, err)
+	}
+	cursor := kubernetesStageCursor{}
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return kubernetesStageCursor{}, fmt.Errorf("parse kubernetes %s cursor: %w", label, err)
+	}
+	if cursor.Stage == "" {
+		cursor.Stage = defaultStage
+	}
+	return cursor, nil
+}
+
+func encodeKubernetesStageCursor(cursor kubernetesStageCursor) string {
+	payload, err := json.Marshal(cursor)
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
 func pullWithCursor(events []*primitives.Event, next string) sourcecdk.Pull {
 	pull := sourcecdk.Pull{Events: events}
 	if strings.TrimSpace(next) != "" {
@@ -660,6 +955,14 @@ func workloadURN(st settings, uid string, namespace string, name string) string 
 
 func serviceAccountURN(st settings, namespace string, name string) string {
 	return fmt.Sprintf("urn:cerebro:%s:kubernetes_service_account:%s:%s:%s", url.PathEscape(st.tenantID), url.PathEscape(st.clusterIdentity()), url.PathEscape(namespace), url.PathEscape(name))
+}
+
+func rbacRoleURN(st settings, kind string, namespace string, name string) string {
+	return fmt.Sprintf("urn:cerebro:%s:kubernetes_rbac_role:%s:%s:%s:%s", url.PathEscape(st.tenantID), url.PathEscape(st.clusterIdentity()), url.PathEscape(kind), url.PathEscape(firstNonEmpty(namespace, "cluster")), url.PathEscape(name))
+}
+
+func rbacBindingURN(st settings, kind string, namespace string, name string) string {
+	return fmt.Sprintf("urn:cerebro:%s:kubernetes_rbac_binding:%s:%s:%s:%s", url.PathEscape(st.tenantID), url.PathEscape(st.clusterIdentity()), url.PathEscape(kind), url.PathEscape(firstNonEmpty(namespace, "cluster")), url.PathEscape(name))
 }
 
 func parseURNs(raw ...string) ([]sourcecdk.URN, error) {
@@ -727,6 +1030,77 @@ func containerState(state v1.ContainerState) string {
 	default:
 		return ""
 	}
+}
+
+func rbacScope(namespace string) string {
+	if strings.TrimSpace(namespace) == "" {
+		return "cluster"
+	}
+	return "namespace"
+}
+
+func rbacRuleSummaries(rules []rbacv1.PolicyRule) []string {
+	values := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		values = append(values, fmt.Sprintf("%s:%s:%s", strings.Join(rule.APIGroups, ","), strings.Join(rule.Resources, ","), strings.Join(rule.Verbs, ",")))
+	}
+	sort.Strings(values)
+	return values
+}
+
+func rbacRuleValues(rules []rbacv1.PolicyRule, field func(rbacv1.PolicyRule) []string) []string {
+	seen := map[string]struct{}{}
+	values := []string{}
+	for _, rule := range rules {
+		for _, value := range field(rule) {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			values = append(values, value)
+		}
+	}
+	sort.Strings(values)
+	return values
+}
+
+func rbacSubjectRefs(subjects []rbacv1.Subject, bindingNamespace string) []string {
+	values := make([]string, 0, len(subjects))
+	for _, subject := range subjects {
+		namespace := subject.Namespace
+		if subject.Kind == "ServiceAccount" {
+			namespace = firstNonEmpty(namespace, bindingNamespace, "default")
+		}
+		if strings.TrimSpace(namespace) == "" {
+			values = append(values, fmt.Sprintf("%s:%s", subject.Kind, subject.Name))
+			continue
+		}
+		values = append(values, fmt.Sprintf("%s:%s/%s", subject.Kind, namespace, subject.Name))
+	}
+	sort.Strings(values)
+	return values
+}
+
+func rbacSubjectValues(subjects []rbacv1.Subject, field func(rbacv1.Subject) string) []string {
+	seen := map[string]struct{}{}
+	values := []string{}
+	for _, subject := range subjects {
+		value := strings.TrimSpace(field(subject))
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return values
 }
 
 func objectTime(value metav1.Time, fallback time.Time) time.Time {

--- a/sources/internal/kubernetes/source.go
+++ b/sources/internal/kubernetes/source.go
@@ -753,13 +753,17 @@ type kubernetesRBACBinding struct {
 
 func (s *Source) rbacRoleEvent(st settings, role kubernetesRBACRole) (*primitives.Event, error) {
 	attrs := rbacRoleAttributes(st, role)
+	rules := role.Rules
+	if rules == nil {
+		rules = []rbacv1.PolicyRule{}
+	}
 	payload := map[string]any{
 		"uid":        role.UID,
 		"name":       role.Name,
 		"namespace":  role.Namespace,
 		"role_kind":  role.Kind,
 		"role_scope": rbacScope(role.Namespace),
-		"rules":      role.Rules,
+		"rules":      rules,
 	}
 	id := "kubernetes-rbac-role-" + stableID(st.clusterIdentity()+"/"+role.Kind+"/"+role.Namespace+"/"+role.Name+"/"+role.UID)
 	return s.event(st, id, "kubernetes.rbac_role", "kubernetes/rbac_role/v1", payload, attrs, objectTime(role.Created, s.now()))
@@ -803,7 +807,7 @@ func rbacBindingAttributes(st settings, binding kubernetesRBACBinding) map[strin
 	attrs["role_kind"] = binding.RoleRef.Kind
 	attrs["role_name"] = binding.RoleRef.Name
 	attrs["subject_count"] = strconv.Itoa(len(binding.Subjects))
-	attrs["subject_refs"] = strings.Join(rbacSubjectRefs(binding.Subjects, binding.Namespace), ";")
+	attrs["subject_refs"] = rbacSubjectRefsAttribute(binding.Subjects, binding.Namespace)
 	attrs["subject_kinds"] = strings.Join(rbacSubjectValues(binding.Subjects, func(subject rbacv1.Subject) string { return subject.Kind }), ",")
 	attrs["subject_names"] = strings.Join(rbacSubjectValues(binding.Subjects, func(subject rbacv1.Subject) string {
 		return subject.Name
@@ -1068,20 +1072,46 @@ func rbacRuleValues(rules []rbacv1.PolicyRule, field func(rbacv1.PolicyRule) []s
 	return values
 }
 
-func rbacSubjectRefs(subjects []rbacv1.Subject, bindingNamespace string) []string {
-	values := make([]string, 0, len(subjects))
+type rbacSubjectRef struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+}
+
+func rbacSubjectRefsAttribute(subjects []rbacv1.Subject, bindingNamespace string) string {
+	refs := rbacSubjectRefs(subjects, bindingNamespace)
+	raw, _ := json.Marshal(refs)
+	return string(raw)
+}
+
+func rbacSubjectRefs(subjects []rbacv1.Subject, bindingNamespace string) []rbacSubjectRef {
+	values := make([]rbacSubjectRef, 0, len(subjects))
 	for _, subject := range subjects {
 		namespace := subject.Namespace
 		if subject.Kind == "ServiceAccount" {
 			namespace = firstNonEmpty(namespace, bindingNamespace, "default")
 		}
-		if strings.TrimSpace(namespace) == "" {
-			values = append(values, fmt.Sprintf("%s:%s", subject.Kind, subject.Name))
+		ref := rbacSubjectRef{
+			Kind: strings.TrimSpace(subject.Kind),
+			Name: strings.TrimSpace(subject.Name),
+		}
+		if strings.TrimSpace(namespace) != "" {
+			ref.Namespace = strings.TrimSpace(namespace)
+		}
+		if ref.Kind == "" || ref.Name == "" {
 			continue
 		}
-		values = append(values, fmt.Sprintf("%s:%s/%s", subject.Kind, namespace, subject.Name))
+		values = append(values, ref)
 	}
-	sort.Strings(values)
+	sort.Slice(values, func(i int, j int) bool {
+		if values[i].Kind != values[j].Kind {
+			return values[i].Kind < values[j].Kind
+		}
+		if values[i].Namespace != values[j].Namespace {
+			return values[i].Namespace < values[j].Namespace
+		}
+		return values[i].Name < values[j].Name
+	})
 	return values
 }
 

--- a/sources/internal/kubernetes/source_test.go
+++ b/sources/internal/kubernetes/source_test.go
@@ -2,6 +2,7 @@ package kubernetesinternal
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -72,6 +73,40 @@ func TestReadRBACRolesEmitsRolesAndClusterRoles(t *testing.T) {
 	}
 }
 
+func TestReadRBACRoleWithoutRulesEmitsEmptyRulesArray(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.clientFactory = func(settings) (clientset, error) {
+		return fake.NewSimpleClientset(
+			&rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty-role", Namespace: "payments", UID: types.UID("role-empty")},
+			},
+		), nil
+	}
+
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "family": familyRBACRole, "kubeconfig_path": "/tmp/kubeconfig", "cluster_id": "prod-cluster"}), nil)
+	if err != nil {
+		t.Fatalf("Read(rbac_role) error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+	var payload struct {
+		Rules []rbacv1.PolicyRule `json:"rules"`
+	}
+	if err := json.Unmarshal(pull.Events[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Rules == nil {
+		t.Fatalf("payload rules = nil, want empty array; payload=%s", string(pull.Events[0].Payload))
+	}
+	if len(payload.Rules) != 0 {
+		t.Fatalf("len(payload.Rules) = %d, want 0", len(payload.Rules))
+	}
+}
+
 func TestReadRBACBindingsEmitsBindingsAndSubjects(t *testing.T) {
 	source, err := New()
 	if err != nil {
@@ -107,11 +142,25 @@ func TestReadRBACBindingsEmitsBindingsAndSubjects(t *testing.T) {
 	if binding.Kind != "kubernetes.rbac_binding" || binding.Attributes["binding_kind"] != "RoleBinding" || binding.Attributes["role_name"] != "secret-reader" {
 		t.Fatalf("binding event = %#v", binding)
 	}
-	if got := binding.Attributes["subject_refs"]; got != "ServiceAccount:payments/api;User:alice@example.com;User:arn:aws:sts::123456789012:assumed-role/Admin/alice@example.com" {
-		t.Fatalf("subject_refs = %q, want service account and slash-bearing user refs", got)
+	wantRefs := []rbacSubjectRef{
+		{Kind: "ServiceAccount", Namespace: "payments", Name: "api"},
+		{Kind: "User", Name: "alice@example.com"},
+		{Kind: "User", Name: "arn:aws:sts::123456789012:assumed-role/Admin/alice@example.com"},
+	}
+	var gotRefs []rbacSubjectRef
+	if err := json.Unmarshal([]byte(binding.Attributes["subject_refs"]), &gotRefs); err != nil {
+		t.Fatalf("unmarshal subject_refs: %v", err)
+	}
+	if !reflect.DeepEqual(gotRefs, wantRefs) {
+		t.Fatalf("subject_refs = %#v, want %#v", gotRefs, wantRefs)
 	}
 	clusterBinding := pull.Events[1]
-	if clusterBinding.Attributes["binding_kind"] != "ClusterRoleBinding" || clusterBinding.Attributes["subject_refs"] != "Group:system:masters" {
+	var gotClusterRefs []rbacSubjectRef
+	if err := json.Unmarshal([]byte(clusterBinding.Attributes["subject_refs"]), &gotClusterRefs); err != nil {
+		t.Fatalf("unmarshal cluster subject_refs: %v", err)
+	}
+	wantClusterRefs := []rbacSubjectRef{{Kind: "Group", Name: "system:masters"}}
+	if clusterBinding.Attributes["binding_kind"] != "ClusterRoleBinding" || !reflect.DeepEqual(gotClusterRefs, wantClusterRefs) {
 		t.Fatalf("cluster binding event = %#v", clusterBinding)
 	}
 }

--- a/sources/internal/kubernetes/source_test.go
+++ b/sources/internal/kubernetes/source_test.go
@@ -1,10 +1,17 @@
 package kubernetesinternal
 
 import (
+	"context"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/writer/cerebro/internal/sourcecdk"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestPodImageDigestsAreSorted(t *testing.T) {
@@ -16,5 +23,95 @@ func TestPodImageDigestsAreSorted(t *testing.T) {
 	want := []string{"sha256:aaaa", "sha256:bbbb"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("podImageDigests() = %#v, want %#v", got, want)
+	}
+}
+
+func TestReadRBACRolesEmitsRolesAndClusterRoles(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.clientFactory = func(settings) (clientset, error) {
+		return fake.NewSimpleClientset(
+			&rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: "secret-reader", Namespace: "payments", UID: types.UID("role-1"), CreationTimestamp: metav1.NewTime(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))},
+				Rules: []rbacv1.PolicyRule{{
+					APIGroups: []string{""},
+					Resources: []string{"secrets"},
+					Verbs:     []string{"get", "list"},
+				}},
+			},
+			&rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin", UID: types.UID("cluster-role-1")},
+				Rules: []rbacv1.PolicyRule{{
+					APIGroups: []string{"*"},
+					Resources: []string{"*"},
+					Verbs:     []string{"*"},
+				}},
+			},
+		), nil
+	}
+
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "family": familyRBACRole, "kubeconfig_path": "/tmp/kubeconfig", "cluster_id": "prod-cluster"}), nil)
+	if err != nil {
+		t.Fatalf("Read(rbac_role) error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(Events) = %d, want 2", len(pull.Events))
+	}
+	role := pull.Events[0]
+	if role.Kind != "kubernetes.rbac_role" || role.Attributes["role_kind"] != "Role" || role.Attributes["role_name"] != "secret-reader" || role.Attributes["namespace"] != "payments" {
+		t.Fatalf("role event = %#v", role)
+	}
+	if got := role.Attributes["verbs"]; got != "get,list" {
+		t.Fatalf("role verbs = %q, want get,list", got)
+	}
+	clusterRole := pull.Events[1]
+	if clusterRole.Attributes["role_kind"] != "ClusterRole" || clusterRole.Attributes["role_scope"] != "cluster" {
+		t.Fatalf("cluster role event = %#v", clusterRole)
+	}
+}
+
+func TestReadRBACBindingsEmitsBindingsAndSubjects(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.clientFactory = func(settings) (clientset, error) {
+		return fake.NewSimpleClientset(
+			&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "secret-reader-binding", Namespace: "payments", UID: types.UID("binding-1")},
+				RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "secret-reader"},
+				Subjects: []rbacv1.Subject{
+					{Kind: "ServiceAccount", Name: "api", Namespace: "payments"},
+					{Kind: "User", Name: "alice@example.com"},
+					{Kind: "User", Name: "arn:aws:sts::123456789012:assumed-role/Admin/alice@example.com"},
+				},
+			},
+			&rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin-binding", UID: types.UID("cluster-binding-1")},
+				RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "cluster-admin"},
+				Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "system:masters"}},
+			},
+		), nil
+	}
+
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "family": familyRBACBinding, "kubeconfig_path": "/tmp/kubeconfig", "cluster_id": "prod-cluster"}), nil)
+	if err != nil {
+		t.Fatalf("Read(rbac_binding) error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(Events) = %d, want 2", len(pull.Events))
+	}
+	binding := pull.Events[0]
+	if binding.Kind != "kubernetes.rbac_binding" || binding.Attributes["binding_kind"] != "RoleBinding" || binding.Attributes["role_name"] != "secret-reader" {
+		t.Fatalf("binding event = %#v", binding)
+	}
+	if got := binding.Attributes["subject_refs"]; got != "ServiceAccount:payments/api;User:alice@example.com;User:arn:aws:sts::123456789012:assumed-role/Admin/alice@example.com" {
+		t.Fatalf("subject_refs = %q, want service account and slash-bearing user refs", got)
+	}
+	clusterBinding := pull.Events[1]
+	if clusterBinding.Attributes["binding_kind"] != "ClusterRoleBinding" || clusterBinding.Attributes["subject_refs"] != "Group:system:masters" {
+		t.Fatalf("cluster binding event = %#v", clusterBinding)
 	}
 }

--- a/sources/kubernetes/catalog.yaml
+++ b/sources/kubernetes/catalog.yaml
@@ -6,6 +6,8 @@ emitted_kinds:
   - kubernetes.namespace
   - kubernetes.pod
   - kubernetes.container
+  - kubernetes.rbac_binding
+  - kubernetes.rbac_role
   - kubernetes.service_account
   - kubernetes.workload
   - kubernetes.workload_identity_binding
@@ -45,6 +47,27 @@ event_contracts:
     required_payload_fields:
       - container_name
       - pod_uid
+  - kind: kubernetes.rbac_binding
+    schema_ref: kubernetes/rbac_binding/v1
+    required_attributes:
+      - cluster_id
+      - binding_name
+      - binding_kind
+      - role_name
+    required_payload_fields:
+      - name
+      - binding_kind
+      - role_ref
+  - kind: kubernetes.rbac_role
+    schema_ref: kubernetes/rbac_role/v1
+    required_attributes:
+      - cluster_id
+      - role_name
+      - role_kind
+    required_payload_fields:
+      - name
+      - role_kind
+      - rules
   - kind: kubernetes.service_account
     schema_ref: kubernetes/service_account/v1
     required_attributes:
@@ -140,12 +163,12 @@ coverage_contract:
     - id: rbac_roles
       type: app_entitlement
       title: Kubernetes RBAC roles
-      support: planned
+      families: [rbac_role]
+      support: supported
       high_value: true
-      known_unsupported_fields: [Role and ClusterRole rules]
     - id: rbac_bindings
       type: relationship
       title: Kubernetes RBAC bindings
-      support: planned
+      families: [rbac_binding]
+      support: supported
       high_value: true
-      known_unsupported_fields: [RoleBinding and ClusterRoleBinding subjects]

--- a/sources/kubernetes/deploy.yaml
+++ b/sources/kubernetes/deploy.yaml
@@ -22,6 +22,16 @@ runtimes:
       family: container
       kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
       per_page: "100"
+  - localId: rbac-role
+    config:
+      family: rbac_role
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
+  - localId: rbac-binding
+    config:
+      family: rbac_binding
+      kubeconfig_path: env:KUBERNETES_KUBECONFIG_PATH
+      per_page: "100"
   - localId: service-account
     config:
       family: service_account


### PR DESCRIPTION
## Summary
- collect Kubernetes Role, ClusterRole, RoleBinding, and ClusterRoleBinding resources as first-class RBAC coverage
- mark Kubernetes RBAC role and binding coverage as supported and add deploy runtimes
- project RBAC bindings into graph links from subjects to roles without creating fake default namespaces for cluster-scoped bindings

## Verification
- go test ./sources/internal/kubernetes
- go test ./internal/sourceprojection
- go test ./sources/kubernetes ./tools/catalogcheck
- PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/jonathan/.codex/tmp/arg0/codex-arg0OudzUg:/Users/jonathan/.raindrop/bin:/Users/jonathan/.antigravity/antigravity/bin:/Users/jonathan/.local/bin:/Users/jonathan/.bun/bin:/Users/jonathan/.cargo/bin:/Users/jonathan/.orbstack/bin:/Applications/Codex.app/Contents/Resources:/Users/jonathan/.orbstack/bin make check