### PR TITLE
Make bootstrap feature dependencies explicit

### DIFF
--- a/internal/bootstrap/agent_graph_reasoning.go
+++ b/internal/bootstrap/agent_graph_reasoning.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/writer/cerebro/internal/graphagent"
-	"github.com/writer/cerebro/internal/graphquery"
 )
 
 func (a *App) handleAgentPlatformGraphReason(w http.ResponseWriter, r *http.Request) {
@@ -45,21 +44,5 @@ func (a *App) handleAgentPlatformGraphReason(w http.ResponseWriter, r *http.Requ
 }
 
 func (a *App) newGraphReasoningService() (*graphagent.Service, error) {
-	graphStore := graphQueryStore(a.deps.GraphStore)
-	if graphStore == nil {
-		return nil, graphquery.ErrRuntimeUnavailable
-	}
-	llm := a.deps.GraphAgentLLM
-	if llm == nil {
-		return nil, errors.Join(graphagent.ErrRuntimeUnavailable, errors.New("graph agent llm is not configured"))
-	}
-	return graphagent.NewServiceWithOptions(graphStore, llm, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
-		TrajectoryStore:             askTrajectoryStore(a.deps.StateStore),
-		EnableGraphProbes:           true,
-		EnableDeterministicFastPath: true,
-		EnableRecovery:              true,
-		EnableMapReduce:             true,
-		MaxDepth:                    2,
-		MaxChildren:                 2,
-	}), nil
+	return newGraphReasoningFeatureService(newGraphReasoningFeatureDeps(a.deps))
 }

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2810,11 +2810,7 @@ func (a *App) reportService() *reports.Service {
 }
 
 func (a *App) newReportService() *reports.Service {
-	return reports.New(
-		findingStore(a.deps.StateStore),
-		graphQueryStore(a.deps.GraphStore),
-		reportStore(a.deps.StateStore),
-	)
+	return newReportFeatureService(newReportFeatureDeps(a.deps))
 }
 
 func (a *App) runtimeService() *sourceruntime.Service {
@@ -2825,18 +2821,11 @@ func (a *App) runtimeService() *sourceruntime.Service {
 }
 
 func newSourceService(sources *sourcecdk.Registry) *sourceops.Service {
-	return sourceops.New(sources)
+	return newSourceFeatureService(newSourceFeatureDeps(sources))
 }
 
 func newRuntimeService(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *sourceruntime.Service {
-	return sourceruntime.New(
-		sources,
-		sourceRuntimeStore(deps.StateStore),
-		deps.AppendLog,
-		sourceProjector(deps.StateStore, deps.GraphStore),
-	).WithConfigResolver(func(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
-		return resolveRuntimeSourceConfigWithStore(ctx, cfg.ConnectorCredentials, cfg.ConnectorSecretStores, deps.StateStore, sourceID, values)
-	})
+	return newRuntimeFeatureService(cfg, newRuntimeFeatureDeps(deps, sources))
 }
 
 func resolveRuntimeSourceConfig(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
@@ -2910,12 +2899,7 @@ func (a *App) claimService() *claims.Service {
 }
 
 func (a *App) newClaimService() *claims.Service {
-	return claims.New(
-		sourceRuntimeStore(a.deps.StateStore),
-		claimStore(a.deps.StateStore),
-		sourceProjectionStateStore(a.deps.StateStore),
-		sourceProjectionGraphStore(a.deps.GraphStore),
-	)
+	return newClaimFeatureService(newClaimFeatureDeps(a.deps))
 }
 
 func (a *App) findingService() *findings.Service {
@@ -2926,14 +2910,7 @@ func (a *App) findingService() *findings.Service {
 }
 
 func (a *App) newFindingService() *findings.Service {
-	return findings.New(
-		sourceRuntimeStore(a.deps.StateStore),
-		eventReplayer(a.deps.AppendLog),
-		findingStore(a.deps.StateStore),
-		findingEvaluationRunStore(a.deps.StateStore),
-		findingEvidenceStore(a.deps.StateStore),
-		claimStore(a.deps.StateStore),
-	).WithFindingCandidateStore(findingCandidateStore(a.deps.StateStore)).WithGraphStore(sourceProjectionGraphStore(a.deps.GraphStore)).WithGraphQueryStore(graphQueryStore(a.deps.GraphStore)).WithAppendLog(a.deps.AppendLog)
+	return newFindingWorkflowFeatureService(newFindingFeatureDeps(a.deps))
 }
 
 const (
@@ -2972,10 +2949,7 @@ func (a *App) knowledgeService() *knowledge.Service {
 }
 
 func (a *App) newKnowledgeService() *knowledge.Service {
-	return knowledge.New(
-		graphQueryStore(a.deps.GraphStore),
-		sourceProjectionGraphStore(a.deps.GraphStore),
-	).WithAppendLog(a.deps.AppendLog)
+	return newKnowledgeFeatureService(newKnowledgeFeatureDeps(a.deps))
 }
 
 func (a *App) graphQueryService() *graphquery.Service {
@@ -2986,7 +2960,7 @@ func (a *App) graphQueryService() *graphquery.Service {
 }
 
 func (a *App) newGraphQueryService() *graphquery.Service {
-	return graphquery.New(graphQueryStore(a.deps.GraphStore))
+	return newGraphQueryFeatureService(newGraphQueryFeatureDeps(a.deps))
 }
 
 func (a *App) graphIngestService() *graphingest.Service {
@@ -3004,21 +2978,11 @@ func (a *App) workflowReplayService() *workflowprojection.Replayer {
 }
 
 func (a *App) newWorkflowReplayService() *workflowprojection.Replayer {
-	return workflowprojection.NewReplayer(
-		eventReplayer(a.deps.AppendLog),
-		sourceProjectionGraphStore(a.deps.GraphStore),
-	)
+	return newWorkflowReplayFeatureService(newWorkflowReplayFeatureDeps(a.deps))
 }
 
 func newGraphIngestService(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *graphingest.Service {
-	return graphingest.New(
-		sources,
-		sourceRuntimeStore(deps.StateStore),
-		sourceProjector(nil, deps.GraphStore),
-		deps.GraphStore,
-	).WithConfigPreparer(func(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
-		return resolveRuntimeSourceConfigWithStore(ctx, cfg.ConnectorCredentials, cfg.ConnectorSecretStores, deps.StateStore, sourceID, values)
-	})
+	return newGraphIngestFeatureService(cfg, newGraphIngestFeatureDeps(deps, sources))
 }
 
 func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {

--- a/internal/bootstrap/feature_dependencies.go
+++ b/internal/bootstrap/feature_dependencies.go
@@ -1,0 +1,282 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+
+	"github.com/writer/cerebro/internal/claims"
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphagent"
+	"github.com/writer/cerebro/internal/graphingest"
+	"github.com/writer/cerebro/internal/graphquery"
+	platformjobs "github.com/writer/cerebro/internal/jobs"
+	"github.com/writer/cerebro/internal/knowledge"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/reports"
+	"github.com/writer/cerebro/internal/runtimeresponse"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceops"
+	"github.com/writer/cerebro/internal/sourceruntime"
+	"github.com/writer/cerebro/internal/workflowprojection"
+)
+
+type sourceFeatureDeps struct {
+	Sources *sourcecdk.Registry
+}
+
+func newSourceFeatureDeps(sources *sourcecdk.Registry) sourceFeatureDeps {
+	return sourceFeatureDeps{Sources: sources}
+}
+
+func newSourceFeatureService(deps sourceFeatureDeps) *sourceops.Service {
+	return sourceops.New(deps.Sources)
+}
+
+type reportFeatureDeps struct {
+	Findings     ports.FindingStore
+	GraphQueries ports.GraphQueryStore
+	Reports      ports.ReportStore
+}
+
+func newReportFeatureDeps(deps Dependencies) reportFeatureDeps {
+	return reportFeatureDeps{
+		Findings:     findingStore(deps.StateStore),
+		GraphQueries: graphQueryStore(deps.GraphStore),
+		Reports:      reportStore(deps.StateStore),
+	}
+}
+
+func newReportFeatureService(deps reportFeatureDeps) *reports.Service {
+	return reports.New(deps.Findings, deps.GraphQueries, deps.Reports)
+}
+
+type runtimeFeatureDeps struct {
+	Sources            *sourcecdk.Registry
+	Runtimes           ports.SourceRuntimeStore
+	AppendLog          ports.AppendLog
+	Projector          ports.SourceProjector
+	RuntimeConfigStore ports.StateStore
+}
+
+func newRuntimeFeatureDeps(deps Dependencies, sources *sourcecdk.Registry) runtimeFeatureDeps {
+	return runtimeFeatureDeps{
+		Sources:            sources,
+		Runtimes:           sourceRuntimeStore(deps.StateStore),
+		AppendLog:          deps.AppendLog,
+		Projector:          sourceProjector(deps.StateStore, deps.GraphStore),
+		RuntimeConfigStore: deps.StateStore,
+	}
+}
+
+func newRuntimeFeatureService(cfg config.Config, deps runtimeFeatureDeps) *sourceruntime.Service {
+	return sourceruntime.New(
+		deps.Sources,
+		deps.Runtimes,
+		deps.AppendLog,
+		deps.Projector,
+	).WithConfigResolver(func(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
+		return resolveRuntimeSourceConfigWithStore(ctx, cfg.ConnectorCredentials, cfg.ConnectorSecretStores, deps.RuntimeConfigStore, sourceID, values)
+	})
+}
+
+type claimFeatureDeps struct {
+	Runtimes        ports.SourceRuntimeStore
+	Claims          ports.ClaimStore
+	ProjectionState ports.ProjectionStateStore
+	ProjectionGraph ports.ProjectionGraphStore
+}
+
+func newClaimFeatureDeps(deps Dependencies) claimFeatureDeps {
+	return claimFeatureDeps{
+		Runtimes:        sourceRuntimeStore(deps.StateStore),
+		Claims:          claimStore(deps.StateStore),
+		ProjectionState: sourceProjectionStateStore(deps.StateStore),
+		ProjectionGraph: sourceProjectionGraphStore(deps.GraphStore),
+	}
+}
+
+func newClaimFeatureService(deps claimFeatureDeps) *claims.Service {
+	return claims.New(deps.Runtimes, deps.Claims, deps.ProjectionState, deps.ProjectionGraph)
+}
+
+type findingFeatureDeps struct {
+	Runtimes        ports.SourceRuntimeStore
+	EventReplayer   ports.EventReplayer
+	Findings        ports.FindingStore
+	EvaluationRuns  ports.FindingEvaluationRunStore
+	Evidence        ports.FindingEvidenceStore
+	Claims          ports.ClaimStore
+	Candidates      ports.FindingCandidateStore
+	ProjectionGraph ports.ProjectionGraphStore
+	GraphQueries    ports.GraphQueryStore
+	AppendLog       ports.AppendLog
+}
+
+func newFindingFeatureDeps(deps Dependencies) findingFeatureDeps {
+	return findingFeatureDeps{
+		Runtimes:        sourceRuntimeStore(deps.StateStore),
+		EventReplayer:   eventReplayer(deps.AppendLog),
+		Findings:        findingStore(deps.StateStore),
+		EvaluationRuns:  findingEvaluationRunStore(deps.StateStore),
+		Evidence:        findingEvidenceStore(deps.StateStore),
+		Claims:          claimStore(deps.StateStore),
+		Candidates:      findingCandidateStore(deps.StateStore),
+		ProjectionGraph: sourceProjectionGraphStore(deps.GraphStore),
+		GraphQueries:    graphQueryStore(deps.GraphStore),
+		AppendLog:       deps.AppendLog,
+	}
+}
+
+func newFindingCoreFeatureService(deps findingFeatureDeps) *findings.Service {
+	return findings.New(
+		deps.Runtimes,
+		deps.EventReplayer,
+		deps.Findings,
+		deps.EvaluationRuns,
+		deps.Evidence,
+		deps.Claims,
+	)
+}
+
+func newFindingCandidateFeatureService(deps findingFeatureDeps) *findings.Service {
+	return newFindingCoreFeatureService(deps).WithFindingCandidateStore(deps.Candidates)
+}
+
+func newFindingWorkflowFeatureService(deps findingFeatureDeps) *findings.Service {
+	return newFindingCandidateFeatureService(deps).
+		WithGraphStore(deps.ProjectionGraph).
+		WithGraphQueryStore(deps.GraphQueries).
+		WithAppendLog(deps.AppendLog)
+}
+
+type knowledgeFeatureDeps struct {
+	GraphQueries    ports.GraphQueryStore
+	ProjectionGraph ports.ProjectionGraphStore
+	AppendLog       ports.AppendLog
+}
+
+func newKnowledgeFeatureDeps(deps Dependencies) knowledgeFeatureDeps {
+	return knowledgeFeatureDeps{
+		GraphQueries:    graphQueryStore(deps.GraphStore),
+		ProjectionGraph: sourceProjectionGraphStore(deps.GraphStore),
+		AppendLog:       deps.AppendLog,
+	}
+}
+
+func newKnowledgeFeatureService(deps knowledgeFeatureDeps) *knowledge.Service {
+	return knowledge.New(deps.GraphQueries, deps.ProjectionGraph).WithAppendLog(deps.AppendLog)
+}
+
+type graphQueryFeatureDeps struct {
+	GraphQueries ports.GraphQueryStore
+}
+
+func newGraphQueryFeatureDeps(deps Dependencies) graphQueryFeatureDeps {
+	return graphQueryFeatureDeps{GraphQueries: graphQueryStore(deps.GraphStore)}
+}
+
+func newGraphQueryFeatureService(deps graphQueryFeatureDeps) *graphquery.Service {
+	return graphquery.New(deps.GraphQueries)
+}
+
+type graphIngestFeatureDeps struct {
+	Sources            *sourcecdk.Registry
+	Runtimes           ports.SourceRuntimeStore
+	Projector          ports.SourceProjector
+	GraphStore         ports.GraphStore
+	RuntimeConfigStore ports.StateStore
+}
+
+func newGraphIngestFeatureDeps(deps Dependencies, sources *sourcecdk.Registry) graphIngestFeatureDeps {
+	return graphIngestFeatureDeps{
+		Sources:            sources,
+		Runtimes:           sourceRuntimeStore(deps.StateStore),
+		Projector:          sourceProjector(nil, deps.GraphStore),
+		GraphStore:         deps.GraphStore,
+		RuntimeConfigStore: deps.StateStore,
+	}
+}
+
+func newGraphIngestFeatureService(cfg config.Config, deps graphIngestFeatureDeps) *graphingest.Service {
+	return graphingest.New(
+		deps.Sources,
+		deps.Runtimes,
+		deps.Projector,
+		deps.GraphStore,
+	).WithConfigPreparer(func(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
+		return resolveRuntimeSourceConfigWithStore(ctx, cfg.ConnectorCredentials, cfg.ConnectorSecretStores, deps.RuntimeConfigStore, sourceID, values)
+	})
+}
+
+type workflowReplayFeatureDeps struct {
+	EventReplayer   ports.EventReplayer
+	ProjectionGraph ports.ProjectionGraphStore
+}
+
+func newWorkflowReplayFeatureDeps(deps Dependencies) workflowReplayFeatureDeps {
+	return workflowReplayFeatureDeps{
+		EventReplayer:   eventReplayer(deps.AppendLog),
+		ProjectionGraph: sourceProjectionGraphStore(deps.GraphStore),
+	}
+}
+
+func newWorkflowReplayFeatureService(deps workflowReplayFeatureDeps) *workflowprojection.Replayer {
+	return workflowprojection.NewReplayer(deps.EventReplayer, deps.ProjectionGraph)
+}
+
+type jobFeatureDeps struct {
+	Jobs ports.JobStore
+}
+
+func newJobFeatureDeps(deps Dependencies) jobFeatureDeps {
+	return jobFeatureDeps{Jobs: jobStore(deps.StateStore)}
+}
+
+func newJobFeatureService(deps jobFeatureDeps) *platformjobs.Service {
+	return platformjobs.New(deps.Jobs)
+}
+
+type runtimeResponseFeatureDeps struct {
+	Blocklist ports.RuntimeBlocklistStore
+}
+
+func newRuntimeResponseFeatureDeps(deps Dependencies) runtimeResponseFeatureDeps {
+	return runtimeResponseFeatureDeps{Blocklist: runtimeBlocklistStore(deps.StateStore)}
+}
+
+func newRuntimeResponseFeatureService(deps runtimeResponseFeatureDeps) *runtimeresponse.Service {
+	return runtimeresponse.New(deps.Blocklist)
+}
+
+type graphReasoningFeatureDeps struct {
+	GraphQueries    ports.GraphQueryStore
+	GraphAgentLLM   graphagent.LLMClient
+	TrajectoryStore ports.AskTrajectoryStore
+}
+
+func newGraphReasoningFeatureDeps(deps Dependencies) graphReasoningFeatureDeps {
+	return graphReasoningFeatureDeps{
+		GraphQueries:    graphQueryStore(deps.GraphStore),
+		GraphAgentLLM:   deps.GraphAgentLLM,
+		TrajectoryStore: askTrajectoryStore(deps.StateStore),
+	}
+}
+
+func newGraphReasoningFeatureService(deps graphReasoningFeatureDeps) (*graphagent.Service, error) {
+	if deps.GraphQueries == nil {
+		return nil, graphquery.ErrRuntimeUnavailable
+	}
+	if deps.GraphAgentLLM == nil {
+		return nil, errors.Join(graphagent.ErrRuntimeUnavailable, errors.New("graph agent llm is not configured"))
+	}
+	return graphagent.NewServiceWithOptions(deps.GraphQueries, deps.GraphAgentLLM, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
+		TrajectoryStore:             deps.TrajectoryStore,
+		EnableGraphProbes:           true,
+		EnableDeterministicFastPath: true,
+		EnableRecovery:              true,
+		EnableMapReduce:             true,
+		MaxDepth:                    2,
+		MaxChildren:                 2,
+	}), nil
+}

--- a/internal/bootstrap/feature_dependencies_test.go
+++ b/internal/bootstrap/feature_dependencies_test.go
@@ -1,0 +1,41 @@
+package bootstrap
+
+import "testing"
+
+func TestFeatureDependencyBundlesAreNilSafe(t *testing.T) {
+	deps := Dependencies{}
+
+	if got := newReportFeatureDeps(deps); got.Findings != nil || got.GraphQueries != nil || got.Reports != nil {
+		t.Fatalf("newReportFeatureDeps() = %#v, want nil stores", got)
+	}
+	if got := newRuntimeFeatureDeps(deps, nil); got.Sources != nil || got.Runtimes != nil || got.AppendLog != nil || got.Projector != nil || got.RuntimeConfigStore != nil {
+		t.Fatalf("newRuntimeFeatureDeps() = %#v, want nil dependencies", got)
+	}
+	if got := newClaimFeatureDeps(deps); got.Runtimes != nil || got.Claims != nil || got.ProjectionState != nil || got.ProjectionGraph != nil {
+		t.Fatalf("newClaimFeatureDeps() = %#v, want nil stores", got)
+	}
+	if got := newFindingFeatureDeps(deps); got.Runtimes != nil || got.EventReplayer != nil || got.Findings != nil || got.EvaluationRuns != nil || got.Evidence != nil || got.Claims != nil || got.Candidates != nil || got.ProjectionGraph != nil || got.GraphQueries != nil || got.AppendLog != nil {
+		t.Fatalf("newFindingFeatureDeps() = %#v, want nil dependencies", got)
+	}
+	if got := newKnowledgeFeatureDeps(deps); got.GraphQueries != nil || got.ProjectionGraph != nil || got.AppendLog != nil {
+		t.Fatalf("newKnowledgeFeatureDeps() = %#v, want nil dependencies", got)
+	}
+	if got := newGraphQueryFeatureDeps(deps); got.GraphQueries != nil {
+		t.Fatalf("newGraphQueryFeatureDeps() = %#v, want nil graph query store", got)
+	}
+	if got := newGraphIngestFeatureDeps(deps, nil); got.Sources != nil || got.Runtimes != nil || got.Projector != nil || got.GraphStore != nil || got.RuntimeConfigStore != nil {
+		t.Fatalf("newGraphIngestFeatureDeps() = %#v, want nil dependencies", got)
+	}
+	if got := newWorkflowReplayFeatureDeps(deps); got.EventReplayer != nil || got.ProjectionGraph != nil {
+		t.Fatalf("newWorkflowReplayFeatureDeps() = %#v, want nil dependencies", got)
+	}
+	if got := newJobFeatureDeps(deps); got.Jobs != nil {
+		t.Fatalf("newJobFeatureDeps() = %#v, want nil job store", got)
+	}
+	if got := newRuntimeResponseFeatureDeps(deps); got.Blocklist != nil {
+		t.Fatalf("newRuntimeResponseFeatureDeps() = %#v, want nil runtime response store", got)
+	}
+	if got := newGraphReasoningFeatureDeps(deps); got.GraphQueries != nil || got.GraphAgentLLM != nil || got.TrajectoryStore != nil {
+		t.Fatalf("newGraphReasoningFeatureDeps() = %#v, want nil dependencies", got)
+	}
+}

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -49,7 +49,7 @@ func (a *App) jobService() *platformjobs.Service {
 }
 
 func (a *App) newJobService() *platformjobs.Service {
-	service := platformjobs.New(jobStore(a.deps.StateStore))
+	service := newJobFeatureService(newJobFeatureDeps(a.deps))
 	service.WithRunner(platformjobs.KindSourceRuntimeSync, a.runSourceRuntimeSyncJob)
 	service.WithRunner(platformjobs.KindSourceRuntimeOrchestrate, a.runSourceRuntimeOrchestrateJob)
 	service.WithRunner(platformjobs.KindGraphIngestRuntime, a.runGraphIngestRuntimeJob)

--- a/internal/bootstrap/runtime_response.go
+++ b/internal/bootstrap/runtime_response.go
@@ -27,7 +27,7 @@ type runtimeBlocklistListResponse struct {
 }
 
 func (a *App) runtimeResponseService() *runtimeresponse.Service {
-	return runtimeresponse.New(runtimeBlocklistStore(a.deps.StateStore))
+	return newRuntimeResponseFeatureService(newRuntimeResponseFeatureDeps(a.deps))
 }
 
 func (a *App) handleRuntimeResponseCapabilities(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- add named dependency bundles for bootstrap-owned feature services
- route service factory construction through those bundles instead of inline store capability discovery
- preserve nil-safe optional dependency behavior with a focused unit test

## Tests
- go test ./internal/bootstrap
- go test ./tools/archtests
- make oss-audit
