### PR TITLE
Add AWS/GCP findings incremental fetch and multicloud correlation

### DIFF
--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -273,8 +273,8 @@ func cloudFindingAffectedResourceType(provider string, rawType string, resourceI
 		return "s3_bucket"
 	case "aws:awsec2instance", "aws:ec2instance", "aws:instance":
 		return "ec2_instance"
-	case "aws:awsiamrole", "aws:iamrole":
-		return "iam_role"
+	case "aws:awsiamrole", "aws:iamrole", "aws:iam_role":
+		return "role"
 	case "aws:awslambdafunction", "aws:lambdafunction":
 		return "lambda_function"
 	case "aws:awsrdsdbinstance", "aws:rdsdbinstance":

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -145,7 +145,181 @@ func cloudResourceMetadataProjections(event *cerebrov1.EventEnvelope, profile id
 	addCloudResourceClassificationLinks(entities, links, tenantID, event, resourceURN, attributes, options)
 	addCloudResourcePublicReachability(entities, links, tenantID, event, resourceURN, provider, attributes)
 	addCloudResourceRuntimeIdentityLinks(entities, links, tenantID, event, resourceURN, provider, attributes)
+	addCloudFindingCorrelation(entities, links, tenantID, event, resourceURN, provider, attributes)
 	return identityProjectionResult(entities, links)
+}
+
+func addCloudFindingCorrelation(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, resourceURN string, provider string, attributes map[string]string) {
+	family := cloudFindingFamily(event, provider, attributes)
+	if family == "" {
+		return
+	}
+	findingID := cloudFindingID(event, attributes)
+	findingURN := projectionURN(tenantID, "security_finding", provider, findingID)
+	if findingURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        findingURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "security.finding",
+		Label:      firstNonEmpty(attributes["title"], attributes["resource_name"], attributes["display_name"], attributes["category"], findingID),
+		Attributes: cloudFindingAttributes(event, provider, family, findingID, attributes),
+	})
+	if resourceURN != "" && resourceURN != findingURN {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, findingURN, relationRepresents, cloudFindingLinkAttributes(event, provider, family, "cloud_provider_finding")))
+	}
+
+	affectedID := firstNonEmpty(attributes["affected_resource_id"], attributes["assessed_resource_id"])
+	if affectedID == "" {
+		return
+	}
+	affectedType := cloudFindingAffectedResourceType(provider, firstNonEmpty(attributes["affected_resource_type"], attributes["assessed_resource_type"]), affectedID)
+	affectedURN := projectionURN(tenantID, provider+"_"+affectedType, affectedID)
+	if affectedURN == "" || affectedURN == resourceURN {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        affectedURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: provider + "." + strings.ReplaceAll(affectedType, "_", "."),
+		Label:      firstNonEmpty(attributes["affected_resource_name"], attributes["assessed_resource_name"], cloudLastPathSegment(affectedID), affectedID),
+		Attributes: compactAttributes(map[string]string{
+			"resource_id":       affectedID,
+			"resource_provider": provider,
+			"resource_type":     affectedType,
+		}),
+	})
+	linkAttrs := cloudFindingLinkAttributes(event, provider, family, "cloud_finding_affected_resource")
+	addProjectedAttribute(linkAttrs, "finding_id", findingID)
+	addProjectedAttribute(linkAttrs, "resource_id", affectedID)
+	addProjectedAttribute(linkAttrs, "resource_type", affectedType)
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), affectedURN, findingURN, relationHasEvidence, linkAttrs))
+	reverseAttrs := cloneStringMap(linkAttrs)
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, affectedURN, relationObservedOn, reverseAttrs))
+}
+
+func cloudFindingFamily(event *cerebrov1.EventEnvelope, provider string, attributes map[string]string) string {
+	family := normalizeCloudType(firstNonEmpty(attributes["resource_type"], attributes["family"]))
+	if family == "" {
+		if kind := strings.TrimSpace(event.GetKind()); strings.HasPrefix(kind, provider+".") {
+			family = normalizeCloudType(strings.TrimPrefix(kind, provider+"."))
+		}
+	}
+	switch provider + ":" + family {
+	case "aws:guardduty_finding", "aws:securityhub_finding", "aws:inspector2_finding", "aws:macie2_finding",
+		"gcp:security_center_finding",
+		"azure:server_vulnerability":
+		return family
+	default:
+		return ""
+	}
+}
+
+func cloudFindingID(event *cerebrov1.EventEnvelope, attributes map[string]string) string {
+	return firstNonEmpty(
+		attributes["finding_arn"],
+		attributes["finding_name"],
+		attributes["finding_id"],
+		attributes["canonical_name"],
+		attributes["resource_id"],
+		attributes["name"],
+		event.GetId(),
+	)
+}
+
+func cloudFindingAttributes(event *cerebrov1.EventEnvelope, provider string, family string, findingID string, attributes map[string]string) map[string]string {
+	return compactAttributes(map[string]string{
+		"affected_resource_id":   firstNonEmpty(attributes["affected_resource_id"], attributes["assessed_resource_id"]),
+		"affected_resource_type": firstNonEmpty(attributes["affected_resource_type"], attributes["assessed_resource_type"]),
+		"category":               attributes["category"],
+		"event_id":               event.GetId(),
+		"finding_id":             findingID,
+		"finding_type":           firstNonEmpty(attributes["finding_type"], family),
+		"provider":               provider,
+		"record_state":           attributes["record_state"],
+		"resource_id":            attributes["resource_id"],
+		"resource_provider":      provider,
+		"severity":               firstNonEmpty(attributes["severity"], attributes["severity_label"], attributes["severity_normalized"]),
+		"source_provider":        firstNonEmpty(attributes["source_provider"], attributes["product_name"]),
+		"status":                 firstNonEmpty(attributes["status"], attributes["state"], attributes["workflow_status"], attributes["status_code"]),
+	})
+}
+
+func cloudFindingLinkAttributes(event *cerebrov1.EventEnvelope, provider string, family string, matchType string) map[string]string {
+	return compactAttributes(map[string]string{
+		"at":         eventObservedAt(event),
+		"event_id":   event.GetId(),
+		"family":     family,
+		"match_type": matchType,
+		"provider":   provider,
+	})
+}
+
+func cloudFindingAffectedResourceType(provider string, rawType string, resourceID string) string {
+	if provider == "azure" && rawType == "" {
+		rawType = azureResourceTypeFromID(resourceID)
+	}
+	cleanType := strings.ReplaceAll(strings.TrimSpace(rawType), "::", "_")
+	if strings.HasPrefix(strings.ToLower(cleanType), "aws_") {
+		cleanType = cleanType[len("aws_"):]
+	}
+	normalized := normalizeCloudType(cleanType)
+	switch provider + ":" + normalized {
+	case "aws:awss3bucket", "aws:s3bucket":
+		return "s3_bucket"
+	case "aws:awsec2instance", "aws:ec2instance":
+		return "ec2_instance"
+	case "aws:awsiamrole", "aws:iamrole":
+		return "iam_role"
+	case "aws:awslambdafunction", "aws:lambdafunction":
+		return "lambda_function"
+	case "aws:awsrdsdbinstance", "aws:rdsdbinstance":
+		return "rds_instance"
+	}
+	return firstNonEmpty(normalized, "resource")
+}
+
+func azureResourceTypeFromID(resourceID string) string {
+	lower := strings.ToLower(strings.TrimSpace(resourceID))
+	providerIndex := strings.LastIndex(lower, "/providers/")
+	if providerIndex < 0 {
+		return ""
+	}
+	providerPath := strings.Trim(strings.TrimSpace(resourceID[providerIndex+len("/providers/"):]), "/")
+	segments := strings.Split(providerPath, "/")
+	if len(segments) < 2 {
+		return providerPath
+	}
+	rawType := segments[0] + "/" + segments[1]
+	switch strings.ToLower(rawType) {
+	case "microsoft.compute/virtualmachines":
+		return "virtual_machine"
+	case "microsoft.storage/storageaccounts":
+		return "storage_account"
+	case "microsoft.sql/servers":
+		return "sql_server"
+	case "microsoft.sql/servers/databases":
+		return "sql_database"
+	default:
+		return rawType
+	}
+}
+
+func cloudLastPathSegment(value string) string {
+	value = strings.Trim(strings.TrimSpace(value), "/")
+	if value == "" {
+		return ""
+	}
+	parts := strings.FieldsFunc(value, func(r rune) bool { return r == '/' || r == ':' })
+	for i := len(parts) - 1; i >= 0; i-- {
+		if part := strings.TrimSpace(parts[i]); part != "" {
+			return part
+		}
+	}
+	return value
 }
 
 func normalizeCloudProvider(value string) string {

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -176,7 +176,7 @@ func addCloudFindingCorrelation(entities map[string]*ports.ProjectedEntity, link
 		return
 	}
 	affectedType := cloudFindingAffectedResourceType(provider, firstNonEmpty(attributes["affected_resource_type"], attributes["assessed_resource_type"]), affectedIDRaw)
-	affectedID := cloudFindingAffectedResourceID(provider, affectedType, affectedIDRaw)
+	affectedID := cloudFindingAffectedResourceID(provider, affectedType, affectedIDRaw, firstNonEmpty(attributes["affected_resource_name"], attributes["assessed_resource_name"]))
 	affectedURN := projectionURN(tenantID, provider+"_"+affectedType, affectedID)
 	if affectedURN == "" || affectedURN == resourceURN {
 		return
@@ -296,30 +296,67 @@ func cloudFindingAffectedResourceType(provider string, rawType string, resourceI
 	return firstNonEmpty(normalized, "resource")
 }
 
-func cloudFindingAffectedResourceID(provider string, resourceType string, resourceID string) string {
+func cloudFindingAffectedResourceID(provider string, resourceType string, resourceID string, resourceName string) string {
 	resourceID = strings.TrimSpace(resourceID)
-	if provider == "gcp" && resourceType == "gcs_bucket" {
-		return firstNonEmpty(gcpBucketNameFromResourceID(resourceID), resourceID)
+	resourceName = strings.TrimSpace(resourceName)
+	if provider == "gcp" {
+		switch resourceType {
+		case "gcs_bucket":
+			return firstNonEmpty(gcpBucketNameFromResourceID(resourceID), resourceID)
+		case "compute_instance":
+			return firstNonEmpty(resourceName, gcpNamedResourceSegment(resourceID, "instances"), cloudLastPathSegment(resourceID), resourceID)
+		case "cloud_sql_instance":
+			return firstNonEmpty(gcpServiceSelfLink(resourceID, "sqladmin.googleapis.com", "sql/v1beta4"), resourceID)
+		case "gke_cluster":
+			return firstNonEmpty(gcpServiceSelfLink(resourceID, "container.googleapis.com", "v1"), resourceID)
+		}
 	}
 	return resourceID
 }
 
-func gcpBucketNameFromResourceID(value string) string {
+func gcpServiceSelfLink(value string, host string, apiPrefix string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return ""
 	}
-	if strings.HasPrefix(strings.ToLower(value), "gs://") {
-		bucket, _, _ := strings.Cut(value[len("gs://"):], "/")
-		return strings.TrimSpace(bucket)
+	lower := strings.ToLower(value)
+	normalizedHost := strings.ToLower(strings.Trim(host, "/"))
+	if strings.HasPrefix(lower, "https://"+normalizedHost+"/") || strings.HasPrefix(lower, "http://"+normalizedHost+"/") {
+		return value
+	}
+	for _, prefix := range []string{"//" + normalizedHost + "/", normalizedHost + "/"} {
+		if strings.HasPrefix(lower, prefix) {
+			path := strings.TrimLeft(value[len(prefix):], "/")
+			if path == "" {
+				return ""
+			}
+			return "https://" + normalizedHost + "/" + strings.Trim(apiPrefix, "/") + "/" + path
+		}
+	}
+	return ""
+}
+
+func gcpNamedResourceSegment(value string, marker string) string {
+	value = strings.TrimSpace(value)
+	marker = strings.Trim(strings.TrimSpace(marker), "/")
+	if value == "" || marker == "" {
+		return ""
 	}
 	parts := strings.Split(strings.Trim(value, "/"), "/")
 	for index := 0; index+1 < len(parts); index++ {
-		if strings.EqualFold(parts[index], "buckets") && strings.TrimSpace(parts[index+1]) != "" {
+		if strings.EqualFold(parts[index], marker) && strings.TrimSpace(parts[index+1]) != "" {
 			return strings.TrimSpace(parts[index+1])
 		}
 	}
 	return ""
+}
+
+func gcpBucketNameFromResourceID(value string) string {
+	if strings.HasPrefix(strings.ToLower(value), "gs://") {
+		bucket, _, _ := strings.Cut(value[len("gs://"):], "/")
+		return strings.TrimSpace(bucket)
+	}
+	return gcpNamedResourceSegment(value, "buckets")
 }
 
 func azureResourceTypeFromID(resourceID string) string {

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -275,6 +275,12 @@ func cloudFindingAffectedResourceType(provider string, rawType string, resourceI
 		return "ec2_instance"
 	case "aws:awsiamrole", "aws:iamrole", "aws:iam_role":
 		return "role"
+	case "aws:awsiamuser", "aws:iamuser", "aws:iam_user":
+		return "user"
+	case "aws:awsiamgroup", "aws:iamgroup", "aws:iam_group":
+		return "group"
+	case "aws:awsiamaccesskey", "aws:iamaccesskey", "aws:iam_access_key", "aws:accesskey", "aws:access_key":
+		return "credential"
 	case "aws:awslambdafunction", "aws:lambdafunction":
 		return "lambda_function"
 	case "aws:awsrdsdbinstance", "aws:rdsdbinstance":

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -271,7 +271,7 @@ func cloudFindingAffectedResourceType(provider string, rawType string, resourceI
 	switch provider + ":" + normalized {
 	case "aws:awss3bucket", "aws:s3bucket":
 		return "s3_bucket"
-	case "aws:awsec2instance", "aws:ec2instance":
+	case "aws:awsec2instance", "aws:ec2instance", "aws:instance":
 		return "ec2_instance"
 	case "aws:awsiamrole", "aws:iamrole":
 		return "iam_role"

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -409,9 +409,10 @@ func azureResourceTypeFromID(resourceID string) string {
 	case "microsoft.storage/storageaccounts":
 		return "storage_account"
 	case "microsoft.sql/servers":
+		if len(segments) >= 4 && strings.EqualFold(segments[3], "databases") {
+			return "sql_database"
+		}
 		return "sql_server"
-	case "microsoft.sql/servers/databases":
-		return "sql_database"
 	default:
 		return rawType
 	}

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -287,6 +287,8 @@ func cloudFindingAffectedResourceType(provider string, rawType string, resourceI
 		return "rds_instance"
 	case "gcp:googlecloudstoragebucket", "gcp:google_cloud_storage_bucket", "gcp:storage_googleapis_com_bucket", "gcp:storage_bucket", "gcp:gcs_bucket":
 		return "gcs_bucket"
+	case "gcp:googlecloudrunservice", "gcp:google_cloud_run_service":
+		return "cloud_run_service"
 	}
 	if provider == "gcp" {
 		if inferred := panopticonGCPResourceTypeFromID(resourceID); inferred != "" {
@@ -304,7 +306,9 @@ func cloudFindingAffectedResourceID(provider string, resourceType string, resour
 		case "gcs_bucket":
 			return firstNonEmpty(gcpBucketNameFromResourceID(resourceID), resourceID)
 		case "compute_instance":
-			return firstNonEmpty(resourceName, gcpNamedResourceSegment(resourceID, "instances"), cloudLastPathSegment(resourceID), resourceID)
+			return firstNonEmpty(gcpNamedResourceSegment(resourceID, "instances"), resourceName, cloudLastPathSegment(resourceID), resourceID)
+		case "cloud_run_service":
+			return firstNonEmpty(gcpServiceRelativeName(resourceID, "run.googleapis.com"), resourceID)
 		case "cloud_sql_instance":
 			return firstNonEmpty(gcpServiceSelfLink(resourceID, "sqladmin.googleapis.com", "sql/v1beta4"), resourceID)
 		case "gke_cluster":
@@ -314,23 +318,51 @@ func cloudFindingAffectedResourceID(provider string, resourceType string, resour
 	return resourceID
 }
 
+func gcpServiceRelativeName(value string, host string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	path := gcpServicePath(value, host)
+	if path != "" {
+		return path
+	}
+	if strings.HasPrefix(value, "projects/") {
+		return value
+	}
+	return ""
+}
+
 func gcpServiceSelfLink(value string, host string, apiPrefix string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return ""
+	}
+	if path := gcpServicePath(value, host); path != "" {
+		return "https://" + strings.ToLower(strings.Trim(host, "/")) + "/" + strings.Trim(apiPrefix, "/") + "/" + path
 	}
 	lower := strings.ToLower(value)
 	normalizedHost := strings.ToLower(strings.Trim(host, "/"))
 	if strings.HasPrefix(lower, "https://"+normalizedHost+"/") || strings.HasPrefix(lower, "http://"+normalizedHost+"/") {
 		return value
 	}
+	return ""
+}
+
+func gcpServicePath(value string, host string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	lower := strings.ToLower(value)
+	normalizedHost := strings.ToLower(strings.Trim(host, "/"))
 	for _, prefix := range []string{"//" + normalizedHost + "/", normalizedHost + "/"} {
 		if strings.HasPrefix(lower, prefix) {
 			path := strings.TrimLeft(value[len(prefix):], "/")
 			if path == "" {
 				return ""
 			}
-			return "https://" + normalizedHost + "/" + strings.Trim(apiPrefix, "/") + "/" + path
+			return path
 		}
 	}
 	return ""

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -171,11 +171,12 @@ func addCloudFindingCorrelation(entities map[string]*ports.ProjectedEntity, link
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, findingURN, relationRepresents, cloudFindingLinkAttributes(event, provider, family, "cloud_provider_finding")))
 	}
 
-	affectedID := firstNonEmpty(attributes["affected_resource_id"], attributes["assessed_resource_id"])
-	if affectedID == "" {
+	affectedIDRaw := firstNonEmpty(attributes["affected_resource_id"], attributes["assessed_resource_id"])
+	if affectedIDRaw == "" {
 		return
 	}
-	affectedType := cloudFindingAffectedResourceType(provider, firstNonEmpty(attributes["affected_resource_type"], attributes["assessed_resource_type"]), affectedID)
+	affectedType := cloudFindingAffectedResourceType(provider, firstNonEmpty(attributes["affected_resource_type"], attributes["assessed_resource_type"]), affectedIDRaw)
+	affectedID := cloudFindingAffectedResourceID(provider, affectedType, affectedIDRaw)
 	affectedURN := projectionURN(tenantID, provider+"_"+affectedType, affectedID)
 	if affectedURN == "" || affectedURN == resourceURN {
 		return
@@ -278,8 +279,41 @@ func cloudFindingAffectedResourceType(provider string, rawType string, resourceI
 		return "lambda_function"
 	case "aws:awsrdsdbinstance", "aws:rdsdbinstance":
 		return "rds_instance"
+	case "gcp:googlecloudstoragebucket", "gcp:google_cloud_storage_bucket", "gcp:storage_googleapis_com_bucket", "gcp:storage_bucket", "gcp:gcs_bucket":
+		return "gcs_bucket"
+	}
+	if provider == "gcp" {
+		if inferred := panopticonGCPResourceTypeFromID(resourceID); inferred != "" {
+			return inferred
+		}
 	}
 	return firstNonEmpty(normalized, "resource")
+}
+
+func cloudFindingAffectedResourceID(provider string, resourceType string, resourceID string) string {
+	resourceID = strings.TrimSpace(resourceID)
+	if provider == "gcp" && resourceType == "gcs_bucket" {
+		return firstNonEmpty(gcpBucketNameFromResourceID(resourceID), resourceID)
+	}
+	return resourceID
+}
+
+func gcpBucketNameFromResourceID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(value), "gs://") {
+		bucket, _, _ := strings.Cut(value[len("gs://"):], "/")
+		return strings.TrimSpace(bucket)
+	}
+	parts := strings.Split(strings.Trim(value, "/"), "/")
+	for index := 0; index+1 < len(parts); index++ {
+		if strings.EqualFold(parts[index], "buckets") && strings.TrimSpace(parts[index+1]) != "" {
+			return strings.TrimSpace(parts[index+1])
+		}
+	}
+	return ""
 }
 
 func azureResourceTypeFromID(resourceID string) string {

--- a/internal/sourceprojection/cloud_resource_test.go
+++ b/internal/sourceprojection/cloud_resource_test.go
@@ -230,6 +230,48 @@ func TestCloudFindingAffectedResourceTypeUsesCanonicalGraphNamespaces(t *testing
 	}
 }
 
+func TestCloudFindingAffectedResourceIDUsesCanonicalGCPKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		resourceType string
+		id           string
+		resourceName string
+		want         string
+	}{
+		{
+			name:         "storage bucket",
+			resourceType: "gcs_bucket",
+			id:           "//storage.googleapis.com/projects/_/buckets/data",
+			want:         "data",
+		},
+		{
+			name:         "compute instance",
+			resourceType: "compute_instance",
+			id:           "//compute.googleapis.com/projects/writer-prod/zones/us-central1-a/instances/web-1",
+			resourceName: "web-1",
+			want:         "web-1",
+		},
+		{
+			name:         "cloud sql instance",
+			resourceType: "cloud_sql_instance",
+			id:           "//sqladmin.googleapis.com/projects/writer-prod/instances/prod-sql",
+			want:         "https://sqladmin.googleapis.com/sql/v1beta4/projects/writer-prod/instances/prod-sql",
+		},
+		{
+			name:         "gke cluster",
+			resourceType: "gke_cluster",
+			id:           "//container.googleapis.com/projects/writer-prod/locations/us-central1/clusters/prod",
+			want:         "https://container.googleapis.com/v1/projects/writer-prod/locations/us-central1/clusters/prod",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloudFindingAffectedResourceID("gcp", tt.resourceType, tt.id, tt.resourceName); got != tt.want {
+				t.Fatalf("cloudFindingAffectedResourceID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestProjectAWSAppRunnerServiceLinksAccountExposureOwnerAndRuntimeRole(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/cloud_resource_test.go
+++ b/internal/sourceprojection/cloud_resource_test.go
@@ -220,6 +220,7 @@ func TestCloudFindingAffectedResourceTypeUsesCanonicalGraphNamespaces(t *testing
 		{name: "aws iam group", provider: "aws", rawType: "AWS::IAM::Group", id: "arn:aws:iam::123456789012:group/Admins", want: "group"},
 		{name: "aws iam access key", provider: "aws", rawType: "AwsIamAccessKey", id: "AKIA123", want: "credential"},
 		{name: "aws guardduty instance", provider: "aws", rawType: "Instance", id: "i-123", want: "ec2_instance"},
+		{name: "gcp cloud run service", provider: "gcp", rawType: "google.cloud.run.Service", id: "//run.googleapis.com/projects/writer-prod/locations/us-central1/services/api", want: "cloud_run_service"},
 		{name: "gcp storage bucket", provider: "gcp", rawType: "google.cloud.storage.Bucket", id: "//storage.googleapis.com/projects/_/buckets/data", want: "gcs_bucket"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -247,9 +248,15 @@ func TestCloudFindingAffectedResourceIDUsesCanonicalGCPKeys(t *testing.T) {
 		{
 			name:         "compute instance",
 			resourceType: "compute_instance",
-			id:           "//compute.googleapis.com/projects/writer-prod/zones/us-central1-a/instances/web-1",
+			id:           "//compute.googleapis.com/projects/writer-prod/zones/us-central1-a/instances/123456789",
 			resourceName: "web-1",
-			want:         "web-1",
+			want:         "123456789",
+		},
+		{
+			name:         "cloud run service",
+			resourceType: "cloud_run_service",
+			id:           "//run.googleapis.com/projects/writer-prod/locations/us-central1/services/api",
+			want:         "projects/writer-prod/locations/us-central1/services/api",
 		},
 		{
 			name:         "cloud sql instance",

--- a/internal/sourceprojection/cloud_resource_test.go
+++ b/internal/sourceprojection/cloud_resource_test.go
@@ -56,6 +56,107 @@ func TestProjectGCPCloudResourceMetadataLinksAccountExposureOwnerClassificationA
 	}
 }
 
+func TestProjectCloudFindingsCorrelatesSecurityFindingAndAffectedResource(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		event              *cerebrov1.EventEnvelope
+		providerURN        string
+		securityFindingURN string
+		affectedURN        string
+		affectedType       string
+	}{
+		{
+			name: "aws security hub",
+			event: &cerebrov1.EventEnvelope{
+				Id:       "aws-securityhub-finding-1",
+				TenantId: "writer",
+				SourceId: "aws",
+				Kind:     "aws.securityhub_finding",
+				Attributes: map[string]string{
+					"affected_resource_id":   "arn:aws:s3:::prod-data",
+					"affected_resource_name": "prod-data",
+					"affected_resource_type": "AWS::S3::Bucket",
+					"finding_id":             "arn:aws:securityhub:us-east-1:123456789012:finding/1",
+					"resource_id":            "arn:aws:securityhub:us-east-1:123456789012:finding/1",
+					"resource_name":          "Public bucket",
+					"resource_provider":      "aws",
+					"resource_type":          "securityhub_finding",
+					"severity":               "HIGH",
+					"status":                 "ACTIVE",
+				},
+			},
+			providerURN:        "urn:cerebro:writer:aws_securityhub_finding:arn:aws:securityhub:us-east-1:123456789012:finding/1",
+			securityFindingURN: "urn:cerebro:writer:security_finding:aws:arn:aws:securityhub:us-east-1:123456789012:finding/1",
+			affectedURN:        "urn:cerebro:writer:aws_s3_bucket:arn:aws:s3:::prod-data",
+			affectedType:       "aws.s3.bucket",
+		},
+		{
+			name: "gcp security command center",
+			event: &cerebrov1.EventEnvelope{
+				Id:       "gcp-security-center-finding-1",
+				TenantId: "writer",
+				SourceId: "gcp",
+				Kind:     "gcp.security_center_finding",
+				Attributes: map[string]string{
+					"affected_resource_id":   "//storage.googleapis.com/projects/_/buckets/data",
+					"affected_resource_name": "data",
+					"affected_resource_type": "google.cloud.storage.Bucket",
+					"finding_name":           "projects/writer-prod/sources/123/findings/public-bucket",
+					"resource_id":            "projects/writer-prod/sources/123/findings/public-bucket",
+					"resource_name":          "PUBLIC_BUCKET_ACL",
+					"resource_provider":      "gcp",
+					"resource_type":          "security_center_finding",
+					"severity":               "HIGH",
+					"status":                 "ACTIVE",
+				},
+			},
+			providerURN:        "urn:cerebro:writer:gcp_security_center_finding:projects/writer-prod/sources/123/findings/public-bucket",
+			securityFindingURN: "urn:cerebro:writer:security_finding:gcp:projects/writer-prod/sources/123/findings/public-bucket",
+			affectedURN:        "urn:cerebro:writer:gcp_google_cloud_storage_bucket://storage.googleapis.com/projects/_/buckets/data",
+			affectedType:       "gcp.google.cloud.storage.bucket",
+		},
+		{
+			name: "azure server vulnerability",
+			event: &cerebrov1.EventEnvelope{
+				Id:       "azure-server-vulnerability-1",
+				TenantId: "writer",
+				SourceId: "azure",
+				Kind:     "azure.server_vulnerability",
+				Attributes: map[string]string{
+					"assessed_resource_id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm1",
+					"display_name":         "Install system updates",
+					"resource_id":          "/subscriptions/sub-1/providers/Microsoft.Security/assessments/assessment-1",
+					"resource_name":        "Install system updates",
+					"resource_provider":    "azure",
+					"resource_type":        "server_vulnerability",
+					"status_code":          "Unhealthy",
+				},
+			},
+			providerURN:        "urn:cerebro:writer:azure_server_vulnerability:/subscriptions/sub-1/providers/Microsoft.Security/assessments/assessment-1",
+			securityFindingURN: "urn:cerebro:writer:security_finding:azure:/subscriptions/sub-1/providers/Microsoft.Security/assessments/assessment-1",
+			affectedURN:        "urn:cerebro:writer:azure_virtual_machine:/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm1",
+			affectedType:       "azure.virtual.machine",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &projectionRecorder{}
+			service := New(state, nil)
+			if _, err := service.Project(context.Background(), tt.event); err != nil {
+				t.Fatalf("Project() error = %v", err)
+			}
+			if entity := state.entities[tt.securityFindingURN]; entity == nil || entity.EntityType != "security.finding" {
+				t.Fatalf("security finding entity = %#v, want security.finding", entity)
+			}
+			if entity := state.entities[tt.affectedURN]; entity == nil || entity.EntityType != tt.affectedType {
+				t.Fatalf("affected entity = %#v, want type %s", entity, tt.affectedType)
+			}
+			assertProjectedLink(t, state, tt.providerURN, relationRepresents, tt.securityFindingURN)
+			assertProjectedLink(t, state, tt.affectedURN, relationHasEvidence, tt.securityFindingURN)
+			assertProjectedLink(t, state, tt.securityFindingURN, relationObservedOn, tt.affectedURN)
+		})
+	}
+}
+
 func TestProjectAWSAppRunnerServiceLinksAccountExposureOwnerAndRuntimeRole(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/cloud_resource_test.go
+++ b/internal/sourceprojection/cloud_resource_test.go
@@ -116,6 +116,31 @@ func TestProjectCloudFindingsCorrelatesSecurityFindingAndAffectedResource(t *tes
 			affectedType:       "aws.ec2.instance",
 		},
 		{
+			name: "aws security hub iam role",
+			event: &cerebrov1.EventEnvelope{
+				Id:       "aws-securityhub-role-finding-1",
+				TenantId: "writer",
+				SourceId: "aws",
+				Kind:     "aws.securityhub_finding",
+				Attributes: map[string]string{
+					"affected_resource_id":   "arn:aws:iam::123456789012:role/AdminRole",
+					"affected_resource_name": "AdminRole",
+					"affected_resource_type": "AWS::IAM::Role",
+					"finding_id":             "arn:aws:securityhub:us-east-1:123456789012:finding/role-1",
+					"resource_id":            "arn:aws:securityhub:us-east-1:123456789012:finding/role-1",
+					"resource_name":          "Admin role finding",
+					"resource_provider":      "aws",
+					"resource_type":          "securityhub_finding",
+					"severity":               "HIGH",
+					"status":                 "ACTIVE",
+				},
+			},
+			providerURN:        "urn:cerebro:writer:aws_securityhub_finding:arn:aws:securityhub:us-east-1:123456789012:finding/role-1",
+			securityFindingURN: "urn:cerebro:writer:security_finding:aws:arn:aws:securityhub:us-east-1:123456789012:finding/role-1",
+			affectedURN:        "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/AdminRole",
+			affectedType:       "aws.role",
+		},
+		{
 			name: "gcp security command center",
 			event: &cerebrov1.EventEnvelope{
 				Id:       "gcp-security-center-finding-1",

--- a/internal/sourceprojection/cloud_resource_test.go
+++ b/internal/sourceprojection/cloud_resource_test.go
@@ -112,8 +112,8 @@ func TestProjectCloudFindingsCorrelatesSecurityFindingAndAffectedResource(t *tes
 			},
 			providerURN:        "urn:cerebro:writer:gcp_security_center_finding:projects/writer-prod/sources/123/findings/public-bucket",
 			securityFindingURN: "urn:cerebro:writer:security_finding:gcp:projects/writer-prod/sources/123/findings/public-bucket",
-			affectedURN:        "urn:cerebro:writer:gcp_google_cloud_storage_bucket://storage.googleapis.com/projects/_/buckets/data",
-			affectedType:       "gcp.google.cloud.storage.bucket",
+			affectedURN:        "urn:cerebro:writer:gcp_gcs_bucket:data",
+			affectedType:       "gcp.gcs.bucket",
 		},
 		{
 			name: "azure server vulnerability",

--- a/internal/sourceprojection/cloud_resource_test.go
+++ b/internal/sourceprojection/cloud_resource_test.go
@@ -187,6 +187,28 @@ func TestProjectCloudFindingsCorrelatesSecurityFindingAndAffectedResource(t *tes
 			affectedURN:        "urn:cerebro:writer:azure_virtual_machine:/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm1",
 			affectedType:       "azure.virtual.machine",
 		},
+		{
+			name: "azure sql database vulnerability",
+			event: &cerebrov1.EventEnvelope{
+				Id:       "azure-sql-database-vulnerability-1",
+				TenantId: "writer",
+				SourceId: "azure",
+				Kind:     "azure.server_vulnerability",
+				Attributes: map[string]string{
+					"assessed_resource_id": "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Sql/servers/sql-prod/databases/appdb",
+					"display_name":         "Database vulnerability",
+					"resource_id":          "/subscriptions/sub-1/providers/Microsoft.Security/assessments/assessment-2",
+					"resource_name":        "Database vulnerability",
+					"resource_provider":    "azure",
+					"resource_type":        "server_vulnerability",
+					"status_code":          "Unhealthy",
+				},
+			},
+			providerURN:        "urn:cerebro:writer:azure_server_vulnerability:/subscriptions/sub-1/providers/Microsoft.Security/assessments/assessment-2",
+			securityFindingURN: "urn:cerebro:writer:security_finding:azure:/subscriptions/sub-1/providers/Microsoft.Security/assessments/assessment-2",
+			affectedURN:        "urn:cerebro:writer:azure_sql_database:/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Sql/servers/sql-prod/databases/appdb",
+			affectedType:       "azure.sql.database",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			state := &projectionRecorder{}

--- a/internal/sourceprojection/cloud_resource_test.go
+++ b/internal/sourceprojection/cloud_resource_test.go
@@ -91,6 +91,31 @@ func TestProjectCloudFindingsCorrelatesSecurityFindingAndAffectedResource(t *tes
 			affectedType:       "aws.s3.bucket",
 		},
 		{
+			name: "aws guardduty ec2 instance",
+			event: &cerebrov1.EventEnvelope{
+				Id:       "aws-guardduty-finding-1",
+				TenantId: "writer",
+				SourceId: "aws",
+				Kind:     "aws.guardduty_finding",
+				Attributes: map[string]string{
+					"affected_resource_id":   "i-123",
+					"affected_resource_name": "i-123",
+					"affected_resource_type": "Instance",
+					"finding_arn":            "arn:aws:guardduty:us-east-1:123456789012:detector/detector-1/finding/gd-finding-1",
+					"resource_id":            "arn:aws:guardduty:us-east-1:123456789012:detector/detector-1/finding/gd-finding-1",
+					"resource_name":          "Credential exfiltration",
+					"resource_provider":      "aws",
+					"resource_type":          "guardduty_finding",
+					"severity":               "HIGH",
+					"status":                 "ACTIVE",
+				},
+			},
+			providerURN:        "urn:cerebro:writer:aws_guardduty_finding:arn:aws:guardduty:us-east-1:123456789012:detector/detector-1/finding/gd-finding-1",
+			securityFindingURN: "urn:cerebro:writer:security_finding:aws:arn:aws:guardduty:us-east-1:123456789012:detector/detector-1/finding/gd-finding-1",
+			affectedURN:        "urn:cerebro:writer:aws_ec2_instance:i-123",
+			affectedType:       "aws.ec2.instance",
+		},
+		{
 			name: "gcp security command center",
 			event: &cerebrov1.EventEnvelope{
 				Id:       "gcp-security-center-finding-1",

--- a/internal/sourceprojection/cloud_resource_test.go
+++ b/internal/sourceprojection/cloud_resource_test.go
@@ -207,6 +207,29 @@ func TestProjectCloudFindingsCorrelatesSecurityFindingAndAffectedResource(t *tes
 	}
 }
 
+func TestCloudFindingAffectedResourceTypeUsesCanonicalGraphNamespaces(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		provider string
+		rawType  string
+		id       string
+		want     string
+	}{
+		{name: "aws iam role", provider: "aws", rawType: "AWS::IAM::Role", id: "arn:aws:iam::123456789012:role/AdminRole", want: "role"},
+		{name: "aws iam user", provider: "aws", rawType: "AWS::IAM::User", id: "arn:aws:iam::123456789012:user/Alice", want: "user"},
+		{name: "aws iam group", provider: "aws", rawType: "AWS::IAM::Group", id: "arn:aws:iam::123456789012:group/Admins", want: "group"},
+		{name: "aws iam access key", provider: "aws", rawType: "AwsIamAccessKey", id: "AKIA123", want: "credential"},
+		{name: "aws guardduty instance", provider: "aws", rawType: "Instance", id: "i-123", want: "ec2_instance"},
+		{name: "gcp storage bucket", provider: "gcp", rawType: "google.cloud.storage.Bucket", id: "//storage.googleapis.com/projects/_/buckets/data", want: "gcs_bucket"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloudFindingAffectedResourceType(tt.provider, tt.rawType, tt.id); got != tt.want {
+				t.Fatalf("cloudFindingAffectedResourceType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestProjectAWSAppRunnerServiceLinksAccountExposureOwnerAndRuntimeRole(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/sources/aws/security_services.go
+++ b/sources/aws/security_services.go
@@ -212,10 +212,11 @@ func awsSecurityFamilies(clientFactory awsClientFactory) []sourcecdk.Family[sett
 			CursorFallback: func(finding securityhubtypes.AwsSecurityFinding) string { return awssdk.ToString(finding.Id) },
 		}),
 		awsFamily(clientFactory, awsFamilyOptions[inspector2types.Finding]{
-			Name:  familyInspector2Finding,
-			Label: "aws inspector2 findings",
-			List:  listInspector2Findings,
-			Event: inspector2FindingEvent,
+			Name:               familyInspector2Finding,
+			Label:              "aws inspector2 findings",
+			List:               listInspector2Findings,
+			ListWithCheckpoint: listInspector2FindingsWithCheckpoint,
+			Event:              inspector2FindingEvent,
 			URN: func(settings settings, finding inspector2types.Finding) (string, error) {
 				resourceID := ""
 				if resource := firstInspector2Resource(finding.Resources); resource != nil {
@@ -409,10 +410,11 @@ func listSecurityHubFindingsWithCheckpoint(ctx context.Context, clients awsClien
 }
 
 func listInspector2Findings(ctx context.Context, clients awsClients, _ settings, cursor string, limit int) ([]inspector2types.Finding, string, error) {
-	out, err := clients.inspector2.ListFindings(ctx, &inspector2.ListFindingsInput{
-		MaxResults: awssdk.Int32(boundedAWSPageSizeInt32(limit, 1, 100)),
-		NextToken:  stringPtr(cursor),
-	})
+	return listInspector2FindingsWithCheckpoint(ctx, clients, settings{}, cursor, limit, nil)
+}
+
+func listInspector2FindingsWithCheckpoint(ctx context.Context, clients awsClients, _ settings, cursor string, limit int, checkpoint *cerebrov1.SourceCheckpoint) ([]inspector2types.Finding, string, error) {
+	out, err := clients.inspector2.ListFindings(ctx, awssecurity.Inspector2ListFindingsInput(boundedAWSPageSizeInt32(limit, 1, 100), cursor, checkpoint, awsFindingCheckpointLookback))
 	if err != nil {
 		return nil, "", err
 	}
@@ -707,7 +709,7 @@ func inspector2FindingEvent(settings settings, finding inspector2types.Finding) 
 	if err != nil {
 		return nil, err
 	}
-	return sourceEvent(settings, "aws-inspector2-finding-"+firstNonEmpty(findingARN, affectedResourceID), "aws.inspector2_finding", "aws/inspector2_finding/v1", payload, attributes, firstTime(finding.UpdatedAt, finding.LastObservedAt, finding.FirstObservedAt))
+	return sourceEvent(settings, "aws-inspector2-finding-"+firstNonEmpty(findingARN, affectedResourceID), "aws.inspector2_finding", "aws/inspector2_finding/v1", payload, attributes, firstTime(finding.LastObservedAt, finding.UpdatedAt, finding.FirstObservedAt))
 }
 
 func macie2FindingEvent(settings settings, finding macie2types.Finding) (*primitives.Event, error) {

--- a/sources/aws/security_services_test.go
+++ b/sources/aws/security_services_test.go
@@ -338,6 +338,38 @@ func TestReadAWSFindingFamiliesWithCheckpointUseUpdatedTimeRequests(t *testing.T
 			t.Fatalf("Macie updatedAt gte = %#v, want %d", criterion.Gte, watermark.Add(-awsFindingCheckpointLookback).UnixMilli())
 		}
 	})
+
+	t.Run("inspector2", func(t *testing.T) {
+		newObservedAt := watermark.Add(time.Hour)
+		oldObservedAt := watermark.Add(-time.Hour)
+		fake := &fakeAWSSecurityServices{
+			inspector2Findings: []inspector2types.Finding{
+				{FindingArn: awssdk.String("arn:aws:inspector2:us-east-1:123456789012:finding/new-finding"), LastObservedAt: &newObservedAt},
+				{FindingArn: awssdk.String("arn:aws:inspector2:us-east-1:123456789012:finding/old-finding"), LastObservedAt: &oldObservedAt},
+			},
+		}
+		source := newSecurityTestSource(t, fake)
+		pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familyInspector2Finding}), nil, checkpoint)
+		if err != nil {
+			t.Fatalf("ReadWithCheckpoint(inspector2_finding) error = %v", err)
+		}
+		if len(pull.Events) != 1 || pull.Events[0].GetAttributes()["finding_arn"] != "arn:aws:inspector2:us-east-1:123456789012:finding/new-finding" {
+			t.Fatalf("events = %#v, want only new Inspector2 finding", pull.Events)
+		}
+		if len(fake.inspector2ListInputs) != 1 {
+			t.Fatalf("len(inspector2ListInputs) = %d, want 1", len(fake.inspector2ListInputs))
+		}
+		input := fake.inspector2ListInputs[0]
+		if input.SortCriteria == nil || input.SortCriteria.Field != inspector2types.SortFieldLastObservedAt || input.SortCriteria.SortOrder != inspector2types.SortOrderDesc {
+			t.Fatalf("Inspector2 sort = %#v, want LastObservedAt DESC", input.SortCriteria)
+		}
+		if input.FilterCriteria == nil || len(input.FilterCriteria.LastObservedAt) != 1 {
+			t.Fatalf("Inspector2 LastObservedAt filter = %#v, want one start filter", input.FilterCriteria)
+		}
+		if got := input.FilterCriteria.LastObservedAt[0].StartInclusive; got == nil || !got.Equal(watermark.Add(-awsFindingCheckpointLookback)) {
+			t.Fatalf("Inspector2 LastObservedAt start = %#v, want %s", got, watermark.Add(-awsFindingCheckpointLookback))
+		}
+	})
 }
 
 func TestReadAWSSecurityHubCheckpointCursorKeepsOriginalWatermark(t *testing.T) {
@@ -444,6 +476,7 @@ type fakeAWSSecurityServices struct {
 	securityHubInputs            []securityhub.GetFindingsInput
 	securityHubTokens            []string
 	inspector2Findings           []inspector2types.Finding
+	inspector2ListInputs         []inspector2.ListFindingsInput
 	macieFindingIDs              []string
 	macieFindings                []macie2types.Finding
 	macieListInputs              []macie2.ListFindingsInput
@@ -516,7 +549,8 @@ type fakeInspector2Security struct {
 	fake *fakeAWSSecurityServices
 }
 
-func (f fakeInspector2Security) ListFindings(context.Context, *inspector2.ListFindingsInput, ...func(*inspector2.Options)) (*inspector2.ListFindingsOutput, error) {
+func (f fakeInspector2Security) ListFindings(_ context.Context, input *inspector2.ListFindingsInput, _ ...func(*inspector2.Options)) (*inspector2.ListFindingsOutput, error) {
+	f.fake.inspector2ListInputs = append(f.fake.inspector2ListInputs, *input)
 	return &inspector2.ListFindingsOutput{Findings: f.fake.inspector2Findings}, nil
 }
 

--- a/sources/aws/security_services_test.go
+++ b/sources/aws/security_services_test.go
@@ -86,7 +86,7 @@ func TestReadAWSSecurityServiceEvents(t *testing.T) {
 			Severity: &securityhubtypes.Severity{Label: securityhubtypes.SeverityLabel("HIGH"), Normalized: awssdk.Int32(70)},
 			Title:    awssdk.String("S3 bucket allows public access"),
 		}},
-		inspector2Findings: []inspector2types.Finding{{
+		inspector2: fakeAWSInspector2Findings{findings: []inspector2types.Finding{{
 			AwsAccountId: awssdk.String("123456789012"),
 			FindingArn:   awssdk.String("arn:aws:inspector2:us-east-1:123456789012:finding/inspector-finding-1"),
 			Resources: []inspector2types.Resource{{
@@ -98,7 +98,7 @@ func TestReadAWSSecurityServiceEvents(t *testing.T) {
 			Status:   inspector2types.FindingStatus("ACTIVE"),
 			Title:    awssdk.String("CVE finding"),
 			Type:     inspector2types.FindingType("PACKAGE_VULNERABILITY"),
-		}},
+		}}},
 		macieFindingIDs: []string{"macie-finding-1"},
 		macieFindings: []macie2types.Finding{{
 			AccountId: awssdk.String("123456789012"),
@@ -343,10 +343,10 @@ func TestReadAWSFindingFamiliesWithCheckpointUseUpdatedTimeRequests(t *testing.T
 		newObservedAt := watermark.Add(time.Hour)
 		oldObservedAt := watermark.Add(-time.Hour)
 		fake := &fakeAWSSecurityServices{
-			inspector2Findings: []inspector2types.Finding{
+			inspector2: fakeAWSInspector2Findings{findings: []inspector2types.Finding{
 				{FindingArn: awssdk.String("arn:aws:inspector2:us-east-1:123456789012:finding/new-finding"), LastObservedAt: &newObservedAt},
 				{FindingArn: awssdk.String("arn:aws:inspector2:us-east-1:123456789012:finding/old-finding"), LastObservedAt: &oldObservedAt},
-			},
+			}},
 		}
 		source := newSecurityTestSource(t, fake)
 		pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familyInspector2Finding}), nil, checkpoint)
@@ -356,10 +356,10 @@ func TestReadAWSFindingFamiliesWithCheckpointUseUpdatedTimeRequests(t *testing.T
 		if len(pull.Events) != 1 || pull.Events[0].GetAttributes()["finding_arn"] != "arn:aws:inspector2:us-east-1:123456789012:finding/new-finding" {
 			t.Fatalf("events = %#v, want only new Inspector2 finding", pull.Events)
 		}
-		if len(fake.inspector2ListInputs) != 1 {
-			t.Fatalf("len(inspector2ListInputs) = %d, want 1", len(fake.inspector2ListInputs))
+		if len(fake.inspector2.listInputs) != 1 {
+			t.Fatalf("len(inspector2ListInputs) = %d, want 1", len(fake.inspector2.listInputs))
 		}
-		input := fake.inspector2ListInputs[0]
+		input := fake.inspector2.listInputs[0]
 		if input.SortCriteria == nil || input.SortCriteria.Field != inspector2types.SortFieldLastObservedAt || input.SortCriteria.SortOrder != inspector2types.SortOrderDesc {
 			t.Fatalf("Inspector2 sort = %#v, want LastObservedAt DESC", input.SortCriteria)
 		}
@@ -475,8 +475,7 @@ type fakeAWSSecurityServices struct {
 	securityHubNextToken         string
 	securityHubInputs            []securityhub.GetFindingsInput
 	securityHubTokens            []string
-	inspector2Findings           []inspector2types.Finding
-	inspector2ListInputs         []inspector2.ListFindingsInput
+	inspector2                   fakeAWSInspector2Findings
 	macieFindingIDs              []string
 	macieFindings                []macie2types.Finding
 	macieListInputs              []macie2.ListFindingsInput
@@ -486,6 +485,11 @@ type fakeAWSSecurityServices struct {
 	lastWAFV2Scope               wafv2types.Scope
 	firewalls                    []networkfirewalltypes.FirewallMetadata
 	firewallDetails              map[string]networkfirewalltypes.Firewall
+}
+
+type fakeAWSInspector2Findings struct {
+	findings   []inspector2types.Finding
+	listInputs []inspector2.ListFindingsInput
 }
 
 func (f *fakeAWSSecurityServices) ListAnalyzers(context.Context, *accessanalyzer.ListAnalyzersInput, ...func(*accessanalyzer.Options)) (*accessanalyzer.ListAnalyzersOutput, error) {
@@ -550,8 +554,8 @@ type fakeInspector2Security struct {
 }
 
 func (f fakeInspector2Security) ListFindings(_ context.Context, input *inspector2.ListFindingsInput, _ ...func(*inspector2.Options)) (*inspector2.ListFindingsOutput, error) {
-	f.fake.inspector2ListInputs = append(f.fake.inspector2ListInputs, *input)
-	return &inspector2.ListFindingsOutput{Findings: f.fake.inspector2Findings}, nil
+	f.fake.inspector2.listInputs = append(f.fake.inspector2.listInputs, *input)
+	return &inspector2.ListFindingsOutput{Findings: f.fake.inspector2.findings}, nil
 }
 
 type fakeMacie2Security struct {

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -1042,8 +1042,7 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 	return s.families.Read(ctx, cfg, cursor)
 }
 
-// ReadWithCheckpoint lets AWS families with provider-supported update ordering
-// stop once they reach the durable runtime watermark.
+// ReadWithCheckpoint lets AWS families with provider-supported update ordering stop once they reach the durable runtime watermark.
 func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
 	return s.families.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
 }

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -34,7 +34,6 @@ const (
 	defaultFamily                                                                                                                                                                                        = familyAudit
 	defaultPageSize                                                                                                                                                                                      = 10
 	gcsObjectContentSampleBytes                                                                                                                                                                          = 64 << 10
-	gcpFindingCheckpointLookback                                                                                                                                                                         = 2 * time.Minute
 	maxPageSize                                                                                                                                                                                          = 200
 	familyAssetMetadata                                                                                                                                                                                  = "asset_metadata"
 	familyAIDataset                                                                                                                                                                                      = "aiplatform_dataset"
@@ -261,8 +260,7 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 	return s.families.Read(ctx, cfg, cursor)
 }
 
-// ReadWithCheckpoint lets GCP families with provider-supported event ordering
-// stop once they reach the durable runtime watermark.
+// ReadWithCheckpoint lets GCP families with provider-supported event ordering stop once they reach the durable runtime watermark.
 func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
 	return s.families.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
 }
@@ -362,54 +360,24 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 		gcpFamily(s, gcpFamilyOptions[gcpcloud.CertificateManagerCertificateMapRecord]{Name: familyCertificateManagerCertificateMap, Label: "gcp certificate manager certificate maps", List: listCertificateManagerCertificateMaps, Event: gcpCloudEvent(gcpcloud.CertificateManagerCertificateMapEvent), URN: gcpResourceURN[gcpcloud.CertificateManagerCertificateMapRecord]("gcp_certificate_manager_certificate_map")}),
 		gcpFamily(s, gcpFamilyOptions[gcpcloud.CertificateManagerCertificateMapEntryRecord]{Name: familyCertificateManagerCertificateMapEntry, Label: "gcp certificate manager certificate map entries", List: listCertificateManagerCertificateMapEntries, Event: gcpCloudEvent(gcpcloud.CertificateManagerCertificateMapEntryEvent), URN: gcpResourceURN[gcpcloud.CertificateManagerCertificateMapEntryRecord]("gcp_certificate_manager_certificate_map_entry")}),
 		gcpFamily(s, gcpFamilyOptions[gcpcloud.CertificateManagerDNSAuthorizationRecord]{Name: familyCertificateManagerDNSAuthorization, Label: "gcp certificate manager dns authorizations", List: listCertificateManagerDNSAuthorizations, Event: gcpCloudEvent(gcpcloud.CertificateManagerDNSAuthorizationEvent), URN: gcpResourceURN[gcpcloud.CertificateManagerDNSAuthorizationRecord]("gcp_certificate_manager_dns_authorization")}),
-		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudFunctionRecord]{
-			Name:  familyCloudFunction,
-			Label: "gcp cloud functions",
-			List:  listCloudFunctions,
-			Event: gcpCloudEvent(gcpcloud.CloudFunctionEvent),
-			URN: func(settings settings, fn gcpcloud.CloudFunctionRecord) (string, error) {
-				return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_function:%s", tenantID(settings), firstNonEmpty(fn.Name, fn.ServiceConfig.URI)), nil
-			},
-		}),
-		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudIDSEndpointRecord]{
-			Name:  familyCloudIDSEndpoint,
-			Label: "gcp cloud ids endpoints",
-			List:  listCloudIDSEndpoints,
-			Event: gcpCloudEvent(gcpcloud.CloudIDSEndpointEvent),
-			URN: func(settings settings, endpoint gcpcloud.CloudIDSEndpointRecord) (string, error) {
-				return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_ids_endpoint:%s", tenantID(settings), endpoint.Name), nil
-			},
-		}),
+		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudFunctionRecord]{Name: familyCloudFunction, Label: "gcp cloud functions", List: listCloudFunctions, Event: gcpCloudEvent(gcpcloud.CloudFunctionEvent), URN: func(settings settings, fn gcpcloud.CloudFunctionRecord) (string, error) {
+			return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_function:%s", tenantID(settings), firstNonEmpty(fn.Name, fn.ServiceConfig.URI)), nil
+		}}),
+		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudIDSEndpointRecord]{Name: familyCloudIDSEndpoint, Label: "gcp cloud ids endpoints", List: listCloudIDSEndpoints, Event: gcpCloudEvent(gcpcloud.CloudIDSEndpointEvent), URN: func(settings settings, endpoint gcpcloud.CloudIDSEndpointRecord) (string, error) {
+			return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_ids_endpoint:%s", tenantID(settings), endpoint.Name), nil
+		}}),
 		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudSchedulerJobRecord]{Name: familyCloudSchedulerJob, Label: "gcp cloud scheduler jobs", List: listCloudSchedulerJobs, Event: gcpCloudEvent(gcpcloud.CloudSchedulerJobEvent), URN: func(settings settings, job gcpcloud.CloudSchedulerJobRecord) (string, error) {
 			return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_scheduler_job:%s", tenantID(settings), firstNonEmpty(job.Name, settings.projectID)), nil
 		}}),
-		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudRunRevisionRecord]{
-			Name:  familyCloudRunRevision,
-			Label: "gcp cloud run revisions",
-			List:  listCloudRunRevisions,
-			Event: gcpCloudEvent(gcpcloud.CloudRunRevisionEvent),
-			URN: func(settings settings, revision gcpcloud.CloudRunRevisionRecord) (string, error) {
-				return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_run_revision:%s", tenantID(settings), firstNonEmpty(revision.Name, revision.UID)), nil
-			},
-		}),
-		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudRunServiceRecord]{
-			Name:  familyCloudRunService,
-			Label: "gcp cloud run services",
-			List:  listCloudRunServices,
-			Event: gcpCloudEvent(gcpcloud.CloudRunServiceEvent),
-			URN: func(settings settings, service gcpcloud.CloudRunServiceRecord) (string, error) {
-				return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_run_service:%s", tenantID(settings), firstNonEmpty(service.Name, service.UID)), nil
-			},
-		}),
-		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudSQLInstanceRecord]{
-			Name:  familyCloudSQLInstance,
-			Label: "gcp cloud sql instances",
-			List:  listCloudSQLInstances,
-			Event: gcpCloudEvent(gcpcloud.CloudSQLInstanceEvent),
-			URN: func(settings settings, instance gcpcloud.CloudSQLInstanceRecord) (string, error) {
-				return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_sql_instance:%s", tenantID(settings), firstNonEmpty(instance.SelfLink, instance.Name)), nil
-			},
-		}),
+		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudRunRevisionRecord]{Name: familyCloudRunRevision, Label: "gcp cloud run revisions", List: listCloudRunRevisions, Event: gcpCloudEvent(gcpcloud.CloudRunRevisionEvent), URN: func(settings settings, revision gcpcloud.CloudRunRevisionRecord) (string, error) {
+			return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_run_revision:%s", tenantID(settings), firstNonEmpty(revision.Name, revision.UID)), nil
+		}}),
+		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudRunServiceRecord]{Name: familyCloudRunService, Label: "gcp cloud run services", List: listCloudRunServices, Event: gcpCloudEvent(gcpcloud.CloudRunServiceEvent), URN: func(settings settings, service gcpcloud.CloudRunServiceRecord) (string, error) {
+			return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_run_service:%s", tenantID(settings), firstNonEmpty(service.Name, service.UID)), nil
+		}}),
+		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudSQLInstanceRecord]{Name: familyCloudSQLInstance, Label: "gcp cloud sql instances", List: listCloudSQLInstances, Event: gcpCloudEvent(gcpcloud.CloudSQLInstanceEvent), URN: func(settings settings, instance gcpcloud.CloudSQLInstanceRecord) (string, error) {
+			return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_sql_instance:%s", tenantID(settings), firstNonEmpty(instance.SelfLink, instance.Name)), nil
+		}}),
 		gcpFamily(s, gcpFamilyOptions[gcpcloud.CloudSQLDatabaseRecord]{Name: familyCloudSQLDatabase, Label: "gcp cloud sql databases", List: listCloudSQLDatabases, Event: gcpCloudEvent(gcpcloud.CloudSQLDatabaseEvent), URN: func(settings settings, database gcpcloud.CloudSQLDatabaseRecord) (string, error) {
 			return fmt.Sprintf("urn:cerebro:%s:gcp_cloud_sql_database:%s", tenantID(settings), gcpcloud.CloudSQLDatabaseResourceID(settings.projectID, database)), nil
 		}}),
@@ -1839,40 +1807,13 @@ func listSecurityCenterFindings(ctx context.Context, source *Source, settings se
 func listSecurityCenterFindingsWithCheckpoint(ctx context.Context, source *Source, settings settings, pageToken string, limit int, checkpoint *cerebrov1.SourceCheckpoint) ([]gcpcloud.SecurityCenterFindingRecord, string, error) {
 	path := "/v2/projects/" + url.PathEscape(settings.projectID) + "/sources/-/findings"
 	readSettings := settings
-	if start, ok := gcpCheckpointStart(checkpoint, gcpFindingCheckpointLookback); ok {
-		readSettings.filter = combineGCPFilters(readSettings.filter, fmt.Sprintf(`event_time >= "%s"`, start.Format(time.RFC3339Nano)))
+	if start, ok := gcpcloud.CheckpointStart(checkpoint, gcpcloud.FindingCheckpointLookback); ok {
+		readSettings.filter = gcpcloud.CombineFilters(readSettings.filter, fmt.Sprintf(`event_time >= "%s"`, start.Format(time.RFC3339Nano)))
 	}
 	query := url.Values{"orderBy": {"event_time desc"}}
 	return listPagedRecords[gcpcloud.SecurityCenterFindingRecord, securityCenterFindingsPageResponse](ctx, source, readSettings, pageToken, limit, securityCenterBaseURL, path, "pageSize", "gcp security command center finding", func(response securityCenterFindingsPageResponse) []json.RawMessage {
 		return response.ListFindingsResults
 	}, true, true, query)
-}
-
-func gcpCheckpointStart(checkpoint *cerebrov1.SourceCheckpoint, lookback time.Duration) (time.Time, bool) {
-	if checkpoint == nil || checkpoint.GetWatermark() == nil {
-		return time.Time{}, false
-	}
-	watermark := checkpoint.GetWatermark().AsTime().UTC()
-	if watermark.IsZero() {
-		return time.Time{}, false
-	}
-	if lookback > 0 {
-		watermark = watermark.Add(-lookback)
-	}
-	return watermark, true
-}
-
-func combineGCPFilters(existing string, incremental string) string {
-	existing = strings.TrimSpace(existing)
-	incremental = strings.TrimSpace(incremental)
-	switch {
-	case existing == "":
-		return incremental
-	case incremental == "":
-		return existing
-	default:
-		return "(" + existing + ") AND (" + incremental + ")"
-	}
 }
 
 func listAuditRecords(ctx context.Context, source *Source, settings settings, pageToken string, limit int) ([]auditRecord, string, error) {

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -34,6 +34,7 @@ const (
 	defaultFamily                                                                                                                                                                                        = familyAudit
 	defaultPageSize                                                                                                                                                                                      = 10
 	gcsObjectContentSampleBytes                                                                                                                                                                          = 64 << 10
+	gcpFindingCheckpointLookback                                                                                                                                                                         = 2 * time.Minute
 	maxPageSize                                                                                                                                                                                          = 200
 	familyAssetMetadata                                                                                                                                                                                  = "asset_metadata"
 	familyAIDataset                                                                                                                                                                                      = "aiplatform_dataset"
@@ -196,12 +197,13 @@ type serviceAccountImpersonationRecord = gcpcloud.ServiceAccountImpersonationRec
 type auditRecord = gcpcloud.AuditRecord
 
 type gcpFamilyOptions[T any] struct {
-	Name     string
-	Label    string
-	List     func(context.Context, *Source, settings, string, int) ([]T, string, error)
-	Event    func(settings, T) (*primitives.Event, error)
-	URN      func(settings, T) (string, error)
-	Discover func(context.Context, *Source, settings) ([]sourcecdk.URN, error)
+	Name               string
+	Label              string
+	List               func(context.Context, *Source, settings, string, int) ([]T, string, error)
+	ListWithCheckpoint func(context.Context, *Source, settings, string, int, *cerebrov1.SourceCheckpoint) ([]T, string, error)
+	Event              func(settings, T) (*primitives.Event, error)
+	URN                func(settings, T) (string, error)
+	Discover           func(context.Context, *Source, settings) ([]sourcecdk.URN, error)
 }
 
 type gcpResourceIdentifier interface{ CerebroResourceID() string }
@@ -257,6 +259,12 @@ func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecd
 // Read returns one page of normalized GCP events.
 func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	return s.families.Read(ctx, cfg, cursor)
+}
+
+// ReadWithCheckpoint lets GCP families with provider-supported event ordering
+// stop once they reach the durable runtime watermark.
+func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	return s.families.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
 }
 
 func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
@@ -626,7 +634,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 				return fmt.Sprintf("urn:cerebro:%s:gcp_service_account_impersonation:%s:%s", tenantID(settings), gcpcloud.SanitizeURNPart(binding.Member), gcpcloud.SanitizeURNPart(binding.Role)), nil
 			},
 		}),
-		gcpFamily(s, gcpFamilyOptions[gcpcloud.SecurityCenterFindingRecord]{Name: familySecurityCenterFinding, Label: "gcp security command center findings", List: listSecurityCenterFindings, Event: gcpCloudEvent(gcpcloud.SecurityCenterFindingEvent), URN: func(settings settings, finding gcpcloud.SecurityCenterFindingRecord) (string, error) {
+		gcpFamily(s, gcpFamilyOptions[gcpcloud.SecurityCenterFindingRecord]{Name: familySecurityCenterFinding, Label: "gcp security command center findings", List: listSecurityCenterFindings, ListWithCheckpoint: listSecurityCenterFindingsWithCheckpoint, Event: gcpCloudEvent(gcpcloud.SecurityCenterFindingEvent), URN: func(settings settings, finding gcpcloud.SecurityCenterFindingRecord) (string, error) {
 			return fmt.Sprintf("urn:cerebro:%s:gcp_security_center_finding:%s", tenantID(settings), firstNonEmpty(finding.Finding.Name, finding.Finding.ResourceName, finding.Resource.Name)), nil
 		}}),
 		gcpFamily(s, gcpFamilyOptions[serviceAccountRecord]{
@@ -671,7 +679,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 }
 
 func gcpFamily[T any](source *Source, options gcpFamilyOptions[T]) sourcecdk.Family[settings] {
-	return sourcecdk.Family[settings]{
+	family := sourcecdk.Family[settings]{
 		Name: options.Name,
 		Check: func(ctx context.Context, settings settings) error {
 			return gcpcloud.CheckList(ctx, source, settings, tenantID(settings), options.List, options.Label)
@@ -695,6 +703,19 @@ func gcpFamily[T any](source *Source, options gcpFamilyOptions[T]) sourcecdk.Fam
 			return gcpcloud.PullFromRecords(records, next, build)
 		},
 	}
+	if options.ListWithCheckpoint != nil {
+		family.ReadWithCheckpoint = func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+			readCheckpoint := sourcecdk.IncrementalCheckpointForCursor("gcp", options.Name, cursor, checkpoint)
+			token := sourcecdk.CursorToken(cursor)
+			records, next, err := options.ListWithCheckpoint(ctx, source, settings, token, settings.perPage, readCheckpoint)
+			if err != nil {
+				return sourcecdk.Pull{}, fmt.Errorf("lookup %s for %s: %w", options.Label, tenantID(settings), err)
+			}
+			build := func(record T) (*primitives.Event, error) { return options.Event(settings, record) }
+			return sourcecdk.IncrementalPullFromRecords("gcp", options.Name, records, next, readCheckpoint, build)
+		}
+	}
+	return family
 }
 
 func parseSettings(cfg sourcecdk.Config) (settings, error) {
@@ -1812,10 +1833,46 @@ func listServiceAccountImpersonation(ctx context.Context, source *Source, settin
 }
 
 func listSecurityCenterFindings(ctx context.Context, source *Source, settings settings, pageToken string, limit int) ([]gcpcloud.SecurityCenterFindingRecord, string, error) {
+	return listSecurityCenterFindingsWithCheckpoint(ctx, source, settings, pageToken, limit, nil)
+}
+
+func listSecurityCenterFindingsWithCheckpoint(ctx context.Context, source *Source, settings settings, pageToken string, limit int, checkpoint *cerebrov1.SourceCheckpoint) ([]gcpcloud.SecurityCenterFindingRecord, string, error) {
 	path := "/v2/projects/" + url.PathEscape(settings.projectID) + "/sources/-/findings"
-	return listPagedRecords[gcpcloud.SecurityCenterFindingRecord, securityCenterFindingsPageResponse](ctx, source, settings, pageToken, limit, securityCenterBaseURL, path, "pageSize", "gcp security command center finding", func(response securityCenterFindingsPageResponse) []json.RawMessage {
+	readSettings := settings
+	if start, ok := gcpCheckpointStart(checkpoint, gcpFindingCheckpointLookback); ok {
+		readSettings.filter = combineGCPFilters(readSettings.filter, fmt.Sprintf(`event_time >= "%s"`, start.Format(time.RFC3339Nano)))
+	}
+	query := url.Values{"orderBy": {"event_time desc"}}
+	return listPagedRecords[gcpcloud.SecurityCenterFindingRecord, securityCenterFindingsPageResponse](ctx, source, readSettings, pageToken, limit, securityCenterBaseURL, path, "pageSize", "gcp security command center finding", func(response securityCenterFindingsPageResponse) []json.RawMessage {
 		return response.ListFindingsResults
-	}, true, true, nil)
+	}, true, true, query)
+}
+
+func gcpCheckpointStart(checkpoint *cerebrov1.SourceCheckpoint, lookback time.Duration) (time.Time, bool) {
+	if checkpoint == nil || checkpoint.GetWatermark() == nil {
+		return time.Time{}, false
+	}
+	watermark := checkpoint.GetWatermark().AsTime().UTC()
+	if watermark.IsZero() {
+		return time.Time{}, false
+	}
+	if lookback > 0 {
+		watermark = watermark.Add(-lookback)
+	}
+	return watermark, true
+}
+
+func combineGCPFilters(existing string, incremental string) string {
+	existing = strings.TrimSpace(existing)
+	incremental = strings.TrimSpace(incremental)
+	switch {
+	case existing == "":
+		return incremental
+	case incremental == "":
+		return existing
+	default:
+		return "(" + existing + ") AND (" + incremental + ")"
+	}
 }
 
 func listAuditRecords(ctx context.Context, source *Source, settings settings, pageToken string, limit int) ([]auditRecord, string, error) {

--- a/sources/gcp/source_test.go
+++ b/sources/gcp/source_test.go
@@ -7,9 +7,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/sources/internal/gcpcloud"
 )
@@ -857,6 +860,95 @@ func TestReadLiveGCPSecurityCoveragePreview(t *testing.T) {
 				t.Fatalf("%s = %q, want %q", tt.attr, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReadLiveGCPSecurityCenterFindingsWithCheckpoint(t *testing.T) {
+	watermark := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	var gotOrderBy string
+	var gotFilter string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v2/projects/writer-prod/sources/-/findings" {
+			http.NotFound(w, r)
+			return
+		}
+		gotOrderBy = r.URL.Query().Get("orderBy")
+		gotFilter = r.URL.Query().Get("filter")
+		writeJSON(t, w, map[string]any{"listFindingsResults": []map[string]any{
+			{
+				"finding": map[string]any{
+					"name":         "projects/writer-prod/sources/123/findings/new-finding",
+					"parent":       "projects/writer-prod/sources/123",
+					"resourceName": "//storage.googleapis.com/projects/_/buckets/data-new",
+					"state":        "ACTIVE",
+					"category":     "PUBLIC_BUCKET_ACL",
+					"severity":     "HIGH",
+					"eventTime":    watermark.Add(time.Hour).Format(time.RFC3339Nano),
+					"createTime":   watermark.Add(time.Hour).Format(time.RFC3339Nano),
+				},
+				"resource": map[string]any{
+					"name":          "//storage.googleapis.com/projects/_/buckets/data-new",
+					"displayName":   "data-new",
+					"type":          "google.cloud.storage.Bucket",
+					"service":       "storage.googleapis.com",
+					"location":      "US",
+					"cloudProvider": "GOOGLE_CLOUD_PLATFORM",
+					"projectName":   "//cloudresourcemanager.googleapis.com/projects/writer-prod",
+				},
+			},
+			{
+				"finding": map[string]any{
+					"name":         "projects/writer-prod/sources/123/findings/old-finding",
+					"parent":       "projects/writer-prod/sources/123",
+					"resourceName": "//storage.googleapis.com/projects/_/buckets/data-old",
+					"state":        "ACTIVE",
+					"category":     "PUBLIC_BUCKET_ACL",
+					"severity":     "LOW",
+					"eventTime":    watermark.Add(-time.Hour).Format(time.RFC3339Nano),
+					"createTime":   watermark.Add(-time.Hour).Format(time.RFC3339Nano),
+				},
+				"resource": map[string]any{
+					"name":          "//storage.googleapis.com/projects/_/buckets/data-old",
+					"displayName":   "data-old",
+					"type":          "google.cloud.storage.Bucket",
+					"service":       "storage.googleapis.com",
+					"location":      "US",
+					"cloudProvider": "GOOGLE_CLOUD_PLATFORM",
+					"projectName":   "//cloudresourcemanager.googleapis.com/projects/writer-prod",
+				},
+			},
+		}})
+	}))
+	defer server.Close()
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url":   server.URL,
+		"family":     familySecurityCenterFinding,
+		"project_id": "writer-prod",
+		"token":      "test-token",
+	}), nil, &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(watermark)})
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(security_center_finding) error = %v", err)
+	}
+	if len(pull.Events) != 1 || pull.Events[0].GetAttributes()["finding_name"] != "projects/writer-prod/sources/123/findings/new-finding" {
+		t.Fatalf("events = %#v, want only new Security Command Center finding", pull.Events)
+	}
+	if pull.ShortCircuitReason != sourcecdk.PullShortCircuitReasonWatermarkReached {
+		t.Fatalf("ShortCircuitReason = %q, want watermark_reached", pull.ShortCircuitReason)
+	}
+	if gotOrderBy != "event_time desc" {
+		t.Fatalf("orderBy = %q, want event_time desc", gotOrderBy)
+	}
+	wantFilter := `event_time >= "` + watermark.Add(-gcpFindingCheckpointLookback).Format(time.RFC3339Nano) + `"`
+	if gotFilter != wantFilter {
+		t.Fatalf("filter = %q, want %q", gotFilter, wantFilter)
+	}
+	if got := pull.Checkpoint.GetWatermark().AsTime(); !got.Equal(watermark.Add(time.Hour)) {
+		t.Fatalf("checkpoint watermark = %s, want %s", got, watermark.Add(time.Hour))
 	}
 }
 

--- a/sources/gcp/source_test.go
+++ b/sources/gcp/source_test.go
@@ -943,7 +943,7 @@ func TestReadLiveGCPSecurityCenterFindingsWithCheckpoint(t *testing.T) {
 	if gotOrderBy != "event_time desc" {
 		t.Fatalf("orderBy = %q, want event_time desc", gotOrderBy)
 	}
-	wantFilter := `event_time >= "` + watermark.Add(-gcpFindingCheckpointLookback).Format(time.RFC3339Nano) + `"`
+	wantFilter := `event_time >= "` + watermark.Add(-gcpcloud.FindingCheckpointLookback).Format(time.RFC3339Nano) + `"`
 	if gotFilter != wantFilter {
 		t.Fatalf("filter = %q, want %q", gotFilter, wantFilter)
 	}

--- a/sources/internal/awssecurity/findings.go
+++ b/sources/internal/awssecurity/findings.go
@@ -7,6 +7,8 @@ import (
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	guarddutytypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
+	"github.com/aws/aws-sdk-go-v2/service/inspector2"
+	inspector2types "github.com/aws/aws-sdk-go-v2/service/inspector2/types"
 	"github.com/aws/aws-sdk-go-v2/service/macie2"
 	macie2types "github.com/aws/aws-sdk-go-v2/service/macie2/types"
 	"github.com/aws/aws-sdk-go-v2/service/securityhub"
@@ -42,6 +44,23 @@ func SecurityHubGetFindingsInput(maxResults int32, token string, checkpoint *cer
 	if start, ok := checkpointStart(checkpoint, lookback); ok {
 		input.Filters = &securityhubtypes.AwsSecurityFindingFilters{
 			UpdatedAt: []securityhubtypes.DateFilter{{Start: awssdk.String(start.Format(time.RFC3339Nano))}},
+		}
+	}
+	return input
+}
+
+func Inspector2ListFindingsInput(maxResults int32, token string, checkpoint *cerebrov1.SourceCheckpoint, lookback time.Duration) *inspector2.ListFindingsInput {
+	input := &inspector2.ListFindingsInput{
+		MaxResults: awssdk.Int32(maxResults),
+		NextToken:  stringPtr(token),
+		SortCriteria: &inspector2types.SortCriteria{
+			Field:     inspector2types.SortFieldLastObservedAt,
+			SortOrder: inspector2types.SortOrderDesc,
+		},
+	}
+	if start, ok := checkpointStart(checkpoint, lookback); ok {
+		input.FilterCriteria = &inspector2types.FilterCriteria{
+			LastObservedAt: []inspector2types.DateFilter{{StartInclusive: awssdk.Time(start)}},
 		}
 	}
 	return input

--- a/sources/internal/gcpcloud/events.go
+++ b/sources/internal/gcpcloud/events.go
@@ -5457,7 +5457,16 @@ func SecurityCenterFindingEvent(settings Settings, record SecurityCenterFindingR
 	if err != nil {
 		return nil, err
 	}
-	return sourceEvent(settings, "gcp-security-center-finding-"+resourceID, "gcp.security_center_finding", "gcp/security_center_finding/v1", payload, attributes)
+	return sourceEventAt(settings, "gcp-security-center-finding-"+resourceID, "gcp.security_center_finding", "gcp/security_center_finding/v1", payload, attributes, securityCenterFindingOccurredAt(record))
+}
+
+func securityCenterFindingOccurredAt(record SecurityCenterFindingRecord) time.Time {
+	for _, value := range []string{record.Finding.EventTime, record.Finding.CreateTime} {
+		if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value)); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Now().UTC()
 }
 
 func WorkloadIdentityPoolEvent(settings Settings, record WorkloadIdentityPoolRecord) (*primitives.Event, error) {

--- a/sources/internal/gcpcloud/events.go
+++ b/sources/internal/gcpcloud/events.go
@@ -12,6 +12,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 )
 
@@ -20,6 +21,35 @@ var gcsContentEmailRE = regexp.MustCompile(`[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{
 var gcsContentClassificationRE = regexp.MustCompile(`\b(restricted|confidential|internal|public)\b`)
 var gcsContentSecretRE = regexp.MustCompile(`(?i)(api[_-]?key|secret|token|password|passwd|private[_-]?key)\s*[:=]\s*["']?[a-z0-9_./+=\-]{12,}`)
 var gcsContentSSNRE = regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`)
+
+const FindingCheckpointLookback = 2 * time.Minute
+
+func CheckpointStart(checkpoint *cerebrov1.SourceCheckpoint, lookback time.Duration) (time.Time, bool) {
+	if checkpoint == nil || checkpoint.GetWatermark() == nil {
+		return time.Time{}, false
+	}
+	watermark := checkpoint.GetWatermark().AsTime().UTC()
+	if watermark.IsZero() {
+		return time.Time{}, false
+	}
+	if lookback > 0 {
+		watermark = watermark.Add(-lookback)
+	}
+	return watermark, true
+}
+
+func CombineFilters(existing string, incremental string) string {
+	existing = strings.TrimSpace(existing)
+	incremental = strings.TrimSpace(incremental)
+	switch {
+	case existing == "":
+		return incremental
+	case incremental == "":
+		return existing
+	default:
+		return "(" + existing + ") AND (" + incremental + ")"
+	}
+}
 
 type Settings struct {
 	ProjectID           string

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -17,7 +17,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"aws":             17802,
 	"azure":           2582,
 	"cosmo":           1112,
-	"gcp":             2078,
+	"gcp":             2074,
 	"github":          2115,
 	"googleworkspace": 827,
 	"grc":             1378,


### PR DESCRIPTION
## Summary
- Adds checkpoint-aware AWS Inspector2 finding reads using LastObservedAt provider filtering/sorting, matching the existing AWS findings incremental pattern.
- Adds checkpoint-aware GCP Security Command Center finding reads using event_time ordering/filtering and sourcecdk watermark short-circuiting.
- Adds shared cloud finding correlation for AWS/GCP/Azure provider findings into `security.finding` entities linked to affected resource evidence nodes.

## Scope
This is intentionally a bounded first slice, not full multicloud incremental fetch:
- Incremental fetch: AWS Inspector2 findings and GCP Security Command Center findings.
- Correlation: AWS GuardDuty/Security Hub/Inspector2/Macie, GCP SCC, and Azure Defender `server_vulnerability` events when affected/assessed resource IDs are present.
- Azure incremental fetch follow-up: the current Azure `server_vulnerability` collector uses the generic ARM resource list path and does not expose a clear, provider-supported updated-time sort/filter cursor in this code path. A safe Azure incremental PR should first add a typed Azure findings/list abstraction or confirm a stable ARM query contract for assessment update timestamps.

## Verification
- `go test ./internal/sourceprojection ./sources/aws ./sources/internal/awssecurity ./sources/gcp ./sources/internal/gcpcloud`
- `git diff --check`
