### PR TITLE
Improve source short-circuiting and incremental fetch

### DIFF
--- a/internal/sourcecdk/cursor.go
+++ b/internal/sourcecdk/cursor.go
@@ -1,0 +1,158 @@
+package sourcecdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+// CursorEnvelope is the common JSON shape for resumable source checkpoints.
+// Opaque source cursors may still use provider-native tokens while a page is
+// actively being fetched; durable checkpoint cursors should prefer this shape.
+type CursorEnvelope struct {
+	Version             int               `json:"version,omitempty"`
+	Source              string            `json:"source,omitempty"`
+	Family              string            `json:"family,omitempty"`
+	Mode                string            `json:"mode,omitempty"`
+	ResumableCheckpoint bool              `json:"resumable_checkpoint,omitempty"`
+	Token               string            `json:"token,omitempty"`
+	Watermark           string            `json:"watermark,omitempty"`
+	BoundaryIDs         []string          `json:"boundary_ids,omitempty"`
+	Extra               map[string]string `json:"extra,omitempty"`
+}
+
+// EncodeCursorEnvelope returns the canonical JSON representation of envelope.
+func EncodeCursorEnvelope(envelope CursorEnvelope) (string, error) {
+	envelope.Source = strings.TrimSpace(envelope.Source)
+	envelope.Family = strings.TrimSpace(envelope.Family)
+	envelope.Mode = strings.TrimSpace(envelope.Mode)
+	envelope.Token = strings.TrimSpace(envelope.Token)
+	envelope.Watermark = strings.TrimSpace(envelope.Watermark)
+	envelope.BoundaryIDs = normalizedCursorValues(envelope.BoundaryIDs)
+	envelope.Extra = normalizedCursorMap(envelope.Extra)
+	payload, err := json.Marshal(envelope)
+	if err != nil {
+		return "", fmt.Errorf("marshal source cursor envelope: %w", err)
+	}
+	return string(payload), nil
+}
+
+// DecodeCursorEnvelope parses a CursorEnvelope from opaque JSON.
+func DecodeCursorEnvelope(opaque string) (CursorEnvelope, bool) {
+	raw := strings.TrimSpace(opaque)
+	if raw == "" || !strings.HasPrefix(raw, "{") {
+		return CursorEnvelope{}, false
+	}
+	var envelope CursorEnvelope
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		return CursorEnvelope{}, false
+	}
+	envelope.Source = strings.TrimSpace(envelope.Source)
+	envelope.Family = strings.TrimSpace(envelope.Family)
+	envelope.Mode = strings.TrimSpace(envelope.Mode)
+	envelope.Token = strings.TrimSpace(envelope.Token)
+	envelope.Watermark = strings.TrimSpace(envelope.Watermark)
+	envelope.BoundaryIDs = normalizedCursorValues(envelope.BoundaryIDs)
+	envelope.Extra = normalizedCursorMap(envelope.Extra)
+	return envelope, true
+}
+
+// ResumableCursorOpaque reports whether opaque is a resumable checkpoint.
+func ResumableCursorOpaque(opaque string) bool {
+	envelope, ok := DecodeCursorEnvelope(opaque)
+	return ok && envelope.ResumableCheckpoint
+}
+
+// CursorWatermark parses a cursor envelope watermark.
+func CursorWatermark(envelope CursorEnvelope) time.Time {
+	if strings.TrimSpace(envelope.Watermark) == "" {
+		return time.Time{}
+	}
+	watermark, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(envelope.Watermark))
+	if err != nil {
+		return time.Time{}
+	}
+	return watermark.UTC()
+}
+
+// SetCursorWatermark writes a UTC RFC3339Nano watermark into envelope.
+func SetCursorWatermark(envelope *CursorEnvelope, watermark time.Time) {
+	if envelope == nil || watermark.IsZero() {
+		return
+	}
+	envelope.Watermark = watermark.UTC().Format(time.RFC3339Nano)
+}
+
+// CursorToken returns the provider-native token carried directly by cursor or
+// by a standard cursor envelope.
+func CursorToken(cursor *cerebrov1.SourceCursor) string {
+	if cursor == nil {
+		return ""
+	}
+	opaque := strings.TrimSpace(cursor.GetOpaque())
+	if envelope, ok := DecodeCursorEnvelope(opaque); ok {
+		return strings.TrimSpace(envelope.Token)
+	}
+	return opaque
+}
+
+// CursorPage parses a one-based page number from CursorToken.
+func CursorPage(cursor *cerebrov1.SourceCursor) (int, error) {
+	token := CursorToken(cursor)
+	if token == "" {
+		return 1, nil
+	}
+	page, err := strconv.Atoi(token)
+	if err != nil {
+		return 0, fmt.Errorf("%w: parse cursor: %w", ErrInvalidConfig, err)
+	}
+	if page < 1 {
+		return 0, fmt.Errorf("%w: cursor page must be greater than zero", ErrInvalidConfig)
+	}
+	return page, nil
+}
+
+func normalizedCursorValues(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizedCursorMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/sourcecdk/cursor_test.go
+++ b/internal/sourcecdk/cursor_test.go
@@ -1,0 +1,128 @@
+package sourcecdk
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+)
+
+func TestCursorEnvelopeCanonicalizesResumableCheckpoint(t *testing.T) {
+	watermark := time.Date(2026, 6, 15, 12, 34, 56, 789, time.UTC)
+	envelope := CursorEnvelope{
+		Version:             1,
+		Source:              " github ",
+		Family:              " pull_request ",
+		Mode:                " incremental_watermark ",
+		ResumableCheckpoint: true,
+		Token:               " 2 ",
+		BoundaryIDs:         []string{" pr-2 ", "pr-1", "pr-2", ""},
+		Extra:               map[string]string{" repo ": " cerebro ", "empty": " "},
+	}
+	SetCursorWatermark(&envelope, watermark)
+
+	opaque, err := EncodeCursorEnvelope(envelope)
+	if err != nil {
+		t.Fatalf("EncodeCursorEnvelope() error = %v", err)
+	}
+	if !ResumableCursorOpaque(opaque) {
+		t.Fatalf("ResumableCursorOpaque(%q) = false, want true", opaque)
+	}
+	decoded, ok := DecodeCursorEnvelope(opaque)
+	if !ok {
+		t.Fatalf("DecodeCursorEnvelope(%q) ok = false, want true", opaque)
+	}
+	if decoded.Source != "github" || decoded.Family != "pull_request" || decoded.Mode != "incremental_watermark" {
+		t.Fatalf("decoded source/family/mode = %q/%q/%q", decoded.Source, decoded.Family, decoded.Mode)
+	}
+	if decoded.Token != "2" {
+		t.Fatalf("decoded token = %q, want 2", decoded.Token)
+	}
+	if got := decoded.BoundaryIDs; len(got) != 2 || got[0] != "pr-1" || got[1] != "pr-2" {
+		t.Fatalf("decoded boundary IDs = %#v, want sorted unique IDs", got)
+	}
+	if got := decoded.Extra["repo"]; got != "cerebro" {
+		t.Fatalf("decoded extra repo = %q, want cerebro", got)
+	}
+	if got := CursorWatermark(decoded); !got.Equal(watermark) {
+		t.Fatalf("CursorWatermark() = %s, want %s", got, watermark)
+	}
+}
+
+func TestCursorEnvelopeRejectsProviderNativeCursor(t *testing.T) {
+	if _, ok := DecodeCursorEnvelope("2"); ok {
+		t.Fatal("DecodeCursorEnvelope(native token) ok = true, want false")
+	}
+	if ResumableCursorOpaque(`{"token":"2"}`) {
+		t.Fatal("ResumableCursorOpaque(non-resumable envelope) = true, want false")
+	}
+	if got := CursorWatermark(CursorEnvelope{Watermark: "not-a-time"}); !got.IsZero() {
+		t.Fatalf("CursorWatermark(invalid) = %s, want zero", got)
+	}
+}
+
+func TestCursorPageReadsEnvelopeToken(t *testing.T) {
+	opaque, err := EncodeCursorEnvelope(CursorEnvelope{ResumableCheckpoint: true, Token: "3"})
+	if err != nil {
+		t.Fatalf("EncodeCursorEnvelope() error = %v", err)
+	}
+	page, err := CursorPage(&cerebrov1.SourceCursor{Opaque: opaque})
+	if err != nil {
+		t.Fatalf("CursorPage(envelope) error = %v", err)
+	}
+	if page != 3 {
+		t.Fatalf("CursorPage(envelope) = %d, want 3", page)
+	}
+	page, err = CursorPage(&cerebrov1.SourceCursor{Opaque: `{"resumable_checkpoint":true}`})
+	if err != nil {
+		t.Fatalf("CursorPage(envelope without token) error = %v", err)
+	}
+	if page != 1 {
+		t.Fatalf("CursorPage(envelope without token) = %d, want 1", page)
+	}
+	if _, err := CursorPage(&cerebrov1.SourceCursor{Opaque: "0"}); !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("CursorPage(0) error = %v, want ErrInvalidConfig", err)
+	}
+}
+
+func TestIncrementalWatermarkFiltersBoundaryEvents(t *testing.T) {
+	watermark := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	events := []*primitives.Event{
+		watermarkTestEvent("newer", watermark.Add(time.Minute)),
+		watermarkTestEvent("seen-boundary", watermark),
+		watermarkTestEvent("new-boundary", watermark),
+		watermarkTestEvent("older", watermark.Add(-time.Minute)),
+	}
+	filtered, reached := IncrementalWatermarkEvents(events, IncrementalWatermarkState{
+		Watermark:   watermark,
+		BoundaryIDs: map[string]struct{}{"seen-boundary": {}},
+	})
+	if !reached {
+		t.Fatal("IncrementalWatermarkEvents reached = false, want true")
+	}
+	if len(filtered) != 2 || filtered[0].GetId() != "newer" || filtered[1].GetId() != "new-boundary" {
+		t.Fatalf("filtered events = %#v, want newer and new-boundary", filtered)
+	}
+	checkpoint := IncrementalWatermarkCheckpoint("github", "pull_request", filtered, IncrementalWatermarkState{})
+	if got := checkpoint.GetWatermark().AsTime(); !got.Equal(watermark.Add(time.Minute)) {
+		t.Fatalf("checkpoint watermark = %s, want newest event", got)
+	}
+	envelope, ok := DecodeCursorEnvelope(checkpoint.GetCursorOpaque())
+	if !ok {
+		t.Fatal("checkpoint cursor is not an envelope")
+	}
+	if got := envelope.BoundaryIDs; len(got) != 1 || got[0] != "newer" {
+		t.Fatalf("checkpoint boundary IDs = %#v, want newest event boundary", got)
+	}
+}
+
+func watermarkTestEvent(id string, occurredAt time.Time) *primitives.Event {
+	return &primitives.Event{
+		Id:         id,
+		OccurredAt: timestamppb.New(occurredAt),
+	}
+}

--- a/internal/sourcecdk/family.go
+++ b/internal/sourcecdk/family.go
@@ -15,7 +15,16 @@ type Family[S any] struct {
 	Name     string
 	Check    func(context.Context, S) error
 	Discover func(context.Context, S) ([]URN, error)
+	Probe    func(context.Context, S, *cerebrov1.SourceCheckpoint) (ChangeProbe, error)
 	Read     func(context.Context, S, *cerebrov1.SourceCursor) (Pull, error)
+}
+
+// ChangeProbe is an optional cheap pre-read result for families that can test
+// whether provider data changed before fetching and projecting the full page.
+type ChangeProbe struct {
+	Unchanged          bool
+	Checkpoint         *cerebrov1.SourceCheckpoint
+	ShortCircuitReason PullShortCircuitReason
 }
 
 // FamilyEngine dispatches source operations to table-driven families.
@@ -103,12 +112,31 @@ func (e *FamilyEngine[S]) Discover(ctx context.Context, cfg Config) ([]URN, erro
 
 // Read reads one page for the configured family.
 func (e *FamilyEngine[S]) Read(ctx context.Context, cfg Config, cursor *cerebrov1.SourceCursor) (Pull, error) {
+	return e.ReadWithCheckpoint(ctx, cfg, cursor, nil)
+}
+
+// ReadWithCheckpoint reads one page and lets families short-circuit with a
+// cheap provider change probe when they support one.
+func (e *FamilyEngine[S]) ReadWithCheckpoint(ctx context.Context, cfg Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (Pull, error) {
 	family, settings, policy, err := e.resolve(cfg)
 	if err != nil {
 		return Pull{}, err
 	}
 	if policy.ExcludesFamily(e.sourceID, family.Name) {
-		return Pull{}, nil
+		return Pull{ShortCircuitReason: PullShortCircuitReasonScopeExcluded}, nil
+	}
+	if family.Probe != nil {
+		probe, err := family.Probe(ctx, settings, checkpoint)
+		if err != nil {
+			return Pull{}, err
+		}
+		if probe.Unchanged {
+			reason := probe.ShortCircuitReason
+			if reason == "" {
+				reason = PullShortCircuitReasonNotModified
+			}
+			return Pull{Checkpoint: probe.Checkpoint, ShortCircuitReason: reason}, nil
+		}
 	}
 	if family.Read == nil {
 		return Pull{}, nil

--- a/internal/sourcecdk/family_scope_test.go
+++ b/internal/sourcecdk/family_scope_test.go
@@ -43,6 +43,9 @@ func TestFamilyEngineSkipsOutOfScopeFamilyBeforeRead(t *testing.T) {
 	if len(pull.Events) != 0 {
 		t.Fatalf("events len = %d, want 0", len(pull.Events))
 	}
+	if pull.ShortCircuitReason != PullShortCircuitReasonScopeExcluded {
+		t.Fatalf("ShortCircuitReason = %q, want scope_excluded", pull.ShortCircuitReason)
+	}
 }
 
 func TestFamilyEngineFiltersOutOfScopeEvents(t *testing.T) {
@@ -84,5 +87,81 @@ func TestFamilyEngineFiltersOutOfScopeEvents(t *testing.T) {
 	}
 	if len(pull.Events) != 1 || pull.Events[0].GetId() != "keep" {
 		t.Fatalf("events = %#v, want only keep", pull.Events)
+	}
+}
+
+func TestFamilyEngineMarksFullyFilteredEvents(t *testing.T) {
+	engine, err := NewFamilyEngineWithSourceID("aws", func(cfg Config) (string, error) {
+		family, _ := cfg.Lookup("family")
+		return family, nil
+	}, func(settings string) string { return settings }, Family[string]{
+		Name: "cloudtrail",
+		Read: func(context.Context, string, *cerebrov1.SourceCursor) (Pull, error) {
+			return Pull{Events: []*primitives.Event{
+				{
+					Id:         "drop",
+					Kind:       "aws.cloudtrail",
+					OccurredAt: timestamppb.New(time.Now().UTC()),
+					Attributes: map[string]string{"resource_urn": "urn:cerebro:tenant:aws_s3_bucket:excluded"},
+				},
+			}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFamilyEngineWithSourceID() error = %v", err)
+	}
+	rawPolicy, err := resourcescope.ConfigValue(resourcescope.Policy{ExcludedResourceURNs: []string{"urn:cerebro:tenant:aws_s3_bucket:excluded"}})
+	if err != nil {
+		t.Fatalf("ConfigValue() error = %v", err)
+	}
+	pull, err := engine.Read(context.Background(), NewConfig(map[string]string{
+		"family":                "cloudtrail",
+		resourcescope.ConfigKey: rawPolicy,
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 0 {
+		t.Fatalf("events = %#v, want none", pull.Events)
+	}
+	if pull.ShortCircuitReason != PullShortCircuitReasonResourceScopeFiltered {
+		t.Fatalf("ShortCircuitReason = %q, want resource_scope_filtered", pull.ShortCircuitReason)
+	}
+}
+
+func TestFamilyEngineProbeShortCircuitsBeforeRead(t *testing.T) {
+	readCalled := false
+	probeCheckpoint := &cerebrov1.SourceCheckpoint{
+		Watermark: timestamppb.New(time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)),
+	}
+	engine, err := NewFamilyEngine(func(cfg Config) (string, error) {
+		family, _ := cfg.Lookup("family")
+		return family, nil
+	}, func(settings string) string { return settings }, Family[string]{
+		Name: "pull_request",
+		Probe: func(context.Context, string, *cerebrov1.SourceCheckpoint) (ChangeProbe, error) {
+			return ChangeProbe{Unchanged: true, Checkpoint: probeCheckpoint}, nil
+		},
+		Read: func(context.Context, string, *cerebrov1.SourceCursor) (Pull, error) {
+			readCalled = true
+			return Pull{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFamilyEngine() error = %v", err)
+	}
+
+	pull, err := engine.ReadWithCheckpoint(context.Background(), NewConfig(map[string]string{"family": "pull_request"}), nil, &cerebrov1.SourceCheckpoint{})
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if readCalled {
+		t.Fatal("family Read was called after unchanged probe")
+	}
+	if pull.Checkpoint != probeCheckpoint {
+		t.Fatal("probe checkpoint was not returned")
+	}
+	if pull.ShortCircuitReason != PullShortCircuitReasonNotModified {
+		t.Fatalf("ShortCircuitReason = %q, want not_modified", pull.ShortCircuitReason)
 	}
 }

--- a/internal/sourcecdk/resource_scope.go
+++ b/internal/sourcecdk/resource_scope.go
@@ -23,5 +23,8 @@ func applyResourceScopePolicy(pull Pull, policy resourcescope.Policy) Pull {
 		return pull
 	}
 	pull.Events = events
+	if len(events) == 0 && pull.ShortCircuitReason == "" {
+		pull.ShortCircuitReason = PullShortCircuitReasonResourceScopeFiltered
+	}
 	return pull
 }

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -76,10 +76,23 @@ func (c Config) Values() map[string]string {
 
 // Pull is one page of source output.
 type Pull struct {
-	Events     []*primitives.Event
-	Checkpoint *cerebrov1.SourceCheckpoint
-	NextCursor *cerebrov1.SourceCursor
+	Events             []*primitives.Event
+	Checkpoint         *cerebrov1.SourceCheckpoint
+	NextCursor         *cerebrov1.SourceCursor
+	ShortCircuitReason PullShortCircuitReason
 }
+
+// PullShortCircuitReason describes source work that intentionally produced no
+// new append-log events.
+type PullShortCircuitReason string
+
+const (
+	PullShortCircuitReasonScopeExcluded         PullShortCircuitReason = "scope_excluded"
+	PullShortCircuitReasonResourceScopeFiltered PullShortCircuitReason = "resource_scope_filtered"
+	PullShortCircuitReasonNotModified           PullShortCircuitReason = "not_modified"
+	PullShortCircuitReasonCheckpointAdvanced    PullShortCircuitReason = "checkpoint_advanced"
+	PullShortCircuitReasonWatermarkReached      PullShortCircuitReason = "watermark_reached"
+)
 
 // Source is the common integration contract for the rewrite.
 type Source interface {
@@ -87,6 +100,14 @@ type Source interface {
 	Check(context.Context, Config) error
 	Discover(context.Context, Config) ([]URN, error)
 	Read(context.Context, Config, *cerebrov1.SourceCursor) (Pull, error)
+}
+
+// CheckpointAwareSource can use the last durable checkpoint while deciding how
+// much remote data to fetch. Source runtimes still pass the normal page cursor
+// for continuation, and provide checkpoint separately so legacy cursor formats
+// do not need to carry watermark metadata.
+type CheckpointAwareSource interface {
+	ReadWithCheckpoint(context.Context, Config, *cerebrov1.SourceCursor, *cerebrov1.SourceCheckpoint) (Pull, error)
 }
 
 // EventContractProvider lets sources attach catalog-level per-kind validation to emitted events.

--- a/internal/sourcecdk/watermark.go
+++ b/internal/sourcecdk/watermark.go
@@ -1,0 +1,153 @@
+package sourcecdk
+
+import (
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+)
+
+const incrementalWatermarkMode = "incremental_watermark"
+
+// IncrementalWatermarkState tracks a high-water mark and the event IDs already
+// seen at that boundary so equal-timestamp events can be deduplicated safely.
+type IncrementalWatermarkState struct {
+	Watermark   time.Time
+	BoundaryIDs map[string]struct{}
+}
+
+// IncrementalWatermarkCheckpointState restores incremental state from a source
+// checkpoint when its cursor envelope belongs to source/family.
+func IncrementalWatermarkCheckpointState(source string, family string, checkpoint *cerebrov1.SourceCheckpoint) IncrementalWatermarkState {
+	state := IncrementalWatermarkState{BoundaryIDs: map[string]struct{}{}}
+	if checkpoint == nil {
+		return state
+	}
+	if watermark := checkpoint.GetWatermark(); watermark != nil && !watermark.AsTime().IsZero() {
+		state.Watermark = watermark.AsTime().UTC()
+	}
+	envelope, ok := DecodeCursorEnvelope(checkpoint.GetCursorOpaque())
+	if !ok || !incrementalCursorMatches(envelope, source, family) {
+		return state
+	}
+	if watermark := CursorWatermark(envelope); !watermark.IsZero() {
+		state.Watermark = watermark.UTC()
+	}
+	for _, id := range envelope.BoundaryIDs {
+		state.BoundaryIDs[strings.TrimSpace(id)] = struct{}{}
+	}
+	return state
+}
+
+// IncrementalWatermarkEvents keeps only events newer than state. It returns
+// true when the page reached the known boundary and the source can stop.
+func IncrementalWatermarkEvents(events []*primitives.Event, state IncrementalWatermarkState) ([]*primitives.Event, bool) {
+	if state.Watermark.IsZero() {
+		return events, false
+	}
+	filtered := make([]*primitives.Event, 0, len(events))
+	reachedWatermark := false
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		occurredAt := event.GetOccurredAt().AsTime().UTC()
+		switch {
+		case occurredAt.After(state.Watermark):
+			filtered = append(filtered, event)
+		case occurredAt.Equal(state.Watermark):
+			if _, seen := state.BoundaryIDs[event.GetId()]; seen {
+				reachedWatermark = true
+				continue
+			}
+			filtered = append(filtered, event)
+		default:
+			reachedWatermark = true
+		}
+	}
+	return filtered, reachedWatermark
+}
+
+// IncrementalWatermarkCheckpoint advances a checkpoint from emitted events.
+func IncrementalWatermarkCheckpoint(source string, family string, events []*primitives.Event, prior IncrementalWatermarkState) *cerebrov1.SourceCheckpoint {
+	watermark := prior.Watermark
+	boundaryIDs := make(map[string]struct{}, len(prior.BoundaryIDs))
+	for id := range prior.BoundaryIDs {
+		boundaryIDs[id] = struct{}{}
+	}
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		occurredAt := event.GetOccurredAt().AsTime().UTC()
+		switch {
+		case watermark.IsZero() || occurredAt.After(watermark):
+			watermark = occurredAt
+			boundaryIDs = map[string]struct{}{event.GetId(): {}}
+		case occurredAt.Equal(watermark):
+			boundaryIDs[event.GetId()] = struct{}{}
+		}
+	}
+	if watermark.IsZero() {
+		return nil
+	}
+	boundaryValues := make([]string, 0, len(boundaryIDs))
+	for id := range boundaryIDs {
+		boundaryValues = append(boundaryValues, id)
+	}
+	envelope := CursorEnvelope{
+		Source:              source,
+		Family:              family,
+		Mode:                incrementalWatermarkMode,
+		ResumableCheckpoint: true,
+		BoundaryIDs:         boundaryValues,
+	}
+	SetCursorWatermark(&envelope, watermark)
+	opaque, _ := EncodeCursorEnvelope(envelope)
+	return &cerebrov1.SourceCheckpoint{
+		Watermark:    timestamppb.New(watermark.UTC()),
+		CursorOpaque: opaque,
+	}
+}
+
+// IncrementalWatermarkCheckpointWithToken stores a provider continuation token
+// inside a checkpoint envelope without dropping watermark metadata.
+func IncrementalWatermarkCheckpointWithToken(checkpoint *cerebrov1.SourceCheckpoint, token string) *cerebrov1.SourceCheckpoint {
+	if checkpoint == nil {
+		return nil
+	}
+	envelope, ok := DecodeCursorEnvelope(checkpoint.GetCursorOpaque())
+	if !ok {
+		return checkpoint
+	}
+	envelope.Token = strings.TrimSpace(token)
+	opaque, err := EncodeCursorEnvelope(envelope)
+	if err != nil {
+		return checkpoint
+	}
+	checkpoint.CursorOpaque = opaque
+	return checkpoint
+}
+
+// EmptyIncrementalWatermarkPull returns an unchanged pull when a source page is
+// empty but a previous incremental watermark exists.
+func EmptyIncrementalWatermarkPull(source string, family string, checkpoint *cerebrov1.SourceCheckpoint) Pull {
+	state := IncrementalWatermarkCheckpointState(source, family, checkpoint)
+	if state.Watermark.IsZero() {
+		return Pull{}
+	}
+	return Pull{
+		Checkpoint:         IncrementalWatermarkCheckpoint(source, family, nil, state),
+		ShortCircuitReason: PullShortCircuitReasonNotModified,
+	}
+}
+
+func incrementalCursorMatches(envelope CursorEnvelope, source string, family string) bool {
+	if strings.TrimSpace(envelope.Source) != "" && strings.TrimSpace(envelope.Source) != strings.TrimSpace(source) {
+		return false
+	}
+	return strings.TrimSpace(envelope.Family) == "" || strings.TrimSpace(envelope.Family) == strings.TrimSpace(family)
+}

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -50,6 +49,7 @@ const (
 	runtimeContractProbeStateConfigKey    = "__cerebro_runtime_contract_probe_state"
 	runtimeLastSyncWatermarkConfigKey     = "__cerebro_runtime_last_sync_watermark"
 	runtimeLastSyncCompletedAtConfigKey   = "__cerebro_runtime_last_sync_completed_at"
+	runtimeShortCircuitReasonConfigKey    = "__cerebro_runtime_short_circuit_reason"
 )
 
 var (
@@ -293,12 +293,19 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		eventContracts = provider.EventContracts()
 	}
 	contractConfigured = len(eventContracts) > 0
+	sourceConfig := sourcecdk.NewConfig(runtimeConfig)
+	originalCheckpoint := cloneCheckpoint(runtime.GetCheckpoint())
+	shortCircuitReason := ""
 	for i := uint32(0); i < pageLimit; i++ {
-		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtimeConfig), cursor)
+		pull, err := readSourcePull(ctx, source, sourceConfig, cursor, originalCheckpoint)
 		if err != nil {
 			return nil, err
 		}
 		pageNumber := i + 1
+		pageShortCircuitReason := string(pullShortCircuitReason(pull))
+		if pageShortCircuitReason != "" {
+			shortCircuitReason = pageShortCircuitReason
+		}
 		eventsRead := boundedUint32(len(pull.Events))
 		recordsScanned += eventsRead
 		telemetry.Event(ctx, "source_runtime.page_read", telemetry.Attrs(
@@ -308,9 +315,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "page", Value: pageNumber},
 			telemetry.Field{Key: "events_read", Value: eventsRead},
 			telemetry.Field{Key: "has_next_cursor", Value: pull.NextCursor != nil},
+			telemetry.Field{Key: "short_circuit_reason", Value: pageShortCircuitReason},
 		))
 		if pull.Checkpoint != nil {
-			runtime.Checkpoint = cloneCheckpoint(pull.Checkpoint)
+			advanceRuntimeCheckpoint(runtime, pull.Checkpoint)
 		}
 		runtime.NextCursor = cloneCursor(pull.NextCursor)
 		pagesRead++
@@ -361,6 +369,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			LinksProjected:     linksProjected,
 			CompletedAt:        runtime.GetLastSyncedAt().AsTime().UTC(),
 			ContractConfigured: len(eventContracts) > 0,
+			ShortCircuitReason: shortCircuitReason,
 		})
 		if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
 			return nil, err
@@ -377,6 +386,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "entities_projected", Value: entitiesProjected},
 			telemetry.Field{Key: "links_projected", Value: linksProjected},
 			telemetry.Field{Key: "has_next_cursor", Value: pull.NextCursor != nil},
+			telemetry.Field{Key: "short_circuit_reason", Value: pageShortCircuitReason},
 		))
 		if pull.NextCursor == nil {
 			break
@@ -392,6 +402,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "entities_projected", Value: entitiesProjected})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "links_projected", Value: linksProjected})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "has_next_cursor", Value: runtime.GetNextCursor() != nil})
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "short_circuit_reason", Value: shortCircuitReason})
 	if watermark, lagSeconds, ok := runtimeWatermarkLag(runtime, time.Now().UTC()); ok {
 		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "checkpoint_watermark", Value: watermark.Format(time.RFC3339Nano)})
 		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "source_runtime_watermark_lag_seconds", Value: lagSeconds})
@@ -483,6 +494,7 @@ type runtimeSyncStatus struct {
 	LinksProjected     uint32
 	CompletedAt        time.Time
 	ContractConfigured bool
+	ShortCircuitReason string
 }
 
 func updateRuntimeSyncStatus(runtime *cerebrov1.SourceRuntime, status runtimeSyncStatus) {
@@ -500,6 +512,11 @@ func updateRuntimeSyncStatus(runtime *cerebrov1.SourceRuntime, status runtimeSyn
 	setRuntimeConfig(runtime.Config, runtimeLinksProjectedConfigKey, fmt.Sprint(status.LinksProjected))
 	if !status.CompletedAt.IsZero() {
 		setRuntimeConfig(runtime.Config, runtimeLastSyncCompletedAtConfigKey, status.CompletedAt.UTC().Format(time.RFC3339Nano))
+	}
+	if strings.TrimSpace(status.ShortCircuitReason) != "" {
+		setRuntimeConfig(runtime.Config, runtimeShortCircuitReasonConfigKey, status.ShortCircuitReason)
+	} else {
+		delete(runtime.Config, runtimeShortCircuitReasonConfigKey)
 	}
 	if watermark := timestampValue(runtime.GetCheckpoint().GetWatermark()); !watermark.IsZero() {
 		setRuntimeConfig(runtime.Config, runtimeLastSyncWatermarkConfigKey, watermark.UTC().Format(time.RFC3339Nano))
@@ -693,6 +710,64 @@ func normalizePageLimit(pageLimit uint32) (uint32, error) {
 		return 0, fmt.Errorf("%w: page_limit must be between 1 and %d", ErrInvalidRequest, maxPageLimit)
 	}
 	return pageLimit, nil
+}
+
+func readSourcePull(ctx context.Context, source sourcecdk.Source, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	if reader, ok := source.(sourcecdk.CheckpointAwareSource); ok {
+		return reader.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
+	}
+	return source.Read(ctx, cfg, cursor)
+}
+
+func pullShortCircuitReason(pull sourcecdk.Pull) sourcecdk.PullShortCircuitReason {
+	if pull.ShortCircuitReason != "" {
+		return pull.ShortCircuitReason
+	}
+	if len(pull.Events) == 0 && pull.Checkpoint != nil {
+		return sourcecdk.PullShortCircuitReasonCheckpointAdvanced
+	}
+	return ""
+}
+
+func advanceRuntimeCheckpoint(runtime *cerebrov1.SourceRuntime, checkpoint *cerebrov1.SourceCheckpoint) {
+	if runtime == nil || checkpoint == nil {
+		return
+	}
+	next := cloneCheckpoint(checkpoint)
+	if next == nil {
+		return
+	}
+	existingWatermark := timestampValue(runtime.GetCheckpoint().GetWatermark())
+	nextWatermark := timestampValue(next.GetWatermark())
+	if !existingWatermark.IsZero() && (nextWatermark.IsZero() || existingWatermark.After(nextWatermark)) {
+		runtime.Checkpoint = cloneCheckpoint(runtime.GetCheckpoint())
+		return
+	}
+	if !existingWatermark.IsZero() && existingWatermark.Equal(nextWatermark) {
+		next = mergeEqualWatermarkCheckpoint(runtime.GetCheckpoint(), next)
+	}
+	runtime.Checkpoint = next
+}
+
+func mergeEqualWatermarkCheckpoint(existing *cerebrov1.SourceCheckpoint, next *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {
+	existingEnvelope, existingOK := sourcecdk.DecodeCursorEnvelope(existing.GetCursorOpaque())
+	nextEnvelope, nextOK := sourcecdk.DecodeCursorEnvelope(next.GetCursorOpaque())
+	if !existingOK || !nextOK {
+		return next
+	}
+	if strings.TrimSpace(existingEnvelope.Source) != strings.TrimSpace(nextEnvelope.Source) ||
+		strings.TrimSpace(existingEnvelope.Family) != strings.TrimSpace(nextEnvelope.Family) ||
+		strings.TrimSpace(existingEnvelope.Mode) != strings.TrimSpace(nextEnvelope.Mode) {
+		return next
+	}
+	nextEnvelope.BoundaryIDs = append(nextEnvelope.BoundaryIDs, existingEnvelope.BoundaryIDs...)
+	opaque, err := sourcecdk.EncodeCursorEnvelope(nextEnvelope)
+	if err != nil {
+		return next
+	}
+	merged := cloneCheckpoint(next)
+	merged.CursorOpaque = opaque
+	return merged
 }
 
 func normalizeListFilter(filter ports.SourceRuntimeFilter) (ports.SourceRuntimeFilter, error) {
@@ -993,20 +1068,10 @@ func runtimeStartCursor(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceCurso
 		return cursor
 	}
 	opaque := strings.TrimSpace(runtime.GetCheckpoint().GetCursorOpaque())
-	if opaque == "" || !resumableCheckpointCursor(opaque) {
+	if opaque == "" || !sourcecdk.ResumableCursorOpaque(opaque) {
 		return nil
 	}
 	return &cerebrov1.SourceCursor{Opaque: opaque}
-}
-
-func resumableCheckpointCursor(opaque string) bool {
-	var payload struct {
-		ResumableCheckpoint bool `json:"resumable_checkpoint"`
-	}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(opaque)), &payload); err != nil {
-		return false
-	}
-	return payload.ResumableCheckpoint
 }
 
 func cloneCheckpoint(checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -448,6 +448,32 @@ func (s *tenantCheckSource) Read(context.Context, sourcecdk.Config, *cerebrov1.S
 	return sourcecdk.Pull{}, nil
 }
 
+type checkpointAwareRuntimeSource struct {
+	seenCheckpoint *cerebrov1.SourceCheckpoint
+	pull           sourcecdk.Pull
+}
+
+func (s *checkpointAwareRuntimeSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "checkpoint_aware"}
+}
+
+func (s *checkpointAwareRuntimeSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (s *checkpointAwareRuntimeSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *checkpointAwareRuntimeSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{}, errors.New("Read called instead of ReadWithCheckpoint")
+}
+
+func (s *checkpointAwareRuntimeSource) ReadWithCheckpoint(_ context.Context, _ sourcecdk.Config, _ *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	s.seenCheckpoint = cloneCheckpoint(checkpoint)
+	return s.pull, nil
+}
+
 func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
@@ -1410,6 +1436,164 @@ func TestSyncRuntimeFollowUpUsesPersistedResumableCheckpointCursor(t *testing.T)
 	}
 	if source.seenCursors[1] != checkpointCursor {
 		t.Fatalf("follow-up sync cursor = %q, want persisted checkpoint cursor %q", source.seenCursors[1], checkpointCursor)
+	}
+}
+
+func TestSyncRuntimePassesCheckpointAndPersistsShortCircuitReason(t *testing.T) {
+	watermark := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	existingCheckpoint := &cerebrov1.SourceCheckpoint{
+		Watermark:    timestamppb.New(watermark),
+		CursorOpaque: `{"source":"github","resumable_checkpoint":true}`,
+	}
+	source := &checkpointAwareRuntimeSource{pull: sourcecdk.Pull{
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    timestamppb.New(watermark),
+			CursorOpaque: `{"source":"github","family":"pull_request","resumable_checkpoint":true}`,
+		},
+		ShortCircuitReason: sourcecdk.PullShortCircuitReasonNotModified,
+	}}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-checkpoint-aware": {
+			Id:         "writer-checkpoint-aware",
+			SourceId:   "checkpoint_aware",
+			TenantId:   "writer",
+			Checkpoint: existingCheckpoint,
+		},
+	}}
+	log := &appendLog{}
+	service := New(registry, store, log, nil)
+
+	resp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-checkpoint-aware"})
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if !proto.Equal(source.seenCheckpoint, existingCheckpoint) {
+		t.Fatalf("ReadWithCheckpoint checkpoint = %v, want %v", source.seenCheckpoint, existingCheckpoint)
+	}
+	if resp.GetPagesRead() != 1 || resp.GetEventsAppended() != 0 {
+		t.Fatalf("Sync() pages/events = %d/%d, want 1/0", resp.GetPagesRead(), resp.GetEventsAppended())
+	}
+	if len(log.events) != 0 {
+		t.Fatalf("len(appendLog.events) = %d, want 0", len(log.events))
+	}
+	stored := store.runtimes["writer-checkpoint-aware"]
+	if got := stored.GetConfig()[runtimeShortCircuitReasonConfigKey]; got != "not_modified" {
+		t.Fatalf("short circuit reason = %q, want not_modified", got)
+	}
+	if got := stored.GetCheckpoint().GetCursorOpaque(); got != source.pull.Checkpoint.GetCursorOpaque() {
+		t.Fatalf("stored checkpoint cursor = %q, want %q", got, source.pull.Checkpoint.GetCursorOpaque())
+	}
+}
+
+func TestSyncRuntimeDoesNotRegressCheckpointWatermark(t *testing.T) {
+	newer := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	older := newer.Add(-time.Hour)
+	source := &checkpointAwareRuntimeSource{pull: sourcecdk.Pull{
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    timestamppb.New(older),
+			CursorOpaque: "older",
+		},
+	}}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-checkpoint-aware": {
+			Id:       "writer-checkpoint-aware",
+			SourceId: "checkpoint_aware",
+			TenantId: "writer",
+			Checkpoint: &cerebrov1.SourceCheckpoint{
+				Watermark:    timestamppb.New(newer),
+				CursorOpaque: "newer",
+			},
+		},
+	}}
+	service := New(registry, store, &appendLog{}, nil)
+
+	if _, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-checkpoint-aware"}); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	stored := store.runtimes["writer-checkpoint-aware"]
+	if got := stored.GetCheckpoint().GetWatermark().AsTime(); !got.Equal(newer) {
+		t.Fatalf("stored watermark = %s, want %s", got, newer)
+	}
+	if got := stored.GetCheckpoint().GetCursorOpaque(); got != "newer" {
+		t.Fatalf("stored checkpoint cursor = %q, want newer", got)
+	}
+	if got := stored.GetConfig()[runtimeShortCircuitReasonConfigKey]; got != "checkpoint_advanced" {
+		t.Fatalf("short circuit reason = %q, want checkpoint_advanced", got)
+	}
+}
+
+func TestSyncRuntimeMergesEqualWatermarkCheckpointBoundaries(t *testing.T) {
+	watermark := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	existingEnvelope := sourcecdk.CursorEnvelope{
+		Version:             1,
+		Source:              "github",
+		Family:              "pull_request",
+		Mode:                "incremental_watermark",
+		ResumableCheckpoint: true,
+		Token:               "2",
+		BoundaryIDs:         []string{"first"},
+	}
+	sourcecdk.SetCursorWatermark(&existingEnvelope, watermark)
+	existingCursor, err := sourcecdk.EncodeCursorEnvelope(existingEnvelope)
+	if err != nil {
+		t.Fatalf("EncodeCursorEnvelope(existing) error = %v", err)
+	}
+	nextEnvelope := sourcecdk.CursorEnvelope{
+		Version:             1,
+		Source:              "github",
+		Family:              "pull_request",
+		Mode:                "incremental_watermark",
+		ResumableCheckpoint: true,
+		BoundaryIDs:         []string{"second"},
+	}
+	sourcecdk.SetCursorWatermark(&nextEnvelope, watermark)
+	nextCursor, err := sourcecdk.EncodeCursorEnvelope(nextEnvelope)
+	if err != nil {
+		t.Fatalf("EncodeCursorEnvelope(next) error = %v", err)
+	}
+	source := &checkpointAwareRuntimeSource{pull: sourcecdk.Pull{
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    timestamppb.New(watermark),
+			CursorOpaque: nextCursor,
+		},
+	}}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-checkpoint-aware": {
+			Id:       "writer-checkpoint-aware",
+			SourceId: "checkpoint_aware",
+			TenantId: "writer",
+			Checkpoint: &cerebrov1.SourceCheckpoint{
+				Watermark:    timestamppb.New(watermark),
+				CursorOpaque: existingCursor,
+			},
+		},
+	}}
+	service := New(registry, store, &appendLog{}, nil)
+
+	if _, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-checkpoint-aware"}); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	storedEnvelope, ok := sourcecdk.DecodeCursorEnvelope(store.runtimes["writer-checkpoint-aware"].GetCheckpoint().GetCursorOpaque())
+	if !ok {
+		t.Fatal("stored checkpoint cursor is not an envelope")
+	}
+	if storedEnvelope.Token != "" {
+		t.Fatalf("stored token = %q, want terminal checkpoint without continuation token", storedEnvelope.Token)
+	}
+	if got := storedEnvelope.BoundaryIDs; len(got) != 2 || got[0] != "first" || got[1] != "second" {
+		t.Fatalf("stored boundary IDs = %#v, want first and second", got)
 	}
 }
 

--- a/sources/github/dependabot_alert.go
+++ b/sources/github/dependabot_alert.go
@@ -64,14 +64,14 @@ func (s *Source) discoverDependabotAlerts(ctx context.Context, client *gogithub.
 	return []sourcecdk.URN{urn}, nil
 }
 
-func (s *Source) readDependabotAlerts(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-	after := readDependabotCursor(cursor)
+func (s *Source) readDependabotAlerts(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	after := sourcecdk.CursorToken(cursor)
 	alerts, resp, err := client.Dependabot.ListRepoAlerts(ctx, settings.owner, settings.repo, dependabotAlertOptions(settings, after, settings.perPage))
 	if err != nil {
 		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github dependabot alerts for repo %s/%s", settings.owner, settings.repo), err)
 	}
 	if len(alerts) == 0 {
-		return sourcecdk.Pull{}, nil
+		return sourcecdk.EmptyIncrementalWatermarkPull("github", familyDependabot, checkpoint), nil
 	}
 	events := make([]*primitives.Event, 0, len(alerts))
 	for _, alert := range alerts {
@@ -81,16 +81,20 @@ func (s *Source) readDependabotAlerts(ctx context.Context, client *gogithub.Clie
 		}
 		events = append(events, event)
 	}
+	state := sourcecdk.IncrementalWatermarkCheckpointState("github", familyDependabot, checkpoint)
+	events, reachedWatermark := sourcecdk.IncrementalWatermarkEvents(events, state)
 	nextCursor := nextAuditCursor(resp)
 	pull := sourcecdk.Pull{
-		Events: events,
-		Checkpoint: &cerebrov1.SourceCheckpoint{
-			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: checkpointDependabotCursor(alerts, nextCursor),
-		},
+		Events:     events,
+		Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familyDependabot, events, state),
+	}
+	if reachedWatermark {
+		pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonWatermarkReached
+		return pull, nil
 	}
 	if nextCursor != "" {
 		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextCursor}
+		pull.Checkpoint = sourcecdk.IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, nextCursor)
 	}
 	return pull, nil
 }
@@ -105,23 +109,6 @@ func dependabotAlertOptions(settings settings, after string, perPage int) *gogit
 			PerPage: perPage,
 		},
 	}
-}
-
-func readDependabotCursor(cursor *cerebrov1.SourceCursor) string {
-	if cursor == nil {
-		return ""
-	}
-	return strings.TrimSpace(cursor.GetOpaque())
-}
-
-func checkpointDependabotCursor(alerts []*gogithub.DependabotAlert, cursor string) string {
-	if cursor != "" {
-		return cursor
-	}
-	if len(alerts) == 0 {
-		return ""
-	}
-	return strconv.Itoa(alerts[len(alerts)-1].GetNumber())
 }
 
 func dependabotAlertEvent(settings settings, alert *gogithub.DependabotAlert) (*primitives.Event, error) {

--- a/sources/github/secret_scanning_alert.go
+++ b/sources/github/secret_scanning_alert.go
@@ -56,8 +56,8 @@ func (s *Source) discoverSecretScanningAlerts(ctx context.Context, client *gogit
 	return []sourcecdk.URN{sourcecdk.URN(fmt.Sprintf("urn:cerebro:%s:secret_scanning", settings.owner))}, nil
 }
 
-func (s *Source) readSecretScanningAlerts(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-	page, err := readPage(cursor)
+func (s *Source) readSecretScanningAlerts(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	page, err := sourcecdk.CursorPage(cursor)
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
@@ -69,7 +69,7 @@ func (s *Source) readSecretScanningAlerts(ctx context.Context, client *gogithub.
 		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github secret scanning alerts for org %s", settings.owner), err)
 	}
 	if len(alerts) == 0 {
-		return sourcecdk.Pull{}, nil
+		return sourcecdk.EmptyIncrementalWatermarkPull("github", familySecretScanning, checkpoint), nil
 	}
 	events := make([]*primitives.Event, 0, len(alerts))
 	for _, alert := range alerts {
@@ -79,15 +79,20 @@ func (s *Source) readSecretScanningAlerts(ctx context.Context, client *gogithub.
 		}
 		events = append(events, event)
 	}
+	state := sourcecdk.IncrementalWatermarkCheckpointState("github", familySecretScanning, checkpoint)
+	events, reachedWatermark := sourcecdk.IncrementalWatermarkEvents(events, state)
 	nextPage := page + 1
 	pull := sourcecdk.Pull{
-		Events: events,
-		Checkpoint: &cerebrov1.SourceCheckpoint{
-			Watermark: events[len(events)-1].OccurredAt,
-		},
+		Events:     events,
+		Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familySecretScanning, events, state),
+	}
+	if reachedWatermark {
+		pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonWatermarkReached
+		return pull, nil
 	}
 	if resp != nil && resp.NextPage > 0 {
 		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strconv.Itoa(nextPage)}
+		pull.Checkpoint = sourcecdk.IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, strconv.Itoa(nextPage))
 	}
 	return pull, nil
 }

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -195,6 +195,12 @@ func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecd
 
 // Read pages through the configured live GitHub event family.
 func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return s.ReadWithCheckpoint(ctx, cfg, cursor, nil)
+}
+
+// ReadWithCheckpoint uses durable checkpoint watermarks to avoid re-emitting
+// unchanged descending GitHub inventory pages.
+func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
 	client, settings, err := s.newClient(cfg, true)
 	if err != nil {
 		return sourcecdk.Pull{}, err
@@ -203,18 +209,22 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 		return s.readAudit(ctx, client, settings, cursor)
 	}
 	if settings.family == familyDependabot {
-		return s.readDependabotAlerts(ctx, client, settings, cursor)
+		return s.readDependabotAlerts(ctx, client, settings, cursor, checkpoint)
 	}
 	if settings.family == familySecretScanning {
-		return s.readSecretScanningAlerts(ctx, client, settings, cursor)
+		return s.readSecretScanningAlerts(ctx, client, settings, cursor, checkpoint)
 	}
 	if settings.family == familyOrgInventory {
 		return s.readOrgInventory(ctx, client, settings)
 	}
 	if settings.family == familyRepository {
-		return s.readRepositories(ctx, client, settings, cursor)
+		return s.readRepositories(ctx, client, settings, cursor, checkpoint)
 	}
-	page, err := readPage(cursor)
+	return s.readPullRequests(ctx, client, settings, cursor, checkpoint)
+}
+
+func (s *Source) readPullRequests(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	page, err := sourcecdk.CursorPage(cursor)
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
@@ -231,7 +241,7 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github repo %s/%s", settings.owner, settings.repo), err)
 	}
 	if len(pulls) == 0 {
-		return sourcecdk.Pull{}, nil
+		return sourcecdk.EmptyIncrementalWatermarkPull("github", familyPullRequest, checkpoint), nil
 	}
 	events := make([]*primitives.Event, 0, len(pulls))
 	for _, pullRequest := range pulls {
@@ -241,30 +251,32 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 		}
 		events = append(events, event)
 	}
-	nextPage := page + 1
+	state := sourcecdk.IncrementalWatermarkCheckpointState("github", familyPullRequest, checkpoint)
+	events, reachedWatermark := sourcecdk.IncrementalWatermarkEvents(events, state)
 	pull := sourcecdk.Pull{
-		Events: events,
-		Checkpoint: &cerebrov1.SourceCheckpoint{
-			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: strconv.Itoa(nextPage),
-		},
+		Events:     events,
+		Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familyPullRequest, events, state),
+	}
+	if reachedWatermark {
+		pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonWatermarkReached
+		return pull, nil
 	}
 	if resp != nil && resp.NextPage > 0 {
-		nextPage = resp.NextPage
 		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strconv.Itoa(resp.NextPage)}
-		pull.Checkpoint.CursorOpaque = strconv.Itoa(nextPage)
+		pull.Checkpoint = sourcecdk.IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, strconv.Itoa(resp.NextPage))
 	}
 	return pull, nil
 }
 
-func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-	page, err := readPage(cursor)
+func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	page, err := sourcecdk.CursorPage(cursor)
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
+	state := sourcecdk.IncrementalWatermarkCheckpointState("github", familyRepository, checkpoint)
 	if settings.repo != "" {
 		if page > 1 {
-			return sourcecdk.Pull{}, nil
+			return sourcecdk.EmptyIncrementalWatermarkPull("github", familyRepository, checkpoint), nil
 		}
 		repo, err := getRepo(ctx, client, settings.owner, settings.repo)
 		if err != nil {
@@ -274,20 +286,23 @@ func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, 
 		if err != nil {
 			return sourcecdk.Pull{}, err
 		}
-		return sourcecdk.Pull{
-			Events: []*primitives.Event{event},
-			Checkpoint: &cerebrov1.SourceCheckpoint{
-				Watermark:    event.OccurredAt,
-				CursorOpaque: "2",
-			},
-		}, nil
+		events, reachedWatermark := sourcecdk.IncrementalWatermarkEvents([]*primitives.Event{event}, state)
+		pull := sourcecdk.Pull{
+			Events:     events,
+			Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familyRepository, events, state),
+		}
+		if reachedWatermark {
+			pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonWatermarkReached
+			return pull, nil
+		}
+		return pull, nil
 	}
 	repos, resp, err := listReposPage(ctx, client, settings.owner, page, settings.perPage)
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
 	if len(repos) == 0 {
-		return sourcecdk.Pull{}, nil
+		return sourcecdk.EmptyIncrementalWatermarkPull("github", familyRepository, checkpoint), nil
 	}
 	events := make([]*primitives.Event, 0, len(repos))
 	for _, repo := range repos {
@@ -297,18 +312,18 @@ func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, 
 		}
 		events = append(events, event)
 	}
-	nextPage := page + 1
+	events, reachedWatermark := sourcecdk.IncrementalWatermarkEvents(events, state)
 	pull := sourcecdk.Pull{
-		Events: events,
-		Checkpoint: &cerebrov1.SourceCheckpoint{
-			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: strconv.Itoa(nextPage),
-		},
+		Events:     events,
+		Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familyRepository, events, state),
+	}
+	if reachedWatermark {
+		pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonWatermarkReached
+		return pull, nil
 	}
 	if resp != nil && resp.NextPage > 0 {
-		nextPage = resp.NextPage
 		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strconv.Itoa(resp.NextPage)}
-		pull.Checkpoint.CursorOpaque = strconv.Itoa(nextPage)
+		pull.Checkpoint = sourcecdk.IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, strconv.Itoa(resp.NextPage))
 	}
 	return pull, nil
 }
@@ -590,20 +605,6 @@ func repoURN(owner string, repo *gogithub.Repository) (sourcecdk.URN, error) {
 		fullName = owner + "/" + name
 	}
 	return sourcecdk.ParseURN(fmt.Sprintf("urn:cerebro:%s:repo:%s", owner, fullName))
-}
-
-func readPage(cursor *cerebrov1.SourceCursor) (int, error) {
-	if cursor == nil || strings.TrimSpace(cursor.Opaque) == "" {
-		return 1, nil
-	}
-	page, err := strconv.Atoi(strings.TrimSpace(cursor.Opaque))
-	if err != nil {
-		return 0, fmt.Errorf("%w: parse cursor: %w", sourcecdk.ErrInvalidConfig, err)
-	}
-	if page < 1 {
-		return 0, fmt.Errorf("%w: cursor page must be greater than zero", sourcecdk.ErrInvalidConfig)
-	}
-	return page, nil
 }
 
 func pullRequestEvent(settings settings, pullRequest *gogithub.PullRequest) (*primitives.Event, error) {

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	gogithub "github.com/google/go-github/v66/github"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -150,6 +151,26 @@ func testGitHubAppPrivateKeyPEM(t *testing.T) string {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	}))
+}
+
+func assertGitHubCheckpointEnvelope(t *testing.T, checkpoint *cerebrov1.SourceCheckpoint, family string) {
+	t.Helper()
+	if checkpoint == nil {
+		t.Fatal("checkpoint = nil, want resumable envelope")
+	}
+	envelope, ok := sourcecdk.DecodeCursorEnvelope(checkpoint.GetCursorOpaque())
+	if !ok {
+		t.Fatalf("checkpoint cursor %q is not an envelope", checkpoint.GetCursorOpaque())
+	}
+	if envelope.Source != "github" {
+		t.Fatalf("checkpoint source = %q, want github", envelope.Source)
+	}
+	if envelope.Family != family {
+		t.Fatalf("checkpoint family = %q, want %q", envelope.Family, family)
+	}
+	if !envelope.ResumableCheckpoint {
+		t.Fatalf("checkpoint resumable = false, want true")
+	}
 }
 
 func TestNewFixtureReplaysFixturePages(t *testing.T) {
@@ -302,8 +323,17 @@ func TestCheckDiscoverAndReadLiveGitHubPullRequestPreview(t *testing.T) {
 	if first.NextCursor == nil || first.NextCursor.Opaque != "2" {
 		t.Fatalf("first.NextCursor = %#v, want page 2", first.NextCursor)
 	}
-	if first.Checkpoint == nil || first.Checkpoint.CursorOpaque != "2" {
-		t.Fatalf("first.Checkpoint = %#v, want cursor 2", first.Checkpoint)
+	assertGitHubCheckpointEnvelope(t, first.Checkpoint, familyPullRequest)
+	firstCheckpoint, ok := sourcecdk.DecodeCursorEnvelope(first.Checkpoint.GetCursorOpaque())
+	if !ok || firstCheckpoint.Token != "2" {
+		t.Fatalf("first.Checkpoint = %#v, want resumable envelope with token 2", first.Checkpoint)
+	}
+	resumed, err := source.Read(context.Background(), readCfg, &cerebrov1.SourceCursor{Opaque: first.Checkpoint.GetCursorOpaque()})
+	if err != nil {
+		t.Fatalf("Read(resumed from checkpoint envelope) error = %v", err)
+	}
+	if len(resumed.Events) != 1 || resumed.Events[0].GetId() != "github-pr-writer-cerebro-442-1776902400" {
+		t.Fatalf("resumed events = %#v, want second fixture PR", resumed.Events)
 	}
 
 	second, err := source.Read(context.Background(), readCfg, first.NextCursor)
@@ -316,8 +346,9 @@ func TestCheckDiscoverAndReadLiveGitHubPullRequestPreview(t *testing.T) {
 	if second.NextCursor != nil {
 		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
 	}
-	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "3" {
-		t.Fatalf("second.Checkpoint = %#v, want cursor 3", second.Checkpoint)
+	assertGitHubCheckpointEnvelope(t, second.Checkpoint, familyPullRequest)
+	if !sourcecdk.ResumableCursorOpaque(second.Checkpoint.GetCursorOpaque()) {
+		t.Fatalf("second.Checkpoint.CursorOpaque = %q, want resumable envelope", second.Checkpoint.GetCursorOpaque())
 	}
 
 	final, err := source.Read(context.Background(), readCfg, &cerebrov1.SourceCursor{Opaque: "3"})
@@ -326,6 +357,77 @@ func TestCheckDiscoverAndReadLiveGitHubPullRequestPreview(t *testing.T) {
 	}
 	if len(final.Events) != 0 {
 		t.Fatalf("len(final.Events) = %d, want 0", len(final.Events))
+	}
+}
+
+func TestReadWithCheckpointShortCircuitsUnchangedPullRequests(t *testing.T) {
+	server := httptest.NewServer(newGitHubAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"owner":    "writer",
+		"per_page": "1",
+		"repo":     "cerebro",
+		"state":    "all",
+	})
+	watermark := time.Date(2026, 4, 23, 2, 0, 0, 0, time.UTC)
+	checkpoint := sourcecdk.IncrementalWatermarkCheckpoint("github", familyPullRequest, []*cerebrov1.EventEnvelope{{
+		Id:         "github-pr-writer-cerebro-443-1776909600",
+		OccurredAt: timestamppb.New(watermark),
+	}}, sourcecdk.IncrementalWatermarkState{})
+
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 0 {
+		t.Fatalf("len(Events) = %d, want 0", len(pull.Events))
+	}
+	if pull.NextCursor != nil {
+		t.Fatalf("NextCursor = %#v, want nil after watermark short-circuit", pull.NextCursor)
+	}
+	if pull.ShortCircuitReason != sourcecdk.PullShortCircuitReasonWatermarkReached {
+		t.Fatalf("ShortCircuitReason = %q, want watermark_reached", pull.ShortCircuitReason)
+	}
+}
+
+func TestReadWithCheckpointKeepsNewEqualTimestampPullRequest(t *testing.T) {
+	server := httptest.NewServer(newGitHubAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"owner":    "writer",
+		"per_page": "1",
+		"repo":     "cerebro",
+		"state":    "all",
+	})
+	watermark := time.Date(2026, 4, 23, 2, 0, 0, 0, time.UTC)
+	checkpoint := sourcecdk.IncrementalWatermarkCheckpoint("github", familyPullRequest, []*cerebrov1.EventEnvelope{{
+		Id:         "different-boundary-id",
+		OccurredAt: timestamppb.New(watermark),
+	}}, sourcecdk.IncrementalWatermarkState{})
+
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want equal-timestamp new event", len(pull.Events))
+	}
+	if got := pull.Events[0].GetId(); got != "github-pr-writer-cerebro-443-1776909600" {
+		t.Fatalf("event id = %q, want first fixture PR", got)
 	}
 }
 

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -18,7 +18,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"azure":           2582,
 	"cosmo":           1112,
 	"gcp":             2078,
-	"github":          2194,
+	"github":          2188,
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2433,


### PR DESCRIPTION
## Summary
- add source CDK cursor envelopes, incremental watermark helpers, and short-circuit reasons on pulls
- let the source runtime pass durable checkpoints into checkpoint-aware sources, persist short-circuit status, and avoid checkpoint watermark regression
- apply incremental watermark early-stop behavior to GitHub pull request, repository, Dependabot, and secret scanning reads

## Tests
- go test ./...
