### PR TITLE
Add shared GRC query cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,15 @@ CEREBRO_CONNECTOR_CREDENTIAL_KEY=
 # Required for browser-submitted connector credentials. All replicas must share the same RSA private key.
 CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY_FILE=
 
+# Optional shared query cache for expensive GRC reads.
+# Use redis/valkey for multi-replica deployments; memory is local-only.
+CEREBRO_CACHE_MODE=off
+CEREBRO_CACHE_URL=
+CEREBRO_CACHE_NAMESPACE=cerebro
+CEREBRO_CACHE_DEFAULT_TTL=30s
+CEREBRO_CACHE_STALE_TTL=5m
+CEREBRO_CACHE_MAX_PAYLOAD_BYTES=1048576
+
 # Graph store: Neo4j/Aura
 CEREBRO_GRAPH_STORE_DRIVER=
 CEREBRO_NEO4J_URI=

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ Core runtime and store variables:
 | `CEREBRO_JETSTREAM_SUBJECT_PREFIX` | JetStream subject prefix | `events` |
 | `CEREBRO_STATE_STORE_DRIVER` | state-store driver; supported value: `postgres` | unset |
 | `CEREBRO_POSTGRES_DSN` | Postgres DSN | unset |
+| `CEREBRO_CACHE_MODE` | optional query-cache driver; supported: `off`, `memory`, `redis`, `valkey` | inferred from `CEREBRO_CACHE_URL`, otherwise `off` |
+| `CEREBRO_CACHE_URL` | Redis/Valkey URL for shared GRC query caching | unset |
+| `CEREBRO_CACHE_NAMESPACE` | cache key namespace, useful per environment | `cerebro` |
+| `CEREBRO_CACHE_DEFAULT_TTL` | default fresh TTL for cacheable GRC reads | `30s` |
+| `CEREBRO_CACHE_STALE_TTL` | stale-if-error window for cacheable GRC reads | `5m` |
+| `CEREBRO_CACHE_MAX_PAYLOAD_BYTES` | maximum response payload eligible for caching | `1048576` |
 | `CEREBRO_CONNECTOR_CREDENTIAL_KEY` | high-entropy key used to seal Cerebro-managed connector credentials in the state store | unset |
 | `CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY` | RSA private key used to decrypt browser-submitted connector credentials; all replicas must share the same key | unset |
 | `CEREBRO_GRAPH_STORE_DRIVER` | graph-store driver; supported value: `neo4j` | unset |

--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -28,6 +28,13 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_POSTGRES_MAX_IDLE_CONNS` | Go default | Optional `database/sql` maximum idle connections. |
 | `CEREBRO_POSTGRES_CONN_MAX_LIFETIME` | Go default | Optional maximum lifetime for pooled Postgres connections. |
 | `CEREBRO_POSTGRES_CONN_MAX_IDLE_TIME` | Go default | Optional maximum idle time for pooled Postgres connections. |
+| `CEREBRO_CACHE_MODE` | inferred | Optional query-cache driver. Supported: `off`, `memory`, `redis`, `valkey`. |
+| `CEREBRO_CACHE_URL` | unset | Redis/Valkey URL. Setting this infers `redis` unless `CEREBRO_CACHE_MODE` is set. |
+| `CEREBRO_CACHE_NAMESPACE` | `cerebro` | Cache key namespace. Use a distinct value per environment. |
+| `CEREBRO_CACHE_DEFAULT_TTL` | `30s` | Default fresh TTL for cacheable GRC read responses. |
+| `CEREBRO_CACHE_STALE_TTL` | `5m` | Additional stale-if-error window for cacheable GRC read responses. |
+| `CEREBRO_CACHE_MAX_PAYLOAD_BYTES` | `1048576` | Maximum response payload size eligible for caching. |
+| `CEREBRO_CACHE_ENABLED` | unset | Compatibility boolean. `false` forces `off`; `true` with no mode selects `redis`. |
 | `CEREBRO_GRAPH_STORE_DRIVER` | inferred | Graph-store driver. Supported: `neo4j`. |
 | `CEREBRO_NEO4J_URI` | unset | Neo4j/Aura URI. Setting this infers `neo4j`. |
 | `CEREBRO_NEO4J_USERNAME` | unset | Neo4j/Aura username. |

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/nats-io/nats.go v1.52.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.28.4
 	github.com/package-url/packageurl-go v0.1.6
+	github.com/redis/go-redis/v9 v9.17.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0
@@ -95,6 +96,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/time v0.14.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
@@ -121,6 +123,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -155,7 +158,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
@@ -260,6 +262,8 @@ github.com/package-url/packageurl-go v0.1.6/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.17.0 h1:K6E+ZlYN95KSMmZeEQPbU/c++wfmEvfFB17yEAq/VhM=
+github.com/redis/go-redis/v9 v9.17.0/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -38,6 +38,7 @@ import (
 	"github.com/writer/cerebro/internal/mcpoauth"
 	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/querycache"
 	"github.com/writer/cerebro/internal/reports"
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -54,6 +55,7 @@ type Dependencies struct {
 	StateStore    ports.StateStore
 	GraphStore    ports.GraphStore
 	GraphAgentLLM graphagent.LLMClient
+	QueryCache    querycache.Cache
 }
 
 // App is the minimal Connect/bootstrap composition root for the rewrite skeleton.
@@ -75,6 +77,7 @@ type App struct {
 	mcpOAuthRegisterLimit *deviceauth.TokenBucket
 	oauthEndpointLimit    *deviceauth.TokenBucket
 	connectorTransitKey   *connectorcredentials.TransitKey
+	queryCacheGroup       queryCacheRefreshGroup
 }
 
 type appServices struct {
@@ -430,6 +433,7 @@ func (a *App) handleResolveFinding(w http.ResponseWriter, r *http.Request) {
 		writeFindingError(w, err)
 		return
 	}
+	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.ResolveFindingResponse{
 		Finding: findingMessage(finding),
 	})
@@ -454,6 +458,7 @@ func (a *App) handleSuppressFinding(w http.ResponseWriter, r *http.Request) {
 		writeFindingError(w, err)
 		return
 	}
+	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.SuppressFindingResponse{
 		Finding: findingMessage(finding),
 	})
@@ -478,6 +483,7 @@ func (a *App) handleAssignFinding(w http.ResponseWriter, r *http.Request) {
 		writeFindingError(w, err)
 		return
 	}
+	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.AssignFindingResponse{
 		Finding: findingMessage(finding),
 	})
@@ -503,6 +509,7 @@ func (a *App) handleSetFindingDueDate(w http.ResponseWriter, r *http.Request) {
 		writeFindingError(w, err)
 		return
 	}
+	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.SetFindingDueDateResponse{
 		Finding: findingMessage(finding),
 	})
@@ -524,6 +531,7 @@ func (a *App) handleAddFindingNote(w http.ResponseWriter, r *http.Request) {
 		writeFindingError(w, err)
 		return
 	}
+	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.AddFindingNoteResponse{
 		Finding: findingMessage(finding),
 	})
@@ -551,6 +559,7 @@ func (a *App) handleLinkFindingTicket(w http.ResponseWriter, r *http.Request) {
 		writeFindingError(w, err)
 		return
 	}
+	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.LinkFindingTicketResponse{
 		Finding: findingMessage(finding),
 	})
@@ -1153,6 +1162,7 @@ func (a *App) handleRunGraphIngestRuntime(w http.ResponseWriter, r *http.Request
 		writeGraphIngestError(w, err)
 		return
 	}
+	bumpGRCCacheForRuntime(r.Context(), a.deps, request.GetRuntimeId(), grcCacheScopeGraph, grcCacheScopeRuntime, grcCacheScopeInventory)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.RunGraphIngestRuntimeResponse{
 		Result: graphIngestRunResultMessage(result),
 	})
@@ -1249,6 +1259,7 @@ func (a *App) handlePutSourceRuntime(w http.ResponseWriter, r *http.Request) {
 		writeSourceRuntimeError(w, err)
 		return
 	}
+	bumpGRCCacheForRuntime(r.Context(), a.deps, request.GetRuntime().GetId(), grcCacheScopeRuntime, grcCacheScopeGraph, grcCacheScopeInventory)
 	writeProtoJSON(w, http.StatusOK, response)
 }
 
@@ -1439,6 +1450,7 @@ func (a *App) handleWriteClaims(w http.ResponseWriter, r *http.Request) {
 		writeClaimError(w, err)
 		return
 	}
+	bumpGRCCacheForRuntime(r.Context(), a.deps, request.GetRuntimeId(), grcCacheScopeGraph, grcCacheScopeInventory)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.WriteClaimsResponse{
 		ClaimsWritten:          response.ClaimsWritten,
 		EntitiesUpserted:       response.EntitiesUpserted,
@@ -1472,6 +1484,7 @@ func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http
 		writeFindingError(w, err)
 		return
 	}
+	bumpGRCCacheForRuntime(r.Context(), a.deps, request.GetId(), grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
 	writeProtoJSON(w, http.StatusOK, findingResponse(response))
 }
 
@@ -1509,6 +1522,7 @@ func (a *App) handleEvaluateSourceRuntimeFindingRules(w http.ResponseWriter, r *
 		writeFindingError(w, err)
 		return
 	}
+	bumpGRCCacheForRuntime(r.Context(), a.deps, request.GetId(), grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
 	writeProtoJSON(w, http.StatusOK, findingRulesResponse(response))
 }
 
@@ -1711,6 +1725,7 @@ func (a *App) handlePromoteFindingCandidate(w http.ResponseWriter, r *http.Reque
 		writeFindingError(w, err)
 		return
 	}
+	a.bumpGRCCacheForFinding(r.Context(), response.Finding)
 	writeProtoJSON(w, http.StatusOK, promoteFindingCandidateResponse(response))
 }
 
@@ -1933,6 +1948,7 @@ func (s *bootstrapService) PutSourceRuntime(ctx context.Context, req *connect.Re
 	if err != nil {
 		return nil, sourceRuntimeConnectError(err)
 	}
+	bumpGRCCacheForRuntime(ctx, s.deps, req.Msg.GetRuntime().GetId(), grcCacheScopeRuntime, grcCacheScopeGraph, grcCacheScopeInventory)
 	return connect.NewResponse(response), nil
 }
 
@@ -1977,6 +1993,7 @@ func (s *bootstrapService) WriteClaims(ctx context.Context, req *connect.Request
 	if err != nil {
 		return nil, claimConnectError(err)
 	}
+	bumpGRCCacheForRuntime(ctx, s.deps, req.Msg.GetRuntimeId(), grcCacheScopeGraph, grcCacheScopeInventory)
 	return connect.NewResponse(&cerebrov1.WriteClaimsResponse{
 		ClaimsWritten:          response.ClaimsWritten,
 		EntitiesUpserted:       response.EntitiesUpserted,
@@ -2157,6 +2174,7 @@ func (s *bootstrapService) PromoteFindingCandidate(ctx context.Context, req *con
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
+	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, response.Finding)
 	return connect.NewResponse(promoteFindingCandidateResponse(response)), nil
 }
 
@@ -2205,6 +2223,7 @@ func (s *bootstrapService) ResolveFinding(ctx context.Context, req *connect.Requ
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
+	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
 	return connect.NewResponse(&cerebrov1.ResolveFindingResponse{Finding: findingMessage(finding)}), nil
 }
 
@@ -2223,6 +2242,7 @@ func (s *bootstrapService) SuppressFinding(ctx context.Context, req *connect.Req
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
+	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
 	return connect.NewResponse(&cerebrov1.SuppressFindingResponse{Finding: findingMessage(finding)}), nil
 }
 
@@ -2241,6 +2261,7 @@ func (s *bootstrapService) AssignFinding(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
+	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
 	return connect.NewResponse(&cerebrov1.AssignFindingResponse{Finding: findingMessage(finding)}), nil
 }
 
@@ -2263,6 +2284,7 @@ func (s *bootstrapService) SetFindingDueDate(ctx context.Context, req *connect.R
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
+	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
 	return connect.NewResponse(&cerebrov1.SetFindingDueDateResponse{Finding: findingMessage(finding)}), nil
 }
 
@@ -2281,6 +2303,7 @@ func (s *bootstrapService) AddFindingNote(ctx context.Context, req *connect.Requ
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
+	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
 	return connect.NewResponse(&cerebrov1.AddFindingNoteResponse{Finding: findingMessage(finding)}), nil
 }
 
@@ -2305,6 +2328,7 @@ func (s *bootstrapService) LinkFindingTicket(ctx context.Context, req *connect.R
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
+	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
 	return connect.NewResponse(&cerebrov1.LinkFindingTicketResponse{Finding: findingMessage(finding)}), nil
 }
 
@@ -2418,6 +2442,7 @@ func (s *bootstrapService) EvaluateSourceRuntimeFindingRules(ctx context.Context
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
+	bumpGRCCacheForRuntime(ctx, s.deps, req.Msg.GetId(), grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
 	return connect.NewResponse(findingRulesResponse(response)), nil
 }
 
@@ -2440,6 +2465,7 @@ func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, re
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
+	bumpGRCCacheForRuntime(ctx, s.deps, req.Msg.GetId(), grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
 	return connect.NewResponse(findingResponse(response)), nil
 }
 
@@ -2603,6 +2629,7 @@ func (s *bootstrapService) RunGraphIngestRuntime(ctx context.Context, req *conne
 	if err != nil {
 		return nil, graphIngestConnectError(err)
 	}
+	bumpGRCCacheForRuntime(ctx, s.deps, req.Msg.GetRuntimeId(), grcCacheScopeGraph, grcCacheScopeRuntime, grcCacheScopeInventory)
 	return connect.NewResponse(&cerebrov1.RunGraphIngestRuntimeResponse{
 		Result: graphIngestRunResultMessage(result),
 	}), nil

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -10,6 +10,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphagent"
 	graphstoreneo4j "github.com/writer/cerebro/internal/graphstore/neo4j"
+	"github.com/writer/cerebro/internal/querycache"
 	statestorepostgres "github.com/writer/cerebro/internal/statestore/postgres"
 )
 
@@ -80,6 +81,31 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 		return fail(err)
 	}
 	if err := pingDependency(ctx, "graph store", deps.GraphStore); err != nil {
+		return fail(err)
+	}
+	switch cfg.Cache.Driver {
+	case "", config.CacheDriverOff:
+	case config.CacheDriverMemory:
+		deps.QueryCache = querycache.NewMemory(querycache.Options{
+			Namespace:       cfg.Cache.Namespace,
+			MaxPayloadBytes: cfg.Cache.MaxPayloadBytes,
+		})
+	case config.CacheDriverRedis, config.CacheDriverValkey:
+		cache, err := querycache.OpenRedis(cfg.Cache.URL, querycache.Options{
+			Namespace:       cfg.Cache.Namespace,
+			MaxPayloadBytes: cfg.Cache.MaxPayloadBytes,
+		})
+		if err != nil {
+			return fail(fmt.Errorf("open query cache: %w", err))
+		}
+		deps.QueryCache = cache
+		closers = append(closers, func(closeCtx context.Context) error {
+			return cache.Close(closeCtx)
+		})
+	default:
+		return fail(fmt.Errorf("unsupported cache driver %q", cfg.Cache.Driver))
+	}
+	if err := pingDependency(ctx, "query cache", deps.QueryCache); err != nil {
 		return fail(err)
 	}
 	if graphAgentLLMConfigured(cfg.GraphAgentLLM) {

--- a/internal/bootstrap/grc_cache.go
+++ b/internal/bootstrap/grc_cache.go
@@ -1,0 +1,386 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/querycache"
+)
+
+const (
+	grcCacheScopeFindings  = "findings"
+	grcCacheScopeEvidence  = "evidence"
+	grcCacheScopeRuntime   = "runtime"
+	grcCacheScopeGraph     = "graph"
+	grcCacheScopeInventory = "inventory"
+)
+
+type queryCacheRefreshGroup struct {
+	group singleflight.Group
+}
+
+func (g *queryCacheRefreshGroup) Do(key string, fn func() (*capturedHTTPResponse, error)) (*capturedHTTPResponse, error) {
+	value, err, _ := g.group.Do(key, func() (any, error) {
+		return fn()
+	})
+	if err != nil {
+		return nil, err
+	}
+	response, _ := value.(*capturedHTTPResponse)
+	return response, nil
+}
+
+type grcCachePolicy struct {
+	Family        string
+	TTL           time.Duration
+	StaleTTL      time.Duration
+	VersionScopes []string
+}
+
+func (a *App) cacheGRCJSON(policy grcCachePolicy, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cache := a.deps.QueryCache
+		if cache == nil || r.Method != http.MethodGet || requestBypassesQueryCache(r) {
+			w.Header().Set("X-Cerebro-Cache", "bypass")
+			next(w, r)
+			return
+		}
+		key := a.grcCacheKey(r, policy)
+		entry, err := cache.Get(r.Context(), key)
+		now := time.Now().UTC()
+		if err == nil {
+			switch entry.State(now) {
+			case querycache.StateFresh:
+				writeCachedJSON(w, http.StatusOK, entry.Payload, "hit", policy)
+				return
+			case querycache.StateStale:
+				response, refreshErr := a.queryCacheGroup.Do(key, func() (*capturedHTTPResponse, error) {
+					return captureHTTPResponse(next, r), nil
+				})
+				if refreshErr == nil && response.cacheableJSON() {
+					_ = cache.Set(r.Context(), key, response.body.Bytes(), policy.TTL, policy.StaleTTL)
+					response.writeTo(w, "miss", policy)
+					return
+				}
+				if refreshErr != nil || response == nil || response.statusCode >= http.StatusInternalServerError {
+					writeCachedJSON(w, http.StatusOK, entry.Payload, "stale", policy)
+					return
+				}
+				response.writeTo(w, "bypass", policy)
+				return
+			}
+		} else if !errors.Is(err, querycache.ErrMiss) {
+			w.Header().Set("X-Cerebro-Cache", "bypass")
+			next(w, r)
+			return
+		}
+
+		response, err := a.queryCacheGroup.Do(key, func() (*capturedHTTPResponse, error) {
+			return captureHTTPResponse(next, r), nil
+		})
+		if err != nil || response == nil {
+			w.Header().Set("X-Cerebro-Cache", "bypass")
+			next(w, r)
+			return
+		}
+		if response.cacheableJSON() {
+			_ = cache.Set(r.Context(), key, response.body.Bytes(), policy.TTL, policy.StaleTTL)
+			response.writeTo(w, "miss", policy)
+			return
+		}
+		response.writeTo(w, "bypass", policy)
+	}
+}
+
+func (a *App) grcCachePolicy(family string, ttl time.Duration, scopes ...string) grcCachePolicy {
+	if ttl <= 0 {
+		ttl = a.cfg.Cache.DefaultTTL
+	}
+	staleTTL := a.cfg.Cache.StaleTTL
+	if staleTTL <= 0 {
+		staleTTL = 5 * time.Minute
+	}
+	return grcCachePolicy{
+		Family:        family,
+		TTL:           ttl,
+		StaleTTL:      staleTTL,
+		VersionScopes: append([]string(nil), scopes...),
+	}
+}
+
+func requestBypassesQueryCache(r *http.Request) bool {
+	cacheControl := strings.ToLower(r.Header.Get("Cache-Control"))
+	return strings.Contains(cacheControl, "no-cache") || strings.Contains(cacheControl, "no-store")
+}
+
+func (a *App) grcCacheKey(r *http.Request, policy grcCachePolicy) string {
+	tenantID := grcCacheTenantID(r)
+	versions := a.grcCacheVersions(r, tenantID, policy.VersionScopes)
+	material := map[string]any{
+		"family":   policy.Family,
+		"method":   r.Method,
+		"path":     r.URL.EscapedPath(),
+		"query":    canonicalRawQuery(r),
+		"auth":     grcCacheAuthMaterial(r),
+		"tenant":   tenantID,
+		"versions": versions,
+	}
+	raw, _ := json.Marshal(material)
+	digest := sha256.Sum256(raw)
+	return "http:grc:" + strings.TrimSpace(policy.Family) + ":" + hex.EncodeToString(digest[:])
+}
+
+func (a *App) grcCacheVersions(r *http.Request, tenantID string, scopes []string) map[string]string {
+	cache := a.deps.QueryCache
+	if cache == nil {
+		return nil
+	}
+	versionScopes := []string{grcGlobalCacheVersionScope()}
+	tenantID = strings.TrimSpace(tenantID)
+	for _, scope := range scopes {
+		scope = strings.TrimSpace(scope)
+		if tenantID != "" && scope != "" {
+			versionScopes = append(versionScopes, grcTenantCacheVersionScope(tenantID, scope))
+		}
+	}
+	sort.Strings(versionScopes)
+	versions := map[string]string{}
+	for _, scope := range versionScopes {
+		version, err := cache.Version(r.Context(), scope)
+		if err != nil || strings.TrimSpace(version) == "" {
+			version = "0"
+		}
+		versions[scope] = version
+	}
+	return versions
+}
+
+func grcCacheTenantID(r *http.Request) string {
+	if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok {
+		if tenantID := strings.TrimSpace(auth.principal.TenantID); tenantID != "" {
+			return tenantID
+		}
+	}
+	if tenantID := strings.TrimSpace(r.URL.Query().Get("tenant_id")); tenantID != "" {
+		return tenantID
+	}
+	if tenantID := strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant")); tenantID != "" {
+		return tenantID
+	}
+	for _, key := range []string{"root_urn", "urn"} {
+		if tenantID := tenantIDFromCerebroURN(r.URL.Query().Get(key)); tenantID != "" {
+			return tenantID
+		}
+	}
+	if tenantID := tenantIDFromCerebroURN(r.PathValue("entityID")); tenantID != "" {
+		return tenantID
+	}
+	return ""
+}
+
+func canonicalRawQuery(r *http.Request) string {
+	if r == nil || r.URL == nil {
+		return ""
+	}
+	return r.URL.Query().Encode()
+}
+
+func grcCacheAuthMaterial(r *http.Request) string {
+	auth, _ := r.Context().Value(authContextKey{}).(authContext)
+	material := map[string]any{
+		"mode":            auth.principal.AuthMode,
+		"name":            auth.principal.Name,
+		"tenant_id":       auth.principal.TenantID,
+		"credential_id":   auth.principal.CredentialID,
+		"client_id":       auth.principal.ClientID,
+		"token_resource":  auth.principal.TokenResource,
+		"allowed_tenants": normalizedStringSlice(auth.principal.AllowedTenants),
+		"scopes":          normalizedStringSlice(auth.principal.Scopes),
+		"groups":          normalizedStringSlice(auth.principal.Groups),
+		"capability":      auth.principal.Capability,
+		"device_id":       auth.principal.DeviceID,
+		"assurance":       auth.principal.AssuranceLevel,
+	}
+	raw, _ := json.Marshal(material)
+	digest := sha256.Sum256(raw)
+	return hex.EncodeToString(digest[:])
+}
+
+func normalizedStringSlice(values []string) []string {
+	out := append([]string(nil), values...)
+	sort.Strings(out)
+	return out
+}
+
+type capturedHTTPResponse struct {
+	header     http.Header
+	body       bytes.Buffer
+	statusCode int
+}
+
+func captureHTTPResponse(handler http.HandlerFunc, r *http.Request) *capturedHTTPResponse {
+	response := &capturedHTTPResponse{header: http.Header{}}
+	handler(response, r)
+	if response.statusCode == 0 {
+		response.statusCode = http.StatusOK
+	}
+	return response
+}
+
+func (w *capturedHTTPResponse) Header() http.Header {
+	return w.header
+}
+
+func (w *capturedHTTPResponse) WriteHeader(statusCode int) {
+	if w.statusCode == 0 {
+		w.statusCode = statusCode
+	}
+}
+
+func (w *capturedHTTPResponse) Write(payload []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.statusCode = http.StatusOK
+	}
+	return w.body.Write(payload)
+}
+
+func (w *capturedHTTPResponse) cacheableJSON() bool {
+	if w == nil || w.statusCode != http.StatusOK || w.body.Len() == 0 {
+		return false
+	}
+	contentType := strings.ToLower(w.header.Get("Content-Type"))
+	return contentType == "" || strings.Contains(contentType, "application/json")
+}
+
+func (w *capturedHTTPResponse) writeTo(dst http.ResponseWriter, cacheState string, policy grcCachePolicy) {
+	copyHeaders(dst.Header(), w.header)
+	setGRCQueryCacheHeaders(dst.Header(), cacheState, policy)
+	dst.WriteHeader(w.statusCode)
+	_, _ = dst.Write(w.body.Bytes())
+}
+
+func writeCachedJSON(w http.ResponseWriter, statusCode int, payload []byte, cacheState string, policy grcCachePolicy) {
+	w.Header().Set("Content-Type", "application/json")
+	setGRCQueryCacheHeaders(w.Header(), cacheState, policy)
+	w.WriteHeader(statusCode)
+	_, _ = w.Write(payload)
+}
+
+func copyHeaders(dst http.Header, src http.Header) {
+	for key, values := range src {
+		dst.Del(key)
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}
+
+func setGRCQueryCacheHeaders(header http.Header, cacheState string, policy grcCachePolicy) {
+	header.Set("X-Cerebro-Cache", cacheState)
+	header.Set("Vary", appendVary(header.Get("Vary"), "Authorization", "X-Cerebro-API-Key", "X-Cerebro-Tenant"))
+	if policy.TTL > 0 {
+		maxAge := int(policy.TTL / time.Second)
+		if maxAge < 1 {
+			maxAge = 1
+		}
+		value := "private, max-age=" + strconv.Itoa(maxAge)
+		if policy.StaleTTL > 0 {
+			stale := int(policy.StaleTTL / time.Second)
+			if stale < 1 {
+				stale = 1
+			}
+			value += ", stale-if-error=" + strconv.Itoa(stale)
+		}
+		header.Set("Cache-Control", value)
+	}
+}
+
+func appendVary(existing string, values ...string) string {
+	seen := map[string]string{}
+	for _, value := range strings.Split(existing, ",") {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			seen[strings.ToLower(trimmed)] = trimmed
+		}
+	}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			seen[strings.ToLower(trimmed)] = trimmed
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, seen[key])
+	}
+	return strings.Join(out, ", ")
+}
+
+func grcGlobalCacheVersionScope() string {
+	return "grc:global"
+}
+
+func grcTenantCacheVersionScope(tenantID string, scope string) string {
+	return "grc:tenant:" + strings.TrimSpace(tenantID) + ":" + strings.TrimSpace(scope)
+}
+
+func bumpGRCCacheVersions(ctx context.Context, cache querycache.Cache, tenantID string, scopes ...string) {
+	if cache == nil {
+		return
+	}
+	_, _ = cache.BumpVersion(ctx, grcGlobalCacheVersionScope())
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return
+	}
+	for _, scope := range scopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		_, _ = cache.BumpVersion(ctx, grcTenantCacheVersionScope(tenantID, scope))
+	}
+}
+
+func (a *App) bumpGRCCacheVersions(ctx context.Context, tenantID string, scopes ...string) {
+	bumpGRCCacheVersions(ctx, a.deps.QueryCache, tenantID, scopes...)
+}
+
+func bumpGRCCacheForFinding(ctx context.Context, cache querycache.Cache, finding *ports.FindingRecord) {
+	if finding == nil {
+		bumpGRCCacheVersions(ctx, cache, "", grcCacheScopeFindings, grcCacheScopeEvidence)
+		return
+	}
+	bumpGRCCacheVersions(ctx, cache, finding.TenantID, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
+}
+
+func (a *App) bumpGRCCacheForFinding(ctx context.Context, finding *ports.FindingRecord) {
+	bumpGRCCacheForFinding(ctx, a.deps.QueryCache, finding)
+}
+
+func bumpGRCCacheForRuntime(ctx context.Context, deps Dependencies, runtimeID string, scopes ...string) {
+	tenantID := ""
+	if store := sourceRuntimeStore(deps.StateStore); store != nil {
+		if runtime, err := store.GetSourceRuntime(ctx, runtimeID); err == nil && runtime != nil {
+			tenantID = runtime.GetTenantId()
+		}
+	}
+	bumpGRCCacheVersions(ctx, deps.QueryCache, tenantID, scopes...)
+}

--- a/internal/bootstrap/grc_cache_test.go
+++ b/internal/bootstrap/grc_cache_test.go
@@ -1,0 +1,99 @@
+package bootstrap
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/querycache"
+)
+
+func TestGRCQueryCacheServesFreshHit(t *testing.T) {
+	app := &App{
+		cfg: config.Config{Cache: config.CacheConfig{DefaultTTL: time.Minute, StaleTTL: time.Minute}},
+		deps: Dependencies{QueryCache: querycache.NewMemory(querycache.Options{
+			Namespace: "test",
+		})},
+	}
+	calls := 0
+	handler := app.cacheGRCJSON(app.grcCachePolicy("test", time.Minute), func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		writeJSON(w, http.StatusOK, map[string]any{"calls": calls})
+	})
+
+	first := httptest.NewRecorder()
+	handler(first, httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=writer", nil))
+	if first.Header().Get("X-Cerebro-Cache") != "miss" {
+		t.Fatalf("first X-Cerebro-Cache = %q, want miss", first.Header().Get("X-Cerebro-Cache"))
+	}
+
+	second := httptest.NewRecorder()
+	handler(second, httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=writer", nil))
+	if second.Header().Get("X-Cerebro-Cache") != "hit" {
+		t.Fatalf("second X-Cerebro-Cache = %q, want hit", second.Header().Get("X-Cerebro-Cache"))
+	}
+	if calls != 1 {
+		t.Fatalf("handler calls = %d, want 1", calls)
+	}
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("cached body = %q, want %q", second.Body.String(), first.Body.String())
+	}
+}
+
+func TestGRCQueryCacheBypassesNoCacheRequest(t *testing.T) {
+	app := &App{
+		cfg:  config.Config{Cache: config.CacheConfig{DefaultTTL: time.Minute, StaleTTL: time.Minute}},
+		deps: Dependencies{QueryCache: querycache.NewMemory(querycache.Options{Namespace: "test"})},
+	}
+	calls := 0
+	handler := app.cacheGRCJSON(app.grcCachePolicy("test", time.Minute), func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		writeJSON(w, http.StatusOK, map[string]any{"calls": calls})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=writer", nil)
+	req.Header.Set("Cache-Control", "no-cache")
+	resp := httptest.NewRecorder()
+	handler(resp, req)
+
+	if resp.Header().Get("X-Cerebro-Cache") != "bypass" {
+		t.Fatalf("X-Cerebro-Cache = %q, want bypass", resp.Header().Get("X-Cerebro-Cache"))
+	}
+	if calls != 1 {
+		t.Fatalf("handler calls = %d, want 1", calls)
+	}
+}
+
+func TestGRCQueryCacheServesStaleOnRefreshError(t *testing.T) {
+	app := &App{
+		cfg:  config.Config{Cache: config.CacheConfig{DefaultTTL: time.Millisecond, StaleTTL: time.Minute}},
+		deps: Dependencies{QueryCache: querycache.NewMemory(querycache.Options{Namespace: "test"})},
+	}
+	calls := 0
+	handler := app.cacheGRCJSON(app.grcCachePolicy("test", time.Millisecond), func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls > 1 {
+			http.Error(w, "backend failed", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"calls": calls})
+	})
+
+	first := httptest.NewRecorder()
+	handler(first, httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=writer", nil))
+	time.Sleep(5 * time.Millisecond)
+
+	second := httptest.NewRecorder()
+	handler(second, httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=writer", nil))
+	if second.Header().Get("X-Cerebro-Cache") != "stale" {
+		t.Fatalf("second X-Cerebro-Cache = %q, want stale", second.Header().Get("X-Cerebro-Cache"))
+	}
+	if second.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want 200", second.Code)
+	}
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("stale body = %q, want %q", second.Body.String(), first.Body.String())
+	}
+}

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -376,6 +376,7 @@ func (a *App) handleUpdateGRCResourceScope(w http.ResponseWriter, r *http.Reques
 		writeGRCError(w, err)
 		return
 	}
+	a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeInventory)
 	writeJSON(w, http.StatusOK, grcInventoryScopeUpdateResponse{Scope: record, GeneratedAt: time.Now().UTC()})
 }
 
@@ -440,6 +441,7 @@ func (a *App) handleCreateGRCInventoryAssetReport(w http.ResponseWriter, r *http
 		writeGRCError(w, err)
 		return
 	}
+	a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeInventory)
 	writeJSON(w, http.StatusCreated, grcInventoryAssetReportResponse{Report: record, GeneratedAt: time.Now().UTC()})
 }
 
@@ -560,6 +562,7 @@ func (a *App) handleUpdateGRCInventoryAssetReportTriage(w http.ResponseWriter, r
 		writeGRCError(w, err)
 		return
 	}
+	a.bumpGRCCacheVersions(r.Context(), record.TenantID, grcCacheScopeInventory)
 	writeJSON(w, http.StatusOK, grcInventoryAssetReportResponse{Report: record, GeneratedAt: time.Now().UTC()})
 }
 

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -196,6 +196,7 @@ func (a *App) runSourceRuntimeSyncJob(ctx context.Context, job *ports.Job, _ *pl
 	if err != nil {
 		return nil, nil, err
 	}
+	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeRuntime, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeGraph, grcCacheScopeInventory)
 	return protoToMap(response), nil, nil
 }
 
@@ -248,6 +249,7 @@ func (a *App) runSourceRuntimeOrchestrateJob(ctx context.Context, job *ports.Job
 	if graphResult.Run.ID != "" {
 		refs["graph_ingest_run_id"] = graphResult.Run.ID
 	}
+	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeRuntime, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeGraph, grcCacheScopeInventory)
 	return result, refs, nil
 }
 
@@ -264,6 +266,7 @@ func (a *App) runGraphIngestRuntimeJob(ctx context.Context, job *ports.Job, _ *p
 	if err != nil {
 		return nil, nil, err
 	}
+	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeGraph, grcCacheScopeRuntime, grcCacheScopeInventory)
 	refs := map[string]string{}
 	if result.Run.ID != "" {
 		refs["graph_ingest_run_id"] = result.Run.ID
@@ -290,6 +293,7 @@ func (a *App) runFindingRulesEvaluateJob(ctx context.Context, job *ports.Job, _ 
 	if err != nil {
 		return nil, nil, err
 	}
+	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
 	payload, err := json.Marshal(result)
 	if err != nil {
 		return nil, nil, err
@@ -312,6 +316,7 @@ func (a *App) runFindingsEvaluateJob(ctx context.Context, job *ports.Job, _ *pla
 	if err != nil {
 		return nil, nil, err
 	}
+	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
 	return protoToMap(findingResponse(result)), nil, nil
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"net/http"
+	"time"
 
 	"connectrpc.com/connect"
 
@@ -68,22 +69,22 @@ func (app *App) registerReportRoutes(mux *http.ServeMux) {
 }
 
 func (app *App) registerGRCRoutes(mux *http.ServeMux) {
-	registerHTTPRoute(mux, "GET /grc/dashboard", routeSurfacePlatformHTTP, app.handleGRCDashboard)
+	registerHTTPRoute(mux, "GET /grc/dashboard", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("dashboard", 30*time.Second, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCDashboard))
 	registerHTTPRoute(mux, "POST /grc/ask", routeSurfacePlatformHTTP, app.handleGRCAsk)
-	registerHTTPRoute(mux, "GET /grc/findings", routeSurfacePlatformHTTP, app.handleGRCFindings)
-	registerHTTPRoute(mux, "GET /grc/controls", routeSurfacePlatformHTTP, app.handleGRCControls)
-	registerHTTPRoute(mux, "GET /grc/evidence", routeSurfacePlatformHTTP, app.handleGRCEvidence)
-	registerHTTPRoute(mux, "GET /grc/inventory/categories", routeSurfacePlatformHTTP, app.handleGRCInventoryCategories)
-	registerHTTPRoute(mux, "GET /grc/inventory/assets", routeSurfacePlatformHTTP, app.handleGRCInventoryAssets)
-	registerHTTPRoute(mux, "GET /grc/inventory/assets/detail", routeSurfacePlatformHTTP, app.handleGRCInventoryAssetDetail)
-	registerHTTPRoute(mux, "GET /grc/inventory/resource-scope", routeSurfacePlatformHTTP, app.handleGRCResourceScope)
+	registerHTTPRoute(mux, "GET /grc/findings", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("findings", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCFindings))
+	registerHTTPRoute(mux, "GET /grc/controls", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("controls", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCControls))
+	registerHTTPRoute(mux, "GET /grc/evidence", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("evidence", time.Minute, grcCacheScopeEvidence, grcCacheScopeFindings, grcCacheScopeRuntime), app.handleGRCEvidence))
+	registerHTTPRoute(mux, "GET /grc/inventory/categories", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.categories", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeInventory), app.handleGRCInventoryCategories))
+	registerHTTPRoute(mux, "GET /grc/inventory/assets", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.assets", 2*time.Minute, grcCacheScopeGraph, grcCacheScopeInventory, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCInventoryAssets))
+	registerHTTPRoute(mux, "GET /grc/inventory/assets/detail", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.asset.detail", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeInventory, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCInventoryAssetDetail))
+	registerHTTPRoute(mux, "GET /grc/inventory/resource-scope", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.resource_scope", time.Minute, grcCacheScopeInventory, grcCacheScopeGraph), app.handleGRCResourceScope))
 	registerHTTPRoute(mux, "POST /grc/inventory/resource-scope", routeSurfacePlatformHTTP, app.handleUpdateGRCResourceScope)
-	registerHTTPRoute(mux, "GET /grc/inventory/asset-reports", routeSurfacePlatformHTTP, app.handleListGRCInventoryAssetReports)
+	registerHTTPRoute(mux, "GET /grc/inventory/asset-reports", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.asset_reports", time.Minute, grcCacheScopeInventory), app.handleListGRCInventoryAssetReports))
 	registerHTTPRoute(mux, "POST /grc/inventory/asset-reports", routeSurfacePlatformHTTP, app.handleCreateGRCInventoryAssetReport)
-	registerHTTPRoute(mux, "GET /grc/inventory/asset-reports/{reportID}", routeSurfacePlatformHTTP, app.handleGetGRCInventoryAssetReport)
+	registerHTTPRoute(mux, "GET /grc/inventory/asset-reports/{reportID}", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.asset_report", time.Minute, grcCacheScopeInventory), app.handleGetGRCInventoryAssetReport))
 	registerHTTPRoute(mux, "PATCH /grc/inventory/asset-reports/{reportID}/triage", routeSurfacePlatformHTTP, app.handleUpdateGRCInventoryAssetReportTriage)
-	registerHTTPRoute(mux, "GET /grc/entities/{entityID}/impact", routeSurfacePlatformHTTP, app.handleGRCEntityImpact)
-	registerHTTPRoute(mux, "GET /grc/audit-packets/{packetID}", routeSurfacePlatformHTTP, app.handleGRCAuditPacket)
+	registerHTTPRoute(mux, "GET /grc/entities/{entityID}/impact", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("entity.impact", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCEntityImpact))
+	registerHTTPRoute(mux, "GET /grc/audit-packets/{packetID}", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("audit.packet", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCAuditPacket))
 }
 
 func (app *App) registerFindingRoutes(mux *http.ServeMux) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,10 @@ const (
 	AppendLogDriverJetStream = "jetstream"
 	StateStoreDriverPostgres = "postgres"
 	GraphStoreDriverNeo4j    = "neo4j"
+	CacheDriverOff           = "off"
+	CacheDriverMemory        = "memory"
+	CacheDriverRedis         = "redis"
+	CacheDriverValkey        = "valkey"
 )
 
 var (
@@ -46,6 +50,7 @@ type Config struct {
 	StateStore           StateStoreConfig
 	GraphStore           GraphStoreConfig
 	GraphAgentLLM        GraphAgentLLMConfig
+	Cache                CacheConfig
 	Auth                 AuthConfig
 	ConnectorCredentials ConnectorCredentialConfig
 	OTEL                 OpenTelemetryConfig
@@ -87,6 +92,16 @@ type GraphStoreConfig struct {
 	Neo4jPassword     string
 	Neo4jDatabase     string
 	Neo4jQueryTimeout time.Duration
+}
+
+// CacheConfig controls optional shared query/response caching.
+type CacheConfig struct {
+	Driver          string
+	URL             string
+	Namespace       string
+	DefaultTTL      time.Duration
+	StaleTTL        time.Duration
+	MaxPayloadBytes int
 }
 
 // GraphAgentLLMConfig selects and configures the graph ask LLM adapter.
@@ -345,6 +360,11 @@ func Load() (Config, error) {
 			Neo4jPassword: strings.TrimSpace(os.Getenv("CEREBRO_NEO4J_PASSWORD")),
 			Neo4jDatabase: strings.TrimSpace(os.Getenv("CEREBRO_NEO4J_DATABASE")),
 		},
+		Cache: CacheConfig{
+			Driver:    strings.ToLower(strings.TrimSpace(os.Getenv("CEREBRO_CACHE_MODE"))),
+			URL:       strings.TrimSpace(os.Getenv("CEREBRO_CACHE_URL")),
+			Namespace: strings.TrimSpace(os.Getenv("CEREBRO_CACHE_NAMESPACE")),
+		},
 		GraphAgentLLM: GraphAgentLLMConfig{
 			Provider:      strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_PROVIDER")),
 			Model:         strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL")),
@@ -464,6 +484,45 @@ func Load() (Config, error) {
 	cfg.StateStore = ApplyPostgresPoolDefaults(cfg.StateStore)
 	if cfg.GraphStore.Neo4jQueryTimeout, err = parseDurationEnv("CEREBRO_NEO4J_QUERY_TIMEOUT", 0); err != nil {
 		return Config{}, err
+	}
+	if cfg.Cache.DefaultTTL, err = parseDurationEnv("CEREBRO_CACHE_DEFAULT_TTL", 30*time.Second); err != nil {
+		return Config{}, err
+	}
+	if cfg.Cache.StaleTTL, err = parseDurationEnv("CEREBRO_CACHE_STALE_TTL", 5*time.Minute); err != nil {
+		return Config{}, err
+	}
+	if cfg.Cache.MaxPayloadBytes, err = parseIntEnv("CEREBRO_CACHE_MAX_PAYLOAD_BYTES", 1<<20); err != nil {
+		return Config{}, err
+	}
+	if cfg.Cache.MaxPayloadBytes <= 0 {
+		return Config{}, fmt.Errorf("CEREBRO_CACHE_MAX_PAYLOAD_BYTES must be greater than zero")
+	}
+	if cfg.Cache.Namespace == "" {
+		cfg.Cache.Namespace = "cerebro"
+	}
+	if enabled, err := parseBoolEnv("CEREBRO_CACHE_ENABLED"); err != nil {
+		return Config{}, err
+	} else if envHasValue("CEREBRO_CACHE_ENABLED") && !enabled {
+		cfg.Cache.Driver = CacheDriverOff
+	} else if envHasValue("CEREBRO_CACHE_ENABLED") && enabled && cfg.Cache.Driver == "" {
+		cfg.Cache.Driver = CacheDriverRedis
+	}
+	if cfg.Cache.Driver == "" {
+		if cfg.Cache.URL != "" {
+			cfg.Cache.Driver = CacheDriverRedis
+		} else {
+			cfg.Cache.Driver = CacheDriverOff
+		}
+	}
+	switch cfg.Cache.Driver {
+	case CacheDriverOff:
+	case CacheDriverMemory:
+	case CacheDriverRedis, CacheDriverValkey:
+		if cfg.Cache.URL == "" {
+			return Config{}, fmt.Errorf("CEREBRO_CACHE_URL is required when CEREBRO_CACHE_MODE=%q", cfg.Cache.Driver)
+		}
+	default:
+		return Config{}, fmt.Errorf("unsupported CEREBRO_CACHE_MODE %q", cfg.Cache.Driver)
 	}
 	cfg.GraphAgentLLM.OpenRouterAPIKey = strings.TrimSpace(os.Getenv("CEREBRO_OPENROUTER_API_KEY"))
 	if raw, ok := os.LookupEnv("CEREBRO_SHUTDOWN_TIMEOUT"); ok && strings.TrimSpace(raw) != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,6 +27,13 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_POSTGRES_MAX_IDLE_CONNS", "")
 	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_LIFETIME", "")
 	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_IDLE_TIME", "")
+	t.Setenv("CEREBRO_CACHE_MODE", "")
+	t.Setenv("CEREBRO_CACHE_URL", "")
+	t.Setenv("CEREBRO_CACHE_NAMESPACE", "")
+	t.Setenv("CEREBRO_CACHE_DEFAULT_TTL", "")
+	t.Setenv("CEREBRO_CACHE_STALE_TTL", "")
+	t.Setenv("CEREBRO_CACHE_MAX_PAYLOAD_BYTES", "")
+	t.Setenv("CEREBRO_CACHE_ENABLED", "")
 	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_NEO4J_URI", "")
 	t.Setenv("CEREBRO_NEO4J_USERNAME", "")
@@ -75,6 +82,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.StateStore.Driver != "" {
 		t.Fatalf("StateStore.Driver = %q, want empty", cfg.StateStore.Driver)
 	}
+	if cfg.Cache.Driver != CacheDriverOff || cfg.Cache.DefaultTTL != 30*time.Second || cfg.Cache.StaleTTL != 5*time.Minute || cfg.Cache.MaxPayloadBytes != 1<<20 {
+		t.Fatalf("Cache defaults = %#v", cfg.Cache)
+	}
 	if cfg.GraphStore.Driver != "" {
 		t.Fatalf("GraphStore.Driver = %q, want empty", cfg.GraphStore.Driver)
 	}
@@ -118,6 +128,13 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_POSTGRES_MAX_IDLE_CONNS", "5")
 	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_LIFETIME", "30m")
 	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_IDLE_TIME", "5m")
+	t.Setenv("CEREBRO_CACHE_MODE", CacheDriverValkey)
+	t.Setenv("CEREBRO_CACHE_URL", "rediss://cache.example.internal:6379")
+	t.Setenv("CEREBRO_CACHE_NAMESPACE", "cerebro:test")
+	t.Setenv("CEREBRO_CACHE_DEFAULT_TTL", "45s")
+	t.Setenv("CEREBRO_CACHE_STALE_TTL", "10m")
+	t.Setenv("CEREBRO_CACHE_MAX_PAYLOAD_BYTES", "2097152")
+	t.Setenv("CEREBRO_CACHE_ENABLED", "")
 	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", GraphStoreDriverNeo4j)
 	t.Setenv("CEREBRO_NEO4J_URI", "neo4j+s://example.databases.neo4j.io")
 	t.Setenv("CEREBRO_NEO4J_USERNAME", "neo4j")
@@ -194,6 +211,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.StateStore.PostgresMaxOpenConns != 20 || cfg.StateStore.PostgresMaxIdleConns != 5 || cfg.StateStore.PostgresConnMaxLifetime != 30*time.Minute || cfg.StateStore.PostgresConnMaxIdleTime != 5*time.Minute {
 		t.Fatalf("StateStore pool config = %#v", cfg.StateStore)
+	}
+	if cfg.Cache.Driver != CacheDriverValkey || cfg.Cache.URL != "rediss://cache.example.internal:6379" || cfg.Cache.Namespace != "cerebro:test" || cfg.Cache.DefaultTTL != 45*time.Second || cfg.Cache.StaleTTL != 10*time.Minute || cfg.Cache.MaxPayloadBytes != 2097152 {
+		t.Fatalf("Cache config = %#v", cfg.Cache)
 	}
 	if cfg.GraphStore.Driver != GraphStoreDriverNeo4j {
 		t.Fatalf("GraphStore.Driver = %q, want %q", cfg.GraphStore.Driver, GraphStoreDriverNeo4j)
@@ -376,6 +396,13 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_POSTGRES_MAX_IDLE_CONNS", "")
 	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_LIFETIME", "")
 	t.Setenv("CEREBRO_POSTGRES_CONN_MAX_IDLE_TIME", "")
+	t.Setenv("CEREBRO_CACHE_MODE", "")
+	t.Setenv("CEREBRO_CACHE_URL", "")
+	t.Setenv("CEREBRO_CACHE_NAMESPACE", "")
+	t.Setenv("CEREBRO_CACHE_DEFAULT_TTL", "")
+	t.Setenv("CEREBRO_CACHE_STALE_TTL", "")
+	t.Setenv("CEREBRO_CACHE_MAX_PAYLOAD_BYTES", "")
+	t.Setenv("CEREBRO_CACHE_ENABLED", "")
 	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_NEO4J_URI", "")
 	t.Setenv("CEREBRO_NEO4J_USERNAME", "")
@@ -958,6 +985,41 @@ func TestLoadInfersDriversFromURLs(t *testing.T) {
 	}
 	if cfg.GraphStore.Driver != GraphStoreDriverNeo4j {
 		t.Fatalf("GraphStore.Driver = %q, want %q", cfg.GraphStore.Driver, GraphStoreDriverNeo4j)
+	}
+}
+
+func TestLoadInfersCacheDriverFromURL(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_CACHE_URL", "redis://127.0.0.1:6379")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Cache.Driver != CacheDriverRedis {
+		t.Fatalf("Cache.Driver = %q, want %q", cfg.Cache.Driver, CacheDriverRedis)
+	}
+	if cfg.Cache.Namespace != "cerebro" {
+		t.Fatalf("Cache.Namespace = %q, want cerebro", cfg.Cache.Namespace)
+	}
+}
+
+func TestLoadRejectsMissingCacheURL(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_CACHE_MODE", CacheDriverRedis)
+	t.Setenv("CEREBRO_CACHE_URL", "")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadRejectsUnsupportedCacheDriver(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_CACHE_MODE", "memcached")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
 	}
 }
 

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1253,7 +1253,13 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 		"CREATE CONSTRAINT cerebro_checkpoint_id IF NOT EXISTS FOR (c:IngestCheckpoint) REQUIRE c.id IS UNIQUE",
 		"CREATE CONSTRAINT cerebro_ingest_run_id IF NOT EXISTS FOR (r:IngestRun) REQUIRE r.id IS UNIQUE",
 		"CREATE INDEX cerebro_entity_tenant_runtime IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.runtime_id)",
+		"CREATE INDEX cerebro_entity_tenant_type IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.entity_type)",
+		"CREATE INDEX cerebro_entity_tenant_source IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.source_id)",
+		"CREATE INDEX cerebro_entity_tenant_source_type IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.source_id, e.entity_type)",
+		"CREATE INDEX cerebro_entity_tenant_label IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.label)",
 		"CREATE INDEX cerebro_relation_tenant_runtime IF NOT EXISTS FOR ()-[r:RELATION]-() ON (r.tenant_id, r.runtime_id)",
+		"CREATE INDEX cerebro_relation_tenant_relation IF NOT EXISTS FOR ()-[r:RELATION]-() ON (r.tenant_id, r.relation)",
+		"CREATE FULLTEXT INDEX cerebro_entity_inventory_fulltext IF NOT EXISTS FOR (e:Entity) ON EACH [e.urn, e.label, e.entity_type, e.attributes_json]",
 	}
 	if _, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
 		for _, statement := range statements {

--- a/internal/querycache/cache.go
+++ b/internal/querycache/cache.go
@@ -1,0 +1,76 @@
+package querycache
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+var ErrMiss = errors.New("query cache miss")
+
+type State string
+
+const (
+	StateMiss  State = "miss"
+	StateFresh State = "fresh"
+	StateStale State = "stale"
+)
+
+type Entry struct {
+	Payload    []byte    `json:"payload"`
+	CreatedAt  time.Time `json:"created_at"`
+	ExpiresAt  time.Time `json:"expires_at"`
+	StaleUntil time.Time `json:"stale_until"`
+}
+
+func (e Entry) State(now time.Time) State {
+	if len(e.Payload) == 0 || e.StaleUntil.IsZero() || !now.Before(e.StaleUntil) {
+		return StateMiss
+	}
+	if !e.ExpiresAt.IsZero() && now.Before(e.ExpiresAt) {
+		return StateFresh
+	}
+	return StateStale
+}
+
+type Cache interface {
+	Get(context.Context, string) (Entry, error)
+	Set(context.Context, string, []byte, time.Duration, time.Duration) error
+	Version(context.Context, string) (string, error)
+	BumpVersion(context.Context, string) (string, error)
+	Ping(context.Context) error
+	Close(context.Context) error
+}
+
+type Options struct {
+	Namespace       string
+	MaxPayloadBytes int
+}
+
+func normalizeOptions(options Options) Options {
+	options.Namespace = strings.Trim(strings.TrimSpace(options.Namespace), ":")
+	if options.Namespace == "" {
+		options.Namespace = "cerebro"
+	}
+	if options.MaxPayloadBytes <= 0 {
+		options.MaxPayloadBytes = 1 << 20
+	}
+	return options
+}
+
+func cacheKey(namespace string, key string) string {
+	key = strings.Trim(strings.TrimSpace(key), ":")
+	if key == "" {
+		key = "empty"
+	}
+	return namespace + ":" + key
+}
+
+func versionKey(namespace string, scope string) string {
+	scope = strings.Trim(strings.TrimSpace(scope), ":")
+	if scope == "" {
+		scope = "global"
+	}
+	return namespace + ":version:" + scope
+}

--- a/internal/querycache/memory.go
+++ b/internal/querycache/memory.go
@@ -1,0 +1,83 @@
+package querycache
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type MemoryCache struct {
+	mu       sync.Mutex
+	options  Options
+	entries  map[string]Entry
+	versions map[string]uint64
+}
+
+func NewMemory(options Options) *MemoryCache {
+	options = normalizeOptions(options)
+	return &MemoryCache{
+		options:  options,
+		entries:  map[string]Entry{},
+		versions: map[string]uint64{},
+	}
+}
+
+func (c *MemoryCache) Get(_ context.Context, key string) (Entry, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	fullKey := cacheKey(c.options.Namespace, key)
+	entry, ok := c.entries[fullKey]
+	if !ok || entry.State(time.Now().UTC()) == StateMiss {
+		delete(c.entries, fullKey)
+		return Entry{}, ErrMiss
+	}
+	entry.Payload = append([]byte(nil), entry.Payload...)
+	return entry, nil
+}
+
+func (c *MemoryCache) Set(_ context.Context, key string, payload []byte, ttl time.Duration, staleTTL time.Duration) error {
+	if len(payload) == 0 || len(payload) > c.options.MaxPayloadBytes {
+		return nil
+	}
+	now := time.Now().UTC()
+	if ttl <= 0 {
+		ttl = time.Second
+	}
+	if staleTTL < 0 {
+		staleTTL = 0
+	}
+	entry := Entry{
+		Payload:    append([]byte(nil), payload...),
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(ttl),
+		StaleUntil: now.Add(ttl + staleTTL),
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[cacheKey(c.options.Namespace, key)] = entry
+	return nil
+}
+
+func (c *MemoryCache) Version(_ context.Context, scope string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strconv.FormatUint(c.versions[versionKey(c.options.Namespace, scope)], 10), nil
+}
+
+func (c *MemoryCache) BumpVersion(_ context.Context, scope string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := versionKey(c.options.Namespace, scope)
+	c.versions[key]++
+	return strconv.FormatUint(c.versions[key], 10), nil
+}
+
+func (c *MemoryCache) Ping(context.Context) error {
+	return nil
+}
+
+func (c *MemoryCache) Close(context.Context) error {
+	return nil
+}

--- a/internal/querycache/redis.go
+++ b/internal/querycache/redis.go
@@ -1,0 +1,94 @@
+package querycache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type RedisCache struct {
+	client  *redis.Client
+	options Options
+}
+
+func OpenRedis(rawURL string, options Options) (*RedisCache, error) {
+	redisOptions, err := redis.ParseURL(strings.TrimSpace(rawURL))
+	if err != nil {
+		return nil, err
+	}
+	return &RedisCache{
+		client:  redis.NewClient(redisOptions),
+		options: normalizeOptions(options),
+	}, nil
+}
+
+func (c *RedisCache) Get(ctx context.Context, key string) (Entry, error) {
+	raw, err := c.client.Get(ctx, cacheKey(c.options.Namespace, key)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return Entry{}, ErrMiss
+	}
+	if err != nil {
+		return Entry{}, err
+	}
+	var entry Entry
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return Entry{}, err
+	}
+	if entry.State(time.Now().UTC()) == StateMiss {
+		return Entry{}, ErrMiss
+	}
+	return entry, nil
+}
+
+func (c *RedisCache) Set(ctx context.Context, key string, payload []byte, ttl time.Duration, staleTTL time.Duration) error {
+	if len(payload) == 0 || len(payload) > c.options.MaxPayloadBytes {
+		return nil
+	}
+	now := time.Now().UTC()
+	if ttl <= 0 {
+		ttl = time.Second
+	}
+	if staleTTL < 0 {
+		staleTTL = 0
+	}
+	entry := Entry{
+		Payload:    append([]byte(nil), payload...),
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(ttl),
+		StaleUntil: now.Add(ttl + staleTTL),
+	}
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	return c.client.Set(ctx, cacheKey(c.options.Namespace, key), raw, ttl+staleTTL).Err()
+}
+
+func (c *RedisCache) Version(ctx context.Context, scope string) (string, error) {
+	value, err := c.client.Get(ctx, versionKey(c.options.Namespace, scope)).Result()
+	if errors.Is(err, redis.Nil) {
+		return "0", nil
+	}
+	return value, err
+}
+
+func (c *RedisCache) BumpVersion(ctx context.Context, scope string) (string, error) {
+	value, err := c.client.Incr(ctx, versionKey(c.options.Namespace, scope)).Result()
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatInt(value, 10), nil
+}
+
+func (c *RedisCache) Ping(ctx context.Context) error {
+	return c.client.Ping(ctx).Err()
+}
+
+func (c *RedisCache) Close(ctx context.Context) error {
+	return c.client.Close()
+}


### PR DESCRIPTION
## Summary
- add optional GRC response caching backed by memory, Redis, or Valkey
- cache expensive GRC GET endpoints with short TTLs, stale-if-error, auth/tenant-aware keys, and mutation/version invalidation
- add Neo4j indexes for common inventory and graph filter shapes

## Verification
- go test ./...
- go test ./internal/config ./internal/querycache ./internal/bootstrap ./internal/graphstore/neo4j