### PR TITLE
Improve identity incremental sync cursors

### DIFF
--- a/internal/sourcecdk/cursor_test.go
+++ b/internal/sourcecdk/cursor_test.go
@@ -159,6 +159,16 @@ func TestIncrementalWatermarkFiltersBoundaryEvents(t *testing.T) {
 	}
 }
 
+func TestIncrementalCheckpointForCursorAllowsEmptyCursor(t *testing.T) {
+	checkpoint := &cerebrov1.SourceCheckpoint{}
+	if got := IncrementalCheckpointForCursor("github", "pull_request", nil, checkpoint); got != checkpoint {
+		t.Fatalf("IncrementalCheckpointForCursor(nil) = %#v, want original checkpoint", got)
+	}
+	if got := IncrementalCheckpointForCursor("github", "pull_request", &cerebrov1.SourceCursor{}, checkpoint); got != checkpoint {
+		t.Fatalf("IncrementalCheckpointForCursor(empty) = %#v, want original checkpoint", got)
+	}
+}
+
 func watermarkTestEvent(id string, occurredAt time.Time) *primitives.Event {
 	return &primitives.Event{
 		Id:         id,

--- a/internal/sourcecdk/family.go
+++ b/internal/sourcecdk/family.go
@@ -12,12 +12,13 @@ import (
 
 // Family groups source behavior for one configured event family.
 type Family[S any] struct {
-	Name               string
-	Check              func(context.Context, S) error
-	Discover           func(context.Context, S) ([]URN, error)
-	Probe              func(context.Context, S, *cerebrov1.SourceCheckpoint) (ChangeProbe, error)
-	Read               func(context.Context, S, *cerebrov1.SourceCursor) (Pull, error)
-	ReadWithCheckpoint func(context.Context, S, *cerebrov1.SourceCursor, *cerebrov1.SourceCheckpoint) (Pull, error)
+	Name                 string
+	IncrementalWatermark bool
+	Check                func(context.Context, S) error
+	Discover             func(context.Context, S) ([]URN, error)
+	Probe                func(context.Context, S, *cerebrov1.SourceCheckpoint) (ChangeProbe, error)
+	Read                 func(context.Context, S, *cerebrov1.SourceCursor) (Pull, error)
+	ReadWithCheckpoint   func(context.Context, S, *cerebrov1.SourceCursor, *cerebrov1.SourceCheckpoint) (Pull, error)
 }
 
 // ChangeProbe is an optional cheap pre-read result for families that can test
@@ -152,6 +153,14 @@ func (e *FamilyEngine[S]) ReadWithCheckpoint(ctx context.Context, cfg Config, cu
 	pull, err := family.Read(ctx, settings, cursor)
 	if err != nil {
 		return Pull{}, err
+	}
+	if family.IncrementalWatermark && e.sourceID != "" {
+		readCheckpoint := IncrementalCheckpointForCursor(e.sourceID, family.Name, cursor, checkpoint)
+		next := ""
+		if pull.NextCursor != nil {
+			next = CursorToken(pull.NextCursor)
+		}
+		pull = IncrementalPullFromEvents(e.sourceID, family.Name, pull.Events, next, readCheckpoint)
 	}
 	return applyResourceScopePolicy(pull, policy), nil
 }

--- a/internal/sourcecdk/family_scope_test.go
+++ b/internal/sourcecdk/family_scope_test.go
@@ -204,3 +204,42 @@ func TestFamilyEngineUsesCheckpointAwareRead(t *testing.T) {
 		t.Fatalf("ShortCircuitReason = %q, want watermark_reached", pull.ShortCircuitReason)
 	}
 }
+
+func TestFamilyEngineAppliesIncrementalWatermarkFallback(t *testing.T) {
+	watermark := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	checkpoint := IncrementalWatermarkCheckpoint("github", "pull_request", []*primitives.Event{
+		{Id: "known", OccurredAt: timestamppb.New(watermark)},
+	}, IncrementalWatermarkState{})
+	engine, err := NewFamilyEngineWithSourceID("github", func(cfg Config) (string, error) {
+		family, _ := cfg.Lookup("family")
+		return family, nil
+	}, func(settings string) string { return settings }, Family[string]{
+		Name:                 "pull_request",
+		IncrementalWatermark: true,
+		Read: func(context.Context, string, *cerebrov1.SourceCursor) (Pull, error) {
+			return Pull{
+				Events: []*primitives.Event{
+					{Id: "new", OccurredAt: timestamppb.New(watermark.Add(time.Minute))},
+				},
+				NextCursor: &cerebrov1.SourceCursor{Opaque: "2"},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFamilyEngineWithSourceID() error = %v", err)
+	}
+
+	pull, err := engine.ReadWithCheckpoint(context.Background(), NewConfig(map[string]string{"family": "pull_request"}), nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 1 || pull.Events[0].GetId() != "new" {
+		t.Fatalf("events = %#v, want event newer than checkpoint", pull.Events)
+	}
+	if pull.NextCursor == nil || CursorToken(pull.NextCursor) != "2" {
+		t.Fatalf("NextCursor = %#v, want provider token 2", pull.NextCursor)
+	}
+	if !ResumableCursorOpaque(pull.NextCursor.GetOpaque()) {
+		t.Fatalf("NextCursor opaque = %q, want resumable envelope", pull.NextCursor.GetOpaque())
+	}
+}

--- a/internal/sourcecdk/watermark.go
+++ b/internal/sourcecdk/watermark.go
@@ -210,11 +210,7 @@ func PullFromRecords[T any](records []T, next string, build func(T) (*primitives
 // than the run's starting watermark.
 func IncrementalPullFromRecords[T any](source string, family string, records []T, next string, checkpoint *cerebrov1.SourceCheckpoint, build func(T) (*primitives.Event, error)) (Pull, error) {
 	if len(records) == 0 {
-		pull := EmptyIncrementalWatermarkPull(source, family, checkpoint)
-		if next = strings.TrimSpace(next); next != "" {
-			pull.NextCursor = &cerebrov1.SourceCursor{Opaque: IncrementalCursor(source, family, next, checkpoint)}
-		}
-		return pull, nil
+		return IncrementalPullFromEvents(source, family, nil, next, checkpoint), nil
 	}
 	events := make([]*primitives.Event, 0, len(records))
 	for _, record := range records {
@@ -224,16 +220,32 @@ func IncrementalPullFromRecords[T any](source string, family string, records []T
 		}
 		events = append(events, event)
 	}
+	return IncrementalPullFromEvents(source, family, events, next, checkpoint), nil
+}
+
+// IncrementalPullFromEvents applies durable watermark filtering to events that
+// were already projected by a provider reader.
+func IncrementalPullFromEvents(source string, family string, events []*primitives.Event, next string, checkpoint *cerebrov1.SourceCheckpoint) Pull {
+	if len(events) == 0 {
+		pull := EmptyIncrementalWatermarkPull(source, family, checkpoint)
+		if next = strings.TrimSpace(next); next != "" {
+			pull.NextCursor = &cerebrov1.SourceCursor{Opaque: IncrementalCursor(source, family, next, checkpoint)}
+		}
+		return pull
+	}
 	pull := IncrementalWatermarkPull(source, family, events, checkpoint, next)
 	if pull.NextCursor != nil {
 		pull.NextCursor.Opaque = IncrementalCursor(source, family, next, checkpoint)
 	}
-	return pull, nil
+	return pull
 }
 
 // IncrementalCheckpointForCursor restores the starting comparison checkpoint
 // from a continuation cursor produced by IncrementalCursor.
 func IncrementalCheckpointForCursor(source string, family string, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {
+	if cursor == nil || strings.TrimSpace(cursor.GetOpaque()) == "" {
+		return checkpoint
+	}
 	envelope, ok := DecodeCursorEnvelope(cursor.GetOpaque())
 	if !ok || strings.TrimSpace(envelope.Source) != strings.TrimSpace(source) || strings.TrimSpace(envelope.Family) != strings.TrimSpace(family) {
 		return checkpoint

--- a/sources/github/catalog.yaml
+++ b/sources/github/catalog.yaml
@@ -59,6 +59,9 @@ coverage_contract:
       high_value: true
       known_unsupported_fields:
         - remediation workflow state
+      notes:
+        - GitHub alert and pull request state is provider lifecycle state, not Cerebro finding remediation state.
+        - Findings and source-runtime consumers must use Cerebro finding status for remediation lifecycle decisions.
     - id: repositories
       type: entity_family
       title: Repositories

--- a/sources/github/dependabot_alert.go
+++ b/sources/github/dependabot_alert.go
@@ -65,23 +65,15 @@ func (s *Source) discoverDependabotAlerts(ctx context.Context, client *gogithub.
 }
 
 func (s *Source) readDependabotAlerts(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	readCheckpoint := sourcecdk.IncrementalCheckpointForCursor("github", familyDependabot, cursor, checkpoint)
 	after := sourcecdk.CursorToken(cursor)
 	alerts, resp, err := client.Dependabot.ListRepoAlerts(ctx, settings.owner, settings.repo, dependabotAlertOptions(settings, after, settings.perPage))
 	if err != nil {
 		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github dependabot alerts for repo %s/%s", settings.owner, settings.repo), err)
 	}
-	if len(alerts) == 0 {
-		return sourcecdk.EmptyIncrementalWatermarkPull("github", familyDependabot, checkpoint), nil
-	}
-	events := make([]*primitives.Event, 0, len(alerts))
-	for _, alert := range alerts {
-		event, err := dependabotAlertEvent(settings, alert)
-		if err != nil {
-			return sourcecdk.Pull{}, err
-		}
-		events = append(events, event)
-	}
-	return sourcecdk.IncrementalWatermarkPull("github", familyDependabot, events, checkpoint, nextAuditCursor(resp)), nil
+	return sourcecdk.IncrementalPullFromRecords("github", familyDependabot, alerts, nextAuditCursor(resp), readCheckpoint, func(alert *gogithub.DependabotAlert) (*primitives.Event, error) {
+		return dependabotAlertEvent(settings, alert)
+	})
 }
 
 func dependabotAlertOptions(settings settings, after string, perPage int) *gogithub.ListAlertsOptions {

--- a/sources/github/secret_scanning_alert.go
+++ b/sources/github/secret_scanning_alert.go
@@ -55,26 +55,18 @@ func (s *Source) discoverSecretScanningAlerts(ctx context.Context, client *gogit
 }
 
 func (s *Source) readSecretScanningAlerts(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	readCheckpoint := sourcecdk.IncrementalCheckpointForCursor("github", familySecretScanning, cursor, checkpoint)
 	alerts, resp, err := listSecretScanningAlertsForOrg(ctx, client, settings, cursor, settings.perPage)
 	if err != nil {
 		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github secret scanning alerts for org %s", settings.owner), err)
-	}
-	if len(alerts) == 0 {
-		return sourcecdk.EmptyIncrementalWatermarkPull("github", familySecretScanning, checkpoint), nil
-	}
-	events := make([]*primitives.Event, 0, len(alerts))
-	for _, alert := range alerts {
-		event, err := secretScanningAlertEvent(settings, alert)
-		if err != nil {
-			return sourcecdk.Pull{}, err
-		}
-		events = append(events, event)
 	}
 	nextCursor := ""
 	if resp != nil {
 		nextCursor = sourcecdk.NextAfterOrPageCursor(resp.After, resp.NextPageToken, resp.NextPage)
 	}
-	return sourcecdk.IncrementalWatermarkPull("github", familySecretScanning, events, checkpoint, nextCursor), nil
+	return sourcecdk.IncrementalPullFromRecords("github", familySecretScanning, alerts, nextCursor, readCheckpoint, func(alert *gogithub.SecretScanningAlert) (*primitives.Event, error) {
+		return secretScanningAlertEvent(settings, alert)
+	})
 }
 
 func listSecretScanningAlertsForOrg(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, perPage int) ([]*gogithub.SecretScanningAlert, *gogithub.Response, error) {

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -224,6 +224,7 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 }
 
 func (s *Source) readPullRequests(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	readCheckpoint := sourcecdk.IncrementalCheckpointForCursor("github", familyPullRequest, cursor, checkpoint)
 	page, err := sourcecdk.CursorPage(cursor)
 	if err != nil {
 		return sourcecdk.Pull{}, err
@@ -240,63 +241,44 @@ func (s *Source) readPullRequests(ctx context.Context, client *gogithub.Client, 
 	if err != nil {
 		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github repo %s/%s", settings.owner, settings.repo), err)
 	}
-	if len(pulls) == 0 {
-		return sourcecdk.EmptyIncrementalWatermarkPull("github", familyPullRequest, checkpoint), nil
-	}
-	events := make([]*primitives.Event, 0, len(pulls))
-	for _, pullRequest := range pulls {
-		event, err := pullRequestEvent(settings, pullRequest)
-		if err != nil {
-			return sourcecdk.Pull{}, err
-		}
-		events = append(events, event)
-	}
 	nextCursor := ""
 	if resp != nil && resp.NextPage > 0 {
 		nextCursor = strconv.Itoa(resp.NextPage)
 	}
-	return sourcecdk.IncrementalWatermarkPull("github", familyPullRequest, events, checkpoint, nextCursor), nil
+	return sourcecdk.IncrementalPullFromRecords("github", familyPullRequest, pulls, nextCursor, readCheckpoint, func(pullRequest *gogithub.PullRequest) (*primitives.Event, error) {
+		return pullRequestEvent(settings, pullRequest)
+	})
 }
 
 func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	readCheckpoint := sourcecdk.IncrementalCheckpointForCursor("github", familyRepository, cursor, checkpoint)
 	page, err := sourcecdk.CursorPage(cursor)
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
 	if settings.repo != "" {
 		if page > 1 {
-			return sourcecdk.EmptyIncrementalWatermarkPull("github", familyRepository, checkpoint), nil
+			return sourcecdk.EmptyIncrementalWatermarkPull("github", familyRepository, readCheckpoint), nil
 		}
 		repo, err := getRepo(ctx, client, settings.owner, settings.repo)
 		if err != nil {
 			return sourcecdk.Pull{}, err
 		}
-		event, err := repositoryEvent(settings, repo)
-		if err != nil {
-			return sourcecdk.Pull{}, err
-		}
-		return sourcecdk.IncrementalWatermarkPull("github", familyRepository, []*primitives.Event{event}, checkpoint, ""), nil
+		return sourcecdk.IncrementalPullFromRecords("github", familyRepository, []*gogithub.Repository{repo}, "", readCheckpoint, func(repo *gogithub.Repository) (*primitives.Event, error) {
+			return repositoryEvent(settings, repo)
+		})
 	}
 	repos, resp, err := listReposPage(ctx, client, settings.owner, page, settings.perPage)
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
-	if len(repos) == 0 {
-		return sourcecdk.EmptyIncrementalWatermarkPull("github", familyRepository, checkpoint), nil
-	}
-	events := make([]*primitives.Event, 0, len(repos))
-	for _, repo := range repos {
-		event, err := repositoryEvent(settings, repo)
-		if err != nil {
-			return sourcecdk.Pull{}, err
-		}
-		events = append(events, event)
-	}
 	nextCursor := ""
 	if resp != nil && resp.NextPage > 0 {
 		nextCursor = strconv.Itoa(resp.NextPage)
 	}
-	return sourcecdk.IncrementalWatermarkPull("github", familyRepository, events, checkpoint, nextCursor), nil
+	return sourcecdk.IncrementalPullFromRecords("github", familyRepository, repos, nextCursor, readCheckpoint, func(repo *gogithub.Repository) (*primitives.Event, error) {
+		return repositoryEvent(settings, repo)
+	})
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -321,17 +321,20 @@ func TestCheckDiscoverAndReadLiveGitHubPullRequestPreview(t *testing.T) {
 	if len(first.Events) != 1 {
 		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
 	}
-	if first.NextCursor == nil || first.NextCursor.Opaque != "2" {
+	if first.NextCursor == nil || sourcecdk.CursorToken(first.NextCursor) != "2" {
 		t.Fatalf("first.NextCursor = %#v, want page 2", first.NextCursor)
+	}
+	if !sourcecdk.ResumableCursorOpaque(first.NextCursor.GetOpaque()) {
+		t.Fatalf("first.NextCursor.Opaque = %q, want resumable envelope", first.NextCursor.GetOpaque())
 	}
 	assertGitHubCheckpointEnvelope(t, first.Checkpoint, familyPullRequest)
 	firstCheckpoint, ok := sourcecdk.DecodeCursorEnvelope(first.Checkpoint.GetCursorOpaque())
 	if !ok || firstCheckpoint.Token != "2" {
 		t.Fatalf("first.Checkpoint = %#v, want resumable envelope with token 2", first.Checkpoint)
 	}
-	resumed, err := source.Read(context.Background(), readCfg, &cerebrov1.SourceCursor{Opaque: first.Checkpoint.GetCursorOpaque()})
+	resumed, err := source.ReadWithCheckpoint(context.Background(), readCfg, first.NextCursor, first.Checkpoint)
 	if err != nil {
-		t.Fatalf("Read(resumed from checkpoint envelope) error = %v", err)
+		t.Fatalf("ReadWithCheckpoint(resumed from continuation cursor) error = %v", err)
 	}
 	if len(resumed.Events) != 1 || resumed.Events[0].GetId() != "github-pr-writer-cerebro-442-1776902400" {
 		t.Fatalf("resumed events = %#v, want second fixture PR", resumed.Events)
@@ -516,7 +519,7 @@ func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
 	if len(first.Events) != 1 {
 		t.Fatalf("len(Read(audit first).Events) = %d, want 1", len(first.Events))
 	}
-	if first.NextCursor == nil || first.NextCursor.Opaque != "cursor-2" {
+	if first.NextCursor == nil || sourcecdk.CursorToken(first.NextCursor) != "cursor-2" {
 		t.Fatalf("first.NextCursor = %#v, want cursor-2", first.NextCursor)
 	}
 	if got := first.Events[0].Kind; got != "github.audit" {
@@ -693,8 +696,11 @@ func TestCheckDiscoverAndReadLiveGitHubDependabotAlertPreview(t *testing.T) {
 	if len(first.Events) != 1 {
 		t.Fatalf("len(Read(dependabot_alert first).Events) = %d, want 1", len(first.Events))
 	}
-	if first.NextCursor == nil || first.NextCursor.Opaque != "cursor-2" {
+	if first.NextCursor == nil || sourcecdk.CursorToken(first.NextCursor) != "cursor-2" {
 		t.Fatalf("first.NextCursor = %#v, want cursor-2", first.NextCursor)
+	}
+	if !sourcecdk.ResumableCursorOpaque(first.NextCursor.GetOpaque()) {
+		t.Fatalf("first.NextCursor.Opaque = %q, want resumable envelope", first.NextCursor.GetOpaque())
 	}
 	if got := first.Events[0].Kind; got != "github.dependabot_alert" {
 		t.Fatalf("first.Events[0].Kind = %q, want github.dependabot_alert", got)
@@ -792,8 +798,11 @@ func TestSecretScanningUsesUpdatedSortAndCursorPagination(t *testing.T) {
 	if len(first.Events) != 1 {
 		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
 	}
-	if first.NextCursor == nil || first.NextCursor.Opaque != "after:cursor-2" {
+	if first.NextCursor == nil || sourcecdk.CursorToken(first.NextCursor) != "after:cursor-2" {
 		t.Fatalf("first.NextCursor = %#v, want after cursor", first.NextCursor)
+	}
+	if !sourcecdk.ResumableCursorOpaque(first.NextCursor.GetOpaque()) {
+		t.Fatalf("first.NextCursor.Opaque = %q, want resumable envelope", first.NextCursor.GetOpaque())
 	}
 
 	second, err := source.ReadWithCheckpoint(context.Background(), cfg, first.NextCursor, nil)

--- a/sources/googleworkspace/catalog.yaml
+++ b/sources/googleworkspace/catalog.yaml
@@ -43,6 +43,9 @@ coverage_contract:
       high_value: true
       known_unsupported_fields:
         - remediation workflow state
+      notes:
+        - Google Workspace suspended, archived, member status, and audit attributes are provider lifecycle state, not Cerebro finding remediation state.
+        - Findings and source-runtime consumers must use Cerebro finding status for remediation lifecycle decisions.
     - id: role_assignments
       type: app_entitlement
       title: Role assignments

--- a/sources/googleworkspace/source.go
+++ b/sources/googleworkspace/source.go
@@ -180,12 +180,16 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 	return s.families.Read(ctx, cfg, cursor)
 }
 
+func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	return s.families.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
+}
+
 func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 	families := []sourcecdk.Family[settings]{}
 	for _, family := range []string{familyAudit, familyGroup, familyGroupMember, familyRoleAssign, familyUser} {
 		familyName := family
 		families = append(families, sourcecdk.Family[settings]{
-			Name: familyName,
+			Name: familyName, IncrementalWatermark: true,
 			Check: func(ctx context.Context, settings settings) error {
 				_, _, err := s.readRawPage(ctx, settings, "", 1)
 				return err
@@ -194,7 +198,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 			Read:     s.readFamily,
 		})
 	}
-	return sourcecdk.NewFamilyEngine(parseSettings, func(settings settings) string {
+	return sourcecdk.NewFamilyEngineWithSourceID("google_workspace", parseSettings, func(settings settings) string {
 		return settings.family
 	}, families...)
 }
@@ -218,7 +222,7 @@ func (s *Source) discoverFamily(ctx context.Context, settings settings) ([]sourc
 }
 
 func (s *Source) readFamily(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-	rawRecords, next, err := s.readRawPage(ctx, settings, strings.TrimSpace(cursor.GetOpaque()), settings.perPage)
+	rawRecords, next, err := s.readRawPage(ctx, settings, sourcecdk.CursorToken(cursor), settings.perPage)
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
@@ -770,10 +774,7 @@ func checkpointCursor(next string, fallback string) string {
 }
 
 func boolString(value bool) string {
-	if value {
-		return "true"
-	}
-	return "false"
+	return strconv.FormatBool(value)
 }
 
 func trimEmpty(values map[string]string) map[string]string {

--- a/sources/googleworkspace/source_test.go
+++ b/sources/googleworkspace/source_test.go
@@ -94,15 +94,18 @@ func TestReadLiveGoogleWorkspaceUserPreview(t *testing.T) {
 	if len(first.Events) != 1 {
 		t.Fatalf("len(Read(user first).Events) = %d, want 1", len(first.Events))
 	}
-	if first.NextCursor == nil || first.NextCursor.Opaque != "page-2" {
+	if first.NextCursor == nil || sourcecdk.CursorToken(first.NextCursor) != "page-2" {
 		t.Fatalf("first.NextCursor = %#v, want page-2", first.NextCursor)
+	}
+	if !sourcecdk.ResumableCursorOpaque(first.NextCursor.GetOpaque()) {
+		t.Fatalf("first.NextCursor.Opaque = %q, want resumable envelope", first.NextCursor.GetOpaque())
 	}
 	if got := first.Events[0].Attributes["email"]; got != "admin@writer.com" {
 		t.Fatalf("first event email = %q, want admin@writer.com", got)
 	}
-	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, first.NextCursor, first.Checkpoint)
 	if err != nil {
-		t.Fatalf("Read(user second) error = %v", err)
+		t.Fatalf("ReadWithCheckpoint(user second) error = %v", err)
 	}
 	if len(second.Events) != 1 {
 		t.Fatalf("len(Read(user second).Events) = %d, want 1", len(second.Events))

--- a/sources/okta/catalog.yaml
+++ b/sources/okta/catalog.yaml
@@ -80,6 +80,9 @@ coverage_contract:
       high_value: true
       known_unsupported_fields:
         - remediation workflow state
+      notes:
+        - Okta user, app, assignment, policy, and audit status fields are provider lifecycle state, not Cerebro finding remediation state.
+        - Findings and source-runtime consumers must use Cerebro finding status for remediation lifecycle decisions.
     - id: threat_insight
       type: entity_family
       title: ThreatInsight configuration

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -324,6 +324,10 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 	return s.families.Read(ctx, cfg, cursor)
 }
 
+func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	return s.families.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
+}
+
 type oktaListFunc[T any] func(context.Context, settings, string, int) ([]T, string, error)
 
 type oktaFamilyOptions[T any] struct {
@@ -339,7 +343,7 @@ type oktaFamilyOptions[T any] struct {
 
 func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 	auditList := s.listAudit
-	return sourcecdk.NewFamilyEngine(s.parseSettings, func(settings settings) string {
+	return sourcecdk.NewFamilyEngineWithSourceID("okta", s.parseSettings, func(settings settings) string {
 		return settings.family
 	},
 		oktaFamily(oktaFamilyOptions[auditRecord]{
@@ -435,7 +439,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 
 func oktaFamily[T any](options oktaFamilyOptions[T]) sourcecdk.Family[settings] {
 	return sourcecdk.Family[settings]{
-		Name: options.Name,
+		Name: options.Name, IncrementalWatermark: true,
 		Check: func(ctx context.Context, settings settings) error {
 			return oktaCheck(ctx, settings, options.List, options.Label)
 		},
@@ -450,7 +454,7 @@ func oktaFamily[T any](options oktaFamilyOptions[T]) sourcecdk.Family[settings] 
 			return oktaURNsFor(settings, records, options.URN)
 		},
 		Read: func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-			records, next, err := options.List(ctx, settings, strings.TrimSpace(cursor.GetOpaque()), settings.perPage)
+			records, next, err := options.List(ctx, settings, sourcecdk.CursorToken(cursor), settings.perPage)
 			if err != nil {
 				return sourcecdk.Pull{}, wrapLookupError(oktaLabel(options.Label, settings), err)
 			}
@@ -1891,10 +1895,7 @@ func firstNonEmpty(values ...string) string {
 }
 
 func boolString(value bool) string {
-	if value {
-		return "true"
-	}
-	return "false"
+	return strconv.FormatBool(value)
 }
 
 func configValue(cfg sourcecdk.Config, key string) string {

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -215,8 +215,11 @@ func TestCheckDiscoverAndReadLiveOktaAuditPreview(t *testing.T) {
 	if len(first.Events) != 1 {
 		t.Fatalf("len(Read(audit first).Events) = %d, want 1", len(first.Events))
 	}
-	if first.NextCursor == nil || first.NextCursor.Opaque != "cursor-2" {
+	if first.NextCursor == nil || sourcecdk.CursorToken(first.NextCursor) != "cursor-2" {
 		t.Fatalf("first.NextCursor = %#v, want cursor-2", first.NextCursor)
+	}
+	if !sourcecdk.ResumableCursorOpaque(first.NextCursor.GetOpaque()) {
+		t.Fatalf("first.NextCursor.Opaque = %q, want resumable envelope", first.NextCursor.GetOpaque())
 	}
 	if got := first.Events[0].Kind; got != "okta.audit" {
 		t.Fatalf("first.Events[0].Kind = %q, want okta.audit", got)
@@ -232,9 +235,9 @@ func TestCheckDiscoverAndReadLiveOktaAuditPreview(t *testing.T) {
 		t.Fatalf("audit payload resource_id = %#v, want 00u1", got)
 	}
 
-	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, first.NextCursor, first.Checkpoint)
 	if err != nil {
-		t.Fatalf("Read(audit second) error = %v", err)
+		t.Fatalf("ReadWithCheckpoint(audit second) error = %v", err)
 	}
 	if len(second.Events) != 1 {
 		t.Fatalf("len(Read(audit second).Events) = %d, want 1", len(second.Events))
@@ -242,8 +245,12 @@ func TestCheckDiscoverAndReadLiveOktaAuditPreview(t *testing.T) {
 	if second.NextCursor != nil {
 		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
 	}
-	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "evt-2" {
-		t.Fatalf("second.Checkpoint = %#v, want evt-2", second.Checkpoint)
+	if second.Checkpoint == nil || !sourcecdk.ResumableCursorOpaque(second.Checkpoint.GetCursorOpaque()) {
+		t.Fatalf("second.Checkpoint = %#v, want resumable watermark envelope", second.Checkpoint)
+	}
+	auditEnvelope, ok := sourcecdk.DecodeCursorEnvelope(second.Checkpoint.GetCursorOpaque())
+	if !ok || auditEnvelope.Family != familyAudit || auditEnvelope.Token != "" {
+		t.Fatalf("second checkpoint envelope = %#v, want terminal audit watermark", auditEnvelope)
 	}
 }
 
@@ -726,8 +733,11 @@ func TestCheckDiscoverAndReadLiveOktaUserPreview(t *testing.T) {
 	if len(first.Events) != 1 {
 		t.Fatalf("len(Read(user first).Events) = %d, want 1", len(first.Events))
 	}
-	if first.NextCursor == nil || first.NextCursor.Opaque != "cursor-user-2" {
+	if first.NextCursor == nil || sourcecdk.CursorToken(first.NextCursor) != "cursor-user-2" {
 		t.Fatalf("first.NextCursor = %#v, want cursor-user-2", first.NextCursor)
+	}
+	if !sourcecdk.ResumableCursorOpaque(first.NextCursor.GetOpaque()) {
+		t.Fatalf("first.NextCursor.Opaque = %q, want resumable envelope", first.NextCursor.GetOpaque())
 	}
 	if got := first.Events[0].Kind; got != "okta.user" {
 		t.Fatalf("first.Events[0].Kind = %q, want okta.user", got)
@@ -745,9 +755,9 @@ func TestCheckDiscoverAndReadLiveOktaUserPreview(t *testing.T) {
 		t.Fatalf("user payload profile.login = %#v, want alice@writer.com", got)
 	}
 
-	second, err := source.Read(context.Background(), readCfg, first.NextCursor)
+	second, err := source.ReadWithCheckpoint(context.Background(), readCfg, first.NextCursor, first.Checkpoint)
 	if err != nil {
-		t.Fatalf("Read(user second) error = %v", err)
+		t.Fatalf("ReadWithCheckpoint(user second) error = %v", err)
 	}
 	if len(second.Events) != 1 {
 		t.Fatalf("len(Read(user second).Events) = %d, want 1", len(second.Events))
@@ -756,8 +766,12 @@ func TestCheckDiscoverAndReadLiveOktaUserPreview(t *testing.T) {
 		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
 	}
 	assertOktaMFAAttributes(t, second.Events[0].Attributes, "false", "0")
-	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "00u2" {
-		t.Fatalf("second.Checkpoint = %#v, want 00u2", second.Checkpoint)
+	if second.Checkpoint == nil || !sourcecdk.ResumableCursorOpaque(second.Checkpoint.GetCursorOpaque()) {
+		t.Fatalf("second.Checkpoint = %#v, want resumable watermark envelope", second.Checkpoint)
+	}
+	userEnvelope, ok := sourcecdk.DecodeCursorEnvelope(second.Checkpoint.GetCursorOpaque())
+	if !ok || userEnvelope.Family != familyUser || userEnvelope.Token != "" {
+		t.Fatalf("second checkpoint envelope = %#v, want terminal user watermark", userEnvelope)
 	}
 }
 

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -18,7 +18,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"azure":           2582,
 	"cosmo":           1112,
 	"gcp":             2078,
-	"github":          2149,
+	"github":          2115,
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2433,


### PR DESCRIPTION
## Summary
- add a Source CDK incremental-watermark family capability that preserves provider continuation tokens while comparing against the run-start checkpoint
- apply checkpoint-aware incremental paging to GitHub current-state/alert families, Google Workspace families, and generic Okta families
- document provider lifecycle state vs Cerebro remediation state in GitHub, Google Workspace, and Okta coverage contracts
- ratchet the GitHub source package LOC budget down after moving shared cursor handling into Source CDK

## Verification
- go test ./internal/sourceruntime ./internal/sourcecdk ./sources/github ./sources/googleworkspace ./sources/okta
- go test ./tools/archtests
- git diff --check