### PR TITLE
Add tenant-scoped connector credential broker

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -191,6 +191,135 @@ paths:
           description: Safe sync and graph activity derived from connector runtime health.
         '404':
           description: Connector source was not found.
+  /connectors/{sourceID}/credentials:
+    post:
+      summary: Broker connector credentials
+      tags:
+        - Connectors
+      parameters:
+        - $ref: '#/components/parameters/sourceID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - runtime_id
+                - encrypted_credentials
+              properties:
+                runtime_id:
+                  type: string
+                  description: Runtime namespace the credential references will be bound to.
+                tenant_id:
+                  type: string
+                  description: Tenant namespace for the credential. May be omitted when the caller is already tenant-scoped by auth context.
+                credential_store_id:
+                  type: string
+                  description: Credential store selected for encrypted browser submission.
+                  default: cerebro_vault
+                  enum:
+                    - cerebro_vault
+                encrypted_credentials:
+                  type: object
+                  description: Browser-encrypted credential fields. The backend unwraps this payload, seals it in the connector vault, and returns only credential references.
+                  required:
+                    - key_id
+                    - algorithm
+                    - wrapped_key
+                    - nonce
+                    - ciphertext
+                  properties:
+                    key_id:
+                      type: string
+                    algorithm:
+                      type: string
+                      enum:
+                        - RSA-OAEP-256+A256GCM
+                    wrapped_key:
+                      type: string
+                    nonce:
+                      type: string
+                    ciphertext:
+                      type: string
+      responses:
+        '201':
+          description: Credential sealed in the connector vault with metadata and non-secret field references. The response never includes plaintext credential values or sealed secret blobs.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - source_id
+                  - tenant_id
+                  - runtime_id
+                  - status
+                  - credential
+                  - credential_references
+                properties:
+                  source_id:
+                    type: string
+                  tenant_id:
+                    type: string
+                  runtime_id:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - stored
+                  credential:
+                    type: object
+                    required:
+                      - id
+                      - tenant_id
+                      - source_id
+                      - runtime_id
+                      - credential_store_id
+                      - auth_method
+                      - key_id
+                      - fields
+                    properties:
+                      id:
+                        type: string
+                      tenant_id:
+                        type: string
+                      source_id:
+                        type: string
+                      runtime_id:
+                        type: string
+                      credential_store_id:
+                        type: string
+                        enum:
+                          - cerebro_vault
+                      auth_method:
+                        type: string
+                        enum:
+                          - encrypted_submission
+                      key_id:
+                        type: string
+                      fields:
+                        type: array
+                        items:
+                          type: string
+                      created_at:
+                        type: string
+                        format: date-time
+                      updated_at:
+                        type: string
+                        format: date-time
+                  credential_references:
+                    type: object
+                    description: Field-to-reference map that can be passed as connector credential_references without exposing the underlying secret.
+                    additionalProperties:
+                      type: string
+        '400':
+          description: Request shape, credential payload context, or credential fields were invalid.
+        '403':
+          description: Caller is not allowed to write credentials for the requested tenant or runtime.
+        '404':
+          description: Connector source was not found.
+        '503':
+          description: Connector credential transport or vault is unavailable.
   /connectors/credential-key:
     get:
       summary: Get connector credential transit key

--- a/internal/bootstrap/auth_connect_policy.go
+++ b/internal/bootstrap/auth_connect_policy.go
@@ -3,11 +3,12 @@ package bootstrap
 import "github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 
 const (
-	scopeCosmoSecurityRead       = "cerebro.cosmo.security.read"
-	scopeFindingCandidatePromote = "cerebro.finding_candidates.promote"
-	scopeFindingLifecycleWrite   = "cerebro.findings.write"
-	scopeGRCInventoryWrite       = "cerebro.grc.inventory.write"
-	scopeRuntimeResponseWrite    = "cerebro.runtime_response.write"
+	scopeCosmoSecurityRead         = "cerebro.cosmo.security.read"
+	scopeFindingCandidatePromote   = "cerebro.finding_candidates.promote"
+	scopeFindingLifecycleWrite     = "cerebro.findings.write"
+	scopeGRCInventoryWrite         = "cerebro.grc.inventory.write"
+	scopeConnectorCredentialsWrite = "cerebro.connector_credentials.write"
+	scopeRuntimeResponseWrite      = "cerebro.runtime_response.write"
 )
 
 type connectProcedureAuthPolicy struct {

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -44,6 +44,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Prefix: "/connector-definitions/", Suffix: "/promote", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Prefix: "/connectors/", Suffix: "/activity", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Prefix: "/connectors/", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Prefix: "/connectors/", Suffix: "/credentials", Scope: scopeConnectorCredentialsWrite, Static: true},
 	{Method: http.MethodPost, Prefix: "/connectors/", Suffix: "/preflight", Static: true, AdminOnly: true},
 	{Method: http.MethodPost, Prefix: "/connectors/", Suffix: "/connections", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Exact: "/reports", Scope: scopeCosmoSecurityRead},

--- a/internal/bootstrap/auth_route_policy_test.go
+++ b/internal/bootstrap/auth_route_policy_test.go
@@ -73,6 +73,21 @@ func TestFindingLifecycleHTTPRoutesRequireWriteScope(t *testing.T) {
 	}
 }
 
+func TestConnectorCredentialBrokerHTTPRouteRequiresWriteScope(t *testing.T) {
+	policy := httpRoutePolicyFor(http.MethodPost, "/connectors/aws/credentials")
+	if policy.Scope != scopeConnectorCredentialsWrite || policy.AdminOnly {
+		t.Fatalf("POST /connectors/{sourceID}/credentials policy = %#v, want connector credential write scope", policy)
+	}
+	readOnly := authPrincipal{Scopes: []string{scopeCosmoSecurityRead}}
+	if err := authorizePrincipalScope(readOnly, scopeConnectorCredentialsWrite); err == nil {
+		t.Fatal("read-only scoped principal authorized for connector credential write scope")
+	}
+	writer := authPrincipal{Scopes: []string{scopeConnectorCredentialsWrite}}
+	if err := authorizePrincipalScope(writer, scopeConnectorCredentialsWrite); err != nil {
+		t.Fatalf("connector credential writer rejected: %v", err)
+	}
+}
+
 func TestFindingLifecycleConnectProceduresRequireWriteScope(t *testing.T) {
 	for _, procedure := range []string{
 		cerebrov1connect.BootstrapServiceResolveFindingProcedure,

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -279,6 +279,13 @@ type connectorConnectionRequest struct {
 	EncryptedCredentials connectorcredentials.EncryptedPayload `json:"encrypted_credentials"`
 }
 
+type connectorCredentialBrokerRequest struct {
+	RuntimeID            string                                `json:"runtime_id"`
+	TenantID             string                                `json:"tenant_id,omitempty"`
+	CredentialStoreID    string                                `json:"credential_store_id,omitempty"`
+	EncryptedCredentials connectorcredentials.EncryptedPayload `json:"encrypted_credentials"`
+}
+
 type connectorPreflightResponse struct {
 	GeneratedAt        string                          `json:"generated_at"`
 	SourceID           string                          `json:"source_id"`
@@ -341,6 +348,15 @@ type connectorConnectionResponse struct {
 	Credential  connectorCredentialView `json:"credential"`
 	ScopePolicy *resourcescope.Policy   `json:"scope_policy,omitempty"`
 	Status      string                  `json:"status,omitempty"`
+}
+
+type connectorCredentialBrokerResponse struct {
+	SourceID             string                  `json:"source_id"`
+	TenantID             string                  `json:"tenant_id"`
+	RuntimeID            string                  `json:"runtime_id"`
+	Status               string                  `json:"status"`
+	Credential           connectorCredentialView `json:"credential"`
+	CredentialReferences map[string]string       `json:"credential_references"`
 }
 
 type connectorCredentialView struct {
@@ -495,6 +511,110 @@ func (a *App) handleConnectorCredentialKey(w http.ResponseWriter, _ *http.Reques
 		return
 	}
 	writeJSON(w, http.StatusOK, a.connectorTransitKey.PublicKey())
+}
+
+func (a *App) handleCreateConnectorCredential(w http.ResponseWriter, r *http.Request) {
+	request := connectorCredentialBrokerRequest{}
+	if err := readConnectorJSON(r, &request); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	sourceID := strings.TrimSpace(r.PathValue("sourceID"))
+	if sourceID == "" {
+		writeConnectorError(w, fmt.Errorf("%w: source_id is required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	if _, err := a.connectorSource(sourceID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		writeConnectorError(w, fmt.Errorf("%w: runtime_id is required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	tenantID, err := effectiveTenantFilter(r.Context(), request.TenantID)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if tenantID == "" {
+		writeConnectorError(w, fmt.Errorf("%w: tenant_id is required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	if err := a.authorizeConnectorCredentialRuntime(r.Context(), sourceID, tenantID, runtimeID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	credentialStoreID, err := normalizeConnectorCredentialStoreID(request.CredentialStoreID, connectorAuthMethodEncryptedSubmission)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if err := a.validateConnectorCredentialStoreAvailable(credentialStoreID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if !connectorEncryptedPayloadPresent(request.EncryptedCredentials) {
+		writeConnectorError(w, fmt.Errorf("%w: encrypted_credentials is required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	if a == nil || a.connectorTransitKey == nil {
+		writeConnectorError(w, connectorcredentials.ErrUnavailable)
+		return
+	}
+	decrypted, err := a.connectorTransitKey.DecryptWithExactAdditionalData(
+		request.EncryptedCredentials,
+		connectorCredentialAdditionalData(request.EncryptedCredentials.KeyID, sourceID, tenantID, runtimeID, credentialStoreID),
+	)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	fields, err := connectorcredentials.ParseCredentialFields(decrypted)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if err := validateConnectorCredentialFields(sourceID, connectorAuthMethodEncryptedSubmission, fields); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	vault, err := connectorCredentialVault(a.cfg.ConnectorCredentials, a.deps.StateStore)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	record, err := vault.Put(r.Context(), connectorcredentials.PlainCredential{
+		TenantID:  tenantID,
+		SourceID:  sourceID,
+		RuntimeID: runtimeID,
+		Fields:    fields,
+	})
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	references := connectorCredentialReferences(record.ID, fields)
+	writeJSON(w, http.StatusCreated, connectorCredentialBrokerResponse{
+		SourceID:  sourceID,
+		TenantID:  tenantID,
+		RuntimeID: runtimeID,
+		Status:    "stored",
+		Credential: connectorCredentialView{
+			ID:         record.ID,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			RuntimeID:  runtimeID,
+			StoreID:    credentialStoreID,
+			AuthMethod: connectorAuthMethodEncryptedSubmission,
+			KeyID:      record.KeyID,
+			Fields:     connectorcredentials.SortedFieldNames(fields),
+			CreatedAt:  connectorcredentials.TimestampOrZero(record.CreatedAt),
+			UpdatedAt:  connectorcredentials.TimestampOrZero(record.UpdatedAt),
+		},
+		CredentialReferences: references,
+	})
 }
 
 func (a *App) handlePreflightConnectorConnection(w http.ResponseWriter, r *http.Request) {
@@ -2845,6 +2965,42 @@ func connectorCredentialAdditionalData(keyID string, sourceID string, tenantID s
 		strings.TrimSpace(credentialStoreID),
 	}
 	return []byte(strings.Join(parts, "\x00"))
+}
+
+func (a *App) authorizeConnectorCredentialRuntime(ctx context.Context, sourceID string, tenantID string, runtimeID string) error {
+	if err := authorizeTenantScopeRequired(ctx, tenantID); err != nil {
+		return err
+	}
+	store := sourceRuntimeStore(a.deps.StateStore)
+	if store == nil {
+		return nil
+	}
+	existing, err := store.GetSourceRuntime(ctx, runtimeID)
+	switch {
+	case err == nil:
+	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
+		return nil
+	default:
+		return err
+	}
+	if strings.TrimSpace(existing.GetTenantId()) != strings.TrimSpace(tenantID) {
+		return errTenantForbidden
+	}
+	if err := authorizeTenantScopeRequired(ctx, existing.GetTenantId()); err != nil {
+		return err
+	}
+	if strings.TrimSpace(existing.GetSourceId()) != strings.TrimSpace(sourceID) {
+		return fmt.Errorf("%w: runtime belongs to a different connector source", connectorcredentials.ErrInvalidRequest)
+	}
+	return nil
+}
+
+func connectorCredentialReferences(credentialID string, fields map[string]string) map[string]string {
+	references := make(map[string]string, len(fields))
+	for _, field := range connectorcredentials.SortedFieldNames(fields) {
+		references[field] = connectorcredentials.Reference(credentialID, field)
+	}
+	return references
 }
 
 func connectorRuntimeConfig(input map[string]string) (map[string]string, error) {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -143,6 +143,237 @@ func TestConnectorConnectionStoresCredentialReference(t *testing.T) {
 	}
 }
 
+func TestConnectorCredentialBrokerStoresReferencesWithoutLeakingSecret(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+
+	key := app.connectorTransitKey.PublicKey()
+	encrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "secret-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-a", "runtime-a", defaultConnectorCredentialStoreID),
+	)
+	if err != nil {
+		t.Fatalf("encrypt credentials: %v", err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":            "runtime-a",
+		"tenant_id":             "tenant-a",
+		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"encrypted_credentials": encrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/connectors/bootstrap_token/credentials", bytes.NewReader(body))
+	req.SetPathValue("sourceID", "bootstrap_token")
+	recorder := httptest.NewRecorder()
+	app.handleCreateConnectorCredential(recorder, req)
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("POST /connectors/{sourceID}/credentials status = %d, want 201: %s", recorder.Code, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), "secret-token") {
+		t.Fatalf("credential broker response leaked secret: %s", recorder.Body.String())
+	}
+	var payload connectorCredentialBrokerResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Status != "stored" {
+		t.Fatalf("status = %q, want stored", payload.Status)
+	}
+	if payload.TenantID != "tenant-a" || payload.SourceID != "bootstrap_token" || payload.RuntimeID != "runtime-a" {
+		t.Fatalf("response identity = tenant %q source %q runtime %q", payload.TenantID, payload.SourceID, payload.RuntimeID)
+	}
+	reference := payload.CredentialReferences["token"]
+	if want := connectorcredentials.Reference(payload.Credential.ID, "token"); reference != want {
+		t.Fatalf("token reference = %q, want %q", reference, want)
+	}
+	record := store.credentials[payload.Credential.ID]
+	if record == nil {
+		t.Fatalf("stored credential %q missing", payload.Credential.ID)
+	}
+	if record.TenantID != "tenant-a" || record.SourceID != "bootstrap_token" || record.RuntimeID != "runtime-a" {
+		t.Fatalf("stored credential identity = tenant %q source %q runtime %q", record.TenantID, record.SourceID, record.RuntimeID)
+	}
+	if strings.Contains(string(record.Sealed), "secret-token") {
+		t.Fatalf("sealed credential leaked secret: %s", string(record.Sealed))
+	}
+	vault, err := connectorCredentialVault(app.cfg.ConnectorCredentials, app.deps.StateStore)
+	if err != nil {
+		t.Fatalf("connectorCredentialVault() error = %v", err)
+	}
+	resolved, err := vault.ResolveReferences(context.Background(), "bootstrap_token", "tenant-a", "runtime-a", map[string]string{"token": reference})
+	if err != nil {
+		t.Fatalf("ResolveReferences() error = %v", err)
+	}
+	if resolved["token"] != "secret-token" {
+		t.Fatalf("resolved token = %q, want secret-token", resolved["token"])
+	}
+	if _, err := vault.ResolveReferences(context.Background(), "bootstrap_token", "tenant-b", "runtime-a", map[string]string{"token": reference}); err == nil {
+		t.Fatal("ResolveReferences() succeeded for the wrong tenant")
+	}
+}
+
+func TestConnectorCredentialBrokerRejectsCrossTenantRequest(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+
+	key := app.connectorTransitKey.PublicKey()
+	encrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "secret-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-b", "runtime-a", defaultConnectorCredentialStoreID),
+	)
+	if err != nil {
+		t.Fatalf("encrypt credentials: %v", err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":            "runtime-a",
+		"tenant_id":             "tenant-b",
+		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"encrypted_credentials": encrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/connectors/bootstrap_token/credentials", bytes.NewReader(body))
+	req.SetPathValue("sourceID", "bootstrap_token")
+	req = req.WithContext(context.WithValue(req.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{TenantID: "tenant-a"},
+	}))
+	recorder := httptest.NewRecorder()
+	app.handleCreateConnectorCredential(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("cross-tenant credential status = %d, want 403", recorder.Code)
+	}
+	if len(store.credentials) != 0 {
+		t.Fatalf("stored credentials after forbidden request = %#v, want none", store.credentials)
+	}
+}
+
+func TestConnectorCredentialBrokerRejectsExistingRuntimeTenantMismatch(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-a": {
+			Id:       "runtime-a",
+			SourceId: "bootstrap_token",
+			TenantId: "tenant-b",
+		},
+	}}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+
+	key := app.connectorTransitKey.PublicKey()
+	encrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "secret-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-a", "runtime-a", defaultConnectorCredentialStoreID),
+	)
+	if err != nil {
+		t.Fatalf("encrypt credentials: %v", err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":            "runtime-a",
+		"tenant_id":             "tenant-a",
+		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"encrypted_credentials": encrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/connectors/bootstrap_token/credentials", bytes.NewReader(body))
+	req.SetPathValue("sourceID", "bootstrap_token")
+	recorder := httptest.NewRecorder()
+	app.handleCreateConnectorCredential(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("runtime tenant mismatch status = %d, want 403", recorder.Code)
+	}
+	if len(store.credentials) != 0 {
+		t.Fatalf("stored credentials after runtime mismatch = %#v, want none", store.credentials)
+	}
+}
+
+func TestConnectorCredentialBrokerRejectsCredentialPayloadAADMismatch(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+
+	key := app.connectorTransitKey.PublicKey()
+	encrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "secret-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-b", "runtime-a", defaultConnectorCredentialStoreID),
+	)
+	if err != nil {
+		t.Fatalf("encrypt credentials: %v", err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":            "runtime-a",
+		"tenant_id":             "tenant-a",
+		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"encrypted_credentials": encrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/connectors/bootstrap_token/credentials", bytes.NewReader(body))
+	req.SetPathValue("sourceID", "bootstrap_token")
+	recorder := httptest.NewRecorder()
+	app.handleCreateConnectorCredential(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("AAD mismatch status = %d, want 400", recorder.Code)
+	}
+	if len(store.credentials) != 0 {
+		t.Fatalf("stored credentials after AAD mismatch = %#v, want none", store.credentials)
+	}
+}
+
 func TestConnectorConnectionStoresValidatedScopePolicy(t *testing.T) {
 	source := &bootstrapTokenSource{id: "bootstrap_token"}
 	registry, err := sourcecdk.NewRegistry(source)

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -123,6 +123,7 @@ func (app *App) registerConnectorRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /connector-definitions/{definitionID}/promote", routeSurfacePlatformHTTP, app.handlePromoteConnectorDefinition)
 	registerHTTPRoute(mux, "GET /connectors/{sourceID}", routeSurfacePlatformHTTP, app.handleGetConnector)
 	registerHTTPRoute(mux, "GET /connectors/{sourceID}/activity", routeSurfacePlatformHTTP, app.handleListConnectorActivity)
+	registerHTTPRoute(mux, "POST /connectors/{sourceID}/credentials", routeSurfacePlatformHTTP, app.handleCreateConnectorCredential)
 	registerHTTPRoute(mux, "POST /connectors/{sourceID}/preflight", routeSurfacePlatformHTTP, app.handlePreflightConnectorConnection)
 	registerHTTPRoute(mux, "POST /connectors/{sourceID}/connections", routeSurfacePlatformHTTP, app.handleCreateConnectorConnection)
 }


### PR DESCRIPTION
## Summary
- add a tenant-scoped connector credential broker endpoint for encrypted browser submissions
- store brokered credentials in the existing connector vault and return only credential references plus metadata
- add a dedicated connector credential write scope while keeping connection creation admin-only
- validate tenant/source/runtime binding before decrypting or persisting credential material

## Verification
- go test ./internal/bootstrap -run 'TestConnectorCredentialBroker|TestPlatformHTTPRoutesHaveAuthPolicies|TestConnectorCredentialBrokerHTTPRouteRequiresWriteScope' -count=1 -v\n- go test ./internal/connectorcredentials ./internal/bootstrap -count=1\n- make test\n- make lint