### PR TITLE
Add connector secret store resolver framework

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -152,7 +152,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Connector catalog with runtime counts, credential capability state, backend-advertised connection methods, credential-store choices, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping.
+          description: Connector catalog with runtime counts, credential capability state, backend-advertised connection methods, credential-store choices, store availability, accepted reference prefixes, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping.
   /connectors/{sourceID}:
     get:
       summary: Get connector operations summary
@@ -309,7 +309,7 @@ paths:
                     type: string
                 credential_references:
                   type: object
-                  description: Non-secret credential references for environment-managed or external-reference methods. Values must be server-resolvable references such as env:CEREBRO_SOURCE_<SOURCE>_<FIELD>; secret-store CLIs/controllers are expected to populate those environment values outside the browser.
+                  description: Non-secret credential references for environment-managed or external-reference methods. Values must use prefixes advertised by /connectors credential_stores metadata, such as env:CEREBRO_SOURCE_<SOURCE>_<FIELD> or scoped AWS Secrets Manager references like aws-sm:us-east-1:cerebro/<tenant>/<source>/<runtime>/credentials#<field>. The browser must never submit plaintext secret values for reference-backed methods.
                   additionalProperties:
                     type: string
                 scope_policy:

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -26,6 +26,7 @@ import (
 	"github.com/writer/cerebro/internal/claims"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/connectorcredentials"
+	"github.com/writer/cerebro/internal/connectorsecretstores"
 	"github.com/writer/cerebro/internal/deviceauth"
 	"github.com/writer/cerebro/internal/deviceauth/risk"
 	"github.com/writer/cerebro/internal/findings"
@@ -2834,19 +2835,20 @@ func newRuntimeService(cfg config.Config, deps Dependencies, sources *sourcecdk.
 		deps.AppendLog,
 		sourceProjector(deps.StateStore, deps.GraphStore),
 	).WithConfigResolver(func(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
-		return resolveRuntimeSourceConfigWithStore(ctx, cfg.ConnectorCredentials, deps.StateStore, sourceID, values)
+		return resolveRuntimeSourceConfigWithStore(ctx, cfg.ConnectorCredentials, cfg.ConnectorSecretStores, deps.StateStore, sourceID, values)
 	})
 }
 
 func resolveRuntimeSourceConfig(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
-	return resolveRuntimeSourceConfigWithStore(ctx, config.ConnectorCredentialConfig{}, nil, sourceID, values)
+	return resolveRuntimeSourceConfigWithStore(ctx, config.ConnectorCredentialConfig{}, config.ConnectorSecretStoreConfig{}, nil, sourceID, values)
 }
 
-func resolveRuntimeSourceConfigWithStore(ctx context.Context, credentialConfig config.ConnectorCredentialConfig, store ports.StateStore, sourceID string, values map[string]string) (map[string]string, error) {
+func resolveRuntimeSourceConfigWithStore(ctx context.Context, credentialConfig config.ConnectorCredentialConfig, secretStoreConfig config.ConnectorSecretStoreConfig, store ports.StateStore, sourceID string, values map[string]string) (map[string]string, error) {
 	if err := authorizeRuntimeConfigEnvReferences(ctx, sourceID, values); err != nil {
 		return nil, err
 	}
 	resolved := values
+	var err error
 	if hasConnectorCredentialReferences(values) {
 		vault, err := connectorCredentialVault(credentialConfig, store)
 		if err != nil {
@@ -2857,7 +2859,14 @@ func resolveRuntimeSourceConfigWithStore(ctx context.Context, credentialConfig c
 			return nil, fmt.Errorf("%w: %w", sourceruntime.ErrInvalidRequest, err)
 		}
 	}
-	resolved, err := config.ResolveSourceRuntimeConfigSecretReferences(ctx, sourceID, resolved)
+	if err := connectorsecretstores.AuthorizeRuntimeReferences(sourceID, resolved[sourceconfig.RuntimeTenantIDKey], resolved[sourceconfig.RuntimeIDKey], resolved); err != nil {
+		return nil, fmt.Errorf("%w: %w", sourceruntime.ErrInvalidRequest, err)
+	}
+	resolved, err = connectorsecretstores.NewResolver(secretStoreConfig).ResolveReferences(ctx, resolved)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", sourceruntime.ErrInvalidRequest, err)
+	}
+	resolved, err = config.ResolveSourceRuntimeConfigSecretReferences(ctx, sourceID, resolved)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", sourceruntime.ErrInvalidRequest, err)
 	}
@@ -3008,7 +3017,7 @@ func newGraphIngestService(cfg config.Config, deps Dependencies, sources *source
 		sourceProjector(nil, deps.GraphStore),
 		deps.GraphStore,
 	).WithConfigPreparer(func(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
-		return resolveRuntimeSourceConfigWithStore(ctx, cfg.ConnectorCredentials, deps.StateStore, sourceID, values)
+		return resolveRuntimeSourceConfigWithStore(ctx, cfg.ConnectorCredentials, cfg.ConnectorSecretStores, deps.StateStore, sourceID, values)
 	})
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/reports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/workflowevents"
@@ -346,6 +347,29 @@ func TestResolveRuntimeSourceConfigRejectsTenantScopedEnvSelectors(t *testing.T)
 	})
 	if !errors.Is(err, errTenantForbidden) {
 		t.Fatalf("resolveRuntimeSourceConfig() error = %v, want tenant forbidden", err)
+	}
+}
+
+func TestResolveRuntimeSourceConfigRejectsUnscopedAWSSecretReferences(t *testing.T) {
+	_, err := resolveRuntimeSourceConfigWithStore(
+		context.Background(),
+		config.ConnectorCredentialConfig{},
+		config.ConnectorSecretStoreConfig{
+			Enabled: []string{connectorStoreAWSSecretsManager},
+			AWSSecretsManager: config.AWSSecretsManagerStoreConfig{
+				Region: "us-east-1",
+			},
+		},
+		nil,
+		"aws",
+		map[string]string{
+			sourceconfig.RuntimeTenantIDKey: "tenant-a",
+			sourceconfig.RuntimeIDKey:       "runtime-a",
+			"value":                         "aws-sm:us-east-1:shared/credentials#value",
+		},
+	)
+	if !errors.Is(err, sourceruntime.ErrInvalidRequest) {
+		t.Fatalf("resolveRuntimeSourceConfig() error = %v, want invalid request", err)
 	}
 }
 

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -18,6 +18,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/connectorcredentials"
+	"github.com/writer/cerebro/internal/connectorsecretstores"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -150,13 +151,34 @@ type connectorVaultView struct {
 }
 
 type connectorStoreView struct {
-	ID        string `json:"id"`
-	Label     string `json:"label"`
-	Provider  string `json:"provider"`
-	Available bool   `json:"available"`
-	Default   bool   `json:"default,omitempty"`
-	Mode      string `json:"mode"`
-	Detail    string `json:"detail,omitempty"`
+	ID                        string                          `json:"id"`
+	Label                     string                          `json:"label"`
+	Provider                  string                          `json:"provider"`
+	Available                 bool                            `json:"available"`
+	Default                   bool                            `json:"default,omitempty"`
+	Mode                      string                          `json:"mode"`
+	Status                    string                          `json:"status,omitempty"`
+	Detail                    string                          `json:"detail,omitempty"`
+	Description               string                          `json:"description,omitempty"`
+	ReferencePrefixes         []string                        `json:"reference_prefixes,omitempty"`
+	ReferencePlaceholder      string                          `json:"reference_placeholder,omitempty"`
+	NativeResolutionAvailable bool                            `json:"native_resolution_available,omitempty"`
+	SetupSteps                []connectorStoreSetupStepView   `json:"setup_steps,omitempty"`
+	RequiredConfig            []connectorStoreConfigFieldView `json:"required_config,omitempty"`
+}
+
+type connectorStoreSetupStepView struct {
+	ID          string `json:"id"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+	Command     string `json:"command,omitempty"`
+}
+
+type connectorStoreConfigFieldView struct {
+	Env         string `json:"env"`
+	Label       string `json:"label"`
+	Required    bool   `json:"required,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type connectorFieldView struct {
@@ -340,7 +362,7 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 		transport.Algorithm = a.connectorTransitKey.PublicKey().Algorithm
 	}
 	vaultStatus := connectorVaultStatus(a.cfg.ConnectorCredentials, a.deps.StateStore)
-	stores := connectorStoreViews(vaultStatus, transport)
+	stores := connectorStoreViews(vaultStatus, transport, a.cfg.ConnectorSecretStores)
 	entries := make([]connectorCatalogEntry, 0, len(sources))
 	for _, source := range sources {
 		entry := connectorCatalogEntry{
@@ -502,6 +524,10 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 	authMethod := normalizeConnectorAuthMethod(request.AuthMethod)
 	credentialStoreID, err := normalizeConnectorCredentialStoreID(request.CredentialStoreID, authMethod)
 	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if err := a.validateConnectorCredentialStoreAvailable(credentialStoreID); err != nil {
 		writeConnectorError(w, err)
 		return
 	}
@@ -1128,12 +1154,30 @@ func (a *App) connectorPreflightStore(storeID string) (connectorStoreView, bool)
 	if a != nil {
 		vaultStatus = connectorVaultStatus(a.cfg.ConnectorCredentials, a.deps.StateStore)
 	}
-	for _, store := range connectorStoreViews(vaultStatus, transport) {
+	secretStoreConfig := config.ConnectorSecretStoreConfig{}
+	if a != nil {
+		secretStoreConfig = a.cfg.ConnectorSecretStores
+	}
+	for _, store := range connectorStoreViews(vaultStatus, transport, secretStoreConfig) {
 		if store.ID == strings.TrimSpace(storeID) {
 			return store, true
 		}
 	}
 	return connectorStoreView{}, false
+}
+
+func (a *App) validateConnectorCredentialStoreAvailable(storeID string) error {
+	store, ok := a.connectorPreflightStore(storeID)
+	if !ok {
+		return fmt.Errorf("%w: credential store %q is not supported", connectorcredentials.ErrInvalidRequest, strings.TrimSpace(storeID))
+	}
+	if !store.Available {
+		if strings.TrimSpace(storeID) == defaultConnectorCredentialStoreID {
+			return fmt.Errorf("%w: credential store %q is not available in this deployment", connectorcredentials.ErrUnavailable, strings.TrimSpace(storeID))
+		}
+		return fmt.Errorf("%w: credential store %q is not available in this deployment", connectorcredentials.ErrInvalidRequest, strings.TrimSpace(storeID))
+	}
+	return nil
 }
 
 func (a *App) connectorScopePreview(sourceID string, source sourcecdk.Source, policy resourcescope.Policy) connectorScopePreviewView {
@@ -1684,7 +1728,7 @@ func (a *App) checkConnectorRuntime(ctx context.Context, runtime *cerebrov1.Sour
 		values[key] = value
 	}
 	values = sourceconfig.WithRuntimeContext(values, runtime.GetTenantId(), runtime.GetId())
-	resolved, err := resolveRuntimeSourceConfigWithStore(ctx, a.cfg.ConnectorCredentials, a.deps.StateStore, runtime.GetSourceId(), values)
+	resolved, err := resolveRuntimeSourceConfigWithStore(ctx, a.cfg.ConnectorCredentials, a.cfg.ConnectorSecretStores, a.deps.StateStore, runtime.GetSourceId(), values)
 	if err != nil {
 		return err
 	}
@@ -1874,71 +1918,193 @@ func connectorEnvComponent(value string) string {
 	return component
 }
 
-func connectorStoreViews(vaultStatus connectorVaultView, transport connectorTransportView) []connectorStoreView {
+func connectorStoreViews(vaultStatus connectorVaultView, transport connectorTransportView, secretStoreConfig config.ConnectorSecretStoreConfig) []connectorStoreView {
 	available := vaultStatus.Available && transport.Available
 	detail := strings.TrimSpace(vaultStatus.Detail)
+	status := "unavailable"
 	if available {
 		detail = "ready"
+		status = "ready"
 	}
 	return []connectorStoreView{
 		{
-			ID:        defaultConnectorCredentialStoreID,
-			Label:     "Cerebro Vault",
-			Provider:  "Cerebro",
-			Available: available,
-			Default:   true,
-			Mode:      "encrypted_submission",
-			Detail:    detail,
+			ID:          defaultConnectorCredentialStoreID,
+			Label:       "Cerebro Vault",
+			Provider:    "Cerebro",
+			Available:   available,
+			Default:     true,
+			Mode:        "encrypted_submission",
+			Status:      status,
+			Detail:      detail,
+			Description: "Cerebro stores one sealed credential envelope in its state store. The browser submits secrets only after encrypting them to the backend transit key.",
+			SetupSteps:  cerebroVaultStoreSetupSteps(),
+			RequiredConfig: []connectorStoreConfigFieldView{
+				{
+					Env:         "CEREBRO_CONNECTOR_CREDENTIAL_KEY",
+					Label:       "Credential envelope key",
+					Required:    true,
+					Description: "Symmetric key material used to seal connector credentials at rest.",
+				},
+				{
+					Env:         "CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY",
+					Label:       "Browser transit private key",
+					Required:    true,
+					Description: "Private key matching /connectors/credential-key for encrypted browser submissions.",
+				},
+			},
 		},
 		{
-			ID:        connectorStoreEnvironmentManaged,
-			Label:     "Environment managed",
-			Provider:  "Deployment",
-			Available: true,
-			Mode:      "environment_managed",
-			Detail:    "ready",
+			ID:                   connectorStoreEnvironmentManaged,
+			Label:                "Environment managed",
+			Provider:             "Deployment",
+			Available:            true,
+			Mode:                 "environment_managed",
+			Status:               "ready",
+			Detail:               "ready",
+			Description:          "Cerebro stores env: references and resolves them inside the backend process. The browser never receives the secret value.",
+			ReferencePrefixes:    []string{"env:"},
+			ReferencePlaceholder: "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>",
+			SetupSteps: []connectorStoreSetupStepView{
+				{
+					ID:          "project_env",
+					Label:       "Project secrets into the Cerebro runtime",
+					Description: "Set source-scoped CEREBRO_SOURCE_<SOURCE>_<FIELD> variables or allow explicit shared env names with CEREBRO_SOURCE_CONFIG_ENV_ALLOWLIST.",
+				},
+			},
+		},
+		connectorExternalStoreView(secretStoreConfig, connectorStoreInfisical, "Infisical", "Infisical"),
+		connectorExternalStoreView(secretStoreConfig, connectorStoreGoogleSecretMgr, "Google Secret Manager", "Google Cloud Platform"),
+		connectorExternalStoreView(secretStoreConfig, connectorStoreAWSSecretsManager, "AWS Secrets Manager", "Amazon Web Services"),
+		connectorExternalStoreView(secretStoreConfig, connectorStoreAzureKeyVault, "Azure Key Vault", "Microsoft Azure"),
+		connectorExternalStoreView(secretStoreConfig, connectorStoreHashiCorpVault, "HashiCorp Vault", "HashiCorp"),
+	}
+}
+
+func connectorExternalStoreView(secretStoreConfig config.ConnectorSecretStoreConfig, id string, label string, provider string) connectorStoreView {
+	enabled := connectorsecretstores.StoreEnabled(secretStoreConfig, id)
+	native := connectorsecretstores.NativeResolutionAvailable(secretStoreConfig, id)
+	status := "needs_configuration"
+	detail := "enable with CEREBRO_CONNECTOR_SECRET_STORES"
+	if enabled {
+		status = "ready"
+		detail = "ready via env projection"
+	}
+	if native {
+		detail = "native resolver ready"
+	}
+	return connectorStoreView{
+		ID:                        id,
+		Label:                     label,
+		Provider:                  provider,
+		Available:                 enabled,
+		Mode:                      connectorCredentialStoreModeRefs,
+		Status:                    status,
+		Detail:                    detail,
+		Description:               connectorExternalStoreDescription(id, label),
+		ReferencePrefixes:         connectorsecretstores.ReferencePrefixes(id),
+		ReferencePlaceholder:      connectorStoreReferencePlaceholder(id),
+		NativeResolutionAvailable: native,
+		SetupSteps:                connectorExternalStoreSetupSteps(id, native),
+		RequiredConfig:            connectorExternalStoreRequiredConfig(id),
+	}
+}
+
+func cerebroVaultStoreSetupSteps() []connectorStoreSetupStepView {
+	return []connectorStoreSetupStepView{
+		{
+			ID:          "configure_state_store",
+			Label:       "Use a credential-capable state store",
+			Description: "The configured state store must implement connector credential persistence.",
 		},
 		{
-			ID:        connectorStoreInfisical,
-			Label:     "Infisical",
-			Provider:  "Infisical",
-			Available: true,
-			Mode:      connectorCredentialStoreModeRefs,
-			Detail:    "reference-backed",
-		},
-		{
-			ID:        connectorStoreGoogleSecretMgr,
-			Label:     "Google Secret Manager",
-			Provider:  "Google Cloud Platform",
-			Available: true,
-			Mode:      connectorCredentialStoreModeRefs,
-			Detail:    "reference-backed",
-		},
-		{
-			ID:        connectorStoreAWSSecretsManager,
-			Label:     "AWS Secrets Manager",
-			Provider:  "Amazon Web Services",
-			Available: true,
-			Mode:      connectorCredentialStoreModeRefs,
-			Detail:    "reference-backed",
-		},
-		{
-			ID:        connectorStoreAzureKeyVault,
-			Label:     "Azure Key Vault",
-			Provider:  "Microsoft Azure",
-			Available: true,
-			Mode:      connectorCredentialStoreModeRefs,
-			Detail:    "reference-backed",
-		},
-		{
-			ID:        connectorStoreHashiCorpVault,
-			Label:     "HashiCorp Vault",
-			Provider:  "HashiCorp",
-			Available: true,
-			Mode:      connectorCredentialStoreModeRefs,
-			Detail:    "reference-backed",
+			ID:          "publish_transit_key",
+			Label:       "Publish the credential transit key",
+			Description: "/connectors/credential-key must return the public key used by the browser before encrypted submission.",
 		},
 	}
+}
+
+func connectorExternalStoreDescription(id string, label string) string {
+	switch id {
+	case connectorStoreAWSSecretsManager:
+		return "Cerebro can resolve aws-sm: references natively when AWS resolver config is present, or consume env: references projected by deployment automation."
+	default:
+		return label + " references are saved as non-secret pointers. Configure deployment-side projection to env: references until a native backend resolver is enabled for this store."
+	}
+}
+
+func connectorStoreReferencePlaceholder(id string) string {
+	switch id {
+	case connectorStoreAWSSecretsManager:
+		return "aws-sm:us-east-1:cerebro/<tenant>/<source>/<runtime>/credentials#<field>"
+	default:
+		return "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>"
+	}
+}
+
+func connectorExternalStoreSetupSteps(id string, native bool) []connectorStoreSetupStepView {
+	steps := []connectorStoreSetupStepView{
+		{
+			ID:          "enable_store",
+			Label:       "Enable the store for connector references",
+			Description: "Add the store id to CEREBRO_CONNECTOR_SECRET_STORES before saving references that target it.",
+			Command:     "CEREBRO_CONNECTOR_SECRET_STORES=" + id,
+		},
+		{
+			ID:          "keep_browser_secretless",
+			Label:       "Submit references, not secret values",
+			Description: "The UI should send credential_references only. Secret material is resolved by the backend or projected into the runtime environment.",
+		},
+	}
+	if id == connectorStoreAWSSecretsManager {
+		description := "Set CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION to enable native aws-sm: resolution with the AWS SDK."
+		if native {
+			description = "Native aws-sm: resolution is enabled for this deployment."
+		}
+		steps = append(steps, connectorStoreSetupStepView{
+			ID:          "configure_native_resolver",
+			Label:       "Configure native AWS resolution",
+			Description: description,
+			Command:     "CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION=us-east-1",
+		})
+	}
+	return steps
+}
+
+func connectorExternalStoreRequiredConfig(id string) []connectorStoreConfigFieldView {
+	fields := []connectorStoreConfigFieldView{
+		{
+			Env:         "CEREBRO_CONNECTOR_SECRET_STORES",
+			Label:       "Enabled connector secret stores",
+			Required:    true,
+			Description: "Comma-separated store ids that this deployment accepts for connector credential references.",
+		},
+	}
+	if id == connectorStoreAWSSecretsManager {
+		fields = append(fields,
+			connectorStoreConfigFieldView{
+				Env:         "CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION",
+				Label:       "AWS resolver region",
+				Description: "Default region used when aws-sm: references do not include a region.",
+			},
+			connectorStoreConfigFieldView{
+				Env:         "CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_PROFILE",
+				Label:       "AWS shared config profile",
+				Description: "Optional shared AWS config profile used by the backend resolver.",
+			},
+			connectorStoreConfigFieldView{
+				Env:         "CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ROLE_ARN",
+				Label:       "AWS resolver role",
+				Description: "Optional role the backend assumes before reading secrets.",
+			},
+			connectorStoreConfigFieldView{
+				Env:         "CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_EXTERNAL_ID",
+				Label:       "AWS external ID",
+				Description: "Optional external ID used with the resolver role.",
+			},
+		)
+	}
+	return fields
 }
 
 func connectorConnectionMethods(sourceID string, stores []connectorStoreView) []connectorConnectionMethodView {
@@ -2555,8 +2721,8 @@ func applyConnectorCredentialReferences(config map[string]string, references map
 		if sourceconfig.InternalKey(trimmedKey) || trimmedKey == resourcescope.ConfigKey {
 			return fmt.Errorf("%w: internal config %q cannot be supplied by connector references", connectorcredentials.ErrInvalidRequest, trimmedKey)
 		}
-		if !sourceconfig.IsSecretReference(trimmedValue) {
-			return fmt.Errorf("%w: credential reference %q must use an env reference", connectorcredentials.ErrInvalidRequest, trimmedKey)
+		if !connectorsecretstores.IsReference(trimmedValue) {
+			return fmt.Errorf("%w: credential reference %q must use an env or connector secret-store reference", connectorcredentials.ErrInvalidRequest, trimmedKey)
 		}
 		config[trimmedKey] = trimmedValue
 	}
@@ -2601,6 +2767,9 @@ func validateConnectorConnectionShape(sourceID string, authMethod string, creden
 		if authMethod == connectorAuthMethodInfisicalCLI && len(references) == 0 {
 			return fmt.Errorf("%w: infisical_cli requires credential references", connectorcredentials.ErrInvalidRequest)
 		}
+		if err := validateConnectorCredentialReferencesForStore(connectorStoreEnvironmentManaged, references); err != nil {
+			return err
+		}
 	case connectorAuthMethodExternalReference:
 		if !connectorExternalReferenceStore(credentialStoreID) {
 			return fmt.Errorf("%w: external_reference requires an external credential store", connectorcredentials.ErrInvalidRequest)
@@ -2611,11 +2780,23 @@ func validateConnectorConnectionShape(sourceID string, authMethod string, creden
 		if len(references) == 0 {
 			return fmt.Errorf("%w: external_reference requires credential references", connectorcredentials.ErrInvalidRequest)
 		}
+		if err := validateConnectorCredentialReferencesForStore(credentialStoreID, references); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("%w: unsupported auth method", connectorcredentials.ErrInvalidRequest)
 	}
 	if err := validateConnectorConfigFields(sourceID, authMethod, config, references); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateConnectorCredentialReferencesForStore(storeID string, references map[string]string) error {
+	for key, value := range references {
+		if err := connectorsecretstores.ValidateReferenceForStore(storeID, value); err != nil {
+			return fmt.Errorf("%w: credential reference %q is not valid for %s", connectorcredentials.ErrInvalidRequest, strings.TrimSpace(key), strings.TrimSpace(storeID))
+		}
 	}
 	return nil
 }

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -347,6 +347,37 @@ func TestConnectorConnectionRejectsUnsupportedCredentialStore(t *testing.T) {
 	}
 }
 
+func TestConnectorConnectionMissingTransitKeyIsUnavailable(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key: "test-connector-vault-key",
+		},
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := []byte(`{"runtime_id":"runtime-a","tenant_id":"tenant-a","credential_store_id":"cerebro_vault","encrypted_credentials":{"key_id":"ignored","algorithm":"RSA-OAEP-256+A256GCM"}}`)
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/connections", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /connectors missing transit key error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("POST /connectors missing transit key status = %d, want 503", resp.StatusCode)
+	}
+}
+
 func TestConnectorCatalogAdvertisesConnectionMethods(t *testing.T) {
 	source := &bootstrapTokenSource{id: "bootstrap_token", emittedKinds: []string{"bootstrap.token"}}
 	registry, err := sourcecdk.NewRegistry(source)
@@ -390,8 +421,11 @@ func TestConnectorCatalogAdvertisesConnectionMethods(t *testing.T) {
 			} `json:"scope_options"`
 		} `json:"connectors"`
 		CredentialStores []struct {
-			ID        string `json:"id"`
-			Available bool   `json:"available"`
+			ID                        string   `json:"id"`
+			Available                 bool     `json:"available"`
+			Status                    string   `json:"status"`
+			ReferencePrefixes         []string `json:"reference_prefixes"`
+			NativeResolutionAvailable bool     `json:"native_resolution_available"`
 		} `json:"credential_stores"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
@@ -420,12 +454,79 @@ func TestConnectorCatalogAdvertisesConnectionMethods(t *testing.T) {
 		t.Fatalf("environment-managed method not saveable: %#v", methods)
 	}
 	stores := map[string]bool{}
+	storePrefixes := map[string][]string{}
+	storeStatuses := map[string]string{}
 	for _, store := range payload.CredentialStores {
 		stores[store.ID] = store.Available
+		storePrefixes[store.ID] = store.ReferencePrefixes
+		storeStatuses[store.ID] = store.Status
 	}
 	if !stores[connectorStoreEnvironmentManaged] {
 		t.Fatalf("environment-managed store not advertised available: %#v", stores)
 	}
+	if stores[connectorStoreAWSSecretsManager] {
+		t.Fatalf("aws secrets manager unexpectedly advertised available without opt-in: %#v", stores)
+	}
+	if got := storeStatuses[connectorStoreAWSSecretsManager]; got != "needs_configuration" {
+		t.Fatalf("aws secrets manager status = %q, want needs_configuration", got)
+	}
+	if got := storePrefixes[connectorStoreAWSSecretsManager]; len(got) != 2 || got[0] != "env:" || got[1] != "aws-sm:" {
+		t.Fatalf("aws secrets manager prefixes = %#v, want env and aws-sm", got)
+	}
+}
+
+func TestConnectorCatalogAdvertisesConfiguredAWSSecretStore(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorSecretStores: config.ConnectorSecretStoreConfig{
+			Enabled: []string{connectorStoreAWSSecretsManager},
+			AWSSecretsManager: config.AWSSecretsManagerStoreConfig{
+				Region: "us-east-1",
+			},
+		},
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors")
+	if err != nil {
+		t.Fatalf("GET /connectors error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /connectors status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		CredentialStores []struct {
+			ID                        string `json:"id"`
+			Available                 bool   `json:"available"`
+			Detail                    string `json:"detail"`
+			NativeResolutionAvailable bool   `json:"native_resolution_available"`
+		} `json:"credential_stores"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	for _, store := range payload.CredentialStores {
+		if store.ID != connectorStoreAWSSecretsManager {
+			continue
+		}
+		if !store.Available || !store.NativeResolutionAvailable || store.Detail != "native resolver ready" {
+			t.Fatalf("aws secret store = %#v, want available native resolver", store)
+		}
+		return
+	}
+	t.Fatalf("aws secret store missing: %#v", payload.CredentialStores)
 }
 
 func TestConnectorCatalogAdvertisesAWSOnboardingGuidance(t *testing.T) {
@@ -920,6 +1021,9 @@ func TestConnectorConnectionStoresEnvironmentManagedReference(t *testing.T) {
 	app := New(config.Config{
 		HTTPAddr:        "127.0.0.1:0",
 		ShutdownTimeout: time.Second,
+		ConnectorSecretStores: config.ConnectorSecretStoreConfig{
+			Enabled: []string{connectorStoreInfisical},
+		},
 	}, Dependencies{StateStore: store}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -1062,6 +1166,9 @@ func TestConnectorConnectionStoresExternalStoreReference(t *testing.T) {
 	app := New(config.Config{
 		HTTPAddr:        "127.0.0.1:0",
 		ShutdownTimeout: time.Second,
+		ConnectorSecretStores: config.ConnectorSecretStoreConfig{
+			Enabled: []string{connectorStoreInfisical},
+		},
 	}, Dependencies{StateStore: store}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -1115,6 +1222,40 @@ func TestConnectorConnectionStoresExternalStoreReference(t *testing.T) {
 	}
 	if got := credentialPayload["credential_store_id"]; got != connectorStoreInfisical {
 		t.Fatalf("credential_store_id = %#v, want %q", got, connectorStoreInfisical)
+	}
+}
+
+func TestConnectorConnectionRejectsMismatchedExternalStoreReference(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorSecretStores: config.ConnectorSecretStoreConfig{
+			Enabled: []string{connectorStoreInfisical},
+		},
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := []byte(`{"runtime_id":"runtime-external","tenant_id":"tenant-a","auth_method":"external_reference","credential_store_id":"infisical","config":{"family":"audit"},"credential_references":{"token":"aws-sm:us-east-1:cerebro/bootstrap-token#token"}}`)
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/connections", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /connectors mismatched external reference error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("POST /connectors mismatched external reference status = %d, want 400", resp.StatusCode)
+	}
+	if source.checkToken != "" {
+		t.Fatalf("source check token = %q, want no source check", source.checkToken)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,19 +42,20 @@ var (
 
 // Config is the minimal bootstrap configuration for the rewrite skeleton.
 type Config struct {
-	HTTPAddr             string
-	ShutdownTimeout      time.Duration
-	ImageTag             string
-	DevMode              bool
-	AppendLog            AppendLogConfig
-	StateStore           StateStoreConfig
-	GraphStore           GraphStoreConfig
-	GraphAgentLLM        GraphAgentLLMConfig
-	Cache                CacheConfig
-	Auth                 AuthConfig
-	ConnectorCredentials ConnectorCredentialConfig
-	OTEL                 OpenTelemetryConfig
-	RateLimit            RateLimitConfig
+	HTTPAddr              string
+	ShutdownTimeout       time.Duration
+	ImageTag              string
+	DevMode               bool
+	AppendLog             AppendLogConfig
+	StateStore            StateStoreConfig
+	GraphStore            GraphStoreConfig
+	GraphAgentLLM         GraphAgentLLMConfig
+	Cache                 CacheConfig
+	Auth                  AuthConfig
+	ConnectorCredentials  ConnectorCredentialConfig
+	ConnectorSecretStores ConnectorSecretStoreConfig
+	OTEL                  OpenTelemetryConfig
+	RateLimit             RateLimitConfig
 }
 
 // RateLimitConfig controls global API rate limiting.
@@ -121,6 +122,21 @@ type GraphAgentLLMConfig struct {
 type ConnectorCredentialConfig struct {
 	Key               string
 	TransitPrivateKey string
+}
+
+// ConnectorSecretStoreConfig controls operator-managed connector secret-store references.
+type ConnectorSecretStoreConfig struct {
+	Enabled           []string
+	AWSSecretsManager AWSSecretsManagerStoreConfig
+}
+
+// AWSSecretsManagerStoreConfig controls AWS Secrets Manager reference resolution.
+type AWSSecretsManagerStoreConfig struct {
+	Region     string
+	Profile    string
+	RoleARN    string
+	ExternalID string
+	Endpoint   string
 }
 
 // OpenTelemetryConfig controls OTLP trace and metric export.
@@ -328,6 +344,10 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	connectorSecretStoresRaw, err := readConfigValue("CEREBRO_CONNECTOR_SECRET_STORES")
+	if err != nil {
+		return Config{}, err
+	}
 	devMode, err := parseBoolEnv("CEREBRO_DEV_MODE")
 	if err != nil {
 		return Config{}, err
@@ -376,6 +396,16 @@ func Load() (Config, error) {
 		ConnectorCredentials: ConnectorCredentialConfig{
 			Key:               connectorCredentialKey,
 			TransitPrivateKey: connectorCredentialTransitPrivateKey,
+		},
+		ConnectorSecretStores: ConnectorSecretStoreConfig{
+			Enabled: parseCSV(connectorSecretStoresRaw),
+			AWSSecretsManager: AWSSecretsManagerStoreConfig{
+				Region:     strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION")),
+				Profile:    strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_PROFILE")),
+				RoleARN:    strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ROLE_ARN")),
+				ExternalID: strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_EXTERNAL_ID")),
+				Endpoint:   strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ENDPOINT")),
+			},
 		},
 		OTEL: OpenTelemetryConfig{
 			ServiceName:     strings.TrimSpace(os.Getenv("CEREBRO_OTEL_SERVICE_NAME")),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -181,6 +181,13 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_KEY_FILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY", "connector-transit-key")
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY_FILE", "")
+	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES", "aws_secrets_manager,infisical")
+	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES_FILE", "")
+	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION", "us-east-1")
+	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_PROFILE", "cerebro-security")
+	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ROLE_ARN", "arn:aws:iam::123456789012:role/cerebro-secrets")
+	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_EXTERNAL_ID", "external-writer")
+	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ENDPOINT", "http://127.0.0.1:4566")
 	clearMCPOAuthEnv(t)
 	clearDeviceAuthEnv(t)
 
@@ -274,6 +281,16 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.ConnectorCredentials.Key != "connector-vault-key" || cfg.ConnectorCredentials.TransitPrivateKey != "connector-transit-key" {
 		t.Fatalf("ConnectorCredentials = %#v", cfg.ConnectorCredentials)
+	}
+	if got := cfg.ConnectorSecretStores.Enabled; len(got) != 2 || got[0] != "aws_secrets_manager" || got[1] != "infisical" {
+		t.Fatalf("ConnectorSecretStores.Enabled = %#v, want configured stores", got)
+	}
+	if cfg.ConnectorSecretStores.AWSSecretsManager.Region != "us-east-1" ||
+		cfg.ConnectorSecretStores.AWSSecretsManager.Profile != "cerebro-security" ||
+		cfg.ConnectorSecretStores.AWSSecretsManager.RoleARN == "" ||
+		cfg.ConnectorSecretStores.AWSSecretsManager.ExternalID != "external-writer" ||
+		cfg.ConnectorSecretStores.AWSSecretsManager.Endpoint != "http://127.0.0.1:4566" {
+		t.Fatalf("ConnectorSecretStores.AWSSecretsManager = %#v", cfg.ConnectorSecretStores.AWSSecretsManager)
 	}
 }
 
@@ -432,6 +449,13 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_KEY_FILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY", "")
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY_FILE", "")
+	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES", "")
+	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES_FILE", "")
+	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION", "")
+	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_PROFILE", "")
+	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ROLE_ARN", "")
+	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_EXTERNAL_ID", "")
+	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ENDPOINT", "")
 	clearMCPOAuthEnv(t)
 	clearDeviceAuthEnv(t)
 }

--- a/internal/connectorsecretstores/references.go
+++ b/internal/connectorsecretstores/references.go
@@ -1,0 +1,416 @@
+package connectorsecretstores
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/sourceconfig"
+)
+
+const (
+	StoreInfisical         = "infisical"
+	StoreGoogleSecretMgr   = "google_secret_manager"
+	StoreAWSSecretsManager = "aws_secrets_manager"
+	StoreAzureKeyVault     = "azure_key_vault"
+	StoreHashiCorpVault    = "hashicorp_vault"
+
+	PrefixInfisical         = "infisical:"
+	PrefixGoogleSecretMgr   = "gsm:"
+	PrefixAWSSecretsManager = "aws-sm:"
+	PrefixAzureKeyVault     = "azkv:"
+	PrefixHashiCorpVault    = "vault:"
+)
+
+var (
+	ErrInvalidReference    = errors.New("invalid connector secret reference")
+	ErrResolverUnavailable = errors.New("connector secret-store resolver unavailable")
+
+	awsRegionPrefixPattern = regexp.MustCompile(`^[a-z]{2}(-gov)?-[a-z0-9-]+-\d$`)
+)
+
+// Reference is the parsed, non-secret address of a value in an operator-managed
+// secret store. The value identifies where the backend should fetch the secret;
+// it never contains the secret material itself.
+type Reference struct {
+	StoreID  string
+	Prefix   string
+	Raw      string
+	SecretID string
+	Region   string
+	Field    string
+}
+
+type awsSecretsManagerAPI interface {
+	GetSecretValue(context.Context, *secretsmanager.GetSecretValueInput, ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+type awsClientFactory func(context.Context, config.AWSSecretsManagerStoreConfig, Reference) (awsSecretsManagerAPI, error)
+
+// Resolver resolves native connector secret-store references that are not
+// handled by the existing env: and credential: runtime resolvers.
+type Resolver struct {
+	cfg              config.ConnectorSecretStoreConfig
+	awsClientFactory awsClientFactory
+}
+
+// NewResolver constructs a resolver chain for configured connector secret stores.
+func NewResolver(cfg config.ConnectorSecretStoreConfig) *Resolver {
+	return &Resolver{
+		cfg:              cfg,
+		awsClientFactory: newAWSSecretsManagerClient,
+	}
+}
+
+// ReferencePrefixes returns the accepted non-secret reference prefixes for one
+// connector store. env: is intentionally included for stores that are projected
+// into the deployment environment by an external controller or CLI.
+func ReferencePrefixes(storeID string) []string {
+	switch strings.TrimSpace(storeID) {
+	case StoreAWSSecretsManager:
+		return []string{"env:", PrefixAWSSecretsManager}
+	default:
+		return []string{"env:"}
+	}
+}
+
+// NativeReferencePrefix returns the store-native reference prefix, if the store
+// has one.
+func NativeReferencePrefix(storeID string) string {
+	switch strings.TrimSpace(storeID) {
+	case StoreInfisical:
+		return PrefixInfisical
+	case StoreGoogleSecretMgr:
+		return PrefixGoogleSecretMgr
+	case StoreAWSSecretsManager:
+		return PrefixAWSSecretsManager
+	case StoreAzureKeyVault:
+		return PrefixAzureKeyVault
+	case StoreHashiCorpVault:
+		return PrefixHashiCorpVault
+	default:
+		return ""
+	}
+}
+
+// NativeResolutionAvailable reports whether Cerebro can fetch native references
+// for the store without relying on deployment-side env projection.
+func NativeResolutionAvailable(cfg config.ConnectorSecretStoreConfig, storeID string) bool {
+	switch strings.TrimSpace(storeID) {
+	case StoreAWSSecretsManager:
+		return StoreEnabled(cfg, storeID) && strings.TrimSpace(cfg.AWSSecretsManager.Region) != ""
+	default:
+		return false
+	}
+}
+
+// StoreEnabled reports whether an operator explicitly enabled a reference store.
+func StoreEnabled(cfg config.ConnectorSecretStoreConfig, storeID string) bool {
+	normalized := strings.TrimSpace(storeID)
+	if normalized == "" {
+		return false
+	}
+	for _, enabled := range cfg.Enabled {
+		if strings.TrimSpace(enabled) == normalized {
+			return true
+		}
+	}
+	return false
+}
+
+// IsReference reports whether value is a supported non-secret reference shape.
+func IsReference(value string) bool {
+	if sourceconfig.IsSecretReference(value) {
+		return true
+	}
+	_, ok, err := ParseReference(value)
+	return ok && err == nil
+}
+
+// ValidateReferenceForStore checks that a non-secret reference belongs to the
+// selected store. env: references are accepted for reference stores because
+// Infisical, GSM, Vault, and other controllers commonly project secret-store
+// values into the Cerebro runtime environment.
+func ValidateReferenceForStore(storeID string, value string) error {
+	if sourceconfig.IsSecretReference(value) {
+		return nil
+	}
+	ref, ok, err := ParseReference(value)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("%w: reference must start with one of %s", ErrInvalidReference, strings.Join(ReferencePrefixes(storeID), ", "))
+	}
+	if ref.StoreID != strings.TrimSpace(storeID) {
+		return fmt.Errorf("%w: %s reference cannot be used with %s", ErrInvalidReference, ref.StoreID, strings.TrimSpace(storeID))
+	}
+	if ref.StoreID != StoreAWSSecretsManager {
+		return fmt.Errorf("%w: native %s references are not supported yet; use env: projection", ErrInvalidReference, ref.StoreID)
+	}
+	return nil
+}
+
+// RuntimeSecretPrefix returns the operator-managed secret namespace that a
+// runtime is allowed to dereference natively.
+func RuntimeSecretPrefix(tenantID string, sourceID string, runtimeID string) string {
+	tenantSegment := referencePathSegment(tenantID)
+	sourceSegment := referencePathSegment(sourceID)
+	runtimeSegment := referencePathSegment(runtimeID)
+	if tenantSegment == "" || sourceSegment == "" || runtimeSegment == "" {
+		return ""
+	}
+	return "cerebro/" + tenantSegment + "/" + sourceSegment + "/" + runtimeSegment + "/"
+}
+
+// AuthorizeRuntimeReferences checks that native references are constrained to
+// the requesting runtime's secret namespace before any backend resolver uses
+// operator credentials to fetch them.
+func AuthorizeRuntimeReferences(sourceID string, tenantID string, runtimeID string, values map[string]string) error {
+	prefix := RuntimeSecretPrefix(tenantID, sourceID, runtimeID)
+	for key, value := range values {
+		ref, ok, err := ParseReference(value)
+		if err != nil {
+			return err
+		}
+		if !ok || ref.StoreID != StoreAWSSecretsManager {
+			continue
+		}
+		if prefix == "" {
+			return fmt.Errorf("%w: aws-sm reference %q requires tenant, source, and runtime scope", ErrInvalidReference, strings.TrimSpace(key))
+		}
+		if !strings.HasPrefix(awsSecretName(ref.SecretID), prefix) {
+			return fmt.Errorf("%w: aws-sm reference %q must use scoped secret prefix %q", ErrInvalidReference, strings.TrimSpace(key), prefix)
+		}
+	}
+	return nil
+}
+
+// ParseReference parses a store-native reference. env: and credential: are
+// handled elsewhere and return ok=false here.
+func ParseReference(value string) (Reference, bool, error) {
+	trimmed := strings.TrimSpace(value)
+	switch {
+	case strings.HasPrefix(trimmed, PrefixAWSSecretsManager):
+		return parseAWSReference(strings.TrimPrefix(trimmed, PrefixAWSSecretsManager))
+	case strings.HasPrefix(trimmed, PrefixGoogleSecretMgr):
+		return parseOpaqueReference(StoreGoogleSecretMgr, PrefixGoogleSecretMgr, strings.TrimPrefix(trimmed, PrefixGoogleSecretMgr))
+	case strings.HasPrefix(trimmed, PrefixAzureKeyVault):
+		return parseOpaqueReference(StoreAzureKeyVault, PrefixAzureKeyVault, strings.TrimPrefix(trimmed, PrefixAzureKeyVault))
+	case strings.HasPrefix(trimmed, PrefixHashiCorpVault):
+		return parseOpaqueReference(StoreHashiCorpVault, PrefixHashiCorpVault, strings.TrimPrefix(trimmed, PrefixHashiCorpVault))
+	case strings.HasPrefix(trimmed, PrefixInfisical):
+		return parseOpaqueReference(StoreInfisical, PrefixInfisical, strings.TrimPrefix(trimmed, PrefixInfisical))
+	default:
+		return Reference{}, false, nil
+	}
+}
+
+// ResolveReferences resolves all native connector secret-store references in
+// values. env: and credential: references are intentionally left untouched for
+// the existing runtime resolvers.
+func (r *Resolver) ResolveReferences(ctx context.Context, values map[string]string) (map[string]string, error) {
+	if values == nil {
+		return map[string]string{}, nil
+	}
+	resolved := make(map[string]string, len(values))
+	for key, value := range values {
+		resolved[key] = value
+		ref, ok, err := ParseReference(value)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		secret, err := r.Resolve(ctx, ref)
+		if err != nil {
+			return nil, fmt.Errorf("resolve connector secret reference %q: %w", strings.TrimSpace(key), err)
+		}
+		resolved[key] = secret
+	}
+	return resolved, nil
+}
+
+// Resolve resolves one parsed native reference.
+func (r *Resolver) Resolve(ctx context.Context, ref Reference) (string, error) {
+	if r == nil {
+		return "", ErrResolverUnavailable
+	}
+	if !StoreEnabled(r.cfg, ref.StoreID) {
+		return "", fmt.Errorf("%w: %s is not enabled", ErrResolverUnavailable, ref.StoreID)
+	}
+	switch ref.StoreID {
+	case StoreAWSSecretsManager:
+		if strings.TrimSpace(r.cfg.AWSSecretsManager.Region) == "" && strings.TrimSpace(ref.Region) == "" {
+			return "", fmt.Errorf("%w: CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION is required", ErrResolverUnavailable)
+		}
+		client, err := r.awsClientFactory(ctx, r.cfg.AWSSecretsManager, ref)
+		if err != nil {
+			return "", err
+		}
+		return resolveAWSSecret(ctx, client, ref)
+	default:
+		return "", fmt.Errorf("%w: native %s references require deployment-side env projection", ErrResolverUnavailable, ref.StoreID)
+	}
+}
+
+func parseAWSReference(body string) (Reference, bool, error) {
+	secretID, field := splitReferenceField(body)
+	if strings.TrimSpace(secretID) == "" {
+		return Reference{}, true, fmt.Errorf("%w: aws-sm reference requires a secret id", ErrInvalidReference)
+	}
+	ref := Reference{StoreID: StoreAWSSecretsManager, Prefix: PrefixAWSSecretsManager, Raw: strings.TrimSpace(body), SecretID: strings.TrimSpace(secretID), Field: strings.TrimSpace(field)}
+	if strings.HasPrefix(ref.SecretID, "arn:") {
+		parts := strings.Split(ref.SecretID, ":")
+		if len(parts) > 3 {
+			ref.Region = strings.TrimSpace(parts[3])
+		}
+		return ref, true, nil
+	}
+	before, after, hasRegion := strings.Cut(ref.SecretID, ":")
+	if hasRegion && awsRegionPrefixPattern.MatchString(before) && strings.TrimSpace(after) != "" {
+		ref.Region = strings.TrimSpace(before)
+		ref.SecretID = strings.TrimSpace(after)
+	}
+	return ref, true, nil
+}
+
+func parseOpaqueReference(storeID string, prefix string, body string) (Reference, bool, error) {
+	secretID, field := splitReferenceField(body)
+	if strings.TrimSpace(secretID) == "" {
+		return Reference{}, true, fmt.Errorf("%w: %s reference requires a secret id", ErrInvalidReference, prefix)
+	}
+	return Reference{
+		StoreID:  storeID,
+		Prefix:   prefix,
+		Raw:      strings.TrimSpace(body),
+		SecretID: strings.TrimSpace(secretID),
+		Field:    strings.TrimSpace(field),
+	}, true, nil
+}
+
+func splitReferenceField(body string) (string, string) {
+	secretID, field, ok := strings.Cut(strings.TrimSpace(body), "#")
+	if !ok {
+		return secretID, ""
+	}
+	return strings.TrimSpace(secretID), strings.TrimSpace(field)
+}
+
+func awsSecretName(secretID string) string {
+	trimmed := strings.TrimSpace(secretID)
+	if index := strings.LastIndex(trimmed, ":secret:"); index >= 0 {
+		return strings.TrimSpace(trimmed[index+len(":secret:"):])
+	}
+	return trimmed
+}
+
+func referencePathSegment(value string) string {
+	var builder strings.Builder
+	for _, char := range strings.TrimSpace(value) {
+		switch {
+		case char >= 'a' && char <= 'z':
+			builder.WriteRune(char)
+		case char >= 'A' && char <= 'Z':
+			builder.WriteRune(char)
+		case char >= '0' && char <= '9':
+			builder.WriteRune(char)
+		case char == '-' || char == '_' || char == '.':
+			builder.WriteRune(char)
+		default:
+			builder.WriteByte('_')
+		}
+	}
+	return strings.Trim(builder.String(), "_")
+}
+
+func newAWSSecretsManagerClient(ctx context.Context, cfg config.AWSSecretsManagerStoreConfig, ref Reference) (awsSecretsManagerAPI, error) {
+	region := strings.TrimSpace(ref.Region)
+	if region == "" {
+		region = strings.TrimSpace(cfg.Region)
+	}
+	options := []func(*awsconfig.LoadOptions) error{awsconfig.WithRegion(region)}
+	if profile := strings.TrimSpace(cfg.Profile); profile != "" {
+		options = append(options, awsconfig.WithSharedConfigProfile(profile))
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, options...)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config for connector secret store: %w", err)
+	}
+	if roleARN := strings.TrimSpace(cfg.RoleARN); roleARN != "" {
+		provider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(awsCfg), roleARN, func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = "cerebro-connector-secret-store"
+			if externalID := strings.TrimSpace(cfg.ExternalID); externalID != "" {
+				options.ExternalID = awssdk.String(externalID)
+			}
+		})
+		awsCfg.Credentials = awssdk.NewCredentialsCache(provider)
+	}
+	return secretsmanager.NewFromConfig(awsCfg, func(options *secretsmanager.Options) {
+		if endpoint := strings.TrimSpace(cfg.Endpoint); endpoint != "" {
+			options.BaseEndpoint = awssdk.String(endpoint)
+		}
+	}), nil
+}
+
+func resolveAWSSecret(ctx context.Context, client awsSecretsManagerAPI, ref Reference) (string, error) {
+	if client == nil {
+		return "", ErrResolverUnavailable
+	}
+	out, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{SecretId: awssdk.String(ref.SecretID)})
+	if err != nil {
+		return "", err
+	}
+	secretValue := ""
+	switch {
+	case out.SecretString != nil:
+		secretValue = awssdk.ToString(out.SecretString)
+	case len(out.SecretBinary) > 0:
+		secretValue = base64.StdEncoding.EncodeToString(out.SecretBinary)
+	default:
+		return "", fmt.Errorf("%w: AWS Secrets Manager returned an empty secret value", ErrInvalidReference)
+	}
+	if strings.TrimSpace(ref.Field) == "" {
+		return secretValue, nil
+	}
+	return jsonField(secretValue, ref.Field)
+}
+
+func jsonField(secretValue string, field string) (string, error) {
+	var object map[string]any
+	decoder := json.NewDecoder(strings.NewReader(secretValue))
+	decoder.UseNumber()
+	if err := decoder.Decode(&object); err != nil {
+		return "", fmt.Errorf("%w: referenced field requires a JSON secret string", ErrInvalidReference)
+	}
+	value, ok := object[strings.TrimSpace(field)]
+	if !ok {
+		return "", fmt.Errorf("%w: referenced field %q is missing", ErrInvalidReference, strings.TrimSpace(field))
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed, nil
+	case json.Number:
+		return typed.String(), nil
+	case bool:
+		return fmt.Sprint(typed), nil
+	default:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return "", fmt.Errorf("%w: referenced field %q is not string-serializable", ErrInvalidReference, strings.TrimSpace(field))
+		}
+		return string(encoded), nil
+	}
+}

--- a/internal/connectorsecretstores/references_test.go
+++ b/internal/connectorsecretstores/references_test.go
@@ -1,0 +1,155 @@
+package connectorsecretstores
+
+import (
+	"context"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+type fakeAWSSecretsManager struct {
+	secretID string
+	value    string
+}
+
+func (f *fakeAWSSecretsManager) GetSecretValue(_ context.Context, input *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	f.secretID = awssdk.ToString(input.SecretId)
+	return &secretsmanager.GetSecretValueOutput{SecretString: awssdk.String(f.value)}, nil
+}
+
+func TestParseAWSReferenceWithRegionAndJSONField(t *testing.T) {
+	ref, ok, err := ParseReference("aws-sm:us-east-1:cerebro/tenant-a/aws/runtime-a/credentials#secret_access_key")
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ParseReference() ok = false, want true")
+	}
+	if ref.StoreID != StoreAWSSecretsManager || ref.Region != "us-east-1" || ref.SecretID != "cerebro/tenant-a/aws/runtime-a/credentials" || ref.Field != "secret_access_key" {
+		t.Fatalf("reference = %#v, want parsed AWS reference", ref)
+	}
+}
+
+func TestParseAWSReferenceKeepsARNSecretID(t *testing.T) {
+	arn := "arn:aws:secretsmanager:us-west-2:123456789012:secret:cerebro/aws/runtime-AbCd"
+	ref, ok, err := ParseReference("aws-sm:" + arn + "#value")
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ParseReference() ok = false, want true")
+	}
+	if ref.Region != "us-west-2" || ref.SecretID != arn || ref.Field != "value" {
+		t.Fatalf("reference = %#v, want ARN secret id and region", ref)
+	}
+}
+
+func TestResolverResolvesAWSSecretJSONField(t *testing.T) {
+	fake := &fakeAWSSecretsManager{value: `{"value":"resolved-value","ttl":3600}`}
+	resolver := NewResolver(config.ConnectorSecretStoreConfig{
+		Enabled: []string{StoreAWSSecretsManager},
+		AWSSecretsManager: config.AWSSecretsManagerStoreConfig{
+			Region: "us-east-1",
+		},
+	})
+	resolver.awsClientFactory = func(context.Context, config.AWSSecretsManagerStoreConfig, Reference) (awsSecretsManagerAPI, error) {
+		return fake, nil
+	}
+
+	resolved, err := resolver.ResolveReferences(context.Background(), map[string]string{
+		"value": "aws-sm:us-east-1:cerebro/tenant-a/aws/runtime-a/credentials#value",
+		"env":   "env:CEREBRO_SOURCE_AWS_VALUE",
+	})
+	if err != nil {
+		t.Fatalf("ResolveReferences() error = %v", err)
+	}
+	if resolved["value"] != "resolved-value" {
+		t.Fatalf("resolved value = %q, want resolved-value", resolved["value"])
+	}
+	if resolved["env"] != "env:CEREBRO_SOURCE_AWS_VALUE" {
+		t.Fatalf("env reference = %q, want unchanged env reference", resolved["env"])
+	}
+	if fake.secretID != "cerebro/tenant-a/aws/runtime-a/credentials" {
+		t.Fatalf("fake secret id = %q, want scoped runtime secret id", fake.secretID)
+	}
+}
+
+func TestResolverPreservesAWSSecretJSONNumberField(t *testing.T) {
+	fake := &fakeAWSSecretsManager{value: `{"account_id":123456789012}`}
+	resolver := NewResolver(config.ConnectorSecretStoreConfig{
+		Enabled: []string{StoreAWSSecretsManager},
+		AWSSecretsManager: config.AWSSecretsManagerStoreConfig{
+			Region: "us-east-1",
+		},
+	})
+	resolver.awsClientFactory = func(context.Context, config.AWSSecretsManagerStoreConfig, Reference) (awsSecretsManagerAPI, error) {
+		return fake, nil
+	}
+
+	resolved, err := resolver.ResolveReferences(context.Background(), map[string]string{
+		"account_id": "aws-sm:us-east-1:cerebro/tenant-a/aws/runtime-a/credentials#account_id",
+	})
+	if err != nil {
+		t.Fatalf("ResolveReferences() error = %v", err)
+	}
+	if resolved["account_id"] != "123456789012" {
+		t.Fatalf("resolved account_id = %q, want exact JSON number literal", resolved["account_id"])
+	}
+}
+
+func TestResolverRejectsDisabledNativeStore(t *testing.T) {
+	resolver := NewResolver(config.ConnectorSecretStoreConfig{})
+	_, err := resolver.ResolveReferences(context.Background(), map[string]string{
+		"value": "aws-sm:us-east-1:cerebro/tenant-a/aws/runtime-a/credentials#value",
+	})
+	if err == nil {
+		t.Fatal("ResolveReferences() error = nil, want disabled store error")
+	}
+}
+
+func TestAuthorizeRuntimeReferencesRequiresScopedAWSSecret(t *testing.T) {
+	err := AuthorizeRuntimeReferences("aws", "tenant-a", "runtime-a", map[string]string{
+		"value": "aws-sm:us-east-1:cerebro/tenant-a/aws/runtime-a/credentials#value",
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeRuntimeReferences(scoped) error = %v", err)
+	}
+
+	err = AuthorizeRuntimeReferences("aws", "tenant-a", "runtime-a", map[string]string{
+		"value": "aws-sm:us-east-1:shared/credentials#value",
+	})
+	if err == nil {
+		t.Fatal("AuthorizeRuntimeReferences(unscoped) error = nil, want invalid reference")
+	}
+}
+
+func TestAuthorizeRuntimeReferencesAcceptsScopedAWSARN(t *testing.T) {
+	arn := "arn:aws:secretsmanager:us-west-2:123456789012:secret:cerebro/tenant-a/aws/runtime-a/credentials-AbCd"
+	err := AuthorizeRuntimeReferences("aws", "tenant-a", "runtime-a", map[string]string{
+		"value": "aws-sm:" + arn + "#value",
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeRuntimeReferences(arn) error = %v", err)
+	}
+}
+
+func TestValidateReferenceForStoreRejectsMismatchedPrefix(t *testing.T) {
+	if err := ValidateReferenceForStore(StoreInfisical, "aws-sm:us-east-1:cerebro/tenant-a/aws/runtime-a/credentials#value"); err == nil {
+		t.Fatal("ValidateReferenceForStore() error = nil, want mismatch error")
+	}
+	if err := ValidateReferenceForStore(StoreInfisical, "env:CEREBRO_SOURCE_AWS_VALUE"); err != nil {
+		t.Fatalf("ValidateReferenceForStore(env) error = %v", err)
+	}
+}
+
+func TestValidateReferenceForStoreRejectsUnsupportedNativePrefix(t *testing.T) {
+	if err := ValidateReferenceForStore(StoreInfisical, "infisical:/cerebro/tenant-a/aws/runtime-a/credentials#value"); err == nil {
+		t.Fatal("ValidateReferenceForStore(infisical native) error = nil, want unsupported native prefix")
+	}
+	if got := ReferencePrefixes(StoreInfisical); len(got) != 1 || got[0] != "env:" {
+		t.Fatalf("ReferencePrefixes(infisical) = %#v, want env only", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a connector secret-store resolver package with typed non-secret references and native AWS Secrets Manager resolution
- expose store status, accepted prefixes, placeholders, setup steps, and required backend config through the connector catalog
- validate credential-store availability and reference prefixes before saving connections, then resolve references through shared runtime and graph ingest paths
- document the accepted reference contract in OpenAPI

## Verification
- go test ./internal/connectorsecretstores
- go test ./internal/config
- go test ./internal/bootstrap -run 'TestConnector|TestResolveRuntimeSourceConfig'
- go test ./internal/...
- make openapi-check
- make lint-bootstrap

## Notes
- AWS Secrets Manager supports native `aws-sm:` references when `CEREBRO_CONNECTOR_SECRET_STORES` includes `aws_secrets_manager` and resolver region/config is present.
- Other external stores now have explicit capability metadata and are accepted only when enabled; they can still use deployment-projected `env:` references until native resolvers are added.
- Frontend consumer PR: writer/cerebro-web#32.
