### PR TITLE
Add AWS EKS node coverage

### DIFF
--- a/internal/sourceprojection/aws_compute.go
+++ b/internal/sourceprojection/aws_compute.go
@@ -8,7 +8,23 @@ import (
 )
 
 func awsEC2InstanceProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return awsComputeProjections(event, "aws_ec2_instance", "aws.ec2.instance")
+	entities, links, err := awsComputeProjections(event, "aws_ec2_instance", "aws.ec2.instance")
+	if err != nil {
+		return nil, nil, err
+	}
+	entityMap := projectedEntitiesMap(entities)
+	linkMap := projectedLinksMap(links)
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	instanceURN := ""
+	if instanceID := firstNonEmpty(attributes["resource_id"], attributes["instance_id"]); instanceID != "" {
+		instanceURN = projectionURN(tenantID, "aws_ec2_instance", instanceID)
+	}
+	addAWSEKSNodeContextLinks(entityMap, linkMap, tenantID, event.GetSourceId(), event, instanceURN, attributes)
+	return identityProjectionResult(entityMap, linkMap)
 }
 
 func awsLambdaFunctionProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -155,6 +171,16 @@ func awsEKSClusterProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projecte
 	attributes := event.GetAttributes()
 	clusterURN := projectionURN(tenantID, "aws_eks_cluster", firstNonEmpty(attributes["cluster_arn"], attributes["resource_id"], attributes["cluster_name"]))
 	addAWSEKSCluster(entityMap, linkMap, tenantID, event.GetSourceId(), event, clusterURN, attributes)
+	nameURN := awsEKSClusterNameURN(tenantID, attributes)
+	if nameURN != "" && clusterURN != "" && nameURN != clusterURN {
+		addAWSEKSCluster(entityMap, linkMap, tenantID, event.GetSourceId(), event, nameURN, map[string]string{
+			"cluster_arn":  attributes["cluster_arn"],
+			"cluster_name": attributes["cluster_name"],
+			"domain":       attributes["domain"],
+			"region":       attributes["region"],
+		})
+		addLink(linkMap, projectedLink(tenantID, event.GetSourceId(), nameURN, clusterURN, relationRepresents, map[string]string{"event_id": event.GetId(), "match_type": "eks_cluster_name"}))
+	}
 	return identityProjectionResult(entityMap, linkMap)
 }
 
@@ -172,9 +198,18 @@ func awsEKSNodegroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 	attributes := event.GetAttributes()
 	nodegroupURN := projectionURN(tenantID, "aws_eks_nodegroup", firstNonEmpty(attributes["nodegroup_arn"], attributes["resource_id"], attributes["nodegroup_name"]))
 	clusterURN := projectionURN(tenantID, "aws_eks_cluster", firstNonEmpty(attributes["cluster_arn"], attributes["cluster_name"]))
+	addAWSEKSNodegroup(entityMap, tenantID, event.GetSourceId(), nodegroupURN, attributes)
+	nameURN := awsEKSNodegroupNameURN(tenantID, attributes)
+	if nameURN != "" && nodegroupURN != "" && nameURN != nodegroupURN {
+		addAWSEKSNodegroup(entityMap, tenantID, event.GetSourceId(), nameURN, attributes)
+		addLink(linkMap, projectedLink(tenantID, event.GetSourceId(), nameURN, nodegroupURN, relationRepresents, map[string]string{"event_id": event.GetId(), "match_type": "eks_nodegroup_name"}))
+	}
 	if clusterURN != "" {
 		addAWSEKSCluster(entityMap, linkMap, tenantID, event.GetSourceId(), event, clusterURN, attributes)
 		addLink(linkMap, projectedLink(tenantID, event.GetSourceId(), nodegroupURN, clusterURN, relationBelongsTo, map[string]string{"event_id": event.GetId(), "match_type": "eks_nodegroup_cluster"}))
+		if nameURN != "" && nameURN != nodegroupURN {
+			addLink(linkMap, projectedLink(tenantID, event.GetSourceId(), nameURN, clusterURN, relationBelongsTo, map[string]string{"event_id": event.GetId(), "match_type": "eks_nodegroup_cluster_name"}))
+		}
 	}
 	return identityProjectionResult(entityMap, linkMap)
 }
@@ -367,6 +402,152 @@ func addAWSEKSCluster(entities map[string]*ports.ProjectedEntity, links map[stri
 	addCloudAccountLink(entities, links, tenantID, sourceID, event, clusterURN, attributes["domain"], "aws")
 	addAWSNetworkContextLinks(entities, links, tenantID, sourceID, event, clusterURN, attributes)
 	addEKSClusterPublicReachability(entities, links, tenantID, sourceID, event, clusterURN, attributes)
+}
+
+func addAWSEKSNodegroup(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, nodegroupURN string, attributes map[string]string) {
+	if nodegroupURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        nodegroupURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "aws.eks.nodegroup",
+		Label:      firstNonEmpty(attributes["nodegroup_name"], attributes["eks_nodegroup_name"], attributes["resource_name"], attributes["nodegroup_arn"]),
+		Attributes: map[string]string{
+			"ami_type":                              strings.TrimSpace(attributes["ami_type"]),
+			"autoscaling_groups":                    strings.TrimSpace(attributes["autoscaling_groups"]),
+			"capacity_type":                         strings.TrimSpace(attributes["capacity_type"]),
+			"cluster_arn":                           strings.TrimSpace(attributes["cluster_arn"]),
+			"cluster_name":                          strings.TrimSpace(firstNonEmpty(attributes["cluster_name"], attributes["eks_cluster_name"])),
+			"desired_size":                          strings.TrimSpace(attributes["desired_size"]),
+			"disk_size_gib":                         strings.TrimSpace(attributes["disk_size_gib"]),
+			"domain":                                strings.TrimSpace(attributes["domain"]),
+			"health_issue_codes":                    strings.TrimSpace(attributes["health_issue_codes"]),
+			"instance_types":                        strings.TrimSpace(attributes["instance_types"]),
+			"label_keys":                            strings.TrimSpace(attributes["label_keys"]),
+			"labels":                                strings.TrimSpace(attributes["labels"]),
+			"launch_template_id":                    strings.TrimSpace(attributes["launch_template_id"]),
+			"launch_template_name":                  strings.TrimSpace(attributes["launch_template_name"]),
+			"launch_template_version":               strings.TrimSpace(attributes["launch_template_version"]),
+			"max_size":                              strings.TrimSpace(attributes["max_size"]),
+			"min_size":                              strings.TrimSpace(attributes["min_size"]),
+			"node_repair_enabled":                   strings.TrimSpace(attributes["node_repair_enabled"]),
+			"node_role_arn":                         strings.TrimSpace(firstNonEmpty(attributes["node_role_arn"], attributes["role_arn"])),
+			"nodegroup_arn":                         strings.TrimSpace(attributes["nodegroup_arn"]),
+			"nodegroup_name":                        strings.TrimSpace(firstNonEmpty(attributes["nodegroup_name"], attributes["eks_nodegroup_name"])),
+			"region":                                strings.TrimSpace(attributes["region"]),
+			"release_version":                       strings.TrimSpace(attributes["release_version"]),
+			"remote_access_ec2_ssh_key":             strings.TrimSpace(attributes["remote_access_ec2_ssh_key"]),
+			"resource_id":                           strings.TrimSpace(firstNonEmpty(attributes["nodegroup_arn"], attributes["resource_id"], attributes["nodegroup_name"], attributes["eks_nodegroup_name"])),
+			"resource_name":                         strings.TrimSpace(firstNonEmpty(attributes["resource_name"], attributes["nodegroup_name"], attributes["eks_nodegroup_name"])),
+			"resource_provider":                     strings.TrimSpace(attributes["resource_provider"]),
+			"resource_type":                         strings.TrimSpace(firstNonEmpty(attributes["resource_type"], "eks_nodegroup")),
+			"state":                                 strings.TrimSpace(firstNonEmpty(attributes["state"], attributes["status"])),
+			"subnet_ids":                            strings.TrimSpace(attributes["subnet_ids"]),
+			"taint_keys":                            strings.TrimSpace(attributes["taint_keys"]),
+			"taints":                                strings.TrimSpace(attributes["taints"]),
+			"update_strategy":                       strings.TrimSpace(attributes["update_strategy"]),
+			"version":                               strings.TrimSpace(attributes["version"]),
+			"warm_pool_enabled":                     strings.TrimSpace(attributes["warm_pool_enabled"]),
+			"warm_pool_max_group_prepared_capacity": strings.TrimSpace(attributes["warm_pool_max_group_prepared_capacity"]),
+			"warm_pool_min_size":                    strings.TrimSpace(attributes["warm_pool_min_size"]),
+			"warm_pool_state":                       strings.TrimSpace(attributes["warm_pool_state"]),
+		},
+	})
+}
+
+func addAWSEKSNodeContextLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, instanceURN string, attributes map[string]string) {
+	if instanceURN == "" || !strings.EqualFold(attributes["eks_node"], "true") {
+		return
+	}
+	clusterName := firstNonEmpty(attributes["eks_cluster_name"], attributes["kubernetes_cluster"], attributes["cluster_name"])
+	clusterURN := ""
+	if clusterID := firstNonEmpty(attributes["eks_cluster_arn"], attributes["cluster_arn"], clusterName); clusterID != "" {
+		clusterURN = projectionURN(tenantID, "aws_eks_cluster", clusterID)
+	}
+	if clusterURN != "" {
+		addAWSEKSClusterReference(entities, tenantID, sourceID, clusterURN, map[string]string{
+			"cluster_arn":  firstNonEmpty(attributes["eks_cluster_arn"], attributes["cluster_arn"]),
+			"cluster_name": clusterName,
+			"domain":       attributes["domain"],
+			"region":       attributes["region"],
+		})
+		addLink(links, projectedLink(tenantID, sourceID, instanceURN, clusterURN, relationBelongsTo, map[string]string{"event_id": event.GetId(), "match_type": "ec2_instance_eks_cluster"}))
+	}
+	nodegroupURN := ""
+	if nodegroupID := firstNonEmpty(attributes["eks_nodegroup_arn"], attributes["nodegroup_arn"]); nodegroupID != "" {
+		nodegroupURN = projectionURN(tenantID, "aws_eks_nodegroup", nodegroupID)
+	}
+	nodegroupURN = firstNonEmpty(nodegroupURN, awsEKSNodegroupNameURN(tenantID, attributes))
+	if nodegroupURN == "" {
+		return
+	}
+	addAWSEKSNodegroupReference(entities, tenantID, sourceID, nodegroupURN, attributes)
+	addLink(links, projectedLink(tenantID, sourceID, instanceURN, nodegroupURN, relationBelongsTo, map[string]string{"event_id": event.GetId(), "match_type": "ec2_instance_eks_nodegroup"}))
+	if clusterURN != "" {
+		addLink(links, projectedLink(tenantID, sourceID, nodegroupURN, clusterURN, relationBelongsTo, map[string]string{"event_id": event.GetId(), "match_type": "eks_nodegroup_cluster"}))
+	}
+}
+
+func addAWSEKSClusterReference(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, clusterURN string, attributes map[string]string) {
+	if clusterURN == "" || entities[clusterURN] != nil {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        clusterURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "aws.eks.cluster",
+		Label:      firstNonEmpty(attributes["cluster_name"], attributes["cluster_arn"]),
+		Attributes: map[string]string{
+			"cluster_arn":  strings.TrimSpace(attributes["cluster_arn"]),
+			"cluster_name": strings.TrimSpace(attributes["cluster_name"]),
+			"domain":       strings.TrimSpace(attributes["domain"]),
+			"region":       strings.TrimSpace(attributes["region"]),
+		},
+	})
+}
+
+func addAWSEKSNodegroupReference(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, nodegroupURN string, attributes map[string]string) {
+	if nodegroupURN == "" || entities[nodegroupURN] != nil {
+		return
+	}
+	nodegroupName := firstNonEmpty(attributes["eks_nodegroup_name"], attributes["nodegroup_name"])
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        nodegroupURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "aws.eks.nodegroup",
+		Label:      nodegroupName,
+		Attributes: map[string]string{
+			"cluster_name":   strings.TrimSpace(firstNonEmpty(attributes["eks_cluster_name"], attributes["cluster_name"], attributes["kubernetes_cluster"])),
+			"domain":         strings.TrimSpace(attributes["domain"]),
+			"nodegroup_name": strings.TrimSpace(nodegroupName),
+			"region":         strings.TrimSpace(attributes["region"]),
+			"resource_type":  "eks_nodegroup",
+		},
+	})
+}
+
+func awsEKSNodegroupNameURN(tenantID string, attributes map[string]string) string {
+	nodegroupName := firstNonEmpty(attributes["eks_nodegroup_name"], attributes["nodegroup_name"])
+	if nodegroupName == "" {
+		return ""
+	}
+	clusterName := firstNonEmpty(attributes["eks_cluster_name"], attributes["kubernetes_cluster"], attributes["cluster_name"])
+	if clusterName != "" {
+		return projectionURN(tenantID, "aws_eks_nodegroup", clusterName, nodegroupName)
+	}
+	return projectionURN(tenantID, "aws_eks_nodegroup", nodegroupName)
+}
+
+func awsEKSClusterNameURN(tenantID string, attributes map[string]string) string {
+	clusterName := firstNonEmpty(attributes["eks_cluster_name"], attributes["kubernetes_cluster"], attributes["cluster_name"])
+	if clusterName == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "aws_eks_cluster", clusterName)
 }
 
 func addEKSClusterPublicReachability(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, clusterURN string, attributes map[string]string) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -3460,6 +3460,10 @@ func TestProjectAWSComputeInventoryDepth(t *testing.T) {
 			Kind:     "aws.ec2_instance",
 			Attributes: map[string]string{
 				"domain":                "123456789012",
+				"eks_cluster_name":      "prod-eks",
+				"eks_node":              "true",
+				"eks_nodegroup_name":    "managed-linux",
+				"eks_nodegroup_type":    "managed",
 				"instance_id":           "i-123",
 				"network_interface_ids": "eni-1",
 				"region":                "us-east-1",
@@ -3580,18 +3584,21 @@ func TestProjectAWSComputeInventoryDepth(t *testing.T) {
 			SourceId: "aws",
 			Kind:     "aws.eks_nodegroup",
 			Attributes: map[string]string{
-				"cluster_arn":       "arn:aws:eks:us-east-1:123456789012:cluster/prod-eks",
-				"cluster_name":      "prod-eks",
-				"domain":            "123456789012",
-				"nodegroup_arn":     "arn:aws:eks:us-east-1:123456789012:nodegroup/prod-eks/managed-linux/uuid",
-				"nodegroup_name":    "managed-linux",
-				"resource_id":       "arn:aws:eks:us-east-1:123456789012:nodegroup/prod-eks/managed-linux/uuid",
-				"resource_name":     "managed-linux",
-				"resource_provider": "aws",
-				"resource_type":     "eks_nodegroup",
-				"role_arn":          "arn:aws:iam::123456789012:role/EKSNodeRole",
-				"role_name":         "EKSNodeRole",
-				"subnet_ids":        "subnet-eks",
+				"cluster_arn":        "arn:aws:eks:us-east-1:123456789012:cluster/prod-eks",
+				"cluster_name":       "prod-eks",
+				"domain":             "123456789012",
+				"desired_size":       "3",
+				"health_issue_codes": "AsgInstanceLaunchFailures",
+				"label_keys":         "workload",
+				"nodegroup_arn":      "arn:aws:eks:us-east-1:123456789012:nodegroup/prod-eks/managed-linux/uuid",
+				"nodegroup_name":     "managed-linux",
+				"resource_id":        "arn:aws:eks:us-east-1:123456789012:nodegroup/prod-eks/managed-linux/uuid",
+				"resource_name":      "managed-linux",
+				"resource_provider":  "aws",
+				"resource_type":      "eks_nodegroup",
+				"role_arn":           "arn:aws:iam::123456789012:role/EKSNodeRole",
+				"role_name":          "EKSNodeRole",
+				"subnet_ids":         "subnet-eks",
 			},
 		},
 		{
@@ -3635,6 +3642,25 @@ func TestProjectAWSComputeInventoryDepth(t *testing.T) {
 				"service_account": "api",
 			},
 		},
+		{
+			Id:       "aws-ec2-instance-i-456",
+			TenantId: "writer",
+			SourceId: "aws",
+			Kind:     "aws.ec2_instance",
+			Attributes: map[string]string{
+				"domain":             "123456789012",
+				"eks_cluster_name":   "prod-eks",
+				"eks_node":           "true",
+				"eks_nodegroup_name": "managed-linux",
+				"instance_id":        "i-456",
+				"region":             "us-east-1",
+				"resource_id":        "i-456",
+				"resource_name":      "later-node",
+				"resource_provider":  "aws",
+				"resource_type":      "ec2_instance",
+				"state":              "running",
+			},
+		},
 	}
 	for _, event := range events {
 		if _, err := service.Project(context.Background(), event); err != nil {
@@ -3648,7 +3674,9 @@ func TestProjectAWSComputeInventoryDepth(t *testing.T) {
 	ecsTaskURN := "urn:cerebro:writer:aws_ecs_task:arn:aws:ecs:us-east-1:123456789012:task/prod/abcd1234"
 	ecsTaskDefinitionURN := "urn:cerebro:writer:aws_ecs_task_definition:arn:aws:ecs:us-east-1:123456789012:task-definition/orders:7"
 	eksClusterURN := "urn:cerebro:writer:aws_eks_cluster:arn:aws:eks:us-east-1:123456789012:cluster/prod-eks"
+	eksClusterNameURN := "urn:cerebro:writer:aws_eks_cluster:prod-eks"
 	eksNodegroupURN := "urn:cerebro:writer:aws_eks_nodegroup:arn:aws:eks:us-east-1:123456789012:nodegroup/prod-eks/managed-linux/uuid"
+	eksNodegroupNameURN := "urn:cerebro:writer:aws_eks_nodegroup:prod-eks:managed-linux"
 	eksFargateProfileURN := "urn:cerebro:writer:aws_eks_fargate_profile:arn:aws:eks:us-east-1:123456789012:fargateprofile/prod-eks/payments/uuid"
 	eksPodIdentityURN := "urn:cerebro:writer:aws_eks_pod_identity_association:arn:aws:eks:us-east-1:123456789012:podidentityassociation/prod-eks/a-123"
 	kubernetesNamespaceURN := "urn:cerebro:writer:kubernetes_namespace:123456789012:prod-eks:payments"
@@ -3662,6 +3690,11 @@ func TestProjectAWSComputeInventoryDepth(t *testing.T) {
 	assertProjectedLink(t, state, ec2URN, relationBelongsTo, "urn:cerebro:writer:aws_subnet:subnet-1")
 	assertProjectedLink(t, state, ec2URN, relationMemberOf, "urn:cerebro:writer:aws_security_group:sg-1")
 	assertProjectedLink(t, state, "urn:cerebro:writer:aws_network_interface:eni-1", relationAttachedTo, ec2URN)
+	assertProjectedLink(t, state, ec2URN, relationBelongsTo, eksClusterNameURN)
+	assertProjectedLink(t, state, eksClusterNameURN, relationRepresents, eksClusterURN)
+	assertProjectedLink(t, state, ec2URN, relationBelongsTo, eksNodegroupNameURN)
+	assertProjectedLink(t, state, eksNodegroupNameURN, relationRepresents, eksNodegroupURN)
+	assertProjectedLink(t, state, "urn:cerebro:writer:aws_ec2_instance:i-456", relationBelongsTo, eksNodegroupNameURN)
 	assertProjectedLink(t, state, lambdaURN, relationRunsAs, "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/LambdaOrdersRole")
 	assertProjectedLink(t, state, lambdaURN, relationMemberOf, "urn:cerebro:writer:aws_security_group:sg-lambda")
 	assertProjectedLink(t, state, ecsServiceURN, relationBelongsTo, "urn:cerebro:writer:aws_ecs_cluster:arn:aws:ecs:us-east-1:123456789012:cluster/prod")
@@ -3675,6 +3708,18 @@ func TestProjectAWSComputeInventoryDepth(t *testing.T) {
 	assertProjectedLink(t, state, ecsTaskDefinitionURN, relationRunsAs, "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/ECSExecutionRole")
 	assertProjectedLink(t, state, eksClusterURN, relationRunsAs, "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/EKSClusterRole")
 	assertProjectedLink(t, state, "urn:cerebro:writer:aws_public_principal:public_internet", relationCanReach, eksClusterURN)
+	if got := state.entities[eksNodegroupURN].Attributes["desired_size"]; got != "3" {
+		t.Fatalf("eks nodegroup desired_size = %q, want 3", got)
+	}
+	if got := state.entities[eksNodegroupURN].Attributes["health_issue_codes"]; got != "AsgInstanceLaunchFailures" {
+		t.Fatalf("eks nodegroup health_issue_codes = %q, want AsgInstanceLaunchFailures", got)
+	}
+	if got := state.entities[eksNodegroupURN].Attributes["resource_id"]; got != "arn:aws:eks:us-east-1:123456789012:nodegroup/prod-eks/managed-linux/uuid" {
+		t.Fatalf("eks nodegroup resource_id = %q, want nodegroup ARN", got)
+	}
+	if got := state.entities[eksNodegroupURN].Attributes["resource_type"]; got != "eks_nodegroup" {
+		t.Fatalf("eks nodegroup resource_type = %q, want eks_nodegroup", got)
+	}
 	assertProjectedLink(t, state, eksNodegroupURN, relationBelongsTo, eksClusterURN)
 	assertProjectedLink(t, state, eksNodegroupURN, relationRunsAs, "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/EKSNodeRole")
 	assertProjectedLink(t, state, eksFargateProfileURN, relationBelongsTo, eksClusterURN)

--- a/sources/aws/catalog.yaml
+++ b/sources/aws/catalog.yaml
@@ -651,10 +651,9 @@ coverage_contract:
     - id: eks_node
       type: entity_family
       title: AWS EKS nodes
-      families: [eks_nodegroup]
-      support: partial
+      families: [ec2_instance, eks_nodegroup]
+      support: supported
       high_value: true
-      known_unsupported_fields: [per-node kubelet and node certificate posture]
     - id: eks_nodegroup
       type: entity_family
       title: AWS EKS node groups

--- a/sources/aws/compute.go
+++ b/sources/aws/compute.go
@@ -420,6 +420,7 @@ func listEKSPodIdentityAssociations(ctx context.Context, clients awsClients, _ s
 func ec2InstanceEvent(settings settings, record awsEC2Instance) (*primitives.Event, error) {
 	instance := record.Instance
 	instanceID := awssdk.ToString(instance.InstanceId)
+	tags := ec2Tags(instance.Tags)
 	roleARN := firstNonEmpty(awssdk.ToString(record.Role.Arn), instanceProfileRoleARN(record.Role))
 	roleName := firstNonEmpty(awssdk.ToString(record.Role.RoleName), roleNameFromARN(roleARN))
 	attributes := map[string]string{
@@ -440,7 +441,7 @@ func ec2InstanceEvent(settings settings, record awsEC2Instance) (*primitives.Eve
 		"region":                settings.region,
 		"relationship":          "runs_as",
 		"resource_id":           instanceID,
-		"resource_name":         firstNonEmpty(ec2NameTag(instance.Tags), instanceID),
+		"resource_name":         firstNonEmpty(tags["Name"], instanceID),
 		"resource_provider":     "aws",
 		"resource_type":         "ec2_instance",
 		"role_arn":              roleARN,
@@ -449,9 +450,10 @@ func ec2InstanceEvent(settings settings, record awsEC2Instance) (*primitives.Eve
 		"security_group_ids":    strings.Join(ec2InstanceSecurityGroupIDs(instance), ","),
 		"state":                 ec2InstanceState(instance),
 		"subnet_id":             awssdk.ToString(instance.SubnetId),
-		"tags":                  encodeAWSTags(ec2Tags(instance.Tags)),
+		"tags":                  encodeAWSTags(tags),
 		"vpc_id":                awssdk.ToString(instance.VpcId),
 	}
+	putAttributes(attributes, ec2EKSNodeAttributes(tags))
 	addTimeAttribute(attributes, "launched_at", instance.LaunchTime)
 	payload, err := json.Marshal(map[string]any{"account_id": settings.accountID, "region": settings.region, "instance": instance, "role": record.Role})
 	if err != nil {
@@ -702,30 +704,57 @@ func eksNodegroupEvent(settings settings, record awsEKSNodegroup) (*primitives.E
 	nodegroupARN := awssdk.ToString(nodegroup.NodegroupArn)
 	roleARN := awssdk.ToString(nodegroup.NodeRole)
 	attributes := map[string]string{
-		"ami_type":           string(nodegroup.AmiType),
-		"capacity_type":      string(nodegroup.CapacityType),
-		"cluster_arn":        clusterARN,
-		"cluster_name":       clusterName,
-		"domain":             settings.accountID,
-		"family":             familyEKSNodegroup,
-		"instance_types":     strings.Join(cleanStrings(nodegroup.InstanceTypes), ","),
-		"node_role_arn":      roleARN,
-		"node_role_name":     roleNameFromARN(roleARN),
-		"nodegroup_arn":      nodegroupARN,
-		"nodegroup_name":     awssdk.ToString(nodegroup.NodegroupName),
-		"region":             settings.region,
-		"relationship":       "runs_as",
-		"resource_id":        nodegroupARN,
-		"resource_name":      awssdk.ToString(nodegroup.NodegroupName),
-		"resource_provider":  "aws",
-		"resource_type":      "eks_nodegroup",
-		"role_arn":           roleARN,
-		"role_name":          roleNameFromARN(roleARN),
-		"security_group_ids": strings.Join(eksNodegroupSecurityGroupIDs(nodegroup), ","),
-		"state":              string(nodegroup.Status),
-		"subnet_ids":         strings.Join(cleanStrings(nodegroup.Subnets), ","),
-		"tags":               encodeAWSTags(nodegroup.Tags),
-		"version":            awssdk.ToString(nodegroup.Version),
+		"ami_type":                              string(nodegroup.AmiType),
+		"autoscaling_groups":                    strings.Join(eksNodegroupAutoScalingGroupNames(nodegroup), ","),
+		"capacity_type":                         string(nodegroup.CapacityType),
+		"cluster_arn":                           clusterARN,
+		"cluster_name":                          clusterName,
+		"desired_size":                          int32AttrString(eksNodegroupDesiredSize(nodegroup)),
+		"disk_size_gib":                         int32AttrString(nodegroup.DiskSize),
+		"domain":                                settings.accountID,
+		"family":                                familyEKSNodegroup,
+		"health_issue_codes":                    strings.Join(eksNodegroupHealthIssueCodes(nodegroup), ","),
+		"health_issue_messages":                 strings.Join(eksNodegroupHealthIssueMessages(nodegroup), "|"),
+		"health_issue_resource_ids":             strings.Join(eksNodegroupHealthIssueResourceIDs(nodegroup), ","),
+		"instance_types":                        strings.Join(cleanStrings(nodegroup.InstanceTypes), ","),
+		"labels":                                encodeJSONAttribute(nodegroup.Labels),
+		"label_keys":                            strings.Join(eksNodegroupLabelKeys(nodegroup.Labels), ","),
+		"launch_template_id":                    eksNodegroupLaunchTemplateID(nodegroup),
+		"launch_template_name":                  eksNodegroupLaunchTemplateName(nodegroup),
+		"launch_template_version":               eksNodegroupLaunchTemplateVersion(nodegroup),
+		"max_size":                              int32AttrString(eksNodegroupMaxSize(nodegroup)),
+		"max_unavailable":                       int32AttrString(eksNodegroupMaxUnavailable(nodegroup)),
+		"max_unavailable_percentage":            int32AttrString(eksNodegroupMaxUnavailablePercentage(nodegroup)),
+		"min_size":                              int32AttrString(eksNodegroupMinSize(nodegroup)),
+		"node_repair_enabled":                   eksNodegroupNodeRepairEnabled(nodegroup),
+		"node_repair_max_parallel_count":        int32AttrString(eksNodegroupNodeRepairMaxParallelCount(nodegroup)),
+		"node_repair_max_parallel_percentage":   int32AttrString(eksNodegroupNodeRepairMaxParallelPercentage(nodegroup)),
+		"node_role_arn":                         roleARN,
+		"node_role_name":                        roleNameFromARN(roleARN),
+		"nodegroup_arn":                         nodegroupARN,
+		"nodegroup_name":                        awssdk.ToString(nodegroup.NodegroupName),
+		"region":                                settings.region,
+		"release_version":                       awssdk.ToString(nodegroup.ReleaseVersion),
+		"remote_access_ec2_ssh_key":             eksNodegroupRemoteAccessSSHKey(nodegroup),
+		"relationship":                          "runs_as",
+		"resource_id":                           nodegroupARN,
+		"resource_name":                         awssdk.ToString(nodegroup.NodegroupName),
+		"resource_provider":                     "aws",
+		"resource_type":                         "eks_nodegroup",
+		"role_arn":                              roleARN,
+		"role_name":                             roleNameFromARN(roleARN),
+		"security_group_ids":                    strings.Join(eksNodegroupSecurityGroupIDs(nodegroup), ","),
+		"state":                                 string(nodegroup.Status),
+		"subnet_ids":                            strings.Join(cleanStrings(nodegroup.Subnets), ","),
+		"tags":                                  encodeAWSTags(nodegroup.Tags),
+		"taint_keys":                            strings.Join(eksNodegroupTaintKeys(nodegroup.Taints), ","),
+		"taints":                                encodeJSONAttribute(nodegroup.Taints),
+		"update_strategy":                       eksNodegroupUpdateStrategy(nodegroup),
+		"version":                               awssdk.ToString(nodegroup.Version),
+		"warm_pool_enabled":                     eksNodegroupWarmPoolEnabled(nodegroup),
+		"warm_pool_max_group_prepared_capacity": int32AttrString(eksNodegroupWarmPoolMaxPrepared(nodegroup)),
+		"warm_pool_min_size":                    int32AttrString(eksNodegroupWarmPoolMinSize(nodegroup)),
+		"warm_pool_state":                       eksNodegroupWarmPoolState(nodegroup),
 	}
 	addTimeAttribute(attributes, "created_at", nodegroup.CreatedAt)
 	addTimeAttribute(attributes, "modified_at", nodegroup.ModifiedAt)
@@ -999,6 +1028,33 @@ func ec2Tags(tags []ec2types.Tag) map[string]string {
 	return out
 }
 
+func ec2EKSNodeAttributes(tags map[string]string) map[string]string {
+	clusterName := firstNonEmpty(tags["eks:cluster-name"], tags["aws:eks:cluster-name"], kubernetesClusterNameTag(tags))
+	nodegroupName := firstNonEmpty(tags["eks:nodegroup-name"], tags["aws:eks:nodegroup-name"])
+	if clusterName == "" && nodegroupName == "" {
+		return nil
+	}
+	return map[string]string{
+		"eks_cluster_name":    clusterName,
+		"eks_node":            "true",
+		"eks_nodegroup_name":  nodegroupName,
+		"eks_nodegroup_type":  firstNonEmpty(tags["eks:nodegroup-type"], tags["aws:eks:nodegroup-type"]),
+		"kubernetes_cluster":  clusterName,
+		"kubernetes_node":     "true",
+		"kubernetes_provider": "aws.eks",
+	}
+}
+
+func kubernetesClusterNameTag(tags map[string]string) string {
+	for key := range tags {
+		key = strings.TrimSpace(key)
+		if strings.HasPrefix(key, "kubernetes.io/cluster/") {
+			return strings.TrimSpace(strings.TrimPrefix(key, "kubernetes.io/cluster/"))
+		}
+	}
+	return ""
+}
+
 func encodeAWSTags(tags map[string]string) string {
 	if len(tags) == 0 {
 		return ""
@@ -1262,6 +1318,186 @@ func eksNodegroupSecurityGroupIDs(nodegroup ekstypes.Nodegroup) []string {
 		}
 	}
 	return cleanStrings(ids)
+}
+
+func eksNodegroupAutoScalingGroupNames(nodegroup ekstypes.Nodegroup) []string {
+	if nodegroup.Resources == nil {
+		return nil
+	}
+	names := make([]string, 0, len(nodegroup.Resources.AutoScalingGroups))
+	for _, group := range nodegroup.Resources.AutoScalingGroups {
+		names = append(names, awssdk.ToString(group.Name))
+	}
+	return cleanStrings(names)
+}
+
+func eksNodegroupHealthIssueCodes(nodegroup ekstypes.Nodegroup) []string {
+	if nodegroup.Health == nil {
+		return nil
+	}
+	codes := make([]string, 0, len(nodegroup.Health.Issues))
+	for _, issue := range nodegroup.Health.Issues {
+		codes = append(codes, string(issue.Code))
+	}
+	return cleanStrings(codes)
+}
+
+func eksNodegroupHealthIssueMessages(nodegroup ekstypes.Nodegroup) []string {
+	if nodegroup.Health == nil {
+		return nil
+	}
+	messages := make([]string, 0, len(nodegroup.Health.Issues))
+	for _, issue := range nodegroup.Health.Issues {
+		messages = append(messages, awssdk.ToString(issue.Message))
+	}
+	return cleanStrings(messages)
+}
+
+func eksNodegroupHealthIssueResourceIDs(nodegroup ekstypes.Nodegroup) []string {
+	if nodegroup.Health == nil {
+		return nil
+	}
+	var ids []string
+	for _, issue := range nodegroup.Health.Issues {
+		ids = append(ids, issue.ResourceIds...)
+	}
+	return cleanStrings(ids)
+}
+
+func eksNodegroupLabelKeys(labels map[string]string) []string {
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return cleanStrings(keys)
+}
+
+func eksNodegroupTaintKeys(taints []ekstypes.Taint) []string {
+	keys := make([]string, 0, len(taints))
+	for _, taint := range taints {
+		keys = append(keys, awssdk.ToString(taint.Key))
+	}
+	return cleanStrings(keys)
+}
+
+func eksNodegroupRemoteAccessSSHKey(nodegroup ekstypes.Nodegroup) string {
+	if nodegroup.RemoteAccess == nil {
+		return ""
+	}
+	return awssdk.ToString(nodegroup.RemoteAccess.Ec2SshKey)
+}
+
+func eksNodegroupLaunchTemplateID(nodegroup ekstypes.Nodegroup) string {
+	if nodegroup.LaunchTemplate == nil {
+		return ""
+	}
+	return awssdk.ToString(nodegroup.LaunchTemplate.Id)
+}
+
+func eksNodegroupLaunchTemplateName(nodegroup ekstypes.Nodegroup) string {
+	if nodegroup.LaunchTemplate == nil {
+		return ""
+	}
+	return awssdk.ToString(nodegroup.LaunchTemplate.Name)
+}
+
+func eksNodegroupLaunchTemplateVersion(nodegroup ekstypes.Nodegroup) string {
+	if nodegroup.LaunchTemplate == nil {
+		return ""
+	}
+	return awssdk.ToString(nodegroup.LaunchTemplate.Version)
+}
+
+func eksNodegroupDesiredSize(nodegroup ekstypes.Nodegroup) *int32 {
+	if nodegroup.ScalingConfig == nil {
+		return nil
+	}
+	return nodegroup.ScalingConfig.DesiredSize
+}
+
+func eksNodegroupMaxSize(nodegroup ekstypes.Nodegroup) *int32 {
+	if nodegroup.ScalingConfig == nil {
+		return nil
+	}
+	return nodegroup.ScalingConfig.MaxSize
+}
+
+func eksNodegroupMinSize(nodegroup ekstypes.Nodegroup) *int32 {
+	if nodegroup.ScalingConfig == nil {
+		return nil
+	}
+	return nodegroup.ScalingConfig.MinSize
+}
+
+func eksNodegroupMaxUnavailable(nodegroup ekstypes.Nodegroup) *int32 {
+	if nodegroup.UpdateConfig == nil {
+		return nil
+	}
+	return nodegroup.UpdateConfig.MaxUnavailable
+}
+
+func eksNodegroupMaxUnavailablePercentage(nodegroup ekstypes.Nodegroup) *int32 {
+	if nodegroup.UpdateConfig == nil {
+		return nil
+	}
+	return nodegroup.UpdateConfig.MaxUnavailablePercentage
+}
+
+func eksNodegroupUpdateStrategy(nodegroup ekstypes.Nodegroup) string {
+	if nodegroup.UpdateConfig == nil {
+		return ""
+	}
+	return string(nodegroup.UpdateConfig.UpdateStrategy)
+}
+
+func eksNodegroupNodeRepairEnabled(nodegroup ekstypes.Nodegroup) string {
+	if nodegroup.NodeRepairConfig == nil {
+		return ""
+	}
+	return boolPtrString(nodegroup.NodeRepairConfig.Enabled)
+}
+
+func eksNodegroupNodeRepairMaxParallelCount(nodegroup ekstypes.Nodegroup) *int32 {
+	if nodegroup.NodeRepairConfig == nil {
+		return nil
+	}
+	return nodegroup.NodeRepairConfig.MaxParallelNodesRepairedCount
+}
+
+func eksNodegroupNodeRepairMaxParallelPercentage(nodegroup ekstypes.Nodegroup) *int32 {
+	if nodegroup.NodeRepairConfig == nil {
+		return nil
+	}
+	return nodegroup.NodeRepairConfig.MaxParallelNodesRepairedPercentage
+}
+
+func eksNodegroupWarmPoolEnabled(nodegroup ekstypes.Nodegroup) string {
+	if nodegroup.WarmPoolConfig == nil {
+		return ""
+	}
+	return boolPtrString(nodegroup.WarmPoolConfig.Enabled)
+}
+
+func eksNodegroupWarmPoolMaxPrepared(nodegroup ekstypes.Nodegroup) *int32 {
+	if nodegroup.WarmPoolConfig == nil {
+		return nil
+	}
+	return nodegroup.WarmPoolConfig.MaxGroupPreparedCapacity
+}
+
+func eksNodegroupWarmPoolMinSize(nodegroup ekstypes.Nodegroup) *int32 {
+	if nodegroup.WarmPoolConfig == nil {
+		return nil
+	}
+	return nodegroup.WarmPoolConfig.MinSize
+}
+
+func eksNodegroupWarmPoolState(nodegroup ekstypes.Nodegroup) string {
+	if nodegroup.WarmPoolConfig == nil {
+		return ""
+	}
+	return string(nodegroup.WarmPoolConfig.PoolState)
 }
 
 func eksFargateSelectorNamespaces(selectors []ekstypes.FargateProfileSelector) []string {

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -948,8 +948,13 @@ func TestReadAWSComputeInventoryEvents(t *testing.T) {
 				SecurityGroups:   []ec2types.GroupIdentifier{{GroupId: awssdk.String("sg-1")}},
 				State:            &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning},
 				SubnetId:         awssdk.String("subnet-1"),
-				Tags:             []ec2types.Tag{{Key: awssdk.String("Name"), Value: awssdk.String("prod-web")}},
-				VpcId:            awssdk.String("vpc-1"),
+				Tags: []ec2types.Tag{
+					{Key: awssdk.String("Name"), Value: awssdk.String("prod-web")},
+					{Key: awssdk.String("eks:cluster-name"), Value: awssdk.String(eksClusterName)},
+					{Key: awssdk.String("eks:nodegroup-name"), Value: awssdk.String("managed-linux")},
+					{Key: awssdk.String("eks:nodegroup-type"), Value: awssdk.String("managed")},
+				},
+				VpcId: awssdk.String("vpc-1"),
 			}},
 			instanceProfiles: map[string]iamtypes.InstanceProfile{
 				"WebProfile": {Roles: []iamtypes.Role{{Arn: awssdk.String(instanceRoleARN), RoleName: awssdk.String("WebInstanceRole"), RoleId: awssdk.String("AROWEB")}}},
@@ -1014,14 +1019,62 @@ func TestReadAWSComputeInventoryEvents(t *testing.T) {
 			}},
 			eksNodegroupNames: map[string][]string{eksClusterName: []string{"managed-linux"}},
 			eksNodegroups: map[string]ekstypes.Nodegroup{awsTestEKSChildKey(eksClusterName, "managed-linux"): {
+				AmiType:       ekstypes.AMITypesAl2023X8664Standard,
+				CapacityType:  ekstypes.CapacityTypesOnDemand,
 				ClusterName:   awssdk.String(eksClusterName),
+				DiskSize:      awssdk.Int32(80),
 				InstanceTypes: []string{"m7g.large"},
-				NodegroupArn:  awssdk.String(nodegroupARN),
-				NodegroupName: awssdk.String("managed-linux"),
-				NodeRole:      awssdk.String("arn:aws:iam::123456789012:role/EKSNodeRole"),
-				Status:        ekstypes.NodegroupStatusActive,
-				Subnets:       []string{"subnet-eks"},
-				Version:       awssdk.String("1.30"),
+				Health: &ekstypes.NodegroupHealth{Issues: []ekstypes.Issue{{
+					Code:        ekstypes.NodegroupIssueCodeAsgInstanceLaunchFailures,
+					Message:     awssdk.String("launch capacity constrained"),
+					ResourceIds: []string{"i-eks-node"},
+				}}},
+				Labels: map[string]string{"workload": "payments"},
+				LaunchTemplate: &ekstypes.LaunchTemplateSpecification{
+					Id:      awssdk.String("lt-123"),
+					Version: awssdk.String("7"),
+				},
+				NodeRepairConfig: &ekstypes.NodeRepairConfig{
+					Enabled:                            awssdk.Bool(true),
+					MaxParallelNodesRepairedCount:      awssdk.Int32(1),
+					MaxParallelNodesRepairedPercentage: awssdk.Int32(20),
+				},
+				NodegroupArn:   awssdk.String(nodegroupARN),
+				NodegroupName:  awssdk.String("managed-linux"),
+				NodeRole:       awssdk.String("arn:aws:iam::123456789012:role/EKSNodeRole"),
+				ReleaseVersion: awssdk.String("1.30.1-20260601"),
+				RemoteAccess: &ekstypes.RemoteAccessConfig{
+					Ec2SshKey:            awssdk.String("eks-node-key"),
+					SourceSecurityGroups: []string{"sg-admin"},
+				},
+				Resources: &ekstypes.NodegroupResources{
+					AutoScalingGroups:         []ekstypes.AutoScalingGroup{{Name: awssdk.String("eks-prod-managed-asg")}},
+					RemoteAccessSecurityGroup: awssdk.String("sg-remote"),
+				},
+				ScalingConfig: &ekstypes.NodegroupScalingConfig{
+					DesiredSize: awssdk.Int32(3),
+					MaxSize:     awssdk.Int32(6),
+					MinSize:     awssdk.Int32(2),
+				},
+				Status:  ekstypes.NodegroupStatusActive,
+				Subnets: []string{"subnet-eks"},
+				Taints: []ekstypes.Taint{{
+					Effect: ekstypes.TaintEffectNoSchedule,
+					Key:    awssdk.String("dedicated"),
+					Value:  awssdk.String("payments"),
+				}},
+				UpdateConfig: &ekstypes.NodegroupUpdateConfig{
+					MaxUnavailable:           awssdk.Int32(1),
+					MaxUnavailablePercentage: awssdk.Int32(33),
+					UpdateStrategy:           ekstypes.NodegroupUpdateStrategiesDefault,
+				},
+				Version: awssdk.String("1.30"),
+				WarmPoolConfig: &ekstypes.WarmPoolConfig{
+					Enabled:                  awssdk.Bool(true),
+					MaxGroupPreparedCapacity: awssdk.Int32(8),
+					MinSize:                  awssdk.Int32(1),
+					PoolState:                ekstypes.WarmPoolStateStopped,
+				},
 			}},
 			eksFargateNames: map[string][]string{eksClusterName: []string{"payments"}},
 			eksFargateProfiles: map[string]ekstypes.FargateProfile{awsTestEKSChildKey(eksClusterName, "payments"): {
@@ -1058,6 +1111,12 @@ func TestReadAWSComputeInventoryEvents(t *testing.T) {
 				}
 				if got := event.Attributes["network_interface_ids"]; got != "eni-1" {
 					t.Fatalf("ec2 network_interface_ids = %q, want eni-1", got)
+				}
+				if got := event.Attributes["eks_cluster_name"]; got != eksClusterName {
+					t.Fatalf("ec2 eks_cluster_name = %q, want %q", got, eksClusterName)
+				}
+				if got := event.Attributes["eks_nodegroup_name"]; got != "managed-linux" {
+					t.Fatalf("ec2 eks_nodegroup_name = %q, want managed-linux", got)
 				}
 			},
 		},
@@ -1118,6 +1177,30 @@ func TestReadAWSComputeInventoryEvents(t *testing.T) {
 			assert: func(t *testing.T, event *cerebrov1.EventEnvelope) {
 				if got := event.Attributes["role_name"]; got != "EKSNodeRole" {
 					t.Fatalf("eks nodegroup role_name = %q, want EKSNodeRole", got)
+				}
+				for key, want := range map[string]string{
+					"autoscaling_groups":                    "eks-prod-managed-asg",
+					"desired_size":                          "3",
+					"disk_size_gib":                         "80",
+					"health_issue_codes":                    "AsgInstanceLaunchFailures",
+					"label_keys":                            "workload",
+					"launch_template_id":                    "lt-123",
+					"max_size":                              "6",
+					"min_size":                              "2",
+					"node_repair_enabled":                   "true",
+					"release_version":                       "1.30.1-20260601",
+					"remote_access_ec2_ssh_key":             "eks-node-key",
+					"security_group_ids":                    "sg-admin,sg-remote",
+					"taint_keys":                            "dedicated",
+					"update_strategy":                       "DEFAULT",
+					"warm_pool_enabled":                     "true",
+					"warm_pool_max_group_prepared_capacity": "8",
+					"warm_pool_min_size":                    "1",
+					"warm_pool_state":                       "STOPPED",
+				} {
+					if got := event.Attributes[key]; got != want {
+						t.Fatalf("eks nodegroup %s = %q, want %q", key, got, want)
+					}
 				}
 			},
 		},

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -14,7 +14,7 @@ const newSourcePackageLOCBudget = 300
 // source grows, move shared behavior into the Source CDK instead of raising it.
 var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"aurelius":        653,
-	"aws":             18757,
+	"aws":             18968,
 	"azure":           2582,
 	"cosmo":           1112,
 	"gcp":             2074,


### PR DESCRIPTION
## Summary
- enrich AWS EKS managed node group records with scaling, launch-template, repair, warm-pool, health, label, taint, and Auto Scaling group posture
- identify EKS-backed EC2 instances from standard node tags and link them into EKS cluster/node group graph context
- promote the EKS node catalog dimension to supported using EC2 instance plus node group coverage

## Tests
- go test ./sources/aws -run 'TestReadAWSComputeInventoryEvents|TestNewFixtureReplaysAWSFamilies|TestAWSFamilyAPIExpectations' -count=1 -v\n- go test ./internal/sourceprojection -run 'TestProjectAWSComputeInventoryDepth' -count=1 -v\n- make catalog-check\n- go test ./tools/archtests -count=1 -v\n- PATH="/tmp/cerebro-sagemaker-verify-bin:$PATH" make verify