### PR TITLE
Retire GitHub self-hosted runner review finding

### DIFF
--- a/internal/findings/coordination_graph_rule_test.go
+++ b/internal/findings/coordination_graph_rule_test.go
@@ -79,7 +79,6 @@ func TestReviewCoordinationGraphRulesHaveDirectCoverage(t *testing.T) {
 	}{
 		{name: "github org owner", rule: newGitHubOrgOwnerConcentrationRule(), sourceID: "github", family: "org_inventory", querySnippet: `"role":"admin"`},
 		{name: "github programmatic credential", rule: newGitHubProgrammaticCredentialReviewRule(), sourceID: "github", family: "audit", querySnippet: `"resource_type":"personal_access_token"`},
-		{name: "github self-hosted runner", rule: newGitHubSelfHostedRunnerReviewRule(), sourceID: "github", family: "audit", querySnippet: `"runner_ephemeral":"true"`},
 		{name: "okta oauth public client", rule: newOktaOAuthPublicClientReviewRule(), sourceID: "okta", family: "application", querySnippet: `"oauth_public_client":"true"`},
 		{name: "okta weak authenticator", rule: newOktaAuthenticatorWeakFactorRule(), sourceID: "okta", family: "authenticator", querySnippet: `"key":"sms"`},
 		{name: "okta threat insight", rule: newOktaThreatInsightNotBlockingRule(), sourceID: "okta", family: "threat_insight", querySnippet: `"action":"block"`},

--- a/internal/findings/current_state_graph_rules_test.go
+++ b/internal/findings/current_state_graph_rules_test.go
@@ -9,6 +9,37 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
+func TestGitHubSelfHostedRunnerReviewRuleRetired(t *testing.T) {
+	rule := newGitHubSelfHostedRunnerReviewRule()
+	metadataRule, ok := rule.(MetadataRule)
+	if !ok {
+		t.Fatal("rule does not expose RuleMetadata")
+	}
+	definition := metadataRule.RuleMetadata()
+	if definition.Lifecycle.Kind != LifecycleRetired || definition.Lifecycle.Anchor != AnchorNone {
+		t.Fatalf("Lifecycle = %+v, want retired/none", definition.Lifecycle)
+	}
+	if definition.Maturity != RuleMaturityRetired {
+		t.Fatalf("Maturity = %q, want %q", definition.Maturity, RuleMaturityRetired)
+	}
+	if _, ok := rule.(GraphRule); ok {
+		t.Fatal("retired self-hosted runner review rule still implements GraphRule")
+	}
+	retirementRule, ok := rule.(openFindingRetirementRule)
+	if !ok || !retirementRule.RetiresOpenFindings() {
+		t.Fatal("retired self-hosted runner review rule does not retire open findings")
+	}
+
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime", SourceId: "github", TenantId: "writer", Config: map[string]string{"family": "audit"}}
+	records, err := rule.Evaluate(context.Background(), runtime, nil)
+	if err != nil {
+		t.Fatalf("Evaluate(retired runner review rule) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("Evaluate(retired runner review rule) returned %d findings, want 0", len(records))
+	}
+}
+
 func TestCurrentStateGraphRulesEmitStableFindings(t *testing.T) {
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime", SourceId: "github", TenantId: "writer", Config: map[string]string{"family": "audit"}}
 	for _, tc := range []struct {
@@ -69,21 +100,6 @@ func TestCurrentStateGraphRulesEmitStableFindings(t *testing.T) {
 				"summary":         "GitHub programmatic access resource deploy_key needs owner/scope review",
 				"action":          "review",
 				"resource_urns":   []any{"urn:cerebro:writer:github_credential:deploy_key@repo"},
-			}},
-		},
-		{
-			name:    "github self hosted runner",
-			rule:    newGitHubSelfHostedRunnerReviewRule(),
-			runtime: runtime,
-			row: ports.CypherRow{Values: map[string]any{
-				"primary_urn":     "urn:cerebro:writer:github_runner:repo:writer/cerebro:777",
-				"primary_label":   "prod-runner-1",
-				"primary_type":    "github.runner",
-				"fingerprint_key": "urn:cerebro:writer:github_runner:repo:writer/cerebro:777",
-				"severity":        "MEDIUM",
-				"summary":         "GitHub self-hosted runner prod-runner-1 needs security review",
-				"action":          "review",
-				"resource_urns":   []any{"urn:cerebro:writer:github_runner:repo:writer/cerebro:777"},
 			}},
 		},
 		{
@@ -192,11 +208,6 @@ func TestCurrentStateGraphRuleQueriesUseEnrichedCurrentState(t *testing.T) {
 			name: "github credentials exclude inactive resources",
 			rule: newGitHubProgrammaticCredentialReviewRule(),
 			want: []string{`entity_type: 'github.credential'`, `"status":"inactive"`},
-		},
-		{
-			name: "github self-hosted runner uses projected runner state",
-			rule: newGitHubSelfHostedRunnerReviewRule(),
-			want: []string{`entity_type: 'github.runner'`, `"runner_status":"inactive"`, `"runner_ephemeral":"true"`},
 		},
 		{
 			name: "okta threat insight checks for blocking mode",

--- a/internal/findings/github_self_hosted_runner_review_rule.go
+++ b/internal/findings/github_self_hosted_runner_review_rule.go
@@ -1,11 +1,33 @@
 package findings
 
-import "github.com/writer/cerebro/internal/ports"
+import (
+	"context"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
 
 const githubSelfHostedRunnerReviewRuleID = "github-self-hosted-runner-review-needed"
 
 func newGitHubSelfHostedRunnerReviewRule() Rule {
-	return newCoordinationGraphRule(RuleDefinition{
+	definition := githubSelfHostedRunnerReviewDefinition()
+	definition.Description = "Retired GitHub runner review rule retained so noisy open findings can be cleaned up without recreating them."
+	definition.Maturity = RuleMaturityRetired
+	definition.Lifecycle = Lifecycle{Kind: LifecycleRetired, Anchor: AnchorNone}
+	definition.Tags = appendUniqueString(cloneStringSlice(definition.Tags), "retired", "cleanup")
+	return newEventRule(eventRuleConfig{
+		definition:         definition,
+		sourceID:           definition.SourceID,
+		retireOpenFindings: true,
+		match:              func(*cerebrov1.EventEnvelope) bool { return false },
+		build: func(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+			return nil, nil
+		},
+	})
+}
+
+func githubSelfHostedRunnerReviewDefinition() RuleDefinition {
+	return RuleDefinition{
 		ID:                githubSelfHostedRunnerReviewRuleID,
 		Name:              "GitHub Self-Hosted Runner Needs Review",
 		Description:       "Detect active non-ephemeral or untrusted GitHub self-hosted runners from projected runner state.",
@@ -22,26 +44,5 @@ func newGitHubSelfHostedRunnerReviewRule() Rule {
 		FingerprintFields: []string{"runner_urn"},
 		ControlRefs:       []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.6"}, {FrameworkName: "ISO 27001:2022", ControlID: "A.8.9"}},
 		Lifecycle:         Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorGraphAnchored},
-	}, map[string][]string{"github": {"audit"}}, `MATCH (runner:Entity {tenant_id: $tenant_id, entity_type: 'github.runner'})
-WHERE NOT coalesce(runner.attributes_json, '') CONTAINS '"runner_status":"inactive"'
-  AND (
-    NOT coalesce(runner.attributes_json, '') CONTAINS '"runner_ephemeral":"true"'
-    OR coalesce(runner.attributes_json, '') CONTAINS '"runner_untrusted":"true"'
-    OR coalesce(runner.attributes_json, '') CONTAINS '"host_trusted":"false"'
-  )
-OPTIONAL MATCH (runner)-[scopeRel:RELATION {relation: 'belongs_to'}]->(scope:Entity {tenant_id: $tenant_id})
-RETURN runner.urn AS primary_urn,
-       runner.label AS primary_label,
-       runner.entity_type AS primary_type,
-       runner.urn AS fingerprint_key,
-       CASE
-         WHEN coalesce(runner.attributes_json, '') CONTAINS '"runner_untrusted":"true"' OR coalesce(runner.attributes_json, '') CONTAINS '"host_trusted":"false"' THEN 'HIGH'
-         ELSE 'MEDIUM'
-       END AS severity,
-       'GitHub self-hosted runner ' + coalesce(runner.label, runner.urn) + ' needs security review' AS summary,
-       'Validate runner ownership, trust, isolation, and ephemeral posture; remove unauthorized persistent runners' AS action,
-       CASE WHEN scope.urn IS NULL THEN [runner.urn] ELSE [runner.urn, scope.urn] END AS resource_urns,
-       CASE WHEN scope.urn IS NULL THEN [] ELSE [{urn: scope.urn, label: scope.label, entity_type: scope.entity_type, relation: 'belongs_to', attributes_json: coalesce(scopeRel.attributes_json, '')}] END AS evidence
-ORDER BY severity DESC, runner.label, runner.urn
-LIMIT $row_limit`, nil)
+	}
 }

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -1197,21 +1197,23 @@
       "pack_id": "github",
       "pack_name": "GitHub",
       "name": "GitHub Self-Hosted Runner Needs Review",
-      "description": "Detect active non-ephemeral or untrusted GitHub self-hosted runners from projected runner state.",
+      "description": "Retired GitHub runner review rule retained so noisy open findings can be cleaned up without recreating them.",
       "source_id": "github",
-      "evaluation_mode": "graph",
+      "evaluation_mode": "event",
       "event_kinds": [
         "github.audit"
       ],
       "output_kind": "finding.github_self_hosted_runner_review_needed",
       "severity": "MEDIUM",
       "status": "open",
-      "maturity": "test",
+      "maturity": "retired",
       "tags": [
         "actions",
         "attack.t1195",
+        "cleanup",
         "github",
         "graph-rule",
+        "retired",
         "self-hosted-runner",
         "supply-chain"
       ],

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -85,7 +85,7 @@ func TestNoConvertRuleUsesEventIdOrMatchedAtFingerprint(t *testing.T) {
 func TestCloseoutSelectorCoversAllRetiredAndConvertRules(t *testing.T) {
 	targets := append(rulepackAuditRulesByClass(t, rulepackAuditClassConvert), rulepackAuditRulesByClass(t, rulepackAuditClassRetire)...)
 	sort.Slice(targets, func(i, j int) bool { return targets[i].RuleID < targets[j].RuleID })
-	if got, want := len(targets), 26; got != want {
+	if got, want := len(targets), 27; got != want {
 		t.Fatalf("CONVERT+RETIRE closeout target count = %d, want %d", got, want)
 	}
 	for i, entry := range targets {
@@ -920,7 +920,7 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 40; got != want {
+	if got, want := len(keepRules), 39; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1099,7 +1099,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "github-repository-collaborator-added", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "github-repository-ruleset-modified", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "github-secret-scanning-alert-created", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
-		{RuleID: "github-self-hosted-runner-review-needed", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},
+		{RuleID: "github-self-hosted-runner-review-needed", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
 		{RuleID: "github-org-owner-role-review-needed", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},
 		{RuleID: "github-programmatic-credential-review-needed", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},
 		{RuleID: "github-webhook-modified", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},

--- a/ops/closeout/rule-ids-24h.txt
+++ b/ops/closeout/rule-ids-24h.txt
@@ -1,3 +1,4 @@
+github-self-hosted-runner-review-needed
 identity-api-token-or-oauth-app-created
 identity-privileged-account-without-mfa
 identity-privileged-no-mfa-plus-sensitive-access


### PR DESCRIPTION
## Summary
- retire the GitHub self-hosted runner review rule so it no longer emits new findings
- mark the rule as a closeout target and refresh the detection catalog
- update regression coverage for the retired rule behavior

## Tests
- go test ./internal/findings -run 'Test(GitHubSelfHostedRunner|BuiltinRuleMetadata|Rulepack|ReviewCoordination|CurrentState|EvaluateSourceRuntimeGraphRules|CloseoutRuleIDFiles|TombstoneFindingsBulk_CloseoutCandidatesRemainUnbounded)' -count=1\n- make detection-catalog-check\n- go test ./cmd/cerebro -run 'Closeout' -count=1