### PR TITLE
Require coverage contracts for deployable sources

### DIFF
--- a/sources/backstage/catalog.yaml
+++ b/sources/backstage/catalog.yaml
@@ -3,6 +3,33 @@ name: Backstage
 description: Backstage catalog source for service ownership and runtime context.
 emitted_kinds:
   - backstage.component
+coverage_contract:
+  owner_domain: engineering
+  authority_domain: backstage
+  dimensions:
+    - id: components
+      type: entity_family
+      title: Backstage components
+      families: [component]
+      support: supported
+      high_value: true
+    - id: ownership_relationships
+      type: relationship
+      title: Component ownership relationships
+      families: [component]
+      support: partial
+      high_value: true
+      known_unsupported_fields:
+        - non-component catalog ownership entities
+        - transitive group membership expansion
+    - id: runtime_context
+      type: relationship
+      title: Runtime annotations and deployment context
+      families: [component]
+      support: partial
+      high_value: true
+      known_unsupported_fields:
+        - provider-specific runtime inventory expansion
 event_contracts:
   - kind: backstage.component
     schema_ref: backstage/component/v1

--- a/sources/emaildomainhealth/catalog.yaml
+++ b/sources/emaildomainhealth/catalog.yaml
@@ -3,6 +3,30 @@ name: Email Domain Health
 description: Email authentication posture source. Probes SPF, DKIM, DMARC, MX, and related DNS records for configured tenant mail domains.
 emitted_kinds:
   - email_domain_health.health
+coverage_contract:
+  owner_domain: security
+  authority_domain: dns
+  dimensions:
+    - id: email_authentication_posture
+      type: entity_family
+      title: Email authentication posture
+      families: [health]
+      support: supported
+      high_value: true
+    - id: dns_record_checks
+      type: entity_family
+      title: SPF, DKIM, DMARC, MX, and related DNS checks
+      families: [health]
+      support: supported
+      high_value: true
+    - id: remediation_state
+      type: remediation_state
+      title: Domain remediation lifecycle state
+      families: [health]
+      support: unsupported
+      high_value: true
+      known_unsupported_fields:
+        - remediation workflow state
 event_contracts:
   - kind: email_domain_health.health
     schema_ref: email_domain_health/health/v1

--- a/sources/evidencecas/catalog.yaml
+++ b/sources/evidencecas/catalog.yaml
@@ -3,6 +3,28 @@ name: EvidenceCAS
 description: EvidenceCAS evidence manifest source.
 emitted_kinds:
   - evidence_cas.object
+coverage_contract:
+  owner_domain: compliance
+  authority_domain: evidence_cas
+  dimensions:
+    - id: evidence_objects
+      type: entity_family
+      title: Evidence manifest objects
+      families: [object]
+      support: supported
+      high_value: true
+    - id: integrity_metadata
+      type: entity_family
+      title: Evidence URI and digest metadata
+      families: [object]
+      support: supported
+      high_value: true
+    - id: source_event_links
+      type: relationship
+      title: Source event evidence links
+      families: [object]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: evidence_cas.object
     schema_ref: evidence_cas/object/v1

--- a/sources/grc/catalog.yaml
+++ b/sources/grc/catalog.yaml
@@ -14,3 +14,67 @@ emitted_kinds:
   - grc.person
   - grc.user
   - grc.integration
+coverage_contract:
+  owner_domain: compliance
+  authority_domain: grc
+  dimensions:
+    - id: frameworks
+      type: entity_family
+      title: GRC frameworks
+      families: [framework]
+      support: supported
+      high_value: true
+    - id: controls
+      type: entity_family
+      title: GRC controls
+      families: [control]
+      support: supported
+      high_value: true
+    - id: control_tests
+      type: lifecycle_state
+      title: Control test status
+      families: [control_test]
+      support: supported
+      high_value: true
+    - id: policies
+      type: entity_family
+      title: Policies and documents
+      families: [policy, document]
+      support: supported
+      high_value: true
+    - id: vendors
+      type: entity_family
+      title: Vendors
+      families: [vendor]
+      support: supported
+      high_value: true
+    - id: vulnerabilities
+      type: entity_family
+      title: Vulnerabilities
+      families: [vulnerability]
+      support: supported
+      high_value: true
+    - id: vulnerable_assets
+      type: relationship
+      title: Vulnerability to asset relationships
+      families: [vulnerable_asset]
+      support: supported
+      high_value: true
+    - id: risk_scenarios
+      type: entity_family
+      title: Risk scenarios
+      families: [risk_scenario]
+      support: supported
+      high_value: true
+    - id: people
+      type: entity_family
+      title: People and users
+      families: [person, user]
+      support: supported
+      high_value: true
+    - id: integrations
+      type: entity_family
+      title: GRC integrations
+      families: [integration]
+      support: supported
+      high_value: true

--- a/sources/kandji/catalog.yaml
+++ b/sources/kandji/catalog.yaml
@@ -5,3 +5,33 @@ emitted_kinds:
   - kandji.application
   - kandji.device
   - kandji.vulnerability
+coverage_contract:
+  owner_domain: endpoint
+  authority_domain: kandji
+  dimensions:
+    - id: devices
+      type: entity_family
+      title: Apple endpoint devices
+      families: [device]
+      support: supported
+      high_value: true
+    - id: applications
+      type: entity_family
+      title: Installed applications
+      families: [application]
+      support: supported
+      high_value: true
+    - id: vulnerabilities
+      type: entity_family
+      title: Endpoint application vulnerabilities
+      families: [vulnerability]
+      support: supported
+      high_value: true
+    - id: remediation_state
+      type: remediation_state
+      title: Vulnerability remediation lifecycle state
+      families: [vulnerability]
+      support: partial
+      high_value: true
+      known_unsupported_fields:
+        - remediation workflow assignee and SLA state

--- a/sources/kolide/catalog.yaml
+++ b/sources/kolide/catalog.yaml
@@ -7,3 +7,37 @@ emitted_kinds:
   - kolide.software
   - kolide.user_device
   - kolide.vulnerability
+coverage_contract:
+  owner_domain: endpoint
+  authority_domain: kolide
+  dimensions:
+    - id: devices
+      type: entity_family
+      title: Endpoint devices
+      families: [device]
+      support: supported
+      high_value: true
+    - id: checks
+      type: lifecycle_state
+      title: Device compliance checks
+      families: [check]
+      support: supported
+      high_value: true
+    - id: software_inventory
+      type: entity_family
+      title: Installed software inventory
+      families: [software]
+      support: supported
+      high_value: true
+    - id: user_device_relationships
+      type: relationship
+      title: User to device relationships
+      families: [user_device]
+      support: supported
+      high_value: true
+    - id: vulnerabilities
+      type: entity_family
+      title: Endpoint software vulnerabilities
+      families: [vulnerability]
+      support: supported
+      high_value: true

--- a/sources/securitytoolingmap/catalog.yaml
+++ b/sources/securitytoolingmap/catalog.yaml
@@ -4,6 +4,22 @@ description: Security and GRC tooling inventory source.
 emitted_kinds:
   - security_tooling_map.tool
   - security_tooling_map.control_mapping
+coverage_contract:
+  owner_domain: security
+  authority_domain: security_tooling_map
+  dimensions:
+    - id: tools
+      type: entity_family
+      title: Security and GRC tools
+      families: [tool]
+      support: supported
+      high_value: true
+    - id: control_mappings
+      type: relationship
+      title: Tool to control mappings
+      families: [control_mapping]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: security_tooling_map.tool
     schema_ref: security_tooling_map/tool/v1

--- a/sources/sentinelone/catalog.yaml
+++ b/sources/sentinelone/catalog.yaml
@@ -17,3 +17,57 @@ runtime_families:
   - group
   - site
   - threat
+coverage_contract:
+  owner_domain: endpoint
+  authority_domain: sentinelone
+  dimensions:
+    - id: activities
+      type: audit_event
+      title: SentinelOne activities
+      families: [activity]
+      support: supported
+      high_value: true
+    - id: agents
+      type: entity_family
+      title: SentinelOne agents
+      families: [agent]
+      support: supported
+      high_value: true
+    - id: applications
+      type: entity_family
+      title: Application inventory
+      families: [application]
+      support: supported
+      high_value: true
+    - id: exclusions
+      type: entity_family
+      title: Security exclusions
+      families: [exclusion]
+      support: supported
+      high_value: true
+    - id: groups
+      type: entity_family
+      title: SentinelOne groups
+      families: [group]
+      support: supported
+      high_value: true
+    - id: sites
+      type: entity_family
+      title: SentinelOne sites
+      families: [site]
+      support: supported
+      high_value: true
+    - id: threats
+      type: entity_family
+      title: Threat detections
+      families: [threat]
+      support: supported
+      high_value: true
+    - id: remediation_state
+      type: remediation_state
+      title: Threat remediation lifecycle state
+      families: [threat]
+      support: partial
+      high_value: true
+      known_unsupported_fields:
+        - investigation owner and exception workflow state

--- a/sources/trustedendpoint/catalog.yaml
+++ b/sources/trustedendpoint/catalog.yaml
@@ -11,6 +11,64 @@ emitted_kinds:
   - trusted_endpoint.grc_evidence
   - trusted_endpoint.trust_gate_decision
   - trusted_endpoint.action_outcome
+coverage_contract:
+  owner_domain: endpoint
+  authority_domain: trusted_endpoint
+  dimensions:
+    - id: agent_identities
+      type: entity_family
+      title: Trusted endpoint agent identities
+      families: [agent_identity]
+      support: supported
+      high_value: true
+    - id: host_posture
+      type: entity_family
+      title: Host posture observations
+      families: [host_posture]
+      support: supported
+      high_value: true
+    - id: repo_worktree_context
+      type: entity_family
+      title: Repository worktree context
+      families: [repo_worktree_context]
+      support: supported
+      high_value: true
+    - id: ai_session_risk
+      type: lifecycle_state
+      title: AI session risk summaries
+      families: [ai_session_summary]
+      support: supported
+      high_value: true
+    - id: ai_workflow_risk
+      type: lifecycle_state
+      title: AI workflow risk assessments
+      families: [ai_workflow_risk]
+      support: supported
+      high_value: true
+    - id: security_findings
+      type: entity_family
+      title: Endpoint security findings
+      families: [security_finding]
+      support: supported
+      high_value: true
+    - id: grc_evidence
+      type: entity_family
+      title: GRC evidence records
+      families: [grc_evidence]
+      support: supported
+      high_value: true
+    - id: trust_gate_decisions
+      type: lifecycle_state
+      title: Trust gate decisions
+      families: [trust_gate_decision]
+      support: supported
+      high_value: true
+    - id: action_outcomes
+      type: audit_event
+      title: Trusted endpoint action outcomes
+      families: [action_outcome]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: trusted_endpoint.agent_identity
     schema_ref: trusted_endpoint/agent_identity/v1

--- a/sources/vulnview/catalog.yaml
+++ b/sources/vulnview/catalog.yaml
@@ -7,3 +7,45 @@ emitted_kinds:
   - vulnview.vulnerability
   - vulnview.asset
   - vulnview.dns_alert
+coverage_contract:
+  owner_domain: security
+  authority_domain: vulnview
+  dimensions:
+    - id: sites
+      type: entity_family
+      title: Attack-surface sites
+      families: [site]
+      support: supported
+      high_value: true
+    - id: scans
+      type: lifecycle_state
+      title: Scan lifecycle state
+      families: [scan]
+      support: supported
+      high_value: true
+    - id: vulnerabilities
+      type: entity_family
+      title: Vulnerabilities
+      families: [vulnerability]
+      support: supported
+      high_value: true
+    - id: assets
+      type: entity_family
+      title: Attack-surface assets
+      families: [asset]
+      support: supported
+      high_value: true
+    - id: dns_alerts
+      type: entity_family
+      title: DNS alerts
+      families: [dns_alert]
+      support: supported
+      high_value: true
+    - id: remediation_state
+      type: remediation_state
+      title: Vulnerability remediation lifecycle state
+      families: [vulnerability]
+      support: unsupported
+      high_value: true
+      known_unsupported_fields:
+        - remediation workflow state

--- a/tools/catalogcheck/catalogcheck.go
+++ b/tools/catalogcheck/catalogcheck.go
@@ -247,6 +247,14 @@ func checkSourceCatalogs(root string) ([]issue, error) {
 			return nil
 		}
 		spec := catalog.Spec
+		hasDeployManifest, err := hasSourceDeployManifest(filepath.Dir(path))
+		if err != nil {
+			issues = append(issues, issue{path: rel, message: err.Error()})
+			return nil
+		}
+		if hasDeployManifest && catalog.CoverageContract == nil {
+			issues = append(issues, issue{path: rel, message: "coverage_contract is required for deployable sources"})
+		}
 		if spec.GetId() != "sdk" && len(spec.GetEmittedKinds()) == 0 {
 			issues = append(issues, issue{path: rel, message: "emitted_kinds is required for built-in pull sources"})
 		}
@@ -272,6 +280,17 @@ func checkSourceCatalogs(root string) ([]issue, error) {
 		return nil, err
 	}
 	return issues, nil
+}
+
+func hasSourceDeployManifest(sourceDir string) (bool, error) {
+	info, err := os.Lstat(filepath.Join(sourceDir, "deploy.yaml"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat deploy.yaml: %w", err)
+	}
+	return !info.IsDir(), nil
 }
 
 func validateFixtureContracts(root string, sourceDir string, contracts []sourcecdk.EventContract) []issue {

--- a/tools/catalogcheck/catalogcheck_test.go
+++ b/tools/catalogcheck/catalogcheck_test.go
@@ -86,6 +86,57 @@ emitted_kinds:
 	}
 }
 
+func TestCheckSourceCatalogsRejectsDeployableSourceWithoutCoverageContract(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "sources/github/catalog.yaml", `
+id: github
+name: GitHub
+description: GitHub source
+emitted_kinds:
+  - github.audit
+`)
+	writeFile(t, root, "sources/github/deploy.yaml", `runtimes: []
+`)
+
+	issues, err := checkSourceCatalogs(root)
+	if err != nil {
+		t.Fatalf("checkSourceCatalogs() error = %v", err)
+	}
+	if !issueMessagesContain(issues, "coverage_contract is required for deployable sources") {
+		t.Fatalf("issues = %#v, want missing coverage_contract issue", issues)
+	}
+}
+
+func TestCheckSourceCatalogsAcceptsDeployableSourceWithCoverageContract(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "sources/github/catalog.yaml", `
+id: github
+name: GitHub
+description: GitHub source
+emitted_kinds:
+  - github.audit
+coverage_contract:
+  owner_domain: source_control
+  authority_domain: github
+  dimensions:
+    - id: audit_events
+      type: audit_event
+      title: Audit events
+      families: [audit]
+      support: supported
+`)
+	writeFile(t, root, "sources/github/deploy.yaml", `runtimes: []
+`)
+
+	issues, err := checkSourceCatalogs(root)
+	if err != nil {
+		t.Fatalf("checkSourceCatalogs() error = %v", err)
+	}
+	if issueMessagesContain(issues, "coverage_contract is required for deployable sources") {
+		t.Fatalf("issues = %#v, want no coverage_contract issue", issues)
+	}
+}
+
 func TestCheckCloudPolicyCoverageRejectsUnmappedCloudPolicyResource(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "policies/cloud/test.json", `{"resource":"aws::unknown::thing"}`)


### PR DESCRIPTION
## Summary\n- require deployable sources with a deploy.yaml to declare a coverage_contract in catalogcheck\n- add coverage contracts for Backstage, Email Domain Health, EvidenceCAS, GRC, Kandji, Kolide, Security Tooling Map, SentinelOne, Trusted Endpoint, and VulnView\n- add catalogcheck tests for deployable source coverage enforcement\n\n## Verification\n- go run ./tools/catalogcheck\n- go test ./tools/catalogcheck ./internal/sourcecdk ./internal/sourceregistry ./tools/sourcedeploy\n- make check-structural\n- PATH=/usr/bin:/bin:/usr/sbin:/sbin:$PATH make check (passed before final rebase onto merged Cloudflare/Kubernetes main; focused checks above passed after rebase)