### PR TITLE
Document Source CDK extraction ratchet

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,4 +84,8 @@ Sources live under `sources/<id>` and must include:
 - fixtures under `testdata/`
 - no direct store writes
 
-Arch tests and custom linters are the enforcement mechanism for keeping future sources inside the Source CDK and preventing regressions toward the older god-object architecture.
+Arch tests and custom linters are the enforcement mechanism for keeping future
+sources inside the Source CDK and preventing regressions toward the older
+god-object architecture. [`SOURCE_CDK_EXTRACTION.md`](./SOURCE_CDK_EXTRACTION.md)
+tracks grandfathered source LOC budgets and the extraction pressure that should
+move shared behavior back into the CDK.

--- a/docs/SOURCE_CDK_EXTRACTION.md
+++ b/docs/SOURCE_CDK_EXTRACTION.md
@@ -1,0 +1,36 @@
+# Source CDK Extraction Plan
+
+New source packages must stay at or below 300 nonblank Go LOC and must not own
+direct store writes, direct process environment reads, background contexts, or
+provider-specific retry/pagination frameworks. Shared behavior belongs in the
+Source CDK, not in one source.
+
+Legacy sources above the 300 LOC budget are grandfathered with exact no-growth ceilings in `tools/archtests/source_packages_test.go`. If one shrinks, lower the budget in the same PR. If one needs new shared behavior, extract the behavior into `internal/sourcecdk` or another shared source-support package before growing the source.
+
+## Extraction Themes
+
+- Move provider client construction, retry policy, and pagination loops into
+  shared Source CDK helpers.
+- Keep normalization, graph projection, persistence, and finding logic outside
+  `sources/*`.
+- Prefer small resource-family readers that emit typed records over one large
+  source-level orchestration file.
+- Add replay fixtures before changing legacy source behavior so extraction does
+  not silently change emitted events.
+
+## Grandfathered Sources
+
+| Source | Current LOC Budget | Extraction Pressure |
+| --- | ---: | --- |
+| `aurelius` | 653 | Split source orchestration from record mapping and shared request plumbing. |
+| `aws` | 19155 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
+| `azure` | 2856 | Extract subscription traversal, client factories, and paginated resource readers. |
+| `cosmo` | 1112 | Move shared API pagination and response normalization into reusable source helpers. |
+| `gcp` | 2120 | Extract project traversal, service clients, and resource-family pagination helpers. |
+| `github` | 2110 | Split audit/event readers from repository/user normalization and shared pagination. |
+| `googleworkspace` | 827 | Extract API client setup and paginated directory readers. |
+| `grc` | 1378 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
+| `okta` | 2433 | Extract client, pagination, and identity/group/application readers into smaller units. |
+| `panopticon` | 820 | Separate request plumbing from emitted record construction. |
+| `sentinelone` | 2181 | Extract API paging, agent/application readers, and shared response normalization. |
+| `vulnview` | 1064 | Split feed/client access from vulnerability record normalization. |

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -1,6 +1,7 @@
 package archtests
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,6 +103,31 @@ func TestGrandfatheredSourceLOCBudgetsRatchetDownToCurrentSize(t *testing.T) {
 		}
 		if lines != budget {
 			t.Fatalf("sources/%s has %d Go LOC but grandfathered budget is %d; keep legacy source budgets as exact no-growth ceilings", name, lines, budget)
+		}
+	}
+}
+
+func TestGrandfatheredSourceExtractionPlanIsDocumented(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "docs", "SOURCE_CDK_EXTRACTION.md"))
+	if err != nil {
+		t.Fatalf("read docs/SOURCE_CDK_EXTRACTION.md: %v", err)
+	}
+	text := string(body)
+	for _, marker := range []string{
+		"New source packages must stay at or below 300 nonblank Go LOC",
+		"exact no-growth ceilings",
+		"Move provider client construction, retry policy, and pagination loops",
+		"Keep normalization, graph projection, persistence, and finding logic outside",
+	} {
+		if !strings.Contains(text, marker) {
+			t.Fatalf("docs/SOURCE_CDK_EXTRACTION.md missing extraction marker %q", marker)
+		}
+	}
+	for name, budget := range grandfatheredSourcePackageLOCBudgets {
+		marker := fmt.Sprintf("| `%s` | %d |", name, budget)
+		if !strings.Contains(text, marker) {
+			t.Fatalf("docs/SOURCE_CDK_EXTRACTION.md missing grandfathered source marker %q", marker)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add a Source CDK extraction plan for grandfathered oversized sources
- require every grandfathered LOC budget to be documented with extraction pressure
- link the extraction plan from the architecture Source CDK section

## Tests
- go test ./tools/archtests
- make docs-drift-check
- make readme-check
- make oss-audit
