### PR TITLE
Retire graph meta-finding and prefer Panopticon cases

### DIFF
--- a/internal/findings/coordination_graph_rule.go
+++ b/internal/findings/coordination_graph_rule.go
@@ -303,44 +303,30 @@ LIMIT $row_limit`, nil)
 }
 
 func newResourceMultipleOpenFindingsRule() Rule {
-	return newCoordinationGraphRule(RuleDefinition{
+	definition := RuleDefinition{
 		ID:          "graph-resource-multiple-open-findings",
 		Name:        "Graph Resource Has Multiple Open Findings",
-		Description: "Detect resources with multiple active findings so remediation can be coordinated by shared resource rather than by individual alert.",
+		Description: "Retired graph meta-finding retained so stale open findings auto-resolve; multiple open findings on a resource is triage context, not a standalone risk.",
 		SourceID:    "graph",
 		EventKinds:  []string{"finding"},
 		OutputKind:  "finding.graph_resource_multiple_open_findings",
-		Severity:    "HIGH",
-		Status:      findingStatusOpen,
-		Maturity:    "test",
-		Tags:        []string{"finding", "coordination", "graph-rule", "prioritization"},
+		Severity:    "INFO",
+		Status:      "retired",
+		Maturity:    RuleMaturityRetired,
+		Tags:        []string{"finding", "coordination", "graph-rule", "prioritization", "retired", "cleanup"},
 		References:  []string{"https://www.iso.org/standard/27001"},
 		FalsePositives: []string{
-			"Multiple findings may be duplicate projections of one upstream issue until deduplication rules converge.",
+			"Multiple findings on one resource are expected during coordinated remediation and should be modeled as case context rather than a separate finding.",
 		},
-		Runbook:           "Prioritize the shared resource, group the findings by rule and owner, and remediate the common root cause.",
+		Runbook:           "Use the underlying open findings or case context as the remediation queue; this meta-finding no longer emits.",
 		FingerprintFields: []string{"resource_urn"},
 		ControlRefs: []ports.FindingControlRef{
 			{FrameworkName: "SOC 2", ControlID: "CC7.1"},
 			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.7"},
 		},
-	}, nil, `MATCH (resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
-WHERE coalesce(finding.attributes_json, '') CONTAINS '"status":"open"'
-WITH resource, finding
-ORDER BY finding.urn
-WITH resource, collect(DISTINCT finding) AS findings, count(DISTINCT finding) AS finding_count
-WHERE finding_count >= $finding_threshold
-RETURN resource.urn AS primary_urn,
-       resource.label AS primary_label,
-       resource.entity_type AS primary_type,
-       resource.urn AS fingerprint_key,
-       'HIGH' AS severity,
-       'Resource has ' + toString(finding_count) + ' open finding(s)' AS summary,
-       'Coordinate remediation by the shared graph resource' AS action,
-       [resource.urn] AS resource_urns,
-       [f IN findings[0..20] | {urn: f.urn, label: f.label, entity_type: f.entity_type, relation: 'has_finding', attributes_json: coalesce(f.attributes_json, '')}] AS evidence
-ORDER BY finding_count DESC, resource.urn
-LIMIT $row_limit`, map[string]any{"finding_threshold": int64(coordinationGraphConcentrationMinimum)})
+		Lifecycle: Lifecycle{Kind: LifecycleRetired, Anchor: AnchorNone},
+	}
+	return newCoordinationGraphRule(definition, nil, "", nil)
 }
 
 func newCoordinationGraphRule(definition RuleDefinition, families map[string][]string, query string, params map[string]any) Rule {
@@ -410,6 +396,9 @@ func (r *coordinationGraphRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports
 	if r == nil || runtime == nil || strings.TrimSpace(runtime.GetTenantId()) == "" {
 		return ports.CypherQueryRequest{}
 	}
+	if r.definition.Lifecycle.Kind == LifecycleRetired {
+		return ports.CypherQueryRequest{}
+	}
 	params := map[string]any{
 		"tenant_id": strings.TrimSpace(runtime.GetTenantId()),
 		"row_limit": int64(coordinationGraphRowLimit),
@@ -422,6 +411,9 @@ func (r *coordinationGraphRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports
 
 func (r *coordinationGraphRule) EvaluateRows(_ context.Context, runtime *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {
 	if r == nil || runtime == nil || len(rows) == 0 {
+		return nil, nil
+	}
+	if r.definition.Lifecycle.Kind == LifecycleRetired {
 		return nil, nil
 	}
 	tenantID := strings.TrimSpace(runtime.GetTenantId())

--- a/internal/findings/coordination_graph_rule_test.go
+++ b/internal/findings/coordination_graph_rule_test.go
@@ -21,7 +21,7 @@ func TestCoordinationGraphRuleSupportsRuntime(t *testing.T) {
 }
 
 func TestCoordinationGraphRuleQueryRequiresTenant(t *testing.T) {
-	rule := newResourceMultipleOpenFindingsRule().(GraphRule)
+	rule := newGRCSourceConcentratedOpenFindingsRule().(GraphRule)
 	if got := rule.QueryFor(&cerebrov1.SourceRuntime{}); got.Query != "" {
 		t.Fatalf("QueryFor(runtime without tenant) = %q, want empty", got.Query)
 	}
@@ -38,9 +38,6 @@ func TestCoordinationGraphRuleQueryRequiresTenant(t *testing.T) {
 	if !strings.Contains(query.Query, "findings[0..20] | {urn: f.urn") {
 		t.Fatalf("query does not cap related finding evidence: %s", query.Query)
 	}
-	if strings.Contains(query.Query, "+ [f IN findings") {
-		t.Fatalf("query projects related finding anchors as ResourceURNs: %s", query.Query)
-	}
 	if !strings.Contains(query.Query, "ORDER BY finding.urn") {
 		t.Fatalf("query does not deterministically order findings before capping: %s", query.Query)
 	}
@@ -49,7 +46,6 @@ func TestCoordinationGraphRuleQueryRequiresTenant(t *testing.T) {
 func TestCoordinationGraphRuleQueryOrdersFindingsBeforeSlice(t *testing.T) {
 	for _, ruleID := range []string{
 		"grc-source-integration-concentrated-open-findings",
-		"graph-resource-multiple-open-findings",
 	} {
 		registry := Builtin()
 		rule, ok := registry.Get(ruleID)
@@ -66,6 +62,39 @@ func TestCoordinationGraphRuleQueryOrdersFindingsBeforeSlice(t *testing.T) {
 		if collectIdx < 0 || orderIdx < 0 || orderIdx > collectIdx {
 			t.Fatalf("rule %s must ORDER BY finding.urn before collecting findings: %s", ruleID, query)
 		}
+	}
+}
+
+func TestResourceMultipleOpenFindingsRuleRetired(t *testing.T) {
+	rule := newResourceMultipleOpenFindingsRule()
+	metadataRule, ok := rule.(MetadataRule)
+	if !ok {
+		t.Fatal("rule does not expose RuleMetadata")
+	}
+	definition := metadataRule.RuleMetadata()
+	if definition.Lifecycle.Kind != LifecycleRetired || definition.Lifecycle.Anchor != AnchorNone {
+		t.Fatalf("Lifecycle = %+v, want retired/none", definition.Lifecycle)
+	}
+	if definition.Maturity != RuleMaturityRetired || definition.Status != "retired" {
+		t.Fatalf("retirement metadata = maturity %q status %q", definition.Maturity, definition.Status)
+	}
+	graphRule, ok := rule.(GraphRule)
+	if !ok {
+		t.Fatal("retired resource multiple-open rule must remain a GraphRule for stale closeout")
+	}
+	query := graphRule.QueryFor(&cerebrov1.SourceRuntime{Id: "runtime", TenantId: "writer", SourceId: "graph"})
+	if query.Query != "" {
+		t.Fatalf("retired rule QueryFor() = %q, want empty", query.Query)
+	}
+	findings, err := graphRule.EvaluateRows(context.Background(), &cerebrov1.SourceRuntime{Id: "runtime", TenantId: "writer", SourceId: "graph"}, []ports.CypherRow{{Values: map[string]any{
+		"primary_urn":     "urn:cerebro:writer:resource:one",
+		"fingerprint_key": "urn:cerebro:writer:resource:one",
+	}}})
+	if err != nil {
+		t.Fatalf("EvaluateRows(retired rule) error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows(retired rule) returned %d findings, want 0", len(findings))
 	}
 }
 
@@ -186,7 +215,7 @@ func TestCoordinationGraphRuleEvaluateRowsBuildsFinding(t *testing.T) {
 }
 
 func TestCoordinationGraphRuleEvaluateRowsCapsResourceURNs(t *testing.T) {
-	rule := newResourceMultipleOpenFindingsRule().(GraphRule)
+	rule := newGRCSourceConcentratedOpenFindingsRule().(GraphRule)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-cosmo-survey-feedback", TenantId: "writer", SourceId: "cosmo", Config: map[string]string{"family": "survey_feedback"}}
 	resourceURNs := []any{"urn:cerebro:writer:resource:one"}
 	for i := 1; i <= coordinationGraphRelatedResourceLimit+5; i++ {
@@ -216,7 +245,7 @@ func TestCoordinationGraphRuleEvaluateRowsCapsResourceURNs(t *testing.T) {
 }
 
 func TestCoordinationGraphRuleEvaluateRowsDropsEvidenceFindingURNResources(t *testing.T) {
-	rule := newResourceMultipleOpenFindingsRule().(GraphRule)
+	rule := newGRCSourceConcentratedOpenFindingsRule().(GraphRule)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-cosmo-message", TenantId: "writer", SourceId: "cosmo", Config: map[string]string{"family": "message"}}
 
 	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{{Values: map[string]any{

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -89,6 +89,12 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 	}
 	queryRequest := rule.QueryFor(runtime)
 	if strings.TrimSpace(queryRequest.Query) == "" {
+		if retiredGraphRule(rule) {
+			if err := s.resolveStaleGraphFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), strings.TrimSpace(runtime.GetId()), spec.GetId(), nil); err != nil {
+				evaluationErr := fmt.Errorf("resolve retired graph findings for rule %q: %w", spec.GetId(), err)
+				return result, s.finishFailedGraphRun(ctx, run, 0, nil, evaluationErr)
+			}
+		}
 		if err := s.finishCompletedGraphRun(ctx, run, 0, nil); err != nil {
 			return result, err
 		}
@@ -159,6 +165,14 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		return result, err
 	}
 	return result, nil
+}
+
+func retiredGraphRule(rule GraphRule) bool {
+	metadataRule, ok := rule.(MetadataRule)
+	if !ok {
+		return false
+	}
+	return metadataRule.RuleMetadata().Lifecycle.Kind == LifecycleRetired
 }
 
 // cypherRowsTruncated reports whether the cypher result hit the effective row cap. When the

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -659,6 +659,41 @@ func TestEvaluateSourceRuntimeGraphRulesEmptyQueryPersistsGraphRuleFlag(t *testi
 	}
 }
 
+func TestEvaluateSourceRuntimeGraphRulesRetiredEmptyQueryResolvesOpenFindings(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-graph", SourceId: "graph", TenantId: "writer"}
+	store := &stubFindingStore{findings: map[string]*ports.FindingRecord{
+		"stale-meta": {
+			ID:             "stale-meta",
+			TenantID:       "writer",
+			RuntimeID:      "runtime-old",
+			RuleID:         "graph-resource-multiple-open-findings",
+			Status:         findingStatusOpen,
+			LastObservedAt: time.Now().UTC().Add(-time.Hour),
+		},
+	}}
+	registry, err := NewRegistry(newResourceMultipleOpenFindingsRule())
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(&stubGraphStore{})
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if len(result.Evaluations) != 1 {
+		t.Fatalf("len(Evaluations) = %d, want 1", len(result.Evaluations))
+	}
+	if got := store.findings["stale-meta"].Status; got != findingStatusResolved {
+		t.Fatalf("retired graph finding status = %q, want resolved", got)
+	}
+	if got := store.findings["stale-meta"].StatusReason; got != "graph_rule_no_longer_matches" {
+		t.Fatalf("retired graph finding status reason = %q", got)
+	}
+	if len(store.updateStatusCalls) != 1 {
+		t.Fatalf("len(updateStatusCalls) = %d, want 1", len(store.updateStatusCalls))
+	}
+}
+
 // TestEvaluateSourceRuntimeGraphRulesFailedRunPreservesGraphTelemetry confirms
 // that even when the cypher query fails the persisted failed run still marks
 // itself as a graph rule, so the rule-class discriminator survives failures

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -1437,29 +1437,31 @@
       "pack_id": "grc",
       "pack_name": "GRC",
       "name": "Graph Resource Has Multiple Open Findings",
-      "description": "Detect resources with multiple active findings so remediation can be coordinated by shared resource rather than by individual alert.",
+      "description": "Retired graph meta-finding retained so stale open findings auto-resolve; multiple open findings on a resource is triage context, not a standalone risk.",
       "source_id": "graph",
       "evaluation_mode": "graph",
       "event_kinds": [
         "finding"
       ],
       "output_kind": "finding.graph_resource_multiple_open_findings",
-      "severity": "HIGH",
-      "status": "open",
-      "maturity": "test",
+      "severity": "INFO",
+      "status": "retired",
+      "maturity": "retired",
       "tags": [
+        "cleanup",
         "coordination",
         "finding",
         "graph-rule",
-        "prioritization"
+        "prioritization",
+        "retired"
       ],
       "references": [
         "https://www.iso.org/standard/27001"
       ],
       "false_positives": [
-        "Multiple findings may be duplicate projections of one upstream issue until deduplication rules converge."
+        "Multiple findings on one resource are expected during coordinated remediation and should be modeled as case context rather than a separate finding."
       ],
-      "runbook": "Prioritize the shared resource, group the findings by rule and owner, and remediate the common root cause.",
+      "runbook": "Use the underlying open findings or case context as the remediation queue; this meta-finding no longer emits.",
       "fingerprint_fields": [
         "resource_urn"
       ],

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -85,7 +85,7 @@ func TestNoConvertRuleUsesEventIdOrMatchedAtFingerprint(t *testing.T) {
 func TestCloseoutSelectorCoversAllRetiredAndConvertRules(t *testing.T) {
 	targets := append(rulepackAuditRulesByClass(t, rulepackAuditClassConvert), rulepackAuditRulesByClass(t, rulepackAuditClassRetire)...)
 	sort.Slice(targets, func(i, j int) bool { return targets[i].RuleID < targets[j].RuleID })
-	if got, want := len(targets), 27; got != want {
+	if got, want := len(targets), 28; got != want {
 		t.Fatalf("CONVERT+RETIRE closeout target count = %d, want %d", got, want)
 	}
 	for i, entry := range targets {
@@ -825,7 +825,7 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 40; got != want {
+	if got, want := len(keepRules), 39; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1038,7 +1038,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "finding-isolated-open-anchor", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "graph"},
 		{RuleID: "graph-aws-ec2-eni-link-missing", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "graph"},
 		{RuleID: "graph-orphan-nonfinding-node", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "graph"},
-		{RuleID: "graph-resource-multiple-open-findings", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "graph"},
+		{RuleID: "graph-resource-multiple-open-findings", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "graph"},
 		{RuleID: "panopticon-curated-case", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "panopticon"},
 		{RuleID: "runtime-active-threat-evidence", Classification: "TTL_EVIDENCE_ONLY", BulkCloseoutThreshold: ">24h", Source: "runtime"},
 		{RuleID: "security-reviewer-reported-finding", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "security_reviewer"},

--- a/internal/sourceprojection/panopticon.go
+++ b/internal/sourceprojection/panopticon.go
@@ -109,39 +109,10 @@ type panopticonAssetStitchTarget struct {
 }
 
 func panopticonAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
+	if _, err := tenantID(event); err != nil {
 		return nil, nil, err
 	}
-	attrs := panopticonProjectionAttributes(event, "alert_id", "case_id", "severity", "status", "title", "ioc_id", "ioc_type", "value", "asset_id", "asset_type", "asset_name")
-	payload := payloadMap(event)
-	alertID := firstAttribute(attrs, "alert_id")
-	if alertID == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	alertURN := panopticonAddAlertEntity(entities, tenantID, event.GetSourceId(), event.GetId(), attrs)
-	caseURN := panopticonAddCaseEntity(entities, tenantID, event.GetSourceId(), event.GetId(), map[string]string{
-		"case_id": firstNonEmpty(firstAttribute(attrs, "case_id"), stringValue(payload, "case_id")),
-	})
-	if caseURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, caseURN, relationBelongsTo, panopticonLinkAttributes(event, "panopticon_alert_case")))
-	}
-	for _, iocURN := range panopticonAddIOCs(entities, tenantID, event.GetSourceId(), event.GetId(), attrs, payload) {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, iocURN, relationHasEvidence, panopticonLinkAttributes(event, "panopticon_alert_ioc")))
-	}
-	for _, assetURN := range panopticonAddAssets(entities, tenantID, event.GetSourceId(), event.GetId(), attrs, payload) {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, assetURN, relationObservedOn, panopticonLinkAttributes(event, "panopticon_alert_asset")))
-	}
-	for _, evidenceURN := range panopticonAddEvidencePointers(entities, tenantID, event.GetSourceId(), event.GetId(), payload) {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, evidenceURN, relationHasEvidence, panopticonLinkAttributes(event, "panopticon_alert_evidence_cas")))
-	}
-	panopticonAddContextAnchors(entities, links, tenantID, event.GetSourceId(), event, alertURN, relationAssociatedWith, attrs, payload, "panopticon_alert_context")
-	panopticonAddIOCContextAnchors(entities, links, tenantID, event.GetSourceId(), event, attrs, payload)
-	panopticonAddAssetContextAnchors(entities, links, tenantID, event.GetSourceId(), event, attrs, payload)
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+	return nil, nil, nil
 }
 
 func panopticonCaseProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/panopticon_test.go
+++ b/internal/sourceprojection/panopticon_test.go
@@ -260,11 +260,11 @@ func TestProjectPanopticonCaseBuildsLinkedGraphAndEvidencePointers(t *testing.T)
 	}
 }
 
-func TestProjectPanopticonAlertAndIOCLinkToCasesAssetsAndEvidence(t *testing.T) {
+func TestProjectPanopticonRawAlertDoesNotProjectDurableGraphContext(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
 
-	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
 		Id:       "panopticon-alert-event-1",
 		TenantId: "writer",
 		SourceId: "panopticon",
@@ -297,7 +297,19 @@ func TestProjectPanopticonAlertAndIOCLinkToCasesAssetsAndEvidence(t *testing.T) 
 	if err != nil {
 		t.Fatalf("Project(alert) error = %v", err)
 	}
-	_, err = service.Project(context.Background(), &cerebrov1.EventEnvelope{
+	if result.EntitiesProjected != 0 || result.LinksProjected != 0 {
+		t.Fatalf("raw Panopticon alert projected durable context: entities=%d links=%d", result.EntitiesProjected, result.LinksProjected)
+	}
+	if len(state.entities) != 0 || len(state.links) != 0 {
+		t.Fatalf("raw Panopticon alert mutated graph state: entities=%d links=%d", len(state.entities), len(state.links))
+	}
+}
+
+func TestProjectPanopticonIOCLinksToCaseAndAlertEvidence(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
 		Id:       "panopticon-ioc-event-1",
 		TenantId: "writer",
 		SourceId: "panopticon",
@@ -324,20 +336,16 @@ func TestProjectPanopticonAlertAndIOCLinkToCasesAssetsAndEvidence(t *testing.T) 
 	alertURN := "urn:cerebro:writer:panopticon_alert:alert-1"
 	caseURN := "urn:cerebro:writer:panopticon_case:case-1"
 	iocURN := "urn:cerebro:writer:panopticon_ioc:ioc-1"
-	assetURN := "urn:cerebro:writer:panopticon_asset:asset-1"
 
-	assertProjectedLink(t, state, alertURN, relationBelongsTo, caseURN)
-	assertProjectedLink(t, state, alertURN, relationHasEvidence, iocURN)
-	assertProjectedLink(t, state, alertURN, relationObservedOn, assetURN)
 	assertProjectedLink(t, state, iocURN, relationBelongsTo, caseURN)
 	assertProjectedLink(t, state, alertURN, relationHasEvidence, iocURN)
 }
 
-func TestProjectPanopticonAlertEnrichesSSHBruteForceAnchors(t *testing.T) {
+func TestProjectPanopticonRawAlertDoesNotEnrichSSHBruteForceAnchors(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
 
-	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
 		Id:       "panopticon-alert-event-ssh",
 		TenantId: "writer",
 		SourceId: "panopticon",
@@ -356,15 +364,12 @@ func TestProjectPanopticonAlertEnrichesSSHBruteForceAnchors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project(alert) error = %v", err)
 	}
-
-	alertURN := "urn:cerebro:writer:panopticon_alert:alert-ssh"
-	ipURN := "urn:cerebro:writer:internet_ip:203.0.113.20"
-	instanceURN := "urn:cerebro:writer:aws_ec2_instance:i-0123456789abcdef0"
-
-	assertProjectedEntityType(t, state, ipURN, "internet.ip")
-	assertProjectedEntityType(t, state, instanceURN, "aws.ec2.instance")
-	assertProjectedLink(t, state, alertURN, relationAssociatedWith, ipURN)
-	assertProjectedLink(t, state, alertURN, relationAssociatedWith, instanceURN)
+	if result.EntitiesProjected != 0 || result.LinksProjected != 0 {
+		t.Fatalf("raw Panopticon alert projected SSH anchors: entities=%d links=%d", result.EntitiesProjected, result.LinksProjected)
+	}
+	if len(state.entities) != 0 || len(state.links) != 0 {
+		t.Fatalf("raw Panopticon alert mutated graph state: entities=%d links=%d", len(state.entities), len(state.links))
+	}
 }
 
 func TestProjectPanopticonCaseEnrichesGitHubGCPAndIdentityAnchors(t *testing.T) {

--- a/ops/closeout/rule-ids-24h.txt
+++ b/ops/closeout/rule-ids-24h.txt
@@ -8,6 +8,7 @@ github-repository-collaborator-added
 github-repository-ruleset-modified
 github-self-hosted-runner-review-needed
 github-webhook-modified
+graph-resource-multiple-open-findings
 identity-api-token-or-oauth-app-created
 identity-privileged-account-without-mfa
 identity-privileged-no-mfa-plus-sensitive-access

--- a/sources/panopticon/catalog.yaml
+++ b/sources/panopticon/catalog.yaml
@@ -10,7 +10,7 @@ coverage_contract:
   authority_domain: panopticon
   dimensions:
     - id: alerts
-      type: lifecycle_state
+      type: audit_event
       title: Raw alerts for evidence and enrichment
       families: [alert]
       support: supported


### PR DESCRIPTION
Summary
- retire the resource multiple-open-findings meta-rule while preserving stale graph-finding resolution
- keep Panopticon cases/IOCs as durable graph context and stop raw alert events from projecting durable graph nodes
- mark raw Panopticon alerts as non-high-value audit evidence in source coverage and include the retired rule in closeout selectors

Tests
- go test ./internal/findings ./internal/sourceprojection ./sources/panopticon -count=1
- make lint
- go test ./... -count=1