### PR TITLE
Retire low-value GitHub audit finding mirrors

### DIFF
--- a/internal/findings/github_audit_signal_rule.go
+++ b/internal/findings/github_audit_signal_rule.go
@@ -37,15 +37,6 @@ type githubAuditCounterEventRule struct {
 	counterStates func(Event) []CounterEventStateUpdate
 }
 
-func newGitHubAuditCounterEventRule(config githubAuditSignalConfig, openAnchor func(map[string]string) string, closeAnchor githubAuditSignalClosePredicate) Rule {
-	return &githubAuditCounterEventRule{
-		Rule:        newGitHubAuditSignalRule(config),
-		definition:  config.definition,
-		openAnchor:  openAnchor,
-		closeAnchor: closeAnchor,
-	}
-}
-
 func newGitHubAggregateAuditCounterEventRule(config githubAuditSignalConfig, openAnchor func(map[string]string) string, closeAnchor githubAuditSignalClosePredicate, counterStates func(Event) []CounterEventStateUpdate) Rule {
 	return &githubAuditCounterEventRule{
 		Rule:          newGitHubAuditSignalRule(config),
@@ -476,33 +467,10 @@ var githubPrivateRepositoryForkingEnabledDefinition = RuleDefinition{
 	Lifecycle:          Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorGraphAnchored},
 }
 
-// Note: the secret-scanning-disabled, push-protection-disabled,
-// branch-protection-disabled, and repository-made-public match configs
-// were removed when these audit-event mirror rules were retired. Their
-// RuleDefinition values (above) are preserved so the retirement wrapper
-// can keep advertising the original output_kind, control refs, and
-// references when the rule appears in the catalog. The forthcoming
-// posture graph rules will reintroduce the trigger logic in a durable
-// state-based form.
-
-var githubRepositoryCollaboratorAddedConfig = githubAuditSignalConfig{
-	definition: githubRepositoryCollaboratorAddedDefinition,
-	actions:    githubAuditActionSet("repo.add_member"),
-	summary: func(attributes map[string]string) string {
-		return fmt.Sprintf("%s was added to %s by %s", firstNonEmpty(attributes["user"], "unknown user"), githubAuditTarget(attributes), githubAuditActor(attributes))
-	},
-}
-
-var githubOrganizationOwnerAddedConfig = githubAuditSignalConfig{
-	definition: githubOrganizationOwnerAddedDefinition,
-	actions:    githubAuditActionSet("org.add_member"),
-	predicate: func(attributes map[string]string) bool {
-		return strings.EqualFold(attributes["permission"], "admin") || strings.EqualFold(attributes["permission"], "owner")
-	},
-	summary: func(attributes map[string]string) string {
-		return fmt.Sprintf("%s was added as a GitHub organization owner by %s", firstNonEmpty(attributes["user"], "unknown user"), githubAuditActor(attributes))
-	},
-}
+// Note: retired GitHub audit-event mirror rules keep their RuleDefinition
+// values above so the retirement wrapper can keep advertising the original
+// output_kind, control refs, and references when the rule appears in the
+// catalog. Their match configs were removed with the event-mirror logic.
 
 var githubCodeSecurityControlSeverities = map[string]string{
 	"business_advanced_security.disabled":                    "CRITICAL",
@@ -544,100 +512,10 @@ var githubCodeSecurityControlsDisabledConfig = githubAuditSignalConfig{
 	},
 }
 
-var githubOrgAuthControlModifiedConfig = githubAuditSignalConfig{
-	definition:        githubOrgAuthControlModifiedDefinition,
-	predicate:         githubOrgAuthControlWeakening,
-	primaryEntityType: func(map[string]string) string { return "github.org" },
-	severity: func(attributes map[string]string) string {
-		action := strings.TrimSpace(attributes["action"])
-		if action == "org.update_saml_provider_settings" {
-			return "HIGH"
-		}
-		return "CRITICAL"
-	},
-	summary: func(attributes map[string]string) string {
-		return fmt.Sprintf("%s modified GitHub organization authentication control %s for %s", githubAuditActor(attributes), strings.TrimSpace(attributes["action"]), githubAuditTarget(attributes))
-	},
-}
-
-var githubOrgIPAllowListModifiedConfig = githubAuditSignalConfig{
-	definition:        githubOrgIPAllowListModifiedDefinition,
-	predicate:         githubIPAllowListWeakeningOrExpansion,
-	primaryEntityType: func(map[string]string) string { return "github.org" },
-	severity: func(attributes map[string]string) string {
-		if strings.Contains(strings.TrimSpace(attributes["action"]), "disable") || strings.Contains(strings.TrimSpace(attributes["action"]), "destroy") {
-			return "HIGH"
-		}
-		return "MEDIUM"
-	},
-	summary: func(attributes map[string]string) string {
-		return fmt.Sprintf("%s modified GitHub organization IP allow list for %s", githubAuditActor(attributes), githubAuditTarget(attributes))
-	},
-}
-
-var githubAppIntegrationInstalledConfig = githubAuditSignalConfig{
-	definition: githubAppIntegrationInstalledDefinition,
-	actions:    githubAuditActionSet("integration_installation.create"),
-	policyID: func(attributes map[string]string) string {
-		if name := strings.TrimSpace(attributes["name"]); name != "" {
-			return "github_app:" + name
-		}
-		return ""
-	},
-	summary: func(attributes map[string]string) string {
-		return fmt.Sprintf("%s installed GitHub App integration %s for %s", githubAuditActor(attributes), firstNonEmpty(attributes["name"], "unknown app"), githubAuditTarget(attributes))
-	},
-}
-
-var githubPersonalAccessTokenCreatedConfig = githubAuditSignalConfig{
-	definition: githubPersonalAccessTokenCreatedDefinition,
-	actions:    githubAuditActionSet("personal_access_token.access_granted"),
-	predicate: func(attributes map[string]string) bool {
-		return strings.EqualFold(attributes["operation_type"], "create")
-	},
-	summary: func(attributes map[string]string) string {
-		return fmt.Sprintf("%s created or authorized a GitHub personal access token for %s", githubAuditActor(attributes), firstNonEmpty(attributes["user"], "unknown user"))
-	},
-}
-
-// githubProtectedBranchPolicyOverrideConfig was removed when the
-// per-override mirror rule was retired; durable posture coverage lives in
-// graph/current-state rules while the retired wrapper keeps stale findings
-// resolvable.
-
-var githubRepositoryRulesetModifiedConfig = githubAuditSignalConfig{
-	definition: githubRepositoryRulesetModifiedDefinition,
-	actions:    githubAuditActionSet("repository_ruleset.destroy", "repository_ruleset.update"),
-	predicate:  githubRepositoryRulesetWeakening,
-	summary: func(attributes map[string]string) string {
-		return fmt.Sprintf("%s modified GitHub repository ruleset %s for %s", githubAuditActor(attributes), firstNonEmpty(attributes["ruleset_name"], attributes["ruleset_id"], "unknown ruleset"), githubAuditTarget(attributes))
-	},
-}
-
-var githubWebhookModifiedConfig = githubAuditSignalConfig{
-	definition: githubWebhookModifiedDefinition,
-	actions:    githubAuditActionSet("hook.config_changed", "hook.create"),
-	predicate:  githubWebhookDestinationPolicyViolating,
-	summary: func(attributes map[string]string) string {
-		return fmt.Sprintf("%s modified GitHub webhook %s for %s", githubAuditActor(attributes), firstNonEmpty(attributes["hook_id"], "unknown hook"), githubAuditTarget(attributes))
-	},
-}
-
-var githubPrivateRepositoryForkingEnabledConfig = githubAuditSignalConfig{
-	definition: githubPrivateRepositoryForkingEnabledDefinition,
-	predicate:  githubPrivateRepositoryForkingEnabled,
-	primaryEntityType: func(attributes map[string]string) string {
-		scope, _ := githubPrivateRepositoryForkingScope(attributes)
-		if scope == "repo" {
-			return "github.code.repository"
-		}
-		return "github.org"
-	},
-	fingerprint: githubPrivateRepositoryForkingFingerprintInputs,
-	summary: func(attributes map[string]string) string {
-		return fmt.Sprintf("%s enabled or reset private repository forking for %s", githubAuditActor(attributes), githubAuditTarget(attributes))
-	},
-}
+// githubProtectedBranchPolicyOverrideConfig and the other retired mirror
+// configs were removed with the per-event finding implementations; durable
+// coverage lives in graph/current-state rules while retired wrappers keep
+// stale findings resolvable.
 
 // newGitHubSecretScanningDisabledRule is retired. The mirror produced one
 // finding per audit event, which collapses repeated tampering on the same
@@ -692,11 +570,11 @@ func newGitHubSelfHostedRunnerChangeRule() Rule {
 }
 
 func newGitHubRepositoryCollaboratorAddedRule() Rule {
-	return newGitHubAuditCounterEventRule(githubRepositoryCollaboratorAddedConfig, githubRepositoryCollaboratorAnchor, githubRepositoryCollaboratorCloseAnchor)
+	return newRetiredGitHubAuditRule(githubRepositoryCollaboratorAddedDefinition)
 }
 
 func newGitHubOrganizationOwnerAddedRule() Rule {
-	return newGitHubAuditCounterEventRule(githubOrganizationOwnerAddedConfig, githubOrganizationOwnerAnchor, githubOrganizationOwnerCloseAnchor)
+	return newRetiredGitHubAuditRule(githubOrganizationOwnerAddedDefinition)
 }
 
 func newGitHubCodeSecurityControlsDisabledRule() Rule {
@@ -704,19 +582,19 @@ func newGitHubCodeSecurityControlsDisabledRule() Rule {
 }
 
 func newGitHubOrgAuthControlModifiedRule() Rule {
-	return newGitHubAggregateAuditCounterEventRule(githubOrgAuthControlModifiedConfig, githubOrgPostureAnchor, githubOrgAuthControlCloseAnchor, githubOrgAuthControlCounterEventStates)
+	return newRetiredGitHubAuditRule(githubOrgAuthControlModifiedDefinition)
 }
 
 func newGitHubOrgIPAllowListModifiedRule() Rule {
-	return newGitHubAggregateAuditCounterEventRule(githubOrgIPAllowListModifiedConfig, githubOrgPostureAnchor, githubOrgIPAllowListCloseAnchor, githubOrgIPAllowListCounterEventStates)
+	return newRetiredGitHubAuditRule(githubOrgIPAllowListModifiedDefinition)
 }
 
 func newGitHubAppIntegrationInstalledRule() Rule {
-	return newGitHubAuditCounterEventRule(githubAppIntegrationInstalledConfig, githubAppIntegrationAnchor, githubAppIntegrationCloseAnchor)
+	return newRetiredGitHubAuditRule(githubAppIntegrationInstalledDefinition)
 }
 
 func newGitHubPersonalAccessTokenCreatedRule() Rule {
-	return newGitHubAuditCounterEventRule(githubPersonalAccessTokenCreatedConfig, githubPersonalAccessTokenAnchor, githubPersonalAccessTokenCloseAnchor)
+	return newRetiredGitHubAuditRule(githubPersonalAccessTokenCreatedDefinition)
 }
 
 // newGitHubProtectedBranchPolicyOverrideRule is retired. Per-event overrides
@@ -728,7 +606,7 @@ func newGitHubProtectedBranchPolicyOverrideRule() Rule {
 }
 
 func newGitHubRepositoryRulesetModifiedRule() Rule {
-	return newGitHubAuditCounterEventRule(githubRepositoryRulesetModifiedConfig, githubRepositoryRulesetAnchor, githubRepositoryRulesetCloseAnchor)
+	return newRetiredGitHubAuditRule(githubRepositoryRulesetModifiedDefinition)
 }
 
 func newGitHubCriticalResourceDeletedRule() Rule {
@@ -736,11 +614,11 @@ func newGitHubCriticalResourceDeletedRule() Rule {
 }
 
 func newGitHubWebhookModifiedRule() Rule {
-	return newGitHubAuditCounterEventRule(githubWebhookModifiedConfig, githubWebhookAnchor, githubWebhookCloseAnchor)
+	return newRetiredGitHubAuditRule(githubWebhookModifiedDefinition)
 }
 
 func newGitHubPrivateRepositoryForkingEnabledRule() Rule {
-	return newGitHubAuditCounterEventRule(githubPrivateRepositoryForkingEnabledConfig, githubPrivateRepositoryForkingAnchor, githubPrivateRepositoryForkingCloseAnchor)
+	return newRetiredGitHubAuditRule(githubPrivateRepositoryForkingEnabledDefinition)
 }
 
 func matchesGitHubSecretScanningOpenAlert(event *cerebrov1.EventEnvelope) bool {
@@ -1071,16 +949,6 @@ func githubObservedPolicyIDs(policyID string) []string {
 	return []string{strings.TrimSpace(policyID)}
 }
 
-func githubAuditActionSet(actions ...string) map[string]struct{} {
-	set := make(map[string]struct{}, len(actions))
-	for _, action := range actions {
-		if strings.TrimSpace(action) != "" {
-			set[strings.TrimSpace(action)] = struct{}{}
-		}
-	}
-	return set
-}
-
 func githubCounterEventAnchor(attributes map[string]string, fields ...string) string {
 	if len(fields) == 0 {
 		return ""
@@ -1120,112 +988,6 @@ func githubSecretScanningAlertCloseAnchor(event Event) (string, bool) {
 	default:
 		return "", false
 	}
-}
-
-func githubRepositoryCollaboratorAnchor(attributes map[string]string) string {
-	return githubCounterEventAnchor(attributes, "repo", "user")
-}
-
-func githubRepositoryCollaboratorCloseAnchor(event Event) (string, bool) {
-	attributes := eventAttributes(event)
-	action := strings.TrimSpace(attributes["action"])
-	switch action {
-	case "member.removed", "repo.remove_member", "repository.remove_member", "repo.remove_collaborator", "repository.remove_collaborator", "org.remove_member":
-		return githubRepositoryCollaboratorAnchor(attributes), true
-	default:
-		return "", false
-	}
-}
-
-func githubOrganizationOwnerAnchor(attributes map[string]string) string {
-	return githubCounterEventAnchor(attributes, "org", "user")
-}
-
-func githubOrganizationOwnerCloseAnchor(event Event) (string, bool) {
-	attributes := eventAttributes(event)
-	action := strings.TrimSpace(attributes["action"])
-	switch action {
-	case "member.removed", "org.remove_member", "organization.remove_member", "org.remove_owner", "organization.remove_owner":
-		return githubOrganizationOwnerAnchor(attributes), true
-	case "org.add_member", "org.update_member", "org.update_member_role", "member.role_changed", "member.updated":
-		permission := strings.ToLower(strings.TrimSpace(firstNonEmpty(attributes["new_permission"], attributes["permission"], attributes["new_role"], attributes["role"])))
-		if permission != "" && permission != "admin" && permission != "owner" {
-			return githubOrganizationOwnerAnchor(attributes), true
-		}
-		return "", false
-	default:
-		return "", false
-	}
-}
-
-func githubAppIntegrationAnchor(attributes map[string]string) string {
-	return githubCounterEventAnchor(attributes, "org", "github_app_id")
-}
-
-func githubAppIntegrationCloseAnchor(event Event) (string, bool) {
-	attributes := eventAttributes(event)
-	switch strings.TrimSpace(attributes["action"]) {
-	case "integration_installation.delete", "integration_installation.destroy", "integration_installation.suspend":
-		return githubAppIntegrationAnchor(attributes), true
-	default:
-		return "", false
-	}
-}
-
-func githubPersonalAccessTokenAnchor(attributes map[string]string) string {
-	return githubCounterEventAnchor(attributes, "user_id", "token_id")
-}
-
-func githubPersonalAccessTokenCloseAnchor(event Event) (string, bool) {
-	attributes := eventAttributes(event)
-	if !githubPersonalAccessTokenClosed(attributes) {
-		return "", false
-	}
-	return githubPersonalAccessTokenAnchor(attributes), true
-}
-
-func githubPersonalAccessTokenClosed(attributes map[string]string) bool {
-	action := strings.TrimSpace(attributes["action"])
-	switch action {
-	case "personal_access_token.access_revoked", "personal_access_token.access_expired", "personal_access_token.expired":
-		return true
-	case "personal_access_token.access_granted":
-		return githubPersonalAccessTokenLifecycleClosed(attributes)
-	default:
-		if !strings.HasPrefix(action, "personal_access_token.") {
-			return false
-		}
-		return githubPersonalAccessTokenLifecycleClosed(attributes)
-	}
-}
-
-func githubPersonalAccessTokenLifecycleClosed(attributes map[string]string) bool {
-	state := strings.ToLower(strings.TrimSpace(firstNonEmpty(
-		attributes["operation_type"],
-		attributes["token_state"],
-		attributes["token_status"],
-		attributes["credential_status"],
-		attributes["lifecycle_status"],
-		attributes["state"],
-		attributes["status"],
-		attributes["reason"],
-	)))
-	switch state {
-	case "remove", "removed", "revoke", "revoked", "access_revoked", "expire", "expired", "expiration", "token_expired":
-		return true
-	}
-	return containsAny(strings.ToLower(firstNonEmpty(attributes["change_type"], attributes["changes"])), "revoke", "remove", "expire", "expired")
-}
-
-func githubOrgPostureAnchor(attributes map[string]string) string {
-	org := strings.TrimSpace(firstNonEmpty(attributes["org"], attributes["organization"]))
-	if org == "" {
-		resourceID := strings.TrimSpace(attributes["resource_id"])
-		if resourceID != "" && !strings.Contains(resourceID, "/") {
-			org = resourceID
-		}
-	}
-	return githubCounterEventAnchor(map[string]string{"org": org}, "org")
 }
 
 func githubCodeSecurityControlsAnchor(attributes map[string]string) string {
@@ -1379,143 +1141,6 @@ func githubRestoredCodeSecurityControls(attributes map[string]string) []string {
 	return deduplicateStrings(restored)
 }
 
-func githubOrgAuthControlCloseAnchor(event Event) (string, bool) {
-	attributes := eventAttributes(event)
-	if !githubOrgAuthControlsRestored(attributes) {
-		return "", false
-	}
-	return githubOrgPostureAnchor(attributes), true
-}
-
-func githubOrgAuthControlsRestored(attributes map[string]string) bool {
-	if githubOrgAuthControlWeakening(attributes) {
-		return false
-	}
-	switch strings.TrimSpace(attributes["action"]) {
-	case "oauth_app_policy.enabled",
-		"org.enable_oauth_app_restrictions",
-		"org.enable_saml_sso",
-		"org.enable_two_factor_requirement",
-		"org.require_two_factor_requirement":
-		return true
-	}
-	return findingAttributeBool(
-		attributes,
-		"auth_control_strengthened",
-		"oauth_app_restrictions_enabled",
-		"oauth_app_restrictions_enforced",
-		"saml_enabled",
-		"saml_enforced",
-		"saml_required",
-		"saml_sso_enabled",
-		"mfa_required",
-		"two_factor_enforced",
-		"two_factor_required",
-		"two_factor_requirement_enabled",
-	)
-}
-
-func githubOrgAuthControlCounterEventStates(event Event) []CounterEventStateUpdate {
-	if !githubAuditSignalKindMatcher(event) {
-		return nil
-	}
-	attributes := eventAttributes(event)
-	return githubCounterEventStateUpdates(
-		githubOrgPostureAnchor(attributes),
-		githubWeakenedAuthControls(attributes),
-		githubRestoredAuthControls(attributes),
-		event,
-	)
-}
-
-func githubRestoredAuthControls(attributes map[string]string) []string {
-	restored := []string{}
-	switch strings.TrimSpace(attributes["action"]) {
-	case "oauth_app_policy.enabled", "org.enable_oauth_app_restrictions":
-		restored = append(restored, "oauth_app_restrictions")
-	case "org.enable_saml_sso":
-		restored = append(restored, "saml")
-	case "org.enable_two_factor_requirement", "org.require_two_factor_requirement":
-		restored = append(restored, "two_factor_requirement")
-	}
-	if findingAttributeBool(attributes, "auth_control_strengthened") {
-		restored = append(restored, "auth_control", "oauth_app_restrictions", "saml", "two_factor_requirement")
-	}
-	if findingAttributeBool(attributes, "oauth_app_restrictions_enabled", "oauth_app_restrictions_enforced") {
-		restored = append(restored, "oauth_app_restrictions")
-	}
-	if findingAttributeBool(attributes, "saml_enabled", "saml_enforced", "saml_required", "saml_sso_enabled") {
-		restored = append(restored, "saml")
-	}
-	if findingAttributeBool(attributes, "mfa_required", "two_factor_enforced", "two_factor_required", "two_factor_requirement_enabled") {
-		restored = append(restored, "two_factor_requirement")
-	}
-	return deduplicateStrings(restored)
-}
-
-func githubOrgIPAllowListCloseAnchor(event Event) (string, bool) {
-	attributes := eventAttributes(event)
-	if !githubIPAllowListRestored(attributes) {
-		return "", false
-	}
-	return githubOrgPostureAnchor(attributes), true
-}
-
-func githubIPAllowListRestored(attributes map[string]string) bool {
-	if githubIPAllowListWeakeningOrExpansion(attributes) {
-		return false
-	}
-	switch strings.TrimSpace(attributes["action"]) {
-	case "ip_allow_list.enable", "ip_allow_list.enabled", "org.enable_ip_allow_list":
-		return true
-	}
-	return findingAttributeBool(attributes, "ip_allow_list_enabled") ||
-		findingAttributeBool(attributes, "allowed_cidrs_compliant", "ip_allow_list_entries_compliant")
-}
-
-func githubOrgIPAllowListCounterEventStates(event Event) []CounterEventStateUpdate {
-	if !githubAuditSignalKindMatcher(event) {
-		return nil
-	}
-	attributes := eventAttributes(event)
-	return githubCounterEventStateUpdates(
-		githubOrgPostureAnchor(attributes),
-		githubWeakenedIPAllowListControls(attributes),
-		githubRestoredIPAllowListControls(attributes),
-		event,
-	)
-}
-
-func githubWeakenedIPAllowListControls(attributes map[string]string) []string {
-	weakened := []string{}
-	if findingAttributeBool(attributes, "ip_allow_list_disabled") || githubAttributeExplicitlyFalse(attributes, "ip_allow_list_enabled") {
-		weakened = append(weakened, "enabled")
-	}
-	if githubAttributeExplicitlyFalse(attributes, "allowed_cidrs_compliant", "ip_allow_list_entries_compliant") ||
-		githubNonEmptyListAttribute(attributes, "non_allowlisted_cidrs") ||
-		githubPositiveCountAttribute(attributes, "non_allowlisted_cidr_count") {
-		weakened = append(weakened, "cidrs")
-	}
-	return deduplicateStrings(weakened)
-}
-
-func githubRestoredIPAllowListControls(attributes map[string]string) []string {
-	restored := []string{}
-	switch strings.TrimSpace(attributes["action"]) {
-	case "ip_allow_list.enable", "ip_allow_list.enabled", "org.enable_ip_allow_list":
-		restored = append(restored, "enabled")
-	}
-	if findingAttributeBool(attributes, "ip_allow_list_enabled") {
-		restored = append(restored, "enabled")
-	}
-	if findingAttributeBool(attributes, "allowed_cidrs_compliant", "ip_allow_list_entries_compliant") ||
-		githubZeroCountAttribute(attributes, "non_allowlisted_cidr_count") ||
-		githubEmptyListAttribute(attributes, "non_allowlisted_cidrs") {
-		restored = append(restored, "cidrs")
-	}
-	return deduplicateStrings(restored)
-}
-
 func githubCounterEventStateUpdates(anchor string, openKeys []string, closeKeys []string, event Event) []CounterEventStateUpdate {
 	anchor = strings.TrimSpace(anchor)
 	if anchor == "" {
@@ -1563,105 +1188,6 @@ func githubCounterEventStateUpdates(anchor string, openKeys []string, closeKeys 
 		})
 	}
 	return states
-}
-
-func githubZeroCountAttribute(attributes map[string]string, keys ...string) bool {
-	for _, key := range keys {
-		if strings.TrimSpace(attributes[key]) == "0" {
-			return true
-		}
-	}
-	return false
-}
-
-func githubEmptyListAttribute(attributes map[string]string, keys ...string) bool {
-	for _, key := range keys {
-		value, ok := attributes[key]
-		if !ok {
-			continue
-		}
-		switch strings.ToLower(strings.TrimSpace(value)) {
-		case "", "[]", "{}", "none", "null":
-			return true
-		}
-	}
-	return false
-}
-
-func githubRepositoryRulesetAnchor(attributes map[string]string) string {
-	return githubCounterEventAnchor(attributes, "repo", "ruleset_id")
-}
-
-func githubRepositoryRulesetCloseAnchor(event Event) (string, bool) {
-	attributes := eventAttributes(event)
-	switch strings.TrimSpace(attributes["action"]) {
-	case "repository_ruleset.destroy":
-		return githubRepositoryRulesetAnchor(attributes), true
-	case "repository_ruleset.update":
-		if githubRepositoryRulesetRestored(attributes) {
-			return githubRepositoryRulesetAnchor(attributes), true
-		}
-		return "", false
-	default:
-		return "", false
-	}
-}
-
-func githubRepositoryRulesetRestored(attributes map[string]string) bool {
-	if githubRepositoryRulesetWeakening(attributes) {
-		return false
-	}
-	enforcement := strings.ToLower(strings.TrimSpace(firstNonEmpty(attributes["new_enforcement"], attributes["enforcement"], attributes["ruleset_enforcement"])))
-	switch enforcement {
-	case "active", "enabled", "enforced":
-		return true
-	}
-	return containsAny(strings.ToLower(firstNonEmpty(attributes["operation_type"], attributes["change_type"], attributes["changes"])), "enable", "restore", "enforce")
-}
-
-func githubWebhookAnchor(attributes map[string]string) string {
-	return githubCounterEventAnchor(attributes, "repo", "hook_id")
-}
-
-func githubWebhookCloseAnchor(event Event) (string, bool) {
-	attributes := eventAttributes(event)
-	switch strings.TrimSpace(attributes["action"]) {
-	case "hook.destroy":
-		return githubWebhookAnchor(attributes), true
-	case "hook.config_changed":
-		if githubWebhookDestinationAllowlisted(attributes) {
-			return githubWebhookAnchor(attributes), true
-		}
-		return "", false
-	default:
-		return "", false
-	}
-}
-
-func githubWebhookDestinationPolicyViolating(attributes map[string]string) bool {
-	return !githubWebhookDestinationAllowlisted(attributes)
-}
-
-func githubWebhookDestinationAllowlisted(attributes map[string]string) bool {
-	return findingAttributeBool(
-		attributes,
-		"allowlisted_destination",
-		"destination_allowlisted",
-		"hook_destination_allowlisted",
-		"hook_url_allowlisted",
-		"url_allowlisted",
-		"webhook_destination_allowlisted",
-		"webhook_url_allowlisted",
-	) || githubAttributeExplicitlyFalse(
-		attributes,
-		"destination_non_allowlisted",
-		"hook_destination_non_allowlisted",
-		"hook_url_non_allowlisted",
-		"non_allowlisted_destination",
-		"url_non_allowlisted",
-		"webhook_destination_non_allowlisted",
-		"webhook_url_non_allowlisted",
-	)
 }
 
 var githubPostureAttributeKeys = []string{
@@ -1719,10 +1245,6 @@ func githubDisabledCodeSecurityControls(attributes map[string]string) []string {
 	return disabled
 }
 
-func githubOrgAuthControlWeakening(attributes map[string]string) bool {
-	return len(githubWeakenedAuthControls(attributes)) > 0
-}
-
 func githubWeakenedAuthControls(attributes map[string]string) []string {
 	weakened := []string{}
 	if githubAttributeExplicitlyFalse(attributes, "oauth_app_restrictions_enabled", "oauth_app_restrictions_enforced") {
@@ -1739,63 +1261,6 @@ func githubWeakenedAuthControls(attributes map[string]string) []string {
 		weakened = append(weakened, "auth_control")
 	}
 	return weakened
-}
-
-func githubIPAllowListWeakeningOrExpansion(attributes map[string]string) bool {
-	if findingAttributeBool(attributes, "ip_allow_list_disabled") || githubAttributeExplicitlyFalse(attributes, "ip_allow_list_enabled") {
-		return true
-	}
-	if githubAttributeExplicitlyFalse(attributes, "allowed_cidrs_compliant", "ip_allow_list_entries_compliant") {
-		return true
-	}
-	return githubNonEmptyListAttribute(attributes, "non_allowlisted_cidrs") || githubPositiveCountAttribute(attributes, "non_allowlisted_cidr_count")
-}
-
-func githubPrivateRepositoryForkingEnabled(attributes map[string]string) bool {
-	_, scopeID := githubPrivateRepositoryForkingScope(attributes)
-	if scopeID == "" {
-		return false
-	}
-	return findingAttributeBool(attributes, "private_repository_forking_enabled", "private_forking_enabled")
-}
-
-func githubPrivateRepositoryForkingAnchor(attributes map[string]string) string {
-	scopeID := strings.TrimSpace(attributes["posture_scope_id"])
-	if scopeID == "" {
-		_, scopeID = githubPrivateRepositoryForkingScope(attributes)
-	}
-	return githubCounterEventAnchor(map[string]string{"scope": scopeID}, "scope")
-}
-
-func githubPrivateRepositoryForkingCloseAnchor(event Event) (string, bool) {
-	attributes := eventAttributes(event)
-	if !githubPrivateRepositoryForkingDisabled(attributes) {
-		return "", false
-	}
-	return githubPrivateRepositoryForkingAnchor(attributes), true
-}
-
-func githubPrivateRepositoryForkingDisabled(attributes map[string]string) bool {
-	if githubPrivateRepositoryForkingEnabled(attributes) {
-		return false
-	}
-	switch strings.TrimSpace(attributes["action"]) {
-	case "org.private_repository_forking_disable",
-		"private_repository_forking.disable",
-		"private_repository_forking.disabled",
-		"repo.private_repository_forking_disable",
-		"repository.private_repository_forking_disabled":
-		return true
-	}
-	return githubAttributeExplicitlyFalse(attributes, "private_repository_forking_enabled", "private_forking_enabled")
-}
-
-func githubPrivateRepositoryForkingFingerprintInputs(event *cerebrov1.EventEnvelope, _ RuleDefinition) []string {
-	_, scopeID := githubPrivateRepositoryForkingScope(eventAttributes(event))
-	if scopeID == "" {
-		return nil
-	}
-	return []string{scopeID}
 }
 
 func githubPrivateRepositoryForkingScope(attributes map[string]string) (string, string) {
@@ -1860,47 +1325,6 @@ func githubAttributeExplicitlyFalse(attributes map[string]string, keys ...string
 		}
 	}
 	return false
-}
-
-func githubNonEmptyListAttribute(attributes map[string]string, keys ...string) bool {
-	for _, key := range keys {
-		value := strings.ToLower(strings.TrimSpace(attributes[key]))
-		switch value {
-		case "", "[]", "{}", "none", "null":
-			continue
-		default:
-			return true
-		}
-	}
-	return false
-}
-
-func githubPositiveCountAttribute(attributes map[string]string, keys ...string) bool {
-	for _, key := range keys {
-		value := strings.TrimSpace(attributes[key])
-		if value != "" && value != "0" {
-			return true
-		}
-	}
-	return false
-}
-
-func githubRepositoryRulesetWeakening(attributes map[string]string) bool {
-	action := strings.TrimSpace(attributes["action"])
-	if action == "repository_ruleset.destroy" {
-		return true
-	}
-	if action != "repository_ruleset.update" {
-		return false
-	}
-	if containsAny(strings.ToLower(firstNonEmpty(attributes["operation_type"], attributes["change_type"], attributes["changes"])), "disable", "remove", "delete", "downgrade", "bypass") {
-		return true
-	}
-	enforcement := strings.ToLower(firstNonEmpty(attributes["new_enforcement"], attributes["enforcement"], attributes["ruleset_enforcement"]))
-	if enforcement == "disabled" || enforcement == "evaluate" {
-		return true
-	}
-	return findingAttributeBool(attributes, "bypass_actor_added", "required_review_removed", "required_status_check_removed", "force_pushes_allowed", "deletions_allowed")
 }
 
 // githubRetirementTag marks the rule definition so operators reading the

--- a/internal/findings/github_audit_signal_rule_test.go
+++ b/internal/findings/github_audit_signal_rule_test.go
@@ -12,120 +12,59 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestGitHubAnchorRequiredFields(t *testing.T) {
-	runtime := &cerebrov1.SourceRuntime{Id: "github-runtime", SourceId: "github", TenantId: "writer"}
-	auditCases := []struct {
-		name     string
-		rule     Rule
-		config   githubAuditSignalConfig
-		attrs    map[string]string
-		required []string
-		missing  []string
-	}{
-		{
-			name:   "organization owner",
-			rule:   newGitHubOrganizationOwnerAddedRule(),
-			config: githubOrganizationOwnerAddedConfig,
-			attrs: map[string]string{
-				"action":     "org.add_member",
-				"org":        "writer",
-				"permission": "admin",
-				"user":       "new-owner",
-			},
-			required: []string{"org"},
-			missing:  []string{"org"},
-		},
-		{
-			name:   "repository ruleset",
-			rule:   newGitHubRepositoryRulesetModifiedRule(),
-			config: githubRepositoryRulesetModifiedConfig,
-			attrs: map[string]string{
-				"action":                        "repository_ruleset.update",
-				"repo":                          "writer/cerebro",
-				"required_status_check_removed": "true",
-				"ruleset_id":                    "42",
-			},
-			required: []string{"ruleset_id"},
-			missing:  []string{"ruleset_id"},
-		},
-		{
-			name:   "webhook",
-			rule:   newGitHubWebhookModifiedRule(),
-			config: githubWebhookModifiedConfig,
-			attrs: map[string]string{
-				"action":  "hook.create",
-				"hook_id": "99",
-				"repo":    "writer/cerebro",
-			},
-			required: []string{"hook_id"},
-			missing:  []string{"hook_id"},
-		},
-		{
-			name:   "app integration",
-			rule:   newGitHubAppIntegrationInstalledRule(),
-			config: githubAppIntegrationInstalledConfig,
-			attrs: map[string]string{
-				"action":        "integration_installation.create",
-				"github_app_id": "123456",
-				"name":          "ci-deployer",
-				"org":           "writer",
-			},
-			required: []string{"github_app_id"},
-			missing:  []string{"github_app_id"},
-		},
-		{
-			name:   "personal access token",
-			rule:   newGitHubPersonalAccessTokenCreatedRule(),
-			config: githubPersonalAccessTokenCreatedConfig,
-			attrs: map[string]string{
-				"action":         "personal_access_token.access_granted",
-				"operation_type": "create",
-				"token_id":       "555",
-				"user":           "octocat",
-				"user_id":        "12345",
-			},
-			required: []string{"user_id", "token_id"},
-			missing:  []string{"user_id", "token_id"},
-		},
+func isRetiredGitHubAuditRule(rule Rule) bool {
+	metadataRule, ok := rule.(MetadataRule)
+	return ok && metadataRule.RuleMetadata().Lifecycle.Kind == LifecycleRetired
+}
+
+func assertGitHubAuditRuleRetired(t *testing.T, rule Rule) {
+	t.Helper()
+	metadataRule, ok := rule.(MetadataRule)
+	if !ok {
+		t.Fatal("rule does not expose RuleMetadata")
 	}
+	definition := metadataRule.RuleMetadata()
+	if definition.Lifecycle.Kind != LifecycleRetired {
+		t.Fatalf("Lifecycle.Kind = %q, want %q", definition.Lifecycle.Kind, LifecycleRetired)
+	}
+	if definition.Lifecycle.Anchor != AnchorNone {
+		t.Fatalf("Lifecycle.Anchor = %q, want %q", definition.Lifecycle.Anchor, AnchorNone)
+	}
+	if definition.Maturity != RuleMaturityRetired {
+		t.Fatalf("Maturity = %q, want %q", definition.Maturity, RuleMaturityRetired)
+	}
+	retirementRule, ok := rule.(openFindingRetirementRule)
+	if !ok || !retirementRule.RetiresOpenFindings() {
+		t.Fatalf("RetiresOpenFindings(%q) = false, want true", rule.Spec().GetId())
+	}
+	runtime := &cerebrov1.SourceRuntime{Id: "github-runtime", SourceId: "github", TenantId: "writer", Config: map[string]string{"family": "audit"}}
+	event := githubAuditEvent("retired-"+rule.Spec().GetId(), map[string]string{"action": "retired.rule.fixture"})
+	records, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(%q) error = %v", rule.Spec().GetId(), err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("Evaluate(%q) returned %d findings, want none", rule.Spec().GetId(), len(records))
+	}
+}
 
-	for _, tc := range auditCases {
+func TestGitHubRetiredAuditChangeRules(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rule Rule
+	}{
+		{name: "repository collaborator", rule: newGitHubRepositoryCollaboratorAddedRule()},
+		{name: "organization owner", rule: newGitHubOrganizationOwnerAddedRule()},
+		{name: "org auth control", rule: newGitHubOrgAuthControlModifiedRule()},
+		{name: "org IP allow list", rule: newGitHubOrgIPAllowListModifiedRule()},
+		{name: "repository ruleset", rule: newGitHubRepositoryRulesetModifiedRule()},
+		{name: "webhook", rule: newGitHubWebhookModifiedRule()},
+		{name: "app integration", rule: newGitHubAppIntegrationInstalledRule()},
+		{name: "personal access token", rule: newGitHubPersonalAccessTokenCreatedRule()},
+		{name: "private repository forking", rule: newGitHubPrivateRepositoryForkingEnabledRule()},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
-			metadataRule, ok := tc.rule.(MetadataRule)
-			if !ok {
-				t.Fatal("rule does not expose RuleMetadata")
-			}
-			definition := metadataRule.RuleMetadata()
-			for _, field := range tc.required {
-				if !slices.Contains(definition.RequiredAttributes, field) {
-					t.Fatalf("RequiredAttributes = %v, want durable anchor field %q", definition.RequiredAttributes, field)
-				}
-			}
-
-			valid := githubAuditEvent("github-anchor-"+strings.ReplaceAll(tc.name, " ", "-"), cloneGitHubTestAttrs(tc.attrs))
-			records, err := tc.rule.Evaluate(context.Background(), runtime, valid)
-			if err != nil || len(records) != 1 {
-				t.Fatalf("Evaluate(valid anchor attrs) = (%v, %v), want one finding", records, err)
-			}
-			if fingerprint := githubAuditSignalFingerprint(valid, tc.config); fingerprint == nil || strings.TrimSpace(*fingerprint) == "" {
-				t.Fatalf("githubAuditSignalFingerprint(valid anchor attrs) = %v, want non-empty fingerprint", fingerprint)
-			}
-
-			for _, missing := range tc.missing {
-				attrs := cloneGitHubTestAttrs(tc.attrs)
-				removeGitHubAnchorTestAttr(attrs, missing)
-				event := githubAuditEvent("github-anchor-missing-"+strings.ReplaceAll(tc.name, " ", "-")+"-"+missing, attrs)
-				records, err := tc.rule.Evaluate(context.Background(), runtime, event)
-				if err != nil {
-					t.Fatalf("Evaluate(missing %s) error = %v", missing, err)
-				}
-				if len(records) != 0 {
-					t.Fatalf("Evaluate(missing %s) returned %d findings, want 0", missing, len(records))
-				}
-				if fingerprint := githubAuditSignalFingerprint(event, tc.config); fingerprint != nil {
-					t.Fatalf("githubAuditSignalFingerprint(missing %s) = %q, want nil", missing, *fingerprint)
-				}
-			}
+			assertGitHubAuditRuleRetired(t, tc.rule)
 		})
 	}
 
@@ -401,6 +340,10 @@ func TestGitHubSelfHostedRunnerChange(t *testing.T) {
 
 func TestGitHubOrgAuthControlModified(t *testing.T) {
 	rule := newGitHubOrgAuthControlModifiedRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	metadataRule, ok := rule.(MetadataRule)
 	if !ok {
 		t.Fatal("rule does not expose RuleMetadata")
@@ -477,8 +420,9 @@ func TestGitHubOrgAuthControlModified(t *testing.T) {
 
 func TestGitHubOrgAuthControlModifiedTrajectory_Restore(t *testing.T) {
 	rule := newGitHubOrgAuthControlModifiedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-org-auth-control-modified does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	assertGitHubRuleTrajectory(t, rule, []Event{
 		newGitHubAuditSignalEvent("github-auth-trajectory-weakened", map[string]string{
@@ -502,8 +446,9 @@ func TestGitHubOrgAuthControlModifiedTrajectory_Restore(t *testing.T) {
 
 func TestGitHubOrgAuthControlModifiedTrajectory_PartialRestoreKeepsFindingOpen(t *testing.T) {
 	rule := newGitHubOrgAuthControlModifiedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-org-auth-control-modified does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	assertGitHubRuleTrajectory(t, rule, []Event{
 		newGitHubAuditSignalEvent("github-auth-partial-oauth-weakened", map[string]string{
@@ -532,6 +477,10 @@ func TestGitHubOrgAuthControlModifiedTrajectory_PartialRestoreKeepsFindingOpen(t
 
 func TestGitHubRepositoryRulesetModifiedRequiresWeakeningSignal(t *testing.T) {
 	rule := newGitHubRepositoryRulesetModifiedRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	runtime := &cerebrov1.SourceRuntime{Id: "github-runtime", SourceId: "github", TenantId: "writer"}
 	event := githubAuditEvent("github-ruleset-active", map[string]string{
 		"action":      "repository_ruleset.update",
@@ -579,6 +528,10 @@ func TestGitHubRepositoryRulesetModifiedRequiresWeakeningSignal(t *testing.T) {
 
 func TestGitHubOrgIpAllowListModified(t *testing.T) {
 	rule := newGitHubOrgIPAllowListModifiedRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	metadataRule, ok := rule.(MetadataRule)
 	if !ok {
 		t.Fatal("rule does not expose RuleMetadata")
@@ -654,8 +607,9 @@ func TestGitHubOrgIpAllowListModified(t *testing.T) {
 
 func TestGitHubOrgIpAllowListModifiedTrajectory_Restore(t *testing.T) {
 	rule := newGitHubOrgIPAllowListModifiedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-org-ip-allow-list-modified does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	assertGitHubRuleTrajectory(t, rule, []Event{
 		newGitHubAuditSignalEvent("github-ip-trajectory-disabled", map[string]string{
@@ -680,8 +634,9 @@ func TestGitHubOrgIpAllowListModifiedTrajectory_Restore(t *testing.T) {
 
 func TestGitHubOrgIpAllowListModifiedTrajectory_PartialRestoreKeepsFindingOpen(t *testing.T) {
 	rule := newGitHubOrgIPAllowListModifiedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-org-ip-allow-list-modified does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	assertGitHubRuleTrajectory(t, rule, []Event{
 		newGitHubAuditSignalEvent("github-ip-partial-disabled", map[string]string{
@@ -1087,6 +1042,10 @@ func TestGitHubCriticalResourceDeletedRetired(t *testing.T) {
 
 func TestGitHubRepositoryCollaboratorAdded(t *testing.T) {
 	rule := newGitHubRepositoryCollaboratorAddedRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	metadataRule, ok := rule.(MetadataRule)
 	if !ok {
 		t.Fatal("rule does not expose RuleMetadata")
@@ -1154,8 +1113,9 @@ func TestGitHubRepositoryCollaboratorAdded(t *testing.T) {
 
 func TestGitHubRepositoryCollaboratorAddedTrajectory(t *testing.T) {
 	rule := newGitHubRepositoryCollaboratorAddedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-repository-collaborator-added does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	assertGitHubRuleTrajectory(t, rule, []Event{
 		newGitHubAuditSignalEvent("github-collab-trajectory-first", map[string]string{
@@ -1265,6 +1225,10 @@ func TestGitHubAuditLifecycle_CloseOnRemoveCounterEvent(t *testing.T) {
 
 func TestGitHubOrganizationOwnerAdded(t *testing.T) {
 	rule := newGitHubOrganizationOwnerAddedRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	metadataRule, ok := rule.(MetadataRule)
 	if !ok {
 		t.Fatal("rule does not expose RuleMetadata")
@@ -1335,8 +1299,9 @@ func TestGitHubOrganizationOwnerAdded(t *testing.T) {
 
 func TestGitHubOrganizationOwnerAddedTrajectory(t *testing.T) {
 	rule := newGitHubOrganizationOwnerAddedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-organization-owner-added does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	t.Run("owner role demoted", func(t *testing.T) {
 		assertGitHubRuleTrajectory(t, rule, []Event{
@@ -1373,6 +1338,10 @@ func TestGitHubOrganizationOwnerAddedTrajectory(t *testing.T) {
 
 func TestGitHubRepositoryRulesetModified(t *testing.T) {
 	rule := newGitHubRepositoryRulesetModifiedRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	metadataRule, ok := rule.(MetadataRule)
 	if !ok {
 		t.Fatal("rule does not expose RuleMetadata")
@@ -1444,8 +1413,9 @@ func TestGitHubRepositoryRulesetModified(t *testing.T) {
 
 func TestGitHubRepositoryRulesetModifiedTrajectory(t *testing.T) {
 	rule := newGitHubRepositoryRulesetModifiedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-repository-ruleset-modified does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	t.Run("restore enforcement", func(t *testing.T) {
 		assertGitHubRuleTrajectory(t, rule, []Event{
@@ -1483,6 +1453,10 @@ func TestGitHubRepositoryRulesetModifiedTrajectory(t *testing.T) {
 
 func TestGitHubWebhookModified(t *testing.T) {
 	rule := newGitHubWebhookModifiedRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	metadataRule, ok := rule.(MetadataRule)
 	if !ok {
 		t.Fatal("rule does not expose RuleMetadata")
@@ -1550,8 +1524,9 @@ func TestGitHubWebhookModified(t *testing.T) {
 
 func TestGitHubWebhookModifiedTrajectory(t *testing.T) {
 	rule := newGitHubWebhookModifiedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-webhook-modified does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	t.Run("destroyed", func(t *testing.T) {
 		assertGitHubRuleTrajectory(t, rule, []Event{
@@ -1588,6 +1563,10 @@ func TestGitHubWebhookModifiedTrajectory(t *testing.T) {
 
 func TestGitHubAppIntegrationInstalled(t *testing.T) {
 	rule := newGitHubAppIntegrationInstalledRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	metadataRule, ok := rule.(MetadataRule)
 	if !ok {
 		t.Fatal("rule does not expose RuleMetadata")
@@ -1660,8 +1639,9 @@ func TestGitHubAppIntegrationInstalled(t *testing.T) {
 
 func TestGitHubAppIntegrationInstalled_InstallUninstall(t *testing.T) {
 	rule := newGitHubAppIntegrationInstalledRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-app-integration-installed does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	for _, closeAction := range []string{"integration_installation.delete", "integration_installation.suspend", "integration_installation.destroy"} {
 		t.Run(closeAction, func(t *testing.T) {
@@ -1686,6 +1666,10 @@ func TestGitHubAppIntegrationInstalled_InstallUninstall(t *testing.T) {
 
 func TestGitHubAppIntegrationCloseAnchor_HandlesDestroy(t *testing.T) {
 	rule := newGitHubAppIntegrationInstalledRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	counterRule, ok := rule.(CounterEventRule)
 	if !ok {
 		t.Fatal("github-app-integration-installed does not implement CounterEventRule")
@@ -1720,6 +1704,10 @@ func TestGitHubAppIntegrationCloseAnchor_HandlesDestroy(t *testing.T) {
 
 func TestGitHubAppIntegrationInstalled_DistinctAppIdsByName(t *testing.T) {
 	rule := newGitHubAppIntegrationInstalledRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	runtime := &cerebrov1.SourceRuntime{Id: "github-runtime", SourceId: "github", TenantId: "writer"}
 	first := githubAuditEvent("github-app-install-same-name-first", map[string]string{
 		"action":        "integration_installation.create",
@@ -1755,6 +1743,10 @@ func TestGitHubAppIntegrationInstalled_DistinctAppIdsByName(t *testing.T) {
 
 func TestGitHubPersonalAccessTokenCreated(t *testing.T) {
 	rule := newGitHubPersonalAccessTokenCreatedRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	metadataRule, ok := rule.(MetadataRule)
 	if !ok {
 		t.Fatal("rule does not expose RuleMetadata")
@@ -1828,8 +1820,9 @@ func TestGitHubPersonalAccessTokenCreated(t *testing.T) {
 
 func TestGitHubPersonalAccessTokenCreatedTrajectory_CreateRevoke(t *testing.T) {
 	rule := newGitHubPersonalAccessTokenCreatedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-personal-access-token-created does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	assertGitHubRuleTrajectory(t, rule, []Event{
 		newGitHubAuditSignalEvent("github-pat-trajectory-create", map[string]string{
@@ -1854,8 +1847,9 @@ func TestGitHubPersonalAccessTokenCreatedTrajectory_CreateRevoke(t *testing.T) {
 
 func TestGitHubPersonalAccessTokenCreatedTrajectory_CreateExpired(t *testing.T) {
 	rule := newGitHubPersonalAccessTokenCreatedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-personal-access-token-created does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	assertGitHubRuleTrajectory(t, rule, []Event{
 		newGitHubAuditSignalEvent("github-pat-trajectory-create-before-expiry", map[string]string{
@@ -1881,8 +1875,9 @@ func TestGitHubPersonalAccessTokenCreatedTrajectory_CreateExpired(t *testing.T) 
 
 func TestGitHubPersonalAccessTokenCreatedTrajectory_NewestEventWins(t *testing.T) {
 	rule := newGitHubPersonalAccessTokenCreatedRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-personal-access-token-created does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	observedAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
 	openEvent := func(id string, at time.Time) Event {
@@ -2049,6 +2044,10 @@ func TestGitHubAuditMirrors_ReplayClosesAddedThenRemoved(t *testing.T) {
 
 func TestGitHubPrivateRepositoryForkingEnabled(t *testing.T) {
 	rule := newGitHubPrivateRepositoryForkingEnabledRule()
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	metadataRule, ok := rule.(MetadataRule)
 	if !ok {
 		t.Fatal("rule does not expose RuleMetadata")
@@ -2172,8 +2171,9 @@ func TestGitHubPrivateRepositoryForkingEnabled(t *testing.T) {
 
 func TestGitHubPrivateRepositoryForkingEnabledTrajectory_Disable(t *testing.T) {
 	rule := newGitHubPrivateRepositoryForkingEnabledRule()
-	if _, ok := rule.(CounterEventRule); !ok {
-		t.Fatal("github-private-repository-forking-enabled does not implement CounterEventRule")
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	t.Run("org scope", func(t *testing.T) {
 		assertGitHubRuleTrajectory(t, rule, []Event{
@@ -2254,16 +2254,6 @@ func cloneGitHubTestAttrs(attrs map[string]string) map[string]string {
 	return cloned
 }
 
-func removeGitHubAnchorTestAttr(attrs map[string]string, field string) {
-	delete(attrs, field)
-	if field != "scope" {
-		return
-	}
-	for _, key := range []string{"enterprise", "enterprise_id", "enterprise_slug", "org", "repo", "repository", "resource_id", "runner_scope"} {
-		delete(attrs, key)
-	}
-}
-
 func assertGitHubAuditMirrorReplayClosed(t *testing.T, rule Rule, events []Event) {
 	t.Helper()
 	if rule == nil {
@@ -2275,6 +2265,10 @@ func assertGitHubAuditMirrorReplayClosed(t *testing.T, rule Rule, events []Event
 	}
 	if len(events) == 0 {
 		t.Fatal("events are required")
+	}
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
 	}
 	ruleID := strings.TrimSpace(spec.GetId())
 	runtimeID := githubTrajectoryRuntimeID(events)

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -565,7 +565,7 @@
       "pack_id": "github",
       "pack_name": "GitHub",
       "name": "GitHub App Integration Installed",
-      "description": "Detect new GitHub App integration installations.",
+      "description": "Retired GitHub audit-mirror rule retained so stale open findings auto-resolve; durable coverage moved to posture findings.",
       "source_id": "github",
       "evaluation_mode": "event",
       "event_kinds": [
@@ -574,14 +574,16 @@
       "output_kind": "finding.github_app_integration_installed",
       "severity": "MEDIUM",
       "status": "open",
-      "maturity": "test",
+      "maturity": "retired",
       "tags": [
         "attack.t1072",
         "attack.t1098",
+        "cleanup",
         "execution",
         "github",
         "github-app",
-        "persistence"
+        "persistence",
+        "retired"
       ],
       "references": [
         "https://docs.github.com/en/apps/using-github-apps/installing-a-github-app-from-a-third-party",
@@ -714,7 +716,7 @@
       "pack_id": "github",
       "pack_name": "GitHub",
       "name": "GitHub Organization Authentication Control Modified",
-      "description": "Detect GitHub organization authentication control changes including SAML, 2FA, and OAuth app restrictions.",
+      "description": "Retired GitHub audit-mirror rule retained so stale open findings auto-resolve; durable coverage moved to posture findings.",
       "source_id": "github",
       "evaluation_mode": "event",
       "event_kinds": [
@@ -723,15 +725,17 @@
       "output_kind": "finding.github_org_auth_control_modified",
       "severity": "CRITICAL",
       "status": "open",
-      "maturity": "test",
+      "maturity": "retired",
       "tags": [
         "attack.t1098",
         "authentication",
+        "cleanup",
         "defense-evasion",
         "github",
         "organization",
         "persistence",
-        "privilege-escalation"
+        "privilege-escalation",
+        "retired"
       ],
       "references": [
         "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github",
@@ -763,7 +767,7 @@
       "pack_id": "github",
       "pack_name": "GitHub",
       "name": "GitHub Organization IP Allow List Modified",
-      "description": "Detect GitHub organization IP allow list changes.",
+      "description": "Retired GitHub audit-mirror rule retained so stale open findings auto-resolve; durable coverage moved to posture findings.",
       "source_id": "github",
       "evaluation_mode": "event",
       "event_kinds": [
@@ -772,13 +776,15 @@
       "output_kind": "finding.github_org_ip_allow_list_modified",
       "severity": "MEDIUM",
       "status": "open",
-      "maturity": "test",
+      "maturity": "retired",
       "tags": [
         "account-manipulation",
         "attack.t1098",
+        "cleanup",
         "github",
         "ip-allow-list",
-        "persistence"
+        "persistence",
+        "retired"
       ],
       "references": [
         "https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-allowed-ip-addresses-for-your-organization",
@@ -854,7 +860,7 @@
       "pack_id": "github",
       "pack_name": "GitHub",
       "name": "GitHub Organization Owner Added",
-      "description": "Detect new GitHub organization members added with owner/admin privileges.",
+      "description": "Retired GitHub audit-mirror rule retained so stale open findings auto-resolve; durable coverage moved to posture findings.",
       "source_id": "github",
       "evaluation_mode": "event",
       "event_kinds": [
@@ -863,13 +869,15 @@
       "output_kind": "finding.github_organization_owner_added",
       "severity": "HIGH",
       "status": "open",
-      "maturity": "test",
+      "maturity": "retired",
       "tags": [
         "attack.t1098.003",
+        "cleanup",
         "github",
         "organization-owner",
         "persistence",
-        "privilege-escalation"
+        "privilege-escalation",
+        "retired"
       ],
       "references": [
         "https://github.com/elastic/detection-rules/blob/main/rules/integrations/github/persistence_github_org_owner_added.toml"
@@ -904,7 +912,7 @@
       "pack_id": "github",
       "pack_name": "GitHub",
       "name": "GitHub Personal Access Token Created",
-      "description": "Detect creation or authorization of GitHub personal access tokens.",
+      "description": "Retired GitHub audit-mirror rule retained so stale open findings auto-resolve; durable coverage moved to posture findings.",
       "source_id": "github",
       "evaluation_mode": "event",
       "event_kinds": [
@@ -913,14 +921,16 @@
       "output_kind": "finding.github_personal_access_token_created",
       "severity": "MEDIUM",
       "status": "open",
-      "maturity": "test",
+      "maturity": "retired",
       "tags": [
         "attack.t1098.001",
         "attack.t1528",
+        "cleanup",
         "credential-access",
         "github",
         "persistence",
-        "personal-access-token"
+        "personal-access-token",
+        "retired"
       ],
       "references": [
         "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens",
@@ -956,7 +966,7 @@
       "pack_id": "github",
       "pack_name": "GitHub",
       "name": "GitHub Private Repository Forking Enabled",
-      "description": "Detect GitHub private repository forking being enabled or reset.",
+      "description": "Retired GitHub audit-mirror rule retained so stale open findings auto-resolve; durable coverage moved to posture findings.",
       "source_id": "github",
       "evaluation_mode": "event",
       "event_kinds": [
@@ -965,12 +975,14 @@
       "output_kind": "finding.github_private_repository_forking_enabled",
       "severity": "MEDIUM",
       "status": "open",
-      "maturity": "test",
+      "maturity": "retired",
       "tags": [
         "attack.t1020",
+        "cleanup",
         "exfiltration",
         "github",
-        "private-forking"
+        "private-forking",
+        "retired"
       ],
       "references": [
         "https://docs.github.com/en/organizations/managing-organization-settings/managing-the-forking-policy-for-your-organization",
@@ -1047,7 +1059,7 @@
       "pack_id": "github",
       "pack_name": "GitHub",
       "name": "GitHub Repository Collaborator Added",
-      "description": "Detect users added as collaborators to GitHub repositories.",
+      "description": "Retired GitHub audit-mirror rule retained so stale open findings auto-resolve; durable coverage moved to posture findings.",
       "source_id": "github",
       "evaluation_mode": "event",
       "event_kinds": [
@@ -1056,12 +1068,14 @@
       "output_kind": "finding.github_repository_collaborator_added",
       "severity": "MEDIUM",
       "status": "open",
-      "maturity": "test",
+      "maturity": "retired",
       "tags": [
         "attack.t1195",
+        "cleanup",
         "collaborator",
         "github",
         "initial-access",
+        "retired",
         "supply-chain"
       ],
       "references": [
@@ -1097,7 +1111,7 @@
       "pack_id": "github",
       "pack_name": "GitHub",
       "name": "GitHub Repository Ruleset Modified",
-      "description": "Detect destructive or weakening changes to GitHub repository rulesets.",
+      "description": "Retired GitHub audit-mirror rule retained so stale open findings auto-resolve; durable coverage moved to posture findings.",
       "source_id": "github",
       "evaluation_mode": "event",
       "event_kinds": [
@@ -1106,12 +1120,14 @@
       "output_kind": "finding.github_repository_ruleset_modified",
       "severity": "HIGH",
       "status": "open",
-      "maturity": "test",
+      "maturity": "retired",
       "tags": [
         "attack.t1562",
         "branch-protection",
+        "cleanup",
         "defense-evasion",
         "github",
+        "retired",
         "ruleset"
       ],
       "references": [
@@ -1243,7 +1259,7 @@
       "pack_id": "github",
       "pack_name": "GitHub",
       "name": "GitHub Webhook Modified",
-      "description": "Detect GitHub webhook creation, deletion, or configuration changes.",
+      "description": "Retired GitHub audit-mirror rule retained so stale open findings auto-resolve; durable coverage moved to posture findings.",
       "source_id": "github",
       "evaluation_mode": "event",
       "event_kinds": [
@@ -1252,11 +1268,13 @@
       "output_kind": "finding.github_webhook_modified",
       "severity": "MEDIUM",
       "status": "open",
-      "maturity": "test",
+      "maturity": "retired",
       "tags": [
         "attack.t1020",
+        "cleanup",
         "exfiltration",
         "github",
+        "retired",
         "webhook"
       ],
       "references": [

--- a/internal/findings/rule_fixture_test.go
+++ b/internal/findings/rule_fixture_test.go
@@ -93,52 +93,52 @@ func TestGitHubSelfHostedRunnerChangeFixtureRetired(t *testing.T) {
 	assertRetiredEventRuleFixture(t, newGitHubSelfHostedRunnerChangeRule(), "testdata/rules/github-self-hosted-runner-change.json")
 }
 
-func TestGitHubRepositoryCollaboratorAddedFixture(t *testing.T) {
-	assertRuleFixture(t, newGitHubRepositoryCollaboratorAddedRule(), "testdata/rules/github-repository-collaborator-added.json")
+func TestGitHubRepositoryCollaboratorAddedFixtureRetired(t *testing.T) {
+	assertRetiredEventRuleFixture(t, newGitHubRepositoryCollaboratorAddedRule(), "testdata/rules/github-repository-collaborator-added.json")
 }
 
-func TestGitHubOrganizationOwnerAddedFixture(t *testing.T) {
-	assertRuleFixture(t, newGitHubOrganizationOwnerAddedRule(), "testdata/rules/github-organization-owner-added.json")
+func TestGitHubOrganizationOwnerAddedFixtureRetired(t *testing.T) {
+	assertRetiredEventRuleFixture(t, newGitHubOrganizationOwnerAddedRule(), "testdata/rules/github-organization-owner-added.json")
 }
 
 func TestGitHubCodeSecurityControlsDisabledFixture(t *testing.T) {
 	assertRuleFixture(t, newGitHubCodeSecurityControlsDisabledRule(), "testdata/rules/github-code-security-controls-disabled.json")
 }
 
-func TestGitHubOrgAuthControlModifiedFixture(t *testing.T) {
-	assertRuleFixture(t, newGitHubOrgAuthControlModifiedRule(), "testdata/rules/github-org-auth-control-modified.json")
+func TestGitHubOrgAuthControlModifiedFixtureRetired(t *testing.T) {
+	assertRetiredEventRuleFixture(t, newGitHubOrgAuthControlModifiedRule(), "testdata/rules/github-org-auth-control-modified.json")
 }
 
-func TestGitHubOrgIPAllowListModifiedFixture(t *testing.T) {
-	assertRuleFixture(t, newGitHubOrgIPAllowListModifiedRule(), "testdata/rules/github-org-ip-allow-list-modified.json")
+func TestGitHubOrgIPAllowListModifiedFixtureRetired(t *testing.T) {
+	assertRetiredEventRuleFixture(t, newGitHubOrgIPAllowListModifiedRule(), "testdata/rules/github-org-ip-allow-list-modified.json")
 }
 
-func TestGitHubAppIntegrationInstalledFixture(t *testing.T) {
-	assertRuleFixture(t, newGitHubAppIntegrationInstalledRule(), "testdata/rules/github-app-integration-installed.json")
+func TestGitHubAppIntegrationInstalledFixtureRetired(t *testing.T) {
+	assertRetiredEventRuleFixture(t, newGitHubAppIntegrationInstalledRule(), "testdata/rules/github-app-integration-installed.json")
 }
 
-func TestGitHubPersonalAccessTokenCreatedFixture(t *testing.T) {
-	assertRuleFixture(t, newGitHubPersonalAccessTokenCreatedRule(), "testdata/rules/github-personal-access-token-created.json")
+func TestGitHubPersonalAccessTokenCreatedFixtureRetired(t *testing.T) {
+	assertRetiredEventRuleFixture(t, newGitHubPersonalAccessTokenCreatedRule(), "testdata/rules/github-personal-access-token-created.json")
 }
 
 func TestGitHubProtectedBranchPolicyOverrideFixtureRetired(t *testing.T) {
 	assertRetiredEventRuleFixture(t, newGitHubProtectedBranchPolicyOverrideRule(), "testdata/rules/github-protected-branch-policy-override.json")
 }
 
-func TestGitHubRepositoryRulesetModifiedFixture(t *testing.T) {
-	assertRuleFixture(t, newGitHubRepositoryRulesetModifiedRule(), "testdata/rules/github-repository-ruleset-modified.json")
+func TestGitHubRepositoryRulesetModifiedFixtureRetired(t *testing.T) {
+	assertRetiredEventRuleFixture(t, newGitHubRepositoryRulesetModifiedRule(), "testdata/rules/github-repository-ruleset-modified.json")
 }
 
 func TestGitHubCriticalResourceDeletedFixture(t *testing.T) {
 	assertRetiredEventRuleFixture(t, newGitHubCriticalResourceDeletedRule(), "testdata/rules/github-critical-resource-deleted.json")
 }
 
-func TestGitHubWebhookModifiedFixture(t *testing.T) {
-	assertRuleFixture(t, newGitHubWebhookModifiedRule(), "testdata/rules/github-webhook-modified.json")
+func TestGitHubWebhookModifiedFixtureRetired(t *testing.T) {
+	assertRetiredEventRuleFixture(t, newGitHubWebhookModifiedRule(), "testdata/rules/github-webhook-modified.json")
 }
 
-func TestGitHubPrivateRepositoryForkingEnabledFixture(t *testing.T) {
-	assertRuleFixture(t, newGitHubPrivateRepositoryForkingEnabledRule(), "testdata/rules/github-private-repository-forking-enabled.json")
+func TestGitHubPrivateRepositoryForkingEnabledFixtureRetired(t *testing.T) {
+	assertRetiredEventRuleFixture(t, newGitHubPrivateRepositoryForkingEnabledRule(), "testdata/rules/github-private-repository-forking-enabled.json")
 }
 
 func TestSentinelOneMitigationFailedFixture(t *testing.T) {

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -64,7 +64,7 @@ func TestRulepackAllRulesDeclareLifecycle(t *testing.T) {
 func TestNoConvertRuleUsesEventIdOrMatchedAtFingerprint(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	convertRules := rulepackAuditRulesByClass(t, rulepackAuditClassConvert)
-	if got, want := len(convertRules), 26; got != want {
+	if got, want := len(convertRules), 17; got != want {
 		t.Fatalf("CONVERT_TO_CURRENT_STATE rule count = %d, want %d", got, want)
 	}
 	rows := make([]string, 0, len(convertRules))
@@ -254,17 +254,6 @@ func rulepackConvertReplayFixtures() map[string]rulepackConvertReplayFixture {
 				"source_provider":     "aws",
 			},
 		},
-		githubAppIntegrationInstalledRuleID: {
-			runtime: rulepackConvertRuntime("github", "audit"),
-			kind:    "github.audit",
-			attributes: map[string]string{
-				"action":        "integration_installation.create",
-				"github_app_id": "123456",
-				"name":          "ci-deployer",
-				"org":           "writer",
-				"resource_type": "integration_installation",
-			},
-		},
 		githubCodeSecurityControlsDisabledRuleID: {
 			runtime: rulepackConvertRuntime("github", "audit"),
 			kind:    "github.audit",
@@ -274,81 +263,6 @@ func rulepackConvertReplayFixtures() map[string]rulepackConvertReplayFixture {
 				"org":                       "writer",
 				"repo":                      "writer/cerebro",
 				"resource_type":             "dependabot_alerts",
-			},
-		},
-		githubOrgAuthControlModifiedRuleID: {
-			runtime: rulepackConvertRuntime("github", "audit"),
-			kind:    "github.audit",
-			attributes: map[string]string{
-				"action":                          "oauth_app_policy.disabled",
-				"oauth_app_restrictions_enabled":  "false",
-				"oauth_app_restrictions_enforced": "false",
-				"org":                             "writer",
-				"resource_id":                     "writer",
-				"resource_type":                   "org",
-			},
-		},
-		githubOrgIPAllowListModifiedRuleID: {
-			runtime: rulepackConvertRuntime("github", "audit"),
-			kind:    "github.audit",
-			attributes: map[string]string{
-				"action":                "ip_allow_list.disable",
-				"ip_allow_list_enabled": "false",
-				"org":                   "writer",
-				"resource_id":           "writer",
-				"resource_type":         "ip_allow_list",
-			},
-		},
-		githubOrganizationOwnerAddedRuleID: {
-			runtime: rulepackConvertRuntime("github", "audit"),
-			kind:    "github.audit",
-			attributes: map[string]string{
-				"action":     "org.add_member",
-				"org":        "writer",
-				"permission": "admin",
-				"user":       "octocat",
-			},
-		},
-		githubPersonalAccessTokenCreatedRuleID: {
-			runtime: rulepackConvertRuntime("github", "audit"),
-			kind:    "github.audit",
-			attributes: map[string]string{
-				"action":         "personal_access_token.access_granted",
-				"operation_type": "create",
-				"token_id":       "555",
-				"user":           "octocat",
-				"user_id":        "12345",
-			},
-		},
-		githubPrivateRepositoryForkingEnabledRuleID: {
-			runtime: rulepackConvertRuntime("github", "audit"),
-			kind:    "github.audit",
-			attributes: map[string]string{
-				"action":                             "private_repository_forking.enable",
-				"org":                                "writer",
-				"private_repository_forking_enabled": "true",
-				"resource_id":                        "writer",
-				"resource_type":                      "org",
-			},
-		},
-		githubRepositoryCollaboratorAddedRuleID: {
-			runtime: rulepackConvertRuntime("github", "audit"),
-			kind:    "github.audit",
-			attributes: map[string]string{
-				"action": "repo.add_member",
-				"repo":   "writer/cerebro",
-				"user":   "octocat",
-			},
-		},
-		githubRepositoryRulesetModifiedRuleID: {
-			runtime: rulepackConvertRuntime("github", "audit"),
-			kind:    "github.audit",
-			attributes: map[string]string{
-				"action":                        "repository_ruleset.update",
-				"repo":                          "writer/cerebro",
-				"required_status_check_removed": "true",
-				"ruleset_id":                    "42",
-				"ruleset_name":                  "main protections",
 			},
 		},
 		githubSecretScanningAlertCreatedRuleID: {
@@ -361,15 +275,6 @@ func rulepackConvertReplayFixtures() map[string]rulepackConvertReplayFixture {
 				"repo":                        "writer/cerebro",
 				"secret_scanning_alert.state": "open",
 				"secret_type":                 "github_personal_access_token",
-			},
-		},
-		githubWebhookModifiedRuleID: {
-			runtime: rulepackConvertRuntime("github", "audit"),
-			kind:    "github.audit",
-			attributes: map[string]string{
-				"action":  "hook.create",
-				"hook_id": "99",
-				"repo":    "writer/cerebro",
 			},
 		},
 		identityAdminPrivilegeGrantedRuleID: {
@@ -1088,21 +993,21 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "cloud-public-resource-exposure", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "cloud"},
 		{RuleID: "data-sensitive-asset-risk", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "asset"},
 		{RuleID: "email-domain-authentication-misconfigured", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "email_domain_health"},
-		{RuleID: "github-app-integration-installed", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
+		{RuleID: "github-app-integration-installed", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
 		{RuleID: "github-code-security-controls-disabled", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "github-dependabot-open-alert", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},
-		{RuleID: "github-org-auth-control-modified", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
-		{RuleID: "github-org-ip-allow-list-modified", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
-		{RuleID: "github-organization-owner-added", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
-		{RuleID: "github-personal-access-token-created", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
-		{RuleID: "github-private-repository-forking-enabled", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
-		{RuleID: "github-repository-collaborator-added", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
-		{RuleID: "github-repository-ruleset-modified", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
+		{RuleID: "github-org-auth-control-modified", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
+		{RuleID: "github-org-ip-allow-list-modified", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
+		{RuleID: "github-organization-owner-added", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
+		{RuleID: "github-personal-access-token-created", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
+		{RuleID: "github-private-repository-forking-enabled", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
+		{RuleID: "github-repository-collaborator-added", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
+		{RuleID: "github-repository-ruleset-modified", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
 		{RuleID: "github-secret-scanning-alert-created", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "github-self-hosted-runner-review-needed", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
 		{RuleID: "github-org-owner-role-review-needed", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},
 		{RuleID: "github-programmatic-credential-review-needed", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},
-		{RuleID: "github-webhook-modified", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
+		{RuleID: "github-webhook-modified", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
 		{RuleID: "grc-control-test-needs-attention", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
 		{RuleID: "grc-failing-control-open-operational-findings", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
 		{RuleID: "grc-failing-control-test-unhealthy-integration", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -3847,9 +3847,12 @@ func TestEvaluateSourceRuntimeRulesSelectsExplicitRules(t *testing.T) {
 
 func TestEvaluateSourceRuntimeRulesReplaysGitHubAuditSOTASignals(t *testing.T) {
 	activeRuleIDs := []string{
+		githubSecretScanningAlertCreatedRuleID,
+		githubCodeSecurityControlsDisabledRuleID,
+	}
+	retiredRuleIDs := []string{
 		githubRepositoryCollaboratorAddedRuleID,
 		githubOrganizationOwnerAddedRuleID,
-		githubCodeSecurityControlsDisabledRuleID,
 		githubOrgAuthControlModifiedRuleID,
 		githubOrgIPAllowListModifiedRuleID,
 		githubAppIntegrationInstalledRuleID,
@@ -3859,6 +3862,7 @@ func TestEvaluateSourceRuntimeRulesReplaysGitHubAuditSOTASignals(t *testing.T) {
 		githubPrivateRepositoryForkingEnabledRuleID,
 	}
 	ruleIDs := append([]string(nil), activeRuleIDs...)
+	ruleIDs = append(ruleIDs, retiredRuleIDs...)
 	service := New(
 		&stubRuntimeStore{
 			runtimes: map[string]*cerebrov1.SourceRuntime{
@@ -3876,7 +3880,7 @@ func TestEvaluateSourceRuntimeRulesReplaysGitHubAuditSOTASignals(t *testing.T) {
 				newGitHubAuditSignalEvent("github-audit-push-protection-disabled", map[string]string{"action": "org.secret_scanning_push_protection_disable", "resource_id": "writer", "resource_type": "org"}),
 				newGitHubAuditSignalEvent("github-audit-branch-protection-disabled", map[string]string{"action": "protected_branch.destroy", "repo": "writer/cerebro", "resource_type": "protected_branch"}),
 				newGitHubAuditSignalEvent("github-audit-repo-made-public", map[string]string{"action": "repo.access", "repo": "writer/cerebro", "previous_visibility": "private", "visibility": "public", "resource_type": "repo"}),
-				newGitHubAuditSignalEvent("github-audit-secret-alert-created", map[string]string{"action": "secret_scanning_alert.create", "repo": "writer/cerebro", "number": "12", "resource_type": "secret_scanning_alert"}),
+				newGitHubAuditSignalEvent("github-audit-secret-alert-created", map[string]string{"action": "secret_scanning_alert.create", "repo": "writer/cerebro", "number": "12", "resource_type": "secret_scanning_alert", "secret_scanning_alert.state": "open"}),
 				newGitHubAuditSignalEvent("github-audit-runner-registered", map[string]string{"action": "repo.register_self_hosted_runner", "repo": "writer/cerebro", "resource_type": "repo", "runner_ephemeral": "false", "runner_id": "777", "runner_registered": "true"}),
 				newGitHubAuditSignalEvent("github-audit-collaborator-added", map[string]string{"action": "repo.add_member", "repo": "writer/cerebro", "resource_type": "repo", "user": "octocat"}),
 				newGitHubAuditSignalEvent("github-audit-owner-added", map[string]string{"action": "org.add_member", "resource_id": "writer", "resource_type": "org", "permission": "admin", "user": "octocat"}),
@@ -3926,8 +3930,16 @@ func TestEvaluateSourceRuntimeRulesReplaysGitHubAuditSOTASignals(t *testing.T) {
 			t.Fatalf("finding %q ResourceURNs missing primary resource %q: %#v", ruleID, primaryResourceURN, findingsByRule[ruleID].ResourceURNs)
 		}
 	}
-	if got := findingsByRule[githubOrganizationOwnerAddedRuleID].Severity; got != "HIGH" {
-		t.Fatalf("organization owner severity = %q, want HIGH", got)
+	for _, ruleID := range retiredRuleIDs {
+		if got := findingCountByRule[ruleID]; got != 0 {
+			t.Fatalf("EvaluateSourceRuntimeRules() emitted %d findings for retired rule %q, want 0", got, ruleID)
+		}
+	}
+	if got := findingsByRule[githubCodeSecurityControlsDisabledRuleID].Severity; got != "CRITICAL" {
+		t.Fatalf("code security controls severity = %q, want CRITICAL", got)
+	}
+	if got := findingsByRule[githubSecretScanningAlertCreatedRuleID].Severity; got != "MEDIUM" {
+		t.Fatalf("secret scanning alert severity = %q, want MEDIUM", got)
 	}
 }
 

--- a/internal/findings/testhelpers_trajectory_test.go
+++ b/internal/findings/testhelpers_trajectory_test.go
@@ -27,6 +27,10 @@ func assertGitHubRuleTrajectory(t *testing.T, rule Rule, events []Event, expecte
 	if len(events) == 0 {
 		t.Fatal("events are required")
 	}
+	if isRetiredGitHubAuditRule(rule) {
+		assertGitHubAuditRuleRetired(t, rule)
+		return
+	}
 	ruleID := strings.TrimSpace(spec.GetId())
 	expectedStatus := githubTrajectoryFindingStatusString(t, expectedFinalStatus)
 	runtimeID := githubTrajectoryRuntimeID(events)

--- a/ops/closeout/rule-ids-24h.txt
+++ b/ops/closeout/rule-ids-24h.txt
@@ -1,4 +1,13 @@
+github-app-integration-installed
+github-org-auth-control-modified
+github-org-ip-allow-list-modified
+github-organization-owner-added
+github-personal-access-token-created
+github-private-repository-forking-enabled
+github-repository-collaborator-added
+github-repository-ruleset-modified
 github-self-hosted-runner-review-needed
+github-webhook-modified
 identity-api-token-or-oauth-app-created
 identity-privileged-account-without-mfa
 identity-privileged-no-mfa-plus-sensitive-access

--- a/ops/closeout/rule-ids-7d.txt
+++ b/ops/closeout/rule-ids-7d.txt
@@ -2,17 +2,8 @@ cloud-effective-admin-permission
 cloud-privilege-path-granted
 cloud-public-resource-exposure
 data-sensitive-asset-risk
-github-app-integration-installed
 github-code-security-controls-disabled
-github-org-auth-control-modified
-github-org-ip-allow-list-modified
-github-organization-owner-added
-github-personal-access-token-created
-github-private-repository-forking-enabled
-github-repository-collaborator-added
-github-repository-ruleset-modified
 github-secret-scanning-alert-created
-github-webhook-modified
 identity-admin-privilege-granted
 identity-auth-control-lifecycle-tampering
 identity-external-or-personal-group-member

--- a/sources/github/audit_test.go
+++ b/sources/github/audit_test.go
@@ -153,15 +153,17 @@ func TestAuditAttributes_ForwardsPostureBooleans(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name   string
-		ruleID string
-		action string
-		raw    map[string]any
+		name         string
+		ruleID       string
+		action       string
+		raw          map[string]any
+		wantFindings int
 	}{
 		{
-			name:   "code security dependabot disabled",
-			ruleID: "github-code-security-controls-disabled",
-			action: "dependabot_alerts.disable",
+			name:         "code security dependabot disabled",
+			ruleID:       "github-code-security-controls-disabled",
+			action:       "dependabot_alerts.disable",
+			wantFindings: 1,
 			raw: map[string]any{
 				"dependabot_alerts_enabled": false,
 				"org":                       "writer",
@@ -171,9 +173,10 @@ func TestAuditAttributes_ForwardsPostureBooleans(t *testing.T) {
 			},
 		},
 		{
-			name:   "org auth two factor disabled",
-			ruleID: "github-org-auth-control-modified",
-			action: "org.disable_two_factor_requirement",
+			name:         "org auth two factor disabled",
+			ruleID:       "github-org-auth-control-modified",
+			action:       "org.disable_two_factor_requirement",
+			wantFindings: 0,
 			raw: map[string]any{
 				"org":                            "writer",
 				"resource_id":                    "writer",
@@ -182,9 +185,10 @@ func TestAuditAttributes_ForwardsPostureBooleans(t *testing.T) {
 			},
 		},
 		{
-			name:   "ip allow list disabled",
-			ruleID: "github-org-ip-allow-list-modified",
-			action: "ip_allow_list.disable",
+			name:         "ip allow list disabled",
+			ruleID:       "github-org-ip-allow-list-modified",
+			action:       "ip_allow_list.disable",
+			wantFindings: 0,
 			raw: map[string]any{
 				"ip_allow_list_enabled": false,
 				"org":                   "writer",
@@ -193,9 +197,10 @@ func TestAuditAttributes_ForwardsPostureBooleans(t *testing.T) {
 			},
 		},
 		{
-			name:   "private repository forking enabled",
-			ruleID: "github-private-repository-forking-enabled",
-			action: "private_repository_forking.enable",
+			name:         "private repository forking enabled",
+			ruleID:       "github-private-repository-forking-enabled",
+			action:       "private_repository_forking.enable",
+			wantFindings: 0,
 			raw: map[string]any{
 				"org":                                "writer",
 				"private_repository_forking_enabled": true,
@@ -218,8 +223,8 @@ func TestAuditAttributes_ForwardsPostureBooleans(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Evaluate(%s) error = %v", tc.ruleID, err)
 			}
-			if len(records) != 1 {
-				t.Fatalf("Evaluate(%s) returned %d findings, want 1; attrs=%v", tc.ruleID, len(records), event.Attributes)
+			if len(records) != tc.wantFindings {
+				t.Fatalf("Evaluate(%s) returned %d findings, want %d; attrs=%v", tc.ruleID, len(records), tc.wantFindings, event.Attributes)
 			}
 		})
 	}
@@ -255,10 +260,6 @@ func TestAuditAttributes_ForwardsWebhookAllowlistKeys(t *testing.T) {
 	}
 
 	rule := mustGitHubFindingRule(t, "github-webhook-modified")
-	counterRule, ok := rule.(findingrules.CounterEventRule)
-	if !ok {
-		t.Fatal("github-webhook-modified does not implement CounterEventRule")
-	}
 	openEvent := auditEventForTest(t, "hook.config_changed", map[string]any{
 		"destination_allowlisted": false,
 		"hook_id":                 99,
@@ -268,18 +269,20 @@ func TestAuditAttributes_ForwardsWebhookAllowlistKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Evaluate(source-backed webhook open event) error = %v", err)
 	}
-	if len(records) != 1 {
-		t.Fatalf("Evaluate(source-backed webhook open event) returned %d findings, want 1; attrs=%v", len(records), openEvent.Attributes)
+	if len(records) != 0 {
+		t.Fatalf("Evaluate(source-backed webhook open event) returned %d findings, want 0 for retired audit mirror; attrs=%v", len(records), openEvent.Attributes)
 	}
-	openAnchor := counterRule.OpenAnchor(records[0].Attributes)
 	closeEvent := auditEventForTest(t, "hook.config_changed", map[string]any{
 		"destination_allowlisted": true,
 		"hook_id":                 99,
 		"repo":                    "writer/cerebro",
 	}, nil)
-	closeAnchor, closes := counterRule.CloseOnEvent(closeEvent)
-	if !closes || closeAnchor != openAnchor {
-		t.Fatalf("CloseOnEvent(source-backed webhook allowlisted event) = (%q, %v), want (%q, true); attrs=%v", closeAnchor, closes, openAnchor, closeEvent.Attributes)
+	records, err = rule.Evaluate(context.Background(), githubAuditRuntimeForRuleTest(), closeEvent)
+	if err != nil {
+		t.Fatalf("Evaluate(source-backed webhook allowlisted event) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("Evaluate(source-backed webhook allowlisted event) returned %d findings, want 0 for retired audit mirror; attrs=%v", len(records), closeEvent.Attributes)
 	}
 }
 

--- a/sources/internal/githubcanary/canary.go
+++ b/sources/internal/githubcanary/canary.go
@@ -298,13 +298,13 @@ func repositoryUpdatedAt(repo *gogithub.Repository, fallback time.Time) time.Tim
 		return fallback.UTC()
 	}
 	if updatedAt := repo.GetUpdatedAt(); !updatedAt.IsZero() {
-		return updatedAt.Time.UTC()
+		return updatedAt.UTC()
 	}
 	if pushedAt := timestamp(repo.PushedAt); pushedAt != nil {
 		return pushedAt.UTC()
 	}
 	if createdAt := repo.GetCreatedAt(); !createdAt.IsZero() {
-		return createdAt.Time.UTC()
+		return createdAt.UTC()
 	}
 	return fallback.UTC()
 }


### PR DESCRIPTION
## Summary
- retire noisy GitHub audit-mirror finding rules that do not represent durable current risk
- keep actionable GitHub coverage for code-security posture and open secret-scanning alerts
- update rulepack audits, fixtures, detection catalog output, and closeout rule lists

## Validation
- go test ./internal/findings -count=1
- go test ./cmd/cerebro -run 'Closeout' -count=1\n- make detection-catalog-generate\n- make detection-catalog-check