### PR TITLE
Add Cerebro agent platform contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The compose stack starts Cerebro with NATS JetStream, Postgres, Neo4j, and a loc
 | Consume release artifacts | `docs/RELEASE_CONTRACT.md` | Covers image tags, runtime deploy contracts, source manifests, and artifact verification. |
 | Troubleshoot operations | `docs/TROUBLESHOOTING.md` | Symptom-to-cause recipes for health, auth, source sync, graph, and MCP OAuth. |
 | Integrate MCP clients | `docs/MCP_DROID_SETUP.md` and `/api/v1/mcp` | Covers stateless Streamable HTTP, OAuth discovery, and compatibility checks. |
+| Shape agent-facing platform contracts | `docs/AGENT_PLATFORM_CONTRACT.md` and `internal/agentplatform` | Cerebro-native runtime, eval, capability, execution, replay, connector, and knowledge principles. |
 | Integrate endpoint telemetry | `docs/ENDPOINT_SECURITY_PLATFORM_INTEGRATION.md` | Covers device-authenticated telemetry, trusted endpoint claims, and trust-gate evidence. |
 | Author policies or finding rules | `policies/`, `internal/findings`, and catalog checks | Run the relevant catalog and finding-rule tests before opening a PR. |
 | Contribute code or docs | `docs/DEVELOPMENT.md`, `docs/NON_GOALS.md`, and the Makefile | Prefer focused `make` targets while iterating; use `make verify` for broad PR preflight. |

--- a/docs/AGENT_PLATFORM_CONTRACT.md
+++ b/docs/AGENT_PLATFORM_CONTRACT.md
@@ -1,0 +1,112 @@
+# Cerebro Agent Platform Contract
+
+This document defines Cerebro's security-agent platform contract: how agent-facing capabilities should grow without
+losing auditability, replayability, tenant safety, or public-repo clarity.
+
+The machine-readable vocabulary lives in `internal/agentplatform`.
+
+## North Star
+
+Cerebro agents should explain and operate on security knowledge through typed contracts, governed capabilities,
+bounded execution, and eval-backed change discipline. The graph, findings, evidence, runtime events, connectors, and
+Ask trajectories remain the source of truth. LLM output is an interface over that substrate, not the substrate itself.
+
+## Contract Domains
+
+| Domain | Cerebro equivalent | Principle |
+| --- | --- | --- |
+| Contract-first runtime | `internal/graphagent`, `internal/ports`, ask trajectories, workflow events | Agent execution is typed, replayable, and isolated from product-specific orchestration. |
+| Evals as product infrastructure | Ask eval scripts, security-agent evals, trace-linked fixtures, local regression reports | Every agent capability has a measurable regression surface before it becomes a default workflow. |
+| Capabilities as governed artifacts | Policy catalogs, source catalogs, finding rules, graph-agent tools, future security skills | Reusable behavior is packaged, versioned, reviewed, and selected for a reason. |
+| Execution behind ports | Runtime response, source runtime sync, workflow event projection, side-effect adapters | Stateful or risky work happens through explicit adapters with limits, cancellation, and audit. |
+| Streaming and replay discipline | SSE Ask events, trajectory persistence, append-log replay, workflow projection | Live execution, durable records, and replay/debug views use one ordered event vocabulary. |
+| Connector identity and OAuth boundaries | Connector catalog, credential stores, MCP OAuth, tenant-scoped API auth | Integrations are authenticated channels with clear public/private surfaces and token ownership. |
+| Knowledge with provenance and budgets | Graph query, knowledge service, citations, evidence pointers, source scopes | Retrieved context is bounded, cited, instruction-safe, and non-blocking when unavailable. |
+
+## Runtime Contract
+
+Agent-facing runtime code should keep these boundaries:
+
+- Raw request input is parsed before entering agent logic.
+- Consumer-visible events have stable names and documented payloads.
+- Durable trajectory or workflow records are append-only.
+- Provider, graph, store, telemetry, and connector dependencies sit behind interfaces.
+- A logical run has one trace id, ordered events, and one terminal outcome.
+- Product-specific UI decisions do not leak into runtime packages.
+
+This matches the current Cerebro direction: `graphagent.Event` defines the live Ask stream, `ports.AskTrajectoryStore`
+records replayable events, and graph/query behavior stays behind ports.
+
+## Eval Contract
+
+New or changed agent capabilities should ship with at least one of:
+
+- A local golden or adversarial eval fixture.
+- A rubric that can fail for unsafe, unsupported, uncited, or ungrounded answers.
+- A trace-linked diagnostic path for reviewing failures.
+- A model/provider comparison when model behavior is the risk.
+
+Default-on behavior should not rely only on manual review. If the capability can affect findings, evidence, controls,
+or remediation recommendations, its eval should check grounding and unsupported-action refusal.
+
+## Capability Contract
+
+Cerebro capabilities should be artifacts, not hidden prompt fragments:
+
+- Policies, finding rules, source definitions, graph tools, and future security skills have ids and versions.
+- Selection is explainable: why this capability was considered, used, or skipped.
+- Ownership and review state are visible where the capability can influence agent output.
+- Capability output is evidence or guidance until a governed workflow promotes it.
+
+## Execution Contract
+
+Agents should never get an unmediated side-effect surface. Execution belongs behind adapters that report:
+
+- Scope and tenant.
+- Limits and timeouts.
+- Cancellation state.
+- Output truncation.
+- Result provenance.
+- Whether the result is advisory, evidence, or an accepted state change.
+
+This keeps Cerebro aligned with its current runtime-response and workflow-event posture: side effects are explicit
+events or API operations, not implicit LLM behavior.
+
+## Streaming And Replay Contract
+
+Live user experience and debugging should converge on the same ordered facts:
+
+- SSE streams are for live UX.
+- Durable trajectories or append-log records are the replay source.
+- Payload redaction and truncation are explicit.
+- Runtime debugger views should show what was requested, what was retrieved, what was executed, and what was persisted.
+- Replays should be able to reproduce planner/query/summary behavior without private deployment context.
+
+## Connector And OAuth Contract
+
+Connector work should preserve hard boundaries:
+
+- Public ingress, private service calls, and MCP surfaces are distinct.
+- Tokens have an owner surface and declared scopes.
+- Tenant and principal are checked before service logic.
+- Credential storage and credential use remain separate concerns.
+- Browser-visible status can describe readiness without exposing sensitive identifiers.
+- Connectors and OAuth are first-class infrastructure, not per-feature glue. New connector-backed agent capabilities
+  should use the shared catalog, credential store, OAuth, MCP, and tenant-scope contracts unless a reviewed exception
+  creates a safer or narrower boundary.
+
+## Knowledge And Memory Contract
+
+Retrieved context must be useful without becoming a prompt-injection or data-leak channel:
+
+- Bound context by item count and byte budget.
+- Preserve source URNs, scopes, and citation status.
+- Treat retrieved text as data, not instructions.
+- Fail open for Ask availability when context systems are unavailable, but expose the fallback reason.
+- Ingest or cache best-effort data only when provenance and tenant scope are clear.
+
+## What Not To Do
+
+Cerebro should not hide durable behavior in prompts, bypass connector identity boundaries, create one-off OAuth flows,
+or give agents unmediated execution surfaces. The platform discipline is the product: typed boundaries, evals,
+capability governance, execution ports, ordered streams, connector identity, and provenance-bounded knowledge.

--- a/internal/agentplatform/contracts.go
+++ b/internal/agentplatform/contracts.go
@@ -1,0 +1,127 @@
+// Package agentplatform names the Cerebro-native agent platform contract.
+//
+// The package is intentionally small and dependency-free. It gives docs,
+// tests, API handlers, and UI clients one stable vocabulary for the pieces
+// Cerebro expects every agent-facing capability to preserve.
+package agentplatform
+
+const ContractVersion = "2026-06-16.cerebro-agent-platform"
+
+type Domain struct {
+	ID         string
+	Name       string
+	Principle  string
+	Owns       []string
+	MustExpose []string
+}
+
+type Invariant struct {
+	ID        string
+	DomainID  string
+	Statement string
+}
+
+var Domains = []Domain{
+	{
+		ID:        "runtime",
+		Name:      "Contract-first runtime",
+		Principle: "Agent execution is typed, replayable, and isolated from product-specific orchestration.",
+		Owns: []string{
+			"closed event schemas",
+			"append-only conversation or trajectory records",
+			"ports for LLM, graph query, persistence, and telemetry",
+		},
+		MustExpose: []string{"trace id", "event order", "terminal outcome", "model route"},
+	},
+	{
+		ID:        "evals",
+		Name:      "Evals as product infrastructure",
+		Principle: "Every agent capability has a measurable regression surface before it becomes a default workflow.",
+		Owns: []string{
+			"golden and adversarial scenarios",
+			"rubric outcomes",
+			"trace-linked diagnostics",
+			"model comparison metadata",
+		},
+		MustExpose: []string{"scenario id", "score", "rubric failures", "trace link"},
+	},
+	{
+		ID:        "capabilities",
+		Name:      "Capabilities as governed artifacts",
+		Principle: "Reusable agent behavior is packaged, versioned, and reviewed instead of hidden in prompts.",
+		Owns: []string{
+			"capability metadata",
+			"selection rules",
+			"review and sharing state",
+			"safe invocation contracts",
+		},
+		MustExpose: []string{"capability id", "version", "owner", "selection reason"},
+	},
+	{
+		ID:        "execution",
+		Name:      "Execution behind ports",
+		Principle: "Stateful or risky work happens through explicit adapters with limits, cancellation, and audit.",
+		Owns: []string{
+			"workspace access",
+			"shell or runtime response dispatch",
+			"side-effect fencing",
+			"result capture and truncation markers",
+		},
+		MustExpose: []string{"adapter kind", "scope", "limits", "cancel state", "truncation state"},
+	},
+	{
+		ID:        "streaming-replay",
+		Name:      "Streaming and replay discipline",
+		Principle: "Live execution, durable records, and replay/debug views use one ordered event vocabulary.",
+		Owns: []string{
+			"monotonic event sequencing",
+			"trajectory persistence",
+			"runtime debugger inputs",
+			"replay fixtures",
+		},
+		MustExpose: []string{"sequence", "stage", "redaction status", "replay source"},
+	},
+	{
+		ID:        "connectors",
+		Name:      "Connector identity and OAuth boundaries",
+		Principle: "Integrations are authenticated channels with clear public/private surfaces and token ownership.",
+		Owns: []string{
+			"connector catalog contracts",
+			"OAuth/token lifecycle",
+			"MCP access",
+			"credential store boundaries",
+		},
+		MustExpose: []string{"principal", "tenant", "scopes", "token owner", "surface"},
+	},
+	{
+		ID:        "knowledge",
+		Name:      "Knowledge with provenance and budgets",
+		Principle: "Retrieved context is bounded, cited, instruction-safe, and non-blocking when unavailable.",
+		Owns: []string{
+			"graph and knowledge retrieval",
+			"citation validation",
+			"context budgets",
+			"best-effort ingestion",
+		},
+		MustExpose: []string{"source urn", "scope", "budget", "citation status", "fallback reason"},
+	},
+}
+
+var Invariants = []Invariant{
+	{ID: "CAP-01", DomainID: "capabilities", Statement: "A capability used by an agent run must be identifiable by id and version."},
+	{ID: "CONN-01", DomainID: "connectors", Statement: "A connector token must not be consumed outside its declared owner surface."},
+	{ID: "EVAL-01", DomainID: "evals", Statement: "A default-on agent capability must have at least one local regression path."},
+	{ID: "EXEC-01", DomainID: "execution", Statement: "Adapters report cancellation and truncation explicitly instead of hiding partial results."},
+	{ID: "KNOW-01", DomainID: "knowledge", Statement: "Retrieved context must carry source scope and citation status when shown to a user or model."},
+	{ID: "RUN-01", DomainID: "runtime", Statement: "Consumer-visible events use stable names and a single terminal outcome per logical run."},
+	{ID: "STREAM-01", DomainID: "streaming-replay", Statement: "Replay records preserve event order even when payloads are redacted or truncated."},
+}
+
+func DomainByID(id string) (Domain, bool) {
+	for _, domain := range Domains {
+		if domain.ID == id {
+			return domain, true
+		}
+	}
+	return Domain{}, false
+}

--- a/internal/agentplatform/contracts_test.go
+++ b/internal/agentplatform/contracts_test.go
@@ -1,0 +1,36 @@
+package agentplatform
+
+import "testing"
+
+func TestContractDomainsHaveRequiredFields(t *testing.T) {
+	if ContractVersion == "" {
+		t.Fatal("contract version must be set")
+	}
+	for _, domain := range Domains {
+		if domain.ID == "" || domain.Name == "" || domain.Principle == "" {
+			t.Fatalf("domain has empty required field: %+v", domain)
+		}
+		if len(domain.Owns) == 0 {
+			t.Fatalf("domain %q must name owned surfaces", domain.ID)
+		}
+		if len(domain.MustExpose) == 0 {
+			t.Fatalf("domain %q must name exposed diagnostics", domain.ID)
+		}
+	}
+}
+
+func TestInvariantsReferenceKnownDomains(t *testing.T) {
+	ids := map[string]bool{}
+	for _, invariant := range Invariants {
+		if invariant.ID == "" || invariant.Statement == "" {
+			t.Fatalf("invariant has empty required field: %+v", invariant)
+		}
+		if ids[invariant.ID] {
+			t.Fatalf("duplicate invariant id %q", invariant.ID)
+		}
+		ids[invariant.ID] = true
+		if _, ok := DomainByID(invariant.DomainID); !ok {
+			t.Fatalf("invariant %q references unknown domain %q", invariant.ID, invariant.DomainID)
+		}
+	}
+}

--- a/sources/internal/githubcanary/canary.go
+++ b/sources/internal/githubcanary/canary.go
@@ -298,13 +298,13 @@ func repositoryUpdatedAt(repo *gogithub.Repository, fallback time.Time) time.Tim
 		return fallback.UTC()
 	}
 	if updatedAt := repo.GetUpdatedAt(); !updatedAt.IsZero() {
-		return updatedAt.Time.UTC()
+		return updatedAt.UTC()
 	}
 	if pushedAt := timestamp(repo.PushedAt); pushedAt != nil {
 		return pushedAt.UTC()
 	}
 	if createdAt := repo.GetCreatedAt(); !createdAt.IsZero() {
-		return createdAt.Time.UTC()
+		return createdAt.UTC()
 	}
 	return fallback.UTC()
 }


### PR DESCRIPTION
## Summary
- define a Cerebro agent platform contract for runtime, eval, capability, execution, replay, connector, and knowledge boundaries
- add a small dependency-free Go vocabulary package with invariant tests
- link the contract from the README choose-your-path table

## Validation
- go test ./internal/agentplatform