### PR TITLE
Harden connector secret reference scoping

### DIFF
--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -570,7 +570,7 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 		}
 		runtimeConfig[resourcescope.ConfigKey] = scopeConfigValue
 	}
-	if err := validateConnectorConnectionShape(sourceID, authMethod, credentialStoreID, runtimeConfig, request.CredentialReferences, request.EncryptedCredentials); err != nil {
+	if err := validateConnectorConnectionShape(sourceID, tenantID, runtimeID, authMethod, credentialStoreID, runtimeConfig, request.CredentialReferences, request.EncryptedCredentials); err != nil {
 		writeConnectorError(w, err)
 		return
 	}
@@ -836,7 +836,23 @@ func (a *App) connectorConnectionPreflight(ctx context.Context, sourceID string,
 		}
 		runtimeConfig[resourcescope.ConfigKey] = scopeConfigValue
 	}
-	if shapeIssue := validateConnectorConnectionShape(sourceID, authMethod, credentialStoreID, runtimeConfig, request.CredentialReferences, request.EncryptedCredentials); shapeIssue != nil {
+	if connectorAuthMethodUsesCredentialReferences(authMethod) && len(request.CredentialReferences) > 0 {
+		if referenceScopeIssue := validateConnectorCredentialReferencesForRuntime(credentialStoreID, sourceID, tenantID, runtimeID, request.CredentialReferences); referenceScopeIssue != nil {
+			response.addPreflightCheck(connectorPreflightCheckView{
+				ID:         "credential_boundary",
+				Label:      "Credential boundary",
+				Status:     "blocked",
+				Severity:   "error",
+				Detail:     connectorPreflightValidationDetail(referenceScopeIssue, "Credential references must stay inside the selected runtime secret namespace."),
+				NextAction: "fix_credential_references",
+				Blocking:   true,
+			})
+			response.CredentialBoundary = a.connectorPreflightCredentialBoundary(sourceID, tenantID, runtimeID, authMethod, credentialStoreID, connectorReferenceTemplateFields(sourceID, authMethod, request.CredentialReferences))
+			response.finalizePreflight()
+			return response, nil
+		}
+	}
+	if shapeIssue := validateConnectorConnectionShape(sourceID, tenantID, runtimeID, authMethod, credentialStoreID, runtimeConfig, request.CredentialReferences, request.EncryptedCredentials); shapeIssue != nil {
 		response.addPreflightCheck(connectorPreflightCheckView{
 			ID:         "config_shape",
 			Label:      "Config and secret boundary",
@@ -846,7 +862,7 @@ func (a *App) connectorConnectionPreflight(ctx context.Context, sourceID string,
 			NextAction: "fix_required_fields",
 			Blocking:   true,
 		})
-		response.CredentialBoundary = a.connectorPreflightCredentialBoundary(sourceID, tenantID, runtimeID, authMethod, credentialStoreID, sortedStringKeys(request.CredentialReferences))
+		response.CredentialBoundary = a.connectorPreflightCredentialBoundary(sourceID, tenantID, runtimeID, authMethod, credentialStoreID, connectorReferenceTemplateFields(sourceID, authMethod, request.CredentialReferences))
 		response.finalizePreflight()
 		return response, nil
 	}
@@ -867,7 +883,7 @@ func (a *App) connectorConnectionPreflight(ctx context.Context, sourceID string,
 		return response, err
 	}
 	plaintextFields := map[string]string(nil)
-	fieldNames := sortedStringKeys(request.CredentialReferences)
+	fieldNames := connectorReferenceTemplateFields(sourceID, authMethod, request.CredentialReferences)
 	if authMethod == connectorAuthMethodEncryptedSubmission {
 		if a == nil || a.connectorTransitKey == nil {
 			response.addPreflightCheck(connectorPreflightCheckView{
@@ -1278,7 +1294,7 @@ func (a *App) connectorPreflightCredentialBoundary(sourceID string, tenantID str
 		if len(boundary.ReferencePrefixes) == 0 {
 			boundary.ReferencePrefixes = connectorsecretstores.ReferencePrefixes(storeID)
 		}
-		boundary.ReferenceNamespace = connectorReferenceNamespace(storeID, tenantID, sourceID, runtimeID)
+		boundary.ReferenceNamespace = a.connectorReferenceNamespace(storeID, tenantID, sourceID, runtimeID)
 		boundary.ReferenceTemplates = a.connectorReferenceTemplates(sourceID, tenantID, runtimeID, storeID, fields)
 	}
 	return boundary
@@ -1303,7 +1319,7 @@ func (a *App) connectorReferenceTemplates(sourceID string, tenantID string, runt
 			Label:       connectorFieldLabel(field),
 			Required:    setContains(required, field),
 			Reference:   a.connectorReferenceForField(storeID, tenantID, sourceID, runtimeID, field),
-			Description: connectorReferenceTemplateDescription(storeID),
+			Description: a.connectorReferenceTemplateDescription(storeID),
 		})
 	}
 	return templates
@@ -1312,28 +1328,27 @@ func (a *App) connectorReferenceTemplates(sourceID string, tenantID string, runt
 func (a *App) connectorReferenceForField(storeID string, tenantID string, sourceID string, runtimeID string, field string) string {
 	switch strings.TrimSpace(storeID) {
 	case connectorStoreAWSSecretsManager:
-		namespace := connectorReferenceNamespace(storeID, tenantID, sourceID, runtimeID)
+		if !connectorsecretstores.NativeResolutionAvailable(a.cfg.ConnectorSecretStores, storeID) {
+			return "env:" + connectorSuggestedEnvName(sourceID, field)
+		}
+		namespace := a.connectorReferenceNamespace(storeID, tenantID, sourceID, runtimeID)
 		if namespace == "" {
-			namespace = connectorStoreReferenceNamespaceTemplate(storeID)
+			namespace = connectorStoreReferenceNamespaceTemplate(storeID, true)
 		}
 		region := strings.TrimSpace(a.cfg.ConnectorSecretStores.AWSSecretsManager.Region)
-		if region == "" {
-			region = "us-east-1"
-		}
 		return "aws-sm:" + region + ":" + namespace + "#" + strings.TrimSpace(field)
 	default:
 		return "env:" + connectorSuggestedEnvName(sourceID, field)
 	}
 }
 
-func connectorReferenceNamespace(storeID string, tenantID string, sourceID string, runtimeID string) string {
+func (a *App) connectorReferenceNamespace(storeID string, tenantID string, sourceID string, runtimeID string) string {
 	switch strings.TrimSpace(storeID) {
 	case connectorStoreAWSSecretsManager:
-		prefix := connectorsecretstores.RuntimeSecretPrefix(tenantID, sourceID, runtimeID)
-		if prefix == "" {
-			return ""
+		if connectorsecretstores.NativeResolutionAvailable(a.cfg.ConnectorSecretStores, storeID) {
+			return connectorsecretstores.RuntimeCredentialSecretName(tenantID, sourceID, runtimeID)
 		}
-		return strings.TrimSuffix(prefix, "/") + "/credentials"
+		return "CEREBRO_SOURCE_" + connectorEnvComponent(sourceID) + "_*"
 	case connectorStoreEnvironmentManaged, connectorStoreInfisical, connectorStoreGoogleSecretMgr, connectorStoreAzureKeyVault, connectorStoreHashiCorpVault:
 		return "CEREBRO_SOURCE_" + connectorEnvComponent(sourceID) + "_*"
 	default:
@@ -1341,9 +1356,12 @@ func connectorReferenceNamespace(storeID string, tenantID string, sourceID strin
 	}
 }
 
-func connectorReferenceTemplateDescription(storeID string) string {
+func (a *App) connectorReferenceTemplateDescription(storeID string) string {
 	switch strings.TrimSpace(storeID) {
 	case connectorStoreAWSSecretsManager:
+		if !connectorsecretstores.NativeResolutionAvailable(a.cfg.ConnectorSecretStores, storeID) {
+			return "Environment projection reference resolved inside the Cerebro backend runtime."
+		}
 		return "Scoped to this tenant, source, and runtime; unscoped aws-sm references are rejected before resolution."
 	default:
 		return "Environment projection reference resolved inside the Cerebro backend runtime."
@@ -2091,6 +2109,10 @@ func connectorExternalStoreView(secretStoreConfig config.ConnectorSecretStoreCon
 	if native {
 		detail = "native resolver ready"
 	}
+	referencePrefixes := connectorsecretstores.ReferencePrefixes(id)
+	if id == connectorStoreAWSSecretsManager && !native {
+		referencePrefixes = []string{"env:"}
+	}
 	return connectorStoreView{
 		ID:                         id,
 		Label:                      label,
@@ -2100,10 +2122,10 @@ func connectorExternalStoreView(secretStoreConfig config.ConnectorSecretStoreCon
 		Status:                     status,
 		Detail:                     detail,
 		Description:                connectorExternalStoreDescription(id, label),
-		ReferencePrefixes:          connectorsecretstores.ReferencePrefixes(id),
-		ReferenceNamespaceTemplate: connectorStoreReferenceNamespaceTemplate(id),
-		ReferenceFieldTemplate:     connectorStoreReferenceFieldTemplate(id),
-		ReferencePlaceholder:       connectorStoreReferencePlaceholder(id),
+		ReferencePrefixes:          referencePrefixes,
+		ReferenceNamespaceTemplate: connectorStoreReferenceNamespaceTemplate(id, native),
+		ReferenceFieldTemplate:     connectorStoreReferenceFieldTemplate(id, native),
+		ReferencePlaceholder:       connectorStoreReferencePlaceholder(id, native),
 		NativeResolutionAvailable:  native,
 		SetupSteps:                 connectorExternalStoreSetupSteps(id, native),
 		RequiredConfig:             connectorExternalStoreRequiredConfig(id),
@@ -2134,18 +2156,24 @@ func connectorExternalStoreDescription(id string, label string) string {
 	}
 }
 
-func connectorStoreReferencePlaceholder(id string) string {
+func connectorStoreReferencePlaceholder(id string, native bool) string {
 	switch id {
 	case connectorStoreAWSSecretsManager:
+		if !native {
+			return "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>"
+		}
 		return "aws-sm:us-east-1:cerebro/<tenant>/<source>/<runtime>/credentials#<field>"
 	default:
 		return "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>"
 	}
 }
 
-func connectorStoreReferenceNamespaceTemplate(id string) string {
+func connectorStoreReferenceNamespaceTemplate(id string, native bool) string {
 	switch strings.TrimSpace(id) {
 	case connectorStoreAWSSecretsManager:
+		if !native {
+			return "CEREBRO_SOURCE_<SOURCE>_*"
+		}
 		return "cerebro/<tenant>/<source>/<runtime>/credentials"
 	case connectorStoreEnvironmentManaged, connectorStoreInfisical, connectorStoreGoogleSecretMgr, connectorStoreAzureKeyVault, connectorStoreHashiCorpVault:
 		return "CEREBRO_SOURCE_<SOURCE>_*"
@@ -2154,9 +2182,12 @@ func connectorStoreReferenceNamespaceTemplate(id string) string {
 	}
 }
 
-func connectorStoreReferenceFieldTemplate(id string) string {
+func connectorStoreReferenceFieldTemplate(id string, native bool) string {
 	switch strings.TrimSpace(id) {
 	case connectorStoreAWSSecretsManager:
+		if !native {
+			return "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>"
+		}
 		return "aws-sm:<region>:cerebro/<tenant>/<source>/<runtime>/credentials#<field>"
 	case connectorStoreEnvironmentManaged, connectorStoreInfisical, connectorStoreGoogleSecretMgr, connectorStoreAzureKeyVault, connectorStoreHashiCorpVault:
 		return "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>"
@@ -2852,7 +2883,7 @@ func applyConnectorCredentialReferences(config map[string]string, references map
 	return nil
 }
 
-func validateConnectorConnectionShape(sourceID string, authMethod string, credentialStoreID string, config map[string]string, references map[string]string, encrypted connectorcredentials.EncryptedPayload) error {
+func validateConnectorConnectionShape(sourceID string, tenantID string, runtimeID string, authMethod string, credentialStoreID string, config map[string]string, references map[string]string, encrypted connectorcredentials.EncryptedPayload) error {
 	switch authMethod {
 	case connectorAuthMethodEncryptedSubmission:
 		if credentialStoreID != defaultConnectorCredentialStoreID {
@@ -2890,7 +2921,7 @@ func validateConnectorConnectionShape(sourceID string, authMethod string, creden
 		if authMethod == connectorAuthMethodInfisicalCLI && len(references) == 0 {
 			return fmt.Errorf("%w: infisical_cli requires credential references", connectorcredentials.ErrInvalidRequest)
 		}
-		if err := validateConnectorCredentialReferencesForStore(connectorStoreEnvironmentManaged, references); err != nil {
+		if err := validateConnectorCredentialReferencesForRuntime(connectorStoreEnvironmentManaged, sourceID, tenantID, runtimeID, references); err != nil {
 			return err
 		}
 	case connectorAuthMethodExternalReference:
@@ -2903,7 +2934,7 @@ func validateConnectorConnectionShape(sourceID string, authMethod string, creden
 		if len(references) == 0 {
 			return fmt.Errorf("%w: external_reference requires credential references", connectorcredentials.ErrInvalidRequest)
 		}
-		if err := validateConnectorCredentialReferencesForStore(credentialStoreID, references); err != nil {
+		if err := validateConnectorCredentialReferencesForRuntime(credentialStoreID, sourceID, tenantID, runtimeID, references); err != nil {
 			return err
 		}
 	default:
@@ -2915,13 +2946,36 @@ func validateConnectorConnectionShape(sourceID string, authMethod string, creden
 	return nil
 }
 
-func validateConnectorCredentialReferencesForStore(storeID string, references map[string]string) error {
+func validateConnectorCredentialReferencesForRuntime(storeID string, sourceID string, tenantID string, runtimeID string, references map[string]string) error {
 	for key, value := range references {
 		if err := connectorsecretstores.ValidateReferenceForStore(storeID, value); err != nil {
 			return fmt.Errorf("%w: credential reference %q is not valid for %s", connectorcredentials.ErrInvalidRequest, strings.TrimSpace(key), strings.TrimSpace(storeID))
 		}
+		if err := connectorsecretstores.AuthorizeRuntimeReferences(sourceID, tenantID, runtimeID, map[string]string{key: value}); err != nil {
+			return fmt.Errorf("%w: credential reference %q is not scoped to this runtime: %w", connectorcredentials.ErrInvalidRequest, strings.TrimSpace(key), err)
+		}
 	}
 	return nil
+}
+
+func connectorAuthMethodUsesCredentialReferences(authMethod string) bool {
+	switch normalizeConnectorAuthMethod(authMethod) {
+	case connectorAuthMethodEnvironmentManaged, connectorAuthMethodInfisicalCLI, connectorAuthMethodExternalReference:
+		return true
+	default:
+		return false
+	}
+}
+
+func connectorReferenceTemplateFields(sourceID string, authMethod string, references map[string]string) []string {
+	if normalizeConnectorAuthMethod(authMethod) == connectorAuthMethodEncryptedSubmission {
+		return sortedStringKeys(references)
+	}
+	schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]
+	if !ok || len(schema.CredentialKeys) == 0 {
+		return sortedStringKeys(references)
+	}
+	return sortedSetKeys(schema.CredentialKeys)
 }
 
 func validateConnectorConfigFields(sourceID string, authMethod string, config map[string]string, references map[string]string) error {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -470,9 +470,72 @@ func TestConnectorCatalogAdvertisesConnectionMethods(t *testing.T) {
 	if got := storeStatuses[connectorStoreAWSSecretsManager]; got != "needs_configuration" {
 		t.Fatalf("aws secrets manager status = %q, want needs_configuration", got)
 	}
-	if got := storePrefixes[connectorStoreAWSSecretsManager]; len(got) != 2 || got[0] != "env:" || got[1] != "aws-sm:" {
-		t.Fatalf("aws secrets manager prefixes = %#v, want env and aws-sm", got)
+	if got := storePrefixes[connectorStoreAWSSecretsManager]; len(got) != 1 || got[0] != "env:" {
+		t.Fatalf("aws secrets manager prefixes = %#v, want env only until native resolver is configured", got)
 	}
+}
+
+func TestConnectorCatalogAdvertisesAWSSecretStoreEnvProjectionUntilNativeConfigured(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorSecretStores: config.ConnectorSecretStoreConfig{
+			Enabled: []string{connectorStoreAWSSecretsManager},
+		},
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors")
+	if err != nil {
+		t.Fatalf("GET /connectors error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /connectors status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		CredentialStores []struct {
+			ID                         string   `json:"id"`
+			Available                  bool     `json:"available"`
+			Detail                     string   `json:"detail"`
+			ReferencePrefixes          []string `json:"reference_prefixes"`
+			ReferenceNamespaceTemplate string   `json:"reference_namespace_template"`
+			ReferenceFieldTemplate     string   `json:"reference_field_template"`
+			NativeResolutionAvailable  bool     `json:"native_resolution_available"`
+		} `json:"credential_stores"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	for _, store := range payload.CredentialStores {
+		if store.ID != connectorStoreAWSSecretsManager {
+			continue
+		}
+		if !store.Available || store.NativeResolutionAvailable || store.Detail != "ready via env projection" {
+			t.Fatalf("aws secret store = %#v, want env projection availability", store)
+		}
+		if len(store.ReferencePrefixes) != 1 || store.ReferencePrefixes[0] != "env:" {
+			t.Fatalf("aws reference prefixes = %#v, want env only", store.ReferencePrefixes)
+		}
+		if store.ReferenceNamespaceTemplate != "CEREBRO_SOURCE_<SOURCE>_*" {
+			t.Fatalf("aws reference namespace template = %q", store.ReferenceNamespaceTemplate)
+		}
+		if store.ReferenceFieldTemplate != "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>" {
+			t.Fatalf("aws reference field template = %q", store.ReferenceFieldTemplate)
+		}
+		return
+	}
+	t.Fatalf("aws secret store missing: %#v", payload.CredentialStores)
 }
 
 func TestConnectorCatalogAdvertisesConfiguredAWSSecretStore(t *testing.T) {
@@ -1395,6 +1458,141 @@ func TestConnectorPreflightValidatesWithoutPersisting(t *testing.T) {
 	}
 	if checks["source_check"] != "passed" {
 		t.Fatalf("source_check status = %q, want passed; checks=%#v", checks["source_check"], checks)
+	}
+}
+
+func TestConnectorPreflightReturnsReferencePlanWhenReferencesMissing(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorSecretStores: config.ConnectorSecretStoreConfig{
+			Enabled: []string{connectorStoreAWSSecretsManager},
+			AWSSecretsManager: config.AWSSecretsManagerStoreConfig{
+				Region: "us-west-2",
+			},
+		},
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":          "runtime-external",
+		"tenant_id":           "tenant-a",
+		"auth_method":         connectorAuthMethodExternalReference,
+		"credential_store_id": connectorStoreAWSSecretsManager,
+		"config":              map[string]string{"family": "audit"},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/preflight", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /connectors/{sourceID}/preflight error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /connectors preflight status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		Status             string `json:"status"`
+		CredentialBoundary struct {
+			ReferenceTemplates []struct {
+				Field     string `json:"field"`
+				Required  bool   `json:"required"`
+				Reference string `json:"reference"`
+			} `json:"reference_templates"`
+		} `json:"credential_boundary"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Status != "blocked" {
+		t.Fatalf("preflight status = %q, want blocked", payload.Status)
+	}
+	if len(payload.CredentialBoundary.ReferenceTemplates) != 1 {
+		t.Fatalf("reference templates = %#v, want token template", payload.CredentialBoundary.ReferenceTemplates)
+	}
+	template := payload.CredentialBoundary.ReferenceTemplates[0]
+	if template.Field != "token" || !template.Required || template.Reference != "aws-sm:us-west-2:cerebro/tenant-a/bootstrap_token/runtime-external/credentials#token" {
+		t.Fatalf("reference template = %#v", template)
+	}
+}
+
+func TestConnectorPreflightBlocksUnscopedAWSReferenceAsCredentialBoundary(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorSecretStores: config.ConnectorSecretStoreConfig{
+			Enabled: []string{connectorStoreAWSSecretsManager},
+			AWSSecretsManager: config.AWSSecretsManagerStoreConfig{
+				Region: "us-west-2",
+			},
+		},
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":          "runtime-external",
+		"tenant_id":           "tenant-a",
+		"auth_method":         connectorAuthMethodExternalReference,
+		"credential_store_id": connectorStoreAWSSecretsManager,
+		"config":              map[string]string{"family": "audit"},
+		"credential_references": map[string]string{
+			"token": "aws-sm:us-west-2:shared/credentials#token", // #nosec G101 -- reference string, not secret material.
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/preflight", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /connectors/{sourceID}/preflight error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /connectors preflight status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		Status string `json:"status"`
+		Checks []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"checks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Status != "blocked" {
+		t.Fatalf("preflight status = %q, want blocked", payload.Status)
+	}
+	checks := map[string]string{}
+	for _, check := range payload.Checks {
+		checks[check.ID] = check.Status
+	}
+	if checks["credential_boundary"] != "blocked" {
+		t.Fatalf("credential_boundary status = %q, want blocked; checks=%#v", checks["credential_boundary"], checks)
+	}
+	if _, ok := checks["source_check"]; ok {
+		t.Fatalf("source_check ran for unscoped reference; checks=%#v", checks)
 	}
 }
 

--- a/internal/connectorsecretstores/references.go
+++ b/internal/connectorsecretstores/references.go
@@ -38,6 +38,7 @@ var (
 	ErrResolverUnavailable = errors.New("connector secret-store resolver unavailable")
 
 	awsRegionPrefixPattern = regexp.MustCompile(`^[a-z]{2}(-gov)?-[a-z0-9-]+-\d$`)
+	referencePathPattern   = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 )
 
 // Reference is the parsed, non-secret address of a value in an operator-managed
@@ -174,11 +175,21 @@ func RuntimeSecretPrefix(tenantID string, sourceID string, runtimeID string) str
 	return "cerebro/" + tenantSegment + "/" + sourceSegment + "/" + runtimeSegment + "/"
 }
 
+// RuntimeCredentialSecretName returns the single operator-managed AWS Secrets
+// Manager name that stores credential JSON for a runtime.
+func RuntimeCredentialSecretName(tenantID string, sourceID string, runtimeID string) string {
+	prefix := RuntimeSecretPrefix(tenantID, sourceID, runtimeID)
+	if prefix == "" {
+		return ""
+	}
+	return prefix + "credentials"
+}
+
 // AuthorizeRuntimeReferences checks that native references are constrained to
 // the requesting runtime's secret namespace before any backend resolver uses
 // operator credentials to fetch them.
 func AuthorizeRuntimeReferences(sourceID string, tenantID string, runtimeID string, values map[string]string) error {
-	prefix := RuntimeSecretPrefix(tenantID, sourceID, runtimeID)
+	expectedSecretName := RuntimeCredentialSecretName(tenantID, sourceID, runtimeID)
 	for key, value := range values {
 		ref, ok, err := ParseReference(value)
 		if err != nil {
@@ -187,11 +198,12 @@ func AuthorizeRuntimeReferences(sourceID string, tenantID string, runtimeID stri
 		if !ok || ref.StoreID != StoreAWSSecretsManager {
 			continue
 		}
-		if prefix == "" {
-			return fmt.Errorf("%w: aws-sm reference %q requires tenant, source, and runtime scope", ErrInvalidReference, strings.TrimSpace(key))
+		if expectedSecretName == "" {
+			return fmt.Errorf("%w: aws-sm reference %q requires canonical tenant, source, and runtime scope", ErrInvalidReference, strings.TrimSpace(key))
 		}
-		if !strings.HasPrefix(awsSecretName(ref.SecretID), prefix) {
-			return fmt.Errorf("%w: aws-sm reference %q must use scoped secret prefix %q", ErrInvalidReference, strings.TrimSpace(key), prefix)
+		secretName := awsSecretName(ref.SecretID)
+		if secretName != expectedSecretName && !strings.HasPrefix(secretName, expectedSecretName+"-") {
+			return fmt.Errorf("%w: aws-sm reference %q must use scoped secret %q", ErrInvalidReference, strings.TrimSpace(key), expectedSecretName)
 		}
 	}
 	return nil
@@ -253,7 +265,7 @@ func (r *Resolver) Resolve(ctx context.Context, ref Reference) (string, error) {
 	}
 	switch ref.StoreID {
 	case StoreAWSSecretsManager:
-		if strings.TrimSpace(r.cfg.AWSSecretsManager.Region) == "" && strings.TrimSpace(ref.Region) == "" {
+		if strings.TrimSpace(r.cfg.AWSSecretsManager.Region) == "" {
 			return "", fmt.Errorf("%w: CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION is required", ErrResolverUnavailable)
 		}
 		client, err := r.awsClientFactory(ctx, r.cfg.AWSSecretsManager, ref)
@@ -318,22 +330,11 @@ func awsSecretName(secretID string) string {
 }
 
 func referencePathSegment(value string) string {
-	var builder strings.Builder
-	for _, char := range strings.TrimSpace(value) {
-		switch {
-		case char >= 'a' && char <= 'z':
-			builder.WriteRune(char)
-		case char >= 'A' && char <= 'Z':
-			builder.WriteRune(char)
-		case char >= '0' && char <= '9':
-			builder.WriteRune(char)
-		case char == '-' || char == '_' || char == '.':
-			builder.WriteRune(char)
-		default:
-			builder.WriteByte('_')
-		}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || !referencePathPattern.MatchString(trimmed) {
+		return ""
 	}
-	return strings.Trim(builder.String(), "_")
+	return trimmed
 }
 
 func newAWSSecretsManagerClient(ctx context.Context, cfg config.AWSSecretsManagerStoreConfig, ref Reference) (awsSecretsManagerAPI, error) {

--- a/internal/connectorsecretstores/references_test.go
+++ b/internal/connectorsecretstores/references_test.go
@@ -110,6 +110,18 @@ func TestResolverRejectsDisabledNativeStore(t *testing.T) {
 	}
 }
 
+func TestResolverRequiresConfiguredAWSRegionForNativeReferences(t *testing.T) {
+	resolver := NewResolver(config.ConnectorSecretStoreConfig{
+		Enabled: []string{StoreAWSSecretsManager},
+	})
+	_, err := resolver.ResolveReferences(context.Background(), map[string]string{
+		"value": "aws-sm:us-east-1:cerebro/tenant-a/aws/runtime-a/credentials#value",
+	})
+	if err == nil {
+		t.Fatal("ResolveReferences() error = nil, want resolver unavailable without configured region")
+	}
+}
+
 func TestAuthorizeRuntimeReferencesRequiresScopedAWSSecret(t *testing.T) {
 	err := AuthorizeRuntimeReferences("aws", "tenant-a", "runtime-a", map[string]string{
 		"value": "aws-sm:us-east-1:cerebro/tenant-a/aws/runtime-a/credentials#value",
@@ -123,6 +135,21 @@ func TestAuthorizeRuntimeReferencesRequiresScopedAWSSecret(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("AuthorizeRuntimeReferences(unscoped) error = nil, want invalid reference")
+	}
+}
+
+func TestAuthorizeRuntimeReferencesRejectsNonCanonicalRuntimeScope(t *testing.T) {
+	if got := RuntimeSecretPrefix("prod/aws", "aws", "runtime-a"); got != "" {
+		t.Fatalf("RuntimeSecretPrefix(unsafe tenant) = %q, want empty", got)
+	}
+	if got := RuntimeSecretPrefix("prod_aws", "aws", "runtime-a"); got != "cerebro/prod_aws/aws/runtime-a/" {
+		t.Fatalf("RuntimeSecretPrefix(canonical tenant) = %q, want canonical prefix", got)
+	}
+	err := AuthorizeRuntimeReferences("aws", "prod/aws", "runtime-a", map[string]string{
+		"value": "aws-sm:us-east-1:cerebro/prod_aws/aws/runtime-a/credentials#value",
+	})
+	if err == nil {
+		t.Fatal("AuthorizeRuntimeReferences(non-canonical tenant) error = nil, want invalid reference")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reject lossy runtime secret namespaces and require canonical tenant/source/runtime segments for native secret references.
- Scope AWS Secrets Manager references to the exact runtime credential secret before resolver use.
- Keep connector catalog/preflight metadata honest: native AWS SM prefixes/templates are only advertised when the backend resolver is configured; otherwise the catalog shows env projection.
- Return reference plans for required credential fields even before references are submitted, so setup UIs can guide operators safely.

## Validation
- go test ./internal/connectorsecretstores ./internal/bootstrap -count=1
- make lint
- make openapi-check
- go test ./internal/...
