### PR TITLE
Add integration factory definition-driven sourcegen

### DIFF
--- a/cmd/cerebro/source_runtime_sdk.go
+++ b/cmd/cerebro/source_runtime_sdk.go
@@ -1,14 +1,16 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/sourcegen"
 )
 
-const sourceRuntimeSDKNewUsage = "usage: %s source-runtime sdk new <source-id> [source_type=json_api] [auth_model=bearer_token|api_token|api_key] [asset_schemas=<schema[,schema]>] [finding_schemas=<schema[,schema]>] [freshness_expectation=<duration>] [failure_modes=<mode[,mode]>] [name=<name>] [description=<description>] [health_path=<path>] [output_dir=<dir>] [dry_run=true] [force=true]"
+const sourceRuntimeSDKNewUsage = "usage: %s source-runtime sdk [new <source-id> [source_type=json_api] [auth_model=bearer_token|api_token|api_key] [asset_schemas=<schema[,schema]>] [finding_schemas=<schema[,schema]>] [freshness_expectation=<duration>] [failure_modes=<mode[,mode]>] [name=<name>] [description=<description>] [health_path=<path>] [output_dir=<dir>] [dry_run=true] [force=true] | classify <definition.json>]"
 
 func runSourceRuntimeSDK(args []string) error {
 	if len(args) == 0 {
@@ -25,9 +27,38 @@ func runSourceRuntimeSDK(args []string) error {
 			return err
 		}
 		return printJSON(result)
+	case "classify":
+		return runSourceRuntimeSDKClassify(args[1:])
 	default:
 		return usageError(fmt.Sprintf(sourceRuntimeSDKNewUsage, os.Args[0]))
 	}
+}
+
+func runSourceRuntimeSDKClassify(args []string) error {
+	if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
+		return usageError(fmt.Sprintf(sourceRuntimeSDKNewUsage, os.Args[0]))
+	}
+	payload, err := os.ReadFile(strings.TrimSpace(args[0])) // #nosec G304 -- operator-provided CLI path.
+	if err != nil {
+		return fmt.Errorf("read connector definition: %w", err)
+	}
+	var definitions []connectordefinitions.Definition
+	if err := json.Unmarshal(payload, &definitions); err == nil {
+		summary, err := connectordefinitions.ClassifyAll(definitions, connectordefinitions.DefaultGrammar())
+		if err != nil {
+			return err
+		}
+		return printJSON(summary)
+	}
+	var definition connectordefinitions.Definition
+	if err := json.Unmarshal(payload, &definition); err != nil {
+		return fmt.Errorf("decode connector definition or definition list: %w", err)
+	}
+	report, err := connectordefinitions.Classify(definition, connectordefinitions.DefaultGrammar())
+	if err != nil {
+		return err
+	}
+	return printJSON(report)
 }
 
 func parseSourceRuntimeSDKNewArgs(args []string) (sourcegen.Request, error) {

--- a/cmd/cerebro/source_runtime_sdk.go
+++ b/cmd/cerebro/source_runtime_sdk.go
@@ -98,7 +98,7 @@ func readConnectorDefinition(path string) (connectordefinitions.Definition, erro
 }
 
 func readConnectorDefinitionPayload(path string) ([]byte, error) {
-	payload, err := os.ReadFile(strings.TrimSpace(path)) // #nosec G304 -- operator-provided CLI path.
+	payload, err := os.ReadFile(strings.TrimSpace(path)) // #nosec G304,G703 -- operator-provided CLI path.
 	if err != nil {
 		return nil, fmt.Errorf("read connector definition: %w", err)
 	}

--- a/cmd/cerebro/source_runtime_sdk.go
+++ b/cmd/cerebro/source_runtime_sdk.go
@@ -10,7 +10,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcegen"
 )
 
-const sourceRuntimeSDKNewUsage = "usage: %s source-runtime sdk [new <source-id> [source_type=json_api] [auth_model=bearer_token|api_token|api_key] [asset_schemas=<schema[,schema]>] [finding_schemas=<schema[,schema]>] [freshness_expectation=<duration>] [failure_modes=<mode[,mode]>] [name=<name>] [description=<description>] [health_path=<path>] [output_dir=<dir>] [dry_run=true] [force=true] | classify <definition.json>]"
+const sourceRuntimeSDKNewUsage = "usage: %s source-runtime sdk [new <source-id> [definition=<definition.json>] [source_type=json_api] [auth_model=bearer_token|api_token|api_key] [asset_schemas=<schema[,schema]>] [finding_schemas=<schema[,schema]>] [freshness_expectation=<duration>] [failure_modes=<mode[,mode]>] [name=<name>] [description=<description>] [health_path=<path>] [output_dir=<dir>] [dry_run=true] [force=true] | classify <definition.json>]"
 
 func runSourceRuntimeSDK(args []string) error {
 	if len(args) == 0 {
@@ -22,7 +22,7 @@ func runSourceRuntimeSDK(args []string) error {
 		if err != nil {
 			return err
 		}
-		result, err := sourcegen.Generate(request)
+		result, err := generateSourceRuntimeSDK(request)
 		if err != nil {
 			return err
 		}
@@ -34,13 +34,37 @@ func runSourceRuntimeSDK(args []string) error {
 	}
 }
 
+func generateSourceRuntimeSDK(request sourcegen.Request) (*sourcegen.Result, error) {
+	if strings.TrimSpace(request.DefinitionPath) == "" {
+		return sourcegen.Generate(request)
+	}
+	definition, err := readConnectorDefinition(request.DefinitionPath)
+	if err != nil {
+		return nil, err
+	}
+	if request.SourceID != "" && strings.TrimSpace(definition.SourceID) != "" && strings.TrimSpace(request.SourceID) != strings.TrimSpace(definition.SourceID) {
+		return nil, fmt.Errorf("source id %q does not match definition source_id %q", request.SourceID, definition.SourceID)
+	}
+	if strings.TrimSpace(definition.SourceID) == "" {
+		definition.SourceID = strings.TrimSpace(request.SourceID)
+	}
+	return sourcegen.GenerateDefinition(sourcegen.DefinitionRequest{
+		Definition:           definition,
+		FreshnessExpectation: request.FreshnessExpectation,
+		HealthPath:           request.HealthPath,
+		OutputDir:            request.OutputDir,
+		DryRun:               request.DryRun,
+		Force:                request.Force,
+	})
+}
+
 func runSourceRuntimeSDKClassify(args []string) error {
 	if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
 		return usageError(fmt.Sprintf(sourceRuntimeSDKNewUsage, os.Args[0]))
 	}
-	payload, err := os.ReadFile(strings.TrimSpace(args[0])) // #nosec G304 -- operator-provided CLI path.
+	payload, err := readConnectorDefinitionPayload(args[0])
 	if err != nil {
-		return fmt.Errorf("read connector definition: %w", err)
+		return err
 	}
 	var definitions []connectordefinitions.Definition
 	if err := json.Unmarshal(payload, &definitions); err == nil {
@@ -61,12 +85,33 @@ func runSourceRuntimeSDKClassify(args []string) error {
 	return printJSON(report)
 }
 
+func readConnectorDefinition(path string) (connectordefinitions.Definition, error) {
+	payload, err := readConnectorDefinitionPayload(path)
+	if err != nil {
+		return connectordefinitions.Definition{}, err
+	}
+	var definition connectordefinitions.Definition
+	if err := json.Unmarshal(payload, &definition); err != nil {
+		return connectordefinitions.Definition{}, fmt.Errorf("decode connector definition: %w", err)
+	}
+	return definition, nil
+}
+
+func readConnectorDefinitionPayload(path string) ([]byte, error) {
+	payload, err := os.ReadFile(strings.TrimSpace(path)) // #nosec G304 -- operator-provided CLI path.
+	if err != nil {
+		return nil, fmt.Errorf("read connector definition: %w", err)
+	}
+	return payload, nil
+}
+
 func parseSourceRuntimeSDKNewArgs(args []string) (sourcegen.Request, error) {
 	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
 		return sourcegen.Request{}, usageError(fmt.Sprintf(sourceRuntimeSDKNewUsage, os.Args[0]))
 	}
 	allowedKeys := map[string]struct{}{
 		"source_type":           {},
+		"definition":            {},
 		"auth_model":            {},
 		"asset_schemas":         {},
 		"finding_schemas":       {},
@@ -106,6 +151,7 @@ func parseSourceRuntimeSDKNewArgs(args []string) (sourcegen.Request, error) {
 	return sourcegen.Request{
 		SourceID:             strings.TrimSpace(args[0]),
 		SourceType:           firstNonEmptyCLI(values["source_type"], sourcegen.SourceTypeJSONAPI),
+		DefinitionPath:       strings.TrimSpace(values["definition"]),
 		AuthModel:            firstNonEmptyCLI(values["auth_model"], sourcegen.AuthModelBearerToken),
 		AssetSchemas:         splitCSV(values["asset_schemas"]),
 		FindingSchemas:       splitCSV(values["finding_schemas"]),

--- a/cmd/cerebro/source_runtime_sdk_test.go
+++ b/cmd/cerebro/source_runtime_sdk_test.go
@@ -94,6 +94,56 @@ func TestRunSourceRuntimeSDKDryRunThroughSourceRuntimeCommand(t *testing.T) {
 	}
 }
 
+func TestRunSourceRuntimeSDKNewFromDefinitionDryRun(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "definition.json")
+	payload := []byte(`{
+		"schema_version": "cerebro.integration/v1",
+		"id": "tenant-a-example_idp",
+		"tenant_id": "tenant-a",
+		"source_id": "example_idp",
+		"display_name": "Example IDP",
+		"auth": {
+			"model": "bearer_token",
+			"credential_fields": [{"key": "token", "secret": true, "reference_only": true}]
+		},
+		"transport": {
+			"base_url": "https://api.example.test",
+			"verification": {"path": "/v1/me"}
+		},
+		"resource_families": [{
+			"id": "users",
+			"path": "/v1/users",
+			"record_selector": "$.data[*]",
+			"id_field": "id",
+			"event": {"kind": "example_idp.user", "schema_ref": "example_idp/user/v1"},
+			"projection": {"template": "identity_user"},
+			"coverage": [{"type": "entity_family", "support": "supported"}]
+		}]
+	}`)
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("write definition: %v", err)
+	}
+	stdout := captureCommandStdout(t, func() {
+		err := runSourceRuntime([]string{"sdk", "new", "example_idp", "definition=" + path, "dry_run=true"})
+		if err != nil {
+			t.Fatalf("runSourceRuntime sdk new definition dry-run error = %v", err)
+		}
+	})
+	var result struct {
+		SourceID  string   `json:"source_id"`
+		AuthModel string   `json:"auth_model"`
+		DryRun    bool     `json:"dry_run"`
+		Files     []string `json:"files"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal definition dry-run output: %v\n%s", err, stdout)
+	}
+	if result.SourceID != "example_idp" || result.AuthModel != "bearer_token" || !result.DryRun || len(result.Files) == 0 {
+		t.Fatalf("definition dry-run result = %#v", result)
+	}
+}
+
 func TestRunSourceRuntimeSDKClassify(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "definition.json")

--- a/cmd/cerebro/source_runtime_sdk_test.go
+++ b/cmd/cerebro/source_runtime_sdk_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -90,6 +91,55 @@ func TestRunSourceRuntimeSDKDryRunThroughSourceRuntimeCommand(t *testing.T) {
 	}
 	if payload.SourceID != "demo_source" || !payload.DryRun || len(payload.Files) == 0 {
 		t.Fatalf("dry-run payload = %#v", payload)
+	}
+}
+
+func TestRunSourceRuntimeSDKClassify(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "definition.json")
+	payload := []byte(`{
+		"schema_version": "cerebro.integration/v1",
+		"id": "example",
+		"tenant_id": "tenant-a",
+		"source_id": "example",
+		"display_name": "Example",
+		"auth": {
+			"model": "bearer_token",
+			"credential_fields": [{"key": "token", "secret": true, "reference_only": true}]
+		},
+		"transport": {
+			"base_url": "https://api.example.test",
+			"verification": {"path": "/v1/me"}
+		},
+		"resource_families": [{
+			"id": "users",
+			"path": "/v1/users",
+			"record_selector": "$.data[*]",
+			"id_field": "id",
+			"event": {"kind": "example.user", "schema_ref": "example/user/v1"},
+			"pagination": {"type": "cursor"},
+			"projection": {"template": "identity_user"},
+			"coverage": [{"type": "entity_family", "support": "supported"}]
+		}]
+	}`)
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("write definition: %v", err)
+	}
+	stdout := captureCommandStdout(t, func() {
+		err := runSourceRuntime([]string{"sdk", "classify", path})
+		if err != nil {
+			t.Fatalf("runSourceRuntime sdk classify error = %v", err)
+		}
+	})
+	var report struct {
+		Verdict  string `json:"verdict"`
+		SourceID string `json:"source_id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("unmarshal classify output: %v\n%s", err, stdout)
+	}
+	if report.SourceID != "example" || report.Verdict != "supported" {
+		t.Fatalf("classify report = %#v", report)
 	}
 }
 

--- a/internal/bootstrap/connector_definitions.go
+++ b/internal/bootstrap/connector_definitions.go
@@ -35,6 +35,7 @@ type connectorDefinitionValidationResponse struct {
 	Definition  connectordefinitions.Definition       `json:"definition"`
 	Validation  connectordefinitions.ValidationResult `json:"validation"`
 	Promotion   connectordefinitions.PromotionState   `json:"promotion"`
+	Support     connectordefinitions.SupportReport    `json:"support"`
 }
 
 type connectorDefinitionPromotionResponse struct {
@@ -109,11 +110,17 @@ func (a *App) handleValidateConnectorDefinition(w http.ResponseWriter, r *http.R
 		writeConnectorError(w, fmt.Errorf("%w: %w", connectorcredentials.ErrInvalidRequest, err))
 		return
 	}
+	support, err := connectordefinitions.Classify(normalized, connectordefinitions.DefaultGrammar())
+	if err != nil {
+		writeConnectorError(w, fmt.Errorf("%w: %w", connectorcredentials.ErrInvalidRequest, err))
+		return
+	}
 	writeJSON(w, http.StatusOK, connectorDefinitionValidationResponse{
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		Definition:  normalized,
 		Validation:  normalized.Validation,
 		Promotion:   normalized.Promotion,
+		Support:     support,
 	})
 }
 

--- a/internal/bootstrap/connector_definitions_test.go
+++ b/internal/bootstrap/connector_definitions_test.go
@@ -331,6 +331,9 @@ func TestConnectorDefinitionValidateDoesNotRequireStore(t *testing.T) {
 	if validation.Validation.Status != connectordefinitions.ValidationBlocked {
 		t.Fatalf("validation status = %q, want blocked", validation.Validation.Status)
 	}
+	if validation.Support.Verdict != connectordefinitions.SupportVerdictBespokeRequired {
+		t.Fatalf("support verdict = %q, want bespoke_required; report=%#v", validation.Support.Verdict, validation.Support)
+	}
 	if len(validation.Promotion.RequiredGates) == 0 {
 		t.Fatalf("required gates = %#v, want blocking gates", validation.Promotion.RequiredGates)
 	}

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -703,10 +703,15 @@ func (app *App) mcpValidateConnectorDefinition(r *http.Request, args map[string]
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidHTTPRequest, err)
 	}
+	support, err := connectordefinitions.Classify(normalized, connectordefinitions.DefaultGrammar())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidHTTPRequest, err)
+	}
 	return map[string]any{
 		"definition": normalized,
 		"validation": normalized.Validation,
 		"promotion":  normalized.Promotion,
+		"support":    support,
 		"metadata":   mcpResponseMetadata(0, 1, nil),
 	}, nil
 }
@@ -1659,6 +1664,7 @@ func mcpTools() []mcpTool {
 				"definition": map[string]any{"type": "object"},
 				"validation": map[string]any{"type": "object"},
 				"promotion":  map[string]any{"type": "object"},
+				"support":    map[string]any{"type": "object"},
 			}),
 			Annotations: mcpReadOnlyAnnotations("Validate Connector Definition"),
 		},

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -98,6 +98,13 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 		if tool["outputSchema"] == nil {
 			t.Fatalf("tool missing outputSchema: %#v", item)
 		}
+		if name == "cerebro.connector_definitions.validate" {
+			outputSchema := tool["outputSchema"].(map[string]any)
+			properties := outputSchema["properties"].(map[string]any)
+			if properties["support"] == nil {
+				t.Fatalf("%s outputSchema missing support report: %#v", name, outputSchema)
+			}
+		}
 		annotations := tool["annotations"].(map[string]any)
 		if annotations["readOnlyHint"] != true {
 			t.Fatalf("tool missing readOnlyHint annotation: %#v", item)
@@ -141,6 +148,54 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 		if !names[want] {
 			t.Fatalf("tools/list missing %s in %#v", want, names)
 		}
+	}
+}
+
+func TestMCPConnectorDefinitionValidateReturnsSupportReport(t *testing.T) {
+	server := newMCPTestServer(t, &stubRuntimeStore{})
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.connector_definitions.validate",
+			"arguments": map[string]any{
+				"definition": map[string]any{
+					"schema_version": "cerebro.integration/v1",
+					"id":             "writer-example_idp",
+					"tenant_id":      "writer",
+					"source_id":      "example_idp",
+					"display_name":   "Example IDP",
+					"auth": map[string]any{
+						"model":             "bearer_token",
+						"credential_fields": []any{map[string]any{"key": "token", "secret": true, "reference_only": true}},
+					},
+					"transport": map[string]any{
+						"base_url":     "https://api.example.test",
+						"verification": map[string]any{"path": "/v1/me"},
+					},
+					"resource_families": []any{map[string]any{
+						"id":              "users",
+						"path":            "/v1/users",
+						"record_selector": "$.data[*]",
+						"id_field":        "id",
+						"event":           map[string]any{"kind": "example_idp.user", "schema_ref": "example_idp/user/v1"},
+						"projection":      map[string]any{"template": "identity_user"},
+						"coverage":        []any{map[string]any{"type": "entity_family", "support": "supported"}},
+					}},
+				},
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("tools/call error = %#v", response["error"])
+	}
+	structured := response["result"].(map[string]any)["structuredContent"].(map[string]any)
+	support := structured["support"].(map[string]any)
+	if support["verdict"] != "supported" || support["source_id"] != "example_idp" {
+		t.Fatalf("support report = %#v", support)
 	}
 }
 

--- a/internal/connectordefinitions/classifier.go
+++ b/internal/connectordefinitions/classifier.go
@@ -1,0 +1,320 @@
+package connectordefinitions
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	SupportVerdictSupported         = "supported"
+	SupportVerdictExtensionRequired = "extension_required"
+	SupportVerdictBespokeRequired   = "bespoke_required"
+
+	SupportStatusReady   = "ready"
+	SupportStatusMissing = "missing"
+)
+
+// Grammar describes the bounded integration language that the generic engine
+// can prove. Add features here before claiming a broad integration wave.
+type Grammar struct {
+	Version             string
+	Runtimes            []string
+	AuthModels          []string
+	Methods             []string
+	PaginationTypes     []string
+	IncrementalStates   []string
+	ProjectionTemplates []string
+}
+
+// SupportReport is a machine-readable proof that a definition is expressible,
+// or a precise list of the generic features it still needs.
+type SupportReport struct {
+	DefinitionID      string           `json:"definition_id"`
+	SourceID          string           `json:"source_id"`
+	GrammarVersion    string           `json:"grammar_version"`
+	Verdict           string           `json:"verdict"`
+	SupportedFeatures []string         `json:"supported_features,omitempty"`
+	MissingFeatures   []string         `json:"missing_features,omitempty"`
+	Checks            []SupportCheck   `json:"checks"`
+	Validation        ValidationResult `json:"validation"`
+}
+
+// SupportSummary aggregates classifier output for an integration target set.
+type SupportSummary struct {
+	GrammarVersion    string          `json:"grammar_version"`
+	Targets           int             `json:"targets"`
+	Supported         int             `json:"supported"`
+	ExtensionRequired int             `json:"extension_required"`
+	BespokeRequired   int             `json:"bespoke_required"`
+	ByVerdict         map[string]int  `json:"by_verdict"`
+	ByAuthModel       map[string]int  `json:"by_auth_model"`
+	MissingFeatures   map[string]int  `json:"missing_features,omitempty"`
+	Reports           []SupportReport `json:"reports"`
+}
+
+// SupportCheck is one classifier proof obligation.
+type SupportCheck struct {
+	ID       string `json:"id"`
+	Category string `json:"category"`
+	Status   string `json:"status"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+// DefaultGrammar returns the first broad generic engine target. The coverage is
+// intentionally explicit: unsupported providers should fail classification with
+// actionable missing-feature identifiers.
+func DefaultGrammar() Grammar {
+	return Grammar{
+		Version: "cerebro.integration/v1",
+		Runtimes: []string{
+			RuntimeJSONAPI,
+		},
+		AuthModels: []string{
+			"none",
+			"api_key",
+			"bearer_token",
+			"basic",
+			"oauth_authorization_code",
+			"oauth_client_credentials",
+			"two_step",
+			"jwt",
+			"signature",
+			"aws_sigv4",
+		},
+		Methods: []string{
+			"GET",
+			"POST",
+		},
+		PaginationTypes: []string{
+			"none",
+			"cursor",
+			"page",
+			"offset",
+			"link",
+			"next_url",
+		},
+		IncrementalStates: []string{
+			"high_watermark",
+			"opaque_cursor",
+		},
+		ProjectionTemplates: []string{
+			"app_entitlement",
+			"asset",
+			"audit_event",
+			"cloud_resource",
+			"endpoint_device",
+			"finding",
+			"group_membership",
+			"identity_group",
+			"identity_user",
+			"repository",
+			"vulnerability",
+		},
+	}
+}
+
+// Classify evaluates whether a definition fits the provided generic engine grammar.
+func Classify(definition Definition, grammar Grammar) (SupportReport, error) {
+	if strings.TrimSpace(grammar.Version) == "" {
+		grammar = DefaultGrammar()
+	}
+	normalized, err := Normalize(definition)
+	if err != nil {
+		return SupportReport{}, err
+	}
+	report := SupportReport{
+		DefinitionID:   normalized.ID,
+		SourceID:       normalized.SourceID,
+		GrammarVersion: grammar.Version,
+		Verdict:        SupportVerdictSupported,
+		Validation:     normalized.Validation,
+	}
+	check := func(category string, feature string, supported bool, detail string) {
+		id := category + "." + feature
+		if supported {
+			report.Checks = append(report.Checks, SupportCheck{ID: id, Category: category, Status: SupportStatusReady, Detail: detail})
+			report.SupportedFeatures = append(report.SupportedFeatures, id)
+			return
+		}
+		report.Checks = append(report.Checks, SupportCheck{ID: id, Category: category, Status: SupportStatusMissing, Detail: detail})
+		report.MissingFeatures = append(report.MissingFeatures, id)
+	}
+	runtimes := setOf(grammar.Runtimes)
+	authModels := setOf(grammar.AuthModels)
+	methods := setOf(grammar.Methods)
+	pagination := setOf(grammar.PaginationTypes)
+	incremental := setOf(grammar.IncrementalStates)
+	projectionTemplates := setOf(grammar.ProjectionTemplates)
+
+	check("runtime", normalized.Runtime, contains(runtimes, normalized.Runtime), "runtime executor")
+	check("auth", normalized.Auth.Model, contains(authModels, normalized.Auth.Model), "provider auth model")
+	if normalized.Transport == nil || strings.TrimSpace(normalized.Transport.BaseURL) == "" {
+		check("transport", "base_url_template", false, "transport base URL is required for generic execution proof")
+	} else {
+		check("transport", "base_url_template", true, "transport base URL is declared")
+	}
+	if normalized.Transport == nil || normalized.Transport.Verification == nil {
+		check("transport", "verification", false, "connection verification endpoint is required for generic acceptance")
+	} else {
+		check("transport", "verification", true, "connection verification endpoint is declared")
+	}
+
+	for _, family := range normalized.ResourceFamilies {
+		method := strings.ToUpper(strings.TrimSpace(family.Method))
+		check("method", method, contains(methods, method), fmt.Sprintf("family %s", family.ID))
+		pageType := "none"
+		if family.Pagination != nil && strings.TrimSpace(family.Pagination.Type) != "" {
+			pageType = strings.TrimSpace(family.Pagination.Type)
+		}
+		check("pagination", pageType, contains(pagination, pageType), fmt.Sprintf("family %s", family.ID))
+		if family.Incremental != nil {
+			state := strings.TrimSpace(family.Incremental.State)
+			if state == "" {
+				state = "high_watermark"
+			}
+			check("incremental", state, contains(incremental, state), fmt.Sprintf("family %s", family.ID))
+		}
+		if family.RecordSelector == "" && family.ListKey == "" {
+			check("record_selector", "jsonpath_or_list_key", false, fmt.Sprintf("family %s needs record_selector or list_key", family.ID))
+		} else {
+			check("record_selector", "jsonpath_or_list_key", true, fmt.Sprintf("family %s", family.ID))
+		}
+		if family.Event.Kind == "" || family.Event.SchemaRef == "" {
+			check("event_contract", "kind_schema_ref", false, fmt.Sprintf("family %s needs event kind and schema ref", family.ID))
+		} else {
+			check("event_contract", "kind_schema_ref", true, fmt.Sprintf("family %s", family.ID))
+		}
+		if family.Projection == nil || strings.TrimSpace(family.Projection.Template) == "" {
+			check("projection", "template", false, fmt.Sprintf("family %s needs a projection template or bespoke projector", family.ID))
+		} else {
+			template := strings.TrimSpace(family.Projection.Template)
+			check("projection", template, contains(projectionTemplates, template), fmt.Sprintf("family %s", family.ID))
+		}
+		if len(family.Coverage) == 0 {
+			check("coverage", "dimensions", false, fmt.Sprintf("family %s needs coverage dimensions", family.ID))
+		} else {
+			check("coverage", "dimensions", true, fmt.Sprintf("family %s", family.ID))
+		}
+	}
+	if normalized.Validation.Status == ValidationBlocked {
+		report.MissingFeatures = append(report.MissingFeatures, "definition.validation_blocked")
+		report.Checks = append(report.Checks, SupportCheck{ID: "definition.validation_blocked", Category: "definition", Status: SupportStatusMissing, Detail: normalized.Validation.Summary})
+	}
+	report.SupportedFeatures = uniqueSorted(report.SupportedFeatures)
+	report.MissingFeatures = uniqueSorted(report.MissingFeatures)
+	sort.SliceStable(report.Checks, func(i int, j int) bool {
+		if report.Checks[i].Status != report.Checks[j].Status {
+			return report.Checks[i].Status == SupportStatusMissing
+		}
+		return report.Checks[i].ID < report.Checks[j].ID
+	})
+	switch {
+	case len(report.MissingFeatures) == 0:
+		report.Verdict = SupportVerdictSupported
+	case onlyExtensionMissing(report.MissingFeatures):
+		report.Verdict = SupportVerdictExtensionRequired
+	default:
+		report.Verdict = SupportVerdictBespokeRequired
+	}
+	return report, nil
+}
+
+// ClassifyAll evaluates a target set and returns both per-definition reports and
+// aggregate coverage counts suitable for CI artifacts.
+func ClassifyAll(definitions []Definition, grammar Grammar) (SupportSummary, error) {
+	if strings.TrimSpace(grammar.Version) == "" {
+		grammar = DefaultGrammar()
+	}
+	summary := SupportSummary{
+		GrammarVersion:  grammar.Version,
+		Targets:         len(definitions),
+		ByVerdict:       map[string]int{},
+		ByAuthModel:     map[string]int{},
+		MissingFeatures: map[string]int{},
+		Reports:         make([]SupportReport, 0, len(definitions)),
+	}
+	for index, definition := range definitions {
+		report, err := Classify(definition, grammar)
+		if err != nil {
+			return SupportSummary{}, fmt.Errorf("classify definitions[%d]: %w", index, err)
+		}
+		summary.Reports = append(summary.Reports, report)
+		summary.ByVerdict[report.Verdict]++
+		normalized, err := Normalize(definition)
+		if err != nil {
+			return SupportSummary{}, fmt.Errorf("normalize definitions[%d]: %w", index, err)
+		}
+		summary.ByAuthModel[normalized.Auth.Model]++
+		for _, missing := range report.MissingFeatures {
+			summary.MissingFeatures[missing]++
+		}
+	}
+	summary.Supported = summary.ByVerdict[SupportVerdictSupported]
+	summary.ExtensionRequired = summary.ByVerdict[SupportVerdictExtensionRequired]
+	summary.BespokeRequired = summary.ByVerdict[SupportVerdictBespokeRequired]
+	if len(summary.MissingFeatures) == 0 {
+		summary.MissingFeatures = nil
+	}
+	sort.SliceStable(summary.Reports, func(i int, j int) bool {
+		if summary.Reports[i].Verdict != summary.Reports[j].Verdict {
+			return summary.Reports[i].Verdict < summary.Reports[j].Verdict
+		}
+		return summary.Reports[i].SourceID < summary.Reports[j].SourceID
+	})
+	return summary, nil
+}
+
+func onlyExtensionMissing(features []string) bool {
+	if len(features) == 0 {
+		return false
+	}
+	for _, feature := range features {
+		switch {
+		case strings.HasPrefix(feature, "auth."),
+			strings.HasPrefix(feature, "method."),
+			strings.HasPrefix(feature, "pagination."),
+			strings.HasPrefix(feature, "incremental."),
+			strings.HasPrefix(feature, "projection."):
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func setOf(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		set[value] = struct{}{}
+	}
+	return set
+}
+
+func contains(set map[string]struct{}, value string) bool {
+	_, ok := set[strings.TrimSpace(value)]
+	return ok
+}
+
+func uniqueSorted(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/connectordefinitions/classifier.go
+++ b/internal/connectordefinitions/classifier.go
@@ -201,8 +201,8 @@ func Classify(definition Definition, grammar Grammar) (SupportReport, error) {
 		report.MissingFeatures = append(report.MissingFeatures, "definition.validation_blocked")
 		report.Checks = append(report.Checks, SupportCheck{ID: "definition.validation_blocked", Category: "definition", Status: SupportStatusMissing, Detail: normalized.Validation.Summary})
 	}
-	report.SupportedFeatures = uniqueSorted(report.SupportedFeatures)
 	report.MissingFeatures = uniqueSorted(report.MissingFeatures)
+	report.SupportedFeatures = uniqueSortedExcept(report.SupportedFeatures, report.MissingFeatures)
 	sort.SliceStable(report.Checks, func(i int, j int) bool {
 		if report.Checks[i].Status != report.Checks[j].Status {
 			return report.Checks[i].Status == SupportStatusMissing
@@ -307,6 +307,28 @@ func uniqueSorted(values []string) []string {
 	for _, value := range values {
 		value = strings.TrimSpace(value)
 		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func uniqueSortedExcept(values []string, excluded []string) []string {
+	excludedSet := setOf(excluded)
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := excludedSet[value]; ok {
 			continue
 		}
 		if _, ok := seen[value]; ok {

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -12,6 +12,8 @@ import (
 const (
 	RuntimeJSONAPI = "json_api"
 
+	SchemaVersionIntegrationV1 = "cerebro.integration/v1"
+
 	StageDraft     = "draft"
 	StageSandbox   = "sandbox"
 	StagePilot     = "pilot"
@@ -26,10 +28,15 @@ const (
 var (
 	ErrInvalidDefinition = errors.New("invalid connector definition")
 
-	idPattern       = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
-	definitionIDRun = regexp.MustCompile(`[^a-z0-9_-]+`)
-	stageOrder      = []string{StageDraft, StageSandbox, StagePilot, StageApproved, StageCertified}
-	stageRank       = map[string]int{
+	idPattern         = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+	definitionIDRun   = regexp.MustCompile(`[^a-z0-9_-]+`)
+	templateVar       = regexp.MustCompile(`\$\{([a-z]+)\.([a-z][a-z0-9_-]*)\}`)
+	statusIdentifier  = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	stageOrder        = []string{StageDraft, StageSandbox, StagePilot, StageApproved, StageCertified}
+	supportedMethods  = map[string]struct{}{"GET": {}, "POST": {}}
+	paginationTypes   = map[string]struct{}{"": {}, "none": {}, "cursor": {}, "page": {}, "offset": {}, "link": {}, "next_url": {}}
+	incrementalStates = map[string]struct{}{"": {}, "high_watermark": {}, "opaque_cursor": {}}
+	stageRank         = map[string]int{
 		StageDraft:     0,
 		StageSandbox:   1,
 		StagePilot:     2,
@@ -41,23 +48,32 @@ var (
 		"api_key":                  {},
 		"bearer_token":             {},
 		"basic":                    {},
+		"oauth_authorization_code": {},
 		"oauth_client_credentials": {},
+		"two_step":                 {},
+		"jwt":                      {},
+		"signature":                {},
+		"aws_sigv4":                {},
 	}
 )
 
 // Definition is a versioned dynamic connector manifest that can be validated,
 // tested, piloted, and later promoted into a built-in Source CDK implementation.
 type Definition struct {
+	SchemaVersion    string           `json:"schema_version,omitempty"`
 	ID               string           `json:"id"`
 	TenantID         string           `json:"tenant_id"`
 	SourceID         string           `json:"source_id"`
 	DisplayName      string           `json:"display_name"`
 	Description      string           `json:"description,omitempty"`
+	Categories       []string         `json:"categories,omitempty"`
 	Runtime          string           `json:"runtime"`
 	Stage            string           `json:"stage"`
+	Maturity         string           `json:"maturity,omitempty"`
 	CurrentVersion   int              `json:"current_version"`
 	ConfigFields     []Field          `json:"config_fields,omitempty"`
 	Auth             AuthSpec         `json:"auth"`
+	Transport        *TransportSpec   `json:"transport,omitempty"`
 	ResourceFamilies []ResourceFamily `json:"resource_families,omitempty"`
 	ScopeOptions     []ScopeOption    `json:"scope_options,omitempty"`
 	Validation       ValidationResult `json:"validation"`
@@ -79,24 +95,123 @@ type Field struct {
 
 // AuthSpec describes the supported credential shape for a connector definition.
 type AuthSpec struct {
-	Model              string   `json:"model"`
-	CredentialFields   []Field  `json:"credential_fields,omitempty"`
-	SupportedStoreIDs  []string `json:"supported_store_ids,omitempty"`
-	RequiresReferences bool     `json:"requires_references,omitempty"`
+	Model                         string            `json:"model"`
+	CredentialFields              []Field           `json:"credential_fields,omitempty"`
+	SupportedStoreIDs             []string          `json:"supported_store_ids,omitempty"`
+	RequiresReferences            bool              `json:"requires_references,omitempty"`
+	AuthorizationURL              string            `json:"authorization_url,omitempty"`
+	TokenURL                      string            `json:"token_url,omitempty"`
+	RefreshURL                    string            `json:"refresh_url,omitempty"`
+	Scopes                        []string          `json:"scopes,omitempty"`
+	ScopeSeparator                string            `json:"scope_separator,omitempty"`
+	TokenRequestAuthMethod        string            `json:"token_request_auth_method,omitempty"`
+	TokenParams                   map[string]string `json:"token_params,omitempty"`
+	RefreshParams                 map[string]string `json:"refresh_params,omitempty"`
+	PKCE                          string            `json:"pkce,omitempty"`
+	TokenExpirationBufferSeconds  int               `json:"token_expiration_buffer_seconds,omitempty"`
+	AlternateAccessTokenJSONPath  string            `json:"alternate_access_token_json_path,omitempty"`
+	AlternateRefreshTokenJSONPath string            `json:"alternate_refresh_token_json_path,omitempty"`
+}
+
+// TransportSpec describes generic HTTP transport behavior shared across families.
+type TransportSpec struct {
+	BaseURL      string            `json:"base_url,omitempty"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	Query        map[string]string `json:"query,omitempty"`
+	Body         map[string]any    `json:"body,omitempty"`
+	Verification *VerificationSpec `json:"verification,omitempty"`
+	Retry        *RetrySpec        `json:"retry,omitempty"`
+}
+
+// VerificationSpec describes the connection check request.
+type VerificationSpec struct {
+	Method       string            `json:"method,omitempty"`
+	Path         string            `json:"path"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	ExpectStatus []int             `json:"expect_status,omitempty"`
+}
+
+// RetrySpec describes provider retry and backoff behavior.
+type RetrySpec struct {
+	Statuses         []int  `json:"statuses,omitempty"`
+	Backoff          string `json:"backoff,omitempty"`
+	RetryAfterHeader string `json:"retry_after_header,omitempty"`
+	MaxAttempts      int    `json:"max_attempts,omitempty"`
+}
+
+// PaginationSpec describes one supported pagination strategy.
+type PaginationSpec struct {
+	Type            string `json:"type,omitempty"`
+	CursorParam     string `json:"cursor_param,omitempty"`
+	CursorJSONPath  string `json:"cursor_json_path,omitempty"`
+	PageParam       string `json:"page_param,omitempty"`
+	PageSizeParam   string `json:"page_size_param,omitempty"`
+	OffsetParam     string `json:"offset_param,omitempty"`
+	LimitParam      string `json:"limit_param,omitempty"`
+	LinkHeader      string `json:"link_header,omitempty"`
+	NextURLJSONPath string `json:"next_url_json_path,omitempty"`
+	StartPage       int    `json:"start_page,omitempty"`
+	PageSize        int    `json:"page_size,omitempty"`
+	InjectFirstPage bool   `json:"inject_first_page,omitempty"`
+}
+
+// IncrementalSpec describes durable state for changed-record reads.
+type IncrementalSpec struct {
+	CursorField string `json:"cursor_field,omitempty"`
+	CursorPath  string `json:"cursor_path,omitempty"`
+	RequestKey  string `json:"request_key,omitempty"`
+	RequestIn   string `json:"request_in,omitempty"`
+	State       string `json:"state,omitempty"`
+}
+
+// EventMappingSpec describes the event contract emitted for a resource family.
+type EventMappingSpec struct {
+	Kind                  string   `json:"kind,omitempty"`
+	SchemaRef             string   `json:"schema_ref,omitempty"`
+	URNKind               string   `json:"urn_kind,omitempty"`
+	RequiredAttributes    []string `json:"required_attributes,omitempty"`
+	RequiredPayloadFields []string `json:"required_payload_fields,omitempty"`
+}
+
+// ProjectionSpec describes a generic projector template for emitted events.
+type ProjectionSpec struct {
+	Template string            `json:"template,omitempty"`
+	Fields   map[string]string `json:"fields,omitempty"`
+}
+
+// CoverageDimensionSpec mirrors sourcecdk coverage dimensions without coupling
+// dynamic connector definitions to source package loading.
+type CoverageDimensionSpec struct {
+	ID                     string   `json:"id,omitempty"`
+	Type                   string   `json:"type"`
+	Title                  string   `json:"title,omitempty"`
+	Families               []string `json:"families,omitempty"`
+	Support                string   `json:"support"`
+	HighValue              bool     `json:"high_value,omitempty"`
+	KnownUnsupportedFields []string `json:"known_unsupported_fields,omitempty"`
+	Notes                  []string `json:"notes,omitempty"`
 }
 
 // ResourceFamily describes one read-only resource collection exposed by the connector runtime.
 type ResourceFamily struct {
-	ID             string `json:"id"`
-	Label          string `json:"label,omitempty"`
-	Path           string `json:"path"`
-	Method         string `json:"method,omitempty"`
-	ListKey        string `json:"list_key,omitempty"`
-	IDField        string `json:"id_field"`
-	NameField      string `json:"name_field,omitempty"`
-	UpdatedAtField string `json:"updated_at_field,omitempty"`
-	EventKind      string `json:"event_kind,omitempty"`
-	DefaultEnabled bool   `json:"default_enabled,omitempty"`
+	ID                    string                  `json:"id"`
+	Label                 string                  `json:"label,omitempty"`
+	Path                  string                  `json:"path"`
+	Method                string                  `json:"method,omitempty"`
+	RecordSelector        string                  `json:"record_selector,omitempty"`
+	ListKey               string                  `json:"list_key,omitempty"`
+	IDField               string                  `json:"id_field"`
+	NameField             string                  `json:"name_field,omitempty"`
+	UpdatedAtField        string                  `json:"updated_at_field,omitempty"`
+	EventKind             string                  `json:"event_kind,omitempty"`
+	Event                 EventMappingSpec        `json:"event,omitempty"`
+	Pagination            *PaginationSpec         `json:"pagination,omitempty"`
+	Incremental           *IncrementalSpec        `json:"incremental,omitempty"`
+	Projection            *ProjectionSpec         `json:"projection,omitempty"`
+	Coverage              []CoverageDimensionSpec `json:"coverage,omitempty"`
+	PermissionsNeeded     []string                `json:"permissions_needed,omitempty"`
+	SensitivePayloadPaths []string                `json:"sensitive_payload_paths,omitempty"`
+	DefaultEnabled        bool                    `json:"default_enabled,omitempty"`
 }
 
 // ScopeOption exposes a resource family as a selectable scope option in the UI.
@@ -154,6 +269,7 @@ type PromotionResult struct {
 
 // Normalize fills defaults, trims strings, and recalculates validation and promotion metadata.
 func Normalize(definition Definition) (Definition, error) {
+	definition.SchemaVersion = strings.TrimSpace(definition.SchemaVersion)
 	definition.TenantID = strings.TrimSpace(definition.TenantID)
 	definition.SourceID = normalizeIdentifier(definition.SourceID)
 	definition.ID = normalizeDefinitionID(definition.ID)
@@ -165,6 +281,7 @@ func Normalize(definition Definition) (Definition, error) {
 		definition.DisplayName = titleFromID(definition.SourceID)
 	}
 	definition.Description = strings.TrimSpace(definition.Description)
+	definition.Categories = normalizeStringList(definition.Categories)
 	definition.Runtime = strings.TrimSpace(definition.Runtime)
 	if definition.Runtime == "" {
 		definition.Runtime = RuntimeJSONAPI
@@ -173,10 +290,23 @@ func Normalize(definition Definition) (Definition, error) {
 	if definition.Stage == "" {
 		definition.Stage = StageDraft
 	}
+	definition.Maturity = strings.TrimSpace(definition.Maturity)
 	definition.Auth.Model = strings.TrimSpace(definition.Auth.Model)
 	if definition.Auth.Model == "" {
 		definition.Auth.Model = "bearer_token"
 	}
+	definition.Auth.AuthorizationURL = strings.TrimSpace(definition.Auth.AuthorizationURL)
+	definition.Auth.TokenURL = strings.TrimSpace(definition.Auth.TokenURL)
+	definition.Auth.RefreshURL = strings.TrimSpace(definition.Auth.RefreshURL)
+	definition.Auth.ScopeSeparator = strings.TrimSpace(definition.Auth.ScopeSeparator)
+	definition.Auth.TokenRequestAuthMethod = strings.TrimSpace(definition.Auth.TokenRequestAuthMethod)
+	definition.Auth.PKCE = strings.TrimSpace(definition.Auth.PKCE)
+	definition.Auth.AlternateAccessTokenJSONPath = strings.TrimSpace(definition.Auth.AlternateAccessTokenJSONPath)
+	definition.Auth.AlternateRefreshTokenJSONPath = strings.TrimSpace(definition.Auth.AlternateRefreshTokenJSONPath)
+	definition.Auth.Scopes = normalizeStringList(definition.Auth.Scopes)
+	definition.Auth.TokenParams = normalizeStringMap(definition.Auth.TokenParams)
+	definition.Auth.RefreshParams = normalizeStringMap(definition.Auth.RefreshParams)
+	definition.Transport = normalizeTransportSpec(definition.Transport)
 	definition.ConfigFields = normalizeFields(definition.ConfigFields)
 	definition.Auth.CredentialFields = normalizeFields(definition.Auth.CredentialFields)
 	definition.Auth.SupportedStoreIDs = normalizeStringList(definition.Auth.SupportedStoreIDs)
@@ -218,6 +348,9 @@ func Validate(definition Definition) ValidationResult {
 	} else {
 		add(passing("stage", "Lifecycle stage", "Lifecycle state is explicit."))
 	}
+	if definition.SchemaVersion != "" && definition.SchemaVersion != SchemaVersionIntegrationV1 {
+		add(blocking("schema_version", "Schema version", fmt.Sprintf("Use %s for integration definitions.", SchemaVersionIntegrationV1)))
+	}
 	if _, ok := authModels[definition.Auth.Model]; !ok {
 		add(blocking("auth", "Auth model", fmt.Sprintf("Auth model %q is not supported.", definition.Auth.Model)))
 	} else if definition.Auth.Model != "none" && len(definition.Auth.CredentialFields) == 0 {
@@ -225,6 +358,7 @@ func Validate(definition Definition) ValidationResult {
 	} else {
 		add(passing("auth", "Auth model", "Credential shape is explicit and reference-aware."))
 	}
+	validateAuthModelDetails(definition.Auth, add)
 	for _, field := range append(append([]Field{}, definition.ConfigFields...), definition.Auth.CredentialFields...) {
 		if !idPattern.MatchString(field.Key) {
 			add(blocking("field_"+field.Key, "Field keys", "Field keys must be lowercase identifiers."))
@@ -233,6 +367,7 @@ func Validate(definition Definition) ValidationResult {
 			add(blocking("secret_"+field.Key, "Secret boundary", "Secret fields must be reference-only in dynamic connector definitions."))
 		}
 	}
+	validateTransport(definition.Transport, add)
 	if len(definition.ResourceFamilies) == 0 {
 		add(blocking("resources", "Resource families", "Add at least one read-only resource family."))
 	} else {
@@ -246,12 +381,15 @@ func Validate(definition Definition) ValidationResult {
 		if path == "" || !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") || strings.Contains(path, "\\") || strings.Contains(path, "://") {
 			add(blocking("path_"+family.ID, "Resource path", "Resource paths must be relative API paths such as /v1/assets."))
 		}
-		if method := strings.ToUpper(strings.TrimSpace(family.Method)); method != "" && method != "GET" {
-			add(blocking("method_"+family.ID, "Read-only method", "Dynamic connector probes and pilots only support GET resource reads."))
+		if method := strings.ToUpper(strings.TrimSpace(family.Method)); method != "" {
+			if _, ok := supportedMethods[method]; !ok {
+				add(blocking("method_"+family.ID, "Read-only method", "Generic connector reads support GET and POST list/search endpoints."))
+			}
 		}
 		if strings.TrimSpace(family.IDField) == "" {
 			add(blocking("id_field_"+family.ID, "Resource identity", "Each resource family needs a stable id field."))
 		}
+		validateFamilyIntegrationFields(family, add)
 	}
 	status := ValidationReady
 	for _, check := range checks {
@@ -377,6 +515,102 @@ func blocking(id string, label string, nextAction string) ValidationCheck {
 	return ValidationCheck{ID: id, Label: label, Status: ValidationBlocked, Severity: "error", NextAction: nextAction, Blocking: true}
 }
 
+func validateAuthModelDetails(auth AuthSpec, add func(ValidationCheck)) {
+	switch auth.Model {
+	case "oauth_authorization_code":
+		if auth.AuthorizationURL == "" {
+			add(blocking("auth_authorization_url", "Authorization URL", "OAuth authorization-code providers require an authorization URL."))
+		}
+		if auth.TokenURL == "" {
+			add(blocking("auth_token_url", "Token URL", "OAuth authorization-code providers require a token URL."))
+		}
+	case "oauth_client_credentials", "two_step":
+		if auth.TokenURL == "" {
+			add(blocking("auth_token_url", "Token URL", "Token-exchange auth models require a token URL."))
+		}
+	case "jwt":
+		if !hasCredentialField(auth.CredentialFields, "private_key") && !hasCredentialField(auth.CredentialFields, "signing_key") {
+			add(blocking("auth_jwt_key", "JWT signing key", "JWT auth requires a private_key or signing_key credential field."))
+		}
+	case "signature", "aws_sigv4":
+		if len(auth.CredentialFields) == 0 {
+			add(blocking("auth_signing_fields", "Signing credentials", "Signed request auth requires explicit credential fields."))
+		}
+	}
+	if auth.TokenExpirationBufferSeconds < 0 {
+		add(blocking("auth_token_expiration_buffer", "Token expiration buffer", "Token expiration buffer must not be negative."))
+	}
+}
+
+func validateTransport(transport *TransportSpec, add func(ValidationCheck)) {
+	if transport == nil {
+		return
+	}
+	if transport.BaseURL != "" && !safeTemplate(transport.BaseURL, map[string]struct{}{"config": {}, "connection": {}, "credential": {}}) {
+		add(blocking("transport_base_url", "Transport base URL", "Base URL templates may only reference config, connection, or credential fields."))
+	}
+	if strings.ContainsAny(transport.BaseURL, "\r\n\t\\") {
+		add(blocking("transport_base_url_chars", "Transport base URL", "Base URL must not contain control characters or backslashes."))
+	}
+	if transport.Verification != nil {
+		method := strings.ToUpper(strings.TrimSpace(transport.Verification.Method))
+		if method == "" {
+			method = "GET"
+		}
+		if _, ok := supportedMethods[method]; !ok {
+			add(blocking("verification_method", "Verification method", "Verification supports GET and POST requests."))
+		}
+		if !validRelativePath(transport.Verification.Path) {
+			add(blocking("verification_path", "Verification path", "Verification path must be a relative API path such as /v1/me."))
+		}
+		for _, status := range transport.Verification.ExpectStatus {
+			if status < 100 || status > 599 {
+				add(blocking("verification_status", "Verification status", "Expected HTTP statuses must be between 100 and 599."))
+			}
+		}
+	}
+	if transport.Retry != nil {
+		for _, status := range transport.Retry.Statuses {
+			if status < 100 || status > 599 {
+				add(blocking("retry_status", "Retry status", "Retry HTTP statuses must be between 100 and 599."))
+			}
+		}
+		if transport.Retry.MaxAttempts < 0 {
+			add(blocking("retry_attempts", "Retry attempts", "Retry attempts must not be negative."))
+		}
+	}
+}
+
+func validateFamilyIntegrationFields(family ResourceFamily, add func(ValidationCheck)) {
+	if family.Pagination != nil {
+		if _, ok := paginationTypes[family.Pagination.Type]; !ok {
+			add(blocking("pagination_"+family.ID, "Pagination", "Pagination type must be none, cursor, page, offset, link, or next_url."))
+		}
+		if family.Pagination.PageSize < 0 {
+			add(blocking("pagination_page_size_"+family.ID, "Pagination page size", "Pagination page size must not be negative."))
+		}
+	}
+	if family.Incremental != nil {
+		if _, ok := incrementalStates[family.Incremental.State]; !ok {
+			add(blocking("incremental_"+family.ID, "Incremental state", "Incremental state must be high_watermark or opaque_cursor."))
+		}
+		if strings.TrimSpace(family.Incremental.CursorField) == "" && strings.TrimSpace(family.Incremental.CursorPath) == "" {
+			add(blocking("incremental_cursor_"+family.ID, "Incremental cursor", "Incremental sync needs a cursor field or cursor path."))
+		}
+	}
+	if family.Event.Kind != "" && !validEventKind(family.Event.Kind) {
+		add(blocking("event_kind_"+family.ID, "Event kind", "Event kinds must use dotted lowercase identifier syntax."))
+	}
+	if family.Event.SchemaRef != "" && strings.ContainsAny(family.Event.SchemaRef, "\r\n\t ") {
+		add(blocking("schema_ref_"+family.ID, "Schema ref", "Schema refs must not contain whitespace."))
+	}
+	for _, dimension := range family.Coverage {
+		if strings.TrimSpace(dimension.Type) == "" || strings.TrimSpace(dimension.Support) == "" {
+			add(blocking("coverage_"+family.ID, "Coverage", "Coverage dimensions need type and support."))
+		}
+	}
+}
+
 func normalizeIdentifier(value string) string {
 	return strings.Trim(strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), " ", "_")), "_-")
 }
@@ -436,6 +670,7 @@ func normalizeResourceFamilies(families []ResourceFamily) []ResourceFamily {
 			family.Method = "GET"
 		}
 		family.ListKey = strings.TrimSpace(family.ListKey)
+		family.RecordSelector = strings.TrimSpace(family.RecordSelector)
 		family.IDField = strings.TrimSpace(family.IDField)
 		family.NameField = strings.TrimSpace(family.NameField)
 		family.UpdatedAtField = strings.TrimSpace(family.UpdatedAtField)
@@ -443,9 +678,114 @@ func normalizeResourceFamilies(families []ResourceFamily) []ResourceFamily {
 		if family.EventKind == "" {
 			family.EventKind = family.ID
 		}
+		family.Event = normalizeEventMapping(family.ID, family.EventKind, family.Event)
+		family.Pagination = normalizePaginationSpec(family.Pagination)
+		family.Incremental = normalizeIncrementalSpec(family.Incremental)
+		family.Projection = normalizeProjectionSpec(family.Projection)
+		family.PermissionsNeeded = normalizeStringList(family.PermissionsNeeded)
+		family.SensitivePayloadPaths = normalizeStringList(family.SensitivePayloadPaths)
+		for i := range family.Coverage {
+			family.Coverage[i] = normalizeCoverageDimensionSpec(family.ID, family.Coverage[i])
+		}
 		normalized = append(normalized, family)
 	}
 	return normalized
+}
+
+func normalizeTransportSpec(transport *TransportSpec) *TransportSpec {
+	if transport == nil {
+		return nil
+	}
+	next := *transport
+	next.BaseURL = strings.TrimSpace(next.BaseURL)
+	next.Headers = normalizeStringMap(next.Headers)
+	next.Query = normalizeStringMap(next.Query)
+	if next.Verification != nil {
+		verification := *next.Verification
+		verification.Method = strings.ToUpper(strings.TrimSpace(verification.Method))
+		if verification.Method == "" {
+			verification.Method = "GET"
+		}
+		verification.Path = strings.TrimSpace(verification.Path)
+		verification.Headers = normalizeStringMap(verification.Headers)
+		next.Verification = &verification
+	}
+	if next.Retry != nil {
+		retry := *next.Retry
+		retry.Backoff = strings.TrimSpace(retry.Backoff)
+		retry.RetryAfterHeader = strings.TrimSpace(retry.RetryAfterHeader)
+		next.Retry = &retry
+	}
+	return &next
+}
+
+func normalizePaginationSpec(pagination *PaginationSpec) *PaginationSpec {
+	if pagination == nil {
+		return nil
+	}
+	next := *pagination
+	next.Type = strings.TrimSpace(next.Type)
+	next.CursorParam = strings.TrimSpace(next.CursorParam)
+	next.CursorJSONPath = strings.TrimSpace(next.CursorJSONPath)
+	next.PageParam = strings.TrimSpace(next.PageParam)
+	next.PageSizeParam = strings.TrimSpace(next.PageSizeParam)
+	next.OffsetParam = strings.TrimSpace(next.OffsetParam)
+	next.LimitParam = strings.TrimSpace(next.LimitParam)
+	next.LinkHeader = strings.TrimSpace(next.LinkHeader)
+	next.NextURLJSONPath = strings.TrimSpace(next.NextURLJSONPath)
+	return &next
+}
+
+func normalizeIncrementalSpec(incremental *IncrementalSpec) *IncrementalSpec {
+	if incremental == nil {
+		return nil
+	}
+	next := *incremental
+	next.CursorField = strings.TrimSpace(next.CursorField)
+	next.CursorPath = strings.TrimSpace(next.CursorPath)
+	next.RequestKey = strings.TrimSpace(next.RequestKey)
+	next.RequestIn = strings.TrimSpace(next.RequestIn)
+	next.State = strings.TrimSpace(next.State)
+	if next.State == "" {
+		next.State = "high_watermark"
+	}
+	return &next
+}
+
+func normalizeEventMapping(familyID string, legacyKind string, event EventMappingSpec) EventMappingSpec {
+	event.Kind = strings.TrimSpace(event.Kind)
+	event.SchemaRef = strings.TrimSpace(event.SchemaRef)
+	event.URNKind = strings.TrimSpace(event.URNKind)
+	event.RequiredAttributes = normalizeStringList(event.RequiredAttributes)
+	event.RequiredPayloadFields = normalizeStringList(event.RequiredPayloadFields)
+	return event
+}
+
+func normalizeProjectionSpec(projection *ProjectionSpec) *ProjectionSpec {
+	if projection == nil {
+		return nil
+	}
+	next := *projection
+	next.Template = normalizeIdentifier(next.Template)
+	next.Fields = normalizeStringMap(next.Fields)
+	return &next
+}
+
+func normalizeCoverageDimensionSpec(familyID string, dimension CoverageDimensionSpec) CoverageDimensionSpec {
+	dimension.ID = normalizeIdentifier(dimension.ID)
+	if dimension.ID == "" && strings.TrimSpace(dimension.Type) != "" {
+		dimension.ID = normalizeIdentifier(familyID + "_" + strings.TrimSpace(dimension.Type))
+	}
+	dimension.Type = strings.TrimSpace(dimension.Type)
+	dimension.Title = strings.TrimSpace(dimension.Title)
+	dimension.Families = normalizeStringList(dimension.Families)
+	if len(dimension.Families) == 0 && familyID != "" {
+		dimension.Families = []string{familyID}
+	}
+	dimension.Support = strings.TrimSpace(dimension.Support)
+	dimension.KnownUnsupportedFields = normalizeStringList(dimension.KnownUnsupportedFields)
+	dimension.Notes = normalizeStringList(dimension.Notes)
+	return dimension
 }
 
 func normalizeScopeOptions(options []ScopeOption, families []ResourceFamily) []ScopeOption {
@@ -503,6 +843,25 @@ func normalizeStringList(values []string) []string {
 	return normalized
 }
 
+func normalizeStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	normalized := make(map[string]string, len(values))
+	for key, value := range values {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		normalized[key] = value
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
 func titleFromID(id string) string {
 	parts := strings.FieldsFunc(id, func(r rune) bool {
 		return r == '_' || r == '-'
@@ -514,4 +873,43 @@ func titleFromID(id string) string {
 		parts[i] = strings.ToUpper(part[:1]) + part[1:]
 	}
 	return strings.Join(parts, " ")
+}
+
+func hasCredentialField(fields []Field, key string) bool {
+	for _, field := range fields {
+		if field.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func safeTemplate(value string, allowedScopes map[string]struct{}) bool {
+	for _, match := range templateVar.FindAllStringSubmatch(value, -1) {
+		if len(match) != 3 {
+			return false
+		}
+		if _, ok := allowedScopes[match[1]]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func validRelativePath(path string) bool {
+	path = strings.TrimSpace(path)
+	return path != "" && strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "//") && !strings.Contains(path, "\\") && !strings.Contains(path, "://")
+}
+
+func validEventKind(kind string) bool {
+	parts := strings.Split(kind, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts {
+		if !statusIdentifier.MatchString(part) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -674,11 +674,12 @@ func normalizeResourceFamilies(families []ResourceFamily) []ResourceFamily {
 		family.IDField = strings.TrimSpace(family.IDField)
 		family.NameField = strings.TrimSpace(family.NameField)
 		family.UpdatedAtField = strings.TrimSpace(family.UpdatedAtField)
-		family.EventKind = strings.TrimSpace(family.EventKind)
+		legacyEventKind := strings.TrimSpace(family.EventKind)
+		family.EventKind = legacyEventKind
 		if family.EventKind == "" {
 			family.EventKind = family.ID
 		}
-		family.Event = normalizeEventMapping(family.Event)
+		family.Event = normalizeEventMapping(legacyEventKind, family.Event)
 		family.Pagination = normalizePaginationSpec(family.Pagination)
 		family.Incremental = normalizeIncrementalSpec(family.Incremental)
 		family.Projection = normalizeProjectionSpec(family.Projection)
@@ -752,8 +753,11 @@ func normalizeIncrementalSpec(incremental *IncrementalSpec) *IncrementalSpec {
 	return &next
 }
 
-func normalizeEventMapping(event EventMappingSpec) EventMappingSpec {
+func normalizeEventMapping(legacyKind string, event EventMappingSpec) EventMappingSpec {
 	event.Kind = strings.TrimSpace(event.Kind)
+	if event.Kind == "" && validEventKind(legacyKind) {
+		event.Kind = strings.TrimSpace(legacyKind)
+	}
 	event.SchemaRef = strings.TrimSpace(event.SchemaRef)
 	event.URNKind = strings.TrimSpace(event.URNKind)
 	event.RequiredAttributes = normalizeStringList(event.RequiredAttributes)

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -678,7 +678,7 @@ func normalizeResourceFamilies(families []ResourceFamily) []ResourceFamily {
 		if family.EventKind == "" {
 			family.EventKind = family.ID
 		}
-		family.Event = normalizeEventMapping(family.ID, family.EventKind, family.Event)
+		family.Event = normalizeEventMapping(family.Event)
 		family.Pagination = normalizePaginationSpec(family.Pagination)
 		family.Incremental = normalizeIncrementalSpec(family.Incremental)
 		family.Projection = normalizeProjectionSpec(family.Projection)
@@ -752,7 +752,7 @@ func normalizeIncrementalSpec(incremental *IncrementalSpec) *IncrementalSpec {
 	return &next
 }
 
-func normalizeEventMapping(familyID string, legacyKind string, event EventMappingSpec) EventMappingSpec {
+func normalizeEventMapping(event EventMappingSpec) EventMappingSpec {
 	event.Kind = strings.TrimSpace(event.Kind)
 	event.SchemaRef = strings.TrimSpace(event.SchemaRef)
 	event.URNKind = strings.TrimSpace(event.URNKind)

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -48,6 +48,43 @@ func TestNormalizeBuildsValidatedDefinition(t *testing.T) {
 	}
 }
 
+func TestNormalizeBackfillsEventKindFromLegacyField(t *testing.T) {
+	definition, err := Normalize(Definition{
+		TenantID:    "tenant-a",
+		SourceID:    "example",
+		DisplayName: "Example",
+		Auth: AuthSpec{
+			Model: "none",
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:        "assets",
+			Path:      "/v1/assets",
+			IDField:   "id",
+			EventKind: "example.assets",
+			Event: EventMappingSpec{
+				SchemaRef: "example/asset/v1",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	family := definition.ResourceFamilies[0]
+	if family.Event.Kind != "example.assets" {
+		t.Fatalf("event kind = %q, want legacy event_kind fallback", family.Event.Kind)
+	}
+	if definition.Validation.Status == ValidationBlocked {
+		t.Fatalf("family unexpectedly blocked: %#v", definition.Validation.Checks)
+	}
+	renormalized, err := Normalize(definition)
+	if err != nil {
+		t.Fatalf("Normalize(renormalized) error = %v", err)
+	}
+	if renormalized.ResourceFamilies[0].Event.Kind != "example.assets" {
+		t.Fatalf("renormalized event kind = %q, want stable legacy fallback", renormalized.ResourceFamilies[0].Event.Kind)
+	}
+}
+
 func TestValidateBlocksUnsafeDynamicDefinition(t *testing.T) {
 	definition, err := Normalize(Definition{
 		ID:          "example",

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -185,13 +185,14 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 		SourceID:      "example",
 		DisplayName:   "Example",
 		Categories:    []string{"identity", "identity", "audit"},
+		//nolint:gosec // Test auth descriptor only; no credential value is stored.
 		Auth: AuthSpec{
 			Model:            "oauth_authorization_code",
 			AuthorizationURL: "https://example.test/oauth/authorize",
 			TokenURL:         "https://example.test/oauth/token",
 			Scopes:           []string{"users.read", "audit.read"},
 			CredentialFields: []Field{{
-				Key:           "client_secret",
+				Key:           "oauth_client_reference",
 				Secret:        true,
 				ReferenceOnly: true,
 			}},

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -381,6 +381,87 @@ func TestClassifyReportsMissingFeatures(t *testing.T) {
 	}
 }
 
+func TestClassifyReportsDisjointSupportedAndMissingFeatures(t *testing.T) {
+	report, err := Classify(Definition{
+		SchemaVersion: SchemaVersionIntegrationV1,
+		ID:            "example",
+		TenantID:      "tenant-a",
+		SourceID:      "example",
+		DisplayName:   "Example",
+		Auth: AuthSpec{
+			Model: "bearer_token",
+			CredentialFields: []Field{{
+				Key:           "token",
+				Secret:        true,
+				ReferenceOnly: true,
+			}},
+		},
+		Transport: &TransportSpec{
+			BaseURL: "https://api.example.test",
+			Verification: &VerificationSpec{
+				Path: "/v1/me",
+			},
+		},
+		ResourceFamilies: []ResourceFamily{
+			{
+				ID:             "users",
+				Path:           "/v1/users",
+				RecordSelector: "$.data.users[*]",
+				IDField:        "id",
+				Event: EventMappingSpec{
+					Kind:      "example.user",
+					SchemaRef: "example/user/v1",
+				},
+				Projection: &ProjectionSpec{
+					Template: "identity_user",
+				},
+				Coverage: []CoverageDimensionSpec{{
+					Type:    "entity_family",
+					Support: "supported",
+				}},
+			},
+			{
+				ID:      "groups",
+				Path:    "/v1/groups",
+				IDField: "id",
+				Event: EventMappingSpec{
+					Kind:      "example.group",
+					SchemaRef: "example/group/v1",
+				},
+				Projection: &ProjectionSpec{
+					Template: "identity_group",
+				},
+				Coverage: []CoverageDimensionSpec{{
+					Type:    "entity_family",
+					Support: "supported",
+				}},
+			},
+		},
+	}, DefaultGrammar())
+	if err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+
+	const feature = "record_selector.jsonpath_or_list_key"
+	if !containsString(report.MissingFeatures, feature) {
+		t.Fatalf("missing features = %#v, want %q", report.MissingFeatures, feature)
+	}
+	if containsString(report.SupportedFeatures, feature) {
+		t.Fatalf("supported features = %#v, must not include missing feature %q", report.SupportedFeatures, feature)
+	}
+	for _, supported := range report.SupportedFeatures {
+		if containsString(report.MissingFeatures, supported) {
+			t.Fatalf("supported and missing features overlap on %q; supported=%#v missing=%#v", supported, report.SupportedFeatures, report.MissingFeatures)
+		}
+	}
+	if !hasSupportCheckStatus(report.Checks, feature, SupportStatusReady) {
+		t.Fatalf("checks = %#v, want ready check for %q", report.Checks, feature)
+	}
+	if !hasSupportCheckStatus(report.Checks, feature, SupportStatusMissing) {
+		t.Fatalf("checks = %#v, want missing check for %q", report.Checks, feature)
+	}
+}
+
 func TestClassifyAllSummarizesTargetSet(t *testing.T) {
 	supported := Definition{
 		SchemaVersion: SchemaVersionIntegrationV1,
@@ -451,6 +532,15 @@ func hasBlockingCheck(checks []ValidationCheck, id string) bool {
 func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSupportCheckStatus(checks []SupportCheck, id string, status string) bool {
+	for _, check := range checks {
+		if check.ID == id && check.Status == status {
 			return true
 		}
 	}

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -81,8 +81,33 @@ func TestValidateBlocksUnsafeDynamicDefinition(t *testing.T) {
 			blocked = append(blocked, check.ID)
 		}
 	}
-	if len(blocked) < 3 {
-		t.Fatalf("blocking checks = %#v, want secret/path/method blockers", blocked)
+	if len(blocked) < 2 {
+		t.Fatalf("blocking checks = %#v, want secret/path blockers", blocked)
+	}
+}
+
+func TestValidateBlocksUnsupportedResourceMethods(t *testing.T) {
+	definition, err := Normalize(Definition{
+		ID:          "example",
+		TenantID:    "tenant-a",
+		SourceID:    "example",
+		DisplayName: "Example",
+		Runtime:     RuntimeJSONAPI,
+		Auth: AuthSpec{
+			Model: "none",
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:      "assets",
+			Path:    "/v1/assets",
+			Method:  "DELETE",
+			IDField: "id",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if !hasBlockingCheck(definition.Validation.Checks, "method_assets") {
+		t.Fatalf("validation checks = %#v, want method_assets blocker", definition.Validation.Checks)
 	}
 }
 
@@ -152,9 +177,242 @@ func TestPromoteMovesOneStageWhenReady(t *testing.T) {
 	}
 }
 
+func TestNormalizeIntegrationDefinition(t *testing.T) {
+	definition, err := Normalize(Definition{
+		SchemaVersion: SchemaVersionIntegrationV1,
+		ID:            "example",
+		TenantID:      "tenant-a",
+		SourceID:      "example",
+		DisplayName:   "Example",
+		Categories:    []string{"identity", "identity", "audit"},
+		Auth: AuthSpec{
+			Model:            "oauth_authorization_code",
+			AuthorizationURL: "https://example.test/oauth/authorize",
+			TokenURL:         "https://example.test/oauth/token",
+			Scopes:           []string{"users.read", "audit.read"},
+			CredentialFields: []Field{{
+				Key:           "client_secret",
+				Secret:        true,
+				ReferenceOnly: true,
+			}},
+		},
+		Transport: &TransportSpec{
+			BaseURL: "https://${connection.domain}/api",
+			Verification: &VerificationSpec{
+				Path:         "/v1/me",
+				ExpectStatus: []int{200, 204},
+			},
+			Retry: &RetrySpec{
+				Statuses:         []int{429, 500},
+				RetryAfterHeader: "Retry-After",
+			},
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:             "users",
+			Path:           "/v1/users",
+			RecordSelector: "$.data[*]",
+			IDField:        "id",
+			Event: EventMappingSpec{
+				Kind:      "example.user",
+				SchemaRef: "example/user/v1",
+			},
+			Pagination: &PaginationSpec{
+				Type:           "cursor",
+				CursorParam:    "cursor",
+				CursorJSONPath: "$.next_cursor",
+			},
+			Incremental: &IncrementalSpec{
+				CursorField: "updated_at",
+			},
+			Projection: &ProjectionSpec{
+				Template: "identity_user",
+				Fields:   map[string]string{"entity_id": "$.id"},
+			},
+			Coverage: []CoverageDimensionSpec{{
+				Type:    "entity_family",
+				Support: "supported",
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if definition.Validation.Status != ValidationReady {
+		t.Fatalf("validation status = %q, want ready: %#v", definition.Validation.Status, definition.Validation.Checks)
+	}
+	if len(definition.Categories) != 2 || definition.Categories[0] != "audit" || definition.Categories[1] != "identity" {
+		t.Fatalf("categories = %#v", definition.Categories)
+	}
+	if got := definition.ResourceFamilies[0].Coverage[0].ID; got != "users_entity_family" {
+		t.Fatalf("coverage id = %q, want users_entity_family", got)
+	}
+}
+
+func TestClassifyReportsSupportedDefinition(t *testing.T) {
+	report, err := Classify(Definition{
+		SchemaVersion: SchemaVersionIntegrationV1,
+		ID:            "example",
+		TenantID:      "tenant-a",
+		SourceID:      "example",
+		DisplayName:   "Example",
+		Auth: AuthSpec{
+			Model: "bearer_token",
+			CredentialFields: []Field{{
+				Key:           "token",
+				Secret:        true,
+				ReferenceOnly: true,
+			}},
+		},
+		Transport: &TransportSpec{
+			BaseURL: "https://api.example.test",
+			Verification: &VerificationSpec{
+				Path: "/v1/me",
+			},
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:             "users",
+			Path:           "/v1/users",
+			RecordSelector: "$.data[*]",
+			IDField:        "id",
+			Event: EventMappingSpec{
+				Kind:      "example.user",
+				SchemaRef: "example/user/v1",
+			},
+			Pagination: &PaginationSpec{
+				Type: "cursor",
+			},
+			Projection: &ProjectionSpec{
+				Template: "identity_user",
+			},
+			Coverage: []CoverageDimensionSpec{{
+				Type:    "entity_family",
+				Support: "supported",
+			}},
+		}},
+	}, DefaultGrammar())
+	if err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+	if report.Verdict != SupportVerdictSupported {
+		t.Fatalf("verdict = %q, want supported; missing=%#v checks=%#v", report.Verdict, report.MissingFeatures, report.Checks)
+	}
+	if len(report.MissingFeatures) != 0 {
+		t.Fatalf("missing features = %#v, want none", report.MissingFeatures)
+	}
+}
+
+func TestClassifyReportsMissingFeatures(t *testing.T) {
+	report, err := Classify(Definition{
+		SchemaVersion: SchemaVersionIntegrationV1,
+		ID:            "example",
+		TenantID:      "tenant-a",
+		SourceID:      "example",
+		DisplayName:   "Example",
+		Runtime:       RuntimeJSONAPI,
+		Auth: AuthSpec{
+			Model: "bearer_token",
+			CredentialFields: []Field{{
+				Key:           "token",
+				Secret:        true,
+				ReferenceOnly: true,
+			}},
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:      "users",
+			Path:    "/v1/users",
+			Method:  "GET",
+			IDField: "id",
+		}},
+	}, DefaultGrammar())
+	if err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+	if report.Verdict != SupportVerdictBespokeRequired {
+		t.Fatalf("verdict = %q, want bespoke_required", report.Verdict)
+	}
+	for _, want := range []string{
+		"transport.base_url_template",
+		"transport.verification",
+		"record_selector.jsonpath_or_list_key",
+		"projection.template",
+		"coverage.dimensions",
+	} {
+		if !containsString(report.MissingFeatures, want) {
+			t.Fatalf("missing features = %#v, want %q", report.MissingFeatures, want)
+		}
+	}
+}
+
+func TestClassifyAllSummarizesTargetSet(t *testing.T) {
+	supported := Definition{
+		SchemaVersion: SchemaVersionIntegrationV1,
+		ID:            "example",
+		TenantID:      "tenant-a",
+		SourceID:      "example",
+		DisplayName:   "Example",
+		Auth: AuthSpec{
+			Model: "bearer_token",
+			CredentialFields: []Field{{
+				Key:           "token",
+				Secret:        true,
+				ReferenceOnly: true,
+			}},
+		},
+		Transport: &TransportSpec{
+			BaseURL: "https://api.example.test",
+			Verification: &VerificationSpec{
+				Path: "/v1/me",
+			},
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:             "users",
+			Path:           "/v1/users",
+			RecordSelector: "$.data[*]",
+			IDField:        "id",
+			Event: EventMappingSpec{
+				Kind:      "example.user",
+				SchemaRef: "example/user/v1",
+			},
+			Projection: &ProjectionSpec{
+				Template: "identity_user",
+			},
+			Coverage: []CoverageDimensionSpec{{
+				Type:    "entity_family",
+				Support: "supported",
+			}},
+		}},
+	}
+	missing := supported
+	missing.ID = "missing"
+	missing.SourceID = "missing"
+	missing.Transport = nil
+	summary, err := ClassifyAll([]Definition{supported, missing}, DefaultGrammar())
+	if err != nil {
+		t.Fatalf("ClassifyAll() error = %v", err)
+	}
+	if summary.Targets != 2 || summary.Supported != 1 || summary.BespokeRequired != 1 {
+		t.Fatalf("summary = %#v", summary)
+	}
+	if summary.ByAuthModel["bearer_token"] != 2 {
+		t.Fatalf("ByAuthModel = %#v, want bearer_token count", summary.ByAuthModel)
+	}
+	if summary.MissingFeatures["transport.base_url_template"] != 1 {
+		t.Fatalf("MissingFeatures = %#v, want missing transport count", summary.MissingFeatures)
+	}
+}
+
 func hasBlockingCheck(checks []ValidationCheck, id string) bool {
 	for _, check := range checks {
 		if check.ID == id && check.Blocking {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
 			return true
 		}
 	}

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -401,6 +401,24 @@ func renderCatalog(request normalizedRequest) string {
 	for _, family := range request.Families {
 		fmt.Fprintf(&b, "  - %s\n", family.EventKind)
 	}
+	fmt.Fprintf(&b, "coverage_contract:\n")
+	fmt.Fprintf(&b, "  owner_domain: source_runtime\n")
+	fmt.Fprintf(&b, "  authority_domain: %s\n", request.SourceID)
+	fmt.Fprintf(&b, "  dimensions:\n")
+	for _, family := range request.Families {
+		fmt.Fprintf(&b, "    - id: %s\n", family.Name)
+		fmt.Fprintf(&b, "      type: entity_family\n")
+		fmt.Fprintf(&b, "      title: %s\n", yamlString(titleFromID(family.Name)))
+		fmt.Fprintf(&b, "      families: [%s]\n", family.Name)
+		fmt.Fprintf(&b, "      support: partial\n")
+		fmt.Fprintf(&b, "      high_value: true\n")
+		fmt.Fprintf(&b, "      notes:\n")
+		fmt.Fprintf(&b, "        - Generated Source Runtime SDK mapping requires provider field review before certification.\n")
+	}
+	fmt.Fprintf(&b, "    - id: incremental_sync\n")
+	fmt.Fprintf(&b, "      type: incremental_sync\n")
+	fmt.Fprintf(&b, "      title: Incremental cursor sync\n")
+	fmt.Fprintf(&b, "      support: planned\n")
 	fmt.Fprintf(&b, "event_contracts:\n")
 	for _, family := range request.Families {
 		fmt.Fprintf(&b, "  - kind: %s\n", family.EventKind)

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/writer/cerebro/internal/connectordefinitions"
 )
 
 const (
@@ -28,18 +30,30 @@ const (
 
 var errMissingSchemas = errors.New("at least one asset_schemas or finding_schemas entry is required")
 var errGeneratedNameCollision = errors.New("generated source names collide")
+var errUnsupportedDefinition = errors.New("connector definition is not executable by sourcegen")
 
 // Request describes a generated Source Runtime SDK integration.
 type Request struct {
 	SourceID             string
 	SourceType           string
 	AuthModel            string
+	DefinitionPath       string
 	AssetSchemas         []string
 	FindingSchemas       []string
 	FreshnessExpectation string
 	FailureModes         []string
 	Name                 string
 	Description          string
+	HealthPath           string
+	OutputDir            string
+	DryRun               bool
+	Force                bool
+}
+
+// DefinitionRequest describes a generated integration backed by a connector definition.
+type DefinitionRequest struct {
+	Definition           connectordefinitions.Definition
+	FreshnessExpectation string
 	HealthPath           string
 	OutputDir            string
 	DryRun               bool
@@ -98,6 +112,20 @@ func Generate(request Request) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	return generateNormalized(normalized)
+}
+
+// GenerateDefinition writes a Source Runtime SDK scaffold from a validated
+// integration definition, or returns the file plan in dry-run mode.
+func GenerateDefinition(request DefinitionRequest) (*Result, error) {
+	normalized, err := normalizeDefinitionRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	return generateNormalized(normalized)
+}
+
+func generateNormalized(normalized normalizedRequest) (*Result, error) {
 	files, err := renderFiles(normalized)
 	if err != nil {
 		return nil, err
@@ -138,6 +166,90 @@ func Generate(request Request) (*Result, error) {
 		}
 	}
 	return result, nil
+}
+
+func normalizeDefinitionRequest(request DefinitionRequest) (normalizedRequest, error) {
+	definition, err := connectordefinitions.Normalize(request.Definition)
+	if err != nil {
+		return normalizedRequest{}, err
+	}
+	report, err := connectordefinitions.Classify(definition, connectordefinitions.DefaultGrammar())
+	if err != nil {
+		return normalizedRequest{}, err
+	}
+	if report.Validation.Status == connectordefinitions.ValidationBlocked {
+		return normalizedRequest{}, fmt.Errorf("%w: definition validation is blocked: %s", errUnsupportedDefinition, strings.Join(report.MissingFeatures, ", "))
+	}
+	if report.Verdict != connectordefinitions.SupportVerdictSupported {
+		return normalizedRequest{}, fmt.Errorf("%w: definition is outside the generic grammar: %s", errUnsupportedDefinition, strings.Join(report.MissingFeatures, ", "))
+	}
+	authModel, err := executableAuthModel(definition.Auth.Model)
+	if err != nil {
+		return normalizedRequest{}, err
+	}
+	tokenScheme, tokenConfigKey, err := authModelConfig(authModel)
+	if err != nil {
+		return normalizedRequest{}, err
+	}
+	sourceID := strings.TrimSpace(definition.SourceID)
+	if !identifierPattern.MatchString(sourceID) {
+		return normalizedRequest{}, fmt.Errorf("source_id %q must start with a lowercase letter and use lowercase letters, digits, underscores, or hyphens", definition.SourceID)
+	}
+	failureModes := []string{"api_error", "auth_error", "rate_limit", "schema_drift"}
+	freshness, err := parseFreshnessExpectation(request.FreshnessExpectation)
+	if err != nil {
+		return normalizedRequest{}, err
+	}
+	healthPath := strings.TrimSpace(request.HealthPath)
+	if healthPath == "" && definition.Transport != nil && definition.Transport.Verification != nil {
+		healthPath = strings.TrimSpace(definition.Transport.Verification.Path)
+	}
+	if healthPath == "" {
+		healthPath = defaultHealthPath
+	}
+	if !strings.HasPrefix(healthPath, "/") || strings.Contains(healthPath, "?") || strings.Contains(healthPath, "#") {
+		return normalizedRequest{}, fmt.Errorf("health_path must be an absolute path without query or fragment")
+	}
+	if strings.ContainsAny(healthPath, "\r\n\t ") {
+		return normalizedRequest{}, fmt.Errorf("health_path must not contain whitespace")
+	}
+	outputDir := strings.TrimSpace(request.OutputDir)
+	if outputDir == "" {
+		outputDir = "."
+	}
+	normalized := normalizedRequest{
+		Request: Request{
+			SourceID:             sourceID,
+			SourceType:           SourceTypeJSONAPI,
+			AuthModel:            authModel,
+			FreshnessExpectation: freshness.String(),
+			FailureModes:         failureModes,
+			Name:                 firstNonEmptyString(definition.DisplayName, titleFromID(sourceID)+" Source Runtime"),
+			Description:          firstNonEmptyString(definition.Description, fmt.Sprintf("%s source runtime generated from a connector definition.", titleFromID(sourceID))),
+			HealthPath:           healthPath,
+			OutputDir:            outputDir,
+			DryRun:               request.DryRun,
+			Force:                request.Force,
+		},
+		FreshnessDuration: freshness,
+		TokenScheme:       tokenScheme,
+		TokenConfigKey:    tokenConfigKey,
+		EnvPrefix:         strings.ToUpper(strings.NewReplacer("-", "_").Replace(sourceID)),
+		PackageName:       packageName(sourceID),
+	}
+	normalized.Families, err = familiesForDefinition(normalized, definition)
+	if err != nil {
+		return normalizedRequest{}, err
+	}
+	if len(normalized.Families) == 0 {
+		return normalizedRequest{}, fmt.Errorf("%w: definition must include at least one executable resource family", errUnsupportedDefinition)
+	}
+	if err := validateGeneratedFamilies(normalized.Families); err != nil {
+		return normalizedRequest{}, err
+	}
+	normalized.DefaultFamily = normalized.Families[0].Name
+	normalized.DefaultPath = normalized.Families[0].Path
+	return normalized, nil
 }
 
 func normalizeRequest(request Request) (normalizedRequest, error) {
@@ -260,6 +372,17 @@ func authModelConfig(authModel string) (string, string, error) {
 	}
 }
 
+func executableAuthModel(authModel string) (string, error) {
+	switch strings.TrimSpace(authModel) {
+	case AuthModelBearerToken, "bearer":
+		return AuthModelBearerToken, nil
+	case AuthModelAPIToken, AuthModelAPIKey:
+		return AuthModelAPIKey, nil
+	default:
+		return "", fmt.Errorf("%w: auth model %q needs provider auth runtime support before sourcegen can emit executable code", errUnsupportedDefinition, authModel)
+	}
+}
+
 func normalizeIdentifiers(label string, values []string) ([]string, error) {
 	seen := map[string]struct{}{}
 	out := make([]string, 0, len(values))
@@ -345,6 +468,98 @@ func familiesForRequest(request normalizedRequest) []familyData {
 		RequiredPayloadFields: []string{"uri", "digest"},
 	})
 	return families
+}
+
+func familiesForDefinition(request normalizedRequest, definition connectordefinitions.Definition) ([]familyData, error) {
+	families := make([]familyData, 0, len(definition.ResourceFamilies))
+	for _, resource := range definition.ResourceFamilies {
+		class, err := executableProjectionClass(resource)
+		if err != nil {
+			return nil, err
+		}
+		name := strings.TrimSpace(resource.ID)
+		eventKind := strings.TrimSpace(resource.Event.Kind)
+		if eventKind == "" {
+			eventKind = request.SourceID + "." + name
+		}
+		schemaRef := strings.TrimSpace(resource.Event.SchemaRef)
+		if schemaRef == "" {
+			schemaRef = request.SourceID + "/" + name + "/v1"
+		}
+		urnKind := strings.TrimSpace(resource.Event.URNKind)
+		if urnKind == "" {
+			urnKind = "runtime_" + name
+		}
+		requiredAttributes := resource.Event.RequiredAttributes
+		if len(requiredAttributes) == 0 {
+			requiredAttributes = requiredAttributesForClass(class)
+		}
+		requiredPayloadFields := resource.Event.RequiredPayloadFields
+		if len(requiredPayloadFields) == 0 {
+			requiredPayloadFields = []string{firstNonEmptyString(resource.IDField, "id")}
+		}
+		families = append(families, familyData{
+			Name:                  name,
+			Schema:                schemaNameFromRef(schemaRef, name),
+			Class:                 class,
+			ConstName:             "family" + pascalIdentifier(name),
+			ProjectorName:         lowerCamelIdentifier(request.SourceID + "_" + name + "_projections"),
+			Path:                  resource.Path,
+			URNKind:               urnKind,
+			EventKind:             eventKind,
+			SchemaRef:             schemaRef,
+			RequiredAttributes:    requiredAttributes,
+			RequiredPayloadFields: requiredPayloadFields,
+		})
+	}
+	return families, nil
+}
+
+func executableProjectionClass(resource connectordefinitions.ResourceFamily) (string, error) {
+	template := ""
+	if resource.Projection != nil {
+		template = strings.TrimSpace(resource.Projection.Template)
+	}
+	if template == "" {
+		return "", fmt.Errorf("%w: family %q needs a projection template before sourcegen can emit executable code", errUnsupportedDefinition, resource.ID)
+	}
+	switch template {
+	case "asset", "cloud_resource", "endpoint_device", "repository":
+		return "asset", nil
+	case "finding", "vulnerability":
+		return "finding", nil
+	case "identity_user", "identity_group", "group_membership", "audit_event", "evidence_cas_reference":
+		return template, nil
+	default:
+		return "", fmt.Errorf("%w: projection template %q is not executable by sourcegen yet", errUnsupportedDefinition, template)
+	}
+}
+
+func requiredAttributesForClass(class string) []string {
+	switch class {
+	case "finding":
+		return []string{"tenant_id", "source_event_id", "finding_id", "resource_urn", "severity", "status"}
+	case "identity_user":
+		return []string{"tenant_id", "source_event_id", "user_id"}
+	case "identity_group":
+		return []string{"tenant_id", "source_event_id", "group_id"}
+	case "group_membership":
+		return []string{"tenant_id", "source_event_id", "group_id", "member_id"}
+	case "audit_event":
+		return []string{"tenant_id", "source_event_id", "event_type", "actor_id"}
+	case "evidence_cas_reference":
+		return []string{"tenant_id", "source_event_id", "evidence_id", "evidence_type", "evidence_cas_uri", "evidence_cas_digest"}
+	default:
+		return []string{"tenant_id", "source_event_id", "resource_urn", "resource_type", "resource_id"}
+	}
+}
+
+func schemaNameFromRef(schemaRef string, fallback string) string {
+	parts := strings.Split(strings.Trim(schemaRef, "/"), "/")
+	if len(parts) >= 2 && strings.TrimSpace(parts[len(parts)-2]) != "" {
+		return strings.TrimSpace(parts[len(parts)-2])
+	}
+	return fallback
 }
 
 func validateGeneratedFamilies(families []familyData) error {
@@ -521,6 +736,14 @@ func idKeysForFamily(family familyData) []string {
 		return []string{"evidence_id", "uri", "digest", "id"}
 	case "finding":
 		return []string{"finding_id", "id", "resource_urn"}
+	case "identity_user":
+		return []string{"user_id", "id", "email", "primary_email", "login"}
+	case "identity_group":
+		return []string{"group_id", "id", "group_email", "email"}
+	case "group_membership":
+		return []string{"membership_id", "id", "group_id", "member_id", "user_id", "email"}
+	case "audit_event":
+		return []string{"event_id", "id", "uuid", "request_id"}
 	default:
 		return []string{"id", "urn", "resource_urn", "name"}
 	}
@@ -548,6 +771,44 @@ func attributePathsForFamily(family familyData) map[string]string {
 		base["status"] = "status|state"
 		base["title"] = "title|name|summary"
 		base["description"] = "description|summary"
+	case "identity_user":
+		base["user_id"] = "user_id|id|uid"
+		base["email"] = "email|primary_email|profile.email"
+		base["primary_email"] = "primary_email|email|profile.email"
+		base["login"] = "login|username|email|profile.login"
+		base["display_name"] = "display_name|name|profile.display_name|profile.name"
+		base["domain"] = "domain|tenant_domain|organization_domain"
+		base["status"] = "status|state|lifecycle_state"
+		base["created_at"] = "created_at|created|profile.created_at"
+		base["last_login_at"] = "last_login_at|last_login|last_seen_at"
+		base["department"] = "department|profile.department"
+		base["job_title"] = "job_title|title|profile.title"
+		base["manager"] = "manager|profile.manager"
+	case "identity_group":
+		base["group_id"] = "group_id|id"
+		base["group_email"] = "group_email|email"
+		base["group_name"] = "group_name|name|display_name"
+		base["domain"] = "domain|tenant_domain|organization_domain"
+		base["description"] = "description|summary"
+	case "group_membership":
+		base["group_id"] = "group_id|group.id|groupId"
+		base["group_email"] = "group_email|group.email"
+		base["group_name"] = "group_name|group.name"
+		base["member_id"] = "member_id|member.id|user_id|user.id|id"
+		base["member_user_id"] = "member_user_id|user_id|user.id|member.id"
+		base["member_email"] = "member_email|user_email|email|member.email|user.email"
+		base["member_name"] = "member_name|name|member.name|user.name"
+		base["member_type"] = "member_type|type|member.type"
+		base["role"] = "role|membership_role"
+	case "audit_event":
+		base["event_type"] = "event_type|event_name|action|type"
+		base["actor_id"] = "actor_id|actor.id|actorId|user_id|user.id"
+		base["actor_email"] = "actor_email|actor.email|email|user.email"
+		base["actor_name"] = "actor_name|actor.name|user.name"
+		base["resource_id"] = "resource_id|target_id|target.id|resource.id|object_id"
+		base["resource_type"] = "resource_type|target_type|target.type|object_type"
+		base["resource_name"] = "resource_name|target_name|target.name|resource.name|object_name"
+		base["resource_email"] = "resource_email|target_email|target.email"
 	case "evidence_cas_reference":
 		base["evidence_id"] = "evidence_id|id|uri"
 		base["evidence_type"] = "evidence_type|type"
@@ -582,11 +843,11 @@ func renderSourceTestGo(request normalizedRequest) string {
 	fmt.Fprintf(&b, "\t\tif r.URL.Path == defaultHealthPath {\n\t\t\tw.WriteHeader(http.StatusNoContent)\n\t\t\treturn\n\t\t}\n")
 	fmt.Fprintf(&b, "\t\tif r.URL.Path != %s {\n\t\t\tt.Fatalf(\"path = %%q\", r.URL.Path)\n\t\t}\n", strconv.Quote(request.DefaultPath))
 	fmt.Fprintf(&b, "\t\tw.Header().Set(\"Content-Type\", \"application/json\")\n")
-	fmt.Fprintf(&b, "\t\t_ = json.NewEncoder(w).Encode(map[string]any{\"items\": []map[string]string{{\"id\": \"record-1\", \"resource_urn\": \"urn:cerebro:tenant:runtime_asset:record-1\", \"resource_type\": \"asset\", \"resource_id\": \"record-1\", \"name\": \"Record One\", \"updated_at\": \"2026-06-01T00:00:00Z\", \"evidence_cas_uri\": \"cas://cases/record-1\", \"evidence_cas_digest\": \"sha256:test\"}}})\n")
+	fmt.Fprintf(&b, "\t\t_ = json.NewEncoder(w).Encode(map[string]any{\"items\": []map[string]string{{\"id\": \"record-1\", \"resource_urn\": \"urn:cerebro:tenant:runtime_asset:record-1\", \"resource_type\": \"asset\", \"resource_id\": \"record-1\", \"name\": \"Record One\", \"updated_at\": \"2026-06-01T00:00:00Z\"}}})\n")
 	fmt.Fprintf(&b, "\t}))\n\tdefer server.Close()\n")
 	fmt.Fprintf(&b, "\tcfg := sourcecdk.NewConfig(map[string]string{\"tenant_id\": \"tenant\", \"base_url\": server.URL, \"family\": defaultFamily, %s: \"test-token\"})\n", strconv.Quote(configKey))
 	fmt.Fprintf(&b, "\tif err := source.Check(context.Background(), cfg); err != nil {\n\t\tt.Fatalf(\"Check() error = %%v\", err)\n\t}\n")
-	fmt.Fprintf(&b, "\tpull, err := source.Read(context.Background(), cfg, nil)\n\tif err != nil {\n\t\tt.Fatalf(\"Read() error = %%v\", err)\n\t}\n\tif len(pull.Events) != 1 {\n\t\tt.Fatalf(\"events = %%d, want 1\", len(pull.Events))\n\t}\n\tevent := pull.Events[0]\n\tif event.Kind != sourceID+\".\"+defaultFamily {\n\t\tt.Fatalf(\"kind = %%q\", event.Kind)\n\t}\n\tif !strings.Contains(event.Attributes[\"evidence_cas_uri\"], \"record-1\") {\n\t\tt.Fatalf(\"evidence_cas_uri = %%q\", event.Attributes[\"evidence_cas_uri\"])\n\t}\n}\n")
+	fmt.Fprintf(&b, "\tpull, err := source.Read(context.Background(), cfg, nil)\n\tif err != nil {\n\t\tt.Fatalf(\"Read() error = %%v\", err)\n\t}\n\tif len(pull.Events) != 1 {\n\t\tt.Fatalf(\"events = %%d, want 1\", len(pull.Events))\n\t}\n\tevent := pull.Events[0]\n\tif event.Kind != sourceID+\".\"+defaultFamily {\n\t\tt.Fatalf(\"kind = %%q\", event.Kind)\n\t}\n\tif strings.TrimSpace(event.Id) == \"\" {\n\t\tt.Fatalf(\"event id is empty: %%#v\", event)\n\t}\n}\n")
 	return b.String()
 }
 
@@ -670,13 +931,25 @@ func renderProjectionGo(request normalizedRequest) string {
 	sourcePrefix := lowerCamelIdentifier(request.SourceID)
 	var b strings.Builder
 	fmt.Fprintf(&b, "package sourceprojection\n\n")
-	fmt.Fprintf(&b, "import (\n\t\"strings\"\n\n\tcerebrov1 \"github.com/writer/cerebro/gen/cerebro/v1\"\n\t\"github.com/writer/cerebro/internal/ports\"\n)\n\n")
+	if projectionNeedsStrings(request.Families) {
+		fmt.Fprintf(&b, "import (\n\t\"strings\"\n\n\tcerebrov1 \"github.com/writer/cerebro/gen/cerebro/v1\"\n\t\"github.com/writer/cerebro/internal/ports\"\n)\n\n")
+	} else {
+		fmt.Fprintf(&b, "import (\n\tcerebrov1 \"github.com/writer/cerebro/gen/cerebro/v1\"\n\t\"github.com/writer/cerebro/internal/ports\"\n)\n\n")
+	}
 	for _, family := range request.Families {
 		switch family.Class {
 		case "asset":
 			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sAssetProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
 		case "finding":
 			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sFindingProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
+		case "identity_user":
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn identityUserProjections(event, identityProjectionProfile{Provider: %s})\n}\n\n", family.ProjectorName, strconv.Quote(request.SourceID))
+		case "identity_group":
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn identityGroupProjections(event, identityProjectionProfile{Provider: %s})\n}\n\n", family.ProjectorName, strconv.Quote(request.SourceID))
+		case "group_membership":
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn identityGroupMembershipProjections(event, identityProjectionProfile{Provider: %s})\n}\n\n", family.ProjectorName, strconv.Quote(request.SourceID))
+		case "audit_event":
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn identityAuditProjections(event, identityProjectionProfile{Provider: %s})\n}\n\n", family.ProjectorName, strconv.Quote(request.SourceID))
 		default:
 			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn runtimeEvidenceProjections(event)\n}\n\n", family.ProjectorName)
 		}
@@ -692,9 +965,17 @@ func renderProjectionGo(request normalizedRequest) string {
 	return b.String()
 }
 
+func projectionNeedsStrings(families []familyData) bool {
+	return firstFamilyClass(families, "asset").Name != "" || firstFamilyClass(families, "finding").Name != ""
+}
+
 func renderProjectionTestGo(request normalizedRequest) string {
 	assetFamily := firstFamilyClass(request.Families, "asset")
 	findingFamily := firstFamilyClass(request.Families, "finding")
+	userFamily := firstFamilyClass(request.Families, "identity_user")
+	groupFamily := firstFamilyClass(request.Families, "identity_group")
+	membershipFamily := firstFamilyClass(request.Families, "group_membership")
+	auditFamily := firstFamilyClass(request.Families, "audit_event")
 	evidenceFamily := firstFamilyClass(request.Families, "evidence_cas_reference")
 	var b strings.Builder
 	fmt.Fprintf(&b, "package sourceprojection\n\n")
@@ -709,9 +990,31 @@ func renderProjectionTestGo(request normalizedRequest) string {
 		fmt.Fprintf(&b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"finding_id\": \"finding-1\", \"title\": \"Finding One\", \"severity\": \"high\", \"status\": \"open\", \"resource_urn\": \"urn:cerebro:tenant:runtime_asset:asset-1\", \"evidence_id\": \"evidence-1\"}}\n", strconv.Quote(request.SourceID), strconv.Quote(findingFamily.EventKind))
 		fmt.Fprintf(&b, "\tentities, links, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tif len(entities) == 0 {\n\t\tt.Fatal(\"expected projected finding\")\n\t}\n\tif len(links) == 0 {\n\t\tt.Fatal(\"expected projected finding links\")\n\t}\n}\n\n", findingFamily.ProjectorName)
 	}
-	fmt.Fprintf(&b, "func Test%sEvidenceCASProjection(t *testing.T) {\n", pascalIdentifier(request.SourceID))
-	fmt.Fprintf(&b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"evidence_id\": \"evidence-1\", \"evidence_type\": \"evidence_cas.artifact\", \"source_event_id\": \"provider-event-1\", \"evidence_cas_uri\": \"cas://cases/evidence-1\", \"evidence_cas_digest\": \"sha256:test\"}}\n", strconv.Quote(request.SourceID), strconv.Quote(evidenceFamily.EventKind))
-	fmt.Fprintf(&b, "\tentities, _, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tvar foundEvidence bool\n\tfor _, entity := range entities {\n\t\tif entity.EntityType == \"runtime.evidence\" {\n\t\t\tfoundEvidence = true\n\t\t}\n\t}\n\tif !foundEvidence {\n\t\tt.Fatalf(\"entities = %%#v\", entities)\n\t}\n}\n", evidenceFamily.ProjectorName)
+	if userFamily.Class == "identity_user" {
+		fmt.Fprintf(&b, "func Test%sIdentityUserProjection(t *testing.T) {\n", pascalIdentifier(request.SourceID))
+		fmt.Fprintf(&b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"user_id\": \"user-1\", \"email\": \"user@example.test\", \"display_name\": \"User One\"}}\n", strconv.Quote(request.SourceID), strconv.Quote(userFamily.EventKind))
+		fmt.Fprintf(&b, "\tentities, _, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tif len(entities) == 0 {\n\t\tt.Fatal(\"expected projected identity user\")\n\t}\n}\n\n", userFamily.ProjectorName)
+	}
+	if groupFamily.Class == "identity_group" {
+		fmt.Fprintf(&b, "func Test%sIdentityGroupProjection(t *testing.T) {\n", pascalIdentifier(request.SourceID))
+		fmt.Fprintf(&b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"group_id\": \"group-1\", \"group_email\": \"group@example.test\", \"group_name\": \"Group One\"}}\n", strconv.Quote(request.SourceID), strconv.Quote(groupFamily.EventKind))
+		fmt.Fprintf(&b, "\tentities, _, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tif len(entities) == 0 {\n\t\tt.Fatal(\"expected projected identity group\")\n\t}\n}\n\n", groupFamily.ProjectorName)
+	}
+	if membershipFamily.Class == "group_membership" {
+		fmt.Fprintf(&b, "func Test%sGroupMembershipProjection(t *testing.T) {\n", pascalIdentifier(request.SourceID))
+		fmt.Fprintf(&b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"group_id\": \"group-1\", \"group_email\": \"group@example.test\", \"member_id\": \"user-1\", \"member_email\": \"user@example.test\"}}\n", strconv.Quote(request.SourceID), strconv.Quote(membershipFamily.EventKind))
+		fmt.Fprintf(&b, "\tentities, links, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tif len(entities) == 0 || len(links) == 0 {\n\t\tt.Fatalf(\"entities/links = %%d/%%d, want membership projection\", len(entities), len(links))\n\t}\n}\n\n", membershipFamily.ProjectorName)
+	}
+	if auditFamily.Class == "audit_event" {
+		fmt.Fprintf(&b, "func Test%sAuditProjection(t *testing.T) {\n", pascalIdentifier(request.SourceID))
+		fmt.Fprintf(&b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"event_type\": \"user.login\", \"actor_id\": \"user-1\", \"actor_email\": \"user@example.test\", \"resource_id\": \"app-1\", \"resource_type\": \"application\"}}\n", strconv.Quote(request.SourceID), strconv.Quote(auditFamily.EventKind))
+		fmt.Fprintf(&b, "\tentities, links, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tif len(entities) == 0 || len(links) == 0 {\n\t\tt.Fatalf(\"entities/links = %%d/%%d, want audit projection\", len(entities), len(links))\n\t}\n}\n\n", auditFamily.ProjectorName)
+	}
+	if evidenceFamily.Class == "evidence_cas_reference" {
+		fmt.Fprintf(&b, "func Test%sEvidenceCASProjection(t *testing.T) {\n", pascalIdentifier(request.SourceID))
+		fmt.Fprintf(&b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"evidence_id\": \"evidence-1\", \"evidence_type\": \"evidence_cas.artifact\", \"source_event_id\": \"provider-event-1\", \"evidence_cas_uri\": \"cas://cases/evidence-1\", \"evidence_cas_digest\": \"sha256:test\"}}\n", strconv.Quote(request.SourceID), strconv.Quote(evidenceFamily.EventKind))
+		fmt.Fprintf(&b, "\tentities, _, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tvar foundEvidence bool\n\tfor _, entity := range entities {\n\t\tif entity.EntityType == \"runtime.evidence\" {\n\t\t\tfoundEvidence = true\n\t\t}\n\t}\n\tif !foundEvidence {\n\t\tt.Fatalf(\"entities = %%#v\", entities)\n\t}\n}\n", evidenceFamily.ProjectorName)
+	}
 	return b.String()
 }
 
@@ -810,4 +1113,13 @@ func titleFromID(value string) string {
 		parts[index] = string(runes)
 	}
 	return strings.Join(parts, " ")
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/tools/sourcedeploy"
 )
@@ -112,6 +113,124 @@ func TestGenerateDryRunDoesNotWriteFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(outputDir, "sources/demo_source/source.go")); !os.IsNotExist(err) {
 		t.Fatalf("source.go exists after dry run, err=%v", err)
+	}
+}
+
+func TestGenerateDefinitionWritesIdentitySource(t *testing.T) {
+	outputDir := t.TempDir()
+	result, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			SchemaVersion: connectordefinitions.SchemaVersionIntegrationV1,
+			ID:            "tenant-a-example_idp",
+			TenantID:      "tenant-a",
+			SourceID:      "example_idp",
+			DisplayName:   "Example IDP",
+			Auth: connectordefinitions.AuthSpec{
+				Model: "bearer_token",
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "token",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL: "https://api.example.test",
+				Verification: &connectordefinitions.VerificationSpec{
+					Path: "/v1/me",
+				},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:             "users",
+				Path:           "/v1/users",
+				RecordSelector: "$.data[*]",
+				IDField:        "id",
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "example_idp.user",
+					SchemaRef: "example_idp/user/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{
+					Template: "identity_user",
+				},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{
+					Type:    "entity_family",
+					Support: "supported",
+				}},
+			}},
+		},
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefinition() error = %v", err)
+	}
+	if result.SourceID != "example_idp" || result.AuthModel != AuthModelBearerToken {
+		t.Fatalf("result = %#v", result)
+	}
+	catalog := readGeneratedFile(t, outputDir, "sources/example_idp/catalog.yaml")
+	for _, want := range []string{"- example_idp.user", "families: [users]", "schema_ref: example_idp/user/v1"} {
+		if !strings.Contains(catalog, want) {
+			t.Fatalf("catalog missing %q:\n%s", want, catalog)
+		}
+	}
+	if _, err := sourcecdk.LoadSourceCatalog([]byte(catalog)); err != nil {
+		t.Fatalf("LoadSourceCatalog() error = %v\n%s", err, catalog)
+	}
+	projection := readGeneratedFile(t, outputDir, "internal/sourceprojection/example_idp.go")
+	for _, want := range []string{"exampleIdpUsersProjections", "identityUserProjections", `Provider: "example_idp"`} {
+		if !strings.Contains(projection, want) {
+			t.Fatalf("projection missing %q:\n%s", want, projection)
+		}
+	}
+	sourceTest := readGeneratedFile(t, outputDir, "sources/example_idp/source_test.go")
+	if strings.Contains(sourceTest, "evidence_cas_uri") {
+		t.Fatalf("definition generated source test should not assume EvidenceCAS fields:\n%s", sourceTest)
+	}
+}
+
+func TestGenerateDefinitionRejectsUnsupportedAuth(t *testing.T) {
+	_, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			ID:          "tenant-a-example",
+			TenantID:    "tenant-a",
+			SourceID:    "example",
+			DisplayName: "Example",
+			Auth: connectordefinitions.AuthSpec{
+				Model:            "oauth_authorization_code",
+				AuthorizationURL: "https://example.test/oauth/authorize",
+				TokenURL:         "https://example.test/oauth/token",
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "client_secret",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL: "https://api.example.test",
+				Verification: &connectordefinitions.VerificationSpec{
+					Path: "/v1/me",
+				},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:             "users",
+				Path:           "/v1/users",
+				RecordSelector: "$.data[*]",
+				IDField:        "id",
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "example.user",
+					SchemaRef: "example/user/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{
+					Template: "identity_user",
+				},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{Type: "entity_family", Support: "supported"}},
+			}},
+		},
+		OutputDir: t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("GenerateDefinition() error = nil, want unsupported auth error")
+	}
+	if !errors.Is(err, errUnsupportedDefinition) {
+		t.Fatalf("GenerateDefinition() error = %v, want errUnsupportedDefinition", err)
 	}
 }
 

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -51,11 +51,18 @@ func TestGenerateWritesSourceRuntimeSDKScaffold(t *testing.T) {
 		"- demo_source.asset_host",
 		"- demo_source.finding_vulnerability",
 		"- demo_source.evidence_cas_reference",
+		"coverage_contract:",
+		"authority_domain: demo_source",
+		"families: [asset_host]",
+		"id: incremental_sync",
 		"schema_ref: demo_source/asset_host/v1",
 	} {
 		if !strings.Contains(catalog, want) {
 			t.Fatalf("catalog missing %q:\n%s", want, catalog)
 		}
+	}
+	if _, err := sourcecdk.LoadSourceCatalog([]byte(catalog)); err != nil {
+		t.Fatalf("LoadSourceCatalog() error = %v\n%s", err, catalog)
 	}
 	receipt := map[string]any{}
 	if err := json.Unmarshal([]byte(readGeneratedFile(t, outputDir, "sources/demo_source/source_health_receipt.json")), &receipt); err != nil {

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -193,12 +193,13 @@ func TestGenerateDefinitionRejectsUnsupportedAuth(t *testing.T) {
 			TenantID:    "tenant-a",
 			SourceID:    "example",
 			DisplayName: "Example",
+			//nolint:gosec // Test auth descriptor only; no credential value is stored.
 			Auth: connectordefinitions.AuthSpec{
 				Model:            "oauth_authorization_code",
 				AuthorizationURL: "https://example.test/oauth/authorize",
 				TokenURL:         "https://example.test/oauth/token",
 				CredentialFields: []connectordefinitions.Field{{
-					Key:           "client_secret",
+					Key:           "oauth_client_reference",
 					Secret:        true,
 					ReferenceOnly: true,
 				}},


### PR DESCRIPTION
## Summary

- extend connector definitions into a broader `cerebro.integration/v1` schema covering auth, transport, verification, retry, pagination, incremental state, event mapping, projection templates, and coverage dimensions
- add a support classifier and batch summary API for proving whether definitions are supported by the generic integration grammar or require extensions/bespoke work
- expose `source-runtime sdk classify <definition.json>` for single definitions or JSON arrays of definitions
- add `source-runtime sdk new <source-id> definition=<definition.json>` so supported static-token JSON API definitions can generate executable Source Runtime SDK packages in one path
- generate identity user/group/membership and audit-event projection wrappers from definition projection templates, while keeping OAuth and other auth models classified but blocked from sourcegen until auth runtime support exists
- return classifier support reports from REST and MCP connector definition validation, and include `coverage_contract` dimensions from sourcegen-generated catalogs

## Tests

- `go test ./internal/connectordefinitions ./internal/sourcegen ./cmd/cerebro ./internal/bootstrap`
- `go test ./tools/catalogcheck ./tools/archtests`
- `go test ./...`
