### PR TITLE
Deepen connector catalog contract

### DIFF
--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/connectorcatalog"
 	"github.com/writer/cerebro/internal/connectorcredentials"
@@ -51,40 +53,97 @@ const (
 	connectorAccessAvailable   = "available"
 	connectorAccessCatalogOnly = "catalog_only"
 	connectorAccessRestricted  = "restricted"
+
+	connectorDefinitionOriginCompiled = "compiled_source"
+	connectorDefinitionOriginCatalog  = "builtin_catalog"
+
+	connectorReadinessStageSetupEnabled        = "setup_enabled"
+	connectorReadinessStageAPIRestricted       = "api_restricted"
+	connectorReadinessStageSourcegenReady      = "sourcegen_ready"
+	connectorReadinessStageCatalogReady        = "catalog_ready"
+	connectorReadinessStageAuthExtensionNeeded = "auth_extension_required"
+	connectorReadinessStageRuntimeNeeded       = "runtime_required"
+	connectorReadinessStageRuntimeUnknown      = "runtime_unknown"
 )
 
 var errConnectorAccessRestricted = errors.New("connector access restricted")
 
 type connectorCatalogEntry struct {
-	SourceID               string                          `json:"source_id"`
-	Name                   string                          `json:"name"`
-	DisplayName            string                          `json:"display_name"`
-	Description            string                          `json:"description"`
-	EmittedKinds           []string                        `json:"emitted_kinds"`
-	Status                 string                          `json:"status"`
-	CatalogStatus          string                          `json:"catalog_status,omitempty"`
-	ClassifierOutput       string                          `json:"classifier_output,omitempty"`
-	AuthModel              string                          `json:"auth_model,omitempty"`
-	RuntimeExecutable      bool                            `json:"runtime_executable,omitempty"`
-	MissingFeatures        []string                        `json:"missing_features,omitempty"`
-	CatalogCategories      []string                        `json:"catalog_categories,omitempty"`
-	VerificationEndpoint   string                          `json:"verification_endpoint,omitempty"`
-	ResourceFamilies       []connectorResourceFamilyView   `json:"resource_families,omitempty"`
-	ConfiguredRuntimes     int                             `json:"configured_runtimes"`
-	HealthyRuntimes        int                             `json:"healthy_runtimes"`
-	NeedsAttentionRuntimes int                             `json:"needs_attention_runtimes"`
-	ConnectionMethods      []connectorConnectionMethodView `json:"connection_methods,omitempty"`
-	ScopeOptions           []connectorScopeOptionView      `json:"scope_options,omitempty"`
-	AccessStatus           string                          `json:"access_status,omitempty"`
-	AccessReason           string                          `json:"access_reason,omitempty"`
-	SetupAllowed           bool                            `json:"setup_allowed"`
-	Requestable            bool                            `json:"requestable,omitempty"`
+	connectorCatalogIdentity
+	connectorCatalogDefinitionState
+	connectorCatalogRuntimeState
+	connectorCatalogSetupState
+	connectorCatalogAccessState
+}
+
+type connectorCatalogIdentity struct {
+	SourceID    string `json:"source_id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description"`
+}
+
+type connectorCatalogDefinitionState struct {
+	EmittedKinds          []string                      `json:"emitted_kinds"`
+	CatalogStatus         string                        `json:"catalog_status,omitempty"`
+	ClassifierOutput      string                        `json:"classifier_output,omitempty"`
+	AuthModel             string                        `json:"auth_model,omitempty"`
+	RuntimeExecutable     bool                          `json:"runtime_executable,omitempty"`
+	MissingFeatures       []string                      `json:"missing_features,omitempty"`
+	CatalogCategories     []string                      `json:"catalog_categories,omitempty"`
+	VerificationEndpoint  string                        `json:"verification_endpoint,omitempty"`
+	ResourceFamilies      []connectorResourceFamilyView `json:"resource_families,omitempty"`
+	CatalogSchemaVersion  string                        `json:"catalog_schema_version,omitempty"`
+	CatalogCurrentVersion int                           `json:"catalog_current_version,omitempty"`
+	CatalogSourcePath     string                        `json:"catalog_source_path,omitempty"`
+	DefinitionOrigin      string                        `json:"definition_origin,omitempty"`
+	ReadinessStage        string                        `json:"readiness_stage,omitempty"`
+	IntegrationDepth      connectorIntegrationDepthView `json:"integration_depth,omitempty"`
+}
+
+type connectorCatalogRuntimeState struct {
+	Status                 string `json:"status"`
+	ConfiguredRuntimes     int    `json:"configured_runtimes"`
+	HealthyRuntimes        int    `json:"healthy_runtimes"`
+	NeedsAttentionRuntimes int    `json:"needs_attention_runtimes"`
+}
+
+type connectorCatalogSetupState struct {
+	ConnectionMethods []connectorConnectionMethodView `json:"connection_methods,omitempty"`
+	ScopeOptions      []connectorScopeOptionView      `json:"scope_options,omitempty"`
+}
+
+type connectorCatalogAccessState struct {
+	AccessStatus        string `json:"access_status,omitempty"`
+	AccessReason        string `json:"access_reason,omitempty"`
+	SetupAllowed        bool   `json:"setup_allowed"`
+	Requestable         bool   `json:"requestable,omitempty"`
+	RequestableReason   string `json:"requestable_reason,omitempty"`
+	RequestAccessURL    string `json:"request_access_url,omitempty"`
+	RequestAccessAction string `json:"request_access_action,omitempty"`
+}
+
+type connectorIntegrationDepthView struct {
+	Level               string `json:"level,omitempty"`
+	Score               int    `json:"score"`
+	AuthModel           string `json:"auth_model,omitempty"`
+	ResourceFamilies    int    `json:"resource_families"`
+	EmittedKinds        int    `json:"emitted_kinds"`
+	CoverageDimensions  int    `json:"coverage_dimensions"`
+	HighValueFamilies   int    `json:"high_value_families"`
+	ProjectionTemplates int    `json:"projection_templates"`
+	ScopeOptions        int    `json:"scope_options"`
+	RuntimeExecutable   bool   `json:"runtime_executable"`
+	SetupEnabled        bool   `json:"setup_enabled"`
 }
 
 type connectorLibraryResponse struct {
 	Connectors          []connectorCatalogEntry `json:"connectors"`
+	GeneratedAt         string                  `json:"generated_at"`
 	TenantID            string                  `json:"tenant_id,omitempty"`
 	RuntimeStore        string                  `json:"runtime_store"`
+	CatalogVersion      string                  `json:"catalog_version,omitempty"`
+	CatalogSourceCommit string                  `json:"catalog_source_commit,omitempty"`
 	CredentialTransport connectorTransportView  `json:"credential_transport"`
 	CredentialVault     connectorVaultView      `json:"credential_vault"`
 	CredentialStores    []connectorStoreView    `json:"credential_stores,omitempty"`
@@ -480,19 +539,28 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 	entries := make([]connectorCatalogEntry, 0, len(sources))
 	for _, source := range sources {
 		entry := connectorCatalogEntry{
-			SourceID:          source.GetId(),
-			Name:              source.GetName(),
-			DisplayName:       connectorDisplayName(source.GetId(), source.GetName()),
-			Description:       source.GetDescription(),
-			EmittedKinds:      append([]string{}, source.GetEmittedKinds()...),
-			Status:            "available",
-			ConnectionMethods: connectorConnectionMethods(source.GetId(), stores),
-			ScopeOptions:      a.connectorScopeOptions(source.GetId(), source.GetEmittedKinds()),
+			connectorCatalogIdentity: connectorCatalogIdentity{
+				SourceID:    source.GetId(),
+				Name:        source.GetName(),
+				DisplayName: connectorDisplayName(source.GetId(), source.GetName()),
+				Description: source.GetDescription(),
+			},
+			connectorCatalogDefinitionState: connectorCatalogDefinitionState{
+				EmittedKinds:     append([]string{}, source.GetEmittedKinds()...),
+				DefinitionOrigin: connectorDefinitionOriginCompiled,
+			},
+			connectorCatalogRuntimeState: connectorCatalogRuntimeState{
+				Status: "available",
+			},
+			connectorCatalogSetupState: connectorCatalogSetupState{
+				ConnectionMethods: connectorConnectionMethods(source.GetId(), stores),
+				ScopeOptions:      a.connectorScopeOptions(source.GetId(), source.GetEmittedKinds()),
+			},
 		}
 		if catalogEntry, ok := definitionsBySourceID[source.GetId()]; ok {
 			applyConnectorCatalogMetadata(&entry, catalogEntry)
 		}
-		if !a.applyConnectorAccess(&entry) {
+		if !a.applyConnectorAccess(&entry, tenantID) {
 			continue
 		}
 		if count := counts[source.GetId()]; count.total > 0 {
@@ -517,17 +585,25 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 			continue
 		}
 		entry := connectorCatalogEntry{
-			SourceID:          sourceID,
-			Name:              catalogEntry.Definition.DisplayName,
-			DisplayName:       connectorDisplayName(sourceID, catalogEntry.Definition.DisplayName),
-			Description:       catalogEntry.Definition.Description,
-			EmittedKinds:      connectorDefinitionEmittedKinds(catalogEntry.Definition),
-			Status:            catalogEntry.Status,
-			ScopeOptions:      connectorScopeOptionsFromDefinition(catalogEntry.Definition),
-			ConnectionMethods: nil,
+			connectorCatalogIdentity: connectorCatalogIdentity{
+				SourceID:    sourceID,
+				Name:        catalogEntry.Definition.DisplayName,
+				DisplayName: connectorDisplayName(sourceID, catalogEntry.Definition.DisplayName),
+				Description: catalogEntry.Definition.Description,
+			},
+			connectorCatalogDefinitionState: connectorCatalogDefinitionState{
+				EmittedKinds:     connectorDefinitionEmittedKinds(catalogEntry.Definition),
+				DefinitionOrigin: connectorDefinitionOriginCatalog,
+			},
+			connectorCatalogRuntimeState: connectorCatalogRuntimeState{
+				Status: catalogEntry.Status,
+			},
+			connectorCatalogSetupState: connectorCatalogSetupState{
+				ScopeOptions: connectorScopeOptionsFromDefinition(catalogEntry.Definition),
+			},
 		}
 		applyConnectorCatalogMetadata(&entry, catalogEntry)
-		if !a.applyConnectorAccess(&entry) {
+		if !a.applyConnectorAccess(&entry, tenantID) {
 			continue
 		}
 		entries = append(entries, entry)
@@ -537,8 +613,11 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 	})
 	return connectorLibraryResponse{
 		Connectors:          entries,
+		GeneratedAt:         time.Now().UTC().Format(time.RFC3339),
 		TenantID:            tenantID,
 		RuntimeStore:        runtimeStoreStatus,
+		CatalogVersion:      connectordefinitions.SchemaVersionIntegrationV1,
+		CatalogSourceCommit: buildinfo.Commit,
 		CredentialTransport: transport,
 		CredentialVault:     vaultStatus,
 		CredentialStores:    stores,
@@ -1656,6 +1735,9 @@ func applyConnectorCatalogMetadata(entry *connectorCatalogEntry, catalogEntry co
 	entry.ClassifierOutput = catalogEntry.ClassifierOutput
 	entry.AuthModel = catalogEntry.Definition.Auth.Model
 	entry.RuntimeExecutable = catalogEntry.Generateable
+	entry.CatalogSchemaVersion = catalogEntry.Definition.SchemaVersion
+	entry.CatalogCurrentVersion = catalogEntry.Definition.CurrentVersion
+	entry.CatalogSourcePath = catalogEntry.Path
 	entry.MissingFeatures = append([]string{}, catalogEntry.Report.MissingFeatures...)
 	entry.CatalogCategories = append([]string{}, catalogEntry.Definition.Categories...)
 	entry.VerificationEndpoint = catalogEntry.VerificationPath
@@ -1677,7 +1759,7 @@ func applyConnectorCatalogMetadata(entry *connectorCatalogEntry, catalogEntry co
 	}
 }
 
-func (a *App) applyConnectorAccess(entry *connectorCatalogEntry) bool {
+func (a *App) applyConnectorAccess(entry *connectorCatalogEntry, tenantID string) bool {
 	if entry == nil {
 		return false
 	}
@@ -1692,6 +1774,7 @@ func (a *App) applyConnectorAccess(entry *connectorCatalogEntry) bool {
 		entry.AccessReason = firstNonEmpty(a.cfg.ConnectorAccess.RestrictionReason, "Connector setup is restricted by this deployment.")
 		entry.SetupAllowed = false
 		entry.Requestable = true
+		entry.RequestableReason = entry.AccessReason
 		entry.ConnectionMethods = nil
 	case hasSetup:
 		entry.AccessStatus = connectorAccessAvailable
@@ -1701,19 +1784,26 @@ func (a *App) applyConnectorAccess(entry *connectorCatalogEntry) bool {
 		entry.AccessReason = connectorCatalogOnlyReason(entry.CatalogStatus)
 		entry.SetupAllowed = false
 		entry.Requestable = true
+		entry.RequestableReason = entry.AccessReason
 	default:
 		entry.AccessStatus = connectorAccessAvailable
 		entry.SetupAllowed = hasSetup
 	}
+	if entry.Requestable {
+		entry.RequestAccessAction = connectorRequestAccessAction(a.cfg.ConnectorAccess.RequestAccessAction, entry)
+		entry.RequestAccessURL = connectorRequestAccessURL(a.cfg.ConnectorAccess.RequestAccessURL, entry, tenantID)
+	}
+	entry.ReadinessStage = connectorReadinessStage(*entry)
+	entry.IntegrationDepth = connectorIntegrationDepth(*entry)
 	return true
 }
 
 func (a *App) requireConnectorSetupAccess(sourceID string) error {
-	if connectorSourceListed(a.cfg.ConnectorAccess.RestrictedSources, sourceID) {
-		return fmt.Errorf("%w: %s", errConnectorAccessRestricted, strings.TrimSpace(sourceID))
-	}
 	if connectorSourceListed(a.cfg.ConnectorAccess.HiddenSources, sourceID) {
 		return fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, strings.TrimSpace(sourceID))
+	}
+	if connectorSourceListed(a.cfg.ConnectorAccess.RestrictedSources, sourceID) {
+		return fmt.Errorf("%w: %s", errConnectorAccessRestricted, strings.TrimSpace(sourceID))
 	}
 	return nil
 }
@@ -1741,6 +1831,111 @@ func connectorCatalogOnlyReason(status string) string {
 	default:
 		return "Catalog metadata is available, but setup is not enabled by this API."
 	}
+}
+
+func connectorRequestAccessAction(configured string, entry *connectorCatalogEntry) string {
+	if action := strings.TrimSpace(configured); action != "" {
+		return action
+	}
+	if entry != nil && entry.AccessStatus == connectorAccessCatalogOnly {
+		return "Request connector"
+	}
+	return "Request access"
+}
+
+func connectorRequestAccessURL(template string, entry *connectorCatalogEntry, tenantID string) string {
+	template = strings.TrimSpace(template)
+	if template == "" || entry == nil {
+		return ""
+	}
+	replacements := map[string]string{
+		"{source_id}":    url.QueryEscape(strings.TrimSpace(entry.SourceID)),
+		"{tenant_id}":    url.QueryEscape(strings.TrimSpace(tenantID)),
+		"{display_name}": url.QueryEscape(strings.TrimSpace(firstNonEmpty(entry.DisplayName, entry.Name, entry.SourceID))),
+	}
+	out := template
+	for token, value := range replacements {
+		out = strings.ReplaceAll(out, token, value)
+	}
+	return out
+}
+
+func connectorReadinessStage(entry connectorCatalogEntry) string {
+	switch {
+	case entry.SetupAllowed:
+		return connectorReadinessStageSetupEnabled
+	case entry.AccessStatus == connectorAccessRestricted:
+		return connectorReadinessStageAPIRestricted
+	case entry.CatalogStatus == connectorcatalog.StatusGenerateable:
+		return connectorReadinessStageSourcegenReady
+	case entry.CatalogStatus == connectorcatalog.StatusNeedsAuthExtension:
+		return connectorReadinessStageAuthExtensionNeeded
+	case entry.CatalogStatus == connectorcatalog.StatusNeedsBespokeRuntime:
+		return connectorReadinessStageRuntimeNeeded
+	case entry.CatalogStatus == connectorcatalog.StatusCatalogReady:
+		return connectorReadinessStageCatalogReady
+	case entry.RuntimeExecutable:
+		return connectorReadinessStageSourcegenReady
+	default:
+		return connectorReadinessStageRuntimeUnknown
+	}
+}
+
+func connectorIntegrationDepth(entry connectorCatalogEntry) connectorIntegrationDepthView {
+	depth := connectorIntegrationDepthView{
+		AuthModel:          strings.TrimSpace(entry.AuthModel),
+		ResourceFamilies:   len(entry.ResourceFamilies),
+		EmittedKinds:       len(entry.EmittedKinds),
+		ScopeOptions:       len(entry.ScopeOptions),
+		RuntimeExecutable:  entry.RuntimeExecutable,
+		SetupEnabled:       entry.SetupAllowed,
+		CoverageDimensions: 0,
+	}
+	for _, family := range entry.ResourceFamilies {
+		depth.CoverageDimensions += len(family.Coverage)
+		if family.HighValue {
+			depth.HighValueFamilies++
+		}
+		if strings.TrimSpace(family.ProjectionTemplate) != "" {
+			depth.ProjectionTemplates++
+		}
+	}
+	score := 0
+	score += minInt(depth.ResourceFamilies, 4) * 10
+	score += minInt(depth.CoverageDimensions, 8) * 3
+	score += minInt(depth.HighValueFamilies, 4) * 5
+	score += minInt(depth.ProjectionTemplates, 4) * 4
+	if depth.AuthModel != "" {
+		score += 8
+	}
+	if depth.RuntimeExecutable {
+		score += 12
+	}
+	if depth.SetupEnabled {
+		score += 20
+	}
+	if score > 100 {
+		score = 100
+	}
+	depth.Score = score
+	switch {
+	case score >= 80:
+		depth.Level = "deep"
+	case score >= 50:
+		depth.Level = "ready"
+	case score >= 25:
+		depth.Level = "cataloged"
+	default:
+		depth.Level = "basic"
+	}
+	return depth
+}
+
+func minInt(left int, right int) int {
+	if left < right {
+		return left
+	}
+	return right
 }
 
 func connectorDefinitionEmittedKinds(definition connectordefinitions.Definition) []string {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/connectorcatalog"
 	"github.com/writer/cerebro/internal/connectorcredentials"
+	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/resourcescope"
@@ -1166,22 +1167,34 @@ func TestConnectorCatalogIncludesBuiltinDefinitionCatalogWhenEnabled(t *testing.
 		HighValue          bool   `json:"high_value"`
 	}
 	type catalogConnector struct {
-		SourceID             string                  `json:"source_id"`
-		CatalogStatus        string                  `json:"catalog_status"`
-		ClassifierOutput     string                  `json:"classifier_output"`
-		AuthModel            string                  `json:"auth_model"`
-		RuntimeExecutable    bool                    `json:"runtime_executable"`
-		VerificationEndpoint string                  `json:"verification_endpoint"`
-		ResourceFamilies     []catalogResourceFamily `json:"resource_families"`
-		AccessStatus         string                  `json:"access_status"`
-		SetupAllowed         bool                    `json:"setup_allowed"`
-		Requestable          bool                    `json:"requestable"`
+		SourceID              string                        `json:"source_id"`
+		CatalogStatus         string                        `json:"catalog_status"`
+		ClassifierOutput      string                        `json:"classifier_output"`
+		AuthModel             string                        `json:"auth_model"`
+		RuntimeExecutable     bool                          `json:"runtime_executable"`
+		VerificationEndpoint  string                        `json:"verification_endpoint"`
+		ResourceFamilies      []catalogResourceFamily       `json:"resource_families"`
+		CatalogSchemaVersion  string                        `json:"catalog_schema_version"`
+		CatalogCurrentVersion int                           `json:"catalog_current_version"`
+		CatalogSourcePath     string                        `json:"catalog_source_path"`
+		DefinitionOrigin      string                        `json:"definition_origin"`
+		ReadinessStage        string                        `json:"readiness_stage"`
+		IntegrationDepth      connectorIntegrationDepthView `json:"integration_depth"`
+		AccessStatus          string                        `json:"access_status"`
+		SetupAllowed          bool                          `json:"setup_allowed"`
+		Requestable           bool                          `json:"requestable"`
 	}
 	var payload struct {
-		Connectors []catalogConnector `json:"connectors"`
+		Connectors          []catalogConnector `json:"connectors"`
+		GeneratedAt         string             `json:"generated_at"`
+		CatalogVersion      string             `json:"catalog_version"`
+		CatalogSourceCommit string             `json:"catalog_source_commit"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode response: %v", err)
+	}
+	if payload.GeneratedAt == "" || payload.CatalogVersion != connectordefinitions.SchemaVersionIntegrationV1 || payload.CatalogSourceCommit == "" {
+		t.Fatalf("catalog response metadata generated=%q version=%q commit=%q, want populated catalog contract", payload.GeneratedAt, payload.CatalogVersion, payload.CatalogSourceCommit)
 	}
 	if len(payload.Connectors) < 101 {
 		t.Fatalf("connectors len = %d, want fixture source plus 100 catalog definitions", len(payload.Connectors))
@@ -1196,6 +1209,12 @@ func TestConnectorCatalogIncludesBuiltinDefinitionCatalogWhenEnabled(t *testing.
 	}
 	if jumpcloud.AccessStatus != connectorAccessCatalogOnly || jumpcloud.SetupAllowed || !jumpcloud.Requestable {
 		t.Fatalf("jumpcloud access = %q setup=%v requestable=%v, want catalog-only requestable", jumpcloud.AccessStatus, jumpcloud.SetupAllowed, jumpcloud.Requestable)
+	}
+	if jumpcloud.DefinitionOrigin != connectorDefinitionOriginCatalog || jumpcloud.CatalogSchemaVersion != connectordefinitions.SchemaVersionIntegrationV1 || jumpcloud.CatalogSourcePath == "" {
+		t.Fatalf("jumpcloud catalog provenance = origin %q schema %q version %d path %q, want builtin catalog provenance", jumpcloud.DefinitionOrigin, jumpcloud.CatalogSchemaVersion, jumpcloud.CatalogCurrentVersion, jumpcloud.CatalogSourcePath)
+	}
+	if jumpcloud.ReadinessStage != connectorReadinessStageSourcegenReady || jumpcloud.IntegrationDepth.Score == 0 || jumpcloud.IntegrationDepth.ResourceFamilies == 0 {
+		t.Fatalf("jumpcloud readiness/depth = %q/%#v, want sourcegen-ready depth signal", jumpcloud.ReadinessStage, jumpcloud.IntegrationDepth)
 	}
 	if jumpcloud.AuthModel != "api_key" || jumpcloud.VerificationEndpoint == "" {
 		t.Fatalf("jumpcloud auth/verification = %q/%q, want catalog metadata", jumpcloud.AuthModel, jumpcloud.VerificationEndpoint)
@@ -1297,9 +1316,11 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
 		},
 		ConnectorAccess: config.ConnectorAccessConfig{
-			HiddenSources:     []string{"auth0"},
-			RestrictedSources: []string{"bootstrap_token", "jumpcloud"},
-			RestrictionReason: "limited preview",
+			HiddenSources:       []string{"auth0", "duo"},
+			RestrictedSources:   []string{"bootstrap_token", "duo", "jumpcloud"},
+			RestrictionReason:   "limited preview",
+			RequestAccessURL:    "https://access.example.com/request?source={source_id}&tenant={tenant_id}",
+			RequestAccessAction: "Request in Access Hub",
 		},
 	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
 	server := httptest.NewServer(app.Handler())
@@ -1319,12 +1340,16 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 	}
 	var payload struct {
 		Connectors []struct {
-			SourceID          string `json:"source_id"`
-			AccessStatus      string `json:"access_status"`
-			AccessReason      string `json:"access_reason"`
-			SetupAllowed      bool   `json:"setup_allowed"`
-			Requestable       bool   `json:"requestable"`
-			ConnectionMethods []struct {
+			SourceID            string `json:"source_id"`
+			AccessStatus        string `json:"access_status"`
+			AccessReason        string `json:"access_reason"`
+			SetupAllowed        bool   `json:"setup_allowed"`
+			Requestable         bool   `json:"requestable"`
+			RequestableReason   string `json:"requestable_reason"`
+			RequestAccessURL    string `json:"request_access_url"`
+			RequestAccessAction string `json:"request_access_action"`
+			ReadinessStage      string `json:"readiness_stage"`
+			ConnectionMethods   []struct {
 				ID string `json:"id"`
 			} `json:"connection_methods"`
 		} `json:"connectors"`
@@ -1333,12 +1358,16 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 	bySourceID := map[string]struct {
-		SourceID          string `json:"source_id"`
-		AccessStatus      string `json:"access_status"`
-		AccessReason      string `json:"access_reason"`
-		SetupAllowed      bool   `json:"setup_allowed"`
-		Requestable       bool   `json:"requestable"`
-		ConnectionMethods []struct {
+		SourceID            string `json:"source_id"`
+		AccessStatus        string `json:"access_status"`
+		AccessReason        string `json:"access_reason"`
+		SetupAllowed        bool   `json:"setup_allowed"`
+		Requestable         bool   `json:"requestable"`
+		RequestableReason   string `json:"requestable_reason"`
+		RequestAccessURL    string `json:"request_access_url"`
+		RequestAccessAction string `json:"request_access_action"`
+		ReadinessStage      string `json:"readiness_stage"`
+		ConnectionMethods   []struct {
 			ID string `json:"id"`
 		} `json:"connection_methods"`
 	}{}
@@ -1348,9 +1377,15 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 	if _, ok := bySourceID["auth0"]; ok {
 		t.Fatal("auth0 was returned despite connector hidden source config")
 	}
+	if _, ok := bySourceID["duo"]; ok {
+		t.Fatal("duo was returned despite hidden source precedence over restricted source config")
+	}
 	bootstrapToken := bySourceID["bootstrap_token"]
 	if bootstrapToken.AccessStatus != connectorAccessRestricted || bootstrapToken.AccessReason != "limited preview" || bootstrapToken.SetupAllowed || !bootstrapToken.Requestable || len(bootstrapToken.ConnectionMethods) != 0 {
 		t.Fatalf("bootstrap_token access = %#v, want restricted without setup methods", bootstrapToken)
+	}
+	if bootstrapToken.RequestableReason != "limited preview" || bootstrapToken.RequestAccessAction != "Request in Access Hub" || bootstrapToken.RequestAccessURL != "https://access.example.com/request?source=bootstrap_token&tenant=" || bootstrapToken.ReadinessStage != connectorReadinessStageAPIRestricted {
+		t.Fatalf("bootstrap_token request metadata = %#v, want requestable restricted connector", bootstrapToken)
 	}
 	jumpcloud := bySourceID["jumpcloud"]
 	if jumpcloud.AccessStatus != connectorAccessRestricted || jumpcloud.AccessReason != "limited preview" || jumpcloud.SetupAllowed || !jumpcloud.Requestable {
@@ -1368,6 +1403,18 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 	}()
 	if preflightResp.StatusCode != http.StatusForbidden {
 		t.Fatalf("restricted preflight status = %d, want 403", preflightResp.StatusCode)
+	}
+	hiddenResp, err := server.Client().Post(server.URL+"/connectors/duo/preflight", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("POST /connectors/duo/preflight error = %v", err)
+	}
+	defer func() {
+		if closeErr := hiddenResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close hidden response: %v", closeErr)
+		}
+	}()
+	if hiddenResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("hidden+restricted preflight status = %d, want hidden precedence 404", hiddenResp.StatusCode)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,9 +133,11 @@ type ConnectorSecretStoreConfig struct {
 
 // ConnectorAccessConfig controls connector catalog visibility and setup gates.
 type ConnectorAccessConfig struct {
-	HiddenSources     []string
-	RestrictedSources []string
-	RestrictionReason string
+	HiddenSources       []string
+	RestrictedSources   []string
+	RestrictionReason   string
+	RequestAccessURL    string
+	RequestAccessAction string
 }
 
 // AWSSecretsManagerStoreConfig controls AWS Secrets Manager reference resolution.
@@ -416,9 +418,11 @@ func Load() (Config, error) {
 			},
 		},
 		ConnectorAccess: ConnectorAccessConfig{
-			HiddenSources:     parseCSV(os.Getenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES")),
-			RestrictedSources: parseCSV(os.Getenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES")),
-			RestrictionReason: strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_RESTRICTION_REASON")),
+			HiddenSources:       parseCSV(os.Getenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES")),
+			RestrictedSources:   parseCSV(os.Getenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES")),
+			RestrictionReason:   strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_RESTRICTION_REASON")),
+			RequestAccessURL:    strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_URL")),
+			RequestAccessAction: strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_ACTION")),
 		},
 		OTEL: OpenTelemetryConfig{
 			ServiceName:     strings.TrimSpace(os.Getenv("CEREBRO_OTEL_SERVICE_NAME")),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -66,6 +66,8 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES", "")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES", "")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTION_REASON", "")
+	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_URL", "")
+	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_ACTION", "")
 	clearMCPOAuthEnv(t)
 	clearDeviceAuthEnv(t)
 
@@ -187,6 +189,8 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES", "internal_source")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES", "aws,auth0")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTION_REASON", "limited preview")
+	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_URL", "https://access.example.com/request?source={source_id}&tenant={tenant_id}")
+	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_ACTION", "Request in Access Hub")
 	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES", "aws_secrets_manager,infisical")
 	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES_FILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION", "us-east-1")
@@ -299,6 +303,12 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.ConnectorAccess.RestrictionReason != "limited preview" {
 		t.Fatalf("ConnectorAccess.RestrictionReason = %q, want limited preview", cfg.ConnectorAccess.RestrictionReason)
+	}
+	if cfg.ConnectorAccess.RequestAccessURL != "https://access.example.com/request?source={source_id}&tenant={tenant_id}" {
+		t.Fatalf("ConnectorAccess.RequestAccessURL = %q, want configured request URL template", cfg.ConnectorAccess.RequestAccessURL)
+	}
+	if cfg.ConnectorAccess.RequestAccessAction != "Request in Access Hub" {
+		t.Fatalf("ConnectorAccess.RequestAccessAction = %q, want configured request action", cfg.ConnectorAccess.RequestAccessAction)
 	}
 	if cfg.ConnectorSecretStores.AWSSecretsManager.Region != "us-east-1" ||
 		cfg.ConnectorSecretStores.AWSSecretsManager.Profile != "cerebro-security" ||
@@ -469,6 +479,8 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES", "")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES", "")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTION_REASON", "")
+	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_URL", "")
+	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_ACTION", "")
 	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION", "")
 	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_PROFILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ROLE_ARN", "")


### PR DESCRIPTION
## Summary
- add catalog provenance, readiness stage, integration depth, and request-access metadata to connector responses
- support deployment-configured connector request access templates
- make hidden connector access precedence consistent across setup endpoints

## Tests
- go test ./internal/config ./internal/bootstrap ./internal/connectorcatalog
- go test ./...
