### PR TITLE
Document durability rebuild contract

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,12 @@ The service can start without optional stores and serve lightweight routes such 
 
 Kuzu and embedded/in-memory database backends are intentionally rejected by config and arch tests.
 
+See [`DURABILITY_CONTRACT.md`](./DURABILITY_CONTRACT.md) for the current
+write-path contract. Source runtime sync and workflow writes are event-backed
+before projection. SDK/runtime claim writes are currently Postgres-backed and
+project from persisted claim state until a `claim.v1.*` event family exists.
+Neo4j remains a projection in both cases; it is not a source of truth.
+
 ## API boundaries
 
 - Connect RPCs live under the generated `BootstrapService` path from `proto/cerebro/v1/bootstrap.proto`.

--- a/docs/DURABILITY_CONTRACT.md
+++ b/docs/DURABILITY_CONTRACT.md
@@ -1,0 +1,55 @@
+# Durability Contract
+
+This document records which Cerebro writes are event-backed today, which writes
+are current-state backed, and how graph rebuilds should treat each path.
+
+Use this with [`ARCHITECTURE.md`](./ARCHITECTURE.md), [`NON_GOALS.md`](./NON_GOALS.md),
+and [`SOURCE_RUNTIME_GUIDE.md`](./SOURCE_RUNTIME_GUIDE.md).
+
+## Current Write Classes
+
+| Write class | Durable record | Projection path | Rebuild source |
+| --- | --- | --- | --- |
+| Source runtime sync | JetStream event envelopes plus runtime cursor state | Source event projector writes Postgres projection rows and Neo4j graph rows when configured | JetStream replay, or bounded source reread for dry-run previews |
+| Workflow decisions, actions, and outcomes | JetStream `workflow.v1.*` event envelopes | Workflow projector writes graph rows after append succeeds | JetStream replay |
+| SDK/runtime claims | Postgres claim rows | Claim service writes Postgres projection rows and Neo4j graph rows when configured | Postgres claim state until claim events exist |
+| Finding current state | Postgres finding, evidence, candidate, and evaluation-run rows | Finding lifecycle methods may emit workflow events for timeline/graph context where configured | Postgres finding state plus workflow replay for workflow context |
+
+The important boundary is that graph state must not become independently
+authoritative. Neo4j remains a projection. Today most graph-affecting writes are
+event-backed, but SDK/runtime claim writes are a documented current-state-backed
+path until a claim event stream lands.
+
+## Required Invariants
+
+- Source runtime sync must append accepted source events before projecting them.
+- Source runtime sync must not advance runtime progress before the page's
+  accepted events have been appended and projected through the configured
+  projector.
+- Workflow projection must happen after the corresponding workflow event append.
+- SDK/runtime claim writes must persist claim rows before writing graph
+  projections.
+- Any new graph-affecting write path must declare whether it is event-backed or
+  current-state backed in this document before it ships.
+- Any new current-state-backed graph write must include a rebuild plan that does
+  not require Neo4j to be authoritative.
+
+## Target Direction
+
+The preferred long-term shape is for SDK/runtime claim writes to become
+event-backed through a stable `claim.v1.*` event family. Until that exists,
+claim rows in Postgres are the rebuild source for claim-derived graph state.
+This is an explicit transition state, not permission for additional
+current-state-backed graph writers.
+
+## Review Checklist
+
+For any PR that touches graph-affecting writes, reviewers should be able to
+answer:
+
+1. What is the durable record?
+2. Which projector writes graph rows?
+3. What happens if append, projection, or current-state persistence fails after
+   a partial write?
+4. How can an operator rebuild or repair graph state without treating Neo4j as
+   authoritative?

--- a/docs/NON_GOALS.md
+++ b/docs/NON_GOALS.md
@@ -80,12 +80,12 @@ Each section lists what Cerebro will not do, why that boundary exists, where in 
 
 ## Graph And Cypher
 
-### Neo4j is a projection, not a write target.
+### Neo4j is a projection, not a store of record.
 
-- The graph is rebuildable from JetStream. Cerebro will not treat any graph node, edge, or property as authoritative if it cannot be reproduced from `entity.*`, `event.*`, or `workflow.v1.*` events. Direct `Neo4jSession.Run` writes from anywhere outside `internal/graphingest`, `internal/sourceprojection`, and `internal/workflowprojection` are out of scope.
+- The graph is rebuildable from durable Cerebro records. Source runtime and workflow graph state must be reproducible from JetStream `entity.*`, `event.*`, or `workflow.v1.*` events. SDK/runtime claim graph state is currently reproducible from Postgres claim rows, as documented in [`docs/DURABILITY_CONTRACT.md`](./DURABILITY_CONTRACT.md), until a `claim.v1.*` event family exists. Direct `Neo4jSession.Run` writes from anywhere outside `internal/graphingest`, `internal/sourceprojection`, `internal/workflowprojection`, and the documented claim projection path are out of scope.
 - Why: the graph drifts the moment two paths can write to it independently. Replayability is the property that lets findings, reports, and reasoning trust traversal results.
-- Enforced in: [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md) "Graph projection", workflow durability packages in `internal/workflowevents` and `internal/workflowprojection`, and graph write arch tests.
-- What would change this: a workflow concept whose durability genuinely cannot be modeled as an event-and-projector pair, ratified before code that writes to Neo4j directly is merged.
+- Enforced in: [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md) "Store boundaries", [`docs/DURABILITY_CONTRACT.md`](./DURABILITY_CONTRACT.md), workflow durability packages in `internal/workflowevents` and `internal/workflowprojection`, and graph write arch tests.
+- What would change this: a workflow or claim concept whose durability genuinely cannot be modeled as either an event-and-projector pair or a documented current-state-backed rebuild source, ratified before code that writes to Neo4j directly is merged.
 
 ### The graph is not a general-purpose graph database product.
 

--- a/tools/archtests/durability_contract_test.go
+++ b/tools/archtests/durability_contract_test.go
@@ -1,0 +1,57 @@
+package archtests
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDurabilityContractDocumentsGraphRebuildSources(t *testing.T) {
+	root := repoRoot(t)
+	contract, err := os.ReadFile(filepath.Join(root, "docs", "DURABILITY_CONTRACT.md"))
+	if err != nil {
+		t.Fatalf("read docs/DURABILITY_CONTRACT.md: %v", err)
+	}
+	for _, marker := range []string{
+		"Source runtime sync",
+		"Workflow decisions, actions, and outcomes",
+		"SDK/runtime claims",
+		"Postgres claim state until claim events exist",
+		"claim.v1.*",
+		"Neo4j remains a projection",
+	} {
+		if !bytes.Contains(contract, []byte(marker)) {
+			t.Fatalf("docs/DURABILITY_CONTRACT.md missing durability marker %q", marker)
+		}
+	}
+
+	architecture, err := os.ReadFile(filepath.Join(root, "docs", "ARCHITECTURE.md"))
+	if err != nil {
+		t.Fatalf("read docs/ARCHITECTURE.md: %v", err)
+	}
+	for _, marker := range []string{
+		"DURABILITY_CONTRACT.md",
+		"SDK/runtime claim writes are currently Postgres-backed",
+		"Neo4j remains a projection",
+	} {
+		if !bytes.Contains(architecture, []byte(marker)) {
+			t.Fatalf("docs/ARCHITECTURE.md missing durability marker %q", marker)
+		}
+	}
+
+	nonGoals, err := os.ReadFile(filepath.Join(root, "docs", "NON_GOALS.md"))
+	if err != nil {
+		t.Fatalf("read docs/NON_GOALS.md: %v", err)
+	}
+	for _, marker := range []string{
+		"Neo4j is a projection, not a store of record",
+		"Source runtime and workflow graph state",
+		"SDK/runtime claim graph state",
+		"DURABILITY_CONTRACT.md",
+	} {
+		if !bytes.Contains(nonGoals, []byte(marker)) {
+			t.Fatalf("docs/NON_GOALS.md missing graph durability marker %q", marker)
+		}
+	}
+}


### PR DESCRIPTION
Summary:
- add a durability contract for graph-affecting write paths
- clarify current event-backed and current-state-backed rebuild sources
- add an arch test that keeps the contract referenced from architecture/non-goals docs

Tests:
- go test ./tools/archtests
- make docs-drift-check
- make readme-check
- make oss-audit