### PR TITLE
Add compliance control selection foundation

### DIFF
--- a/docs/COMPLIANCE_CONTROLS.md
+++ b/docs/COMPLIANCE_CONTROLS.md
@@ -1,0 +1,108 @@
+# Compliance Controls
+
+Cerebro stores compliance controls as YAML control packs. The built-in pack lives at `internal/compliance/control_families.yaml`; custom packs should use the same schema and can be merged with the built-in pack before validation.
+
+The control pack is intentionally richer than a tag list. A control can describe what it is meant to prove, what evidence is acceptable, how fresh that evidence should be, and which other controls it maps to. Findings and generated policy rules still carry `ControlRefs`; the compliance package resolves those refs into selected controls and coverage.
+
+## Control Pack Shape
+
+```yaml
+version: "2026-06-17"
+frameworks:
+  - id: customer-audit-2026
+    name: Customer Audit 2026
+    framework_version: "2026"
+    tags: [customer_audit]
+    families:
+      - id: IAM
+        name: Identity Controls
+        tags: [identity]
+        controls:
+          - id: IAM-1
+            title: Privileged access requires MFA
+            objective: Privileged users authenticate with phishing-resistant MFA.
+            intent: Reduce account takeover risk for administrative access.
+            applicability: [production, privileged_access]
+            assessment_methods: [examine, test]
+            owner_domain: identity
+            automatable: true
+            manual_evidence_allowed: true
+            freshness_sla: 30d
+            tags: [mfa, privileged_access]
+            evidence_expectations:
+              - id: privileged-mfa-state
+                type: identity_configuration
+                description: MFA posture for privileged users.
+                required: true
+                assessment_methods: [examine]
+                freshness_sla: 30d
+                accepted_from: [okta, github]
+            maps_to:
+              - framework_name: SOC 2
+                control_id: CC6.1
+```
+
+Required fields are intentionally small for compatibility: catalog `version`, framework `name`, family `id` and `name`, and control `id`. Rich controls should add `title`, `objective`, `intent`, `assessment_methods`, `evidence_expectations`, and `maps_to` as soon as they are known.
+
+Assessment methods are limited to `examine`, `interview`, and `test`. Evidence expectations require `id` and `type` when present. `maps_to` entries must reference controls that exist in the merged catalog.
+
+## Custom Frameworks
+
+Custom frameworks should be separate YAML packs with stable framework IDs. Load and merge them with the built-in pack before building the catalog index:
+
+```go
+catalog, err := compliance.LoadControlCatalogFiles(
+	"internal/compliance/control_families.yaml",
+	"customer/control_pack.yaml",
+)
+index, issues := compliance.BuildCatalogIndex(catalog)
+```
+
+Use `maps_to` to connect custom controls to controls already covered by generated policy rules. Rule coverage resolution credits the selected custom control when a rule maps to any equivalent control in `maps_to`.
+
+## Control Selections
+
+A control selection is a named scope for a report, audit request, customer questionnaire, internal review, or compliance program view.
+
+```yaml
+id: customer-audit-security
+name: Customer Audit Security Scope
+frameworks:
+  - name: Customer Audit 2026
+    controls: [IAM-1]
+include_tags: [identity]
+include_owner_domains: [identity]
+include_evidence_types: [identity_configuration]
+exclude_controls:
+  - framework_name: SOC 2
+    control_id: CC6.2
+```
+
+Selections can include whole frameworks, families, explicit controls, tags, owner domains, and evidence types. Exclusions are applied last. An empty selection resolves to the full merged catalog, which is useful for completeness checks.
+
+## Coverage Resolution
+
+Coverage is resolved in two steps:
+
+1. Resolve a `ControlSelection` into concrete controls from the catalog index.
+2. Compare selected controls and their `maps_to` aliases with rule `ControlRefs`.
+
+The result reports selected control count, mapped rule IDs, controls without rule coverage, rules by control, and controls by rule. This is the foundation for later control posture and auditor evidence packets.
+
+## Validation
+
+`go run ./tools/catalogcheck` validates the built-in control pack and policy mappings. The shared compliance package also exposes:
+
+- `LoadControlCatalog` and `LoadControlCatalogFiles`
+- `MergeControlCatalogs`
+- `BuildCatalogIndex`
+- `LoadControlSelection`
+- `ResolveControlSelection`
+- `ResolveRuleCoverage`
+
+Run focused checks after changing control authoring code:
+
+```bash
+go test ./internal/compliance ./tools/catalogcheck
+go run ./tools/catalogcheck -summary=false
+```

--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -6,7 +6,7 @@ The `policies/` tree is the checked-in authoring catalog for security policy and
 
 Policies are generated into Go rule definitions in `internal/findings/policy_rule_catalog_gen.go` with `make policy-rule-generate`. The generated policy rules register in the built-in `policy` rule pack, publish auditor-facing control refs in `internal/findings/public_detection_catalog.json`, and evaluate dedicated `policy.evidence` / `policy.result` events that identify a failed `policy_id`, `check_id`, or `rule_id`.
 
-Generated rule copy, evidence type, assessment methods, false-positive guidance, and auditor notes are enriched from `internal/compliance/policy_rule_extensions.yaml`; see `docs/POLICY_RULE_EXTENSIONS.md`.
+Generated rule copy, evidence type, assessment methods, false-positive guidance, and auditor notes are enriched from `internal/compliance/policy_rule_extensions.yaml`; see `docs/POLICY_RULE_EXTENSIONS.md`. Control pack authoring, custom frameworks, and selected control coverage are documented in `docs/COMPLIANCE_CONTROLS.md`.
 
 ## Policy Structure
 

--- a/internal/compliance/catalog.go
+++ b/internal/compliance/catalog.go
@@ -1,0 +1,593 @@
+package compliance
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const DefaultControlCatalogPath = "internal/compliance/control_families.yaml"
+
+type ValidationIssue struct {
+	Path    string
+	Message string
+}
+
+func (i ValidationIssue) Error() string {
+	if strings.TrimSpace(i.Path) == "" {
+		return i.Message
+	}
+	return i.Path + ": " + i.Message
+}
+
+type ControlCatalog struct {
+	Version    string      `json:"version" yaml:"version"`
+	Frameworks []Framework `json:"frameworks" yaml:"frameworks"`
+}
+
+type Framework struct {
+	ID          string   `json:"id,omitempty" yaml:"id,omitempty"`
+	Name        string   `json:"name" yaml:"name"`
+	Version     string   `json:"framework_version,omitempty" yaml:"framework_version,omitempty"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Families    []Family `json:"families" yaml:"families"`
+}
+
+type Family struct {
+	ID          string    `json:"id" yaml:"id"`
+	Name        string    `json:"name" yaml:"name"`
+	Description string    `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags        []string  `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Controls    []Control `json:"controls" yaml:"controls"`
+}
+
+type Control struct {
+	ID                    string                `json:"id" yaml:"id"`
+	Title                 string                `json:"title,omitempty" yaml:"title,omitempty"`
+	Objective             string                `json:"objective,omitempty" yaml:"objective,omitempty"`
+	Intent                string                `json:"intent,omitempty" yaml:"intent,omitempty"`
+	Applicability         []string              `json:"applicability,omitempty" yaml:"applicability,omitempty"`
+	AssessmentMethods     []string              `json:"assessment_methods,omitempty" yaml:"assessment_methods,omitempty"`
+	EvidenceExpectations  []EvidenceExpectation `json:"evidence_expectations,omitempty" yaml:"evidence_expectations,omitempty"`
+	FreshnessSLA          string                `json:"freshness_sla,omitempty" yaml:"freshness_sla,omitempty"`
+	OwnerDomain           string                `json:"owner_domain,omitempty" yaml:"owner_domain,omitempty"`
+	Automatable           *bool                 `json:"automatable,omitempty" yaml:"automatable,omitempty"`
+	ManualEvidenceAllowed *bool                 `json:"manual_evidence_allowed,omitempty" yaml:"manual_evidence_allowed,omitempty"`
+	Tags                  []string              `json:"tags,omitempty" yaml:"tags,omitempty"`
+	MapsTo                []ControlRef          `json:"maps_to,omitempty" yaml:"maps_to,omitempty"`
+}
+
+type EvidenceExpectation struct {
+	ID                string   `json:"id" yaml:"id"`
+	Title             string   `json:"title,omitempty" yaml:"title,omitempty"`
+	Type              string   `json:"type" yaml:"type"`
+	Description       string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Required          *bool    `json:"required,omitempty" yaml:"required,omitempty"`
+	AssessmentMethods []string `json:"assessment_methods,omitempty" yaml:"assessment_methods,omitempty"`
+	FreshnessSLA      string   `json:"freshness_sla,omitempty" yaml:"freshness_sla,omitempty"`
+	AcceptedFrom      []string `json:"accepted_from,omitempty" yaml:"accepted_from,omitempty"`
+}
+
+type ControlRef struct {
+	FrameworkID   string `json:"framework_id,omitempty" yaml:"framework_id,omitempty"`
+	FrameworkName string `json:"framework_name,omitempty" yaml:"framework_name,omitempty"`
+	Framework     string `json:"framework,omitempty" yaml:"framework,omitempty"`
+	ControlID     string `json:"control_id" yaml:"control_id"`
+}
+
+type ResolvedControl struct {
+	FrameworkID      string                `json:"framework_id,omitempty"`
+	FrameworkName    string                `json:"framework_name"`
+	FrameworkVersion string                `json:"framework_version,omitempty"`
+	FamilyID         string                `json:"family_id"`
+	FamilyName       string                `json:"family_name"`
+	Control          Control               `json:"control"`
+	EffectiveTags    []string              `json:"effective_tags,omitempty"`
+	Evidence         []EvidenceExpectation `json:"evidence_expectations,omitempty"`
+}
+
+type CatalogIndex struct {
+	frameworksByName map[string]*Framework
+	frameworksByID   map[string]*Framework
+	families         map[string]map[string]*Family
+	controls         map[string]map[string]*ResolvedControl
+	controlKeys      []string
+}
+
+func LoadControlCatalogFile(path string) (ControlCatalog, error) {
+	content, err := readLocalYAMLFile(path) // #nosec G304 -- control pack path is an operator-provided local YAML file; readLocalYAMLFile rejects symlinks.
+	if err != nil {
+		return ControlCatalog{}, err
+	}
+	return LoadControlCatalog(content)
+}
+
+func LoadControlCatalogFiles(paths ...string) (ControlCatalog, error) {
+	catalogs := make([]ControlCatalog, 0, len(paths))
+	for _, path := range paths {
+		catalog, err := LoadControlCatalogFile(path)
+		if err != nil {
+			return ControlCatalog{}, err
+		}
+		catalogs = append(catalogs, catalog)
+	}
+	return MergeControlCatalogs(catalogs...), nil
+}
+
+func LoadControlCatalog(content []byte) (ControlCatalog, error) {
+	var catalog ControlCatalog
+	if err := yaml.Unmarshal(content, &catalog); err != nil {
+		return ControlCatalog{}, err
+	}
+	return catalog, nil
+}
+
+func readLocalYAMLFile(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("symlinked YAML files are not allowed: %s", path)
+	}
+	return os.ReadFile(path) // #nosec G304 -- control packs and selections are operator-provided local YAML files; symlinks are rejected above.
+}
+
+func MergeControlCatalogs(catalogs ...ControlCatalog) ControlCatalog {
+	var merged ControlCatalog
+	for _, catalog := range catalogs {
+		if strings.TrimSpace(merged.Version) == "" {
+			merged.Version = strings.TrimSpace(catalog.Version)
+		}
+		merged.Frameworks = append(merged.Frameworks, catalog.Frameworks...)
+	}
+	return merged
+}
+
+func BuildCatalogIndex(catalog ControlCatalog) (*CatalogIndex, []ValidationIssue) {
+	index := &CatalogIndex{
+		frameworksByName: map[string]*Framework{},
+		frameworksByID:   map[string]*Framework{},
+		families:         map[string]map[string]*Family{},
+		controls:         map[string]map[string]*ResolvedControl{},
+	}
+	issues := ValidateControlCatalog(catalog)
+	for frameworkIdx := range catalog.Frameworks {
+		framework := &catalog.Frameworks[frameworkIdx]
+		frameworkName := strings.TrimSpace(framework.Name)
+		if frameworkName == "" {
+			continue
+		}
+		frameworkID := strings.TrimSpace(framework.ID)
+		index.frameworksByName[frameworkName] = framework
+		if frameworkID != "" {
+			index.frameworksByID[frameworkID] = framework
+		}
+		frameworkKey := frameworkCatalogKey(*framework)
+		index.families[frameworkKey] = map[string]*Family{}
+		index.controls[frameworkKey] = map[string]*ResolvedControl{}
+		for familyIdx := range framework.Families {
+			family := &framework.Families[familyIdx]
+			familyID := strings.TrimSpace(family.ID)
+			if familyID == "" {
+				continue
+			}
+			index.families[frameworkKey][familyID] = family
+			for controlIdx := range family.Controls {
+				control := family.Controls[controlIdx]
+				control.ID = strings.TrimSpace(control.ID)
+				if control.ID == "" {
+					continue
+				}
+				control = cloneControl(control)
+				refKey := controlKey(frameworkName, control.ID)
+				resolved := &ResolvedControl{
+					FrameworkID:      frameworkID,
+					FrameworkName:    frameworkName,
+					FrameworkVersion: strings.TrimSpace(framework.Version),
+					FamilyID:         familyID,
+					FamilyName:       strings.TrimSpace(family.Name),
+					Control:          control,
+					EffectiveTags:    mergedTags(framework.Tags, family.Tags, control.Tags),
+					Evidence:         append([]EvidenceExpectation(nil), control.EvidenceExpectations...),
+				}
+				index.controls[frameworkKey][control.ID] = resolved
+				index.controlKeys = append(index.controlKeys, refKey)
+			}
+		}
+	}
+	sort.Strings(index.controlKeys)
+	normalizeMappedControlRefs(index)
+	mapIssues := validateControlMappings(catalog, index)
+	issues = append(issues, mapIssues...)
+	return index, issues
+}
+
+func ValidateControlCatalog(catalog ControlCatalog) []ValidationIssue {
+	var issues []ValidationIssue
+	if strings.TrimSpace(catalog.Version) == "" {
+		issues = append(issues, ValidationIssue{Message: "version is required"})
+	}
+	frameworkNames := map[string]struct{}{}
+	frameworkIDs := map[string]struct{}{}
+	for frameworkIdx, framework := range catalog.Frameworks {
+		frameworkPath := fmt.Sprintf("frameworks[%d]", frameworkIdx)
+		frameworkName := strings.TrimSpace(framework.Name)
+		frameworkID := strings.TrimSpace(framework.ID)
+		if frameworkName == "" {
+			issues = append(issues, ValidationIssue{Message: frameworkPath + ".name is required"})
+			continue
+		}
+		if _, exists := frameworkNames[frameworkName]; exists {
+			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("framework %q is duplicated", frameworkName)})
+			continue
+		}
+		frameworkNames[frameworkName] = struct{}{}
+		if frameworkID != "" {
+			if _, exists := frameworkIDs[frameworkID]; exists {
+				issues = append(issues, ValidationIssue{Message: fmt.Sprintf("framework id %q is duplicated", frameworkID)})
+			}
+			frameworkIDs[frameworkID] = struct{}{}
+		}
+		if len(framework.Families) == 0 {
+			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("framework %q requires at least one family", frameworkName)})
+		}
+		issues = append(issues, validateTags(frameworkPath+".tags", framework.Tags)...)
+		familyIDs := map[string]struct{}{}
+		controlIDs := map[string]struct{}{}
+		for familyIdx, family := range framework.Families {
+			familyPath := fmt.Sprintf("%s.families[%d]", frameworkPath, familyIdx)
+			familyID := strings.TrimSpace(family.ID)
+			if familyID == "" {
+				issues = append(issues, ValidationIssue{Message: familyPath + ".id is required"})
+			} else if _, exists := familyIDs[familyID]; exists {
+				issues = append(issues, ValidationIssue{Message: fmt.Sprintf("framework %q family %q is duplicated", frameworkName, familyID)})
+			}
+			familyIDs[familyID] = struct{}{}
+			if strings.TrimSpace(family.Name) == "" {
+				issues = append(issues, ValidationIssue{Message: familyPath + ".name is required"})
+			}
+			if len(family.Controls) == 0 {
+				issues = append(issues, ValidationIssue{Message: fmt.Sprintf("framework %q family %q requires at least one control", frameworkName, familyID)})
+			}
+			issues = append(issues, validateTags(familyPath+".tags", family.Tags)...)
+			for controlIdx, control := range family.Controls {
+				controlPath := fmt.Sprintf("%s.controls[%d]", familyPath, controlIdx)
+				controlID := strings.TrimSpace(control.ID)
+				if controlID == "" {
+					issues = append(issues, ValidationIssue{Message: controlPath + ".id is required"})
+					continue
+				}
+				if _, exists := controlIDs[controlID]; exists {
+					issues = append(issues, ValidationIssue{Message: fmt.Sprintf("framework %q control %q is duplicated", frameworkName, controlID)})
+				}
+				controlIDs[controlID] = struct{}{}
+				issues = append(issues, validateControl(controlPath, control)...)
+			}
+		}
+	}
+	return issues
+}
+
+func (index *CatalogIndex) HasControl(frameworkName, controlID string) bool {
+	_, ok := index.Control(ControlRef{FrameworkName: frameworkName, ControlID: controlID})
+	return ok
+}
+
+func (index *CatalogIndex) Control(ref ControlRef) (ResolvedControl, bool) {
+	if index == nil {
+		return ResolvedControl{}, false
+	}
+	framework, ok := index.resolveFramework(ref)
+	if !ok {
+		return ResolvedControl{}, false
+	}
+	controls := index.controls[frameworkCatalogKey(*framework)]
+	if controls == nil {
+		return ResolvedControl{}, false
+	}
+	control, ok := controls[strings.TrimSpace(ref.ControlID)]
+	if !ok || control == nil {
+		return ResolvedControl{}, false
+	}
+	return cloneResolvedControl(*control), true
+}
+
+func (index *CatalogIndex) Controls() []ResolvedControl {
+	if index == nil {
+		return nil
+	}
+	controls := make([]ResolvedControl, 0, len(index.controlKeys))
+	for _, key := range index.controlKeys {
+		frameworkName, controlID, ok := strings.Cut(key, "\x00")
+		if !ok {
+			continue
+		}
+		if control, ok := index.Control(ControlRef{FrameworkName: frameworkName, ControlID: controlID}); ok {
+			controls = append(controls, control)
+		}
+	}
+	return controls
+}
+
+func (index *CatalogIndex) ControlKeys() []string {
+	if index == nil {
+		return nil
+	}
+	return append([]string(nil), index.controlKeys...)
+}
+
+func (index *CatalogIndex) FamilyControls(frameworkName, familyID string) ([]ResolvedControl, bool) {
+	if index == nil {
+		return nil, false
+	}
+	frameworkName = strings.TrimSpace(frameworkName)
+	framework, ok := index.resolveFramework(ControlRef{FrameworkName: frameworkName})
+	if !ok {
+		framework, ok = index.resolveFramework(ControlRef{FrameworkID: frameworkName})
+	}
+	if !ok {
+		return nil, false
+	}
+	familyID = strings.TrimSpace(familyID)
+	families := index.families[frameworkCatalogKey(*framework)]
+	if _, ok := families[familyID]; !ok {
+		return nil, false
+	}
+	controls := make([]ResolvedControl, 0)
+	for _, control := range index.controls[frameworkCatalogKey(*framework)] {
+		if control.FamilyID == familyID {
+			controls = append(controls, cloneResolvedControl(*control))
+		}
+	}
+	sortResolvedControls(controls)
+	return controls, true
+}
+
+func (index *CatalogIndex) FrameworkControls(ref ControlRef) ([]ResolvedControl, bool) {
+	if index == nil {
+		return nil, false
+	}
+	framework, ok := index.resolveFramework(ref)
+	if !ok {
+		return nil, false
+	}
+	controlsByID := index.controls[frameworkCatalogKey(*framework)]
+	controls := make([]ResolvedControl, 0, len(controlsByID))
+	for _, control := range controlsByID {
+		controls = append(controls, cloneResolvedControl(*control))
+	}
+	sortResolvedControls(controls)
+	return controls, true
+}
+
+func NormalizeControlRef(ref ControlRef) ControlRef {
+	ref.FrameworkID = strings.TrimSpace(ref.FrameworkID)
+	ref.FrameworkName = strings.TrimSpace(ref.FrameworkName)
+	ref.Framework = strings.TrimSpace(ref.Framework)
+	ref.ControlID = strings.TrimSpace(ref.ControlID)
+	if ref.FrameworkName == "" && ref.Framework != "" {
+		ref.FrameworkName = ref.Framework
+	}
+	return ref
+}
+
+func ControlKey(ref ControlRef) string {
+	ref = NormalizeControlRef(ref)
+	return controlKey(firstNonEmpty(ref.FrameworkName, ref.FrameworkID), ref.ControlID)
+}
+
+func (index *CatalogIndex) resolveFramework(ref ControlRef) (*Framework, bool) {
+	ref = NormalizeControlRef(ref)
+	if ref.FrameworkID != "" {
+		framework, ok := index.frameworksByID[ref.FrameworkID]
+		if ok {
+			return framework, true
+		}
+	}
+	if ref.FrameworkName != "" {
+		framework, ok := index.frameworksByName[ref.FrameworkName]
+		if ok {
+			return framework, true
+		}
+	}
+	return nil, false
+}
+
+func validateControl(path string, control Control) []ValidationIssue {
+	var issues []ValidationIssue
+	issues = append(issues, validateAssessmentMethods(path+".assessment_methods", control.AssessmentMethods)...)
+	issues = append(issues, validateTags(path+".tags", control.Tags)...)
+	for expectationIdx, expectation := range control.EvidenceExpectations {
+		expectationPath := fmt.Sprintf("%s.evidence_expectations[%d]", path, expectationIdx)
+		if strings.TrimSpace(expectation.ID) == "" {
+			issues = append(issues, ValidationIssue{Message: expectationPath + ".id is required"})
+		}
+		if strings.TrimSpace(expectation.Type) == "" {
+			issues = append(issues, ValidationIssue{Message: expectationPath + ".type is required"})
+		}
+		issues = append(issues, validateAssessmentMethods(expectationPath+".assessment_methods", expectation.AssessmentMethods)...)
+		issues = append(issues, validateStringList(expectationPath+".accepted_from", expectation.AcceptedFrom)...)
+	}
+	for mapIdx, ref := range control.MapsTo {
+		ref = NormalizeControlRef(ref)
+		refPath := fmt.Sprintf("%s.maps_to[%d]", path, mapIdx)
+		if ref.FrameworkID == "" && ref.FrameworkName == "" {
+			issues = append(issues, ValidationIssue{Message: refPath + ".framework_name is required"})
+		}
+		if ref.ControlID == "" {
+			issues = append(issues, ValidationIssue{Message: refPath + ".control_id is required"})
+		}
+	}
+	return issues
+}
+
+func validateControlMappings(catalog ControlCatalog, index *CatalogIndex) []ValidationIssue {
+	var issues []ValidationIssue
+	for frameworkIdx, framework := range catalog.Frameworks {
+		for familyIdx, family := range framework.Families {
+			for controlIdx, control := range family.Controls {
+				controlPath := fmt.Sprintf("frameworks[%d].families[%d].controls[%d]", frameworkIdx, familyIdx, controlIdx)
+				for mapIdx, ref := range control.MapsTo {
+					ref = NormalizeControlRef(ref)
+					if ref.ControlID == "" || (ref.FrameworkID == "" && ref.FrameworkName == "") {
+						continue
+					}
+					if _, ok := index.Control(ref); !ok {
+						framework := firstNonEmpty(ref.FrameworkName, ref.FrameworkID)
+						issues = append(issues, ValidationIssue{Message: fmt.Sprintf("%s.maps_to[%d] %s %s is not declared", controlPath, mapIdx, framework, ref.ControlID)})
+					}
+				}
+			}
+		}
+	}
+	return issues
+}
+
+func normalizeMappedControlRefs(index *CatalogIndex) {
+	if index == nil {
+		return
+	}
+	for _, controls := range index.controls {
+		for _, control := range controls {
+			if control == nil {
+				continue
+			}
+			for idx, ref := range control.Control.MapsTo {
+				target, ok := index.Control(ref)
+				if !ok {
+					continue
+				}
+				control.Control.MapsTo[idx] = ControlRef{
+					FrameworkID:   target.FrameworkID,
+					FrameworkName: target.FrameworkName,
+					ControlID:     target.Control.ID,
+				}
+			}
+		}
+	}
+}
+
+func validateAssessmentMethods(path string, values []string) []ValidationIssue {
+	var issues []ValidationIssue
+	for idx, value := range values {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		switch normalized {
+		case "examine", "interview", "test":
+		default:
+			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("%s[%d] must be one of examine, interview, test", path, idx)})
+		}
+	}
+	return issues
+}
+
+func validateTags(path string, values []string) []ValidationIssue {
+	return validateStringList(path, values)
+}
+
+func validateStringList(path string, values []string) []ValidationIssue {
+	var issues []ValidationIssue
+	for idx, value := range values {
+		if strings.TrimSpace(value) == "" {
+			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("%s[%d] must be non-empty", path, idx)})
+		}
+	}
+	return issues
+}
+
+func mergedTags(values ...[]string) []string {
+	seen := map[string]struct{}{}
+	var tags []string
+	for _, set := range values {
+		for _, value := range set {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			tags = append(tags, value)
+		}
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+func cloneResolvedControl(control ResolvedControl) ResolvedControl {
+	control.Control = cloneControl(control.Control)
+	control.EffectiveTags = append([]string(nil), control.EffectiveTags...)
+	control.Evidence = cloneEvidenceExpectations(control.Evidence)
+	return control
+}
+
+func cloneControl(control Control) Control {
+	control.Applicability = append([]string(nil), control.Applicability...)
+	control.AssessmentMethods = append([]string(nil), control.AssessmentMethods...)
+	control.EvidenceExpectations = cloneEvidenceExpectations(control.EvidenceExpectations)
+	control.Tags = append([]string(nil), control.Tags...)
+	control.MapsTo = append([]ControlRef(nil), control.MapsTo...)
+	return control
+}
+
+func cloneEvidenceExpectations(expectations []EvidenceExpectation) []EvidenceExpectation {
+	if len(expectations) == 0 {
+		return nil
+	}
+	values := make([]EvidenceExpectation, 0, len(expectations))
+	for _, expectation := range expectations {
+		expectation.AssessmentMethods = append([]string(nil), expectation.AssessmentMethods...)
+		expectation.AcceptedFrom = append([]string(nil), expectation.AcceptedFrom...)
+		values = append(values, expectation)
+	}
+	return values
+}
+
+func sortResolvedControls(controls []ResolvedControl) {
+	sort.Slice(controls, func(i, j int) bool {
+		left := controlKey(controls[i].FrameworkName, controls[i].Control.ID)
+		right := controlKey(controls[j].FrameworkName, controls[j].Control.ID)
+		if left == right {
+			return controls[i].FamilyID < controls[j].FamilyID
+		}
+		return left < right
+	})
+}
+
+func frameworkCatalogKey(framework Framework) string {
+	if id := strings.TrimSpace(framework.ID); id != "" {
+		return "id:" + id
+	}
+	return "name:" + strings.TrimSpace(framework.Name)
+}
+
+func controlKey(frameworkName, controlID string) string {
+	return strings.TrimSpace(frameworkName) + "\x00" + strings.TrimSpace(controlID)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func IssuesError(issues []ValidationIssue) error {
+	if len(issues) == 0 {
+		return nil
+	}
+	lines := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		lines = append(lines, issue.Error())
+	}
+	sort.Strings(lines)
+	return errors.New(strings.Join(lines, "\n"))
+}

--- a/internal/compliance/catalog_test.go
+++ b/internal/compliance/catalog_test.go
@@ -1,0 +1,191 @@
+package compliance
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildCatalogIndexAcceptsRichCustomControlPack(t *testing.T) {
+	catalog := loadTestCatalog(t, `
+version: "2026-06-17"
+frameworks:
+  - id: soc2
+    name: SOC 2
+    framework_version: "2022"
+    families:
+      - id: CC6
+        name: Logical and Physical Access
+        controls:
+          - id: CC6.1
+            title: Logical access is restricted
+            assessment_methods: [examine, test]
+            tags: [identity]
+            evidence_expectations:
+              - id: mfa-config
+                type: identity_configuration
+                description: MFA settings for privileged access.
+                assessment_methods: [examine]
+  - id: customer-audit-2026
+    name: Customer Audit 2026
+    families:
+      - id: IAM
+        name: Identity Controls
+        tags: [identity]
+        controls:
+          - id: IAM-1
+            title: Privileged access requires MFA
+            objective: Privileged users authenticate with phishing-resistant MFA.
+            intent: Reduce the likelihood of account takeover for administrative access.
+            owner_domain: identity
+            assessment_methods: [examine, test]
+            evidence_expectations:
+              - id: privileged-mfa-state
+                type: identity_configuration
+                required: true
+                accepted_from: [okta, github]
+            maps_to:
+              - framework_name: SOC 2
+                control_id: CC6.1
+`)
+	index, issues := BuildCatalogIndex(catalog)
+	if len(issues) != 0 {
+		t.Fatalf("BuildCatalogIndex() issues = %#v, want none", issues)
+	}
+	control, ok := index.Control(ControlRef{FrameworkID: "customer-audit-2026", ControlID: "IAM-1"})
+	if !ok {
+		t.Fatal("Control(Customer Audit 2026 IAM-1) not found")
+	}
+	if control.Control.Objective == "" || control.Control.Intent == "" {
+		t.Fatalf("rich control fields were not retained: %#v", control.Control)
+	}
+	if !stringSliceContains(control.EffectiveTags, "identity") {
+		t.Fatalf("EffectiveTags = %#v, want inherited identity tag", control.EffectiveTags)
+	}
+	if len(control.Evidence) != 1 || control.Evidence[0].Type != "identity_configuration" {
+		t.Fatalf("Evidence = %#v, want identity_configuration expectation", control.Evidence)
+	}
+}
+
+func TestBuildCatalogIndexRejectsInvalidAssessmentMethodAndMapping(t *testing.T) {
+	catalog := loadTestCatalog(t, `
+version: "2026-06-17"
+frameworks:
+  - name: Custom
+    families:
+      - id: IAM
+        name: Identity Controls
+        controls:
+          - id: IAM-1
+            assessment_methods: [observe]
+            maps_to:
+              - framework_name: Missing
+                control_id: M-1
+`)
+	_, issues := BuildCatalogIndex(catalog)
+	if !issueContains(issues, "assessment_methods[0] must be one of examine, interview, test") {
+		t.Fatalf("issues = %#v, want invalid assessment method", issues)
+	}
+	if !issueContains(issues, "maps_to[0] Missing M-1 is not declared") {
+		t.Fatalf("issues = %#v, want missing mapping target", issues)
+	}
+}
+
+func TestMergeControlCatalogsAllowsCustomPacksToMapToBuiltins(t *testing.T) {
+	builtin := loadTestCatalog(t, `
+version: "2026-06-17"
+frameworks:
+  - name: SOC 2
+    families:
+      - id: CC6
+        name: Logical and Physical Access
+        controls:
+          - id: CC6.1
+`)
+	custom := loadTestCatalog(t, `
+version: "customer-2026"
+frameworks:
+  - name: Customer Framework
+    families:
+      - id: IAM
+        name: Identity Controls
+        controls:
+          - id: IAM-1
+            maps_to:
+              - framework_name: SOC 2
+                control_id: CC6.1
+`)
+	merged := MergeControlCatalogs(builtin, custom)
+	index, issues := BuildCatalogIndex(merged)
+	if len(issues) != 0 {
+		t.Fatalf("BuildCatalogIndex() issues = %#v, want none", issues)
+	}
+	if !index.HasControl("Customer Framework", "IAM-1") {
+		t.Fatal("merged custom control not found")
+	}
+}
+
+func TestBuildCatalogIndexDoesNotMutateCallerCatalogWhenNormalizingMappings(t *testing.T) {
+	catalog := loadTestCatalog(t, `
+version: "2026-06-17"
+frameworks:
+  - id: soc2
+    name: SOC 2
+    families:
+      - id: CC6
+        name: Logical and Physical Access
+        controls:
+          - id: CC6.1
+  - id: custom
+    name: Custom Framework
+    families:
+      - id: IAM
+        name: Identity Controls
+        controls:
+          - id: IAM-1
+            maps_to:
+              - framework_id: soc2
+                control_id: CC6.1
+`)
+	index, issues := BuildCatalogIndex(catalog)
+	if len(issues) != 0 {
+		t.Fatalf("BuildCatalogIndex() issues = %#v, want none", issues)
+	}
+	stored, ok := index.Control(ControlRef{FrameworkName: "Custom Framework", ControlID: "IAM-1"})
+	if !ok {
+		t.Fatal("Control(Custom Framework IAM-1) not found")
+	}
+	if got := stored.Control.MapsTo[0].FrameworkName; got != "SOC 2" {
+		t.Fatalf("stored maps_to framework_name = %q, want SOC 2", got)
+	}
+	original := catalog.Frameworks[1].Families[0].Controls[0].MapsTo[0]
+	if original.FrameworkID != "soc2" || original.FrameworkName != "" {
+		t.Fatalf("original maps_to = %#v, want caller catalog left untouched", original)
+	}
+}
+
+func loadTestCatalog(t *testing.T, content string) ControlCatalog {
+	t.Helper()
+	catalog, err := LoadControlCatalog([]byte(content))
+	if err != nil {
+		t.Fatalf("LoadControlCatalog() error = %v", err)
+	}
+	return catalog
+}
+
+func issueContains(issues []ValidationIssue, want string) bool {
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/compliance/selection.go
+++ b/internal/compliance/selection.go
@@ -1,0 +1,313 @@
+package compliance
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ControlSelection struct {
+	ID                   string               `json:"id" yaml:"id"`
+	Name                 string               `json:"name" yaml:"name"`
+	Description          string               `json:"description,omitempty" yaml:"description,omitempty"`
+	Frameworks           []FrameworkSelection `json:"frameworks,omitempty" yaml:"frameworks,omitempty"`
+	IncludeControls      []ControlRef         `json:"include_controls,omitempty" yaml:"include_controls,omitempty"`
+	ExcludeControls      []ControlRef         `json:"exclude_controls,omitempty" yaml:"exclude_controls,omitempty"`
+	IncludeTags          []string             `json:"include_tags,omitempty" yaml:"include_tags,omitempty"`
+	ExcludeTags          []string             `json:"exclude_tags,omitempty" yaml:"exclude_tags,omitempty"`
+	IncludeOwnerDomains  []string             `json:"include_owner_domains,omitempty" yaml:"include_owner_domains,omitempty"`
+	IncludeEvidenceTypes []string             `json:"include_evidence_types,omitempty" yaml:"include_evidence_types,omitempty"`
+}
+
+type FrameworkSelection struct {
+	ID         string   `json:"id,omitempty" yaml:"id,omitempty"`
+	Name       string   `json:"name,omitempty" yaml:"name,omitempty"`
+	IncludeAll bool     `json:"include_all,omitempty" yaml:"include_all,omitempty"`
+	Families   []string `json:"families,omitempty" yaml:"families,omitempty"`
+	Controls   []string `json:"controls,omitempty" yaml:"controls,omitempty"`
+}
+
+type SelectionResolution struct {
+	SelectionID string            `json:"selection_id,omitempty"`
+	Controls    []ResolvedControl `json:"controls"`
+	ControlKeys []string          `json:"control_keys"`
+}
+
+type RuleControlMapping struct {
+	RuleID      string       `json:"rule_id"`
+	ControlRefs []ControlRef `json:"control_refs"`
+}
+
+type RuleCoverage struct {
+	SelectedControls int                     `json:"selected_controls"`
+	MappedRules      []string                `json:"mapped_rules"`
+	UnmappedControls []ControlRef            `json:"unmapped_controls"`
+	RulesByControl   map[string][]string     `json:"rules_by_control"`
+	ControlsByRule   map[string][]ControlRef `json:"controls_by_rule"`
+}
+
+func LoadControlSelectionFile(path string) (ControlSelection, error) {
+	content, err := readLocalYAMLFile(path) // #nosec G304 -- control selection path is an operator-provided local YAML file; readLocalYAMLFile rejects symlinks.
+	if err != nil {
+		return ControlSelection{}, err
+	}
+	return LoadControlSelection(content)
+}
+
+func LoadControlSelection(content []byte) (ControlSelection, error) {
+	var selection ControlSelection
+	if err := yaml.Unmarshal(content, &selection); err != nil {
+		return ControlSelection{}, err
+	}
+	return selection, nil
+}
+
+func ResolveControlSelection(index *CatalogIndex, selection ControlSelection) (SelectionResolution, []ValidationIssue) {
+	var issues []ValidationIssue
+	if index == nil {
+		return SelectionResolution{SelectionID: strings.TrimSpace(selection.ID)}, []ValidationIssue{{Message: "control catalog index is required"}}
+	}
+	selected := map[string]ResolvedControl{}
+	if selectionEmpty(selection) {
+		for _, control := range index.Controls() {
+			selected[ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID})] = control
+		}
+	} else {
+		for idx, frameworkSelection := range selection.Frameworks {
+			controls, frameworkIssues := resolveFrameworkSelection(index, idx, frameworkSelection)
+			issues = append(issues, frameworkIssues...)
+			for _, control := range controls {
+				selected[ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID})] = control
+			}
+		}
+		for idx, ref := range selection.IncludeControls {
+			control, ok := index.Control(ref)
+			if !ok {
+				ref = NormalizeControlRef(ref)
+				issues = append(issues, ValidationIssue{Message: fmt.Sprintf("include_controls[%d] %s %s is not declared", idx, firstNonEmpty(ref.FrameworkName, ref.FrameworkID), ref.ControlID)})
+				continue
+			}
+			selected[ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID})] = control
+		}
+		if len(selection.IncludeTags) != 0 || len(selection.IncludeOwnerDomains) != 0 || len(selection.IncludeEvidenceTypes) != 0 {
+			for _, control := range index.Controls() {
+				if controlMatchesSelectionFilters(control, selection) {
+					selected[ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID})] = control
+				}
+			}
+		}
+	}
+	for idx, ref := range selection.ExcludeControls {
+		control, ok := index.Control(ref)
+		if !ok {
+			ref = NormalizeControlRef(ref)
+			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("exclude_controls[%d] %s %s is not declared", idx, firstNonEmpty(ref.FrameworkName, ref.FrameworkID), ref.ControlID)})
+			continue
+		}
+		delete(selected, ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID}))
+	}
+	for key, control := range selected {
+		if hasAnyFold(control.EffectiveTags, selection.ExcludeTags) {
+			delete(selected, key)
+		}
+	}
+	result := SelectionResolution{SelectionID: strings.TrimSpace(selection.ID)}
+	for key, control := range selected {
+		result.ControlKeys = append(result.ControlKeys, key)
+		result.Controls = append(result.Controls, control)
+	}
+	sort.Strings(result.ControlKeys)
+	sortResolvedControls(result.Controls)
+	return result, issues
+}
+
+func ResolveRuleCoverage(resolution SelectionResolution, rules []RuleControlMapping) RuleCoverage {
+	selected := map[string]ControlRef{}
+	aliases := map[string][]string{}
+	for _, control := range resolution.Controls {
+		ref := ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID}
+		selectedKey := ControlKey(ref)
+		selected[selectedKey] = ref
+		aliases[selectedKey] = appendUniqueString(aliases[selectedKey], selectedKey)
+		for _, mappedRef := range control.Control.MapsTo {
+			mappedRef = NormalizeControlRef(mappedRef)
+			if mappedRef.ControlID == "" || (mappedRef.FrameworkID == "" && mappedRef.FrameworkName == "") {
+				continue
+			}
+			mappedKey := ControlKey(mappedRef)
+			aliases[mappedKey] = appendUniqueString(aliases[mappedKey], selectedKey)
+		}
+	}
+	coverage := RuleCoverage{
+		SelectedControls: len(selected),
+		RulesByControl:   map[string][]string{},
+		ControlsByRule:   map[string][]ControlRef{},
+	}
+	mappedRules := map[string]struct{}{}
+	for _, rule := range rules {
+		ruleID := strings.TrimSpace(rule.RuleID)
+		if ruleID == "" {
+			continue
+		}
+		for _, ref := range rule.ControlRefs {
+			candidateKey := ControlKey(ref)
+			selectedKeys := aliases[candidateKey]
+			if len(selectedKeys) == 0 {
+				continue
+			}
+			for _, selectedKey := range selectedKeys {
+				selectedRef, ok := selected[selectedKey]
+				if !ok {
+					continue
+				}
+				mappedRules[ruleID] = struct{}{}
+				coverage.RulesByControl[selectedKey] = appendUniqueString(coverage.RulesByControl[selectedKey], ruleID)
+				coverage.ControlsByRule[ruleID] = appendUniqueControlRef(coverage.ControlsByRule[ruleID], selectedRef)
+			}
+		}
+	}
+	for ruleID := range mappedRules {
+		coverage.MappedRules = append(coverage.MappedRules, ruleID)
+	}
+	sort.Strings(coverage.MappedRules)
+	for key, ref := range selected {
+		if len(coverage.RulesByControl[key]) == 0 {
+			coverage.UnmappedControls = append(coverage.UnmappedControls, ref)
+		}
+	}
+	sort.Slice(coverage.UnmappedControls, func(i, j int) bool {
+		return ControlKey(coverage.UnmappedControls[i]) < ControlKey(coverage.UnmappedControls[j])
+	})
+	for key := range coverage.RulesByControl {
+		sort.Strings(coverage.RulesByControl[key])
+	}
+	for ruleID := range coverage.ControlsByRule {
+		sort.Slice(coverage.ControlsByRule[ruleID], func(i, j int) bool {
+			return ControlKey(coverage.ControlsByRule[ruleID][i]) < ControlKey(coverage.ControlsByRule[ruleID][j])
+		})
+	}
+	return coverage
+}
+
+func resolveFrameworkSelection(index *CatalogIndex, idx int, selection FrameworkSelection) ([]ResolvedControl, []ValidationIssue) {
+	ref := ControlRef{FrameworkID: strings.TrimSpace(selection.ID), FrameworkName: strings.TrimSpace(selection.Name)}
+	var issues []ValidationIssue
+	if ref.FrameworkID == "" && ref.FrameworkName == "" {
+		return nil, []ValidationIssue{{Message: fmt.Sprintf("frameworks[%d].name or frameworks[%d].id is required", idx, idx)}}
+	}
+	if selection.IncludeAll || (len(selection.Families) == 0 && len(selection.Controls) == 0) {
+		controls, ok := index.FrameworkControls(ref)
+		if !ok {
+			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("frameworks[%d] %s is not declared", idx, firstNonEmpty(ref.FrameworkName, ref.FrameworkID))})
+		}
+		return controls, issues
+	}
+	selected := map[string]ResolvedControl{}
+	for familyIdx, familyID := range selection.Families {
+		familyID = strings.TrimSpace(familyID)
+		if familyID == "" {
+			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("frameworks[%d].families[%d] is required", idx, familyIdx)})
+			continue
+		}
+		controls, ok := index.FamilyControls(firstNonEmpty(ref.FrameworkName, ref.FrameworkID), familyID)
+		if !ok {
+			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("frameworks[%d].families[%d] %s is not declared", idx, familyIdx, familyID)})
+			continue
+		}
+		for _, control := range controls {
+			selected[ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID})] = control
+		}
+	}
+	for controlIdx, controlID := range selection.Controls {
+		controlID = strings.TrimSpace(controlID)
+		if controlID == "" {
+			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("frameworks[%d].controls[%d] is required", idx, controlIdx)})
+			continue
+		}
+		control, ok := index.Control(ControlRef{FrameworkID: ref.FrameworkID, FrameworkName: ref.FrameworkName, ControlID: controlID})
+		if !ok {
+			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("frameworks[%d].controls[%d] %s is not declared", idx, controlIdx, controlID)})
+			continue
+		}
+		selected[ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID})] = control
+	}
+	controls := make([]ResolvedControl, 0, len(selected))
+	for _, control := range selected {
+		controls = append(controls, control)
+	}
+	sortResolvedControls(controls)
+	return controls, issues
+}
+
+func selectionEmpty(selection ControlSelection) bool {
+	return len(selection.Frameworks) == 0 &&
+		len(selection.IncludeControls) == 0 &&
+		len(selection.IncludeTags) == 0 &&
+		len(selection.IncludeOwnerDomains) == 0 &&
+		len(selection.IncludeEvidenceTypes) == 0
+}
+
+func controlMatchesSelectionFilters(control ResolvedControl, selection ControlSelection) bool {
+	if len(selection.IncludeTags) != 0 && !hasAnyFold(control.EffectiveTags, selection.IncludeTags) {
+		return false
+	}
+	if len(selection.IncludeOwnerDomains) != 0 && !stringSetContainsFold(selection.IncludeOwnerDomains, control.Control.OwnerDomain) {
+		return false
+	}
+	if len(selection.IncludeEvidenceTypes) != 0 && !controlHasEvidenceType(control, selection.IncludeEvidenceTypes) {
+		return false
+	}
+	return true
+}
+
+func controlHasEvidenceType(control ResolvedControl, evidenceTypes []string) bool {
+	for _, expectation := range control.Evidence {
+		if stringSetContainsFold(evidenceTypes, expectation.Type) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAnyFold(values []string, needles []string) bool {
+	for _, value := range values {
+		if stringSetContainsFold(needles, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSetContainsFold(values []string, needle string) bool {
+	needle = strings.TrimSpace(needle)
+	if needle == "" {
+		return false
+	}
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func appendUniqueString(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func appendUniqueControlRef(values []ControlRef, value ControlRef) []ControlRef {
+	value = NormalizeControlRef(value)
+	for _, existing := range values {
+		if ControlKey(existing) == ControlKey(value) {
+			return values
+		}
+	}
+	return append(values, value)
+}

--- a/internal/compliance/selection_test.go
+++ b/internal/compliance/selection_test.go
@@ -1,0 +1,128 @@
+package compliance
+
+import "testing"
+
+func TestLoadControlSelectionReadsYAML(t *testing.T) {
+	selection, err := LoadControlSelection([]byte(`
+id: customer-audit
+name: Customer Audit
+frameworks:
+  - name: SOC 2
+    controls: [CC6.1]
+include_tags: [identity]
+exclude_controls:
+  - framework_name: SOC 2
+    control_id: CC6.2
+`))
+	if err != nil {
+		t.Fatalf("LoadControlSelection() error = %v", err)
+	}
+	if selection.ID != "customer-audit" || len(selection.Frameworks) != 1 || len(selection.ExcludeControls) != 1 {
+		t.Fatalf("selection = %#v, want parsed YAML selection", selection)
+	}
+}
+
+func TestResolveControlSelectionSupportsFrameworkFamiliesAndExclusions(t *testing.T) {
+	index := testSelectionIndex(t)
+	resolution, issues := ResolveControlSelection(index, ControlSelection{
+		ID: "soc2-cc6-without-cc6-2",
+		Frameworks: []FrameworkSelection{{
+			Name:     "SOC 2",
+			Families: []string{"CC6"},
+		}},
+		ExcludeControls: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.2"}},
+	})
+	if len(issues) != 0 {
+		t.Fatalf("ResolveControlSelection() issues = %#v, want none", issues)
+	}
+	if len(resolution.Controls) != 1 {
+		t.Fatalf("len(Controls) = %d, want 1", len(resolution.Controls))
+	}
+	if got := resolution.Controls[0].Control.ID; got != "CC6.1" {
+		t.Fatalf("selected control = %q, want CC6.1", got)
+	}
+}
+
+func TestResolveControlSelectionSupportsTagOwnerAndEvidenceFilters(t *testing.T) {
+	index := testSelectionIndex(t)
+	resolution, issues := ResolveControlSelection(index, ControlSelection{
+		ID:                   "identity-configuration",
+		IncludeTags:          []string{"identity"},
+		IncludeOwnerDomains:  []string{"identity"},
+		IncludeEvidenceTypes: []string{"identity_configuration"},
+	})
+	if len(issues) != 0 {
+		t.Fatalf("ResolveControlSelection() issues = %#v, want none", issues)
+	}
+	if len(resolution.Controls) != 1 || resolution.Controls[0].Control.ID != "IAM-1" {
+		t.Fatalf("Controls = %#v, want custom IAM-1", resolution.Controls)
+	}
+}
+
+func TestResolveRuleCoverageCreditsMappedCustomFrameworkControls(t *testing.T) {
+	index := testSelectionIndex(t)
+	resolution, issues := ResolveControlSelection(index, ControlSelection{
+		Frameworks: []FrameworkSelection{{
+			ID:       "custom",
+			Controls: []string{"IAM-1"},
+		}},
+	})
+	if len(issues) != 0 {
+		t.Fatalf("ResolveControlSelection() issues = %#v, want none", issues)
+	}
+	coverage := ResolveRuleCoverage(resolution, []RuleControlMapping{{
+		RuleID:      "identity-mfa-required",
+		ControlRefs: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+	}})
+	if coverage.SelectedControls != 1 {
+		t.Fatalf("SelectedControls = %d, want 1", coverage.SelectedControls)
+	}
+	if len(coverage.MappedRules) != 1 || coverage.MappedRules[0] != "identity-mfa-required" {
+		t.Fatalf("MappedRules = %#v, want identity-mfa-required", coverage.MappedRules)
+	}
+	customKey := ControlKey(ControlRef{FrameworkName: "Custom Framework", ControlID: "IAM-1"})
+	if got := coverage.RulesByControl[customKey]; len(got) != 1 || got[0] != "identity-mfa-required" {
+		t.Fatalf("RulesByControl[%q] = %#v, want identity-mfa-required", customKey, got)
+	}
+	if len(coverage.UnmappedControls) != 0 {
+		t.Fatalf("UnmappedControls = %#v, want none", coverage.UnmappedControls)
+	}
+}
+
+func testSelectionIndex(t *testing.T) *CatalogIndex {
+	t.Helper()
+	catalog := loadTestCatalog(t, `
+version: "2026-06-17"
+frameworks:
+  - id: soc2
+    name: SOC 2
+    families:
+      - id: CC6
+        name: Logical and Physical Access
+        controls:
+          - id: CC6.1
+            tags: [identity]
+          - id: CC6.2
+            tags: [identity]
+  - id: custom
+    name: Custom Framework
+    families:
+      - id: IAM
+        name: Identity Controls
+        controls:
+          - id: IAM-1
+            owner_domain: identity
+            tags: [identity]
+            evidence_expectations:
+              - id: privileged-mfa-state
+                type: identity_configuration
+            maps_to:
+              - framework_id: soc2
+                control_id: CC6.1
+`)
+	index, issues := BuildCatalogIndex(catalog)
+	if len(issues) != 0 {
+		t.Fatalf("BuildCatalogIndex() issues = %#v, want none", issues)
+	}
+	return index
+}

--- a/tools/catalogcheck/catalogcheck.go
+++ b/tools/catalogcheck/catalogcheck.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/connectorcatalog"
 	findinganalysis "github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -21,31 +22,6 @@ import (
 type issue struct {
 	path    string
 	message string
-}
-
-type complianceControlCatalogIndex struct {
-	controls map[string]map[string]struct{}
-}
-
-type complianceControlCatalog struct {
-	Version    string                              `yaml:"version"`
-	Frameworks []complianceControlCatalogFramework `yaml:"frameworks"`
-}
-
-type complianceControlCatalogFramework struct {
-	Name     string                           `yaml:"name"`
-	Families []complianceControlCatalogFamily `yaml:"families"`
-}
-
-type complianceControlCatalogFamily struct {
-	ID       string                            `yaml:"id"`
-	Name     string                            `yaml:"name"`
-	Controls []complianceControlCatalogControl `yaml:"controls"`
-}
-
-type complianceControlCatalogControl struct {
-	ID   string `yaml:"id"`
-	Name string `yaml:"name"`
 }
 
 func main() {
@@ -114,8 +90,8 @@ func checkRepository(root string) ([]issue, error) {
 	return issues, nil
 }
 
-func loadComplianceControlCatalog(root string) (*complianceControlCatalogIndex, []issue, error) {
-	path := filepath.Join(root, "internal", "compliance", "control_families.yaml")
+func loadComplianceControlCatalog(root string) (*compliance.CatalogIndex, []issue, error) {
+	path := filepath.Join(root, filepath.FromSlash(compliance.DefaultControlCatalogPath))
 	rel := slashRel(root, path)
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -124,65 +100,16 @@ func loadComplianceControlCatalog(root string) (*complianceControlCatalogIndex, 
 		}
 		return nil, nil, fmt.Errorf("read %s: %w", rel, err)
 	}
-	var catalog complianceControlCatalog
-	if err := yaml.Unmarshal(content, &catalog); err != nil {
+	catalog, err := compliance.LoadControlCatalog(content)
+	if err != nil {
 		return nil, []issue{{path: rel, message: "invalid YAML: " + err.Error()}}, nil
 	}
-	index := &complianceControlCatalogIndex{controls: map[string]map[string]struct{}{}}
-	var issues []issue
-	if strings.TrimSpace(catalog.Version) == "" {
-		issues = append(issues, issue{path: rel, message: "version is required"})
-	}
-	for frameworkIdx, framework := range catalog.Frameworks {
-		frameworkName := strings.TrimSpace(framework.Name)
-		if frameworkName == "" {
-			issues = append(issues, issue{path: rel, message: fmt.Sprintf("frameworks[%d].name is required", frameworkIdx)})
-			continue
-		}
-		if _, exists := index.controls[frameworkName]; exists {
-			issues = append(issues, issue{path: rel, message: fmt.Sprintf("framework %q is duplicated", frameworkName)})
-			continue
-		}
-		index.controls[frameworkName] = map[string]struct{}{}
-		if len(framework.Families) == 0 {
-			issues = append(issues, issue{path: rel, message: fmt.Sprintf("framework %q requires at least one family", frameworkName)})
-		}
-		for familyIdx, family := range framework.Families {
-			if strings.TrimSpace(family.ID) == "" {
-				issues = append(issues, issue{path: rel, message: fmt.Sprintf("framework %q families[%d].id is required", frameworkName, familyIdx)})
-			}
-			if strings.TrimSpace(family.Name) == "" {
-				issues = append(issues, issue{path: rel, message: fmt.Sprintf("framework %q families[%d].name is required", frameworkName, familyIdx)})
-			}
-			if len(family.Controls) == 0 {
-				issues = append(issues, issue{path: rel, message: fmt.Sprintf("framework %q family %q requires at least one control", frameworkName, strings.TrimSpace(family.ID))})
-			}
-			for controlIdx, control := range family.Controls {
-				controlID := strings.TrimSpace(control.ID)
-				if controlID == "" {
-					issues = append(issues, issue{path: rel, message: fmt.Sprintf("framework %q family %q controls[%d].id is required", frameworkName, strings.TrimSpace(family.ID), controlIdx)})
-					continue
-				}
-				if _, exists := index.controls[frameworkName][controlID]; exists {
-					issues = append(issues, issue{path: rel, message: fmt.Sprintf("framework %q control %q is duplicated", frameworkName, controlID)})
-				}
-				index.controls[frameworkName][controlID] = struct{}{}
-			}
-		}
+	index, validationIssues := compliance.BuildCatalogIndex(catalog)
+	issues := make([]issue, 0, len(validationIssues))
+	for _, validationIssue := range validationIssues {
+		issues = append(issues, issue{path: rel, message: validationIssue.Message})
 	}
 	return index, issues, nil
-}
-
-func (catalog *complianceControlCatalogIndex) hasControl(frameworkName, controlID string) bool {
-	if catalog == nil {
-		return true
-	}
-	controls, ok := catalog.controls[strings.TrimSpace(frameworkName)]
-	if !ok {
-		return false
-	}
-	_, ok = controls[strings.TrimSpace(controlID)]
-	return ok
 }
 
 func checkConnectorDefinitionCatalog(root string) ([]issue, error) {
@@ -221,11 +148,11 @@ func analyzeConnectorDefinitionCatalog(root string) (string, connectorcatalog.An
 	return catalogRoot, analysis, err
 }
 
-func checkFindingRuleMetadata(controlCatalog *complianceControlCatalogIndex) []issue {
+func checkFindingRuleMetadata(controlCatalog *compliance.CatalogIndex) []issue {
 	var issues []issue
 	for _, metadata := range findinganalysis.BuiltinRuleMetadata() {
 		for _, ref := range metadata.ControlRefs {
-			if !controlCatalog.hasControl(ref.FrameworkName, ref.ControlID) {
+			if controlCatalog != nil && !controlCatalog.HasControl(ref.FrameworkName, ref.ControlID) {
 				issues = append(issues, issue{
 					path:    "internal/findings",
 					message: fmt.Sprintf("rule %q control ref %s %s is not declared in internal/compliance/control_families.yaml", metadata.ID, ref.FrameworkName, ref.ControlID),
@@ -250,7 +177,7 @@ func checkCorrelationCatalog() []issue {
 	return nil
 }
 
-func checkPolicies(root string, controlCatalog *complianceControlCatalogIndex) ([]issue, error) {
+func checkPolicies(root string, controlCatalog *compliance.CatalogIndex) ([]issue, error) {
 	policiesRoot := filepath.Join(root, "policies")
 	ids := map[string]string{}
 	var issues []issue
@@ -309,7 +236,7 @@ func validateControlMapping(path string, raw map[string]json.RawMessage) []issue
 	return issues
 }
 
-func validatePolicy(path string, raw map[string]json.RawMessage, controlCatalog *complianceControlCatalogIndex) []issue {
+func validatePolicy(path string, raw map[string]json.RawMessage, controlCatalog *compliance.CatalogIndex) []issue {
 	var issues []issue
 	for _, field := range []string{"id", "name", "description", "severity"} {
 		if stringField(raw, field) == "" {
@@ -354,7 +281,7 @@ func validateStringArrayField(path string, raw map[string]json.RawMessage, field
 	return nil
 }
 
-func validateFrameworks(path string, raw map[string]json.RawMessage, controlCatalog *complianceControlCatalogIndex) []issue {
+func validateFrameworks(path string, raw map[string]json.RawMessage, controlCatalog *compliance.CatalogIndex) []issue {
 	value, ok := raw["frameworks"]
 	if !ok {
 		return []issue{{path: path, message: "frameworks is required"}}
@@ -381,7 +308,7 @@ func validateFrameworks(path string, raw map[string]json.RawMessage, controlCata
 				issues = append(issues, issue{path: path, message: fmt.Sprintf("frameworks[%d].controls[%d] is required", idx, controlIdx)})
 				continue
 			}
-			if frameworkName != "" && !controlCatalog.hasControl(frameworkName, controlID) {
+			if controlCatalog != nil && frameworkName != "" && !controlCatalog.HasControl(frameworkName, controlID) {
 				issues = append(issues, issue{path: path, message: fmt.Sprintf("frameworks[%d].controls[%d] %s %s is not declared in internal/compliance/control_families.yaml", idx, controlIdx, frameworkName, controlID)})
 			}
 		}


### PR DESCRIPTION
## Summary
- add a typed compliance package for YAML control packs with richer control semantics, evidence expectations, and custom-framework `maps_to` relationships
- add YAML control selection loading, selection resolution, and rule coverage resolution that credits selected custom controls through mapped equivalents
- reuse the shared catalog validator from `tools/catalogcheck` and document custom framework/control selection authoring

## Validation
- `go test ./internal/compliance ./tools/catalogcheck`
- `go run ./tools/catalogcheck -summary=false`
- `go run ./tools/policyrulegen --check`
- `go run ./tools/detectioncatalog --check`
- `python3 scripts/docs_drift_check.py`
- `git diff --check`
- `go test ./...`

## Follow-up
- build control posture aggregation on top of selected controls
- expose custom framework validation/import flows
- generate auditor evidence packets from selected controls, findings, and evidence records
