### PR TITLE
Enforce source coverage contracts

### DIFF
--- a/sources/anthropic/catalog.yaml
+++ b/sources/anthropic/catalog.yaml
@@ -5,6 +5,28 @@ emitted_kinds:
   - anthropic.user
   - anthropic.workspace
   - anthropic.api_key
+coverage_contract:
+  owner_domain: ai
+  authority_domain: anthropic
+  dimensions:
+    - id: api_keys
+      type: app_entitlement
+      title: API keys
+      families: [api_key]
+      support: supported
+      high_value: true
+    - id: users
+      type: entity_family
+      title: Organization users
+      families: [user]
+      support: supported
+      high_value: true
+    - id: workspaces
+      type: entity_family
+      title: Workspaces
+      families: [workspace]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: anthropic.user
     schema_ref: anthropic/user/v1

--- a/sources/aurelius/catalog.yaml
+++ b/sources/aurelius/catalog.yaml
@@ -7,6 +7,40 @@ emitted_kinds:
   - aurelius.image_scan
   - aurelius.catalog_promotion
   - aurelius.policy_exception
+coverage_contract:
+  owner_domain: vulnerability_management
+  authority_domain: aurelius
+  dimensions:
+    - id: catalog_promotions
+      type: lifecycle_state
+      title: Catalog promotions
+      families: [catalog_promotion]
+      support: supported
+      high_value: true
+    - id: findings
+      type: entity_family
+      title: Findings
+      families: [finding]
+      support: supported
+      high_value: true
+    - id: image_scans
+      type: entity_family
+      title: Image scans
+      families: [image_scan]
+      support: supported
+      high_value: true
+    - id: policy_exceptions
+      type: app_entitlement
+      title: Policy exceptions
+      families: [policy_exception]
+      support: supported
+      high_value: true
+    - id: verdicts
+      type: lifecycle_state
+      title: Image policy verdicts
+      families: [verdict]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: aurelius.verdict
     schema_ref: aurelius/verdict/v1

--- a/sources/cerebro/catalog.yaml
+++ b/sources/cerebro/catalog.yaml
@@ -3,6 +3,16 @@ name: Cerebro
 description: Cerebro product telemetry source. Reads structured access audit telemetry exported as NDJSON archives.
 emitted_kinds:
   - cerebro.api_access
+coverage_contract:
+  owner_domain: product_telemetry
+  authority_domain: cerebro
+  dimensions:
+    - id: api_access
+      type: audit_event
+      title: API access telemetry
+      families: [access]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: cerebro.api_access
     schema_ref: cerebro/api_access/v1

--- a/sources/cosmo/catalog.yaml
+++ b/sources/cosmo/catalog.yaml
@@ -6,3 +6,30 @@ emitted_kinds:
   - cosmo.message
   - cosmo.session
   - cosmo.survey_feedback
+coverage_contract:
+  owner_domain: product_telemetry
+  authority_domain: cosmo
+  dimensions:
+    - id: facts
+      type: entity_family
+      title: Memory facts
+      families: [fact]
+      support: supported
+      high_value: true
+    - id: messages
+      type: audit_event
+      title: Message exports
+      families: [message]
+      support: supported
+      high_value: true
+    - id: sessions
+      type: entity_family
+      title: Memory sessions
+      families: [session]
+      support: supported
+      high_value: true
+    - id: survey_feedback
+      type: entity_family
+      title: Survey feedback
+      families: [survey_feedback]
+      support: supported

--- a/sources/duo/catalog.yaml
+++ b/sources/duo/catalog.yaml
@@ -8,6 +8,34 @@ emitted_kinds:
   - duo.phone
   - duo.token
   - duo.web_authn_credential
+coverage_contract:
+  owner_domain: identity
+  authority_domain: duo
+  dimensions:
+    - id: endpoints
+      type: entity_family
+      title: Endpoints
+      families: [endpoint]
+      support: supported
+      high_value: true
+    - id: groups
+      type: entity_family
+      title: Groups
+      families: [group]
+      support: supported
+      high_value: true
+    - id: mfa_devices
+      type: entity_family
+      title: MFA phones, hardware tokens, and WebAuthn credentials
+      families: [phone, token, web_authn_credential]
+      support: supported
+      high_value: true
+    - id: users
+      type: entity_family
+      title: Users
+      families: [user]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: duo.user
     schema_ref: duo/user/v1

--- a/sources/okta/catalog.yaml
+++ b/sources/okta/catalog.yaml
@@ -38,6 +38,12 @@ coverage_contract:
       families: [application]
       support: supported
       high_value: true
+    - id: authenticators
+      type: entity_family
+      title: Authenticators
+      families: [authenticator]
+      support: supported
+      high_value: true
     - id: audit_events
       type: audit_event
       title: Audit events
@@ -61,6 +67,12 @@ coverage_contract:
       title: Incremental cursor sync
       support: supported
       high_value: true
+    - id: policy_rules
+      type: entity_family
+      title: Policy rules
+      families: [policy_rule]
+      support: supported
+      high_value: true
     - id: remediation_state
       type: remediation_state
       title: Remediation lifecycle state
@@ -68,6 +80,12 @@ coverage_contract:
       high_value: true
       known_unsupported_fields:
         - remediation workflow state
+    - id: threat_insight
+      type: entity_family
+      title: ThreatInsight configuration
+      families: [threat_insight]
+      support: supported
+      high_value: true
     - id: users
       type: entity_family
       title: Users

--- a/sources/openai/catalog.yaml
+++ b/sources/openai/catalog.yaml
@@ -7,6 +7,40 @@ emitted_kinds:
   - openai.service_account
   - openai.api_key
   - openai.admin_api_key
+coverage_contract:
+  owner_domain: ai
+  authority_domain: openai
+  dimensions:
+    - id: admin_api_keys
+      type: app_entitlement
+      title: Organization admin API keys
+      families: [admin_api_key]
+      support: supported
+      high_value: true
+    - id: api_keys
+      type: app_entitlement
+      title: Project API keys
+      families: [api_key]
+      support: supported
+      high_value: true
+    - id: projects
+      type: entity_family
+      title: Projects
+      families: [project]
+      support: supported
+      high_value: true
+    - id: service_accounts
+      type: entity_family
+      title: Service accounts
+      families: [service_account]
+      support: supported
+      high_value: true
+    - id: users
+      type: entity_family
+      title: Organization users
+      families: [user]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: openai.user
     schema_ref: openai/user/v1

--- a/sources/pagerduty/catalog.yaml
+++ b/sources/pagerduty/catalog.yaml
@@ -9,6 +9,51 @@ emitted_kinds:
   - pagerduty.escalation_policy
   - pagerduty.integration
   - pagerduty.vendor
+coverage_contract:
+  owner_domain: incident_management
+  authority_domain: pagerduty
+  dimensions:
+    - id: escalation_policies
+      type: lifecycle_state
+      title: Escalation policies
+      families: [escalation_policy]
+      support: supported
+      high_value: true
+    - id: integrations
+      type: entity_family
+      title: Service integrations
+      families: [integration]
+      support: supported
+      high_value: true
+    - id: schedules
+      type: entity_family
+      title: Schedules
+      families: [schedule]
+      support: supported
+      high_value: true
+    - id: services
+      type: entity_family
+      title: Services
+      families: [service]
+      support: supported
+      high_value: true
+    - id: teams
+      type: entity_family
+      title: Teams
+      families: [team]
+      support: supported
+      high_value: true
+    - id: users
+      type: entity_family
+      title: Users
+      families: [user]
+      support: supported
+      high_value: true
+    - id: vendors
+      type: entity_family
+      title: Vendors
+      families: [vendor]
+      support: supported
 event_contracts:
   - kind: pagerduty.user
     schema_ref: pagerduty/user/v1

--- a/sources/panopticon/catalog.yaml
+++ b/sources/panopticon/catalog.yaml
@@ -5,6 +5,28 @@ emitted_kinds:
   - panopticon.alert
   - panopticon.case
   - panopticon.ioc
+coverage_contract:
+  owner_domain: security_operations
+  authority_domain: panopticon
+  dimensions:
+    - id: alerts
+      type: lifecycle_state
+      title: Alerts
+      families: [alert]
+      support: supported
+      high_value: true
+    - id: cases
+      type: lifecycle_state
+      title: Cases
+      families: [case]
+      support: supported
+      high_value: true
+    - id: iocs
+      type: entity_family
+      title: Indicators of compromise
+      families: [ioc]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: panopticon.alert
     schema_ref: panopticon/alert/v1

--- a/sources/sdk/catalog.yaml
+++ b/sources/sdk/catalog.yaml
@@ -2,3 +2,21 @@ id: sdk
 name: SDK Push Source
 description: Generic push-based source used by SDK-onboarded applications.
 emitted_kinds: []
+coverage_contract:
+  owner_domain: platform
+  authority_domain: sdk
+  dimensions:
+    - id: pull_inventory
+      type: entity_family
+      title: Pull inventory discovery
+      support: unsupported
+      high_value: true
+      known_unsupported_fields:
+        - SDK push sources do not declare built-in emitted kinds.
+    - id: push_ingress
+      type: lifecycle_state
+      title: SDK push ingestion surface
+      support: supported
+      high_value: true
+      notes:
+        - SDK source validates push runtime configuration and does not perform pull inventory discovery.

--- a/sources/slack/catalog.yaml
+++ b/sources/slack/catalog.yaml
@@ -6,6 +6,34 @@ emitted_kinds:
   - slack.user
   - slack.channel
   - slack.user_group
+coverage_contract:
+  owner_domain: collaboration
+  authority_domain: slack
+  dimensions:
+    - id: channels
+      type: entity_family
+      title: Channels
+      families: [channel]
+      support: supported
+      high_value: true
+    - id: teams
+      type: entity_family
+      title: Teams
+      families: [team]
+      support: supported
+      high_value: true
+    - id: user_groups
+      type: relationship
+      title: User groups
+      families: [user_group]
+      support: supported
+      high_value: true
+    - id: users
+      type: entity_family
+      title: Users
+      families: [user]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: slack.team
     schema_ref: slack/team/v1

--- a/sources/tailscale/catalog.yaml
+++ b/sources/tailscale/catalog.yaml
@@ -9,6 +9,52 @@ emitted_kinds:
   - tailscale.tag
   - tailscale.service
   - tailscale.grant
+coverage_contract:
+  owner_domain: network
+  authority_domain: tailscale
+  dimensions:
+    - id: acl_grants
+      type: app_entitlement
+      title: ACL grants
+      families: [grant]
+      support: supported
+      high_value: true
+    - id: devices
+      type: entity_family
+      title: Devices
+      families: [device]
+      support: supported
+      high_value: true
+    - id: groups
+      type: relationship
+      title: ACL groups
+      families: [group]
+      support: supported
+      high_value: true
+    - id: services
+      type: entity_family
+      title: Services
+      families: [service]
+      support: supported
+      high_value: true
+    - id: tag_owners
+      type: app_entitlement
+      title: Tag owners
+      families: [tag]
+      support: supported
+      high_value: true
+    - id: tailnet
+      type: entity_family
+      title: Tailnet settings
+      families: [tailnet]
+      support: supported
+      high_value: true
+    - id: users
+      type: entity_family
+      title: Users
+      families: [user]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: tailscale.tailnet
     schema_ref: tailscale/tailnet/v1

--- a/sources/trivy/catalog.yaml
+++ b/sources/trivy/catalog.yaml
@@ -6,6 +6,34 @@ emitted_kinds:
   - trivy.image_package
   - trivy.image_vulnerability
   - trivy.fix
+coverage_contract:
+  owner_domain: vulnerability_management
+  authority_domain: trivy
+  dimensions:
+    - id: fixes
+      type: remediation_state
+      title: Available package fixes
+      families: [fix]
+      support: supported
+      high_value: true
+    - id: image_packages
+      type: entity_family
+      title: Image packages
+      families: [image_package]
+      support: supported
+      high_value: true
+    - id: image_scans
+      type: entity_family
+      title: Image scan reports
+      families: [image_scan]
+      support: supported
+      high_value: true
+    - id: image_vulnerabilities
+      type: entity_family
+      title: Image vulnerabilities
+      families: [image_vulnerability]
+      support: supported
+      high_value: true
 event_contracts:
   - kind: trivy.image_scan
     schema_ref: trivy/image_scan/v1

--- a/tools/catalogcheck/catalogcheck.go
+++ b/tools/catalogcheck/catalogcheck.go
@@ -247,13 +247,8 @@ func checkSourceCatalogs(root string) ([]issue, error) {
 			return nil
 		}
 		spec := catalog.Spec
-		hasDeployManifest, err := hasSourceDeployManifest(filepath.Dir(path))
-		if err != nil {
-			issues = append(issues, issue{path: rel, message: err.Error()})
-			return nil
-		}
-		if hasDeployManifest && catalog.CoverageContract == nil {
-			issues = append(issues, issue{path: rel, message: "coverage_contract is required for deployable sources"})
+		if catalog.CoverageContract == nil {
+			issues = append(issues, issue{path: rel, message: "coverage_contract is required for built-in sources"})
 		}
 		if spec.GetId() != "sdk" && len(spec.GetEmittedKinds()) == 0 {
 			issues = append(issues, issue{path: rel, message: "emitted_kinds is required for built-in pull sources"})

--- a/tools/catalogcheck/catalogcheck_test.go
+++ b/tools/catalogcheck/catalogcheck_test.go
@@ -30,6 +30,15 @@ name: GitHub
 description: GitHub source
 emitted_kinds:
   - github.audit
+coverage_contract:
+  owner_domain: source_control
+  authority_domain: github
+  dimensions:
+    - id: audit_events
+      type: audit_event
+      title: Audit events
+      families: [audit]
+      support: supported
 kind_lifecycle:
   - kind: github.secret_scanning
     status: planned
@@ -86,7 +95,7 @@ emitted_kinds:
 	}
 }
 
-func TestCheckSourceCatalogsRejectsDeployableSourceWithoutCoverageContract(t *testing.T) {
+func TestCheckSourceCatalogsRejectsSourceWithoutCoverageContract(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "sources/github/catalog.yaml", `
 id: github
@@ -95,19 +104,17 @@ description: GitHub source
 emitted_kinds:
   - github.audit
 `)
-	writeFile(t, root, "sources/github/deploy.yaml", `runtimes: []
-`)
 
 	issues, err := checkSourceCatalogs(root)
 	if err != nil {
 		t.Fatalf("checkSourceCatalogs() error = %v", err)
 	}
-	if !issueMessagesContain(issues, "coverage_contract is required for deployable sources") {
+	if !issueMessagesContain(issues, "coverage_contract is required for built-in sources") {
 		t.Fatalf("issues = %#v, want missing coverage_contract issue", issues)
 	}
 }
 
-func TestCheckSourceCatalogsAcceptsDeployableSourceWithCoverageContract(t *testing.T) {
+func TestCheckSourceCatalogsAcceptsSourceWithCoverageContract(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "sources/github/catalog.yaml", `
 id: github
@@ -125,14 +132,12 @@ coverage_contract:
       families: [audit]
       support: supported
 `)
-	writeFile(t, root, "sources/github/deploy.yaml", `runtimes: []
-`)
 
 	issues, err := checkSourceCatalogs(root)
 	if err != nil {
 		t.Fatalf("checkSourceCatalogs() error = %v", err)
 	}
-	if issueMessagesContain(issues, "coverage_contract is required for deployable sources") {
+	if issueMessagesContain(issues, "coverage_contract is required for built-in sources") {
 		t.Fatalf("issues = %#v, want no coverage_contract issue", issues)
 	}
 }
@@ -278,6 +283,44 @@ runtimes:
 	}
 	if !issueMessagesContain(issues, "coverage_contract does not cover deploy runtime families: effective_permission") {
 		t.Fatalf("issues = %#v, want unsupported strict runtime family coverage issue", issues)
+	}
+}
+
+func TestCheckCloudPolicyCoverageRejectsUncoveredDeployRuntimeFamilyForAnySource(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "policies/custom/test.json", `{}`)
+	writeFile(t, root, "sources/okta/catalog.yaml", `
+id: okta
+name: Okta
+description: Okta source
+emitted_kinds:
+  - okta.user
+coverage_contract:
+  owner_domain: identity
+  authority_domain: okta
+  dimensions:
+    - id: users
+      type: entity_family
+      title: Users
+      families: [user]
+      support: supported
+`)
+	writeFile(t, root, "sources/okta/deploy.yaml", `
+runtimes:
+  - localId: user
+    config:
+      family: user
+  - localId: authenticator
+    config:
+      family: authenticator
+`)
+
+	issues, err := checkCloudPolicyCoverage(root)
+	if err != nil {
+		t.Fatalf("checkCloudPolicyCoverage() error = %v", err)
+	}
+	if !issueMessagesContain(issues, "coverage_contract does not cover deploy runtime families: authenticator") {
+		t.Fatalf("issues = %#v, want uncovered deploy runtime family issue", issues)
 	}
 }
 

--- a/tools/catalogcheck/cloud_policy_coverage.go
+++ b/tools/catalogcheck/cloud_policy_coverage.go
@@ -428,21 +428,13 @@ var minimumCloudCoverageDimensions = map[string][]string{
 	},
 }
 
-var strictCloudRuntimeCoverageSources = map[string]struct{}{
-	"aws":        {},
-	"azure":      {},
-	"cloudflare": {},
-	"gcp":        {},
-	"kubernetes": {},
-}
-
 func checkCloudPolicyCoverage(root string) ([]issue, error) {
 	dimensions, err := loadCoverageDimensions(root)
 	if err != nil {
 		return nil, err
 	}
 	issues := checkRequiredCloudCoverageDimensions(dimensions)
-	issues = append(issues, checkStrictCloudRuntimeCoverage(root, dimensions)...)
+	issues = append(issues, checkStrictDeployRuntimeCoverage(root, dimensions)...)
 	policiesRoot := filepath.Join(root, "policies")
 	err = filepath.WalkDir(policiesRoot, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
@@ -512,14 +504,19 @@ func checkRequiredCloudCoverageDimensions(dimensions map[string]map[string]sourc
 	return issues
 }
 
-func checkStrictCloudRuntimeCoverage(root string, dimensions map[string]map[string]sourcecdk.CoverageDimension) []issue {
+func checkStrictDeployRuntimeCoverage(root string, dimensions map[string]map[string]sourcecdk.CoverageDimension) []issue {
 	var issues []issue
-	for sourceID := range strictCloudRuntimeCoverageSources {
-		sourceDimensions, ok := dimensions[sourceID]
-		if !ok {
+	for sourceID, sourceDimensions := range dimensions {
+		sourceDir := filepath.Join(root, "sources", sourceID)
+		hasDeployManifest, err := hasSourceDeployManifest(sourceDir)
+		if err != nil {
+			issues = append(issues, issue{path: fmt.Sprintf("sources/%s/catalog.yaml", sourceID), message: err.Error()})
 			continue
 		}
-		deployFamilies, err := loadDeployRuntimeFamilies(filepath.Join(root, "sources", sourceID, "deploy.yaml"))
+		if !hasDeployManifest {
+			continue
+		}
+		deployFamilies, err := loadDeployRuntimeFamilies(filepath.Join(sourceDir, "deploy.yaml"))
 		if err != nil {
 			issues = append(issues, issue{path: fmt.Sprintf("sources/%s/deploy.yaml", sourceID), message: err.Error()})
 			continue


### PR DESCRIPTION
## Summary
- require every built-in source catalog to declare a non-empty coverage_contract
- add coverage contracts for the remaining no-contract sources, including AI, collaboration, incident, telemetry, scan, and push sources
- keep deploy runtime-family enforcement universal and cover the missing Okta deploy families

## Verification
- go run ./tools/catalogcheck
- go test ./tools/catalogcheck ./tools/archtests
- PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/jonathan/.codex/tmp/arg0/codex-arg0OudzUg:/Users/jonathan/.raindrop/bin:/Users/jonathan/.antigravity/antigravity/bin:/Users/jonathan/.local/bin:/Users/jonathan/.bun/bin:/Users/jonathan/.cargo/bin:/Users/jonathan/.orbstack/bin:/Applications/Codex.app/Contents/Resources:/Users/jonathan/.orbstack/bin make check-structural