### PR TITLE
Align GitHub security alert pagination with current API

### DIFF
--- a/internal/sourcecdk/cursor.go
+++ b/internal/sourcecdk/cursor.go
@@ -117,6 +117,50 @@ func CursorPage(cursor *cerebrov1.SourceCursor) (int, error) {
 	return page, nil
 }
 
+// CursorAfterOrPage parses a cursor token for endpoints that prefer Link
+// header after cursors but may still fall back to page tokens. Untyped numeric
+// tokens are treated as legacy page cursors and ignored so migrations back to
+// the collection head remain correct under watermark filtering.
+func CursorAfterOrPage(cursor *cerebrov1.SourceCursor) (string, string, error) {
+	token := strings.TrimSpace(CursorToken(cursor))
+	if token == "" {
+		return "", "", nil
+	}
+	if after, ok := strings.CutPrefix(token, "after:"); ok {
+		return strings.TrimSpace(after), "", nil
+	}
+	if page, ok := strings.CutPrefix(token, "page:"); ok {
+		page = strings.TrimSpace(page)
+		parsed, err := strconv.Atoi(page)
+		if err != nil {
+			return "", "", fmt.Errorf("%w: parse page cursor: %w", ErrInvalidConfig, err)
+		}
+		if parsed < 1 {
+			return "", "", fmt.Errorf("%w: page cursor must be greater than zero", ErrInvalidConfig)
+		}
+		return "", page, nil
+	}
+	if _, err := strconv.Atoi(token); err == nil {
+		return "", "", nil
+	}
+	return token, "", nil
+}
+
+// NextAfterOrPageCursor prefers a Link-header after cursor and falls back to
+// page tokens for endpoints or GitHub Enterprise versions that still emit them.
+func NextAfterOrPageCursor(after string, nextPageToken string, nextPage int) string {
+	if after = strings.TrimSpace(after); after != "" {
+		return "after:" + after
+	}
+	if nextPageToken = strings.TrimSpace(nextPageToken); nextPageToken != "" {
+		return "page:" + nextPageToken
+	}
+	if nextPage > 0 {
+		return "page:" + strconv.Itoa(nextPage)
+	}
+	return ""
+}
+
 func normalizedCursorValues(values []string) []string {
 	if len(values) == 0 {
 		return nil

--- a/internal/sourcecdk/cursor_test.go
+++ b/internal/sourcecdk/cursor_test.go
@@ -89,6 +89,45 @@ func TestCursorPageReadsEnvelopeToken(t *testing.T) {
 	}
 }
 
+func TestCursorAfterOrPageReadsTypedTokens(t *testing.T) {
+	after, page, err := CursorAfterOrPage(&cerebrov1.SourceCursor{Opaque: "after:cursor-2"})
+	if err != nil {
+		t.Fatalf("CursorAfterOrPage(after) error = %v", err)
+	}
+	if after != "cursor-2" || page != "" {
+		t.Fatalf("CursorAfterOrPage(after) = %q/%q, want cursor-2/empty", after, page)
+	}
+	after, page, err = CursorAfterOrPage(&cerebrov1.SourceCursor{Opaque: "page:2"})
+	if err != nil {
+		t.Fatalf("CursorAfterOrPage(page) error = %v", err)
+	}
+	if after != "" || page != "2" {
+		t.Fatalf("CursorAfterOrPage(page) = %q/%q, want empty/2", after, page)
+	}
+	after, page, err = CursorAfterOrPage(&cerebrov1.SourceCursor{Opaque: "2"})
+	if err != nil {
+		t.Fatalf("CursorAfterOrPage(legacy) error = %v", err)
+	}
+	if after != "" || page != "" {
+		t.Fatalf("CursorAfterOrPage(legacy) = %q/%q, want empty/empty", after, page)
+	}
+	if _, _, err := CursorAfterOrPage(&cerebrov1.SourceCursor{Opaque: "page:0"}); !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("CursorAfterOrPage(page:0) error = %v, want ErrInvalidConfig", err)
+	}
+}
+
+func TestNextAfterOrPageCursorPrefersAfter(t *testing.T) {
+	if got := NextAfterOrPageCursor("cursor-2", "3", 4); got != "after:cursor-2" {
+		t.Fatalf("NextAfterOrPageCursor(after) = %q, want after cursor", got)
+	}
+	if got := NextAfterOrPageCursor("", "3", 4); got != "page:3" {
+		t.Fatalf("NextAfterOrPageCursor(token) = %q, want page token", got)
+	}
+	if got := NextAfterOrPageCursor("", "", 4); got != "page:4" {
+		t.Fatalf("NextAfterOrPageCursor(page) = %q, want page fallback", got)
+	}
+}
+
 func TestIncrementalWatermarkFiltersBoundaryEvents(t *testing.T) {
 	watermark := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
 	events := []*primitives.Event{

--- a/internal/sourcecdk/watermark.go
+++ b/internal/sourcecdk/watermark.go
@@ -132,6 +132,27 @@ func IncrementalWatermarkCheckpointWithToken(checkpoint *cerebrov1.SourceCheckpo
 	return checkpoint
 }
 
+// IncrementalWatermarkPull filters events against the durable watermark and
+// attaches a continuation token only when the watermark boundary was not
+// reached.
+func IncrementalWatermarkPull(source string, family string, events []*primitives.Event, checkpoint *cerebrov1.SourceCheckpoint, nextCursor string) Pull {
+	state := IncrementalWatermarkCheckpointState(source, family, checkpoint)
+	filtered, reachedWatermark := IncrementalWatermarkEvents(events, state)
+	pull := Pull{
+		Events:     filtered,
+		Checkpoint: IncrementalWatermarkCheckpoint(source, family, filtered, state),
+	}
+	if reachedWatermark {
+		pull.ShortCircuitReason = PullShortCircuitReasonWatermarkReached
+		return pull
+	}
+	if nextCursor = strings.TrimSpace(nextCursor); nextCursor != "" {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextCursor}
+		pull.Checkpoint = IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, nextCursor)
+	}
+	return pull
+}
+
 // EmptyIncrementalWatermarkPull returns an unchanged pull when a source page is
 // empty but a previous incremental watermark exists.
 func EmptyIncrementalWatermarkPull(source string, family string, checkpoint *cerebrov1.SourceCheckpoint) Pull {

--- a/sources/github/dependabot_alert.go
+++ b/sources/github/dependabot_alert.go
@@ -81,22 +81,7 @@ func (s *Source) readDependabotAlerts(ctx context.Context, client *gogithub.Clie
 		}
 		events = append(events, event)
 	}
-	state := sourcecdk.IncrementalWatermarkCheckpointState("github", familyDependabot, checkpoint)
-	events, reachedWatermark := sourcecdk.IncrementalWatermarkEvents(events, state)
-	nextCursor := nextAuditCursor(resp)
-	pull := sourcecdk.Pull{
-		Events:     events,
-		Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familyDependabot, events, state),
-	}
-	if reachedWatermark {
-		pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonWatermarkReached
-		return pull, nil
-	}
-	if nextCursor != "" {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextCursor}
-		pull.Checkpoint = sourcecdk.IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, nextCursor)
-	}
-	return pull, nil
+	return sourcecdk.IncrementalWatermarkPull("github", familyDependabot, events, checkpoint, nextAuditCursor(resp)), nil
 }
 
 func dependabotAlertOptions(settings settings, after string, perPage int) *gogithub.ListAlertsOptions {

--- a/sources/github/secret_scanning_alert.go
+++ b/sources/github/secret_scanning_alert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -39,10 +40,7 @@ type secretScanningAlertPayload struct {
 }
 
 func (s *Source) checkSecretScanningAlerts(ctx context.Context, client *gogithub.Client, settings settings) error {
-	_, _, err := client.SecretScanning.ListAlertsForOrg(ctx, settings.owner, &gogithub.SecretScanningAlertListOptions{
-		State:       settings.state,
-		ListOptions: gogithub.ListOptions{PerPage: 1},
-	})
+	_, _, err := listSecretScanningAlertsForOrg(ctx, client, settings, nil, 1)
 	if err != nil {
 		return wrapLookupError(fmt.Sprintf("github secret scanning alerts for org %s", settings.owner), err)
 	}
@@ -57,14 +55,7 @@ func (s *Source) discoverSecretScanningAlerts(ctx context.Context, client *gogit
 }
 
 func (s *Source) readSecretScanningAlerts(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
-	page, err := sourcecdk.CursorPage(cursor)
-	if err != nil {
-		return sourcecdk.Pull{}, err
-	}
-	alerts, resp, err := client.SecretScanning.ListAlertsForOrg(ctx, settings.owner, &gogithub.SecretScanningAlertListOptions{
-		State:       settings.state,
-		ListOptions: gogithub.ListOptions{Page: page, PerPage: settings.perPage},
-	})
+	alerts, resp, err := listSecretScanningAlertsForOrg(ctx, client, settings, cursor, settings.perPage)
 	if err != nil {
 		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github secret scanning alerts for org %s", settings.owner), err)
 	}
@@ -79,21 +70,37 @@ func (s *Source) readSecretScanningAlerts(ctx context.Context, client *gogithub.
 		}
 		events = append(events, event)
 	}
-	state := sourcecdk.IncrementalWatermarkCheckpointState("github", familySecretScanning, checkpoint)
-	events, _ = sourcecdk.IncrementalWatermarkEvents(events, state)
-	// GitHub's secret scanning API does not expose updated_at ordering in the
-	// client version we use, so an older-created page can still contain a
-	// recently updated alert. Keep filtering by watermark, but keep paginating.
-	pull := sourcecdk.Pull{
-		Events:     events,
-		Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familySecretScanning, events, state),
+	nextCursor := ""
+	if resp != nil {
+		nextCursor = sourcecdk.NextAfterOrPageCursor(resp.After, resp.NextPageToken, resp.NextPage)
 	}
-	if resp != nil && resp.NextPage > 0 {
-		nextPage := strconv.Itoa(resp.NextPage)
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextPage}
-		pull.Checkpoint = sourcecdk.IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, nextPage)
+	return sourcecdk.IncrementalWatermarkPull("github", familySecretScanning, events, checkpoint, nextCursor), nil
+}
+
+func listSecretScanningAlertsForOrg(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, perPage int) ([]*gogithub.SecretScanningAlert, *gogithub.Response, error) {
+	after, page, err := sourcecdk.CursorAfterOrPage(cursor)
+	if err != nil {
+		return nil, nil, err
 	}
-	return pull, nil
+	query := url.Values{
+		"after":     {after},
+		"direction": {"desc"},
+		"per_page":  {strconv.Itoa(perPage)},
+		"sort":      {"updated"},
+		"state":     {settings.state},
+	}
+	if page != "" {
+		query.Del("after")
+		query.Set("page", page)
+	}
+	path := fmt.Sprintf("orgs/%s/secret-scanning/alerts?%s", url.PathEscape(settings.owner), query.Encode())
+	req, err := client.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var alerts []*gogithub.SecretScanningAlert
+	resp, err := client.Do(ctx, req, &alerts)
+	return alerts, resp, err
 }
 
 func secretScanningAlertEvent(settings settings, alert *gogithub.SecretScanningAlert) (*primitives.Event, error) {

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -251,21 +251,11 @@ func (s *Source) readPullRequests(ctx context.Context, client *gogithub.Client, 
 		}
 		events = append(events, event)
 	}
-	state := sourcecdk.IncrementalWatermarkCheckpointState("github", familyPullRequest, checkpoint)
-	events, reachedWatermark := sourcecdk.IncrementalWatermarkEvents(events, state)
-	pull := sourcecdk.Pull{
-		Events:     events,
-		Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familyPullRequest, events, state),
-	}
-	if reachedWatermark {
-		pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonWatermarkReached
-		return pull, nil
-	}
+	nextCursor := ""
 	if resp != nil && resp.NextPage > 0 {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strconv.Itoa(resp.NextPage)}
-		pull.Checkpoint = sourcecdk.IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, strconv.Itoa(resp.NextPage))
+		nextCursor = strconv.Itoa(resp.NextPage)
 	}
-	return pull, nil
+	return sourcecdk.IncrementalWatermarkPull("github", familyPullRequest, events, checkpoint, nextCursor), nil
 }
 
 func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
@@ -273,7 +263,6 @@ func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, 
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
-	state := sourcecdk.IncrementalWatermarkCheckpointState("github", familyRepository, checkpoint)
 	if settings.repo != "" {
 		if page > 1 {
 			return sourcecdk.EmptyIncrementalWatermarkPull("github", familyRepository, checkpoint), nil
@@ -286,16 +275,7 @@ func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, 
 		if err != nil {
 			return sourcecdk.Pull{}, err
 		}
-		events, reachedWatermark := sourcecdk.IncrementalWatermarkEvents([]*primitives.Event{event}, state)
-		pull := sourcecdk.Pull{
-			Events:     events,
-			Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familyRepository, events, state),
-		}
-		if reachedWatermark {
-			pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonWatermarkReached
-			return pull, nil
-		}
-		return pull, nil
+		return sourcecdk.IncrementalWatermarkPull("github", familyRepository, []*primitives.Event{event}, checkpoint, ""), nil
 	}
 	repos, resp, err := listReposPage(ctx, client, settings.owner, page, settings.perPage)
 	if err != nil {
@@ -312,20 +292,11 @@ func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, 
 		}
 		events = append(events, event)
 	}
-	events, reachedWatermark := sourcecdk.IncrementalWatermarkEvents(events, state)
-	pull := sourcecdk.Pull{
-		Events:     events,
-		Checkpoint: sourcecdk.IncrementalWatermarkCheckpoint("github", familyRepository, events, state),
-	}
-	if reachedWatermark {
-		pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonWatermarkReached
-		return pull, nil
-	}
+	nextCursor := ""
 	if resp != nil && resp.NextPage > 0 {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strconv.Itoa(resp.NextPage)}
-		pull.Checkpoint = sourcecdk.IncrementalWatermarkCheckpointWithToken(pull.Checkpoint, strconv.Itoa(resp.NextPage))
+		nextCursor = strconv.Itoa(resp.NextPage)
 	}
-	return pull, nil
+	return sourcecdk.IncrementalWatermarkPull("github", familyRepository, events, checkpoint, nextCursor), nil
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -748,71 +749,26 @@ func TestDependabotAlertEventIncludesDismissedBy(t *testing.T) {
 	}
 }
 
-func TestSecretScanningContinuesPastWatermarkBecausePagesAreNotUpdatedOrdered(t *testing.T) {
-	watermark := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
-	envelope := sourcecdk.CursorEnvelope{
-		Version:             1,
-		Source:              "github",
-		Family:              familySecretScanning,
-		Mode:                "incremental_watermark",
-		ResumableCheckpoint: true,
-	}
-	sourcecdk.SetCursorWatermark(&envelope, watermark)
-	opaque, err := sourcecdk.EncodeCursorEnvelope(envelope)
-	if err != nil {
-		t.Fatalf("EncodeCursorEnvelope() error = %v", err)
-	}
-	checkpoint := &cerebrov1.SourceCheckpoint{
-		Watermark:    timestamppb.New(watermark),
-		CursorOpaque: opaque,
-	}
-	requestedPages := []string{}
+func TestSecretScanningUsesUpdatedSortAndCursorPagination(t *testing.T) {
+	queries := []url.Values{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/api/v3/orgs/writer/secret-scanning/alerts" {
 			http.NotFound(w, r)
 			return
 		}
-		page := r.URL.Query().Get("page")
-		requestedPages = append(requestedPages, page)
-		if page == "" || page == "1" {
-			w.Header().Set("Link", "</api/v3/orgs/writer/secret-scanning/alerts?page=2>; rel=\"next\", </api/v3/orgs/writer/secret-scanning/alerts?page=2>; rel=\"last\"")
-			if err := json.NewEncoder(w).Encode([]map[string]any{
-				{
-					"number":      1,
-					"state":       "open",
-					"secret_type": "token",
-					"created_at":  "2026-04-24T00:00:00Z",
-					"updated_at":  "2026-04-24T11:00:00Z",
-					"repository": map[string]any{
-						"full_name": "writer/cerebro",
-					},
-				},
-			}); err != nil {
-				t.Fatalf("encode secret scanning page 1: %v", err)
-			}
+		query := r.URL.Query()
+		queries = append(queries, query)
+		if query.Get("after") == "" {
+			w.Header().Set("Link", "</api/v3/orgs/writer/secret-scanning/alerts?after=cursor-2>; rel=\"next\"")
+			encodeSecretScanningAlerts(t, w, 1, "2026-04-24T14:00:00Z")
 			return
 		}
-		if page == "2" {
-			if err := json.NewEncoder(w).Encode([]map[string]any{
-				{
-					"number":      2,
-					"state":       "open",
-					"secret_type": "token",
-					"created_at":  "2026-04-01T00:00:00Z",
-					"updated_at":  "2026-04-24T14:00:00Z",
-					"repository": map[string]any{
-						"full_name": "writer/cerebro",
-					},
-				},
-			}); err != nil {
-				t.Fatalf("encode secret scanning page 2: %v", err)
-			}
+		if query.Get("after") == "cursor-2" {
+			encodeSecretScanningAlerts(t, w, 2, "2026-04-24T13:00:00Z")
 			return
 		}
-		if err := json.NewEncoder(w).Encode([]map[string]any{}); err != nil {
-			t.Fatalf("encode empty secret scanning page: %v", err)
-		}
+		t.Fatalf("unexpected after cursor %q", query.Get("after"))
 	}))
 	defer server.Close()
 
@@ -829,35 +785,96 @@ func TestSecretScanningContinuesPastWatermarkBecausePagesAreNotUpdatedOrdered(t 
 		"token":    "test-token",
 	})
 
-	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, checkpoint)
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
 	if err != nil {
 		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
 	}
-	if len(first.Events) != 0 {
-		t.Fatalf("len(first.Events) = %d, want 0", len(first.Events))
+	if len(first.Events) != 1 {
+		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
 	}
-	if first.ShortCircuitReason == sourcecdk.PullShortCircuitReasonWatermarkReached {
-		t.Fatalf("first.ShortCircuitReason = %q, want no watermark stop", first.ShortCircuitReason)
-	}
-	if first.NextCursor == nil || first.NextCursor.Opaque != "2" {
-		t.Fatalf("first.NextCursor = %#v, want page 2", first.NextCursor)
+	if first.NextCursor == nil || first.NextCursor.Opaque != "after:cursor-2" {
+		t.Fatalf("first.NextCursor = %#v, want after cursor", first.NextCursor)
 	}
 
-	second, err := source.ReadWithCheckpoint(context.Background(), cfg, first.NextCursor, checkpoint)
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, first.NextCursor, nil)
 	if err != nil {
 		t.Fatalf("ReadWithCheckpoint(second) error = %v", err)
 	}
 	if len(second.Events) != 1 {
-		t.Fatalf("len(second.Events) = %d, want recently updated older-created alert", len(second.Events))
+		t.Fatalf("len(second.Events) = %d, want 1", len(second.Events))
 	}
 	if got := second.Events[0].Attributes["alert_number"]; got != "2" {
 		t.Fatalf("second alert_number = %q, want 2", got)
 	}
-	if second.NextCursor != nil {
-		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
+	if len(queries) != 2 {
+		t.Fatalf("len(queries) = %d, want 2", len(queries))
 	}
-	if len(requestedPages) != 2 || requestedPages[0] != "1" || requestedPages[1] != "2" {
-		t.Fatalf("requested pages = %#v, want first page then page 2", requestedPages)
+	for i, query := range queries {
+		if got := query.Get("sort"); got != "updated" {
+			t.Fatalf("query %d sort = %q, want updated", i, got)
+		}
+		if got := query.Get("direction"); got != "desc" {
+			t.Fatalf("query %d direction = %q, want desc", i, got)
+		}
+	}
+	if _, ok := queries[0]["after"]; !ok {
+		t.Fatalf("first query missing empty after cursor: %#v", queries[0])
+	}
+	if got := queries[1].Get("after"); got != "cursor-2" {
+		t.Fatalf("second query after = %q, want cursor-2", got)
+	}
+}
+
+func TestSecretScanningShortCircuitsAtUpdatedWatermark(t *testing.T) {
+	watermark := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	checkpoint := &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(watermark)}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		requests++
+		w.Header().Set("Link", "</api/v3/orgs/writer/secret-scanning/alerts?after=cursor-2>; rel=\"next\"")
+		encodeSecretScanningAlerts(t, w, 1, "2026-04-24T11:00:00Z")
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familySecretScanning,
+		"owner":    "writer",
+		"per_page": "1",
+		"token":    "test-token",
+	})
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if pull.ShortCircuitReason != sourcecdk.PullShortCircuitReasonWatermarkReached {
+		t.Fatalf("ShortCircuitReason = %q, want watermark_reached", pull.ShortCircuitReason)
+	}
+	if pull.NextCursor != nil {
+		t.Fatalf("NextCursor = %#v, want nil", pull.NextCursor)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want one-page short circuit", requests)
+	}
+}
+
+func encodeSecretScanningAlerts(t *testing.T, w http.ResponseWriter, number int, updatedAt string) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode([]map[string]any{{
+		"number":      number,
+		"state":       "open",
+		"secret_type": "token",
+		"created_at":  "2026-04-01T00:00:00Z",
+		"updated_at":  updatedAt,
+		"repository":  map[string]any{"full_name": "writer/cerebro"},
+	}}); err != nil {
+		t.Fatalf("encode secret scanning alerts: %v", err)
 	}
 }
 

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -18,7 +18,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"azure":           2582,
 	"cosmo":           1112,
 	"gcp":             2078,
-	"github":          2187,
+	"github":          2149,
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2433,


### PR DESCRIPTION
## Summary
- request secret scanning alerts sorted by `updated` descending and cursor-paginated via the Link header, matching the current GitHub REST API behavior
- re-enable safe watermark short-circuiting for secret scanning now that the stream is ordered by `updated_at`
- share typed cursor parsing and incremental watermark pull assembly in Source CDK across GitHub families

## Research notes
- GitHub REST pagination docs say the response `Link` header is the canonical source for additional pages and may use `page`, `before`/`after`, or `since` depending on endpoint.
- GitHub secret scanning docs expose `sort=updated`, `direction=desc`, `before`, `after`, and say an initial cursor can be requested with an empty `after` query string.
- GitHub Dependabot docs/changelog have moved alert pagination toward `before`/`after` cursors, with offset pagination removed for Dependabot alerts on 2025-10-14.

## Tests
- `go test ./internal/sourcecdk ./sources/github ./tools/archtests`
- `make lint`
- `go test ./...`
