### PR TITLE
Expose connector access gates

### DIFF
--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -47,7 +47,13 @@ const (
 	connectorStoreAzureKeyVault      = "azure_key_vault"
 	connectorStoreHashiCorpVault     = "hashicorp_vault"
 	connectorCredentialStoreModeRefs = "reference"
+
+	connectorAccessAvailable   = "available"
+	connectorAccessCatalogOnly = "catalog_only"
+	connectorAccessRestricted  = "restricted"
 )
+
+var errConnectorAccessRestricted = errors.New("connector access restricted")
 
 type connectorCatalogEntry struct {
 	SourceID               string                          `json:"source_id"`
@@ -69,6 +75,10 @@ type connectorCatalogEntry struct {
 	NeedsAttentionRuntimes int                             `json:"needs_attention_runtimes"`
 	ConnectionMethods      []connectorConnectionMethodView `json:"connection_methods,omitempty"`
 	ScopeOptions           []connectorScopeOptionView      `json:"scope_options,omitempty"`
+	AccessStatus           string                          `json:"access_status,omitempty"`
+	AccessReason           string                          `json:"access_reason,omitempty"`
+	SetupAllowed           bool                            `json:"setup_allowed"`
+	Requestable            bool                            `json:"requestable,omitempty"`
 }
 
 type connectorLibraryResponse struct {
@@ -482,6 +492,9 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 		if catalogEntry, ok := definitionsBySourceID[source.GetId()]; ok {
 			applyConnectorCatalogMetadata(&entry, catalogEntry)
 		}
+		if !a.applyConnectorAccess(&entry) {
+			continue
+		}
 		if count := counts[source.GetId()]; count.total > 0 {
 			entry.ConfiguredRuntimes = count.total
 			entry.HealthyRuntimes = count.healthy
@@ -514,6 +527,9 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 			ConnectionMethods: nil,
 		}
 		applyConnectorCatalogMetadata(&entry, catalogEntry)
+		if !a.applyConnectorAccess(&entry) {
+			continue
+		}
 		entries = append(entries, entry)
 	}
 	sort.Slice(entries, func(i, j int) bool {
@@ -626,6 +642,10 @@ func (a *App) handleCreateConnectorCredential(w http.ResponseWriter, r *http.Req
 		writeConnectorError(w, fmt.Errorf("%w: source_id is required", connectorcredentials.ErrInvalidRequest))
 		return
 	}
+	if err := a.requireConnectorSetupAccess(sourceID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
 	if _, err := a.connectorSource(sourceID); err != nil {
 		writeConnectorError(w, err)
 		return
@@ -703,6 +723,10 @@ func (a *App) handleListConnectorCredentials(w http.ResponseWriter, r *http.Requ
 		writeConnectorError(w, fmt.Errorf("%w: source_id is required", connectorcredentials.ErrInvalidRequest))
 		return
 	}
+	if err := a.requireConnectorSetupAccess(sourceID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
 	if _, err := a.connectorSource(sourceID); err != nil {
 		writeConnectorError(w, err)
 		return
@@ -760,6 +784,10 @@ func (a *App) handleGetConnectorCredential(w http.ResponseWriter, r *http.Reques
 		writeConnectorError(w, fmt.Errorf("%w: source_id and credential_id are required", connectorcredentials.ErrInvalidRequest))
 		return
 	}
+	if err := a.requireConnectorSetupAccess(sourceID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
 	if _, err := a.connectorSource(sourceID); err != nil {
 		writeConnectorError(w, err)
 		return
@@ -804,6 +832,10 @@ func (a *App) handleRotateConnectorCredential(w http.ResponseWriter, r *http.Req
 	credentialID := strings.TrimSpace(r.PathValue("credentialID"))
 	if sourceID == "" || credentialID == "" {
 		writeConnectorError(w, fmt.Errorf("%w: source_id and credential_id are required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	if err := a.requireConnectorSetupAccess(sourceID); err != nil {
+		writeConnectorError(w, err)
 		return
 	}
 	if _, err := a.connectorSource(sourceID); err != nil {
@@ -913,6 +945,10 @@ func (a *App) handleRevokeConnectorCredential(w http.ResponseWriter, r *http.Req
 		writeConnectorError(w, fmt.Errorf("%w: source_id and credential_id are required", connectorcredentials.ErrInvalidRequest))
 		return
 	}
+	if err := a.requireConnectorSetupAccess(sourceID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
 	if _, err := a.connectorSource(sourceID); err != nil {
 		writeConnectorError(w, err)
 		return
@@ -964,6 +1000,10 @@ func (a *App) handlePreflightConnectorConnection(w http.ResponseWriter, r *http.
 		writeConnectorError(w, fmt.Errorf("%w: source_id is required", connectorcredentials.ErrInvalidRequest))
 		return
 	}
+	if err := a.requireConnectorSetupAccess(sourceID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
 	response, err := a.connectorConnectionPreflight(r.Context(), sourceID, request)
 	if err != nil {
 		writeConnectorError(w, err)
@@ -981,6 +1021,10 @@ func (a *App) handleCreateConnectorConnection(w http.ResponseWriter, r *http.Req
 	sourceID := strings.TrimSpace(r.PathValue("sourceID"))
 	if sourceID == "" {
 		writeConnectorError(w, fmt.Errorf("%w: source_id is required", connectorcredentials.ErrInvalidRequest))
+		return
+	}
+	if err := a.requireConnectorSetupAccess(sourceID); err != nil {
+		writeConnectorError(w, err)
 		return
 	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
@@ -1630,6 +1674,72 @@ func applyConnectorCatalogMetadata(entry *connectorCatalogEntry, catalogEntry co
 	}
 	if len(entry.ScopeOptions) == 0 {
 		entry.ScopeOptions = connectorScopeOptionsFromDefinition(catalogEntry.Definition)
+	}
+}
+
+func (a *App) applyConnectorAccess(entry *connectorCatalogEntry) bool {
+	if entry == nil {
+		return false
+	}
+	sourceID := strings.TrimSpace(entry.SourceID)
+	if sourceID == "" || connectorSourceListed(a.cfg.ConnectorAccess.HiddenSources, sourceID) {
+		return false
+	}
+	hasSetup := len(entry.ConnectionMethods) > 0
+	switch {
+	case connectorSourceListed(a.cfg.ConnectorAccess.RestrictedSources, sourceID):
+		entry.AccessStatus = connectorAccessRestricted
+		entry.AccessReason = firstNonEmpty(a.cfg.ConnectorAccess.RestrictionReason, "Connector setup is restricted by this deployment.")
+		entry.SetupAllowed = false
+		entry.Requestable = true
+		entry.ConnectionMethods = nil
+	case hasSetup:
+		entry.AccessStatus = connectorAccessAvailable
+		entry.SetupAllowed = true
+	case entry.CatalogStatus != "":
+		entry.AccessStatus = connectorAccessCatalogOnly
+		entry.AccessReason = connectorCatalogOnlyReason(entry.CatalogStatus)
+		entry.SetupAllowed = false
+		entry.Requestable = true
+	default:
+		entry.AccessStatus = connectorAccessAvailable
+		entry.SetupAllowed = hasSetup
+	}
+	return true
+}
+
+func (a *App) requireConnectorSetupAccess(sourceID string) error {
+	if connectorSourceListed(a.cfg.ConnectorAccess.RestrictedSources, sourceID) {
+		return fmt.Errorf("%w: %s", errConnectorAccessRestricted, strings.TrimSpace(sourceID))
+	}
+	if connectorSourceListed(a.cfg.ConnectorAccess.HiddenSources, sourceID) {
+		return fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, strings.TrimSpace(sourceID))
+	}
+	return nil
+}
+
+func connectorSourceListed(values []string, sourceID string) bool {
+	normalized := strings.TrimSpace(sourceID)
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), normalized) {
+			return true
+		}
+	}
+	return false
+}
+
+func connectorCatalogOnlyReason(status string) string {
+	switch strings.TrimSpace(status) {
+	case connectorcatalog.StatusGenerateable:
+		return "Catalog definition is sourcegen-ready, but setup is not enabled by this API."
+	case connectorcatalog.StatusNeedsAuthExtension:
+		return "Catalog definition needs an auth extension before setup can be enabled."
+	case connectorcatalog.StatusNeedsBespokeRuntime:
+		return "Catalog definition needs a bespoke runtime before setup can be enabled."
+	case connectorcatalog.StatusCatalogReady:
+		return "Catalog definition is available, but setup is not enabled by this API."
+	default:
+		return "Catalog metadata is available, but setup is not enabled by this API."
 	}
 }
 
@@ -3953,7 +4063,8 @@ func writeConnectorError(w http.ResponseWriter, err error) {
 	case errors.Is(err, connectorcredentials.ErrUnavailable),
 		errors.Is(err, sourceruntime.ErrRuntimeUnavailable):
 		http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
-	case errors.Is(err, errTenantForbidden):
+	case errors.Is(err, errTenantForbidden),
+		errors.Is(err, errConnectorAccessRestricted):
 		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 	default:
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -1173,6 +1173,9 @@ func TestConnectorCatalogIncludesBuiltinDefinitionCatalogWhenEnabled(t *testing.
 		RuntimeExecutable    bool                    `json:"runtime_executable"`
 		VerificationEndpoint string                  `json:"verification_endpoint"`
 		ResourceFamilies     []catalogResourceFamily `json:"resource_families"`
+		AccessStatus         string                  `json:"access_status"`
+		SetupAllowed         bool                    `json:"setup_allowed"`
+		Requestable          bool                    `json:"requestable"`
 	}
 	var payload struct {
 		Connectors []catalogConnector `json:"connectors"`
@@ -1190,6 +1193,9 @@ func TestConnectorCatalogIncludesBuiltinDefinitionCatalogWhenEnabled(t *testing.
 	jumpcloud := bySourceID["jumpcloud"]
 	if jumpcloud.CatalogStatus != connectorcatalog.StatusGenerateable || !jumpcloud.RuntimeExecutable {
 		t.Fatalf("jumpcloud status = %q executable=%v, want generateable executable", jumpcloud.CatalogStatus, jumpcloud.RuntimeExecutable)
+	}
+	if jumpcloud.AccessStatus != connectorAccessCatalogOnly || jumpcloud.SetupAllowed || !jumpcloud.Requestable {
+		t.Fatalf("jumpcloud access = %q setup=%v requestable=%v, want catalog-only requestable", jumpcloud.AccessStatus, jumpcloud.SetupAllowed, jumpcloud.Requestable)
 	}
 	if jumpcloud.AuthModel != "api_key" || jumpcloud.VerificationEndpoint == "" {
 		t.Fatalf("jumpcloud auth/verification = %q/%q, want catalog metadata", jumpcloud.AuthModel, jumpcloud.VerificationEndpoint)
@@ -1273,6 +1279,95 @@ func TestConnectorSchemaForGenerateableCatalogDefinition(t *testing.T) {
 	}
 	if _, ok := connectorSchemaForSource("jenkins"); ok {
 		t.Fatal("connectorSchemaForSource(jenkins) = true, want bespoke runtime entries excluded")
+	}
+}
+
+func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token", emittedKinds: []string{"bootstrap.token"}}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	registry.WithBuiltinDefinitionCatalog()
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+		ConnectorAccess: config.ConnectorAccessConfig{
+			HiddenSources:     []string{"auth0"},
+			RestrictedSources: []string{"bootstrap_token", "jumpcloud"},
+			RestrictionReason: "limited preview",
+		},
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors")
+	if err != nil {
+		t.Fatalf("GET /connectors error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /connectors status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		Connectors []struct {
+			SourceID          string `json:"source_id"`
+			AccessStatus      string `json:"access_status"`
+			AccessReason      string `json:"access_reason"`
+			SetupAllowed      bool   `json:"setup_allowed"`
+			Requestable       bool   `json:"requestable"`
+			ConnectionMethods []struct {
+				ID string `json:"id"`
+			} `json:"connection_methods"`
+		} `json:"connectors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	bySourceID := map[string]struct {
+		SourceID          string `json:"source_id"`
+		AccessStatus      string `json:"access_status"`
+		AccessReason      string `json:"access_reason"`
+		SetupAllowed      bool   `json:"setup_allowed"`
+		Requestable       bool   `json:"requestable"`
+		ConnectionMethods []struct {
+			ID string `json:"id"`
+		} `json:"connection_methods"`
+	}{}
+	for _, connector := range payload.Connectors {
+		bySourceID[connector.SourceID] = connector
+	}
+	if _, ok := bySourceID["auth0"]; ok {
+		t.Fatal("auth0 was returned despite connector hidden source config")
+	}
+	bootstrapToken := bySourceID["bootstrap_token"]
+	if bootstrapToken.AccessStatus != connectorAccessRestricted || bootstrapToken.AccessReason != "limited preview" || bootstrapToken.SetupAllowed || !bootstrapToken.Requestable || len(bootstrapToken.ConnectionMethods) != 0 {
+		t.Fatalf("bootstrap_token access = %#v, want restricted without setup methods", bootstrapToken)
+	}
+	jumpcloud := bySourceID["jumpcloud"]
+	if jumpcloud.AccessStatus != connectorAccessRestricted || jumpcloud.AccessReason != "limited preview" || jumpcloud.SetupAllowed || !jumpcloud.Requestable {
+		t.Fatalf("jumpcloud access = %#v, want restricted catalog metadata", jumpcloud)
+	}
+
+	preflightResp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/preflight", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("POST /connectors/bootstrap_token/preflight error = %v", err)
+	}
+	defer func() {
+		if closeErr := preflightResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close preflight response: %v", closeErr)
+		}
+	}()
+	if preflightResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("restricted preflight status = %d, want 403", preflightResp.StatusCode)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	Auth                  AuthConfig
 	ConnectorCredentials  ConnectorCredentialConfig
 	ConnectorSecretStores ConnectorSecretStoreConfig
+	ConnectorAccess       ConnectorAccessConfig
 	OTEL                  OpenTelemetryConfig
 	RateLimit             RateLimitConfig
 }
@@ -128,6 +129,13 @@ type ConnectorCredentialConfig struct {
 type ConnectorSecretStoreConfig struct {
 	Enabled           []string
 	AWSSecretsManager AWSSecretsManagerStoreConfig
+}
+
+// ConnectorAccessConfig controls connector catalog visibility and setup gates.
+type ConnectorAccessConfig struct {
+	HiddenSources     []string
+	RestrictedSources []string
+	RestrictionReason string
 }
 
 // AWSSecretsManagerStoreConfig controls AWS Secrets Manager reference resolution.
@@ -406,6 +414,11 @@ func Load() (Config, error) {
 				ExternalID: strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_EXTERNAL_ID")),
 				Endpoint:   strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ENDPOINT")),
 			},
+		},
+		ConnectorAccess: ConnectorAccessConfig{
+			HiddenSources:     parseCSV(os.Getenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES")),
+			RestrictedSources: parseCSV(os.Getenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES")),
+			RestrictionReason: strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_RESTRICTION_REASON")),
 		},
 		OTEL: OpenTelemetryConfig{
 			ServiceName:     strings.TrimSpace(os.Getenv("CEREBRO_OTEL_SERVICE_NAME")),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -63,6 +63,9 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_KEY_FILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY", "")
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY_FILE", "")
+	t.Setenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES", "")
+	t.Setenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES", "")
+	t.Setenv("CEREBRO_CONNECTOR_RESTRICTION_REASON", "")
 	clearMCPOAuthEnv(t)
 	clearDeviceAuthEnv(t)
 
@@ -181,6 +184,9 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_KEY_FILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY", "connector-transit-key")
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY_FILE", "")
+	t.Setenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES", "internal_source")
+	t.Setenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES", "aws,auth0")
+	t.Setenv("CEREBRO_CONNECTOR_RESTRICTION_REASON", "limited preview")
 	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES", "aws_secrets_manager,infisical")
 	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES_FILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION", "us-east-1")
@@ -284,6 +290,15 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if got := cfg.ConnectorSecretStores.Enabled; len(got) != 2 || got[0] != "aws_secrets_manager" || got[1] != "infisical" {
 		t.Fatalf("ConnectorSecretStores.Enabled = %#v, want configured stores", got)
+	}
+	if got := cfg.ConnectorAccess.HiddenSources; len(got) != 1 || got[0] != "internal_source" {
+		t.Fatalf("ConnectorAccess.HiddenSources = %#v, want internal_source", got)
+	}
+	if got := cfg.ConnectorAccess.RestrictedSources; len(got) != 2 || got[0] != "auth0" || got[1] != "aws" {
+		t.Fatalf("ConnectorAccess.RestrictedSources = %#v, want auth0/aws", got)
+	}
+	if cfg.ConnectorAccess.RestrictionReason != "limited preview" {
+		t.Fatalf("ConnectorAccess.RestrictionReason = %q, want limited preview", cfg.ConnectorAccess.RestrictionReason)
 	}
 	if cfg.ConnectorSecretStores.AWSSecretsManager.Region != "us-east-1" ||
 		cfg.ConnectorSecretStores.AWSSecretsManager.Profile != "cerebro-security" ||
@@ -451,6 +466,9 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY_FILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES", "")
 	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES_FILE", "")
+	t.Setenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES", "")
+	t.Setenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES", "")
+	t.Setenv("CEREBRO_CONNECTOR_RESTRICTION_REASON", "")
 	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION", "")
 	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_PROFILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ROLE_ARN", "")


### PR DESCRIPTION
## Summary
- add API response metadata for connector access and setup availability
- support deployment-level hidden and restricted connector source gates
- block setup and credential operations when connector setup is restricted

## Tests
- go test ./internal/config ./internal/bootstrap ./internal/connectorcatalog
- go test ./...