### PR TITLE
chore(source): harden freshness probe policy

### DIFF
--- a/docs/SOURCE_RUNTIME_GUIDE.md
+++ b/docs/SOURCE_RUNTIME_GUIDE.md
@@ -148,9 +148,20 @@ canary_observed_at
 canary_updated_at
 canary_hash
 canary_confidence=authoritative|heuristic
+canary_skip_count
+canary_full_read_at
+canary_reconcile_reason=initial|changed|short_circuit|max_skip_count|max_skip_age
 ```
 
 Treat authoritative canaries, such as documented delta tokens, differently from heuristic canaries, such as newest audit-log event probes. Heuristic probes are dirty signals: they are useful for skipping likely unchanged scans, but they still need periodic full reconciliation if the provider does not document complete coverage.
+
+Use `sourcecdk.FamilyFreshnessReadOptions` to make that policy explicit:
+
+- set `MaxSkipCount` and `MaxSkipAge` for heuristic canaries so they cannot skip forever,
+- set `ProbeErrorMode=fail_open` only when a failed metadata call can safely fall through to the normal read path,
+- store opaque canary resource IDs and hashes only; do not persist provider document IDs, actor names, raw filter phrases, tenant names, or other customer-shaped metadata in `CursorEnvelope.Extra`.
+
+Runtime telemetry records bounded freshness labels such as source, family, confidence, skip count, and forced-reconciliation reason. It must not emit canary hashes or provider resource IDs.
 
 ## Bootstrap runtimes from JSON
 

--- a/internal/sourcecdk/family.go
+++ b/internal/sourcecdk/family.go
@@ -17,6 +17,7 @@ type Family[S any] struct {
 	Check                func(context.Context, S) error
 	Discover             func(context.Context, S) ([]URN, error)
 	Probe                func(context.Context, S, *cerebrov1.SourceCheckpoint) (ChangeProbe, error)
+	ProbeOptions         FamilyFreshnessReadOptions
 	Read                 func(context.Context, S, *cerebrov1.SourceCursor) (Pull, error)
 	ReadWithCheckpoint   func(context.Context, S, *cerebrov1.SourceCursor, *cerebrov1.SourceCheckpoint) (Pull, error)
 }
@@ -130,7 +131,13 @@ func (e *FamilyEngine[S]) ReadWithCheckpoint(ctx context.Context, cfg Config, cu
 	if family.Probe != nil {
 		probe, err := family.Probe(ctx, settings, checkpoint)
 		if err != nil {
-			return Pull{}, err
+			if normalizeFamilyFreshnessProbeErrorMode(family.ProbeOptions.ProbeErrorMode) == FamilyFreshnessProbeErrorFailOpen {
+				probe = ChangeProbe{}
+			} else {
+				return Pull{}, err
+			}
+		} else {
+			probe = applyFamilyFreshnessReadOptions(e.sourceID, family.Name, checkpoint, probe, family.ProbeOptions)
 		}
 		if probe.Unchanged {
 			reason := probe.ShortCircuitReason

--- a/internal/sourcecdk/freshness.go
+++ b/internal/sourcecdk/freshness.go
@@ -3,6 +3,7 @@ package sourcecdk
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,6 +23,9 @@ const (
 	FamilyFreshnessExtraUpdatedAt  = "canary_updated_at"
 	FamilyFreshnessExtraHash       = "canary_hash"
 	FamilyFreshnessExtraConfidence = "canary_confidence"
+	FamilyFreshnessExtraSkipCount  = "canary_skip_count"
+	FamilyFreshnessExtraFullReadAt = "canary_full_read_at"
+	FamilyFreshnessExtraReason     = "canary_reconcile_reason"
 )
 
 // FamilyFreshnessConfidence describes whether an unchanged freshness canary is
@@ -31,6 +35,23 @@ type FamilyFreshnessConfidence string
 const (
 	FamilyFreshnessConfidenceAuthoritative FamilyFreshnessConfidence = "authoritative"
 	FamilyFreshnessConfidenceHeuristic     FamilyFreshnessConfidence = "heuristic"
+)
+
+// FamilyFreshnessProbeErrorMode controls what BeginFamilyFreshnessReadWithOptions
+// does when the cheap metadata probe fails.
+type FamilyFreshnessProbeErrorMode string
+
+const (
+	FamilyFreshnessProbeErrorFailClosed FamilyFreshnessProbeErrorMode = "fail_closed"
+	FamilyFreshnessProbeErrorFailOpen   FamilyFreshnessProbeErrorMode = "fail_open"
+)
+
+const (
+	FamilyFreshnessReasonInitial      = "initial"
+	FamilyFreshnessReasonChanged      = "changed"
+	FamilyFreshnessReasonShortCircuit = "short_circuit"
+	FamilyFreshnessReasonMaxSkipCount = "max_skip_count"
+	FamilyFreshnessReasonMaxSkipAge   = "max_skip_age"
 )
 
 // FamilyFreshnessProbe is the normalized provider canary stored in
@@ -43,6 +64,29 @@ type FamilyFreshnessProbe struct {
 	UpdatedAt  time.Time
 	Hash       string
 	Confidence FamilyFreshnessConfidence
+	SkipCount  int
+	FullReadAt time.Time
+	Reason     string
+}
+
+// FamilyFreshnessReadOptions makes probe policy explicit for connectors that
+// use freshness metadata before a normal family read.
+type FamilyFreshnessReadOptions struct {
+	Confidence     FamilyFreshnessConfidence
+	MaxSkipCount   int
+	MaxSkipAge     time.Duration
+	ProbeErrorMode FamilyFreshnessProbeErrorMode
+	Now            func() time.Time
+}
+
+// FamilyFreshnessCheckpointInfo describes freshness metadata restored from a
+// checkpoint without exposing provider-specific hash or resource fields.
+type FamilyFreshnessCheckpointInfo struct {
+	Source     string
+	Family     string
+	Confidence FamilyFreshnessConfidence
+	SkipCount  int
+	Reason     string
 }
 
 // FamilyFreshnessHash returns a stable digest for the provider fields that
@@ -75,15 +119,45 @@ func FamilyFreshnessProbeFromCheckpoint(source string, family string, checkpoint
 	if !ok || !familyFreshnessEnvelopeMatches(envelope, source, family) {
 		return FamilyFreshnessProbe{}, false
 	}
+	return familyFreshnessProbeFromEnvelope(envelope)
+}
+
+// FamilyFreshnessInfoFromCheckpoint restores bounded freshness metadata for
+// runtime health and telemetry without exposing provider canary identities.
+func FamilyFreshnessInfoFromCheckpoint(checkpoint *cerebrov1.SourceCheckpoint) (FamilyFreshnessCheckpointInfo, bool) {
+	if checkpoint == nil {
+		return FamilyFreshnessCheckpointInfo{}, false
+	}
+	envelope, ok := DecodeCursorEnvelope(checkpoint.GetCursorOpaque())
+	if !ok {
+		return FamilyFreshnessCheckpointInfo{}, false
+	}
+	probe, ok := familyFreshnessProbeFromEnvelope(envelope)
+	if !ok {
+		return FamilyFreshnessCheckpointInfo{}, false
+	}
+	return FamilyFreshnessCheckpointInfo{
+		Source:     strings.TrimSpace(envelope.Source),
+		Family:     strings.TrimSpace(envelope.Family),
+		Confidence: probe.Confidence,
+		SkipCount:  probe.SkipCount,
+		Reason:     probe.Reason,
+	}, true
+}
+
+func familyFreshnessProbeFromEnvelope(envelope CursorEnvelope) (FamilyFreshnessProbe, bool) {
 	extra := envelope.Extra
 	probe := FamilyFreshnessProbe{
 		Kind:       strings.TrimSpace(extra[FamilyFreshnessExtraKind]),
 		ResourceID: strings.TrimSpace(extra[FamilyFreshnessExtraResourceID]),
 		Hash:       strings.TrimSpace(extra[FamilyFreshnessExtraHash]),
 		Confidence: normalizeFamilyFreshnessConfidence(extra[FamilyFreshnessExtraConfidence]),
+		SkipCount:  parseFamilyFreshnessInt(extra[FamilyFreshnessExtraSkipCount]),
+		Reason:     normalizeFamilyFreshnessReason(extra[FamilyFreshnessExtraReason]),
 	}
 	probe.ObservedAt = parseFamilyFreshnessTime(extra[FamilyFreshnessExtraObservedAt])
 	probe.UpdatedAt = parseFamilyFreshnessTime(extra[FamilyFreshnessExtraUpdatedAt])
+	probe.FullReadAt = parseFamilyFreshnessTime(extra[FamilyFreshnessExtraFullReadAt])
 	probe, valid := normalizeFamilyFreshnessProbe(probe)
 	if !valid || probe.Hash == "" {
 		return FamilyFreshnessProbe{}, false
@@ -114,14 +188,25 @@ func FamilyFreshnessChangeProbe(source string, family string, checkpoint *cerebr
 // BeginFamilyFreshnessRead restores probe metadata from continuation cursors
 // and runs a start-of-family freshness probe when no provider cursor is active.
 func BeginFamilyFreshnessRead(source string, family string, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint, probe func(*cerebrov1.SourceCheckpoint) (ChangeProbe, error)) (*cerebrov1.SourceCheckpoint, *Pull, error) {
+	return BeginFamilyFreshnessReadWithOptions(source, family, cursor, checkpoint, probe, FamilyFreshnessReadOptions{})
+}
+
+// BeginFamilyFreshnessReadWithOptions restores probe metadata from continuation
+// cursors, applies explicit stale-heuristic policy, and runs a start-of-family
+// freshness probe when no provider cursor is active.
+func BeginFamilyFreshnessReadWithOptions(source string, family string, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint, probe func(*cerebrov1.SourceCheckpoint) (ChangeProbe, error), options FamilyFreshnessReadOptions) (*cerebrov1.SourceCheckpoint, *Pull, error) {
 	readCheckpoint := FamilyFreshnessCheckpointFromCursor(source, family, cursor, checkpoint)
 	if strings.TrimSpace(CursorToken(cursor)) != "" || probe == nil {
 		return readCheckpoint, nil, nil
 	}
 	change, err := probe(checkpoint)
 	if err != nil {
+		if normalizeFamilyFreshnessProbeErrorMode(options.ProbeErrorMode) == FamilyFreshnessProbeErrorFailOpen {
+			return readCheckpoint, nil, nil
+		}
 		return nil, nil, err
 	}
+	change = applyFamilyFreshnessReadOptions(source, family, checkpoint, change, options)
 	if change.Unchanged {
 		reason := change.ShortCircuitReason
 		if reason == "" {
@@ -164,13 +249,34 @@ func FamilyFreshnessCheckpoint(source string, family string, checkpoint *cerebro
 	envelope.Extra[FamilyFreshnessExtraResourceID] = normalized.ResourceID
 	if !normalized.ObservedAt.IsZero() {
 		envelope.Extra[FamilyFreshnessExtraObservedAt] = normalized.ObservedAt.UTC().Format(time.RFC3339Nano)
+	} else {
+		delete(envelope.Extra, FamilyFreshnessExtraObservedAt)
 	}
 	if !normalized.UpdatedAt.IsZero() {
 		envelope.Extra[FamilyFreshnessExtraUpdatedAt] = normalized.UpdatedAt.UTC().Format(time.RFC3339Nano)
+	} else {
+		delete(envelope.Extra, FamilyFreshnessExtraUpdatedAt)
 	}
 	envelope.Extra[FamilyFreshnessExtraHash] = normalized.Hash
 	if normalized.Confidence != "" {
 		envelope.Extra[FamilyFreshnessExtraConfidence] = string(normalized.Confidence)
+	} else {
+		delete(envelope.Extra, FamilyFreshnessExtraConfidence)
+	}
+	if normalized.SkipCount > 0 {
+		envelope.Extra[FamilyFreshnessExtraSkipCount] = strconv.Itoa(normalized.SkipCount)
+	} else {
+		delete(envelope.Extra, FamilyFreshnessExtraSkipCount)
+	}
+	if !normalized.FullReadAt.IsZero() {
+		envelope.Extra[FamilyFreshnessExtraFullReadAt] = normalized.FullReadAt.UTC().Format(time.RFC3339Nano)
+	} else {
+		delete(envelope.Extra, FamilyFreshnessExtraFullReadAt)
+	}
+	if normalized.Reason != "" {
+		envelope.Extra[FamilyFreshnessExtraReason] = normalized.Reason
+	} else {
+		delete(envelope.Extra, FamilyFreshnessExtraReason)
 	}
 	encoded, err := EncodeCursorEnvelope(envelope)
 	if err != nil {
@@ -220,7 +326,12 @@ func normalizeFamilyFreshnessProbe(probe FamilyFreshnessProbe) (FamilyFreshnessP
 	probe.Hash = strings.TrimSpace(probe.Hash)
 	probe.ObservedAt = probe.ObservedAt.UTC()
 	probe.UpdatedAt = probe.UpdatedAt.UTC()
+	probe.FullReadAt = probe.FullReadAt.UTC()
 	probe.Confidence = normalizeFamilyFreshnessConfidence(string(probe.Confidence))
+	if probe.SkipCount < 0 {
+		probe.SkipCount = 0
+	}
+	probe.Reason = normalizeFamilyFreshnessReason(probe.Reason)
 	if probe.Hash == "" {
 		probe.Hash = FamilyFreshnessHash(
 			probe.Kind,
@@ -232,12 +343,108 @@ func normalizeFamilyFreshnessProbe(probe FamilyFreshnessProbe) (FamilyFreshnessP
 	return probe, probe.Kind != "" && probe.Hash != ""
 }
 
+func applyFamilyFreshnessReadOptions(source string, family string, checkpoint *cerebrov1.SourceCheckpoint, change ChangeProbe, options FamilyFreshnessReadOptions) ChangeProbe {
+	nextProbe, hasNext := FamilyFreshnessProbeFromCheckpoint(source, family, change.Checkpoint)
+	if !hasNext {
+		return change
+	}
+	previousProbe, hasPrevious := FamilyFreshnessProbeFromCheckpoint(source, family, checkpoint)
+	now := familyFreshnessNow(options)
+	if nextProbe.ObservedAt.IsZero() {
+		nextProbe.ObservedAt = now
+	}
+	if options.Confidence != "" {
+		nextProbe.Confidence = options.Confidence
+	}
+	if !change.Unchanged {
+		nextProbe.SkipCount = 0
+		nextProbe.FullReadAt = nextProbe.ObservedAt
+		if hasPrevious {
+			nextProbe.Reason = FamilyFreshnessReasonChanged
+		} else {
+			nextProbe.Reason = FamilyFreshnessReasonInitial
+		}
+		change.Checkpoint = FamilyFreshnessCheckpoint(source, family, change.Checkpoint, nextProbe)
+		return change
+	}
+	nextProbe.FullReadAt = previousProbe.FullReadAt
+	forceReason := familyFreshnessForceReason(previousProbe, hasPrevious, options, now)
+	if forceReason != "" {
+		nextProbe.SkipCount = 0
+		nextProbe.FullReadAt = nextProbe.ObservedAt
+		nextProbe.Reason = forceReason
+		change.Unchanged = false
+		change.ShortCircuitReason = ""
+		change.Checkpoint = FamilyFreshnessCheckpoint(source, family, change.Checkpoint, nextProbe)
+		return change
+	}
+	if hasPrevious {
+		nextProbe.SkipCount = previousProbe.SkipCount + 1
+	}
+	nextProbe.Reason = FamilyFreshnessReasonShortCircuit
+	change.Checkpoint = FamilyFreshnessCheckpoint(source, family, change.Checkpoint, nextProbe)
+	return change
+}
+
+func familyFreshnessForceReason(previous FamilyFreshnessProbe, hasPrevious bool, options FamilyFreshnessReadOptions, now time.Time) string {
+	if !hasPrevious {
+		return ""
+	}
+	if options.MaxSkipCount > 0 && previous.SkipCount >= options.MaxSkipCount {
+		return FamilyFreshnessReasonMaxSkipCount
+	}
+	if options.MaxSkipAge > 0 {
+		if previous.FullReadAt.IsZero() {
+			return FamilyFreshnessReasonMaxSkipAge
+		}
+		if !now.IsZero() && !previous.FullReadAt.After(now) && now.Sub(previous.FullReadAt) >= options.MaxSkipAge {
+			return FamilyFreshnessReasonMaxSkipAge
+		}
+	}
+	return ""
+}
+
+func familyFreshnessNow(options FamilyFreshnessReadOptions) time.Time {
+	if options.Now != nil {
+		if now := options.Now().UTC(); !now.IsZero() {
+			return now
+		}
+	}
+	return time.Now().UTC()
+}
+
 func normalizeFamilyFreshnessConfidence(confidence string) FamilyFreshnessConfidence {
 	switch FamilyFreshnessConfidence(strings.ToLower(strings.TrimSpace(confidence))) {
 	case FamilyFreshnessConfidenceAuthoritative:
 		return FamilyFreshnessConfidenceAuthoritative
 	case FamilyFreshnessConfidenceHeuristic:
 		return FamilyFreshnessConfidenceHeuristic
+	default:
+		return ""
+	}
+}
+
+func normalizeFamilyFreshnessProbeErrorMode(mode FamilyFreshnessProbeErrorMode) FamilyFreshnessProbeErrorMode {
+	switch FamilyFreshnessProbeErrorMode(strings.ToLower(strings.TrimSpace(string(mode)))) {
+	case FamilyFreshnessProbeErrorFailOpen:
+		return FamilyFreshnessProbeErrorFailOpen
+	default:
+		return FamilyFreshnessProbeErrorFailClosed
+	}
+}
+
+func normalizeFamilyFreshnessReason(reason string) string {
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case FamilyFreshnessReasonInitial:
+		return FamilyFreshnessReasonInitial
+	case FamilyFreshnessReasonChanged:
+		return FamilyFreshnessReasonChanged
+	case FamilyFreshnessReasonShortCircuit:
+		return FamilyFreshnessReasonShortCircuit
+	case FamilyFreshnessReasonMaxSkipCount:
+		return FamilyFreshnessReasonMaxSkipCount
+	case FamilyFreshnessReasonMaxSkipAge:
+		return FamilyFreshnessReasonMaxSkipAge
 	default:
 		return ""
 	}
@@ -253,6 +460,14 @@ func parseFamilyFreshnessTime(value string) time.Time {
 		return time.Time{}
 	}
 	return parsed.UTC()
+}
+
+func parseFamilyFreshnessInt(value string) int {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || parsed < 0 {
+		return 0
+	}
+	return parsed
 }
 
 func familyFreshnessEnvelopeMatches(envelope CursorEnvelope, source string, family string) bool {

--- a/internal/sourcecdk/freshness_test.go
+++ b/internal/sourcecdk/freshness_test.go
@@ -1,6 +1,7 @@
 package sourcecdk
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -150,5 +151,157 @@ func TestBeginFamilyFreshnessReadCarriesProbeFromContinuationCursor(t *testing.T
 	}
 	if _, ok := FamilyFreshnessProbeFromCheckpoint("github", "audit", readCheckpoint); !ok {
 		t.Fatalf("read checkpoint %q missing freshness probe", readCheckpoint.GetCursorOpaque())
+	}
+}
+
+func TestBeginFamilyFreshnessReadIncrementsHeuristicSkipCount(t *testing.T) {
+	now := time.Date(2026, 6, 16, 15, 30, 0, 0, time.UTC)
+	fullReadAt := now.Add(-time.Hour)
+	hash := FamilyFreshnessHash("audit_log_latest_event", "latest_event", now.Format(time.RFC3339Nano))
+	checkpoint := FamilyFreshnessCheckpoint("github", "audit", nil, FamilyFreshnessProbe{
+		Kind:       "audit_log_latest_event",
+		ResourceID: "latest_event",
+		UpdatedAt:  now,
+		Hash:       hash,
+		Confidence: FamilyFreshnessConfidenceHeuristic,
+		SkipCount:  1,
+		FullReadAt: fullReadAt,
+	})
+
+	readCheckpoint, shortCircuit, err := BeginFamilyFreshnessReadWithOptions("github", "audit", nil, checkpoint, func(*cerebrov1.SourceCheckpoint) (ChangeProbe, error) {
+		return FamilyFreshnessChangeProbe("github", "audit", checkpoint, FamilyFreshnessProbe{
+			Kind:       "audit_log_latest_event",
+			ResourceID: "latest_event",
+			ObservedAt: now.Add(time.Minute),
+			UpdatedAt:  now,
+			Hash:       hash,
+			Confidence: FamilyFreshnessConfidenceHeuristic,
+		}), nil
+	}, FamilyFreshnessReadOptions{
+		MaxSkipCount: 3,
+		MaxSkipAge:   24 * time.Hour,
+		Now:          func() time.Time { return now.Add(time.Minute) },
+	})
+	if err != nil {
+		t.Fatalf("BeginFamilyFreshnessReadWithOptions() error = %v", err)
+	}
+	if shortCircuit == nil {
+		t.Fatal("shortCircuit = nil, want unchanged probe short circuit")
+	}
+	probe, ok := FamilyFreshnessProbeFromCheckpoint("github", "audit", readCheckpoint)
+	if !ok {
+		t.Fatal("read checkpoint missing freshness probe")
+	}
+	if probe.SkipCount != 2 {
+		t.Fatalf("skip count = %d, want 2", probe.SkipCount)
+	}
+	if !probe.FullReadAt.Equal(fullReadAt) {
+		t.Fatalf("full read at = %s, want %s", probe.FullReadAt, fullReadAt)
+	}
+	if probe.Reason != FamilyFreshnessReasonShortCircuit {
+		t.Fatalf("reason = %q, want short_circuit", probe.Reason)
+	}
+}
+
+func TestBeginFamilyFreshnessReadForcesFullReadAfterMaxSkipCount(t *testing.T) {
+	now := time.Date(2026, 6, 16, 15, 30, 0, 0, time.UTC)
+	hash := FamilyFreshnessHash("audit_log_latest_event", "latest_event", now.Format(time.RFC3339Nano))
+	checkpoint := FamilyFreshnessCheckpoint("github", "audit", nil, FamilyFreshnessProbe{
+		Kind:       "audit_log_latest_event",
+		ResourceID: "latest_event",
+		UpdatedAt:  now,
+		Hash:       hash,
+		Confidence: FamilyFreshnessConfidenceHeuristic,
+		SkipCount:  3,
+		FullReadAt: now.Add(-time.Hour),
+	})
+
+	readCheckpoint, shortCircuit, err := BeginFamilyFreshnessReadWithOptions("github", "audit", nil, checkpoint, func(*cerebrov1.SourceCheckpoint) (ChangeProbe, error) {
+		return FamilyFreshnessChangeProbe("github", "audit", checkpoint, FamilyFreshnessProbe{
+			Kind:       "audit_log_latest_event",
+			ResourceID: "latest_event",
+			ObservedAt: now,
+			UpdatedAt:  now,
+			Hash:       hash,
+			Confidence: FamilyFreshnessConfidenceHeuristic,
+		}), nil
+	}, FamilyFreshnessReadOptions{
+		MaxSkipCount: 3,
+		Now:          func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("BeginFamilyFreshnessReadWithOptions() error = %v", err)
+	}
+	if shortCircuit != nil {
+		t.Fatalf("shortCircuit = %#v, want forced full read", shortCircuit)
+	}
+	probe, ok := FamilyFreshnessProbeFromCheckpoint("github", "audit", readCheckpoint)
+	if !ok {
+		t.Fatal("read checkpoint missing freshness probe")
+	}
+	if probe.SkipCount != 0 {
+		t.Fatalf("skip count = %d, want reset after forced read", probe.SkipCount)
+	}
+	if !probe.FullReadAt.Equal(now) {
+		t.Fatalf("full read at = %s, want %s", probe.FullReadAt, now)
+	}
+	if probe.Reason != FamilyFreshnessReasonMaxSkipCount {
+		t.Fatalf("reason = %q, want max_skip_count", probe.Reason)
+	}
+}
+
+func TestBeginFamilyFreshnessReadForcesFullReadAfterMaxSkipAge(t *testing.T) {
+	now := time.Date(2026, 6, 16, 15, 30, 0, 0, time.UTC)
+	hash := FamilyFreshnessHash("audit_log_latest_event", "latest_event", now.Format(time.RFC3339Nano))
+	checkpoint := FamilyFreshnessCheckpoint("github", "audit", nil, FamilyFreshnessProbe{
+		Kind:       "audit_log_latest_event",
+		ResourceID: "latest_event",
+		UpdatedAt:  now,
+		Hash:       hash,
+		Confidence: FamilyFreshnessConfidenceHeuristic,
+		FullReadAt: now.Add(-25 * time.Hour),
+	})
+
+	readCheckpoint, shortCircuit, err := BeginFamilyFreshnessReadWithOptions("github", "audit", nil, checkpoint, func(*cerebrov1.SourceCheckpoint) (ChangeProbe, error) {
+		return FamilyFreshnessChangeProbe("github", "audit", checkpoint, FamilyFreshnessProbe{
+			Kind:       "audit_log_latest_event",
+			ResourceID: "latest_event",
+			ObservedAt: now,
+			UpdatedAt:  now,
+			Hash:       hash,
+			Confidence: FamilyFreshnessConfidenceHeuristic,
+		}), nil
+	}, FamilyFreshnessReadOptions{
+		MaxSkipAge: 24 * time.Hour,
+		Now:        func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("BeginFamilyFreshnessReadWithOptions() error = %v", err)
+	}
+	if shortCircuit != nil {
+		t.Fatalf("shortCircuit = %#v, want forced full read", shortCircuit)
+	}
+	probe, ok := FamilyFreshnessProbeFromCheckpoint("github", "audit", readCheckpoint)
+	if !ok {
+		t.Fatal("read checkpoint missing freshness probe")
+	}
+	if probe.Reason != FamilyFreshnessReasonMaxSkipAge {
+		t.Fatalf("reason = %q, want max_skip_age", probe.Reason)
+	}
+}
+
+func TestBeginFamilyFreshnessReadCanFailOpenOnProbeError(t *testing.T) {
+	checkpoint := &cerebrov1.SourceCheckpoint{CursorOpaque: "checkpoint"}
+	readCheckpoint, shortCircuit, err := BeginFamilyFreshnessReadWithOptions("github", "audit", nil, checkpoint, func(*cerebrov1.SourceCheckpoint) (ChangeProbe, error) {
+		return ChangeProbe{}, errors.New("provider metadata probe failed")
+	}, FamilyFreshnessReadOptions{ProbeErrorMode: FamilyFreshnessProbeErrorFailOpen})
+	if err != nil {
+		t.Fatalf("BeginFamilyFreshnessReadWithOptions() error = %v", err)
+	}
+	if shortCircuit != nil {
+		t.Fatalf("shortCircuit = %#v, want normal read fallback", shortCircuit)
+	}
+	if readCheckpoint != checkpoint {
+		t.Fatalf("readCheckpoint = %p, want original checkpoint %p", readCheckpoint, checkpoint)
 	}
 }

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -308,7 +308,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		}
 		eventsRead := boundedUint32(len(pull.Events))
 		recordsScanned += eventsRead
-		telemetry.Event(ctx, "source_runtime.page_read", telemetry.Attrs(
+		pageReadAttrs := withFamilyFreshnessTelemetry(telemetry.Attrs(
 			telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
 			telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()},
 			telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()},
@@ -316,7 +316,8 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "events_read", Value: eventsRead},
 			telemetry.Field{Key: "has_next_cursor", Value: pull.NextCursor != nil},
 			telemetry.Field{Key: "short_circuit_reason", Value: pageShortCircuitReason},
-		))
+		), pull.Checkpoint)
+		telemetry.Event(ctx, "source_runtime.page_read", pageReadAttrs)
 		if pull.Checkpoint != nil {
 			advanceRuntimeCheckpoint(runtime, pull.Checkpoint)
 		}
@@ -374,7 +375,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
 			return nil, err
 		}
-		telemetry.Event(ctx, "source_runtime.page_committed", telemetry.Attrs(
+		pageCommittedAttrs := withFamilyFreshnessTelemetry(telemetry.Attrs(
 			telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
 			telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()},
 			telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()},
@@ -387,7 +388,8 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "links_projected", Value: linksProjected},
 			telemetry.Field{Key: "has_next_cursor", Value: pull.NextCursor != nil},
 			telemetry.Field{Key: "short_circuit_reason", Value: pageShortCircuitReason},
-		))
+		), runtime.GetCheckpoint())
+		telemetry.Event(ctx, "source_runtime.page_committed", pageCommittedAttrs)
 		if pull.NextCursor == nil {
 			break
 		}
@@ -403,6 +405,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "links_projected", Value: linksProjected})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "has_next_cursor", Value: runtime.GetNextCursor() != nil})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "short_circuit_reason", Value: shortCircuitReason})
+	spanAttributes = withFamilyFreshnessTelemetry(spanAttributes, runtime.GetCheckpoint())
 	if watermark, lagSeconds, ok := runtimeWatermarkLag(runtime, time.Now().UTC()); ok {
 		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "checkpoint_watermark", Value: watermark.Format(time.RFC3339Nano)})
 		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "source_runtime_watermark_lag_seconds", Value: lagSeconds})
@@ -658,6 +661,37 @@ func runtimeWatermarkLag(runtime *cerebrov1.SourceRuntime, now time.Time) (time.
 		lag = 0
 	}
 	return watermark, int64(lag.Seconds()), true
+}
+
+func withFamilyFreshnessTelemetry(attributes telemetry.Attributes, checkpoint *cerebrov1.SourceCheckpoint) telemetry.Attributes {
+	info, ok := sourcecdk.FamilyFreshnessInfoFromCheckpoint(checkpoint)
+	if !ok {
+		return attributes
+	}
+	if strings.TrimSpace(info.Source) != "" {
+		attributes = attributes.WithField(telemetry.Field{Key: "family_freshness_source", Value: info.Source})
+	}
+	if strings.TrimSpace(info.Family) != "" {
+		attributes = attributes.WithField(telemetry.Field{Key: "family_freshness_family", Value: info.Family})
+	}
+	if info.Confidence != "" {
+		attributes = attributes.WithField(telemetry.Field{Key: "family_freshness_confidence", Value: string(info.Confidence)})
+	}
+	attributes = attributes.WithField(telemetry.Field{Key: "family_freshness_skip_count", Value: info.SkipCount})
+	if info.Reason != "" {
+		attributes = attributes.WithField(telemetry.Field{Key: "family_freshness_reconcile_reason", Value: info.Reason})
+		attributes = attributes.WithField(telemetry.Field{Key: "family_freshness_forced_reconcile", Value: familyFreshnessForcedReconcile(info.Reason)})
+	}
+	return attributes
+}
+
+func familyFreshnessForcedReconcile(reason string) bool {
+	switch strings.TrimSpace(reason) {
+	case sourcecdk.FamilyFreshnessReasonMaxSkipAge, sourcecdk.FamilyFreshnessReasonMaxSkipCount:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Service) resolveConfig(ctx context.Context, sourceID string, tenantID string, runtimeID string, config map[string]string) (map[string]string, error) {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1264,6 +1264,58 @@ func TestSyncRuntimeTelemetryClassifiesErrorsWithoutRawSecret(t *testing.T) {
 	}
 }
 
+func TestSyncRuntimeTelemetryIncludesBoundedFreshnessMetadata(t *testing.T) {
+	checkpoint := sourcecdk.FamilyFreshnessCheckpoint("github", "audit", nil, sourcecdk.FamilyFreshnessProbe{
+		Kind:       "audit_log_latest_event",
+		ResourceID: "github-audit-sensitive-document-id",
+		Hash:       "sensitive-canary-hash",
+		Confidence: sourcecdk.FamilyFreshnessConfidenceHeuristic,
+		SkipCount:  2,
+		Reason:     sourcecdk.FamilyFreshnessReasonShortCircuit,
+	})
+	source := &checkpointAwareRuntimeSource{pull: sourcecdk.Pull{
+		Checkpoint:         checkpoint,
+		ShortCircuitReason: sourcecdk.PullShortCircuitReasonNotModified,
+	}}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-checkpoint-aware": {
+			Id:       "writer-checkpoint-aware",
+			SourceId: "checkpoint_aware",
+			TenantId: "writer",
+		},
+	}}
+	service := New(registry, store, &appendLog{}, nil)
+
+	stderr := captureSourceRuntimeStderr(t, func() {
+		if _, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-checkpoint-aware"}); err != nil {
+			t.Fatalf("Sync() error = %v", err)
+		}
+	})
+
+	payload := sourceRuntimeTelemetryPayload(t, stderr, "source_runtime.sync")
+	for key, want := range map[string]any{
+		"family_freshness_source":           "github",
+		"family_freshness_family":           "audit",
+		"family_freshness_confidence":       "heuristic",
+		"family_freshness_reconcile_reason": "short_circuit",
+		"family_freshness_forced_reconcile": false,
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if got := payload["family_freshness_skip_count"]; got != float64(2) {
+		t.Fatalf("telemetry family_freshness_skip_count = %#v, want 2; payload=%#v", got, payload)
+	}
+	if strings.Contains(stderr, "github-audit-sensitive-document-id") || strings.Contains(stderr, "sensitive-canary-hash") {
+		t.Fatalf("freshness telemetry leaked raw canary metadata: %s", stderr)
+	}
+}
+
 func TestSyncRuntimePersistsFailureCategories(t *testing.T) {
 	for _, tt := range []struct {
 		name string

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -66,7 +66,7 @@ func (s *Source) discoverAudit(ctx context.Context, client *gogithub.Client, set
 }
 
 func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
-	readCheckpoint, shortCircuit, err := sourcecdk.BeginFamilyFreshnessRead("github", familyAudit, cursor, checkpoint, func(checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.ChangeProbe, error) {
+	readCheckpoint, shortCircuit, err := sourcecdk.BeginFamilyFreshnessReadWithOptions("github", familyAudit, cursor, checkpoint, func(checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.ChangeProbe, error) {
 		probe, err := githubaudit.LatestEventChangeProbe(ctx, settings.owner, settings.auditInclude, settings.auditPhrase, checkpoint, func(ctx context.Context, opts *gogithub.GetAuditLogOptions) ([]*gogithub.AuditEntry, *gogithub.Response, error) {
 			return client.Organizations.GetAuditLog(ctx, settings.owner, opts)
 		})
@@ -74,7 +74,7 @@ func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, setting
 			return sourcecdk.ChangeProbe{}, wrapLookupError(fmt.Sprintf("github audit log canary for org %s", settings.owner), err)
 		}
 		return probe, nil
-	})
+	}, githubaudit.FreshnessReadOptions())
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -23,6 +23,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcehttp"
+	"github.com/writer/cerebro/sources/internal/githubaudit"
 )
 
 func TestNewLoadsCatalog(t *testing.T) {
@@ -656,7 +657,7 @@ func TestGitHubAuditFreshnessProbeShortCircuitsUnchangedAuditLog(t *testing.T) {
 	if !ok {
 		t.Fatalf("first checkpoint %q missing freshness probe", first.Checkpoint.GetCursorOpaque())
 	}
-	if probe.Kind != "audit_log_latest_event" || probe.ResourceID != "github-audit-audit-doc-1" {
+	if probe.Kind != "audit_log_latest_event" || probe.ResourceID != "latest_event" {
 		t.Fatalf("probe = %#v, want audit log latest event canary", probe)
 	}
 
@@ -673,6 +674,197 @@ func TestGitHubAuditFreshnessProbeShortCircuitsUnchangedAuditLog(t *testing.T) {
 	}
 	if len(auditQueries) != 1 || auditQueries[0].Get("order") != "desc" {
 		t.Fatalf("audit requests after unchanged checkpoint = %#v, want one desc canary", auditQueries)
+	}
+}
+
+func TestGitHubAuditFreshnessProbeForcesReconcileAfterMaxSkips(t *testing.T) {
+	auditQueries := []url.Values{}
+	auditEntry := map[string]any{
+		"@timestamp":   1776916397852,
+		"_document_id": "audit-doc-1",
+		"action":       "org.update_member",
+		"created_at":   1776916397852,
+		"org":          "writer",
+		"org_id":       1,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v3/orgs/writer/audit-log" {
+			http.NotFound(w, r)
+			return
+		}
+		auditQueries = append(auditQueries, r.URL.Query())
+		if err := json.NewEncoder(w).Encode([]map[string]any{auditEntry}); err != nil {
+			t.Fatalf("encode audit response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familyAudit,
+		"owner":    "writer",
+		"token":    "test-token",
+	})
+
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
+	}
+	probe, ok := sourcecdk.FamilyFreshnessProbeFromCheckpoint("github", familyAudit, first.Checkpoint)
+	if !ok {
+		t.Fatalf("first checkpoint %q missing freshness probe", first.Checkpoint.GetCursorOpaque())
+	}
+	probe.SkipCount = githubaudit.FreshnessMaxSkipCount
+	probe.FullReadAt = time.Now().UTC()
+	checkpoint := sourcecdk.FamilyFreshnessCheckpoint("github", familyAudit, first.Checkpoint, probe)
+
+	auditQueries = nil
+	forced, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(forced) error = %v", err)
+	}
+	if len(forced.Events) != 1 {
+		t.Fatalf("len(forced.Events) = %d, want full audit scan after max skips", len(forced.Events))
+	}
+	if forced.ShortCircuitReason != "" {
+		t.Fatalf("forced.ShortCircuitReason = %q, want empty after full scan", forced.ShortCircuitReason)
+	}
+	if len(auditQueries) != 2 || auditQueries[0].Get("order") != "desc" || auditQueries[1].Get("order") != "asc" {
+		t.Fatalf("audit requests after max skips = %#v, want desc canary then asc scan", auditQueries)
+	}
+	nextProbe, ok := sourcecdk.FamilyFreshnessProbeFromCheckpoint("github", familyAudit, forced.Checkpoint)
+	if !ok {
+		t.Fatalf("forced checkpoint %q missing freshness probe", forced.Checkpoint.GetCursorOpaque())
+	}
+	if nextProbe.SkipCount != 0 {
+		t.Fatalf("forced skip count = %d, want reset", nextProbe.SkipCount)
+	}
+	if nextProbe.Reason != sourcecdk.FamilyFreshnessReasonMaxSkipCount {
+		t.Fatalf("forced reason = %q, want max_skip_count", nextProbe.Reason)
+	}
+}
+
+func TestGitHubAuditFreshnessProbeFailsOpenToFullRead(t *testing.T) {
+	auditQueries := []url.Values{}
+	auditEntry := map[string]any{
+		"@timestamp":   1776916397852,
+		"_document_id": "audit-doc-1",
+		"action":       "org.update_member",
+		"created_at":   1776916397852,
+		"org":          "writer",
+		"org_id":       1,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v3/orgs/writer/audit-log" {
+			http.NotFound(w, r)
+			return
+		}
+		query := r.URL.Query()
+		auditQueries = append(auditQueries, query)
+		if query.Get("order") == "desc" {
+			http.Error(w, "metadata probe failed", http.StatusInternalServerError)
+			return
+		}
+		if err := json.NewEncoder(w).Encode([]map[string]any{auditEntry}); err != nil {
+			t.Fatalf("encode audit response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familyAudit,
+		"owner":    "writer",
+		"token":    "test-token",
+	})
+
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(pull.Events) = %d, want full audit scan after canary error", len(pull.Events))
+	}
+	if len(auditQueries) != 2 || auditQueries[0].Get("order") != "desc" || auditQueries[1].Get("order") != "asc" {
+		t.Fatalf("audit requests after canary error = %#v, want desc canary then asc scan", auditQueries)
+	}
+}
+
+func TestGitHubAuditFreshnessCheckpointDoesNotExposeProviderMetadata(t *testing.T) {
+	auditEntry := map[string]any{
+		"@timestamp":   1776916397852,
+		"_document_id": "audit-doc-sensitive-tenant-123",
+		"action":       "org.update_member",
+		"actor":        "octocat-sensitive",
+		"created_at":   1776916397852,
+		"org":          "writer",
+		"org_id":       1,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v3/orgs/writer/audit-log" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("phrase"); got != "actor:octocat-sensitive repo:writer/private" {
+			t.Fatalf("audit phrase = %q, want configured phrase", got)
+		}
+		if err := json.NewEncoder(w).Encode([]map[string]any{auditEntry}); err != nil {
+			t.Fatalf("encode audit response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familyAudit,
+		"owner":    "writer",
+		"phrase":   "actor:octocat-sensitive repo:writer/private",
+		"token":    "test-token",
+	})
+
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	envelope, ok := sourcecdk.DecodeCursorEnvelope(pull.Checkpoint.GetCursorOpaque())
+	if !ok {
+		t.Fatalf("checkpoint cursor %q is not an envelope", pull.Checkpoint.GetCursorOpaque())
+	}
+	for _, forbidden := range []string{
+		"audit-doc-sensitive-tenant-123",
+		"octocat-sensitive",
+		"actor:octocat-sensitive",
+		"repo:writer/private",
+	} {
+		if strings.Contains(pull.Checkpoint.GetCursorOpaque(), forbidden) {
+			t.Fatalf("checkpoint cursor leaked %q: %s", forbidden, pull.Checkpoint.GetCursorOpaque())
+		}
+		for key, value := range envelope.Extra {
+			if strings.Contains(value, forbidden) {
+				t.Fatalf("checkpoint extra %s leaked %q in %q", key, forbidden, value)
+			}
+		}
+	}
+	if got := envelope.Extra[sourcecdk.FamilyFreshnessExtraResourceID]; got != "latest_event" {
+		t.Fatalf("canary resource id = %q, want opaque latest_event", got)
 	}
 }
 

--- a/sources/internal/githubaudit/freshness.go
+++ b/sources/internal/githubaudit/freshness.go
@@ -12,7 +12,13 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
-const latestEventKind = "audit_log_latest_event"
+const (
+	latestEventKind       = "audit_log_latest_event"
+	latestEventResourceID = "latest_event"
+
+	FreshnessMaxSkipCount = 24
+	FreshnessMaxSkipAge   = 24 * time.Hour
+)
 
 // ListFunc fetches GitHub audit entries with caller-supplied options.
 type ListFunc func(context.Context, *gogithub.GetAuditLogOptions) ([]*gogithub.AuditEntry, *gogithub.Response, error)
@@ -33,6 +39,17 @@ func Options(include string, phrase string, order string, after string, perPage 
 	return opts
 }
 
+// FreshnessReadOptions returns the bounded policy for GitHub audit's heuristic
+// latest-event canary.
+func FreshnessReadOptions() sourcecdk.FamilyFreshnessReadOptions {
+	return sourcecdk.FamilyFreshnessReadOptions{
+		Confidence:     sourcecdk.FamilyFreshnessConfidenceHeuristic,
+		MaxSkipCount:   FreshnessMaxSkipCount,
+		MaxSkipAge:     FreshnessMaxSkipAge,
+		ProbeErrorMode: sourcecdk.FamilyFreshnessProbeErrorFailOpen,
+	}
+}
+
 // LatestEventChangeProbe fetches the newest audit-log event and returns a
 // heuristic family freshness ChangeProbe.
 func LatestEventChangeProbe(ctx context.Context, owner string, include string, phrase string, checkpoint *cerebrov1.SourceCheckpoint, list ListFunc) (sourcecdk.ChangeProbe, error) {
@@ -44,20 +61,16 @@ func LatestEventChangeProbe(ctx context.Context, owner string, include string, p
 }
 
 func latestEventProbe(owner string, include string, phrase string, entries []*gogithub.AuditEntry, observedAt time.Time) sourcecdk.FamilyFreshnessProbe {
-	resourceID := "org:" + strings.TrimSpace(owner)
 	updatedAt := time.Time{}
-	hashParts := []string{latestEventKind, resourceID, "empty", include, phrase}
+	hashParts := []string{latestEventKind, latestEventResourceID, strings.TrimSpace(owner), "empty", include, phrase}
 	if len(entries) > 0 && entries[0] != nil {
 		entry := entries[0]
 		updatedAt = occurredAt(entry)
-		if eventID := eventID(entry, updatedAt); eventID != "" {
-			resourceID = eventID
-		}
-		hashParts = []string{latestEventKind, resourceID, updatedAt.Format(time.RFC3339Nano), entry.GetAction(), entry.GetActor(), include, phrase}
+		hashParts = []string{latestEventKind, latestEventResourceID, strings.TrimSpace(owner), eventID(entry, updatedAt), updatedAt.Format(time.RFC3339Nano), entry.GetAction(), entry.GetActor(), include, phrase}
 	}
 	return sourcecdk.FamilyFreshnessProbe{
 		Kind:       latestEventKind,
-		ResourceID: resourceID,
+		ResourceID: latestEventResourceID,
 		ObservedAt: observedAt,
 		UpdatedAt:  updatedAt,
 		Hash:       sourcecdk.FamilyFreshnessHash(hashParts...),


### PR DESCRIPTION
Summary:
- Add explicit freshness probe policy options for bounded heuristic skips, max skip age, and fail-open metadata probe errors.
- Make GitHub audit freshness canary metadata opaque and add regression coverage that checkpoint extras do not expose provider metadata.
- Emit bounded runtime telemetry for freshness source/family/confidence/skip state and document the new policy fields.
- Preserve refreshed probe checkpoints through FamilyEngine forced-reconcile reads.

Tests:
- go test ./...
- ./scripts/leak_check.sh range origin/main..HEAD
- ./scripts/leak_check.sh pr-body