### PR TITLE
Address incremental fetch review feedback

### DIFF
--- a/internal/sourcecdk/catalog_test.go
+++ b/internal/sourcecdk/catalog_test.go
@@ -203,6 +203,63 @@ coverage_contract:
 	}
 }
 
+func TestNewRegistryPreservesCatalogCheckpointAwareSources(t *testing.T) {
+	_, err := LoadSourceCatalog([]byte(`
+id: checkpoint_catalog_source
+name: Checkpoint Catalog Source
+emitted_kinds:
+  - checkpoint_catalog_source.event
+event_contracts:
+  - kind: checkpoint_catalog_source.event
+    schema_ref: checkpoint_catalog_source/event/v1
+    required_attributes:
+      - required_attribute
+coverage_contract:
+  owner_domain: code
+  dimensions:
+    - id: incremental
+      type: incremental_sync
+      title: Incremental sync
+      support: supported
+`))
+	if err != nil {
+		t.Fatalf("LoadSourceCatalog() error = %v", err)
+	}
+	source := &catalogCheckpointAwareSource{
+		catalogTestSource: catalogTestSource{id: "checkpoint_catalog_source"},
+		pull:              Pull{ShortCircuitReason: PullShortCircuitReasonNotModified},
+	}
+	registry, err := NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	registered, ok := registry.Get("checkpoint_catalog_source")
+	if !ok {
+		t.Fatal("registry missing checkpoint_catalog_source")
+	}
+	if _, ok := registered.(EventContractProvider); !ok {
+		t.Fatalf("registered source does not implement EventContractProvider")
+	}
+	if _, ok := registered.(CoverageContractProvider); !ok {
+		t.Fatalf("registered source does not implement CoverageContractProvider")
+	}
+	reader, ok := registered.(CheckpointAwareSource)
+	if !ok {
+		t.Fatalf("registered source does not implement CheckpointAwareSource")
+	}
+	checkpoint := &cerebrov1.SourceCheckpoint{CursorOpaque: "checkpoint"}
+	pull, err := reader.ReadWithCheckpoint(context.Background(), NewConfig(nil), nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if source.seenCheckpoint != checkpoint {
+		t.Fatalf("ReadWithCheckpoint checkpoint = %p, want %p", source.seenCheckpoint, checkpoint)
+	}
+	if pull.ShortCircuitReason != PullShortCircuitReasonNotModified {
+		t.Fatalf("ShortCircuitReason = %q, want %q", pull.ShortCircuitReason, PullShortCircuitReasonNotModified)
+	}
+}
+
 type catalogTestSource struct {
 	id string
 }
@@ -221,6 +278,17 @@ func (catalogTestSource) Discover(context.Context, Config) ([]URN, error) {
 
 func (catalogTestSource) Read(context.Context, Config, *cerebrov1.SourceCursor) (Pull, error) {
 	return Pull{}, nil
+}
+
+type catalogCheckpointAwareSource struct {
+	catalogTestSource
+	pull           Pull
+	seenCheckpoint *cerebrov1.SourceCheckpoint
+}
+
+func (s *catalogCheckpointAwareSource) ReadWithCheckpoint(_ context.Context, _ Config, _ *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (Pull, error) {
+	s.seenCheckpoint = checkpoint
+	return s.pull, nil
 }
 
 func TestLoadCatalogRejectsInvalidLifecycleStatus(t *testing.T) {

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -166,6 +166,16 @@ func (s *catalogContractSource) EventContracts() []EventContract {
 	return cloneEventContracts(s.contracts)
 }
 
+func (s *catalogContractSource) ReadWithCheckpoint(ctx context.Context, cfg Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (Pull, error) {
+	if s == nil || sourceIsNil(s.Source) {
+		return Pull{}, fmt.Errorf("source is required")
+	}
+	if reader, ok := s.Source.(CheckpointAwareSource); ok {
+		return reader.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
+	}
+	return s.Read(ctx, cfg, cursor)
+}
+
 func sourceWithCatalogEventContracts(source Source, sourceID string) Source {
 	if _, ok := source.(EventContractProvider); ok {
 		return source
@@ -187,6 +197,27 @@ func (s *catalogCoverageSource) CoverageContract() CoverageContract {
 		return CoverageContract{}
 	}
 	return cloneCoverageContract(s.coverage)
+}
+
+func (s *catalogCoverageSource) EventContracts() []EventContract {
+	if s == nil {
+		return nil
+	}
+	provider, ok := s.Source.(EventContractProvider)
+	if !ok {
+		return nil
+	}
+	return cloneEventContracts(provider.EventContracts())
+}
+
+func (s *catalogCoverageSource) ReadWithCheckpoint(ctx context.Context, cfg Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (Pull, error) {
+	if s == nil || sourceIsNil(s.Source) {
+		return Pull{}, fmt.Errorf("source is required")
+	}
+	if reader, ok := s.Source.(CheckpointAwareSource); ok {
+		return reader.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
+	}
+	return s.Read(ctx, cfg, cursor)
 }
 
 func sourceWithCatalogCoverageContract(source Source, sourceID string) Source {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -740,13 +740,40 @@ func advanceRuntimeCheckpoint(runtime *cerebrov1.SourceRuntime, checkpoint *cere
 	existingWatermark := timestampValue(runtime.GetCheckpoint().GetWatermark())
 	nextWatermark := timestampValue(next.GetWatermark())
 	if !existingWatermark.IsZero() && (nextWatermark.IsZero() || existingWatermark.After(nextWatermark)) {
-		runtime.Checkpoint = cloneCheckpoint(runtime.GetCheckpoint())
+		runtime.Checkpoint = checkpointWithoutContinuationToken(runtime.GetCheckpoint())
 		return
 	}
 	if !existingWatermark.IsZero() && existingWatermark.Equal(nextWatermark) {
 		next = mergeEqualWatermarkCheckpoint(runtime.GetCheckpoint(), next)
 	}
 	runtime.Checkpoint = next
+}
+
+func checkpointWithoutContinuationToken(checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {
+	terminal := cloneCheckpoint(checkpoint)
+	if terminal == nil {
+		return nil
+	}
+	opaque := strings.TrimSpace(terminal.GetCursorOpaque())
+	if opaque == "" {
+		return terminal
+	}
+	envelope, ok := sourcecdk.DecodeCursorEnvelope(opaque)
+	if !ok {
+		terminal.CursorOpaque = ""
+		return terminal
+	}
+	if envelope.Token == "" {
+		return terminal
+	}
+	envelope.Token = ""
+	nextOpaque, err := sourcecdk.EncodeCursorEnvelope(envelope)
+	if err != nil {
+		terminal.CursorOpaque = ""
+		return terminal
+	}
+	terminal.CursorOpaque = nextOpaque
+	return terminal
 }
 
 func mergeEqualWatermarkCheckpoint(existing *cerebrov1.SourceCheckpoint, next *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1492,6 +1492,20 @@ func TestSyncRuntimePassesCheckpointAndPersistsShortCircuitReason(t *testing.T) 
 func TestSyncRuntimeDoesNotRegressCheckpointWatermark(t *testing.T) {
 	newer := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
 	older := newer.Add(-time.Hour)
+	existingEnvelope := sourcecdk.CursorEnvelope{
+		Version:             1,
+		Source:              "github",
+		Family:              "pull_request",
+		Mode:                "incremental_watermark",
+		ResumableCheckpoint: true,
+		Token:               "2",
+		BoundaryIDs:         []string{"newer"},
+	}
+	sourcecdk.SetCursorWatermark(&existingEnvelope, newer)
+	existingCursor, err := sourcecdk.EncodeCursorEnvelope(existingEnvelope)
+	if err != nil {
+		t.Fatalf("EncodeCursorEnvelope(existing) error = %v", err)
+	}
 	source := &checkpointAwareRuntimeSource{pull: sourcecdk.Pull{
 		Checkpoint: &cerebrov1.SourceCheckpoint{
 			Watermark:    timestamppb.New(older),
@@ -1509,7 +1523,7 @@ func TestSyncRuntimeDoesNotRegressCheckpointWatermark(t *testing.T) {
 			TenantId: "writer",
 			Checkpoint: &cerebrov1.SourceCheckpoint{
 				Watermark:    timestamppb.New(newer),
-				CursorOpaque: "newer",
+				CursorOpaque: existingCursor,
 			},
 		},
 	}}
@@ -1522,8 +1536,15 @@ func TestSyncRuntimeDoesNotRegressCheckpointWatermark(t *testing.T) {
 	if got := stored.GetCheckpoint().GetWatermark().AsTime(); !got.Equal(newer) {
 		t.Fatalf("stored watermark = %s, want %s", got, newer)
 	}
-	if got := stored.GetCheckpoint().GetCursorOpaque(); got != "newer" {
-		t.Fatalf("stored checkpoint cursor = %q, want newer", got)
+	storedEnvelope, ok := sourcecdk.DecodeCursorEnvelope(stored.GetCheckpoint().GetCursorOpaque())
+	if !ok {
+		t.Fatal("stored checkpoint cursor is not an envelope")
+	}
+	if storedEnvelope.Token != "" {
+		t.Fatalf("stored token = %q, want terminal checkpoint without continuation token", storedEnvelope.Token)
+	}
+	if got := storedEnvelope.BoundaryIDs; len(got) != 1 || got[0] != "newer" {
+		t.Fatalf("stored boundary IDs = %#v, want newer", got)
 	}
 	if got := stored.GetConfig()[runtimeShortCircuitReasonConfigKey]; got != "checkpoint_advanced" {
 		t.Fatalf("short circuit reason = %q, want checkpoint_advanced", got)

--- a/sources/github/secret_scanning_alert.go
+++ b/sources/github/secret_scanning_alert.go
@@ -80,19 +80,18 @@ func (s *Source) readSecretScanningAlerts(ctx context.Context, client *gogithub.
 		events = append(events, event)
 	}
 	state := sourcecdk.IncrementalWatermarkCheckpointState("github", familySecretScanning, checkpoint)
-	events, reachedWatermark := sourcecdk.IncrementalWatermarkEvents(events, state)
-	nextPage := page + 1
+	events, _ = sourcecdk.IncrementalWatermarkEvents(events, state)
+	// GitHub's secret scanning API does not expose updated_at ordering in the
+	// client version we use, so an older-created page can still contain a
+	// recently updated alert. Keep filtering by watermark, but keep paginating.
 	pull := sourcecdk.Pull{
 		Events:     events,
 		Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familySecretScanning, events, state),
 	}
-	if reachedWatermark {
-		pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonWatermarkReached
-		return pull, nil
-	}
 	if resp != nil && resp.NextPage > 0 {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strconv.Itoa(nextPage)}
-		pull.Checkpoint = sourcecdk.IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, strconv.Itoa(nextPage))
+		nextPage := strconv.Itoa(resp.NextPage)
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextPage}
+		pull.Checkpoint = sourcecdk.IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, nextPage)
 	}
 	return pull, nil
 }

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -748,6 +748,119 @@ func TestDependabotAlertEventIncludesDismissedBy(t *testing.T) {
 	}
 }
 
+func TestSecretScanningContinuesPastWatermarkBecausePagesAreNotUpdatedOrdered(t *testing.T) {
+	watermark := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	envelope := sourcecdk.CursorEnvelope{
+		Version:             1,
+		Source:              "github",
+		Family:              familySecretScanning,
+		Mode:                "incremental_watermark",
+		ResumableCheckpoint: true,
+	}
+	sourcecdk.SetCursorWatermark(&envelope, watermark)
+	opaque, err := sourcecdk.EncodeCursorEnvelope(envelope)
+	if err != nil {
+		t.Fatalf("EncodeCursorEnvelope() error = %v", err)
+	}
+	checkpoint := &cerebrov1.SourceCheckpoint{
+		Watermark:    timestamppb.New(watermark),
+		CursorOpaque: opaque,
+	}
+	requestedPages := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v3/orgs/writer/secret-scanning/alerts" {
+			http.NotFound(w, r)
+			return
+		}
+		page := r.URL.Query().Get("page")
+		requestedPages = append(requestedPages, page)
+		if page == "" || page == "1" {
+			w.Header().Set("Link", "</api/v3/orgs/writer/secret-scanning/alerts?page=2>; rel=\"next\", </api/v3/orgs/writer/secret-scanning/alerts?page=2>; rel=\"last\"")
+			if err := json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"number":      1,
+					"state":       "open",
+					"secret_type": "token",
+					"created_at":  "2026-04-24T00:00:00Z",
+					"updated_at":  "2026-04-24T11:00:00Z",
+					"repository": map[string]any{
+						"full_name": "writer/cerebro",
+					},
+				},
+			}); err != nil {
+				t.Fatalf("encode secret scanning page 1: %v", err)
+			}
+			return
+		}
+		if page == "2" {
+			if err := json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"number":      2,
+					"state":       "open",
+					"secret_type": "token",
+					"created_at":  "2026-04-01T00:00:00Z",
+					"updated_at":  "2026-04-24T14:00:00Z",
+					"repository": map[string]any{
+						"full_name": "writer/cerebro",
+					},
+				},
+			}); err != nil {
+				t.Fatalf("encode secret scanning page 2: %v", err)
+			}
+			return
+		}
+		if err := json.NewEncoder(w).Encode([]map[string]any{}); err != nil {
+			t.Fatalf("encode empty secret scanning page: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familySecretScanning,
+		"owner":    "writer",
+		"per_page": "1",
+		"token":    "test-token",
+	})
+
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
+	}
+	if len(first.Events) != 0 {
+		t.Fatalf("len(first.Events) = %d, want 0", len(first.Events))
+	}
+	if first.ShortCircuitReason == sourcecdk.PullShortCircuitReasonWatermarkReached {
+		t.Fatalf("first.ShortCircuitReason = %q, want no watermark stop", first.ShortCircuitReason)
+	}
+	if first.NextCursor == nil || first.NextCursor.Opaque != "2" {
+		t.Fatalf("first.NextCursor = %#v, want page 2", first.NextCursor)
+	}
+
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, first.NextCursor, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(second) error = %v", err)
+	}
+	if len(second.Events) != 1 {
+		t.Fatalf("len(second.Events) = %d, want recently updated older-created alert", len(second.Events))
+	}
+	if got := second.Events[0].Attributes["alert_number"]; got != "2" {
+		t.Fatalf("second alert_number = %q, want 2", got)
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
+	}
+	if len(requestedPages) != 2 || requestedPages[0] != "1" || requestedPages[1] != "2" {
+		t.Fatalf("requested pages = %#v, want first page then page 2", requestedPages)
+	}
+}
+
 func TestSecretScanningAlertEventIncludesActorLogins(t *testing.T) {
 	observedAt := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
 	event, err := secretScanningAlertEvent(settings{owner: "writer"}, &gogithub.SecretScanningAlert{

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -18,7 +18,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"azure":           2582,
 	"cosmo":           1112,
 	"gcp":             2078,
-	"github":          2188,
+	"github":          2187,
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2433,


### PR DESCRIPTION
## Summary
- forward checkpoint-aware reads through catalog contract and coverage wrappers
- keep secret-scanning pagination going when the updated_at watermark is reached because the API is not updated-ordered
- clear stale continuation tokens when preserving a higher runtime watermark

## Tests
- go test ./internal/sourcecdk ./internal/sourceruntime ./sources/github ./tools/archtests
- make lint
- go test ./...