### PR TITLE
Add agent platform contract API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -63,6 +63,19 @@ paths:
       responses:
         '200':
           description: Embedded OpenAPI YAML.
+  /api/v1/agent-platform/contract:
+    get:
+      operationId: getAgentPlatformContract
+      summary: Get agent platform contract
+      tags:
+        - Platform
+      responses:
+        '200':
+          description: Cerebro agent platform domains, capabilities, runtime events, connector infrastructure, and provenance requirements.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentPlatformContract'
   /api/v1/mcp:
     get:
       summary: Reject MCP stateful event-stream transport
@@ -2948,6 +2961,310 @@ components:
         type: integer
         minimum: 1
   schemas:
+    AgentPlatformContract:
+      type: object
+      required:
+        - version
+        - domains
+        - invariants
+        - capabilities
+        - runtime_events
+        - provenance_requirements
+        - connector_infrastructure
+      properties:
+        version:
+          type: string
+        domains:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformDomain'
+        invariants:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformInvariant'
+        capabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformCapability'
+        runtime_events:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformRuntimeEvent'
+        provenance_requirements:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformProvenanceRequirement'
+        connector_infrastructure:
+          $ref: '#/components/schemas/AgentPlatformConnectorInfrastructure'
+    AgentPlatformDomain:
+      type: object
+      required:
+        - id
+        - name
+        - principle
+        - console_surface
+        - owns
+        - must_expose
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        principle:
+          type: string
+        console_surface:
+          type: string
+        owns:
+          type: array
+          items:
+            type: string
+        must_expose:
+          type: array
+          items:
+            type: string
+    AgentPlatformInvariant:
+      type: object
+      required:
+        - id
+        - domain_id
+        - statement
+      properties:
+        id:
+          type: string
+        domain_id:
+          type: string
+        statement:
+          type: string
+    AgentPlatformCapability:
+      type: object
+      required:
+        - id
+        - name
+        - domain_id
+        - kind
+        - version
+        - owner
+        - risk
+        - default_on
+        - summary
+        - console_surfaces
+        - required_scopes
+        - eval
+        - runtime_events
+        - provenance
+        - review
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        domain_id:
+          type: string
+        kind:
+          type: string
+        version:
+          type: string
+        owner:
+          type: string
+        risk:
+          type: string
+          enum: [low, medium, high]
+        default_on:
+          type: boolean
+        summary:
+          type: string
+        console_surfaces:
+          type: array
+          items:
+            type: string
+        required_scopes:
+          type: array
+          items:
+            type: string
+        connector_dependencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformConnectorDependency'
+        eval:
+          $ref: '#/components/schemas/AgentPlatformEvalStatus'
+        runtime_events:
+          type: array
+          items:
+            type: string
+        provenance:
+          type: array
+          items:
+            type: string
+        review:
+          $ref: '#/components/schemas/AgentPlatformReviewStatus'
+    AgentPlatformConnectorDependency:
+      type: object
+      required:
+        - source_id
+        - purpose
+        - auth_models
+        - required_scopes
+        - token_owner
+        - credential_store
+        - oauth_surface
+        - mcp_surface
+        - tenant_scoped
+        - readiness
+      properties:
+        source_id:
+          type: string
+        purpose:
+          type: string
+        auth_models:
+          type: array
+          items:
+            type: string
+        required_scopes:
+          type: array
+          items:
+            type: string
+        token_owner:
+          type: string
+        credential_store:
+          type: string
+        oauth_surface:
+          type: string
+        mcp_surface:
+          type: string
+        tenant_scoped:
+          type: boolean
+        readiness:
+          type: string
+    AgentPlatformEvalStatus:
+      type: object
+      required:
+        - required
+        - status
+        - local_commands
+        - scenario_sets
+        - rubrics
+      properties:
+        required:
+          type: boolean
+        status:
+          type: string
+        local_commands:
+          type: array
+          items:
+            type: string
+        scenario_sets:
+          type: array
+          items:
+            type: string
+        rubrics:
+          type: array
+          items:
+            type: string
+    AgentPlatformReviewStatus:
+      type: object
+      required:
+        - state
+        - cadence
+        - required_approvers
+      properties:
+        state:
+          type: string
+        cadence:
+          type: string
+        required_approvers:
+          type: array
+          items:
+            type: string
+    AgentPlatformRuntimeEvent:
+      type: object
+      required:
+        - name
+        - domain_id
+        - stage
+        - sequence_required
+        - terminal
+        - replayable
+        - payload_fields
+        - provenance_fields
+      properties:
+        name:
+          type: string
+        domain_id:
+          type: string
+        stage:
+          type: string
+        sequence_required:
+          type: boolean
+        terminal:
+          type: boolean
+        replayable:
+          type: boolean
+        payload_fields:
+          type: array
+          items:
+            type: string
+        provenance_fields:
+          type: array
+          items:
+            type: string
+    AgentPlatformProvenanceRequirement:
+      type: object
+      required:
+        - surface
+        - domain_id
+        - required_fields
+        - citation_required
+        - budget_required
+        - fallback_required
+      properties:
+        surface:
+          type: string
+        domain_id:
+          type: string
+        required_fields:
+          type: array
+          items:
+            type: string
+        citation_required:
+          type: boolean
+        budget_required:
+          type: boolean
+        fallback_required:
+          type: boolean
+    AgentPlatformConnectorInfrastructure:
+      type: object
+      required:
+        - auth_models
+        - oauth_surfaces
+        - credential_stores
+        - token_boundaries
+        - mcp_surfaces
+        - required_controls
+      properties:
+        auth_models:
+          type: array
+          items:
+            type: string
+        oauth_surfaces:
+          type: array
+          items:
+            type: string
+        credential_stores:
+          type: array
+          items:
+            type: string
+        token_boundaries:
+          type: array
+          items:
+            type: string
+        mcp_surfaces:
+          type: array
+          items:
+            type: string
+        required_controls:
+          type: array
+          items:
+            type: string
     EncryptedConnectorCredentialPayload:
       type: object
       required:

--- a/internal/agentplatform/contracts.go
+++ b/internal/agentplatform/contracts.go
@@ -7,25 +7,112 @@ package agentplatform
 
 const ContractVersion = "2026-06-16.cerebro-agent-platform"
 
+type Contract struct {
+	Version                 string                  `json:"version"`
+	Domains                 []Domain                `json:"domains"`
+	Invariants              []Invariant             `json:"invariants"`
+	Capabilities            []Capability            `json:"capabilities"`
+	RuntimeEvents           []RuntimeEvent          `json:"runtime_events"`
+	ProvenanceRequirements  []ProvenanceRequirement `json:"provenance_requirements"`
+	ConnectorInfrastructure ConnectorInfrastructure `json:"connector_infrastructure"`
+}
+
 type Domain struct {
-	ID         string
-	Name       string
-	Principle  string
-	Owns       []string
-	MustExpose []string
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Principle      string   `json:"principle"`
+	ConsoleSurface string   `json:"console_surface"`
+	Owns           []string `json:"owns"`
+	MustExpose     []string `json:"must_expose"`
 }
 
 type Invariant struct {
-	ID        string
-	DomainID  string
-	Statement string
+	ID        string `json:"id"`
+	DomainID  string `json:"domain_id"`
+	Statement string `json:"statement"`
+}
+
+type Capability struct {
+	ID                    string                `json:"id"`
+	Name                  string                `json:"name"`
+	DomainID              string                `json:"domain_id"`
+	Kind                  string                `json:"kind"`
+	Version               string                `json:"version"`
+	Owner                 string                `json:"owner"`
+	Risk                  string                `json:"risk"`
+	DefaultOn             bool                  `json:"default_on"`
+	Summary               string                `json:"summary"`
+	ConsoleSurfaces       []string              `json:"console_surfaces"`
+	RequiredScopes        []string              `json:"required_scopes"`
+	ConnectorDependencies []ConnectorDependency `json:"connector_dependencies,omitempty"`
+	Eval                  EvalStatus            `json:"eval"`
+	RuntimeEvents         []string              `json:"runtime_events"`
+	Provenance            []string              `json:"provenance"`
+	Review                ReviewStatus          `json:"review"`
+}
+
+type ConnectorDependency struct {
+	SourceID        string   `json:"source_id"`
+	Purpose         string   `json:"purpose"`
+	AuthModels      []string `json:"auth_models"`
+	RequiredScopes  []string `json:"required_scopes"`
+	TokenOwner      string   `json:"token_owner"`
+	CredentialStore string   `json:"credential_store"`
+	OAuthSurface    string   `json:"oauth_surface"`
+	MCPSurface      string   `json:"mcp_surface"`
+	TenantScoped    bool     `json:"tenant_scoped"`
+	Readiness       string   `json:"readiness"`
+}
+
+type EvalStatus struct {
+	Required      bool     `json:"required"`
+	Status        string   `json:"status"`
+	LocalCommands []string `json:"local_commands"`
+	ScenarioSets  []string `json:"scenario_sets"`
+	Rubrics       []string `json:"rubrics"`
+}
+
+type ReviewStatus struct {
+	State             string   `json:"state"`
+	Cadence           string   `json:"cadence"`
+	RequiredApprovers []string `json:"required_approvers"`
+}
+
+type RuntimeEvent struct {
+	Name             string   `json:"name"`
+	DomainID         string   `json:"domain_id"`
+	Stage            string   `json:"stage"`
+	SequenceRequired bool     `json:"sequence_required"`
+	Terminal         bool     `json:"terminal"`
+	Replayable       bool     `json:"replayable"`
+	PayloadFields    []string `json:"payload_fields"`
+	ProvenanceFields []string `json:"provenance_fields"`
+}
+
+type ProvenanceRequirement struct {
+	Surface          string   `json:"surface"`
+	DomainID         string   `json:"domain_id"`
+	RequiredFields   []string `json:"required_fields"`
+	CitationRequired bool     `json:"citation_required"`
+	BudgetRequired   bool     `json:"budget_required"`
+	FallbackRequired bool     `json:"fallback_required"`
+}
+
+type ConnectorInfrastructure struct {
+	AuthModels       []string `json:"auth_models"`
+	OAuthSurfaces    []string `json:"oauth_surfaces"`
+	CredentialStores []string `json:"credential_stores"`
+	TokenBoundaries  []string `json:"token_boundaries"`
+	MCPSurfaces      []string `json:"mcp_surfaces"`
+	RequiredControls []string `json:"required_controls"`
 }
 
 var Domains = []Domain{
 	{
-		ID:        "runtime",
-		Name:      "Contract-first runtime",
-		Principle: "Agent execution is typed, replayable, and isolated from product-specific orchestration.",
+		ID:             "runtime",
+		Name:           "Contract-first runtime",
+		Principle:      "Agent execution is typed, replayable, and isolated from product-specific orchestration.",
+		ConsoleSurface: "Ask console, trace drawer, runtime status",
 		Owns: []string{
 			"closed event schemas",
 			"append-only conversation or trajectory records",
@@ -34,9 +121,10 @@ var Domains = []Domain{
 		MustExpose: []string{"trace id", "event order", "terminal outcome", "model route"},
 	},
 	{
-		ID:        "evals",
-		Name:      "Evals as product infrastructure",
-		Principle: "Every agent capability has a measurable regression surface before it becomes a default workflow.",
+		ID:             "evals",
+		Name:           "Evals as product infrastructure",
+		Principle:      "Every agent capability has a measurable regression surface before it becomes a default workflow.",
+		ConsoleSurface: "Developer evals",
 		Owns: []string{
 			"golden and adversarial scenarios",
 			"rubric outcomes",
@@ -46,9 +134,10 @@ var Domains = []Domain{
 		MustExpose: []string{"scenario id", "score", "rubric failures", "trace link"},
 	},
 	{
-		ID:        "capabilities",
-		Name:      "Capabilities as governed artifacts",
-		Principle: "Reusable agent behavior is packaged, versioned, and reviewed instead of hidden in prompts.",
+		ID:             "capabilities",
+		Name:           "Capabilities as governed artifacts",
+		Principle:      "Reusable agent behavior is packaged, versioned, and reviewed instead of hidden in prompts.",
+		ConsoleSurface: "Security producers, policies, connector builder",
 		Owns: []string{
 			"capability metadata",
 			"selection rules",
@@ -58,9 +147,10 @@ var Domains = []Domain{
 		MustExpose: []string{"capability id", "version", "owner", "selection reason"},
 	},
 	{
-		ID:        "execution",
-		Name:      "Execution behind ports",
-		Principle: "Stateful or risky work happens through explicit adapters with limits, cancellation, and audit.",
+		ID:             "execution",
+		Name:           "Execution behind ports",
+		Principle:      "Stateful or risky work happens through explicit adapters with limits, cancellation, and audit.",
+		ConsoleSurface: "Runtime response and workflow views",
 		Owns: []string{
 			"workspace access",
 			"shell or runtime response dispatch",
@@ -70,9 +160,10 @@ var Domains = []Domain{
 		MustExpose: []string{"adapter kind", "scope", "limits", "cancel state", "truncation state"},
 	},
 	{
-		ID:        "streaming-replay",
-		Name:      "Streaming and replay discipline",
-		Principle: "Live execution, durable records, and replay/debug views use one ordered event vocabulary.",
+		ID:             "streaming-replay",
+		Name:           "Streaming and replay discipline",
+		Principle:      "Live execution, durable records, and replay/debug views use one ordered event vocabulary.",
+		ConsoleSurface: "Ask trace drawer and eval artifacts",
 		Owns: []string{
 			"monotonic event sequencing",
 			"trajectory persistence",
@@ -82,9 +173,10 @@ var Domains = []Domain{
 		MustExpose: []string{"sequence", "stage", "redaction status", "replay source"},
 	},
 	{
-		ID:        "connectors",
-		Name:      "Connector identity and OAuth boundaries",
-		Principle: "Integrations are authenticated channels with clear public/private surfaces and token ownership.",
+		ID:             "connectors",
+		Name:           "Connector identity and OAuth boundaries",
+		Principle:      "Integrations are authenticated channels with clear public/private surfaces and token ownership.",
+		ConsoleSurface: "Connectors, identity contract, MCP status",
 		Owns: []string{
 			"connector catalog contracts",
 			"OAuth/token lifecycle",
@@ -94,9 +186,10 @@ var Domains = []Domain{
 		MustExpose: []string{"principal", "tenant", "scopes", "token owner", "surface"},
 	},
 	{
-		ID:        "knowledge",
-		Name:      "Knowledge with provenance and budgets",
-		Principle: "Retrieved context is bounded, cited, instruction-safe, and non-blocking when unavailable.",
+		ID:             "knowledge",
+		Name:           "Knowledge with provenance and budgets",
+		Principle:      "Retrieved context is bounded, cited, instruction-safe, and non-blocking when unavailable.",
+		ConsoleSurface: "Graph answers, evidence, inventory, findings",
 		Owns: []string{
 			"graph and knowledge retrieval",
 			"citation validation",
@@ -117,6 +210,501 @@ var Invariants = []Invariant{
 	{ID: "STREAM-01", DomainID: "streaming-replay", Statement: "Replay records preserve event order even when payloads are redacted or truncated."},
 }
 
+var Capabilities = []Capability{
+	{
+		ID:              "grc-ask",
+		Name:            "GRC ask workflow",
+		DomainID:        "runtime",
+		Kind:            "agent-workflow",
+		Version:         "1.0.0",
+		Owner:           "cerebro-platform",
+		Risk:            "medium",
+		DefaultOn:       true,
+		Summary:         "Answers security and compliance questions from graph, findings, evidence, and runtime context.",
+		ConsoleSurfaces: []string{"Ask console", "GRC dashboard", "trace drawer"},
+		RequiredScopes:  []string{"cosmo.security.read"},
+		Eval: EvalStatus{
+			Required:      true,
+			Status:        "required",
+			LocalCommands: []string{"npm run eval:ask:local", "npm run eval:ask:adversarial"},
+			ScenarioSets:  []string{"ask-golden", "ask-adversarial"},
+			Rubrics:       []string{"groundedness", "source use", "safe refusal", "answer completeness"},
+		},
+		RuntimeEvents: []string{"agent.run.started", "capability.selected", "knowledge.retrieval.completed", "agent.run.completed", "agent.run.failed"},
+		Provenance:    []string{"ask-answer"},
+		Review: ReviewStatus{
+			State:             "required",
+			Cadence:           "before default workflow changes",
+			RequiredApprovers: []string{"platform", "security"},
+		},
+	},
+	{
+		ID:              "security-eval-harness",
+		Name:            "Security eval harness",
+		DomainID:        "evals",
+		Kind:            "eval-suite",
+		Version:         "1.0.0",
+		Owner:           "cerebro-platform",
+		Risk:            "low",
+		DefaultOn:       true,
+		Summary:         "Runs golden and adversarial scenarios with trace-linked rubric outcomes for agent-facing workflows.",
+		ConsoleSurfaces: []string{"Developer evals", "pull request checks"},
+		RequiredScopes:  []string{"cosmo.security.read"},
+		Eval: EvalStatus{
+			Required:      true,
+			Status:        "self-covered",
+			LocalCommands: []string{"npm run eval:security-agent:local"},
+			ScenarioSets:  []string{"security-agent-golden"},
+			Rubrics:       []string{"triage accuracy", "evidence quality", "risk calibration"},
+		},
+		RuntimeEvents: []string{"eval.scenario.started", "eval.scenario.completed"},
+		Provenance:    []string{"eval-result"},
+		Review: ReviewStatus{
+			State:             "required",
+			Cadence:           "with rubric or fixture changes",
+			RequiredApprovers: []string{"platform"},
+		},
+	},
+	{
+		ID:              "trace-streaming-replay",
+		Name:            "Trace streaming and replay",
+		DomainID:        "streaming-replay",
+		Kind:            "event-contract",
+		Version:         "1.0.0",
+		Owner:           "cerebro-platform",
+		Risk:            "medium",
+		DefaultOn:       true,
+		Summary:         "Keeps live execution, persisted traces, eval artifacts, and replay fixtures on one ordered event vocabulary.",
+		ConsoleSurfaces: []string{"trace drawer", "Developer evals", "workflow replay"},
+		RequiredScopes:  []string{"cosmo.security.read"},
+		Eval: EvalStatus{
+			Required:      true,
+			Status:        "required",
+			LocalCommands: []string{"go test ./internal/workflowevents ./internal/bootstrap -run Test.*Replay"},
+			ScenarioSets:  []string{"trace-replay", "redacted-event-replay"},
+			Rubrics:       []string{"event ordering", "terminal outcome", "redaction status", "replay source"},
+		},
+		RuntimeEvents: []string{"agent.run.started", "capability.selected", "agent.run.completed", "agent.run.failed", "eval.scenario.completed"},
+		Provenance:    []string{"replay-record"},
+		Review: ReviewStatus{
+			State:             "required",
+			Cadence:           "with event schema or replay fixture changes",
+			RequiredApprovers: []string{"platform"},
+		},
+	},
+	{
+		ID:              "connector-oauth-mcp",
+		Name:            "Connector OAuth and MCP boundary",
+		DomainID:        "connectors",
+		Kind:            "integration-infrastructure",
+		Version:         "1.0.0",
+		Owner:           "cerebro-platform",
+		Risk:            "high",
+		DefaultOn:       true,
+		Summary:         "Makes connector identity, OAuth token ownership, credential storage, and MCP exposure explicit platform contracts.",
+		ConsoleSurfaces: []string{"Connectors", "connector builder", "MCP status"},
+		RequiredScopes:  []string{"cosmo.security.read", "connector.credentials.read", "connector.credentials.write"},
+		ConnectorDependencies: []ConnectorDependency{
+			// #nosec G101 -- static platform metadata only; no secret values.
+			{
+				SourceID:        "catalog-managed",
+				Purpose:         "Connector setup, credential lifecycle, runtime sync, and MCP tool exposure.",
+				AuthModels:      []string{"oauth_authorization_code", "oauth_client_credentials", "api_key", "environment_reference", "external_secret_reference"},
+				RequiredScopes:  []string{"connector.credentials.read", "connector.credentials.write"},
+				TokenOwner:      "declared connector surface",
+				CredentialStore: "tenant-scoped credential broker or declared external reference",
+				OAuthSurface:    "/oauth/* and /.well-known/oauth-*",
+				MCPSurface:      "/api/v1/mcp",
+				TenantScoped:    true,
+				Readiness:       "required",
+			},
+		},
+		Eval: EvalStatus{
+			Required:      true,
+			Status:        "required",
+			LocalCommands: []string{"go test ./internal/bootstrap -run 'Test.*OAuth|Test.*MCP|TestConnector'"},
+			ScenarioSets:  []string{"connector-auth-boundaries", "mcp-protected-resource"},
+			Rubrics:       []string{"token owner isolation", "scope enforcement", "tenant isolation", "credential redaction"},
+		},
+		RuntimeEvents: []string{"connector.auth.boundary.checked", "adapter.execution.started", "adapter.execution.completed"},
+		Provenance:    []string{"connector-call", "mcp-tool-result"},
+		Review: ReviewStatus{
+			State:             "required",
+			Cadence:           "before auth surface or connector catalog changes",
+			RequiredApprovers: []string{"platform", "security"},
+		},
+	},
+	{
+		ID:              "source-runtime-sync",
+		Name:            "Source runtime sync",
+		DomainID:        "execution",
+		Kind:            "runtime-adapter",
+		Version:         "1.0.0",
+		Owner:           "cerebro-platform",
+		Risk:            "medium",
+		DefaultOn:       true,
+		Summary:         "Runs source sync, graph ingest, claim writes, and finding evaluation through explicit runtime adapters.",
+		ConsoleSurfaces: []string{"Source runtimes", "runtime freshness", "ingest health"},
+		RequiredScopes:  []string{"cosmo.security.read"},
+		Eval: EvalStatus{
+			Required:      true,
+			Status:        "required",
+			LocalCommands: []string{"go test ./internal/bootstrap -run Test.*SourceRuntime"},
+			ScenarioSets:  []string{"runtime-sync-health", "finding-evaluation"},
+			Rubrics:       []string{"adapter status", "cancellation state", "truncation state", "tenant scope"},
+		},
+		RuntimeEvents: []string{"adapter.execution.started", "adapter.execution.completed", "adapter.execution.failed"},
+		Provenance:    []string{"source-runtime-event"},
+		Review: ReviewStatus{
+			State:             "required",
+			Cadence:           "with runtime adapter changes",
+			RequiredApprovers: []string{"platform"},
+		},
+	},
+	{
+		ID:              "finding-rule-evaluation",
+		Name:            "Finding rule evaluation",
+		DomainID:        "capabilities",
+		Kind:            "governed-capability",
+		Version:         "1.0.0",
+		Owner:           "cerebro-platform",
+		Risk:            "medium",
+		DefaultOn:       true,
+		Summary:         "Packages finding candidate promotion, rejection, and rule evaluation as reviewable capability behavior.",
+		ConsoleSurfaces: []string{"Finding rules", "source runtime finding evaluations", "GRC findings"},
+		RequiredScopes:  []string{"cosmo.security.read", "finding.candidate.promote"},
+		Eval: EvalStatus{
+			Required:      true,
+			Status:        "required",
+			LocalCommands: []string{"go test ./internal/findings"},
+			ScenarioSets:  []string{"finding-rule-fixtures"},
+			Rubrics:       []string{"precision", "recall", "evidence sufficiency", "risk reason quality"},
+		},
+		RuntimeEvents: []string{"capability.selected", "eval.scenario.completed"},
+		Provenance:    []string{"finding-evidence", "finding-evaluation-run"},
+		Review: ReviewStatus{
+			State:             "required",
+			Cadence:           "before promotion or rule behavior changes",
+			RequiredApprovers: []string{"security"},
+		},
+	},
+	{
+		ID:              "runtime-response-actions",
+		Name:            "Runtime response actions",
+		DomainID:        "execution",
+		Kind:            "side-effect-adapter",
+		Version:         "1.0.0",
+		Owner:           "cerebro-platform",
+		Risk:            "high",
+		DefaultOn:       false,
+		Summary:         "Executes explicit containment actions through scoped adapters with audit, cancellation, and result capture.",
+		ConsoleSurfaces: []string{"Runtime response", "workflow actions", "blocklist"},
+		RequiredScopes:  []string{"runtime.response.write"},
+		Eval: EvalStatus{
+			Required:      true,
+			Status:        "required",
+			LocalCommands: []string{"go test ./internal/bootstrap -run TestRecordRuntimeResponseWorkflowAppendsActionEvent"},
+			ScenarioSets:  []string{"runtime-response-actions"},
+			Rubrics:       []string{"trusted-scope enforcement", "audit completeness", "result status"},
+		},
+		RuntimeEvents: []string{"adapter.execution.started", "adapter.execution.completed", "adapter.execution.failed"},
+		Provenance:    []string{"runtime-response-action"},
+		Review: ReviewStatus{
+			State:             "required",
+			Cadence:           "before adding or changing mutating actions",
+			RequiredApprovers: []string{"platform", "security"},
+		},
+	},
+	{
+		ID:              "knowledge-provenance",
+		Name:            "Knowledge provenance",
+		DomainID:        "knowledge",
+		Kind:            "retrieval-contract",
+		Version:         "1.0.0",
+		Owner:           "cerebro-platform",
+		Risk:            "medium",
+		DefaultOn:       true,
+		Summary:         "Requires cited, scoped, budgeted context with explicit fallback when graph or evidence is unavailable.",
+		ConsoleSurfaces: []string{"Graph answers", "evidence", "inventory", "findings"},
+		RequiredScopes:  []string{"cosmo.security.read"},
+		Eval: EvalStatus{
+			Required:      true,
+			Status:        "required",
+			LocalCommands: []string{"go test ./internal/bootstrap -run 'Test.*GRC|Test.*Evidence|Test.*Inventory'"},
+			ScenarioSets:  []string{"knowledge-provenance", "citation-status"},
+			Rubrics:       []string{"citation coverage", "scope preservation", "fallback clarity", "context budget"},
+		},
+		RuntimeEvents: []string{"knowledge.retrieval.completed", "agent.run.completed", "agent.run.failed"},
+		Provenance:    []string{"knowledge-context", "graph-neighborhood", "evidence-record"},
+		Review: ReviewStatus{
+			State:             "required",
+			Cadence:           "with retrieval or user-visible answer changes",
+			RequiredApprovers: []string{"platform", "security"},
+		},
+	},
+}
+
+var RuntimeEvents = []RuntimeEvent{
+	{
+		Name:             "agent.run.started",
+		DomainID:         "runtime",
+		Stage:            "start",
+		SequenceRequired: true,
+		Replayable:       true,
+		PayloadFields:    []string{"trace_id", "tenant_id", "capability_hint", "model_route"},
+		ProvenanceFields: []string{"trace_id", "scope"},
+	},
+	{
+		Name:             "capability.selected",
+		DomainID:         "capabilities",
+		Stage:            "selection",
+		SequenceRequired: true,
+		Replayable:       true,
+		PayloadFields:    []string{"capability_id", "version", "selection_reason", "owner"},
+		ProvenanceFields: []string{"capability_id", "version", "selection_reason"},
+	},
+	{
+		Name:             "connector.auth.boundary.checked",
+		DomainID:         "connectors",
+		Stage:            "authorization",
+		SequenceRequired: true,
+		Replayable:       true,
+		PayloadFields:    []string{"source_id", "principal", "tenant", "scopes", "token_owner", "surface"},
+		ProvenanceFields: []string{"source_urn", "scope", "token_owner"},
+	},
+	{
+		Name:             "knowledge.retrieval.completed",
+		DomainID:         "knowledge",
+		Stage:            "retrieval",
+		SequenceRequired: true,
+		Replayable:       true,
+		PayloadFields:    []string{"source_urn", "scope", "budget", "citation_status", "fallback_reason"},
+		ProvenanceFields: []string{"source_urn", "scope", "citation_status", "fallback_reason"},
+	},
+	{
+		Name:             "adapter.execution.started",
+		DomainID:         "execution",
+		Stage:            "execution",
+		SequenceRequired: true,
+		Replayable:       true,
+		PayloadFields:    []string{"adapter_kind", "scope", "limits"},
+		ProvenanceFields: []string{"scope", "adapter_kind"},
+	},
+	{
+		Name:             "adapter.execution.completed",
+		DomainID:         "execution",
+		Stage:            "terminal",
+		SequenceRequired: true,
+		Replayable:       true,
+		PayloadFields:    []string{"adapter_kind", "cancel_state", "truncation_state", "result_ref"},
+		ProvenanceFields: []string{"scope", "adapter_kind", "truncation_state"},
+	},
+	{
+		Name:             "adapter.execution.failed",
+		DomainID:         "execution",
+		Stage:            "terminal",
+		SequenceRequired: true,
+		Terminal:         true,
+		Replayable:       true,
+		PayloadFields:    []string{"adapter_kind", "cancel_state", "truncation_state", "error_class"},
+		ProvenanceFields: []string{"scope", "adapter_kind", "truncation_state"},
+	},
+	{
+		Name:             "eval.scenario.started",
+		DomainID:         "evals",
+		Stage:            "start",
+		SequenceRequired: true,
+		Replayable:       true,
+		PayloadFields:    []string{"scenario_id", "capability_id", "model_route"},
+		ProvenanceFields: []string{"scenario_id", "capability_id"},
+	},
+	{
+		Name:             "eval.scenario.completed",
+		DomainID:         "evals",
+		Stage:            "terminal",
+		SequenceRequired: true,
+		Terminal:         true,
+		Replayable:       true,
+		PayloadFields:    []string{"scenario_id", "score", "rubric_failures", "trace_link"},
+		ProvenanceFields: []string{"scenario_id", "score", "trace_link"},
+	},
+	{
+		Name:             "agent.run.completed",
+		DomainID:         "runtime",
+		Stage:            "terminal",
+		SequenceRequired: true,
+		Terminal:         true,
+		Replayable:       true,
+		PayloadFields:    []string{"trace_id", "terminal_outcome", "model_route", "redaction_status"},
+		ProvenanceFields: []string{"trace_id", "terminal_outcome"},
+	},
+	{
+		Name:             "agent.run.failed",
+		DomainID:         "runtime",
+		Stage:            "terminal",
+		SequenceRequired: true,
+		Terminal:         true,
+		Replayable:       true,
+		PayloadFields:    []string{"trace_id", "terminal_outcome", "error_class", "redaction_status"},
+		ProvenanceFields: []string{"trace_id", "terminal_outcome"},
+	},
+}
+
+var ProvenanceRequirements = []ProvenanceRequirement{
+	{
+		Surface:          "ask-answer",
+		DomainID:         "knowledge",
+		RequiredFields:   []string{"source_urn", "scope", "budget", "citation_status", "fallback_reason"},
+		CitationRequired: true,
+		BudgetRequired:   true,
+		FallbackRequired: true,
+	},
+	{
+		Surface:          "connector-call",
+		DomainID:         "connectors",
+		RequiredFields:   []string{"source_urn", "principal", "tenant", "scopes", "token_owner", "surface"},
+		CitationRequired: false,
+		BudgetRequired:   false,
+		FallbackRequired: true,
+	},
+	{
+		Surface:          "mcp-tool-result",
+		DomainID:         "connectors",
+		RequiredFields:   []string{"source_urn", "principal", "tenant", "scopes", "token_owner", "surface", "tool_name"},
+		CitationRequired: false,
+		BudgetRequired:   false,
+		FallbackRequired: true,
+	},
+	{
+		Surface:          "source-runtime-event",
+		DomainID:         "execution",
+		RequiredFields:   []string{"runtime_id", "source_urn", "tenant", "adapter_kind", "scope", "truncation_state"},
+		CitationRequired: false,
+		BudgetRequired:   false,
+		FallbackRequired: false,
+	},
+	{
+		Surface:          "runtime-response-action",
+		DomainID:         "execution",
+		RequiredFields:   []string{"adapter_kind", "scope", "limits", "cancel_state", "truncation_state"},
+		CitationRequired: false,
+		BudgetRequired:   false,
+		FallbackRequired: false,
+	},
+	{
+		Surface:          "eval-result",
+		DomainID:         "evals",
+		RequiredFields:   []string{"scenario_id", "score", "rubric_failures", "trace_link"},
+		CitationRequired: false,
+		BudgetRequired:   false,
+		FallbackRequired: false,
+	},
+	{
+		Surface:          "replay-record",
+		DomainID:         "streaming-replay",
+		RequiredFields:   []string{"trace_id", "sequence", "stage", "redaction_status", "replay_source", "terminal_outcome"},
+		CitationRequired: false,
+		BudgetRequired:   false,
+		FallbackRequired: false,
+	},
+	{
+		Surface:          "finding-evaluation-run",
+		DomainID:         "capabilities",
+		RequiredFields:   []string{"run_id", "runtime_id", "source_urn", "score", "rubric_failures", "trace_link"},
+		CitationRequired: false,
+		BudgetRequired:   false,
+		FallbackRequired: false,
+	},
+	{
+		Surface:          "finding-evidence",
+		DomainID:         "capabilities",
+		RequiredFields:   []string{"source_urn", "scope", "citation_status", "evidence_id"},
+		CitationRequired: true,
+		BudgetRequired:   false,
+		FallbackRequired: false,
+	},
+	{
+		Surface:          "knowledge-context",
+		DomainID:         "knowledge",
+		RequiredFields:   []string{"source_urn", "scope", "budget", "citation_status", "fallback_reason"},
+		CitationRequired: true,
+		BudgetRequired:   true,
+		FallbackRequired: true,
+	},
+	{
+		Surface:          "graph-neighborhood",
+		DomainID:         "knowledge",
+		RequiredFields:   []string{"source_urn", "scope", "entity_urn", "budget", "citation_status", "fallback_reason"},
+		CitationRequired: true,
+		BudgetRequired:   true,
+		FallbackRequired: true,
+	},
+	{
+		Surface:          "evidence-record",
+		DomainID:         "knowledge",
+		RequiredFields:   []string{"source_urn", "scope", "evidence_id", "citation_status"},
+		CitationRequired: true,
+		BudgetRequired:   false,
+		FallbackRequired: false,
+	},
+}
+
+var ConnectorInfrastructureProfile = ConnectorInfrastructure{
+	AuthModels: []string{
+		"oauth_authorization_code",
+		"oauth_client_credentials",
+		"api_key",
+		"environment_reference",
+		"external_secret_reference",
+	},
+	OAuthSurfaces: []string{
+		"/.well-known/oauth-protected-resource",
+		"/.well-known/oauth-protected-resource/api/v1/mcp",
+		"/.well-known/oauth-authorization-server",
+		"/oauth/authorize",
+		"/oauth/callback",
+		"/oauth/token",
+		"/oauth/revoke",
+		"/oauth/register",
+	},
+	CredentialStores: []string{
+		"tenant-scoped credential broker",
+		"environment",
+		"external-reference",
+	},
+	TokenBoundaries: []string{
+		"principal",
+		"tenant",
+		"scopes",
+		"token owner",
+		"surface",
+		"resource",
+	},
+	MCPSurfaces: []string{
+		"/api/v1/mcp",
+	},
+	RequiredControls: []string{
+		"protected-resource metadata for MCP",
+		"read/write credential scopes",
+		"tenant-scoped token exchange",
+		"credential rotation and revocation",
+		"connector preflight before connection creation",
+		"secret redaction in UI, API, logs, traces, and eval artifacts",
+	},
+}
+
+func Snapshot() Contract {
+	return Contract{
+		Version:                 ContractVersion,
+		Domains:                 cloneDomains(Domains),
+		Invariants:              cloneInvariants(Invariants),
+		Capabilities:            cloneCapabilities(Capabilities),
+		RuntimeEvents:           cloneRuntimeEvents(RuntimeEvents),
+		ProvenanceRequirements:  cloneProvenanceRequirements(ProvenanceRequirements),
+		ConnectorInfrastructure: cloneConnectorInfrastructure(ConnectorInfrastructureProfile),
+	}
+}
+
 func DomainByID(id string) (Domain, bool) {
 	for _, domain := range Domains {
 		if domain.ID == id {
@@ -124,4 +712,78 @@ func DomainByID(id string) (Domain, bool) {
 		}
 	}
 	return Domain{}, false
+}
+
+func cloneDomains(domains []Domain) []Domain {
+	out := make([]Domain, 0, len(domains))
+	for _, domain := range domains {
+		domain.Owns = cloneStrings(domain.Owns)
+		domain.MustExpose = cloneStrings(domain.MustExpose)
+		out = append(out, domain)
+	}
+	return out
+}
+
+func cloneInvariants(invariants []Invariant) []Invariant {
+	return append([]Invariant(nil), invariants...)
+}
+
+func cloneCapabilities(capabilities []Capability) []Capability {
+	out := make([]Capability, 0, len(capabilities))
+	for _, capability := range capabilities {
+		capability.ConsoleSurfaces = cloneStrings(capability.ConsoleSurfaces)
+		capability.RequiredScopes = cloneStrings(capability.RequiredScopes)
+		capability.ConnectorDependencies = cloneConnectorDependencies(capability.ConnectorDependencies)
+		capability.Eval.LocalCommands = cloneStrings(capability.Eval.LocalCommands)
+		capability.Eval.ScenarioSets = cloneStrings(capability.Eval.ScenarioSets)
+		capability.Eval.Rubrics = cloneStrings(capability.Eval.Rubrics)
+		capability.RuntimeEvents = cloneStrings(capability.RuntimeEvents)
+		capability.Provenance = cloneStrings(capability.Provenance)
+		capability.Review.RequiredApprovers = cloneStrings(capability.Review.RequiredApprovers)
+		out = append(out, capability)
+	}
+	return out
+}
+
+func cloneConnectorDependencies(dependencies []ConnectorDependency) []ConnectorDependency {
+	out := make([]ConnectorDependency, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		dependency.AuthModels = cloneStrings(dependency.AuthModels)
+		dependency.RequiredScopes = cloneStrings(dependency.RequiredScopes)
+		out = append(out, dependency)
+	}
+	return out
+}
+
+func cloneRuntimeEvents(events []RuntimeEvent) []RuntimeEvent {
+	out := make([]RuntimeEvent, 0, len(events))
+	for _, event := range events {
+		event.PayloadFields = cloneStrings(event.PayloadFields)
+		event.ProvenanceFields = cloneStrings(event.ProvenanceFields)
+		out = append(out, event)
+	}
+	return out
+}
+
+func cloneProvenanceRequirements(requirements []ProvenanceRequirement) []ProvenanceRequirement {
+	out := make([]ProvenanceRequirement, 0, len(requirements))
+	for _, requirement := range requirements {
+		requirement.RequiredFields = cloneStrings(requirement.RequiredFields)
+		out = append(out, requirement)
+	}
+	return out
+}
+
+func cloneConnectorInfrastructure(infrastructure ConnectorInfrastructure) ConnectorInfrastructure {
+	infrastructure.AuthModels = cloneStrings(infrastructure.AuthModels)
+	infrastructure.OAuthSurfaces = cloneStrings(infrastructure.OAuthSurfaces)
+	infrastructure.CredentialStores = cloneStrings(infrastructure.CredentialStores)
+	infrastructure.TokenBoundaries = cloneStrings(infrastructure.TokenBoundaries)
+	infrastructure.MCPSurfaces = cloneStrings(infrastructure.MCPSurfaces)
+	infrastructure.RequiredControls = cloneStrings(infrastructure.RequiredControls)
+	return infrastructure
+}
+
+func cloneStrings(values []string) []string {
+	return append([]string(nil), values...)
 }

--- a/internal/agentplatform/contracts_test.go
+++ b/internal/agentplatform/contracts_test.go
@@ -6,9 +6,16 @@ func TestContractDomainsHaveRequiredFields(t *testing.T) {
 	if ContractVersion == "" {
 		t.Fatal("contract version must be set")
 	}
+	snapshot := Snapshot()
+	if snapshot.Version != ContractVersion {
+		t.Fatalf("snapshot version = %q, want %q", snapshot.Version, ContractVersion)
+	}
 	for _, domain := range Domains {
 		if domain.ID == "" || domain.Name == "" || domain.Principle == "" {
 			t.Fatalf("domain has empty required field: %+v", domain)
+		}
+		if domain.ConsoleSurface == "" {
+			t.Fatalf("domain %q must name a console surface", domain.ID)
 		}
 		if len(domain.Owns) == 0 {
 			t.Fatalf("domain %q must name owned surfaces", domain.ID)
@@ -17,6 +24,188 @@ func TestContractDomainsHaveRequiredFields(t *testing.T) {
 			t.Fatalf("domain %q must name exposed diagnostics", domain.ID)
 		}
 	}
+}
+
+func TestCapabilitiesHaveGovernanceAndEvals(t *testing.T) {
+	if len(Capabilities) < len(Domains) {
+		t.Fatalf("capability registry has %d entries, want at least one per domain", len(Capabilities))
+	}
+	ids := map[string]bool{}
+	coveredDomains := map[string]bool{}
+	runtimeEvents := runtimeEventNames()
+	provenanceSurfaces := provenanceRequirementSurfaces()
+
+	for _, capability := range Capabilities {
+		if capability.ID == "" || capability.Name == "" || capability.Version == "" || capability.Owner == "" || capability.Kind == "" {
+			t.Fatalf("capability has empty required field: %+v", capability)
+		}
+		if ids[capability.ID] {
+			t.Fatalf("duplicate capability id %q", capability.ID)
+		}
+		ids[capability.ID] = true
+		if _, ok := DomainByID(capability.DomainID); !ok {
+			t.Fatalf("capability %q references unknown domain %q", capability.ID, capability.DomainID)
+		}
+		coveredDomains[capability.DomainID] = true
+		if capability.DefaultOn {
+			if !capability.Eval.Required || len(capability.Eval.LocalCommands) == 0 {
+				t.Fatalf("default-on capability %q must have required local eval commands", capability.ID)
+			}
+		}
+		if len(capability.ConsoleSurfaces) == 0 {
+			t.Fatalf("capability %q must name console surfaces", capability.ID)
+		}
+		if capability.Review.State == "" || capability.Review.Cadence == "" {
+			t.Fatalf("capability %q must define review state and cadence", capability.ID)
+		}
+		for _, event := range capability.RuntimeEvents {
+			if !runtimeEvents[event] {
+				t.Fatalf("capability %q references unknown runtime event %q", capability.ID, event)
+			}
+		}
+		for _, surface := range capability.Provenance {
+			if !provenanceSurfaces[surface] {
+				t.Fatalf("capability %q references unknown provenance surface %q", capability.ID, surface)
+			}
+		}
+	}
+	for _, domain := range Domains {
+		if !coveredDomains[domain.ID] {
+			t.Fatalf("domain %q has no registered capability", domain.ID)
+		}
+	}
+}
+
+func TestConnectorInfrastructureIsFirstClass(t *testing.T) {
+	infrastructure := ConnectorInfrastructureProfile
+	for _, required := range []string{"oauth_authorization_code", "oauth_client_credentials"} {
+		if !containsString(infrastructure.AuthModels, required) {
+			t.Fatalf("connector infrastructure missing auth model %q", required)
+		}
+	}
+	for _, required := range []string{"/oauth/token", "/oauth/revoke", "/api/v1/mcp"} {
+		if !containsString(infrastructure.OAuthSurfaces, required) && !containsString(infrastructure.MCPSurfaces, required) {
+			t.Fatalf("connector infrastructure missing surface %q", required)
+		}
+	}
+	for _, required := range []string{"principal", "tenant", "scopes", "token owner", "surface"} {
+		if !containsString(infrastructure.TokenBoundaries, required) {
+			t.Fatalf("connector infrastructure missing token boundary %q", required)
+		}
+	}
+	capability, ok := capabilityByID("connector-oauth-mcp")
+	if !ok {
+		t.Fatal("connector-oauth-mcp capability missing")
+	}
+	if len(capability.ConnectorDependencies) == 0 {
+		t.Fatal("connector-oauth-mcp must declare connector dependencies")
+	}
+	for _, dependency := range capability.ConnectorDependencies {
+		if dependency.TokenOwner == "" || dependency.CredentialStore == "" || dependency.OAuthSurface == "" || dependency.MCPSurface == "" {
+			t.Fatalf("connector dependency must expose token owner, credential store, OAuth, and MCP surfaces: %+v", dependency)
+		}
+		if !dependency.TenantScoped {
+			t.Fatalf("connector dependency %q must be tenant scoped", dependency.SourceID)
+		}
+	}
+}
+
+func TestRuntimeEventsAreUniqueAndReplayable(t *testing.T) {
+	ids := map[string]bool{}
+	terminalCount := 0
+	for _, event := range RuntimeEvents {
+		if event.Name == "" || event.DomainID == "" || event.Stage == "" {
+			t.Fatalf("runtime event has empty required field: %+v", event)
+		}
+		if ids[event.Name] {
+			t.Fatalf("duplicate runtime event name %q", event.Name)
+		}
+		ids[event.Name] = true
+		if _, ok := DomainByID(event.DomainID); !ok {
+			t.Fatalf("runtime event %q references unknown domain %q", event.Name, event.DomainID)
+		}
+		if !event.SequenceRequired || !event.Replayable {
+			t.Fatalf("runtime event %q must require sequencing and replay", event.Name)
+		}
+		if event.Terminal {
+			terminalCount++
+		}
+		if len(event.PayloadFields) == 0 {
+			t.Fatalf("runtime event %q must define payload fields", event.Name)
+		}
+	}
+	if terminalCount == 0 {
+		t.Fatal("runtime event vocabulary must include terminal events")
+	}
+}
+
+func TestProvenanceRequirementsCoverKnowledgeAndConnectors(t *testing.T) {
+	requiredFields := []string{"source_urn", "scope", "citation_status", "fallback_reason"}
+	ask, ok := provenanceRequirementBySurface("ask-answer")
+	if !ok {
+		t.Fatal("ask-answer provenance requirement missing")
+	}
+	for _, field := range requiredFields {
+		if !containsString(ask.RequiredFields, field) {
+			t.Fatalf("ask-answer provenance missing field %q", field)
+		}
+	}
+	if !ask.CitationRequired || !ask.BudgetRequired || !ask.FallbackRequired {
+		t.Fatalf("ask-answer provenance must require citations, budgets, and fallback: %+v", ask)
+	}
+
+	connector, ok := provenanceRequirementBySurface("connector-call")
+	if !ok {
+		t.Fatal("connector-call provenance requirement missing")
+	}
+	for _, field := range []string{"principal", "tenant", "scopes", "token_owner", "surface"} {
+		if !containsString(connector.RequiredFields, field) {
+			t.Fatalf("connector-call provenance missing field %q", field)
+		}
+	}
+}
+
+func runtimeEventNames() map[string]bool {
+	events := map[string]bool{}
+	for _, event := range RuntimeEvents {
+		events[event.Name] = true
+	}
+	return events
+}
+
+func provenanceRequirementSurfaces() map[string]bool {
+	surfaces := map[string]bool{}
+	for _, requirement := range ProvenanceRequirements {
+		surfaces[requirement.Surface] = true
+	}
+	return surfaces
+}
+
+func capabilityByID(id string) (Capability, bool) {
+	for _, capability := range Capabilities {
+		if capability.ID == id {
+			return capability, true
+		}
+	}
+	return Capability{}, false
+}
+
+func provenanceRequirementBySurface(surface string) (ProvenanceRequirement, bool) {
+	for _, requirement := range ProvenanceRequirements {
+		if requirement.Surface == surface {
+			return requirement, true
+		}
+	}
+	return ProvenanceRequirement{}, false
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func TestInvariantsReferenceKnownDomains(t *testing.T) {

--- a/internal/bootstrap/agent_platform.go
+++ b/internal/bootstrap/agent_platform.go
@@ -1,0 +1,11 @@
+package bootstrap
+
+import (
+	"net/http"
+
+	"github.com/writer/cerebro/internal/agentplatform"
+)
+
+func (a *App) handleAgentPlatformContract(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, agentplatform.Snapshot())
+}

--- a/internal/bootstrap/agent_platform_test.go
+++ b/internal/bootstrap/agent_platform_test.go
@@ -1,0 +1,34 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/writer/cerebro/internal/agentplatform"
+)
+
+func TestHandleAgentPlatformContract(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/agent-platform/contract", nil)
+
+	(&App{}).handleAgentPlatformContract(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var contract agentplatform.Contract
+	if err := json.Unmarshal(recorder.Body.Bytes(), &contract); err != nil {
+		t.Fatalf("decode contract: %v", err)
+	}
+	if contract.Version != agentplatform.ContractVersion {
+		t.Fatalf("version = %q, want %q", contract.Version, agentplatform.ContractVersion)
+	}
+	if len(contract.Capabilities) == 0 {
+		t.Fatal("contract response missing capabilities")
+	}
+	if len(contract.ConnectorInfrastructure.OAuthSurfaces) == 0 {
+		t.Fatal("contract response missing connector OAuth surfaces")
+	}
+}

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -25,6 +25,7 @@ type httpAuthRoutePolicy struct {
 }
 
 var httpAuthRoutePolicies = []httpAuthRoutePolicy{
+	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/contract", Scope: scopeCosmoSecurityRead, Static: true},
 	{Exact: "/api/v1/mcp", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/metrics", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Prefix: "/reports/", Suffix: "/runs", Static: true, AdminOnly: true},

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -23,6 +23,7 @@ func (app *App) registerRoutes(mux *http.ServeMux, cfg config.Config, deps Depen
 	app.registerConnectRoutes(mux, cfg, deps, sources)
 	app.registerPublicRoutes(mux)
 	app.registerOAuthRoutes(mux)
+	app.registerAgentPlatformRoutes(mux)
 	app.registerReportRoutes(mux)
 	app.registerGRCRoutes(mux)
 	app.registerFindingRoutes(mux)
@@ -49,6 +50,10 @@ func (app *App) registerPublicRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /livez", routeSurfacePublicHTTP, app.handleLiveness)
 	registerHTTPRoute(mux, "GET /metrics", routeSurfacePlatformHTTP, app.handleMetrics)
 	registerHTTPRoute(mux, "GET /openapi.yaml", routeSurfacePublicHTTP, app.handleOpenAPI)
+}
+
+func (app *App) registerAgentPlatformRoutes(mux *http.ServeMux) {
+	registerHTTPRoute(mux, "GET /api/v1/agent-platform/contract", routeSurfacePlatformHTTP, app.handleAgentPlatformContract)
 }
 
 func (app *App) registerOAuthRoutes(mux *http.ServeMux) {


### PR DESCRIPTION
## Summary
- Expose a Cerebro agent platform contract at `/api/v1/agent-platform/contract`.
- Add a governed capability registry with connector/OAuth/MCP boundaries, eval hooks, runtime events, and provenance requirements.
- Document the endpoint in OpenAPI and add route policy plus handler coverage.

## Verification
- `go test ./internal/agentplatform ./internal/bootstrap`
- `go test ./...`
- `make lint`
- phrase scan for restricted terms