### PR TITLE
Add metadata canary checkpoints and GitHub probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-
 | `email_domain_health` | Email domain authentication posture source (SPF, DKIM, DMARC, MX, MTA-STS) | health |
 | `evidence_cas` | EvidenceCAS content-addressed evidence reference source | object manifests |
 | `gcp` | GCP IAM, Cloud Identity, service-account, and audit source | audit, groups, IAM role assignments, service accounts, resource exposure |
-| `github` | GitHub audit, repository, Dependabot, and pull request source | audit, repository, Dependabot alerts, pull requests |
+| `github` | GitHub audit, repository, Dependabot, and pull request source | audit, repository, Dependabot alerts, pull requests; repository and optional org-inventory audit-log freshness probes |
 | `google_workspace` | Google Workspace Directory and Admin audit source | audit, groups, group members, role assignments, users |
 | `grc` | Governance/risk/compliance source | configured GRC families |
 | `kandji` | Kandji device/application/vulnerability source | devices, applications, vulnerabilities |

--- a/docs/SOURCE_RUNTIME_GUIDE.md
+++ b/docs/SOURCE_RUNTIME_GUIDE.md
@@ -273,6 +273,16 @@ Sources may include:
 - `sources/<source-id>/deploy.yaml`, which declares source-level secret names and canonical runtime config,
 - `sources/<source-id>/source_health_receipt.json`, when a source ships a health receipt.
 
+Catalogs may declare family-level freshness probes under `families[].freshness_probe`.
+Use `confidence: authoritative` only for provider tokens or resource versions that
+prove the scoped collection is unchanged. Use `confidence: heuristic` for cheap
+signals such as newest updated resources or newest audit-log events; these can
+reduce API calls, but runtimes must still force reconciliation after the declared
+skip duration, skip count, reconciliation interval, manifest-version change, or
+runtime config-hash change. GitHub audit-log canaries are a high-confidence broad
+organization dirty signal when credentials can read the audit log, but they are
+still heuristic and do not replace periodic family-specific reconciliation.
+
 The deploy manifest intentionally declares what the source needs, not when or where your platform should schedule it. Deployment cadence and concrete secrets belong in your deployment system.
 
 See [`docs/RELEASE_CONTRACT.md`](./RELEASE_CONTRACT.md) for how source manifests contribute to `cerebro-runtime-contract.json`.

--- a/internal/sourcecdk/canary.go
+++ b/internal/sourcecdk/canary.go
@@ -1,0 +1,314 @@
+package sourcecdk
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+const canaryCheckpointMode = "metadata_canary"
+
+const (
+	CanaryKindKey       = "canary_kind"
+	CanaryResourceIDKey = "canary_resource_id"
+	CanaryObservedAtKey = "canary_observed_at"
+	CanaryUpdatedAtKey  = "canary_updated_at"
+	CanaryHashKey       = "canary_hash"
+	CanaryConfidenceKey = "canary_confidence"
+	ManifestVersionKey  = "manifest_version"
+
+	CanaryConfigHashKey           = "canary_config_hash"
+	CanaryFirstSkippedKey         = "canary_first_skipped_at"
+	CanaryLastSkippedKey          = "canary_last_skipped_at"
+	CanarySkipCountKey            = "canary_skip_count"
+	CanaryReconciledAtKey         = "canary_reconciled_at"
+	CanaryConfidenceHeuristic     = "heuristic"
+	CanaryConfidenceAuthoritative = "authoritative"
+)
+
+// CanaryReconciliationPolicy controls when a matching metadata canary may
+// short-circuit and when it must force a normal reconciliation.
+type CanaryReconciliationPolicy struct {
+	Confidence             string
+	MaxSkipDuration        time.Duration
+	MaxConsecutiveSkips    int
+	ReconciliationInterval time.Duration
+	ManifestVersion        string
+	ConfigHash             string
+	Now                    time.Time
+}
+
+// FingerprintCheckpoint creates a checkpoint that stores metadata canary state
+// in CursorEnvelope.Extra without requiring a SourceCheckpoint proto change.
+func FingerprintCheckpoint(source, family string, watermark time.Time, metadata map[string]string) *cerebrov1.SourceCheckpoint {
+	source = strings.TrimSpace(source)
+	family = strings.TrimSpace(family)
+	if source == "" || family == "" {
+		return nil
+	}
+	metadata = normalizedCursorMap(metadata)
+	if watermark.IsZero() && len(metadata) == 0 {
+		return nil
+	}
+	envelope := CursorEnvelope{
+		Source:              source,
+		Family:              family,
+		Mode:                canaryCheckpointMode,
+		ResumableCheckpoint: true,
+		Extra:               metadata,
+	}
+	if !watermark.IsZero() {
+		SetCursorWatermark(&envelope, watermark)
+	}
+	opaque, err := EncodeCursorEnvelope(envelope)
+	if err != nil {
+		return nil
+	}
+	checkpoint := &cerebrov1.SourceCheckpoint{CursorOpaque: opaque}
+	if !watermark.IsZero() {
+		checkpoint.Watermark = timestamppb.New(watermark.UTC())
+	}
+	return checkpoint
+}
+
+// CheckpointFingerprint returns a cloned metadata canary map from checkpoint
+// when its cursor envelope belongs to source/family.
+func CheckpointFingerprint(checkpoint *cerebrov1.SourceCheckpoint, source, family string) map[string]string {
+	if checkpoint == nil {
+		return nil
+	}
+	envelope, ok := DecodeCursorEnvelope(checkpoint.GetCursorOpaque())
+	if !ok || !incrementalCursorMatches(envelope, source, family) || len(envelope.Extra) == 0 {
+		return nil
+	}
+	return normalizedCursorMap(envelope.Extra)
+}
+
+// MergeFingerprintCheckpoint writes canary metadata into checkpoint while
+// preserving any existing watermark, continuation token, and boundary IDs.
+func MergeFingerprintCheckpoint(checkpoint *cerebrov1.SourceCheckpoint, source, family string, metadata map[string]string) *cerebrov1.SourceCheckpoint {
+	return fingerprintCheckpointWithMetadata(checkpoint, source, family, metadata, nil)
+}
+
+// ReconciledFingerprintCheckpoint marks metadata as reconciled by a normal
+// family read and resets consecutive skip history.
+func ReconciledFingerprintCheckpoint(checkpoint *cerebrov1.SourceCheckpoint, source, family string, watermark time.Time, metadata map[string]string, now time.Time) *cerebrov1.SourceCheckpoint {
+	if checkpoint == nil {
+		checkpoint = FingerprintCheckpoint(source, family, watermark, metadata)
+	}
+	now = normalizeCanaryTime(now)
+	metadata = normalizedCursorMap(metadata)
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+	metadata[CanaryReconciledAtKey] = now.Format(time.RFC3339Nano)
+	metadata[CanarySkipCountKey] = "0"
+	return fingerprintCheckpointWithMetadata(checkpoint, source, family, metadata, []string{
+		CanaryFirstSkippedKey,
+		CanaryLastSkippedKey,
+	})
+}
+
+// SkippedFingerprintCheckpoint marks metadata as short-circuited and advances
+// the skip history kept in CursorEnvelope.Extra.
+func SkippedFingerprintCheckpoint(checkpoint *cerebrov1.SourceCheckpoint, source, family string, metadata map[string]string, now time.Time) *cerebrov1.SourceCheckpoint {
+	stored := CheckpointFingerprint(checkpoint, source, family)
+	now = normalizeCanaryTime(now)
+	metadata = normalizedCursorMap(metadata)
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+	if stored != nil {
+		if first := strings.TrimSpace(stored[CanaryFirstSkippedKey]); first != "" {
+			metadata[CanaryFirstSkippedKey] = first
+		}
+		metadata[CanarySkipCountKey] = strconv.Itoa(canarySkipCount(stored) + 1)
+	}
+	if strings.TrimSpace(metadata[CanaryFirstSkippedKey]) == "" {
+		metadata[CanaryFirstSkippedKey] = now.Format(time.RFC3339Nano)
+	}
+	metadata[CanaryLastSkippedKey] = now.Format(time.RFC3339Nano)
+	if strings.TrimSpace(metadata[CanarySkipCountKey]) == "" {
+		metadata[CanarySkipCountKey] = "1"
+	}
+	return fingerprintCheckpointWithMetadata(checkpoint, source, family, metadata, nil)
+}
+
+// FreshnessProbeReconciliationReason returns the first guardrail reason that
+// requires a normal sync for a matching freshness probe. Empty means the probe
+// may short-circuit.
+func FreshnessProbeReconciliationReason(metadata map[string]string, policy CanaryReconciliationPolicy) PullReconciliationReason {
+	metadata = normalizedCursorMap(metadata)
+	if len(metadata) == 0 {
+		return PullReconciliationReasonCanaryStateMissing
+	}
+	if strings.TrimSpace(policy.ManifestVersion) != "" && strings.TrimSpace(metadata[ManifestVersionKey]) != strings.TrimSpace(policy.ManifestVersion) {
+		return PullReconciliationReasonCanaryManifestChanged
+	}
+	if strings.TrimSpace(policy.ConfigHash) != "" && strings.TrimSpace(metadata[CanaryConfigHashKey]) != strings.TrimSpace(policy.ConfigHash) {
+		return PullReconciliationReasonSourceConfigChanged
+	}
+	confidence := strings.ToLower(strings.TrimSpace(policy.Confidence))
+	if confidence == "" {
+		confidence = strings.ToLower(strings.TrimSpace(metadata[CanaryConfidenceKey]))
+	}
+	if confidence == "" {
+		confidence = CanaryConfidenceHeuristic
+	}
+	if confidence != CanaryConfidenceHeuristic {
+		return ""
+	}
+	now := normalizeCanaryTime(policy.Now)
+	if policy.MaxConsecutiveSkips > 0 && canarySkipCount(metadata) >= policy.MaxConsecutiveSkips {
+		return PullReconciliationReasonMaxConsecutiveSkips
+	}
+	if policy.MaxSkipDuration > 0 {
+		firstSkipped := parseCanaryTime(metadata[CanaryFirstSkippedKey])
+		if firstSkipped.IsZero() && canarySkipCount(metadata) > 0 {
+			return PullReconciliationReasonCanaryStateMissing
+		}
+		if !firstSkipped.IsZero() && !now.Before(firstSkipped.Add(policy.MaxSkipDuration)) {
+			return PullReconciliationReasonMaxSkipDuration
+		}
+	}
+	if policy.ReconciliationInterval > 0 {
+		reconciledAt := parseCanaryTime(metadata[CanaryReconciledAtKey])
+		if reconciledAt.IsZero() {
+			return PullReconciliationReasonCanaryStateMissing
+		}
+		if !now.Before(reconciledAt.Add(policy.ReconciliationInterval)) {
+			return PullReconciliationReasonReconciliationInterval
+		}
+	}
+	return ""
+}
+
+// FingerprintHash returns a stable SHA-256 hash for shallow provider metadata.
+func FingerprintHash(values map[string]string) string {
+	values = normalizedCursorMap(values)
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	hash := sha256.New()
+	for _, key := range keys {
+		hash.Write([]byte(key))
+		hash.Write([]byte{0})
+		hash.Write([]byte(values[key]))
+		hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+// ConfigHash returns a stable SHA-256 hash for source runtime config values.
+func ConfigHash(values map[string]string) string {
+	return FingerprintHash(values)
+}
+
+func fingerprintCheckpointWithMetadata(checkpoint *cerebrov1.SourceCheckpoint, source, family string, metadata map[string]string, deleteKeys []string) *cerebrov1.SourceCheckpoint {
+	source = strings.TrimSpace(source)
+	family = strings.TrimSpace(family)
+	if source == "" || family == "" {
+		return checkpoint
+	}
+	next := cloneCanaryCheckpoint(checkpoint)
+	if next == nil {
+		return FingerprintCheckpoint(source, family, time.Time{}, metadata)
+	}
+	envelope, ok := DecodeCursorEnvelope(next.GetCursorOpaque())
+	if !ok || !incrementalCursorMatches(envelope, source, family) {
+		envelope = CursorEnvelope{
+			Source:              source,
+			Family:              family,
+			Mode:                canaryCheckpointMode,
+			ResumableCheckpoint: true,
+		}
+		if watermark := timestampCanaryTime(next.GetWatermark()); !watermark.IsZero() {
+			SetCursorWatermark(&envelope, watermark)
+		}
+	}
+	if strings.TrimSpace(envelope.Source) == "" {
+		envelope.Source = source
+	}
+	if strings.TrimSpace(envelope.Family) == "" {
+		envelope.Family = family
+	}
+	if strings.TrimSpace(envelope.Mode) == "" {
+		envelope.Mode = canaryCheckpointMode
+	}
+	envelope.ResumableCheckpoint = true
+	if envelope.Extra == nil {
+		envelope.Extra = map[string]string{}
+	}
+	for _, key := range deleteKeys {
+		delete(envelope.Extra, strings.TrimSpace(key))
+	}
+	for key, value := range normalizedCursorMap(metadata) {
+		envelope.Extra[key] = value
+	}
+	envelope.Extra = normalizedCursorMap(envelope.Extra)
+	opaque, err := EncodeCursorEnvelope(envelope)
+	if err != nil {
+		return checkpoint
+	}
+	next.CursorOpaque = opaque
+	if next.Watermark == nil {
+		if watermark := CursorWatermark(envelope); !watermark.IsZero() {
+			next.Watermark = timestamppb.New(watermark.UTC())
+		}
+	}
+	return next
+}
+
+func canarySkipCount(metadata map[string]string) int {
+	count, err := strconv.Atoi(strings.TrimSpace(metadata[CanarySkipCountKey]))
+	if err != nil || count < 0 {
+		return 0
+	}
+	return count
+}
+
+func parseCanaryTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
+}
+
+func normalizeCanaryTime(value time.Time) time.Time {
+	if value.IsZero() {
+		return time.Now().UTC()
+	}
+	return value.UTC()
+}
+
+func timestampCanaryTime(value *timestamppb.Timestamp) time.Time {
+	if value == nil || !value.IsValid() {
+		return time.Time{}
+	}
+	return value.AsTime().UTC()
+}
+
+func cloneCanaryCheckpoint(checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {
+	if checkpoint == nil {
+		return nil
+	}
+	next := &cerebrov1.SourceCheckpoint{CursorOpaque: checkpoint.GetCursorOpaque()}
+	if watermark := timestampCanaryTime(checkpoint.GetWatermark()); !watermark.IsZero() {
+		next.Watermark = timestamppb.New(watermark)
+	}
+	return next
+}

--- a/internal/sourcecdk/canary_test.go
+++ b/internal/sourcecdk/canary_test.go
@@ -1,0 +1,160 @@
+package sourcecdk
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+)
+
+func TestFingerprintCheckpointRoundTrip(t *testing.T) {
+	watermark := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	checkpoint := FingerprintCheckpoint(" github ", " repository ", watermark, map[string]string{
+		" " + CanaryKindKey + " ": " newest_updated_resource ",
+		CanaryHashKey:             " abc123 ",
+		"empty":                   " ",
+	})
+	if checkpoint == nil {
+		t.Fatal("FingerprintCheckpoint() = nil, want checkpoint")
+	}
+	if got := checkpoint.GetWatermark().AsTime(); !got.Equal(watermark) {
+		t.Fatalf("checkpoint watermark = %s, want %s", got, watermark)
+	}
+	metadata := CheckpointFingerprint(checkpoint, "github", "repository")
+	if metadata[CanaryKindKey] != "newest_updated_resource" || metadata[CanaryHashKey] != "abc123" {
+		t.Fatalf("CheckpointFingerprint() = %#v, want normalized canary metadata", metadata)
+	}
+	if _, ok := metadata["empty"]; ok {
+		t.Fatalf("CheckpointFingerprint() kept empty metadata: %#v", metadata)
+	}
+}
+
+func TestCheckpointFingerprintRejectsMalformedOrMismatchedMetadata(t *testing.T) {
+	if got := CheckpointFingerprint(&cerebrov1.SourceCheckpoint{CursorOpaque: "native-token"}, "github", "repository"); got != nil {
+		t.Fatalf("CheckpointFingerprint(native) = %#v, want nil", got)
+	}
+	checkpoint := FingerprintCheckpoint("github", "repository", time.Now().UTC(), map[string]string{CanaryHashKey: "abc"})
+	if got := CheckpointFingerprint(checkpoint, "github", "audit"); got != nil {
+		t.Fatalf("CheckpointFingerprint(wrong family) = %#v, want nil", got)
+	}
+}
+
+func TestMergeFingerprintCheckpointPreservesIncrementalBoundaries(t *testing.T) {
+	watermark := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	checkpoint := IncrementalWatermarkCheckpoint("github", "repository", []*primitives.Event{
+		{Id: "repo-boundary", OccurredAt: timestamppb.New(watermark)},
+	}, IncrementalWatermarkState{})
+
+	merged := MergeFingerprintCheckpoint(checkpoint, "github", "repository", map[string]string{
+		CanaryHashKey:       "abc",
+		CanaryConfidenceKey: CanaryConfidenceHeuristic,
+	})
+	envelope, ok := DecodeCursorEnvelope(merged.GetCursorOpaque())
+	if !ok {
+		t.Fatal("merged checkpoint cursor is not an envelope")
+	}
+	if envelope.Mode != incrementalWatermarkMode {
+		t.Fatalf("merged mode = %q, want incremental watermark mode", envelope.Mode)
+	}
+	if got := envelope.BoundaryIDs; len(got) != 1 || got[0] != "repo-boundary" {
+		t.Fatalf("boundary IDs = %#v, want existing repo boundary", got)
+	}
+	if envelope.Extra[CanaryHashKey] != "abc" {
+		t.Fatalf("merged extra = %#v, want canary hash", envelope.Extra)
+	}
+}
+
+func TestSkippedAndReconciledFingerprintCheckpointHistory(t *testing.T) {
+	reconciledAt := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	firstSkip := reconciledAt.Add(time.Hour)
+	secondSkip := firstSkip.Add(time.Hour)
+	checkpoint := ReconciledFingerprintCheckpoint(nil, "github", "repository", reconciledAt, map[string]string{
+		CanaryHashKey:      "abc",
+		ManifestVersionKey: "v1",
+	}, reconciledAt)
+	checkpoint = SkippedFingerprintCheckpoint(checkpoint, "github", "repository", map[string]string{CanaryHashKey: "abc"}, firstSkip)
+	checkpoint = SkippedFingerprintCheckpoint(checkpoint, "github", "repository", map[string]string{CanaryHashKey: "abc"}, secondSkip)
+
+	metadata := CheckpointFingerprint(checkpoint, "github", "repository")
+	if metadata[CanarySkipCountKey] != "2" {
+		t.Fatalf("skip count = %q, want 2", metadata[CanarySkipCountKey])
+	}
+	if metadata[CanaryFirstSkippedKey] != firstSkip.Format(time.RFC3339Nano) {
+		t.Fatalf("first skipped = %q, want first skip timestamp", metadata[CanaryFirstSkippedKey])
+	}
+
+	checkpoint = ReconciledFingerprintCheckpoint(checkpoint, "github", "repository", reconciledAt, map[string]string{CanaryHashKey: "abc"}, secondSkip)
+	metadata = CheckpointFingerprint(checkpoint, "github", "repository")
+	if metadata[CanarySkipCountKey] != "0" {
+		t.Fatalf("reconciled skip count = %q, want 0", metadata[CanarySkipCountKey])
+	}
+	if metadata[CanaryFirstSkippedKey] != "" || metadata[CanaryLastSkippedKey] != "" {
+		t.Fatalf("reconciled skip metadata = %#v, want cleared skip timestamps", metadata)
+	}
+}
+
+func TestFreshnessProbeReconciliationReason(t *testing.T) {
+	now := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	base := map[string]string{
+		CanaryHashKey:         "abc",
+		CanaryConfidenceKey:   CanaryConfidenceHeuristic,
+		CanaryConfigHashKey:   "cfg-a",
+		CanaryReconciledAtKey: now.Add(-time.Hour).Format(time.RFC3339Nano),
+		CanaryFirstSkippedKey: now.Add(-30 * time.Minute).Format(time.RFC3339Nano),
+		CanarySkipCountKey:    "1",
+		ManifestVersionKey:    "v1",
+	}
+	policy := CanaryReconciliationPolicy{
+		Confidence:             CanaryConfidenceHeuristic,
+		MaxSkipDuration:        time.Hour,
+		MaxConsecutiveSkips:    3,
+		ReconciliationInterval: 24 * time.Hour,
+		ManifestVersion:        "v1",
+		ConfigHash:             "cfg-a",
+		Now:                    now,
+	}
+	if got := FreshnessProbeReconciliationReason(base, policy); got != "" {
+		t.Fatalf("normal guardrail reason = %q, want empty", got)
+	}
+
+	withSkipCount := cloneMetadata(base)
+	withSkipCount[CanarySkipCountKey] = "3"
+	if got := FreshnessProbeReconciliationReason(withSkipCount, policy); got != PullReconciliationReasonMaxConsecutiveSkips {
+		t.Fatalf("skip count guardrail = %q, want max_consecutive_skips", got)
+	}
+
+	withSkipDuration := cloneMetadata(base)
+	withSkipDuration[CanaryFirstSkippedKey] = now.Add(-time.Hour).Format(time.RFC3339Nano)
+	if got := FreshnessProbeReconciliationReason(withSkipDuration, policy); got != PullReconciliationReasonMaxSkipDuration {
+		t.Fatalf("skip duration guardrail = %q, want max_skip_duration", got)
+	}
+
+	withConfigChange := cloneMetadata(base)
+	withConfigChange[CanaryConfigHashKey] = "cfg-b"
+	if got := FreshnessProbeReconciliationReason(withConfigChange, policy); got != PullReconciliationReasonSourceConfigChanged {
+		t.Fatalf("config guardrail = %q, want source_config_changed", got)
+	}
+
+	withManifestChange := cloneMetadata(base)
+	withManifestChange[ManifestVersionKey] = "v0"
+	if got := FreshnessProbeReconciliationReason(withManifestChange, policy); got != PullReconciliationReasonCanaryManifestChanged {
+		t.Fatalf("manifest guardrail = %q, want canary_manifest_version_changed", got)
+	}
+
+	withReconciliationInterval := cloneMetadata(base)
+	withReconciliationInterval[CanaryReconciledAtKey] = now.Add(-24 * time.Hour).Format(time.RFC3339Nano)
+	if got := FreshnessProbeReconciliationReason(withReconciliationInterval, policy); got != PullReconciliationReasonReconciliationInterval {
+		t.Fatalf("interval guardrail = %q, want reconciliation_interval", got)
+	}
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	clone := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		clone[key] = value
+	}
+	return clone
+}

--- a/internal/sourcecdk/catalog.go
+++ b/internal/sourcecdk/catalog.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -21,6 +22,7 @@ type catalogFile struct {
 	Description    string                 `yaml:"description"`
 	EmittedKinds   []string               `yaml:"emitted_kinds"`
 	KindLifecycle  []catalogKindLifecycle `yaml:"kind_lifecycle"`
+	Families       []CatalogFamily        `yaml:"families"`
 	EventContracts []EventContract        `yaml:"event_contracts"`
 	Coverage       CoverageContract       `yaml:"coverage_contract"`
 }
@@ -33,8 +35,27 @@ type catalogKindLifecycle struct {
 
 type SourceCatalog struct {
 	Spec             *cerebrov1.SourceSpec
+	Families         []CatalogFamily
 	EventContracts   []EventContract
 	CoverageContract *CoverageContract
+}
+
+// CatalogFamily declares optional per-family source catalog capabilities.
+type CatalogFamily struct {
+	ID             string          `yaml:"id"`
+	Incremental    string          `yaml:"incremental"`
+	FreshnessProbe *FreshnessProbe `yaml:"freshness_probe,omitempty"`
+}
+
+// FreshnessProbe declares whether a family supports a cheap change signal and
+// how authoritative that signal is for short-circuiting reads.
+type FreshnessProbe struct {
+	Supported              bool   `yaml:"supported"`
+	CanaryKind             string `yaml:"canary_kind"`
+	Confidence             string `yaml:"confidence"`
+	ReconciliationInterval string `yaml:"reconciliation_interval"`
+	MaxSkipDuration        string `yaml:"max_skip_duration"`
+	MaxConsecutiveSkips    int    `yaml:"max_consecutive_skips"`
 }
 
 // LoadCatalog parses a source catalog.yaml file into a source spec.
@@ -68,6 +89,10 @@ func LoadSourceCatalog(data []byte) (*SourceCatalog, error) {
 	if err := validateCatalogLifecycle(catalog.KindLifecycle); err != nil {
 		return nil, err
 	}
+	families, err := normalizeCatalogFamilies(catalog.Families)
+	if err != nil {
+		return nil, err
+	}
 	eventContracts, err := ValidateEventContracts(catalog.EventContracts)
 	if err != nil {
 		return nil, err
@@ -88,7 +113,7 @@ func LoadSourceCatalog(data []byte) (*SourceCatalog, error) {
 		Name:         catalog.Name,
 		Description:  catalog.Description,
 		EmittedKinds: emittedKinds,
-	}, EventContracts: eventContracts, CoverageContract: coverage}, nil
+	}, Families: families, EventContracts: eventContracts, CoverageContract: coverage}, nil
 }
 
 func registerCatalogEventContracts(sourceID string, contracts []EventContract) {
@@ -184,6 +209,79 @@ func validateCatalogLifecycle(entries []catalogKindLifecycle) error {
 		if replacement != "" && !validEventKind(replacement) {
 			return fmt.Errorf("kind_lifecycle kind %q has invalid replacement %q", kind, replacement)
 		}
+	}
+	return nil
+}
+
+func normalizeCatalogFamilies(families []CatalogFamily) ([]CatalogFamily, error) {
+	if len(families) == 0 {
+		return nil, nil
+	}
+	seen := map[string]struct{}{}
+	normalized := make([]CatalogFamily, 0, len(families))
+	for _, family := range families {
+		family.ID = strings.TrimSpace(family.ID)
+		family.Incremental = strings.TrimSpace(family.Incremental)
+		if family.ID == "" {
+			return nil, fmt.Errorf("families id is required")
+		}
+		if _, ok := seen[family.ID]; ok {
+			return nil, fmt.Errorf("duplicate family %q", family.ID)
+		}
+		seen[family.ID] = struct{}{}
+		probe, err := normalizeFreshnessProbe(family.ID, family.FreshnessProbe)
+		if err != nil {
+			return nil, err
+		}
+		family.FreshnessProbe = probe
+		normalized = append(normalized, family)
+	}
+	return normalized, nil
+}
+
+func normalizeFreshnessProbe(family string, probe *FreshnessProbe) (*FreshnessProbe, error) {
+	if probe == nil {
+		return nil, nil
+	}
+	normalized := *probe
+	normalized.CanaryKind = strings.TrimSpace(normalized.CanaryKind)
+	normalized.Confidence = strings.ToLower(strings.TrimSpace(normalized.Confidence))
+	normalized.ReconciliationInterval = strings.TrimSpace(normalized.ReconciliationInterval)
+	normalized.MaxSkipDuration = strings.TrimSpace(normalized.MaxSkipDuration)
+	if normalized.Supported && normalized.CanaryKind == "" {
+		return nil, fmt.Errorf("family %q freshness_probe canary_kind is required when supported", family)
+	}
+	switch normalized.Confidence {
+	case "":
+		if normalized.Supported {
+			normalized.Confidence = CanaryConfidenceHeuristic
+		}
+	case CanaryConfidenceAuthoritative, CanaryConfidenceHeuristic:
+	default:
+		return nil, fmt.Errorf("family %q freshness_probe confidence must be one of authoritative or heuristic", family)
+	}
+	if normalized.MaxConsecutiveSkips < 0 {
+		return nil, fmt.Errorf("family %q freshness_probe max_consecutive_skips must be non-negative", family)
+	}
+	if err := validateFreshnessProbeDuration(family, "reconciliation_interval", normalized.ReconciliationInterval); err != nil {
+		return nil, err
+	}
+	if err := validateFreshnessProbeDuration(family, "max_skip_duration", normalized.MaxSkipDuration); err != nil {
+		return nil, err
+	}
+	return &normalized, nil
+}
+
+func validateFreshnessProbeDuration(family string, field string, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return fmt.Errorf("family %q freshness_probe %s must be a Go duration: %w", family, field, err)
+	}
+	if duration <= 0 {
+		return fmt.Errorf("family %q freshness_probe %s must be greater than zero", family, field)
 	}
 	return nil
 }

--- a/internal/sourcecdk/catalog_test.go
+++ b/internal/sourcecdk/catalog_test.go
@@ -131,6 +131,96 @@ coverage_contract:
 	}
 }
 
+func TestLoadSourceCatalogParsesFamilyFreshnessProbe(t *testing.T) {
+	catalog, err := LoadSourceCatalog([]byte(`
+id: github
+name: GitHub
+emitted_kinds:
+  - github.code.repository
+families:
+  - id: repository
+    incremental: watermark
+    freshness_probe:
+      supported: true
+      canary_kind: newest_updated_resource
+      confidence: heuristic
+      reconciliation_interval: 24h
+      max_skip_duration: 6h
+      max_consecutive_skips: 3
+`))
+	if err != nil {
+		t.Fatalf("LoadSourceCatalog() error = %v", err)
+	}
+	if len(catalog.Families) != 1 {
+		t.Fatalf("len(Families) = %d, want 1", len(catalog.Families))
+	}
+	family := catalog.Families[0]
+	if family.ID != "repository" || family.Incremental != "watermark" {
+		t.Fatalf("family = %#v, want repository/watermark", family)
+	}
+	if family.FreshnessProbe == nil {
+		t.Fatal("FreshnessProbe = nil, want parsed probe")
+	}
+	if got := family.FreshnessProbe.Confidence; got != CanaryConfidenceHeuristic {
+		t.Fatalf("probe confidence = %q, want heuristic", got)
+	}
+	if got := family.FreshnessProbe.MaxConsecutiveSkips; got != 3 {
+		t.Fatalf("max skips = %d, want 3", got)
+	}
+}
+
+func TestLoadSourceCatalogRejectsInvalidFreshnessProbe(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{
+			name: "confidence",
+			body: `
+families:
+  - id: repository
+    freshness_probe:
+      supported: true
+      canary_kind: newest_updated_resource
+      confidence: maybe
+`,
+		},
+		{
+			name: "duration",
+			body: `
+families:
+  - id: repository
+    freshness_probe:
+      supported: true
+      canary_kind: newest_updated_resource
+      confidence: heuristic
+      max_skip_duration: soon
+`,
+		},
+		{
+			name: "missing kind",
+			body: `
+families:
+  - id: repository
+    freshness_probe:
+      supported: true
+      confidence: heuristic
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := LoadSourceCatalog([]byte(`
+id: github
+name: GitHub
+emitted_kinds:
+  - github.code.repository
+` + tt.body)); err == nil {
+				t.Fatal("LoadSourceCatalog() error = nil, want invalid freshness probe error")
+			}
+		})
+	}
+}
+
 func TestNewRegistryPreservesCatalogEventContracts(t *testing.T) {
 	_, err := LoadSourceCatalog([]byte(`
 id: contract_source

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -76,10 +76,11 @@ func (c Config) Values() map[string]string {
 
 // Pull is one page of source output.
 type Pull struct {
-	Events             []*primitives.Event
-	Checkpoint         *cerebrov1.SourceCheckpoint
-	NextCursor         *cerebrov1.SourceCursor
-	ShortCircuitReason PullShortCircuitReason
+	Events               []*primitives.Event
+	Checkpoint           *cerebrov1.SourceCheckpoint
+	NextCursor           *cerebrov1.SourceCursor
+	ShortCircuitReason   PullShortCircuitReason
+	ReconciliationReason PullReconciliationReason
 }
 
 // PullShortCircuitReason describes source work that intentionally produced no
@@ -92,6 +93,19 @@ const (
 	PullShortCircuitReasonNotModified           PullShortCircuitReason = "not_modified"
 	PullShortCircuitReasonCheckpointAdvanced    PullShortCircuitReason = "checkpoint_advanced"
 	PullShortCircuitReasonWatermarkReached      PullShortCircuitReason = "watermark_reached"
+)
+
+// PullReconciliationReason describes why a source intentionally bypassed an
+// otherwise-unchanged freshness probe and ran a normal reconciliation.
+type PullReconciliationReason string
+
+const (
+	PullReconciliationReasonMaxSkipDuration        PullReconciliationReason = "max_skip_duration"
+	PullReconciliationReasonMaxConsecutiveSkips    PullReconciliationReason = "max_consecutive_skips"
+	PullReconciliationReasonReconciliationInterval PullReconciliationReason = "reconciliation_interval"
+	PullReconciliationReasonCanaryManifestChanged  PullReconciliationReason = "canary_manifest_version_changed"
+	PullReconciliationReasonSourceConfigChanged    PullReconciliationReason = "source_config_changed"
+	PullReconciliationReasonCanaryStateMissing     PullReconciliationReason = "canary_state_missing"
 )
 
 // Source is the common integration contract for the rewrite.

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -50,6 +50,7 @@ const (
 	runtimeLastSyncWatermarkConfigKey     = "__cerebro_runtime_last_sync_watermark"
 	runtimeLastSyncCompletedAtConfigKey   = "__cerebro_runtime_last_sync_completed_at"
 	runtimeShortCircuitReasonConfigKey    = "__cerebro_runtime_short_circuit_reason"
+	runtimeReconciliationReasonConfigKey  = "__cerebro_runtime_reconciliation_reason"
 )
 
 var (
@@ -296,6 +297,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	sourceConfig := sourcecdk.NewConfig(runtimeConfig)
 	originalCheckpoint := cloneCheckpoint(runtime.GetCheckpoint())
 	shortCircuitReason := ""
+	reconciliationReason := ""
 	for i := uint32(0); i < pageLimit; i++ {
 		pull, err := readSourcePull(ctx, source, sourceConfig, cursor, originalCheckpoint)
 		if err != nil {
@@ -305,6 +307,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		pageShortCircuitReason := string(pullShortCircuitReason(pull))
 		if pageShortCircuitReason != "" {
 			shortCircuitReason = pageShortCircuitReason
+		}
+		pageReconciliationReason := strings.TrimSpace(string(pull.ReconciliationReason))
+		if pageReconciliationReason != "" {
+			reconciliationReason = pageReconciliationReason
 		}
 		eventsRead := boundedUint32(len(pull.Events))
 		recordsScanned += eventsRead
@@ -316,6 +322,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "events_read", Value: eventsRead},
 			telemetry.Field{Key: "has_next_cursor", Value: pull.NextCursor != nil},
 			telemetry.Field{Key: "short_circuit_reason", Value: pageShortCircuitReason},
+			telemetry.Field{Key: "reconciliation_reason", Value: pageReconciliationReason},
 		))
 		if pull.Checkpoint != nil {
 			advanceRuntimeCheckpoint(runtime, pull.Checkpoint)
@@ -361,15 +368,16 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		}
 		runtime.LastSyncedAt = timestamppb.Now()
 		updateRuntimeSyncStatus(runtime, runtimeSyncStatus{
-			Status:             "completed",
-			RecordsScanned:     recordsScanned,
-			RecordsAccepted:    eventsAppended,
-			RecordsRejected:    recordsRejected,
-			EntitiesProjected:  entitiesProjected,
-			LinksProjected:     linksProjected,
-			CompletedAt:        runtime.GetLastSyncedAt().AsTime().UTC(),
-			ContractConfigured: len(eventContracts) > 0,
-			ShortCircuitReason: shortCircuitReason,
+			Status:               "completed",
+			RecordsScanned:       recordsScanned,
+			RecordsAccepted:      eventsAppended,
+			RecordsRejected:      recordsRejected,
+			EntitiesProjected:    entitiesProjected,
+			LinksProjected:       linksProjected,
+			CompletedAt:          runtime.GetLastSyncedAt().AsTime().UTC(),
+			ContractConfigured:   len(eventContracts) > 0,
+			ShortCircuitReason:   shortCircuitReason,
+			ReconciliationReason: reconciliationReason,
 		})
 		if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
 			return nil, err
@@ -387,6 +395,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "links_projected", Value: linksProjected},
 			telemetry.Field{Key: "has_next_cursor", Value: pull.NextCursor != nil},
 			telemetry.Field{Key: "short_circuit_reason", Value: pageShortCircuitReason},
+			telemetry.Field{Key: "reconciliation_reason", Value: pageReconciliationReason},
 		))
 		if pull.NextCursor == nil {
 			break
@@ -403,6 +412,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "links_projected", Value: linksProjected})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "has_next_cursor", Value: runtime.GetNextCursor() != nil})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "short_circuit_reason", Value: shortCircuitReason})
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "reconciliation_reason", Value: reconciliationReason})
 	if watermark, lagSeconds, ok := runtimeWatermarkLag(runtime, time.Now().UTC()); ok {
 		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "checkpoint_watermark", Value: watermark.Format(time.RFC3339Nano)})
 		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "source_runtime_watermark_lag_seconds", Value: lagSeconds})
@@ -486,15 +496,16 @@ func sourceRuntimeFailureCategory(err error) string {
 }
 
 type runtimeSyncStatus struct {
-	Status             string
-	RecordsScanned     uint32
-	RecordsAccepted    uint32
-	RecordsRejected    uint32
-	EntitiesProjected  uint32
-	LinksProjected     uint32
-	CompletedAt        time.Time
-	ContractConfigured bool
-	ShortCircuitReason string
+	Status               string
+	RecordsScanned       uint32
+	RecordsAccepted      uint32
+	RecordsRejected      uint32
+	EntitiesProjected    uint32
+	LinksProjected       uint32
+	CompletedAt          time.Time
+	ContractConfigured   bool
+	ShortCircuitReason   string
+	ReconciliationReason string
 }
 
 func updateRuntimeSyncStatus(runtime *cerebrov1.SourceRuntime, status runtimeSyncStatus) {
@@ -517,6 +528,11 @@ func updateRuntimeSyncStatus(runtime *cerebrov1.SourceRuntime, status runtimeSyn
 		setRuntimeConfig(runtime.Config, runtimeShortCircuitReasonConfigKey, status.ShortCircuitReason)
 	} else {
 		delete(runtime.Config, runtimeShortCircuitReasonConfigKey)
+	}
+	if strings.TrimSpace(status.ReconciliationReason) != "" {
+		setRuntimeConfig(runtime.Config, runtimeReconciliationReasonConfigKey, status.ReconciliationReason)
+	} else {
+		delete(runtime.Config, runtimeReconciliationReasonConfigKey)
 	}
 	if watermark := timestampValue(runtime.GetCheckpoint().GetWatermark()); !watermark.IsZero() {
 		setRuntimeConfig(runtime.Config, runtimeLastSyncWatermarkConfigKey, watermark.UTC().Format(time.RFC3339Nano))
@@ -788,6 +804,9 @@ func mergeEqualWatermarkCheckpoint(existing *cerebrov1.SourceCheckpoint, next *c
 		return next
 	}
 	nextEnvelope.BoundaryIDs = append(nextEnvelope.BoundaryIDs, existingEnvelope.BoundaryIDs...)
+	if len(nextEnvelope.Extra) == 0 && len(existingEnvelope.Extra) > 0 {
+		nextEnvelope.Extra = existingEnvelope.Extra
+	}
 	opaque, err := sourcecdk.EncodeCursorEnvelope(nextEnvelope)
 	if err != nil {
 		return next

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1489,6 +1489,40 @@ func TestSyncRuntimePassesCheckpointAndPersistsShortCircuitReason(t *testing.T) 
 	}
 }
 
+func TestSyncRuntimePersistsReconciliationReason(t *testing.T) {
+	source := &checkpointAwareRuntimeSource{pull: sourcecdk.Pull{
+		Events:               []*cerebrov1.EventEnvelope{runtimeTestEvent("event-1", "checkpoint_aware", "checkpoint_aware.event")},
+		ReconciliationReason: sourcecdk.PullReconciliationReasonMaxConsecutiveSkips,
+	}}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-checkpoint-aware": {
+			Id:       "writer-checkpoint-aware",
+			SourceId: "checkpoint_aware",
+			TenantId: "writer",
+		},
+	}}
+	service := New(registry, store, &appendLog{}, nil)
+
+	resp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-checkpoint-aware"})
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if resp.GetEventsAppended() != 1 {
+		t.Fatalf("EventsAppended = %d, want 1", resp.GetEventsAppended())
+	}
+	stored := store.runtimes["writer-checkpoint-aware"]
+	if got := stored.GetConfig()[runtimeReconciliationReasonConfigKey]; got != "max_consecutive_skips" {
+		t.Fatalf("reconciliation reason = %q, want max_consecutive_skips", got)
+	}
+	if got := stored.GetConfig()[runtimeShortCircuitReasonConfigKey]; got != "" {
+		t.Fatalf("short circuit reason = %q, want empty", got)
+	}
+}
+
 func TestSyncRuntimeDoesNotRegressCheckpointWatermark(t *testing.T) {
 	newer := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
 	older := newer.Add(-time.Hour)

--- a/sources/github/catalog.yaml
+++ b/sources/github/catalog.yaml
@@ -9,6 +9,32 @@ emitted_kinds:
   - github.org_member
   - github.pull_request
   - github.secret_scanning_alert
+families:
+  - id: audit
+    incremental: cursor
+  - id: dependabot_alert
+    incremental: watermark
+  - id: org_inventory
+    freshness_probe:
+      supported: true
+      canary_kind: newest_audit_event
+      confidence: heuristic
+      reconciliation_interval: 24h
+      max_skip_duration: 6h
+      max_consecutive_skips: 3
+  - id: pull_request
+    incremental: watermark
+  - id: repository
+    incremental: watermark
+    freshness_probe:
+      supported: true
+      canary_kind: newest_updated_resource
+      confidence: heuristic
+      reconciliation_interval: 24h
+      max_skip_duration: 6h
+      max_consecutive_skips: 3
+  - id: secret_scanning_alert
+    incremental: watermark
 coverage_contract:
   owner_domain: source_control
   authority_domain: github

--- a/sources/github/org_inventory.go
+++ b/sources/github/org_inventory.go
@@ -13,6 +13,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/internal/githubcanary"
 )
 
 const familyOrgInventory = "org_inventory"
@@ -55,8 +56,19 @@ func (s *Source) discoverOrgInventory(ctx context.Context, client *gogithub.Clie
 	return []sourcecdk.URN{sourcecdk.URN(fmt.Sprintf("urn:cerebro:%s:org_inventory", settings.owner))}, nil
 }
 
-func (s *Source) readOrgInventory(ctx context.Context, client *gogithub.Client, settings settings) (sourcecdk.Pull, error) {
+func (s *Source) readOrgInventory(ctx context.Context, client *gogithub.Client, settings settings, checkpoint *cerebrov1.SourceCheckpoint, configHash string) (sourcecdk.Pull, error) {
 	now := time.Now().UTC()
+	var canary *githubcanary.Result
+	var err error
+	if settings.auditLogCanary {
+		canary, err = githubcanary.ProbeAuditLog(ctx, client, settings.owner, checkpoint, configHash, now)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		if pull, ok := canary.ShortCircuitPull(); ok {
+			return pull, nil
+		}
+	}
 	var events []*primitives.Event
 
 	// Members
@@ -101,14 +113,15 @@ func (s *Source) readOrgInventory(ctx context.Context, client *gogithub.Client, 
 	}
 
 	if len(events) == 0 {
-		return sourcecdk.Pull{}, nil
+		return canary.Apply(sourcecdk.Pull{}, "github", familyOrgInventory), nil
 	}
-	return sourcecdk.Pull{
+	pull := sourcecdk.Pull{
 		Events: events,
 		Checkpoint: &cerebrov1.SourceCheckpoint{
 			Watermark: timestamppb.New(now),
 		},
-	}, nil
+	}
+	return canary.Apply(pull, "github", familyOrgInventory), nil
 }
 
 func orgMemberEvent(settings settings, user *gogithub.User, role string, now time.Time) (*primitives.Event, error) {

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -19,6 +19,7 @@ import (
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcehttp"
+	"github.com/writer/cerebro/sources/internal/githubcanary"
 )
 
 //go:embed catalog.yaml
@@ -60,6 +61,7 @@ type settings struct {
 	auditInclude        string
 	auditPhrase         string
 	auditOrder          string
+	auditLogCanary      bool
 	perPage             int
 }
 
@@ -215,10 +217,10 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 		return s.readSecretScanningAlerts(ctx, client, settings, cursor, checkpoint)
 	}
 	if settings.family == familyOrgInventory {
-		return s.readOrgInventory(ctx, client, settings)
+		return s.readOrgInventory(ctx, client, settings, checkpoint, sourcecdk.ConfigHash(cfg.Values()))
 	}
 	if settings.family == familyRepository {
-		return s.readRepositories(ctx, client, settings, cursor, checkpoint)
+		return s.readRepositories(ctx, client, settings, cursor, checkpoint, sourcecdk.ConfigHash(cfg.Values()))
 	}
 	return s.readPullRequests(ctx, client, settings, cursor, checkpoint)
 }
@@ -250,35 +252,10 @@ func (s *Source) readPullRequests(ctx context.Context, client *gogithub.Client, 
 	})
 }
 
-func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
-	readCheckpoint := sourcecdk.IncrementalCheckpointForCursor("github", familyRepository, cursor, checkpoint)
-	page, err := sourcecdk.CursorPage(cursor)
-	if err != nil {
-		return sourcecdk.Pull{}, err
-	}
-	if settings.repo != "" {
-		if page > 1 {
-			return sourcecdk.EmptyIncrementalWatermarkPull("github", familyRepository, readCheckpoint), nil
-		}
-		repo, err := getRepo(ctx, client, settings.owner, settings.repo)
-		if err != nil {
-			return sourcecdk.Pull{}, err
-		}
-		return sourcecdk.IncrementalPullFromRecords("github", familyRepository, []*gogithub.Repository{repo}, "", readCheckpoint, func(repo *gogithub.Repository) (*primitives.Event, error) {
-			return repositoryEvent(settings, repo)
-		})
-	}
-	repos, resp, err := listReposPage(ctx, client, settings.owner, page, settings.perPage)
-	if err != nil {
-		return sourcecdk.Pull{}, err
-	}
-	nextCursor := ""
-	if resp != nil && resp.NextPage > 0 {
-		nextCursor = strconv.Itoa(resp.NextPage)
-	}
-	return sourcecdk.IncrementalPullFromRecords("github", familyRepository, repos, nextCursor, readCheckpoint, func(repo *gogithub.Repository) (*primitives.Event, error) {
-		return repositoryEvent(settings, repo)
-	})
+func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint, configHash string) (sourcecdk.Pull, error) {
+	options := githubcanary.RepositoryReadOptions{Owner: settings.owner, Repo: settings.repo, PerPage: settings.perPage, ConfigHash: configHash, Cursor: cursor, Checkpoint: checkpoint}
+	options.Build = func(repo *gogithub.Repository) (*primitives.Event, error) { return repositoryEvent(settings, repo) }
+	return githubcanary.ReadRepositories(ctx, client, options)
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {
@@ -387,7 +364,7 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL 
 	switch settings.family {
 	case familyAudit, familyDependabot, familyOrgInventory, familyPullRequest, familyRepository, familySecretScanning:
 	default:
-		return settings, fmt.Errorf("github family must be one of %s, %s, %s, %s, or %s", familyPullRequest, familyAudit, familyDependabot, familyRepository, familySecretScanning)
+		return settings, fmt.Errorf("github family must be one of %s, %s, %s, %s, %s, or %s", familyPullRequest, familyAudit, familyDependabot, familyOrgInventory, familyRepository, familySecretScanning)
 	}
 	if rawPerPage, ok := cfg.Lookup("per_page"); ok && strings.TrimSpace(rawPerPage) != "" {
 		perPage, err := strconv.Atoi(strings.TrimSpace(rawPerPage))
@@ -398,6 +375,11 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL 
 			return settings, fmt.Errorf("github per_page must be between 1 and %d", maxPageSize)
 		}
 		settings.perPage = perPage
+	}
+	if rawAuditLogCanary := configValue(cfg, "audit_log_canary"); rawAuditLogCanary != "" {
+		if settings.auditLogCanary, err = strconv.ParseBool(rawAuditLogCanary); err != nil {
+			return settings, fmt.Errorf("parse github audit_log_canary: %w", err)
+		}
 	}
 	switch settings.family {
 	case familyPullRequest:

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcehttp"
+	"github.com/writer/cerebro/sources/internal/githubcanary"
 )
 
 func TestNewLoadsCatalog(t *testing.T) {
@@ -481,6 +483,213 @@ func TestReadLiveGitHubRepositoryPreviewIncludesOwnerLogin(t *testing.T) {
 	}
 }
 
+func TestRepositoryMetadataCanaryShortCircuitsUnchangedInventory(t *testing.T) {
+	var canaryRequests int
+	var fullRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v3/orgs/writer/repos" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("per_page") == "1" {
+			canaryRequests++
+		} else {
+			fullRequests++
+		}
+		encodeRepositoryPage(t, w, "2026-04-23T00:00:00Z")
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familyRepository,
+		"owner":    "writer",
+		"per_page": "10",
+	})
+
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("first events = %d, want 1", len(first.Events))
+	}
+	if metadata := sourcecdk.CheckpointFingerprint(first.Checkpoint, "github", familyRepository); metadata[sourcecdk.CanaryHashKey] == "" {
+		t.Fatalf("first checkpoint metadata = %#v, want canary hash", metadata)
+	}
+
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, first.Checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(second) error = %v", err)
+	}
+	if len(second.Events) != 0 {
+		t.Fatalf("second events = %d, want short-circuit", len(second.Events))
+	}
+	if second.ShortCircuitReason != sourcecdk.PullShortCircuitReasonNotModified {
+		t.Fatalf("second reason = %q, want not_modified", second.ShortCircuitReason)
+	}
+	if canaryRequests != 2 || fullRequests != 1 {
+		t.Fatalf("requests canary/full = %d/%d, want 2/1", canaryRequests, fullRequests)
+	}
+}
+
+func TestRepositoryMetadataCanaryFallsThroughWhenChanged(t *testing.T) {
+	var fullRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v3/orgs/writer/repos" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("per_page") != "1" {
+			fullRequests++
+		}
+		encodeRepositoryPage(t, w, "2026-04-24T00:00:00Z")
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familyRepository,
+		"owner":    "writer",
+		"per_page": "10",
+	})
+	checkpoint := sourcecdk.ReconciledFingerprintCheckpoint(nil, "github", familyRepository, time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC), map[string]string{
+		sourcecdk.CanaryHashKey:       "old-hash",
+		sourcecdk.CanaryConfidenceKey: sourcecdk.CanaryConfidenceHeuristic,
+		sourcecdk.ManifestVersionKey:  githubcanary.RepositoryManifestVersion,
+		sourcecdk.CanaryConfigHashKey: sourcecdk.ConfigHash(cfg.Values()),
+	}, time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC))
+
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("events = %d, want changed canary full read", len(pull.Events))
+	}
+	if pull.ShortCircuitReason != "" {
+		t.Fatalf("ShortCircuitReason = %q, want empty on changed canary", pull.ShortCircuitReason)
+	}
+	if fullRequests != 1 {
+		t.Fatalf("full requests = %d, want 1", fullRequests)
+	}
+}
+
+func TestRepositoryMetadataCanaryForcesReconciliationAfterMaxSkips(t *testing.T) {
+	var fullRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v3/orgs/writer/repos" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("per_page") != "1" {
+			fullRequests++
+		}
+		encodeRepositoryPage(t, w, "2026-04-23T00:00:00Z")
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familyRepository,
+		"owner":    "writer",
+		"per_page": "10",
+	})
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
+	}
+	checkpoint := first.Checkpoint
+	for i := 0; i < githubcanary.MaxConsecutiveSkips; i++ {
+		checkpoint = sourcecdk.SkippedFingerprintCheckpoint(checkpoint, "github", familyRepository, sourcecdk.CheckpointFingerprint(checkpoint, "github", familyRepository), time.Now().Add(time.Duration(i)*time.Minute))
+	}
+
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(forced) error = %v", err)
+	}
+	if pull.ReconciliationReason != sourcecdk.PullReconciliationReasonMaxConsecutiveSkips {
+		t.Fatalf("ReconciliationReason = %q, want max_consecutive_skips", pull.ReconciliationReason)
+	}
+	if fullRequests != 2 {
+		t.Fatalf("full requests = %d, want initial and forced full reads", fullRequests)
+	}
+}
+
+func TestRepositoryMetadataCanaryReturnsProviderError(t *testing.T) {
+	var fullRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v3/orgs/writer/repos" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("per_page") == "1" {
+			http.Error(w, `{"message":"unavailable"}`, http.StatusInternalServerError)
+			return
+		}
+		fullRequests++
+		encodeRepositoryPage(t, w, "2026-04-23T00:00:00Z")
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familyRepository,
+		"owner":    "writer",
+	})
+
+	if _, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil); err == nil {
+		t.Fatal("ReadWithCheckpoint() error = nil, want canary provider error")
+	}
+	if fullRequests != 0 {
+		t.Fatalf("full requests = %d, want canary failure before full read", fullRequests)
+	}
+}
+
+func encodeRepositoryPage(t *testing.T, w http.ResponseWriter, updatedAt string) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode([]map[string]any{{
+		"id":             1,
+		"name":           "cerebro",
+		"full_name":      "writer/cerebro",
+		"html_url":       "https://github.com/writer/cerebro",
+		"visibility":     "public",
+		"default_branch": "main",
+		"private":        false,
+		"archived":       false,
+		"fork":           false,
+		"created_at":     "2026-04-22T00:00:00Z",
+		"updated_at":     updatedAt,
+		"owner":          map[string]any{"login": "writer"},
+	}}); err != nil {
+		t.Fatalf("encode repos response: %v", err)
+	}
+}
+
 func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
 	server := httptest.NewServer(newGitHubAPIHandler(t))
 	defer server.Close()
@@ -581,6 +790,242 @@ func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
 	}
 	if second.Checkpoint.CursorOpaque != "" {
 		t.Fatalf("second.Checkpoint.CursorOpaque = %q, want empty cursor on terminal audit page", second.Checkpoint.CursorOpaque)
+	}
+}
+
+func TestOrgInventoryAuditLogCanaryShortCircuitsWhenAuthorizedUnchanged(t *testing.T) {
+	var auditRequests int
+	var memberRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v3/orgs/writer/audit-log":
+			auditRequests++
+			if got := r.URL.Query().Get("order"); got != "desc" {
+				t.Fatalf("audit canary order = %q, want desc", got)
+			}
+			encodeAuditCanaryEntry(t, w, "audit-doc-1")
+		case "/api/v3/orgs/writer/members":
+			memberRequests++
+			encodeOrgMembers(t, w)
+		case "/api/v3/orgs/writer/outside_collaborators":
+			if err := json.NewEncoder(w).Encode([]map[string]any{}); err != nil {
+				t.Fatalf("encode outside collaborators: %v", err)
+			}
+		case "/api/v3/orgs/writer/installations":
+			if err := json.NewEncoder(w).Encode(map[string]any{"installations": []map[string]any{}}); err != nil {
+				t.Fatalf("encode installations: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"audit_log_canary": "true",
+		"base_url":         server.URL,
+		"family":           familyOrgInventory,
+		"owner":            "writer",
+		"token":            "test-token",
+	})
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
+	}
+	if len(first.Events) == 0 {
+		t.Fatal("first Events = 0, want org inventory read")
+	}
+	if metadata := sourcecdk.CheckpointFingerprint(first.Checkpoint, "github", familyOrgInventory); metadata[sourcecdk.CanaryKindKey] != githubcanary.AuditLogKind {
+		t.Fatalf("first checkpoint metadata = %#v, want audit-log canary", metadata)
+	}
+
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, first.Checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(second) error = %v", err)
+	}
+	if len(second.Events) != 0 {
+		t.Fatalf("second Events = %d, want short-circuit", len(second.Events))
+	}
+	if second.ShortCircuitReason != sourcecdk.PullShortCircuitReasonNotModified {
+		t.Fatalf("second ShortCircuitReason = %q, want not_modified", second.ShortCircuitReason)
+	}
+	if auditRequests != 2 || memberRequests != 1 {
+		t.Fatalf("audit/member requests = %d/%d, want 2/1", auditRequests, memberRequests)
+	}
+}
+
+func TestOrgInventoryAuditLogCanaryFallsThroughWhenAuthorizedChanged(t *testing.T) {
+	var auditRequests int
+	var memberRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v3/orgs/writer/audit-log":
+			auditRequests++
+			encodeAuditCanaryEntry(t, w, "audit-doc-"+strconv.Itoa(auditRequests))
+		case "/api/v3/orgs/writer/members":
+			memberRequests++
+			encodeOrgMembers(t, w)
+		case "/api/v3/orgs/writer/outside_collaborators":
+			if err := json.NewEncoder(w).Encode([]map[string]any{}); err != nil {
+				t.Fatalf("encode outside collaborators: %v", err)
+			}
+		case "/api/v3/orgs/writer/installations":
+			if err := json.NewEncoder(w).Encode(map[string]any{"installations": []map[string]any{}}); err != nil {
+				t.Fatalf("encode installations: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"audit_log_canary": "true",
+		"base_url":         server.URL,
+		"family":           familyOrgInventory,
+		"owner":            "writer",
+		"token":            "test-token",
+	})
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
+	}
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, first.Checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(second) error = %v", err)
+	}
+	if len(second.Events) == 0 {
+		t.Fatal("second Events = 0, want changed canary full read")
+	}
+	if second.ShortCircuitReason != "" {
+		t.Fatalf("second ShortCircuitReason = %q, want empty changed canary", second.ShortCircuitReason)
+	}
+	if auditRequests != 2 || memberRequests != 2 {
+		t.Fatalf("audit/member requests = %d/%d, want 2/2", auditRequests, memberRequests)
+	}
+}
+
+func TestOrgInventoryAuditLogCanaryUnauthorizedFallsBack(t *testing.T) {
+	var memberRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v3/orgs/writer/audit-log":
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
+		case "/api/v3/orgs/writer/members":
+			memberRequests++
+			encodeOrgMembers(t, w)
+		case "/api/v3/orgs/writer/outside_collaborators":
+			if err := json.NewEncoder(w).Encode([]map[string]any{}); err != nil {
+				t.Fatalf("encode outside collaborators: %v", err)
+			}
+		case "/api/v3/orgs/writer/installations":
+			if err := json.NewEncoder(w).Encode(map[string]any{"installations": []map[string]any{}}); err != nil {
+				t.Fatalf("encode installations: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"audit_log_canary": "true",
+		"base_url":         server.URL,
+		"family":           familyOrgInventory,
+		"owner":            "writer",
+		"token":            "test-token",
+	})
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) == 0 {
+		t.Fatal("Events = 0, want fallback org inventory read")
+	}
+	if pull.ShortCircuitReason != "" {
+		t.Fatalf("ShortCircuitReason = %q, want empty fallback", pull.ShortCircuitReason)
+	}
+	if memberRequests != 1 {
+		t.Fatalf("member requests = %d, want 1", memberRequests)
+	}
+}
+
+func TestOrgInventoryAuditLogCanaryProviderError(t *testing.T) {
+	var memberRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v3/orgs/writer/audit-log":
+			http.Error(w, `{"message":"unavailable"}`, http.StatusInternalServerError)
+		case "/api/v3/orgs/writer/members":
+			memberRequests++
+			encodeOrgMembers(t, w)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"audit_log_canary": "true",
+		"base_url":         server.URL,
+		"family":           familyOrgInventory,
+		"owner":            "writer",
+		"token":            "test-token",
+	})
+	if _, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil); err == nil {
+		t.Fatal("ReadWithCheckpoint() error = nil, want audit canary provider error")
+	}
+	if memberRequests != 0 {
+		t.Fatalf("member requests = %d, want canary error before fallback read", memberRequests)
+	}
+}
+
+func encodeAuditCanaryEntry(t *testing.T, w http.ResponseWriter, documentID string) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode([]map[string]any{{
+		"@timestamp":   1776916397852,
+		"_document_id": documentID,
+		"action":       "org.update_member",
+		"actor":        "octocat",
+		"created_at":   1776916397852,
+		"org":          "writer",
+	}}); err != nil {
+		t.Fatalf("encode audit canary entry: %v", err)
+	}
+}
+
+func encodeOrgMembers(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode([]map[string]any{{
+		"login":    "octocat",
+		"id":       1,
+		"html_url": "https://github.com/octocat",
+	}}); err != nil {
+		t.Fatalf("encode org members: %v", err)
 	}
 }
 

--- a/sources/internal/githubcanary/canary.go
+++ b/sources/internal/githubcanary/canary.go
@@ -1,0 +1,345 @@
+package githubcanary
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	gogithub "github.com/google/go-github/v66/github"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+const (
+	RepositoryKind            = "newest_updated_resource"
+	AuditLogKind              = "newest_audit_event"
+	RepositoryManifestVersion = "github_repository_canary_v1"
+	AuditLogManifestVersion   = "github_audit_log_canary_v1"
+	MaxSkipDuration           = 6 * time.Hour
+	ReconciliationInterval    = 24 * time.Hour
+	MaxConsecutiveSkips       = 3
+)
+
+type Result struct {
+	Metadata             map[string]string
+	Watermark            time.Time
+	ObservedAt           time.Time
+	ShortCircuit         bool
+	Checkpoint           *cerebrov1.SourceCheckpoint
+	ReconciliationReason sourcecdk.PullReconciliationReason
+}
+
+type RepositoryReadOptions struct {
+	Owner      string
+	Repo       string
+	PerPage    int
+	ConfigHash string
+	Cursor     *cerebrov1.SourceCursor
+	Checkpoint *cerebrov1.SourceCheckpoint
+	Build      func(*gogithub.Repository) (*primitives.Event, error)
+}
+
+func ReadRepositories(ctx context.Context, client *gogithub.Client, options RepositoryReadOptions) (sourcecdk.Pull, error) {
+	readCheckpoint := sourcecdk.IncrementalCheckpointForCursor("github", "repository", options.Cursor, options.Checkpoint)
+	page, err := sourcecdk.CursorPage(options.Cursor)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	var canary *Result
+	if strings.TrimSpace(options.Repo) == "" && page == 1 && sourcecdk.CursorToken(options.Cursor) == "" {
+		canary, err = ProbeRepository(ctx, client, options.Owner, options.Checkpoint, options.ConfigHash, time.Now().UTC())
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		if pull, ok := canary.ShortCircuitPull(); ok {
+			return pull, nil
+		}
+	}
+	if strings.TrimSpace(options.Repo) != "" {
+		if page > 1 {
+			return sourcecdk.EmptyIncrementalWatermarkPull("github", "repository", readCheckpoint), nil
+		}
+		repo, err := getRepository(ctx, client, options.Owner, options.Repo)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		return sourcecdk.IncrementalPullFromRecords("github", "repository", []*gogithub.Repository{repo}, "", readCheckpoint, options.Build)
+	}
+	repos, resp, err := listRepositoriesPage(ctx, client, options.Owner, page, options.PerPage)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	nextCursor := ""
+	if resp != nil && resp.NextPage > 0 {
+		nextCursor = strconv.Itoa(resp.NextPage)
+	}
+	pull, err := sourcecdk.IncrementalPullFromRecords("github", "repository", repos, nextCursor, readCheckpoint, options.Build)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	return canary.Apply(pull, "github", "repository"), nil
+}
+
+func (r *Result) ShortCircuitPull() (sourcecdk.Pull, bool) {
+	if r == nil || !r.ShortCircuit {
+		return sourcecdk.Pull{}, false
+	}
+	return sourcecdk.Pull{
+		Checkpoint:         r.Checkpoint,
+		ShortCircuitReason: sourcecdk.PullShortCircuitReasonNotModified,
+	}, true
+}
+
+func (r *Result) Apply(pull sourcecdk.Pull, source, family string) sourcecdk.Pull {
+	if r == nil {
+		return pull
+	}
+	pull.Checkpoint = sourcecdk.ReconciledFingerprintCheckpoint(pull.Checkpoint, source, family, r.Watermark, r.Metadata, r.ObservedAt)
+	pull.ReconciliationReason = r.ReconciliationReason
+	return pull
+}
+
+func ProbeRepository(ctx context.Context, client *gogithub.Client, owner string, checkpoint *cerebrov1.SourceCheckpoint, configHash string, observedAt time.Time) (*Result, error) {
+	repos, err := newestRepository(ctx, client, owner)
+	if err != nil {
+		return nil, err
+	}
+	metadata, watermark := RepositoryMetadata(owner, repos, configHash, observedAt)
+	return evaluate(checkpoint, "github", "repository", metadata, watermark, observedAt, policy(sourcecdk.CanaryConfidenceHeuristic, RepositoryManifestVersion, configHash, observedAt)), nil
+}
+
+func ProbeAuditLog(ctx context.Context, client *gogithub.Client, owner string, checkpoint *cerebrov1.SourceCheckpoint, configHash string, observedAt time.Time) (*Result, error) {
+	entries, _, err := client.Organizations.GetAuditLog(ctx, owner, &gogithub.GetAuditLogOptions{
+		Include: gogithub.String("all"),
+		Order:   gogithub.String("desc"),
+		ListCursorOptions: gogithub.ListCursorOptions{
+			PerPage: 1,
+		},
+	})
+	if err != nil {
+		if AuditLogUnavailable(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("github audit log canary for org %s: %w", owner, err)
+	}
+	metadata, watermark := AuditLogMetadata(owner, entries, configHash, observedAt)
+	return evaluate(checkpoint, "github", "org_inventory", metadata, watermark, observedAt, policy(sourcecdk.CanaryConfidenceHeuristic, AuditLogManifestVersion, configHash, observedAt)), nil
+}
+
+func RepositoryMetadata(owner string, repos []*gogithub.Repository, configHash string, observedAt time.Time) (map[string]string, time.Time) {
+	observedAt = observedAt.UTC()
+	fields := map[string]string{"source": "github", "family": "repository", "owner": owner}
+	resourceID := "none"
+	updatedAt := observedAt
+	if len(repos) > 0 && repos[0] != nil {
+		repo := repos[0]
+		fullName := repositoryFullName(owner, repo)
+		repoID := ""
+		if repo.GetID() != 0 {
+			repoID = strconv.FormatInt(repo.GetID(), 10)
+		}
+		resourceID = firstNonEmpty(repoID, fullName)
+		updatedAt = repositoryUpdatedAt(repo, observedAt)
+		fields["repo_id"] = repoID
+		fields["full_name"] = fullName
+		fields["resource_id"] = resourceID
+		fields["updated_at"] = updatedAt.Format(time.RFC3339Nano)
+		if pushedAt := timestamp(repo.PushedAt); pushedAt != nil {
+			fields["pushed_at"] = pushedAt.UTC().Format(time.RFC3339Nano)
+		}
+	} else {
+		fields["empty"] = "true"
+	}
+	return metadata(RepositoryKind, resourceID, RepositoryManifestVersion, configHash, updatedAt, observedAt, fields), updatedAt
+}
+
+func AuditLogMetadata(owner string, entries []*gogithub.AuditEntry, configHash string, observedAt time.Time) (map[string]string, time.Time) {
+	observedAt = observedAt.UTC()
+	fields := map[string]string{"source": "github", "family": "org_inventory", "owner": owner}
+	resourceID := "none"
+	updatedAt := observedAt
+	if len(entries) > 0 && entries[0] != nil {
+		entry := entries[0]
+		updatedAt = auditOccurredAt(entry)
+		if updatedAt.IsZero() {
+			updatedAt = observedAt
+		}
+		resourceID = firstNonEmpty(entry.GetDocumentID(), entry.GetAction(), strconv.FormatInt(updatedAt.UnixMilli(), 10))
+		fields["document_id"] = entry.GetDocumentID()
+		fields["action"] = entry.GetAction()
+		fields["resource_id"] = resourceID
+		fields["updated_at"] = updatedAt.Format(time.RFC3339Nano)
+	} else {
+		fields["empty"] = "true"
+	}
+	return metadata(AuditLogKind, resourceID, AuditLogManifestVersion, configHash, updatedAt, observedAt, fields), updatedAt
+}
+
+func AuditLogUnavailable(err error) bool {
+	var apiErr *gogithub.ErrorResponse
+	if !errors.As(err, &apiErr) || apiErr.Response == nil {
+		return false
+	}
+	switch apiErr.Response.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return true
+	default:
+		return false
+	}
+}
+
+func evaluate(checkpoint *cerebrov1.SourceCheckpoint, source, family string, metadata map[string]string, watermark time.Time, observedAt time.Time, policy sourcecdk.CanaryReconciliationPolicy) *Result {
+	result := &Result{Metadata: metadata, Watermark: watermark, ObservedAt: observedAt.UTC()}
+	stored := sourcecdk.CheckpointFingerprint(checkpoint, source, family)
+	if strings.TrimSpace(stored[sourcecdk.CanaryHashKey]) == "" || stored[sourcecdk.CanaryHashKey] != metadata[sourcecdk.CanaryHashKey] {
+		return result
+	}
+	if reason := sourcecdk.FreshnessProbeReconciliationReason(stored, policy); reason != "" {
+		result.ReconciliationReason = reason
+		return result
+	}
+	result.ShortCircuit = true
+	result.Checkpoint = sourcecdk.SkippedFingerprintCheckpoint(checkpoint, source, family, metadata, observedAt)
+	return result
+}
+
+func policy(confidence, manifestVersion, configHash string, now time.Time) sourcecdk.CanaryReconciliationPolicy {
+	return sourcecdk.CanaryReconciliationPolicy{
+		Confidence:             confidence,
+		MaxSkipDuration:        MaxSkipDuration,
+		MaxConsecutiveSkips:    MaxConsecutiveSkips,
+		ReconciliationInterval: ReconciliationInterval,
+		ManifestVersion:        manifestVersion,
+		ConfigHash:             configHash,
+		Now:                    now,
+	}
+}
+
+func newestRepository(ctx context.Context, client *gogithub.Client, owner string) ([]*gogithub.Repository, error) {
+	repos, _, err := listRepositoriesPage(ctx, client, owner, 1, 1)
+	return repos, err
+}
+
+func listRepositoriesPage(ctx context.Context, client *gogithub.Client, owner string, page int, perPage int) ([]*gogithub.Repository, *gogithub.Response, error) {
+	repos, resp, err := client.Repositories.ListByOrg(ctx, owner, &gogithub.RepositoryListByOrgOptions{
+		Type:      "all",
+		Sort:      "updated",
+		Direction: "desc",
+		ListOptions: gogithub.ListOptions{
+			Page:    page,
+			PerPage: perPage,
+		},
+	})
+	if err == nil {
+		return repos, resp, nil
+	}
+	if !isNotFound(err) {
+		return nil, nil, fmt.Errorf("list github org repos for %s: %w", owner, err)
+	}
+	repos, resp, err = client.Repositories.ListByUser(ctx, owner, &gogithub.RepositoryListByUserOptions{
+		Type:      "owner",
+		Sort:      "updated",
+		Direction: "desc",
+		ListOptions: gogithub.ListOptions{
+			Page:    page,
+			PerPage: perPage,
+		},
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("github owner %s: %w", owner, err)
+	}
+	return repos, resp, nil
+}
+
+func getRepository(ctx context.Context, client *gogithub.Client, owner string, repo string) (*gogithub.Repository, error) {
+	repository, _, err := client.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		return nil, fmt.Errorf("github repo %s/%s: %w", owner, repo, err)
+	}
+	return repository, nil
+}
+
+func metadata(kind, resourceID, manifestVersion, configHash string, updatedAt time.Time, observedAt time.Time, fields map[string]string) map[string]string {
+	out := map[string]string{
+		sourcecdk.CanaryKindKey:       kind,
+		sourcecdk.CanaryResourceIDKey: resourceID,
+		sourcecdk.CanaryObservedAtKey: observedAt.UTC().Format(time.RFC3339Nano),
+		sourcecdk.CanaryUpdatedAtKey:  updatedAt.UTC().Format(time.RFC3339Nano),
+		sourcecdk.CanaryHashKey:       sourcecdk.FingerprintHash(fields),
+		sourcecdk.CanaryConfidenceKey: sourcecdk.CanaryConfidenceHeuristic,
+		sourcecdk.ManifestVersionKey:  manifestVersion,
+		sourcecdk.CanaryConfigHashKey: configHash,
+	}
+	return out
+}
+
+func repositoryFullName(owner string, repo *gogithub.Repository) string {
+	if repo == nil {
+		return ""
+	}
+	if fullName := strings.TrimSpace(repo.GetFullName()); fullName != "" {
+		return fullName
+	}
+	name := strings.TrimSpace(repo.GetName())
+	if name == "" {
+		return ""
+	}
+	return strings.TrimSpace(owner) + "/" + name
+}
+
+func repositoryUpdatedAt(repo *gogithub.Repository, fallback time.Time) time.Time {
+	if repo == nil {
+		return fallback.UTC()
+	}
+	if updatedAt := repo.GetUpdatedAt(); !updatedAt.IsZero() {
+		return updatedAt.Time.UTC()
+	}
+	if pushedAt := timestamp(repo.PushedAt); pushedAt != nil {
+		return pushedAt.UTC()
+	}
+	if createdAt := repo.GetCreatedAt(); !createdAt.IsZero() {
+		return createdAt.Time.UTC()
+	}
+	return fallback.UTC()
+}
+
+func auditOccurredAt(entry *gogithub.AuditEntry) time.Time {
+	if entry == nil {
+		return time.Time{}
+	}
+	if stamp := entry.GetTimestamp(); !stamp.IsZero() {
+		return stamp.UTC()
+	}
+	if stamp := entry.GetCreatedAt(); !stamp.IsZero() {
+		return stamp.UTC()
+	}
+	return time.Time{}
+}
+
+func timestamp(value *gogithub.Timestamp) *time.Time {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	result := value.UTC()
+	return &result
+}
+
+func isNotFound(err error) bool {
+	var apiErr *gogithub.ErrorResponse
+	return errors.As(err, &apiErr) && apiErr.Response != nil && apiErr.Response.StatusCode == http.StatusNotFound
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -18,7 +18,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"azure":           2582,
 	"cosmo":           1112,
 	"gcp":             2074,
-	"github":          2115,
+	"github":          2110,
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2433,


### PR DESCRIPTION
## Summary

- add Source CDK helpers for metadata canary checkpoint fingerprints, skip history, config hashes, and heuristic reconciliation guardrails
- add catalog-level family freshness_probe parsing/validation and declare GitHub repository/org-inventory probe capabilities
- add GitHub repository newest-updated canary short-circuiting and optional org audit-log canary fallback behavior
- persist explicit reconciliation reasons in source runtime status/telemetry

Closes #1066
Closes #1067
Closes #1068
Closes #1069
Closes #1070

## Tests

- go test ./...
- go run ./tools/catalogcheck
