### PR TITLE
fix: Stabilize Cerebro dependency startup

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -395,7 +395,11 @@ func runSourceRuntime(args []string) error {
 		return fmt.Errorf("configure telemetry: %w", err)
 	}
 	defer shutdownTelemetry(context.Background(), closeTelemetry, cfg.ShutdownTimeout)
-	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+	openDependencies := bootstrap.OpenDependencies
+	if args[0] == "bootstrap" {
+		openDependencies = bootstrap.OpenSourceRuntimeBootstrapDependencies
+	}
+	deps, closeDeps, err := openDependencies(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("open dependencies: %w", err)
 	}

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -23,10 +23,12 @@ import (
 )
 
 const (
-	connectTimeout      = 5 * time.Second
-	defaultReplayLimit  = 100
-	maxReplayLimit      = 1000
-	maxReplayCandidates = 5000
+	connectTimeout             = 5 * time.Second
+	defaultReplayLimit         = 100
+	maxReplayLimit             = 1000
+	maxReplayCandidates        = 5000
+	publishRetryAttempts       = 4
+	publishRetryInitialBackoff = 50 * time.Millisecond
 )
 
 type publisher interface {
@@ -155,6 +157,11 @@ func (l *Log) Ping(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("jetstream account info: %w", err)
 	}
+	if l.replay != nil {
+		if _, err := l.replayStream(ctx); err != nil {
+			return fmt.Errorf("jetstream stream readiness: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -188,10 +195,64 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 	if event.Id != "" {
 		msg.Header.Set(nats.MsgIdHdr, event.Id)
 	}
-	if _, err := l.js.PublishMsg(ctx, msg); err != nil {
+	if err := l.publishMsg(ctx, msg); err != nil {
 		return fmt.Errorf("publish event: %w", err)
 	}
 	return nil
+}
+
+func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg) error {
+	attempts := 1
+	if msg.Header.Get(nats.MsgIdHdr) != "" {
+		attempts = publishRetryAttempts
+	}
+	backoff := publishRetryInitialBackoff
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if _, err = l.js.PublishMsg(ctx, msg); err == nil {
+			return nil
+		}
+		if attempt == attempts || !retryablePublishError(err) || ctx.Err() != nil {
+			return err
+		}
+		if waitErr := waitBeforePublishRetry(ctx, backoff); waitErr != nil {
+			return waitErr
+		}
+		backoff *= 2
+	}
+	return err
+}
+
+func retryablePublishError(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	for _, fragment := range []string{
+		"no response",
+		"timeout",
+		"temporarily unavailable",
+		"connection",
+		"reconnect",
+		"broken pipe",
+		"reset by peer",
+	} {
+		if strings.Contains(text, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func waitBeforePublishRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // Replay returns the newest matching stored envelopes in append order.

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -19,9 +19,11 @@ import (
 )
 
 type fakePublisher struct {
-	accountErr error
-	publishErr error
-	published  *nats.Msg
+	accountErr   error
+	publishErr   error
+	publishErrs  []error
+	published    *nats.Msg
+	publishCalls int
 }
 
 func (f *fakePublisher) AccountInfo(context.Context) (*natsjetstream.AccountInfo, error) {
@@ -29,7 +31,13 @@ func (f *fakePublisher) AccountInfo(context.Context) (*natsjetstream.AccountInfo
 }
 
 func (f *fakePublisher) PublishMsg(_ context.Context, msg *nats.Msg, _ ...natsjetstream.PublishOpt) (*natsjetstream.PubAck, error) {
+	f.publishCalls++
 	f.published = msg
+	if len(f.publishErrs) > 0 {
+		err := f.publishErrs[0]
+		f.publishErrs = f.publishErrs[1:]
+		return &natsjetstream.PubAck{}, err
+	}
 	return &natsjetstream.PubAck{}, f.publishErr
 }
 
@@ -97,6 +105,40 @@ func TestAppendPublishesEnvelope(t *testing.T) {
 	}
 	if !proto.Equal(&decoded, event) {
 		t.Fatalf("decoded envelope = %#v, want %#v", &decoded, event)
+	}
+}
+
+func TestAppendRetriesTransientPublishErrorWhenMessageIDIsSet(t *testing.T) {
+	pub := &fakePublisher{
+		publishErrs: []error{
+			errors.New("nats: no response from stream"),
+			nil,
+		},
+	}
+	log := &Log{js: pub, subjectPrefix: "events"}
+
+	err := log.Append(context.Background(), &cerebrov1.EventEnvelope{
+		Id:   "evt-1",
+		Kind: "entity.upsert",
+	})
+	if err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if pub.publishCalls != 2 {
+		t.Fatalf("publish calls = %d, want 2", pub.publishCalls)
+	}
+}
+
+func TestAppendDoesNotRetryWithoutMessageID(t *testing.T) {
+	pub := &fakePublisher{publishErr: errors.New("nats: no response from stream")}
+	log := &Log{js: pub, subjectPrefix: "events"}
+
+	err := log.Append(context.Background(), &cerebrov1.EventEnvelope{Kind: "entity.upsert"})
+	if err == nil {
+		t.Fatal("Append() error = nil, want non-nil")
+	}
+	if pub.publishCalls != 1 {
+		t.Fatalf("publish calls = %d, want 1", pub.publishCalls)
 	}
 }
 
@@ -262,6 +304,30 @@ func TestPingSurfacesPublisherError(t *testing.T) {
 	log := &Log{js: &fakePublisher{accountErr: errors.New("down")}, subjectPrefix: "events"}
 	if err := log.Ping(context.Background()); err == nil {
 		t.Fatal("Ping() error = nil, want non-nil")
+	}
+}
+
+func TestPingRequiresMatchingStreamWhenReplayManagerIsConfigured(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{Config: natsjetstream.StreamConfig{Name: "OTHER", Subjects: []string{"other.>"}}},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+	if err := log.Ping(context.Background()); err == nil {
+		t.Fatal("Ping() error = nil, want non-nil")
+	}
+}
+
+func TestPingAcceptsMatchingStream(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}}},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+	if err := log.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping() error = %v", err)
 	}
 }
 

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -14,7 +14,7 @@ import (
 	statestorepostgres "github.com/writer/cerebro/internal/statestore/postgres"
 )
 
-const dependencyPingTimeout = 5 * time.Second
+const dependencyPingTimeout = 15 * time.Second
 
 type closer func(context.Context) error
 
@@ -127,6 +127,45 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 			return fail(fmt.Errorf("open graph agent llm: %w", err))
 		}
 		deps.GraphAgentLLM = llm
+	}
+	return deps, closeAll, nil
+}
+
+// OpenSourceRuntimeBootstrapDependencies opens only the state-store dependency
+// required to validate and persist source runtime definitions.
+func OpenSourceRuntimeBootstrapDependencies(ctx context.Context, cfg config.Config) (Dependencies, func() error, error) {
+	var (
+		deps    Dependencies
+		closers []closer
+	)
+	closeAll := func() error {
+		var errs []error
+		closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), dependencyPingTimeout)
+		defer cancel()
+		for i := len(closers) - 1; i >= 0; i-- {
+			if err := closers[i](closeCtx); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return errors.Join(errs...)
+	}
+	fail := func(err error) (Dependencies, func() error, error) {
+		_ = closeAll()
+		return Dependencies{}, func() error { return nil }, err
+	}
+
+	if cfg.StateStore.Driver == config.StateStoreDriverPostgres {
+		stateStore, err := statestorepostgres.Open(cfg.StateStore)
+		if err != nil {
+			return fail(fmt.Errorf("open state store: %w", err))
+		}
+		deps.StateStore = stateStore
+		closers = append(closers, func(context.Context) error {
+			return stateStore.Close()
+		})
+	}
+	if err := pingDependency(ctx, "state store", deps.StateStore); err != nil {
+		return fail(err)
 	}
 	return deps, closeAll, nil
 }

--- a/internal/bootstrap/dependencies_test.go
+++ b/internal/bootstrap/dependencies_test.go
@@ -87,3 +87,22 @@ func TestOpenDependenciesRejectsUnsupportedGraphStoreDriver(t *testing.T) {
 		t.Fatal("OpenDependencies() error = nil, want non-nil")
 	}
 }
+
+func TestOpenSourceRuntimeBootstrapDependenciesIgnoresUnusedStores(t *testing.T) {
+	deps, closeAll, err := OpenSourceRuntimeBootstrapDependencies(context.Background(), config.Config{
+		AppendLog:  config.AppendLogConfig{Driver: config.AppendLogDriverJetStream},
+		GraphStore: config.GraphStoreConfig{Driver: "alternate"},
+	})
+	if err != nil {
+		t.Fatalf("OpenSourceRuntimeBootstrapDependencies() error = %v", err)
+	}
+	if deps.AppendLog != nil {
+		t.Fatal("AppendLog != nil, want nil")
+	}
+	if deps.GraphStore != nil {
+		t.Fatal("GraphStore != nil, want nil")
+	}
+	if err := closeAll(); err != nil {
+		t.Fatalf("closeAll() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Open only the state store for source-runtime bootstrap so unrelated append-log or graph-store startup issues do not block runtime definition persistence.
- Increase dependency ping budget and verify JetStream stream readiness during append-log startup.
- Retry transient JetStream publish failures when events have idempotency message IDs.

## Test Plan

- `go test ./internal/bootstrap ./internal/appendlog/jetstream ./cmd/cerebro -count=1`
- `make lint`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed startup/retry behavior and idempotent event publish handling.
