### PR TITLE
Force graph reasoning to authenticated tenant

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -148,7 +148,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GRCAskRequest'
+              $ref: '#/components/schemas/AgentPlatformGraphReasonRequest'
       responses:
         '200':
           description: Structured graph reasoning envelope with query plan, validation, rows, graph context, citations, and provenance.
@@ -3325,6 +3325,32 @@ components:
           $ref: '#/components/schemas/AgentPlatformGraphStageTimings'
         provenance:
           $ref: '#/components/schemas/AgentPlatformGraphReasonProvenance'
+    AgentPlatformGraphReasonRequest:
+      type: object
+      required:
+        - question
+      properties:
+        question:
+          type: string
+          minLength: 1
+          maxLength: 4096
+        scope_urn:
+          type: string
+          description: Optional Cerebro URN inside the authenticated tenant to focus graph reasoning.
+        model:
+          type: string
+          default: claude-sonnet-4-6
+        history:
+          type: array
+          items:
+            type: object
+            required: [role, content]
+            properties:
+              role:
+                type: string
+                enum: [user, assistant]
+              content:
+                type: string
     AgentPlatformGraphQueryPlanEvent:
       type: object
       required:

--- a/internal/bootstrap/agent_graph_reasoning.go
+++ b/internal/bootstrap/agent_graph_reasoning.go
@@ -1,9 +1,11 @@
 package bootstrap
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphquery"
@@ -17,7 +19,7 @@ func (a *App) handleAgentPlatformGraphReason(w http.ResponseWriter, r *http.Requ
 		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
 		return
 	}
-	if err := authorizeTenantID(r.Context(), request.TenantID); err != nil {
+	if err := forceGraphReasoningTenant(r.Context(), &request); err != nil {
 		writeGRCError(w, err)
 		return
 	}
@@ -42,6 +44,28 @@ func (a *App) handleAgentPlatformGraphReason(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	writeJSON(w, http.StatusOK, response)
+}
+
+func forceGraphReasoningTenant(ctx context.Context, request *graphagent.AskRequest) error {
+	if request == nil {
+		return nil
+	}
+	requestedTenantID := strings.TrimSpace(request.TenantID)
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	if !ok {
+		request.TenantID = requestedTenantID
+		return nil
+	}
+	tenantID := strings.TrimSpace(auth.principal.TenantID)
+	if tenantID == "" {
+		return errTenantForbidden
+	}
+	if requestedTenantID != "" && requestedTenantID != tenantID {
+		recordAccessAuditRequestedTenant(ctx, requestedTenantID)
+		return errTenantForbidden
+	}
+	request.TenantID = tenantID
+	return authorizeTenantID(ctx, tenantID)
 }
 
 func (a *App) newGraphReasoningService() (*graphagent.Service, error) {

--- a/internal/bootstrap/agent_graph_reasoning_test.go
+++ b/internal/bootstrap/agent_graph_reasoning_test.go
@@ -1,7 +1,6 @@
 package bootstrap
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -36,15 +35,11 @@ LIMIT 25`,
 		},
 		Summary: "Review `urn:cerebro:writer:asset:alpha` first.",
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphAgentLLM: llm}, nil)
+	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: graphStore, GraphAgentLLM: llm}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	body := []byte(`{"tenant_id":"writer","question":"Which scoped asset should I review?","scope_urn":"urn:cerebro:writer:asset:alpha"}`)
-	resp, err := server.Client().Post(server.URL+"/api/v1/agent-platform/graph/reason", "application/json", bytes.NewReader(body))
-	if err != nil {
-		t.Fatalf("POST graph reason error = %v", err)
-	}
+	resp := postAgentGraphReason(t, server, `{"question":"Which scoped asset should I review?","scope_urn":"urn:cerebro:writer:asset:alpha"}`)
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
@@ -59,6 +54,9 @@ LIMIT 25`,
 	if response.TraceID == "" || response.QueryPlan == nil || response.Cypher == nil {
 		t.Fatalf("response missing trace/query/cypher: %#v", response)
 	}
+	if response.TenantID != "writer" {
+		t.Fatalf("tenant_id = %q, want authenticated tenant writer", response.TenantID)
+	}
 	if len(response.Rows) != 1 || response.Rows[0]["entity_urn"] != "urn:cerebro:writer:asset:alpha" {
 		t.Fatalf("rows = %#v", response.Rows)
 	}
@@ -67,17 +65,59 @@ LIMIT 25`,
 	}
 }
 
-func TestHandleAgentPlatformGraphReasonRequiresLLM(t *testing.T) {
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: &stubGraphStore{}}, nil)
+func TestHandleAgentPlatformGraphReasonRejectsTenantOverride(t *testing.T) {
+	app := New(graphReasoningAuthConfig(), Dependencies{
+		GraphStore:    &stubGraphStore{},
+		GraphAgentLLM: graphagent.NewStubLLMClient(),
+	}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	resp, err := server.Client().Post(server.URL+"/api/v1/agent-platform/graph/reason", "application/json", strings.NewReader(`{"tenant_id":"writer","question":"hello"}`))
-	if err != nil {
-		t.Fatalf("POST graph reason error = %v", err)
+	resp := postAgentGraphReason(t, server, `{"tenant_id":"other","question":"hello"}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
 	}
+}
+
+func TestHandleAgentPlatformGraphReasonRequiresLLM(t *testing.T) {
+	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: &stubGraphStore{}}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp := postAgentGraphReason(t, server, `{"question":"hello"}`)
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
 	}
+}
+
+func graphReasoningAuthConfig() config.Config {
+	return config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APIKeys: []config.APIKey{{
+				Key:       "test-key",
+				Principal: "tester",
+				TenantID:  "writer",
+			}},
+		},
+	}
+}
+
+func postAgentGraphReason(t *testing.T, server *httptest.Server, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent-platform/graph/reason", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST graph reason error = %v", err)
+	}
+	return resp
 }

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -1437,15 +1437,12 @@ func (app *App) mcpGraphPaths(r *http.Request, args map[string]any) (any, error)
 
 func (app *App) mcpGraphReason(r *http.Request, args map[string]any) (any, error) {
 	request := graphagent.AskRequest{
-		TenantID: mcpTenantArg(r, args),
+		TenantID: mcpStringArg(args, "tenant_id"),
 		Question: mcpStringArg(args, "question"),
 		ScopeURN: mcpStringArg(args, "scope_urn"),
 		Model:    mcpStringArg(args, "model"),
 	}
-	if request.TenantID == "" && requiresTenantFilter(r.Context()) {
-		return nil, errTenantForbidden
-	}
-	if err := authorizeTenantID(r.Context(), request.TenantID); err != nil {
+	if err := forceGraphReasoningTenant(r.Context(), &request); err != nil {
 		return nil, err
 	}
 	if request.ScopeURN != "" {
@@ -1933,7 +1930,6 @@ func mcpTools() []mcpTool {
 			Title:       "Graph Reasoning",
 			Description: "Answer a tenant-scoped graph question with query plan, guarded Cypher, rows, graph evidence, citations, and provenance.",
 			InputSchema: mcpObjectSchema(map[string]any{
-				"tenant_id": map[string]any{"type": "string"},
 				"question":  map[string]any{"type": "string"},
 				"scope_urn": map[string]any{"type": "string"},
 				"model":     map[string]any{"type": "string"},

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -1808,9 +1808,29 @@ LIMIT 25`,
 	if provenance["surface"] != "graph-reasoning" || provenance["citation_status"] != "valid" {
 		t.Fatalf("graph.reason provenance = %#v", provenance)
 	}
+	if content["tenant_id"] != "writer" {
+		t.Fatalf("graph.reason tenant_id = %#v, want authenticated tenant writer", content["tenant_id"])
+	}
 	metadata := content["metadata"].(map[string]any)
 	if metadata["returned"] != float64(1) || metadata["stateless"] != true {
 		t.Fatalf("graph.reason metadata = %#v", metadata)
+	}
+
+	overrideResponse, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.graph.reason",
+			"arguments": map[string]any{
+				"tenant_id": "other",
+				"question":  "Which asset should I review first?",
+			},
+		},
+	})
+	overrideResult := overrideResponse["result"].(map[string]any)
+	if overrideResult["isError"] != true || !strings.Contains(overrideResult["content"].([]any)[0].(map[string]any)["text"].(string), "tenant forbidden") {
+		t.Fatalf("graph.reason tenant override response = %#v", overrideResponse)
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive agent graph reasoning tenant scope from the authenticated principal instead of request input
- reject HTTP and MCP graph reasoning calls that try to override tenant_id
- remove tenant_id from the advertised graph reasoning request schema and MCP tool input

## Validation
- go test ./internal/bootstrap ./internal/graphagent ./internal/agentplatform
- make openapi-check openapi-lint
- go test ./...
- make lint
- git diff --check
