### PR TITLE
Add executable Auth0 OAuth connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-
 | --- | --- | --- |
 | `anthropic` | Anthropic organization source | users, workspaces, API keys |
 | `aurelius` | SaaS/business-operation export source | configured catalog families |
+| `auth0` | Auth0 Management API source | users, roles, audit events |
 | `aws` | AWS IAM, cloud, workload, network exposure, and CloudTrail source | access keys, IAM users/groups/roles/trust, EC2, ECS, EKS, Lambda, public endpoints, resource exposure, CloudTrail |
 | `azure` | Azure Entra ID, RBAC, activity, and audit source | activity logs, directory audit, users, groups, role/app assignments, service principals, credentials, resource exposure |
 | `backstage` | Backstage catalog source | components |

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -1116,6 +1116,18 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 			writeConnectorError(w, err)
 			return
 		}
+		validated, err := broker.MarkValidated(r.Context(), connectorcredentials.ValidateRequest{
+			CredentialID: result.Record.ID,
+			TenantID:     tenantID,
+			SourceID:     sourceID,
+			RuntimeID:    runtimeID,
+			Actor:        connectorCredentialActor(r),
+		})
+		if err != nil {
+			writeConnectorError(w, err)
+			return
+		}
+		result.Record = validated
 		for field, reference := range result.References {
 			runtime.Config[field] = reference
 		}
@@ -1479,6 +1491,67 @@ var connectorSchemas = map[string]connectorSchema{
 		CredentialKeys:      stringSet("token"),
 		RequiredCredentials: []string{"token"},
 	},
+}
+
+func connectorSchemaForSource(sourceID string) (connectorSchema, bool) {
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return connectorSchema{}, false
+	}
+	if schema, ok := connectorSchemas[sourceID]; ok {
+		return schema, true
+	}
+	entry, ok, err := connectorcatalog.BuiltinEntry(sourceID)
+	if err != nil || !ok || !entry.Generateable || entry.Status != connectorcatalog.StatusGenerateable {
+		return connectorSchema{}, false
+	}
+	return connectorSchemaFromDefinition(entry.Definition), true
+}
+
+func connectorSchemaFromDefinition(definition connectordefinitions.Definition) connectorSchema {
+	schema := connectorSchema{
+		ConfigKeys:     stringSet("family", "health_path", "base_url", "token_url", "failure_modes", "expected_cadence_seconds", "stale_after_seconds"),
+		CredentialKeys: map[string]struct{}{},
+	}
+	for _, field := range definition.ConfigFields {
+		key := strings.TrimSpace(field.Key)
+		if key == "" {
+			continue
+		}
+		schema.ConfigKeys[key] = struct{}{}
+		if field.Required {
+			schema.RequiredConfig = append(schema.RequiredConfig, key)
+		}
+	}
+	for _, field := range definition.Auth.CredentialFields {
+		key := strings.TrimSpace(field.Key)
+		if key == "" {
+			continue
+		}
+		schema.CredentialKeys[key] = struct{}{}
+		schema.RequiredCredentials = append(schema.RequiredCredentials, key)
+	}
+	for _, family := range definition.ResourceFamilies {
+		if family.Pagination == nil {
+			continue
+		}
+		addConnectorSchemaConfigKey(schema.ConfigKeys, family.Pagination.PageParam)
+		addConnectorSchemaConfigKey(schema.ConfigKeys, family.Pagination.PageSizeParam)
+		addConnectorSchemaConfigKey(schema.ConfigKeys, family.Pagination.OffsetParam)
+		addConnectorSchemaConfigKey(schema.ConfigKeys, family.Pagination.LimitParam)
+		addConnectorSchemaConfigKey(schema.ConfigKeys, family.Pagination.CursorParam)
+	}
+	schema.RequiredConfig = sortedUniqueStrings(schema.RequiredConfig)
+	schema.RequiredCredentials = sortedUniqueStrings(schema.RequiredCredentials)
+	return schema
+}
+
+func addConnectorSchemaConfigKey(keys map[string]struct{}, key string) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return
+	}
+	keys[key] = struct{}{}
 }
 
 func connectorRuntimeCounts(runtimes []*cerebrov1.SourceRuntime) map[string]connectorRuntimeCount {
@@ -1904,7 +1977,7 @@ func (a *App) connectorReferenceTemplates(sourceID string, tenantID string, runt
 		return nil
 	}
 	required := map[string]struct{}{}
-	if schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]; ok {
+	if schema, ok := connectorSchemaForSource(sourceID); ok {
 		required = stringSet(schema.RequiredCredentials...)
 	}
 	templates := make([]connectorReferenceTemplateView, 0, len(fields))
@@ -2505,7 +2578,7 @@ func connectorDisplayName(sourceID string, fallback string) string {
 }
 
 func connectorConfigFields(sourceID string, authMethod string) []connectorFieldView {
-	schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]
+	schema, ok := connectorSchemaForSource(sourceID)
 	if !ok {
 		return nil
 	}
@@ -2539,7 +2612,7 @@ func connectorCredentialFields(sourceID string, authMethod string) []connectorFi
 	if authMethod == connectorAuthMethodAWSSSOProfile {
 		return nil
 	}
-	schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]
+	schema, ok := connectorSchemaForSource(sourceID)
 	if !ok {
 		return nil
 	}
@@ -3589,7 +3662,7 @@ func connectorReferenceTemplateFields(sourceID string, authMethod string, refere
 	if normalizeConnectorAuthMethod(authMethod) == connectorAuthMethodEncryptedSubmission {
 		return sortedStringKeys(references)
 	}
-	schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]
+	schema, ok := connectorSchemaForSource(sourceID)
 	if !ok || len(schema.CredentialKeys) == 0 {
 		return sortedStringKeys(references)
 	}
@@ -3597,7 +3670,7 @@ func connectorReferenceTemplateFields(sourceID string, authMethod string, refere
 }
 
 func validateConnectorConfigFields(sourceID string, authMethod string, config map[string]string, references map[string]string) error {
-	schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]
+	schema, ok := connectorSchemaForSource(sourceID)
 	if !ok {
 		return nil
 	}
@@ -3638,7 +3711,7 @@ func validateConnectorCredentialFields(sourceID string, authMethod string, field
 	if authMethod != connectorAuthMethodEncryptedSubmission {
 		return nil
 	}
-	schema, ok := connectorSchemas[strings.TrimSpace(sourceID)]
+	schema, ok := connectorSchemaForSource(sourceID)
 	if !ok {
 		return nil
 	}
@@ -3670,6 +3743,21 @@ func sortedStringKeys(values map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func sortedUniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		set[value] = struct{}{}
+	}
+	return sortedSetKeys(set)
 }
 
 func copyStringMap(values map[string]string) map[string]string {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -265,6 +265,32 @@ func TestConnectorConnectionStoresCredentialReference(t *testing.T) {
 	if got := credentialPayload["credential_store_id"]; got != defaultConnectorCredentialStoreID {
 		t.Fatalf("credential_store_id = %#v, want %q", got, defaultConnectorCredentialStoreID)
 	}
+	if got := credentialPayload["status"]; got != connectorcredentials.StatusValid {
+		t.Fatalf("credential status = %#v, want %q", got, connectorcredentials.StatusValid)
+	}
+	credentialID, ok := credentialPayload["id"].(string)
+	if !ok || credentialID == "" {
+		t.Fatalf("credential id = %#v, want non-empty string", credentialPayload["id"])
+	}
+	if got, ok := credentialPayload["last_validated_at"].(string); !ok || strings.TrimSpace(got) == "" {
+		t.Fatalf("credential last_validated_at = %#v, want validation timestamp", credentialPayload["last_validated_at"])
+	}
+	record := store.credentials[credentialID]
+	if record == nil {
+		t.Fatalf("stored credential %q missing", credentialID)
+	}
+	if record.LastValidatedAt.IsZero() {
+		t.Fatal("stored credential LastValidatedAt is zero")
+	}
+	auditTypes := map[string]bool{}
+	for _, event := range store.audit {
+		if event.CredentialID == credentialID {
+			auditTypes[event.EventType] = true
+		}
+	}
+	if !auditTypes[connectorcredentials.AuditEventStored] || !auditTypes[connectorcredentials.AuditEventValidated] {
+		t.Fatalf("credential audit types = %#v, want stored and validated", auditTypes)
+	}
 	runtime := store.runtimes["runtime-a"]
 	if runtime == nil {
 		t.Fatal("stored runtime missing")
@@ -1168,12 +1194,26 @@ func TestConnectorCatalogIncludesBuiltinDefinitionCatalogWhenEnabled(t *testing.
 	if jumpcloud.AuthModel != "api_key" || jumpcloud.VerificationEndpoint == "" {
 		t.Fatalf("jumpcloud auth/verification = %q/%q, want catalog metadata", jumpcloud.AuthModel, jumpcloud.VerificationEndpoint)
 	}
-	entraID := bySourceID["microsoft_entra_id"]
-	if entraID.CatalogStatus != connectorcatalog.StatusNeedsAuthExtension || entraID.RuntimeExecutable {
-		t.Fatalf("microsoft_entra_id status = %q executable=%v, want needs_auth_extension not executable", entraID.CatalogStatus, entraID.RuntimeExecutable)
+	auth0 := bySourceID["auth0"]
+	if auth0.CatalogStatus != connectorcatalog.StatusGenerateable || !auth0.RuntimeExecutable {
+		t.Fatalf("auth0 status = %q executable=%v, want generateable executable", auth0.CatalogStatus, auth0.RuntimeExecutable)
 	}
-	if entraID.ClassifierOutput != "supported" {
-		t.Fatalf("microsoft_entra_id classifier_output = %q, want supported", entraID.ClassifierOutput)
+	if auth0.AuthModel != "oauth_client_credentials" || auth0.VerificationEndpoint != "/users" {
+		t.Fatalf("auth0 auth/verification = %q/%q, want oauth client credentials /users", auth0.AuthModel, auth0.VerificationEndpoint)
+	}
+	hasNeedsAuthExtension := false
+	for _, connector := range payload.Connectors {
+		if connector.CatalogStatus != connectorcatalog.StatusNeedsAuthExtension {
+			continue
+		}
+		hasNeedsAuthExtension = true
+		if connector.RuntimeExecutable {
+			t.Fatalf("%s status = %q executable=%v, want needs_auth_extension not executable", connector.SourceID, connector.CatalogStatus, connector.RuntimeExecutable)
+		}
+		break
+	}
+	if !hasNeedsAuthExtension {
+		t.Fatal("catalog has no needs_auth_extension entries")
 	}
 	jenkins := bySourceID["jenkins"]
 	if jenkins.CatalogStatus != connectorcatalog.StatusNeedsBespokeRuntime {
@@ -1186,6 +1226,53 @@ func TestConnectorCatalogIncludesBuiltinDefinitionCatalogWhenEnabled(t *testing.
 		if family.ProjectionTemplate == "" || !family.HighValue {
 			t.Fatalf("jenkins family = %#v, want projection and high-value coverage", family)
 		}
+	}
+}
+
+func TestConnectorSchemaForGenerateableCatalogDefinition(t *testing.T) {
+	schema, ok := connectorSchemaForSource("auth0")
+	if !ok {
+		t.Fatal("connectorSchemaForSource(auth0) = false, want catalog-derived schema")
+	}
+	for _, key := range []string{"domain", "family", "health_path", "token_url", "per_page", "take", "from", "failure_modes", "expected_cadence_seconds", "stale_after_seconds"} {
+		if _, ok := schema.ConfigKeys[key]; !ok {
+			t.Fatalf("auth0 config keys missing %q: %#v", key, sortedSetKeys(schema.ConfigKeys))
+		}
+	}
+	if got := strings.Join(schema.RequiredConfig, ","); got != "domain" {
+		t.Fatalf("auth0 required config = %q, want domain", got)
+	}
+	for _, key := range []string{"client_id", "client_secret"} {
+		if _, ok := schema.CredentialKeys[key]; !ok {
+			t.Fatalf("auth0 credential keys missing %q: %#v", key, sortedSetKeys(schema.CredentialKeys))
+		}
+	}
+	if got := strings.Join(schema.RequiredCredentials, ","); got != "client_id,client_secret" {
+		t.Fatalf("auth0 required credentials = %q, want client_id,client_secret", got)
+	}
+	err := validateConnectorConfigFields("auth0", connectorAuthMethodExternalReference, map[string]string{ // #nosec G101 -- Test-only credential reference placeholders, not live secrets.
+		"domain":        "example.us.auth0.com",
+		"family":        "users",
+		"health_path":   "/users",
+		"per_page":      "100",
+		"client_id":     "env:AUTH0_CLIENT_ID",
+		"client_secret": "env:AUTH0_CLIENT_SECRET",
+	}, map[string]string{ // #nosec G101 -- Test-only credential reference placeholders, not live secrets.
+		"client_id":     "env:AUTH0_CLIENT_ID",
+		"client_secret": "env:AUTH0_CLIENT_SECRET",
+	})
+	if err != nil {
+		t.Fatalf("validateConnectorConfigFields(auth0 external reference) error = %v", err)
+	}
+	err = validateConnectorCredentialFields("auth0", connectorAuthMethodEncryptedSubmission, map[string]string{ // #nosec G101 -- Test-only credential values, not live secrets.
+		"client_id":     "auth0-client",
+		"client_secret": "auth0-secret",
+	})
+	if err != nil {
+		t.Fatalf("validateConnectorCredentialFields(auth0 encrypted submission) error = %v", err)
+	}
+	if _, ok := connectorSchemaForSource("jenkins"); ok {
+		t.Fatal("connectorSchemaForSource(jenkins) = true, want bespoke runtime entries excluded")
 	}
 }
 

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -120,11 +120,11 @@ entries:
 	}
 }
 
-func TestAnalyzeDirMarksOAuthSupportedDefinitionAsAuthExtension(t *testing.T) {
+func TestAnalyzeDirMarksOAuthClientCredentialsDefinitionAsGenerateable(t *testing.T) {
 	root := t.TempDir()
 	writeCatalogFile(t, root, strings.ReplaceAll(strings.ReplaceAll(minimalDefinitionYAML(),
 		"model: bearer_token", "model: oauth_client_credentials\n        token_url: https://api.example.test/oauth/token"),
-		"key: token", "key: client_secret"))
+		"key: token", "key: client_id\n            reference_only: true\n          - key: client_secret"))
 
 	analysis, err := AnalyzeDir(root, Options{DryRunSourcegen: true})
 	if err != nil {
@@ -133,11 +133,11 @@ func TestAnalyzeDirMarksOAuthSupportedDefinitionAsAuthExtension(t *testing.T) {
 	if len(analysis.Issues) != 0 {
 		t.Fatalf("issues = %#v, want none", analysis.Issues)
 	}
-	if got := analysis.Entries[0].Status; got != StatusNeedsAuthExtension {
-		t.Fatalf("status = %q, want %q", got, StatusNeedsAuthExtension)
+	if got := analysis.Entries[0].Status; got != StatusGenerateable {
+		t.Fatalf("status = %q, want %q", got, StatusGenerateable)
 	}
-	if analysis.Summary.NeedsAuthExtension != 1 {
-		t.Fatalf("summary = %#v, want auth extension count", analysis.Summary)
+	if analysis.Summary.Generateable != 1 {
+		t.Fatalf("summary = %#v, want generateable count", analysis.Summary)
 	}
 }
 
@@ -236,7 +236,7 @@ func TestBuiltinCatalogIncludesAdditionalGapEntries(t *testing.T) {
 		"ethena":        StatusGenerateable,
 		"google_drive":  StatusNeedsAuthExtension,
 		"hitrust_mycsf": StatusGenerateable,
-		"ramp":          StatusNeedsAuthExtension,
+		"ramp":          StatusGenerateable,
 		"rippling":      StatusGenerateable,
 		"segment":       StatusGenerateable,
 		"swif_ai":       StatusGenerateable,

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -20,9 +20,10 @@ import (
 const (
 	SourceTypeJSONAPI = "json_api"
 
-	AuthModelBearerToken = "bearer_token"
-	AuthModelAPIToken    = "api_token"
-	AuthModelAPIKey      = "api_key"
+	AuthModelBearerToken            = "bearer_token"
+	AuthModelAPIToken               = "api_token"
+	AuthModelAPIKey                 = "api_key"
+	AuthModelOAuthClientCredentials = "oauth_client_credentials" // #nosec G101 -- auth model identifier, not credential material.
 
 	defaultFreshnessExpectation = 24 * time.Hour
 	defaultHealthPath           = "/healthz"
@@ -82,6 +83,10 @@ type normalizedRequest struct {
 	PackageName       string
 	DefaultFamily     string
 	DefaultPath       string
+	BaseURLTemplate   string
+	ConfigKeys        []string
+	CredentialKeys    []string
+	OAuth             *oauthClientCredentialsData
 	Families          []familyData
 }
 
@@ -95,8 +100,20 @@ type familyData struct {
 	URNKind               string
 	EventKind             string
 	SchemaRef             string
+	IDKeys                []string
+	ListKeys              []string
+	CursorParam           string
+	PageSizeParams        []string
 	RequiredAttributes    []string
 	RequiredPayloadFields []string
+}
+
+type oauthClientCredentialsData struct {
+	TokenURLTemplate        string
+	Scopes                  []string
+	ScopeSeparator          string
+	TokenParams             map[string]string
+	ExpirationBufferSeconds int
 }
 
 type generatedFile struct {
@@ -191,6 +208,10 @@ func normalizeDefinitionRequest(request DefinitionRequest) (normalizedRequest, e
 	if err != nil {
 		return normalizedRequest{}, err
 	}
+	oauth, err := oauthClientCredentialsForDefinition(definition.Auth)
+	if err != nil {
+		return normalizedRequest{}, err
+	}
 	sourceID := strings.TrimSpace(definition.SourceID)
 	if !identifierPattern.MatchString(sourceID) {
 		return normalizedRequest{}, fmt.Errorf("source_id %q must start with a lowercase letter and use lowercase letters, digits, underscores, or hyphens", definition.SourceID)
@@ -236,6 +257,10 @@ func normalizeDefinitionRequest(request DefinitionRequest) (normalizedRequest, e
 		TokenConfigKey:    tokenConfigKey,
 		EnvPrefix:         strings.ToUpper(strings.NewReplacer("-", "_").Replace(sourceID)),
 		PackageName:       packageName(sourceID),
+		BaseURLTemplate:   transportBaseURL(definition.Transport),
+		ConfigKeys:        fieldKeys(definition.ConfigFields),
+		CredentialKeys:    fieldKeys(definition.Auth.CredentialFields),
+		OAuth:             oauth,
 	}
 	normalized.Families, err = familiesForDefinition(normalized, definition)
 	if err != nil {
@@ -367,8 +392,10 @@ func authModelConfig(authModel string) (string, string, error) {
 		return "Bearer", "token", nil
 	case AuthModelAPIToken, AuthModelAPIKey:
 		return "Token", "api_token", nil
+	case AuthModelOAuthClientCredentials:
+		return "Bearer", "token", nil
 	default:
-		return "", "", fmt.Errorf("auth_model %q must be one of %s, %s, or %s", authModel, AuthModelBearerToken, AuthModelAPIToken, AuthModelAPIKey)
+		return "", "", fmt.Errorf("auth_model %q must be one of %s, %s, %s, or %s", authModel, AuthModelBearerToken, AuthModelAPIToken, AuthModelAPIKey, AuthModelOAuthClientCredentials)
 	}
 }
 
@@ -378,9 +405,87 @@ func executableAuthModel(authModel string) (string, error) {
 		return AuthModelBearerToken, nil
 	case AuthModelAPIToken, AuthModelAPIKey:
 		return AuthModelAPIKey, nil
+	case AuthModelOAuthClientCredentials:
+		return AuthModelOAuthClientCredentials, nil
 	default:
 		return "", fmt.Errorf("%w: auth model %q needs provider auth runtime support before sourcegen can emit executable code", errUnsupportedDefinition, authModel)
 	}
+}
+
+func oauthClientCredentialsForDefinition(auth connectordefinitions.AuthSpec) (*oauthClientCredentialsData, error) {
+	if strings.TrimSpace(auth.Model) != AuthModelOAuthClientCredentials {
+		return nil, nil
+	}
+	if strings.TrimSpace(auth.TokenURL) == "" {
+		return nil, fmt.Errorf("%w: oauth_client_credentials requires token_url", errUnsupportedDefinition)
+	}
+	if !hasCredentialField(auth.CredentialFields, "client_id") {
+		return nil, fmt.Errorf("%w: oauth_client_credentials requires client_id credential field", errUnsupportedDefinition)
+	}
+	if !hasCredentialField(auth.CredentialFields, "client_secret") {
+		return nil, fmt.Errorf("%w: oauth_client_credentials requires client_secret credential field", errUnsupportedDefinition)
+	}
+	separator := strings.TrimSpace(auth.ScopeSeparator)
+	if separator == "" {
+		separator = " "
+	}
+	buffer := auth.TokenExpirationBufferSeconds
+	if buffer == 0 {
+		buffer = 60
+	}
+	return &oauthClientCredentialsData{
+		TokenURLTemplate:        strings.TrimSpace(auth.TokenURL),
+		Scopes:                  append([]string{}, auth.Scopes...),
+		ScopeSeparator:          separator,
+		TokenParams:             cloneStringMap(auth.TokenParams),
+		ExpirationBufferSeconds: buffer,
+	}, nil
+}
+
+func transportBaseURL(transport *connectordefinitions.TransportSpec) string {
+	if transport == nil {
+		return ""
+	}
+	return strings.TrimSpace(transport.BaseURL)
+}
+
+func fieldKeys(fields []connectordefinitions.Field) []string {
+	keys := make([]string, 0, len(fields))
+	seen := map[string]struct{}{}
+	for _, field := range fields {
+		key := strings.TrimSpace(field.Key)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func hasCredentialField(fields []connectordefinitions.Field, key string) bool {
+	key = strings.TrimSpace(key)
+	for _, field := range fields {
+		if strings.TrimSpace(field.Key) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func normalizeIdentifiers(label string, values []string) ([]string, error) {
@@ -508,11 +613,79 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			URNKind:               urnKind,
 			EventKind:             eventKind,
 			SchemaRef:             schemaRef,
+			IDKeys:                idKeysForResource(resource),
+			ListKeys:              listKeysForResource(resource),
+			CursorParam:           cursorParamForResource(resource),
+			PageSizeParams:        pageSizeParamsForResource(resource),
 			RequiredAttributes:    requiredAttributes,
 			RequiredPayloadFields: requiredPayloadFields,
 		})
 	}
 	return families, nil
+}
+
+func idKeysForResource(resource connectordefinitions.ResourceFamily) []string {
+	keys := []string{}
+	for _, key := range []string{resource.IDField, resource.NameField} {
+		if key = strings.TrimSpace(key); key != "" {
+			keys = append(keys, key)
+		}
+	}
+	return uniqueStrings(keys)
+}
+
+func listKeysForResource(resource connectordefinitions.ResourceFamily) []string {
+	keys := []string{}
+	if key := strings.TrimSpace(resource.ListKey); key != "" {
+		keys = append(keys, key)
+	}
+	selector := strings.TrimSpace(resource.RecordSelector)
+	if strings.HasPrefix(selector, "$.") && strings.HasSuffix(selector, "[*]") {
+		key := strings.TrimSuffix(strings.TrimPrefix(selector, "$."), "[*]")
+		key = strings.Trim(strings.TrimSpace(key), ".")
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	return uniqueStrings(keys)
+}
+
+func cursorParamForResource(resource connectordefinitions.ResourceFamily) string {
+	if resource.Pagination == nil {
+		return ""
+	}
+	return strings.TrimSpace(resource.Pagination.CursorParam)
+}
+
+func pageSizeParamsForResource(resource connectordefinitions.ResourceFamily) []string {
+	if resource.Pagination == nil {
+		return nil
+	}
+	params := []string{}
+	if param := strings.TrimSpace(resource.Pagination.PageSizeParam); param != "" {
+		params = append(params, param)
+	}
+	if param := strings.TrimSpace(resource.Pagination.LimitParam); param != "" {
+		params = append(params, param)
+	}
+	return uniqueStrings(params)
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 func executableProjectionClass(resource connectordefinitions.ResourceFamily) (string, error) {
@@ -658,20 +831,50 @@ func renderDeploy(request normalizedRequest) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "sourceId: %s\n", request.SourceID)
 	fmt.Fprintf(&b, "secretKeys:\n")
-	fmt.Fprintf(&b, "  - %s_BASE_URL\n", request.EnvPrefix)
-	fmt.Fprintf(&b, "  - %s\n", tokenEnv)
+	secretKeys := []string{}
+	if len(request.ConfigKeys) == 0 && strings.TrimSpace(request.BaseURLTemplate) == "" {
+		secretKeys = append(secretKeys, request.EnvPrefix+"_BASE_URL")
+	}
+	for _, key := range request.ConfigKeys {
+		secretKeys = append(secretKeys, envNameForConfigKey(request, key))
+	}
+	if request.OAuth != nil {
+		for _, key := range request.CredentialKeys {
+			secretKeys = append(secretKeys, envNameForConfigKey(request, key))
+		}
+	} else {
+		secretKeys = append(secretKeys, tokenEnv)
+	}
+	for _, key := range uniqueStrings(secretKeys) {
+		fmt.Fprintf(&b, "  - %s\n", key)
+	}
 	fmt.Fprintf(&b, "runtimes:\n")
 	fmt.Fprintf(&b, "  - localId: %s\n", strings.ReplaceAll(request.DefaultFamily, "_", "-"))
 	fmt.Fprintf(&b, "    config:\n")
-	fmt.Fprintf(&b, "      base_url: env:%s_BASE_URL\n", request.EnvPrefix)
+	if len(request.ConfigKeys) == 0 && strings.TrimSpace(request.BaseURLTemplate) == "" {
+		fmt.Fprintf(&b, "      base_url: env:%s_BASE_URL\n", request.EnvPrefix)
+	}
+	for _, key := range request.ConfigKeys {
+		fmt.Fprintf(&b, "      %s: env:%s\n", key, envNameForConfigKey(request, key))
+	}
 	fmt.Fprintf(&b, "      family: %s\n", request.DefaultFamily)
 	fmt.Fprintf(&b, "      failure_modes: %s\n", strings.Join(request.FailureModes, ","))
 	fmt.Fprintf(&b, "      health_path: %s\n", request.HealthPath)
 	fmt.Fprintf(&b, "      expected_cadence_seconds: %q\n", strconv.FormatInt(int64(request.FreshnessDuration.Seconds()), 10))
 	fmt.Fprintf(&b, "      stale_after_seconds: %q\n", strconv.FormatInt(int64(request.FreshnessDuration.Seconds()), 10))
 	fmt.Fprintf(&b, "      per_page: %q\n", "100")
-	fmt.Fprintf(&b, "      %s: env:%s\n", request.TokenConfigKey, tokenEnv)
+	if request.OAuth != nil {
+		for _, key := range request.CredentialKeys {
+			fmt.Fprintf(&b, "      %s: env:%s\n", key, envNameForConfigKey(request, key))
+		}
+	} else {
+		fmt.Fprintf(&b, "      %s: env:%s\n", request.TokenConfigKey, tokenEnv)
+	}
 	return b.String()
+}
+
+func envNameForConfigKey(request normalizedRequest, key string) string {
+	return request.EnvPrefix + "_" + strings.ToUpper(strings.NewReplacer("-", "_", ".", "_").Replace(strings.TrimSpace(key)))
 }
 
 func renderSourceGo(request normalizedRequest) string {
@@ -694,12 +897,28 @@ func renderSourceGo(request normalizedRequest) string {
 	fmt.Fprintf(&b, "\tsourceID = %s\n", strconv.Quote(request.SourceID))
 	fmt.Fprintf(&b, "\tdefaultFamily = %s\n", request.Families[0].ConstName)
 	fmt.Fprintf(&b, "\tdefaultHealthPath = %s\n", strconv.Quote(request.HealthPath))
+	fmt.Fprintf(&b, "\tdefaultBaseURLTemplate = %s\n", strconv.Quote(request.BaseURLTemplate))
 	fmt.Fprintf(&b, "\ttokenScheme = %s\n", strconv.Quote(request.TokenScheme))
+	if request.OAuth != nil {
+		fmt.Fprintf(&b, "\toauthTokenURLTemplate = %s // #nosec G101 -- token endpoint URL template, not credential material.\n", strconv.Quote(request.OAuth.TokenURLTemplate))
+		fmt.Fprintf(&b, "\toauthScopeSeparator = %s\n", strconv.Quote(request.OAuth.ScopeSeparator))
+		fmt.Fprintf(&b, "\toauthTokenExpirationBuffer = %d * time.Second\n", request.OAuth.ExpirationBufferSeconds)
+	}
 	for _, family := range request.Families {
 		fmt.Fprintf(&b, "\t%s = %s\n", family.ConstName, strconv.Quote(family.Name))
 	}
 	fmt.Fprintf(&b, ")\n\n")
-	fmt.Fprintf(&b, "type Source struct {\n\tinner *jsonapi.Source\n\tallowLoopback bool\n}\n\n")
+	templateKeys := uniqueStrings(append(append([]string{}, request.ConfigKeys...), request.CredentialKeys...))
+	fmt.Fprintf(&b, "var templateKeys = []string{%s}\n\n", quotedStrings(templateKeys))
+	if request.OAuth != nil {
+		fmt.Fprintf(&b, "var oauthScopes = []string{%s}\n\n", quotedStrings(request.OAuth.Scopes))
+		fmt.Fprintf(&b, "var oauthTokenParams = map[string]string{%s}\n\n", renderedAttributeMap(request.OAuth.TokenParams))
+	}
+	fmt.Fprintf(&b, "type Source struct {\n\tinner *jsonapi.Source\n\tallowLoopback bool\n")
+	if request.OAuth != nil {
+		fmt.Fprintf(&b, "\ttokenCache sourcehttp.ClientCredentialsCache\n")
+	}
+	fmt.Fprintf(&b, "}\n\n")
 	fmt.Fprintf(&b, "func New() (*Source, error) {\n")
 	fmt.Fprintf(&b, "\tspec, err := loadSpec()\n\tif err != nil {\n\t\treturn nil, err\n\t}\n")
 	fmt.Fprintf(&b, "\tinner, err := jsonapi.New(spec, jsonapi.Options{\n")
@@ -710,6 +929,15 @@ func renderSourceGo(request normalizedRequest) string {
 		fmt.Fprintf(&b, "\t\t\t\tPath: %s,\n", strconv.Quote(family.Path))
 		fmt.Fprintf(&b, "\t\t\t\tURNKind: %s,\n", strconv.Quote(family.URNKind))
 		fmt.Fprintf(&b, "\t\t\t\tIDKeys: []string{%s},\n", quotedStrings(idKeysForFamily(family)))
+		if strings.TrimSpace(family.CursorParam) != "" {
+			fmt.Fprintf(&b, "\t\t\t\tCursorParam: %s,\n", strconv.Quote(family.CursorParam))
+		}
+		if len(family.PageSizeParams) != 0 {
+			fmt.Fprintf(&b, "\t\t\t\tPageSizeParams: []string{%s},\n", quotedStrings(family.PageSizeParams))
+		}
+		if len(family.ListKeys) != 0 {
+			fmt.Fprintf(&b, "\t\t\t\tListKeys: []string{%s},\n", quotedStrings(family.ListKeys))
+		}
 		fmt.Fprintf(&b, "\t\t\t\tTimestampKeys: []string{%s},\n", quotedStrings([]string{"observed_at", "updated_at", "last_seen_at", "created_at"}))
 		fmt.Fprintf(&b, "\t\t\t\tAttributes: map[string]string{%s},\n", renderedAttributeMap(attributePathsForFamily(family)))
 		fmt.Fprintf(&b, "\t\t\t\tStaticAttributes: map[string]string{%s},\n", renderedAttributeMap(staticAttributesForFamily(request, family)))
@@ -719,10 +947,17 @@ func renderSourceGo(request normalizedRequest) string {
 	fmt.Fprintf(&b, "\tif err != nil {\n\t\treturn nil, err\n\t}\n")
 	fmt.Fprintf(&b, "\treturn &Source{inner: inner}, nil\n}\n\n")
 	fmt.Fprintf(&b, "func (s *Source) Spec() *cerebrov1.SourceSpec {\n\tif s == nil || s.inner == nil {\n\t\treturn nil\n\t}\n\treturn s.inner.Spec()\n}\n\n")
-	fmt.Fprintf(&b, "func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {\n\tif err := s.checkHealth(ctx, cfg); err != nil {\n\t\treturn err\n\t}\n\treturn s.inner.Check(ctx, cfg)\n}\n\n")
-	fmt.Fprintf(&b, "func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {\n\treturn s.inner.Discover(ctx, cfg)\n}\n\n")
-	fmt.Fprintf(&b, "func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {\n\treturn s.inner.Read(ctx, cfg, cursor)\n}\n\n")
+	fmt.Fprintf(&b, "func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {\n\truntimeCfg, err := s.runtimeConfig(ctx, cfg)\n\tif err != nil {\n\t\treturn err\n\t}\n\tif err := s.checkHealth(ctx, runtimeCfg); err != nil {\n\t\treturn err\n\t}\n\treturn s.inner.Check(ctx, runtimeCfg)\n}\n\n")
+	fmt.Fprintf(&b, "func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {\n\truntimeCfg, err := s.runtimeConfig(ctx, cfg)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\treturn s.inner.Discover(ctx, runtimeCfg)\n}\n\n")
+	fmt.Fprintf(&b, "func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {\n\truntimeCfg, err := s.runtimeConfig(ctx, cfg)\n\tif err != nil {\n\t\treturn sourcecdk.Pull{}, err\n\t}\n\treturn s.inner.Read(ctx, runtimeCfg, cursor)\n}\n\n")
+	fmt.Fprintf(&b, "func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourcecdk.Config, error) {\n\tvalues := cfg.Values()\n\tif strings.TrimSpace(values[\"base_url\"]) == \"\" && strings.TrimSpace(defaultBaseURLTemplate) != \"\" {\n\t\tbaseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)\n\t\tif err != nil {\n\t\t\treturn sourcecdk.Config{}, err\n\t\t}\n\t\tvalues[\"base_url\"] = baseURL\n\t}\n")
+	if request.OAuth != nil {
+		fmt.Fprintf(&b, "\tif s == nil {\n\t\treturn sourcecdk.Config{}, fmt.Errorf(\"%%s source is required\", sourceID)\n\t}\n\ttoken, err := s.tokenCache.Token(ctx, cfg, sourcehttp.ClientCredentialsOptions{\n\t\tSourceID: sourceID,\n\t\tTokenURLTemplate: oauthTokenURLTemplate,\n\t\tTemplateKeys: templateKeys,\n\t\tScopes: oauthScopes,\n\t\tScopeSeparator: oauthScopeSeparator,\n\t\tTokenParams: oauthTokenParams,\n\t\tExpirationBuffer: oauthTokenExpirationBuffer,\n\t\tAllowLoopback: s.allowLoopback,\n\t})\n\tif err != nil {\n\t\treturn sourcecdk.Config{}, err\n\t}\n\tvalues[\"token\"] = token\n")
+	}
+	fmt.Fprintf(&b, "\treturn sourcecdk.NewConfig(values), nil\n}\n\n")
 	fmt.Fprintf(&b, "func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {\n\tbaseURL, _, err := sourcehttp.NormalizeBaseURL(sourceID, configValue(cfg, \"base_url\"), s != nil && s.allowLoopback)\n\tif err != nil {\n\t\treturn err\n\t}\n\tpath := firstNonEmpty(configValue(cfg, \"health_path\"), defaultHealthPath)\n\tpath, err = sourcehttp.NormalizeRequestPath(sourceID, path)\n\tif err != nil {\n\t\treturn err\n\t}\n\treq, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)\n\tif err != nil {\n\t\treturn fmt.Errorf(\"build %%s health request: %%w\", sourceID, err)\n\t}\n\treq.Header.Set(\"Accept\", \"application/json\")\n\tif token := strings.TrimSpace(firstNonEmpty(configValue(cfg, \"token\"), configValue(cfg, \"api_token\"))); token != \"\" {\n\t\treq.Header.Set(\"Authorization\", tokenScheme+\" \"+token)\n\t}\n\tclient := sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: sourceID, AllowLoopback: s != nil && s.allowLoopback, Timeout: 10 * time.Second})\n\tresp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})\n\tif err != nil {\n\t\treturn err\n\t}\n\tif resp.StatusCode < 200 || resp.StatusCode >= 300 {\n\t\treturn fmt.Errorf(\"%%s health endpoint %%s returned HTTP %%d\", sourceID, path, resp.StatusCode)\n\t}\n\treturn nil\n}\n\n")
+	b.WriteString("func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {\n\trendered := strings.TrimSpace(template)\n\tfor _, key := range templateKeys {\n\t\tfor _, prefix := range []string{\"config\", \"credential\", \"connection\"} {\n\t\t\tplaceholder := \"${\" + prefix + \".\" + key + \"}\"\n\t\t\tif !strings.Contains(rendered, placeholder) {\n\t\t\t\tcontinue\n\t\t\t}\n\t\t\tvalue, err := requiredConfigValue(cfg, key)\n\t\t\tif err != nil {\n\t\t\t\treturn \"\", err\n\t\t\t}\n\t\t\trendered = strings.ReplaceAll(rendered, placeholder, value)\n\t\t}\n\t}\n\tif strings.Contains(rendered, \"${\") {\n\t\treturn \"\", fmt.Errorf(\"%w: %s template %q contains unresolved variable\", sourcecdk.ErrInvalidConfig, sourceID, template)\n\t}\n\treturn rendered, nil\n}\n\n")
+	b.WriteString("func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {\n\tvalue := strings.TrimSpace(configValue(cfg, key))\n\tif value == \"\" {\n\t\treturn \"\", fmt.Errorf(\"%w: %s %s is required\", sourcecdk.ErrInvalidConfig, sourceID, key)\n\t}\n\treturn value, nil\n}\n\n")
 	fmt.Fprintf(&b, "func loadSpec() (*cerebrov1.SourceSpec, error) {\n\tspecBytes, err := catalogFS.ReadFile(\"catalog.yaml\")\n\tif err != nil {\n\t\treturn nil, fmt.Errorf(\"read catalog: %%w\", err)\n\t}\n\tspec, err := sourcecdk.LoadCatalog(specBytes)\n\tif err != nil {\n\t\treturn nil, fmt.Errorf(\"load catalog: %%w\", err)\n\t}\n\treturn spec, nil\n}\n\n")
 	fmt.Fprintf(&b, "func configValue(cfg sourcecdk.Config, key string) string {\n\tvalue, _ := cfg.Lookup(key)\n\treturn value\n}\n\n")
 	fmt.Fprintf(&b, "func firstNonEmpty(values ...string) string {\n\tfor _, value := range values {\n\t\tif strings.TrimSpace(value) != \"\" {\n\t\t\treturn strings.TrimSpace(value)\n\t\t}\n\t}\n\treturn \"\"\n}\n\n")
@@ -731,22 +966,24 @@ func renderSourceGo(request normalizedRequest) string {
 }
 
 func idKeysForFamily(family familyData) []string {
+	base := append([]string{}, family.IDKeys...)
 	switch family.Class {
 	case "evidence_cas_reference":
-		return []string{"evidence_id", "uri", "digest", "id"}
+		base = append(base, "evidence_id", "uri", "digest", "id")
 	case "finding":
-		return []string{"finding_id", "id", "resource_urn"}
+		base = append(base, "finding_id", "id", "resource_urn")
 	case "identity_user":
-		return []string{"user_id", "id", "email", "primary_email", "login"}
+		base = append(base, "user_id", "id", "email", "primary_email", "login")
 	case "identity_group":
-		return []string{"group_id", "id", "group_email", "email"}
+		base = append(base, "group_id", "id", "group_email", "email")
 	case "group_membership":
-		return []string{"membership_id", "id", "group_id", "member_id", "user_id", "email"}
+		base = append(base, "membership_id", "id", "group_id", "member_id", "user_id", "email")
 	case "audit_event":
-		return []string{"event_id", "id", "uuid", "request_id"}
+		base = append(base, "event_id", "id", "uuid", "request_id")
 	default:
-		return []string{"id", "urn", "resource_urn", "name"}
+		base = append(base, "id", "urn", "resource_urn", "name")
 	}
+	return uniqueStrings(base)
 }
 
 func attributePathsForFamily(family familyData) map[string]string {
@@ -832,23 +1069,55 @@ func staticAttributesForFamily(request normalizedRequest, family familyData) map
 }
 
 func renderSourceTestGo(request normalizedRequest) string {
-	configKey := request.TokenConfigKey
 	var b strings.Builder
 	fmt.Fprintf(&b, "package %s\n\n", request.PackageName)
 	fmt.Fprintf(&b, "import (\n\t\"context\"\n\t\"encoding/json\"\n\t\"net/http\"\n\t\"net/http/httptest\"\n\t\"strings\"\n\t\"testing\"\n\n\t\"github.com/writer/cerebro/internal/sourcecdk\"\n)\n\n")
 	fmt.Fprintf(&b, "func TestSourceCheckAndRead(t *testing.T) {\n")
 	fmt.Fprintf(&b, "\tsource, err := New()\n\tif err != nil {\n\t\tt.Fatalf(\"New() error = %%v\", err)\n\t}\n\tsource.allowLoopbackForTest()\n")
+	if request.OAuth != nil {
+		fmt.Fprintf(&b, "\ttokenRequests := 0\n")
+	}
 	fmt.Fprintf(&b, "\tserver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n")
+	if request.OAuth != nil {
+		fmt.Fprintf(&b, "\t\tif r.URL.Path == \"/oauth/token\" {\n\t\t\ttokenRequests++\n\t\t\tif r.Method != http.MethodPost {\n\t\t\t\tt.Fatalf(\"token method = %%s\", r.Method)\n\t\t\t}\n\t\t\tr.Body = http.MaxBytesReader(w, r.Body, 1<<20)\n\t\t\tif err := r.ParseForm(); err != nil {\n\t\t\t\tt.Fatalf(\"ParseForm() error = %%v\", err)\n\t\t\t}\n\t\t\tif got := r.Form.Get(\"grant_type\"); got != \"client_credentials\" {\n\t\t\t\tt.Fatalf(\"grant_type = %%q\", got)\n\t\t\t}\n\t\t\tif got := r.Form.Get(\"client_id\"); got != \"client-id\" {\n\t\t\t\tt.Fatalf(\"client_id = %%q\", got)\n\t\t\t}\n\t\t\tif got := r.Form.Get(\"client_secret\"); got != \"client-secret\" {\n\t\t\t\tt.Fatalf(\"client_secret = %%q\", got)\n\t\t\t}\n\t\t\tw.Header().Set(\"Content-Type\", \"application/json\")\n\t\t\t_ = json.NewEncoder(w).Encode(map[string]any{\"access_token\": \"test-token\", \"expires_in\": 600})\n\t\t\treturn\n\t\t}\n")
+	}
 	fmt.Fprintf(&b, "\t\tif r.Header.Get(\"Authorization\") != %s {\n\t\t\tt.Fatalf(\"Authorization = %%q\", r.Header.Get(\"Authorization\"))\n\t\t}\n", strconv.Quote(request.TokenScheme+" test-token"))
-	fmt.Fprintf(&b, "\t\tif r.URL.Path == defaultHealthPath {\n\t\t\tw.WriteHeader(http.StatusNoContent)\n\t\t\treturn\n\t\t}\n")
+	if request.HealthPath != request.DefaultPath {
+		fmt.Fprintf(&b, "\t\tif r.URL.Path == defaultHealthPath {\n\t\t\tw.WriteHeader(http.StatusNoContent)\n\t\t\treturn\n\t\t}\n")
+	}
 	fmt.Fprintf(&b, "\t\tif r.URL.Path != %s {\n\t\t\tt.Fatalf(\"path = %%q\", r.URL.Path)\n\t\t}\n", strconv.Quote(request.DefaultPath))
 	fmt.Fprintf(&b, "\t\tw.Header().Set(\"Content-Type\", \"application/json\")\n")
 	fmt.Fprintf(&b, "\t\t_ = json.NewEncoder(w).Encode(map[string]any{\"items\": []map[string]string{{\"id\": \"record-1\", \"resource_urn\": \"urn:cerebro:tenant:runtime_asset:record-1\", \"resource_type\": \"asset\", \"resource_id\": \"record-1\", \"name\": \"Record One\", \"updated_at\": \"2026-06-01T00:00:00Z\"}}})\n")
 	fmt.Fprintf(&b, "\t}))\n\tdefer server.Close()\n")
-	fmt.Fprintf(&b, "\tcfg := sourcecdk.NewConfig(map[string]string{\"tenant_id\": \"tenant\", \"base_url\": server.URL, \"family\": defaultFamily, %s: \"test-token\"})\n", strconv.Quote(configKey))
+	fmt.Fprintf(&b, "\tcfgValues := map[string]string{\"tenant_id\": \"tenant\", \"base_url\": server.URL, \"family\": defaultFamily")
+	if request.OAuth != nil {
+		fmt.Fprintf(&b, ", \"token_url\": server.URL + \"/oauth/token\", \"client_id\": \"client-id\", \"client_secret\": \"client-secret\"")
+		for _, key := range request.ConfigKeys {
+			if key == "base_url" || key == "family" || key == "token_url" {
+				continue
+			}
+			fmt.Fprintf(&b, ", %s: %s", strconv.Quote(key), strconv.Quote(testConfigValue(key)))
+		}
+	} else {
+		fmt.Fprintf(&b, ", %s: \"test-token\"", strconv.Quote(request.TokenConfigKey))
+	}
+	fmt.Fprintf(&b, "}\n\tcfg := sourcecdk.NewConfig(cfgValues)\n")
 	fmt.Fprintf(&b, "\tif err := source.Check(context.Background(), cfg); err != nil {\n\t\tt.Fatalf(\"Check() error = %%v\", err)\n\t}\n")
-	fmt.Fprintf(&b, "\tpull, err := source.Read(context.Background(), cfg, nil)\n\tif err != nil {\n\t\tt.Fatalf(\"Read() error = %%v\", err)\n\t}\n\tif len(pull.Events) != 1 {\n\t\tt.Fatalf(\"events = %%d, want 1\", len(pull.Events))\n\t}\n\tevent := pull.Events[0]\n\tif event.Kind != sourceID+\".\"+defaultFamily {\n\t\tt.Fatalf(\"kind = %%q\", event.Kind)\n\t}\n\tif strings.TrimSpace(event.Id) == \"\" {\n\t\tt.Fatalf(\"event id is empty: %%#v\", event)\n\t}\n}\n")
+	fmt.Fprintf(&b, "\tpull, err := source.Read(context.Background(), cfg, nil)\n\tif err != nil {\n\t\tt.Fatalf(\"Read() error = %%v\", err)\n\t}\n\tif len(pull.Events) != 1 {\n\t\tt.Fatalf(\"events = %%d, want 1\", len(pull.Events))\n\t}\n\tevent := pull.Events[0]\n")
+	if request.OAuth != nil {
+		fmt.Fprintf(&b, "\tif tokenRequests != 1 {\n\t\tt.Fatalf(\"token requests = %%d, want 1 cached token\", tokenRequests)\n\t}\n")
+	}
+	fmt.Fprintf(&b, "\tif event.Kind != %s {\n\t\tt.Fatalf(\"kind = %%q\", event.Kind)\n\t}\n\tif strings.TrimSpace(event.Id) == \"\" {\n\t\tt.Fatalf(\"event id is empty: %%#v\", event)\n\t}\n}\n", strconv.Quote(request.Families[0].EventKind))
 	return b.String()
+}
+
+func testConfigValue(key string) string {
+	switch strings.TrimSpace(key) {
+	case "domain":
+		return "example.test"
+	default:
+		return "test-" + strings.TrimSpace(key)
+	}
 }
 
 func renderReadFixture() string {

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -125,7 +125,7 @@ func TestGenerateDefinitionWritesIdentitySource(t *testing.T) {
 			TenantID:      "tenant-a",
 			SourceID:      "example_idp",
 			DisplayName:   "Example IDP",
-			Auth: connectordefinitions.AuthSpec{
+			Auth: connectordefinitions.AuthSpec{ // #nosec G101 -- credential field names only, not secret values.
 				Model: "bearer_token",
 				CredentialFields: []connectordefinitions.Field{{
 					Key:           "token",
@@ -183,6 +183,103 @@ func TestGenerateDefinitionWritesIdentitySource(t *testing.T) {
 	sourceTest := readGeneratedFile(t, outputDir, "sources/example_idp/source_test.go")
 	if strings.Contains(sourceTest, "evidence_cas_uri") {
 		t.Fatalf("definition generated source test should not assume EvidenceCAS fields:\n%s", sourceTest)
+	}
+}
+
+func TestGenerateDefinitionWritesOAuthClientCredentialsSource(t *testing.T) {
+	outputDir := t.TempDir()
+	result, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			SchemaVersion: connectordefinitions.SchemaVersionIntegrationV1,
+			ID:            "tenant-a-auth0",
+			TenantID:      "tenant-a",
+			SourceID:      "auth0",
+			DisplayName:   "Auth0",
+			ConfigFields: []connectordefinitions.Field{{
+				Key:      "domain",
+				Required: true,
+			}},
+			Auth: connectordefinitions.AuthSpec{ // #nosec G101 -- Test-only OAuth credential field names, not live secrets.
+				Model:    AuthModelOAuthClientCredentials,
+				TokenURL: "https://${config.domain}/oauth/token",
+				Scopes:   []string{"read:users"},
+				TokenParams: map[string]string{
+					"audience": "https://${config.domain}/api/v2/",
+				},
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "client_id",
+					ReferenceOnly: true,
+				}, {
+					Key:           "client_secret",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL: "https://${config.domain}/api/v2",
+				Verification: &connectordefinitions.VerificationSpec{
+					Path: "/users",
+				},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:             "users",
+				Path:           "/users",
+				RecordSelector: "$[*]",
+				IDField:        "user_id",
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "auth0.users",
+					SchemaRef: "auth0/users/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{
+					Template: "identity_user",
+				},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{
+					Type:      "entity_family",
+					Support:   "supported",
+					HighValue: true,
+				}},
+			}},
+		},
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefinition() error = %v", err)
+	}
+	if result.SourceID != "auth0" || result.AuthModel != AuthModelOAuthClientCredentials {
+		t.Fatalf("result = %#v", result)
+	}
+	source := readGeneratedFile(t, outputDir, "sources/auth0/source.go")
+	for _, want := range []string{
+		"oauthTokenURLTemplate",
+		"sourcehttp.ClientCredentialsOptions",
+		"TokenURLTemplate: oauthTokenURLTemplate",
+		"sourcehttp.ClientCredentialsCache",
+		"oauthTokenExpirationBuffer",
+		"renderTemplate(defaultBaseURLTemplate",
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("source.go missing %q:\n%s", want, source)
+		}
+	}
+	deploy := readGeneratedFile(t, outputDir, "sources/auth0/deploy.yaml")
+	for _, want := range []string{
+		"domain: env:AUTH0_DOMAIN",
+		"client_id: env:AUTH0_CLIENT_ID",
+		"client_secret: env:AUTH0_CLIENT_SECRET",
+	} {
+		if !strings.Contains(deploy, want) {
+			t.Fatalf("deploy.yaml missing %q:\n%s", want, deploy)
+		}
+	}
+	sourceTest := readGeneratedFile(t, outputDir, "sources/auth0/source_test.go")
+	for _, want := range []string{
+		`r.URL.Path == "/oauth/token"`,
+		`tokenRequests != 1`,
+		`"token_url": server.URL + "/oauth/token"`,
+	} {
+		if !strings.Contains(sourceTest, want) {
+			t.Fatalf("source_test.go missing %q:\n%s", want, sourceTest)
+		}
 	}
 }
 

--- a/internal/sourcehttp/oauth_client_credentials.go
+++ b/internal/sourcehttp/oauth_client_credentials.go
@@ -1,0 +1,193 @@
+package sourcehttp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+// ClientCredentialsOptions describes a generic OAuth 2.0 client-credentials exchange.
+type ClientCredentialsOptions struct {
+	SourceID         string
+	TokenURLTemplate string
+	TemplateKeys     []string
+	Scopes           []string
+	ScopeSeparator   string
+	TokenParams      map[string]string
+	ExpirationBuffer time.Duration
+	AllowLoopback    bool
+	Timeout          time.Duration
+}
+
+// ClientCredentialsCache caches one access token until shortly before expiry.
+type ClientCredentialsCache struct {
+	mu        sync.Mutex
+	value     string
+	expiresAt time.Time
+}
+
+// Token returns a cached bearer token or exchanges client_id/client_secret for a new one.
+func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config, options ClientCredentialsOptions) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("%s oauth token cache is required", sourceID(options.SourceID))
+	}
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.value != "" && now.Before(c.expiresAt) {
+		return c.value, nil
+	}
+	tokenURL, err := renderTemplate(firstNonEmpty(configValue(cfg, "token_url"), options.TokenURLTemplate), cfg, options)
+	if err != nil {
+		return "", err
+	}
+	tokenURL, err = normalizeOAuthURL(tokenURL, options)
+	if err != nil {
+		return "", err
+	}
+	clientID, err := requiredConfigValue(cfg, "client_id", options)
+	if err != nil {
+		return "", err
+	}
+	clientSecret, err := requiredConfigValue(cfg, "client_secret", options)
+	if err != nil {
+		return "", err
+	}
+	form := url.Values{"grant_type": {"client_credentials"}, "client_id": {clientID}, "client_secret": {clientSecret}}
+	if scope := strings.Join(options.Scopes, firstNonEmpty(options.ScopeSeparator, " ")); strings.TrimSpace(scope) != "" {
+		form.Set("scope", scope)
+	}
+	for key, template := range options.TokenParams {
+		value, err := renderTemplate(template, cfg, options)
+		if err != nil {
+			return "", err
+		}
+		form.Set(key, value)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("build %s token request: %w", sourceID(options.SourceID), err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := DoWithRetry(ctx, NewClient(ClientOptions{
+		SourceID:      sourceID(options.SourceID),
+		AllowLoopback: options.AllowLoopback,
+		Timeout:       firstNonZeroDuration(options.Timeout, 10*time.Second),
+	}), req, RetryOptions{})
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("%s token endpoint returned HTTP %d", sourceID(options.SourceID), resp.StatusCode)
+	}
+	var payload struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+		return "", fmt.Errorf("decode %s token response: %w", sourceID(options.SourceID), err)
+	}
+	token := strings.TrimSpace(payload.AccessToken)
+	if token == "" {
+		return "", fmt.Errorf("%s token response missing access_token", sourceID(options.SourceID))
+	}
+	expiresIn := payload.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 300
+	}
+	c.value = token
+	c.expiresAt = now.Add(time.Duration(expiresIn)*time.Second - firstNonZeroDuration(options.ExpirationBuffer, time.Minute))
+	if !c.expiresAt.After(now) {
+		c.expiresAt = now.Add(time.Minute)
+	}
+	return c.value, nil
+}
+
+func renderTemplate(template string, cfg sourcecdk.Config, options ClientCredentialsOptions) (string, error) {
+	rendered := strings.TrimSpace(template)
+	for _, key := range options.TemplateKeys {
+		for _, prefix := range []string{"config", "credential", "connection"} {
+			placeholder := "${" + prefix + "." + key + "}"
+			if !strings.Contains(rendered, placeholder) {
+				continue
+			}
+			value, err := requiredConfigValue(cfg, key, options)
+			if err != nil {
+				return "", err
+			}
+			rendered = strings.ReplaceAll(rendered, placeholder, value)
+		}
+	}
+	if strings.Contains(rendered, "${") {
+		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID), template)
+	}
+	return rendered, nil
+}
+
+func normalizeOAuthURL(raw string, options ClientCredentialsOptions) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse %s token_url: %w", sourceID(options.SourceID), err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("%w: %s token_url must be absolute", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID))
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", fmt.Errorf("%w: %s token_url must not include user info, query, or fragment", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID))
+	}
+	baseURL, _, err := NormalizeBaseURL(sourceID(options.SourceID), parsed.Scheme+"://"+parsed.Host, options.AllowLoopback)
+	if err != nil {
+		return "", err
+	}
+	path := parsed.EscapedPath()
+	if strings.TrimSpace(path) == "" {
+		path = "/"
+	}
+	return baseURL + path, nil
+}
+
+func requiredConfigValue(cfg sourcecdk.Config, key string, options ClientCredentialsOptions) (string, error) {
+	value := strings.TrimSpace(configValue(cfg, key))
+	if value == "" {
+		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID), key)
+	}
+	return value, nil
+}
+
+func configValue(cfg sourcecdk.Config, key string) string {
+	value, _ := cfg.Lookup(key)
+	return value
+}
+
+func sourceID(value string) string {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		return trimmed
+	}
+	return "source"
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func firstNonZeroDuration(values ...time.Duration) time.Duration {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/internal/sourceprojection/auth0.go
+++ b/internal/sourceprojection/auth0.go
@@ -1,0 +1,18 @@
+package sourceprojection
+
+import (
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func auth0UsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return identityUserProjections(event, identityProjectionProfile{Provider: "auth0"})
+}
+
+func auth0RolesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return identityGroupProjections(event, identityProjectionProfile{Provider: "auth0"})
+}
+
+func auth0AuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return identityAuditProjections(event, identityProjectionProfile{Provider: "auth0"})
+}

--- a/internal/sourceprojection/auth0_test.go
+++ b/internal/sourceprojection/auth0_test.go
@@ -1,0 +1,40 @@
+package sourceprojection
+
+import (
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestAuth0IdentityUserProjection(t *testing.T) {
+	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "auth0", Kind: "auth0.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
+	entities, _, err := auth0UsersProjections(event)
+	if err != nil {
+		t.Fatalf("projection error = %v", err)
+	}
+	if len(entities) == 0 {
+		t.Fatal("expected projected identity user")
+	}
+}
+
+func TestAuth0IdentityGroupProjection(t *testing.T) {
+	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "auth0", Kind: "auth0.roles", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "group_name": "Group One"}}
+	entities, _, err := auth0RolesProjections(event)
+	if err != nil {
+		t.Fatalf("projection error = %v", err)
+	}
+	if len(entities) == 0 {
+		t.Fatal("expected projected identity group")
+	}
+}
+
+func TestAuth0AuditProjection(t *testing.T) {
+	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "auth0", Kind: "auth0.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
+	entities, links, err := auth0AuditEventsProjections(event)
+	if err != nil {
+		t.Fatalf("projection error = %v", err)
+	}
+	if len(entities) == 0 || len(links) == 0 {
+		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+	}
+}

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -44,6 +44,9 @@ func NewRegistry(projectors ...EventProjector) (*Registry, error) {
 
 var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"backstage.component":                           backstageComponentProjections,
+	"auth0.audit_events":                            auth0AuditEventsProjections,
+	"auth0.roles":                                   auth0RolesProjections,
+	"auth0.users":                                   auth0UsersProjections,
 	"aurelius.catalog_promotion":                    aureliusCatalogPromotionProjections,
 	"aurelius.finding":                              aureliusFindingProjections,
 	"aurelius.image_scan":                           aureliusImageScanProjections,

--- a/internal/sourceregistry/registry.go
+++ b/internal/sourceregistry/registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 	anthropicsource "github.com/writer/cerebro/sources/anthropic"
 	aureliussource "github.com/writer/cerebro/sources/aurelius"
+	auth0source "github.com/writer/cerebro/sources/auth0"
 	awssource "github.com/writer/cerebro/sources/aws"
 	azuresource "github.com/writer/cerebro/sources/azure"
 	backstagesource "github.com/writer/cerebro/sources/backstage"
@@ -58,6 +59,12 @@ var builtinSourceLoaders = []builtinSourceLoader{
 		name: "anthropic",
 		load: func() (sourcecdk.Source, error) {
 			return anthropicsource.New()
+		},
+	},
+	{
+		name: "auth0",
+		load: func() (sourcecdk.Source, error) {
+			return auth0source.New()
 		},
 	},
 	{

--- a/internal/sourceregistry/registry_test.go
+++ b/internal/sourceregistry/registry_test.go
@@ -14,6 +14,13 @@ func TestBuiltin(t *testing.T) {
 	if aurelius.Spec().Name != "Aurelius" {
 		t.Fatalf("aurelius Spec().Name = %q, want %q", aurelius.Spec().Name, "Aurelius")
 	}
+	auth0, ok := registry.Get("auth0")
+	if !ok {
+		t.Fatal("Get(auth0) = false, want true")
+	}
+	if auth0.Spec().Name != "Auth0" {
+		t.Fatalf("auth0 Spec().Name = %q, want %q", auth0.Spec().Name, "Auth0")
+	}
 	aws, ok := registry.Get("aws")
 	if !ok {
 		t.Fatal("Get(aws) = false, want true")

--- a/sources/auth0/PR_BODY.md
+++ b/sources/auth0/PR_BODY.md
@@ -1,0 +1,16 @@
+## Summary
+
+- Adds the `auth0` Source Runtime SDK scaffold.
+- Includes runtime adapter, health check, EvidenceCAS reference events, graph projection scaffolds, tests, and a source-health receipt.
+
+## Generated runtime contract
+
+- Source type: `json_api`
+- Auth model: `oauth_client_credentials`
+- Health endpoint: `/source-runtimes/health?source_id=auth0`
+- Freshness: `24h0m0s`
+
+## Tests
+
+- `go test ./sources/auth0 ./internal/sourceprojection -count=1`
+- `make catalog-check`

--- a/sources/auth0/SOURCE_RUNTIME.md
+++ b/sources/auth0/SOURCE_RUNTIME.md
@@ -1,0 +1,28 @@
+# Auth0
+
+Generated Source Runtime SDK scaffold for `auth0`.
+
+## Runtime input
+
+- Source type: `json_api`
+- Auth model: `oauth_client_credentials`
+- Freshness expectation: `24h0m0s`
+- Failure modes: `api_error,auth_error,rate_limit,schema_drift`
+
+## Runtime output
+
+- Adapter package: `sources/auth0`
+- Health endpoint: `/source-runtimes/health?source_id=auth0`
+- Source health receipt: `sources/auth0/source_health_receipt.json`
+- EvidenceCAS reference kind: `auth0.evidence_cas_reference`
+
+## Families
+
+- `users`, emits `auth0.users`, reads `/users`
+- `roles`, emits `auth0.roles`, reads `/roles`
+- `audit_events`, emits `auth0.audit_events`, reads `/logs`
+
+## Tests
+
+- `go test ./sources/auth0 ./internal/sourceprojection -count=1`
+- `make catalog-check`

--- a/sources/auth0/catalog.yaml
+++ b/sources/auth0/catalog.yaml
@@ -1,0 +1,65 @@
+id: auth0
+name: "Auth0"
+description: "Auth0 connector definition catalog entry for high-value security and operations resources."
+emitted_kinds:
+  - auth0.users
+  - auth0.roles
+  - auth0.audit_events
+coverage_contract:
+  owner_domain: source_runtime
+  authority_domain: auth0
+  dimensions:
+    - id: users
+      type: entity_family
+      title: "Users"
+      families: [users]
+      support: partial
+      high_value: true
+      notes:
+        - Generated Source Runtime SDK mapping requires provider field review before certification.
+    - id: roles
+      type: entity_family
+      title: "Roles"
+      families: [roles]
+      support: partial
+      high_value: true
+      notes:
+        - Generated Source Runtime SDK mapping requires provider field review before certification.
+    - id: audit_events
+      type: entity_family
+      title: "Audit Events"
+      families: [audit_events]
+      support: partial
+      high_value: true
+      notes:
+        - Generated Source Runtime SDK mapping requires provider field review before certification.
+    - id: incremental_sync
+      type: incremental_sync
+      title: Incremental cursor sync
+      support: planned
+event_contracts:
+  - kind: auth0.users
+    schema_ref: auth0/users/v1
+    required_attributes:
+      - tenant_id
+      - source_event_id
+      - user_id
+    required_payload_fields:
+      - user_id
+  - kind: auth0.roles
+    schema_ref: auth0/roles/v1
+    required_attributes:
+      - tenant_id
+      - source_event_id
+      - group_id
+    required_payload_fields:
+      - id
+  - kind: auth0.audit_events
+    schema_ref: auth0/audit_events/v1
+    required_attributes:
+      - tenant_id
+      - source_event_id
+      - event_type
+      - actor_id
+    required_payload_fields:
+      - log_id

--- a/sources/auth0/deploy.yaml
+++ b/sources/auth0/deploy.yaml
@@ -1,0 +1,17 @@
+sourceId: auth0
+secretKeys:
+  - AUTH0_DOMAIN
+  - AUTH0_CLIENT_ID
+  - AUTH0_CLIENT_SECRET
+runtimes:
+  - localId: users
+    config:
+      domain: env:AUTH0_DOMAIN
+      family: users
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /users
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      client_id: env:AUTH0_CLIENT_ID
+      client_secret: env:AUTH0_CLIENT_SECRET

--- a/sources/auth0/source.go
+++ b/sources/auth0/source.go
@@ -1,0 +1,248 @@
+package auth0
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehttp"
+	"github.com/writer/cerebro/sources/internal/jsonapi"
+)
+
+//go:embed catalog.yaml
+var catalogFS embed.FS
+
+const (
+	sourceID                   = "auth0"
+	defaultFamily              = familyUsers
+	defaultHealthPath          = "/users"
+	defaultBaseURLTemplate     = "https://${config.domain}/api/v2"
+	tokenScheme                = "Bearer"
+	oauthTokenURLTemplate      = "https://${config.domain}/oauth/token" // #nosec G101 -- token endpoint URL template, not credential material.
+	oauthScopeSeparator        = " "
+	oauthTokenExpirationBuffer = 60 * time.Second
+	familyUsers                = "users"
+	familyRoles                = "roles"
+	familyAuditEvents          = "audit_events"
+)
+
+var templateKeys = []string{"domain", "client_id", "client_secret"}
+
+var oauthScopes = []string{"read:logs", "read:roles", "read:users"}
+
+var oauthTokenParams = map[string]string{"audience": "https://${config.domain}/api/v2/"}
+
+type Source struct {
+	inner         *jsonapi.Source
+	allowLoopback bool
+	tokenCache    sourcehttp.ClientCredentialsCache
+}
+
+func New() (*Source, error) {
+	spec, err := loadSpec()
+	if err != nil {
+		return nil, err
+	}
+	inner, err := jsonapi.New(spec, jsonapi.Options{
+		SourceID:        sourceID,
+		DefaultFamily:   defaultFamily,
+		RequireTenantID: true,
+		TokenScheme:     tokenScheme,
+		Families: []jsonapi.Family{
+			{
+				Name:             familyUsers,
+				Path:             "/users",
+				URNKind:          "runtime_users",
+				IDKeys:           []string{"user_id", "name", "id", "email", "primary_email", "login"},
+				PageSizeParams:   []string{"per_page"},
+				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
+				Attributes:       map[string]string{"created_at": "created_at|created|profile.created_at", "department": "department|profile.department", "display_name": "display_name|name|profile.display_name|profile.name", "domain": "domain|tenant_domain|organization_domain", "email": "email|primary_email|profile.email", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "job_title": "job_title|title|profile.title", "last_login_at": "last_login_at|last_login|last_seen_at", "login": "login|username|email|profile.login", "manager": "manager|profile.manager", "observed_at": "observed_at|updated_at|last_seen_at", "primary_email": "primary_email|email|profile.email", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "status": "status|state|lifecycle_state", "tenant_id": "tenant_id|metadata.tenant_id", "user_id": "user_id|id|uid"},
+				StaticAttributes: map[string]string{"record_class": "identity_user", "schema": "users", "source_system": "auth0"},
+			},
+			{
+				Name:             familyRoles,
+				Path:             "/roles",
+				URNKind:          "runtime_roles",
+				IDKeys:           []string{"id", "name", "group_id", "group_email", "email"},
+				PageSizeParams:   []string{"per_page"},
+				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
+				Attributes:       map[string]string{"description": "description|summary", "domain": "domain|tenant_domain|organization_domain", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "group_email": "group_email|email", "group_id": "group_id|id", "group_name": "group_name|name|display_name", "observed_at": "observed_at|updated_at|last_seen_at", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
+				StaticAttributes: map[string]string{"record_class": "identity_group", "schema": "roles", "source_system": "auth0"},
+			},
+			{
+				Name:             familyAuditEvents,
+				Path:             "/logs",
+				URNKind:          "runtime_audit_events",
+				IDKeys:           []string{"log_id", "event_id", "id", "uuid", "request_id"},
+				CursorParam:      "from",
+				PageSizeParams:   []string{"take"},
+				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
+				Attributes:       map[string]string{"actor_email": "actor_email|actor.email|email|user.email", "actor_id": "actor_id|actor.id|actorId|user_id|user.id", "actor_name": "actor_name|actor.name|user.name", "event_type": "event_type|event_name|action|type", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|updated_at|last_seen_at", "resource_email": "resource_email|target_email|target.email", "resource_id": "resource_id|target_id|target.id|resource.id|object_id", "resource_name": "resource_name|target_name|target.name|resource.name|object_name", "resource_type": "resource_type|target_type|target.type|object_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
+				StaticAttributes: map[string]string{"record_class": "audit_event", "schema": "audit_events", "source_system": "auth0"},
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Source{inner: inner}, nil
+}
+
+func (s *Source) Spec() *cerebrov1.SourceSpec {
+	if s == nil || s.inner == nil {
+		return nil
+	}
+	return s.inner.Spec()
+}
+
+func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
+	runtimeCfg, err := s.runtimeConfig(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	if err := s.checkHealth(ctx, runtimeCfg); err != nil {
+		return err
+	}
+	return s.inner.Check(ctx, runtimeCfg)
+}
+
+func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	runtimeCfg, err := s.runtimeConfig(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return s.inner.Discover(ctx, runtimeCfg)
+}
+
+func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	runtimeCfg, err := s.runtimeConfig(ctx, cfg)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	return s.inner.Read(ctx, runtimeCfg, cursor)
+}
+
+func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourcecdk.Config, error) {
+	values := cfg.Values()
+	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
+		baseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)
+		if err != nil {
+			return sourcecdk.Config{}, err
+		}
+		values["base_url"] = baseURL
+	}
+	if s == nil {
+		return sourcecdk.Config{}, fmt.Errorf("%s source is required", sourceID)
+	}
+	token, err := s.tokenCache.Token(ctx, cfg, sourcehttp.ClientCredentialsOptions{
+		SourceID:         sourceID,
+		TokenURLTemplate: oauthTokenURLTemplate,
+		TemplateKeys:     templateKeys,
+		Scopes:           oauthScopes,
+		ScopeSeparator:   oauthScopeSeparator,
+		TokenParams:      oauthTokenParams,
+		ExpirationBuffer: oauthTokenExpirationBuffer,
+		AllowLoopback:    s.allowLoopback,
+	})
+	if err != nil {
+		return sourcecdk.Config{}, err
+	}
+	values["token"] = token
+	return sourcecdk.NewConfig(values), nil
+}
+
+func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
+	baseURL, _, err := sourcehttp.NormalizeBaseURL(sourceID, configValue(cfg, "base_url"), s != nil && s.allowLoopback)
+	if err != nil {
+		return err
+	}
+	path := firstNonEmpty(configValue(cfg, "health_path"), defaultHealthPath)
+	path, err = sourcehttp.NormalizeRequestPath(sourceID, path)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("build %s health request: %w", sourceID, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if token := strings.TrimSpace(firstNonEmpty(configValue(cfg, "token"), configValue(cfg, "api_token"))); token != "" {
+		req.Header.Set("Authorization", tokenScheme+" "+token)
+	}
+	client := sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: sourceID, AllowLoopback: s != nil && s.allowLoopback, Timeout: 10 * time.Second})
+	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s health endpoint %s returned HTTP %d", sourceID, path, resp.StatusCode)
+	}
+	return nil
+}
+
+func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {
+	rendered := strings.TrimSpace(template)
+	for _, key := range templateKeys {
+		for _, prefix := range []string{"config", "credential", "connection"} {
+			placeholder := "${" + prefix + "." + key + "}"
+			if !strings.Contains(rendered, placeholder) {
+				continue
+			}
+			value, err := requiredConfigValue(cfg, key)
+			if err != nil {
+				return "", err
+			}
+			rendered = strings.ReplaceAll(rendered, placeholder, value)
+		}
+	}
+	if strings.Contains(rendered, "${") {
+		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID, template)
+	}
+	return rendered, nil
+}
+
+func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {
+	value := strings.TrimSpace(configValue(cfg, key))
+	if value == "" {
+		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID, key)
+	}
+	return value, nil
+}
+
+func loadSpec() (*cerebrov1.SourceSpec, error) {
+	specBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read catalog: %w", err)
+	}
+	spec, err := sourcecdk.LoadCatalog(specBytes)
+	if err != nil {
+		return nil, fmt.Errorf("load catalog: %w", err)
+	}
+	return spec, nil
+}
+
+func configValue(cfg sourcecdk.Config, key string) string {
+	value, _ := cfg.Lookup(key)
+	return value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func (s *Source) allowLoopbackForTest() {
+	if s != nil && s.inner != nil {
+		s.inner.AllowLoopbackBaseURL = true
+		s.allowLoopback = true
+	}
+}

--- a/sources/auth0/source_health_receipt.json
+++ b/sources/auth0/source_health_receipt.json
@@ -1,0 +1,17 @@
+{
+  "adapter_health_path": "/users",
+  "auth_model": "oauth_client_credentials",
+  "evidence_cas_reference_kind": "auth0.evidence_cas_reference",
+  "expected_cadence_seconds": 86400,
+  "failure_modes": [
+    "api_error",
+    "auth_error",
+    "rate_limit",
+    "schema_drift"
+  ],
+  "health_endpoint": "/source-runtimes/health?source_id=auth0",
+  "receipt_kind": "source_health.receipt",
+  "source_id": "auth0",
+  "source_type": "json_api",
+  "stale_after_seconds": 86400
+}

--- a/sources/auth0/source_test.go
+++ b/sources/auth0/source_test.go
@@ -1,0 +1,76 @@
+package auth0
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+func TestSourceCheckAndRead(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	tokenRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/token" {
+			tokenRequests++
+			if r.Method != http.MethodPost {
+				t.Fatalf("token method = %s", r.Method)
+			}
+			r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm() error = %v", err)
+			}
+			if got := r.Form.Get("grant_type"); got != "client_credentials" {
+				t.Fatalf("grant_type = %q", got)
+			}
+			if got := r.Form.Get("client_id"); got != "client-id" {
+				t.Fatalf("client_id = %q", got)
+			}
+			if got := r.Form.Get("client_secret"); got != "client-secret" {
+				t.Fatalf("client_secret = %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token", "expires_in": 600})
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		if r.URL.Path != "/users" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]string{{"id": "record-1", "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1", "resource_type": "asset", "resource_id": "record-1", "name": "Record One", "updated_at": "2026-06-01T00:00:00Z"}}})
+	}))
+	defer server.Close()
+	cfgValues := map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": defaultFamily, "token_url": server.URL + "/oauth/token", "client_id": "client-id", "client_secret": "client-secret", "domain": "example.test"}
+	cfg := sourcecdk.NewConfig(cfgValues)
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(pull.Events))
+	}
+	event := pull.Events[0]
+	if tokenRequests != 1 {
+		t.Fatalf("token requests = %d, want 1 cached token", tokenRequests)
+	}
+	if event.Kind != "auth0.users" {
+		t.Fatalf("kind = %q", event.Kind)
+	}
+	if strings.TrimSpace(event.Id) == "" {
+		t.Fatalf("event id is empty: %#v", event)
+	}
+}

--- a/sources/auth0/testdata/read_users.json
+++ b/sources/auth0/testdata/read_users.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    {
+      "evidence_cas_digest": "sha256:test",
+      "evidence_cas_uri": "cas://cases/record-1",
+      "id": "record-1",
+      "name": "Record One",
+      "resource_id": "record-1",
+      "resource_type": "asset",
+      "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1",
+      "updated_at": "2026-06-01T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add shared OAuth client-credentials token exchange/cache support under sourcehttp for generated connectors
- generate and register an executable Auth0 source runtime with credential lifecycle, verification/read path, source-health receipt, and graph projections
- derive bootstrap connector schemas from generateable catalog definitions while leaving bespoke-runtime entries non-executable
- mark encrypted connector credentials validated after successful source verification

## Verification
- go test ./internal/sourcehttp ./internal/sourcegen ./internal/connectorcatalog ./sources/auth0 ./internal/sourceprojection ./internal/sourceregistry ./internal/bootstrap ./internal/connectorcredentials ./internal/connectorsecretstores ./internal/sourceruntime ./cmd/cerebro ./tools/archtests
- make catalog-check
- go test ./...
