### PR TITLE
Add agent graph reasoning surface

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -136,6 +136,32 @@ paths:
           description: Invalid capability decision request.
         '404':
           description: Capability was not found.
+  /api/v1/agent-platform/graph/reason:
+    post:
+      operationId: reasonOverAgentPlatformGraph
+      summary: Reason over the graph for an agent
+      tags:
+        - Platform
+        - Graph
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GRCAskRequest'
+      responses:
+        '200':
+          description: Structured graph reasoning envelope with query plan, validation, rows, graph context, citations, and provenance.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentPlatformGraphReasonResponse'
+        '400':
+          description: Invalid graph reasoning request.
+        '403':
+          description: Tenant or scope is not allowed.
+        '503':
+          description: Graph or LLM runtime unavailable.
   /api/v1/mcp:
     get:
       summary: Reject MCP stateful event-stream transport
@@ -3239,6 +3265,212 @@ components:
           type: array
           items:
             type: string
+    AgentPlatformGraphReasonResponse:
+      type: object
+      required:
+        - question
+        - tenant_id
+        - model
+        - rows
+        - citations
+        - provenance
+      properties:
+        trace_id:
+          type: string
+        question:
+          type: string
+        tenant_id:
+          type: string
+        scope_urn:
+          type: string
+        model:
+          type: string
+        rationale:
+          type: string
+        probe:
+          type: object
+          additionalProperties: true
+        query_plan:
+          $ref: '#/components/schemas/AgentPlatformGraphQueryPlanEvent'
+        cypher:
+          $ref: '#/components/schemas/AgentPlatformGraphCypherEvent'
+        recovery:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        rows:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        graph:
+          $ref: '#/components/schemas/GetEntityNeighborhoodResponse'
+        answer_markdown:
+          type: string
+        citations:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformGraphCitation'
+        citation_validation:
+          $ref: '#/components/schemas/AgentPlatformGraphCitationValidation'
+        unsupported_query:
+          type: object
+          additionalProperties: true
+        progress:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformGraphProgressEvent'
+        timings:
+          $ref: '#/components/schemas/AgentPlatformGraphStageTimings'
+        provenance:
+          $ref: '#/components/schemas/AgentPlatformGraphReasonProvenance'
+    AgentPlatformGraphQueryPlanEvent:
+      type: object
+      required:
+        - plan
+        - source
+        - deterministic
+        - corrected
+      properties:
+        plan:
+          $ref: '#/components/schemas/AgentPlatformGraphQueryPlan'
+        diagnostics:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        source:
+          type: string
+        deterministic:
+          type: boolean
+        corrected:
+          type: boolean
+    AgentPlatformGraphQueryPlan:
+      type: object
+      required:
+        - intent
+      properties:
+        intent:
+          type: string
+        confidence:
+          type: number
+        scope_urn:
+          type: string
+        limit:
+          type: integer
+        filters:
+          type: object
+          additionalProperties:
+            type: string
+        group_by:
+          type: string
+    AgentPlatformGraphCypherEvent:
+      type: object
+      required:
+        - cypher
+        - validator
+      properties:
+        cypher:
+          type: string
+        validator:
+          $ref: '#/components/schemas/AgentPlatformGraphValidatorResult'
+    AgentPlatformGraphValidatorResult:
+      type: object
+      required:
+        - ok
+      properties:
+        ok:
+          type: boolean
+        code:
+          type: string
+        reason:
+          type: string
+        warnings:
+          type: array
+          items:
+            type: string
+    AgentPlatformGraphCitation:
+      type: object
+      required:
+        - urn
+        - span
+      properties:
+        urn:
+          type: string
+        span:
+          type: array
+          minItems: 2
+          maxItems: 2
+          items:
+            type: integer
+    AgentPlatformGraphCitationValidation:
+      type: object
+      required:
+        - ok
+        - row_urn_count
+        - referenced_urn_count
+      properties:
+        ok:
+          type: boolean
+        warnings:
+          type: array
+          items:
+            type: string
+        row_urn_count:
+          type: integer
+        referenced_urn_count:
+          type: integer
+    AgentPlatformGraphProgressEvent:
+      type: object
+      required:
+        - stage
+        - message
+        - elapsed_ms
+      properties:
+        stage:
+          type: string
+        message:
+          type: string
+        elapsed_ms:
+          type: integer
+    AgentPlatformGraphStageTimings:
+      type: object
+      properties:
+        probe_ms:
+          type: integer
+        draft_ms:
+          type: integer
+        conversion_ms:
+          type: integer
+        validate_ms:
+          type: integer
+        execute_ms:
+          type: integer
+        summarize_ms:
+          type: integer
+        citation_validation_ms:
+          type: integer
+    AgentPlatformGraphReasonProvenance:
+      type: object
+      required:
+        - surface
+        - citation_status
+      properties:
+        surface:
+          type: string
+        trace_id:
+          type: string
+        source_urns:
+          type: array
+          items:
+            type: string
+        scope:
+          type: string
+        citation_status:
+          type: string
+        fallback_reason:
+          type: string
     AgentPlatformDomain:
       type: object
       required:

--- a/internal/agentplatform/contracts.go
+++ b/internal/agentplatform/contracts.go
@@ -442,6 +442,33 @@ var Capabilities = []Capability{
 			RequiredApprovers: []string{"platform", "security"},
 		},
 	},
+	{
+		ID:              "graph-reasoning",
+		Name:            "Agent graph reasoning",
+		DomainID:        "knowledge",
+		Kind:            "agent-graph-reasoning",
+		Version:         "1.0.0",
+		Owner:           "cerebro-platform",
+		Risk:            "medium",
+		DefaultOn:       true,
+		Summary:         "Lets agents ask bounded graph questions and receive a structured reasoning envelope with query plan, validation, rows, graph context, citations, and provenance.",
+		ConsoleSurfaces: []string{"Agent platform graph API", "Ask console", "trace drawer"},
+		RequiredScopes:  []string{"cosmo.security.read"},
+		Eval: EvalStatus{
+			Required:      true,
+			Status:        "required",
+			LocalCommands: []string{"go test ./internal/graphagent ./internal/bootstrap -run Test.*Reason"},
+			ScenarioSets:  []string{"graph-reasoning-envelope", "graph-reasoning-unsupported-query"},
+			Rubrics:       []string{"read-only validation", "query plan transparency", "citation grounding", "provenance completeness"},
+		},
+		RuntimeEvents: []string{"agent.run.started", "capability.selected", "knowledge.retrieval.completed", "agent.run.completed", "agent.run.failed"},
+		Provenance:    []string{"graph-reasoning", "knowledge-context", "graph-neighborhood"},
+		Review: ReviewStatus{
+			State:             "required",
+			Cadence:           "before graph reasoning API or query contract changes",
+			RequiredApprovers: []string{"platform", "security"},
+		},
+	},
 }
 
 var RuntimeEvents = []RuntimeEvent{
@@ -635,6 +662,14 @@ var ProvenanceRequirements = []ProvenanceRequirement{
 		Surface:          "graph-neighborhood",
 		DomainID:         "knowledge",
 		RequiredFields:   []string{"source_urn", "scope", "entity_urn", "budget", "citation_status", "fallback_reason"},
+		CitationRequired: true,
+		BudgetRequired:   true,
+		FallbackRequired: true,
+	},
+	{
+		Surface:          "graph-reasoning",
+		DomainID:         "knowledge",
+		RequiredFields:   []string{"trace_id", "source_urns", "scope", "citation_status", "fallback_reason"},
 		CitationRequired: true,
 		BudgetRequired:   true,
 		FallbackRequired: true,

--- a/internal/bootstrap/agent_graph_reasoning.go
+++ b/internal/bootstrap/agent_graph_reasoning.go
@@ -1,0 +1,65 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/writer/cerebro/internal/graphagent"
+	"github.com/writer/cerebro/internal/graphquery"
+)
+
+func (a *App) handleAgentPlatformGraphReason(w http.ResponseWriter, r *http.Request) {
+	var request graphagent.AskRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxGRCAskBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
+		return
+	}
+	if err := authorizeTenantID(r.Context(), request.TenantID); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	if request.ScopeURN != "" {
+		if err := authorizeCerebroURNTenant(r.Context(), request.ScopeURN); err != nil {
+			writeGRCError(w, err)
+			return
+		}
+	}
+	if err := graphagent.ValidateRequest(request); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	service, err := a.newGraphReasoningService()
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	response, err := service.Reason(r.Context(), request)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *App) newGraphReasoningService() (*graphagent.Service, error) {
+	graphStore := graphQueryStore(a.deps.GraphStore)
+	if graphStore == nil {
+		return nil, graphquery.ErrRuntimeUnavailable
+	}
+	llm := a.deps.GraphAgentLLM
+	if llm == nil {
+		return nil, errors.Join(graphagent.ErrRuntimeUnavailable, errors.New("graph agent llm is not configured"))
+	}
+	return graphagent.NewServiceWithOptions(graphStore, llm, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
+		TrajectoryStore:             askTrajectoryStore(a.deps.StateStore),
+		EnableGraphProbes:           true,
+		EnableDeterministicFastPath: true,
+		EnableRecovery:              true,
+		EnableMapReduce:             true,
+		MaxDepth:                    2,
+		MaxChildren:                 2,
+	}), nil
+}

--- a/internal/bootstrap/agent_graph_reasoning_test.go
+++ b/internal/bootstrap/agent_graph_reasoning_test.go
@@ -1,0 +1,83 @@
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphagent"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestHandleAgentPlatformGraphReason(t *testing.T) {
+	graphStore := &stubGraphStore{
+		cypherRows: [][]ports.CypherRow{{
+			{Values: map[string]any{
+				"entity_urn":  "urn:cerebro:writer:asset:alpha",
+				"entity_type": "asset",
+				"label":       "alpha",
+			}},
+		}},
+		neighborhood: &ports.EntityNeighborhood{
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:asset:alpha", EntityType: "asset", Label: "alpha"},
+		},
+	}
+	llm := &graphagent.StubLLMClient{
+		DraftResponse: &graphagent.DraftResponse{
+			Rationale: "Reasoning over scoped graph rows.",
+			Cypher: `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS entity_urn, e.entity_type AS entity_type, e.label AS label
+LIMIT 25`,
+		},
+		Summary: "Review `urn:cerebro:writer:asset:alpha` first.",
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphAgentLLM: llm}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := []byte(`{"tenant_id":"writer","question":"Which scoped asset should I review?","scope_urn":"urn:cerebro:writer:asset:alpha"}`)
+	resp, err := server.Client().Post(server.URL+"/api/v1/agent-platform/graph/reason", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST graph reason error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Fatalf("content-type = %q, want application/json", got)
+	}
+	var response graphagent.ReasonResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		t.Fatalf("decode graph reason response: %v", err)
+	}
+	if response.TraceID == "" || response.QueryPlan == nil || response.Cypher == nil {
+		t.Fatalf("response missing trace/query/cypher: %#v", response)
+	}
+	if len(response.Rows) != 1 || response.Rows[0]["entity_urn"] != "urn:cerebro:writer:asset:alpha" {
+		t.Fatalf("rows = %#v", response.Rows)
+	}
+	if response.Provenance.Surface != "graph-reasoning" || response.Provenance.CitationStatus != "valid" {
+		t.Fatalf("provenance = %#v, want valid graph reasoning provenance", response.Provenance)
+	}
+}
+
+func TestHandleAgentPlatformGraphReasonRequiresLLM(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: &stubGraphStore{}}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Post(server.URL+"/api/v1/agent-platform/graph/reason", "application/json", strings.NewReader(`{"tenant_id":"writer","question":"hello"}`))
+	if err != nil {
+		t.Fatalf("POST graph reason error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+}

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -28,6 +28,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/contract", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/capabilities", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/capability-decisions", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/graph/reason", Scope: scopeCosmoSecurityRead, Static: true},
 	{Exact: "/api/v1/mcp", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/metrics", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Prefix: "/reports/", Suffix: "/runs", Static: true, AdminOnly: true},

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -19,6 +19,7 @@ import (
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/connectordefinitions"
 	findingdomain "github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/riskplan"
@@ -569,6 +570,8 @@ func (app *App) mcpToolStructuredContent(r *http.Request, name string, args map[
 		return app.mcpGraphImpact(r, args)
 	case "cerebro.graph.paths":
 		return app.mcpGraphPaths(r, args)
+	case "cerebro.graph.reason":
+		return app.mcpGraphReason(r, args)
 	case "cerebro.investigation.context":
 		return app.mcpInvestigationContext(r, args)
 	case "cerebro.findings.action.propose":
@@ -1432,6 +1435,47 @@ func (app *App) mcpGraphPaths(r *http.Request, args map[string]any) (any, error)
 	return mcpAddResponseMetadata(value, mcpResponseMetadata(limitApplied, mcpMapArrayCount(value, "paths"), nil)), nil
 }
 
+func (app *App) mcpGraphReason(r *http.Request, args map[string]any) (any, error) {
+	request := graphagent.AskRequest{
+		TenantID: mcpTenantArg(r, args),
+		Question: mcpStringArg(args, "question"),
+		ScopeURN: mcpStringArg(args, "scope_urn"),
+		Model:    mcpStringArg(args, "model"),
+	}
+	if request.TenantID == "" && requiresTenantFilter(r.Context()) {
+		return nil, errTenantForbidden
+	}
+	if err := authorizeTenantID(r.Context(), request.TenantID); err != nil {
+		return nil, err
+	}
+	if request.ScopeURN != "" {
+		if err := authorizeCerebroURNTenant(r.Context(), request.ScopeURN); err != nil {
+			return nil, mcpNormalizeIDLookupError(err, ports.ErrGraphEntityNotFound)
+		}
+	}
+	if err := graphagent.ValidateRequest(request); err != nil {
+		return nil, err
+	}
+	service, err := app.newGraphReasoningService()
+	if err != nil {
+		return nil, err
+	}
+	response, err := service.Reason(r.Context(), request)
+	if err != nil {
+		return nil, err
+	}
+	value, err := jsonValue(response)
+	if err != nil {
+		return nil, err
+	}
+	rows := 0
+	if typed, ok := value.(map[string]any); ok {
+		rows = mcpMapArrayCount(typed, "rows")
+		return mcpAddResponseMetadata(typed, mcpResponseMetadata(0, rows, nil)), nil
+	}
+	return value, nil
+}
+
 func (app *App) mcpInvestigationContext(r *http.Request, args map[string]any) (any, error) {
 	findingID := mcpStringArg(args, "finding_id")
 	if findingID == "" {
@@ -1883,6 +1927,29 @@ func mcpTools() []mcpTool {
 			}, nil),
 			OutputSchema: mcpOutputSchema(nil),
 			Annotations:  mcpReadOnlyAnnotations("Graph Attack Paths"),
+		},
+		{
+			Name:        "cerebro.graph.reason",
+			Title:       "Graph Reasoning",
+			Description: "Answer a tenant-scoped graph question with query plan, guarded Cypher, rows, graph evidence, citations, and provenance.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"tenant_id": map[string]any{"type": "string"},
+				"question":  map[string]any{"type": "string"},
+				"scope_urn": map[string]any{"type": "string"},
+				"model":     map[string]any{"type": "string"},
+			}, []string{"question"}),
+			OutputSchema: mcpOutputSchema(map[string]any{
+				"trace_id":            map[string]any{"type": "string"},
+				"query_plan":          map[string]any{"type": "object"},
+				"cypher":              map[string]any{"type": "object"},
+				"rows":                map[string]any{"type": "array"},
+				"graph":               map[string]any{"type": "object"},
+				"answer_markdown":     map[string]any{"type": "string"},
+				"citations":           map[string]any{"type": "array"},
+				"citation_validation": map[string]any{"type": "object"},
+				"provenance":          map[string]any{"type": "object"},
+			}),
+			Annotations: mcpReadOnlyAnnotations("Graph Reasoning"),
 		},
 		{
 			Name:        "cerebro.investigation.context",
@@ -2456,19 +2523,19 @@ func (app *App) mcpGetPrompt(_ *http.Request, rawParams json.RawMessage) (map[st
 		if findingID == "" {
 			return nil, fmt.Errorf("%w: finding_id is required", errInvalidHTTPRequest)
 		}
-		text = "Investigate Cerebro finding " + findingID + ". First read cerebro://investigation/finding/" + url.PathEscape(findingID) + ", then use cerebro.evidence.list, cerebro.assets.get, cerebro.graph.neighborhood, cerebro.graph.impact, and cerebro.findings.action.propose with dry_run=true for recommended next steps. Never infer data from inaccessible IDs, never reveal redacted values, and treat tenant-forbidden or not-found tool results as a hard boundary."
+		text = "Investigate Cerebro finding " + findingID + ". First read cerebro://investigation/finding/" + url.PathEscape(findingID) + ", then use cerebro.evidence.list, cerebro.assets.get, cerebro.graph.reason, cerebro.graph.neighborhood, cerebro.graph.impact, and cerebro.findings.action.propose with dry_run=true for recommended next steps. Never infer data from inaccessible IDs, never reveal redacted values, and treat tenant-forbidden or not-found tool results as a hard boundary."
 	case "investigate_asset":
 		assetURN := mcpStringArg(args, "asset_urn")
 		if assetURN == "" {
 			return nil, fmt.Errorf("%w: asset_urn is required", errInvalidHTTPRequest)
 		}
-		text = "Investigate Cerebro asset " + assetURN + ". Read cerebro://asset/" + url.PathEscape(assetURN) + ", then use cerebro.graph.neighborhood, cerebro.graph.impact, cerebro.findings.search, and cerebro.risk.summary to explain blast radius and related findings. Never infer data from inaccessible IDs, never reveal redacted values, and treat tenant-forbidden or not-found tool results as a hard boundary."
+		text = "Investigate Cerebro asset " + assetURN + ". Read cerebro://asset/" + url.PathEscape(assetURN) + ", then use cerebro.graph.reason, cerebro.graph.neighborhood, cerebro.graph.impact, cerebro.findings.search, and cerebro.risk.summary to explain blast radius and related findings. Never infer data from inaccessible IDs, never reveal redacted values, and treat tenant-forbidden or not-found tool results as a hard boundary."
 	case "summarize_tenant_risk":
 		tenantID := mcpStringArg(args, "tenant_id")
 		if tenantID == "" {
-			text = "Summarize tenant risk for the authenticated Cerebro principal using cerebro.risk.summary, cerebro.findings.search, cerebro.graph.paths, and dry-run-only proposal tools for next actions. Never infer data from inaccessible IDs, never reveal redacted values, and treat tenant-forbidden or not-found tool results as a hard boundary."
+			text = "Summarize tenant risk for the authenticated Cerebro principal using cerebro.risk.summary, cerebro.findings.search, cerebro.graph.reason, cerebro.graph.paths, and dry-run-only proposal tools for next actions. Never infer data from inaccessible IDs, never reveal redacted values, and treat tenant-forbidden or not-found tool results as a hard boundary."
 		} else {
-			text = "Summarize Cerebro tenant " + tenantID + " risk using cerebro.risk.summary, cerebro.findings.search, cerebro.graph.paths, and dry-run-only proposal tools for next actions. Never infer data from inaccessible IDs, never reveal redacted values, and treat tenant-forbidden or not-found tool results as a hard boundary."
+			text = "Summarize Cerebro tenant " + tenantID + " risk using cerebro.risk.summary, cerebro.findings.search, cerebro.graph.reason, cerebro.graph.paths, and dry-run-only proposal tools for next actions. Never infer data from inaccessible IDs, never reveal redacted values, and treat tenant-forbidden or not-found tool results as a hard boundary."
 		}
 	default:
 		return nil, fmt.Errorf("%w: unknown prompt %q", errInvalidHTTPRequest, name)

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -13,6 +13,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -141,6 +142,7 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 		"cerebro.graph.neighborhood",
 		"cerebro.graph.impact",
 		"cerebro.graph.paths",
+		"cerebro.graph.reason",
 		"cerebro.investigation.context",
 		"cerebro.findings.action.propose",
 		"cerebro.source_runtimes.refresh.propose",
@@ -1754,6 +1756,64 @@ func TestMCPGraphNeighborhood(t *testing.T) {
 	}
 }
 
+func TestMCPGraphReason(t *testing.T) {
+	graph := &stubGraphStore{
+		cypherRows: [][]ports.CypherRow{{
+			{Values: map[string]any{
+				"entity_urn":  "urn:cerebro:writer:asset:prod-db",
+				"entity_type": "asset",
+				"label":       "prod-db",
+			}},
+		}},
+		neighborhood: &ports.EntityNeighborhood{
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:asset:prod-db", EntityType: "asset", Label: "prod-db"},
+		},
+	}
+	llm := &graphagent.StubLLMClient{
+		DraftResponse: &graphagent.DraftResponse{
+			Rationale: "Answering with scoped graph evidence.",
+			Cypher: `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS entity_urn, e.entity_type AS entity_type, e.label AS label
+LIMIT 25`,
+		},
+		Summary: "Review `urn:cerebro:writer:asset:prod-db` first.",
+	}
+	server := newMCPTestServerWithGraphReasoning(t, &stubRuntimeStore{}, graph, llm)
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.graph.reason",
+			"arguments": map[string]any{
+				"question":  "Which asset should I review first?",
+				"scope_urn": "urn:cerebro:writer:asset:prod-db",
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("graph.reason error = %#v", response["error"])
+	}
+	content := response["result"].(map[string]any)["structuredContent"].(map[string]any)
+	if content["trace_id"] == "" || content["query_plan"] == nil || content["cypher"] == nil {
+		t.Fatalf("graph.reason missing trace/query/cypher: %#v", content)
+	}
+	rows := content["rows"].([]any)
+	if len(rows) != 1 || rows[0].(map[string]any)["entity_urn"] != "urn:cerebro:writer:asset:prod-db" {
+		t.Fatalf("graph.reason rows = %#v", rows)
+	}
+	provenance := content["provenance"].(map[string]any)
+	if provenance["surface"] != "graph-reasoning" || provenance["citation_status"] != "valid" {
+		t.Fatalf("graph.reason provenance = %#v", provenance)
+	}
+	metadata := content["metadata"].(map[string]any)
+	if metadata["returned"] != float64(1) || metadata["stateless"] != true {
+		t.Fatalf("graph.reason metadata = %#v", metadata)
+	}
+}
+
 func TestMCPGraphToolMetadataNormalizesLimits(t *testing.T) {
 	graph := &stubGraphStore{
 		neighborhood: &ports.EntityNeighborhood{
@@ -1996,6 +2056,11 @@ func newMCPTestServer(t *testing.T, store *stubRuntimeStore) *httptest.Server {
 
 func newMCPTestServerWithGraph(t *testing.T, store *stubRuntimeStore, graph *stubGraphStore) *httptest.Server {
 	t.Helper()
+	return newMCPTestServerWithGraphReasoning(t, store, graph, nil)
+}
+
+func newMCPTestServerWithGraphReasoning(t *testing.T, store *stubRuntimeStore, graph *stubGraphStore, llm graphagent.LLMClient) *httptest.Server {
+	t.Helper()
 	app := New(config.Config{
 		HTTPAddr:        "127.0.0.1:0",
 		ShutdownTimeout: time.Second,
@@ -2007,7 +2072,7 @@ func newMCPTestServerWithGraph(t *testing.T, store *stubRuntimeStore, graph *stu
 				TenantID:  "writer",
 			}},
 		},
-	}, Dependencies{StateStore: store, GraphStore: graph}, nil)
+	}, Dependencies{StateStore: store, GraphStore: graph, GraphAgentLLM: llm}, nil)
 	return httptest.NewServer(app.Handler())
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -56,6 +56,7 @@ func (app *App) registerAgentPlatformRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/contract", routeSurfacePlatformHTTP, app.handleAgentPlatformContract)
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/capabilities", routeSurfacePlatformHTTP, app.handleAgentPlatformCapabilities)
 	registerHTTPRoute(mux, "POST /api/v1/agent-platform/capability-decisions", routeSurfacePlatformHTTP, app.handleAgentPlatformCapabilityDecision)
+	registerHTTPRoute(mux, "POST /api/v1/agent-platform/graph/reason", routeSurfacePlatformHTTP, app.handleAgentPlatformGraphReason)
 }
 
 func (app *App) registerOAuthRoutes(mux *http.ServeMux) {

--- a/internal/graphagent/reason.go
+++ b/internal/graphagent/reason.go
@@ -1,0 +1,168 @@
+package graphagent
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type ReasonResponse struct {
+	TraceID            string                    `json:"trace_id,omitempty"`
+	Question           string                    `json:"question"`
+	TenantID           string                    `json:"tenant_id"`
+	ScopeURN           string                    `json:"scope_urn,omitempty"`
+	Model              string                    `json:"model"`
+	Rationale          string                    `json:"rationale,omitempty"`
+	Probe              *GraphProbe               `json:"probe,omitempty"`
+	QueryPlan          *QueryPlanEvent           `json:"query_plan,omitempty"`
+	Cypher             *CypherEvent              `json:"cypher,omitempty"`
+	Recovery           []RecoveryEvent           `json:"recovery,omitempty"`
+	Rows               []map[string]any          `json:"rows"`
+	Graph              *ports.EntityNeighborhood `json:"graph,omitempty"`
+	AnswerMarkdown     string                    `json:"answer_markdown,omitempty"`
+	Citations          []Citation                `json:"citations"`
+	CitationValidation *CitationValidation       `json:"citation_validation,omitempty"`
+	UnsupportedQuery   *UnsupportedQuery         `json:"unsupported_query,omitempty"`
+	Progress           []ProgressEvent           `json:"progress,omitempty"`
+	Timings            StageTimings              `json:"timings,omitempty"`
+	Provenance         ReasonProvenance          `json:"provenance"`
+}
+
+type ReasonProvenance struct {
+	Surface        string   `json:"surface"`
+	TraceID        string   `json:"trace_id,omitempty"`
+	SourceURNs     []string `json:"source_urns,omitempty"`
+	Scope          string   `json:"scope,omitempty"`
+	CitationStatus string   `json:"citation_status"`
+	FallbackReason string   `json:"fallback_reason,omitempty"`
+}
+
+func (s *Service) Reason(ctx context.Context, request AskRequest) (*ReasonResponse, error) {
+	response := &ReasonResponse{
+		Question:  strings.TrimSpace(request.Question),
+		TenantID:  strings.TrimSpace(request.TenantID),
+		ScopeURN:  strings.TrimSpace(request.ScopeURN),
+		Model:     normalizeModel(request.Model),
+		Rows:      []map[string]any{},
+		Citations: []Citation{},
+		Provenance: ReasonProvenance{
+			Surface:        "graph-reasoning",
+			Scope:          reasonScope(request),
+			CitationStatus: "not_applicable",
+		},
+	}
+	err := s.Stream(ctx, request, func(event Event) error {
+		response.observe(event)
+		return nil
+	})
+	if response.Provenance.TraceID == "" && response.TraceID != "" {
+		response.Provenance.TraceID = response.TraceID
+	}
+	if response.Provenance.CitationStatus == "not_applicable" && len(response.Rows) > 0 {
+		response.Provenance.CitationStatus = "missing"
+	}
+	return response, err
+}
+
+func reasonScope(request AskRequest) string {
+	if scope := strings.TrimSpace(request.ScopeURN); scope != "" {
+		return scope
+	}
+	return strings.TrimSpace(request.TenantID)
+}
+
+func (r *ReasonResponse) observe(event Event) {
+	if r == nil {
+		return
+	}
+	switch data := event.Data.(type) {
+	case ProgressEvent:
+		r.Progress = append(r.Progress, data)
+	case GraphProbeEvent:
+		probe := data.Probe
+		r.Probe = &probe
+	case RationaleEvent:
+		r.Rationale = data.Text
+	case QueryPlanEvent:
+		plan := data
+		r.QueryPlan = &plan
+	case CypherEvent:
+		cypher := data
+		r.Cypher = &cypher
+	case RecoveryEvent:
+		r.Recovery = append(r.Recovery, data)
+	case RowsEvent:
+		r.Rows = data.Rows
+		r.Graph = data.Graph
+		r.Provenance.SourceURNs = rowURNs(data.Rows)
+		if len(data.Rows) > 0 {
+			r.Provenance.CitationStatus = "pending"
+		}
+	case SummaryEvent:
+		r.AnswerMarkdown = data.Markdown
+		r.Citations = data.Citations
+		r.CitationValidation = data.CitationValidation
+		r.UnsupportedQuery = data.UnsupportedQuery
+		r.Provenance.CitationStatus = citationStatus(data.CitationValidation, data.Citations, r.Rows)
+		if data.UnsupportedQuery != nil {
+			r.Provenance.FallbackReason = data.UnsupportedQuery.Code
+		}
+	case DoneEvent:
+		r.TraceID = data.TraceID
+		r.Timings = data.Timings
+		r.Provenance.TraceID = data.TraceID
+		if data.CypherRefused && r.Provenance.FallbackReason == "" {
+			r.Provenance.FallbackReason = "cypher_refused"
+		}
+	}
+}
+
+func citationStatus(validation *CitationValidation, citations []Citation, rows []map[string]any) string {
+	if validation != nil {
+		if validation.OK {
+			return "valid"
+		}
+		return "warning"
+	}
+	if len(rows) == 0 {
+		return "not_applicable"
+	}
+	if len(citations) == 0 {
+		return "missing"
+	}
+	return "unknown"
+}
+
+func rowURNs(rows []map[string]any) []string {
+	set := map[string]bool{}
+	for _, row := range rows {
+		for _, value := range row {
+			collectURNs(value, set)
+		}
+	}
+	urns := make([]string, 0, len(set))
+	for urn := range set {
+		urns = append(urns, urn)
+	}
+	sort.Strings(urns)
+	return urns
+}
+
+func collectURNs(value any, out map[string]bool) {
+	switch typed := value.(type) {
+	case string:
+		for _, urn := range summaryURNPattern.FindAllString(typed, -1) {
+			out[urn] = true
+		}
+	case []any:
+		for _, item := range typed {
+			collectURNs(item, out)
+		}
+	case map[string]any:
+		for _, item := range typed {
+			collectURNs(item, out)
+		}
+	}
+}

--- a/internal/graphagent/reason_test.go
+++ b/internal/graphagent/reason_test.go
@@ -1,0 +1,98 @@
+package graphagent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestServiceReasonReturnsStructuredGraphEnvelope(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"entity_urn":  "urn:cerebro:writer:asset:alpha",
+				"entity_type": "asset",
+				"label":       "alpha",
+			},
+		}},
+		graph: &ports.EntityNeighborhood{
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:asset:alpha", EntityType: "asset", Label: "alpha"},
+		},
+	}
+	llm := &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Rationale: "Finding scoped graph rows.",
+			Cypher: `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS entity_urn, e.entity_type AS entity_type, e.label AS label
+LIMIT 25`,
+		},
+		Summary: "Review `urn:cerebro:writer:asset:alpha` first.",
+	}
+	service := NewServiceWithOptions(store, llm, ValidatorOptions{}, ServiceOptions{
+		EnableGraphProbes: true,
+	})
+
+	response, err := service.Reason(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "Which scoped asset should I review?",
+		ScopeURN: "urn:cerebro:writer:asset:alpha",
+	})
+	if err != nil {
+		t.Fatalf("Reason() error = %v", err)
+	}
+	if response.TraceID == "" || response.Provenance.TraceID != response.TraceID {
+		t.Fatalf("trace/provenance = %#v", response.Provenance)
+	}
+	if response.Probe == nil {
+		t.Fatal("response missing graph probe")
+	}
+	if response.QueryPlan == nil || response.QueryPlan.Plan.Intent == "" {
+		t.Fatalf("query plan = %#v, want populated plan", response.QueryPlan)
+	}
+	if response.Cypher == nil || !response.Cypher.Validator.OK {
+		t.Fatalf("cypher = %#v, want validated query", response.Cypher)
+	}
+	if len(response.Rows) != 1 || response.Rows[0]["entity_urn"] != "urn:cerebro:writer:asset:alpha" {
+		t.Fatalf("rows = %#v", response.Rows)
+	}
+	if response.Graph == nil || response.Graph.Root == nil {
+		t.Fatal("response missing graph neighborhood")
+	}
+	if response.AnswerMarkdown != "Review `urn:cerebro:writer:asset:alpha` first." {
+		t.Fatalf("answer = %q", response.AnswerMarkdown)
+	}
+	if len(response.Citations) != 1 || response.Citations[0].URN != "urn:cerebro:writer:asset:alpha" {
+		t.Fatalf("citations = %#v", response.Citations)
+	}
+	if response.CitationValidation == nil || !response.CitationValidation.OK {
+		t.Fatalf("citation validation = %#v", response.CitationValidation)
+	}
+	if response.Provenance.Surface != "graph-reasoning" || response.Provenance.CitationStatus != "valid" {
+		t.Fatalf("provenance = %#v, want valid graph reasoning provenance", response.Provenance)
+	}
+	if len(response.Provenance.SourceURNs) != 1 || response.Provenance.SourceURNs[0] != "urn:cerebro:writer:asset:alpha" {
+		t.Fatalf("source urns = %#v", response.Provenance.SourceURNs)
+	}
+}
+
+func TestServiceReasonPreservesUnsupportedQuery(t *testing.T) {
+	service := NewService(&askStore{}, &StubLLMClient{DraftResponse: &DraftResponse{
+		Rationale: "Planning filtered high-risk findings.",
+		Plan:      &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"owner": "security"}},
+	}}, ValidatorOptions{})
+
+	response, err := service.Reason(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "show security-owned risk findings",
+	})
+	if err != nil {
+		t.Fatalf("Reason() error = %v", err)
+	}
+	if response.UnsupportedQuery == nil || response.UnsupportedQuery.Code != "query_plan_conversion_failed" {
+		t.Fatalf("unsupported query = %#v", response.UnsupportedQuery)
+	}
+	if response.Provenance.FallbackReason != "query_plan_conversion_failed" {
+		t.Fatalf("fallback reason = %q", response.Provenance.FallbackReason)
+	}
+}


### PR DESCRIPTION
## Summary
- add a structured agent graph reasoning API that wraps the guarded graph-agent pipeline in one JSON envelope
- register graph reasoning as an agent-platform capability with provenance requirements
- expose `cerebro.graph.reason` through MCP and update investigation prompts to use it

## Validation
- go test ./internal/graphagent ./internal/agentplatform ./internal/bootstrap
- make openapi-check openapi-lint
- make lint
- go test ./...
- git diff --check
