### PR TITLE
Deepen Auth0 connector catalog definition

### DIFF
--- a/internal/connectorcatalog/catalog/identity-access-secrets.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets.yaml
@@ -12,9 +12,21 @@ entries:
       categories:
         - identity
         - access
+      config_fields:
+        - key: domain
+          label: "Tenant domain"
+          required: true
+          placeholder: "example.us.auth0.com"
+          help: "Auth0 tenant domain used for Management API requests."
       auth:
         model: oauth_client_credentials
         token_url: "https://${config.domain}/oauth/token"
+        scopes:
+          - read:users
+          - read:roles
+          - read:logs
+        token_params:
+          audience: "https://${config.domain}/api/v2/"
         credential_fields:
           - key: client_id
             reference_only: true
@@ -22,18 +34,19 @@ entries:
             secret: true
             reference_only: true
       transport:
-        base_url: "https://${config.domain}"
+        base_url: "https://${config.domain}/api/v2"
         verification:
           method: GET
-          path: /api/v2/clients
+          path: /users
           expect_status: [200]
       resource_families:
         - id: users
           label: Users
-          path: /v1/users
+          path: /users
           method: GET
-          record_selector: "$.data[*]"
-          id_field: id
+          record_selector: "$[*]"
+          id_field: user_id
+          name_field: name
           event:
             kind: auth0.users
             schema_ref: auth0/users/v1
@@ -47,41 +60,42 @@ entries:
               support: partial
               high_value: true
           pagination:
-            type: cursor
-            cursor_param: cursor
-            cursor_json_path: "$.next_cursor"
-            page_size_param: limit
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 0
             page_size: 100
-        - id: groups
-          label: Groups
-          path: /v1/groups
+        - id: roles
+          label: Roles
+          path: /roles
           method: GET
-          record_selector: "$.data[*]"
+          record_selector: "$[*]"
           id_field: id
+          name_field: name
           event:
-            kind: auth0.groups
-            schema_ref: auth0/groups/v1
+            kind: auth0.roles
+            schema_ref: auth0/roles/v1
           projection:
             template: identity_group
           coverage:
-            - id: groups
+            - id: roles
               type: entity_family
-              title: "Identity groups"
-              families: [groups]
+              title: "Identity roles"
+              families: [roles]
               support: partial
               high_value: true
           pagination:
-            type: cursor
-            cursor_param: cursor
-            cursor_json_path: "$.next_cursor"
-            page_size_param: limit
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 0
             page_size: 100
         - id: audit_events
           label: "Audit events"
-          path: /v1/audit/events
+          path: /logs
           method: GET
-          record_selector: "$.data[*]"
-          id_field: id
+          record_selector: "$[*]"
+          id_field: log_id
           event:
             kind: auth0.audit_events
             schema_ref: auth0/audit_events/v1
@@ -96,9 +110,9 @@ entries:
               high_value: true
           pagination:
             type: cursor
-            cursor_param: cursor
-            cursor_json_path: "$.next_cursor"
-            page_size_param: limit
+            cursor_param: from
+            cursor_json_path: "$[-1].log_id"
+            page_size_param: take
             page_size: 100
   - classifier_output: supported
     definition:

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/writer/cerebro/internal/connectordefinitions"
 )
 
 func TestAnalyzeDirAcceptsGenerateableCatalogEntry(t *testing.T) {
@@ -186,6 +188,46 @@ func TestBuiltinEntryFindsNormalizedSourceID(t *testing.T) {
 	if entry.Definition.SourceID != "jumpcloud" || entry.Status != StatusGenerateable {
 		t.Fatalf("entry = %#v, want generateable jumpcloud", entry)
 	}
+}
+
+func TestBuiltinCatalogAuth0UsesManagementAPIShape(t *testing.T) {
+	entry, ok, err := BuiltinEntry("auth0")
+	if err != nil {
+		t.Fatalf("BuiltinEntry() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("BuiltinEntry(auth0) ok = false, want true")
+	}
+	definition := entry.Definition
+	if definition.Transport == nil || definition.Transport.BaseURL != "https://${config.domain}/api/v2" {
+		t.Fatalf("auth0 transport = %#v, want Management API v2 base", definition.Transport)
+	}
+	if definition.Transport.Verification == nil || definition.Transport.Verification.Path != "/users" {
+		t.Fatalf("auth0 verification = %#v, want /users", definition.Transport.Verification)
+	}
+	if got := definition.Auth.TokenParams["audience"]; got != "https://${config.domain}/api/v2/" {
+		t.Fatalf("auth0 audience token param = %q", got)
+	}
+	if len(definition.ConfigFields) != 1 || definition.ConfigFields[0].Key != "domain" || !definition.ConfigFields[0].Required {
+		t.Fatalf("auth0 config fields = %#v, want required domain", definition.ConfigFields)
+	}
+	assertCatalogFamily(t, definition.ResourceFamilies, "users", "/users", "$[*]", "user_id")
+	assertCatalogFamily(t, definition.ResourceFamilies, "roles", "/roles", "$[*]", "id")
+	assertCatalogFamily(t, definition.ResourceFamilies, "audit_events", "/logs", "$[*]", "log_id")
+}
+
+func assertCatalogFamily(t *testing.T, families []connectordefinitions.ResourceFamily, id string, path string, selector string, idField string) {
+	t.Helper()
+	for _, family := range families {
+		if family.ID != id {
+			continue
+		}
+		if family.Path != path || family.RecordSelector != selector || family.IDField != idField {
+			t.Fatalf("family %s = %#v, want path=%s selector=%s id_field=%s", id, family, path, selector, idField)
+		}
+		return
+	}
+	t.Fatalf("family %s not found in %#v", id, families)
 }
 
 func minimalDefinitionYAML() string {


### PR DESCRIPTION
## Summary
- replace the generic Auth0 /v1 placeholder families with Auth0 Management API v2 users, roles, and logs resources
- add explicit Auth0 tenant domain config, Management API audience, and read scopes
- cover the Auth0 catalog shape with a regression test

## Tests
- go test ./internal/connectorcatalog
- go test ./internal/connectorcatalog ./internal/bootstrap
- make catalog-check

## Sources
- Auth0 Management API reference: https://auth0.com/docs/api/management/v2
- Auth0 users endpoint docs: https://auth0.com/docs/api/management/v2/users/get-users
- Auth0 roles endpoint docs: https://auth0.com/docs/api/management/v2/roles/get-roles
- Auth0 logs retrieval docs: https://auth0.com/docs/deploy-monitor/logs/retrieve-log-events-using-mgmt-api