### PR TITLE
devex: avoid duplicate pre-commit lint

### DIFF
--- a/scripts/pre_commit_checks.sh
+++ b/scripts/pre_commit_checks.sh
@@ -17,9 +17,7 @@ if [ -n "$staged_go" ]; then
     printf '%s\n' "$unformatted" | xargs gofmt -w
     printf '%s\n' "$unformatted" | xargs git add
   fi
-
-  echo "golangci-lint: checking staged Go changes..."
-  make lint
 fi
 
+echo "verify: running full local validation, including golangci-lint..."
 make verify


### PR DESCRIPTION
## Summary
- remove the standalone pre-commit `make lint` call that duplicated `make verify`
- keep a clearer verify message noting golangci-lint is included in the single validation run

## Validation
- pre-commit hook ran full `make verify` successfully while creating the commit
- pre-push hook ran full `make verify` successfully before pushing

Addresses feedback from #1084: https://github.com/writer/cerebro/pull/1084#discussion_r3422631517