### PR TITLE
feat(source): add family freshness probes

### DIFF
--- a/docs/SOURCE_RUNTIME_GUIDE.md
+++ b/docs/SOURCE_RUNTIME_GUIDE.md
@@ -135,6 +135,23 @@ Operational guidance:
 - Watch provider rate limits and partial-page errors.
 - Treat cursor advancement as the sign that sync is healthy.
 
+## Family freshness probes
+
+Some source families can make a cheap metadata call before the expensive read path. Cerebro calls this a family freshness probe. If the provider canary is unchanged, the source returns a `not_modified` short circuit and persists the refreshed probe checkpoint; if it changed, the source continues into the normal read path.
+
+Use `sourcecdk.Family.Probe` or a checkpoint-aware source read for this pattern. Store probe metadata in `sourcecdk.CursorEnvelope.Extra` with:
+
+```text
+canary_kind
+canary_resource_id
+canary_observed_at
+canary_updated_at
+canary_hash
+canary_confidence=authoritative|heuristic
+```
+
+Treat authoritative canaries, such as documented delta tokens, differently from heuristic canaries, such as newest audit-log event probes. Heuristic probes are dirty signals: they are useful for skipping likely unchanged scans, but they still need periodic full reconciliation if the provider does not document complete coverage.
+
 ## Bootstrap runtimes from JSON
 
 The CLI can load a list of runtimes from an environment variable:

--- a/internal/sourcecdk/freshness.go
+++ b/internal/sourcecdk/freshness.go
@@ -1,0 +1,270 @@
+package sourcecdk
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+const (
+	// FamilyFreshnessProbeMode marks checkpoints that only carry a family-level
+	// freshness canary and should not be treated as provider pagination cursors.
+	FamilyFreshnessProbeMode = "family_freshness_probe"
+
+	FamilyFreshnessExtraKind       = "canary_kind"
+	FamilyFreshnessExtraResourceID = "canary_resource_id"
+	FamilyFreshnessExtraObservedAt = "canary_observed_at"
+	FamilyFreshnessExtraUpdatedAt  = "canary_updated_at"
+	FamilyFreshnessExtraHash       = "canary_hash"
+	FamilyFreshnessExtraConfidence = "canary_confidence"
+)
+
+// FamilyFreshnessConfidence describes whether an unchanged freshness canary is
+// provider-authoritative or only a high-correlation dirty signal.
+type FamilyFreshnessConfidence string
+
+const (
+	FamilyFreshnessConfidenceAuthoritative FamilyFreshnessConfidence = "authoritative"
+	FamilyFreshnessConfidenceHeuristic     FamilyFreshnessConfidence = "heuristic"
+)
+
+// FamilyFreshnessProbe is the normalized provider canary stored in
+// CursorEnvelope.Extra so connectors can skip expensive reads when a cheap,
+// family-level metadata resource has not changed.
+type FamilyFreshnessProbe struct {
+	Kind       string
+	ResourceID string
+	ObservedAt time.Time
+	UpdatedAt  time.Time
+	Hash       string
+	Confidence FamilyFreshnessConfidence
+}
+
+// FamilyFreshnessHash returns a stable digest for the provider fields that
+// define whether a canary changed. Do not include ObservedAt in these parts.
+func FamilyFreshnessHash(parts ...string) string {
+	hash := sha256.New()
+	wrote := false
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		wrote = true
+		_, _ = hash.Write([]byte(part))
+		_, _ = hash.Write([]byte{0})
+	}
+	if !wrote {
+		return ""
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+// FamilyFreshnessProbeFromCheckpoint restores a family freshness canary from a
+// checkpoint cursor envelope.
+func FamilyFreshnessProbeFromCheckpoint(source string, family string, checkpoint *cerebrov1.SourceCheckpoint) (FamilyFreshnessProbe, bool) {
+	if checkpoint == nil {
+		return FamilyFreshnessProbe{}, false
+	}
+	envelope, ok := DecodeCursorEnvelope(checkpoint.GetCursorOpaque())
+	if !ok || !familyFreshnessEnvelopeMatches(envelope, source, family) {
+		return FamilyFreshnessProbe{}, false
+	}
+	extra := envelope.Extra
+	probe := FamilyFreshnessProbe{
+		Kind:       strings.TrimSpace(extra[FamilyFreshnessExtraKind]),
+		ResourceID: strings.TrimSpace(extra[FamilyFreshnessExtraResourceID]),
+		Hash:       strings.TrimSpace(extra[FamilyFreshnessExtraHash]),
+		Confidence: normalizeFamilyFreshnessConfidence(extra[FamilyFreshnessExtraConfidence]),
+	}
+	probe.ObservedAt = parseFamilyFreshnessTime(extra[FamilyFreshnessExtraObservedAt])
+	probe.UpdatedAt = parseFamilyFreshnessTime(extra[FamilyFreshnessExtraUpdatedAt])
+	probe, valid := normalizeFamilyFreshnessProbe(probe)
+	if !valid || probe.Hash == "" {
+		return FamilyFreshnessProbe{}, false
+	}
+	return probe, true
+}
+
+// FamilyFreshnessChangeProbe compares a newly observed family freshness canary
+// with the durable checkpoint and returns the ChangeProbe expected by Family.
+func FamilyFreshnessChangeProbe(source string, family string, checkpoint *cerebrov1.SourceCheckpoint, probe FamilyFreshnessProbe) ChangeProbe {
+	next := FamilyFreshnessCheckpoint(source, family, checkpoint, probe)
+	normalized, valid := normalizeFamilyFreshnessProbe(probe)
+	if !valid {
+		return ChangeProbe{Checkpoint: next}
+	}
+	previous, ok := FamilyFreshnessProbeFromCheckpoint(source, family, checkpoint)
+	unchanged := ok &&
+		previous.Kind == normalized.Kind &&
+		previous.ResourceID == normalized.ResourceID &&
+		previous.Hash == normalized.Hash
+	return ChangeProbe{
+		Unchanged:          unchanged,
+		Checkpoint:         next,
+		ShortCircuitReason: PullShortCircuitReasonNotModified,
+	}
+}
+
+// BeginFamilyFreshnessRead restores probe metadata from continuation cursors
+// and runs a start-of-family freshness probe when no provider cursor is active.
+func BeginFamilyFreshnessRead(source string, family string, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint, probe func(*cerebrov1.SourceCheckpoint) (ChangeProbe, error)) (*cerebrov1.SourceCheckpoint, *Pull, error) {
+	readCheckpoint := FamilyFreshnessCheckpointFromCursor(source, family, cursor, checkpoint)
+	if strings.TrimSpace(CursorToken(cursor)) != "" || probe == nil {
+		return readCheckpoint, nil, nil
+	}
+	change, err := probe(checkpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+	if change.Unchanged {
+		reason := change.ShortCircuitReason
+		if reason == "" {
+			reason = PullShortCircuitReasonNotModified
+		}
+		return change.Checkpoint, &Pull{Checkpoint: change.Checkpoint, ShortCircuitReason: reason}, nil
+	}
+	if change.Checkpoint != nil {
+		readCheckpoint = change.Checkpoint
+	}
+	return readCheckpoint, nil, nil
+}
+
+// FamilyFreshnessCheckpoint stores a family freshness canary in a checkpoint
+// cursor envelope while preserving existing cursor, watermark, boundary, and
+// extra metadata where possible.
+func FamilyFreshnessCheckpoint(source string, family string, checkpoint *cerebrov1.SourceCheckpoint, probe FamilyFreshnessProbe) *cerebrov1.SourceCheckpoint {
+	next := cloneCheckpointForFreshness(checkpoint)
+	normalized, valid := normalizeFamilyFreshnessProbe(probe)
+	if !valid {
+		return next
+	}
+	if next == nil {
+		next = &cerebrov1.SourceCheckpoint{}
+	}
+	opaque := strings.TrimSpace(next.GetCursorOpaque())
+	envelope, ok := DecodeCursorEnvelope(opaque)
+	if !ok || !familyFreshnessEnvelopeMatches(envelope, source, family) {
+		envelope = CursorEnvelope{Token: opaque}
+	}
+	envelope.Source = strings.TrimSpace(source)
+	envelope.Family = strings.TrimSpace(family)
+	if strings.TrimSpace(envelope.Mode) == "" {
+		envelope.Mode = FamilyFreshnessProbeMode
+	}
+	if envelope.Extra == nil {
+		envelope.Extra = map[string]string{}
+	}
+	envelope.Extra[FamilyFreshnessExtraKind] = normalized.Kind
+	envelope.Extra[FamilyFreshnessExtraResourceID] = normalized.ResourceID
+	if !normalized.ObservedAt.IsZero() {
+		envelope.Extra[FamilyFreshnessExtraObservedAt] = normalized.ObservedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if !normalized.UpdatedAt.IsZero() {
+		envelope.Extra[FamilyFreshnessExtraUpdatedAt] = normalized.UpdatedAt.UTC().Format(time.RFC3339Nano)
+	}
+	envelope.Extra[FamilyFreshnessExtraHash] = normalized.Hash
+	if normalized.Confidence != "" {
+		envelope.Extra[FamilyFreshnessExtraConfidence] = string(normalized.Confidence)
+	}
+	encoded, err := EncodeCursorEnvelope(envelope)
+	if err != nil {
+		return next
+	}
+	next.CursorOpaque = encoded
+	return next
+}
+
+// FamilyFreshnessCheckpointFromCursor copies probe metadata from a cursor
+// envelope into a checkpoint. This is useful when continuation cursors must
+// carry a run-start canary across pages.
+func FamilyFreshnessCheckpointFromCursor(source string, family string, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {
+	if cursor == nil {
+		return checkpoint
+	}
+	return FamilyFreshnessCheckpointFromCheckpoint(source, family, &cerebrov1.SourceCheckpoint{CursorOpaque: cursor.GetOpaque()}, checkpoint)
+}
+
+// FamilyFreshnessCheckpointFromCheckpoint copies probe metadata from one
+// checkpoint envelope into another checkpoint.
+func FamilyFreshnessCheckpointFromCheckpoint(source string, family string, from *cerebrov1.SourceCheckpoint, checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {
+	probe, ok := FamilyFreshnessProbeFromCheckpoint(source, family, from)
+	if !ok {
+		return checkpoint
+	}
+	return FamilyFreshnessCheckpoint(source, family, checkpoint, probe)
+}
+
+// FamilyFreshnessCursor returns a provider cursor wrapped with freshness probe
+// metadata when from carries one. CursorToken unwraps the provider token.
+func FamilyFreshnessCursor(source string, family string, from *cerebrov1.SourceCheckpoint, cursor string) string {
+	cursor = strings.TrimSpace(cursor)
+	if cursor == "" {
+		return ""
+	}
+	checkpoint := FamilyFreshnessCheckpointFromCheckpoint(source, family, from, &cerebrov1.SourceCheckpoint{CursorOpaque: cursor})
+	if checkpoint == nil {
+		return cursor
+	}
+	return checkpoint.GetCursorOpaque()
+}
+
+func normalizeFamilyFreshnessProbe(probe FamilyFreshnessProbe) (FamilyFreshnessProbe, bool) {
+	probe.Kind = strings.TrimSpace(probe.Kind)
+	probe.ResourceID = strings.TrimSpace(probe.ResourceID)
+	probe.Hash = strings.TrimSpace(probe.Hash)
+	probe.ObservedAt = probe.ObservedAt.UTC()
+	probe.UpdatedAt = probe.UpdatedAt.UTC()
+	probe.Confidence = normalizeFamilyFreshnessConfidence(string(probe.Confidence))
+	if probe.Hash == "" {
+		probe.Hash = FamilyFreshnessHash(
+			probe.Kind,
+			probe.ResourceID,
+			probe.UpdatedAt.Format(time.RFC3339Nano),
+			string(probe.Confidence),
+		)
+	}
+	return probe, probe.Kind != "" && probe.Hash != ""
+}
+
+func normalizeFamilyFreshnessConfidence(confidence string) FamilyFreshnessConfidence {
+	switch FamilyFreshnessConfidence(strings.ToLower(strings.TrimSpace(confidence))) {
+	case FamilyFreshnessConfidenceAuthoritative:
+		return FamilyFreshnessConfidenceAuthoritative
+	case FamilyFreshnessConfidenceHeuristic:
+		return FamilyFreshnessConfidenceHeuristic
+	default:
+		return ""
+	}
+}
+
+func parseFamilyFreshnessTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
+}
+
+func familyFreshnessEnvelopeMatches(envelope CursorEnvelope, source string, family string) bool {
+	if strings.TrimSpace(envelope.Source) != "" && strings.TrimSpace(envelope.Source) != strings.TrimSpace(source) {
+		return false
+	}
+	return strings.TrimSpace(envelope.Family) == "" || strings.TrimSpace(envelope.Family) == strings.TrimSpace(family)
+}
+
+func cloneCheckpointForFreshness(checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {
+	if checkpoint == nil {
+		return nil
+	}
+	return proto.Clone(checkpoint).(*cerebrov1.SourceCheckpoint)
+}

--- a/internal/sourcecdk/freshness_test.go
+++ b/internal/sourcecdk/freshness_test.go
@@ -1,0 +1,154 @@
+package sourcecdk
+
+import (
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestFamilyFreshnessCheckpointStoresCanaryExtra(t *testing.T) {
+	observedAt := time.Date(2026, 6, 16, 15, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2026, 6, 16, 14, 59, 0, 0, time.UTC)
+	checkpoint := FamilyFreshnessCheckpoint(" github ", " audit ", &cerebrov1.SourceCheckpoint{CursorOpaque: "cursor-2"}, FamilyFreshnessProbe{
+		Kind:       " audit_log_latest_event ",
+		ResourceID: " github-audit-1 ",
+		ObservedAt: observedAt,
+		UpdatedAt:  updatedAt,
+		Hash:       " canary-hash ",
+		Confidence: FamilyFreshnessConfidenceHeuristic,
+	})
+
+	envelope, ok := DecodeCursorEnvelope(checkpoint.GetCursorOpaque())
+	if !ok {
+		t.Fatalf("checkpoint cursor %q is not an envelope", checkpoint.GetCursorOpaque())
+	}
+	if envelope.Source != "github" || envelope.Family != "audit" || envelope.Mode != FamilyFreshnessProbeMode {
+		t.Fatalf("envelope source/family/mode = %q/%q/%q", envelope.Source, envelope.Family, envelope.Mode)
+	}
+	if envelope.Token != "cursor-2" {
+		t.Fatalf("envelope token = %q, want cursor-2", envelope.Token)
+	}
+	if envelope.ResumableCheckpoint {
+		t.Fatal("freshness-only checkpoint is resumable, want metadata-only cursor")
+	}
+	if got := envelope.Extra[FamilyFreshnessExtraKind]; got != "audit_log_latest_event" {
+		t.Fatalf("canary kind = %q, want audit_log_latest_event", got)
+	}
+	if got := envelope.Extra[FamilyFreshnessExtraResourceID]; got != "github-audit-1" {
+		t.Fatalf("canary resource = %q, want github-audit-1", got)
+	}
+	if got := envelope.Extra[FamilyFreshnessExtraObservedAt]; got != observedAt.Format(time.RFC3339Nano) {
+		t.Fatalf("canary observed_at = %q, want %s", got, observedAt.Format(time.RFC3339Nano))
+	}
+	if got := envelope.Extra[FamilyFreshnessExtraUpdatedAt]; got != updatedAt.Format(time.RFC3339Nano) {
+		t.Fatalf("canary updated_at = %q, want %s", got, updatedAt.Format(time.RFC3339Nano))
+	}
+
+	probe, ok := FamilyFreshnessProbeFromCheckpoint("github", "audit", checkpoint)
+	if !ok {
+		t.Fatal("FamilyFreshnessProbeFromCheckpoint() ok = false, want true")
+	}
+	if probe.Kind != "audit_log_latest_event" || probe.ResourceID != "github-audit-1" || probe.Hash != "canary-hash" {
+		t.Fatalf("probe = %#v, want normalized canary", probe)
+	}
+}
+
+func TestFamilyFreshnessChangeProbeIgnoresObservedAtForChangeDetection(t *testing.T) {
+	updatedAt := time.Date(2026, 6, 16, 14, 59, 0, 0, time.UTC)
+	hash := FamilyFreshnessHash("audit_log_latest_event", "github-audit-1", updatedAt.Format(time.RFC3339Nano))
+	checkpoint := FamilyFreshnessCheckpoint("github", "audit", nil, FamilyFreshnessProbe{
+		Kind:       "audit_log_latest_event",
+		ResourceID: "github-audit-1",
+		ObservedAt: updatedAt.Add(time.Minute),
+		UpdatedAt:  updatedAt,
+		Hash:       hash,
+		Confidence: FamilyFreshnessConfidenceHeuristic,
+	})
+
+	change := FamilyFreshnessChangeProbe("github", "audit", checkpoint, FamilyFreshnessProbe{
+		Kind:       "audit_log_latest_event",
+		ResourceID: "github-audit-1",
+		ObservedAt: updatedAt.Add(time.Hour),
+		UpdatedAt:  updatedAt,
+		Hash:       hash,
+		Confidence: FamilyFreshnessConfidenceHeuristic,
+	})
+	if !change.Unchanged {
+		t.Fatal("ChangeProbe.Unchanged = false, want true for same canary hash")
+	}
+	if change.ShortCircuitReason != PullShortCircuitReasonNotModified {
+		t.Fatalf("ShortCircuitReason = %q, want not_modified", change.ShortCircuitReason)
+	}
+
+	nextProbe, ok := FamilyFreshnessProbeFromCheckpoint("github", "audit", change.Checkpoint)
+	if !ok {
+		t.Fatal("updated checkpoint missing freshness probe")
+	}
+	if !nextProbe.ObservedAt.Equal(updatedAt.Add(time.Hour)) {
+		t.Fatalf("observed_at = %s, want refreshed observed time", nextProbe.ObservedAt)
+	}
+}
+
+func TestFamilyFreshnessCheckpointPreservesExistingResumableEnvelope(t *testing.T) {
+	opaque, err := EncodeCursorEnvelope(CursorEnvelope{
+		Source:              "github",
+		Family:              "pull_request",
+		Mode:                "incremental_watermark",
+		ResumableCheckpoint: true,
+		Token:               "2",
+		BoundaryIDs:         []string{"pr-1"},
+		Extra:               map[string]string{"existing": "kept"},
+	})
+	if err != nil {
+		t.Fatalf("EncodeCursorEnvelope() error = %v", err)
+	}
+
+	checkpoint := FamilyFreshnessCheckpoint("github", "pull_request", &cerebrov1.SourceCheckpoint{CursorOpaque: opaque}, FamilyFreshnessProbe{
+		Kind:       "repo_updated_at",
+		ResourceID: "writer/cerebro",
+		Hash:       "hash",
+	})
+	envelope, ok := DecodeCursorEnvelope(checkpoint.GetCursorOpaque())
+	if !ok {
+		t.Fatal("checkpoint cursor is not an envelope")
+	}
+	if !envelope.ResumableCheckpoint || envelope.Mode != "incremental_watermark" || envelope.Token != "2" {
+		t.Fatalf("envelope resumable/mode/token = %v/%q/%q", envelope.ResumableCheckpoint, envelope.Mode, envelope.Token)
+	}
+	if got := envelope.BoundaryIDs; len(got) != 1 || got[0] != "pr-1" {
+		t.Fatalf("boundary IDs = %#v, want pr-1", got)
+	}
+	if got := envelope.Extra["existing"]; got != "kept" {
+		t.Fatalf("existing extra = %q, want kept", got)
+	}
+	if got := envelope.Extra[FamilyFreshnessExtraHash]; got != "hash" {
+		t.Fatalf("canary hash = %q, want hash", got)
+	}
+}
+
+func TestBeginFamilyFreshnessReadCarriesProbeFromContinuationCursor(t *testing.T) {
+	checkpoint := FamilyFreshnessCheckpoint("github", "audit", nil, FamilyFreshnessProbe{
+		Kind:       "audit_log_latest_event",
+		ResourceID: "github-audit-1",
+		Hash:       "hash",
+	})
+	cursor := &cerebrov1.SourceCursor{Opaque: FamilyFreshnessCursor("github", "audit", checkpoint, "cursor-2")}
+
+	readCheckpoint, shortCircuit, err := BeginFamilyFreshnessRead("github", "audit", cursor, nil, func(*cerebrov1.SourceCheckpoint) (ChangeProbe, error) {
+		t.Fatal("probe should not run while a continuation cursor is active")
+		return ChangeProbe{}, nil
+	})
+	if err != nil {
+		t.Fatalf("BeginFamilyFreshnessRead() error = %v", err)
+	}
+	if shortCircuit != nil {
+		t.Fatalf("shortCircuit = %#v, want nil while cursor is active", shortCircuit)
+	}
+	if got := CursorToken(cursor); got != "cursor-2" {
+		t.Fatalf("CursorToken(cursor) = %q, want cursor-2", got)
+	}
+	if _, ok := FamilyFreshnessProbeFromCheckpoint("github", "audit", readCheckpoint); !ok {
+		t.Fatalf("read checkpoint %q missing freshness probe", readCheckpoint.GetCursorOpaque())
+	}
+}

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -94,6 +94,15 @@ const (
 	PullShortCircuitReasonWatermarkReached      PullShortCircuitReason = "watermark_reached"
 )
 
+// NotModifiedPull returns a not_modified short-circuit when a checkpoint was
+// refreshed without producing events.
+func NotModifiedPull(checkpoint *cerebrov1.SourceCheckpoint) Pull {
+	if checkpoint == nil {
+		return Pull{}
+	}
+	return Pull{Checkpoint: checkpoint, ShortCircuitReason: PullShortCircuitReasonNotModified}
+}
+
 // Source is the common integration contract for the rewrite.
 type Source interface {
 	Spec() *cerebrov1.SourceSpec

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -788,12 +788,27 @@ func mergeEqualWatermarkCheckpoint(existing *cerebrov1.SourceCheckpoint, next *c
 		return next
 	}
 	nextEnvelope.BoundaryIDs = append(nextEnvelope.BoundaryIDs, existingEnvelope.BoundaryIDs...)
+	nextEnvelope.Extra = mergeCursorEnvelopeExtra(existingEnvelope.Extra, nextEnvelope.Extra)
 	opaque, err := sourcecdk.EncodeCursorEnvelope(nextEnvelope)
 	if err != nil {
 		return next
 	}
 	merged := cloneCheckpoint(next)
 	merged.CursorOpaque = opaque
+	return merged
+}
+
+func mergeCursorEnvelopeExtra(existing map[string]string, next map[string]string) map[string]string {
+	if len(existing) == 0 && len(next) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(existing)+len(next))
+	for key, value := range existing {
+		merged[key] = value
+	}
+	for key, value := range next {
+		merged[key] = value
+	}
 	return merged
 }
 

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1561,6 +1561,12 @@ func TestSyncRuntimeMergesEqualWatermarkCheckpointBoundaries(t *testing.T) {
 		ResumableCheckpoint: true,
 		Token:               "2",
 		BoundaryIDs:         []string{"first"},
+		Extra: map[string]string{
+			sourcecdk.FamilyFreshnessExtraKind:       "repo_updated_at",
+			sourcecdk.FamilyFreshnessExtraResourceID: "writer/cerebro",
+			sourcecdk.FamilyFreshnessExtraHash:       "old-hash",
+			"preserved":                              "yes",
+		},
 	}
 	sourcecdk.SetCursorWatermark(&existingEnvelope, watermark)
 	existingCursor, err := sourcecdk.EncodeCursorEnvelope(existingEnvelope)
@@ -1574,6 +1580,9 @@ func TestSyncRuntimeMergesEqualWatermarkCheckpointBoundaries(t *testing.T) {
 		Mode:                "incremental_watermark",
 		ResumableCheckpoint: true,
 		BoundaryIDs:         []string{"second"},
+		Extra: map[string]string{
+			sourcecdk.FamilyFreshnessExtraHash: "new-hash",
+		},
 	}
 	sourcecdk.SetCursorWatermark(&nextEnvelope, watermark)
 	nextCursor, err := sourcecdk.EncodeCursorEnvelope(nextEnvelope)
@@ -1615,6 +1624,15 @@ func TestSyncRuntimeMergesEqualWatermarkCheckpointBoundaries(t *testing.T) {
 	}
 	if got := storedEnvelope.BoundaryIDs; len(got) != 2 || got[0] != "first" || got[1] != "second" {
 		t.Fatalf("stored boundary IDs = %#v, want first and second", got)
+	}
+	if got := storedEnvelope.Extra["preserved"]; got != "yes" {
+		t.Fatalf("stored preserved extra = %q, want yes", got)
+	}
+	if got := storedEnvelope.Extra[sourcecdk.FamilyFreshnessExtraHash]; got != "new-hash" {
+		t.Fatalf("stored canary hash = %q, want next checkpoint hash", got)
+	}
+	if got := storedEnvelope.Extra[sourcecdk.FamilyFreshnessExtraKind]; got != "repo_updated_at" {
+		t.Fatalf("stored canary kind = %q, want existing kind", got)
 	}
 }
 

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -16,6 +16,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/internal/githubaudit"
 )
 
 type auditPayload struct {
@@ -46,7 +47,7 @@ type auditPayload struct {
 }
 
 func (s *Source) checkAudit(ctx context.Context, client *gogithub.Client, settings settings) error {
-	_, _, err := client.Organizations.GetAuditLog(ctx, settings.owner, auditOptions(settings, "", 1))
+	_, _, err := client.Organizations.GetAuditLog(ctx, settings.owner, githubaudit.Options(settings.auditInclude, settings.auditPhrase, settings.auditOrder, "", 1))
 	if err != nil {
 		return wrapLookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
 	}
@@ -64,14 +65,29 @@ func (s *Source) discoverAudit(ctx context.Context, client *gogithub.Client, set
 	return []sourcecdk.URN{urn}, nil
 }
 
-func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	readCheckpoint, shortCircuit, err := sourcecdk.BeginFamilyFreshnessRead("github", familyAudit, cursor, checkpoint, func(checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.ChangeProbe, error) {
+		probe, err := githubaudit.LatestEventChangeProbe(ctx, settings.owner, settings.auditInclude, settings.auditPhrase, checkpoint, func(ctx context.Context, opts *gogithub.GetAuditLogOptions) ([]*gogithub.AuditEntry, *gogithub.Response, error) {
+			return client.Organizations.GetAuditLog(ctx, settings.owner, opts)
+		})
+		if err != nil {
+			return sourcecdk.ChangeProbe{}, wrapLookupError(fmt.Sprintf("github audit log canary for org %s", settings.owner), err)
+		}
+		return probe, nil
+	})
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	if shortCircuit != nil {
+		return *shortCircuit, nil
+	}
 	after := readAuditCursor(cursor)
-	entries, resp, err := client.Organizations.GetAuditLog(ctx, settings.owner, auditOptions(settings, after, settings.perPage))
+	entries, resp, err := client.Organizations.GetAuditLog(ctx, settings.owner, githubaudit.Options(settings.auditInclude, settings.auditPhrase, settings.auditOrder, after, settings.perPage))
 	if err != nil {
 		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
 	}
 	if len(entries) == 0 {
-		return sourcecdk.Pull{}, nil
+		return sourcecdk.NotModifiedPull(readCheckpoint), nil
 	}
 	events := make([]*primitives.Event, 0, len(entries))
 	actorResolutionCache := map[string]auditActorResolution{}
@@ -83,10 +99,8 @@ func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, setting
 		// can't tell a bot apart from a user. Resolution returns
 		// Type=Bot for GitHub Apps, Type=Organization for org-self
 		// events, Type=Unresolved for deleted/placeholder logins
-		// (deploy_key, retired bot apps), and Type=User otherwise. The
-		// shared cache keeps the per-pull cost at one /users/{login}
-		// call per unique actor, which is well within the 5000/hour
-		// authenticated rate limit for any realistic audit volume.
+		// (deploy_key, retired bot apps), and Type=User otherwise.
+		// Resolutions are cached per page to avoid repeated actor lookups.
 		actorResolution := auditActorResolution{}
 		if strings.TrimSpace(entry.GetActor()) != "" {
 			actorResolution = resolveAuditActor(ctx, client, entry.GetActor(), actorResolutionCache)
@@ -100,37 +114,22 @@ func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, setting
 	nextCursor := nextAuditCursor(resp)
 	pull := sourcecdk.Pull{
 		Events: events,
-		Checkpoint: &cerebrov1.SourceCheckpoint{
+		Checkpoint: sourcecdk.FamilyFreshnessCheckpointFromCheckpoint("github", familyAudit, readCheckpoint, &cerebrov1.SourceCheckpoint{
 			Watermark:    events[len(events)-1].OccurredAt,
 			CursorOpaque: checkpointAuditCursor(entries, nextCursor),
-		},
+		}),
 	}
 	if nextCursor != "" {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextCursor}
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: sourcecdk.FamilyFreshnessCursor("github", familyAudit, readCheckpoint, nextCursor)}
 	}
 	return pull, nil
-}
-
-func auditOptions(settings settings, after string, perPage int) *gogithub.GetAuditLogOptions {
-	opts := &gogithub.GetAuditLogOptions{
-		Include: gogithub.String(settings.auditInclude),
-		Order:   gogithub.String(settings.auditOrder),
-		ListCursorOptions: gogithub.ListCursorOptions{
-			After:   after,
-			PerPage: perPage,
-		},
-	}
-	if settings.auditPhrase != "" {
-		opts.Phrase = gogithub.String(settings.auditPhrase)
-	}
-	return opts
 }
 
 func readAuditCursor(cursor *cerebrov1.SourceCursor) string {
 	if cursor == nil {
 		return ""
 	}
-	return strings.TrimSpace(cursor.GetOpaque())
+	return strings.TrimSpace(sourcecdk.CursorToken(cursor))
 }
 
 type auditActorResolution struct {

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -206,7 +206,7 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 		return sourcecdk.Pull{}, err
 	}
 	if settings.family == familyAudit {
-		return s.readAudit(ctx, client, settings, cursor)
+		return s.readAudit(ctx, client, settings, cursor, checkpoint)
 	}
 	if settings.family == familyDependabot {
 		return s.readDependabotAlerts(ctx, client, settings, cursor, checkpoint)

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -579,8 +579,100 @@ func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
 	if second.Checkpoint == nil {
 		t.Fatalf("second.Checkpoint = nil, want non-nil with empty CursorOpaque")
 	}
-	if second.Checkpoint.CursorOpaque != "" {
-		t.Fatalf("second.Checkpoint.CursorOpaque = %q, want empty cursor on terminal audit page", second.Checkpoint.CursorOpaque)
+	secondEnvelope, ok := sourcecdk.DecodeCursorEnvelope(second.Checkpoint.GetCursorOpaque())
+	if !ok {
+		t.Fatalf("second.Checkpoint.CursorOpaque = %q, want canary envelope", second.Checkpoint.GetCursorOpaque())
+	}
+	if secondEnvelope.Token != "" {
+		t.Fatalf("second checkpoint token = %q, want empty cursor on terminal audit page", secondEnvelope.Token)
+	}
+	if secondEnvelope.Extra[sourcecdk.FamilyFreshnessExtraKind] != "audit_log_latest_event" {
+		t.Fatalf("second checkpoint canary kind = %q, want audit_log_latest_event", secondEnvelope.Extra[sourcecdk.FamilyFreshnessExtraKind])
+	}
+}
+
+func TestGitHubAuditFreshnessProbeShortCircuitsUnchangedAuditLog(t *testing.T) {
+	auditQueries := []url.Values{}
+	auditEntry := map[string]any{
+		"@timestamp":   1776916397852,
+		"_document_id": "audit-doc-1",
+		"action":       "org.update_member",
+		"created_at":   1776916397852,
+		"org":          "writer",
+		"org_id":       1,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v3/orgs/writer/audit-log" {
+			http.NotFound(w, r)
+			return
+		}
+		query := r.URL.Query()
+		auditQueries = append(auditQueries, query)
+		switch query.Get("order") {
+		case "desc":
+			if got := query.Get("per_page"); got != "1" {
+				t.Fatalf("audit canary per_page = %q, want 1", got)
+			}
+			if got := query.Get("after"); got != "" {
+				t.Fatalf("audit canary after = %q, want empty", got)
+			}
+		case "asc":
+		default:
+			t.Fatalf("audit order = %q, want asc scan or desc canary", query.Get("order"))
+		}
+		if err := json.NewEncoder(w).Encode([]map[string]any{auditEntry}); err != nil {
+			t.Fatalf("encode audit response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familyAudit,
+		"owner":    "writer",
+		"token":    "test-token",
+	})
+
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
+	}
+	if len(auditQueries) != 2 {
+		t.Fatalf("audit requests = %d, want canary plus scan", len(auditQueries))
+	}
+	if auditQueries[0].Get("order") != "desc" || auditQueries[1].Get("order") != "asc" {
+		t.Fatalf("audit request order = %q/%q, want desc canary then asc scan", auditQueries[0].Get("order"), auditQueries[1].Get("order"))
+	}
+	probe, ok := sourcecdk.FamilyFreshnessProbeFromCheckpoint("github", familyAudit, first.Checkpoint)
+	if !ok {
+		t.Fatalf("first checkpoint %q missing freshness probe", first.Checkpoint.GetCursorOpaque())
+	}
+	if probe.Kind != "audit_log_latest_event" || probe.ResourceID != "github-audit-audit-doc-1" {
+		t.Fatalf("probe = %#v, want audit log latest event canary", probe)
+	}
+
+	auditQueries = nil
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, first.Checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(second) error = %v", err)
+	}
+	if len(second.Events) != 0 {
+		t.Fatalf("len(second.Events) = %d, want unchanged short circuit", len(second.Events))
+	}
+	if second.ShortCircuitReason != sourcecdk.PullShortCircuitReasonNotModified {
+		t.Fatalf("ShortCircuitReason = %q, want not_modified", second.ShortCircuitReason)
+	}
+	if len(auditQueries) != 1 || auditQueries[0].Get("order") != "desc" {
+		t.Fatalf("audit requests after unchanged checkpoint = %#v, want one desc canary", auditQueries)
 	}
 }
 
@@ -1294,8 +1386,21 @@ func newGitHubAPIHandler(t *testing.T) http.Handler {
 				t.Fatalf("encode users response: %v", err)
 			}
 		case "/api/v3/orgs/writer/audit-log":
-			if got := r.URL.Query().Get("order"); got != "asc" {
-				t.Fatalf("audit order = %q, want asc", got)
+			switch got := r.URL.Query().Get("order"); got {
+			case "desc":
+				if got := r.URL.Query().Get("per_page"); got != "1" {
+					t.Fatalf("audit canary per_page = %q, want 1", got)
+				}
+				if got := r.URL.Query().Get("after"); got != "" {
+					t.Fatalf("audit canary after = %q, want empty", got)
+				}
+				if err := json.NewEncoder(w).Encode(auditEntries[:1]); err != nil {
+					t.Fatalf("encode audit canary: %v", err)
+				}
+				return
+			case "asc":
+			default:
+				t.Fatalf("audit order = %q, want asc or desc canary", got)
 			}
 			after := r.URL.Query().Get("after")
 			if after == "" {

--- a/sources/internal/githubaudit/freshness.go
+++ b/sources/internal/githubaudit/freshness.go
@@ -1,0 +1,89 @@
+package githubaudit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	gogithub "github.com/google/go-github/v66/github"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+const latestEventKind = "audit_log_latest_event"
+
+// ListFunc fetches GitHub audit entries with caller-supplied options.
+type ListFunc func(context.Context, *gogithub.GetAuditLogOptions) ([]*gogithub.AuditEntry, *gogithub.Response, error)
+
+// Options builds GitHub audit-log list options.
+func Options(include string, phrase string, order string, after string, perPage int) *gogithub.GetAuditLogOptions {
+	opts := &gogithub.GetAuditLogOptions{
+		Include: gogithub.String(include),
+		Order:   gogithub.String(order),
+		ListCursorOptions: gogithub.ListCursorOptions{
+			After:   strings.TrimSpace(after),
+			PerPage: perPage,
+		},
+	}
+	if strings.TrimSpace(phrase) != "" {
+		opts.Phrase = gogithub.String(strings.TrimSpace(phrase))
+	}
+	return opts
+}
+
+// LatestEventChangeProbe fetches the newest audit-log event and returns a
+// heuristic family freshness ChangeProbe.
+func LatestEventChangeProbe(ctx context.Context, owner string, include string, phrase string, checkpoint *cerebrov1.SourceCheckpoint, list ListFunc) (sourcecdk.ChangeProbe, error) {
+	entries, _, err := list(ctx, Options(include, phrase, "desc", "", 1))
+	if err != nil {
+		return sourcecdk.ChangeProbe{}, err
+	}
+	return sourcecdk.FamilyFreshnessChangeProbe("github", "audit", checkpoint, latestEventProbe(owner, include, phrase, entries, time.Now().UTC())), nil
+}
+
+func latestEventProbe(owner string, include string, phrase string, entries []*gogithub.AuditEntry, observedAt time.Time) sourcecdk.FamilyFreshnessProbe {
+	resourceID := "org:" + strings.TrimSpace(owner)
+	updatedAt := time.Time{}
+	hashParts := []string{latestEventKind, resourceID, "empty", include, phrase}
+	if len(entries) > 0 && entries[0] != nil {
+		entry := entries[0]
+		updatedAt = occurredAt(entry)
+		if eventID := eventID(entry, updatedAt); eventID != "" {
+			resourceID = eventID
+		}
+		hashParts = []string{latestEventKind, resourceID, updatedAt.Format(time.RFC3339Nano), entry.GetAction(), entry.GetActor(), include, phrase}
+	}
+	return sourcecdk.FamilyFreshnessProbe{
+		Kind:       latestEventKind,
+		ResourceID: resourceID,
+		ObservedAt: observedAt,
+		UpdatedAt:  updatedAt,
+		Hash:       sourcecdk.FamilyFreshnessHash(hashParts...),
+		Confidence: sourcecdk.FamilyFreshnessConfidenceHeuristic,
+	}
+}
+
+func eventID(entry *gogithub.AuditEntry, at time.Time) string {
+	if documentID := strings.TrimSpace(entry.GetDocumentID()); documentID != "" {
+		return "github-audit-" + documentID
+	}
+	if !at.IsZero() {
+		return fmt.Sprintf("github-audit-%s-%d", strings.TrimSpace(entry.GetAction()), at.UnixMilli())
+	}
+	return strings.TrimSpace(entry.GetAction())
+}
+
+func occurredAt(entry *gogithub.AuditEntry) time.Time {
+	if entry == nil {
+		return time.Time{}
+	}
+	if stamp := entry.GetTimestamp(); !stamp.IsZero() {
+		return stamp.UTC()
+	}
+	if stamp := entry.GetCreatedAt(); !stamp.IsZero() {
+		return stamp.UTC()
+	}
+	return time.Time{}
+}


### PR DESCRIPTION
Summary:
- Add Source CDK helpers for family freshness probes and canary metadata.
- Apply the probe to the GitHub audit source so unchanged latest-event metadata can short-circuit reads.
- Preserve cursor envelope extras when equal-watermark checkpoints merge.

Tests:
- go test ./...