### PR TITLE
Normalize graph preflight tenant errors

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,7 +74,9 @@ domain package.
 The agent platform graph preflight contract lives in `internal/agentplatform`.
 The bootstrap budget includes the HTTP and MCP request/response mapping needed
 to force authenticated tenant context, expose preflight to agents, and attach
-that preflight envelope to graph reasoning responses.
+that preflight envelope to graph reasoning responses. Bootstrap also maps
+preflight tenant-required blockers into the graph reasoning boundary's
+invalid-request error shape.
 
 ## Postgres migrations
 

--- a/internal/bootstrap/agent_graph_reasoning.go
+++ b/internal/bootstrap/agent_graph_reasoning.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/writer/cerebro/internal/agentplatform"
@@ -41,7 +42,7 @@ func (a *App) handleAgentPlatformGraphReason(w http.ResponseWriter, r *http.Requ
 		ProvenanceRequirement: "graph-reasoning",
 	})
 	if !preflight.Enabled {
-		writeGRCError(w, errScopeForbidden)
+		writeGRCError(w, agentPreflightDeniedError(preflight))
 		return
 	}
 	request.PlatformContext = &preflight
@@ -65,4 +66,13 @@ func (a *App) handleAgentPlatformGraphReason(w http.ResponseWriter, r *http.Requ
 
 func (a *App) newGraphReasoningService() (*graphagent.Service, error) {
 	return newGraphReasoningFeatureService(newGraphReasoningFeatureDeps(a.deps))
+}
+
+func agentPreflightDeniedError(preflight agentplatform.AgentRunPreflight) error {
+	for _, blocker := range preflight.Blockers {
+		if blocker.Code == "tenant_required" {
+			return fmt.Errorf("%w: tenant_id is required", graphagent.ErrInvalidRequest)
+		}
+	}
+	return errScopeForbidden
 }

--- a/internal/bootstrap/agent_graph_reasoning_test.go
+++ b/internal/bootstrap/agent_graph_reasoning_test.go
@@ -86,6 +86,31 @@ func TestHandleAgentPlatformGraphReasonRejectsTenantOverride(t *testing.T) {
 	}
 }
 
+func TestHandleAgentPlatformGraphReasonMissingTenantWithoutAuthIsBadRequest(t *testing.T) {
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{
+		GraphStore:    &stubGraphStore{},
+		GraphAgentLLM: graphagent.NewStubLLMClient(),
+	}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Post(
+		server.URL+"/api/v1/agent-platform/graph/reason",
+		"application/json",
+		strings.NewReader(`{"question":"hello"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST graph reason error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
 func TestHandleAgentPlatformGraphReasonRequiresLLM(t *testing.T) {
 	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: &stubGraphStore{}}, nil)
 	server := httptest.NewServer(app.Handler())

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -1470,7 +1470,7 @@ func (app *App) mcpGraphReason(r *http.Request, args map[string]any) (any, error
 		ProvenanceRequirement: "graph-reasoning",
 	})
 	if !preflight.Enabled {
-		return nil, errScopeForbidden
+		return nil, agentPreflightDeniedError(preflight)
 	}
 	request.PlatformContext = &preflight
 	if err := graphagent.ValidateRequest(request); err != nil {
@@ -3610,6 +3610,7 @@ func safeMCPToolError(err error) string {
 	case errors.Is(err, errTenantForbidden):
 		return "tenant forbidden"
 	case errors.Is(err, errInvalidHTTPRequest),
+		errors.Is(err, graphagent.ErrInvalidRequest),
 		errors.Is(err, graphquery.ErrInvalidRequest),
 		errors.Is(err, sourceruntime.ErrInvalidRequest),
 		errors.Is(err, findingdomain.ErrInvalidRequest):

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -1923,6 +1923,36 @@ LIMIT 25`,
 	}
 }
 
+func TestMCPGraphReasonMissingTenantWithoutAuthReportsInvalidRequest(t *testing.T) {
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{
+		StateStore:    &stubRuntimeStore{},
+		GraphStore:    &stubGraphStore{},
+		GraphAgentLLM: graphagent.NewStubLLMClient(),
+	}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	response, _ := postMCPWithoutAuth(t, server, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.graph.reason",
+			"arguments": map[string]any{
+				"question": "Which asset should I review first?",
+			},
+		},
+	})
+	result := response["result"].(map[string]any)
+	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	if result["isError"] != true || !strings.Contains(text, "tenant_id is required") || strings.Contains(text, "scope forbidden") {
+		t.Fatalf("graph.reason missing tenant response = %#v", response)
+	}
+}
+
 func TestMCPAgentPreflight(t *testing.T) {
 	server := newMCPTestServerWithGraphReasoning(t, &stubRuntimeStore{}, &stubGraphStore{}, graphagent.NewStubLLMClient())
 	defer server.Close()

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const bootstrapProductionGoLineBudget = 22161
+const bootstrapProductionGoLineBudget = 22172
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- map graph preflight tenant-required blockers to invalid-request responses instead of forbidden responses
- make MCP graph reasoning surface graph-agent validation errors clearly
- add HTTP and MCP regression tests for auth-disabled missing-tenant graph reasoning requests

## Validation
- go test ./internal/bootstrap -run 'TestHandleAgentPlatformGraphReasonMissingTenantWithoutAuthIsBadRequest|TestMCPGraphReasonMissingTenantWithoutAuthReportsInvalidRequest'\n- go test ./internal/bootstrap\n- go test ./...\n- make lint\n- git diff --check