### PR TITLE
SEC-1065 AWS findings incremental fetch

### DIFF
--- a/internal/sourcecdk/family.go
+++ b/internal/sourcecdk/family.go
@@ -12,11 +12,12 @@ import (
 
 // Family groups source behavior for one configured event family.
 type Family[S any] struct {
-	Name     string
-	Check    func(context.Context, S) error
-	Discover func(context.Context, S) ([]URN, error)
-	Probe    func(context.Context, S, *cerebrov1.SourceCheckpoint) (ChangeProbe, error)
-	Read     func(context.Context, S, *cerebrov1.SourceCursor) (Pull, error)
+	Name               string
+	Check              func(context.Context, S) error
+	Discover           func(context.Context, S) ([]URN, error)
+	Probe              func(context.Context, S, *cerebrov1.SourceCheckpoint) (ChangeProbe, error)
+	Read               func(context.Context, S, *cerebrov1.SourceCursor) (Pull, error)
+	ReadWithCheckpoint func(context.Context, S, *cerebrov1.SourceCursor, *cerebrov1.SourceCheckpoint) (Pull, error)
 }
 
 // ChangeProbe is an optional cheap pre-read result for families that can test
@@ -137,6 +138,13 @@ func (e *FamilyEngine[S]) ReadWithCheckpoint(ctx context.Context, cfg Config, cu
 			}
 			return Pull{Checkpoint: probe.Checkpoint, ShortCircuitReason: reason}, nil
 		}
+	}
+	if family.ReadWithCheckpoint != nil {
+		pull, err := family.ReadWithCheckpoint(ctx, settings, cursor, checkpoint)
+		if err != nil {
+			return Pull{}, err
+		}
+		return applyResourceScopePolicy(pull, policy), nil
 	}
 	if family.Read == nil {
 		return Pull{}, nil

--- a/internal/sourcecdk/family_scope_test.go
+++ b/internal/sourcecdk/family_scope_test.go
@@ -165,3 +165,42 @@ func TestFamilyEngineProbeShortCircuitsBeforeRead(t *testing.T) {
 		t.Fatalf("ShortCircuitReason = %q, want not_modified", pull.ShortCircuitReason)
 	}
 }
+
+func TestFamilyEngineUsesCheckpointAwareRead(t *testing.T) {
+	checkpoint := &cerebrov1.SourceCheckpoint{
+		Watermark: timestamppb.New(time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)),
+	}
+	var seenCheckpoint *cerebrov1.SourceCheckpoint
+	readCalled := false
+	engine, err := NewFamilyEngine(func(cfg Config) (string, error) {
+		family, _ := cfg.Lookup("family")
+		return family, nil
+	}, func(settings string) string { return settings }, Family[string]{
+		Name: "securityhub_finding",
+		Read: func(context.Context, string, *cerebrov1.SourceCursor) (Pull, error) {
+			readCalled = true
+			return Pull{}, nil
+		},
+		ReadWithCheckpoint: func(_ context.Context, _ string, _ *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (Pull, error) {
+			seenCheckpoint = checkpoint
+			return Pull{ShortCircuitReason: PullShortCircuitReasonWatermarkReached}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFamilyEngine() error = %v", err)
+	}
+
+	pull, err := engine.ReadWithCheckpoint(context.Background(), NewConfig(map[string]string{"family": "securityhub_finding"}), nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if readCalled {
+		t.Fatal("fallback Read was called")
+	}
+	if seenCheckpoint != checkpoint {
+		t.Fatalf("checkpoint = %p, want %p", seenCheckpoint, checkpoint)
+	}
+	if pull.ShortCircuitReason != PullShortCircuitReasonWatermarkReached {
+		t.Fatalf("ShortCircuitReason = %q, want watermark_reached", pull.ShortCircuitReason)
+	}
+}

--- a/internal/sourcecdk/watermark.go
+++ b/internal/sourcecdk/watermark.go
@@ -166,6 +166,118 @@ func EmptyIncrementalWatermarkPull(source string, family string, checkpoint *cer
 	}
 }
 
+// PullFromRecords projects provider records into events and advances a simple
+// page-token checkpoint.
+func PullFromRecords[T any](records []T, next string, build func(T) (*primitives.Event, error), cursorFallback func(T) string) (Pull, error) {
+	if len(records) == 0 {
+		if next = strings.TrimSpace(next); next != "" {
+			return Pull{NextCursor: &cerebrov1.SourceCursor{Opaque: next}}, nil
+		}
+		return Pull{}, nil
+	}
+	events := make([]*primitives.Event, 0, len(records))
+	for _, record := range records {
+		event, err := build(record)
+		if err != nil {
+			return Pull{}, err
+		}
+		events = append(events, event)
+	}
+	fallback := events[len(events)-1].GetId()
+	if cursorFallback != nil {
+		fallback = cursorFallback(records[len(records)-1])
+	}
+	cursorOpaque := strings.TrimSpace(next)
+	if cursorOpaque == "" {
+		cursorOpaque = fallback
+	}
+	pull := Pull{
+		Events: events,
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    events[len(events)-1].OccurredAt,
+			CursorOpaque: cursorOpaque,
+		},
+	}
+	if next = strings.TrimSpace(next); next != "" {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
+	}
+	return pull, nil
+}
+
+// IncrementalPullFromRecords projects records into events and applies durable
+// watermark filtering. Continuation cursors carry the original comparison
+// checkpoint so later sync calls do not drop older pages that are still newer
+// than the run's starting watermark.
+func IncrementalPullFromRecords[T any](source string, family string, records []T, next string, checkpoint *cerebrov1.SourceCheckpoint, build func(T) (*primitives.Event, error)) (Pull, error) {
+	if len(records) == 0 {
+		pull := EmptyIncrementalWatermarkPull(source, family, checkpoint)
+		if next = strings.TrimSpace(next); next != "" {
+			pull.NextCursor = &cerebrov1.SourceCursor{Opaque: IncrementalCursor(source, family, next, checkpoint)}
+		}
+		return pull, nil
+	}
+	events := make([]*primitives.Event, 0, len(records))
+	for _, record := range records {
+		event, err := build(record)
+		if err != nil {
+			return Pull{}, err
+		}
+		events = append(events, event)
+	}
+	pull := IncrementalWatermarkPull(source, family, events, checkpoint, next)
+	if pull.NextCursor != nil {
+		pull.NextCursor.Opaque = IncrementalCursor(source, family, next, checkpoint)
+	}
+	return pull, nil
+}
+
+// IncrementalCheckpointForCursor restores the starting comparison checkpoint
+// from a continuation cursor produced by IncrementalCursor.
+func IncrementalCheckpointForCursor(source string, family string, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {
+	envelope, ok := DecodeCursorEnvelope(cursor.GetOpaque())
+	if !ok || strings.TrimSpace(envelope.Source) != strings.TrimSpace(source) || strings.TrimSpace(envelope.Family) != strings.TrimSpace(family) {
+		return checkpoint
+	}
+	envelope.Token = ""
+	opaque, err := EncodeCursorEnvelope(envelope)
+	if err != nil {
+		opaque = cursor.GetOpaque()
+	}
+	readCheckpoint := &cerebrov1.SourceCheckpoint{CursorOpaque: opaque}
+	if watermark := CursorWatermark(envelope); !watermark.IsZero() {
+		readCheckpoint.Watermark = timestamppb.New(watermark.UTC())
+	}
+	return readCheckpoint
+}
+
+// IncrementalCursor wraps a provider token with the comparison watermark and
+// boundary IDs used for this incremental scan.
+func IncrementalCursor(source string, family string, token string, checkpoint *cerebrov1.SourceCheckpoint) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	state := IncrementalWatermarkCheckpointState(source, family, checkpoint)
+	envelope := CursorEnvelope{
+		Source:              source,
+		Family:              family,
+		Mode:                incrementalWatermarkMode,
+		ResumableCheckpoint: true,
+		Token:               token,
+	}
+	if !state.Watermark.IsZero() {
+		SetCursorWatermark(&envelope, state.Watermark)
+	}
+	for id := range state.BoundaryIDs {
+		envelope.BoundaryIDs = append(envelope.BoundaryIDs, id)
+	}
+	opaque, err := EncodeCursorEnvelope(envelope)
+	if err != nil {
+		return token
+	}
+	return opaque
+}
+
 func incrementalCursorMatches(envelope CursorEnvelope, source string, family string) bool {
 	if strings.TrimSpace(envelope.Source) != "" && strings.TrimSpace(envelope.Source) != strings.TrimSpace(source) {
 		return false

--- a/sources/aws/security_services.go
+++ b/sources/aws/security_services.go
@@ -28,22 +28,25 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2"
 	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/internal/awssecurity"
 )
 
 const (
-	familyAccessAnalyzer      = "access_analyzer"
-	familyConfigRecorder      = "config_recorder"
-	familyGuardDutyDetector   = "guardduty_detector"
-	familyGuardDutyFinding    = "guardduty_finding"
-	familyInspector2Finding   = "inspector2_finding"
-	familyMacie2Finding       = "macie2_finding"
-	familyNetworkFirewall     = "network_firewall"
-	familySecurityHubFinding  = "securityhub_finding"
-	familyWAFV2WebACL         = "wafv2_web_acl"
-	accessAnalyzerMissing     = accessanalyzertypes.AnalyzerStatus("MISSING")
-	configRecorderMissingName = "missing-"
+	familyAccessAnalyzer         = "access_analyzer"
+	familyConfigRecorder         = "config_recorder"
+	familyGuardDutyDetector      = "guardduty_detector"
+	familyGuardDutyFinding       = "guardduty_finding"
+	familyInspector2Finding      = "inspector2_finding"
+	familyMacie2Finding          = "macie2_finding"
+	familyNetworkFirewall        = "network_firewall"
+	familySecurityHubFinding     = "securityhub_finding"
+	familyWAFV2WebACL            = "wafv2_web_acl"
+	accessAnalyzerMissing        = accessanalyzertypes.AnalyzerStatus("MISSING")
+	configRecorderMissingName    = "missing-"
+	awsFindingCheckpointLookback = 2 * time.Minute
 )
 
 type awsSecurityClients struct {
@@ -185,10 +188,11 @@ func awsSecurityFamilies(clientFactory awsClientFactory) []sourcecdk.Family[sett
 			CursorFallback: func(detector awsGuardDutyDetector) string { return detector.DetectorID },
 		}),
 		awsFamily(clientFactory, awsFamilyOptions[awsGuardDutyFinding]{
-			Name:  familyGuardDutyFinding,
-			Label: "aws guardduty findings",
-			List:  listGuardDutyFindings,
-			Event: guardDutyFindingEvent,
+			Name:               familyGuardDutyFinding,
+			Label:              "aws guardduty findings",
+			List:               listGuardDutyFindings,
+			ListWithCheckpoint: listGuardDutyFindingsWithCheckpoint,
+			Event:              guardDutyFindingEvent,
 			URN: func(settings settings, finding awsGuardDutyFinding) (string, error) {
 				return fmt.Sprintf("urn:cerebro:%s:aws_guardduty_finding:%s", settings.accountID, firstNonEmpty(awssdk.ToString(finding.Finding.Arn), awssdk.ToString(finding.Finding.Id))), nil
 			},
@@ -197,10 +201,11 @@ func awsSecurityFamilies(clientFactory awsClientFactory) []sourcecdk.Family[sett
 			},
 		}),
 		awsFamily(clientFactory, awsFamilyOptions[securityhubtypes.AwsSecurityFinding]{
-			Name:  familySecurityHubFinding,
-			Label: "aws security hub findings",
-			List:  listSecurityHubFindings,
-			Event: securityHubFindingEvent,
+			Name:               familySecurityHubFinding,
+			Label:              "aws security hub findings",
+			List:               listSecurityHubFindings,
+			ListWithCheckpoint: listSecurityHubFindingsWithCheckpoint,
+			Event:              securityHubFindingEvent,
 			URN: func(settings settings, finding securityhubtypes.AwsSecurityFinding) (string, error) {
 				return fmt.Sprintf("urn:cerebro:%s:aws_securityhub_finding:%s", settings.accountID, awssdk.ToString(finding.Id)), nil
 			},
@@ -221,10 +226,11 @@ func awsSecurityFamilies(clientFactory awsClientFactory) []sourcecdk.Family[sett
 			CursorFallback: func(finding inspector2types.Finding) string { return awssdk.ToString(finding.FindingArn) },
 		}),
 		awsFamily(clientFactory, awsFamilyOptions[macie2types.Finding]{
-			Name:  familyMacie2Finding,
-			Label: "aws macie2 findings",
-			List:  listMacie2Findings,
-			Event: macie2FindingEvent,
+			Name:               familyMacie2Finding,
+			Label:              "aws macie2 findings",
+			List:               listMacie2Findings,
+			ListWithCheckpoint: listMacie2FindingsWithCheckpoint,
+			Event:              macie2FindingEvent,
 			URN: func(settings settings, finding macie2types.Finding) (string, error) {
 				return fmt.Sprintf("urn:cerebro:%s:aws_macie2_finding:%s", settings.accountID, awssdk.ToString(finding.Id)), nil
 			},
@@ -330,7 +336,11 @@ func listGuardDutyDetectors(ctx context.Context, clients awsClients, settings se
 	return records, awssdk.ToString(output.NextToken), nil
 }
 
-func listGuardDutyFindings(ctx context.Context, clients awsClients, _ settings, cursor string, limit int) ([]awsGuardDutyFinding, string, error) {
+func listGuardDutyFindings(ctx context.Context, clients awsClients, settings settings, cursor string, limit int) ([]awsGuardDutyFinding, string, error) {
+	return listGuardDutyFindingsWithCheckpoint(ctx, clients, settings, cursor, limit, nil)
+}
+
+func listGuardDutyFindingsWithCheckpoint(ctx context.Context, clients awsClients, _ settings, cursor string, limit int, checkpoint *cerebrov1.SourceCheckpoint) ([]awsGuardDutyFinding, string, error) {
 	detectors, err := listAllGuardDutyDetectors(ctx, clients)
 	if err != nil {
 		return nil, "", err
@@ -353,11 +363,8 @@ func listGuardDutyFindings(ctx context.Context, clients awsClients, _ settings, 
 	records := make([]awsGuardDutyFinding, 0, remaining)
 	for state.DetectorIndex < len(detectors) && len(records) < remaining {
 		detectorID := detectors[state.DetectorIndex]
-		output, err := clients.guardDuty.ListFindings(ctx, &guardduty.ListFindingsInput{
-			DetectorId: awssdk.String(detectorID),
-			MaxResults: awssdk.Int32(boundedAWSPageSizeInt32(remaining-len(records), 1, 50)),
-			NextToken:  stringPtr(state.FindingToken),
-		})
+		input := awssecurity.GuardDutyListFindingsInput(detectorID, boundedAWSPageSizeInt32(remaining-len(records), 1, 50), state.FindingToken, checkpoint, awsFindingCheckpointLookback)
+		output, err := clients.guardDuty.ListFindings(ctx, input)
 		if err != nil {
 			return nil, "", fmt.Errorf("list guardduty findings for detector %q: %w", detectorID, err)
 		}
@@ -381,13 +388,16 @@ func listGuardDutyFindings(ctx context.Context, clients awsClients, _ settings, 
 	return records, "", nil
 }
 
-func listSecurityHubFindings(ctx context.Context, clients awsClients, _ settings, cursor string, limit int) ([]securityhubtypes.AwsSecurityFinding, string, error) {
-	output, err := clients.securityHub.GetFindings(ctx, &securityhub.GetFindingsInput{
-		MaxResults: awssdk.Int32(boundedAWSPageSizeInt32(limit, 1, 100)),
-		NextToken:  stringPtr(cursor),
-	})
+func listSecurityHubFindings(ctx context.Context, clients awsClients, settings settings, cursor string, limit int) ([]securityhubtypes.AwsSecurityFinding, string, error) {
+	return listSecurityHubFindingsWithCheckpoint(ctx, clients, settings, cursor, limit, nil)
+}
+
+func listSecurityHubFindingsWithCheckpoint(ctx context.Context, clients awsClients, _ settings, cursor string, limit int, checkpoint *cerebrov1.SourceCheckpoint) ([]securityhubtypes.AwsSecurityFinding, string, error) {
+	input := awssecurity.SecurityHubGetFindingsInput(boundedAWSPageSizeInt32(limit, 1, 100), cursor, checkpoint, awsFindingCheckpointLookback)
+	output, err := clients.securityHub.GetFindings(ctx, input)
 	if cursor != "" && optionalAWSError(err, "InvalidInputException") && strings.Contains(fmt.Sprint(err), "NextToken") {
-		output, err = clients.securityHub.GetFindings(ctx, &securityhub.GetFindingsInput{MaxResults: awssdk.Int32(boundedAWSPageSizeInt32(limit, 1, 100))})
+		input.NextToken = nil
+		output, err = clients.securityHub.GetFindings(ctx, input)
 	}
 	if err != nil && optionalAWSError(err, "AccessDeniedException", "InvalidAccessException", "ResourceNotFoundException") {
 		return nil, "", nil
@@ -409,11 +419,13 @@ func listInspector2Findings(ctx context.Context, clients awsClients, _ settings,
 	return out.Findings, awssdk.ToString(out.NextToken), nil
 }
 
-func listMacie2Findings(ctx context.Context, clients awsClients, _ settings, cursor string, limit int) ([]macie2types.Finding, string, error) {
-	out, err := clients.macie2.ListFindings(ctx, &macie2.ListFindingsInput{
-		MaxResults: awssdk.Int32(boundedAWSPageSizeInt32(limit, 1, 50)),
-		NextToken:  stringPtr(cursor),
-	})
+func listMacie2Findings(ctx context.Context, clients awsClients, settings settings, cursor string, limit int) ([]macie2types.Finding, string, error) {
+	return listMacie2FindingsWithCheckpoint(ctx, clients, settings, cursor, limit, nil)
+}
+
+func listMacie2FindingsWithCheckpoint(ctx context.Context, clients awsClients, _ settings, cursor string, limit int, checkpoint *cerebrov1.SourceCheckpoint) ([]macie2types.Finding, string, error) {
+	input := awssecurity.MacieListFindingsInput(boundedAWSPageSizeInt32(limit, 1, 50), cursor, checkpoint, awsFindingCheckpointLookback)
+	out, err := clients.macie2.ListFindings(ctx, input)
 	if err != nil {
 		return nil, "", err
 	}

--- a/sources/aws/security_services_test.go
+++ b/sources/aws/security_services_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
@@ -22,7 +23,9 @@ import (
 	securityhubtypes "github.com/aws/aws-sdk-go-v2/service/securityhub/types"
 	"github.com/aws/aws-sdk-go-v2/service/wafv2"
 	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
@@ -240,6 +243,165 @@ func TestListSecurityHubFindingsRetriesExpiredCursor(t *testing.T) {
 	}
 }
 
+func TestReadAWSFindingFamiliesWithCheckpointUseUpdatedTimeRequests(t *testing.T) {
+	watermark := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	checkpoint := awsSecurityTestCheckpoint(watermark)
+
+	t.Run("securityhub", func(t *testing.T) {
+		fake := &fakeAWSSecurityServices{
+			securityHubFindings: []securityhubtypes.AwsSecurityFinding{
+				{Id: awssdk.String("new-finding"), UpdatedAt: awssdk.String(watermark.Add(time.Hour).Format(time.RFC3339))},
+				{Id: awssdk.String("old-finding"), UpdatedAt: awssdk.String(watermark.Add(-time.Hour).Format(time.RFC3339))},
+			},
+		}
+		source := newSecurityTestSource(t, fake)
+		pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familySecurityHubFinding}), nil, checkpoint)
+		if err != nil {
+			t.Fatalf("ReadWithCheckpoint(securityhub_finding) error = %v", err)
+		}
+		if len(pull.Events) != 1 || pull.Events[0].GetId() != "aws-securityhub-finding-new-finding" {
+			t.Fatalf("events = %#v, want only new Security Hub finding", pull.Events)
+		}
+		if pull.ShortCircuitReason != sourcecdk.PullShortCircuitReasonWatermarkReached {
+			t.Fatalf("ShortCircuitReason = %q, want watermark_reached", pull.ShortCircuitReason)
+		}
+		if len(fake.securityHubInputs) != 1 {
+			t.Fatalf("len(securityHubInputs) = %d, want 1", len(fake.securityHubInputs))
+		}
+		input := fake.securityHubInputs[0]
+		if len(input.SortCriteria) != 1 || awssdk.ToString(input.SortCriteria[0].Field) != "UpdatedAt" || input.SortCriteria[0].SortOrder != securityhubtypes.SortOrderDescending {
+			t.Fatalf("Security Hub sort = %#v, want UpdatedAt desc", input.SortCriteria)
+		}
+		if input.Filters == nil || len(input.Filters.UpdatedAt) != 1 {
+			t.Fatalf("Security Hub UpdatedAt filter = %#v, want one start filter", input.Filters)
+		}
+		assertAWSFindingFilterStart(t, awssdk.ToString(input.Filters.UpdatedAt[0].Start), watermark)
+	})
+
+	t.Run("guardduty", func(t *testing.T) {
+		fake := &fakeAWSSecurityServices{
+			guardDutyDetectorIDs: []string{"detector-1"},
+			guardDutyFindingIDs:  map[string][]string{"detector-1": {"new-finding", "old-finding"}},
+			guardDutyFindings: map[string]guarddutytypes.Finding{
+				"new-finding": {Arn: awssdk.String("arn:aws:guardduty:us-east-1:123456789012:detector/detector-1/finding/new-finding"), Id: awssdk.String("new-finding"), UpdatedAt: awssdk.String(watermark.Add(time.Hour).Format(time.RFC3339))},
+				"old-finding": {Arn: awssdk.String("arn:aws:guardduty:us-east-1:123456789012:detector/detector-1/finding/old-finding"), Id: awssdk.String("old-finding"), UpdatedAt: awssdk.String(watermark.Add(-time.Hour).Format(time.RFC3339))},
+			},
+		}
+		source := newSecurityTestSource(t, fake)
+		pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familyGuardDutyFinding}), nil, checkpoint)
+		if err != nil {
+			t.Fatalf("ReadWithCheckpoint(guardduty_finding) error = %v", err)
+		}
+		if len(pull.Events) != 1 || pull.Events[0].GetAttributes()["finding_id"] != "new-finding" {
+			t.Fatalf("events = %#v, want only new GuardDuty finding", pull.Events)
+		}
+		if len(fake.guardDutyListInputs) != 1 {
+			t.Fatalf("len(guardDutyListInputs) = %d, want 1", len(fake.guardDutyListInputs))
+		}
+		input := fake.guardDutyListInputs[0]
+		if input.SortCriteria == nil || awssdk.ToString(input.SortCriteria.AttributeName) != "updatedAt" || input.SortCriteria.OrderBy != guarddutytypes.OrderByDesc {
+			t.Fatalf("GuardDuty sort = %#v, want updatedAt DESC", input.SortCriteria)
+		}
+		condition := input.FindingCriteria.Criterion["updatedAt"]
+		if condition.GreaterThanOrEqual == nil || *condition.GreaterThanOrEqual != watermark.Add(-awsFindingCheckpointLookback).UnixMilli() {
+			t.Fatalf("GuardDuty updatedAt gte = %#v, want %d", condition.GreaterThanOrEqual, watermark.Add(-awsFindingCheckpointLookback).UnixMilli())
+		}
+	})
+
+	t.Run("macie", func(t *testing.T) {
+		newUpdatedAt := watermark.Add(time.Hour)
+		oldUpdatedAt := watermark.Add(-time.Hour)
+		fake := &fakeAWSSecurityServices{
+			macieFindingIDs: []string{"new-finding", "old-finding"},
+			macieFindings: []macie2types.Finding{
+				{Id: awssdk.String("new-finding"), UpdatedAt: &newUpdatedAt},
+				{Id: awssdk.String("old-finding"), UpdatedAt: &oldUpdatedAt},
+			},
+		}
+		source := newSecurityTestSource(t, fake)
+		pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familyMacie2Finding}), nil, checkpoint)
+		if err != nil {
+			t.Fatalf("ReadWithCheckpoint(macie2_finding) error = %v", err)
+		}
+		if len(pull.Events) != 1 || pull.Events[0].GetId() != "aws-macie2-finding-new-finding" {
+			t.Fatalf("events = %#v, want only new Macie finding", pull.Events)
+		}
+		if len(fake.macieListInputs) != 1 {
+			t.Fatalf("len(macieListInputs) = %d, want 1", len(fake.macieListInputs))
+		}
+		input := fake.macieListInputs[0]
+		if input.SortCriteria == nil || awssdk.ToString(input.SortCriteria.AttributeName) != "updatedAt" || input.SortCriteria.OrderBy != macie2types.OrderByDesc {
+			t.Fatalf("Macie sort = %#v, want updatedAt DESC", input.SortCriteria)
+		}
+		criterion := input.FindingCriteria.Criterion["updatedAt"]
+		if criterion.Gte == nil || *criterion.Gte != watermark.Add(-awsFindingCheckpointLookback).UnixMilli() {
+			t.Fatalf("Macie updatedAt gte = %#v, want %d", criterion.Gte, watermark.Add(-awsFindingCheckpointLookback).UnixMilli())
+		}
+	})
+}
+
+func TestReadAWSSecurityHubCheckpointCursorKeepsOriginalWatermark(t *testing.T) {
+	watermark := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	firstUpdatedAt := watermark.Add(2 * time.Hour)
+	secondUpdatedAt := watermark.Add(time.Hour)
+	fake := &fakeAWSSecurityServices{
+		securityHubFindings: []securityhubtypes.AwsSecurityFinding{{
+			Id:        awssdk.String("first-page"),
+			UpdatedAt: awssdk.String(firstUpdatedAt.Format(time.RFC3339)),
+		}},
+		securityHubNextToken: "token-2",
+	}
+	source := newSecurityTestSource(t, fake)
+	cfg := sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familySecurityHubFinding})
+
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, awsSecurityTestCheckpoint(watermark))
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
+	}
+	if len(first.Events) != 1 || first.NextCursor == nil || first.Checkpoint == nil {
+		t.Fatalf("first pull = %#v, want event, checkpoint, and next cursor", first)
+	}
+	if got := first.Checkpoint.GetWatermark().AsTime(); !got.Equal(firstUpdatedAt) {
+		t.Fatalf("first checkpoint watermark = %s, want %s", got, firstUpdatedAt)
+	}
+
+	fake.securityHubFindings = []securityhubtypes.AwsSecurityFinding{{
+		Id:        awssdk.String("second-page"),
+		UpdatedAt: awssdk.String(secondUpdatedAt.Format(time.RFC3339)),
+	}}
+	fake.securityHubNextToken = ""
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, first.NextCursor, first.Checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(second) error = %v", err)
+	}
+	if len(second.Events) != 1 || second.Events[0].GetId() != "aws-securityhub-finding-second-page" {
+		t.Fatalf("second events = %#v, want second-page despite advanced runtime checkpoint", second.Events)
+	}
+	if len(fake.securityHubInputs) != 2 {
+		t.Fatalf("len(securityHubInputs) = %d, want 2", len(fake.securityHubInputs))
+	}
+	if got := awssdk.ToString(fake.securityHubInputs[1].NextToken); got != "token-2" {
+		t.Fatalf("second NextToken = %q, want token-2", got)
+	}
+	assertAWSFindingFilterStart(t, awssdk.ToString(fake.securityHubInputs[1].Filters.UpdatedAt[0].Start), watermark)
+}
+
+func awsSecurityTestCheckpoint(watermark time.Time) *cerebrov1.SourceCheckpoint {
+	return &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(watermark.UTC())}
+}
+
+func assertAWSFindingFilterStart(t *testing.T, raw string, watermark time.Time) {
+	t.Helper()
+	got, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		t.Fatalf("parse filter start %q: %v", raw, err)
+	}
+	want := watermark.Add(-awsFindingCheckpointLookback)
+	if !got.Equal(want) {
+		t.Fatalf("filter start = %s, want %s", got, want)
+	}
+}
+
 func newSecurityTestSource(t *testing.T, fake *fakeAWSSecurityServices) *Source {
 	t.Helper()
 	spec, err := loadSpec()
@@ -274,13 +436,18 @@ type fakeAWSSecurityServices struct {
 	guardDutyDetectors           map[string]guardduty.GetDetectorOutput
 	guardDutyFindingIDs          map[string][]string
 	guardDutyFindings            map[string]guarddutytypes.Finding
+	guardDutyListInputs          []guardduty.ListFindingsInput
 	securityHubFindings          []securityhubtypes.AwsSecurityFinding
 	securityHubError             error
 	securityHubExpiredTokenError error
+	securityHubNextToken         string
+	securityHubInputs            []securityhub.GetFindingsInput
 	securityHubTokens            []string
 	inspector2Findings           []inspector2types.Finding
 	macieFindingIDs              []string
 	macieFindings                []macie2types.Finding
+	macieListInputs              []macie2.ListFindingsInput
+	macieNextToken               string
 	wafv2Summaries               []wafv2types.WebACLSummary
 	wafv2Details                 map[string]wafv2types.WebACL
 	lastWAFV2Scope               wafv2types.Scope
@@ -314,6 +481,7 @@ func (f fakeGuardDutySecurity) GetDetector(_ context.Context, input *guardduty.G
 }
 
 func (f fakeGuardDutySecurity) ListFindings(_ context.Context, input *guardduty.ListFindingsInput, _ ...func(*guardduty.Options)) (*guardduty.ListFindingsOutput, error) {
+	f.fake.guardDutyListInputs = append(f.fake.guardDutyListInputs, *input)
 	return &guardduty.ListFindingsOutput{FindingIds: f.fake.guardDutyFindingIDs[awssdk.ToString(input.DetectorId)]}, nil
 }
 
@@ -332,6 +500,7 @@ type fakeSecurityHubSecurity struct {
 }
 
 func (f fakeSecurityHubSecurity) GetFindings(_ context.Context, input *securityhub.GetFindingsInput, _ ...func(*securityhub.Options)) (*securityhub.GetFindingsOutput, error) {
+	f.fake.securityHubInputs = append(f.fake.securityHubInputs, *input)
 	token := awssdk.ToString(input.NextToken)
 	f.fake.securityHubTokens = append(f.fake.securityHubTokens, token)
 	if token != "" && f.fake.securityHubExpiredTokenError != nil {
@@ -340,7 +509,7 @@ func (f fakeSecurityHubSecurity) GetFindings(_ context.Context, input *securityh
 	if f.fake.securityHubError != nil {
 		return nil, f.fake.securityHubError
 	}
-	return &securityhub.GetFindingsOutput{Findings: f.fake.securityHubFindings}, nil
+	return &securityhub.GetFindingsOutput{Findings: f.fake.securityHubFindings, NextToken: stringPtr(f.fake.securityHubNextToken)}, nil
 }
 
 type fakeInspector2Security struct {
@@ -355,8 +524,9 @@ type fakeMacie2Security struct {
 	fake *fakeAWSSecurityServices
 }
 
-func (f fakeMacie2Security) ListFindings(context.Context, *macie2.ListFindingsInput, ...func(*macie2.Options)) (*macie2.ListFindingsOutput, error) {
-	return &macie2.ListFindingsOutput{FindingIds: f.fake.macieFindingIDs}, nil
+func (f fakeMacie2Security) ListFindings(_ context.Context, input *macie2.ListFindingsInput, _ ...func(*macie2.Options)) (*macie2.ListFindingsOutput, error) {
+	f.fake.macieListInputs = append(f.fake.macieListInputs, *input)
+	return &macie2.ListFindingsOutput{FindingIds: f.fake.macieFindingIDs, NextToken: stringPtr(f.fake.macieNextToken)}, nil
 }
 
 func (f fakeMacie2Security) GetFindings(context.Context, *macie2.GetFindingsInput, ...func(*macie2.Options)) (*macie2.GetFindingsOutput, error) {

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -812,13 +812,14 @@ type awsIdentityStoreAPI interface {
 }
 
 type awsFamilyOptions[T any] struct {
-	Name           string
-	Label          string
-	List           func(context.Context, awsClients, settings, string, int) ([]T, string, error)
-	Event          func(settings, T) (*primitives.Event, error)
-	URN            func(settings, T) (string, error)
-	Discover       func(context.Context, awsClients, settings) ([]sourcecdk.URN, error)
-	CursorFallback func(T) string
+	Name               string
+	Label              string
+	List               func(context.Context, awsClients, settings, string, int) ([]T, string, error)
+	ListWithCheckpoint func(context.Context, awsClients, settings, string, int, *cerebrov1.SourceCheckpoint) ([]T, string, error)
+	Event              func(settings, T) (*primitives.Event, error)
+	URN                func(settings, T) (string, error)
+	Discover           func(context.Context, awsClients, settings) ([]sourcecdk.URN, error)
+	CursorFallback     func(T) string
 }
 
 type iamPolicyAssignment struct {
@@ -1030,6 +1031,12 @@ func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecd
 // Read returns one page of normalized AWS events.
 func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	return s.families.Read(ctx, cfg, cursor)
+}
+
+// ReadWithCheckpoint lets AWS families with provider-supported update ordering
+// stop once they reach the durable runtime watermark.
+func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	return s.families.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
 }
 
 func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
@@ -2532,7 +2539,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 }
 
 func awsFamily[T any](clientFactory awsClientFactory, options awsFamilyOptions[T]) sourcecdk.Family[settings] {
-	return sourcecdk.Family[settings]{
+	family := sourcecdk.Family[settings]{
 		Name: options.Name,
 		Check: func(ctx context.Context, settings settings) error {
 			clients, err := clientFactory(ctx, settings)
@@ -2565,9 +2572,25 @@ func awsFamily[T any](clientFactory awsClientFactory, options awsFamilyOptions[T
 				return sourcecdk.Pull{}, fmt.Errorf("lookup %s for %s: %w", options.Label, settings.accountID, err)
 			}
 			build := func(record T) (*primitives.Event, error) { return options.Event(settings, record) }
-			return awsPullFromRecords(records, next, build, options.CursorFallback)
+			return sourcecdk.PullFromRecords(records, next, build, options.CursorFallback)
 		},
 	}
+	if options.ListWithCheckpoint != nil {
+		family.ReadWithCheckpoint = func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+			clients, err := clientFactory(ctx, settings)
+			if err != nil {
+				return sourcecdk.Pull{}, err
+			}
+			readCheckpoint := sourcecdk.IncrementalCheckpointForCursor("aws", options.Name, cursor, checkpoint)
+			records, next, err := options.ListWithCheckpoint(ctx, clients, settings, sourcecdk.CursorToken(cursor), settings.perPage, readCheckpoint)
+			if err != nil {
+				return sourcecdk.Pull{}, fmt.Errorf("lookup %s for %s: %w", options.Label, settings.accountID, err)
+			}
+			build := func(record T) (*primitives.Event, error) { return options.Event(settings, record) }
+			return sourcecdk.IncrementalPullFromRecords("aws", options.Name, records, next, readCheckpoint, build)
+		}
+	}
+	return family
 }
 
 func newAWSClients(ctx context.Context, settings settings) (awsClients, error) {
@@ -4384,38 +4407,6 @@ func sourceEvent(settings settings, id string, kind string, schemaRef string, pa
 		Payload:    payload,
 		Attributes: attributes,
 	}, nil
-}
-
-func awsPullFromRecords[T any](records []T, next string, build func(T) (*primitives.Event, error), cursorFallback func(T) string) (sourcecdk.Pull, error) {
-	if len(records) == 0 {
-		if next != "" {
-			return sourcecdk.Pull{NextCursor: &cerebrov1.SourceCursor{Opaque: next}}, nil
-		}
-		return sourcecdk.Pull{}, nil
-	}
-	events := make([]*primitives.Event, 0, len(records))
-	for _, record := range records {
-		event, err := build(record)
-		if err != nil {
-			return sourcecdk.Pull{}, err
-		}
-		events = append(events, event)
-	}
-	fallback := events[len(events)-1].GetId()
-	if cursorFallback != nil {
-		fallback = cursorFallback(records[len(records)-1])
-	}
-	pull := sourcecdk.Pull{
-		Events: events,
-		Checkpoint: &cerebrov1.SourceCheckpoint{
-			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: firstNonEmpty(next, fallback),
-		},
-	}
-	if next != "" {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
-	}
-	return pull, nil
 }
 
 func awsCheck[T any](ctx context.Context, clients awsClients, settings settings, list func(context.Context, awsClients, settings, string, int) ([]T, string, error), label string) error {

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -219,9 +219,9 @@ func TestParseSettingsRejectsUnsafeAssumeRoleConfig(t *testing.T) {
 }
 
 func TestAWSPullFromRecordsPreservesNextCursorWithoutEvents(t *testing.T) {
-	pull, err := awsPullFromRecords[string](nil, "next-page", nil, nil)
+	pull, err := sourcecdk.PullFromRecords[string](nil, "next-page", nil, nil)
 	if err != nil {
-		t.Fatalf("awsPullFromRecords() error = %v", err)
+		t.Fatalf("PullFromRecords() error = %v", err)
 	}
 	if len(pull.Events) != 0 {
 		t.Fatalf("len(Events) = %d, want 0", len(pull.Events))

--- a/sources/internal/awssecurity/findings.go
+++ b/sources/internal/awssecurity/findings.go
@@ -1,0 +1,80 @@
+package awssecurity
+
+import (
+	"strings"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	guarddutytypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
+	"github.com/aws/aws-sdk-go-v2/service/macie2"
+	macie2types "github.com/aws/aws-sdk-go-v2/service/macie2/types"
+	"github.com/aws/aws-sdk-go-v2/service/securityhub"
+	securityhubtypes "github.com/aws/aws-sdk-go-v2/service/securityhub/types"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func GuardDutyListFindingsInput(detectorID string, maxResults int32, token string, checkpoint *cerebrov1.SourceCheckpoint, lookback time.Duration) *guardduty.ListFindingsInput {
+	input := &guardduty.ListFindingsInput{
+		DetectorId:   awssdk.String(detectorID),
+		MaxResults:   awssdk.Int32(maxResults),
+		NextToken:    stringPtr(token),
+		SortCriteria: &guarddutytypes.SortCriteria{AttributeName: awssdk.String("updatedAt"), OrderBy: guarddutytypes.OrderByDesc},
+	}
+	if start, ok := checkpointStart(checkpoint, lookback); ok {
+		input.FindingCriteria = &guarddutytypes.FindingCriteria{Criterion: map[string]guarddutytypes.Condition{
+			"updatedAt": {GreaterThanOrEqual: awssdk.Int64(start.UnixMilli())},
+		}}
+	}
+	return input
+}
+
+func SecurityHubGetFindingsInput(maxResults int32, token string, checkpoint *cerebrov1.SourceCheckpoint, lookback time.Duration) *securityhub.GetFindingsInput {
+	input := &securityhub.GetFindingsInput{
+		MaxResults: awssdk.Int32(maxResults),
+		NextToken:  stringPtr(token),
+		SortCriteria: []securityhubtypes.SortCriterion{{
+			Field:     awssdk.String("UpdatedAt"),
+			SortOrder: securityhubtypes.SortOrderDescending,
+		}},
+	}
+	if start, ok := checkpointStart(checkpoint, lookback); ok {
+		input.Filters = &securityhubtypes.AwsSecurityFindingFilters{
+			UpdatedAt: []securityhubtypes.DateFilter{{Start: awssdk.String(start.Format(time.RFC3339Nano))}},
+		}
+	}
+	return input
+}
+
+func MacieListFindingsInput(maxResults int32, token string, checkpoint *cerebrov1.SourceCheckpoint, lookback time.Duration) *macie2.ListFindingsInput {
+	input := &macie2.ListFindingsInput{
+		MaxResults:   awssdk.Int32(maxResults),
+		NextToken:    stringPtr(token),
+		SortCriteria: &macie2types.SortCriteria{AttributeName: awssdk.String("updatedAt"), OrderBy: macie2types.OrderByDesc},
+	}
+	if start, ok := checkpointStart(checkpoint, lookback); ok {
+		input.FindingCriteria = &macie2types.FindingCriteria{Criterion: map[string]macie2types.CriterionAdditionalProperties{
+			"updatedAt": {Gte: awssdk.Int64(start.UnixMilli())},
+		}}
+	}
+	return input
+}
+
+func checkpointStart(checkpoint *cerebrov1.SourceCheckpoint, lookback time.Duration) (time.Time, bool) {
+	if checkpoint == nil || checkpoint.GetWatermark() == nil {
+		return time.Time{}, false
+	}
+	watermark := checkpoint.GetWatermark().AsTime().UTC()
+	if watermark.IsZero() {
+		return time.Time{}, false
+	}
+	return watermark.Add(-lookback), true
+}
+
+func stringPtr(value string) *string {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		return &trimmed
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add checkpoint-aware table-driven source family reads and shared Source CDK record/incremental pull helpers
- enable updated-time descending incremental fetch for AWS Security Hub, GuardDuty, and Macie findings
- preserve the original comparison watermark in continuation cursors so paginated resumes do not drop older new findings

## Scope notes
- keeps the lane tight to SEC-1065 AWS findings and avoids catalog changes that could collide with #1046
- leaves Inspector2, broader AWS inventory, GCP audit/SCC, and Cloud Asset Inventory feed/history work as follow-up lanes

## Tests
- go test ./internal/sourcecdk ./sources/internal/awssecurity ./sources/aws ./tools/archtests
- go test ./...
