### PR TITLE
Add agent capability control plane

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -76,6 +76,66 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentPlatformContract'
+  /api/v1/agent-platform/capabilities:
+    get:
+      operationId: listAgentPlatformCapabilities
+      summary: List governed agent platform capabilities
+      tags:
+        - Platform
+      parameters:
+        - name: domain_id
+          in: query
+          schema:
+            type: string
+        - name: kind
+          in: query
+          schema:
+            type: string
+        - name: owner
+          in: query
+          schema:
+            type: string
+        - name: risk
+          in: query
+          schema:
+            type: string
+            enum: [low, medium, high]
+        - name: default_on
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Filtered capability registry with operational totals.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentPlatformCapabilityRegistry'
+        '400':
+          description: Invalid capability filter.
+  /api/v1/agent-platform/capability-decisions:
+    post:
+      operationId: decideAgentPlatformCapability
+      summary: Decide whether an agent platform capability is selectable
+      tags:
+        - Platform
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentPlatformCapabilityDecisionRequest'
+      responses:
+        '200':
+          description: Capability selection decision with scopes, eval, connector, runtime event, and provenance gates.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentPlatformCapabilityDecision'
+        '400':
+          description: Invalid capability decision request.
+        '404':
+          description: Capability was not found.
   /api/v1/mcp:
     get:
       summary: Reject MCP stateful event-stream transport
@@ -2996,6 +3056,189 @@ components:
             $ref: '#/components/schemas/AgentPlatformProvenanceRequirement'
         connector_infrastructure:
           $ref: '#/components/schemas/AgentPlatformConnectorInfrastructure'
+    AgentPlatformCapabilityRegistry:
+      type: object
+      required:
+        - version
+        - filters
+        - capabilities
+        - totals
+      properties:
+        version:
+          type: string
+        filters:
+          $ref: '#/components/schemas/AgentPlatformCapabilityRegistryFilter'
+        capabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformCapability'
+        totals:
+          $ref: '#/components/schemas/AgentPlatformCapabilityRegistryTotals'
+    AgentPlatformCapabilityRegistryFilter:
+      type: object
+      properties:
+        domain_id:
+          type: string
+        kind:
+          type: string
+        owner:
+          type: string
+        risk:
+          type: string
+          enum: [low, medium, high]
+        default_on:
+          type: boolean
+    AgentPlatformCapabilityRegistryTotals:
+      type: object
+      required:
+        - capabilities
+        - default_on
+        - default_off
+        - by_domain
+        - by_risk
+      properties:
+        capabilities:
+          type: integer
+        default_on:
+          type: integer
+        default_off:
+          type: integer
+        by_domain:
+          type: object
+          additionalProperties:
+            type: integer
+        by_risk:
+          type: object
+          additionalProperties:
+            type: integer
+    AgentPlatformCapabilityDecisionRequest:
+      type: object
+      required:
+        - capability_id
+      properties:
+        capability_id:
+          type: string
+        tenant_id:
+          type: string
+        actor_id:
+          type: string
+        requested_scopes:
+          type: array
+          items:
+            type: string
+        connector_readiness:
+          type: object
+          additionalProperties:
+            type: string
+        eval_status_overrides:
+          type: object
+          additionalProperties:
+            type: string
+        allow_preview:
+          type: boolean
+        selection_reason:
+          type: string
+        provenance_requirement:
+          type: string
+    AgentPlatformCapabilityDecision:
+      type: object
+      required:
+        - version
+        - capability_id
+        - capability_version
+        - domain_id
+        - enabled
+        - reason
+        - blockers
+        - required_scopes
+        - runtime_events
+        - provenance
+        - eval
+        - review
+      properties:
+        version:
+          type: string
+        capability_id:
+          type: string
+        capability_version:
+          type: string
+        domain_id:
+          type: string
+        tenant_id:
+          type: string
+        actor_id:
+          type: string
+        enabled:
+          type: boolean
+        reason:
+          type: string
+        blockers:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformCapabilityDecisionBlocker'
+        required_scopes:
+          type: array
+          items:
+            type: string
+        missing_scopes:
+          type: array
+          items:
+            type: string
+        required_connectors:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformConnectorDependency'
+        runtime_events:
+          type: array
+          items:
+            type: string
+        provenance:
+          type: array
+          items:
+            type: string
+        eval:
+          $ref: '#/components/schemas/AgentPlatformCapabilityEvalGate'
+        review:
+          $ref: '#/components/schemas/AgentPlatformReviewStatus'
+        connector_infrastructure:
+          $ref: '#/components/schemas/AgentPlatformConnectorInfrastructure'
+    AgentPlatformCapabilityDecisionBlocker:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        fields:
+          type: array
+          items:
+            type: string
+    AgentPlatformCapabilityEvalGate:
+      type: object
+      required:
+        - required
+        - status
+        - passing
+        - scenario_sets
+        - rubrics
+      properties:
+        required:
+          type: boolean
+        status:
+          type: string
+        passing:
+          type: boolean
+        scenario_sets:
+          type: array
+          items:
+            type: string
+        rubrics:
+          type: array
+          items:
+            type: string
     AgentPlatformDomain:
       type: object
       required:

--- a/internal/agentplatform/contracts_test.go
+++ b/internal/agentplatform/contracts_test.go
@@ -110,6 +110,106 @@ func TestConnectorInfrastructureIsFirstClass(t *testing.T) {
 	}
 }
 
+func TestListCapabilitiesFiltersAndTotals(t *testing.T) {
+	defaultOn := true
+	registry := ListCapabilities(CapabilityRegistryFilter{
+		DomainID:  "connectors",
+		DefaultOn: &defaultOn,
+	})
+
+	if registry.Version != ContractVersion {
+		t.Fatalf("version = %q, want %q", registry.Version, ContractVersion)
+	}
+	if registry.Totals.Capabilities == 0 {
+		t.Fatal("filtered registry must include connector capabilities")
+	}
+	if registry.Totals.DefaultOff != 0 {
+		t.Fatalf("default_off = %d, want 0", registry.Totals.DefaultOff)
+	}
+	if registry.Totals.ByDomain["connectors"] != registry.Totals.Capabilities {
+		t.Fatalf("connector total = %d, want %d", registry.Totals.ByDomain["connectors"], registry.Totals.Capabilities)
+	}
+	for _, capability := range registry.Capabilities {
+		if capability.DomainID != "connectors" || !capability.DefaultOn {
+			t.Fatalf("capability does not match filter: %+v", capability)
+		}
+	}
+}
+
+func TestDecideCapabilityAllowsDefaultOnCapability(t *testing.T) {
+	decision, ok := DecideCapability(CapabilityDecisionRequest{
+		CapabilityID:    "grc-ask",
+		TenantID:        "tenant-1",
+		ActorID:         "actor-1",
+		RequestedScopes: []string{"cosmo.security.read"},
+	})
+	if !ok {
+		t.Fatal("grc-ask capability missing")
+	}
+	if !decision.Enabled {
+		t.Fatalf("decision enabled = false, blockers = %+v", decision.Blockers)
+	}
+	if decision.Reason != "default_enabled" {
+		t.Fatalf("reason = %q, want default_enabled", decision.Reason)
+	}
+	if decision.TenantID != "tenant-1" || decision.ActorID != "actor-1" {
+		t.Fatalf("decision lost caller context: %+v", decision)
+	}
+	if len(decision.RuntimeEvents) == 0 || len(decision.Provenance) == 0 {
+		t.Fatalf("decision must carry runtime events and provenance: %+v", decision)
+	}
+}
+
+func TestDecideCapabilityReportsControlPlaneBlockers(t *testing.T) {
+	decision, ok := DecideCapability(CapabilityDecisionRequest{
+		CapabilityID:        "connector-oauth-mcp",
+		RequestedScopes:     []string{"cosmo.security.read"},
+		EvalStatusOverrides: map[string]string{"connector-oauth-mcp": "failed"},
+	})
+	if !ok {
+		t.Fatal("connector-oauth-mcp capability missing")
+	}
+	if decision.Enabled {
+		t.Fatal("decision enabled = true, want blocked")
+	}
+	for _, want := range []string{"missing_scope", "connector_readiness_unknown", "eval_not_passing"} {
+		if !decisionHasBlocker(decision, want) {
+			t.Fatalf("decision missing blocker %q: %+v", want, decision.Blockers)
+		}
+	}
+	if len(decision.RequiredConnectors) == 0 {
+		t.Fatal("decision must carry required connector dependencies")
+	}
+	if decision.ConnectorInfrastructure == nil || len(decision.ConnectorInfrastructure.AuthModels) == 0 {
+		t.Fatal("connector decision must include connector infrastructure")
+	}
+}
+
+func TestDecideCapabilityPreviewGate(t *testing.T) {
+	blocked, ok := DecideCapability(CapabilityDecisionRequest{
+		CapabilityID:    "runtime-response-actions",
+		RequestedScopes: []string{"runtime.response.write"},
+	})
+	if !ok {
+		t.Fatal("runtime-response-actions capability missing")
+	}
+	if blocked.Enabled || !decisionHasBlocker(blocked, "preview_required") {
+		t.Fatalf("default-off capability must require preview: %+v", blocked)
+	}
+
+	allowed, ok := DecideCapability(CapabilityDecisionRequest{
+		CapabilityID:    "runtime-response-actions",
+		RequestedScopes: []string{"runtime.response.write"},
+		AllowPreview:    true,
+	})
+	if !ok {
+		t.Fatal("runtime-response-actions capability missing")
+	}
+	if !allowed.Enabled || allowed.Reason != "preview_allowed" {
+		t.Fatalf("preview decision = %+v, want enabled preview_allowed", allowed)
+	}
+}
+
 func TestRuntimeEventsAreUniqueAndReplayable(t *testing.T) {
 	ids := map[string]bool{}
 	terminalCount := 0
@@ -202,6 +302,15 @@ func provenanceRequirementBySurface(surface string) (ProvenanceRequirement, bool
 func containsString(values []string, needle string) bool {
 	for _, value := range values {
 		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func decisionHasBlocker(decision CapabilityDecision, code string) bool {
+	for _, blocker := range decision.Blockers {
+		if blocker.Code == code {
 			return true
 		}
 	}

--- a/internal/agentplatform/control_plane.go
+++ b/internal/agentplatform/control_plane.go
@@ -1,0 +1,381 @@
+package agentplatform
+
+import (
+	"sort"
+	"strings"
+)
+
+type CapabilityRegistryFilter struct {
+	DomainID  string `json:"domain_id,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	Owner     string `json:"owner,omitempty"`
+	Risk      string `json:"risk,omitempty"`
+	DefaultOn *bool  `json:"default_on,omitempty"`
+}
+
+type CapabilityRegistry struct {
+	Version      string                   `json:"version"`
+	Filters      CapabilityRegistryFilter `json:"filters"`
+	Capabilities []Capability             `json:"capabilities"`
+	Totals       CapabilityRegistryTotals `json:"totals"`
+}
+
+type CapabilityRegistryTotals struct {
+	Capabilities int            `json:"capabilities"`
+	DefaultOn    int            `json:"default_on"`
+	DefaultOff   int            `json:"default_off"`
+	ByDomain     map[string]int `json:"by_domain"`
+	ByRisk       map[string]int `json:"by_risk"`
+}
+
+type CapabilityDecisionRequest struct {
+	CapabilityID          string            `json:"capability_id"`
+	TenantID              string            `json:"tenant_id,omitempty"`
+	ActorID               string            `json:"actor_id,omitempty"`
+	RequestedScopes       []string          `json:"requested_scopes,omitempty"`
+	ConnectorReadiness    map[string]string `json:"connector_readiness,omitempty"`
+	EvalStatusOverrides   map[string]string `json:"eval_status_overrides,omitempty"`
+	AllowPreview          bool              `json:"allow_preview,omitempty"`
+	SelectionReason       string            `json:"selection_reason,omitempty"`
+	ProvenanceRequirement string            `json:"provenance_requirement,omitempty"`
+}
+
+type CapabilityDecision struct {
+	Version                 string                      `json:"version"`
+	CapabilityID            string                      `json:"capability_id"`
+	CapabilityVersion       string                      `json:"capability_version"`
+	DomainID                string                      `json:"domain_id"`
+	TenantID                string                      `json:"tenant_id,omitempty"`
+	ActorID                 string                      `json:"actor_id,omitempty"`
+	Enabled                 bool                        `json:"enabled"`
+	Reason                  string                      `json:"reason"`
+	Blockers                []CapabilityDecisionBlocker `json:"blockers"`
+	RequiredScopes          []string                    `json:"required_scopes"`
+	MissingScopes           []string                    `json:"missing_scopes,omitempty"`
+	RequiredConnectors      []ConnectorDependency       `json:"required_connectors,omitempty"`
+	RuntimeEvents           []string                    `json:"runtime_events"`
+	Provenance              []string                    `json:"provenance"`
+	Eval                    CapabilityEvalGate          `json:"eval"`
+	Review                  ReviewStatus                `json:"review"`
+	ConnectorInfrastructure *ConnectorInfrastructure    `json:"connector_infrastructure,omitempty"`
+}
+
+type CapabilityDecisionBlocker struct {
+	Code    string   `json:"code"`
+	Message string   `json:"message"`
+	Fields  []string `json:"fields,omitempty"`
+}
+
+type CapabilityEvalGate struct {
+	Required     bool     `json:"required"`
+	Status       string   `json:"status"`
+	Passing      bool     `json:"passing"`
+	ScenarioSets []string `json:"scenario_sets"`
+	Rubrics      []string `json:"rubrics"`
+}
+
+func ListCapabilities(filter CapabilityRegistryFilter) CapabilityRegistry {
+	filter = normalizeCapabilityRegistryFilter(filter)
+	capabilities := make([]Capability, 0, len(Capabilities))
+	for _, capability := range Capabilities {
+		if !matchesCapabilityFilter(capability, filter) {
+			continue
+		}
+		capabilities = append(capabilities, cloneCapability(capability))
+	}
+	return CapabilityRegistry{
+		Version:      ContractVersion,
+		Filters:      filter,
+		Capabilities: capabilities,
+		Totals:       capabilityRegistryTotals(capabilities),
+	}
+}
+
+func DecideCapability(request CapabilityDecisionRequest) (CapabilityDecision, bool) {
+	request = normalizeCapabilityDecisionRequest(request)
+	capability, ok := CapabilityByID(request.CapabilityID)
+	if !ok {
+		return CapabilityDecision{}, false
+	}
+
+	requiredScopes := uniqueSortedStrings(append(cloneStrings(capability.RequiredScopes), connectorRequiredScopes(capability.ConnectorDependencies)...))
+	missingScopes := missingStrings(requiredScopes, request.RequestedScopes)
+	requiredConnectors := requiredConnectorDependencies(capability.ConnectorDependencies)
+	eval := capabilityEvalGate(capability, request.EvalStatusOverrides)
+	blockers := make([]CapabilityDecisionBlocker, 0, 4)
+
+	if !capability.DefaultOn && !request.AllowPreview {
+		blockers = append(blockers, CapabilityDecisionBlocker{
+			Code:    "preview_required",
+			Message: "Capability is not default-on and requires explicit preview selection.",
+		})
+	}
+	if len(missingScopes) > 0 {
+		blockers = append(blockers, CapabilityDecisionBlocker{
+			Code:    "missing_scope",
+			Message: "Caller is missing one or more required scopes.",
+			Fields:  missingScopes,
+		})
+	}
+	for _, dependency := range requiredConnectors {
+		readiness := normalizedReadiness(request.ConnectorReadiness[dependency.SourceID])
+		if !connectorReady(readiness) {
+			code := "connector_not_ready"
+			message := "Required connector dependency is not ready."
+			if readiness == "" {
+				code = "connector_readiness_unknown"
+				message = "Required connector dependency readiness was not provided."
+			}
+			blockers = append(blockers, CapabilityDecisionBlocker{
+				Code:    code,
+				Message: message,
+				Fields:  []string{dependency.SourceID},
+			})
+		}
+	}
+	if eval.Required && !eval.Passing {
+		blockers = append(blockers, CapabilityDecisionBlocker{
+			Code:    "eval_not_passing",
+			Message: "Capability eval gate is not passing.",
+			Fields:  []string{eval.Status},
+		})
+	}
+	if request.ProvenanceRequirement != "" && !containsValue(capability.Provenance, request.ProvenanceRequirement) {
+		blockers = append(blockers, CapabilityDecisionBlocker{
+			Code:    "provenance_requirement_missing",
+			Message: "Capability does not satisfy the requested provenance surface.",
+			Fields:  []string{request.ProvenanceRequirement},
+		})
+	}
+
+	reason := "default_enabled"
+	if request.AllowPreview && !capability.DefaultOn {
+		reason = "preview_allowed"
+	}
+	if len(blockers) > 0 {
+		reason = "blocked_by_policy"
+	}
+	if request.SelectionReason != "" && len(blockers) == 0 {
+		reason = request.SelectionReason
+	}
+
+	return CapabilityDecision{
+		Version:                 ContractVersion,
+		CapabilityID:            capability.ID,
+		CapabilityVersion:       capability.Version,
+		DomainID:                capability.DomainID,
+		TenantID:                request.TenantID,
+		ActorID:                 request.ActorID,
+		Enabled:                 len(blockers) == 0,
+		Reason:                  reason,
+		Blockers:                blockers,
+		RequiredScopes:          requiredScopes,
+		MissingScopes:           missingScopes,
+		RequiredConnectors:      requiredConnectors,
+		RuntimeEvents:           cloneStrings(capability.RuntimeEvents),
+		Provenance:              cloneStrings(capability.Provenance),
+		Eval:                    eval,
+		Review:                  cloneReviewStatus(capability.Review),
+		ConnectorInfrastructure: connectorInfrastructureForDecision(requiredConnectors),
+	}, true
+}
+
+func CapabilityByID(id string) (Capability, bool) {
+	id = strings.TrimSpace(id)
+	for _, capability := range Capabilities {
+		if capability.ID == id {
+			return cloneCapability(capability), true
+		}
+	}
+	return Capability{}, false
+}
+
+func normalizeCapabilityRegistryFilter(filter CapabilityRegistryFilter) CapabilityRegistryFilter {
+	filter.DomainID = strings.TrimSpace(filter.DomainID)
+	filter.Kind = strings.TrimSpace(filter.Kind)
+	filter.Owner = strings.TrimSpace(filter.Owner)
+	filter.Risk = strings.TrimSpace(filter.Risk)
+	return filter
+}
+
+func normalizeCapabilityDecisionRequest(request CapabilityDecisionRequest) CapabilityDecisionRequest {
+	request.CapabilityID = strings.TrimSpace(request.CapabilityID)
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.ActorID = strings.TrimSpace(request.ActorID)
+	request.SelectionReason = strings.TrimSpace(request.SelectionReason)
+	request.ProvenanceRequirement = strings.TrimSpace(request.ProvenanceRequirement)
+	request.RequestedScopes = uniqueSortedStrings(request.RequestedScopes)
+	if request.ConnectorReadiness == nil {
+		request.ConnectorReadiness = map[string]string{}
+	}
+	if request.EvalStatusOverrides == nil {
+		request.EvalStatusOverrides = map[string]string{}
+	}
+	return request
+}
+
+func matchesCapabilityFilter(capability Capability, filter CapabilityRegistryFilter) bool {
+	if filter.DomainID != "" && capability.DomainID != filter.DomainID {
+		return false
+	}
+	if filter.Kind != "" && capability.Kind != filter.Kind {
+		return false
+	}
+	if filter.Owner != "" && capability.Owner != filter.Owner {
+		return false
+	}
+	if filter.Risk != "" && capability.Risk != filter.Risk {
+		return false
+	}
+	if filter.DefaultOn != nil && capability.DefaultOn != *filter.DefaultOn {
+		return false
+	}
+	return true
+}
+
+func capabilityRegistryTotals(capabilities []Capability) CapabilityRegistryTotals {
+	totals := CapabilityRegistryTotals{
+		Capabilities: len(capabilities),
+		ByDomain:     map[string]int{},
+		ByRisk:       map[string]int{},
+	}
+	for _, capability := range capabilities {
+		if capability.DefaultOn {
+			totals.DefaultOn++
+		} else {
+			totals.DefaultOff++
+		}
+		totals.ByDomain[capability.DomainID]++
+		totals.ByRisk[capability.Risk]++
+	}
+	return totals
+}
+
+func connectorRequiredScopes(dependencies []ConnectorDependency) []string {
+	scopes := []string{}
+	for _, dependency := range dependencies {
+		scopes = append(scopes, dependency.RequiredScopes...)
+	}
+	return scopes
+}
+
+func requiredConnectorDependencies(dependencies []ConnectorDependency) []ConnectorDependency {
+	required := []ConnectorDependency{}
+	for _, dependency := range dependencies {
+		if strings.EqualFold(strings.TrimSpace(dependency.Readiness), "required") {
+			required = append(required, cloneConnectorDependency(dependency))
+		}
+	}
+	return required
+}
+
+func capabilityEvalGate(capability Capability, overrides map[string]string) CapabilityEvalGate {
+	status := strings.TrimSpace(overrides[capability.ID])
+	if status == "" {
+		status = capability.Eval.Status
+	}
+	status = strings.TrimSpace(status)
+	return CapabilityEvalGate{
+		Required:     capability.Eval.Required,
+		Status:       status,
+		Passing:      evalStatusPassing(status),
+		ScenarioSets: cloneStrings(capability.Eval.ScenarioSets),
+		Rubrics:      cloneStrings(capability.Eval.Rubrics),
+	}
+}
+
+func evalStatusPassing(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "blocked", "failed", "failing", "missing", "not_run", "unknown":
+		return false
+	default:
+		return true
+	}
+}
+
+func normalizedReadiness(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func connectorReady(readiness string) bool {
+	switch readiness {
+	case "ready", "healthy", "available", "connected", "configured":
+		return true
+	default:
+		return false
+	}
+}
+
+func connectorInfrastructureForDecision(connectors []ConnectorDependency) *ConnectorInfrastructure {
+	if len(connectors) == 0 {
+		return nil
+	}
+	infrastructure := cloneConnectorInfrastructure(ConnectorInfrastructureProfile)
+	return &infrastructure
+}
+
+func cloneCapability(capability Capability) Capability {
+	capability.ConsoleSurfaces = cloneStrings(capability.ConsoleSurfaces)
+	capability.RequiredScopes = cloneStrings(capability.RequiredScopes)
+	capability.ConnectorDependencies = cloneConnectorDependencies(capability.ConnectorDependencies)
+	capability.Eval.LocalCommands = cloneStrings(capability.Eval.LocalCommands)
+	capability.Eval.ScenarioSets = cloneStrings(capability.Eval.ScenarioSets)
+	capability.Eval.Rubrics = cloneStrings(capability.Eval.Rubrics)
+	capability.RuntimeEvents = cloneStrings(capability.RuntimeEvents)
+	capability.Provenance = cloneStrings(capability.Provenance)
+	capability.Review = cloneReviewStatus(capability.Review)
+	return capability
+}
+
+func cloneConnectorDependency(dependency ConnectorDependency) ConnectorDependency {
+	dependency.AuthModels = cloneStrings(dependency.AuthModels)
+	dependency.RequiredScopes = cloneStrings(dependency.RequiredScopes)
+	return dependency
+}
+
+func cloneReviewStatus(review ReviewStatus) ReviewStatus {
+	review.RequiredApprovers = cloneStrings(review.RequiredApprovers)
+	return review
+}
+
+func missingStrings(required []string, available []string) []string {
+	availableSet := stringSet(available)
+	missing := []string{}
+	for _, value := range required {
+		if !availableSet[value] {
+			missing = append(missing, value)
+		}
+	}
+	return missing
+}
+
+func uniqueSortedStrings(values []string) []string {
+	set := stringSet(values)
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func stringSet(values []string) map[string]bool {
+	set := map[string]bool{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		set[value] = true
+	}
+	return set
+}
+
+func containsValue(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/bootstrap/agent_platform.go
+++ b/internal/bootstrap/agent_platform.go
@@ -1,11 +1,59 @@
 package bootstrap
 
 import (
+	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/writer/cerebro/internal/agentplatform"
 )
 
 func (a *App) handleAgentPlatformContract(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, agentplatform.Snapshot())
+}
+
+func (a *App) handleAgentPlatformCapabilities(w http.ResponseWriter, r *http.Request) {
+	filter, err := agentPlatformCapabilityFilterFromRequest(r)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, http.StatusOK, agentplatform.ListCapabilities(filter))
+}
+
+func (a *App) handleAgentPlatformCapabilityDecision(w http.ResponseWriter, r *http.Request) {
+	var request agentplatform.CapabilityDecisionRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxProtoJSONBodyBytes)).Decode(&request); err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(request.CapabilityID) == "" {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	decision, ok := agentplatform.DecideCapability(request)
+	if !ok {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, decision)
+}
+
+func agentPlatformCapabilityFilterFromRequest(r *http.Request) (agentplatform.CapabilityRegistryFilter, error) {
+	query := r.URL.Query()
+	filter := agentplatform.CapabilityRegistryFilter{
+		DomainID: strings.TrimSpace(query.Get("domain_id")),
+		Kind:     strings.TrimSpace(query.Get("kind")),
+		Owner:    strings.TrimSpace(query.Get("owner")),
+		Risk:     strings.TrimSpace(query.Get("risk")),
+	}
+	if raw := strings.TrimSpace(query.Get("default_on")); raw != "" {
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			return agentplatform.CapabilityRegistryFilter{}, err
+		}
+		filter.DefaultOn = &value
+	}
+	return filter, nil
 }

--- a/internal/bootstrap/agent_platform_test.go
+++ b/internal/bootstrap/agent_platform_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -30,5 +31,76 @@ func TestHandleAgentPlatformContract(t *testing.T) {
 	}
 	if len(contract.ConnectorInfrastructure.OAuthSurfaces) == 0 {
 		t.Fatal("contract response missing connector OAuth surfaces")
+	}
+}
+
+func TestHandleAgentPlatformCapabilities(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/agent-platform/capabilities?domain_id=connectors&default_on=true", nil)
+
+	(&App{}).handleAgentPlatformCapabilities(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var registry agentplatform.CapabilityRegistry
+	if err := json.Unmarshal(recorder.Body.Bytes(), &registry); err != nil {
+		t.Fatalf("decode registry: %v", err)
+	}
+	if registry.Version != agentplatform.ContractVersion {
+		t.Fatalf("version = %q, want %q", registry.Version, agentplatform.ContractVersion)
+	}
+	if registry.Totals.Capabilities == 0 {
+		t.Fatal("registry response missing capabilities")
+	}
+	for _, capability := range registry.Capabilities {
+		if capability.DomainID != "connectors" || !capability.DefaultOn {
+			t.Fatalf("capability does not match filter: %+v", capability)
+		}
+	}
+}
+
+func TestHandleAgentPlatformCapabilitiesRejectsBadFilter(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/agent-platform/capabilities?default_on=maybe", nil)
+
+	(&App{}).handleAgentPlatformCapabilities(recorder, request)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", recorder.Code)
+	}
+}
+
+func TestHandleAgentPlatformCapabilityDecision(t *testing.T) {
+	body := []byte(`{"capability_id":"grc-ask","tenant_id":"tenant-1","actor_id":"actor-1","requested_scopes":["cosmo.security.read"]}`)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/agent-platform/capability-decisions", bytes.NewReader(body))
+
+	(&App{}).handleAgentPlatformCapabilityDecision(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var decision agentplatform.CapabilityDecision
+	if err := json.Unmarshal(recorder.Body.Bytes(), &decision); err != nil {
+		t.Fatalf("decode decision: %v", err)
+	}
+	if !decision.Enabled {
+		t.Fatalf("decision enabled = false, blockers = %+v", decision.Blockers)
+	}
+	if decision.CapabilityID != "grc-ask" || decision.TenantID != "tenant-1" || decision.ActorID != "actor-1" {
+		t.Fatalf("decision lost request context: %+v", decision)
+	}
+}
+
+func TestHandleAgentPlatformCapabilityDecisionReportsUnknownCapability(t *testing.T) {
+	body := []byte(`{"capability_id":"missing-capability","requested_scopes":["cosmo.security.read"]}`)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/agent-platform/capability-decisions", bytes.NewReader(body))
+
+	(&App{}).handleAgentPlatformCapabilityDecision(recorder, request)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", recorder.Code)
 	}
 }

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -26,6 +26,8 @@ type httpAuthRoutePolicy struct {
 
 var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/contract", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/capabilities", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/capability-decisions", Scope: scopeCosmoSecurityRead, Static: true},
 	{Exact: "/api/v1/mcp", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/metrics", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Prefix: "/reports/", Suffix: "/runs", Static: true, AdminOnly: true},

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -54,6 +54,8 @@ func (app *App) registerPublicRoutes(mux *http.ServeMux) {
 
 func (app *App) registerAgentPlatformRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/contract", routeSurfacePlatformHTTP, app.handleAgentPlatformContract)
+	registerHTTPRoute(mux, "GET /api/v1/agent-platform/capabilities", routeSurfacePlatformHTTP, app.handleAgentPlatformCapabilities)
+	registerHTTPRoute(mux, "POST /api/v1/agent-platform/capability-decisions", routeSurfacePlatformHTTP, app.handleAgentPlatformCapabilityDecision)
 }
 
 func (app *App) registerOAuthRoutes(mux *http.ServeMux) {


### PR DESCRIPTION
## Summary
- Add a filtered capability registry endpoint with operational totals.
- Add a capability decision endpoint that gates selection on scopes, preview state, connector readiness, eval status, and provenance requirements.
- Document the new API shapes in OpenAPI and cover the package and HTTP behavior with tests.

## Verification
- `go test ./internal/agentplatform ./internal/bootstrap`
- `go test ./...`
- `make openapi-check openapi-lint`
- `make lint`