### PR TITLE
feat: Enrich Cloudflare rule and role coverage

### DIFF
--- a/sources/cloudflare/catalog.yaml
+++ b/sources/cloudflare/catalog.yaml
@@ -26,14 +26,14 @@ coverage_contract:
       families: [access_application]
       support: partial
       high_value: true
-      known_unsupported_fields: [zone-scoped Access applications, nested policy expansion]
+      known_unsupported_fields: [zone-scoped Access applications]
     - id: access_groups
       type: app_entitlement
       title: Zero Trust Access groups
       families: [access_group]
       support: partial
       high_value: true
-      known_unsupported_fields: [zone-scoped Access groups, group rule expansion]
+      known_unsupported_fields: [zone-scoped Access groups]
     - id: accounts
       type: entity_family
       title: Accounts
@@ -44,9 +44,8 @@ coverage_contract:
       type: entity_family
       title: Account rulesets
       families: [account_ruleset]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [ruleset rule version expansion]
     - id: audit_logs
       type: audit_event
       title: Account audit logs
@@ -88,16 +87,15 @@ coverage_contract:
       type: app_entitlement
       title: Account roles
       families: [role]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [custom permission group expansion]
     - id: worker_scripts
       type: entity_family
       title: Workers scripts
       families: [worker_script]
       support: partial
       high_value: true
-      known_unsupported_fields: [script content and secret bindings]
+      known_unsupported_fields: [script content and secret binding values]
     - id: zones
       type: entity_family
       title: Zones
@@ -108,9 +106,8 @@ coverage_contract:
       type: entity_family
       title: Zone rulesets
       families: [zone_ruleset]
-      support: partial
+      support: supported
       high_value: true
-      known_unsupported_fields: [ruleset rule version expansion]
 event_contracts:
   - kind: cloudflare.access_application
     schema_ref: cloudflare/access_application/v1

--- a/sources/cloudflare/source.go
+++ b/sources/cloudflare/source.go
@@ -125,6 +125,7 @@ func cloudflareFamilies() []jsonapi.Family {
 		{
 			Name:             "account_ruleset",
 			Path:             "/accounts/{account_id}/rulesets",
+			DetailPath:       "/accounts/{account_id}/rulesets/{id}",
 			PathParams:       []string{"account_id"},
 			URNKind:          "cloudflare_account_ruleset",
 			IDKeys:           []string{"id"},
@@ -136,6 +137,7 @@ func cloudflareFamilies() []jsonapi.Family {
 		{
 			Name:             "zone_ruleset",
 			Path:             "/zones/{zone_id}/rulesets",
+			DetailPath:       "/zones/{zone_id}/rulesets/{id}",
 			PathParams:       []string{"zone_id"},
 			URNKind:          "cloudflare_zone_ruleset",
 			IDKeys:           []string{"id"},

--- a/sources/cloudflare/source.go
+++ b/sources/cloudflare/source.go
@@ -87,7 +87,7 @@ func cloudflareFamilies() []jsonapi.Family {
 			URNKind:          "cloudflare_role",
 			IDKeys:           []string{"id"},
 			ListKeys:         cloudflareResultListKeys(),
-			Attributes:       map[string]string{"role_id": "id", "name": "name", "description": "description", "permissions": "permissions"},
+			Attributes:       map[string]string{"role_id": "id", "name": "name", "description": "description", "permissions": "permissions", "permission_groups": "permission_groups"},
 			StaticAttributes: cloudflareStaticAttributes(),
 		},
 		{
@@ -130,7 +130,7 @@ func cloudflareFamilies() []jsonapi.Family {
 			IDKeys:           []string{"id"},
 			TimestampKeys:    []string{"last_updated"},
 			ListKeys:         cloudflareResultListKeys(),
-			Attributes:       map[string]string{"ruleset_id": "id", "account_id": "account_id", "name": "name", "kind": "kind", "phase": "phase", "version": "version", "last_updated": "last_updated"},
+			Attributes:       map[string]string{"ruleset_id": "id", "account_id": "account_id", "name": "name", "kind": "kind", "phase": "phase", "version": "version", "last_updated": "last_updated", "rules": "rules"},
 			StaticAttributes: cloudflareStaticAttributes(),
 		},
 		{
@@ -141,7 +141,7 @@ func cloudflareFamilies() []jsonapi.Family {
 			IDKeys:           []string{"id"},
 			TimestampKeys:    []string{"last_updated"},
 			ListKeys:         cloudflareResultListKeys(),
-			Attributes:       map[string]string{"ruleset_id": "id", "zone_id": "zone_id", "name": "name", "kind": "kind", "phase": "phase", "version": "version", "last_updated": "last_updated"},
+			Attributes:       map[string]string{"ruleset_id": "id", "zone_id": "zone_id", "name": "name", "kind": "kind", "phase": "phase", "version": "version", "last_updated": "last_updated", "rules": "rules"},
 			StaticAttributes: cloudflareStaticAttributes(),
 		},
 		{
@@ -152,7 +152,7 @@ func cloudflareFamilies() []jsonapi.Family {
 			IDKeys:           []string{"id"},
 			TimestampKeys:    []string{"created_at", "updated_at"},
 			ListKeys:         cloudflareResultListKeys(),
-			Attributes:       map[string]string{"application_id": "id", "account_id": "account_id", "name": "name", "domain": "domain", "type": "type", "aud": "aud", "session_duration": "session_duration"},
+			Attributes:       map[string]string{"application_id": "id", "account_id": "account_id", "name": "name", "domain": "domain", "type": "type", "aud": "aud", "session_duration": "session_duration", "policies": "policies", "allowed_idps": "allowed_idps", "auto_redirect_to_identity": "auto_redirect_to_identity"},
 			StaticAttributes: cloudflareStaticAttributes(),
 		},
 		{
@@ -163,7 +163,7 @@ func cloudflareFamilies() []jsonapi.Family {
 			IDKeys:           []string{"id"},
 			TimestampKeys:    []string{"created_at", "updated_at"},
 			ListKeys:         cloudflareResultListKeys(),
-			Attributes:       map[string]string{"group_id": "id", "account_id": "account_id", "name": "name"},
+			Attributes:       map[string]string{"group_id": "id", "account_id": "account_id", "name": "name", "include": "include", "exclude": "exclude", "require": "require"},
 			StaticAttributes: cloudflareStaticAttributes(),
 		},
 		{
@@ -174,7 +174,7 @@ func cloudflareFamilies() []jsonapi.Family {
 			IDKeys:           []string{"id"},
 			TimestampKeys:    []string{"created_at", "updated_at"},
 			ListKeys:         cloudflareResultListKeys(),
-			Attributes:       map[string]string{"rule_id": "id", "account_id": "account_id", "name": "name", "action": "action", "traffic": "traffic", "enabled": "enabled", "precedence": "precedence"},
+			Attributes:       map[string]string{"rule_id": "id", "account_id": "account_id", "name": "name", "action": "action", "traffic": "traffic", "enabled": "enabled", "precedence": "precedence", "filters": "filters", "rule_settings": "rule_settings"},
 			StaticAttributes: cloudflareStaticAttributes(),
 		},
 		{
@@ -185,7 +185,7 @@ func cloudflareFamilies() []jsonapi.Family {
 			IDKeys:           []string{"id"},
 			TimestampKeys:    []string{"created_on", "modified_on"},
 			ListKeys:         cloudflareResultListKeys(),
-			Attributes:       map[string]string{"script_id": "id", "account_id": "account_id", "created_on": "created_on", "modified_on": "modified_on", "compatibility_date": "compatibility_date", "tags": "tags"},
+			Attributes:       map[string]string{"script_id": "id", "account_id": "account_id", "created_on": "created_on", "modified_on": "modified_on", "compatibility_date": "compatibility_date", "tags": "tags", "bindings": "bindings", "placement": "placement"},
 			StaticAttributes: cloudflareStaticAttributes(),
 		},
 		{

--- a/sources/cloudflare/source.go
+++ b/sources/cloudflare/source.go
@@ -83,6 +83,7 @@ func cloudflareFamilies() []jsonapi.Family {
 		{
 			Name:             "role",
 			Path:             "/accounts/{account_id}/roles",
+			DetailPath:       "/accounts/{account_id}/roles/{id}",
 			PathParams:       []string{"account_id"},
 			URNKind:          "cloudflare_role",
 			IDKeys:           []string{"id"},

--- a/sources/cloudflare/source_test.go
+++ b/sources/cloudflare/source_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -67,5 +68,104 @@ func TestReadMemberUsesAccountPathParamAndResultList(t *testing.T) {
 	}
 	if got := event.Attributes["email"]; got != "alice@example.com" {
 		t.Fatalf("email = %q, want alice@example.com", got)
+	}
+}
+
+func TestReadCloudflareCoverageAttributes(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		family   string
+		path     string
+		config   map[string]string
+		payload  map[string]any
+		attr     string
+		contains string
+	}{
+		{
+			name:    "role permission groups",
+			family:  "role",
+			path:    "/accounts/account-1/roles",
+			config:  map[string]string{"account_id": "account-1"},
+			payload: map[string]any{"id": "role-1", "name": "Security Reviewer", "permission_groups": []map[string]any{{"id": "pg-logs", "name": "Logs Read"}}, "permissions": []map[string]any{{"id": "analytics:read"}}},
+			attr:    "permission_groups", contains: "Logs Read",
+		},
+		{
+			name:    "account ruleset rules",
+			family:  "account_ruleset",
+			path:    "/accounts/account-1/rulesets",
+			config:  map[string]string{"account_id": "account-1"},
+			payload: map[string]any{"id": "ruleset-1", "name": "Account WAF", "rules": []map[string]any{{"id": "rule-1", "version": "3", "action": "block"}}},
+			attr:    "rules", contains: `"version":"3"`,
+		},
+		{
+			name:    "zone ruleset rules",
+			family:  "zone_ruleset",
+			path:    "/zones/zone-1/rulesets",
+			config:  map[string]string{"zone_id": "zone-1"},
+			payload: map[string]any{"id": "ruleset-2", "name": "Zone WAF", "rules": []map[string]any{{"id": "rule-2", "version": "7", "action": "challenge"}}},
+			attr:    "rules", contains: `"version":"7"`,
+		},
+		{
+			name:    "access application policies",
+			family:  "access_application",
+			path:    "/accounts/account-1/access/apps",
+			config:  map[string]string{"account_id": "account-1"},
+			payload: map[string]any{"id": "app-1", "name": "Admin", "policies": []map[string]any{{"id": "policy-1", "decision": "allow"}}, "allowed_idps": []string{"okta"}, "auto_redirect_to_identity": true},
+			attr:    "policies", contains: "policy-1",
+		},
+		{
+			name:    "access group rules",
+			family:  "access_group",
+			path:    "/accounts/account-1/access/groups",
+			config:  map[string]string{"account_id": "account-1"},
+			payload: map[string]any{"id": "group-1", "name": "Employees", "include": []map[string]any{{"email_domain": map[string]any{"domain": "writer.com"}}}, "require": []map[string]any{{"group": map[string]any{"id": "okta-group-1"}}}},
+			attr:    "include", contains: "writer.com",
+		},
+		{
+			name:    "gateway rule settings",
+			family:  "gateway_rule",
+			path:    "/accounts/account-1/gateway/rules",
+			config:  map[string]string{"account_id": "account-1"},
+			payload: map[string]any{"id": "gateway-rule-1", "name": "Block Malware", "filters": []string{"dns"}, "rule_settings": map[string]any{"block_page_enabled": true}},
+			attr:    "rule_settings", contains: "block_page_enabled",
+		},
+		{
+			name:    "worker script bindings",
+			family:  "worker_script",
+			path:    "/accounts/account-1/workers/scripts",
+			config:  map[string]string{"account_id": "account-1"},
+			payload: map[string]any{"id": "worker-1", "bindings": []map[string]any{{"name": "CACHE", "type": "kv_namespace", "namespace_id": "kv-1"}}, "placement": map[string]any{"mode": "smart"}},
+			attr:    "bindings", contains: "kv_namespace",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.URL.EscapedPath(); got != tt.path {
+					t.Fatalf("request path = %q, want %s", got, tt.path)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"result": []map[string]any{tt.payload}})
+			}))
+			defer server.Close()
+
+			source, err := New()
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			source.inner.AllowLoopbackBaseURL = true
+			config := map[string]string{"base_url": server.URL, "family": tt.family, "tenant_id": "writer", "token": "token-1"}
+			for key, value := range tt.config {
+				config[key] = value
+			}
+			pull, err := source.Read(context.Background(), sourcecdk.NewConfig(config), nil)
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+			}
+			if got := pull.Events[0].Attributes[tt.attr]; !strings.Contains(got, tt.contains) {
+				t.Fatalf("%s = %q, want to contain %q", tt.attr, got, tt.contains)
+			}
+		})
 	}
 }

--- a/sources/cloudflare/source_test.go
+++ b/sources/cloudflare/source_test.go
@@ -87,9 +87,15 @@ func TestReadCloudflareCoverageAttributes(t *testing.T) {
 			name:    "role permission groups",
 			family:  "role",
 			path:    "/accounts/account-1/roles",
+			detail:  "/accounts/account-1/roles/role-1",
 			config:  map[string]string{"account_id": "account-1"},
-			payload: map[string]any{"id": "role-1", "name": "Security Reviewer", "permission_groups": []map[string]any{{"id": "pg-logs", "name": "Logs Read"}}, "permissions": []map[string]any{{"id": "analytics:read"}}},
-			attr:    "permission_groups", contains: "Logs Read",
+			payload: map[string]any{"id": "role-1", "name": "Security Reviewer", "permissions": []map[string]any{{"id": "analytics:read"}}},
+			enriched: map[string]any{
+				"id":                "role-1",
+				"name":              "Security Reviewer",
+				"permission_groups": []map[string]any{{"id": "pg-logs", "name": "Logs Read"}},
+			},
+			attr: "permission_groups", contains: "Logs Read",
 		},
 		{
 			name:    "account ruleset rules",
@@ -185,5 +191,55 @@ func TestReadCloudflareCoverageAttributes(t *testing.T) {
 				t.Fatalf("%s = %q, want to contain %q", tt.attr, got, tt.contains)
 			}
 		})
+	}
+}
+
+func TestReadRulesetDetailFailureKeepsListRecords(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch got := r.URL.EscapedPath(); got {
+		case "/accounts/account-1/rulesets":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"result": []map[string]any{
+					{"id": "ruleset-1", "name": "Stale WAF"},
+					{"id": "ruleset-2", "name": "Live WAF"},
+				},
+				"result_info": map[string]any{"page": 1, "total_pages": 2},
+			})
+		case "/accounts/account-1/rulesets/ruleset-1":
+			http.Error(w, "temporary detail error", http.StatusBadGateway)
+		case "/accounts/account-1/rulesets/ruleset-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{"id": "ruleset-2", "name": "Live WAF", "rules": []map[string]any{{"id": "rule-2", "action": "block"}}}})
+		default:
+			t.Fatalf("unexpected request path %q", got)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"account_id": "account-1",
+		"base_url":   server.URL,
+		"family":     "account_ruleset",
+		"tenant_id":  "writer",
+		"token":      "token-1",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(Events) = %d, want 2", len(pull.Events))
+	}
+	if pull.NextCursor.GetOpaque() != "2" {
+		t.Fatalf("NextCursor = %q, want 2", pull.NextCursor.GetOpaque())
+	}
+	if got := pull.Events[0].Attributes["name"]; got != "Stale WAF" {
+		t.Fatalf("first ruleset name = %q, want Stale WAF", got)
+	}
+	if got := pull.Events[1].Attributes["rules"]; !strings.Contains(got, "rule-2") {
+		t.Fatalf("second ruleset rules = %q, want rule-2", got)
 	}
 }

--- a/sources/cloudflare/source_test.go
+++ b/sources/cloudflare/source_test.go
@@ -76,8 +76,10 @@ func TestReadCloudflareCoverageAttributes(t *testing.T) {
 		name     string
 		family   string
 		path     string
+		detail   string
 		config   map[string]string
 		payload  map[string]any
+		enriched map[string]any
 		attr     string
 		contains string
 	}{
@@ -93,17 +95,29 @@ func TestReadCloudflareCoverageAttributes(t *testing.T) {
 			name:    "account ruleset rules",
 			family:  "account_ruleset",
 			path:    "/accounts/account-1/rulesets",
+			detail:  "/accounts/account-1/rulesets/ruleset-1",
 			config:  map[string]string{"account_id": "account-1"},
-			payload: map[string]any{"id": "ruleset-1", "name": "Account WAF", "rules": []map[string]any{{"id": "rule-1", "version": "3", "action": "block"}}},
-			attr:    "rules", contains: `"version":"3"`,
+			payload: map[string]any{"id": "ruleset-1", "name": "Account WAF"},
+			enriched: map[string]any{
+				"id":    "ruleset-1",
+				"name":  "Account WAF",
+				"rules": []map[string]any{{"id": "rule-1", "version": "3", "action": "block"}},
+			},
+			attr: "rules", contains: `"version":"3"`,
 		},
 		{
 			name:    "zone ruleset rules",
 			family:  "zone_ruleset",
 			path:    "/zones/zone-1/rulesets",
+			detail:  "/zones/zone-1/rulesets/ruleset-2",
 			config:  map[string]string{"zone_id": "zone-1"},
-			payload: map[string]any{"id": "ruleset-2", "name": "Zone WAF", "rules": []map[string]any{{"id": "rule-2", "version": "7", "action": "challenge"}}},
-			attr:    "rules", contains: `"version":"7"`,
+			payload: map[string]any{"id": "ruleset-2", "name": "Zone WAF"},
+			enriched: map[string]any{
+				"id":    "ruleset-2",
+				"name":  "Zone WAF",
+				"rules": []map[string]any{{"id": "rule-2", "version": "7", "action": "challenge"}},
+			},
+			attr: "rules", contains: `"version":"7"`,
 		},
 		{
 			name:    "access application policies",
@@ -140,10 +154,14 @@ func TestReadCloudflareCoverageAttributes(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if got := r.URL.EscapedPath(); got != tt.path {
+				switch got := r.URL.EscapedPath(); got {
+				case tt.path:
+					_ = json.NewEncoder(w).Encode(map[string]any{"result": []map[string]any{tt.payload}})
+				case tt.detail:
+					_ = json.NewEncoder(w).Encode(map[string]any{"result": tt.enriched})
+				default:
 					t.Fatalf("request path = %q, want %s", got, tt.path)
 				}
-				_ = json.NewEncoder(w).Encode(map[string]any{"result": []map[string]any{tt.payload}})
 			}))
 			defer server.Close()
 

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -33,6 +33,7 @@ const (
 type Family struct {
 	Name             string
 	Path             string
+	DetailPath       string
 	PathParams       []string
 	CursorParam      string
 	URNKind          string
@@ -274,7 +275,40 @@ func (s *Source) list(ctx context.Context, family Family, settings settings, cur
 			records = append(records, record)
 		}
 	}
+	if strings.TrimSpace(family.DetailPath) != "" {
+		var err error
+		records, err = s.enrichRecords(ctx, family, settings, records)
+		if err != nil {
+			return nil, "", err
+		}
+	}
 	return records, next, nil
+}
+
+func (s *Source) enrichRecords(ctx context.Context, family Family, settings settings, records []record) ([]record, error) {
+	enriched := make([]record, 0, len(records))
+	for _, original := range records {
+		path, err := resolveRecordPath(s.options.SourceID, family.DetailPath, settings.pathParams, original.Values)
+		if err != nil {
+			return nil, fmt.Errorf("%s %s detail path: %w", s.options.SourceID, settings.family, err)
+		}
+		detailSettings := settings
+		detailSettings.path = path
+		var body json.RawMessage
+		if err := s.getJSON(ctx, detailSettings, url.Values{}, &body); err != nil {
+			return nil, err
+		}
+		raw, err := detailRecordRaw(body)
+		if err != nil {
+			return nil, fmt.Errorf("%s %s detail: %w", s.options.SourceID, settings.family, err)
+		}
+		next, err := mergedRecord(family, original, raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s %s detail: %w", s.options.SourceID, settings.family, err)
+		}
+		enriched = append(enriched, next)
+	}
+	return enriched, nil
 }
 
 func pageSizeParams(family Family) []string {
@@ -545,6 +579,45 @@ func recordFromRaw(family Family, raw json.RawMessage) (record, error) {
 	return record{Raw: cloneRaw(raw), Values: values, ID: id, Identity: recordIdentity(id, values)}, nil
 }
 
+func detailRecordRaw(raw json.RawMessage) (json.RawMessage, error) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil, err
+	}
+	for _, key := range []string{"result", "data", "item", "record"} {
+		value := object[key]
+		if len(value) == 0 {
+			continue
+		}
+		var nested map[string]any
+		if err := json.Unmarshal(value, &nested); err == nil {
+			return cloneRaw(value), nil
+		}
+	}
+	if _, ok := object["id"]; ok {
+		return cloneRaw(raw), nil
+	}
+	return nil, fmt.Errorf("response did not contain a detail record")
+}
+
+func mergedRecord(family Family, original record, raw json.RawMessage) (record, error) {
+	detailValues := map[string]any{}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&detailValues); err != nil {
+		return record{}, fmt.Errorf("decode detail record: %w", err)
+	}
+	merged := cloneValues(original.Values)
+	for key, value := range detailValues {
+		merged[key] = value
+	}
+	mergedRaw, err := json.Marshal(merged)
+	if err != nil {
+		return record{}, fmt.Errorf("marshal merged detail record: %w", err)
+	}
+	return recordFromRaw(family, mergedRaw)
+}
+
 func urnsFor(settings settings, family Family, records []record) ([]sourcecdk.URN, error) {
 	kind := firstNonEmpty(family.URNKind, family.Name)
 	urns := make([]sourcecdk.URN, 0, len(records))
@@ -734,6 +807,30 @@ func resolvePathParams(sourceID string, path string, cfg sourcecdk.Config, param
 	return resolved, values, nil
 }
 
+func resolveRecordPath(sourceID string, path string, pathParams map[string]string, values map[string]any) (string, error) {
+	resolved := strings.TrimSpace(path)
+	for {
+		start := strings.Index(resolved, "{")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(resolved[start:], "}")
+		if end < 0 {
+			return "", fmt.Errorf("%s path contains unresolved path parameter in %q", sourceID, resolved)
+		}
+		param := strings.TrimSpace(resolved[start+1 : start+end])
+		if param == "" {
+			return "", fmt.Errorf("%s path contains empty path parameter in %q", sourceID, resolved)
+		}
+		value := firstNonEmpty(pathParams[param], firstValueString(values, param))
+		if value == "" {
+			return "", &pathParamError{sourceID: sourceID, param: param}
+		}
+		resolved = resolved[:start] + url.PathEscape(value) + resolved[start+end+1:]
+	}
+	return sourcehttp.NormalizeRequestPath(sourceID, resolved)
+}
+
 func configValue(cfg sourcecdk.Config, key string) string {
 	value, ok := cfg.Lookup(key)
 	if !ok {
@@ -775,6 +872,14 @@ func attributePaths(path string) []string {
 		}
 	}
 	return paths
+}
+
+func cloneValues(values map[string]any) map[string]any {
+	cloned := make(map[string]any, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func dedupeRecords(records []record) []record {

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -290,21 +290,28 @@ func (s *Source) enrichRecords(ctx context.Context, family Family, settings sett
 	for _, original := range records {
 		path, err := resolveRecordPath(s.options.SourceID, family.DetailPath, settings.pathParams, original.Values)
 		if err != nil {
-			return nil, fmt.Errorf("%s %s detail path: %w", s.options.SourceID, settings.family, err)
+			enriched = append(enriched, original)
+			continue
 		}
 		detailSettings := settings
 		detailSettings.path = path
 		var body json.RawMessage
 		if err := s.getJSON(ctx, detailSettings, url.Values{}, &body); err != nil {
-			return nil, err
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			enriched = append(enriched, original)
+			continue
 		}
 		raw, err := detailRecordRaw(body)
 		if err != nil {
-			return nil, fmt.Errorf("%s %s detail: %w", s.options.SourceID, settings.family, err)
+			enriched = append(enriched, original)
+			continue
 		}
 		next, err := mergedRecord(family, original, raw)
 		if err != nil {
-			return nil, fmt.Errorf("%s %s detail: %w", s.options.SourceID, settings.family, err)
+			enriched = append(enriched, original)
+			continue
 		}
 		enriched = append(enriched, next)
 	}


### PR DESCRIPTION
## Summary
- expose Cloudflare ruleset rule JSON, role permission groups, Access app policies, Access group rules, Gateway filters/settings, and Worker bindings/placement from existing JSON API responses
- promote Cloudflare account/zone rulesets and account roles to supported coverage while keeping zone-scoped Access, inherited Gateway behavior, and Worker content/secrets as explicit remaining gaps
- add focused Cloudflare source tests for the newly emitted coverage attributes

## Tests
- go test ./sources/cloudflare ./tools/catalogcheck ./tools/archtests
- go run ./tools/catalogcheck
- PATH=/usr/bin:/bin:/usr/sbin:/sbin:$PATH make check-structural
- git diff --check