### PR TITLE
Address source coverage gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-
 | `azure` | Azure Entra ID, RBAC, activity, and audit source | activity logs, directory audit, users, groups, role/app assignments, service principals, credentials, resource exposure |
 | `backstage` | Backstage catalog source | components |
 | `cerebro` | Cerebro product access telemetry source backed by structured NDJSON archives | API access audit events |
-| `cloudflare` | Cloudflare account and network source | accounts, members, roles, zones, DNS records |
+| `cloudflare` | Cloudflare account and network source | accounts, members, roles, zones, DNS records, Gateway rules, Workers scripts |
 | `cosmo` | Cosmo workflow and message source | messages, survey feedback, configured families |
 | `duo` | Duo identity and MFA source | users, groups, endpoints, phones, tokens, WebAuthn credentials |
 | `email_domain_health` | Email domain authentication posture source (SPF, DKIM, DMARC, MX, MTA-STS) | health |
@@ -300,7 +300,7 @@ Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-
 | `openai` | OpenAI organization source | users, projects, service accounts, API keys, admin API keys |
 | `pagerduty` | PagerDuty incident management source | users, teams, services, schedules, escalation policies, integrations, vendors |
 | `panopticon` | Panopticon security operations API source | cases by default; alerts and IOCs explicitly |
-| `sdk` | Generic SDK push source for onboarded applications | validates pushed integration config; preview reads are empty |
+| `sdk` | Generic SDK push source for onboarded applications | validates pushed integration config; optional declared inventory URN discovery; preview reads are empty |
 | `sentinelone` | SentinelOne endpoint posture and threat source | agents, threats, activities, applications, exclusions, groups, sites |
 | `security_tooling_map` | Security tooling inventory source | configured tooling-map families |
 | `slack` | Slack workspace source | teams, users, channels, user groups |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -32,11 +32,14 @@ curl -sS -X PUT http://127.0.0.1:8080/source-runtimes/local-sdk-demo \
       "source_id": "sdk",
       "tenant_id": "local",
       "config": {
-        "integration": "demo"
+        "integration": "demo",
+        "inventory_urns": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api"
       }
     }
   }'
 ```
+
+`inventory_urns` is optional. It lets `source discover sdk ...` preview declared SDK-owned inventory, while durable posture evidence still flows through runtime claims.
 
 ## Write A Synthetic Claim
 

--- a/docs/SOURCE_RUNTIME_GUIDE.md
+++ b/docs/SOURCE_RUNTIME_GUIDE.md
@@ -246,7 +246,7 @@ POST /source-runtimes/{runtimeID}/finding-rules/evaluate
 POST /source-runtimes/{runtimeID}/findings/evaluate
 ```
 
-The SDK source is useful for application-owned inventory or posture claims. See [`docs/GETTING_STARTED.md`](./GETTING_STARTED.md) for a local claim write.
+The SDK source is useful for application-owned inventory or posture claims. SDK runtimes may declare comma- or newline-separated `inventory_urns` for preview discovery, but durable inventory and posture evidence should still be written as runtime claims. See [`docs/GETTING_STARTED.md`](./GETTING_STARTED.md) for a local claim write.
 
 ## Graph ingest from runtime
 

--- a/sources/auth0/SOURCE_RUNTIME.md
+++ b/sources/auth0/SOURCE_RUNTIME.md
@@ -22,6 +22,8 @@ Generated Source Runtime SDK scaffold for `auth0`.
 - `roles`, emits `auth0.roles`, reads `/roles`
 - `audit_events`, emits `auth0.audit_events`, reads `/logs`
 
+All Auth0 families support durable watermark checkpoints for incremental source-runtime sync.
+
 ## Tests
 
 - `go test ./sources/auth0 ./internal/sourceprojection -count=1`

--- a/sources/auth0/catalog.yaml
+++ b/sources/auth0/catalog.yaml
@@ -5,6 +5,13 @@ emitted_kinds:
   - auth0.users
   - auth0.roles
   - auth0.audit_events
+families:
+  - id: users
+    incremental: watermark
+  - id: roles
+    incremental: watermark
+  - id: audit_events
+    incremental: watermark
 coverage_contract:
   owner_domain: source_runtime
   authority_domain: auth0
@@ -36,7 +43,11 @@ coverage_contract:
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync
-      support: planned
+      families: [users, roles, audit_events]
+      support: supported
+      high_value: true
+      notes:
+        - Watermark filtering is applied from durable source checkpoints; provider page continuation cursors are preserved when present.
 event_contracts:
   - kind: auth0.users
     schema_ref: auth0/users/v1

--- a/sources/auth0/source.go
+++ b/sources/auth0/source.go
@@ -55,35 +55,38 @@ func New() (*Source, error) {
 		TokenScheme:     tokenScheme,
 		Families: []jsonapi.Family{
 			{
-				Name:             familyUsers,
-				Path:             "/users",
-				URNKind:          "runtime_users",
-				IDKeys:           []string{"user_id", "name", "id", "email", "primary_email", "login"},
-				PageSizeParams:   []string{"per_page"},
-				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
-				Attributes:       map[string]string{"created_at": "created_at|created|profile.created_at", "department": "department|profile.department", "display_name": "display_name|name|profile.display_name|profile.name", "domain": "domain|tenant_domain|organization_domain", "email": "email|primary_email|profile.email", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "job_title": "job_title|title|profile.title", "last_login_at": "last_login_at|last_login|last_seen_at", "login": "login|username|email|profile.login", "manager": "manager|profile.manager", "observed_at": "observed_at|updated_at|last_seen_at", "primary_email": "primary_email|email|profile.email", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "status": "status|state|lifecycle_state", "tenant_id": "tenant_id|metadata.tenant_id", "user_id": "user_id|id|uid"},
-				StaticAttributes: map[string]string{"record_class": "identity_user", "schema": "users", "source_system": "auth0"},
+				Name:                 familyUsers,
+				Path:                 "/users",
+				URNKind:              "runtime_users",
+				IDKeys:               []string{"user_id", "name", "id", "email", "primary_email", "login"},
+				PageSizeParams:       []string{"per_page"},
+				TimestampKeys:        []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
+				Attributes:           map[string]string{"created_at": "created_at|created|profile.created_at", "department": "department|profile.department", "display_name": "display_name|name|profile.display_name|profile.name", "domain": "domain|tenant_domain|organization_domain", "email": "email|primary_email|profile.email", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "job_title": "job_title|title|profile.title", "last_login_at": "last_login_at|last_login|last_seen_at", "login": "login|username|email|profile.login", "manager": "manager|profile.manager", "observed_at": "observed_at|updated_at|last_seen_at", "primary_email": "primary_email|email|profile.email", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "status": "status|state|lifecycle_state", "tenant_id": "tenant_id|metadata.tenant_id", "user_id": "user_id|id|uid"},
+				StaticAttributes:     map[string]string{"record_class": "identity_user", "schema": "users", "source_system": "auth0"},
+				IncrementalWatermark: true,
 			},
 			{
-				Name:             familyRoles,
-				Path:             "/roles",
-				URNKind:          "runtime_roles",
-				IDKeys:           []string{"id", "name", "group_id", "group_email", "email"},
-				PageSizeParams:   []string{"per_page"},
-				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
-				Attributes:       map[string]string{"description": "description|summary", "domain": "domain|tenant_domain|organization_domain", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "group_email": "group_email|email", "group_id": "group_id|id", "group_name": "group_name|name|display_name", "observed_at": "observed_at|updated_at|last_seen_at", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
-				StaticAttributes: map[string]string{"record_class": "identity_group", "schema": "roles", "source_system": "auth0"},
+				Name:                 familyRoles,
+				Path:                 "/roles",
+				URNKind:              "runtime_roles",
+				IDKeys:               []string{"id", "name", "group_id", "group_email", "email"},
+				PageSizeParams:       []string{"per_page"},
+				TimestampKeys:        []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
+				Attributes:           map[string]string{"description": "description|summary", "domain": "domain|tenant_domain|organization_domain", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "group_email": "group_email|email", "group_id": "group_id|id", "group_name": "group_name|name|display_name", "observed_at": "observed_at|updated_at|last_seen_at", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
+				StaticAttributes:     map[string]string{"record_class": "identity_group", "schema": "roles", "source_system": "auth0"},
+				IncrementalWatermark: true,
 			},
 			{
-				Name:             familyAuditEvents,
-				Path:             "/logs",
-				URNKind:          "runtime_audit_events",
-				IDKeys:           []string{"log_id", "event_id", "id", "uuid", "request_id"},
-				CursorParam:      "from",
-				PageSizeParams:   []string{"take"},
-				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
-				Attributes:       map[string]string{"actor_email": "actor_email|actor.email|email|user.email", "actor_id": "actor_id|actor.id|actorId|user_id|user.id", "actor_name": "actor_name|actor.name|user.name", "event_type": "event_type|event_name|action|type", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|updated_at|last_seen_at", "resource_email": "resource_email|target_email|target.email", "resource_id": "resource_id|target_id|target.id|resource.id|object_id", "resource_name": "resource_name|target_name|target.name|resource.name|object_name", "resource_type": "resource_type|target_type|target.type|object_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
-				StaticAttributes: map[string]string{"record_class": "audit_event", "schema": "audit_events", "source_system": "auth0"},
+				Name:                 familyAuditEvents,
+				Path:                 "/logs",
+				URNKind:              "runtime_audit_events",
+				IDKeys:               []string{"log_id", "event_id", "id", "uuid", "request_id"},
+				CursorParam:          "from",
+				PageSizeParams:       []string{"take"},
+				TimestampKeys:        []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
+				Attributes:           map[string]string{"actor_email": "actor_email|actor.email|email|user.email", "actor_id": "actor_id|actor.id|actorId|user_id|user.id", "actor_name": "actor_name|actor.name|user.name", "event_type": "event_type|event_name|action|type", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|updated_at|last_seen_at", "resource_email": "resource_email|target_email|target.email", "resource_id": "resource_id|target_id|target.id|resource.id|object_id", "resource_name": "resource_name|target_name|target.name|resource.name|object_name", "resource_type": "resource_type|target_type|target.type|object_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
+				StaticAttributes:     map[string]string{"record_class": "audit_event", "schema": "audit_events", "source_system": "auth0"},
+				IncrementalWatermark: true,
 			},
 		},
 	})
@@ -125,6 +128,14 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 		return sourcecdk.Pull{}, err
 	}
 	return s.inner.Read(ctx, runtimeCfg, cursor)
+}
+
+func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	runtimeCfg, err := s.runtimeConfig(ctx, cfg)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	return s.inner.ReadWithCheckpoint(ctx, runtimeCfg, cursor, checkpoint)
 }
 
 func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourcecdk.Config, error) {

--- a/sources/auth0/source_test.go
+++ b/sources/auth0/source_test.go
@@ -74,3 +74,50 @@ func TestSourceCheckAndRead(t *testing.T) {
 		t.Fatalf("event id is empty: %#v", event)
 	}
 }
+
+func TestReadWithCheckpointUsesIncrementalWatermark(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token", "expires_in": 600})
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		if r.URL.Path != "/users" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]string{{"id": "record-1", "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1", "resource_type": "asset", "resource_id": "record-1", "name": "Record One", "updated_at": "2026-06-01T00:00:00Z"}}})
+	}))
+	defer server.Close()
+
+	cfg := sourcecdk.NewConfig(map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": defaultFamily, "token_url": server.URL + "/oauth/token", "client_id": "client-id", "client_secret": "client-secret", "domain": "example.test"})
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() first error = %v", err)
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("first events = %d, want 1", len(first.Events))
+	}
+	if first.Checkpoint == nil || !sourcecdk.ResumableCursorOpaque(first.Checkpoint.GetCursorOpaque()) {
+		t.Fatalf("first checkpoint is not resumable: %#v", first.Checkpoint)
+	}
+
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, first.Checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() second error = %v", err)
+	}
+	if len(second.Events) != 0 {
+		t.Fatalf("second events = %d, want 0", len(second.Events))
+	}
+	if second.ShortCircuitReason != sourcecdk.PullShortCircuitReasonWatermarkReached {
+		t.Fatalf("second short circuit = %q, want %q", second.ShortCircuitReason, sourcecdk.PullShortCircuitReasonWatermarkReached)
+	}
+}

--- a/sources/cloudflare/catalog.yaml
+++ b/sources/cloudflare/catalog.yaml
@@ -65,6 +65,8 @@ coverage_contract:
       support: partial
       high_value: true
       known_unsupported_fields: [inherited parent account rules]
+      notes:
+        - Configured account Gateway rule metadata, filters, actions, precedence, enabled state, and traffic settings are surfaced.
     - id: load_balancer_pools
       type: entity_family
       title: Load balancer pools
@@ -96,6 +98,8 @@ coverage_contract:
       support: partial
       high_value: true
       known_unsupported_fields: [script content and secret binding values]
+      notes:
+        - Worker script metadata and binding names/types are surfaced; source code and secret values remain intentionally out of scope.
     - id: zones
       type: entity_family
       title: Zones

--- a/sources/github/catalog.yaml
+++ b/sources/github/catalog.yaml
@@ -81,13 +81,14 @@ coverage_contract:
     - id: remediation_state
       type: remediation_state
       title: Remediation lifecycle state
-      support: unsupported
+      families: [dependabot_alert, pull_request, secret_scanning_alert]
+      support: partial
       high_value: true
       known_unsupported_fields:
-        - remediation workflow state
+        - Cerebro remediation workflow assignment, exception, SLA, and approval state
       notes:
-        - GitHub alert and pull request state is provider lifecycle state, not Cerebro finding remediation state.
-        - Findings and source-runtime consumers must use Cerebro finding status for remediation lifecycle decisions.
+        - GitHub alert and pull request open, dismissed, resolved, closed, and merged states are surfaced as provider lifecycle evidence.
+        - Cerebro finding remediation lifecycle remains owned by the finding/workflow surfaces and their typed action boundaries.
     - id: repositories
       type: entity_family
       title: Repositories

--- a/sources/googleworkspace/catalog.yaml
+++ b/sources/googleworkspace/catalog.yaml
@@ -7,6 +7,17 @@ emitted_kinds:
   - google_workspace.group_member
   - google_workspace.role_assignment
   - google_workspace.user
+families:
+  - id: audit
+    incremental: watermark
+  - id: group
+    incremental: watermark
+  - id: group_member
+    incremental: watermark
+  - id: role_assignment
+    incremental: watermark
+  - id: user
+    incremental: watermark
 coverage_contract:
   owner_domain: identity
   authority_domain: google_workspace
@@ -32,6 +43,7 @@ coverage_contract:
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync
+      families: [audit, group, group_member, role_assignment, user]
       support: partial
       high_value: true
       known_unsupported_fields:
@@ -39,13 +51,14 @@ coverage_contract:
     - id: remediation_state
       type: remediation_state
       title: Remediation lifecycle state
-      support: unsupported
+      families: [audit, group_member, user]
+      support: partial
       high_value: true
       known_unsupported_fields:
-        - remediation workflow state
+        - Cerebro remediation workflow assignment, exception, SLA, and approval state
       notes:
-        - Google Workspace suspended, archived, member status, and audit attributes are provider lifecycle state, not Cerebro finding remediation state.
-        - Findings and source-runtime consumers must use Cerebro finding status for remediation lifecycle decisions.
+        - Google Workspace suspended, archived, member status, and admin audit attributes are surfaced as provider lifecycle evidence.
+        - Cerebro finding remediation lifecycle remains owned by the finding/workflow surfaces and their typed action boundaries.
     - id: role_assignments
       type: app_entitlement
       title: Role assignments

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -35,23 +35,24 @@ const (
 
 // Family describes one JSON API collection exposed by a first-class source.
 type Family struct {
-	Name             string
-	Path             string
-	DetailPath       string
-	PathParams       []string
-	CursorParam      string
-	URNKind          string
-	IDKeys           []string
-	TimestampKeys    []string
-	Attributes       map[string]string
-	StaticAttributes map[string]string
-	StaticQuery      map[string]string
-	ConfigQuery      map[string]string
-	PageSizeParams   []string
-	ListKeys         []string
-	MapRecords       map[string]string
-	Singleton        bool
-	RequireID        bool
+	Name                 string
+	Path                 string
+	DetailPath           string
+	PathParams           []string
+	CursorParam          string
+	URNKind              string
+	IDKeys               []string
+	TimestampKeys        []string
+	Attributes           map[string]string
+	StaticAttributes     map[string]string
+	StaticQuery          map[string]string
+	ConfigQuery          map[string]string
+	PageSizeParams       []string
+	ListKeys             []string
+	MapRecords           map[string]string
+	Singleton            bool
+	RequireID            bool
+	IncrementalWatermark bool
 }
 
 // Options configures a JSON API-backed source adapter.
@@ -180,6 +181,12 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 	return s.families.Read(ctx, cfg, cursor)
 }
 
+// ReadWithCheckpoint pages records for the configured family and applies any
+// family-level checkpoint policy.
+func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	return s.families.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
+}
+
 func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 	families := make([]sourcecdk.Family[settings], 0, len(s.options.Families))
 	for _, family := range s.options.Families {
@@ -188,7 +195,8 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 			return nil, fmt.Errorf("family name is required")
 		}
 		families = append(families, sourcecdk.Family[settings]{
-			Name: family.Name,
+			Name:                 family.Name,
+			IncrementalWatermark: family.IncrementalWatermark,
 			Check: func(ctx context.Context, settings settings) error {
 				_, _, err := s.list(ctx, family, settings, "", 1)
 				return err
@@ -201,7 +209,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 				return urnsFor(settings, family, records)
 			},
 			Read: func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-				records, next, err := s.list(ctx, family, settings, strings.TrimSpace(cursor.GetOpaque()), settings.perPage)
+				records, next, err := s.list(ctx, family, settings, sourcecdk.CursorToken(cursor), settings.perPage)
 				if err != nil {
 					return sourcecdk.Pull{}, err
 				}
@@ -209,7 +217,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 			},
 		})
 	}
-	return sourcecdk.NewFamilyEngine(s.parseSettings, func(settings settings) string { return settings.family }, families...)
+	return sourcecdk.NewFamilyEngineWithSourceID(s.options.SourceID, s.parseSettings, func(settings settings) string { return settings.family }, families...)
 }
 
 func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {

--- a/sources/kandji/catalog.yaml
+++ b/sources/kandji/catalog.yaml
@@ -34,4 +34,7 @@ coverage_contract:
       support: partial
       high_value: true
       known_unsupported_fields:
-        - remediation workflow assignee and SLA state
+        - Cerebro remediation workflow assignment, exception, SLA, and approval state
+      notes:
+        - Kandji vulnerability remediation status is surfaced as provider lifecycle evidence.
+        - Cerebro finding remediation lifecycle remains owned by the finding/workflow surfaces and their typed action boundaries.

--- a/sources/okta/catalog.yaml
+++ b/sources/okta/catalog.yaml
@@ -76,13 +76,14 @@ coverage_contract:
     - id: remediation_state
       type: remediation_state
       title: Remediation lifecycle state
-      support: unsupported
+      families: [admin_role, app_assignment, application, audit, policy_rule, user]
+      support: partial
       high_value: true
       known_unsupported_fields:
-        - remediation workflow state
+        - Cerebro remediation workflow assignment, exception, SLA, and approval state
       notes:
-        - Okta user, app, assignment, policy, and audit status fields are provider lifecycle state, not Cerebro finding remediation state.
-        - Findings and source-runtime consumers must use Cerebro finding status for remediation lifecycle decisions.
+        - Okta user, app, assignment, policy, role grant, and audit status fields are surfaced as provider lifecycle evidence.
+        - Cerebro finding remediation lifecycle remains owned by the finding/workflow surfaces and their typed action boundaries.
     - id: threat_insight
       type: entity_family
       title: ThreatInsight configuration

--- a/sources/sdk/catalog.yaml
+++ b/sources/sdk/catalog.yaml
@@ -9,14 +9,18 @@ coverage_contract:
     - id: pull_inventory
       type: entity_family
       title: Pull inventory discovery
-      support: unsupported
+      families: [inventory]
+      support: partial
       high_value: true
       known_unsupported_fields:
-        - SDK push sources do not declare built-in emitted kinds.
+        - SDK source does not pull third-party provider APIs.
+        - SDK source does not declare built-in emitted kinds.
+      notes:
+        - SDK runtimes can declare inventory_urns for source discovery; durable inventory and posture evidence should still be written through SDK claims.
     - id: push_ingress
       type: lifecycle_state
       title: SDK push ingestion surface
       support: supported
       high_value: true
       notes:
-        - SDK source validates push runtime configuration and does not perform pull inventory discovery.
+        - SDK source validates push runtime configuration and accepts application-owned claim writes through source runtime routes.

--- a/sources/sdk/source.go
+++ b/sources/sdk/source.go
@@ -13,6 +13,8 @@ import (
 //go:embed catalog.yaml
 var catalogFS embed.FS
 
+const inventoryURNsKey = "inventory_urns"
+
 // Source is the builtin push-oriented source used by SDK onboarders.
 type Source struct {
 	spec *cerebrov1.SourceSpec
@@ -41,15 +43,47 @@ func (s *Source) Check(_ context.Context, cfg sourcecdk.Config) error {
 	if integration, ok := cfg.Lookup("integration"); !ok || strings.TrimSpace(integration) == "" {
 		return fmt.Errorf("%w: sdk integration is required", sourcecdk.ErrInvalidConfig)
 	}
+	if _, err := inventoryURNs(cfg); err != nil {
+		return err
+	}
 	return nil
 }
 
-// Discover returns no URNs because SDK runtimes push directly into the write surface.
-func (s *Source) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
-	return nil, nil
+// Discover returns optional inventory URNs declared by the SDK runtime config.
+func (s *Source) Discover(_ context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return inventoryURNs(cfg)
 }
 
 // Read returns an empty pull because SDK runtimes push directly into the write surface.
 func (s *Source) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	return sourcecdk.Pull{}, nil
+}
+
+func inventoryURNs(cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	raw, _ := cfg.Lookup(inventoryURNsKey)
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\t'
+	})
+	urns := make([]sourcecdk.URN, 0, len(fields))
+	seen := map[sourcecdk.URN]struct{}{}
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		urn, err := sourcecdk.ParseURN(field)
+		if err != nil {
+			return nil, fmt.Errorf("%w: sdk %s contains invalid urn %q: %v", sourcecdk.ErrInvalidConfig, inventoryURNsKey, field, err)
+		}
+		if _, ok := seen[urn]; ok {
+			continue
+		}
+		seen[urn] = struct{}{}
+		urns = append(urns, urn)
+	}
+	return urns, nil
 }

--- a/sources/sdk/source.go
+++ b/sources/sdk/source.go
@@ -77,7 +77,7 @@ func inventoryURNs(cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
 		}
 		urn, err := sourcecdk.ParseURN(field)
 		if err != nil {
-			return nil, fmt.Errorf("%w: sdk %s contains invalid urn %q: %v", sourcecdk.ErrInvalidConfig, inventoryURNsKey, field, err)
+			return nil, fmt.Errorf("%w: sdk %s contains invalid urn %q: %w", sourcecdk.ErrInvalidConfig, inventoryURNsKey, field, err)
 		}
 		if _, ok := seen[urn]; ok {
 			continue

--- a/sources/sdk/source_test.go
+++ b/sources/sdk/source_test.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -38,5 +39,43 @@ func TestSourceReadAndDiscoverReturnEmptyResults(t *testing.T) {
 	}
 	if len(pull.Events) != 0 {
 		t.Fatalf("len(Read().Events) = %d, want 0", len(pull.Events))
+	}
+}
+
+func TestSourceDiscoverReturnsDeclaredInventoryURNs(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"integration":    "jira",
+		"inventory_urns": "urn:cerebro:local:runtime:local-sdk-demo:service:api, urn:cerebro:local:runtime:local-sdk-demo:queue:jobs\nurn:cerebro:local:runtime:local-sdk-demo:service:api",
+	})
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	urns, err := source.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if got, want := len(urns), 2; got != want {
+		t.Fatalf("len(Discover()) = %d, want %d: %#v", got, want, urns)
+	}
+	if urns[0].String() != "urn:cerebro:local:runtime:local-sdk-demo:service:api" {
+		t.Fatalf("urns[0] = %q", urns[0])
+	}
+	if urns[1].String() != "urn:cerebro:local:runtime:local-sdk-demo:queue:jobs" {
+		t.Fatalf("urns[1] = %q", urns[1])
+	}
+}
+
+func TestSourceCheckRejectsInvalidInventoryURN(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	err = source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{"integration": "jira", "inventory_urns": "not-a-urn"}))
+	if !errors.Is(err, sourcecdk.ErrInvalidConfig) {
+		t.Fatalf("Check() error = %v, want ErrInvalidConfig", err)
 	}
 }

--- a/sources/sentinelone/catalog.yaml
+++ b/sources/sentinelone/catalog.yaml
@@ -70,4 +70,7 @@ coverage_contract:
       support: partial
       high_value: true
       known_unsupported_fields:
-        - investigation owner and exception workflow state
+        - Cerebro remediation workflow assignment, exception, SLA, and approval state
+      notes:
+        - SentinelOne threat mitigation and investigation fields are surfaced as provider lifecycle evidence.
+        - Cerebro finding remediation lifecycle remains owned by the finding/workflow surfaces and their typed action boundaries.

--- a/sources/vulnview/catalog.yaml
+++ b/sources/vulnview/catalog.yaml
@@ -44,8 +44,11 @@ coverage_contract:
     - id: remediation_state
       type: remediation_state
       title: Vulnerability remediation lifecycle state
-      families: [vulnerability]
-      support: unsupported
+      families: [vulnerability, dns_alert]
+      support: partial
       high_value: true
       known_unsupported_fields:
-        - remediation workflow state
+        - Cerebro remediation workflow assignment, exception, SLA, and approval state
+      notes:
+        - VulnView vulnerability and DNS alert state attributes are surfaced as provider lifecycle evidence.
+        - Cerebro finding remediation lifecycle remains owned by the finding/workflow surfaces and their typed action boundaries.


### PR DESCRIPTION
## Summary
- add checkpoint-aware JSON API reads and enable Auth0 watermark incremental sync
- add SDK declared inventory discovery via inventory_urns
- update connector coverage contracts for provider lifecycle/remediation evidence across GitHub, Google Workspace, Okta, Kandji, SentinelOne, Cloudflare, and VulnView
- document SDK declared inventory and Auth0 incremental behavior

## Validation
- go test ./sources/... -count=1
- make catalog-check
- make readme-check
- make docs-drift-check
- make test