### PR TITLE
Deepen agent graph preflight context

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -136,6 +136,29 @@ paths:
           description: Invalid capability decision request.
         '404':
           description: Capability was not found.
+  /api/v1/agent-platform/preflight:
+    post:
+      operationId: preflightAgentPlatformRun
+      summary: Resolve agent run preconditions
+      tags:
+        - Platform
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentPlatformPreflightRequest'
+      responses:
+        '200':
+          description: Tenant-scoped capability, graph, connector, policy, and write-back preflight envelope.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentPlatformPreflight'
+        '400':
+          description: Invalid preflight request.
+        '403':
+          description: Tenant or graph scope is not allowed.
   /api/v1/agent-platform/graph/reason:
     post:
       operationId: reasonOverAgentPlatformGraph
@@ -3144,14 +3167,6 @@ components:
       properties:
         capability_id:
           type: string
-        tenant_id:
-          type: string
-        actor_id:
-          type: string
-        requested_scopes:
-          type: array
-          items:
-            type: string
         connector_readiness:
           type: object
           additionalProperties:
@@ -3166,6 +3181,97 @@ components:
           type: string
         provenance_requirement:
           type: string
+    AgentPlatformPreflightRequest:
+      type: object
+      properties:
+        capability_ids:
+          type: array
+          items:
+            type: string
+          description: Defaults to graph-reasoning when omitted.
+        question:
+          type: string
+        scope_urn:
+          type: string
+          description: Optional Cerebro URN inside the authenticated tenant to focus graph planning.
+        model:
+          type: string
+        connector_readiness:
+          type: object
+          additionalProperties:
+            type: string
+        eval_status_overrides:
+          type: object
+          additionalProperties:
+            type: string
+        allow_preview:
+          type: boolean
+        selection_reason:
+          type: string
+        provenance_requirement:
+          type: string
+    AgentPlatformPreflight:
+      type: object
+      required:
+        - version
+        - enabled
+        - reason
+        - blockers
+        - selected_capabilities
+        - capability_decisions
+        - graph_context
+        - connector_context
+        - policy
+        - write_back
+        - runtime_events
+        - provenance
+      properties:
+        version:
+          type: string
+        tenant_id:
+          type: string
+        actor_id:
+          type: string
+        question:
+          type: string
+        scope_urn:
+          type: string
+        model:
+          type: string
+        enabled:
+          type: boolean
+        reason:
+          type: string
+        blockers:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformCapabilityDecisionBlocker'
+        selected_capabilities:
+          type: array
+          items:
+            type: string
+        capability_decisions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformCapabilityDecision'
+        graph_context:
+          $ref: '#/components/schemas/AgentPlatformGraphPlanningContext'
+        connector_context:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformConnectorGraphNode'
+        policy:
+          $ref: '#/components/schemas/AgentPlatformPolicyDecision'
+        write_back:
+          $ref: '#/components/schemas/AgentPlatformWriteBackContract'
+        runtime_events:
+          type: array
+          items:
+            type: string
+        provenance:
+          type: array
+          items:
+            type: string
     AgentPlatformCapabilityDecision:
       type: object
       required:
@@ -3265,6 +3371,162 @@ components:
           type: array
           items:
             type: string
+    AgentPlatformGraphPlanningContext:
+      type: object
+      required:
+        - reasoning_surface
+        - read_only
+        - citation_required
+        - provenance_required
+        - budget
+        - query_modes
+        - provenance_surfaces
+      properties:
+        tenant_id:
+          type: string
+        scope_urn:
+          type: string
+        scope_tenant_id:
+          type: string
+        reasoning_surface:
+          type: string
+        read_only:
+          type: boolean
+        citation_required:
+          type: boolean
+        provenance_required:
+          type: boolean
+        budget:
+          $ref: '#/components/schemas/AgentPlatformContextBudget'
+        query_modes:
+          type: array
+          items:
+            type: string
+        provenance_surfaces:
+          type: array
+          items:
+            type: string
+    AgentPlatformContextBudget:
+      type: object
+      required:
+        - max_rows
+        - max_depth
+        - max_children
+      properties:
+        max_rows:
+          type: integer
+        max_depth:
+          type: integer
+        max_children:
+          type: integer
+    AgentPlatformConnectorGraphNode:
+      type: object
+      required:
+        - source_id
+        - node_urn
+        - purpose
+        - auth_models
+        - required_scopes
+        - token_owner
+        - credential_boundary
+        - oauth_surface
+        - mcp_surface
+        - readiness
+        - required
+        - satisfied
+      properties:
+        source_id:
+          type: string
+        node_urn:
+          type: string
+        oauth_node_urn:
+          type: string
+        tenant_id:
+          type: string
+        purpose:
+          type: string
+        auth_models:
+          type: array
+          items:
+            type: string
+        required_scopes:
+          type: array
+          items:
+            type: string
+        token_owner:
+          type: string
+        credential_boundary:
+          type: string
+        oauth_surface:
+          type: string
+        mcp_surface:
+          type: string
+        readiness:
+          type: string
+        required:
+          type: boolean
+        satisfied:
+          type: boolean
+    AgentPlatformPolicyDecision:
+      type: object
+      required:
+        - passing
+        - tenant_forced
+        - checks
+      properties:
+        passing:
+          type: boolean
+        tenant_forced:
+          type: boolean
+        tenant_id:
+          type: string
+        checks:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPlatformPolicyCheck'
+    AgentPlatformPolicyCheck:
+      type: object
+      required:
+        - id
+        - status
+        - message
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+          enum: [pass, blocked, not_applicable]
+        message:
+          type: string
+        fields:
+          type: array
+          items:
+            type: string
+    AgentPlatformWriteBackContract:
+      type: object
+      required:
+        - required
+        - trace_id_required
+        - required_events
+        - graph_updates
+        - provenance_surfaces
+      properties:
+        required:
+          type: boolean
+        trace_id_required:
+          type: boolean
+        required_events:
+          type: array
+          items:
+            type: string
+        graph_updates:
+          type: array
+          items:
+            type: string
+        provenance_surfaces:
+          type: array
+          items:
+            type: string
     AgentPlatformGraphReasonResponse:
       type: object
       required:
@@ -3323,6 +3585,8 @@ components:
             $ref: '#/components/schemas/AgentPlatformGraphProgressEvent'
         timings:
           $ref: '#/components/schemas/AgentPlatformGraphStageTimings'
+        preflight:
+          $ref: '#/components/schemas/AgentPlatformPreflight'
         provenance:
           $ref: '#/components/schemas/AgentPlatformGraphReasonProvenance'
     AgentPlatformGraphReasonRequest:
@@ -3497,6 +3761,22 @@ components:
           type: string
         fallback_reason:
           type: string
+        capability_ids:
+          type: array
+          items:
+            type: string
+        policy_checks:
+          type: array
+          items:
+            type: string
+        connector_node_urns:
+          type: array
+          items:
+            type: string
+        write_back_events:
+          type: array
+          items:
+            type: string
     AgentPlatformDomain:
       type: object
       required:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,6 +71,11 @@ the long-running reasoning pipeline. That deadline is owned by `net/http` and
 the response writer, so the hook belongs in bootstrap instead of the graphagent
 domain package.
 
+The agent platform graph preflight contract lives in `internal/agentplatform`.
+The bootstrap budget includes the HTTP and MCP request/response mapping needed
+to force authenticated tenant context, expose preflight to agents, and attach
+that preflight envelope to graph reasoning responses.
+
 ## Postgres migrations
 
 State-store schema preparation runs at service startup and before store operations. Most migrations use additive `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, or `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` patterns.

--- a/internal/agentplatform/contracts.go
+++ b/internal/agentplatform/contracts.go
@@ -206,6 +206,7 @@ var Invariants = []Invariant{
 	{ID: "EVAL-01", DomainID: "evals", Statement: "A default-on agent capability must have at least one local regression path."},
 	{ID: "EXEC-01", DomainID: "execution", Statement: "Adapters report cancellation and truncation explicitly instead of hiding partial results."},
 	{ID: "KNOW-01", DomainID: "knowledge", Statement: "Retrieved context must carry source scope and citation status when shown to a user or model."},
+	{ID: "PLAN-01", DomainID: "runtime", Statement: "Agent runs resolve tenant, scope, capability, connector, and write-back preconditions before planning."},
 	{ID: "RUN-01", DomainID: "runtime", Statement: "Consumer-visible events use stable names and a single terminal outcome per logical run."},
 	{ID: "STREAM-01", DomainID: "streaming-replay", Statement: "Replay records preserve event order even when payloads are redacted or truncated."},
 }
@@ -461,8 +462,8 @@ var Capabilities = []Capability{
 			ScenarioSets:  []string{"graph-reasoning-envelope", "graph-reasoning-unsupported-query"},
 			Rubrics:       []string{"read-only validation", "query plan transparency", "citation grounding", "provenance completeness"},
 		},
-		RuntimeEvents: []string{"agent.run.started", "capability.selected", "knowledge.retrieval.completed", "agent.run.completed", "agent.run.failed"},
-		Provenance:    []string{"graph-reasoning", "knowledge-context", "graph-neighborhood"},
+		RuntimeEvents: []string{"agent.preflight.completed", "agent.run.started", "capability.selected", "knowledge.retrieval.completed", "agent.run.completed", "agent.run.failed"},
+		Provenance:    []string{"agent-run-preflight", "graph-reasoning", "knowledge-context", "graph-neighborhood"},
 		Review: ReviewStatus{
 			State:             "required",
 			Cadence:           "before graph reasoning API or query contract changes",
@@ -472,6 +473,15 @@ var Capabilities = []Capability{
 }
 
 var RuntimeEvents = []RuntimeEvent{
+	{
+		Name:             "agent.preflight.completed",
+		DomainID:         "runtime",
+		Stage:            "preflight",
+		SequenceRequired: true,
+		Replayable:       true,
+		PayloadFields:    []string{"tenant_id", "actor_id", "capability_ids", "scope_urn", "policy_checks", "connector_gates", "write_back_contract"},
+		ProvenanceFields: []string{"tenant_id", "scope", "capability_id", "policy_check", "connector_node_urn"},
+	},
 	{
 		Name:             "agent.run.started",
 		DomainID:         "runtime",
@@ -578,6 +588,14 @@ var RuntimeEvents = []RuntimeEvent{
 }
 
 var ProvenanceRequirements = []ProvenanceRequirement{
+	{
+		Surface:          "agent-run-preflight",
+		DomainID:         "runtime",
+		RequiredFields:   []string{"tenant_id", "scope", "capability_id", "policy_check", "connector_node_urn", "write_back_event"},
+		CitationRequired: false,
+		BudgetRequired:   true,
+		FallbackRequired: true,
+	},
 	{
 		Surface:          "ask-answer",
 		DomainID:         "knowledge",

--- a/internal/agentplatform/contracts_test.go
+++ b/internal/agentplatform/contracts_test.go
@@ -185,6 +185,92 @@ func TestDecideCapabilityReportsControlPlaneBlockers(t *testing.T) {
 	}
 }
 
+func TestDecideCapabilityAllowsScopeUnrestrictedPrincipal(t *testing.T) {
+	decision, ok := DecideCapability(CapabilityDecisionRequest{
+		CapabilityID:      "graph-reasoning",
+		TenantID:          "tenant-1",
+		ScopeUnrestricted: true,
+	})
+	if !ok {
+		t.Fatal("graph-reasoning capability missing")
+	}
+	if !decision.Enabled {
+		t.Fatalf("decision enabled = false, blockers = %+v", decision.Blockers)
+	}
+	if len(decision.MissingScopes) != 0 {
+		t.Fatalf("missing scopes = %+v, want none for unrestricted principal", decision.MissingScopes)
+	}
+}
+
+func TestPreflightAgentRunBuildsGraphPlanningContext(t *testing.T) {
+	preflight := PreflightAgentRun(AgentRunPreflightRequest{
+		TenantID:        "tenant-1",
+		ActorID:         "actor-1",
+		CapabilityIDs:   []string{"graph-reasoning"},
+		RequestedScopes: []string{"cosmo.security.read"},
+		Question:        "What should I inspect?",
+		ScopeURN:        "urn:cerebro:tenant-1:asset:app",
+	})
+
+	if !preflight.Enabled {
+		t.Fatalf("preflight enabled = false, blockers = %+v", preflight.Blockers)
+	}
+	if preflight.Reason != "preflight_passed" {
+		t.Fatalf("reason = %q, want preflight_passed", preflight.Reason)
+	}
+	if preflight.GraphContext.TenantID != "tenant-1" || preflight.GraphContext.ScopeTenantID != "tenant-1" {
+		t.Fatalf("graph context = %+v", preflight.GraphContext)
+	}
+	if !preflight.GraphContext.ReadOnly || !preflight.GraphContext.CitationRequired || !preflight.GraphContext.ProvenanceRequired {
+		t.Fatalf("graph context must be read-only, cited, and provenance-required: %+v", preflight.GraphContext)
+	}
+	if !containsString(preflight.RuntimeEvents, "agent.preflight.completed") || !containsString(preflight.Provenance, "agent-run-preflight") {
+		t.Fatalf("preflight missing runtime/provenance contract: events=%v provenance=%v", preflight.RuntimeEvents, preflight.Provenance)
+	}
+	if !preflight.WriteBack.Required || !preflight.WriteBack.TraceIDRequired {
+		t.Fatalf("write-back contract = %+v, want required trace-linked write-back", preflight.WriteBack)
+	}
+}
+
+func TestPreflightAgentRunBlocksScopeTenantMismatch(t *testing.T) {
+	preflight := PreflightAgentRun(AgentRunPreflightRequest{
+		TenantID:        "tenant-1",
+		CapabilityIDs:   []string{"graph-reasoning"},
+		RequestedScopes: []string{"cosmo.security.read"},
+		ScopeURN:        "urn:cerebro:other:asset:app",
+	})
+
+	if preflight.Enabled {
+		t.Fatalf("preflight enabled = true, want blocked")
+	}
+	if !decisionHasBlockerFromList(preflight.Blockers, "scope_tenant") {
+		t.Fatalf("preflight blockers = %+v, want scope_tenant", preflight.Blockers)
+	}
+}
+
+func TestPreflightAgentRunIncludesConnectorOAuthNodes(t *testing.T) {
+	preflight := PreflightAgentRun(AgentRunPreflightRequest{
+		TenantID:           "tenant-1",
+		CapabilityIDs:      []string{"connector-oauth-mcp"},
+		ScopeUnrestricted:  true,
+		ConnectorReadiness: map[string]string{"catalog-managed": "connected"},
+	})
+
+	if !preflight.Enabled {
+		t.Fatalf("preflight enabled = false, blockers = %+v", preflight.Blockers)
+	}
+	if len(preflight.ConnectorContext) != 1 {
+		t.Fatalf("connector context = %+v, want one connector node", preflight.ConnectorContext)
+	}
+	connector := preflight.ConnectorContext[0]
+	if connector.NodeURN != "urn:cerebro:tenant-1:connector:catalog-managed" || connector.OAuthNodeURN == "" {
+		t.Fatalf("connector graph node = %+v", connector)
+	}
+	if !connector.Required || !connector.Satisfied || connector.TokenOwner == "" || connector.CredentialBoundary == "" {
+		t.Fatalf("connector gate = %+v, want satisfied required OAuth/credential boundary", connector)
+	}
+}
+
 func TestDecideCapabilityPreviewGate(t *testing.T) {
 	blocked, ok := DecideCapability(CapabilityDecisionRequest{
 		CapabilityID:    "runtime-response-actions",
@@ -309,7 +395,11 @@ func containsString(values []string, needle string) bool {
 }
 
 func decisionHasBlocker(decision CapabilityDecision, code string) bool {
-	for _, blocker := range decision.Blockers {
+	return decisionHasBlockerFromList(decision.Blockers, code)
+}
+
+func decisionHasBlockerFromList(blockers []CapabilityDecisionBlocker, code string) bool {
+	for _, blocker := range blockers {
 		if blocker.Code == code {
 			return true
 		}

--- a/internal/agentplatform/control_plane.go
+++ b/internal/agentplatform/control_plane.go
@@ -33,6 +33,7 @@ type CapabilityDecisionRequest struct {
 	TenantID              string            `json:"tenant_id,omitempty"`
 	ActorID               string            `json:"actor_id,omitempty"`
 	RequestedScopes       []string          `json:"requested_scopes,omitempty"`
+	ScopeUnrestricted     bool              `json:"scope_unrestricted,omitempty"`
 	ConnectorReadiness    map[string]string `json:"connector_readiness,omitempty"`
 	EvalStatusOverrides   map[string]string `json:"eval_status_overrides,omitempty"`
 	AllowPreview          bool              `json:"allow_preview,omitempty"`
@@ -99,7 +100,10 @@ func DecideCapability(request CapabilityDecisionRequest) (CapabilityDecision, bo
 	}
 
 	requiredScopes := uniqueSortedStrings(append(cloneStrings(capability.RequiredScopes), connectorRequiredScopes(capability.ConnectorDependencies)...))
-	missingScopes := missingStrings(requiredScopes, request.RequestedScopes)
+	missingScopes := []string{}
+	if !request.ScopeUnrestricted {
+		missingScopes = missingStrings(requiredScopes, request.RequestedScopes)
+	}
 	requiredConnectors := requiredConnectorDependencies(capability.ConnectorDependencies)
 	eval := capabilityEvalGate(capability, request.EvalStatusOverrides)
 	blockers := make([]CapabilityDecisionBlocker, 0, 4)
@@ -342,11 +346,34 @@ func missingStrings(required []string, available []string) []string {
 	availableSet := stringSet(available)
 	missing := []string{}
 	for _, value := range required {
-		if !availableSet[value] {
+		if !scopeSetContains(availableSet, value) {
 			missing = append(missing, value)
 		}
 	}
 	return missing
+}
+
+func scopeSetContains(availableSet map[string]bool, required string) bool {
+	for _, candidate := range scopeAliases(required) {
+		if availableSet[candidate] {
+			return true
+		}
+	}
+	return false
+}
+
+func scopeAliases(scope string) []string {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		return nil
+	}
+	aliases := []string{scope}
+	if strings.HasPrefix(scope, "cerebro.") {
+		aliases = append(aliases, strings.TrimPrefix(scope, "cerebro."))
+	} else {
+		aliases = append(aliases, "cerebro."+scope)
+	}
+	return aliases
 }
 
 func uniqueSortedStrings(values []string) []string {

--- a/internal/agentplatform/preflight.go
+++ b/internal/agentplatform/preflight.go
@@ -1,0 +1,400 @@
+package agentplatform
+
+import (
+	"strings"
+)
+
+const (
+	DefaultAgentRunCapabilityID = "graph-reasoning"
+	defaultGraphContextMaxRows  = 25
+	defaultGraphContextDepth    = 2
+	defaultGraphContextChildren = 2
+)
+
+type AgentRunPreflightRequest struct {
+	TenantID              string            `json:"tenant_id,omitempty"`
+	ActorID               string            `json:"actor_id,omitempty"`
+	CapabilityIDs         []string          `json:"capability_ids,omitempty"`
+	Question              string            `json:"question,omitempty"`
+	ScopeURN              string            `json:"scope_urn,omitempty"`
+	Model                 string            `json:"model,omitempty"`
+	RequestedScopes       []string          `json:"requested_scopes,omitempty"`
+	ScopeUnrestricted     bool              `json:"scope_unrestricted,omitempty"`
+	ConnectorReadiness    map[string]string `json:"connector_readiness,omitempty"`
+	EvalStatusOverrides   map[string]string `json:"eval_status_overrides,omitempty"`
+	AllowPreview          bool              `json:"allow_preview,omitempty"`
+	SelectionReason       string            `json:"selection_reason,omitempty"`
+	ProvenanceRequirement string            `json:"provenance_requirement,omitempty"`
+}
+
+type AgentRunPreflight struct {
+	Version              string                      `json:"version"`
+	TenantID             string                      `json:"tenant_id,omitempty"`
+	ActorID              string                      `json:"actor_id,omitempty"`
+	Question             string                      `json:"question,omitempty"`
+	ScopeURN             string                      `json:"scope_urn,omitempty"`
+	Model                string                      `json:"model,omitempty"`
+	Enabled              bool                        `json:"enabled"`
+	Reason               string                      `json:"reason"`
+	Blockers             []CapabilityDecisionBlocker `json:"blockers"`
+	SelectedCapabilities []string                    `json:"selected_capabilities"`
+	CapabilityDecisions  []CapabilityDecision        `json:"capability_decisions"`
+	GraphContext         AgentGraphPlanningContext   `json:"graph_context"`
+	ConnectorContext     []AgentConnectorGraphNode   `json:"connector_context"`
+	Policy               AgentPolicyDecision         `json:"policy"`
+	WriteBack            AgentWriteBackContract      `json:"write_back"`
+	RuntimeEvents        []string                    `json:"runtime_events"`
+	Provenance           []string                    `json:"provenance"`
+}
+
+type AgentGraphPlanningContext struct {
+	TenantID           string             `json:"tenant_id,omitempty"`
+	ScopeURN           string             `json:"scope_urn,omitempty"`
+	ScopeTenantID      string             `json:"scope_tenant_id,omitempty"`
+	ReasoningSurface   string             `json:"reasoning_surface"`
+	ReadOnly           bool               `json:"read_only"`
+	CitationRequired   bool               `json:"citation_required"`
+	ProvenanceRequired bool               `json:"provenance_required"`
+	Budget             AgentContextBudget `json:"budget"`
+	QueryModes         []string           `json:"query_modes"`
+	ProvenanceSurfaces []string           `json:"provenance_surfaces"`
+}
+
+type AgentContextBudget struct {
+	MaxRows     int `json:"max_rows"`
+	MaxDepth    int `json:"max_depth"`
+	MaxChildren int `json:"max_children"`
+}
+
+type AgentConnectorGraphNode struct {
+	SourceID           string   `json:"source_id"`
+	NodeURN            string   `json:"node_urn"`
+	OAuthNodeURN       string   `json:"oauth_node_urn,omitempty"`
+	TenantID           string   `json:"tenant_id,omitempty"`
+	Purpose            string   `json:"purpose"`
+	AuthModels         []string `json:"auth_models"`
+	RequiredScopes     []string `json:"required_scopes"`
+	TokenOwner         string   `json:"token_owner"`
+	CredentialBoundary string   `json:"credential_boundary"`
+	OAuthSurface       string   `json:"oauth_surface"`
+	MCPSurface         string   `json:"mcp_surface"`
+	Readiness          string   `json:"readiness"`
+	Required           bool     `json:"required"`
+	Satisfied          bool     `json:"satisfied"`
+}
+
+type AgentPolicyDecision struct {
+	Passing      bool               `json:"passing"`
+	TenantForced bool               `json:"tenant_forced"`
+	TenantID     string             `json:"tenant_id,omitempty"`
+	Checks       []AgentPolicyCheck `json:"checks"`
+}
+
+type AgentPolicyCheck struct {
+	ID      string   `json:"id"`
+	Status  string   `json:"status"`
+	Message string   `json:"message"`
+	Fields  []string `json:"fields,omitempty"`
+}
+
+type AgentWriteBackContract struct {
+	Required           bool     `json:"required"`
+	TraceIDRequired    bool     `json:"trace_id_required"`
+	RequiredEvents     []string `json:"required_events"`
+	GraphUpdates       []string `json:"graph_updates"`
+	ProvenanceSurfaces []string `json:"provenance_surfaces"`
+}
+
+func PreflightAgentRun(request AgentRunPreflightRequest) AgentRunPreflight {
+	request = normalizeAgentRunPreflightRequest(request)
+	capabilityIDs := request.CapabilityIDs
+	if len(capabilityIDs) == 0 {
+		capabilityIDs = []string{DefaultAgentRunCapabilityID}
+	}
+
+	decisions := make([]CapabilityDecision, 0, len(capabilityIDs))
+	blockers := []CapabilityDecisionBlocker{}
+	for _, capabilityID := range capabilityIDs {
+		decision, ok := DecideCapability(CapabilityDecisionRequest{
+			CapabilityID:          capabilityID,
+			TenantID:              request.TenantID,
+			ActorID:               request.ActorID,
+			RequestedScopes:       request.RequestedScopes,
+			ScopeUnrestricted:     request.ScopeUnrestricted,
+			ConnectorReadiness:    request.ConnectorReadiness,
+			EvalStatusOverrides:   request.EvalStatusOverrides,
+			AllowPreview:          request.AllowPreview,
+			SelectionReason:       request.SelectionReason,
+			ProvenanceRequirement: request.ProvenanceRequirement,
+		})
+		if !ok {
+			blockers = append(blockers, CapabilityDecisionBlocker{
+				Code:    "capability_not_found",
+				Message: "Requested capability was not found.",
+				Fields:  []string{capabilityID},
+			})
+			continue
+		}
+		decisions = append(decisions, decision)
+		if !decision.Enabled {
+			blockers = append(blockers, CapabilityDecisionBlocker{
+				Code:    "capability_blocked",
+				Message: "Requested capability is blocked by one or more gates.",
+				Fields:  []string{decision.CapabilityID},
+			})
+			blockers = append(blockers, decision.Blockers...)
+		}
+	}
+
+	graphContext := agentGraphPlanningContext(request, decisions)
+	connectorContext := agentConnectorGraphNodes(request, decisions)
+	policy := agentPolicyDecision(request, decisions, graphContext, connectorContext)
+	for _, check := range policy.Checks {
+		if check.Status == "blocked" {
+			blockers = append(blockers, CapabilityDecisionBlocker{
+				Code:    check.ID,
+				Message: check.Message,
+				Fields:  cloneStrings(check.Fields),
+			})
+		}
+	}
+
+	runtimeEvents := agentPreflightRuntimeEvents(decisions)
+	provenance := agentPreflightProvenance(decisions)
+	writeBack := AgentWriteBackContract{
+		Required:           true,
+		TraceIDRequired:    true,
+		RequiredEvents:     runtimeEvents,
+		GraphUpdates:       []string{"agent_run_summary", "capability_selection", "knowledge_context", "connector_gate_status"},
+		ProvenanceSurfaces: provenance,
+	}
+
+	enabled := len(blockers) == 0 && policy.Passing
+	reason := "preflight_passed"
+	if !enabled {
+		reason = "blocked_by_policy"
+	}
+	return AgentRunPreflight{
+		Version:              ContractVersion,
+		TenantID:             request.TenantID,
+		ActorID:              request.ActorID,
+		Question:             request.Question,
+		ScopeURN:             request.ScopeURN,
+		Model:                request.Model,
+		Enabled:              enabled,
+		Reason:               reason,
+		Blockers:             dedupeDecisionBlockers(blockers),
+		SelectedCapabilities: enabledCapabilityIDs(decisions),
+		CapabilityDecisions:  decisions,
+		GraphContext:         graphContext,
+		ConnectorContext:     connectorContext,
+		Policy:               policy,
+		WriteBack:            writeBack,
+		RuntimeEvents:        runtimeEvents,
+		Provenance:           provenance,
+	}
+}
+
+func normalizeAgentRunPreflightRequest(request AgentRunPreflightRequest) AgentRunPreflightRequest {
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.ActorID = strings.TrimSpace(request.ActorID)
+	request.Question = strings.TrimSpace(request.Question)
+	request.ScopeURN = strings.TrimSpace(request.ScopeURN)
+	request.Model = strings.TrimSpace(request.Model)
+	request.SelectionReason = strings.TrimSpace(request.SelectionReason)
+	request.ProvenanceRequirement = strings.TrimSpace(request.ProvenanceRequirement)
+	request.CapabilityIDs = uniqueSortedStrings(request.CapabilityIDs)
+	request.RequestedScopes = uniqueSortedStrings(request.RequestedScopes)
+	if request.ConnectorReadiness == nil {
+		request.ConnectorReadiness = map[string]string{}
+	}
+	if request.EvalStatusOverrides == nil {
+		request.EvalStatusOverrides = map[string]string{}
+	}
+	return request
+}
+
+func agentGraphPlanningContext(request AgentRunPreflightRequest, decisions []CapabilityDecision) AgentGraphPlanningContext {
+	return AgentGraphPlanningContext{
+		TenantID:           request.TenantID,
+		ScopeURN:           request.ScopeURN,
+		ScopeTenantID:      tenantIDFromCerebroURN(request.ScopeURN),
+		ReasoningSurface:   "graph-reasoning",
+		ReadOnly:           true,
+		CitationRequired:   true,
+		ProvenanceRequired: true,
+		Budget: AgentContextBudget{
+			MaxRows:     defaultGraphContextMaxRows,
+			MaxDepth:    defaultGraphContextDepth,
+			MaxChildren: defaultGraphContextChildren,
+		},
+		QueryModes:         []string{"read_only_cypher", "bounded_neighborhood", "citation_grounded_summary"},
+		ProvenanceSurfaces: agentPreflightProvenance(decisions),
+	}
+}
+
+func agentConnectorGraphNodes(request AgentRunPreflightRequest, decisions []CapabilityDecision) []AgentConnectorGraphNode {
+	nodes := []AgentConnectorGraphNode{}
+	seen := map[string]struct{}{}
+	for _, decision := range decisions {
+		for _, dependency := range decision.RequiredConnectors {
+			key := dependency.SourceID
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			readiness := normalizedReadiness(request.ConnectorReadiness[dependency.SourceID])
+			if readiness == "" {
+				readiness = "unknown"
+			}
+			sourceURNPart := safeURNPart(dependency.SourceID)
+			nodeURN := "urn:cerebro:" + safeURNPart(request.TenantID) + ":connector:" + sourceURNPart
+			oauthNodeURN := ""
+			if strings.TrimSpace(dependency.OAuthSurface) != "" {
+				oauthNodeURN = "urn:cerebro:" + safeURNPart(request.TenantID) + ":oauth:" + sourceURNPart
+			}
+			nodes = append(nodes, AgentConnectorGraphNode{
+				SourceID:           dependency.SourceID,
+				NodeURN:            nodeURN,
+				OAuthNodeURN:       oauthNodeURN,
+				TenantID:           request.TenantID,
+				Purpose:            dependency.Purpose,
+				AuthModels:         cloneStrings(dependency.AuthModels),
+				RequiredScopes:     cloneStrings(dependency.RequiredScopes),
+				TokenOwner:         dependency.TokenOwner,
+				CredentialBoundary: dependency.CredentialStore,
+				OAuthSurface:       dependency.OAuthSurface,
+				MCPSurface:         dependency.MCPSurface,
+				Readiness:          readiness,
+				Required:           true,
+				Satisfied:          connectorReady(readiness),
+			})
+		}
+	}
+	return nodes
+}
+
+func agentPolicyDecision(request AgentRunPreflightRequest, decisions []CapabilityDecision, graphContext AgentGraphPlanningContext, connectors []AgentConnectorGraphNode) AgentPolicyDecision {
+	checks := []AgentPolicyCheck{}
+	if request.TenantID == "" {
+		checks = append(checks, AgentPolicyCheck{ID: "tenant_required", Status: "blocked", Message: "Agent runs require an authenticated tenant."})
+	} else {
+		checks = append(checks, AgentPolicyCheck{ID: "tenant_forced", Status: "pass", Message: "Agent run tenant is derived from the authenticated principal.", Fields: []string{request.TenantID}})
+	}
+	switch {
+	case graphContext.ScopeURN == "":
+		checks = append(checks, AgentPolicyCheck{ID: "scope_tenant", Status: "not_applicable", Message: "No graph scope URN was requested."})
+	case graphContext.ScopeTenantID == "":
+		checks = append(checks, AgentPolicyCheck{ID: "scope_tenant", Status: "pass", Message: "Requested scope is not a tenant-bearing Cerebro URN."})
+	case graphContext.ScopeTenantID == request.TenantID:
+		checks = append(checks, AgentPolicyCheck{ID: "scope_tenant", Status: "pass", Message: "Requested graph scope belongs to the effective tenant.", Fields: []string{graphContext.ScopeURN}})
+	default:
+		checks = append(checks, AgentPolicyCheck{ID: "scope_tenant", Status: "blocked", Message: "Requested graph scope belongs to a different tenant.", Fields: []string{graphContext.ScopeURN}})
+	}
+	for _, decision := range decisions {
+		status := "pass"
+		message := "Capability gates passed."
+		if !decision.Enabled {
+			status = "blocked"
+			message = "Capability gates blocked the run."
+		}
+		checks = append(checks, AgentPolicyCheck{ID: "capability:" + decision.CapabilityID, Status: status, Message: message, Fields: []string{decision.CapabilityID}})
+	}
+	for _, connector := range connectors {
+		status := "pass"
+		message := "Connector precondition passed."
+		if !connector.Satisfied {
+			status = "blocked"
+			message = "Connector precondition is not satisfied."
+		}
+		checks = append(checks, AgentPolicyCheck{ID: "connector:" + connector.SourceID, Status: status, Message: message, Fields: []string{connector.NodeURN}})
+	}
+	passing := true
+	for _, check := range checks {
+		if check.Status == "blocked" {
+			passing = false
+			break
+		}
+	}
+	return AgentPolicyDecision{
+		Passing:      passing,
+		TenantForced: request.TenantID != "",
+		TenantID:     request.TenantID,
+		Checks:       checks,
+	}
+}
+
+func agentPreflightRuntimeEvents(decisions []CapabilityDecision) []string {
+	events := []string{"agent.preflight.completed"}
+	for _, decision := range decisions {
+		events = append(events, decision.RuntimeEvents...)
+	}
+	return uniqueSortedStrings(events)
+}
+
+func agentPreflightProvenance(decisions []CapabilityDecision) []string {
+	surfaces := []string{"agent-run-preflight"}
+	for _, decision := range decisions {
+		surfaces = append(surfaces, decision.Provenance...)
+	}
+	return uniqueSortedStrings(surfaces)
+}
+
+func enabledCapabilityIDs(decisions []CapabilityDecision) []string {
+	ids := []string{}
+	for _, decision := range decisions {
+		if decision.Enabled {
+			ids = append(ids, decision.CapabilityID)
+		}
+	}
+	return uniqueSortedStrings(ids)
+}
+
+func dedupeDecisionBlockers(blockers []CapabilityDecisionBlocker) []CapabilityDecisionBlocker {
+	seen := map[string]struct{}{}
+	out := make([]CapabilityDecisionBlocker, 0, len(blockers))
+	for _, blocker := range blockers {
+		key := blocker.Code + "\x00" + strings.Join(blocker.Fields, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		blocker.Fields = cloneStrings(blocker.Fields)
+		out = append(out, blocker)
+	}
+	return out
+}
+
+func tenantIDFromCerebroURN(urn string) string {
+	parts := strings.SplitN(strings.TrimSpace(urn), ":", 5)
+	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
+		return ""
+	}
+	return strings.TrimSpace(parts[2])
+}
+
+func safeURNPart(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '_' || r == '-' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "unknown"
+	}
+	return b.String()
+}

--- a/internal/bootstrap/agent_graph_reasoning.go
+++ b/internal/bootstrap/agent_graph_reasoning.go
@@ -1,12 +1,11 @@
 package bootstrap
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 
+	"github.com/writer/cerebro/internal/agentplatform"
 	"github.com/writer/cerebro/internal/graphagent"
 )
 
@@ -18,16 +17,34 @@ func (a *App) handleAgentPlatformGraphReason(w http.ResponseWriter, r *http.Requ
 		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
 		return
 	}
-	if err := forceGraphReasoningTenant(r.Context(), &request); err != nil {
+	resolved, err := resolveAgentPlatformRequestContext(r.Context(), request.TenantID, "", nil)
+	if err != nil {
 		writeGRCError(w, err)
 		return
 	}
+	request.TenantID = resolved.TenantID
 	if request.ScopeURN != "" {
 		if err := authorizeCerebroURNTenant(r.Context(), request.ScopeURN); err != nil {
 			writeGRCError(w, err)
 			return
 		}
 	}
+	preflight := agentplatform.PreflightAgentRun(agentplatform.AgentRunPreflightRequest{
+		TenantID:              request.TenantID,
+		ActorID:               resolved.ActorID,
+		CapabilityIDs:         []string{agentplatform.DefaultAgentRunCapabilityID},
+		Question:              request.Question,
+		ScopeURN:              request.ScopeURN,
+		Model:                 request.Model,
+		RequestedScopes:       resolved.RequestedScopes,
+		ScopeUnrestricted:     resolved.ScopeUnrestricted || !resolved.Authenticated,
+		ProvenanceRequirement: "graph-reasoning",
+	})
+	if !preflight.Enabled {
+		writeGRCError(w, errScopeForbidden)
+		return
+	}
+	request.PlatformContext = &preflight
 	if err := graphagent.ValidateRequest(request); err != nil {
 		writeGRCError(w, err)
 		return
@@ -44,28 +61,6 @@ func (a *App) handleAgentPlatformGraphReason(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	writeJSON(w, http.StatusOK, response)
-}
-
-func forceGraphReasoningTenant(ctx context.Context, request *graphagent.AskRequest) error {
-	if request == nil {
-		return nil
-	}
-	requestedTenantID := strings.TrimSpace(request.TenantID)
-	auth, ok := ctx.Value(authContextKey{}).(authContext)
-	if !ok {
-		request.TenantID = requestedTenantID
-		return nil
-	}
-	tenantID := strings.TrimSpace(auth.principal.TenantID)
-	if tenantID == "" {
-		return errTenantForbidden
-	}
-	if requestedTenantID != "" && requestedTenantID != tenantID {
-		recordAccessAuditRequestedTenant(ctx, requestedTenantID)
-		return errTenantForbidden
-	}
-	request.TenantID = tenantID
-	return authorizeTenantID(ctx, tenantID)
 }
 
 func (a *App) newGraphReasoningService() (*graphagent.Service, error) {

--- a/internal/bootstrap/agent_graph_reasoning_test.go
+++ b/internal/bootstrap/agent_graph_reasoning_test.go
@@ -63,6 +63,12 @@ LIMIT 25`,
 	if response.Provenance.Surface != "graph-reasoning" || response.Provenance.CitationStatus != "valid" {
 		t.Fatalf("provenance = %#v, want valid graph reasoning provenance", response.Provenance)
 	}
+	if response.Preflight == nil || !response.Preflight.Enabled {
+		t.Fatalf("preflight = %#v, want enabled graph reasoning preflight", response.Preflight)
+	}
+	if response.Preflight.TenantID != "writer" || len(response.Provenance.PolicyChecks) == 0 {
+		t.Fatalf("preflight/provenance = preflight:%#v provenance:%#v", response.Preflight, response.Provenance)
+	}
 }
 
 func TestHandleAgentPlatformGraphReasonRejectsTenantOverride(t *testing.T) {

--- a/internal/bootstrap/agent_platform.go
+++ b/internal/bootstrap/agent_platform.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -28,6 +29,15 @@ func (a *App) handleAgentPlatformCapabilityDecision(w http.ResponseWriter, r *ht
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
+	resolved, err := resolveAgentPlatformRequestContext(r.Context(), request.TenantID, request.ActorID, request.RequestedScopes)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return
+	}
+	request.TenantID = resolved.TenantID
+	request.ActorID = resolved.ActorID
+	request.RequestedScopes = resolved.RequestedScopes
+	request.ScopeUnrestricted = resolved.ScopeUnrestricted
 	if strings.TrimSpace(request.CapabilityID) == "" {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
@@ -38,6 +48,32 @@ func (a *App) handleAgentPlatformCapabilityDecision(w http.ResponseWriter, r *ht
 		return
 	}
 	writeJSON(w, http.StatusOK, decision)
+}
+
+func (a *App) handleAgentPlatformPreflight(w http.ResponseWriter, r *http.Request) {
+	var request agentplatform.AgentRunPreflightRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxProtoJSONBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	resolved, err := resolveAgentPlatformRequestContext(r.Context(), request.TenantID, request.ActorID, request.RequestedScopes)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return
+	}
+	request.TenantID = resolved.TenantID
+	request.ActorID = resolved.ActorID
+	request.RequestedScopes = resolved.RequestedScopes
+	request.ScopeUnrestricted = resolved.ScopeUnrestricted
+	if request.ScopeURN != "" {
+		if err := authorizeCerebroURNTenant(r.Context(), request.ScopeURN); err != nil {
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, agentplatform.PreflightAgentRun(request))
 }
 
 func agentPlatformCapabilityFilterFromRequest(r *http.Request) (agentplatform.CapabilityRegistryFilter, error) {
@@ -56,4 +92,53 @@ func agentPlatformCapabilityFilterFromRequest(r *http.Request) (agentplatform.Ca
 		filter.DefaultOn = &value
 	}
 	return filter, nil
+}
+
+type agentPlatformResolvedContext struct {
+	TenantID          string
+	ActorID           string
+	RequestedScopes   []string
+	ScopeUnrestricted bool
+	Authenticated     bool
+}
+
+func resolveAgentPlatformRequestContext(ctx context.Context, requestedTenantID string, requestedActorID string, requestedScopes []string) (agentPlatformResolvedContext, error) {
+	resolved := agentPlatformResolvedContext{
+		TenantID:        strings.TrimSpace(requestedTenantID),
+		ActorID:         strings.TrimSpace(requestedActorID),
+		RequestedScopes: append([]string(nil), requestedScopes...),
+	}
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	if !ok {
+		return resolved, nil
+	}
+	resolved.Authenticated = true
+	tenantID := strings.TrimSpace(auth.principal.TenantID)
+	if tenantID == "" {
+		return agentPlatformResolvedContext{}, errTenantForbidden
+	}
+	if resolved.TenantID != "" && resolved.TenantID != tenantID {
+		recordAccessAuditRequestedTenant(ctx, resolved.TenantID)
+		return agentPlatformResolvedContext{}, errTenantForbidden
+	}
+	resolved.TenantID = tenantID
+	resolved.ActorID = agentPlatformPrincipalActorID(auth.principal, resolved.ActorID)
+	if principalScopeRestricted(auth.principal) {
+		resolved.RequestedScopes = append([]string(nil), auth.principal.Scopes...)
+		resolved.ScopeUnrestricted = false
+	} else {
+		resolved.RequestedScopes = nil
+		resolved.ScopeUnrestricted = true
+	}
+	return resolved, authorizeTenantID(ctx, tenantID)
+}
+
+func agentPlatformPrincipalActorID(principal authPrincipal, fallback string) string {
+	for _, value := range []string{principal.Name, principal.ClientID, principal.DeviceID, principal.CredentialID} {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return strings.TrimSpace(fallback)
 }

--- a/internal/bootstrap/agent_platform_test.go
+++ b/internal/bootstrap/agent_platform_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/writer/cerebro/internal/agentplatform"
+	"github.com/writer/cerebro/internal/config"
 )
 
 func TestHandleAgentPlatformContract(t *testing.T) {
@@ -93,6 +95,99 @@ func TestHandleAgentPlatformCapabilityDecision(t *testing.T) {
 	}
 }
 
+func TestAgentPlatformCapabilityDecisionForcesAuthenticatedTenantAndScopes(t *testing.T) {
+	app := New(agentPlatformAuthConfig(), Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent-platform/capability-decisions", bytes.NewReader([]byte(`{
+		"capability_id": "graph-reasoning",
+		"tenant_id": "writer",
+		"actor_id": "body-actor",
+		"requested_scopes": ["not.real"]
+	}`)))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST capability decision: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var decision agentplatform.CapabilityDecision
+	if err := json.NewDecoder(resp.Body).Decode(&decision); err != nil {
+		t.Fatalf("decode decision: %v", err)
+	}
+	if !decision.Enabled {
+		t.Fatalf("decision enabled = false, blockers = %+v", decision.Blockers)
+	}
+	if decision.TenantID != "writer" || decision.ActorID != "tester" {
+		t.Fatalf("decision context = %+v, want authenticated tenant/actor", decision)
+	}
+
+	overrideReq, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent-platform/capability-decisions", bytes.NewReader([]byte(`{
+		"capability_id": "graph-reasoning",
+		"tenant_id": "other",
+		"requested_scopes": ["cosmo.security.read"]
+	}`)))
+	if err != nil {
+		t.Fatalf("NewRequest override: %v", err)
+	}
+	overrideReq.Header.Set("Authorization", "Bearer test-key")
+	overrideReq.Header.Set("Content-Type", "application/json")
+	overrideResp, err := server.Client().Do(overrideReq)
+	if err != nil {
+		t.Fatalf("POST override capability decision: %v", err)
+	}
+	defer func() { _ = overrideResp.Body.Close() }()
+	if overrideResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("override status = %d, want 403", overrideResp.StatusCode)
+	}
+}
+
+func TestHandleAgentPlatformPreflight(t *testing.T) {
+	app := New(agentPlatformAuthConfig(), Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent-platform/preflight", bytes.NewReader([]byte(`{
+		"capability_ids": ["graph-reasoning"],
+		"question": "What should I inspect?",
+		"scope_urn": "urn:cerebro:writer:asset:prod-db"
+	}`)))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST preflight: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var preflight agentplatform.AgentRunPreflight
+	if err := json.NewDecoder(resp.Body).Decode(&preflight); err != nil {
+		t.Fatalf("decode preflight: %v", err)
+	}
+	if !preflight.Enabled || preflight.TenantID != "writer" || preflight.ActorID != "tester" {
+		t.Fatalf("preflight = %+v, want enabled authenticated context", preflight)
+	}
+	if preflight.GraphContext.ScopeTenantID != "writer" || !preflight.WriteBack.Required {
+		t.Fatalf("preflight graph/write-back = graph:%+v write:%+v", preflight.GraphContext, preflight.WriteBack)
+	}
+	if len(preflight.Policy.Checks) == 0 || len(preflight.CapabilityDecisions) != 1 {
+		t.Fatalf("preflight missing policy/capability context: %+v", preflight)
+	}
+}
+
 func TestHandleAgentPlatformCapabilityDecisionReportsUnknownCapability(t *testing.T) {
 	body := []byte(`{"capability_id":"missing-capability","requested_scopes":["cosmo.security.read"]}`)
 	recorder := httptest.NewRecorder()
@@ -102,5 +197,23 @@ func TestHandleAgentPlatformCapabilityDecisionReportsUnknownCapability(t *testin
 
 	if recorder.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", recorder.Code)
+	}
+}
+
+func agentPlatformAuthConfig() config.Config {
+	return config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APICredentials: []config.APICredential{{
+				ID:        "test-credential",
+				ClientID:  "test-client",
+				Key:       "test-key",
+				Principal: "tester",
+				TenantID:  "writer",
+				Scopes:    []string{scopeCosmoSecurityRead},
+			}},
+		},
 	}
 }

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -28,6 +28,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/contract", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/capabilities", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/capability-decisions", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/preflight", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/graph/reason", Scope: scopeCosmoSecurityRead, Static: true},
 	{Exact: "/api/v1/mcp", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/metrics", Scope: scopeCosmoSecurityRead, Static: true},

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -1464,6 +1464,8 @@ func grcHTTPStatusCode(err error) int {
 	switch {
 	case errors.Is(err, errTenantForbidden):
 		statusCode = http.StatusForbidden
+	case errors.Is(err, errScopeForbidden):
+		statusCode = http.StatusForbidden
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound),
 		errors.Is(err, ports.ErrFindingNotFound),
 		errors.Is(err, ports.ErrFindingEvidenceNotFound),

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/agentplatform"
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/connectordefinitions"
 	findingdomain "github.com/writer/cerebro/internal/findings"
@@ -573,6 +574,8 @@ func (app *App) mcpToolStructuredContent(r *http.Request, name string, args map[
 		return app.mcpGraphImpact(r, args)
 	case "cerebro.graph.paths":
 		return app.mcpGraphPaths(r, args)
+	case "cerebro.agent.preflight":
+		return app.mcpAgentPreflight(r, args)
 	case "cerebro.graph.reason":
 		return app.mcpGraphReason(r, args)
 	case "cerebro.investigation.context":
@@ -1445,14 +1448,31 @@ func (app *App) mcpGraphReason(r *http.Request, args map[string]any) (any, error
 		ScopeURN: mcpStringArg(args, "scope_urn"),
 		Model:    mcpStringArg(args, "model"),
 	}
-	if err := forceGraphReasoningTenant(r.Context(), &request); err != nil {
+	resolved, err := resolveAgentPlatformRequestContext(r.Context(), request.TenantID, "", nil)
+	if err != nil {
 		return nil, err
 	}
+	request.TenantID = resolved.TenantID
 	if request.ScopeURN != "" {
 		if err := authorizeCerebroURNTenant(r.Context(), request.ScopeURN); err != nil {
 			return nil, mcpNormalizeIDLookupError(err, ports.ErrGraphEntityNotFound)
 		}
 	}
+	preflight := agentplatform.PreflightAgentRun(agentplatform.AgentRunPreflightRequest{
+		TenantID:              request.TenantID,
+		ActorID:               resolved.ActorID,
+		CapabilityIDs:         []string{agentplatform.DefaultAgentRunCapabilityID},
+		Question:              request.Question,
+		ScopeURN:              request.ScopeURN,
+		Model:                 request.Model,
+		RequestedScopes:       resolved.RequestedScopes,
+		ScopeUnrestricted:     resolved.ScopeUnrestricted || !resolved.Authenticated,
+		ProvenanceRequirement: "graph-reasoning",
+	})
+	if !preflight.Enabled {
+		return nil, errScopeForbidden
+	}
+	request.PlatformContext = &preflight
 	if err := graphagent.ValidateRequest(request); err != nil {
 		return nil, err
 	}
@@ -1472,6 +1492,43 @@ func (app *App) mcpGraphReason(r *http.Request, args map[string]any) (any, error
 	if typed, ok := value.(map[string]any); ok {
 		rows = mcpMapArrayCount(typed, "rows")
 		return mcpAddResponseMetadata(typed, mcpResponseMetadata(0, rows, nil)), nil
+	}
+	return value, nil
+}
+
+func (app *App) mcpAgentPreflight(r *http.Request, args map[string]any) (any, error) {
+	request := agentplatform.AgentRunPreflightRequest{
+		TenantID:              mcpStringArg(args, "tenant_id"),
+		ActorID:               mcpStringArg(args, "actor_id"),
+		CapabilityIDs:         mcpStringListArg(args, "capability_ids"),
+		Question:              mcpStringArg(args, "question"),
+		ScopeURN:              mcpStringArg(args, "scope_urn"),
+		Model:                 mcpStringArg(args, "model"),
+		RequestedScopes:       mcpStringListArg(args, "requested_scopes"),
+		ConnectorReadiness:    mcpStringMapArg(args, "connector_readiness"),
+		AllowPreview:          mcpBoolArg(args, "allow_preview"),
+		SelectionReason:       mcpStringArg(args, "selection_reason"),
+		ProvenanceRequirement: mcpStringArg(args, "provenance_requirement"),
+	}
+	resolved, err := resolveAgentPlatformRequestContext(r.Context(), request.TenantID, request.ActorID, request.RequestedScopes)
+	if err != nil {
+		return nil, err
+	}
+	request.TenantID = resolved.TenantID
+	request.ActorID = resolved.ActorID
+	request.RequestedScopes = resolved.RequestedScopes
+	request.ScopeUnrestricted = resolved.ScopeUnrestricted
+	if request.ScopeURN != "" {
+		if err := authorizeCerebroURNTenant(r.Context(), request.ScopeURN); err != nil {
+			return nil, mcpNormalizeIDLookupError(err, ports.ErrGraphEntityNotFound)
+		}
+	}
+	value, err := jsonValue(agentplatform.PreflightAgentRun(request))
+	if err != nil {
+		return nil, err
+	}
+	if typed, ok := value.(map[string]any); ok {
+		return mcpAddResponseMetadata(typed, mcpResponseMetadata(0, mcpMapArrayCount(typed, "capability_decisions"), nil)), nil
 	}
 	return value, nil
 }
@@ -1929,6 +1986,37 @@ func mcpTools() []mcpTool {
 			Annotations:  mcpReadOnlyAnnotations("Graph Attack Paths"),
 		},
 		{
+			Name:        "cerebro.agent.preflight",
+			Title:       "Agent Run Preflight",
+			Description: "Resolve tenant-scoped capability, graph, connector, policy, and write-back preconditions before an agent plans work.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"capability_ids": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				"question":       map[string]any{"type": "string"},
+				"scope_urn":      map[string]any{"type": "string"},
+				"model":          map[string]any{"type": "string"},
+				"connector_readiness": map[string]any{
+					"type":                 "object",
+					"additionalProperties": map[string]any{"type": "string"},
+				},
+				"allow_preview":          map[string]any{"type": "boolean"},
+				"selection_reason":       map[string]any{"type": "string"},
+				"provenance_requirement": map[string]any{"type": "string"},
+			}, nil),
+			OutputSchema: mcpOutputSchema(map[string]any{
+				"tenant_id":            map[string]any{"type": "string"},
+				"enabled":              map[string]any{"type": "boolean"},
+				"blockers":             map[string]any{"type": "array"},
+				"capability_decisions": map[string]any{"type": "array"},
+				"graph_context":        map[string]any{"type": "object"},
+				"connector_context":    map[string]any{"type": "array"},
+				"policy":               map[string]any{"type": "object"},
+				"write_back":           map[string]any{"type": "object"},
+				"runtime_events":       map[string]any{"type": "array"},
+				"provenance":           map[string]any{"type": "array"},
+			}),
+			Annotations: mcpReadOnlyAnnotations("Agent Run Preflight"),
+		},
+		{
 			Name:        "cerebro.graph.reason",
 			Title:       "Graph Reasoning",
 			Description: "Answer a tenant-scoped graph question with query plan, guarded Cypher, rows, graph evidence, citations, and provenance.",
@@ -1946,6 +2034,7 @@ func mcpTools() []mcpTool {
 				"answer_markdown":     map[string]any{"type": "string"},
 				"citations":           map[string]any{"type": "array"},
 				"citation_validation": map[string]any{"type": "object"},
+				"preflight":           map[string]any{"type": "object"},
 				"provenance":          map[string]any{"type": "object"},
 			}),
 			Annotations: mcpReadOnlyAnnotations("Graph Reasoning"),
@@ -3279,6 +3368,57 @@ func mcpRuntimeIDsArg(args map[string]any) []string {
 		values = append(values, splitMCPStringList(mcpAnyString(typed))...)
 	}
 	return normalizeMCPStringList(values)
+}
+
+func mcpStringListArg(args map[string]any, key string) []string {
+	raw, ok := args[key]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch typed := raw.(type) {
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			values = append(values, mcpAnyString(item))
+		}
+		return normalizeMCPStringList(values)
+	case []string:
+		return normalizeMCPStringList(typed)
+	case string:
+		return normalizeMCPStringList(splitMCPStringList(typed))
+	default:
+		return normalizeMCPStringList(splitMCPStringList(mcpAnyString(typed)))
+	}
+}
+
+func mcpStringMapArg(args map[string]any, key string) map[string]string {
+	raw, ok := args[key]
+	if !ok || raw == nil {
+		return nil
+	}
+	out := map[string]string{}
+	switch typed := raw.(type) {
+	case map[string]any:
+		for itemKey, itemValue := range typed {
+			itemKey = strings.TrimSpace(itemKey)
+			itemString := strings.TrimSpace(mcpAnyString(itemValue))
+			if itemKey != "" && itemString != "" {
+				out[itemKey] = itemString
+			}
+		}
+	case map[string]string:
+		for itemKey, itemValue := range typed {
+			itemKey = strings.TrimSpace(itemKey)
+			itemValue = strings.TrimSpace(itemValue)
+			if itemKey != "" && itemValue != "" {
+				out[itemKey] = itemValue
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func splitMCPStringList(value string) []string {

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -144,6 +144,7 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 		"cerebro.graph.neighborhood",
 		"cerebro.graph.impact",
 		"cerebro.graph.paths",
+		"cerebro.agent.preflight",
 		"cerebro.graph.reason",
 		"cerebro.investigation.context",
 		"cerebro.findings.action.propose",
@@ -204,6 +205,7 @@ var mcpToolDomainSurfaceContracts = map[string]mcpToolDomainSurfaceContract{
 	"cerebro.graph.neighborhood":              {Markers: []string{"GET /platform/graph/neighborhood"}},
 	"cerebro.graph.impact":                    {Markers: []string{"GET /platform/graph/impact"}},
 	"cerebro.graph.paths":                     {Markers: []string{"GET /platform/graph/attack-paths"}},
+	"cerebro.agent.preflight":                 {Markers: []string{"POST /api/v1/agent-platform/preflight"}},
 	"cerebro.graph.reason":                    {Markers: []string{"POST /api/v1/agent-platform/graph/reason"}},
 	"cerebro.investigation.context":           {Markers: []string{"GET /findings/{findingID}", "GET /source-runtimes/{runtimeID}/finding-evidence", "GET /platform/graph/neighborhood"}},
 	"cerebro.findings.action.propose":         {Markers: []string{"POST /findings/{findingID}/resolve", "POST /findings/{findingID}/suppress", "POST /findings/{findingID}/notes", "POST /findings/{findingID}/tickets"}},
@@ -1887,6 +1889,14 @@ LIMIT 25`,
 	if provenance["surface"] != "graph-reasoning" || provenance["citation_status"] != "valid" {
 		t.Fatalf("graph.reason provenance = %#v", provenance)
 	}
+	preflight := content["preflight"].(map[string]any)
+	if preflight["tenant_id"] != "writer" || preflight["enabled"] != true {
+		t.Fatalf("graph.reason preflight = %#v", preflight)
+	}
+	preflightPolicy := preflight["policy"].(map[string]any)
+	if preflightPolicy["passing"] != true {
+		t.Fatalf("graph.reason preflight policy = %#v", preflightPolicy)
+	}
 	if content["tenant_id"] != "writer" {
 		t.Fatalf("graph.reason tenant_id = %#v, want authenticated tenant writer", content["tenant_id"])
 	}
@@ -1910,6 +1920,57 @@ LIMIT 25`,
 	overrideResult := overrideResponse["result"].(map[string]any)
 	if overrideResult["isError"] != true || !strings.Contains(overrideResult["content"].([]any)[0].(map[string]any)["text"].(string), "tenant forbidden") {
 		t.Fatalf("graph.reason tenant override response = %#v", overrideResponse)
+	}
+}
+
+func TestMCPAgentPreflight(t *testing.T) {
+	server := newMCPTestServerWithGraphReasoning(t, &stubRuntimeStore{}, &stubGraphStore{}, graphagent.NewStubLLMClient())
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.agent.preflight",
+			"arguments": map[string]any{
+				"capability_ids": []any{"graph-reasoning"},
+				"question":       "What should I inspect?",
+				"scope_urn":      "urn:cerebro:writer:asset:prod-db",
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("agent.preflight error = %#v", response["error"])
+	}
+	content := response["result"].(map[string]any)["structuredContent"].(map[string]any)
+	if content["tenant_id"] != "writer" || content["enabled"] != true {
+		t.Fatalf("agent.preflight content = %#v", content)
+	}
+	graphContext := content["graph_context"].(map[string]any)
+	if graphContext["scope_tenant_id"] != "writer" || graphContext["read_only"] != true {
+		t.Fatalf("agent.preflight graph_context = %#v", graphContext)
+	}
+	writeBack := content["write_back"].(map[string]any)
+	if writeBack["required"] != true || writeBack["trace_id_required"] != true {
+		t.Fatalf("agent.preflight write_back = %#v", writeBack)
+	}
+
+	overrideResponse, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.agent.preflight",
+			"arguments": map[string]any{
+				"tenant_id":      "other",
+				"capability_ids": []any{"graph-reasoning"},
+			},
+		},
+	})
+	overrideResult := overrideResponse["result"].(map[string]any)
+	if overrideResult["isError"] != true || !strings.Contains(overrideResult["content"].([]any)[0].(map[string]any)["text"].(string), "tenant forbidden") {
+		t.Fatalf("agent.preflight tenant override response = %#v", overrideResponse)
 	}
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -56,6 +56,7 @@ func (app *App) registerAgentPlatformRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/contract", routeSurfacePlatformHTTP, app.handleAgentPlatformContract)
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/capabilities", routeSurfacePlatformHTTP, app.handleAgentPlatformCapabilities)
 	registerHTTPRoute(mux, "POST /api/v1/agent-platform/capability-decisions", routeSurfacePlatformHTTP, app.handleAgentPlatformCapabilityDecision)
+	registerHTTPRoute(mux, "POST /api/v1/agent-platform/preflight", routeSurfacePlatformHTTP, app.handleAgentPlatformPreflight)
 	registerHTTPRoute(mux, "POST /api/v1/agent-platform/graph/reason", routeSurfacePlatformHTTP, app.handleAgentPlatformGraphReason)
 }
 

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/writer/cerebro/internal/agentplatform"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -31,11 +32,12 @@ const (
 var summaryURNPattern = regexp.MustCompile(`urn:cerebro:[A-Za-z0-9_:@./#%+-]+`)
 
 type AskRequest struct {
-	TenantID string           `json:"tenant_id"`
-	Question string           `json:"question"`
-	ScopeURN string           `json:"scope_urn,omitempty"`
-	Model    string           `json:"model,omitempty"`
-	History  []HistoryMessage `json:"history,omitempty"`
+	TenantID        string                           `json:"tenant_id"`
+	Question        string                           `json:"question"`
+	ScopeURN        string                           `json:"scope_urn,omitempty"`
+	Model           string                           `json:"model,omitempty"`
+	History         []HistoryMessage                 `json:"history,omitempty"`
+	PlatformContext *agentplatform.AgentRunPreflight `json:"-"`
 }
 
 type Emitter func(Event) error

--- a/internal/graphagent/reason.go
+++ b/internal/graphagent/reason.go
@@ -5,38 +5,44 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/writer/cerebro/internal/agentplatform"
 	"github.com/writer/cerebro/internal/ports"
 )
 
 type ReasonResponse struct {
-	TraceID            string                    `json:"trace_id,omitempty"`
-	Question           string                    `json:"question"`
-	TenantID           string                    `json:"tenant_id"`
-	ScopeURN           string                    `json:"scope_urn,omitempty"`
-	Model              string                    `json:"model"`
-	Rationale          string                    `json:"rationale,omitempty"`
-	Probe              *GraphProbe               `json:"probe,omitempty"`
-	QueryPlan          *QueryPlanEvent           `json:"query_plan,omitempty"`
-	Cypher             *CypherEvent              `json:"cypher,omitempty"`
-	Recovery           []RecoveryEvent           `json:"recovery,omitempty"`
-	Rows               []map[string]any          `json:"rows"`
-	Graph              *ports.EntityNeighborhood `json:"graph,omitempty"`
-	AnswerMarkdown     string                    `json:"answer_markdown,omitempty"`
-	Citations          []Citation                `json:"citations"`
-	CitationValidation *CitationValidation       `json:"citation_validation,omitempty"`
-	UnsupportedQuery   *UnsupportedQuery         `json:"unsupported_query,omitempty"`
-	Progress           []ProgressEvent           `json:"progress,omitempty"`
-	Timings            StageTimings              `json:"timings,omitempty"`
-	Provenance         ReasonProvenance          `json:"provenance"`
+	TraceID            string                           `json:"trace_id,omitempty"`
+	Question           string                           `json:"question"`
+	TenantID           string                           `json:"tenant_id"`
+	ScopeURN           string                           `json:"scope_urn,omitempty"`
+	Model              string                           `json:"model"`
+	Rationale          string                           `json:"rationale,omitempty"`
+	Probe              *GraphProbe                      `json:"probe,omitempty"`
+	QueryPlan          *QueryPlanEvent                  `json:"query_plan,omitempty"`
+	Cypher             *CypherEvent                     `json:"cypher,omitempty"`
+	Recovery           []RecoveryEvent                  `json:"recovery,omitempty"`
+	Rows               []map[string]any                 `json:"rows"`
+	Graph              *ports.EntityNeighborhood        `json:"graph,omitempty"`
+	AnswerMarkdown     string                           `json:"answer_markdown,omitempty"`
+	Citations          []Citation                       `json:"citations"`
+	CitationValidation *CitationValidation              `json:"citation_validation,omitempty"`
+	UnsupportedQuery   *UnsupportedQuery                `json:"unsupported_query,omitempty"`
+	Progress           []ProgressEvent                  `json:"progress,omitempty"`
+	Timings            StageTimings                     `json:"timings,omitempty"`
+	Preflight          *agentplatform.AgentRunPreflight `json:"preflight,omitempty"`
+	Provenance         ReasonProvenance                 `json:"provenance"`
 }
 
 type ReasonProvenance struct {
-	Surface        string   `json:"surface"`
-	TraceID        string   `json:"trace_id,omitempty"`
-	SourceURNs     []string `json:"source_urns,omitempty"`
-	Scope          string   `json:"scope,omitempty"`
-	CitationStatus string   `json:"citation_status"`
-	FallbackReason string   `json:"fallback_reason,omitempty"`
+	Surface           string   `json:"surface"`
+	TraceID           string   `json:"trace_id,omitempty"`
+	SourceURNs        []string `json:"source_urns,omitempty"`
+	Scope             string   `json:"scope,omitempty"`
+	CitationStatus    string   `json:"citation_status"`
+	FallbackReason    string   `json:"fallback_reason,omitempty"`
+	CapabilityIDs     []string `json:"capability_ids,omitempty"`
+	PolicyChecks      []string `json:"policy_checks,omitempty"`
+	ConnectorNodeURNs []string `json:"connector_node_urns,omitempty"`
+	WriteBackEvents   []string `json:"write_back_events,omitempty"`
 }
 
 func (s *Service) Reason(ctx context.Context, request AskRequest) (*ReasonResponse, error) {
@@ -47,11 +53,21 @@ func (s *Service) Reason(ctx context.Context, request AskRequest) (*ReasonRespon
 		Model:     normalizeModel(request.Model),
 		Rows:      []map[string]any{},
 		Citations: []Citation{},
+		Preflight: request.PlatformContext,
 		Provenance: ReasonProvenance{
 			Surface:        "graph-reasoning",
 			Scope:          reasonScope(request),
 			CitationStatus: "not_applicable",
 		},
+	}
+	if request.PlatformContext != nil {
+		response.Provenance.CapabilityIDs = cloneStrings(request.PlatformContext.SelectedCapabilities)
+		response.Provenance.PolicyChecks = preflightPolicyCheckIDs(request.PlatformContext.Policy.Checks)
+		response.Provenance.ConnectorNodeURNs = preflightConnectorNodeURNs(request.PlatformContext.ConnectorContext)
+		response.Provenance.WriteBackEvents = cloneStrings(request.PlatformContext.WriteBack.RequiredEvents)
+		if scope := strings.TrimSpace(request.PlatformContext.GraphContext.ScopeURN); scope != "" {
+			response.Provenance.Scope = scope
+		}
 	}
 	err := s.Stream(ctx, request, func(event Event) error {
 		response.observe(event)
@@ -64,6 +80,35 @@ func (s *Service) Reason(ctx context.Context, request AskRequest) (*ReasonRespon
 		response.Provenance.CitationStatus = "missing"
 	}
 	return response, err
+}
+
+func preflightPolicyCheckIDs(checks []agentplatform.AgentPolicyCheck) []string {
+	ids := make([]string, 0, len(checks))
+	for _, check := range checks {
+		if check.ID != "" {
+			ids = append(ids, check.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func preflightConnectorNodeURNs(nodes []agentplatform.AgentConnectorGraphNode) []string {
+	urns := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if node.NodeURN != "" {
+			urns = append(urns, node.NodeURN)
+		}
+		if node.OAuthNodeURN != "" {
+			urns = append(urns, node.OAuthNodeURN)
+		}
+	}
+	sort.Strings(urns)
+	return urns
+}
+
+func cloneStrings(values []string) []string {
+	return append([]string(nil), values...)
 }
 
 func reasonScope(request AskRequest) string {

--- a/internal/graphagent/reason_test.go
+++ b/internal/graphagent/reason_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/writer/cerebro/internal/agentplatform"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -33,10 +34,19 @@ LIMIT 25`,
 		EnableGraphProbes: true,
 	})
 
+	preflight := agentplatform.PreflightAgentRun(agentplatform.AgentRunPreflightRequest{
+		TenantID:        "writer",
+		ActorID:         "tester",
+		CapabilityIDs:   []string{"graph-reasoning"},
+		RequestedScopes: []string{"cosmo.security.read"},
+		Question:        "Which scoped asset should I review?",
+		ScopeURN:        "urn:cerebro:writer:asset:alpha",
+	})
 	response, err := service.Reason(context.Background(), AskRequest{
-		TenantID: "writer",
-		Question: "Which scoped asset should I review?",
-		ScopeURN: "urn:cerebro:writer:asset:alpha",
+		TenantID:        "writer",
+		Question:        "Which scoped asset should I review?",
+		ScopeURN:        "urn:cerebro:writer:asset:alpha",
+		PlatformContext: &preflight,
 	})
 	if err != nil {
 		t.Fatalf("Reason() error = %v", err)
@@ -73,6 +83,15 @@ LIMIT 25`,
 	}
 	if len(response.Provenance.SourceURNs) != 1 || response.Provenance.SourceURNs[0] != "urn:cerebro:writer:asset:alpha" {
 		t.Fatalf("source urns = %#v", response.Provenance.SourceURNs)
+	}
+	if response.Preflight == nil || !response.Preflight.Enabled {
+		t.Fatalf("preflight = %#v, want enabled preflight context", response.Preflight)
+	}
+	if len(response.Provenance.CapabilityIDs) != 1 || response.Provenance.CapabilityIDs[0] != "graph-reasoning" {
+		t.Fatalf("provenance capability ids = %#v", response.Provenance.CapabilityIDs)
+	}
+	if len(response.Provenance.PolicyChecks) == 0 || len(response.Provenance.WriteBackEvents) == 0 {
+		t.Fatalf("provenance missing policy/write-back trail: %#v", response.Provenance)
 	}
 }
 

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const bootstrapProductionGoLineBudget = 21937
+const bootstrapProductionGoLineBudget = 22161
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- add a tenant-forced agent run preflight contract that composes capability gates, graph scope, connector/OAuth nodes, policy checks, and write-back requirements
- expose preflight over HTTP and MCP, and attach the preflight envelope/provenance trail to graph reasoning responses
- force authenticated tenant/scope context into agent-platform decisions and document the bootstrap mapping budget

## Validation
- go test ./internal/agentplatform ./internal/graphagent ./internal/bootstrap
- go test ./...
- make openapi-check openapi-lint
- make lint
- git diff --check