### PR TITLE
Deepen GCP runtime coverage contracts

### DIFF
--- a/sources/gcp/catalog.yaml
+++ b/sources/gcp/catalog.yaml
@@ -518,7 +518,13 @@ coverage_contract:
     - id: dns_managed_zone
       type: entity_family
       title: Cloud DNS managed zones
-      families: [dns_managed_zone, dns_record_set]
+      families: [dns_managed_zone]
+      support: supported
+      high_value: true
+    - id: dns_record_set
+      type: entity_family
+      title: Cloud DNS record sets
+      families: [dns_record_set]
       support: supported
       high_value: true
     - id: gcs_bucket
@@ -561,6 +567,18 @@ coverage_contract:
       type: app_entitlement
       title: IAM policy bindings
       families: [iam_role_assignment]
+      support: supported
+      high_value: true
+    - id: effective_permission
+      type: app_entitlement
+      title: Effective IAM permissions
+      families: [effective_permission]
+      support: supported
+      high_value: true
+    - id: asset_metadata
+      type: entity_family
+      title: Cloud Asset metadata and data sensitivity
+      families: [asset_metadata]
       support: supported
       high_value: true
     - id: kms_key

--- a/sources/kubernetes/catalog.yaml
+++ b/sources/kubernetes/catalog.yaml
@@ -132,7 +132,7 @@ coverage_contract:
     - id: pods
       type: entity_family
       title: Kubernetes pods
-      families: [pod]
+      families: [pod, container]
       support: supported
       high_value: true
     - id: service_accounts

--- a/tools/catalogcheck/catalogcheck_test.go
+++ b/tools/catalogcheck/catalogcheck_test.go
@@ -188,6 +188,13 @@ func TestCloudPolicyCoverageMapsGCPExpansionTargets(t *testing.T) {
 		"gcp::certificatemanager::certificate_map":        "certificate_manager_certificate_map",
 		"gcp::certificatemanager::certificate_map_entry":  "certificate_manager_certificate_map_entry",
 		"gcp::certificatemanager::dns_authorization":      "certificate_manager_dns_authorization",
+		"gcp::cloudscheduler::job":                        "cloud_scheduler_job",
+		"gcp::dns::record_set":                            "dns_record_set",
+		"gcp::iam::effective_permission":                  "effective_permission",
+		"gcp::orgpolicy::policy":                          "org_policy",
+		"gcp::pubsub::subscription":                       "pubsub_subscription",
+		"gcp::pubsub::topic":                              "pubsub_topic",
+		"gcp::serviceusage::service":                      "service_usage_service",
 		"gcp::vpcaccess::connector":                       "vpc_access_connector",
 	}
 	for resource, wantDimension := range tests {
@@ -198,6 +205,44 @@ func TestCloudPolicyCoverageMapsGCPExpansionTargets(t *testing.T) {
 		if alias.SourceID != "gcp" || alias.DimensionID != wantDimension {
 			t.Fatalf("cloudPolicyCoverageAliases[%q] = %#v, want gcp/%s", resource, alias, wantDimension)
 		}
+	}
+}
+
+func TestCheckCloudPolicyCoverageRejectsUncoveredStrictRuntimeFamily(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "policies/cloud/test.json", `{"resource":"gcp::compute::instance"}`)
+	writeFile(t, root, "sources/gcp/catalog.yaml", `
+id: gcp
+name: GCP
+description: GCP source
+emitted_kinds:
+  - gcp.compute_instance
+coverage_contract:
+  owner_domain: cloud
+  authority_domain: gcp
+  dimensions:
+    - id: compute_instance
+      type: entity_family
+      title: Compute instances
+      families: [compute_instance]
+      support: supported
+`)
+	writeFile(t, root, "sources/gcp/deploy.yaml", `
+runtimes:
+  - localId: compute-instance
+    config:
+      family: compute_instance
+  - localId: effective-permission
+    config:
+      family: effective_permission
+`)
+
+	issues, err := checkCloudPolicyCoverage(root)
+	if err != nil {
+		t.Fatalf("checkCloudPolicyCoverage() error = %v", err)
+	}
+	if !issueMessagesContain(issues, "coverage_contract does not cover deploy runtime families: effective_permission") {
+		t.Fatalf("issues = %#v, want missing strict runtime family coverage issue", issues)
 	}
 }
 

--- a/tools/catalogcheck/cloud_policy_coverage.go
+++ b/tools/catalogcheck/cloud_policy_coverage.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"gopkg.in/yaml.v3"
 )
 
 type cloudCoverageAlias struct {
@@ -113,6 +114,8 @@ var cloudPolicyCoverageAliases = map[string]cloudCoverageAlias{
 	"gcp::aiplatform::dataset":                        {SourceID: "gcp", DimensionID: "aiplatform_dataset"},
 	"gcp::aiplatform::endpoint":                       {SourceID: "gcp", DimensionID: "aiplatform_endpoint"},
 	"gcp::artifact_registry::repository":              {SourceID: "gcp", DimensionID: "artifact_registry_repository"},
+	"gcp::asset::data_sensitivity":                    {SourceID: "gcp", DimensionID: "asset_metadata"},
+	"gcp::asset::metadata":                            {SourceID: "gcp", DimensionID: "asset_metadata"},
 	"gcp::bigquery::dataset":                          {SourceID: "gcp", DimensionID: "bigquery_dataset"},
 	"gcp::bigquery::table":                            {SourceID: "gcp", DimensionID: "bigquery_table"},
 	"gcp::bigtable::instance":                         {SourceID: "gcp", DimensionID: "bigtable_instance"},
@@ -125,7 +128,9 @@ var cloudPolicyCoverageAliases = map[string]cloudCoverageAlias{
 	"gcp::certificatemanager::certificate_map":        {SourceID: "gcp", DimensionID: "certificate_manager_certificate_map"},
 	"gcp::certificatemanager::certificate_map_entry":  {SourceID: "gcp", DimensionID: "certificate_manager_certificate_map_entry"},
 	"gcp::certificatemanager::dns_authorization":      {SourceID: "gcp", DimensionID: "certificate_manager_dns_authorization"},
+	"gcp::cloud_scheduler::job":                       {SourceID: "gcp", DimensionID: "cloud_scheduler_job"},
 	"gcp::cloudfunctions::function":                   {SourceID: "gcp", DimensionID: "cloud_function"},
+	"gcp::cloudscheduler::job":                        {SourceID: "gcp", DimensionID: "cloud_scheduler_job"},
 	"gcp::cloudrun::revision":                         {SourceID: "gcp", DimensionID: "cloud_run_revision"},
 	"gcp::cloudrun::service":                          {SourceID: "gcp", DimensionID: "cloud_run_service"},
 	"gcp::compute::address":                           {SourceID: "gcp", DimensionID: "compute_address"},
@@ -161,9 +166,11 @@ var cloudPolicyCoverageAliases = map[string]cloudCoverageAlias{
 	"gcp::container::node_pool":                       {SourceID: "gcp", DimensionID: "gke_node_pool"},
 	"gcp::container_registry::registry":               {SourceID: "gcp", DimensionID: "container_registry"},
 	"gcp::dns::managed_zone":                          {SourceID: "gcp", DimensionID: "dns_managed_zone"},
+	"gcp::dns::record_set":                            {SourceID: "gcp", DimensionID: "dns_record_set"},
 	"gcp::gke::cluster_role":                          {SourceID: "kubernetes", DimensionID: "rbac_roles"},
 	"gcp::gke::cluster_role_binding":                  {SourceID: "kubernetes", DimensionID: "rbac_bindings"},
 	"gcp::gke::role":                                  {SourceID: "kubernetes", DimensionID: "rbac_roles"},
+	"gcp::iam::effective_permission":                  {SourceID: "gcp", DimensionID: "effective_permission"},
 	"gcp::iam::member":                                {SourceID: "gcp", DimensionID: "iam_role_assignment"},
 	"gcp::iam::policy":                                {SourceID: "gcp", DimensionID: "iam_role_assignment"},
 	"gcp::iam::service_account":                       {SourceID: "gcp", DimensionID: "service_account"},
@@ -173,10 +180,16 @@ var cloudPolicyCoverageAliases = map[string]cloudCoverageAlias{
 	"gcp::logging::project_sink":                      {SourceID: "gcp", DimensionID: "logging_project_sink"},
 	"gcp::monitoring::alert_policy":                   {SourceID: "gcp", DimensionID: "monitoring_alert_policy"},
 	"gcp::monitoring::notification_channel":           {SourceID: "gcp", DimensionID: "monitoring_notification_channel"},
+	"gcp::org_policy::policy":                         {SourceID: "gcp", DimensionID: "org_policy"},
+	"gcp::orgpolicy::policy":                          {SourceID: "gcp", DimensionID: "org_policy"},
+	"gcp::pubsub::subscription":                       {SourceID: "gcp", DimensionID: "pubsub_subscription"},
+	"gcp::pubsub::topic":                              {SourceID: "gcp", DimensionID: "pubsub_topic"},
 	"gcp::resourcemanager::project":                   {SourceID: "gcp", DimensionID: "resourcemanager_project"},
 	"gcp::run::service":                               {SourceID: "gcp", DimensionID: "cloud_run_service"},
 	"gcp::secretmanager::secret_version":              {SourceID: "gcp", DimensionID: "secret_manager_version"},
 	"gcp::secret_manager::secret_version":             {SourceID: "gcp", DimensionID: "secret_manager_version"},
+	"gcp::service_usage::service":                     {SourceID: "gcp", DimensionID: "service_usage_service"},
+	"gcp::serviceusage::service":                      {SourceID: "gcp", DimensionID: "service_usage_service"},
 	"gcp::spanner::database":                          {SourceID: "gcp", DimensionID: "spanner_database"},
 	"gcp::spanner::instance":                          {SourceID: "gcp", DimensionID: "spanner_instance"},
 	"gcp::sql::database":                              {SourceID: "gcp", DimensionID: "cloud_sql_database"},
@@ -330,6 +343,7 @@ var minimumCloudCoverageDimensions = map[string][]string{
 		"aiplatform_endpoint",
 		"artifact_registry_image",
 		"artifact_registry_repository",
+		"asset_metadata",
 		"audit",
 		"bigquery_dataset",
 		"bigquery_table",
@@ -343,6 +357,7 @@ var minimumCloudCoverageDimensions = map[string][]string{
 		"cloud_ids_endpoint",
 		"cloud_run_revision",
 		"cloud_run_service",
+		"cloud_scheduler_job",
 		"cloud_sql_database",
 		"cloud_sql_instance",
 		"cloud_sql_user",
@@ -382,6 +397,8 @@ var minimumCloudCoverageDimensions = map[string][]string{
 		"container_registry",
 		"container_vulnerability",
 		"dns_managed_zone",
+		"dns_record_set",
+		"effective_permission",
 		"gcs_bucket",
 		"gcs_object",
 		"gke_cluster",
@@ -394,6 +411,9 @@ var minimumCloudCoverageDimensions = map[string][]string{
 		"logging_project_sink",
 		"monitoring_alert_policy",
 		"monitoring_notification_channel",
+		"org_policy",
+		"pubsub_subscription",
+		"pubsub_topic",
 		"resourcemanager_project",
 		"resource_exposure",
 		"secret_manager_secret",
@@ -401,10 +421,18 @@ var minimumCloudCoverageDimensions = map[string][]string{
 		"service_account",
 		"service_account_impersonation",
 		"service_account_key",
+		"service_usage_service",
 		"spanner_database",
 		"spanner_instance",
 		"vpc_access_connector",
 	},
+}
+
+var strictCloudRuntimeCoverageSources = map[string]struct{}{
+	"azure":      {},
+	"cloudflare": {},
+	"gcp":        {},
+	"kubernetes": {},
 }
 
 func checkCloudPolicyCoverage(root string) ([]issue, error) {
@@ -413,6 +441,7 @@ func checkCloudPolicyCoverage(root string) ([]issue, error) {
 		return nil, err
 	}
 	issues := checkRequiredCloudCoverageDimensions(dimensions)
+	issues = append(issues, checkStrictCloudRuntimeCoverage(root, dimensions)...)
 	policiesRoot := filepath.Join(root, "policies")
 	err = filepath.WalkDir(policiesRoot, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
@@ -482,6 +511,30 @@ func checkRequiredCloudCoverageDimensions(dimensions map[string]map[string]sourc
 	return issues
 }
 
+func checkStrictCloudRuntimeCoverage(root string, dimensions map[string]map[string]sourcecdk.CoverageDimension) []issue {
+	var issues []issue
+	for sourceID := range strictCloudRuntimeCoverageSources {
+		sourceDimensions, ok := dimensions[sourceID]
+		if !ok {
+			continue
+		}
+		deployFamilies, err := loadDeployRuntimeFamilies(filepath.Join(root, "sources", sourceID, "deploy.yaml"))
+		if err != nil {
+			issues = append(issues, issue{path: fmt.Sprintf("sources/%s/deploy.yaml", sourceID), message: err.Error()})
+			continue
+		}
+		coveredFamilies := coverageFamilies(sourceDimensions)
+		missing := sortedStringSetDifference(deployFamilies, coveredFamilies)
+		if len(missing) > 0 {
+			issues = append(issues, issue{
+				path:    fmt.Sprintf("sources/%s/catalog.yaml", sourceID),
+				message: fmt.Sprintf("coverage_contract does not cover deploy runtime families: %s", strings.Join(missing, ", ")),
+			})
+		}
+	}
+	return issues
+}
+
 func loadCoverageDimensions(root string) (map[string]map[string]sourcecdk.CoverageDimension, error) {
 	sourcesRoot := filepath.Join(root, "sources")
 	dimensions := map[string]map[string]sourcecdk.CoverageDimension{}
@@ -518,6 +571,56 @@ func loadCoverageDimensions(root string) (map[string]map[string]sourcecdk.Covera
 		return nil, err
 	}
 	return dimensions, nil
+}
+
+type sourceDeployManifest struct {
+	Runtimes []struct {
+		Config map[string]string `yaml:"config"`
+	} `yaml:"runtimes"`
+}
+
+func loadDeployRuntimeFamilies(path string) (map[string]struct{}, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read deploy.yaml: %w", err)
+	}
+	var manifest sourceDeployManifest
+	if err := yaml.Unmarshal(content, &manifest); err != nil {
+		return nil, fmt.Errorf("decode deploy.yaml: %w", err)
+	}
+	families := map[string]struct{}{}
+	for _, runtime := range manifest.Runtimes {
+		family := strings.TrimSpace(runtime.Config["family"])
+		if family == "" {
+			continue
+		}
+		families[family] = struct{}{}
+	}
+	return families, nil
+}
+
+func coverageFamilies(dimensions map[string]sourcecdk.CoverageDimension) map[string]struct{} {
+	families := map[string]struct{}{}
+	for _, dimension := range dimensions {
+		for _, family := range dimension.Families {
+			family = strings.TrimSpace(family)
+			if family != "" {
+				families[family] = struct{}{}
+			}
+		}
+	}
+	return families
+}
+
+func sortedStringSetDifference(left map[string]struct{}, right map[string]struct{}) []string {
+	out := make([]string, 0)
+	for value := range left {
+		if _, ok := right[value]; !ok {
+			out = append(out, value)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 func splitPolicyResources(value string) []string {


### PR DESCRIPTION
## Summary
- add explicit GCP coverage dimensions for Cloud Asset metadata/data sensitivity, Cloud DNS record sets, and effective IAM permissions
- add GCP aliases and minimum coverage requirements for the newly locked-in GCP runtime families
- enforce deploy runtime-family coverage for strict cloud sources: Azure, Cloudflare, GCP, and Kubernetes
- group Kubernetes container runtimes under pod coverage so the stricter gate reflects existing collection behavior

## Verification
- go run ./tools/catalogcheck
- go test ./tools/catalogcheck ./tools/archtests
- PATH=/usr/bin:/bin:/usr/sbin:/sbin:$PATH make check-structural