### PR TITLE
Stop projecting SentinelOne activity events as assets

### DIFF
--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -364,6 +364,7 @@ func integrityCheckDefinitions() ([]IntegrityCheck, []string) {
 		{Name: "aws_public_endpoints_without_instance_link", Expected: 0},
 		{Name: "open_findings_missing_primary_has_finding_edge", Expected: 0},
 		{Name: "github_workflow_job_runners_projected_as_assets", Expected: 0},
+		{Name: "sentinelone_activity_events_projected_as_assets", Expected: 0},
 	}
 	queries := []string{
 		"MATCH (src:Entity)-[r:RELATION]->(dst:Entity) WHERE src.tenant_id <> dst.tenant_id OR src.tenant_id <> r.tenant_id OR dst.tenant_id <> r.tenant_id RETURN count(r)",
@@ -375,6 +376,7 @@ func integrityCheckDefinitions() ([]IntegrityCheck, []string) {
 		"MATCH (e:Entity) WHERE e.entity_type IN ['aws.elastic.ip', 'aws.network.interface'] AND ((coalesce(e.attributes_json, '') CONTAINS '\"attached_instance_id\":\"' AND NOT coalesce(e.attributes_json, '') CONTAINS '\"attached_instance_id\":\"\"') OR (coalesce(e.attributes_json, '') CONTAINS '\"associated_instance_id\":\"' AND NOT coalesce(e.attributes_json, '') CONTAINS '\"associated_instance_id\":\"\"')) AND NOT EXISTS { MATCH (e)-[:RELATION {relation: 'attached_to'}]->(:Entity {entity_type: 'aws.ec2.instance'}) } AND NOT EXISTS { MATCH (e)-[:RELATION {relation: 'associated_with'}]->(:Entity {entity_type: 'aws.ec2.instance'}) } RETURN count(e)",
 		"MATCH (finding:Entity {entity_type: 'finding'}) WITH finding, coalesce(finding.attributes_json, '') AS attrs WHERE attrs CONTAINS '\"status\":\"open\"' AND attrs CONTAINS '\"primary_resource_urn\":\"' WITH finding, split(split(attrs, '\"primary_resource_urn\":\"')[1], '\"')[0] AS primary_urn WHERE primary_urn <> '' MATCH (resource:Entity {tenant_id: finding.tenant_id, urn: primary_urn}) WHERE NOT EXISTS { MATCH (resource)-[:RELATION {relation: 'has_finding'}]->(finding) } RETURN count(finding)",
 		"MATCH (e:Entity {entity_type: 'github.runner'}) WHERE coalesce(e.attributes_json, '') CONTAINS '\"action\":\"workflows.' RETURN count(e)",
+		"MATCH (e:Entity {entity_type: 'sentinelone.activity'}) RETURN count(e)",
 	}
 	return checks, queries
 }

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -134,6 +134,29 @@ func TestIntegrityChecksIncludeHostedWorkflowRunnerAssetInvariant(t *testing.T) 
 	t.Fatalf("integrity checks missing hosted workflow runner asset invariant: %#v", checks)
 }
 
+func TestIntegrityChecksIncludeSentinelOneActivityAssetInvariant(t *testing.T) {
+	checks, queries := integrityCheckDefinitions()
+	if len(checks) != len(queries) {
+		t.Fatalf("integrity check definitions have %d checks and %d queries", len(checks), len(queries))
+	}
+	for i, check := range checks {
+		if check.Name != "sentinelone_activity_events_projected_as_assets" {
+			continue
+		}
+		query := queries[i]
+		for _, expected := range []string{
+			"sentinelone.activity",
+			"RETURN count(e)",
+		} {
+			if !strings.Contains(query, expected) {
+				t.Fatalf("sentinelone activity integrity query missing %q:\n%s", expected, query)
+			}
+		}
+		return
+	}
+	t.Fatalf("integrity checks missing sentinelone activity asset invariant: %#v", checks)
+}
+
 func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	if os.Getenv("CEREBRO_RUN_NEO4J_DOCKER") != "1" {
 		t.Skip("set CEREBRO_RUN_NEO4J_DOCKER=1 to run Neo4j Docker integration test")

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -373,53 +373,11 @@ func sentinelOneGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 }
 
 func sentinelOneActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenant, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-
-	activityID := strings.TrimSpace(attrs["activity_id"])
-	if activityID == "" {
-		return nil, nil, nil
-	}
-	activityURN := projectionURN(tenant, "sentinelone_activity", activityID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        activityURN,
-		TenantID:   tenant,
-		SourceID:   event.GetSourceId(),
-		EntityType: sentinelOneEntityActivity,
-		Label:      firstNonEmpty(attrs["primary_description"], activityID),
-		Attributes: map[string]string{
-			"activity_id":         activityID,
-			"activity_type":       strings.TrimSpace(attrs["activity_type"]),
-			"activity_uuid":       strings.TrimSpace(attrs["activity_uuid"]),
-			"primary_description": strings.TrimSpace(attrs["primary_description"]),
-			"agent_id":            strings.TrimSpace(attrs["agent_id"]),
-			"site_id":             strings.TrimSpace(attrs["site_id"]),
-			"group_id":            strings.TrimSpace(attrs["group_id"]),
-			"threat_id":           strings.TrimSpace(attrs["threat_id"]),
-			"user_id":             strings.TrimSpace(attrs["user_id"]),
-			"os_family":           strings.TrimSpace(attrs["os_family"]),
-			"tenant_host":         strings.TrimSpace(attrs["tenant_host"]),
-			"event_id":            event.GetId(),
-			"at":                  eventObservedAt(event),
-		},
-	})
-
-	if agentID := strings.TrimSpace(attrs["agent_id"]); agentID != "" {
-		agentURN := sentinelOneAgentURN(tenant, agentID)
-		addLink(links, projectedLink(tenant, event.GetSourceId(), activityURN, agentURN, relationObservedOn, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
-	}
-	if threatID := strings.TrimSpace(attrs["threat_id"]); threatID != "" {
-		threatURN := sentinelOneThreatURN(tenant, threatID)
-		addLink(links, projectedLink(tenant, event.GetSourceId(), activityURN, threatURN, relationActedOn, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
-	}
-
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+	// Activities are audit-event evidence, not durable inventory. Finding rules
+	// read the source event directly when an activity contributes evidence; the
+	// graph should retain current SentinelOne state through agent, threat,
+	// exclusion, site, and group entities.
+	return nil, nil, nil
 }
 
 func sentinelOneExclusionProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -324,10 +324,10 @@ func TestProjectSentinelOneGroupSiteLink(t *testing.T) {
 	assertProjectedLink(t, state, groupURN, relationBelongsTo, siteURN)
 }
 
-func TestProjectSentinelOneActivityLinksAgentAndThreat(t *testing.T) {
+func TestProjectSentinelOneActivityDoesNotMaterializeAuditEvent(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
-	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
 		Id:       "s1-activity-1",
 		TenantId: "writer",
 		SourceId: "sentinelone",
@@ -340,17 +340,16 @@ func TestProjectSentinelOneActivityLinksAgentAndThreat(t *testing.T) {
 			"threat_id":           "threat-1",
 			"site_id":             "site-1",
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Project(activity) error = %v", err)
 	}
-	activityURN := "urn:cerebro:writer:sentinelone_activity:activity-1"
-	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
-	threatURN := "urn:cerebro:writer:sentinelone_threat:threat-1"
-	if state.entities[activityURN] == nil {
-		t.Fatal("activity entity missing")
+	if result.EntitiesProjected != 0 || result.LinksProjected != 0 {
+		t.Fatalf("activity projection = entities %d links %d, want no graph projection", result.EntitiesProjected, result.LinksProjected)
 	}
-	assertProjectedLink(t, state, activityURN, relationObservedOn, agentURN)
-	assertProjectedLink(t, state, activityURN, relationActedOn, threatURN)
+	if len(state.entities) != 0 || len(state.links) != 0 {
+		t.Fatalf("activity audit event should not materialize graph records: entities=%#v links=%#v", state.entities, state.links)
+	}
 }
 
 func TestProjectSentinelOneApplicationInventoryContainedByAgent(t *testing.T) {


### PR DESCRIPTION
## Summary
- keep SentinelOne activity rows as event evidence instead of durable graph inventory
- preserve durable SentinelOne graph state on agents, threats, exclusions, sites, and groups
- add graph integrity coverage to catch activity-event asset projection if it reappears

## Tests
- go test ./internal/sourceprojection -run 'TestProjectSentinelOne(Activity|Agent|Threat)' -count=1\n- go test ./internal/graphstore/neo4j -run 'TestIntegrityChecksInclude' -count=1\n- go test ./internal/sourceprojection ./internal/graphstore/neo4j ./cmd/cerebro -count=1\n- make lint