### PR TITLE
Harden GitHub runner inventory projection

### DIFF
--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -363,6 +363,7 @@ func integrityCheckDefinitions() ([]IntegrityCheck, []string) {
 		{Name: "github_code_repositories_without_owner_link", Expected: 0},
 		{Name: "aws_public_endpoints_without_instance_link", Expected: 0},
 		{Name: "open_findings_missing_primary_has_finding_edge", Expected: 0},
+		{Name: "github_workflow_job_runners_projected_as_assets", Expected: 0},
 	}
 	queries := []string{
 		"MATCH (src:Entity)-[r:RELATION]->(dst:Entity) WHERE src.tenant_id <> dst.tenant_id OR src.tenant_id <> r.tenant_id OR dst.tenant_id <> r.tenant_id RETURN count(r)",
@@ -373,6 +374,7 @@ func integrityCheckDefinitions() ([]IntegrityCheck, []string) {
 		"MATCH (e:Entity) WHERE e.source_id = 'github' AND e.entity_type = 'github.code.repository' AND coalesce(e.attributes_json, '') CONTAINS '\"owner_login\":\"' AND NOT coalesce(e.attributes_json, '') CONTAINS '\"owner_login\":\"\"' AND NOT EXISTS { MATCH (e)-[:RELATION {relation: 'belongs_to'}]->(:Entity {entity_type: 'github.org'}) } RETURN count(e)",
 		"MATCH (e:Entity) WHERE e.entity_type IN ['aws.elastic.ip', 'aws.network.interface'] AND ((coalesce(e.attributes_json, '') CONTAINS '\"attached_instance_id\":\"' AND NOT coalesce(e.attributes_json, '') CONTAINS '\"attached_instance_id\":\"\"') OR (coalesce(e.attributes_json, '') CONTAINS '\"associated_instance_id\":\"' AND NOT coalesce(e.attributes_json, '') CONTAINS '\"associated_instance_id\":\"\"')) AND NOT EXISTS { MATCH (e)-[:RELATION {relation: 'attached_to'}]->(:Entity {entity_type: 'aws.ec2.instance'}) } AND NOT EXISTS { MATCH (e)-[:RELATION {relation: 'associated_with'}]->(:Entity {entity_type: 'aws.ec2.instance'}) } RETURN count(e)",
 		"MATCH (finding:Entity {entity_type: 'finding'}) WITH finding, coalesce(finding.attributes_json, '') AS attrs WHERE attrs CONTAINS '\"status\":\"open\"' AND attrs CONTAINS '\"primary_resource_urn\":\"' WITH finding, split(split(attrs, '\"primary_resource_urn\":\"')[1], '\"')[0] AS primary_urn WHERE primary_urn <> '' MATCH (resource:Entity {tenant_id: finding.tenant_id, urn: primary_urn}) WHERE NOT EXISTS { MATCH (resource)-[:RELATION {relation: 'has_finding'}]->(finding) } RETURN count(finding)",
+		"MATCH (e:Entity {entity_type: 'github.runner'}) WHERE coalesce(e.attributes_json, '') CONTAINS '\"action\":\"workflows.' RETURN count(e)",
 	}
 	return checks, queries
 }

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -110,6 +110,30 @@ func TestIntegrityChecksIncludeOpenFindingPrimaryAnchorInvariant(t *testing.T) {
 	t.Fatalf("integrity checks missing open finding primary anchor invariant: %#v", checks)
 }
 
+func TestIntegrityChecksIncludeHostedWorkflowRunnerAssetInvariant(t *testing.T) {
+	checks, queries := integrityCheckDefinitions()
+	if len(checks) != len(queries) {
+		t.Fatalf("integrity check definitions have %d checks and %d queries", len(checks), len(queries))
+	}
+	for i, check := range checks {
+		if check.Name != "github_workflow_job_runners_projected_as_assets" {
+			continue
+		}
+		query := queries[i]
+		for _, expected := range []string{
+			"github.runner",
+			"\"action\":\"workflows.",
+			"RETURN count(e)",
+		} {
+			if !strings.Contains(query, expected) {
+				t.Fatalf("hosted workflow runner integrity query missing %q:\n%s", expected, query)
+			}
+		}
+		return
+	}
+	t.Fatalf("integrity checks missing hosted workflow runner asset invariant: %#v", checks)
+}
+
 func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	if os.Getenv("CEREBRO_RUN_NEO4J_DOCKER") != "1" {
 		t.Skip("set CEREBRO_RUN_NEO4J_DOCKER=1 to run Neo4j Docker integration test")

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -1244,17 +1244,22 @@ func githubSelfHostedRunnerProjection(tenantID string, attributes map[string]str
 }
 
 func githubAuditProjectsSelfHostedRunner(attributes map[string]string) bool {
-	action := strings.ToLower(strings.TrimSpace(attributes["action"]))
+	action := strings.TrimSpace(attributes["action"])
+	return githubSelfHostedRunnerAuditAction(action)
+}
+
+func githubSelfHostedRunnerAuditAction(action string) bool {
+	action = strings.ToLower(strings.TrimSpace(action))
 	if action == "" {
 		return false
 	}
 	// GitHub audit rows such as workflows.prepared_workflow_job include per-job
 	// GitHub-hosted runner IDs. Those are ephemeral execution details, not
 	// customer-managed self-hosted runner assets.
-	if !strings.Contains(action, "self_hosted_runner") {
+	if strings.HasPrefix(action, "workflows.") {
 		return false
 	}
-	return true
+	return strings.Contains(action, "self_hosted_runner")
 }
 
 func githubRunnerScope(scope string) (string, string) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -2369,6 +2369,27 @@ func TestProjectGitHubAuditSkipsWorkflowJobHostedRunnerInventory(t *testing.T) {
 	}
 }
 
+func TestGitHubSelfHostedRunnerAuditActionClassifiesAssetLifecycleOnly(t *testing.T) {
+	for _, tc := range []struct {
+		action string
+		want   bool
+	}{
+		{action: "repo.register_self_hosted_runner", want: true},
+		{action: "repo.remove_self_hosted_runner", want: true},
+		{action: "org.register_self_hosted_runner", want: true},
+		{action: "business.remove_self_hosted_runner", want: true},
+		{action: "workflows.prepared_workflow_job", want: false},
+		{action: "workflows.completed_workflow_run", want: false},
+		{action: "repo.runner_group_updated", want: false},
+		{action: "repo.register_runner", want: false},
+		{action: "", want: false},
+	} {
+		if got := githubSelfHostedRunnerAuditAction(tc.action); got != tc.want {
+			t.Fatalf("githubSelfHostedRunnerAuditAction(%q) = %v, want %v", tc.action, got, tc.want)
+		}
+	}
+}
+
 // Missing actor_id alone is not enough to call an audit actor a credential:
 // GitHub git audit rows for real users can also omit actor_id. The source
 // resolves those actors through /users/{login} and stamps actor_type=User, and


### PR DESCRIPTION
## Summary
- make hosted workflow runner audit rows explicitly ineligible for durable GitHub runner asset projection
- keep self-hosted runner lifecycle actions eligible for runner projection
- add a graph integrity invariant to catch hosted workflow runners if they are projected as assets again

## Tests
- go test ./internal/sourceprojection -run 'Test(ProjectGitHubAudit|GitHubSelfHostedRunnerAuditAction)' -count=1\n- go test ./internal/graphstore/neo4j -run 'TestIntegrityChecksInclude' -count=1\n- go test ./internal/sourceprojection ./internal/graphstore/neo4j ./cmd/cerebro -count=1\n- make lint