### PR TITLE
Add connector credential lifecycle broker

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -341,6 +341,10 @@ paths:
                       type: string
         '200':
           description: Existing credential metadata and references returned for a replayed idempotent request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorCredentialBrokerResponse'
         '400':
           description: Request shape, credential payload context, or credential fields were invalid.
         '403':
@@ -432,6 +436,10 @@ paths:
                 $ref: '#/components/schemas/ConnectorCredentialBrokerResponse'
         '200':
           description: Existing replacement credential returned for a replayed idempotent request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorCredentialBrokerResponse'
         '400':
           description: Request shape, credential payload context, or credential fields were invalid.
         '403':

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -192,6 +192,67 @@ paths:
         '404':
           description: Connector source was not found.
   /connectors/{sourceID}/credentials:
+    get:
+      summary: List connector credential metadata
+      tags:
+        - Connectors
+      parameters:
+        - $ref: '#/components/parameters/sourceID'
+        - name: tenant_id
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: runtime_id
+          in: query
+          schema:
+            type: string
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum:
+              - pending
+              - valid
+              - invalid
+              - revoked
+              - rotating
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1000
+      responses:
+        '200':
+          description: Credential metadata for a tenant/source/runtime. Plaintext credentials and sealed blobs are never returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - source_id
+                  - tenant_id
+                  - credentials
+                properties:
+                  source_id:
+                    type: string
+                  tenant_id:
+                    type: string
+                  runtime_id:
+                    type: string
+                  credentials:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ConnectorCredential'
+        '400':
+          description: Tenant or query filter was invalid.
+        '403':
+          description: Caller is not allowed to inspect credentials for the requested tenant.
+        '404':
+          description: Connector source was not found.
+        '503':
+          description: Connector credential vault is unavailable.
     post:
       summary: Broker connector credentials
       tags:
@@ -220,6 +281,9 @@ paths:
                   default: cerebro_vault
                   enum:
                     - cerebro_vault
+                idempotency_key:
+                  type: string
+                  description: Optional caller-supplied key used to safely retry one credential submission for the same tenant, source, and runtime.
                 encrypted_credentials:
                   type: object
                   description: Browser-encrypted credential fields. The backend unwraps this payload, seals it in the connector vault, and returns only credential references.
@@ -267,51 +331,16 @@ paths:
                     type: string
                     enum:
                       - stored
+                      - existing
                   credential:
-                    type: object
-                    required:
-                      - id
-                      - tenant_id
-                      - source_id
-                      - runtime_id
-                      - credential_store_id
-                      - auth_method
-                      - key_id
-                      - fields
-                    properties:
-                      id:
-                        type: string
-                      tenant_id:
-                        type: string
-                      source_id:
-                        type: string
-                      runtime_id:
-                        type: string
-                      credential_store_id:
-                        type: string
-                        enum:
-                          - cerebro_vault
-                      auth_method:
-                        type: string
-                        enum:
-                          - encrypted_submission
-                      key_id:
-                        type: string
-                      fields:
-                        type: array
-                        items:
-                          type: string
-                      created_at:
-                        type: string
-                        format: date-time
-                      updated_at:
-                        type: string
-                        format: date-time
+                    $ref: '#/components/schemas/ConnectorCredential'
                   credential_references:
                     type: object
                     description: Field-to-reference map that can be passed as connector credential_references without exposing the underlying secret.
                     additionalProperties:
                       type: string
+        '200':
+          description: Existing credential metadata and references returned for a replayed idempotent request.
         '400':
           description: Request shape, credential payload context, or credential fields were invalid.
         '403':
@@ -320,6 +349,141 @@ paths:
           description: Connector source was not found.
         '503':
           description: Connector credential transport or vault is unavailable.
+  /connectors/{sourceID}/credentials/{credentialID}:
+    get:
+      summary: Get connector credential metadata
+      tags:
+        - Connectors
+      parameters:
+        - $ref: '#/components/parameters/sourceID'
+        - name: credentialID
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Credential metadata and recent broker audit events. Plaintext credentials and sealed blobs are never returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - source_id
+                  - credential
+                properties:
+                  source_id:
+                    type: string
+                  credential:
+                    $ref: '#/components/schemas/ConnectorCredential'
+                  audit:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ConnectorCredentialAuditEvent'
+        '403':
+          description: Caller is not allowed to inspect credentials for the credential tenant.
+        '404':
+          description: Connector source or credential was not found.
+        '503':
+          description: Connector credential vault is unavailable.
+  /connectors/{sourceID}/credentials/{credentialID}/rotate:
+    post:
+      summary: Rotate connector credential
+      tags:
+        - Connectors
+      parameters:
+        - $ref: '#/components/parameters/sourceID'
+        - name: credentialID
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - encrypted_credentials
+              properties:
+                tenant_id:
+                  type: string
+                runtime_id:
+                  type: string
+                credential_store_id:
+                  type: string
+                  default: cerebro_vault
+                  enum:
+                    - cerebro_vault
+                idempotency_key:
+                  type: string
+                revoke_previous:
+                  type: boolean
+                  description: When true, revokes the previous credential after the replacement is sealed.
+                encrypted_credentials:
+                  $ref: '#/components/schemas/EncryptedConnectorCredentialPayload'
+      responses:
+        '201':
+          description: Replacement credential sealed and linked to the previous credential.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorCredentialBrokerResponse'
+        '200':
+          description: Existing replacement credential returned for a replayed idempotent request.
+        '400':
+          description: Request shape, credential payload context, or credential fields were invalid.
+        '403':
+          description: Caller is not allowed to rotate credentials for the credential tenant.
+        '404':
+          description: Connector source or credential was not found.
+        '503':
+          description: Connector credential transport or vault is unavailable.
+  /connectors/{sourceID}/credentials/{credentialID}/revoke:
+    post:
+      summary: Revoke connector credential
+      tags:
+        - Connectors
+      parameters:
+        - $ref: '#/components/parameters/sourceID'
+        - name: credentialID
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+      responses:
+        '200':
+          description: Credential marked revoked. Runtime resolution rejects future use of this credential reference.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - source_id
+                  - credential
+                properties:
+                  source_id:
+                    type: string
+                  credential:
+                    $ref: '#/components/schemas/ConnectorCredential'
+        '400':
+          description: Request shape was invalid.
+        '403':
+          description: Caller is not allowed to revoke credentials for the credential tenant.
+        '404':
+          description: Connector source or credential was not found.
+        '503':
+          description: Connector credential vault is unavailable.
   /connectors/credential-key:
     get:
       summary: Get connector credential transit key
@@ -2776,6 +2940,154 @@ components:
         type: integer
         minimum: 1
   schemas:
+    EncryptedConnectorCredentialPayload:
+      type: object
+      required:
+        - key_id
+        - algorithm
+        - wrapped_key
+        - nonce
+        - ciphertext
+      properties:
+        key_id:
+          type: string
+        algorithm:
+          type: string
+          enum:
+            - RSA-OAEP-256+A256GCM
+        wrapped_key:
+          type: string
+        nonce:
+          type: string
+        ciphertext:
+          type: string
+    ConnectorCredential:
+      type: object
+      required:
+        - id
+        - tenant_id
+        - source_id
+        - runtime_id
+        - credential_store_id
+        - auth_method
+        - status
+        - key_id
+        - fields
+      properties:
+        id:
+          type: string
+        tenant_id:
+          type: string
+        source_id:
+          type: string
+        runtime_id:
+          type: string
+        credential_store_id:
+          type: string
+        auth_method:
+          type: string
+        status:
+          type: string
+          enum:
+            - pending
+            - valid
+            - invalid
+            - revoked
+            - rotating
+        key_id:
+          type: string
+        fields:
+          type: array
+          items:
+            type: string
+        created_by:
+          type: string
+        updated_by:
+          type: string
+        revoked_by:
+          type: string
+        previous_credential_id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        revoked_at:
+          type: string
+          format: date-time
+        last_used_at:
+          type: string
+          format: date-time
+        last_validated_at:
+          type: string
+          format: date-time
+    ConnectorCredentialAuditEvent:
+      type: object
+      required:
+        - id
+        - credential_id
+        - tenant_id
+        - source_id
+        - runtime_id
+        - event_type
+      properties:
+        id:
+          type: string
+        credential_id:
+          type: string
+        tenant_id:
+          type: string
+        source_id:
+          type: string
+        runtime_id:
+          type: string
+        event_type:
+          type: string
+          enum:
+            - stored
+            - rotated
+            - revoked
+            - used
+            - validated
+        actor:
+          type: string
+        status:
+          type: string
+        detail:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    ConnectorCredentialBrokerResponse:
+      type: object
+      required:
+        - source_id
+        - tenant_id
+        - runtime_id
+        - status
+        - credential
+        - credential_references
+      properties:
+        source_id:
+          type: string
+        tenant_id:
+          type: string
+        runtime_id:
+          type: string
+        status:
+          type: string
+          enum:
+            - stored
+            - rotated
+            - existing
+        credential:
+          $ref: '#/components/schemas/ConnectorCredential'
+        credential_references:
+          type: object
+          additionalProperties:
+            type: string
     ConnectorDefinitionListResponse:
       type: object
       required:

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2850,11 +2850,11 @@ func resolveRuntimeSourceConfigWithStore(ctx context.Context, credentialConfig c
 	resolved := values
 	var err error
 	if hasConnectorCredentialReferences(values) {
-		vault, err := connectorCredentialVault(credentialConfig, store)
+		broker, err := connectorCredentialBroker(credentialConfig, store, nil)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", sourceruntime.ErrRuntimeUnavailable, err)
 		}
-		resolved, err = vault.ResolveReferences(ctx, sourceID, values[sourceconfig.RuntimeTenantIDKey], values[sourceconfig.RuntimeIDKey], values)
+		resolved, err = broker.ResolveReferences(ctx, sourceID, values[sourceconfig.RuntimeTenantIDKey], values[sourceconfig.RuntimeIDKey], values)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", sourceruntime.ErrInvalidRequest, err)
 		}

--- a/internal/bootstrap/auth_connect_policy.go
+++ b/internal/bootstrap/auth_connect_policy.go
@@ -7,6 +7,7 @@ const (
 	scopeFindingCandidatePromote   = "cerebro.finding_candidates.promote"
 	scopeFindingLifecycleWrite     = "cerebro.findings.write"
 	scopeGRCInventoryWrite         = "cerebro.grc.inventory.write"
+	scopeConnectorCredentialsRead  = "cerebro.connector_credentials.read"
 	scopeConnectorCredentialsWrite = "cerebro.connector_credentials.write"
 	scopeRuntimeResponseWrite      = "cerebro.runtime_response.write"
 )

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -17,6 +17,7 @@ type httpAuthRoutePolicy struct {
 	Method    string
 	Exact     string
 	Prefix    string
+	Contains  string
 	Suffix    string
 	Scope     string
 	Static    bool
@@ -43,8 +44,12 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPut, Prefix: "/connector-definitions/", Static: true, AdminOnly: true},
 	{Method: http.MethodPost, Prefix: "/connector-definitions/", Suffix: "/promote", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Prefix: "/connectors/", Suffix: "/activity", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Prefix: "/connectors/", Suffix: "/credentials", Scope: scopeConnectorCredentialsRead, Static: true},
+	{Method: http.MethodGet, Prefix: "/connectors/", Contains: "/credentials/", Scope: scopeConnectorCredentialsRead, Static: true},
 	{Method: http.MethodGet, Prefix: "/connectors/", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Prefix: "/connectors/", Suffix: "/credentials", Scope: scopeConnectorCredentialsWrite, Static: true},
+	{Method: http.MethodPost, Prefix: "/connectors/", Suffix: "/rotate", Scope: scopeConnectorCredentialsWrite, Static: true},
+	{Method: http.MethodPost, Prefix: "/connectors/", Suffix: "/revoke", Scope: scopeConnectorCredentialsWrite, Static: true},
 	{Method: http.MethodPost, Prefix: "/connectors/", Suffix: "/preflight", Static: true, AdminOnly: true},
 	{Method: http.MethodPost, Prefix: "/connectors/", Suffix: "/connections", Static: true, AdminOnly: true},
 	{Method: http.MethodGet, Exact: "/reports", Scope: scopeCosmoSecurityRead},
@@ -137,10 +142,13 @@ func routePolicyPathMatches(policy httpAuthRoutePolicy, path string) bool {
 	if policy.Prefix != "" && !strings.HasPrefix(path, policy.Prefix) {
 		return false
 	}
+	if policy.Contains != "" && !strings.Contains(path, policy.Contains) {
+		return false
+	}
 	if policy.Suffix != "" && !strings.HasSuffix(path, policy.Suffix) {
 		return false
 	}
-	return policy.Exact != "" || policy.Prefix != "" || policy.Suffix != ""
+	return policy.Exact != "" || policy.Prefix != "" || policy.Contains != "" || policy.Suffix != ""
 }
 
 func httpRouteStaticAccessPathKnown(path string) bool {

--- a/internal/bootstrap/auth_route_policy_test.go
+++ b/internal/bootstrap/auth_route_policy_test.go
@@ -78,9 +78,31 @@ func TestConnectorCredentialBrokerHTTPRouteRequiresWriteScope(t *testing.T) {
 	if policy.Scope != scopeConnectorCredentialsWrite || policy.AdminOnly {
 		t.Fatalf("POST /connectors/{sourceID}/credentials policy = %#v, want connector credential write scope", policy)
 	}
+	for _, path := range []string{
+		"/connectors/aws/credentials",
+		"/connectors/aws/credentials/cred_123",
+	} {
+		policy := httpRoutePolicyFor(http.MethodGet, path)
+		if policy.Scope != scopeConnectorCredentialsRead || policy.AdminOnly {
+			t.Fatalf("GET %s policy = %#v, want connector credential read scope", path, policy)
+		}
+	}
+	for _, path := range []string{
+		"/connectors/aws/credentials/cred_123/rotate",
+		"/connectors/aws/credentials/cred_123/revoke",
+	} {
+		policy := httpRoutePolicyFor(http.MethodPost, path)
+		if policy.Scope != scopeConnectorCredentialsWrite || policy.AdminOnly {
+			t.Fatalf("POST %s policy = %#v, want connector credential write scope", path, policy)
+		}
+	}
 	readOnly := authPrincipal{Scopes: []string{scopeCosmoSecurityRead}}
 	if err := authorizePrincipalScope(readOnly, scopeConnectorCredentialsWrite); err == nil {
 		t.Fatal("read-only scoped principal authorized for connector credential write scope")
+	}
+	credentialReader := authPrincipal{Scopes: []string{scopeConnectorCredentialsRead}}
+	if err := authorizePrincipalScope(credentialReader, scopeConnectorCredentialsRead); err != nil {
+		t.Fatalf("connector credential reader rejected: %v", err)
 	}
 	writer := authPrincipal{Scopes: []string{scopeConnectorCredentialsWrite}}
 	if err := authorizePrincipalScope(writer, scopeConnectorCredentialsWrite); err != nil {

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -3270,14 +3270,6 @@ func (a *App) authorizeConnectorCredentialRuntime(ctx context.Context, sourceID 
 	return nil
 }
 
-func connectorCredentialReferences(credentialID string, fields map[string]string) map[string]string {
-	references := make(map[string]string, len(fields))
-	for _, field := range connectorcredentials.SortedFieldNames(fields) {
-		references[field] = connectorcredentials.Reference(credentialID, field)
-	}
-	return references
-}
-
 func connectorRuntimeConfig(input map[string]string) (map[string]string, error) {
 	config := make(map[string]string, len(input))
 	for key, value := range input {

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -283,7 +283,21 @@ type connectorCredentialBrokerRequest struct {
 	RuntimeID            string                                `json:"runtime_id"`
 	TenantID             string                                `json:"tenant_id,omitempty"`
 	CredentialStoreID    string                                `json:"credential_store_id,omitempty"`
+	IdempotencyKey       string                                `json:"idempotency_key,omitempty"`
 	EncryptedCredentials connectorcredentials.EncryptedPayload `json:"encrypted_credentials"`
+}
+
+type connectorCredentialRotateRequest struct {
+	RuntimeID            string                                `json:"runtime_id,omitempty"`
+	TenantID             string                                `json:"tenant_id,omitempty"`
+	CredentialStoreID    string                                `json:"credential_store_id,omitempty"`
+	IdempotencyKey       string                                `json:"idempotency_key,omitempty"`
+	RevokePrevious       bool                                  `json:"revoke_previous,omitempty"`
+	EncryptedCredentials connectorcredentials.EncryptedPayload `json:"encrypted_credentials"`
+}
+
+type connectorCredentialRevokeRequest struct {
+	Reason string `json:"reason,omitempty"`
 }
 
 type connectorPreflightResponse struct {
@@ -360,16 +374,50 @@ type connectorCredentialBrokerResponse struct {
 }
 
 type connectorCredentialView struct {
-	ID         string   `json:"id"`
-	TenantID   string   `json:"tenant_id"`
-	SourceID   string   `json:"source_id"`
-	RuntimeID  string   `json:"runtime_id"`
-	StoreID    string   `json:"credential_store_id"`
-	AuthMethod string   `json:"auth_method"`
-	KeyID      string   `json:"key_id"`
-	Fields     []string `json:"fields"`
-	CreatedAt  string   `json:"created_at,omitempty"`
-	UpdatedAt  string   `json:"updated_at,omitempty"`
+	ID                   string   `json:"id"`
+	TenantID             string   `json:"tenant_id"`
+	SourceID             string   `json:"source_id"`
+	RuntimeID            string   `json:"runtime_id"`
+	StoreID              string   `json:"credential_store_id"`
+	AuthMethod           string   `json:"auth_method"`
+	Status               string   `json:"status"`
+	KeyID                string   `json:"key_id"`
+	Fields               []string `json:"fields"`
+	CreatedBy            string   `json:"created_by,omitempty"`
+	UpdatedBy            string   `json:"updated_by,omitempty"`
+	RevokedBy            string   `json:"revoked_by,omitempty"`
+	PreviousCredentialID string   `json:"previous_credential_id,omitempty"`
+	CreatedAt            string   `json:"created_at,omitempty"`
+	UpdatedAt            string   `json:"updated_at,omitempty"`
+	RevokedAt            string   `json:"revoked_at,omitempty"`
+	LastUsedAt           string   `json:"last_used_at,omitempty"`
+	LastValidatedAt      string   `json:"last_validated_at,omitempty"`
+}
+
+type connectorCredentialListResponse struct {
+	SourceID    string                    `json:"source_id"`
+	TenantID    string                    `json:"tenant_id"`
+	RuntimeID   string                    `json:"runtime_id,omitempty"`
+	Credentials []connectorCredentialView `json:"credentials"`
+}
+
+type connectorCredentialDetailResponse struct {
+	SourceID   string                         `json:"source_id"`
+	Credential connectorCredentialView        `json:"credential"`
+	Audit      []connectorCredentialAuditView `json:"audit,omitempty"`
+}
+
+type connectorCredentialAuditView struct {
+	ID           string `json:"id"`
+	CredentialID string `json:"credential_id"`
+	TenantID     string `json:"tenant_id"`
+	SourceID     string `json:"source_id"`
+	RuntimeID    string `json:"runtime_id"`
+	EventType    string `json:"event_type"`
+	Actor        string `json:"actor,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Detail       string `json:"detail,omitempty"`
+	CreatedAt    string `json:"created_at,omitempty"`
 }
 
 func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
@@ -555,65 +603,299 @@ func (a *App) handleCreateConnectorCredential(w http.ResponseWriter, r *http.Req
 		writeConnectorError(w, err)
 		return
 	}
-	if !connectorEncryptedPayloadPresent(request.EncryptedCredentials) {
-		writeConnectorError(w, fmt.Errorf("%w: encrypted_credentials is required", connectorcredentials.ErrInvalidRequest))
-		return
-	}
-	if a == nil || a.connectorTransitKey == nil {
-		writeConnectorError(w, connectorcredentials.ErrUnavailable)
-		return
-	}
-	decrypted, err := a.connectorTransitKey.DecryptWithExactAdditionalData(
-		request.EncryptedCredentials,
-		connectorCredentialAdditionalData(request.EncryptedCredentials.KeyID, sourceID, tenantID, runtimeID, credentialStoreID),
-	)
+	broker, err := connectorCredentialBroker(a.cfg.ConnectorCredentials, a.deps.StateStore, a.connectorTransitKey)
 	if err != nil {
 		writeConnectorError(w, err)
 		return
 	}
-	fields, err := connectorcredentials.ParseCredentialFields(decrypted)
-	if err != nil {
-		writeConnectorError(w, err)
-		return
-	}
-	if err := validateConnectorCredentialFields(sourceID, connectorAuthMethodEncryptedSubmission, fields); err != nil {
-		writeConnectorError(w, err)
-		return
-	}
-	vault, err := connectorCredentialVault(a.cfg.ConnectorCredentials, a.deps.StateStore)
-	if err != nil {
-		writeConnectorError(w, err)
-		return
-	}
-	record, err := vault.Put(r.Context(), connectorcredentials.PlainCredential{
-		TenantID:  tenantID,
-		SourceID:  sourceID,
-		RuntimeID: runtimeID,
-		Fields:    fields,
+	result, err := broker.StoreEncrypted(r.Context(), connectorcredentials.StoreEncryptedRequest{
+		TenantID:             tenantID,
+		SourceID:             sourceID,
+		RuntimeID:            runtimeID,
+		CredentialStoreID:    credentialStoreID,
+		AuthMethod:           connectorAuthMethodEncryptedSubmission,
+		Actor:                connectorCredentialActor(r),
+		IdempotencyKey:       connectorCredentialIdempotencyKey(r, request.IdempotencyKey),
+		EncryptedCredentials: request.EncryptedCredentials,
+		ValidateFields: func(fields map[string]string) error {
+			return validateConnectorCredentialFields(sourceID, connectorAuthMethodEncryptedSubmission, fields)
+		},
 	})
 	if err != nil {
 		writeConnectorError(w, err)
 		return
 	}
-	references := connectorCredentialReferences(record.ID, fields)
-	writeJSON(w, http.StatusCreated, connectorCredentialBrokerResponse{
+	status := "stored"
+	httpStatus := http.StatusCreated
+	if !result.Created {
+		status = "existing"
+		httpStatus = http.StatusOK
+	}
+	writeJSON(w, httpStatus, connectorCredentialBrokerResponse{
 		SourceID:  sourceID,
 		TenantID:  tenantID,
 		RuntimeID: runtimeID,
-		Status:    "stored",
-		Credential: connectorCredentialView{
-			ID:         record.ID,
-			TenantID:   tenantID,
-			SourceID:   sourceID,
-			RuntimeID:  runtimeID,
-			StoreID:    credentialStoreID,
-			AuthMethod: connectorAuthMethodEncryptedSubmission,
-			KeyID:      record.KeyID,
-			Fields:     connectorcredentials.SortedFieldNames(fields),
-			CreatedAt:  connectorcredentials.TimestampOrZero(record.CreatedAt),
-			UpdatedAt:  connectorcredentials.TimestampOrZero(record.UpdatedAt),
+		Status:    status,
+		Credential: func() connectorCredentialView {
+			return connectorCredentialViewFromRecord(result.Record)
+		}(),
+		CredentialReferences: result.References,
+	})
+}
+
+func (a *App) handleListConnectorCredentials(w http.ResponseWriter, r *http.Request) {
+	sourceID := strings.TrimSpace(r.PathValue("sourceID"))
+	if sourceID == "" {
+		writeConnectorError(w, fmt.Errorf("%w: source_id is required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	if _, err := a.connectorSource(sourceID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	tenantID, err := effectiveTenantFilter(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if tenantID == "" {
+		writeConnectorError(w, fmt.Errorf("%w: tenant_id is required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	limit, err := connectorQueryInt(r, "limit", 100, 1000)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	broker, err := connectorCredentialBroker(a.cfg.ConnectorCredentials, a.deps.StateStore, a.connectorTransitKey)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	records, err := broker.List(r.Context(), ports.ConnectorCredentialFilter{
+		TenantID:  tenantID,
+		SourceID:  sourceID,
+		RuntimeID: r.URL.Query().Get("runtime_id"),
+		Status:    r.URL.Query().Get("status"),
+		Limit:     limit,
+	})
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	views := make([]connectorCredentialView, 0, len(records))
+	for _, record := range records {
+		if err := authorizeTenantID(r.Context(), record.TenantID); err != nil {
+			writeConnectorError(w, err)
+			return
+		}
+		views = append(views, connectorCredentialViewFromRecord(record))
+	}
+	writeJSON(w, http.StatusOK, connectorCredentialListResponse{
+		SourceID:    sourceID,
+		TenantID:    tenantID,
+		RuntimeID:   strings.TrimSpace(r.URL.Query().Get("runtime_id")),
+		Credentials: views,
+	})
+}
+
+func (a *App) handleGetConnectorCredential(w http.ResponseWriter, r *http.Request) {
+	sourceID := strings.TrimSpace(r.PathValue("sourceID"))
+	credentialID := strings.TrimSpace(r.PathValue("credentialID"))
+	if sourceID == "" || credentialID == "" {
+		writeConnectorError(w, fmt.Errorf("%w: source_id and credential_id are required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	if _, err := a.connectorSource(sourceID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	broker, err := connectorCredentialBroker(a.cfg.ConnectorCredentials, a.deps.StateStore, a.connectorTransitKey)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	record, err := broker.Get(r.Context(), credentialID)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if strings.TrimSpace(record.SourceID) != sourceID {
+		writeConnectorError(w, ports.ErrConnectorCredentialNotFound)
+		return
+	}
+	if err := authorizeTenantID(r.Context(), record.TenantID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	events, err := broker.AuditEvents(r.Context(), credentialID, 50)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, connectorCredentialDetailResponse{
+		SourceID:   sourceID,
+		Credential: connectorCredentialViewFromRecord(record),
+		Audit:      connectorCredentialAuditViews(events),
+	})
+}
+
+func (a *App) handleRotateConnectorCredential(w http.ResponseWriter, r *http.Request) {
+	request := connectorCredentialRotateRequest{}
+	if err := readConnectorJSON(r, &request); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	sourceID := strings.TrimSpace(r.PathValue("sourceID"))
+	credentialID := strings.TrimSpace(r.PathValue("credentialID"))
+	if sourceID == "" || credentialID == "" {
+		writeConnectorError(w, fmt.Errorf("%w: source_id and credential_id are required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	if _, err := a.connectorSource(sourceID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	broker, err := connectorCredentialBroker(a.cfg.ConnectorCredentials, a.deps.StateStore, a.connectorTransitKey)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	previous, err := broker.Get(r.Context(), credentialID)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if strings.TrimSpace(previous.SourceID) != sourceID {
+		writeConnectorError(w, ports.ErrConnectorCredentialNotFound)
+		return
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		tenantID = strings.TrimSpace(previous.TenantID)
+	}
+	tenantID, err = effectiveTenantFilter(r.Context(), tenantID)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		runtimeID = strings.TrimSpace(previous.RuntimeID)
+	}
+	if tenantID != strings.TrimSpace(previous.TenantID) || runtimeID != strings.TrimSpace(previous.RuntimeID) {
+		writeConnectorError(w, fmt.Errorf("%w: credential rotation must keep the existing tenant and runtime", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	if err := a.authorizeConnectorCredentialRuntime(r.Context(), sourceID, tenantID, runtimeID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	credentialStoreID, err := normalizeConnectorCredentialStoreID(firstNonEmpty(request.CredentialStoreID, previous.CredentialStoreID), connectorAuthMethodEncryptedSubmission)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if err := a.validateConnectorCredentialStoreAvailable(credentialStoreID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	result, err := broker.StoreEncrypted(r.Context(), connectorcredentials.StoreEncryptedRequest{
+		TenantID:             tenantID,
+		SourceID:             sourceID,
+		RuntimeID:            runtimeID,
+		CredentialStoreID:    credentialStoreID,
+		AuthMethod:           connectorAuthMethodEncryptedSubmission,
+		Actor:                connectorCredentialActor(r),
+		IdempotencyKey:       connectorCredentialIdempotencyKey(r, request.IdempotencyKey),
+		PreviousCredentialID: credentialID,
+		EncryptedCredentials: request.EncryptedCredentials,
+		ValidateFields: func(fields map[string]string) error {
+			return validateConnectorCredentialFields(sourceID, connectorAuthMethodEncryptedSubmission, fields)
 		},
-		CredentialReferences: references,
+	})
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if request.RevokePrevious {
+		if _, err := broker.Revoke(r.Context(), connectorcredentials.RevokeRequest{
+			CredentialID: credentialID,
+			TenantID:     tenantID,
+			SourceID:     sourceID,
+			RuntimeID:    runtimeID,
+			Actor:        connectorCredentialActor(r),
+			Detail:       "rotated",
+		}); err != nil {
+			writeConnectorError(w, err)
+			return
+		}
+	}
+	status := "rotated"
+	httpStatus := http.StatusCreated
+	if !result.Created {
+		status = "existing"
+		httpStatus = http.StatusOK
+	}
+	writeJSON(w, httpStatus, connectorCredentialBrokerResponse{
+		SourceID:             sourceID,
+		TenantID:             tenantID,
+		RuntimeID:            runtimeID,
+		Status:               status,
+		Credential:           connectorCredentialViewFromRecord(result.Record),
+		CredentialReferences: result.References,
+	})
+}
+
+func (a *App) handleRevokeConnectorCredential(w http.ResponseWriter, r *http.Request) {
+	request := connectorCredentialRevokeRequest{}
+	if err := readConnectorJSON(r, &request); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	sourceID := strings.TrimSpace(r.PathValue("sourceID"))
+	credentialID := strings.TrimSpace(r.PathValue("credentialID"))
+	if sourceID == "" || credentialID == "" {
+		writeConnectorError(w, fmt.Errorf("%w: source_id and credential_id are required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	if _, err := a.connectorSource(sourceID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	broker, err := connectorCredentialBroker(a.cfg.ConnectorCredentials, a.deps.StateStore, a.connectorTransitKey)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	record, err := broker.Get(r.Context(), credentialID)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	if strings.TrimSpace(record.SourceID) != sourceID {
+		writeConnectorError(w, ports.ErrConnectorCredentialNotFound)
+		return
+	}
+	if err := authorizeTenantID(r.Context(), record.TenantID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	updated, err := broker.Revoke(r.Context(), connectorcredentials.RevokeRequest{
+		CredentialID: credentialID,
+		TenantID:     record.TenantID,
+		SourceID:     sourceID,
+		RuntimeID:    record.RuntimeID,
+		Actor:        connectorCredentialActor(r),
+		Detail:       request.Reason,
+	})
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, connectorCredentialDetailResponse{
+		SourceID:   sourceID,
+		Credential: connectorCredentialViewFromRecord(updated),
 	})
 }
 
@@ -759,29 +1041,31 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if authMethod == connectorAuthMethodEncryptedSubmission {
-		vault, err := connectorCredentialVault(a.cfg.ConnectorCredentials, a.deps.StateStore)
+		broker, err := connectorCredentialBroker(a.cfg.ConnectorCredentials, a.deps.StateStore, a.connectorTransitKey)
 		if err != nil {
 			writeConnectorError(w, err)
 			return
 		}
-		record, err := vault.Put(r.Context(), connectorcredentials.PlainCredential{
-			TenantID:  tenantID,
-			SourceID:  sourceID,
-			RuntimeID: runtimeID,
-			Fields:    plaintextFields,
+		result, err := broker.StoreEncrypted(r.Context(), connectorcredentials.StoreEncryptedRequest{
+			TenantID:             tenantID,
+			SourceID:             sourceID,
+			RuntimeID:            runtimeID,
+			CredentialStoreID:    credentialStoreID,
+			AuthMethod:           authMethod,
+			Actor:                connectorCredentialActor(r),
+			EncryptedCredentials: request.EncryptedCredentials,
+			ValidateFields: func(fields map[string]string) error {
+				return validateConnectorCredentialFields(sourceID, authMethod, fields)
+			},
 		})
 		if err != nil {
 			writeConnectorError(w, err)
 			return
 		}
-		for _, field := range connectorcredentials.SortedFieldNames(plaintextFields) {
-			runtime.Config[field] = connectorcredentials.Reference(record.ID, field)
+		for field, reference := range result.References {
+			runtime.Config[field] = reference
 		}
-		credential.ID = record.ID
-		credential.KeyID = record.KeyID
-		credential.Fields = connectorcredentials.SortedFieldNames(plaintextFields)
-		credential.CreatedAt = connectorcredentials.TimestampOrZero(record.CreatedAt)
-		credential.UpdatedAt = connectorcredentials.TimestampOrZero(record.UpdatedAt)
+		credential = connectorCredentialViewFromRecord(result.Record)
 	}
 	if scopeConfigValue != "" {
 		runtime.Config[resourcescope.ConfigKey] = scopeConfigValue
@@ -2955,16 +3239,7 @@ func connectorExternalReferenceStore(id string) bool {
 }
 
 func connectorCredentialAdditionalData(keyID string, sourceID string, tenantID string, runtimeID string, credentialStoreID string) []byte {
-	parts := []string{
-		"connector-credential",
-		"v1",
-		strings.TrimSpace(keyID),
-		strings.TrimSpace(sourceID),
-		strings.TrimSpace(tenantID),
-		strings.TrimSpace(runtimeID),
-		strings.TrimSpace(credentialStoreID),
-	}
-	return []byte(strings.Join(parts, "\x00"))
+	return connectorcredentials.TransitAdditionalData(keyID, sourceID, tenantID, runtimeID, credentialStoreID)
 }
 
 func (a *App) authorizeConnectorCredentialRuntime(ctx context.Context, sourceID string, tenantID string, runtimeID string) error {
@@ -3238,6 +3513,108 @@ func sortedSetKeys(values map[string]struct{}) []string {
 func setContains(values map[string]struct{}, key string) bool {
 	_, ok := values[key]
 	return ok
+}
+
+func connectorCredentialViewFromRecord(record *ports.ConnectorCredentialRecord) connectorCredentialView {
+	if record == nil {
+		return connectorCredentialView{}
+	}
+	return connectorCredentialView{
+		ID:                   record.ID,
+		TenantID:             record.TenantID,
+		SourceID:             record.SourceID,
+		RuntimeID:            record.RuntimeID,
+		StoreID:              firstNonEmpty(record.CredentialStoreID, defaultConnectorCredentialStoreID),
+		AuthMethod:           firstNonEmpty(record.AuthMethod, connectorAuthMethodEncryptedSubmission),
+		Status:               firstNonEmpty(record.Status, connectorcredentials.StatusValid),
+		KeyID:                record.KeyID,
+		Fields:               append([]string{}, record.Fields...),
+		CreatedBy:            record.CreatedBy,
+		UpdatedBy:            record.UpdatedBy,
+		RevokedBy:            record.RevokedBy,
+		PreviousCredentialID: record.PreviousCredentialID,
+		CreatedAt:            connectorcredentials.TimestampOrZero(record.CreatedAt),
+		UpdatedAt:            connectorcredentials.TimestampOrZero(record.UpdatedAt),
+		RevokedAt:            connectorcredentials.TimestampOrZero(record.RevokedAt),
+		LastUsedAt:           connectorcredentials.TimestampOrZero(record.LastUsedAt),
+		LastValidatedAt:      connectorcredentials.TimestampOrZero(record.LastValidatedAt),
+	}
+}
+
+func connectorCredentialAuditViews(events []*ports.ConnectorCredentialAuditRecord) []connectorCredentialAuditView {
+	views := make([]connectorCredentialAuditView, 0, len(events))
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		views = append(views, connectorCredentialAuditView{
+			ID:           event.ID,
+			CredentialID: event.CredentialID,
+			TenantID:     event.TenantID,
+			SourceID:     event.SourceID,
+			RuntimeID:    event.RuntimeID,
+			EventType:    event.EventType,
+			Actor:        event.Actor,
+			Status:       event.Status,
+			Detail:       event.Detail,
+			CreatedAt:    connectorcredentials.TimestampOrZero(event.CreatedAt),
+		})
+	}
+	return views
+}
+
+func connectorCredentialActor(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok {
+		if name := strings.TrimSpace(auth.principal.Name); name != "" {
+			return name
+		}
+		if clientID := strings.TrimSpace(auth.principal.ClientID); clientID != "" {
+			return clientID
+		}
+		if credentialID := strings.TrimSpace(auth.principal.CredentialID); credentialID != "" {
+			return credentialID
+		}
+	}
+	return ""
+}
+
+func connectorCredentialIdempotencyKey(r *http.Request, bodyValue string) string {
+	if value := strings.TrimSpace(bodyValue); value != "" {
+		return value
+	}
+	if r == nil {
+		return ""
+	}
+	return strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+}
+
+func connectorQueryInt(r *http.Request, key string, defaultValue int, maxValue int) (int, error) {
+	if r == nil || r.URL == nil {
+		return defaultValue, nil
+	}
+	value := strings.TrimSpace(r.URL.Query().Get(key))
+	if value == "" {
+		return defaultValue, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 0 {
+		return 0, fmt.Errorf("%w: query parameter %q must be a non-negative integer", connectorcredentials.ErrInvalidRequest, key)
+	}
+	if maxValue > 0 && parsed > maxValue {
+		return maxValue, nil
+	}
+	return parsed, nil
+}
+
+func connectorCredentialBroker(credentialConfig config.ConnectorCredentialConfig, store ports.StateStore, transit *connectorcredentials.TransitKey) (*connectorcredentials.Broker, error) {
+	vault, err := connectorCredentialVault(credentialConfig, store)
+	if err != nil {
+		return nil, err
+	}
+	return connectorcredentials.NewBroker(vault, transit), nil
 }
 
 func connectorCredentialVault(credentialConfig config.ConnectorCredentialConfig, store ports.StateStore) (*connectorcredentials.Vault, error) {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -538,6 +538,7 @@ func TestConnectorCredentialBrokerRotatesCredential(t *testing.T) {
 		"runtime_id":            "runtime-a",
 		"tenant_id":             "tenant-a",
 		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"idempotency_key":       "rotate-request-1",
 		"revoke_previous":       true,
 		"encrypted_credentials": rotatedEncrypted,
 	})
@@ -564,6 +565,29 @@ func TestConnectorCredentialBrokerRotatesCredential(t *testing.T) {
 	}
 	if got := store.credentials[created.Credential.ID].Status; got != connectorcredentials.StatusRevoked {
 		t.Fatalf("previous credential status = %q, want revoked", got)
+	}
+	revokedAt := store.credentials[created.Credential.ID].RevokedAt
+	auditCount := len(store.audit)
+	replayReq := httptest.NewRequest(http.MethodPost, "/connectors/bootstrap_token/credentials/"+created.Credential.ID+"/rotate", bytes.NewReader(rotateBody))
+	replayReq.SetPathValue("sourceID", "bootstrap_token")
+	replayReq.SetPathValue("credentialID", created.Credential.ID)
+	replayRecorder := httptest.NewRecorder()
+	app.handleRotateConnectorCredential(replayRecorder, replayReq)
+	if replayRecorder.Code != http.StatusOK {
+		t.Fatalf("rotate replay status = %d, want 200: %s", replayRecorder.Code, replayRecorder.Body.String())
+	}
+	var replayed connectorCredentialBrokerResponse
+	if err := json.NewDecoder(replayRecorder.Body).Decode(&replayed); err != nil {
+		t.Fatalf("decode replay response: %v", err)
+	}
+	if replayed.Credential.ID != rotated.Credential.ID {
+		t.Fatalf("replayed credential id = %q, want %q", replayed.Credential.ID, rotated.Credential.ID)
+	}
+	if got := store.credentials[created.Credential.ID].RevokedAt; !got.Equal(revokedAt) {
+		t.Fatalf("replay mutated previous revoked_at = %s, want %s", got, revokedAt)
+	}
+	if got := len(store.audit); got != auditCount {
+		t.Fatalf("replay audit count = %d, want %d", got, auditCount)
 	}
 	broker, err := connectorCredentialBroker(app.cfg.ConnectorCredentials, app.deps.StateStore, nil)
 	if err != nil {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -113,6 +113,27 @@ func (s *connectorTestStore) UpdateConnectorCredentialMetadata(_ context.Context
 	return &cloned, nil
 }
 
+func (s *connectorTestStore) MarkConnectorCredentialUsed(_ context.Context, id string, usedAt time.Time, staleBefore time.Time) (*ports.ConnectorCredentialRecord, bool, error) {
+	record, ok := s.credentials[id]
+	if !ok {
+		return nil, false, ports.ErrConnectorCredentialNotFound
+	}
+	if usedAt.IsZero() {
+		usedAt = time.Now().UTC()
+	}
+	if staleBefore.IsZero() {
+		staleBefore = usedAt.Add(-time.Hour)
+	}
+	if !record.LastUsedAt.IsZero() && record.LastUsedAt.After(staleBefore) {
+		cloned := cloneConnectorTestCredential(record)
+		return &cloned, false, nil
+	}
+	record.LastUsedAt = usedAt.UTC()
+	record.UpdatedAt = usedAt.UTC()
+	cloned := cloneConnectorTestCredential(record)
+	return &cloned, true, nil
+}
+
 func (s *connectorTestStore) AppendConnectorCredentialAuditEvent(_ context.Context, event *ports.ConnectorCredentialAuditRecord) error {
 	if event == nil {
 		return nil

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +33,7 @@ import (
 type connectorTestStore struct {
 	*stubRuntimeStore
 	credentials map[string]*ports.ConnectorCredentialRecord
+	audit       []*ports.ConnectorCredentialAuditRecord
 	definitions map[string]*ports.ConnectorDefinitionRecord
 }
 
@@ -39,10 +41,13 @@ func (s *connectorTestStore) PutConnectorCredential(_ context.Context, record *p
 	if s.credentials == nil {
 		s.credentials = map[string]*ports.ConnectorCredentialRecord{}
 	}
-	cloned := *record
-	cloned.Sealed = append([]byte{}, record.Sealed...)
-	cloned.CreatedAt = time.Now().UTC()
-	cloned.UpdatedAt = cloned.CreatedAt
+	cloned := cloneConnectorTestCredential(record)
+	if cloned.CreatedAt.IsZero() {
+		cloned.CreatedAt = time.Now().UTC()
+	}
+	if cloned.UpdatedAt.IsZero() {
+		cloned.UpdatedAt = cloned.CreatedAt
+	}
 	s.credentials[record.ID] = &cloned
 	return nil
 }
@@ -52,9 +57,119 @@ func (s *connectorTestStore) GetConnectorCredential(_ context.Context, id string
 	if !ok {
 		return nil, ports.ErrConnectorCredentialNotFound
 	}
+	cloned := cloneConnectorTestCredential(record)
+	return &cloned, nil
+}
+
+func (s *connectorTestStore) ListConnectorCredentials(_ context.Context, filter ports.ConnectorCredentialFilter) ([]*ports.ConnectorCredentialRecord, error) {
+	records := []*ports.ConnectorCredentialRecord{}
+	for _, record := range s.credentials {
+		if !connectorCredentialRecordMatches(record, filter) {
+			continue
+		}
+		cloned := cloneConnectorTestCredential(record)
+		records = append(records, &cloned)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].UpdatedAt.After(records[j].UpdatedAt)
+	})
+	if filter.Limit > 0 && len(records) > filter.Limit {
+		records = records[:filter.Limit]
+	}
+	return records, nil
+}
+
+func (s *connectorTestStore) UpdateConnectorCredentialMetadata(_ context.Context, id string, update ports.ConnectorCredentialMetadataUpdate) (*ports.ConnectorCredentialRecord, error) {
+	record, ok := s.credentials[id]
+	if !ok {
+		return nil, ports.ErrConnectorCredentialNotFound
+	}
+	if update.Status != "" {
+		record.Status = update.Status
+	}
+	if update.Fields != nil {
+		record.Fields = append([]string{}, update.Fields...)
+	}
+	if update.UpdatedBy != "" {
+		record.UpdatedBy = update.UpdatedBy
+	}
+	if update.RevokedBy != "" {
+		record.RevokedBy = update.RevokedBy
+	}
+	if update.PreviousCredentialID != "" {
+		record.PreviousCredentialID = update.PreviousCredentialID
+	}
+	if update.RevokedAt != nil {
+		record.RevokedAt = *update.RevokedAt
+	}
+	if update.LastUsedAt != nil {
+		record.LastUsedAt = *update.LastUsedAt
+	}
+	if update.LastValidatedAt != nil {
+		record.LastValidatedAt = *update.LastValidatedAt
+	}
+	record.UpdatedAt = time.Now().UTC()
+	cloned := cloneConnectorTestCredential(record)
+	return &cloned, nil
+}
+
+func (s *connectorTestStore) AppendConnectorCredentialAuditEvent(_ context.Context, event *ports.ConnectorCredentialAuditRecord) error {
+	if event == nil {
+		return nil
+	}
+	cloned := *event
+	s.audit = append(s.audit, &cloned)
+	return nil
+}
+
+func (s *connectorTestStore) ListConnectorCredentialAuditEvents(_ context.Context, credentialID string, limit int) ([]*ports.ConnectorCredentialAuditRecord, error) {
+	events := []*ports.ConnectorCredentialAuditRecord{}
+	for _, event := range s.audit {
+		if event.CredentialID != credentialID {
+			continue
+		}
+		cloned := *event
+		events = append(events, &cloned)
+	}
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].CreatedAt.After(events[j].CreatedAt)
+	})
+	if limit > 0 && len(events) > limit {
+		events = events[:limit]
+	}
+	return events, nil
+}
+
+func cloneConnectorTestCredential(record *ports.ConnectorCredentialRecord) ports.ConnectorCredentialRecord {
 	cloned := *record
 	cloned.Sealed = append([]byte{}, record.Sealed...)
-	return &cloned, nil
+	cloned.Fields = append([]string{}, record.Fields...)
+	return cloned
+}
+
+func connectorCredentialRecordMatches(record *ports.ConnectorCredentialRecord, filter ports.ConnectorCredentialFilter) bool {
+	if record == nil {
+		return false
+	}
+	if filter.ID != "" && record.ID != filter.ID {
+		return false
+	}
+	if filter.TenantID != "" && record.TenantID != filter.TenantID {
+		return false
+	}
+	if filter.SourceID != "" && record.SourceID != filter.SourceID {
+		return false
+	}
+	if filter.RuntimeID != "" && record.RuntimeID != filter.RuntimeID {
+		return false
+	}
+	if filter.Status != "" && record.Status != filter.Status {
+		return false
+	}
+	if filter.IdempotencyKey != "" && record.IdempotencyKey != filter.IdempotencyKey {
+		return false
+	}
+	return true
 }
 
 func TestConnectorConnectionStoresCredentialReference(t *testing.T) {
@@ -224,6 +339,242 @@ func TestConnectorCredentialBrokerStoresReferencesWithoutLeakingSecret(t *testin
 	}
 	if _, err := vault.ResolveReferences(context.Background(), "bootstrap_token", "tenant-b", "runtime-a", map[string]string{"token": reference}); err == nil {
 		t.Fatal("ResolveReferences() succeeded for the wrong tenant")
+	}
+}
+
+func TestConnectorCredentialBrokerListsAndDeduplicatesByIdempotencyKey(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+
+	key := app.connectorTransitKey.PublicKey()
+	encrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "secret-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-a", "runtime-a", defaultConnectorCredentialStoreID),
+	)
+	if err != nil {
+		t.Fatalf("encrypt credentials: %v", err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":            "runtime-a",
+		"tenant_id":             "tenant-a",
+		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"idempotency_key":       "request-1",
+		"encrypted_credentials": encrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	for i, wantStatus := range []int{http.StatusCreated, http.StatusOK} {
+		req := httptest.NewRequest(http.MethodPost, "/connectors/bootstrap_token/credentials", bytes.NewReader(body))
+		req.SetPathValue("sourceID", "bootstrap_token")
+		recorder := httptest.NewRecorder()
+		app.handleCreateConnectorCredential(recorder, req)
+		if recorder.Code != wantStatus {
+			t.Fatalf("request %d status = %d, want %d: %s", i+1, recorder.Code, wantStatus, recorder.Body.String())
+		}
+	}
+	if got := len(store.credentials); got != 1 {
+		t.Fatalf("stored credentials = %d, want 1", got)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/connectors/bootstrap_token/credentials?tenant_id=tenant-a", nil)
+	req.SetPathValue("sourceID", "bootstrap_token")
+	recorder := httptest.NewRecorder()
+	app.handleListConnectorCredentials(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET /connectors/{sourceID}/credentials status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var payload connectorCredentialListResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(payload.Credentials) != 1 {
+		t.Fatalf("listed credentials = %d, want 1", len(payload.Credentials))
+	}
+	if got := payload.Credentials[0].Status; got != connectorcredentials.StatusValid {
+		t.Fatalf("listed credential status = %q, want valid", got)
+	}
+	if got := payload.Credentials[0].Fields; len(got) != 1 || got[0] != "token" {
+		t.Fatalf("listed credential fields = %#v, want token", got)
+	}
+	if strings.Contains(recorder.Body.String(), "secret-token") {
+		t.Fatalf("list response leaked secret: %s", recorder.Body.String())
+	}
+}
+
+func TestConnectorCredentialBrokerRevocationBlocksUse(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+
+	key := app.connectorTransitKey.PublicKey()
+	encrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "secret-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-a", "runtime-a", defaultConnectorCredentialStoreID),
+	)
+	if err != nil {
+		t.Fatalf("encrypt credentials: %v", err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"runtime_id":            "runtime-a",
+		"tenant_id":             "tenant-a",
+		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"encrypted_credentials": encrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	createReq := httptest.NewRequest(http.MethodPost, "/connectors/bootstrap_token/credentials", bytes.NewReader(body))
+	createReq.SetPathValue("sourceID", "bootstrap_token")
+	createRecorder := httptest.NewRecorder()
+	app.handleCreateConnectorCredential(createRecorder, createReq)
+	if createRecorder.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201: %s", createRecorder.Code, createRecorder.Body.String())
+	}
+	var created connectorCredentialBrokerResponse
+	if err := json.NewDecoder(createRecorder.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	revokeReq := httptest.NewRequest(http.MethodPost, "/connectors/bootstrap_token/credentials/"+created.Credential.ID+"/revoke", strings.NewReader(`{"reason":"operator requested"}`))
+	revokeReq.SetPathValue("sourceID", "bootstrap_token")
+	revokeReq.SetPathValue("credentialID", created.Credential.ID)
+	revokeRecorder := httptest.NewRecorder()
+	app.handleRevokeConnectorCredential(revokeRecorder, revokeReq)
+	if revokeRecorder.Code != http.StatusOK {
+		t.Fatalf("revoke status = %d, want 200: %s", revokeRecorder.Code, revokeRecorder.Body.String())
+	}
+	if got := store.credentials[created.Credential.ID].Status; got != connectorcredentials.StatusRevoked {
+		t.Fatalf("stored status = %q, want revoked", got)
+	}
+	broker, err := connectorCredentialBroker(app.cfg.ConnectorCredentials, app.deps.StateStore, nil)
+	if err != nil {
+		t.Fatalf("connectorCredentialBroker() error = %v", err)
+	}
+	if _, err := broker.ResolveReferences(context.Background(), "bootstrap_token", "tenant-a", "runtime-a", map[string]string{"token": created.CredentialReferences["token"]}); err == nil {
+		t.Fatal("ResolveReferences() after revoke error = nil, want error")
+	}
+}
+
+func TestConnectorCredentialBrokerRotatesCredential(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+
+	key := app.connectorTransitKey.PublicKey()
+	initialEncrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "old-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-a", "runtime-a", defaultConnectorCredentialStoreID),
+	)
+	if err != nil {
+		t.Fatalf("encrypt initial credentials: %v", err)
+	}
+	initialBody, err := json.Marshal(map[string]any{
+		"runtime_id":            "runtime-a",
+		"tenant_id":             "tenant-a",
+		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"encrypted_credentials": initialEncrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal initial request: %v", err)
+	}
+	createReq := httptest.NewRequest(http.MethodPost, "/connectors/bootstrap_token/credentials", bytes.NewReader(initialBody))
+	createReq.SetPathValue("sourceID", "bootstrap_token")
+	createRecorder := httptest.NewRecorder()
+	app.handleCreateConnectorCredential(createRecorder, createReq)
+	if createRecorder.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201: %s", createRecorder.Code, createRecorder.Body.String())
+	}
+	var created connectorCredentialBrokerResponse
+	if err := json.NewDecoder(createRecorder.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	rotatedEncrypted, err := encryptConnectorCredentialsForTestWithAAD(
+		key,
+		map[string]string{"token": "new-token"},
+		connectorCredentialAdditionalData(key.KeyID, "bootstrap_token", "tenant-a", "runtime-a", defaultConnectorCredentialStoreID),
+	)
+	if err != nil {
+		t.Fatalf("encrypt rotated credentials: %v", err)
+	}
+	rotateBody, err := json.Marshal(map[string]any{
+		"runtime_id":            "runtime-a",
+		"tenant_id":             "tenant-a",
+		"credential_store_id":   defaultConnectorCredentialStoreID,
+		"revoke_previous":       true,
+		"encrypted_credentials": rotatedEncrypted,
+	})
+	if err != nil {
+		t.Fatalf("marshal rotate request: %v", err)
+	}
+	rotateReq := httptest.NewRequest(http.MethodPost, "/connectors/bootstrap_token/credentials/"+created.Credential.ID+"/rotate", bytes.NewReader(rotateBody))
+	rotateReq.SetPathValue("sourceID", "bootstrap_token")
+	rotateReq.SetPathValue("credentialID", created.Credential.ID)
+	rotateRecorder := httptest.NewRecorder()
+	app.handleRotateConnectorCredential(rotateRecorder, rotateReq)
+	if rotateRecorder.Code != http.StatusCreated {
+		t.Fatalf("rotate status = %d, want 201: %s", rotateRecorder.Code, rotateRecorder.Body.String())
+	}
+	var rotated connectorCredentialBrokerResponse
+	if err := json.NewDecoder(rotateRecorder.Body).Decode(&rotated); err != nil {
+		t.Fatalf("decode rotate response: %v", err)
+	}
+	if rotated.Credential.ID == created.Credential.ID {
+		t.Fatalf("rotated credential reused previous id %q", rotated.Credential.ID)
+	}
+	if got := rotated.Credential.PreviousCredentialID; got != created.Credential.ID {
+		t.Fatalf("previous credential id = %q, want %q", got, created.Credential.ID)
+	}
+	if got := store.credentials[created.Credential.ID].Status; got != connectorcredentials.StatusRevoked {
+		t.Fatalf("previous credential status = %q, want revoked", got)
+	}
+	broker, err := connectorCredentialBroker(app.cfg.ConnectorCredentials, app.deps.StateStore, nil)
+	if err != nil {
+		t.Fatalf("connectorCredentialBroker() error = %v", err)
+	}
+	resolved, err := broker.ResolveReferences(context.Background(), "bootstrap_token", "tenant-a", "runtime-a", map[string]string{"token": rotated.CredentialReferences["token"]})
+	if err != nil {
+		t.Fatalf("ResolveReferences() rotated error = %v", err)
+	}
+	if got := resolved["token"]; got != "new-token" {
+		t.Fatalf("resolved rotated token = %q, want new-token", got)
 	}
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -123,7 +123,11 @@ func (app *App) registerConnectorRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /connector-definitions/{definitionID}/promote", routeSurfacePlatformHTTP, app.handlePromoteConnectorDefinition)
 	registerHTTPRoute(mux, "GET /connectors/{sourceID}", routeSurfacePlatformHTTP, app.handleGetConnector)
 	registerHTTPRoute(mux, "GET /connectors/{sourceID}/activity", routeSurfacePlatformHTTP, app.handleListConnectorActivity)
+	registerHTTPRoute(mux, "GET /connectors/{sourceID}/credentials", routeSurfacePlatformHTTP, app.handleListConnectorCredentials)
 	registerHTTPRoute(mux, "POST /connectors/{sourceID}/credentials", routeSurfacePlatformHTTP, app.handleCreateConnectorCredential)
+	registerHTTPRoute(mux, "GET /connectors/{sourceID}/credentials/{credentialID}", routeSurfacePlatformHTTP, app.handleGetConnectorCredential)
+	registerHTTPRoute(mux, "POST /connectors/{sourceID}/credentials/{credentialID}/rotate", routeSurfacePlatformHTTP, app.handleRotateConnectorCredential)
+	registerHTTPRoute(mux, "POST /connectors/{sourceID}/credentials/{credentialID}/revoke", routeSurfacePlatformHTTP, app.handleRevokeConnectorCredential)
 	registerHTTPRoute(mux, "POST /connectors/{sourceID}/preflight", routeSurfacePlatformHTTP, app.handlePreflightConnectorConnection)
 	registerHTTPRoute(mux, "POST /connectors/{sourceID}/connections", routeSurfacePlatformHTTP, app.handleCreateConnectorConnection)
 }

--- a/internal/connectorcredentials/broker.go
+++ b/internal/connectorcredentials/broker.go
@@ -277,9 +277,11 @@ func (b *Broker) ResolveReferences(ctx context.Context, sourceID string, tenantI
 	if err != nil {
 		return nil, err
 	}
+	now := b.now()
+	staleBefore := now.Add(-credentialUseTrackingInterval)
 	for _, credentialID := range credentialIDs {
-		record, err := b.vault.store.GetConnectorCredential(ctx, credentialID)
-		if err != nil {
+		record, tracked, err := b.vault.store.MarkConnectorCredentialUsed(ctx, credentialID, now, staleBefore)
+		if err != nil || !tracked {
 			continue
 		}
 		if err := b.appendAudit(ctx, record, AuditEventUsed, "", ""); err != nil {

--- a/internal/connectorcredentials/broker.go
+++ b/internal/connectorcredentials/broker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -98,29 +99,12 @@ func (b *Broker) StoreEncrypted(ctx context.Context, request StoreEncryptedReque
 		authMethod = "encrypted_submission"
 	}
 	if idempotencyKey != "" {
-		existing, err := b.vault.store.ListConnectorCredentials(ctx, ports.ConnectorCredentialFilter{
-			TenantID:       tenantID,
-			SourceID:       sourceID,
-			RuntimeID:      runtimeID,
-			IdempotencyKey: idempotencyKey,
-			Limit:          1,
-		})
+		result, found, err := b.replayStoreEncrypted(ctx, sourceID, tenantID, runtimeID, idempotencyKey)
 		if err != nil {
 			return StoreEncryptedResult{}, err
 		}
-		if len(existing) > 0 {
-			record := existing[0]
-			if err := authorizeRecord(record, sourceID, tenantID, runtimeID); err != nil {
-				return StoreEncryptedResult{}, err
-			}
-			if err := authorizeRecordStatus(record); err != nil {
-				return StoreEncryptedResult{}, err
-			}
-			return StoreEncryptedResult{
-				Record:     record,
-				References: referencesForFields(record.ID, record.Fields),
-				Created:    false,
-			}, nil
+		if found {
+			return result, nil
 		}
 	}
 	if !encryptedPayloadPresent(request.EncryptedCredentials) {
@@ -171,6 +155,15 @@ func (b *Broker) StoreEncrypted(ctx context.Context, request StoreEncryptedReque
 		PreviousCredentialID: previousCredentialID,
 	})
 	if err != nil {
+		if idempotencyKey != "" && errors.Is(err, ports.ErrConnectorCredentialIdempotencyConflict) {
+			result, found, replayErr := b.replayStoreEncrypted(ctx, sourceID, tenantID, runtimeID, idempotencyKey)
+			if replayErr != nil {
+				return StoreEncryptedResult{}, replayErr
+			}
+			if found {
+				return result, nil
+			}
+		}
 		return StoreEncryptedResult{}, err
 	}
 	eventType := AuditEventStored
@@ -185,6 +178,34 @@ func (b *Broker) StoreEncrypted(ctx context.Context, request StoreEncryptedReque
 		References: referencesForFields(record.ID, SortedFieldNames(fields)),
 		Created:    true,
 	}, nil
+}
+
+func (b *Broker) replayStoreEncrypted(ctx context.Context, sourceID string, tenantID string, runtimeID string, idempotencyKey string) (StoreEncryptedResult, bool, error) {
+	existing, err := b.vault.store.ListConnectorCredentials(ctx, ports.ConnectorCredentialFilter{
+		TenantID:       tenantID,
+		SourceID:       sourceID,
+		RuntimeID:      runtimeID,
+		IdempotencyKey: idempotencyKey,
+		Limit:          1,
+	})
+	if err != nil {
+		return StoreEncryptedResult{}, false, err
+	}
+	if len(existing) == 0 {
+		return StoreEncryptedResult{}, false, nil
+	}
+	record := existing[0]
+	if err := authorizeRecord(record, sourceID, tenantID, runtimeID); err != nil {
+		return StoreEncryptedResult{}, false, err
+	}
+	if err := authorizeRecordStatus(record); err != nil {
+		return StoreEncryptedResult{}, false, err
+	}
+	return StoreEncryptedResult{
+		Record:     record,
+		References: referencesForFields(record.ID, record.Fields),
+		Created:    false,
+	}, true, nil
 }
 
 func (b *Broker) List(ctx context.Context, filter ports.ConnectorCredentialFilter) ([]*ports.ConnectorCredentialRecord, error) {

--- a/internal/connectorcredentials/broker.go
+++ b/internal/connectorcredentials/broker.go
@@ -1,0 +1,358 @@
+package connectorcredentials
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceconfig"
+)
+
+const (
+	AuditEventStored    = "stored"
+	AuditEventRotated   = "rotated"
+	AuditEventRevoked   = "revoked"
+	AuditEventUsed      = "used"
+	AuditEventValidated = "validated"
+)
+
+type Broker struct {
+	vault   *Vault
+	transit *TransitKey
+	now     func() time.Time
+}
+
+type StoreEncryptedRequest struct {
+	SourceID             string
+	TenantID             string
+	RuntimeID            string
+	CredentialStoreID    string
+	AuthMethod           string
+	Actor                string
+	IdempotencyKey       string
+	PreviousCredentialID string
+	EncryptedCredentials EncryptedPayload
+	ValidateFields       func(map[string]string) error
+}
+
+type StoreEncryptedResult struct {
+	Record     *ports.ConnectorCredentialRecord
+	References map[string]string
+	Created    bool
+}
+
+type RevokeRequest struct {
+	CredentialID string
+	SourceID     string
+	TenantID     string
+	RuntimeID    string
+	Actor        string
+	Detail       string
+}
+
+type ValidateRequest struct {
+	CredentialID string
+	SourceID     string
+	TenantID     string
+	RuntimeID    string
+	Actor        string
+}
+
+func NewBroker(vault *Vault, transit *TransitKey) *Broker {
+	return &Broker{
+		vault:   vault,
+		transit: transit,
+		now:     func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func (b *Broker) StoreEncrypted(ctx context.Context, request StoreEncryptedRequest) (StoreEncryptedResult, error) {
+	if b == nil || b.vault == nil || b.vault.store == nil {
+		return StoreEncryptedResult{}, ErrUnavailable
+	}
+	sourceID := strings.TrimSpace(request.SourceID)
+	tenantID := strings.TrimSpace(request.TenantID)
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	credentialStoreID := strings.TrimSpace(request.CredentialStoreID)
+	authMethod := strings.TrimSpace(request.AuthMethod)
+	actor := strings.TrimSpace(request.Actor)
+	idempotencyKey := strings.TrimSpace(request.IdempotencyKey)
+	previousCredentialID := strings.TrimSpace(request.PreviousCredentialID)
+	if sourceID == "" {
+		return StoreEncryptedResult{}, fmt.Errorf("%w: source_id is required", ErrInvalidRequest)
+	}
+	if tenantID == "" {
+		return StoreEncryptedResult{}, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
+	}
+	if runtimeID == "" {
+		return StoreEncryptedResult{}, fmt.Errorf("%w: runtime_id is required", ErrInvalidRequest)
+	}
+	if credentialStoreID == "" {
+		credentialStoreID = "cerebro_vault"
+	}
+	if authMethod == "" {
+		authMethod = "encrypted_submission"
+	}
+	if idempotencyKey != "" {
+		existing, err := b.vault.store.ListConnectorCredentials(ctx, ports.ConnectorCredentialFilter{
+			TenantID:       tenantID,
+			SourceID:       sourceID,
+			RuntimeID:      runtimeID,
+			IdempotencyKey: idempotencyKey,
+			Limit:          1,
+		})
+		if err != nil {
+			return StoreEncryptedResult{}, err
+		}
+		if len(existing) > 0 {
+			record := existing[0]
+			if err := authorizeRecord(record, sourceID, tenantID, runtimeID); err != nil {
+				return StoreEncryptedResult{}, err
+			}
+			if err := authorizeRecordStatus(record); err != nil {
+				return StoreEncryptedResult{}, err
+			}
+			return StoreEncryptedResult{
+				Record:     record,
+				References: referencesForFields(record.ID, record.Fields),
+				Created:    false,
+			}, nil
+		}
+	}
+	if !encryptedPayloadPresent(request.EncryptedCredentials) {
+		return StoreEncryptedResult{}, fmt.Errorf("%w: encrypted_credentials is required", ErrInvalidRequest)
+	}
+	if b.transit == nil {
+		return StoreEncryptedResult{}, ErrUnavailable
+	}
+	if previousCredentialID != "" {
+		previous, err := b.vault.store.GetConnectorCredential(ctx, previousCredentialID)
+		if err != nil {
+			return StoreEncryptedResult{}, err
+		}
+		if err := authorizeRecord(previous, sourceID, tenantID, runtimeID); err != nil {
+			return StoreEncryptedResult{}, err
+		}
+		if err := authorizeRecordStatus(previous); err != nil {
+			return StoreEncryptedResult{}, err
+		}
+	}
+	decrypted, err := b.transit.DecryptWithExactAdditionalData(
+		request.EncryptedCredentials,
+		TransitAdditionalData(request.EncryptedCredentials.KeyID, sourceID, tenantID, runtimeID, credentialStoreID),
+	)
+	if err != nil {
+		return StoreEncryptedResult{}, err
+	}
+	fields, err := ParseCredentialFields(decrypted)
+	if err != nil {
+		return StoreEncryptedResult{}, err
+	}
+	if request.ValidateFields != nil {
+		if err := request.ValidateFields(fields); err != nil {
+			return StoreEncryptedResult{}, err
+		}
+	}
+	record, err := b.vault.Put(ctx, PlainCredential{
+		TenantID:             tenantID,
+		SourceID:             sourceID,
+		RuntimeID:            runtimeID,
+		CredentialStoreID:    credentialStoreID,
+		AuthMethod:           authMethod,
+		Status:               StatusValid,
+		Fields:               fields,
+		CreatedBy:            actor,
+		UpdatedBy:            actor,
+		IdempotencyKey:       idempotencyKey,
+		PreviousCredentialID: previousCredentialID,
+	})
+	if err != nil {
+		return StoreEncryptedResult{}, err
+	}
+	eventType := AuditEventStored
+	if previousCredentialID != "" {
+		eventType = AuditEventRotated
+	}
+	if err := b.appendAudit(ctx, record, eventType, actor, ""); err != nil {
+		return StoreEncryptedResult{}, err
+	}
+	return StoreEncryptedResult{
+		Record:     record,
+		References: referencesForFields(record.ID, SortedFieldNames(fields)),
+		Created:    true,
+	}, nil
+}
+
+func (b *Broker) List(ctx context.Context, filter ports.ConnectorCredentialFilter) ([]*ports.ConnectorCredentialRecord, error) {
+	if b == nil || b.vault == nil || b.vault.store == nil {
+		return nil, ErrUnavailable
+	}
+	return b.vault.store.ListConnectorCredentials(ctx, filter)
+}
+
+func (b *Broker) Get(ctx context.Context, credentialID string) (*ports.ConnectorCredentialRecord, error) {
+	if b == nil || b.vault == nil || b.vault.store == nil {
+		return nil, ErrUnavailable
+	}
+	return b.vault.store.GetConnectorCredential(ctx, credentialID)
+}
+
+func (b *Broker) Revoke(ctx context.Context, request RevokeRequest) (*ports.ConnectorCredentialRecord, error) {
+	if b == nil || b.vault == nil || b.vault.store == nil {
+		return nil, ErrUnavailable
+	}
+	credentialID := strings.TrimSpace(request.CredentialID)
+	if credentialID == "" {
+		return nil, fmt.Errorf("%w: credential_id is required", ErrInvalidRequest)
+	}
+	record, err := b.vault.store.GetConnectorCredential(ctx, credentialID)
+	if err != nil {
+		return nil, err
+	}
+	if err := authorizeRecord(record, request.SourceID, request.TenantID, request.RuntimeID); err != nil {
+		return nil, err
+	}
+	now := b.now()
+	updated, err := b.vault.store.UpdateConnectorCredentialMetadata(ctx, credentialID, ports.ConnectorCredentialMetadataUpdate{
+		Status:    StatusRevoked,
+		UpdatedBy: strings.TrimSpace(request.Actor),
+		RevokedBy: strings.TrimSpace(request.Actor),
+		RevokedAt: &now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := b.appendAudit(ctx, updated, AuditEventRevoked, request.Actor, request.Detail); err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func (b *Broker) MarkValidated(ctx context.Context, request ValidateRequest) (*ports.ConnectorCredentialRecord, error) {
+	if b == nil || b.vault == nil || b.vault.store == nil {
+		return nil, ErrUnavailable
+	}
+	credentialID := strings.TrimSpace(request.CredentialID)
+	if credentialID == "" {
+		return nil, fmt.Errorf("%w: credential_id is required", ErrInvalidRequest)
+	}
+	record, err := b.vault.store.GetConnectorCredential(ctx, credentialID)
+	if err != nil {
+		return nil, err
+	}
+	if err := authorizeRecord(record, request.SourceID, request.TenantID, request.RuntimeID); err != nil {
+		return nil, err
+	}
+	if err := authorizeRecordStatus(record); err != nil {
+		return nil, err
+	}
+	now := b.now()
+	updated, err := b.vault.store.UpdateConnectorCredentialMetadata(ctx, credentialID, ports.ConnectorCredentialMetadataUpdate{
+		Status:          StatusValid,
+		UpdatedBy:       strings.TrimSpace(request.Actor),
+		LastValidatedAt: &now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := b.appendAudit(ctx, updated, AuditEventValidated, request.Actor, ""); err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func (b *Broker) ResolveReferences(ctx context.Context, sourceID string, tenantID string, runtimeID string, values map[string]string) (map[string]string, error) {
+	if b == nil || b.vault == nil || b.vault.store == nil {
+		return nil, ErrUnavailable
+	}
+	credentialIDs := credentialIDsFromValues(values)
+	resolved, err := b.vault.ResolveReferences(ctx, sourceID, tenantID, runtimeID, values)
+	if err != nil {
+		return nil, err
+	}
+	for _, credentialID := range credentialIDs {
+		record, err := b.vault.store.GetConnectorCredential(ctx, credentialID)
+		if err != nil {
+			continue
+		}
+		if err := b.appendAudit(ctx, record, AuditEventUsed, "", ""); err != nil {
+			continue
+		}
+	}
+	return resolved, nil
+}
+
+func (b *Broker) AuditEvents(ctx context.Context, credentialID string, limit int) ([]*ports.ConnectorCredentialAuditRecord, error) {
+	if b == nil || b.vault == nil || b.vault.store == nil {
+		return nil, ErrUnavailable
+	}
+	return b.vault.store.ListConnectorCredentialAuditEvents(ctx, credentialID, limit)
+}
+
+func (b *Broker) appendAudit(ctx context.Context, record *ports.ConnectorCredentialRecord, eventType string, actor string, detail string) error {
+	if record == nil {
+		return ports.ErrConnectorCredentialNotFound
+	}
+	return b.vault.store.AppendConnectorCredentialAuditEvent(ctx, &ports.ConnectorCredentialAuditRecord{
+		ID:           randomAuditID(),
+		CredentialID: record.ID,
+		TenantID:     record.TenantID,
+		SourceID:     record.SourceID,
+		RuntimeID:    record.RuntimeID,
+		EventType:    strings.TrimSpace(eventType),
+		Actor:        strings.TrimSpace(actor),
+		Status:       strings.TrimSpace(record.Status),
+		Detail:       strings.TrimSpace(detail),
+		CreatedAt:    b.now(),
+	})
+}
+
+func referencesForFields(credentialID string, fields []string) map[string]string {
+	references := make(map[string]string, len(fields))
+	for _, field := range fields {
+		if field = strings.TrimSpace(field); field != "" {
+			references[field] = Reference(credentialID, field)
+		}
+	}
+	return references
+}
+
+func encryptedPayloadPresent(payload EncryptedPayload) bool {
+	return strings.TrimSpace(payload.KeyID) != "" ||
+		strings.TrimSpace(payload.Algorithm) != "" ||
+		strings.TrimSpace(payload.WrappedKey) != "" ||
+		strings.TrimSpace(payload.Nonce) != "" ||
+		strings.TrimSpace(payload.Ciphertext) != ""
+}
+
+func credentialIDsFromValues(values map[string]string) []string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		credentialID, _, ok := sourceconfig.CredentialReference(value)
+		if !ok {
+			continue
+		}
+		credentialID = strings.TrimSpace(credentialID)
+		if credentialID == "" {
+			continue
+		}
+		seen[credentialID] = struct{}{}
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func randomAuditID() string {
+	var raw [12]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return fmt.Sprintf("credential-audit-%d", time.Now().UnixNano())
+	}
+	return "credential-audit-" + base64.RawURLEncoding.EncodeToString(raw[:])
+}

--- a/internal/connectorcredentials/broker.go
+++ b/internal/connectorcredentials/broker.go
@@ -216,6 +216,9 @@ func (b *Broker) Revoke(ctx context.Context, request RevokeRequest) (*ports.Conn
 	if err := authorizeRecord(record, request.SourceID, request.TenantID, request.RuntimeID); err != nil {
 		return nil, err
 	}
+	if strings.TrimSpace(record.Status) == StatusRevoked {
+		return record, nil
+	}
 	now := b.now()
 	updated, err := b.vault.store.UpdateConnectorCredentialMetadata(ctx, credentialID, ports.ConnectorCredentialMetadataUpdate{
 		Status:    StatusRevoked,

--- a/internal/connectorcredentials/credentials.go
+++ b/internal/connectorcredentials/credentials.go
@@ -34,6 +34,8 @@ const (
 	StatusInvalid  = "invalid"
 	StatusRevoked  = "revoked"
 	StatusRotating = "rotating"
+
+	credentialUseTrackingInterval = time.Hour
 )
 
 var (
@@ -344,7 +346,6 @@ func (v *Vault) ResolveReferences(ctx context.Context, sourceID string, tenantID
 			if err := authorizeRecordStatus(record); err != nil {
 				return nil, err
 			}
-			_, _ = v.store.UpdateConnectorCredentialMetadata(ctx, credentialID, ports.ConnectorCredentialMetadataUpdate{LastUsedAt: timePtr(time.Now().UTC())})
 			fields, err = v.open(record)
 			if err != nil {
 				return nil, err
@@ -623,6 +624,18 @@ func authorizeRecordStatus(record *ports.ConnectorCredentialRecord) error {
 	}
 }
 
+func shouldTrackCredentialUse(lastUsedAt time.Time, now time.Time) bool {
+	if lastUsedAt.IsZero() {
+		return true
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	cutoff := now.UTC().Add(-credentialUseTrackingInterval)
+	lastUsedAt = lastUsedAt.UTC()
+	return lastUsedAt.Before(cutoff) || lastUsedAt.Equal(cutoff)
+}
+
 func credentialAAD(id string, tenantID string, sourceID string, runtimeID string, keyID string) []byte {
 	return []byte(strings.Join([]string{
 		strings.TrimSpace(id),
@@ -652,8 +665,4 @@ func TimestampOrZero(value time.Time) string {
 		return ""
 	}
 	return value.UTC().Format(time.RFC3339Nano)
-}
-
-func timePtr(value time.Time) *time.Time {
-	return &value
 }

--- a/internal/connectorcredentials/credentials.go
+++ b/internal/connectorcredentials/credentials.go
@@ -624,18 +624,6 @@ func authorizeRecordStatus(record *ports.ConnectorCredentialRecord) error {
 	}
 }
 
-func shouldTrackCredentialUse(lastUsedAt time.Time, now time.Time) bool {
-	if lastUsedAt.IsZero() {
-		return true
-	}
-	if now.IsZero() {
-		now = time.Now().UTC()
-	}
-	cutoff := now.UTC().Add(-credentialUseTrackingInterval)
-	lastUsedAt = lastUsedAt.UTC()
-	return lastUsedAt.Before(cutoff) || lastUsedAt.Equal(cutoff)
-}
-
 func credentialAAD(id string, tenantID string, sourceID string, runtimeID string, keyID string) []byte {
 	return []byte(strings.Join([]string{
 		strings.TrimSpace(id),

--- a/internal/connectorcredentials/credentials.go
+++ b/internal/connectorcredentials/credentials.go
@@ -28,6 +28,12 @@ const (
 	transitAlgorithm = "RSA-OAEP-256+A256GCM"
 	rsaOAEPAlgorithm = "RSA-OAEP-256"
 	sealedAlgorithm  = "AES-256-GCM"
+
+	StatusPending  = "pending"
+	StatusValid    = "valid"
+	StatusInvalid  = "invalid"
+	StatusRevoked  = "revoked"
+	StatusRotating = "rotating"
 )
 
 var (
@@ -61,11 +67,18 @@ type Vault struct {
 }
 
 type PlainCredential struct {
-	ID        string
-	TenantID  string
-	SourceID  string
-	RuntimeID string
-	Fields    map[string]string
+	ID                   string
+	TenantID             string
+	SourceID             string
+	RuntimeID            string
+	CredentialStoreID    string
+	AuthMethod           string
+	Status               string
+	CreatedBy            string
+	UpdatedBy            string
+	IdempotencyKey       string
+	PreviousCredentialID string
+	Fields               map[string]string
 }
 
 type sealedCredential struct {
@@ -280,13 +293,24 @@ func (v *Vault) Put(ctx context.Context, credential PlainCredential) (*ports.Con
 	if err != nil {
 		return nil, err
 	}
+	now := time.Now().UTC()
 	record := &ports.ConnectorCredentialRecord{
-		ID:        normalized.ID,
-		TenantID:  normalized.TenantID,
-		SourceID:  normalized.SourceID,
-		RuntimeID: normalized.RuntimeID,
-		KeyID:     v.keyID,
-		Sealed:    sealed,
+		ID:                   normalized.ID,
+		TenantID:             normalized.TenantID,
+		SourceID:             normalized.SourceID,
+		RuntimeID:            normalized.RuntimeID,
+		CredentialStoreID:    normalized.CredentialStoreID,
+		AuthMethod:           normalized.AuthMethod,
+		Status:               normalized.Status,
+		KeyID:                v.keyID,
+		Fields:               SortedFieldNames(normalized.Fields),
+		Sealed:               sealed,
+		CreatedBy:            normalized.CreatedBy,
+		UpdatedBy:            normalized.UpdatedBy,
+		IdempotencyKey:       normalized.IdempotencyKey,
+		PreviousCredentialID: normalized.PreviousCredentialID,
+		CreatedAt:            now,
+		UpdatedAt:            now,
 	}
 	if err := v.store.PutConnectorCredential(ctx, record); err != nil {
 		return nil, err
@@ -317,6 +341,10 @@ func (v *Vault) ResolveReferences(ctx context.Context, sourceID string, tenantID
 			if err := authorizeRecord(record, sourceID, tenantID, runtimeID); err != nil {
 				return nil, err
 			}
+			if err := authorizeRecordStatus(record); err != nil {
+				return nil, err
+			}
+			_, _ = v.store.UpdateConnectorCredentialMetadata(ctx, credentialID, ports.ConnectorCredentialMetadataUpdate{LastUsedAt: timePtr(time.Now().UTC())})
 			fields, err = v.open(record)
 			if err != nil {
 				return nil, err
@@ -334,6 +362,19 @@ func (v *Vault) ResolveReferences(ctx context.Context, sourceID string, tenantID
 
 func Reference(id string, field string) string {
 	return sourceconfig.CredentialReferenceValue(id, field)
+}
+
+func TransitAdditionalData(keyID string, sourceID string, tenantID string, runtimeID string, credentialStoreID string) []byte {
+	parts := []string{
+		"connector-credential",
+		"v1",
+		strings.TrimSpace(keyID),
+		strings.TrimSpace(sourceID),
+		strings.TrimSpace(tenantID),
+		strings.TrimSpace(runtimeID),
+		strings.TrimSpace(credentialStoreID),
+	}
+	return []byte(strings.Join(parts, "\x00"))
 }
 
 func ParseCredentialFields(data []byte) (map[string]string, error) {
@@ -361,10 +402,17 @@ func SortedFieldNames(fields map[string]string) []string {
 
 func normalizeCredential(input PlainCredential) (PlainCredential, error) {
 	credential := PlainCredential{
-		ID:        strings.TrimSpace(input.ID),
-		TenantID:  strings.TrimSpace(input.TenantID),
-		SourceID:  strings.TrimSpace(input.SourceID),
-		RuntimeID: strings.TrimSpace(input.RuntimeID),
+		ID:                   strings.TrimSpace(input.ID),
+		TenantID:             strings.TrimSpace(input.TenantID),
+		SourceID:             strings.TrimSpace(input.SourceID),
+		RuntimeID:            strings.TrimSpace(input.RuntimeID),
+		CredentialStoreID:    strings.TrimSpace(input.CredentialStoreID),
+		AuthMethod:           strings.TrimSpace(input.AuthMethod),
+		Status:               strings.TrimSpace(input.Status),
+		CreatedBy:            strings.TrimSpace(input.CreatedBy),
+		UpdatedBy:            strings.TrimSpace(input.UpdatedBy),
+		IdempotencyKey:       strings.TrimSpace(input.IdempotencyKey),
+		PreviousCredentialID: strings.TrimSpace(input.PreviousCredentialID),
 	}
 	if credential.ID == "" {
 		id, err := randomCredentialID()
@@ -385,12 +433,36 @@ func normalizeCredential(input PlainCredential) (PlainCredential, error) {
 	if credential.RuntimeID == "" {
 		return PlainCredential{}, fmt.Errorf("%w: runtime_id is required", ErrInvalidRequest)
 	}
+	if credential.CredentialStoreID == "" {
+		credential.CredentialStoreID = "cerebro_vault"
+	}
+	if credential.AuthMethod == "" {
+		credential.AuthMethod = "encrypted_submission"
+	}
+	if credential.Status == "" {
+		credential.Status = StatusValid
+	}
+	if !validCredentialStatus(credential.Status) {
+		return PlainCredential{}, fmt.Errorf("%w: connector credential status is invalid", ErrInvalidRequest)
+	}
+	if credential.UpdatedBy == "" {
+		credential.UpdatedBy = credential.CreatedBy
+	}
 	fields, err := normalizeFields(input.Fields)
 	if err != nil {
 		return PlainCredential{}, err
 	}
 	credential.Fields = fields
 	return credential, nil
+}
+
+func validCredentialStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case StatusPending, StatusValid, StatusInvalid, StatusRevoked, StatusRotating:
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizeFields(input map[string]string) (map[string]string, error) {
@@ -537,6 +609,20 @@ func authorizeRecord(record *ports.ConnectorCredentialRecord, sourceID string, t
 	return nil
 }
 
+func authorizeRecordStatus(record *ports.ConnectorCredentialRecord) error {
+	if record == nil {
+		return ports.ErrConnectorCredentialNotFound
+	}
+	switch strings.TrimSpace(record.Status) {
+	case "", StatusValid, StatusRotating:
+		return nil
+	case StatusRevoked:
+		return fmt.Errorf("%w: connector credential is revoked", ErrInvalidRequest)
+	default:
+		return fmt.Errorf("%w: connector credential is not usable", ErrInvalidRequest)
+	}
+}
+
 func credentialAAD(id string, tenantID string, sourceID string, runtimeID string, keyID string) []byte {
 	return []byte(strings.Join([]string{
 		strings.TrimSpace(id),
@@ -566,4 +652,8 @@ func TimestampOrZero(value time.Time) string {
 		return ""
 	}
 	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func timePtr(value time.Time) *time.Time {
+	return &value
 }

--- a/internal/connectorcredentials/credentials_test.go
+++ b/internal/connectorcredentials/credentials_test.go
@@ -276,28 +276,6 @@ func TestBrokerResolveReferencesThrottlesUsedAudit(t *testing.T) {
 	}
 }
 
-func TestShouldTrackCredentialUse(t *testing.T) {
-	now := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
-	tests := []struct {
-		name       string
-		lastUsedAt time.Time
-		want       bool
-	}{
-		{name: "never used", want: true},
-		{name: "inside interval", lastUsedAt: now.Add(-credentialUseTrackingInterval + time.Second), want: false},
-		{name: "at interval", lastUsedAt: now.Add(-credentialUseTrackingInterval), want: true},
-		{name: "older than interval", lastUsedAt: now.Add(-credentialUseTrackingInterval - time.Second), want: true},
-		{name: "future timestamp", lastUsedAt: now.Add(time.Minute), want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldTrackCredentialUse(tt.lastUsedAt, now); got != tt.want {
-				t.Fatalf("shouldTrackCredentialUse() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestTransitKeyDecryptsHybridPayload(t *testing.T) {
 	transit, err := NewTransitKey()
 	if err != nil {

--- a/internal/connectorcredentials/credentials_test.go
+++ b/internal/connectorcredentials/credentials_test.go
@@ -19,6 +19,8 @@ type memoryStore struct {
 	records         map[string]*ports.ConnectorCredentialRecord
 	audit           []*ports.ConnectorCredentialAuditRecord
 	metadataUpdates int
+	putErr          error
+	putErrRecord    *ports.ConnectorCredentialRecord
 }
 
 func (s *memoryStore) Ping(context.Context) error { return nil }
@@ -26,6 +28,13 @@ func (s *memoryStore) Ping(context.Context) error { return nil }
 func (s *memoryStore) PutConnectorCredential(_ context.Context, record *ports.ConnectorCredentialRecord) error {
 	if s.records == nil {
 		s.records = map[string]*ports.ConnectorCredentialRecord{}
+	}
+	if s.putErr != nil {
+		if s.putErrRecord != nil {
+			cloned := cloneMemoryCredential(s.putErrRecord)
+			s.records[cloned.ID] = &cloned
+		}
+		return s.putErr
 	}
 	cloned := cloneMemoryCredential(record)
 	s.records[record.ID] = &cloned
@@ -207,6 +216,73 @@ func TestVaultStoresEncryptedCredentialReferences(t *testing.T) {
 	}
 	if _, err := vault.ResolveReferences(context.Background(), "github", "tenant-a", "runtime-b", map[string]string{"token": Reference(record.ID, "token")}); err == nil {
 		t.Fatal("ResolveReferences() runtime mismatch error = nil, want error")
+	}
+}
+
+func TestBrokerStoreEncryptedReplaysConcurrentIdempotencyConflict(t *testing.T) {
+	transit, err := NewTransitKey()
+	if err != nil {
+		t.Fatalf("NewTransitKey() error = %v", err)
+	}
+	now := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	winner := &ports.ConnectorCredentialRecord{
+		ID:                   "credential-winner",
+		TenantID:             "tenant-a",
+		SourceID:             "github",
+		RuntimeID:            "runtime-a",
+		CredentialStoreID:    "cerebro_vault",
+		AuthMethod:           "encrypted_submission",
+		Status:               StatusValid,
+		KeyID:                "test-vault-key",
+		Fields:               []string{"token"},
+		Sealed:               []byte("sealed"),
+		CreatedBy:            "alice",
+		UpdatedBy:            "alice",
+		IdempotencyKey:       "request-1",
+		CreatedAt:            now,
+		UpdatedAt:            now,
+		PreviousCredentialID: "",
+	}
+	store := &memoryStore{
+		putErr:       ports.ErrConnectorCredentialIdempotencyConflict,
+		putErrRecord: winner,
+	}
+	vault, err := NewVault(store, "test-vault-key")
+	if err != nil {
+		t.Fatalf("NewVault() error = %v", err)
+	}
+	broker := NewBroker(vault, transit)
+	payload, err := encryptForTransit(
+		transit,
+		[]byte(`{"token":"secret-token"}`),
+		TransitAdditionalData(transit.PublicKey().KeyID, "github", "tenant-a", "runtime-a", "cerebro_vault"),
+	)
+	if err != nil {
+		t.Fatalf("encryptForTransit() error = %v", err)
+	}
+	result, err := broker.StoreEncrypted(context.Background(), StoreEncryptedRequest{
+		SourceID:             "github",
+		TenantID:             "tenant-a",
+		RuntimeID:            "runtime-a",
+		CredentialStoreID:    "cerebro_vault",
+		Actor:                "alice",
+		IdempotencyKey:       "request-1",
+		EncryptedCredentials: payload,
+	})
+	if err != nil {
+		t.Fatalf("StoreEncrypted() error = %v", err)
+	}
+	if result.Created {
+		t.Fatal("StoreEncrypted() Created = true, want replayed result")
+	}
+	if result.Record == nil || result.Record.ID != winner.ID {
+		t.Fatalf("StoreEncrypted() record ID = %v, want %s", result.Record, winner.ID)
+	}
+	if got := result.References["token"]; got != Reference(winner.ID, "token") {
+		t.Fatalf("replayed token reference = %q, want %q", got, Reference(winner.ID, "token"))
+	}
+	if got := len(store.audit); got != 0 {
+		t.Fatalf("audit rows after replay = %d, want 0", got)
 	}
 }
 

--- a/internal/connectorcredentials/credentials_test.go
+++ b/internal/connectorcredentials/credentials_test.go
@@ -8,13 +8,16 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/writer/cerebro/internal/ports"
 )
 
 type memoryStore struct {
 	records map[string]*ports.ConnectorCredentialRecord
+	audit   []*ports.ConnectorCredentialAuditRecord
 }
 
 func (s *memoryStore) Ping(context.Context) error { return nil }
@@ -23,8 +26,7 @@ func (s *memoryStore) PutConnectorCredential(_ context.Context, record *ports.Co
 	if s.records == nil {
 		s.records = map[string]*ports.ConnectorCredentialRecord{}
 	}
-	cloned := *record
-	cloned.Sealed = append([]byte{}, record.Sealed...)
+	cloned := cloneMemoryCredential(record)
 	s.records[record.ID] = &cloned
 	return nil
 }
@@ -34,9 +36,119 @@ func (s *memoryStore) GetConnectorCredential(_ context.Context, id string) (*por
 	if !ok {
 		return nil, ports.ErrConnectorCredentialNotFound
 	}
+	cloned := cloneMemoryCredential(record)
+	return &cloned, nil
+}
+
+func (s *memoryStore) ListConnectorCredentials(_ context.Context, filter ports.ConnectorCredentialFilter) ([]*ports.ConnectorCredentialRecord, error) {
+	records := []*ports.ConnectorCredentialRecord{}
+	for _, record := range s.records {
+		if !memoryCredentialMatches(record, filter) {
+			continue
+		}
+		cloned := cloneMemoryCredential(record)
+		records = append(records, &cloned)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].UpdatedAt.After(records[j].UpdatedAt)
+	})
+	if filter.Limit > 0 && len(records) > filter.Limit {
+		records = records[:filter.Limit]
+	}
+	return records, nil
+}
+
+func (s *memoryStore) UpdateConnectorCredentialMetadata(_ context.Context, id string, update ports.ConnectorCredentialMetadataUpdate) (*ports.ConnectorCredentialRecord, error) {
+	record, ok := s.records[id]
+	if !ok {
+		return nil, ports.ErrConnectorCredentialNotFound
+	}
+	if update.Status != "" {
+		record.Status = update.Status
+	}
+	if update.Fields != nil {
+		record.Fields = append([]string{}, update.Fields...)
+	}
+	if update.UpdatedBy != "" {
+		record.UpdatedBy = update.UpdatedBy
+	}
+	if update.RevokedBy != "" {
+		record.RevokedBy = update.RevokedBy
+	}
+	if update.PreviousCredentialID != "" {
+		record.PreviousCredentialID = update.PreviousCredentialID
+	}
+	if update.RevokedAt != nil {
+		record.RevokedAt = *update.RevokedAt
+	}
+	if update.LastUsedAt != nil {
+		record.LastUsedAt = *update.LastUsedAt
+	}
+	if update.LastValidatedAt != nil {
+		record.LastValidatedAt = *update.LastValidatedAt
+	}
+	record.UpdatedAt = time.Now().UTC()
+	cloned := cloneMemoryCredential(record)
+	return &cloned, nil
+}
+
+func (s *memoryStore) AppendConnectorCredentialAuditEvent(_ context.Context, event *ports.ConnectorCredentialAuditRecord) error {
+	if event == nil {
+		return nil
+	}
+	cloned := *event
+	s.audit = append(s.audit, &cloned)
+	return nil
+}
+
+func (s *memoryStore) ListConnectorCredentialAuditEvents(_ context.Context, credentialID string, limit int) ([]*ports.ConnectorCredentialAuditRecord, error) {
+	events := []*ports.ConnectorCredentialAuditRecord{}
+	for _, event := range s.audit {
+		if event.CredentialID != credentialID {
+			continue
+		}
+		cloned := *event
+		events = append(events, &cloned)
+	}
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].CreatedAt.After(events[j].CreatedAt)
+	})
+	if limit > 0 && len(events) > limit {
+		events = events[:limit]
+	}
+	return events, nil
+}
+
+func cloneMemoryCredential(record *ports.ConnectorCredentialRecord) ports.ConnectorCredentialRecord {
 	cloned := *record
 	cloned.Sealed = append([]byte{}, record.Sealed...)
-	return &cloned, nil
+	cloned.Fields = append([]string{}, record.Fields...)
+	return cloned
+}
+
+func memoryCredentialMatches(record *ports.ConnectorCredentialRecord, filter ports.ConnectorCredentialFilter) bool {
+	if record == nil {
+		return false
+	}
+	if filter.ID != "" && record.ID != filter.ID {
+		return false
+	}
+	if filter.TenantID != "" && record.TenantID != filter.TenantID {
+		return false
+	}
+	if filter.SourceID != "" && record.SourceID != filter.SourceID {
+		return false
+	}
+	if filter.RuntimeID != "" && record.RuntimeID != filter.RuntimeID {
+		return false
+	}
+	if filter.Status != "" && record.Status != filter.Status {
+		return false
+	}
+	if filter.IdempotencyKey != "" && record.IdempotencyKey != filter.IdempotencyKey {
+		return false
+	}
+	return true
 }
 
 func TestVaultStoresEncryptedCredentialReferences(t *testing.T) {

--- a/internal/connectorcredentials/credentials_test.go
+++ b/internal/connectorcredentials/credentials_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 type memoryStore struct {
-	records map[string]*ports.ConnectorCredentialRecord
-	audit   []*ports.ConnectorCredentialAuditRecord
+	records         map[string]*ports.ConnectorCredentialRecord
+	audit           []*ports.ConnectorCredentialAuditRecord
+	metadataUpdates int
 }
 
 func (s *memoryStore) Ping(context.Context) error { return nil }
@@ -63,6 +64,7 @@ func (s *memoryStore) UpdateConnectorCredentialMetadata(_ context.Context, id st
 	if !ok {
 		return nil, ports.ErrConnectorCredentialNotFound
 	}
+	s.metadataUpdates++
 	if update.Status != "" {
 		record.Status = update.Status
 	}
@@ -90,6 +92,28 @@ func (s *memoryStore) UpdateConnectorCredentialMetadata(_ context.Context, id st
 	record.UpdatedAt = time.Now().UTC()
 	cloned := cloneMemoryCredential(record)
 	return &cloned, nil
+}
+
+func (s *memoryStore) MarkConnectorCredentialUsed(_ context.Context, id string, usedAt time.Time, staleBefore time.Time) (*ports.ConnectorCredentialRecord, bool, error) {
+	record, ok := s.records[id]
+	if !ok {
+		return nil, false, ports.ErrConnectorCredentialNotFound
+	}
+	if usedAt.IsZero() {
+		usedAt = time.Now().UTC()
+	}
+	if staleBefore.IsZero() {
+		staleBefore = usedAt.Add(-credentialUseTrackingInterval)
+	}
+	if !record.LastUsedAt.IsZero() && record.LastUsedAt.After(staleBefore) {
+		cloned := cloneMemoryCredential(record)
+		return &cloned, false, nil
+	}
+	s.metadataUpdates++
+	record.LastUsedAt = usedAt.UTC()
+	record.UpdatedAt = usedAt.UTC()
+	cloned := cloneMemoryCredential(record)
+	return &cloned, true, nil
 }
 
 func (s *memoryStore) AppendConnectorCredentialAuditEvent(_ context.Context, event *ports.ConnectorCredentialAuditRecord) error {
@@ -183,6 +207,94 @@ func TestVaultStoresEncryptedCredentialReferences(t *testing.T) {
 	}
 	if _, err := vault.ResolveReferences(context.Background(), "github", "tenant-a", "runtime-b", map[string]string{"token": Reference(record.ID, "token")}); err == nil {
 		t.Fatal("ResolveReferences() runtime mismatch error = nil, want error")
+	}
+}
+
+func TestBrokerResolveReferencesThrottlesUsedAudit(t *testing.T) {
+	store := &memoryStore{}
+	vault, err := NewVault(store, "test-vault-key")
+	if err != nil {
+		t.Fatalf("NewVault() error = %v", err)
+	}
+	broker := NewBroker(vault, nil)
+	record, err := vault.Put(context.Background(), PlainCredential{
+		TenantID:  "tenant-a",
+		SourceID:  "github",
+		RuntimeID: "runtime-a",
+		Fields:    map[string]string{"token": "secret-token"},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	values := map[string]string{
+		"token":      Reference(record.ID, "token"),
+		"token_copy": Reference(record.ID, "token"),
+	}
+	if _, err := broker.ResolveReferences(context.Background(), "github", "tenant-a", "runtime-a", values); err != nil {
+		t.Fatalf("ResolveReferences() error = %v", err)
+	}
+	if got := len(store.audit); got != 1 {
+		t.Fatalf("used audit count after first resolve = %d, want 1", got)
+	}
+	if store.metadataUpdates != 1 {
+		t.Fatalf("metadata updates after first resolve = %d, want 1", store.metadataUpdates)
+	}
+	lastUsedAt := store.records[record.ID].LastUsedAt
+	if lastUsedAt.IsZero() {
+		t.Fatal("last_used_at was not recorded on first broker resolve")
+	}
+	if _, err := broker.ResolveReferences(context.Background(), "github", "tenant-a", "runtime-a", values); err != nil {
+		t.Fatalf("second ResolveReferences() error = %v", err)
+	}
+	if got := len(store.audit); got != 1 {
+		t.Fatalf("used audit count after throttled resolve = %d, want 1", got)
+	}
+	if store.metadataUpdates != 1 {
+		t.Fatalf("metadata updates after throttled resolve = %d, want 1", store.metadataUpdates)
+	}
+	if got := store.records[record.ID].LastUsedAt; !got.Equal(lastUsedAt) {
+		t.Fatalf("throttled resolve changed last_used_at = %s, want %s", got, lastUsedAt)
+	}
+	store.records[record.ID].LastUsedAt = time.Now().UTC().Add(-credentialUseTrackingInterval - time.Minute)
+	if _, err := broker.ResolveReferences(context.Background(), "github", "tenant-a", "runtime-a", map[string]string{"missing": Reference(record.ID, "missing")}); err == nil {
+		t.Fatal("missing field ResolveReferences() error = nil, want error")
+	}
+	if got := len(store.audit); got != 1 {
+		t.Fatalf("used audit count after failed resolve = %d, want 1", got)
+	}
+	if store.metadataUpdates != 1 {
+		t.Fatalf("metadata updates after failed resolve = %d, want 1", store.metadataUpdates)
+	}
+	if _, err := broker.ResolveReferences(context.Background(), "github", "tenant-a", "runtime-a", values); err != nil {
+		t.Fatalf("stale ResolveReferences() error = %v", err)
+	}
+	if got := len(store.audit); got != 2 {
+		t.Fatalf("used audit count after stale resolve = %d, want 2", got)
+	}
+	if store.metadataUpdates != 2 {
+		t.Fatalf("metadata updates after stale resolve = %d, want 2", store.metadataUpdates)
+	}
+}
+
+func TestShouldTrackCredentialUse(t *testing.T) {
+	now := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		lastUsedAt time.Time
+		want       bool
+	}{
+		{name: "never used", want: true},
+		{name: "inside interval", lastUsedAt: now.Add(-credentialUseTrackingInterval + time.Second), want: false},
+		{name: "at interval", lastUsedAt: now.Add(-credentialUseTrackingInterval), want: true},
+		{name: "older than interval", lastUsedAt: now.Add(-credentialUseTrackingInterval - time.Second), want: true},
+		{name: "future timestamp", lastUsedAt: now.Add(time.Minute), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldTrackCredentialUse(tt.lastUsedAt, now); got != tt.want {
+				t.Fatalf("shouldTrackCredentialUse() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/ports/connectorcredentials.go
+++ b/internal/ports/connectorcredentials.go
@@ -11,14 +11,63 @@ var ErrConnectorCredentialNotFound = errors.New("connector credential not found"
 
 // ConnectorCredentialRecord stores one encrypted connector credential envelope.
 type ConnectorCredentialRecord struct {
-	ID        string
-	TenantID  string
-	SourceID  string
-	RuntimeID string
-	KeyID     string
-	Sealed    []byte
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID                   string
+	TenantID             string
+	SourceID             string
+	RuntimeID            string
+	CredentialStoreID    string
+	AuthMethod           string
+	Status               string
+	KeyID                string
+	Fields               []string
+	Sealed               []byte
+	CreatedBy            string
+	UpdatedBy            string
+	RevokedBy            string
+	PreviousCredentialID string
+	IdempotencyKey       string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	RevokedAt            time.Time
+	LastUsedAt           time.Time
+	LastValidatedAt      time.Time
+}
+
+// ConnectorCredentialFilter scopes connector credential metadata queries.
+type ConnectorCredentialFilter struct {
+	ID             string
+	TenantID       string
+	SourceID       string
+	RuntimeID      string
+	Status         string
+	IdempotencyKey string
+	Limit          int
+}
+
+// ConnectorCredentialMetadataUpdate describes non-secret credential metadata updates.
+type ConnectorCredentialMetadataUpdate struct {
+	Status               string
+	Fields               []string
+	UpdatedBy            string
+	RevokedBy            string
+	PreviousCredentialID string
+	RevokedAt            *time.Time
+	LastUsedAt           *time.Time
+	LastValidatedAt      *time.Time
+}
+
+// ConnectorCredentialAuditRecord records one credential broker lifecycle event.
+type ConnectorCredentialAuditRecord struct {
+	ID           string
+	CredentialID string
+	TenantID     string
+	SourceID     string
+	RuntimeID    string
+	EventType    string
+	Actor        string
+	Status       string
+	Detail       string
+	CreatedAt    time.Time
 }
 
 // ConnectorCredentialStore persists encrypted connector credentials.
@@ -26,4 +75,8 @@ type ConnectorCredentialStore interface {
 	StateStore
 	PutConnectorCredential(context.Context, *ConnectorCredentialRecord) error
 	GetConnectorCredential(context.Context, string) (*ConnectorCredentialRecord, error)
+	ListConnectorCredentials(context.Context, ConnectorCredentialFilter) ([]*ConnectorCredentialRecord, error)
+	UpdateConnectorCredentialMetadata(context.Context, string, ConnectorCredentialMetadataUpdate) (*ConnectorCredentialRecord, error)
+	AppendConnectorCredentialAuditEvent(context.Context, *ConnectorCredentialAuditRecord) error
+	ListConnectorCredentialAuditEvents(context.Context, string, int) ([]*ConnectorCredentialAuditRecord, error)
 }

--- a/internal/ports/connectorcredentials.go
+++ b/internal/ports/connectorcredentials.go
@@ -9,6 +9,10 @@ import (
 // ErrConnectorCredentialNotFound indicates that a stored connector credential does not exist.
 var ErrConnectorCredentialNotFound = errors.New("connector credential not found")
 
+// ErrConnectorCredentialIdempotencyConflict indicates that another request stored
+// a connector credential with the same scoped idempotency key first.
+var ErrConnectorCredentialIdempotencyConflict = errors.New("connector credential idempotency conflict")
+
 // ConnectorCredentialRecord stores one encrypted connector credential envelope.
 type ConnectorCredentialRecord struct {
 	ID                   string

--- a/internal/ports/connectorcredentials.go
+++ b/internal/ports/connectorcredentials.go
@@ -77,6 +77,7 @@ type ConnectorCredentialStore interface {
 	GetConnectorCredential(context.Context, string) (*ConnectorCredentialRecord, error)
 	ListConnectorCredentials(context.Context, ConnectorCredentialFilter) ([]*ConnectorCredentialRecord, error)
 	UpdateConnectorCredentialMetadata(context.Context, string, ConnectorCredentialMetadataUpdate) (*ConnectorCredentialRecord, error)
+	MarkConnectorCredentialUsed(context.Context, string, time.Time, time.Time) (*ConnectorCredentialRecord, bool, error)
 	AppendConnectorCredentialAuditEvent(context.Context, *ConnectorCredentialAuditRecord) error
 	ListConnectorCredentialAuditEvents(context.Context, string, int) ([]*ConnectorCredentialAuditRecord, error)
 }

--- a/internal/statestore/postgres/connectorcredentials.go
+++ b/internal/statestore/postgres/connectorcredentials.go
@@ -3,10 +3,14 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
+	"time"
 
+	"github.com/writer/cerebro/internal/connectorcredentials"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -21,8 +25,36 @@ var ensureConnectorCredentialStatements = []string{
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS credential_store_id TEXT NOT NULL DEFAULT 'cerebro_vault'`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS auth_method TEXT NOT NULL DEFAULT 'encrypted_submission'`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'valid'`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS fields_json JSONB NOT NULL DEFAULT '[]'::jsonb`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS created_by TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS updated_by TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS revoked_by TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS previous_credential_id TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS idempotency_key TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMPTZ`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMPTZ`,
+	`ALTER TABLE connector_credentials ADD COLUMN IF NOT EXISTS last_validated_at TIMESTAMPTZ`,
 	`CREATE INDEX IF NOT EXISTS connector_credentials_tenant_source_idx ON connector_credentials (tenant_id, source_id, updated_at DESC)`,
 	`CREATE INDEX IF NOT EXISTS connector_credentials_runtime_idx ON connector_credentials (runtime_id, updated_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS connector_credentials_status_idx ON connector_credentials (tenant_id, source_id, status, updated_at DESC)`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS connector_credentials_idempotency_idx ON connector_credentials (tenant_id, source_id, runtime_id, idempotency_key) WHERE idempotency_key <> ''`,
+	`CREATE TABLE IF NOT EXISTS connector_credential_audit_events (
+  id TEXT PRIMARY KEY,
+  credential_id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  runtime_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  actor TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT '',
+  detail TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS connector_credential_audit_credential_idx ON connector_credential_audit_events (credential_id, created_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS connector_credential_audit_tenant_source_idx ON connector_credential_audit_events (tenant_id, source_id, created_at DESC)`,
 }
 
 func (s *Store) PutConnectorCredential(ctx context.Context, credential *ports.ConnectorCredentialRecord) error {
@@ -54,22 +86,66 @@ func (s *Store) PutConnectorCredential(ctx context.Context, credential *ports.Co
 	if len(credential.Sealed) == 0 {
 		return errors.New("connector credential envelope is required")
 	}
+	fieldsJSON, err := json.Marshal(normalizeConnectorCredentialFields(credential.Fields))
+	if err != nil {
+		return fmt.Errorf("encode connector credential fields: %w", err)
+	}
+	status := strings.TrimSpace(credential.Status)
+	if status == "" {
+		status = connectorcredentials.StatusValid
+	}
+	storeID := strings.TrimSpace(credential.CredentialStoreID)
+	if storeID == "" {
+		storeID = "cerebro_vault"
+	}
+	authMethod := strings.TrimSpace(credential.AuthMethod)
+	if authMethod == "" {
+		authMethod = "encrypted_submission"
+	}
 	if _, err := s.db.ExecContext(ctx, `
-INSERT INTO connector_credentials (id, tenant_id, source_id, runtime_id, key_id, sealed)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO connector_credentials (
+  id, tenant_id, source_id, runtime_id, credential_store_id, auth_method, status, key_id,
+  fields_json, sealed, created_by, updated_by, revoked_by, previous_credential_id, idempotency_key,
+  revoked_at, last_used_at, last_validated_at
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 ON CONFLICT (id)
 DO UPDATE SET tenant_id = EXCLUDED.tenant_id,
               source_id = EXCLUDED.source_id,
               runtime_id = EXCLUDED.runtime_id,
+              credential_store_id = EXCLUDED.credential_store_id,
+              auth_method = EXCLUDED.auth_method,
+              status = EXCLUDED.status,
               key_id = EXCLUDED.key_id,
+              fields_json = EXCLUDED.fields_json,
               sealed = EXCLUDED.sealed,
+              created_by = EXCLUDED.created_by,
+              updated_by = EXCLUDED.updated_by,
+              revoked_by = EXCLUDED.revoked_by,
+              previous_credential_id = EXCLUDED.previous_credential_id,
+              idempotency_key = EXCLUDED.idempotency_key,
+              revoked_at = EXCLUDED.revoked_at,
+              last_used_at = EXCLUDED.last_used_at,
+              last_validated_at = EXCLUDED.last_validated_at,
               updated_at = NOW()`,
 		id,
 		strings.TrimSpace(credential.TenantID),
 		strings.TrimSpace(credential.SourceID),
 		strings.TrimSpace(credential.RuntimeID),
+		storeID,
+		authMethod,
+		status,
 		strings.TrimSpace(credential.KeyID),
+		string(fieldsJSON),
 		credential.Sealed,
+		strings.TrimSpace(credential.CreatedBy),
+		strings.TrimSpace(credential.UpdatedBy),
+		strings.TrimSpace(credential.RevokedBy),
+		strings.TrimSpace(credential.PreviousCredentialID),
+		strings.TrimSpace(credential.IdempotencyKey),
+		nullableTime(credential.RevokedAt),
+		nullableTime(credential.LastUsedAt),
+		nullableTime(credential.LastValidatedAt),
 	); err != nil {
 		return fmt.Errorf("upsert connector credential %q: %w", id, err)
 	}
@@ -87,19 +163,13 @@ func (s *Store) GetConnectorCredential(ctx context.Context, credentialID string)
 	if err := s.ensureConnectorCredentialTable(ctx); err != nil {
 		return nil, err
 	}
-	record := &ports.ConnectorCredentialRecord{ID: id}
-	if err := s.db.QueryRowContext(ctx, `
-SELECT tenant_id, source_id, runtime_id, key_id, sealed, created_at, updated_at
+	record, err := scanConnectorCredentialRecord(s.db.QueryRowContext(ctx, `
+SELECT id, tenant_id, source_id, runtime_id, credential_store_id, auth_method, status, key_id,
+       fields_json, sealed, created_by, updated_by, revoked_by, previous_credential_id, idempotency_key,
+       created_at, updated_at, revoked_at, last_used_at, last_validated_at
 FROM connector_credentials
-WHERE id = $1`, id).Scan(
-		&record.TenantID,
-		&record.SourceID,
-		&record.RuntimeID,
-		&record.KeyID,
-		&record.Sealed,
-		&record.CreatedAt,
-		&record.UpdatedAt,
-	); err != nil {
+WHERE id = $1`, id))
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("%w: %s", ports.ErrConnectorCredentialNotFound, id)
 		}
@@ -108,6 +178,278 @@ WHERE id = $1`, id).Scan(
 	return record, nil
 }
 
+func (s *Store) ListConnectorCredentials(ctx context.Context, filter ports.ConnectorCredentialFilter) ([]*ports.ConnectorCredentialRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureConnectorCredentialTable(ctx); err != nil {
+		return nil, err
+	}
+	clauses := []string{"1 = 1"}
+	args := []any{}
+	addClause := func(column string, value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		args = append(args, value)
+		clauses = append(clauses, fmt.Sprintf("%s = $%d", column, len(args)))
+	}
+	addClause("id", filter.ID)
+	addClause("tenant_id", filter.TenantID)
+	addClause("source_id", filter.SourceID)
+	addClause("runtime_id", filter.RuntimeID)
+	addClause("status", filter.Status)
+	addClause("idempotency_key", filter.IdempotencyKey)
+	limit := filter.Limit
+	if limit <= 0 || limit > 1000 {
+		limit = 1000
+	}
+	args = append(args, limit)
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+SELECT id, tenant_id, source_id, runtime_id, credential_store_id, auth_method, status, key_id,
+       fields_json, sealed, created_by, updated_by, revoked_by, previous_credential_id, idempotency_key,
+       created_at, updated_at, revoked_at, last_used_at, last_validated_at
+FROM connector_credentials
+WHERE %s
+ORDER BY updated_at DESC, created_at DESC
+LIMIT $%d`, strings.Join(clauses, " AND "), len(args)), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list connector credentials: %w", err)
+	}
+	defer rows.Close()
+	records := []*ports.ConnectorCredentialRecord{}
+	for rows.Next() {
+		record, err := scanConnectorCredentialRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate connector credentials: %w", err)
+	}
+	return records, nil
+}
+
+func (s *Store) UpdateConnectorCredentialMetadata(ctx context.Context, credentialID string, update ports.ConnectorCredentialMetadataUpdate) (*ports.ConnectorCredentialRecord, error) {
+	id := strings.TrimSpace(credentialID)
+	if id == "" {
+		return nil, errors.New("connector credential id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureConnectorCredentialTable(ctx); err != nil {
+		return nil, err
+	}
+	assignments := []string{"updated_at = NOW()"}
+	args := []any{}
+	addString := func(column string, value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		args = append(args, value)
+		assignments = append(assignments, fmt.Sprintf("%s = $%d", column, len(args)))
+	}
+	addString("status", update.Status)
+	addString("updated_by", update.UpdatedBy)
+	addString("revoked_by", update.RevokedBy)
+	addString("previous_credential_id", update.PreviousCredentialID)
+	if update.Fields != nil {
+		fieldsJSON, err := json.Marshal(normalizeConnectorCredentialFields(update.Fields))
+		if err != nil {
+			return nil, fmt.Errorf("encode connector credential fields: %w", err)
+		}
+		args = append(args, string(fieldsJSON))
+		assignments = append(assignments, fmt.Sprintf("fields_json = $%d::jsonb", len(args)))
+	}
+	addTime := func(column string, value *time.Time) {
+		if value == nil {
+			return
+		}
+		args = append(args, nullableTime(*value))
+		assignments = append(assignments, fmt.Sprintf("%s = $%d", column, len(args)))
+	}
+	addTime("revoked_at", update.RevokedAt)
+	addTime("last_used_at", update.LastUsedAt)
+	addTime("last_validated_at", update.LastValidatedAt)
+	args = append(args, id)
+	result, err := s.db.ExecContext(ctx, fmt.Sprintf("UPDATE connector_credentials SET %s WHERE id = $%d", strings.Join(assignments, ", "), len(args)), args...)
+	if err != nil {
+		return nil, fmt.Errorf("update connector credential %q: %w", id, err)
+	}
+	if rows, err := result.RowsAffected(); err == nil && rows == 0 {
+		return nil, fmt.Errorf("%w: %s", ports.ErrConnectorCredentialNotFound, id)
+	}
+	return s.GetConnectorCredential(ctx, id)
+}
+
+func (s *Store) AppendConnectorCredentialAuditEvent(ctx context.Context, event *ports.ConnectorCredentialAuditRecord) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if event == nil {
+		return errors.New("connector credential audit event is required")
+	}
+	if err := s.ensureConnectorCredentialTable(ctx); err != nil {
+		return err
+	}
+	id := strings.TrimSpace(event.ID)
+	if id == "" {
+		id = fmt.Sprintf("credential-audit-%d", time.Now().UnixNano())
+	}
+	if strings.TrimSpace(event.CredentialID) == "" {
+		return errors.New("connector credential audit credential id is required")
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO connector_credential_audit_events (
+  id, credential_id, tenant_id, source_id, runtime_id, event_type, actor, status, detail, created_at
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, COALESCE($10::timestamptz, NOW()))`,
+		id,
+		strings.TrimSpace(event.CredentialID),
+		strings.TrimSpace(event.TenantID),
+		strings.TrimSpace(event.SourceID),
+		strings.TrimSpace(event.RuntimeID),
+		strings.TrimSpace(event.EventType),
+		strings.TrimSpace(event.Actor),
+		strings.TrimSpace(event.Status),
+		strings.TrimSpace(event.Detail),
+		nullableTime(event.CreatedAt),
+	); err != nil {
+		return fmt.Errorf("append connector credential audit event %q: %w", id, err)
+	}
+	return nil
+}
+
+func (s *Store) ListConnectorCredentialAuditEvents(ctx context.Context, credentialID string, limit int) ([]*ports.ConnectorCredentialAuditRecord, error) {
+	id := strings.TrimSpace(credentialID)
+	if id == "" {
+		return nil, errors.New("connector credential id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureConnectorCredentialTable(ctx); err != nil {
+		return nil, err
+	}
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, credential_id, tenant_id, source_id, runtime_id, event_type, actor, status, detail, created_at
+FROM connector_credential_audit_events
+WHERE credential_id = $1
+ORDER BY created_at DESC
+LIMIT $2`, id, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list connector credential audit events: %w", err)
+	}
+	defer rows.Close()
+	events := []*ports.ConnectorCredentialAuditRecord{}
+	for rows.Next() {
+		event := &ports.ConnectorCredentialAuditRecord{}
+		if err := rows.Scan(
+			&event.ID,
+			&event.CredentialID,
+			&event.TenantID,
+			&event.SourceID,
+			&event.RuntimeID,
+			&event.EventType,
+			&event.Actor,
+			&event.Status,
+			&event.Detail,
+			&event.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan connector credential audit event: %w", err)
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate connector credential audit events: %w", err)
+	}
+	return events, nil
+}
+
 func (s *Store) ensureConnectorCredentialTable(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.connectorCredentialReady, "connector credential", ensureConnectorCredentialStatements)
+}
+
+type connectorCredentialScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanConnectorCredentialRecord(scanner connectorCredentialScanner) (*ports.ConnectorCredentialRecord, error) {
+	record := &ports.ConnectorCredentialRecord{}
+	var fieldsJSON []byte
+	var createdBy sql.NullString
+	var updatedBy sql.NullString
+	var revokedBy sql.NullString
+	var previousCredentialID sql.NullString
+	var idempotencyKey sql.NullString
+	var revokedAt sql.NullTime
+	var lastUsedAt sql.NullTime
+	var lastValidatedAt sql.NullTime
+	if err := scanner.Scan(
+		&record.ID,
+		&record.TenantID,
+		&record.SourceID,
+		&record.RuntimeID,
+		&record.CredentialStoreID,
+		&record.AuthMethod,
+		&record.Status,
+		&record.KeyID,
+		&fieldsJSON,
+		&record.Sealed,
+		&createdBy,
+		&updatedBy,
+		&revokedBy,
+		&previousCredentialID,
+		&idempotencyKey,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+		&revokedAt,
+		&lastUsedAt,
+		&lastValidatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(fieldsJSON, &record.Fields); err != nil {
+		return nil, fmt.Errorf("decode connector credential fields: %w", err)
+	}
+	record.Fields = normalizeConnectorCredentialFields(record.Fields)
+	record.CreatedBy = createdBy.String
+	record.UpdatedBy = updatedBy.String
+	record.RevokedBy = revokedBy.String
+	record.PreviousCredentialID = previousCredentialID.String
+	record.IdempotencyKey = idempotencyKey.String
+	if revokedAt.Valid {
+		record.RevokedAt = revokedAt.Time
+	}
+	if lastUsedAt.Valid {
+		record.LastUsedAt = lastUsedAt.Time
+	}
+	if lastValidatedAt.Valid {
+		record.LastValidatedAt = lastValidatedAt.Time
+	}
+	return record, nil
+}
+
+func normalizeConnectorCredentialFields(fields []string) []string {
+	seen := map[string]struct{}{}
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		seen[field] = struct{}{}
+	}
+	normalized := make([]string, 0, len(seen))
+	for field := range seen {
+		normalized = append(normalized, field)
+	}
+	sort.Strings(normalized)
+	return normalized
 }

--- a/internal/statestore/postgres/connectorcredentials.go
+++ b/internal/statestore/postgres/connectorcredentials.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
+
 	"github.com/writer/cerebro/internal/connectorcredentials"
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -147,9 +149,24 @@ DO UPDATE SET tenant_id = EXCLUDED.tenant_id,
 		nullableTime(credential.LastUsedAt),
 		nullableTime(credential.LastValidatedAt),
 	); err != nil {
+		if isConnectorCredentialIdempotencyConflict(err) {
+			return fmt.Errorf("%w: %s", ports.ErrConnectorCredentialIdempotencyConflict, strings.TrimSpace(credential.IdempotencyKey))
+		}
 		return fmt.Errorf("upsert connector credential %q: %w", id, err)
 	}
 	return nil
+}
+
+func isConnectorCredentialIdempotencyConflict(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	if pgErr.Code != "23505" {
+		return false
+	}
+	return strings.Contains(pgErr.ConstraintName, "connector_credentials_idempotency_idx") ||
+		strings.Contains(pgErr.Message, "connector_credentials_idempotency_idx")
 }
 
 func (s *Store) GetConnectorCredential(ctx context.Context, credentialID string) (*ports.ConnectorCredentialRecord, error) {

--- a/internal/statestore/postgres/connectorcredentials.go
+++ b/internal/statestore/postgres/connectorcredentials.go
@@ -286,6 +286,43 @@ func (s *Store) UpdateConnectorCredentialMetadata(ctx context.Context, credentia
 	return s.GetConnectorCredential(ctx, id)
 }
 
+func (s *Store) MarkConnectorCredentialUsed(ctx context.Context, credentialID string, usedAt time.Time, staleBefore time.Time) (*ports.ConnectorCredentialRecord, bool, error) {
+	id := strings.TrimSpace(credentialID)
+	if id == "" {
+		return nil, false, errors.New("connector credential id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, false, errors.New("postgres is not configured")
+	}
+	if err := s.ensureConnectorCredentialTable(ctx); err != nil {
+		return nil, false, err
+	}
+	if usedAt.IsZero() {
+		usedAt = time.Now().UTC()
+	}
+	if staleBefore.IsZero() {
+		staleBefore = usedAt.Add(-time.Hour)
+	}
+	record, err := scanConnectorCredentialRecord(s.db.QueryRowContext(ctx, `
+UPDATE connector_credentials
+SET last_used_at = $2, updated_at = $2
+WHERE id = $1 AND (last_used_at IS NULL OR last_used_at <= $3)
+RETURNING id, tenant_id, source_id, runtime_id, credential_store_id, auth_method, status, key_id,
+       fields_json, sealed, created_by, updated_by, revoked_by, previous_credential_id, idempotency_key,
+       created_at, updated_at, revoked_at, last_used_at, last_validated_at`, id, usedAt.UTC(), staleBefore.UTC()))
+	if err == nil {
+		return record, true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		record, getErr := s.GetConnectorCredential(ctx, id)
+		if getErr != nil {
+			return nil, false, getErr
+		}
+		return record, false, nil
+	}
+	return nil, false, fmt.Errorf("mark connector credential used %q: %w", id, err)
+}
+
 func (s *Store) AppendConnectorCredentialAuditEvent(ctx context.Context, event *ports.ConnectorCredentialAuditRecord) error {
 	if s == nil || s.db == nil {
 		return errors.New("postgres is not configured")

--- a/internal/statestore/postgres/connectorcredentials.go
+++ b/internal/statestore/postgres/connectorcredentials.go
@@ -217,7 +217,7 @@ LIMIT $%d`, strings.Join(clauses, " AND "), len(args)), args...)
 	if err != nil {
 		return nil, fmt.Errorf("list connector credentials: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	records := []*ports.ConnectorCredentialRecord{}
 	for rows.Next() {
 		record, err := scanConnectorCredentialRecord(rows)
@@ -347,7 +347,7 @@ LIMIT $2`, id, limit)
 	if err != nil {
 		return nil, fmt.Errorf("list connector credential audit events: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	events := []*ports.ConnectorCredentialAuditRecord{}
 	for rows.Next() {
 		event := &ports.ConnectorCredentialAuditRecord{}

--- a/internal/statestore/postgres/connectorcredentials_test.go
+++ b/internal/statestore/postgres/connectorcredentials_test.go
@@ -1,0 +1,27 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestIsConnectorCredentialIdempotencyConflict(t *testing.T) {
+	err := &pgconn.PgError{
+		Code:           "23505",
+		ConstraintName: "connector_credentials_idempotency_idx",
+	}
+	if !isConnectorCredentialIdempotencyConflict(err) {
+		t.Fatal("isConnectorCredentialIdempotencyConflict() = false, want true")
+	}
+	if isConnectorCredentialIdempotencyConflict(errors.New("not unique")) {
+		t.Fatal("isConnectorCredentialIdempotencyConflict(non-pg error) = true, want false")
+	}
+	if isConnectorCredentialIdempotencyConflict(&pgconn.PgError{
+		Code:           "23505",
+		ConstraintName: "connector_credentials_pkey",
+	}) {
+		t.Fatal("isConnectorCredentialIdempotencyConflict(primary key conflict) = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- add connector credential lifecycle broker support for list/get/revoke/rotate flows
- persist credential metadata, status, audit events, idempotency keys, and last-use markers
- enforce credential status at broker use time and expose lifecycle endpoints in OpenAPI

## Validation
- go test ./internal/connectorcredentials ./internal/bootstrap ./internal/statestore/postgres -count=1
- make openapi-check openapi-lint