### PR TITLE
Add bootstrap surface guardrail

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,6 +55,16 @@ Neo4j remains a projection in both cases; it is not a source of truth.
 - HTTP-only surfaces are route-grouped in `internal/bootstrap/routes.go` so platform, internal, and public routes are explicit while the remaining Connect coverage gap is closed.
 - Public unauthenticated routes are limited to `/health`, `/healthz`, `/livez`, `/openapi.yaml`, OAuth metadata routes, and `/.well-known/device-jwks.json` when API auth is enabled.
 
+## Bootstrap ownership
+
+`internal/bootstrap` is the outer composition root for the server. It owns
+routing, auth, request/response mapping, and dependency wiring. New domain behavior should land behind a domain package and service interface first, with bootstrap limited to translating the HTTP or Connect boundary into that domain contract.
+
+Production Go under `internal/bootstrap` is ratcheted by `tools/archtests` so
+new routes and handlers do not quietly grow the bootstrap surface. If a PR must
+increase that budget, the PR should explain why the behavior cannot move behind
+a domain package yet and update this architecture note alongside the test.
+
 ## Postgres migrations
 
 State-store schema preparation runs at service startup and before store operations. Most migrations use additive `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, or `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` patterns.

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -1,0 +1,121 @@
+package archtests
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const bootstrapProductionGoLineBudget = 21933
+
+type bootstrapFileLineCount struct {
+	path  string
+	lines int
+}
+
+func TestBootstrapProductionSurfaceDoesNotGrow(t *testing.T) {
+	root := repoRoot(t)
+	counts := bootstrapProductionLineCounts(t, root, filepath.Join(root, "internal", "bootstrap"))
+	total := 0
+	for _, count := range counts {
+		total += count.lines
+	}
+	if total <= bootstrapProductionGoLineBudget {
+		return
+	}
+	t.Fatalf(
+		"internal/bootstrap production Go grew to %d lines, budget %d (+%d).\n%s\nMove new domain behavior behind a domain package and keep bootstrap focused on routing, auth, request/response mapping, and dependency wiring; update the budget only with an architecture note.",
+		total,
+		bootstrapProductionGoLineBudget,
+		total-bootstrapProductionGoLineBudget,
+		topBootstrapFiles(counts, 8),
+	)
+}
+
+func TestArchitectureDocumentsBootstrapOwnership(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "docs", "ARCHITECTURE.md"))
+	if err != nil {
+		t.Fatalf("read docs/ARCHITECTURE.md: %v", err)
+	}
+	for _, marker := range []string{
+		"## Bootstrap ownership",
+		"outer composition root",
+		"routing, auth, request/response mapping, and dependency wiring",
+		"New domain behavior should land behind a domain package",
+		"Production Go under `internal/bootstrap` is ratcheted by `tools/archtests`",
+	} {
+		if !bytes.Contains(body, []byte(marker)) {
+			t.Fatalf("docs/ARCHITECTURE.md missing bootstrap ownership marker %q", marker)
+		}
+	}
+}
+
+func bootstrapProductionLineCounts(t *testing.T, root string, dir string) []bootstrapFileLineCount {
+	t.Helper()
+	counts := []bootstrapFileLineCount{}
+	if err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		counts = append(counts, bootstrapFileLineCount{
+			path:  filepath.ToSlash(shortPath(root, path)),
+			lines: countLines(t, path),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("scan internal/bootstrap: %v", err)
+	}
+	return counts
+}
+
+func countLines(t *testing.T, path string) int {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer file.Close()
+
+	lines := 0
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines++
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan %s: %v", path, err)
+	}
+	return lines
+}
+
+func topBootstrapFiles(counts []bootstrapFileLineCount, limit int) string {
+	sort.Slice(counts, func(i, j int) bool {
+		if counts[i].lines == counts[j].lines {
+			return counts[i].path < counts[j].path
+		}
+		return counts[i].lines > counts[j].lines
+	})
+	if limit > len(counts) {
+		limit = len(counts)
+	}
+	lines := make([]string, 0, limit+1)
+	lines = append(lines, "largest bootstrap production files:")
+	for i := 0; i < limit; i++ {
+		lines = append(lines, fmt.Sprintf("- %s: %d", counts[i].path, counts[i].lines))
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
## Summary
- document bootstrap as the outer composition root rather than a domain owner
- add an arch-test line-count ratchet for production internal/bootstrap code
- make future bootstrap growth require an explicit architecture update

## Tests
- go test ./tools/archtests
- make docs-drift-check
- make readme-check
- make oss-audit
