### PR TITLE
Document source sync recovery contract

### DIFF
--- a/docs/DURABILITY_CONTRACT.md
+++ b/docs/DURABILITY_CONTRACT.md
@@ -4,7 +4,8 @@ This document records which Cerebro writes are event-backed today, which writes
 are current-state backed, and how graph rebuilds should treat each path.
 
 Use this with [`ARCHITECTURE.md`](./ARCHITECTURE.md), [`NON_GOALS.md`](./NON_GOALS.md),
-and [`SOURCE_RUNTIME_GUIDE.md`](./SOURCE_RUNTIME_GUIDE.md).
+[`SOURCE_RUNTIME_GUIDE.md`](./SOURCE_RUNTIME_GUIDE.md), and
+[`SOURCE_SYNC_RECOVERY.md`](./SOURCE_SYNC_RECOVERY.md).
 
 ## Current Write Classes
 
@@ -26,6 +27,7 @@ path until a claim event stream lands.
 - Source runtime sync must not advance runtime progress before the page's
   accepted events have been appended and projected through the configured
   projector.
+- Source runtime page recovery must follow [`SOURCE_SYNC_RECOVERY.md`](./SOURCE_SYNC_RECOVERY.md) until a transactional sync ledger or outbox exists.
 - Workflow projection must happen after the corresponding workflow event append.
 - SDK/runtime claim writes must persist claim rows before writing graph
   projections.

--- a/docs/SOURCE_SYNC_RECOVERY.md
+++ b/docs/SOURCE_SYNC_RECOVERY.md
@@ -1,0 +1,48 @@
+# Source Sync Recovery Contract
+
+Source runtime sync is page-oriented. The current implementation intentionally
+orders each page as append, project, then progress. It does not yet have a
+transactional page ledger or outbox, so this ordering is the recovery contract
+until that ledger exists.
+
+## Current Commit Sequence
+
+For each source page:
+
+1. Read the next page from the Source CDK source.
+2. Validate each emitted event envelope and source-specific event contract.
+3. Append each accepted event to the append log.
+4. Project each appended event through the configured source projector.
+5. Persist runtime progress with `PutSourceRuntime` only after the page's
+   accepted events have been appended and projected.
+6. Emit `source_runtime.page_committed` after progress persistence succeeds.
+
+Runtime progress includes cursor and checkpoint state. It must not advance ahead
+of accepted event append and projection.
+
+## Failure And Replay Rules
+
+- If page read or event validation fails, no accepted event from that failure is
+  committed.
+- If append fails, projection and runtime progress must not run for that event.
+- If projection fails after append, the sync fails before runtime progress is
+  persisted. Repair should replay or re-project the appended event; Neo4j must
+  not be treated as the source of truth.
+- If runtime progress persistence fails after append and projection, the next
+  sync may reread the same page. Append and projection paths must therefore be
+  idempotent by stable event identity.
+- Operators should use append-log replay or bounded source reread to repair
+  projection gaps; checkpoint state alone is not a rebuild source.
+
+## Target Ledger/Outbox Shape
+
+The target hardening step is a source-sync ledger or outbox that records page
+commit state with runtime ID, source ID, page attempt, accepted event IDs,
+checkpoint hash, and projection/progress status. Runtime progress should advance
+in the same durable transaction as the page commit marker, or recovery should
+scan incomplete page commits and finish append-log replay/projection before
+marking the page committed.
+
+Until that exists, changes to source sync must preserve the append, project,
+then progress ordering and keep `source_runtime.page_committed` as the last
+successful page signal.

--- a/tools/archtests/durability_contract_test.go
+++ b/tools/archtests/durability_contract_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -53,5 +54,65 @@ func TestDurabilityContractDocumentsGraphRebuildSources(t *testing.T) {
 		if !bytes.Contains(nonGoals, []byte(marker)) {
 			t.Fatalf("docs/NON_GOALS.md missing graph durability marker %q", marker)
 		}
+	}
+}
+
+func TestSourceSyncRecoveryContractDocumentsCommitOrdering(t *testing.T) {
+	root := repoRoot(t)
+	contract, err := os.ReadFile(filepath.Join(root, "docs", "SOURCE_SYNC_RECOVERY.md"))
+	if err != nil {
+		t.Fatalf("read docs/SOURCE_SYNC_RECOVERY.md: %v", err)
+	}
+	for _, marker := range []string{
+		"append, project, then progress",
+		"Persist runtime progress with `PutSourceRuntime` only after",
+		"If projection fails after append",
+		"transactional page ledger or outbox",
+		"source_runtime.page_committed",
+	} {
+		if !bytes.Contains(contract, []byte(marker)) {
+			t.Fatalf("docs/SOURCE_SYNC_RECOVERY.md missing source sync recovery marker %q", marker)
+		}
+	}
+
+	durability, err := os.ReadFile(filepath.Join(root, "docs", "DURABILITY_CONTRACT.md"))
+	if err != nil {
+		t.Fatalf("read docs/DURABILITY_CONTRACT.md: %v", err)
+	}
+	for _, marker := range []string{
+		"SOURCE_SYNC_RECOVERY.md",
+		"transactional sync ledger or outbox",
+	} {
+		if !bytes.Contains(durability, []byte(marker)) {
+			t.Fatalf("docs/DURABILITY_CONTRACT.md missing source sync recovery marker %q", marker)
+		}
+	}
+}
+
+func TestSourceRuntimeSyncCommitOrderingStaysAppendProjectProgress(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "internal", "sourceruntime", "service.go"))
+	if err != nil {
+		t.Fatalf("read internal/sourceruntime/service.go: %v", err)
+	}
+	syncBody := string(body)
+	start := strings.Index(syncBody, "func (s *Service) Sync(")
+	if start < 0 {
+		t.Fatal("source runtime Sync implementation not found")
+	}
+	end := strings.Index(syncBody[start:], "func sourceRuntimeTelemetryErrorKind")
+	if end < 0 {
+		t.Fatal("source runtime Sync implementation end marker not found")
+	}
+	syncBody = syncBody[start : start+end]
+	appendIndex := strings.Index(syncBody, "s.appendLog.Append(ctx, syncedEvent)")
+	projectIndex := strings.Index(syncBody, "s.projector.Project(ctx, syncedEvent)")
+	progressIndex := strings.Index(syncBody, "s.store.PutSourceRuntime(ctx, runtime)")
+	committedTelemetryIndex := strings.Index(syncBody, "source_runtime.page_committed")
+	if appendIndex < 0 || projectIndex < 0 || progressIndex < 0 || committedTelemetryIndex < 0 {
+		t.Fatalf("source runtime Sync missing append/project/progress/page_committed markers")
+	}
+	if !(appendIndex < projectIndex && projectIndex < progressIndex && progressIndex < committedTelemetryIndex) {
+		t.Fatalf("source runtime Sync commit order changed; want append before project before progress before page_committed telemetry")
 	}
 }


### PR DESCRIPTION
## Summary
- document source runtime sync append/project/progress commit ordering
- add failure and replay rules for append, projection, and runtime progress persistence gaps
- add an arch test that watches the sync implementation ordering and durability-doc markers

## Tests
- go test ./tools/archtests
- make docs-drift-check
- make readme-check
- make oss-audit
