### PR TITLE
feat: Enrich Azure ARM coverage attributes

### DIFF
--- a/sources/azure/catalog.yaml
+++ b/sources/azure/catalog.yaml
@@ -105,9 +105,8 @@ coverage_contract:
       type: entity_family
       title: Azure Activity Log Alert
       families: [activity_log_alert]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [alert condition expansion, action group links]
     - id: ad_authorization_policy
       type: entity_family
       title: Azure authorization policy
@@ -157,23 +156,22 @@ coverage_contract:
       type: entity_family
       title: Azure Application Gateway
       families: [application_gateway]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [listener TLS and WAF policy detail]
     - id: application_insight
       type: entity_family
       title: Azure Application Insights
       families: [application_insight]
       support: partial
       high_value: true
-      known_unsupported_fields: [alert and retention settings]
+      known_unsupported_fields: [alert settings]
     - id: cognitive_services_account
       type: entity_family
       title: Azure Cognitive Services accounts
       families: [cognitive_services_account]
       support: partial
       high_value: true
-      known_unsupported_fields: [network ACLs and model deployment detail]
+      known_unsupported_fields: [model deployment detail]
     - id: container_registry
       type: entity_family
       title: Azure Container Registry
@@ -224,9 +222,8 @@ coverage_contract:
       type: entity_family
       title: Azure Databricks workspaces
       families: [databricks_workspace]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [workspace network and access settings]
     - id: diagnostic_setting
       type: entity_family
       title: Azure diagnostic settings
@@ -305,16 +302,14 @@ coverage_contract:
       type: entity_family
       title: Azure Load Balancers
       families: [load_balancer]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [frontend IP, backend pool, and rule detail]
     - id: log_alert
       type: entity_family
       title: Azure log alert rules
       families: [log_alert]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [query and action group detail]
     - id: machine_learning_workspace
       type: entity_family
       title: Azure Machine Learning workspaces
@@ -332,9 +327,8 @@ coverage_contract:
       type: entity_family
       title: Azure metric alert rules
       families: [metric_alert_rule]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [criteria and action group detail]
     - id: defender_config
       type: entity_family
       title: Microsoft Defender for Cloud configuration
@@ -378,16 +372,14 @@ coverage_contract:
       type: app_entitlement
       title: Azure role definitions
       families: [role]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [role definition action expansion]
     - id: route_table
       type: entity_family
       title: Azure route tables
       families: [route_table]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [route next-hop detail]
     - id: scale_set_virtual_machine
       type: entity_family
       title: Azure scale set virtual machines
@@ -399,9 +391,8 @@ coverage_contract:
       type: entity_family
       title: Azure security contacts
       families: [security_contact]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [Defender contact notification settings]
     - id: server_vulnerability
       type: entity_family
       title: Azure server vulnerabilities
@@ -427,7 +418,7 @@ coverage_contract:
       families: [sql_managed_instance]
       support: partial
       high_value: true
-      known_unsupported_fields: [managed instance network and TDE settings]
+      known_unsupported_fields: [TDE settings]
     - id: sql_server
       type: entity_family
       title: Azure SQL servers
@@ -507,7 +498,7 @@ coverage_contract:
       families: [virtual_machine_scale_set]
       support: partial
       high_value: true
-      known_unsupported_fields: [instance and upgrade policy detail]
+      known_unsupported_fields: [per-instance posture]
     - id: virtual_network
       type: entity_family
       title: Azure virtual networks

--- a/sources/azure/source.go
+++ b/sources/azure/source.go
@@ -1612,7 +1612,7 @@ func assetMetadataEvent(settings settings, record armResourceRecord) (*primitive
 func genericARMResourceEvent(settings settings, record armTypedResourceRecord, family string, kind string, schemaRef string) (*primitives.Event, error) {
 	attributes := azureResourceAttributes(settings, record, family)
 	addAzureIdentityAttributes(attributes, record.Identity)
-	setAttributes(attributes, map[string]string{"kind": firstNonEmpty(record.Kind, kind), "public_network_access": propertyString(record, "publicNetworkAccess"), "state": firstNonEmpty(propertyString(record, "provisioningState"), propertyString(record, "status"))})
+	setAttributes(attributes, azurearm.ResourceAttributes(family, record.Kind, kind, azurearm.Properties(record.Properties)))
 	payload, err := payloadWithRaw(record.raw, azureResourcePayload(settings))
 	if err != nil {
 		return nil, err

--- a/sources/azure/source_test.go
+++ b/sources/azure/source_test.go
@@ -293,6 +293,11 @@ func TestReadLiveAzureGenericARMPreview(t *testing.T) {
 			if got := event.Attributes["public_network_access"]; got != "Enabled" {
 				t.Fatalf("public_network_access = %q, want Enabled", got)
 			}
+			for attr, want := range genericAzureARMExpectedAttributes(definition.Name) {
+				if got := event.Attributes[attr]; got != want {
+					t.Fatalf("%s = %q, want %q", attr, got, want)
+				}
+			}
 		})
 	}
 }
@@ -532,7 +537,7 @@ func newAzureAPIHandler(t *testing.T) http.Handler {
 		case "/subscriptions/sub-1/resources":
 			writeJSON(t, w, map[string]any{"value": []map[string]any{{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Storage/storageAccounts/data", "name": "data", "type": "Microsoft.Storage/storageAccounts", "location": "eastus", "tags": map[string]string{"data_classification": "restricted", "owner": "security@writer.com", "tier": "critical", "pii": "true", "env": "prod"}}}})
 		case "/subscriptions/sub-1/providers/Microsoft.CognitiveServices/accounts":
-			writeJSON(t, w, map[string]any{"value": []map[string]any{{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.CognitiveServices/accounts/openai-prod", "name": "openai-prod", "type": "Microsoft.CognitiveServices/accounts", "kind": "OpenAI", "location": "eastus", "sku": map[string]any{"name": "S0", "tier": "Standard"}, "identity": map[string]any{"type": "SystemAssigned", "principalId": "openai-principal-1", "tenantId": "tenant-1"}, "tags": map[string]string{"owner": "ai@writer.com", "team": "ai", "env": "prod"}, "properties": map[string]any{"publicNetworkAccess": "Enabled", "provisioningState": "Succeeded", "customSubDomainName": "openai-prod"}}}})
+			writeJSON(t, w, map[string]any{"value": []map[string]any{{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.CognitiveServices/accounts/openai-prod", "name": "openai-prod", "type": "Microsoft.CognitiveServices/accounts", "kind": "OpenAI", "location": "eastus", "sku": map[string]any{"name": "S0", "tier": "Standard"}, "identity": map[string]any{"type": "SystemAssigned", "principalId": "openai-principal-1", "tenantId": "tenant-1"}, "tags": map[string]string{"owner": "ai@writer.com", "team": "ai", "env": "prod"}, "properties": map[string]any{"publicNetworkAccess": "Enabled", "provisioningState": "Succeeded", "customSubDomainName": "openai-prod", "networkAcls": map[string]any{"defaultAction": "Deny", "virtualNetworkRules": []any{map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/ai"}}}}}}})
 		case "/subscriptions/sub-1/providers/Microsoft.MachineLearningServices/workspaces":
 			writeJSON(t, w, map[string]any{"value": []map[string]any{{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.MachineLearningServices/workspaces/ml-prod", "name": "ml-prod", "type": "Microsoft.MachineLearningServices/workspaces", "location": "eastus", "identity": map[string]any{"type": "SystemAssigned", "principalId": "ml-principal-1", "tenantId": "tenant-1"}, "tags": map[string]string{"owner": "ml@writer.com", "team": "ml", "env": "prod"}, "properties": map[string]any{"publicNetworkAccess": "Enabled", "provisioningState": "Succeeded", "friendlyName": "ml-prod"}}}})
 		case "/subscriptions/sub-1/providers/Microsoft.Compute/virtualMachines":
@@ -597,19 +602,151 @@ func writeGenericAzureARMTestResponse(t *testing.T, w http.ResponseWriter, path 
 func genericAzureARMTestPayload(definition azurearm.Definition) map[string]any {
 	name := strings.ReplaceAll(definition.Name, "_", "-") + "-prod"
 	return map[string]any{
-		"id":       "/subscriptions/sub-1/resourceGroups/rg-prod/providers/" + definition.ProviderPath + "/" + name,
-		"name":     name,
-		"type":     definition.ProviderPath,
-		"kind":     definition.Kind,
-		"location": "eastus",
-		"sku":      map[string]any{"name": "Standard", "tier": "Standard"},
-		"identity": map[string]any{"type": "SystemAssigned", "principalId": name + "-principal", "tenantId": "tenant-1"},
-		"tags":     map[string]string{"env": "prod", "owner": "platform@writer.com", "team": "platform"},
-		"properties": map[string]any{
-			"provisioningState":   "Succeeded",
-			"publicNetworkAccess": "Enabled",
-		},
+		"id":         "/subscriptions/sub-1/resourceGroups/rg-prod/providers/" + definition.ProviderPath + "/" + name,
+		"name":       name,
+		"type":       definition.ProviderPath,
+		"kind":       definition.Kind,
+		"location":   "eastus",
+		"sku":        map[string]any{"name": "Standard", "tier": "Standard"},
+		"identity":   map[string]any{"type": "SystemAssigned", "principalId": name + "-principal", "tenantId": "tenant-1"},
+		"tags":       map[string]string{"env": "prod", "owner": "platform@writer.com", "team": "platform"},
+		"properties": genericAzureARMTestProperties(definition.Name),
 	}
+}
+
+func genericAzureARMTestProperties(family string) map[string]any {
+	properties := map[string]any{"provisioningState": "Succeeded", "publicNetworkAccess": "Enabled"}
+	switch family {
+	case "activity_log_alert":
+		properties["enabled"] = true
+		properties["scopes"] = []any{"/subscriptions/sub-1"}
+		properties["condition"] = map[string]any{"allOf": []any{map[string]any{"field": "category", "equals": "Administrative"}, map[string]any{"field": "operationName", "containsAny": []any{"Microsoft.Compute/virtualMachines/write"}}}}
+		properties["actions"] = map[string]any{"actionGroups": []any{map[string]any{"actionGroupId": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Insights/actionGroups/secops"}}}
+	case "application_gateway":
+		properties["operationalState"] = "Running"
+		properties["frontendIPConfigurations"] = []any{map[string]any{"id": "frontend-1", "name": "appgw-frontend", "properties": map[string]any{"publicIPAddress": map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/publicIPAddresses/appgw-pip"}}}}
+		properties["gatewayIPConfigurations"] = []any{map[string]any{"name": "appgw-ipconfig", "properties": map[string]any{"subnet": map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/appgw"}}}}
+		properties["backendAddressPools"] = []any{map[string]any{"name": "backend-api"}}
+		properties["httpListeners"] = []any{map[string]any{"name": "https-listener"}}
+		properties["sslCertificates"] = []any{map[string]any{"name": "wildcard-cert"}}
+		properties["sslPolicy"] = map[string]any{"minProtocolVersion": "TLSv1_2"}
+		properties["firewallPolicy"] = map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/appgw-waf"}
+		properties["webApplicationFirewallConfiguration"] = map[string]any{"enabled": true, "firewallMode": "Prevention"}
+	case "application_insight":
+		properties["AppId"] = "appinsights-app-id"
+		properties["Application_Type"] = "web"
+		properties["RetentionInDays"] = 90
+		properties["DisableLocalAuth"] = true
+		properties["WorkspaceResourceId"] = "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.OperationalInsights/workspaces/law-prod"
+	case "cognitive_services_account":
+		properties["endpoint"] = "https://openai-prod.cognitiveservices.azure.com/"
+		properties["customSubDomainName"] = "openai-prod"
+		properties["disableLocalAuth"] = true
+		properties["networkAcls"] = map[string]any{"defaultAction": "Deny", "bypass": "AzureServices", "virtualNetworkRules": []any{map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/ai"}}, "ipRules": []any{map[string]any{"value": "203.0.113.10"}}}
+	case "databricks_workspace":
+		properties["managedResourceGroupId"] = "/subscriptions/sub-1/resourceGroups/databricks-managed"
+		properties["requiredNsgRules"] = "NoAzureDatabricksRules"
+		properties["parameters"] = map[string]any{"customPublicSubnetName": map[string]any{"value": "dbx-public"}, "customPrivateSubnetName": map[string]any{"value": "dbx-private"}, "natGatewayName": map[string]any{"value": "dbx-nat"}}
+		properties["accessConnector"] = map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Databricks/accessConnectors/dbx-connector"}
+	case "load_balancer":
+		properties["frontendIPConfigurations"] = []any{map[string]any{"id": "frontend-lb", "name": "lb-frontend", "properties": map[string]any{"publicIPAddress": map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/publicIPAddresses/lb-pip"}, "subnet": map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/web"}}}}
+		properties["backendAddressPools"] = []any{map[string]any{"name": "backend-web"}}
+		properties["probes"] = []any{map[string]any{"name": "https-probe"}}
+		properties["loadBalancingRules"] = []any{map[string]any{"name": "https-rule"}}
+		properties["inboundNatRules"] = []any{map[string]any{"name": "ssh-nat"}}
+	case "log_alert":
+		properties["enabled"] = true
+		properties["scopes"] = []any{"/subscriptions/sub-1/resourceGroups/rg-prod"}
+		properties["severity"] = 2
+		properties["evaluationFrequency"] = "PT5M"
+		properties["windowSize"] = "PT15M"
+		properties["criteria"] = map[string]any{"allOf": []any{map[string]any{"query": "SecurityEvent | count"}}}
+		properties["actions"] = map[string]any{"actionGroups": []any{"/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Insights/actionGroups/secops"}}
+	case "machine_learning_workspace":
+		properties["discoveryUrl"] = "https://ml-prod.discovery.azureml.net/"
+		properties["friendlyName"] = "ML Prod"
+		properties["keyVault"] = "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.KeyVault/vaults/ml-kv"
+		properties["storageAccount"] = "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Storage/storageAccounts/mlstorage"
+		properties["containerRegistry"] = "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.ContainerRegistry/registries/mlacr"
+		properties["applicationInsights"] = "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Insights/components/ml-ai"
+		properties["imageBuildCompute"] = "build-cluster"
+		properties["hbiWorkspace"] = true
+		properties["privateEndpointConnections"] = []any{map[string]any{"name": "ml-pe"}}
+	case "metric_alert_rule":
+		properties["enabled"] = true
+		properties["scopes"] = []any{"/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm1"}
+		properties["severity"] = 1
+		properties["evaluationFrequency"] = "PT1M"
+		properties["windowSize"] = "PT5M"
+		properties["autoMitigate"] = true
+		properties["targetResourceType"] = "Microsoft.Compute/virtualMachines"
+		properties["targetResourceRegion"] = "eastus"
+		properties["criteria"] = map[string]any{"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria", "allOf": []any{map[string]any{"metricName": "Percentage CPU", "operator": "GreaterThan", "threshold": 90}}}
+		properties["actions"] = []any{map[string]any{"actionGroupId": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Insights/actionGroups/secops"}}
+	case "role":
+		properties["roleName"] = "Security Reader"
+		properties["type"] = "BuiltInRole"
+		properties["assignableScopes"] = []any{"/subscriptions/sub-1"}
+		properties["permissions"] = []any{map[string]any{"actions": []any{"Microsoft.Security/*/read"}, "notActions": []any{"Microsoft.Authorization/*/delete"}, "dataActions": []any{"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"}}}
+	case "route_table":
+		properties["disableBgpRoutePropagation"] = true
+		properties["routes"] = []any{map[string]any{"name": "default-to-firewall", "properties": map[string]any{"addressPrefix": "0.0.0.0/0", "nextHopType": "VirtualAppliance", "nextHopIpAddress": "10.0.0.4"}}}
+		properties["subnets"] = []any{map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/web"}}
+	case "security_contact":
+		properties["emails"] = "secops@writer.com"
+		properties["phone"] = "+14155550100"
+		properties["alertNotifications"] = "On"
+		properties["alertsToAdmins"] = "On"
+	case "sql_managed_instance":
+		properties["administratorLogin"] = "sqladmin"
+		properties["fullyQualifiedDomainName"] = "mi-prod.database.windows.net"
+		properties["publicDataEndpointEnabled"] = false
+		properties["minimalTlsVersion"] = "1.2"
+		properties["subnetId"] = "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/sqlmi"
+		properties["licenseType"] = "LicenseIncluded"
+		properties["vCores"] = 8
+		properties["storageSizeInGB"] = 512
+		properties["zoneRedundant"] = true
+	case "virtual_machine_scale_set":
+		properties["upgradePolicy"] = map[string]any{"mode": "Automatic"}
+		properties["overprovision"] = true
+		properties["singlePlacementGroup"] = false
+		properties["orchestrationMode"] = "Uniform"
+		properties["virtualMachineProfile"] = map[string]any{"osProfile": map[string]any{"computerNamePrefix": "vmss", "adminUsername": "azureuser"}, "storageProfile": map[string]any{"imageReference": map[string]any{"publisher": "Canonical", "offer": "0001-com-ubuntu-server-jammy", "sku": "22_04-lts", "version": "latest"}}, "networkProfile": map[string]any{"networkInterfaceConfigurations": []any{map[string]any{"properties": map[string]any{"networkSecurityGroup": map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/networkSecurityGroups/vmss-nsg"}, "ipConfigurations": []any{map[string]any{"properties": map[string]any{"subnet": map[string]any{"id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/vmss"}}}}}}}}}
+	}
+	return properties
+}
+
+func genericAzureARMExpectedAttributes(family string) map[string]string {
+	switch family {
+	case "activity_log_alert":
+		return map[string]string{"condition_fields": "category,operationName", "action_group_ids": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Insights/actionGroups/secops"}
+	case "application_gateway":
+		return map[string]string{"http_listener_names": "https-listener", "ssl_policy_min_protocol_version": "TLSv1_2", "waf_firewall_mode": "Prevention"}
+	case "application_insight":
+		return map[string]string{"retention_in_days": "90", "disable_local_auth": "true"}
+	case "cognitive_services_account":
+		return map[string]string{"network_default_action": "Deny", "virtual_network_subnet_ids": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/ai"}
+	case "databricks_workspace":
+		return map[string]string{"managed_resource_group_id": "/subscriptions/sub-1/resourceGroups/databricks-managed", "private_subnet_name": "dbx-private"}
+	case "load_balancer":
+		return map[string]string{"backend_pool_names": "backend-web", "load_balancing_rule_names": "https-rule", "public_ip_ids": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/publicIPAddresses/lb-pip"}
+	case "log_alert":
+		return map[string]string{"query": "SecurityEvent | count", "action_group_ids": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Insights/actionGroups/secops"}
+	case "metric_alert_rule":
+		return map[string]string{"criteria_metric_names": "Percentage CPU", "criteria_thresholds": "90", "action_group_ids": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Insights/actionGroups/secops"}
+	case "role":
+		return map[string]string{"role_name": "Security Reader", "actions": "Microsoft.Security/*/read"}
+	case "route_table":
+		return map[string]string{"next_hop_types": "VirtualAppliance", "next_hop_ip_addresses": "10.0.0.4"}
+	case "security_contact":
+		return map[string]string{"emails": "secops@writer.com", "alert_notifications": "On", "alerts_to_admins": "On"}
+	case "sql_managed_instance":
+		return map[string]string{"subnet_id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/sqlmi", "public_data_endpoint_enabled": "false"}
+	case "virtual_machine_scale_set":
+		return map[string]string{"upgrade_mode": "Automatic", "subnet_ids": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod/subnets/vmss"}
+	}
+	return nil
 }
 
 func newAzurePaginationTestSource(t *testing.T, server *httptest.Server, family string) (*Source, settings) {

--- a/sources/internal/azurearm/attributes.go
+++ b/sources/internal/azurearm/attributes.go
@@ -1,0 +1,332 @@
+package azurearm
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+type Properties map[string]any
+
+func ResourceAttributes(family string, recordKind string, fallbackKind string, properties Properties) map[string]string {
+	attributes := map[string]string{
+		"kind":                  firstNonEmpty(recordKind, fallbackKind),
+		"public_network_access": stringAt(properties, "publicNetworkAccess"),
+		"state":                 firstNonEmpty(stringAt(properties, "provisioningState"), stringAt(properties, "status"), stringAt(properties, "state")),
+	}
+	switch family {
+	case "activity_log_alert":
+		set(attributes, "enabled", stringAt(properties, "enabled"))
+		set(attributes, "scopes", strings.Join(stringsAt(properties, "scopes"), ","))
+		set(attributes, "condition_fields", strings.Join(valuesFromArray(properties, []string{"condition", "allOf"}, "field"), ","))
+		set(attributes, "condition_equals", strings.Join(valuesFromArray(properties, []string{"condition", "allOf"}, "equals"), ","))
+		set(attributes, "condition_contains_any", strings.Join(valuesFromArray(properties, []string{"condition", "allOf"}, "containsAny"), ","))
+		set(attributes, "action_group_ids", strings.Join(valuesFromArray(properties, []string{"actions", "actionGroups"}, "actionGroupId"), ","))
+	case "application_gateway":
+		set(attributes, "operational_state", stringAt(properties, "operationalState"))
+		set(attributes, "frontend_ip_configuration_names", strings.Join(valuesFromArray(properties, []string{"frontendIPConfigurations"}, "name"), ","))
+		set(attributes, "frontend_ip_configuration_ids", strings.Join(valuesFromArray(properties, []string{"frontendIPConfigurations"}, "id"), ","))
+		set(attributes, "public_ip_ids", strings.Join(referenceIDsFromArray(properties, []string{"frontendIPConfigurations"}, "publicIPAddress"), ","))
+		set(attributes, "subnet_ids", strings.Join(referenceIDsFromArray(properties, []string{"gatewayIPConfigurations"}, "subnet"), ","))
+		set(attributes, "backend_pool_names", strings.Join(valuesFromArray(properties, []string{"backendAddressPools"}, "name"), ","))
+		set(attributes, "http_listener_names", strings.Join(valuesFromArray(properties, []string{"httpListeners"}, "name"), ","))
+		set(attributes, "ssl_certificate_names", strings.Join(valuesFromArray(properties, []string{"sslCertificates"}, "name"), ","))
+		set(attributes, "ssl_policy_min_protocol_version", stringAt(properties, "sslPolicy", "minProtocolVersion"))
+		set(attributes, "firewall_policy_id", stringAt(properties, "firewallPolicy", "id"))
+		set(attributes, "waf_enabled", stringAt(properties, "webApplicationFirewallConfiguration", "enabled"))
+		set(attributes, "waf_firewall_mode", stringAt(properties, "webApplicationFirewallConfiguration", "firewallMode"))
+	case "application_insight":
+		set(attributes, "app_id", stringAt(properties, "AppId"))
+		set(attributes, "application_type", stringAt(properties, "Application_Type"))
+		set(attributes, "flow_type", stringAt(properties, "Flow_Type"))
+		set(attributes, "request_source", stringAt(properties, "Request_Source"))
+		set(attributes, "ingestion_mode", stringAt(properties, "IngestionMode"))
+		set(attributes, "retention_in_days", stringAt(properties, "RetentionInDays"))
+		set(attributes, "sampling_percentage", stringAt(properties, "SamplingPercentage"))
+		set(attributes, "disable_local_auth", stringAt(properties, "DisableLocalAuth"))
+		set(attributes, "workspace_resource_id", stringAt(properties, "WorkspaceResourceId"))
+		set(attributes, "public_network_access_for_ingestion", stringAt(properties, "publicNetworkAccessForIngestion"))
+		set(attributes, "public_network_access_for_query", stringAt(properties, "publicNetworkAccessForQuery"))
+	case "cognitive_services_account":
+		set(attributes, "endpoint", stringAt(properties, "endpoint"))
+		set(attributes, "custom_subdomain_name", stringAt(properties, "customSubDomainName"))
+		set(attributes, "disable_local_auth", stringAt(properties, "disableLocalAuth"))
+		set(attributes, "network_default_action", stringAt(properties, "networkAcls", "defaultAction"))
+		set(attributes, "network_bypass", stringAt(properties, "networkAcls", "bypass"))
+		set(attributes, "virtual_network_subnet_ids", strings.Join(referenceIDsFromArray(properties, []string{"networkAcls", "virtualNetworkRules"}, "id"), ","))
+		set(attributes, "ip_rules", strings.Join(valuesFromArray(properties, []string{"networkAcls", "ipRules"}, "value"), ","))
+	case "databricks_workspace":
+		set(attributes, "managed_resource_group_id", stringAt(properties, "managedResourceGroupId"))
+		set(attributes, "required_nsg_rules", stringAt(properties, "requiredNsgRules"))
+		set(attributes, "public_subnet_name", databricksParameter(properties, "customPublicSubnetName"))
+		set(attributes, "private_subnet_name", databricksParameter(properties, "customPrivateSubnetName"))
+		set(attributes, "nat_gateway_name", databricksParameter(properties, "natGatewayName"))
+		set(attributes, "access_connector_id", stringAt(properties, "accessConnector", "id"))
+	case "load_balancer":
+		set(attributes, "frontend_ip_configuration_names", strings.Join(valuesFromArray(properties, []string{"frontendIPConfigurations"}, "name"), ","))
+		set(attributes, "frontend_ip_configuration_ids", strings.Join(valuesFromArray(properties, []string{"frontendIPConfigurations"}, "id"), ","))
+		set(attributes, "public_ip_ids", strings.Join(referenceIDsFromArray(properties, []string{"frontendIPConfigurations"}, "publicIPAddress"), ","))
+		set(attributes, "subnet_ids", strings.Join(referenceIDsFromArray(properties, []string{"frontendIPConfigurations"}, "subnet"), ","))
+		set(attributes, "backend_pool_names", strings.Join(valuesFromArray(properties, []string{"backendAddressPools"}, "name"), ","))
+		set(attributes, "probe_names", strings.Join(valuesFromArray(properties, []string{"probes"}, "name"), ","))
+		set(attributes, "load_balancing_rule_names", strings.Join(valuesFromArray(properties, []string{"loadBalancingRules"}, "name"), ","))
+		set(attributes, "inbound_nat_rule_names", strings.Join(valuesFromArray(properties, []string{"inboundNatRules"}, "name"), ","))
+	case "log_alert":
+		set(attributes, "enabled", stringAt(properties, "enabled"))
+		set(attributes, "scopes", strings.Join(stringsAt(properties, "scopes"), ","))
+		set(attributes, "severity", stringAt(properties, "severity"))
+		set(attributes, "query", stringAt(properties, "criteria", "allOf", "0", "query"))
+		set(attributes, "evaluation_frequency", stringAt(properties, "evaluationFrequency"))
+		set(attributes, "window_size", stringAt(properties, "windowSize"))
+		set(attributes, "action_group_ids", strings.Join(stringsAt(properties, "actions", "actionGroups"), ","))
+	case "machine_learning_workspace":
+		set(attributes, "public_network_access", firstNonEmpty(attributes["public_network_access"], stringAt(properties, "publicNetworkAccess")))
+		set(attributes, "discovery_url", stringAt(properties, "discoveryUrl"))
+		set(attributes, "friendly_name", stringAt(properties, "friendlyName"))
+		set(attributes, "key_vault_id", stringAt(properties, "keyVault"))
+		set(attributes, "storage_account_id", stringAt(properties, "storageAccount"))
+		set(attributes, "container_registry_id", stringAt(properties, "containerRegistry"))
+		set(attributes, "application_insights_id", stringAt(properties, "applicationInsights"))
+		set(attributes, "image_build_compute", stringAt(properties, "imageBuildCompute"))
+		set(attributes, "hbi_workspace", stringAt(properties, "hbiWorkspace"))
+		set(attributes, "private_endpoint_connection_count", strconv.Itoa(len(arrayAt(properties, "privateEndpointConnections"))))
+	case "metric_alert_rule":
+		set(attributes, "enabled", stringAt(properties, "enabled"))
+		set(attributes, "scopes", strings.Join(stringsAt(properties, "scopes"), ","))
+		set(attributes, "severity", stringAt(properties, "severity"))
+		set(attributes, "evaluation_frequency", stringAt(properties, "evaluationFrequency"))
+		set(attributes, "window_size", stringAt(properties, "windowSize"))
+		set(attributes, "auto_mitigate", stringAt(properties, "autoMitigate"))
+		set(attributes, "target_resource_type", stringAt(properties, "targetResourceType"))
+		set(attributes, "target_resource_region", stringAt(properties, "targetResourceRegion"))
+		set(attributes, "criteria_type", stringAt(properties, "criteria", "odata.type"))
+		set(attributes, "criteria_metric_names", strings.Join(valuesFromArray(properties, []string{"criteria", "allOf"}, "metricName"), ","))
+		set(attributes, "criteria_operators", strings.Join(valuesFromArray(properties, []string{"criteria", "allOf"}, "operator"), ","))
+		set(attributes, "criteria_thresholds", strings.Join(valuesFromArray(properties, []string{"criteria", "allOf"}, "threshold"), ","))
+		set(attributes, "action_group_ids", strings.Join(valuesFromArray(properties, []string{"actions"}, "actionGroupId"), ","))
+	case "role":
+		set(attributes, "role_name", stringAt(properties, "roleName"))
+		set(attributes, "role_type", stringAt(properties, "type"))
+		set(attributes, "assignable_scopes", strings.Join(stringsAt(properties, "assignableScopes"), ","))
+		set(attributes, "actions", strings.Join(valuesFromArray(properties, []string{"permissions"}, "actions"), ","))
+		set(attributes, "not_actions", strings.Join(valuesFromArray(properties, []string{"permissions"}, "notActions"), ","))
+		set(attributes, "data_actions", strings.Join(valuesFromArray(properties, []string{"permissions"}, "dataActions"), ","))
+		set(attributes, "not_data_actions", strings.Join(valuesFromArray(properties, []string{"permissions"}, "notDataActions"), ","))
+	case "route_table":
+		set(attributes, "disable_bgp_route_propagation", stringAt(properties, "disableBgpRoutePropagation"))
+		set(attributes, "route_names", strings.Join(valuesFromArray(properties, []string{"routes"}, "name"), ","))
+		set(attributes, "route_count", strconv.Itoa(len(arrayAt(properties, "routes"))))
+		set(attributes, "address_prefixes", strings.Join(valuesFromArray(properties, []string{"routes"}, "addressPrefix"), ","))
+		set(attributes, "next_hop_types", strings.Join(valuesFromArray(properties, []string{"routes"}, "nextHopType"), ","))
+		set(attributes, "next_hop_ip_addresses", strings.Join(valuesFromArray(properties, []string{"routes"}, "nextHopIpAddress"), ","))
+		set(attributes, "subnet_ids", strings.Join(valuesFromArray(properties, []string{"subnets"}, "id"), ","))
+	case "security_contact":
+		set(attributes, "emails", stringAt(properties, "emails"))
+		set(attributes, "phone", stringAt(properties, "phone"))
+		set(attributes, "alert_notifications", stringAt(properties, "alertNotifications"))
+		set(attributes, "alerts_to_admins", stringAt(properties, "alertsToAdmins"))
+	case "sql_managed_instance":
+		set(attributes, "administrator_login", stringAt(properties, "administratorLogin"))
+		set(attributes, "public_host", stringAt(properties, "fullyQualifiedDomainName"))
+		set(attributes, "public_data_endpoint_enabled", stringAt(properties, "publicDataEndpointEnabled"))
+		set(attributes, "min_tls_version", stringAt(properties, "minimalTlsVersion"))
+		set(attributes, "subnet_id", stringAt(properties, "subnetId"))
+		set(attributes, "license_type", stringAt(properties, "licenseType"))
+		set(attributes, "vcores", stringAt(properties, "vCores"))
+		set(attributes, "storage_size_gb", stringAt(properties, "storageSizeInGB"))
+		set(attributes, "zone_redundant", stringAt(properties, "zoneRedundant"))
+		set(attributes, "proxy_override", stringAt(properties, "proxyOverride"))
+	case "virtual_machine_scale_set":
+		set(attributes, "upgrade_mode", stringAt(properties, "upgradePolicy", "mode"))
+		set(attributes, "overprovision", stringAt(properties, "overprovision"))
+		set(attributes, "single_placement_group", stringAt(properties, "singlePlacementGroup"))
+		set(attributes, "orchestration_mode", stringAt(properties, "orchestrationMode"))
+		set(attributes, "computer_name_prefix", stringAt(properties, "virtualMachineProfile", "osProfile", "computerNamePrefix"))
+		set(attributes, "admin_username", stringAt(properties, "virtualMachineProfile", "osProfile", "adminUsername"))
+		set(attributes, "image_publisher", stringAt(properties, "virtualMachineProfile", "storageProfile", "imageReference", "publisher"))
+		set(attributes, "image_offer", stringAt(properties, "virtualMachineProfile", "storageProfile", "imageReference", "offer"))
+		set(attributes, "image_sku", stringAt(properties, "virtualMachineProfile", "storageProfile", "imageReference", "sku"))
+		set(attributes, "image_version", stringAt(properties, "virtualMachineProfile", "storageProfile", "imageReference", "version"))
+		set(attributes, "subnet_ids", strings.Join(vmssSubnetIDs(properties), ","))
+		set(attributes, "nsg_ids", strings.Join(vmssNetworkSecurityGroupIDs(properties), ","))
+	}
+	trimEmpty(attributes)
+	return attributes
+}
+
+func databricksParameter(properties Properties, key string) string {
+	return stringAt(properties, "parameters", key, "value")
+}
+
+func vmssSubnetIDs(properties Properties) []string {
+	configs := arrayAt(properties, "virtualMachineProfile", "networkProfile", "networkInterfaceConfigurations")
+	values := make([]string, 0)
+	for _, configValue := range configs {
+		config := mapFromAny(configValue)
+		for _, ipValue := range arrayAt(mapFromAny(config["properties"]), "ipConfigurations") {
+			ipConfig := mapFromAny(ipValue)
+			values = append(values, stringAt(mapFromAny(ipConfig["properties"]), "subnet", "id"))
+		}
+	}
+	return unique(values)
+}
+
+func vmssNetworkSecurityGroupIDs(properties Properties) []string {
+	configs := arrayAt(properties, "virtualMachineProfile", "networkProfile", "networkInterfaceConfigurations")
+	values := make([]string, 0, len(configs))
+	for _, configValue := range configs {
+		config := mapFromAny(configValue)
+		values = append(values, stringAt(mapFromAny(config["properties"]), "networkSecurityGroup", "id"))
+	}
+	return unique(values)
+}
+
+func referenceIDsFromArray(values Properties, arrayPath []string, referenceKey string) []string {
+	out := make([]string, 0)
+	for _, item := range arrayAt(values, arrayPath...) {
+		itemMap := mapFromAny(item)
+		properties := mapFromAny(itemMap["properties"])
+		out = append(out, firstNonEmpty(stringAt(itemMap, referenceKey, "id"), stringAt(properties, referenceKey, "id"), stringAt(itemMap, referenceKey)))
+	}
+	return unique(out)
+}
+
+func valuesFromArray(values Properties, arrayPath []string, field string) []string {
+	out := make([]string, 0)
+	for _, item := range arrayAt(values, arrayPath...) {
+		itemMap := mapFromAny(item)
+		if itemMap == nil {
+			continue
+		}
+		properties := mapFromAny(itemMap["properties"])
+		candidates := []any{nestedAny(itemMap, strings.Split(field, ".")...), nestedAny(properties, strings.Split(field, ".")...)}
+		for _, candidate := range candidates {
+			out = append(out, stringsAtAny(candidate)...)
+		}
+	}
+	return unique(out)
+}
+
+func stringsAt(values Properties, keys ...string) []string {
+	return stringsAtAny(nestedAny(values, keys...))
+}
+
+func stringsAtAny(value any) []string {
+	switch typed := value.(type) {
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			values = append(values, stringify(item))
+		}
+		return unique(values)
+	case []string:
+		return unique(typed)
+	default:
+		return unique([]string{stringify(typed)})
+	}
+}
+
+func stringAt(values Properties, keys ...string) string {
+	return stringify(nestedAny(values, keys...))
+}
+
+func arrayAt(values Properties, keys ...string) []any {
+	value := nestedAny(values, keys...)
+	if typed, ok := value.([]any); ok {
+		return typed
+	}
+	return nil
+}
+
+func nestedAny(value any, keys ...string) any {
+	current := value
+	for _, key := range keys {
+		if index, err := strconv.Atoi(key); err == nil {
+			items, ok := current.([]any)
+			if !ok || index < 0 || index >= len(items) {
+				return nil
+			}
+			current = items[index]
+			continue
+		}
+		currentMap := mapFromAny(current)
+		if currentMap == nil {
+			return nil
+		}
+		current = currentMap[key]
+	}
+	return current
+}
+
+func mapFromAny(value any) Properties {
+	if typed, ok := value.(map[string]any); ok {
+		return Properties(typed)
+	}
+	if typed, ok := value.(Properties); ok {
+		return typed
+	}
+	return nil
+}
+
+func stringify(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case bool:
+		if typed {
+			return "true"
+		}
+		return "false"
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(typed)
+	case json.Number:
+		return typed.String()
+	default:
+		return ""
+	}
+}
+
+func set(attributes map[string]string, key string, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		delete(attributes, key)
+		return
+	}
+	attributes[key] = value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func trimEmpty(attributes map[string]string) {
+	for key, value := range attributes {
+		if strings.TrimSpace(value) == "" {
+			delete(attributes, key)
+		}
+	}
+}
+
+func unique(values []string) []string {
+	seen := map[string]struct{}{}
+	out := values[:0]
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- add reusable Azure ARM attribute extraction for alert, route, network, role, security contact, Databricks, Cognitive Services, SQL MI, and VMSS resource families
- emit the previously-missing alert/action, listener/WAF, frontend/backend/rule, route next-hop, role action, and contact notification fields from generic ARM collectors
- update Azure coverage contracts for the families now backed by those fields, reducing Azure partial dimensions from 35 to 26

## Tests
- go test ./sources/azure ./sources/internal/azurearm ./tools/catalogcheck ./tools/archtests
- go run ./tools/catalogcheck
- PATH=/usr/bin:/bin:/usr/sbin:/sbin:$PATH make check-structural
- git diff --check