### PR TITLE
Skip hosted workflow runners in graph inventory

### DIFF
--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -1211,6 +1211,9 @@ func githubProgrammaticCredentialStatus(attributes map[string]string) string {
 }
 
 func githubSelfHostedRunnerProjection(tenantID string, attributes map[string]string) (string, map[string]string) {
+	if !githubAuditProjectsSelfHostedRunner(attributes) {
+		return "", nil
+	}
 	runnerID := strings.TrimSpace(attributes["runner_id"])
 	if runnerID == "" {
 		return "", nil
@@ -1238,6 +1241,20 @@ func githubSelfHostedRunnerProjection(tenantID string, attributes map[string]str
 	addProjectedAttribute(attrs, "runner_state", attributes["runner_state"])
 	addProjectedAttribute(attrs, "runner_untrusted", firstNonEmpty(attributes["runner_untrusted"], attributes["host_untrusted"], attributes["untrusted_host"]))
 	return projectionURN(tenantID, "github_runner", scopeID, runnerID), attrs
+}
+
+func githubAuditProjectsSelfHostedRunner(attributes map[string]string) bool {
+	action := strings.ToLower(strings.TrimSpace(attributes["action"]))
+	if action == "" {
+		return false
+	}
+	// GitHub audit rows such as workflows.prepared_workflow_job include per-job
+	// GitHub-hosted runner IDs. Those are ephemeral execution details, not
+	// customer-managed self-hosted runner assets.
+	if !strings.Contains(action, "self_hosted_runner") {
+		return false
+	}
+	return true
 }
 
 func githubRunnerScope(scope string) (string, string) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -2337,6 +2337,38 @@ func TestProjectGitHubAuditProjectsSelfHostedRunnerState(t *testing.T) {
 	}
 }
 
+func TestProjectGitHubAuditSkipsWorkflowJobHostedRunnerInventory(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	_, err := New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-audit-workflow-job",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"action":                  "workflows.prepared_workflow_job",
+			"org":                     "writer",
+			"repo":                    "writer/cerebro",
+			"resource_id":             "writer/cerebro",
+			"resource_type":           "repo",
+			"runner_group_name":       "GitHub Actions",
+			"runner_id":               "1002207767",
+			"runner_name":             "GitHub Actions 1002207767",
+			"runner_scope":            "repo:writer/cerebro",
+			"source_runtime_id":       "writer-github-audit",
+			"transport_protocol_name": "ssh",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	for urn, entity := range graph.entities {
+		if entity.EntityType == "github.runner" {
+			t.Fatalf("unexpected github.runner entity %q from workflow job audit row: %#v", urn, entity)
+		}
+	}
+}
+
 // Missing actor_id alone is not enough to call an audit actor a credential:
 // GitHub git audit rows for real users can also omit actor_id. The source
 // resolves those actors through /users/{login} and stamps actor_type=User, and


### PR DESCRIPTION
## Summary
- avoid projecting hosted workflow job runner IDs as durable GitHub runner assets
- keep self-hosted runner lifecycle audit events eligible for runner projection
- add regression coverage for workflow job audit rows that include runner metadata

## Tests
- go test ./internal/sourceprojection -count=1
- go test ./internal/sourceprojection ./sources/github -count=1
- make lint