### PR TITLE
feat: represent security reviewer findings

### DIFF
--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -170,7 +170,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 66 rules across cloud, identity, GitHub, GRC, runtime, endpoint, and vulnerability domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 67 rules across cloud, identity, GitHub, GRC, runtime, endpoint, and vulnerability domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -2857,6 +2857,55 @@
       ]
     },
     {
+      "id": "security-reviewer-reported-finding",
+      "pack_id": "security_reviewer",
+      "pack_name": "Security Reviewer",
+      "name": "Security Reviewer Reported Finding",
+      "description": "Represent validated security-reviewer output as deterministic finding records for candidate review and promotion.",
+      "source_id": "security_reviewer",
+      "evaluation_mode": "event",
+      "event_kinds": [
+        "droid.review_finding",
+        "security_reviewer.finding",
+        "security_reviewer.review_finding"
+      ],
+      "output_kind": "finding.security_reviewer_reported",
+      "severity": "dynamic",
+      "status": "open",
+      "maturity": "candidate",
+      "tags": [
+        "code-review",
+        "finding-candidate",
+        "security-reviewer",
+        "software-supply-chain"
+      ],
+      "references": [
+        "https://owasp.org/www-project-code-review-guide/"
+      ],
+      "false_positives": [
+        "Reviewer output that is advisory-only, already mitigated by changed code, or not exploitable after manual validation."
+      ],
+      "runbook": "Validate the reviewer evidence against the changed code, confirm exploitability and remediation owner, then promote or reject the candidate finding.",
+      "fingerprint_fields": [
+        "tenant_id",
+        "review_subject",
+        "reviewer_rule",
+        "file",
+        "line",
+        "message"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC7.1"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.8.8"
+        }
+      ]
+    },
+    {
       "id": "sentinelone-agent-detect-only-mode",
       "pack_id": "sentinelone",
       "pack_name": "SentinelOne",

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -88,8 +88,8 @@ func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
 
 func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	packs := builtinRulePacks()
-	if got := len(packs); got != 9 {
-		t.Fatalf("len(builtinRulePacks()) = %d, want 9", got)
+	if got := len(packs); got != 10 {
+		t.Fatalf("len(builtinRulePacks()) = %d, want 10", got)
 	}
 	rules := flattenRulePacks(packs)
 	if got := len(rules); got < 10 {

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -60,6 +60,12 @@ func builtinRulePacks() []RulePack {
 			Rules:       []Rule{newRuntimeActiveThreatEvidenceRule()},
 		},
 		{
+			ID:          "security_reviewer",
+			Name:        "Security Reviewer",
+			Description: "Security-reviewer reported code and workflow findings.",
+			Rules:       []Rule{newSecurityReviewerFindingRule()},
+		},
+		{
 			ID:          "grc",
 			Name:        "GRC",
 			Description: "Provider-neutral GRC control, vulnerability, and vendor-risk findings.",

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -920,7 +920,7 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 39; got != want {
+	if got, want := len(keepRules), 40; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1135,6 +1135,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "graph-orphan-nonfinding-node", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "graph"},
 		{RuleID: "graph-resource-multiple-open-findings", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "graph"},
 		{RuleID: "runtime-active-threat-evidence", Classification: "TTL_EVIDENCE_ONLY", BulkCloseoutThreshold: ">24h", Source: "runtime"},
+		{RuleID: "security-reviewer-reported-finding", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "security_reviewer"},
 		{RuleID: "sentinelone-agent-detect-only-mode", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "sentinelone"},
 		{RuleID: "sentinelone-agent-not-up-to-date", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "sentinelone"},
 		{RuleID: "sentinelone-agent-stale", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "sentinelone"},

--- a/internal/findings/runtime_kind.go
+++ b/internal/findings/runtime_kind.go
@@ -55,6 +55,8 @@ func defaultRuntimeFamily(sourceID string) string {
 		return "audit"
 	case "sentinelone":
 		return "threat"
+	case "security_reviewer":
+		return "finding"
 	default:
 		return ""
 	}

--- a/internal/findings/security_reviewer_finding_rule.go
+++ b/internal/findings/security_reviewer_finding_rule.go
@@ -1,0 +1,231 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	securityReviewerFindingRuleID  = "security-reviewer-reported-finding"
+	securityReviewerFindingTitle   = "Security Reviewer Reported Finding"
+	securityReviewerFindingSource  = "security_reviewer"
+	securityReviewerFindingCheckID = "security-reviewer-finding"
+)
+
+var securityReviewerFindingControlRefs = []ports.FindingControlRef{
+	{FrameworkName: "SOC 2", ControlID: "CC7.1"},
+	{FrameworkName: "ISO 27001:2022", ControlID: "A.8.8"},
+}
+
+var securityReviewerFindingDefinition = RuleDefinition{
+	ID:             securityReviewerFindingRuleID,
+	Name:           securityReviewerFindingTitle,
+	Description:    "Represent validated security-reviewer output as deterministic finding records for candidate review and promotion.",
+	SourceID:       securityReviewerFindingSource,
+	EventKinds:     []string{"security_reviewer.finding", "security_reviewer.review_finding", "droid.review_finding"},
+	OutputKind:     "finding.security_reviewer_reported",
+	Severity:       "dynamic",
+	Status:         findingStatusOpen,
+	Maturity:       RuleMaturityCandidate,
+	Tags:           []string{"code-review", "security-reviewer", "finding-candidate", "software-supply-chain"},
+	References:     []string{"https://owasp.org/www-project-code-review-guide/"},
+	FalsePositives: []string{"Reviewer output that is advisory-only, already mitigated by changed code, or not exploitable after manual validation."},
+	Runbook:        "Validate the reviewer evidence against the changed code, confirm exploitability and remediation owner, then promote or reject the candidate finding.",
+	FingerprintFields: []string{
+		"tenant_id",
+		"review_subject",
+		"reviewer_rule",
+		"file",
+		"line",
+		"message",
+	},
+	ControlRefs: securityReviewerFindingControlRefs,
+	Lifecycle:   Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorSourceState},
+}
+
+var securityReviewerFindingKindMatcher = eventKindMatcher(securityReviewerFindingDefinition.EventKinds...)
+
+func newSecurityReviewerFindingRule() Rule {
+	return newEventRule(eventRuleConfig{
+		definition: securityReviewerFindingDefinition,
+		sourceID:   securityReviewerFindingSource,
+		match:      matchesSecurityReviewerFinding,
+		build: func(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+			return securityReviewerFinding(ctx, runtime, event)
+		},
+	})
+}
+
+func matchesSecurityReviewerFinding(event *cerebrov1.EventEnvelope) bool {
+	if !securityReviewerFindingKindMatcher(event) {
+		return false
+	}
+	attrs := eventAttributes(event)
+	if securityReviewerMessage(attrs) == "" {
+		return false
+	}
+	return securityReviewerStableAnchor(attrs) != ""
+}
+
+func securityReviewerFinding(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+	attrs := eventAttributes(event)
+	projectedContext, err := buildFindingProjectionContext(ctx, event, findingProjectionContextOptions{
+		CollectAllLinkURNs: true,
+		ResourceFallbacks: []string{
+			attrs["resource_urn"],
+			attrs["review_subject"],
+			attrs["repository"],
+			attrs["file"],
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("project security reviewer finding context for event %q: %w", event.GetId(), err)
+	}
+	reviewerRule := securityReviewerRule(attrs)
+	message := securityReviewerMessage(attrs)
+	reviewSubject := securityReviewerReviewSubject(attrs)
+	file := strings.TrimSpace(attrs["file"])
+	line := strings.TrimSpace(attrs["line"])
+	severity := securityReviewerSeverity(attrs)
+	observedAt := time.Time{}
+	if event.GetOccurredAt() != nil {
+		observedAt = event.GetOccurredAt().AsTime().UTC()
+	}
+	findingAttributes := map[string]string{
+		"base_sha":             strings.TrimSpace(attrs["base_sha"]),
+		"branch":               strings.TrimSpace(attrs["branch"]),
+		"column":               strings.TrimSpace(attrs["column"]),
+		"comment_url":          firstNonEmpty(attrs["comment_url"], attrs["url"], attrs["html_url"]),
+		"event_id":             strings.TrimSpace(event.GetId()),
+		"event_kind":           strings.TrimSpace(event.GetKind()),
+		"file":                 file,
+		"head_sha":             strings.TrimSpace(attrs["head_sha"]),
+		"line":                 line,
+		"message":              message,
+		"primary_resource_urn": projectedContext.PrimaryResourceURN,
+		"pull_request":         firstNonEmpty(attrs["pull_request"], attrs["pull_request_number"], attrs["pr_number"]),
+		"repository":           strings.TrimSpace(attrs["repository"]),
+		"review_subject":       reviewSubject,
+		"reviewer":             firstNonEmpty(attrs["reviewer"], attrs["reviewer_id"], attrs["actor"]),
+		"reviewer_rule":        reviewerRule,
+		"reviewer_source":      firstNonEmpty(attrs["reviewer_source"], attrs["source"], attrs["tool"], "security-reviewer"),
+		"security_reviewed_at": firstNonEmpty(attrs["reviewed_at"], attrs["detected_at"], attrs["observed_at"]),
+		"severity":             severity,
+		"source_runtime_id":    strings.TrimSpace(runtime.GetId()),
+		"tenant_id":            strings.TrimSpace(event.GetTenantId()),
+	}
+	for key, value := range securityReviewerFindingDefinition.AttributeMap() {
+		findingAttributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(findingAttributes)
+	graphRows := []*cerebrov1.GraphEvidenceRow{
+		newGraphEvidenceRow("Security reviewer finding", map[string]string{
+			"event_id":        strings.TrimSpace(event.GetId()),
+			"file":            file,
+			"line":            line,
+			"message":         message,
+			"review_subject":  reviewSubject,
+			"reviewer_rule":   reviewerRule,
+			"reviewer_source": findingAttributes["reviewer_source"],
+			"severity":        severity,
+		}),
+	}
+	fingerprint := hashFindingFingerprint(
+		securityReviewerFindingRuleID,
+		event.GetTenantId(),
+		reviewSubject,
+		reviewerRule,
+		file,
+		line,
+		message,
+	)
+	observedPolicyIDs := []string{}
+	if reviewerRule != "" {
+		observedPolicyIDs = append(observedPolicyIDs, reviewerRule)
+	}
+	return &ports.FindingRecord{
+		ID:                fingerprint,
+		Fingerprint:       fingerprint,
+		TenantID:          strings.TrimSpace(event.GetTenantId()),
+		RuntimeID:         strings.TrimSpace(runtime.GetId()),
+		RuleID:            securityReviewerFindingRuleID,
+		Title:             securityReviewerFindingTitle,
+		Severity:          severity,
+		Status:            findingStatusOpen,
+		Summary:           securityReviewerSummary(reviewerRule, file, line, message),
+		ResourceURNs:      projectedContext.ResourceURNs,
+		EventIDs:          []string{strings.TrimSpace(event.GetId())},
+		ObservedPolicyIDs: observedPolicyIDs,
+		PolicyID:          reviewerRule,
+		PolicyName:        reviewerRule,
+		CheckID:           firstNonEmpty(reviewerRule, securityReviewerFindingCheckID),
+		CheckName:         firstNonEmpty(reviewerRule, securityReviewerFindingTitle),
+		ControlRefs:       cloneFindingControlRefs(securityReviewerFindingDefinition.ControlRefs),
+		GraphEvidenceRows: graphRows,
+		Attributes:        findingAttributes,
+		FirstObservedAt:   observedAt,
+		LastObservedAt:    observedAt,
+	}, nil
+}
+
+func securityReviewerStableAnchor(attrs map[string]string) string {
+	return firstNonEmpty(
+		securityReviewerReviewSubject(attrs),
+		strings.TrimSpace(attrs["resource_urn"]),
+		strings.TrimSpace(attrs["file"]),
+		strings.TrimSpace(attrs["repository"]),
+	)
+}
+
+func securityReviewerReviewSubject(attrs map[string]string) string {
+	return firstNonEmpty(
+		attrs["review_subject"],
+		attrs["pull_request_url"],
+		attrs["pull_request"],
+		attrs["head_sha"],
+		attrs["branch"],
+		attrs["repository"],
+	)
+}
+
+func securityReviewerRule(attrs map[string]string) string {
+	return firstNonEmpty(attrs["rule"], attrs["rule_id"], attrs["check_id"], attrs["scanner_rule_id"], attrs["category"])
+}
+
+func securityReviewerMessage(attrs map[string]string) string {
+	return firstNonEmpty(attrs["message"], attrs["summary"], attrs["title"], attrs["description"])
+}
+
+func securityReviewerSeverity(attrs map[string]string) string {
+	switch strings.ToLower(firstNonEmpty(attrs["severity"], attrs["priority"], attrs["level"])) {
+	case "critical", "p0", "blocker":
+		return "CRITICAL"
+	case "high", "p1", "error":
+		return "HIGH"
+	case "medium", "moderate", "p2", "warning":
+		return "MEDIUM"
+	case "low", "p3":
+		return "LOW"
+	case "info", "informational", "notice", "p4":
+		return "INFO"
+	default:
+		return "MEDIUM"
+	}
+}
+
+func securityReviewerSummary(rule string, file string, line string, message string) string {
+	location := strings.TrimSpace(file)
+	if location != "" && strings.TrimSpace(line) != "" {
+		location += ":" + strings.TrimSpace(line)
+	}
+	if location == "" {
+		location = "reviewed code"
+	}
+	label := firstNonEmpty(rule, "security reviewer")
+	return fmt.Sprintf("%s reported %s in %s", label, message, location)
+}

--- a/internal/findings/security_reviewer_finding_rule_test.go
+++ b/internal/findings/security_reviewer_finding_rule_test.go
@@ -1,0 +1,237 @@
+package findings
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestSecurityReviewerFindingRuleMapsReviewerFindingDeterministically(t *testing.T) {
+	rule := newSecurityReviewerFindingRule()
+	runtime := securityReviewerRuntime()
+	event := securityReviewerEvent("reviewer-finding-1", map[string]string{
+		"base_sha":         "base-1",
+		"branch":           "codex/sec-1058-security-reviewer-findings-20260616",
+		"file":             "internal/bootstrap/app.go",
+		"head_sha":         "head-1",
+		"line":             "42",
+		"message":          "handler accepts reviewer-controlled redirect target",
+		"pull_request":     "1058",
+		"repository":       "writer/cerebro",
+		"review_subject":   "https://github.com/writer/cerebro/pull/1058",
+		"reviewer":         "security-reviewer",
+		"reviewer_source":  "droid-review",
+		"rule":             "open-redirect",
+		"severity":         "high",
+		"pull_request_url": "https://github.com/writer/cerebro/pull/1058",
+	})
+
+	records, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if got := len(records); got != 1 {
+		t.Fatalf("Evaluate() returned %d records, want 1", got)
+	}
+	finding := records[0]
+	wantFingerprint := hashFindingFingerprint(
+		securityReviewerFindingRuleID,
+		event.GetTenantId(),
+		"https://github.com/writer/cerebro/pull/1058",
+		"open-redirect",
+		"internal/bootstrap/app.go",
+		"42",
+		"handler accepts reviewer-controlled redirect target",
+	)
+	if finding.ID != wantFingerprint || finding.Fingerprint != wantFingerprint {
+		t.Fatalf("finding ID/fingerprint = %q/%q, want %q", finding.ID, finding.Fingerprint, wantFingerprint)
+	}
+	if finding.RuleID != securityReviewerFindingRuleID {
+		t.Fatalf("RuleID = %q, want %q", finding.RuleID, securityReviewerFindingRuleID)
+	}
+	if finding.Severity != "HIGH" {
+		t.Fatalf("Severity = %q, want HIGH", finding.Severity)
+	}
+	if finding.Status != findingStatusOpen {
+		t.Fatalf("Status = %q, want %q", finding.Status, findingStatusOpen)
+	}
+	if finding.PolicyID != "open-redirect" || finding.CheckID != "open-redirect" {
+		t.Fatalf("PolicyID/CheckID = %q/%q, want reviewer rule", finding.PolicyID, finding.CheckID)
+	}
+	if got := strings.Join(finding.EventIDs, ","); got != "reviewer-finding-1" {
+		t.Fatalf("EventIDs = %q, want reviewer-finding-1", got)
+	}
+	if got := finding.Attributes["reviewer"]; got != "security-reviewer" {
+		t.Fatalf("Attributes[reviewer] = %q, want security-reviewer", got)
+	}
+	if got := finding.Attributes["review_subject"]; got != "https://github.com/writer/cerebro/pull/1058" {
+		t.Fatalf("Attributes[review_subject] = %q", got)
+	}
+	if got := finding.Attributes["source_runtime_id"]; got != runtime.GetId() {
+		t.Fatalf("Attributes[source_runtime_id] = %q, want %q", got, runtime.GetId())
+	}
+	if got := len(finding.GraphEvidenceRows); got != 1 {
+		t.Fatalf("GraphEvidenceRows = %d, want 1", got)
+	}
+	if got := finding.GraphEvidenceRows[0].GetAttributes()["reviewer_rule"]; got != "open-redirect" {
+		t.Fatalf("GraphEvidenceRows[0].Attributes[reviewer_rule] = %q, want open-redirect", got)
+	}
+}
+
+func TestSecurityReviewerFindingRuleFingerprintIgnoresEventIDAndObservedAt(t *testing.T) {
+	rule := newSecurityReviewerFindingRule()
+	runtime := securityReviewerRuntime()
+	attrs := map[string]string{
+		"file":           "internal/findings/candidates.go",
+		"line":           "101",
+		"message":        "candidate transition is not compare-and-swap protected",
+		"repository":     "writer/cerebro",
+		"review_subject": "https://github.com/writer/cerebro/pull/1058",
+		"rule":           "candidate-lifecycle-atomicity",
+		"severity":       "P1",
+	}
+	first := securityReviewerEvent("reviewer-finding-a", attrs)
+	second := securityReviewerEvent("reviewer-finding-b", attrs)
+	second.OccurredAt = timestamppb.New(first.GetOccurredAt().AsTime().Add(2 * time.Hour))
+
+	firstRecords, err := rule.Evaluate(context.Background(), runtime, first)
+	if err != nil {
+		t.Fatalf("Evaluate(first) error = %v", err)
+	}
+	secondRecords, err := rule.Evaluate(context.Background(), runtime, second)
+	if err != nil {
+		t.Fatalf("Evaluate(second) error = %v", err)
+	}
+	if firstRecords[0].Fingerprint != secondRecords[0].Fingerprint {
+		t.Fatalf("fingerprint changed across equivalent reviewer findings: %q vs %q", firstRecords[0].Fingerprint, secondRecords[0].Fingerprint)
+	}
+	if firstRecords[0].EventIDs[0] == secondRecords[0].EventIDs[0] {
+		t.Fatalf("event IDs unexpectedly equal: %v", firstRecords[0].EventIDs)
+	}
+}
+
+func TestSecurityReviewerFindingRuleRequiresMessageAndStableAnchor(t *testing.T) {
+	rule := newSecurityReviewerFindingRule()
+	runtime := securityReviewerRuntime()
+	for _, tc := range []struct {
+		name  string
+		attrs map[string]string
+	}{
+		{
+			name: "missing message",
+			attrs: map[string]string{
+				"file":           "internal/findings/candidates.go",
+				"review_subject": "https://github.com/writer/cerebro/pull/1058",
+				"rule":           "candidate-lifecycle-atomicity",
+			},
+		},
+		{
+			name: "missing anchor",
+			attrs: map[string]string{
+				"message": "reviewer finding without stable subject",
+				"rule":    "missing-anchor",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			records, err := rule.Evaluate(context.Background(), runtime, securityReviewerEvent("reviewer-no-match", tc.attrs))
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			if len(records) != 0 {
+				t.Fatalf("Evaluate() returned %d records, want no match", len(records))
+			}
+		})
+	}
+}
+
+func TestSecurityReviewerFindingRuleEntersCandidateEvaluationPipeline(t *testing.T) {
+	rule := newSecurityReviewerFindingRule()
+	registry, err := NewRegistry(rule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	runtime := securityReviewerRuntime()
+	store := &stubFindingStore{}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{runtime.GetId(): runtime}},
+		&stubReplayer{events: []*cerebrov1.EventEnvelope{
+			securityReviewerEvent("reviewer-finding-1", map[string]string{
+				"file":           "internal/bootstrap/app.go",
+				"line":           "42",
+				"message":        "handler accepts reviewer-controlled redirect target",
+				"repository":     "writer/cerebro",
+				"review_subject": "https://github.com/writer/cerebro/pull/1058",
+				"reviewer":       "security-reviewer",
+				"rule":           "open-redirect",
+				"severity":       "high",
+			}),
+		}},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	).WithFindingCandidateStore(store)
+
+	result, err := service.EvaluateSourceRuntimeCandidateRules(context.Background(), EvaluateCandidateRulesRequest{
+		RuntimeID: runtime.GetId(),
+		RuleIDs:   []string{securityReviewerFindingRuleID},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeCandidateRules() error = %v", err)
+	}
+	if got := store.candidateState.upsertCount; got != 1 {
+		t.Fatalf("candidate upserts = %d, want 1", got)
+	}
+	if got := len(result.Evaluations); got != 1 {
+		t.Fatalf("evaluations = %d, want 1", got)
+	}
+	candidates := result.Evaluations[0].Candidates
+	if got := len(candidates); got != 1 {
+		t.Fatalf("candidates = %d, want 1", got)
+	}
+	candidate := candidates[0]
+	if candidate.Status != findingCandidateStatusCandidate {
+		t.Fatalf("candidate status = %q, want %q", candidate.Status, findingCandidateStatusCandidate)
+	}
+	if candidate.Finding == nil || candidate.Finding.RuleID != securityReviewerFindingRuleID {
+		t.Fatalf("candidate finding = %#v, want security reviewer rule", candidate.Finding)
+	}
+	if got := len(candidate.Evidence); got != 1 {
+		t.Fatalf("candidate evidence = %d, want 1", got)
+	}
+	if got := len(candidate.Evidence[0].GetGraphRows()); got != 1 {
+		t.Fatalf("candidate evidence graph rows = %d, want reviewer graph evidence", got)
+	}
+}
+
+func securityReviewerRuntime() *cerebrov1.SourceRuntime {
+	return &cerebrov1.SourceRuntime{
+		Id:       "security-reviewer-runtime",
+		SourceId: securityReviewerFindingSource,
+		TenantId: "writer",
+	}
+}
+
+func securityReviewerEvent(id string, attrs map[string]string) *cerebrov1.EventEnvelope {
+	copied := make(map[string]string, len(attrs))
+	for key, value := range attrs {
+		copied[key] = value
+	}
+	occurredAt := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   securityReviewerFindingSource,
+		Kind:       "security_reviewer.finding",
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  "security-reviewer/finding/v1",
+		Attributes: copied,
+	}
+}


### PR DESCRIPTION
## Summary
- add a Security Reviewer finding rule pack and event rule for reviewer-reported findings
- map reviewer output deterministically into candidate-ready finding records with evidence and metadata
- publish the rule in the generated detection catalog and update rulepack tests

## Tests
- go test ./internal/findings -count=1
- go test ./internal/...
- go test ./cmd/cerebro -count=1
- make detection-catalog-check
- go test ./...
