### PR TITLE
Add MCP domain parity guardrail

### DIFF
--- a/docs/MCP_DROID_SETUP.md
+++ b/docs/MCP_DROID_SETUP.md
@@ -20,6 +20,18 @@ The endpoint is a stateless Streamable HTTP MCP endpoint:
 
 Do not advertise or emulate a stateful SSE session on this route. Native Droid uses the MCP SDK Streamable HTTP client for `type: "http"` servers, and it treats stateful session/SSE signals as part of the transport contract.
 
+## Tool/domain parity
+
+MCP tools are adapters over existing Cerebro domain surfaces, not a parallel
+product API. Each tool must map to an HTTP route, Connect RPC, report contract,
+or explicitly named composite of those surfaces. Agent-oriented tools such as
+investigation context and risk action planning may bundle multiple reads, but
+their source domain surfaces must stay listed in the MCP parity test.
+
+Mutating workflows are exposed only as proposal tools with `dry_run=true`,
+`readOnlyHint=true`, and a response that describes the required write scope
+without applying the action.
+
 ## Native Droid client configuration
 
 Use an HTTP MCP server entry. Keep the URL on the MCP route itself, not just the origin.

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -151,6 +153,82 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 			t.Fatalf("tools/list missing %s in %#v", want, names)
 		}
 	}
+}
+
+func TestMCPToolsDeclareDomainSurfaceParity(t *testing.T) {
+	corpus := mcpDomainSurfaceCorpus(t)
+	tools := map[string]bool{}
+	for _, tool := range mcpTools() {
+		tools[tool.Name] = true
+		contract, ok := mcpToolDomainSurfaceContracts[tool.Name]
+		if !ok {
+			t.Fatalf("%s has no MCP domain surface contract", tool.Name)
+		}
+		if len(contract.Markers) == 0 {
+			t.Fatalf("%s domain surface contract has no markers", tool.Name)
+		}
+		for _, marker := range contract.Markers {
+			if !strings.Contains(corpus, marker) {
+				t.Fatalf("%s domain surface marker %q not found in API/domain corpus", tool.Name, marker)
+			}
+		}
+	}
+	for name := range mcpToolDomainSurfaceContracts {
+		if !tools[name] {
+			t.Fatalf("MCP domain surface contract covers missing tool %s", name)
+		}
+	}
+}
+
+type mcpToolDomainSurfaceContract struct {
+	Markers []string
+}
+
+var mcpToolDomainSurfaceContracts = map[string]mcpToolDomainSurfaceContract{
+	"cerebro.health":                          {Markers: []string{"GET /health"}},
+	"cerebro.version":                         {Markers: []string{"GetVersion"}},
+	"cerebro.source_runtimes.list":            {Markers: []string{"GET /source-runtimes"}},
+	"cerebro.connector_definitions.list":      {Markers: []string{"GET /connector-definitions"}},
+	"cerebro.connector_definitions.validate":  {Markers: []string{"POST /connector-definitions/validate"}},
+	"cerebro.findings.list":                   {Markers: []string{"GET /source-runtimes/{runtimeID}/findings"}},
+	"cerebro.findings.get":                    {Markers: []string{"GET /findings/{findingID}"}},
+	"cerebro.findings.search":                 {Markers: []string{"GET /source-runtimes/{runtimeID}/findings", "GET /grc/findings"}},
+	"cerebro.runtimes.status":                 {Markers: []string{"GET /source-runtimes/{runtimeID}", "GET /source-runtimes/{runtimeID}/findings"}},
+	"cerebro.evidence.list":                   {Markers: []string{"GET /source-runtimes/{runtimeID}/finding-evidence"}},
+	"cerebro.evidence.get":                    {Markers: []string{"GET /finding-evidence/{evidenceID}"}},
+	"cerebro.assets.search":                   {Markers: []string{"GET /grc/inventory/assets"}},
+	"cerebro.assets.get":                      {Markers: []string{"GET /grc/inventory/assets/detail"}},
+	"cerebro.risk.summary":                    {Markers: []string{"GET /grc/dashboard", "GET /source-runtimes/{runtimeID}/findings"}},
+	"cerebro.risk.actions.list":               {Markers: []string{"risk-action-plan", "internal/riskplan"}},
+	"cerebro.risk.actions.explain":            {Markers: []string{"risk-action-plan", "internal/riskplan"}},
+	"cerebro.graph.neighborhood":              {Markers: []string{"GET /platform/graph/neighborhood"}},
+	"cerebro.graph.impact":                    {Markers: []string{"GET /platform/graph/impact"}},
+	"cerebro.graph.paths":                     {Markers: []string{"GET /platform/graph/attack-paths"}},
+	"cerebro.graph.reason":                    {Markers: []string{"POST /api/v1/agent-platform/graph/reason"}},
+	"cerebro.investigation.context":           {Markers: []string{"GET /findings/{findingID}", "GET /source-runtimes/{runtimeID}/finding-evidence", "GET /platform/graph/neighborhood"}},
+	"cerebro.findings.action.propose":         {Markers: []string{"POST /findings/{findingID}/resolve", "POST /findings/{findingID}/suppress", "POST /findings/{findingID}/notes", "POST /findings/{findingID}/tickets"}},
+	"cerebro.source_runtimes.refresh.propose": {Markers: []string{"POST /source-runtimes/{runtimeID}/sync"}},
+}
+
+func mcpDomainSurfaceCorpus(t *testing.T) string {
+	t.Helper()
+	root := bootstrapRepoRoot(t)
+	var builder strings.Builder
+	for _, rel := range []string{
+		"internal/bootstrap/routes.go",
+		"proto/cerebro/v1/bootstrap.proto",
+		"api/openapi.yaml",
+		"docs/MCP_DROID_SETUP.md",
+		"docs/FINDINGS_PLATFORM_ARCHITECTURE.md",
+	} {
+		body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		builder.Write(body)
+		builder.WriteByte('\n')
+	}
+	return builder.String()
 }
 
 func TestMCPConnectorDefinitionValidateReturnsSupportReport(t *testing.T) {


### PR DESCRIPTION
## Summary
- document MCP tools as adapters over existing domain surfaces
- add a parity test that requires every MCP tool to name its underlying HTTP, Connect, report, or composite domain surface
- keep proposal-style tools dry-run/read-only in the existing tool-list contract

## Tests
- go test ./internal/bootstrap ./tools/archtests
- make docs-drift-check
- make readme-check
- make oss-audit
