### PR TITLE
Add compliance control posture evaluation

### DIFF
--- a/docs/COMPLIANCE_CONTROLS.md
+++ b/docs/COMPLIANCE_CONTROLS.md
@@ -89,6 +89,32 @@ Coverage is resolved in two steps:
 
 The result reports selected control count, mapped rule IDs, controls without rule coverage, rules by control, and controls by rule. This is the foundation for later control posture and auditor evidence packets.
 
+## Control Posture
+
+Control posture turns a selected control scope into an auditor-facing operating status. It combines:
+
+- selected controls from `ResolveControlSelection`
+- rule coverage from `ResolveRuleCoverage`
+- open finding signals
+- evidence signals
+- assessment overrides for exceptions, manual review, and not-applicable scope decisions
+
+`EvaluateControlPosture` returns one `ControlPosture` per selected control. Evidence and findings can attach directly to the selected control, to a mapped control reference, or to a mapped rule ID. This lets custom framework controls receive posture credit from existing generated rules while preserving the customer-facing control ID in the output.
+
+Statuses are intentionally ordered for audit review:
+
+| Status | Meaning |
+| --- | --- |
+| `not_applicable` | An active scope override says the control does not apply to this assessment. |
+| `exception` | An active exception or compensating-control approval covers the selected control. |
+| `failing` | One or more open findings map to the selected control. |
+| `missing_evidence` | Required evidence expectations are not present. |
+| `stale_evidence` | Evidence exists but is older than the control or evidence freshness window. |
+| `manual_review` | Evidence exists, but interview/manual assessment is still required before reliance. |
+| `passing` | Required evidence is present and no open findings are mapped to the control. |
+
+The posture output keeps control identity, finding IDs, evidence IDs, freshness data, and exception/not-applicable IDs in separate nested blocks. It includes mapped rule IDs, open finding IDs, evidence IDs, missing or stale evidence expectation IDs, exception/not-applicable IDs, freshness SLA, latest evidence time, and evidence due date. `SummarizeControlPosture` aggregates the posture list into counts by status for dashboard and report headers.
+
 ## Validation
 
 `go run ./tools/catalogcheck` validates the built-in control pack and policy mappings. The shared compliance package also exposes:
@@ -99,6 +125,8 @@ The result reports selected control count, mapped rule IDs, controls without rul
 - `LoadControlSelection`
 - `ResolveControlSelection`
 - `ResolveRuleCoverage`
+- `EvaluateControlPosture`
+- `SummarizeControlPosture`
 
 Run focused checks after changing control authoring code:
 

--- a/internal/compliance/posture.go
+++ b/internal/compliance/posture.go
@@ -1,0 +1,667 @@
+package compliance
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type ControlPostureStatus string
+
+const (
+	ControlPosturePassing         ControlPostureStatus = "passing"
+	ControlPostureFailing         ControlPostureStatus = "failing"
+	ControlPostureMissingEvidence ControlPostureStatus = "missing_evidence"
+	ControlPostureStaleEvidence   ControlPostureStatus = "stale_evidence"
+	ControlPostureManualReview    ControlPostureStatus = "manual_review"
+	ControlPostureException       ControlPostureStatus = "exception"
+	ControlPostureNotApplicable   ControlPostureStatus = "not_applicable"
+)
+
+type ControlPostureInput struct {
+	Selection    SelectionResolution      `json:"selection"`
+	RuleCoverage RuleCoverage             `json:"rule_coverage"`
+	Findings     []ControlFindingSignal   `json:"findings,omitempty"`
+	Evidence     []ControlEvidenceSignal  `json:"evidence,omitempty"`
+	Overrides    []ControlPostureOverride `json:"overrides,omitempty"`
+	Now          time.Time                `json:"-"`
+}
+
+type ControlFindingSignal struct {
+	ID              string       `json:"id,omitempty"`
+	RuleID          string       `json:"rule_id,omitempty"`
+	Title           string       `json:"title,omitempty"`
+	Status          string       `json:"status,omitempty"`
+	Severity        string       `json:"severity,omitempty"`
+	ControlRefs     []ControlRef `json:"control_refs,omitempty"`
+	FirstObservedAt time.Time    `json:"first_observed_at,omitempty"`
+	LastObservedAt  time.Time    `json:"last_observed_at,omitempty"`
+}
+
+type ControlEvidenceSignal struct {
+	ID           string       `json:"id,omitempty"`
+	RuleID       string       `json:"rule_id,omitempty"`
+	EvidenceType string       `json:"evidence_type,omitempty"`
+	Status       string       `json:"status,omitempty"`
+	Source       string       `json:"source,omitempty"`
+	ControlRefs  []ControlRef `json:"control_refs,omitempty"`
+	ObservedAt   time.Time    `json:"observed_at,omitempty"`
+	ExpiresAt    time.Time    `json:"expires_at,omitempty"`
+	Manual       bool         `json:"manual,omitempty"`
+}
+
+type ControlPostureOverride struct {
+	ID          string               `json:"id,omitempty"`
+	RuleID      string               `json:"rule_id,omitempty"`
+	Status      ControlPostureStatus `json:"status"`
+	Reason      string               `json:"reason,omitempty"`
+	ControlRefs []ControlRef         `json:"control_refs,omitempty"`
+	ObservedAt  time.Time            `json:"observed_at,omitempty"`
+	ExpiresAt   time.Time            `json:"expires_at,omitempty"`
+}
+
+type ControlPosture struct {
+	SelectionID string                       `json:"selection_id,omitempty"`
+	Control     ControlPostureControl        `json:"control"`
+	Status      ControlPostureStatus         `json:"status"`
+	Reasons     []string                     `json:"reasons,omitempty"`
+	Tags        []string                     `json:"tags,omitempty"`
+	MappedRules []string                     `json:"mapped_rules,omitempty"`
+	Findings    ControlPostureFindingSummary `json:"findings,omitempty"`
+	Evidence    ControlPostureEvidence       `json:"evidence,omitempty"`
+	Overrides   ControlPostureOverrides      `json:"overrides,omitempty"`
+}
+
+type ControlPostureControl struct {
+	FrameworkID      string `json:"framework_id,omitempty"`
+	FrameworkName    string `json:"framework_name"`
+	FrameworkVersion string `json:"framework_version,omitempty"`
+	FamilyID         string `json:"family_id"`
+	FamilyName       string `json:"family_name"`
+	ControlID        string `json:"control_id"`
+	Title            string `json:"title,omitempty"`
+	OwnerDomain      string `json:"owner_domain,omitempty"`
+}
+
+type ControlPostureFindingSummary struct {
+	OpenFindingIDs []string `json:"open_finding_ids,omitempty"`
+}
+
+type ControlPostureEvidence struct {
+	EvidenceIDs            []string  `json:"evidence_ids,omitempty"`
+	MissingEvidenceIDs     []string  `json:"missing_evidence_ids,omitempty"`
+	StaleEvidenceIDs       []string  `json:"stale_evidence_ids,omitempty"`
+	ManualEvidenceIDs      []string  `json:"manual_evidence_ids,omitempty"`
+	EvidenceExpectationIDs []string  `json:"evidence_expectation_ids,omitempty"`
+	RequiredEvidenceIDs    []string  `json:"required_evidence_ids,omitempty"`
+	FreshnessSLA           string    `json:"freshness_sla,omitempty"`
+	LatestEvidenceAt       time.Time `json:"latest_evidence_at,omitempty"`
+	EvidenceDueAt          time.Time `json:"evidence_due_at,omitempty"`
+}
+
+type ControlPostureOverrides struct {
+	ExceptionIDs     []string `json:"exception_ids,omitempty"`
+	NotApplicableIDs []string `json:"not_applicable_ids,omitempty"`
+}
+
+type ControlPostureSummary struct {
+	SelectionID string                       `json:"selection_id,omitempty"`
+	Total       int                          `json:"total"`
+	ByStatus    map[ControlPostureStatus]int `json:"by_status"`
+}
+
+func EvaluateControlPosture(input ControlPostureInput) []ControlPosture {
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	context := buildControlPostureContext(input.Selection, input.RuleCoverage)
+	buckets := map[string]*controlPostureBucket{}
+	for _, control := range input.Selection.Controls {
+		key := ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID})
+		buckets[key] = &controlPostureBucket{
+			control:     control,
+			mappedRules: append([]string(nil), input.RuleCoverage.RulesByControl[key]...),
+		}
+	}
+	for _, finding := range input.Findings {
+		if !findingIsOpen(finding.Status) {
+			continue
+		}
+		for _, key := range matchingPostureControlKeys(context, finding.RuleID, finding.ControlRefs) {
+			if bucket := buckets[key]; bucket != nil {
+				bucket.openFindings = append(bucket.openFindings, finding)
+			}
+		}
+	}
+	for _, evidence := range input.Evidence {
+		if !evidenceUsable(evidence.Status) {
+			continue
+		}
+		for _, key := range matchingPostureControlKeys(context, evidence.RuleID, evidence.ControlRefs) {
+			if bucket := buckets[key]; bucket != nil {
+				bucket.evidence = append(bucket.evidence, evidence)
+			}
+		}
+	}
+	for _, override := range input.Overrides {
+		if !postureOverrideActive(override, now) {
+			continue
+		}
+		for _, key := range matchingPostureControlKeys(context, override.RuleID, override.ControlRefs) {
+			if bucket := buckets[key]; bucket != nil {
+				bucket.overrides = append(bucket.overrides, override)
+			}
+		}
+	}
+	postures := make([]ControlPosture, 0, len(input.Selection.Controls))
+	for _, control := range input.Selection.Controls {
+		key := ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID})
+		bucket := buckets[key]
+		if bucket == nil {
+			bucket = &controlPostureBucket{control: control}
+		}
+		postures = append(postures, evaluateControlPosture(input.Selection.SelectionID, bucket, now))
+	}
+	sort.Slice(postures, func(i, j int) bool {
+		return ControlKey(ControlRef{FrameworkName: postures[i].Control.FrameworkName, ControlID: postures[i].Control.ControlID}) <
+			ControlKey(ControlRef{FrameworkName: postures[j].Control.FrameworkName, ControlID: postures[j].Control.ControlID})
+	})
+	return postures
+}
+
+func SummarizeControlPosture(selectionID string, postures []ControlPosture) ControlPostureSummary {
+	summary := ControlPostureSummary{
+		SelectionID: strings.TrimSpace(selectionID),
+		Total:       len(postures),
+		ByStatus:    map[ControlPostureStatus]int{},
+	}
+	for _, posture := range postures {
+		summary.ByStatus[posture.Status]++
+	}
+	return summary
+}
+
+type controlPostureBucket struct {
+	control      ResolvedControl
+	mappedRules  []string
+	openFindings []ControlFindingSignal
+	evidence     []ControlEvidenceSignal
+	overrides    []ControlPostureOverride
+}
+
+type controlPostureContext struct {
+	selectedKeys map[string]struct{}
+	aliases      map[string][]string
+	keysByRuleID map[string][]string
+}
+
+func buildControlPostureContext(resolution SelectionResolution, coverage RuleCoverage) controlPostureContext {
+	context := controlPostureContext{
+		selectedKeys: map[string]struct{}{},
+		aliases:      map[string][]string{},
+		keysByRuleID: map[string][]string{},
+	}
+	for _, control := range resolution.Controls {
+		ref := ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID}
+		selectedKey := ControlKey(ref)
+		context.selectedKeys[selectedKey] = struct{}{}
+		context.aliases[selectedKey] = appendUniqueString(context.aliases[selectedKey], selectedKey)
+		if control.FrameworkID != "" {
+			frameworkIDKey := ControlKey(ControlRef{FrameworkID: control.FrameworkID, ControlID: control.Control.ID})
+			context.aliases[frameworkIDKey] = appendUniqueString(context.aliases[frameworkIDKey], selectedKey)
+		}
+		for _, mappedRef := range control.Control.MapsTo {
+			mappedKey := ControlKey(mappedRef)
+			context.aliases[mappedKey] = appendUniqueString(context.aliases[mappedKey], selectedKey)
+		}
+	}
+	for key, rules := range coverage.RulesByControl {
+		if _, ok := context.selectedKeys[key]; !ok {
+			continue
+		}
+		for _, ruleID := range rules {
+			ruleID = strings.TrimSpace(ruleID)
+			if ruleID == "" {
+				continue
+			}
+			context.keysByRuleID[ruleID] = appendUniqueString(context.keysByRuleID[ruleID], key)
+		}
+	}
+	for ruleID, refs := range coverage.ControlsByRule {
+		ruleID = strings.TrimSpace(ruleID)
+		if ruleID == "" {
+			continue
+		}
+		for _, ref := range refs {
+			for _, key := range context.aliases[ControlKey(ref)] {
+				if _, ok := context.selectedKeys[key]; !ok {
+					continue
+				}
+				context.keysByRuleID[ruleID] = appendUniqueString(context.keysByRuleID[ruleID], key)
+			}
+		}
+	}
+	for ruleID := range context.keysByRuleID {
+		sort.Strings(context.keysByRuleID[ruleID])
+	}
+	return context
+}
+
+func matchingPostureControlKeys(context controlPostureContext, ruleID string, refs []ControlRef) []string {
+	keys := []string{}
+	ruleID = strings.TrimSpace(ruleID)
+	if ruleID != "" {
+		keys = appendUniqueStrings(keys, context.keysByRuleID[ruleID]...)
+	}
+	for _, ref := range refs {
+		keys = appendUniqueStrings(keys, context.aliases[ControlKey(ref)]...)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func evaluateControlPosture(selectionID string, bucket *controlPostureBucket, now time.Time) ControlPosture {
+	control := bucket.control
+	posture := ControlPosture{
+		SelectionID: strings.TrimSpace(selectionID),
+		Control: ControlPostureControl{
+			FrameworkID:      control.FrameworkID,
+			FrameworkName:    control.FrameworkName,
+			FrameworkVersion: control.FrameworkVersion,
+			FamilyID:         control.FamilyID,
+			FamilyName:       control.FamilyName,
+			ControlID:        control.Control.ID,
+			Title:            control.Control.Title,
+			OwnerDomain:      control.Control.OwnerDomain,
+		},
+		Status:      ControlPosturePassing,
+		Tags:        append([]string(nil), control.EffectiveTags...),
+		MappedRules: sortedUniqueStrings(bucket.mappedRules),
+		Findings: ControlPostureFindingSummary{
+			OpenFindingIDs: sortedUniqueStrings(controlFindingIDs(bucket.openFindings)),
+		},
+		Evidence: ControlPostureEvidence{
+			EvidenceIDs:       sortedUniqueStrings(controlEvidenceIDs(bucket.evidence)),
+			ManualEvidenceIDs: sortedUniqueStrings(manualEvidenceIDs(bucket.evidence)),
+			FreshnessSLA:      effectiveControlFreshnessSLA(control),
+		},
+		Overrides: ControlPostureOverrides{
+			ExceptionIDs:     sortedUniqueStrings(postureOverrideIDs(bucket.overrides, ControlPostureException)),
+			NotApplicableIDs: sortedUniqueStrings(postureOverrideIDs(bucket.overrides, ControlPostureNotApplicable)),
+		},
+	}
+	posture.Evidence.EvidenceExpectationIDs, posture.Evidence.RequiredEvidenceIDs = evidenceExpectationIDs(control.Evidence)
+	posture.Evidence.LatestEvidenceAt = latestEvidenceTime(bucket.evidence)
+	posture.Evidence.EvidenceDueAt = evidenceDueAt(posture.Evidence.LatestEvidenceAt, posture.Evidence.FreshnessSLA)
+
+	if hasPostureOverride(bucket.overrides, ControlPostureNotApplicable) {
+		posture.Status = ControlPostureNotApplicable
+		posture.Reasons = append(posture.Reasons, overrideReason(bucket.overrides, ControlPostureNotApplicable, "Control is marked not applicable for this assessment scope."))
+		return finalizeControlPosture(posture)
+	}
+	if hasPostureOverride(bucket.overrides, ControlPostureException) {
+		posture.Status = ControlPostureException
+		posture.Reasons = append(posture.Reasons, overrideReason(bucket.overrides, ControlPostureException, "Control has an active exception for this assessment scope."))
+		return finalizeControlPosture(posture)
+	}
+	if len(bucket.openFindings) > 0 {
+		posture.Status = ControlPostureFailing
+		posture.Reasons = append(posture.Reasons, fmt.Sprintf("%d open finding(s) indicate the control is not operating as expected.", len(bucket.openFindings)))
+		return finalizeControlPosture(posture)
+	}
+
+	missingEvidenceIDs, staleEvidenceIDs := assessEvidenceExpectations(control, bucket.evidence, now)
+	posture.Evidence.MissingEvidenceIDs = sortedUniqueStrings(missingEvidenceIDs)
+	posture.Evidence.StaleEvidenceIDs = sortedUniqueStrings(staleEvidenceIDs)
+	if len(posture.Evidence.MissingEvidenceIDs) > 0 {
+		posture.Status = ControlPostureMissingEvidence
+		posture.Reasons = append(posture.Reasons, missingEvidenceReason(posture.Evidence.MissingEvidenceIDs, posture.MappedRules))
+		return finalizeControlPosture(posture)
+	}
+	if len(posture.Evidence.StaleEvidenceIDs) > 0 {
+		posture.Status = ControlPostureStaleEvidence
+		posture.Reasons = append(posture.Reasons, fmt.Sprintf("%d evidence item(s) are older than the required freshness window.", len(posture.Evidence.StaleEvidenceIDs)))
+		return finalizeControlPosture(posture)
+	}
+	if postureRequiresManualReview(control, bucket.evidence, bucket.overrides) {
+		posture.Status = ControlPostureManualReview
+		posture.Reasons = append(posture.Reasons, "Evidence is present but requires human assessment before audit reliance.")
+		return finalizeControlPosture(posture)
+	}
+	posture.Reasons = append(posture.Reasons, "Required evidence is present and no open findings are mapped to the selected control.")
+	return finalizeControlPosture(posture)
+}
+
+func assessEvidenceExpectations(control ResolvedControl, evidence []ControlEvidenceSignal, now time.Time) ([]string, []string) {
+	if len(control.Evidence) == 0 {
+		if len(evidence) == 0 {
+			return []string{"control-evidence"}, nil
+		}
+		return nil, staleEvidenceIDsForExpectation(EvidenceExpectation{ID: "control-evidence", FreshnessSLA: control.Control.FreshnessSLA}, evidence, now)
+	}
+	missing := []string{}
+	stale := []string{}
+	for _, expectation := range control.Evidence {
+		if !evidenceExpectationRequired(expectation) {
+			continue
+		}
+		matches := evidenceForExpectation(expectation, evidence)
+		if len(matches) == 0 {
+			missing = appendUniqueString(missing, strings.TrimSpace(expectation.ID))
+			continue
+		}
+		stale = appendUniqueStrings(stale, staleEvidenceIDsForExpectation(expectationWithControlFreshness(expectation, control.Control.FreshnessSLA), matches, now)...)
+	}
+	return missing, stale
+}
+
+func evidenceForExpectation(expectation EvidenceExpectation, evidence []ControlEvidenceSignal) []ControlEvidenceSignal {
+	expectedType := strings.TrimSpace(expectation.Type)
+	if expectedType == "" {
+		return append([]ControlEvidenceSignal(nil), evidence...)
+	}
+	matches := []ControlEvidenceSignal{}
+	for _, item := range evidence {
+		if strings.EqualFold(strings.TrimSpace(item.EvidenceType), expectedType) {
+			matches = append(matches, item)
+		}
+	}
+	return matches
+}
+
+func staleEvidenceIDsForExpectation(expectation EvidenceExpectation, evidence []ControlEvidenceSignal, now time.Time) []string {
+	stale := []string{}
+	window, hasWindow := parseFreshnessWindow(expectation.FreshnessSLA)
+	for _, item := range evidence {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			id = strings.TrimSpace(expectation.ID)
+		}
+		if !item.ExpiresAt.IsZero() && !item.ExpiresAt.After(now) {
+			stale = appendUniqueString(stale, id)
+			continue
+		}
+		if hasWindow && !item.ObservedAt.IsZero() && item.ObservedAt.Add(window).Before(now) {
+			stale = appendUniqueString(stale, id)
+		}
+	}
+	return stale
+}
+
+func expectationWithControlFreshness(expectation EvidenceExpectation, fallback string) EvidenceExpectation {
+	if strings.TrimSpace(expectation.FreshnessSLA) == "" {
+		expectation.FreshnessSLA = strings.TrimSpace(fallback)
+	}
+	return expectation
+}
+
+func evidenceExpectationRequired(expectation EvidenceExpectation) bool {
+	return expectation.Required == nil || *expectation.Required
+}
+
+func evidenceExpectationIDs(expectations []EvidenceExpectation) ([]string, []string) {
+	all := []string{}
+	required := []string{}
+	for _, expectation := range expectations {
+		id := strings.TrimSpace(expectation.ID)
+		if id == "" {
+			continue
+		}
+		all = appendUniqueString(all, id)
+		if evidenceExpectationRequired(expectation) {
+			required = appendUniqueString(required, id)
+		}
+	}
+	sort.Strings(all)
+	sort.Strings(required)
+	return all, required
+}
+
+func effectiveControlFreshnessSLA(control ResolvedControl) string {
+	if value := strings.TrimSpace(control.Control.FreshnessSLA); value != "" {
+		return value
+	}
+	for _, expectation := range control.Evidence {
+		if !evidenceExpectationRequired(expectation) {
+			continue
+		}
+		if value := strings.TrimSpace(expectation.FreshnessSLA); value != "" {
+			return value
+		}
+	}
+	for _, expectation := range control.Evidence {
+		if value := strings.TrimSpace(expectation.FreshnessSLA); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func postureRequiresManualReview(control ResolvedControl, evidence []ControlEvidenceSignal, overrides []ControlPostureOverride) bool {
+	for _, override := range overrides {
+		if override.Status == ControlPostureManualReview {
+			return true
+		}
+	}
+	for _, item := range evidence {
+		if item.Manual {
+			return true
+		}
+	}
+	if hasAssessmentMethod(control.Control.AssessmentMethods, "interview") {
+		return true
+	}
+	for _, expectation := range control.Evidence {
+		if hasAssessmentMethod(expectation.AssessmentMethods, "interview") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAssessmentMethod(values []string, method string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), method) {
+			return true
+		}
+	}
+	return false
+}
+
+func findingIsOpen(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "open", "finding_status_open":
+		return true
+	case "resolved", "closed", "suppressed", "finding_status_resolved", "finding_status_suppressed":
+		return false
+	default:
+		return true
+	}
+}
+
+func evidenceUsable(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "invalid", "rejected", "failed", "error":
+		return false
+	default:
+		return true
+	}
+}
+
+func postureOverrideActive(override ControlPostureOverride, now time.Time) bool {
+	switch override.Status {
+	case ControlPostureException, ControlPostureNotApplicable, ControlPostureManualReview:
+	default:
+		return false
+	}
+	return override.ExpiresAt.IsZero() || override.ExpiresAt.After(now)
+}
+
+func overrideReason(overrides []ControlPostureOverride, status ControlPostureStatus, fallback string) string {
+	for _, override := range overrides {
+		if override.Status != status {
+			continue
+		}
+		if reason := strings.TrimSpace(override.Reason); reason != "" {
+			return reason
+		}
+	}
+	return fallback
+}
+
+func missingEvidenceReason(missingEvidenceIDs []string, mappedRules []string) string {
+	if len(mappedRules) == 0 {
+		return "No mapped rules or evidence are available for this selected control."
+	}
+	if len(missingEvidenceIDs) == 1 && missingEvidenceIDs[0] == "control-evidence" {
+		return "No evidence has been supplied for this selected control."
+	}
+	return fmt.Sprintf("%d required evidence expectation(s) are missing.", len(missingEvidenceIDs))
+}
+
+func latestEvidenceTime(evidence []ControlEvidenceSignal) time.Time {
+	var latest time.Time
+	for _, item := range evidence {
+		if item.ObservedAt.After(latest) {
+			latest = item.ObservedAt
+		}
+	}
+	return latest
+}
+
+func evidenceDueAt(latest time.Time, freshnessSLA string) time.Time {
+	if latest.IsZero() {
+		return time.Time{}
+	}
+	window, ok := parseFreshnessWindow(freshnessSLA)
+	if !ok {
+		return time.Time{}
+	}
+	return latest.Add(window)
+}
+
+func parseFreshnessWindow(value string) (time.Duration, bool) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return 0, false
+	}
+	if duration, err := time.ParseDuration(value); err == nil {
+		return duration, true
+	}
+	multiplier := 24 * time.Hour
+	switch {
+	case strings.HasSuffix(value, "d"):
+		value = strings.TrimSpace(strings.TrimSuffix(value, "d"))
+	case strings.HasSuffix(value, "w"):
+		value = strings.TrimSpace(strings.TrimSuffix(value, "w"))
+		multiplier = 7 * 24 * time.Hour
+	default:
+		return 0, false
+	}
+	count, err := strconv.Atoi(value)
+	if err != nil || count <= 0 {
+		return 0, false
+	}
+	return time.Duration(count) * multiplier, true
+}
+
+func controlFindingIDs(findings []ControlFindingSignal) []string {
+	ids := []string{}
+	for _, finding := range findings {
+		if id := strings.TrimSpace(finding.ID); id != "" {
+			ids = appendUniqueString(ids, id)
+		}
+	}
+	return ids
+}
+
+func controlEvidenceIDs(evidence []ControlEvidenceSignal) []string {
+	ids := []string{}
+	for _, item := range evidence {
+		if id := strings.TrimSpace(item.ID); id != "" {
+			ids = appendUniqueString(ids, id)
+		}
+	}
+	return ids
+}
+
+func manualEvidenceIDs(evidence []ControlEvidenceSignal) []string {
+	ids := []string{}
+	for _, item := range evidence {
+		if !item.Manual {
+			continue
+		}
+		if id := strings.TrimSpace(item.ID); id != "" {
+			ids = appendUniqueString(ids, id)
+		}
+	}
+	return ids
+}
+
+func postureOverrideIDs(overrides []ControlPostureOverride, status ControlPostureStatus) []string {
+	ids := []string{}
+	for _, override := range overrides {
+		if override.Status != status {
+			continue
+		}
+		if id := strings.TrimSpace(override.ID); id != "" {
+			ids = appendUniqueString(ids, id)
+		}
+	}
+	return ids
+}
+
+func hasPostureOverride(overrides []ControlPostureOverride, status ControlPostureStatus) bool {
+	for _, override := range overrides {
+		if override.Status == status {
+			return true
+		}
+	}
+	return false
+}
+
+func finalizeControlPosture(posture ControlPosture) ControlPosture {
+	posture.Tags = sortedUniqueStrings(posture.Tags)
+	posture.MappedRules = sortedUniqueStrings(posture.MappedRules)
+	posture.Findings.OpenFindingIDs = sortedUniqueStrings(posture.Findings.OpenFindingIDs)
+	posture.Evidence.EvidenceIDs = sortedUniqueStrings(posture.Evidence.EvidenceIDs)
+	posture.Evidence.MissingEvidenceIDs = sortedUniqueStrings(posture.Evidence.MissingEvidenceIDs)
+	posture.Evidence.StaleEvidenceIDs = sortedUniqueStrings(posture.Evidence.StaleEvidenceIDs)
+	posture.Evidence.ManualEvidenceIDs = sortedUniqueStrings(posture.Evidence.ManualEvidenceIDs)
+	posture.Evidence.EvidenceExpectationIDs = sortedUniqueStrings(posture.Evidence.EvidenceExpectationIDs)
+	posture.Evidence.RequiredEvidenceIDs = sortedUniqueStrings(posture.Evidence.RequiredEvidenceIDs)
+	posture.Overrides.ExceptionIDs = sortedUniqueStrings(posture.Overrides.ExceptionIDs)
+	posture.Overrides.NotApplicableIDs = sortedUniqueStrings(posture.Overrides.NotApplicableIDs)
+	posture.Reasons = sortedUniqueStrings(posture.Reasons)
+	return posture
+}
+
+func appendUniqueStrings(values []string, additions ...string) []string {
+	for _, value := range additions {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		values = appendUniqueString(values, value)
+	}
+	return values
+}
+
+func sortedUniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	unique := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		unique = appendUniqueString(unique, value)
+	}
+	sort.Strings(unique)
+	return unique
+}

--- a/internal/compliance/posture_test.go
+++ b/internal/compliance/posture_test.go
@@ -1,0 +1,284 @@
+package compliance
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEvaluateControlPosturePassingWithMappedCustomControlEvidence(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	resolution, coverage := testPostureResolution(t)
+
+	postures := EvaluateControlPosture(ControlPostureInput{
+		Selection:    resolution,
+		RuleCoverage: coverage,
+		Now:          now,
+		Evidence: []ControlEvidenceSignal{{
+			ID:           "evidence-1",
+			RuleID:       "identity-mfa-required",
+			EvidenceType: "identity_configuration",
+			Status:       "passing",
+			ObservedAt:   now.Add(-2 * time.Hour),
+		}},
+	})
+
+	if len(postures) != 1 {
+		t.Fatalf("len(postures) = %d, want 1", len(postures))
+	}
+	posture := postures[0]
+	if posture.Status != ControlPosturePassing {
+		t.Fatalf("Status = %q, want passing: %#v", posture.Status, posture)
+	}
+	if got := posture.MappedRules; len(got) != 1 || got[0] != "identity-mfa-required" {
+		t.Fatalf("MappedRules = %#v, want identity-mfa-required", got)
+	}
+	if got := posture.Evidence.EvidenceIDs; len(got) != 1 || got[0] != "evidence-1" {
+		t.Fatalf("EvidenceIDs = %#v, want evidence-1", got)
+	}
+	if posture.Evidence.LatestEvidenceAt.IsZero() || posture.Evidence.EvidenceDueAt.IsZero() {
+		t.Fatalf("evidence timestamps = latest %s due %s, want both set", posture.Evidence.LatestEvidenceAt, posture.Evidence.EvidenceDueAt)
+	}
+	if posture.Evidence.FreshnessSLA != "30d" {
+		t.Fatalf("FreshnessSLA = %q, want 30d from required expectation", posture.Evidence.FreshnessSLA)
+	}
+}
+
+func TestEvaluateControlPostureFailingBeatsFreshEvidence(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	resolution, coverage := testPostureResolution(t)
+
+	postures := EvaluateControlPosture(ControlPostureInput{
+		Selection:    resolution,
+		RuleCoverage: coverage,
+		Now:          now,
+		Findings: []ControlFindingSignal{{
+			ID:          "finding-1",
+			RuleID:      "identity-mfa-required",
+			Status:      "open",
+			ControlRefs: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+		}},
+		Evidence: []ControlEvidenceSignal{{
+			ID:           "evidence-1",
+			RuleID:       "identity-mfa-required",
+			EvidenceType: "identity_configuration",
+			Status:       "passing",
+			ObservedAt:   now.Add(-2 * time.Hour),
+		}},
+	})
+
+	posture := postures[0]
+	if posture.Status != ControlPostureFailing {
+		t.Fatalf("Status = %q, want failing: %#v", posture.Status, posture)
+	}
+	if got := posture.Findings.OpenFindingIDs; len(got) != 1 || got[0] != "finding-1" {
+		t.Fatalf("OpenFindingIDs = %#v, want finding-1", got)
+	}
+}
+
+func TestEvaluateControlPostureMissingAndStaleEvidence(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	resolution, coverage := testPostureResolution(t)
+
+	missing := EvaluateControlPosture(ControlPostureInput{
+		Selection:    resolution,
+		RuleCoverage: coverage,
+		Now:          now,
+	})
+	if got := missing[0].Status; got != ControlPostureMissingEvidence {
+		t.Fatalf("missing Status = %q, want missing_evidence: %#v", got, missing[0])
+	}
+	if got := missing[0].Evidence.MissingEvidenceIDs; len(got) != 1 || got[0] != "privileged-mfa-state" {
+		t.Fatalf("MissingEvidenceIDs = %#v, want privileged-mfa-state", got)
+	}
+
+	stale := EvaluateControlPosture(ControlPostureInput{
+		Selection:    resolution,
+		RuleCoverage: coverage,
+		Now:          now,
+		Evidence: []ControlEvidenceSignal{{
+			ID:           "evidence-stale",
+			RuleID:       "identity-mfa-required",
+			EvidenceType: "identity_configuration",
+			ObservedAt:   now.Add(-45 * 24 * time.Hour),
+		}},
+	})
+	if got := stale[0].Status; got != ControlPostureStaleEvidence {
+		t.Fatalf("stale Status = %q, want stale_evidence: %#v", got, stale[0])
+	}
+	if got := stale[0].Evidence.StaleEvidenceIDs; len(got) != 1 || got[0] != "evidence-stale" {
+		t.Fatalf("StaleEvidenceIDs = %#v, want evidence-stale", got)
+	}
+}
+
+func TestEvaluateControlPostureExceptionAndNotApplicableOverrides(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	resolution, coverage := testPostureResolution(t)
+
+	exception := EvaluateControlPosture(ControlPostureInput{
+		Selection:    resolution,
+		RuleCoverage: coverage,
+		Now:          now,
+		Findings: []ControlFindingSignal{{
+			ID:     "finding-1",
+			RuleID: "identity-mfa-required",
+			Status: "open",
+		}},
+		Overrides: []ControlPostureOverride{{
+			ID:        "exception-1",
+			RuleID:    "identity-mfa-required",
+			Status:    ControlPostureException,
+			Reason:    "Compensating access control accepted through quarter end.",
+			ExpiresAt: now.Add(24 * time.Hour),
+		}},
+	})
+	if got := exception[0].Status; got != ControlPostureException {
+		t.Fatalf("exception Status = %q, want exception: %#v", got, exception[0])
+	}
+	if got := exception[0].Overrides.ExceptionIDs; len(got) != 1 || got[0] != "exception-1" {
+		t.Fatalf("ExceptionIDs = %#v, want exception-1", got)
+	}
+
+	idlessException := EvaluateControlPosture(ControlPostureInput{
+		Selection:    resolution,
+		RuleCoverage: coverage,
+		Now:          now,
+		Findings: []ControlFindingSignal{{
+			ID:     "finding-1",
+			RuleID: "identity-mfa-required",
+			Status: "open",
+		}},
+		Overrides: []ControlPostureOverride{{
+			RuleID:    "identity-mfa-required",
+			Status:    ControlPostureException,
+			ExpiresAt: now.Add(24 * time.Hour),
+		}},
+	})
+	if got := idlessException[0].Status; got != ControlPostureException {
+		t.Fatalf("idless exception Status = %q, want exception: %#v", got, idlessException[0])
+	}
+
+	notApplicable := EvaluateControlPosture(ControlPostureInput{
+		Selection:    resolution,
+		RuleCoverage: coverage,
+		Now:          now,
+		Findings: []ControlFindingSignal{{
+			ID:     "finding-1",
+			RuleID: "identity-mfa-required",
+			Status: "open",
+		}},
+		Overrides: []ControlPostureOverride{{
+			ID:        "scope-1",
+			RuleID:    "identity-mfa-required",
+			Status:    ControlPostureNotApplicable,
+			Reason:    "Privileged access is not in scope for this review.",
+			ExpiresAt: now.Add(24 * time.Hour),
+		}},
+	})
+	if got := notApplicable[0].Status; got != ControlPostureNotApplicable {
+		t.Fatalf("not-applicable Status = %q, want not_applicable: %#v", got, notApplicable[0])
+	}
+
+	expiredException := EvaluateControlPosture(ControlPostureInput{
+		Selection:    resolution,
+		RuleCoverage: coverage,
+		Now:          now,
+		Findings: []ControlFindingSignal{{
+			ID:     "finding-1",
+			RuleID: "identity-mfa-required",
+			Status: "open",
+		}},
+		Overrides: []ControlPostureOverride{{
+			ID:        "exception-1",
+			RuleID:    "identity-mfa-required",
+			Status:    ControlPostureException,
+			ExpiresAt: now.Add(-24 * time.Hour),
+		}},
+	})
+	if got := expiredException[0].Status; got != ControlPostureFailing {
+		t.Fatalf("expired exception Status = %q, want failing: %#v", got, expiredException[0])
+	}
+}
+
+func TestEvaluateControlPostureManualReviewAndSummary(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	resolution, coverage := testPostureResolution(t)
+
+	postures := EvaluateControlPosture(ControlPostureInput{
+		Selection:    resolution,
+		RuleCoverage: coverage,
+		Now:          now,
+		Evidence: []ControlEvidenceSignal{{
+			ID:           "attestation-1",
+			RuleID:       "identity-mfa-required",
+			EvidenceType: "identity_configuration",
+			ObservedAt:   now.Add(-2 * time.Hour),
+			Manual:       true,
+		}},
+	})
+	if got := postures[0].Status; got != ControlPostureManualReview {
+		t.Fatalf("Status = %q, want manual_review: %#v", got, postures[0])
+	}
+	summary := SummarizeControlPosture(resolution.SelectionID, postures)
+	if summary.Total != 1 || summary.ByStatus[ControlPostureManualReview] != 1 {
+		t.Fatalf("summary = %#v, want one manual_review posture", summary)
+	}
+}
+
+func testPostureResolution(t *testing.T) (SelectionResolution, RuleCoverage) {
+	t.Helper()
+	index := testPostureIndex(t)
+	resolution, issues := ResolveControlSelection(index, ControlSelection{
+		ID: "custom-iam",
+		Frameworks: []FrameworkSelection{{
+			ID:       "custom",
+			Controls: []string{"IAM-1"},
+		}},
+	})
+	if len(issues) != 0 {
+		t.Fatalf("ResolveControlSelection() issues = %#v, want none", issues)
+	}
+	coverage := ResolveRuleCoverage(resolution, []RuleControlMapping{{
+		RuleID:      "identity-mfa-required",
+		ControlRefs: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+	}})
+	return resolution, coverage
+}
+
+func testPostureIndex(t *testing.T) *CatalogIndex {
+	t.Helper()
+	catalog := loadTestCatalog(t, `
+version: "2026-06-17"
+frameworks:
+  - id: soc2
+    name: SOC 2
+    families:
+      - id: CC6
+        name: Logical and Physical Access
+        controls:
+          - id: CC6.1
+            title: Logical access is restricted.
+  - id: custom
+    name: Custom Framework
+    families:
+      - id: IAM
+        name: Identity Controls
+        controls:
+          - id: IAM-1
+            title: Privileged access requires MFA
+            owner_domain: identity
+            tags: [identity, privileged_access]
+            evidence_expectations:
+              - id: privileged-mfa-state
+                type: identity_configuration
+                required: true
+                freshness_sla: 30d
+            maps_to:
+              - framework_id: soc2
+                control_id: CC6.1
+`)
+	index, issues := BuildCatalogIndex(catalog)
+	if len(issues) != 0 {
+		t.Fatalf("BuildCatalogIndex() issues = %#v, want none", issues)
+	}
+	return index
+}


### PR DESCRIPTION
## Summary
- add a reusable compliance posture evaluator that combines selected controls, mapped rule coverage, finding signals, evidence signals, and scoped overrides
- support auditor-facing statuses for passing, failing, missing evidence, stale evidence, manual review, exceptions, and not-applicable controls
- document posture semantics and add focused tests for mapped custom controls, evidence freshness, overrides, and summaries

## Validation
- go test ./internal/compliance ./tools/catalogcheck
- go run ./tools/catalogcheck -summary=false
- python3 scripts/docs_drift_check.py
- git diff --check
- make lint
- go test ./...
- go run ./tools/policyrulegen --check
- go run ./tools/detectioncatalog --check