### PR TITLE
Add compliance control profiles and coverage index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit workflow-e2e-test workflow-replay-test finding-rule-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check policy-rule-generate policy-rule-check detection-catalog-generate detection-catalog-check docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit workflow-e2e-test workflow-replay-test finding-rule-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check policy-rule-generate policy-rule-check detection-catalog-generate detection-catalog-check docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -217,8 +217,15 @@ openapi-lint: ## Lint the OpenAPI spec with Spectral.
 openapi-sync: ## Update OpenAPI route parity metadata.
 	go run ./scripts/openapi_route_parity.go --write
 
-catalog-check: ## Verify the source catalog is current.
+catalog-check: ## Verify source, connector, and compliance catalogs are current.
 	go run ./tools/catalogcheck
+	go run ./tools/controlindex --check
+
+control-index-generate: ## Regenerate compliance control coverage index.
+	go run ./tools/controlindex --write
+
+control-index-check: ## Verify compliance control coverage index is current.
+	go run ./tools/controlindex --check
 
 policy-rule-generate: ## Regenerate generated policy rule catalog.
 	go run ./tools/policyrulegen --write
@@ -232,7 +239,7 @@ detection-catalog-generate: ## Regenerate public detection catalog.
 detection-catalog-check: ## Verify public detection catalog is current.
 	go run ./tools/detectioncatalog --check
 
-docs-autogen: openapi-sync proto-generate policy-rule-generate detection-catalog-generate ## Regenerate checked-in generated docs and catalogs.
+docs-autogen: openapi-sync proto-generate policy-rule-generate control-index-generate detection-catalog-generate ## Regenerate checked-in generated docs and catalogs.
 
 docs-drift-check: ## Check documentation drift rules.
 	python3 scripts/docs_drift_check.py

--- a/docs/COMPLIANCE_CONTROLS.md
+++ b/docs/COMPLIANCE_CONTROLS.md
@@ -84,6 +84,25 @@ exclude_controls:
 
 Selections can include whole frameworks, families, explicit controls, tags, owner domains, evidence types, applicability labels, assessment methods, automatable controls, and controls that allow or disallow manual evidence. Assessment method filters match both control-level methods and expectation-level methods. Exclusions are applied last. An empty selection resolves to the full merged catalog, which is useful for completeness checks.
 
+## Control Profiles
+
+Control profiles are reusable YAML selections. The built-in profile set lives at `internal/compliance/control_profiles.yaml`; each profile uses the same fields as a `ControlSelection`.
+
+```yaml
+version: "2026-06-17"
+profiles:
+  - id: customer-production-access
+    name: Customer Production Access
+    description: Production identity and privileged-access scope for customer audit evidence.
+    frameworks:
+      - name: Customer Audit 2026
+        controls: [IAM-1]
+    include_applicability: [production]
+    include_assessment_methods: [examine, test]
+```
+
+Use profiles for common auditor views, control subsets, custom framework launches, or product-packaged compliance views. Custom frameworks can ship their own profile YAML beside their control pack and use the same resolver APIs.
+
 ## Coverage Resolution
 
 Coverage is resolved in two steps:
@@ -92,6 +111,15 @@ Coverage is resolved in two steps:
 2. Compare selected controls and their `maps_to` aliases with rule `ControlRefs`.
 
 The result reports selected control count, mapped rule IDs, controls without rule coverage, rules by control, and controls by rule. This is the foundation for later control posture and auditor evidence packets.
+
+`BuildControlCoverageIndex` applies this process to a full profile set. The checked-in `internal/compliance/control_coverage_index.yaml` is generated from the built-in profiles and builtin rule metadata. It gives reviewers a stable YAML view of selected controls, mapped rules, unmapped controls, and per-profile coverage summaries.
+
+Regenerate and verify the index with:
+
+```bash
+make control-index-generate
+make control-index-check
+```
 
 ## Control Posture
 
@@ -144,6 +172,9 @@ The packet builder uses the same matching rules as posture evaluation. Evidence 
 - `LoadControlSelection`
 - `ResolveControlSelection`
 - `ResolveRuleCoverage`
+- `LoadControlProfileSet`
+- `ResolveControlProfiles`
+- `BuildControlCoverageIndex`
 - `EvaluateControlPosture`
 - `SummarizeControlPosture`
 - `BuildControlEvidencePacket`
@@ -153,4 +184,5 @@ Run focused checks after changing control authoring code:
 ```bash
 go test ./internal/compliance ./tools/catalogcheck
 go run ./tools/catalogcheck -summary=false
+go run ./tools/controlindex --check
 ```

--- a/internal/compliance/control_coverage_index.yaml
+++ b/internal/compliance/control_coverage_index.yaml
@@ -1,0 +1,13473 @@
+version: "2026-06-17"
+profiles:
+    - id: cloud-security-benchmarks
+      name: Cloud Security Benchmarks
+      description: Cloud and workload configuration controls for account management, vulnerability management, logging, network defense, and benchmark posture.
+      summary:
+        selected_controls: 72
+        mapped_controls: 72
+        unmapped_controls: 0
+        mapped_rules: 354
+      controls:
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.10"
+          mapped_rules:
+            - aws-iam-password-policy
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.12"
+          mapped_rules:
+            - aws-iam-user-console-inactive
+            - aws-iam-user-unused-credentials
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.13"
+          mapped_rules:
+            - aws-iam-single-access-key
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.14"
+          mapped_rules:
+            - aws-iam-access-key-rotation
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.15"
+          mapped_rules:
+            - aws-iam-no-policies-attached-user
+            - aws-iam-users-via-groups
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.16"
+          mapped_rules:
+            - aws-ec2-iam-instance-profile
+            - aws-iam-policy-no-admin-star
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.19"
+          mapped_rules:
+            - aws-iam-expired-certificates
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.20"
+          mapped_rules:
+            - aws-iam-support-role
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.21"
+          mapped_rules:
+            - aws-iam-access-analyzer-enabled
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.4"
+          mapped_rules:
+            - aws-iam-root-no-access-keys
+            - aws-iam-user-mfa-enabled
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.5"
+          mapped_rules:
+            - aws-iam-root-mfa-enabled
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.8"
+          mapped_rules:
+            - aws-iam-password-policy
+            - aws-password-policy-minimum-length
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "1"
+          family_name: Identity and Access Management
+          control_id: "1.9"
+          mapped_rules:
+            - aws-iam-password-policy
+            - aws-password-policy-no-reuse
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "2"
+          family_name: Storage
+          control_id: 2.1.1
+          mapped_rules:
+            - aws-s3-bucket-encryption-enabled
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "2"
+          family_name: Storage
+          control_id: 2.1.2
+          mapped_rules:
+            - aws-s3-bucket-ssl-only
+            - aws-s3-https-only
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "2"
+          family_name: Storage
+          control_id: 2.1.5
+          mapped_rules:
+            - aws-s3-bucket-no-public-access
+            - aws-s3-bucket-policy-public
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "2"
+          family_name: Storage
+          control_id: 2.2.1
+          mapped_rules:
+            - aws-ebs-encryption-default
+            - aws-ec2-ebs-volume-encrypted
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "2"
+          family_name: Storage
+          control_id: 2.3.1
+          mapped_rules:
+            - aws-rds-encryption-enabled
+            - aws-redshift-public
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "2"
+          family_name: Storage
+          control_id: 2.3.2
+          mapped_rules:
+            - aws-redshift-no-encryption
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "2"
+          family_name: Storage
+          control_id: 2.3.3
+          mapped_rules:
+            - aws-rds-no-public-access
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "2"
+          family_name: Storage
+          control_id: "2.6"
+          mapped_rules:
+            - aws-apigateway-public
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "3"
+          family_name: Logging
+          control_id: "3.1"
+          mapped_rules:
+            - aws-cloudtrail-enabled
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "3"
+          family_name: Logging
+          control_id: "3.10"
+          mapped_rules:
+            - aws-cloudtrail-s3-data-events
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "3"
+          family_name: Logging
+          control_id: "3.11"
+          mapped_rules:
+            - aws-cloudtrail-s3-data-events
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "3"
+          family_name: Logging
+          control_id: "3.2"
+          mapped_rules:
+            - aws-cloudtrail-log-integrity
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "3"
+          family_name: Logging
+          control_id: "3.5"
+          mapped_rules:
+            - aws-config-enabled-all-regions
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "3"
+          family_name: Logging
+          control_id: "3.6"
+          mapped_rules:
+            - aws-s3-bucket-logging-enabled
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "3"
+          family_name: Logging
+          control_id: "3.7"
+          mapped_rules:
+            - aws-cloudtrail-kms-encryption
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "3"
+          family_name: Logging
+          control_id: "3.8"
+          mapped_rules:
+            - aws-kms-key-rotation-enabled
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "3"
+          family_name: Logging
+          control_id: "3.9"
+          mapped_rules:
+            - aws-vpc-flow-logs-enabled
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "4"
+          family_name: Monitoring
+          control_id: "4.1"
+          mapped_rules:
+            - aws-cloudwatch-alarm-missing
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "4"
+          family_name: Monitoring
+          control_id: "4.15"
+          mapped_rules:
+            - aws-guardduty-disabled
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "4"
+          family_name: Monitoring
+          control_id: "4.16"
+          mapped_rules:
+            - aws-security-hub-enabled
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "5"
+          family_name: Networking
+          control_id: "5.1"
+          mapped_rules:
+            - aws-nacl-admin-ports-restricted
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "5"
+          family_name: Networking
+          control_id: "5.2"
+          mapped_rules:
+            - aws-ec2-public-ip-ssh
+            - aws-ec2-public-ports-restricted
+            - aws-ecs-ssh-denied
+            - aws-security-group-restrict-ssh
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "5"
+          family_name: Networking
+          control_id: "5.3"
+          mapped_rules:
+            - aws-ec2-public-ip-rdp
+            - aws-ec2-public-ports-restricted
+            - aws-security-group-restrict-rdp
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "5"
+          family_name: Networking
+          control_id: "5.4"
+          mapped_rules:
+            - aws-default-sg-no-rules
+            - aws-ec2-sg-no-all-traffic-ingress
+        - framework_name: CIS AWS Foundations Benchmark v2.0
+          family_id: "5"
+          family_name: Networking
+          control_id: "5.6"
+          mapped_rules:
+            - aws-ec2-imdsv2-required
+        - framework_name: CIS Controls v8
+          family_id: "12"
+          family_name: Network Infrastructure Management
+          control_id: "12"
+          mapped_rules:
+            - aws-api-gateway-no-authorization
+            - aws-bedrock-custom-model-public
+            - aws-codebuild-public-trigger
+            - aws-ec2-ami-not-public
+            - aws-ec2-ebs-snapshot-not-public
+            - aws-ec2-internet-facing-iam
+            - aws-ec2-public-ip-rdp
+            - aws-ec2-public-ip-ssh
+            - aws-ec2-sg-no-all-traffic-ingress
+            - aws-ecr-public-repository
+            - aws-ecs-secrets-in-env-vars
+            - aws-eks-public-endpoint-disabled
+            - aws-elasticache-public
+            - aws-elb-internet-facing-no-waf
+            - aws-elb-target-public-subnet
+            - aws-lambda-in-vpc
+            - aws-lambda-not-publicly-accessible
+            - aws-lambda-secrets-in-env-vars
+            - aws-opensearch-public
+            - aws-rds-no-public-access
+            - aws-rds-public-snapshot
+            - aws-redshift-public
+            - aws-s3-bucket-cleartext-key
+            - aws-s3-bucket-no-public-access
+            - aws-s3-bucket-policy-public
+            - aws-s3-public-write
+            - aws-sagemaker-model-artifact-public
+            - aws-sagemaker-notebook-internet-access
+            - aws-sagemaker-training-no-vpc
+            - aws-sns-public-access
+            - aws-sqs-public-access
+            - azure-cosmosdb-public
+            - azure-cosmosdb-public-access
+            - azure-ml-workspace-public-network
+            - azure-nsg-admin-port
+            - azure-nsg-restrict-ssh
+            - azure-openai-public-network
+            - azure-sql-public-network-access
+            - azure-sqlserver-public
+            - azure-storage-blob-public-access-disabled
+            - azure-storage-public-write
+            - azure-storage-secrets-artifact
+            - azure-vm-public-ip-rdp
+            - azure-vm-public-ip-ssh
+            - bucket-public-large-files
+            - bucket-public-low-exposure
+            - bucket-public-sensitive
+            - cve-2023-20867
+            - cve-2023-4863
+            - cve-2024-6387
+            - efs-public-subnet
+            - gcp-bigquery-public
+            - gcp-bigquery-public-dataset
+            - gcp-bucket-public-write
+            - gcp-bucket-secrets
+            - gcp-cloudrun-no-vpc-connector
+            - gcp-cloudrun-public-ingress
+            - gcp-cloudsql-no-public-ip
+            - gcp-compute-no-public-ip
+            - gcp-compute-public-ssh
+            - gcp-dns-dnssec
+            - gcp-gke-private-cluster
+            - gcp-iam-binding-no-allUsers
+            - gcp-kms-public
+            - gcp-storage-bucket-no-public
+            - gcp-storage-no-public-allusers
+            - gcp-vertex-ai-dataset-public
+            - gcp-vertex-ai-public-endpoint
+            - github-actions-self-hosted-public
+            - github-public-repo-branch-protection
+            - github-repo-internal-exposed
+            - github-runner-group-scope
+            - github-runner-public-repo
+            - github-secret-scanning-alert
+            - k8s-ingress-no-wildcard-host
+            - k8s-ingress-public
+            - k8s-network-policy-selector-present
+            - k8s-node-public-exposure
+            - k8s-service-external-ip
+            - k8s-service-loadbalancer-internal
+            - k8s-service-no-nodeport
+            - k8s-workload-not-default-namespace
+            - log4shell-public
+            - m365-file-shared-externally
+            - m365-sharepoint-anonymous-link
+            - mlops-public-vuln
+            - public-resource-cleartext-admin-keys
+            - public-resource-cleartext-keys
+            - public-resource-cross-account-keys
+            - public-resource-keys-data-access
+            - public-saas-keys
+            - public-vm-cross-account-keys
+            - ray-ai-public
+            - saas-token-exposed
+            - serverless-public-admin
+            - serverless-public-high-priv
+            - serverless-unauth-privileged
+            - serverless-unauthenticated-invocation
+            - storage-key-exposed
+            - vm-internet-vuln-privileged
+            - vm-medium-exposure-vuln-data
+            - vm-public-admin
+            - vm-public-data-access
+            - vm-public-eol
+            - vm-public-eol-targeted
+            - vm-public-high-priv
+            - vm-public-high-privileges
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-common-dep
+            - vm-public-vuln-cross-account-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+            - vpc-external-peering
+        - framework_name: CIS Controls v8
+          family_id: "13"
+          family_name: Network Monitoring and Defense
+          control_id: "13"
+          mapped_rules:
+            - aws-api-gateway-no-authorization
+            - aws-bedrock-custom-model-public
+            - aws-codebuild-public-trigger
+            - aws-ec2-ami-not-public
+            - aws-ec2-ebs-snapshot-not-public
+            - aws-ec2-internet-facing-iam
+            - aws-ec2-public-ip-rdp
+            - aws-ec2-public-ip-ssh
+            - aws-ec2-sg-no-all-traffic-ingress
+            - aws-ecr-public-repository
+            - aws-ecs-secrets-in-env-vars
+            - aws-eks-public-endpoint-disabled
+            - aws-elasticache-public
+            - aws-elb-internet-facing-no-waf
+            - aws-elb-target-public-subnet
+            - aws-lambda-in-vpc
+            - aws-lambda-not-publicly-accessible
+            - aws-lambda-secrets-in-env-vars
+            - aws-opensearch-public
+            - aws-rds-no-public-access
+            - aws-rds-public-snapshot
+            - aws-redshift-public
+            - aws-s3-bucket-cleartext-key
+            - aws-s3-bucket-no-public-access
+            - aws-s3-bucket-policy-public
+            - aws-s3-public-write
+            - aws-sagemaker-model-artifact-public
+            - aws-sagemaker-notebook-internet-access
+            - aws-sagemaker-training-no-vpc
+            - aws-sns-public-access
+            - aws-sqs-public-access
+            - azure-cosmosdb-public
+            - azure-cosmosdb-public-access
+            - azure-ml-workspace-public-network
+            - azure-nsg-admin-port
+            - azure-nsg-restrict-ssh
+            - azure-openai-public-network
+            - azure-sql-public-network-access
+            - azure-sqlserver-public
+            - azure-storage-blob-public-access-disabled
+            - azure-storage-public-write
+            - azure-storage-secrets-artifact
+            - azure-vm-public-ip-rdp
+            - azure-vm-public-ip-ssh
+            - bucket-public-large-files
+            - bucket-public-low-exposure
+            - bucket-public-sensitive
+            - cve-2023-20867
+            - cve-2023-4863
+            - cve-2024-6387
+            - efs-public-subnet
+            - gcp-bigquery-public
+            - gcp-bigquery-public-dataset
+            - gcp-bucket-public-write
+            - gcp-bucket-secrets
+            - gcp-cloudrun-public-ingress
+            - gcp-cloudsql-no-public-ip
+            - gcp-compute-no-public-ip
+            - gcp-compute-public-ssh
+            - gcp-gke-private-cluster
+            - gcp-iam-binding-no-allUsers
+            - gcp-kms-public
+            - gcp-storage-bucket-no-public
+            - gcp-storage-no-public-allusers
+            - gcp-vertex-ai-dataset-public
+            - gcp-vertex-ai-public-endpoint
+            - github-actions-self-hosted-public
+            - github-public-repo-branch-protection
+            - github-repo-internal-exposed
+            - github-runner-group-scope
+            - github-runner-public-repo
+            - github-secret-scanning-alert
+            - k8s-ingress-no-wildcard-host
+            - k8s-ingress-public
+            - k8s-network-policy-selector-present
+            - k8s-node-public-exposure
+            - k8s-service-external-ip
+            - k8s-service-loadbalancer-internal
+            - k8s-service-no-nodeport
+            - k8s-workload-not-default-namespace
+            - log4shell-public
+            - m365-file-shared-externally
+            - m365-sharepoint-anonymous-link
+            - mlops-public-vuln
+            - public-resource-cleartext-admin-keys
+            - public-resource-cleartext-keys
+            - public-resource-cross-account-keys
+            - public-resource-keys-data-access
+            - public-saas-keys
+            - public-vm-cross-account-keys
+            - ray-ai-public
+            - saas-token-exposed
+            - serverless-public-admin
+            - serverless-public-high-priv
+            - serverless-unauth-privileged
+            - storage-key-exposed
+            - vm-internet-vuln-privileged
+            - vm-medium-exposure-vuln-data
+            - vm-public-admin
+            - vm-public-data-access
+            - vm-public-eol
+            - vm-public-eol-targeted
+            - vm-public-high-priv
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-common-dep
+            - vm-public-vuln-cross-account-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+            - vpc-external-peering
+        - framework_name: CIS Controls v8
+          family_id: "4"
+          family_name: Secure Configuration of Enterprise Assets and Software
+          control_id: "4"
+          mapped_rules:
+            - azure-vm-approved-extensions-only
+        - framework_name: CIS Controls v8
+          family_id: "4"
+          family_name: Secure Configuration of Enterprise Assets and Software
+          control_id: "4.3"
+          mapped_rules:
+            - endpoint-jamf-screenlock
+            - endpoint-screenlock-configured
+        - framework_name: CIS Controls v8
+          family_id: "5"
+          family_name: Account Management
+          control_id: "5"
+          mapped_rules:
+            - account-lateral-dormant
+            - admin-inactive-keys
+            - admin-keys-unrotated
+            - admin-keys-year-unrotated
+            - ai-agent-lambda-data-access
+            - ai-model-excessive-agency
+            - ai-model-third-party-access
+            - aws-apigateway-public
+            - aws-bedrock-custom-model-public
+            - aws-codebuild-privileged-mode
+            - aws-codebuild-public-logs
+            - aws-ec2-ami-not-public
+            - aws-ec2-ebs-snapshot-not-public
+            - aws-ec2-instance-profile-attached
+            - aws-ec2-internet-facing-iam
+            - aws-ecr-public-repository
+            - aws-eks-public-endpoint-disabled
+            - aws-iam-access-key-rotation
+            - aws-iam-no-policies-attached-user
+            - aws-iam-password-policy
+            - aws-iam-policy-no-admin-star
+            - aws-iam-role-confused-deputy-prevention
+            - aws-iam-role-cross-account-admin
+            - aws-iam-role-trust-any-principal
+            - aws-iam-role-wildcard-trust
+            - aws-iam-root-mfa-enabled
+            - aws-iam-root-no-access-keys
+            - aws-iam-saml-provider-stale
+            - aws-iam-service-account-open-assume
+            - aws-iam-user-console-inactive
+            - aws-iam-user-mfa-enabled
+            - aws-iam-user-multiple-access-keys
+            - aws-iam-user-unused-credentials
+            - aws-lambda-not-publicly-accessible
+            - aws-opensearch-public
+            - aws-rds-iam-authentication
+            - aws-rds-no-public-access
+            - aws-rds-public-snapshot
+            - aws-redshift-public
+            - aws-s3-bucket-logging-enabled
+            - aws-s3-bucket-no-public-access
+            - aws-s3-bucket-policy-public
+            - aws-s3-public-write
+            - aws-sagemaker-model-artifact-public
+            - aws-sagemaker-notebook-internet-access
+            - aws-sagemaker-notebook-root-access
+            - aws-secretsmanager-secret-used
+            - aws-security-group-restrict-rdp
+            - aws-security-group-restrict-ssh
+            - aws-sns-public-access
+            - aws-sqs-public-access
+            - aws-user-data-no-mfa
+            - aws-user-inactive-admin-no-mfa
+            - aws-user-inactive-data-no-mfa
+            - azure-ad-guest-access-restricted
+            - azure-aks-rbac-enabled
+            - azure-cosmosdb-public
+            - azure-cosmosdb-public-access
+            - azure-function-anonymous-access
+            - azure-function-public
+            - azure-ml-workspace-public-network
+            - azure-nsg-admin-port
+            - azure-nsg-restrict-ssh
+            - azure-openai-public-network
+            - azure-sql-public-network-access
+            - azure-storage-blob-public-access-disabled
+            - azure-storage-network-allow
+            - azure-storage-network-default-deny
+            - azure-storage-public-write
+            - bedrock-excessive-permissions
+            - bucket-cleartext-admin-keys
+            - bucket-cleartext-keys-data
+            - bucket-dormant-principal
+            - bucket-keys-excessive-access
+            - bucket-public-low-exposure
+            - container-cross-account-keys
+            - container-image-cleartext-keys
+            - cross-provider-dormant-privileged
+            - cross-provider-privileged-access-no-mfa
+            - cve-2024-21626
+            - data-access-keys-unrotated
+            - data-resource-excessive-access
+            - data-resource-org-access
+            - db-dormant-principal
+            - dirty-pipe-privileged
+            - gcp-bigquery-public
+            - gcp-bigquery-public-dataset
+            - gcp-bucket-public-write
+            - gcp-cloudrun-default-service-account
+            - gcp-compute-no-default-service-account
+            - gcp-compute-serial-port-disabled
+            - gcp-external-domain-admin
+            - gcp-firewall-admin-port
+            - gcp-gke-default-sa
+            - gcp-iam-binding-no-allAuthenticatedUsers
+            - gcp-iam-binding-no-allUsers
+            - gcp-iam-minimize-user-managed-keys
+            - gcp-iam-sa-no-admin-privileges
+            - gcp-kms-public
+            - gcp-sa-admin-privileges
+            - gcp-sa-admin-user-combined
+            - gcp-sa-impersonation
+            - gcp-sa-no-full-project-access
+            - gcp-service-account-key-rotation
+            - gcp-storage-bucket-no-public
+            - gcp-storage-no-public-allusers
+            - gcp-storage-uniform-bucket-access
+            - gcp-vertex-ai-dataset-public
+            - gcp-vertex-ai-public-endpoint
+            - gcr-excessive-privileges
+            - github-admin-without-2fa
+            - github-oidc-overly-permissive
+            - github-org-workflow-permissions
+            - github-runner-group-scope
+            - github-workflow-write-permissions
+            - gke-cluster-admin
+            - gke-pod-create
+            - gke-wildcard-permissions
+            - group-excessive-admin
+            - group-excessive-data-priv
+            - group-excessive-high-priv
+            - iam-inactive-privileged-account
+            - iam-unknown-account-trusted
+            - internal-vm-cross-account-keys
+            - k8s-cluster-admin-wildcard
+            - k8s-pod-create
+            - k8s-pod-no-privileged
+            - k8s-rbac-cluster-admin-used
+            - k8s-rbac-high-risk-binding
+            - k8s-rbac-medium-risk-binding
+            - k8s-rbac-pod-create-privileges
+            - k8s-rbac-secret-read-access
+            - k8s-rbac-wildcard-permissions-assigned
+            - k8s-role-wildcard-permissions
+            - k8s-service-account-token-mount
+            - k8s-wildcard-permissions
+            - log4shell-privileged
+            - m365-file-shared-externally
+            - m365-guest-admin
+            - m365-inactive-admin
+            - m365-sharepoint-anonymous-link
+            - mlops-public-vuln
+            - notebook-excessive-agency
+            - okta-admin-dormant
+            - privileged-inactive-keys
+            - privileged-keys-unrotated
+            - public-resource-cleartext-admin-keys
+            - public-resource-cleartext-keys
+            - public-resource-cross-account-keys
+            - public-resource-keys-data-access
+            - public-vm-cross-account-keys
+            - resource-cleartext-keys-admin
+            - resource-cleartext-keys-privileged
+            - sa-external-principal-assume
+            - sa-external-web-identity
+            - sa-inactive-assigned
+            - sa-inactive-privileged
+            - sa-lateral-admin
+            - serverless-public-admin
+            - serverless-public-high-priv
+            - serverless-unauth-privileged
+            - serverless-unauthenticated-invocation
+            - terraform-cloud-no-team-access-control
+            - third-party-sa-admin
+            - third-party-sa-privileged
+            - unknown-account-trusted
+            - user-data-access-unused-password
+            - user-excessive-admin
+            - user-excessive-data-priv
+            - user-excessive-high-priv
+            - user-lateral-admin
+            - user-privileged-access-keys
+            - user-privileged-unused-password
+            - vm-cleartext-keys-cross-account
+            - vm-dormant-sa
+            - vm-internet-vuln-privileged
+            - vm-medium-exposure-vuln-data
+            - vm-public-admin
+            - vm-public-data-access
+            - vm-public-high-priv
+            - vm-public-high-privileges
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-cross-account-keys
+            - vm-ssh-private-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+        - framework_name: CIS Controls v8
+          family_id: "5"
+          family_name: Account Management
+          control_id: "5.3"
+          mapped_rules:
+            - identity-stale-accounts-disabled
+        - framework_name: CIS Controls v8
+          family_id: "6"
+          family_name: Access Control Management
+          control_id: "6"
+          mapped_rules:
+            - account-lateral-dormant
+            - admin-inactive-keys
+            - admin-keys-unrotated
+            - admin-keys-year-unrotated
+            - ai-agent-lambda-data-access
+            - ai-model-excessive-agency
+            - ai-model-third-party-access
+            - aws-alb-no-authentication
+            - aws-api-gateway-no-authorization
+            - aws-apigateway-public
+            - aws-appsync-no-authorization
+            - aws-bedrock-custom-model-public
+            - aws-codebuild-privileged-mode
+            - aws-codebuild-public-logs
+            - aws-ec2-ami-not-public
+            - aws-ec2-ebs-snapshot-not-public
+            - aws-ec2-instance-profile-attached
+            - aws-ec2-internet-facing-iam
+            - aws-ecr-public-repository
+            - aws-eks-public-endpoint-disabled
+            - aws-iam-access-key-rotation
+            - aws-iam-no-policies-attached-user
+            - aws-iam-password-policy
+            - aws-iam-policy-no-admin-star
+            - aws-iam-role-confused-deputy-prevention
+            - aws-iam-role-cross-account-admin
+            - aws-iam-role-trust-any-principal
+            - aws-iam-role-wildcard-trust
+            - aws-iam-root-mfa-enabled
+            - aws-iam-root-no-access-keys
+            - aws-iam-saml-provider-stale
+            - aws-iam-service-account-open-assume
+            - aws-iam-user-console-inactive
+            - aws-iam-user-mfa-enabled
+            - aws-iam-user-multiple-access-keys
+            - aws-iam-user-unused-credentials
+            - aws-lambda-not-publicly-accessible
+            - aws-opensearch-public
+            - aws-rds-iam-authentication
+            - aws-rds-no-public-access
+            - aws-rds-public-snapshot
+            - aws-redshift-public
+            - aws-s3-bucket-logging-enabled
+            - aws-s3-bucket-mfa-delete
+            - aws-s3-bucket-no-public-access
+            - aws-s3-bucket-policy-public
+            - aws-s3-public-write
+            - aws-sagemaker-model-artifact-public
+            - aws-sagemaker-notebook-internet-access
+            - aws-sagemaker-notebook-root-access
+            - aws-secretsmanager-secret-used
+            - aws-security-group-restrict-rdp
+            - aws-security-group-restrict-ssh
+            - aws-sns-public-access
+            - aws-sqs-public-access
+            - aws-user-data-no-mfa
+            - aws-user-inactive-admin-no-mfa
+            - aws-user-inactive-data-no-mfa
+            - azure-ad-guest-access-restricted
+            - azure-aks-rbac-enabled
+            - azure-cosmosdb-public
+            - azure-cosmosdb-public-access
+            - azure-function-anonymous-access
+            - azure-function-public
+            - azure-ml-workspace-public-network
+            - azure-nsg-admin-port
+            - azure-nsg-restrict-ssh
+            - azure-openai-public-network
+            - azure-sql-azure-ad-admin
+            - azure-sql-public-network-access
+            - azure-storage-blob-public-access-disabled
+            - azure-storage-network-allow
+            - azure-storage-network-default-deny
+            - azure-storage-public-write
+            - azure-user-mfa-disabled
+            - bedrock-excessive-permissions
+            - bucket-cleartext-admin-keys
+            - bucket-cleartext-keys-data
+            - bucket-dormant-principal
+            - bucket-keys-excessive-access
+            - bucket-public-low-exposure
+            - container-cross-account-keys
+            - container-image-cleartext-keys
+            - cross-provider-dormant-privileged
+            - cross-provider-privileged-access-no-mfa
+            - cve-2024-21626
+            - data-access-keys-unrotated
+            - data-resource-excessive-access
+            - data-resource-org-access
+            - db-dormant-principal
+            - dirty-pipe-privileged
+            - gcp-bigquery-public
+            - gcp-bigquery-public-dataset
+            - gcp-bucket-public-write
+            - gcp-cloud-run-allow-unauthenticated
+            - gcp-cloudrun-default-service-account
+            - gcp-compute-no-default-service-account
+            - gcp-compute-serial-port-disabled
+            - gcp-external-domain-admin
+            - gcp-firewall-admin-port
+            - gcp-gke-default-sa
+            - gcp-iam-binding-no-allAuthenticatedUsers
+            - gcp-iam-binding-no-allUsers
+            - gcp-iam-minimize-user-managed-keys
+            - gcp-iam-sa-no-admin-privileges
+            - gcp-kms-public
+            - gcp-sa-admin-privileges
+            - gcp-sa-admin-user-combined
+            - gcp-sa-impersonation
+            - gcp-sa-no-full-project-access
+            - gcp-service-account-key-rotation
+            - gcp-storage-bucket-no-public
+            - gcp-storage-no-public-allusers
+            - gcp-storage-uniform-bucket-access
+            - gcp-vertex-ai-dataset-public
+            - gcp-vertex-ai-public-endpoint
+            - gcr-excessive-privileges
+            - github-admin-without-2fa
+            - github-oidc-overly-permissive
+            - github-org-2fa-disabled
+            - github-org-workflow-permissions
+            - github-runner-group-scope
+            - github-workflow-write-permissions
+            - gke-cluster-admin
+            - gke-pod-create
+            - gke-wildcard-permissions
+            - group-excessive-admin
+            - group-excessive-data-priv
+            - group-excessive-high-priv
+            - iam-inactive-privileged-account
+            - iam-unknown-account-trusted
+            - internal-vm-cross-account-keys
+            - k8s-cluster-admin-wildcard
+            - k8s-ingress-no-authentication
+            - k8s-ingress-public
+            - k8s-pod-create
+            - k8s-pod-no-privileged
+            - k8s-rbac-cluster-admin-used
+            - k8s-rbac-high-risk-binding
+            - k8s-rbac-medium-risk-binding
+            - k8s-rbac-pod-create-privileges
+            - k8s-rbac-secret-read-access
+            - k8s-rbac-wildcard-permissions-assigned
+            - k8s-role-wildcard-permissions
+            - k8s-service-account-token-mount
+            - k8s-wildcard-permissions
+            - log4shell-privileged
+            - m365-file-shared-externally
+            - m365-guest-admin
+            - m365-inactive-admin
+            - m365-sharepoint-anonymous-link
+            - mlops-public-vuln
+            - notebook-excessive-agency
+            - okta-admin-dormant
+            - okta-app-no-mfa
+            - okta-password-policy-weak
+            - okta-user-mfa-disabled
+            - privileged-inactive-keys
+            - privileged-keys-unrotated
+            - public-resource-cleartext-admin-keys
+            - public-resource-cleartext-keys
+            - public-resource-cross-account-keys
+            - public-resource-keys-data-access
+            - public-vm-cross-account-keys
+            - ray-ai-public
+            - resource-cleartext-keys-admin
+            - resource-cleartext-keys-privileged
+            - sa-external-principal-assume
+            - sa-external-web-identity
+            - sa-inactive-assigned
+            - sa-inactive-privileged
+            - sa-lateral-admin
+            - serverless-public-admin
+            - serverless-public-high-priv
+            - serverless-unauth-privileged
+            - serverless-unauthenticated-invocation
+            - terraform-cloud-no-team-access-control
+            - third-party-sa-admin
+            - third-party-sa-privileged
+            - unknown-account-trusted
+            - user-data-access-unused-password
+            - user-excessive-admin
+            - user-excessive-data-priv
+            - user-excessive-high-priv
+            - user-lateral-admin
+            - user-privileged-access-keys
+            - user-privileged-unused-password
+            - vm-cleartext-keys-cross-account
+            - vm-dormant-sa
+            - vm-empty-password
+            - vm-internet-vuln-privileged
+            - vm-medium-exposure-vuln-data
+            - vm-public-admin
+            - vm-public-data-access
+            - vm-public-high-priv
+            - vm-public-high-privileges
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-cross-account-keys
+            - vm-ssh-private-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+        - framework_name: CIS Controls v8
+          family_id: "6"
+          family_name: Access Control Management
+          control_id: "6.3"
+          mapped_rules:
+            - identity-saas-mfa-enforced
+        - framework_name: CIS Controls v8
+          family_id: "6"
+          family_name: Access Control Management
+          control_id: "6.4"
+          mapped_rules:
+            - identity-saas-mfa-enforced
+        - framework_name: CIS Controls v8
+          family_id: "7"
+          family_name: Continuous Vulnerability Management
+          control_id: "7"
+          mapped_rules:
+            - aws-ecr-immutable-tags
+            - aws-ecr-scan-on-push
+            - aws-lambda-runtime-supported
+            - azure-vm-approved-extensions-only
+            - cisa-kev-vulnerability-present
+            - container-eol-writable
+            - container-openssl-vuln
+            - cve-2021-45046
+            - cve-2021-45105
+            - cve-2023-20867
+            - cve-2023-4863
+            - cve-2024-21626
+            - cve-2024-6387
+            - dirty-pipe-privileged
+            - gcr-unscanned
+            - github-code-scanning-critical
+            - github-dependabot-critical-alert
+            - github-dependabot-high-alert
+            - gitlab-runner-unprotected-tags
+            - k8s-cluster-unsupported-version
+            - k8s-pod-image-pinned-by-digest
+            - k8s-pod-image-tag-not-latest
+            - k8s-resource-no-deprecated-api
+            - k8s-service-external-ip
+            - log4shell-privileged
+            - log4shell-public
+            - ml-model-untrusted-source
+            - mlops-public-vuln
+            - openssl-vuln-internal
+            - vm-internet-vuln-privileged
+            - vm-kernel-vuln-container
+            - vm-medium-exposure-vuln-data
+            - vm-public-eol
+            - vm-public-high-privileges
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-common-dep
+            - vm-public-vuln-cross-account-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+        - framework_name: CIS Controls v8
+          family_id: "8"
+          family_name: Audit Log Management
+          control_id: "8"
+          mapped_rules:
+            - aws-cloudtrail-enabled
+            - aws-cloudwatch-alarm-missing
+            - aws-cloudwatch-log-group-encrypted
+            - aws-cloudwatch-log-group-retention
+            - aws-codebuild-public-logs
+            - aws-config-enabled-all-regions
+            - aws-ec2-detailed-monitoring-enabled
+            - aws-eks-control-plane-logging
+            - aws-guardduty-c2-traffic
+            - aws-guardduty-crypto-mining
+            - aws-guardduty-malware-finding
+            - aws-rds-logging-enabled
+            - aws-s3-bucket-logging-enabled
+            - aws-vpc-flow-logs-enabled
+            - azure-defender-storage
+            - azure-keyvault-logging
+            - azure-sql-auditing-enabled
+            - container-runtime-exec-detected
+            - gcp-audit-logging-enabled
+            - gcp-logging-disabled
+            - github-repo-secrets-exposure
+            - ml-model-registry-no-versioning
+            - okta-suspicious-login
+            - s3-read-logging-disabled
+            - s3-write-logging-disabled
+            - sentinelone-threat-detected
+            - threat-intel-malicious-domain-resolution
+            - threat-intel-malicious-ip-connection
+            - vpc-dns-logging
+            - vpc-no-dns-resolver-logging
+        - framework_name: CIS EKS Benchmark v1.3
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.4.1
+          mapped_rules:
+            - aws-eks-private-endpoint
+        - framework_name: CIS GKE Benchmark v1.4
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.1.1
+          mapped_rules:
+            - gcp-gke-no-alpha-clusters
+        - framework_name: CIS GKE Benchmark v1.4
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.2.1
+          mapped_rules:
+            - gcp-gke-metadata-server
+        - framework_name: CIS GKE Benchmark v1.4
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.3.1
+          mapped_rules:
+            - gcp-gke-secrets-kms-encryption
+        - framework_name: CIS GKE Benchmark v1.4
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.5.1
+          mapped_rules:
+            - gcp-gke-shielded-nodes
+        - framework_name: CIS GKE Benchmark v1.4
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.5.2
+          mapped_rules:
+            - gcp-gke-auto-repair
+        - framework_name: CIS GKE Benchmark v1.4
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.5.3
+          mapped_rules:
+            - gcp-gke-auto-upgrade
+        - framework_name: CIS GKE Benchmark v1.4
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.5.4
+          mapped_rules:
+            - gcp-gke-cos-containerd
+        - framework_name: CIS GKE Benchmark v1.4
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.6.1
+          mapped_rules:
+            - gcp-gke-dashboard-disabled
+        - framework_name: CIS GKE Benchmark v1.4
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.6.3
+          mapped_rules:
+            - gcp-gke-network-policy-enabled
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.1.1
+          mapped_rules:
+            - gke-cluster-admin
+            - k8s-rbac-cluster-admin-used
+            - k8s-rbac-high-risk-binding
+            - k8s-rbac-medium-risk-binding
+            - k8s-rbac-pod-create-privileges
+            - k8s-rbac-secret-read-access
+            - k8s-rbac-wildcard-permissions-assigned
+            - k8s-role-wildcard-permissions
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.1.3
+          mapped_rules:
+            - gke-cluster-admin
+            - k8s-cluster-admin-wildcard
+            - k8s-rbac-cluster-admin-used
+            - k8s-rbac-high-risk-binding
+            - k8s-rbac-medium-risk-binding
+            - k8s-rbac-pod-create-privileges
+            - k8s-rbac-secret-read-access
+            - k8s-rbac-wildcard-permissions-assigned
+            - k8s-role-wildcard-permissions
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.1.4
+          mapped_rules:
+            - gke-cluster-admin
+            - k8s-rbac-cluster-admin-used
+            - k8s-rbac-high-risk-binding
+            - k8s-rbac-medium-risk-binding
+            - k8s-rbac-pod-create-privileges
+            - k8s-rbac-secret-read-access
+            - k8s-rbac-wildcard-permissions-assigned
+            - k8s-role-wildcard-permissions
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.1.6
+          mapped_rules:
+            - k8s-service-account-token-mount
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.2.1
+          mapped_rules:
+            - k8s-missing-pss
+            - k8s-namespace-missing-pss-label
+            - k8s-pod-no-hostpath-volumes
+            - k8s-pod-no-privilege-escalation
+            - k8s-pod-no-privileged
+            - k8s-pod-seccomp-runtime-default
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.2.2
+          mapped_rules:
+            - k8s-missing-pss
+            - k8s-namespace-missing-pss-label
+            - k8s-pod-no-host-pid
+            - k8s-pod-no-hostpath-volumes
+            - k8s-pod-no-privilege-escalation
+            - k8s-pod-seccomp-runtime-default
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.2.3
+          mapped_rules:
+            - k8s-missing-pss
+            - k8s-namespace-missing-pss-label
+            - k8s-pod-no-hostpath-volumes
+            - k8s-pod-no-privilege-escalation
+            - k8s-pod-seccomp-runtime-default
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.2.4
+          mapped_rules:
+            - k8s-missing-pss
+            - k8s-namespace-missing-pss-label
+            - k8s-pod-no-host-network
+            - k8s-pod-no-hostpath-volumes
+            - k8s-pod-no-privilege-escalation
+            - k8s-pod-readonly-root-filesystem
+            - k8s-pod-seccomp-runtime-default
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.2.5
+          mapped_rules:
+            - k8s-missing-pss
+            - k8s-namespace-missing-pss-label
+            - k8s-pod-no-hostpath-volumes
+            - k8s-pod-no-privilege-escalation
+            - k8s-pod-seccomp-runtime-default
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.2.6
+          mapped_rules:
+            - k8s-missing-pss
+            - k8s-namespace-missing-pss-label
+            - k8s-pod-no-hostpath-volumes
+            - k8s-pod-no-privilege-escalation
+            - k8s-pod-no-run-as-root
+            - k8s-pod-seccomp-runtime-default
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.2.7
+          mapped_rules:
+            - k8s-missing-pss
+            - k8s-namespace-missing-pss-label
+            - k8s-pod-drop-all-capabilities
+            - k8s-pod-no-hostpath-volumes
+            - k8s-pod-no-privilege-escalation
+            - k8s-pod-seccomp-runtime-default
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.2.8
+          mapped_rules:
+            - k8s-missing-pss
+            - k8s-namespace-missing-pss-label
+            - k8s-pod-no-hostpath-volumes
+            - k8s-pod-no-privilege-escalation
+            - k8s-pod-seccomp-runtime-default
+        - framework_name: CIS Kubernetes Benchmark
+          family_id: "5"
+          family_name: Policies
+          control_id: 5.3.2
+          mapped_rules:
+            - k8s-network-policy-default-deny
+      rules:
+        - rule_id: account-lateral-dormant
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: admin-inactive-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: admin-keys-unrotated
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: admin-keys-year-unrotated
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: ai-agent-lambda-data-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: ai-model-excessive-agency
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: ai-model-third-party-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-alb-no-authentication
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-api-gateway-no-authorization
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-apigateway-public
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "2.6"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-appsync-no-authorization
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-bedrock-custom-model-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-cloudtrail-enabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "3.1"
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-cloudtrail-kms-encryption
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "3.7"
+        - rule_id: aws-cloudtrail-log-integrity
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "3.2"
+        - rule_id: aws-cloudtrail-s3-data-events
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "3.10"
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "3.11"
+        - rule_id: aws-cloudwatch-alarm-missing
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "4.1"
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-cloudwatch-log-group-encrypted
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-cloudwatch-log-group-retention
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-codebuild-privileged-mode
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-codebuild-public-logs
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-codebuild-public-trigger
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-config-enabled-all-regions
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "3.5"
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-default-sg-no-rules
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.4"
+        - rule_id: aws-ebs-encryption-default
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.2.1
+        - rule_id: aws-ec2-ami-not-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-ec2-detailed-monitoring-enabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-ec2-ebs-snapshot-not-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-ec2-ebs-volume-encrypted
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.2.1
+        - rule_id: aws-ec2-iam-instance-profile
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.16"
+        - rule_id: aws-ec2-imdsv2-required
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.6"
+        - rule_id: aws-ec2-instance-profile-attached
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-ec2-internet-facing-iam
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-ec2-public-ip-rdp
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.3"
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-ec2-public-ip-ssh
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.2"
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-ec2-public-ports-restricted
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.2"
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.3"
+        - rule_id: aws-ec2-sg-no-all-traffic-ingress
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.4"
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-ecr-immutable-tags
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: aws-ecr-public-repository
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-ecr-scan-on-push
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: aws-ecs-secrets-in-env-vars
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-ecs-ssh-denied
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.2"
+        - rule_id: aws-eks-control-plane-logging
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-eks-private-endpoint
+          controls:
+            - framework_name: CIS EKS Benchmark v1.3
+              control_id: 5.4.1
+        - rule_id: aws-eks-public-endpoint-disabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-elasticache-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-elb-internet-facing-no-waf
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-elb-target-public-subnet
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-guardduty-c2-traffic
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-guardduty-crypto-mining
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-guardduty-disabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "4.15"
+        - rule_id: aws-guardduty-malware-finding
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-iam-access-analyzer-enabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.21"
+        - rule_id: aws-iam-access-key-rotation
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.14"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-expired-certificates
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.19"
+        - rule_id: aws-iam-no-policies-attached-user
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.15"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-password-policy
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.10"
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.8"
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.9"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-policy-no-admin-star
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.16"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-role-confused-deputy-prevention
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-role-cross-account-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-role-trust-any-principal
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-role-wildcard-trust
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-root-mfa-enabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.5"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-root-no-access-keys
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.4"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-saml-provider-stale
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-service-account-open-assume
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-single-access-key
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.13"
+        - rule_id: aws-iam-support-role
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.20"
+        - rule_id: aws-iam-user-console-inactive
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.12"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-user-mfa-enabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.4"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-user-multiple-access-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-user-unused-credentials
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.12"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-iam-users-via-groups
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.15"
+        - rule_id: aws-kms-key-rotation-enabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "3.8"
+        - rule_id: aws-lambda-in-vpc
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-lambda-not-publicly-accessible
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-lambda-runtime-supported
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: aws-lambda-secrets-in-env-vars
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-nacl-admin-ports-restricted
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.1"
+        - rule_id: aws-opensearch-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-password-policy-minimum-length
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.8"
+        - rule_id: aws-password-policy-no-reuse
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "1.9"
+        - rule_id: aws-rds-encryption-enabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.3.1
+        - rule_id: aws-rds-iam-authentication
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-rds-logging-enabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-rds-no-public-access
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.3.3
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-rds-public-snapshot
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-redshift-no-encryption
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.3.2
+        - rule_id: aws-redshift-public
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.3.1
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-s3-bucket-cleartext-key
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-s3-bucket-encryption-enabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.1.1
+        - rule_id: aws-s3-bucket-logging-enabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "3.6"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: aws-s3-bucket-mfa-delete
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-s3-bucket-no-public-access
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.1.5
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-s3-bucket-policy-public
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.1.5
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-s3-bucket-ssl-only
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.1.2
+        - rule_id: aws-s3-https-only
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: 2.1.2
+        - rule_id: aws-s3-public-write
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-sagemaker-model-artifact-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-sagemaker-notebook-internet-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-sagemaker-notebook-root-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-sagemaker-training-no-vpc
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: aws-secretsmanager-secret-used
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-security-group-restrict-rdp
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.3"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-security-group-restrict-ssh
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "5.2"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-security-hub-enabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "4.16"
+        - rule_id: aws-sns-public-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-sqs-public-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-user-data-no-mfa
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-user-inactive-admin-no-mfa
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-user-inactive-data-no-mfa
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: aws-vpc-flow-logs-enabled
+          controls:
+            - framework_name: CIS AWS Foundations Benchmark v2.0
+              control_id: "3.9"
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: azure-ad-guest-access-restricted
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-aks-rbac-enabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-cosmosdb-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-cosmosdb-public-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-defender-storage
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: azure-function-anonymous-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-function-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-keyvault-logging
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: azure-ml-workspace-public-network
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-nsg-admin-port
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-nsg-restrict-ssh
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-openai-public-network
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-sql-auditing-enabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: azure-sql-azure-ad-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-sql-public-network-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-sqlserver-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: azure-storage-blob-public-access-disabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-storage-network-allow
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-storage-network-default-deny
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-storage-public-write
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-storage-secrets-artifact
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: azure-user-mfa-disabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: azure-vm-approved-extensions-only
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "4"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: azure-vm-public-ip-rdp
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: azure-vm-public-ip-ssh
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: bedrock-excessive-permissions
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: bucket-cleartext-admin-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: bucket-cleartext-keys-data
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: bucket-dormant-principal
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: bucket-keys-excessive-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: bucket-public-large-files
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: bucket-public-low-exposure
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: bucket-public-sensitive
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: cisa-kev-vulnerability-present
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: container-cross-account-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: container-eol-writable
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: container-image-cleartext-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: container-openssl-vuln
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: container-runtime-exec-detected
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: cross-provider-dormant-privileged
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: cross-provider-privileged-access-no-mfa
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: cve-2021-45046
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: cve-2021-45105
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: cve-2023-20867
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: cve-2023-4863
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: cve-2024-21626
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: cve-2024-6387
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: data-access-keys-unrotated
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: data-resource-excessive-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: data-resource-org-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: db-dormant-principal
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: dirty-pipe-privileged
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: efs-public-subnet
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: endpoint-jamf-screenlock
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "4.3"
+        - rule_id: endpoint-screenlock-configured
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "4.3"
+        - rule_id: gcp-audit-logging-enabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: gcp-bigquery-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-bigquery-public-dataset
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-bucket-public-write
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-bucket-secrets
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: gcp-cloud-run-allow-unauthenticated
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-cloudrun-default-service-account
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-cloudrun-no-vpc-connector
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+        - rule_id: gcp-cloudrun-public-ingress
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: gcp-cloudsql-no-public-ip
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: gcp-compute-no-default-service-account
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-compute-no-public-ip
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: gcp-compute-public-ssh
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: gcp-compute-serial-port-disabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-dns-dnssec
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+        - rule_id: gcp-external-domain-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-firewall-admin-port
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-gke-auto-repair
+          controls:
+            - framework_name: CIS GKE Benchmark v1.4
+              control_id: 5.5.2
+        - rule_id: gcp-gke-auto-upgrade
+          controls:
+            - framework_name: CIS GKE Benchmark v1.4
+              control_id: 5.5.3
+        - rule_id: gcp-gke-cos-containerd
+          controls:
+            - framework_name: CIS GKE Benchmark v1.4
+              control_id: 5.5.4
+        - rule_id: gcp-gke-dashboard-disabled
+          controls:
+            - framework_name: CIS GKE Benchmark v1.4
+              control_id: 5.6.1
+        - rule_id: gcp-gke-default-sa
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-gke-metadata-server
+          controls:
+            - framework_name: CIS GKE Benchmark v1.4
+              control_id: 5.2.1
+        - rule_id: gcp-gke-network-policy-enabled
+          controls:
+            - framework_name: CIS GKE Benchmark v1.4
+              control_id: 5.6.3
+        - rule_id: gcp-gke-no-alpha-clusters
+          controls:
+            - framework_name: CIS GKE Benchmark v1.4
+              control_id: 5.1.1
+        - rule_id: gcp-gke-private-cluster
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: gcp-gke-secrets-kms-encryption
+          controls:
+            - framework_name: CIS GKE Benchmark v1.4
+              control_id: 5.3.1
+        - rule_id: gcp-gke-shielded-nodes
+          controls:
+            - framework_name: CIS GKE Benchmark v1.4
+              control_id: 5.5.1
+        - rule_id: gcp-iam-binding-no-allAuthenticatedUsers
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-iam-binding-no-allUsers
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-iam-minimize-user-managed-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-iam-sa-no-admin-privileges
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-kms-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-logging-disabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: gcp-sa-admin-privileges
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-sa-admin-user-combined
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-sa-impersonation
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-sa-no-full-project-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-service-account-key-rotation
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-storage-bucket-no-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-storage-no-public-allusers
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-storage-uniform-bucket-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-vertex-ai-dataset-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcp-vertex-ai-public-endpoint
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcr-excessive-privileges
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gcr-unscanned
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: github-actions-self-hosted-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: github-admin-without-2fa
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: github-code-scanning-critical
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: github-dependabot-critical-alert
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: github-dependabot-high-alert
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: github-oidc-overly-permissive
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: github-org-2fa-disabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: github-org-workflow-permissions
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: github-public-repo-branch-protection
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: github-repo-internal-exposed
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: github-repo-secrets-exposure
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: github-runner-group-scope
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: github-runner-public-repo
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: github-secret-scanning-alert
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: github-workflow-write-permissions
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gitlab-runner-unprotected-tags
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: gke-cluster-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.4
+        - rule_id: gke-pod-create
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: gke-wildcard-permissions
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: group-excessive-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: group-excessive-data-priv
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: group-excessive-high-priv
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: iam-inactive-privileged-account
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: iam-unknown-account-trusted
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: identity-saas-mfa-enforced
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6.3"
+            - framework_name: CIS Controls v8
+              control_id: "6.4"
+        - rule_id: identity-stale-accounts-disabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5.3"
+        - rule_id: internal-vm-cross-account-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: k8s-cluster-admin-wildcard
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.3
+        - rule_id: k8s-cluster-unsupported-version
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: k8s-ingress-no-authentication
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: k8s-ingress-no-wildcard-host
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: k8s-ingress-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: k8s-missing-pss
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.2
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.4
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.5
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.6
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.7
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.8
+        - rule_id: k8s-namespace-missing-pss-label
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.2
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.4
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.5
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.6
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.7
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.8
+        - rule_id: k8s-network-policy-default-deny
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.3.2
+        - rule_id: k8s-network-policy-selector-present
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: k8s-node-public-exposure
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: k8s-pod-create
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: k8s-pod-drop-all-capabilities
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.7
+        - rule_id: k8s-pod-image-pinned-by-digest
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: k8s-pod-image-tag-not-latest
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: k8s-pod-no-host-network
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.4
+        - rule_id: k8s-pod-no-host-pid
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.2
+        - rule_id: k8s-pod-no-hostpath-volumes
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.2
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.4
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.5
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.6
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.7
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.8
+        - rule_id: k8s-pod-no-privilege-escalation
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.2
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.4
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.5
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.6
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.7
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.8
+        - rule_id: k8s-pod-no-privileged
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.1
+        - rule_id: k8s-pod-no-run-as-root
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.6
+        - rule_id: k8s-pod-readonly-root-filesystem
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.4
+        - rule_id: k8s-pod-seccomp-runtime-default
+          controls:
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.2
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.4
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.5
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.6
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.7
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.2.8
+        - rule_id: k8s-rbac-cluster-admin-used
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.4
+        - rule_id: k8s-rbac-high-risk-binding
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.4
+        - rule_id: k8s-rbac-medium-risk-binding
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.4
+        - rule_id: k8s-rbac-pod-create-privileges
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.4
+        - rule_id: k8s-rbac-secret-read-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.4
+        - rule_id: k8s-rbac-wildcard-permissions-assigned
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.4
+        - rule_id: k8s-resource-no-deprecated-api
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: k8s-role-wildcard-permissions
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.1
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.3
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.4
+        - rule_id: k8s-service-account-token-mount
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Kubernetes Benchmark
+              control_id: 5.1.6
+        - rule_id: k8s-service-external-ip
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: k8s-service-loadbalancer-internal
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: k8s-service-no-nodeport
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: k8s-wildcard-permissions
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: k8s-workload-not-default-namespace
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: log4shell-privileged
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: log4shell-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: m365-file-shared-externally
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: m365-guest-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: m365-inactive-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: m365-sharepoint-anonymous-link
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: ml-model-registry-no-versioning
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: ml-model-untrusted-source
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: mlops-public-vuln
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: notebook-excessive-agency
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: okta-admin-dormant
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: okta-app-no-mfa
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: okta-password-policy-weak
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: okta-suspicious-login
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: okta-user-mfa-disabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: openssl-vuln-internal
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: privileged-inactive-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: privileged-keys-unrotated
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: public-resource-cleartext-admin-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: public-resource-cleartext-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: public-resource-cross-account-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: public-resource-keys-data-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: public-saas-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: public-vm-cross-account-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: ray-ai-public
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: resource-cleartext-keys-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: resource-cleartext-keys-privileged
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: s3-read-logging-disabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: s3-write-logging-disabled
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: sa-external-principal-assume
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: sa-external-web-identity
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: sa-inactive-assigned
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: sa-inactive-privileged
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: sa-lateral-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: saas-token-exposed
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: sentinelone-threat-detected
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: serverless-public-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: serverless-public-high-priv
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: serverless-unauth-privileged
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: serverless-unauthenticated-invocation
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: storage-key-exposed
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: terraform-cloud-no-team-access-control
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: third-party-sa-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: third-party-sa-privileged
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: threat-intel-malicious-domain-resolution
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: threat-intel-malicious-ip-connection
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: unknown-account-trusted
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: user-data-access-unused-password
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: user-excessive-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: user-excessive-data-priv
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: user-excessive-high-priv
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: user-lateral-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: user-privileged-access-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: user-privileged-unused-password
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: vm-cleartext-keys-cross-account
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: vm-dormant-sa
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: vm-empty-password
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: vm-internet-vuln-privileged
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-kernel-vuln-container
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-medium-exposure-vuln-data
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-public-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: vm-public-data-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: vm-public-eol
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-public-eol-targeted
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: vm-public-high-priv
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: vm-public-high-privileges
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-public-privileged-vuln-common-dep
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-public-vuln
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-public-vuln-common-dep
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-public-vuln-cross-account-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-ssh-private-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+        - rule_id: vm-vuln-cleartext-keys
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-vuln-data-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-vuln-keys-data-access
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vm-vuln-lateral-admin
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+            - framework_name: CIS Controls v8
+              control_id: "5"
+            - framework_name: CIS Controls v8
+              control_id: "6"
+            - framework_name: CIS Controls v8
+              control_id: "7"
+        - rule_id: vpc-dns-logging
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+        - rule_id: vpc-external-peering
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "12"
+            - framework_name: CIS Controls v8
+              control_id: "13"
+        - rule_id: vpc-no-dns-resolver-logging
+          controls:
+            - framework_name: CIS Controls v8
+              control_id: "8"
+    - id: iso-technology-controls
+      name: ISO Technology Controls
+      description: Technology implementation controls for access, operations, logging, vulnerability management, and secure configuration evidence.
+      summary:
+        selected_controls: 34
+        mapped_controls: 14
+        unmapped_controls: 20
+        mapped_rules: 98
+      controls:
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.1
+          mapped_rules:
+            - endpoint-jamf-screenlock
+            - endpoint-screenlock-configured
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.10
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.11
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.12
+          mapped_rules:
+            - m365-dlp-policy-missing
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.13
+          mapped_rules:
+            - aws-rds-backup-enabled
+            - aws-rds-deletion-protection
+            - aws-s3-bucket-versioning-enabled
+            - aws-s3-cross-region-replication
+            - bucket-sensitive-no-lock
+            - gcp-sql-backup-enabled
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.14
+          mapped_rules:
+            - aws-rds-multi-az-enabled
+            - k8s-deployment-multiple-replicas
+            - k8s-pod-liveness-probe-required
+            - k8s-pod-readiness-probe-required
+            - k8s-pod-resource-limits
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.15
+          mapped_rules:
+            - grc-failing-control-test-unhealthy-integration
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.16
+          mapped_rules:
+            - aws-guardduty-c2-traffic
+            - aws-guardduty-crypto-mining
+            - aws-guardduty-malware-finding
+            - azure-defender-storage
+            - container-runtime-exec-detected
+            - identity-okta-account-lock-events-24h
+            - identity-okta-application-lifecycle-tampering-30d
+            - identity-okta-password-reset-or-unlock-attempt-spike-24h
+            - identity-okta-possible-dos-attack-1h
+            - identity-okta-rate-limit-violations-24h
+            - identity-okta-threat-insight-not-blocking
+            - identity-okta-threatinsight-detected-30d
+            - identity-okta-unauthorized-app-access-attempts-7d
+            - identity-okta-user-reported-suspicious-activity-30d
+            - okta-suspicious-login
+            - sentinelone-agent-not-up-to-date
+            - sentinelone-agent-stale
+            - sentinelone-command-control
+            - sentinelone-malware
+            - sentinelone-threat-detected
+            - threat-intel-malicious-domain-resolution
+            - threat-intel-malicious-ip-connection
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.17
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.18
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.19
+          mapped_rules:
+            - aws-rds-auto-minor-upgrade
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.2
+          mapped_rules:
+            - github-org-owner-role-review-needed
+            - identity-okta-admin-plus-app-owner
+            - identity-okta-admin-privilege-grant-events-30d
+            - identity-okta-api-token-created-30d
+            - identity-okta-api-token-revoked-30d
+            - identity-okta-group-grants-admin-app
+            - identity-okta-superadmin-count
+            - identity-okta-support-session-impersonation-30d
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.20
+          mapped_rules:
+            - cloud-current-public-exposure-review-needed
+            - cloud-effective-admin-permission
+            - cloud-exposed-privileged-compute-role
+            - cloud-privilege-path-granted
+            - cloud-public-exposure-privileged-principal
+            - cloud-public-resource-exposure
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.21
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.22
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.23
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.24
+          mapped_rules:
+            - aws-cloudtrail-kms-encryption
+            - azure-vm-unmanaged-disk
+            - bucket-sensitive-no-lock
+            - endpoint-disk-encryption
+            - endpoint-intune-disk-encryption
+            - endpoint-jamf-disk-encryption
+            - endpoint-kandji-disk-encryption
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.25
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.26
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.27
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.28
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.29
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.3
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.30
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.31
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.32
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.33
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.34
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.4
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.5
+          mapped_rules:
+            - identity-google-workspace-admin-mfa
+            - identity-okta-admin-mfa
+            - identity-okta-admin-no-mfa-granular
+            - identity-okta-authenticator-weak-factor-enabled
+            - identity-okta-mfa-factor-reset-events-30d
+            - identity-okta-password-view-events-30d
+            - identity-saas-mfa-enforced
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.6
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.7
+          mapped_rules:
+            - endpoint-edr-installed
+            - endpoint-kandji-edr-installed
+            - sentinelone-agent-detect-only-mode
+            - sentinelone-command-control
+            - sentinelone-infected-endpoint-privileged-owner
+            - sentinelone-malware
+            - sentinelone-protection-control-tampering
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.8
+          mapped_rules:
+            - aws-rds-auto-minor-upgrade
+            - grc-isolated-target-enrichment-gap
+            - grc-overdue-vulnerability-live-on-assets
+            - grc-source-integration-concentrated-open-findings
+            - grc-vulnerability-sla-overdue
+            - security-reviewer-reported-finding
+            - vulnview-actionable-external-finding
+            - vulnview-external-asset-concentrated-signal
+        - framework_name: ISO 27001:2022
+          family_id: A.8
+          family_name: Technology Controls
+          control_id: A.8.9
+          mapped_rules:
+            - github-app-integration-installed
+            - github-code-security-controls-disabled
+            - github-org-auth-control-modified
+            - github-org-ip-allow-list-modified
+            - github-organization-owner-added
+            - github-personal-access-token-created
+            - github-private-repository-forking-enabled
+            - github-repository-collaborator-added
+            - github-repository-ruleset-modified
+            - github-secret-scanning-alert-created
+            - github-self-hosted-runner-review-needed
+            - github-webhook-modified
+            - identity-okta-idp-lifecycle-changes-30d
+            - identity-okta-network-zone-deactivation-30d
+            - identity-okta-network-zone-delete-events-30d
+            - identity-okta-network-zone-modify-events-30d
+            - identity-okta-org2org-lifecycle-change-30d
+            - identity-okta-policy-lifecycle-tampering-30d
+            - identity-okta-policy-rule-lifecycle-tampering
+            - identity-okta-policy-rule-lifecycle-tampering-30d
+            - sentinelone-risky-exclusion
+      rules:
+        - rule_id: aws-cloudtrail-kms-encryption
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.24
+        - rule_id: aws-guardduty-c2-traffic
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: aws-guardduty-crypto-mining
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: aws-guardduty-malware-finding
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: aws-rds-auto-minor-upgrade
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.19
+            - framework_name: ISO 27001:2022
+              control_id: A.8.8
+        - rule_id: aws-rds-backup-enabled
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.13
+        - rule_id: aws-rds-deletion-protection
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.13
+        - rule_id: aws-rds-multi-az-enabled
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.14
+        - rule_id: aws-s3-bucket-versioning-enabled
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.13
+        - rule_id: aws-s3-cross-region-replication
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.13
+        - rule_id: azure-defender-storage
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: azure-vm-unmanaged-disk
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.24
+        - rule_id: bucket-sensitive-no-lock
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.13
+            - framework_name: ISO 27001:2022
+              control_id: A.8.24
+        - rule_id: cloud-current-public-exposure-review-needed
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.20
+        - rule_id: cloud-effective-admin-permission
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.20
+        - rule_id: cloud-exposed-privileged-compute-role
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.20
+        - rule_id: cloud-privilege-path-granted
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.20
+        - rule_id: cloud-public-exposure-privileged-principal
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.20
+        - rule_id: cloud-public-resource-exposure
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.20
+        - rule_id: container-runtime-exec-detected
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: endpoint-disk-encryption
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.24
+        - rule_id: endpoint-edr-installed
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.7
+        - rule_id: endpoint-intune-disk-encryption
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.24
+        - rule_id: endpoint-jamf-disk-encryption
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.24
+        - rule_id: endpoint-jamf-screenlock
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.1
+        - rule_id: endpoint-kandji-disk-encryption
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.24
+        - rule_id: endpoint-kandji-edr-installed
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.7
+        - rule_id: endpoint-screenlock-configured
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.1
+        - rule_id: gcp-sql-backup-enabled
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.13
+        - rule_id: github-app-integration-installed
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-code-security-controls-disabled
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-org-auth-control-modified
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-org-ip-allow-list-modified
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-org-owner-role-review-needed
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.2
+        - rule_id: github-organization-owner-added
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-personal-access-token-created
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-private-repository-forking-enabled
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-repository-collaborator-added
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-repository-ruleset-modified
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-secret-scanning-alert-created
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-self-hosted-runner-review-needed
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: github-webhook-modified
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: grc-failing-control-test-unhealthy-integration
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.15
+        - rule_id: grc-isolated-target-enrichment-gap
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.8
+        - rule_id: grc-overdue-vulnerability-live-on-assets
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.8
+        - rule_id: grc-source-integration-concentrated-open-findings
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.8
+        - rule_id: grc-vulnerability-sla-overdue
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.8
+        - rule_id: identity-google-workspace-admin-mfa
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.5
+        - rule_id: identity-okta-account-lock-events-24h
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: identity-okta-admin-mfa
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.5
+        - rule_id: identity-okta-admin-no-mfa-granular
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.5
+        - rule_id: identity-okta-admin-plus-app-owner
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.2
+        - rule_id: identity-okta-admin-privilege-grant-events-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.2
+        - rule_id: identity-okta-api-token-created-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.2
+        - rule_id: identity-okta-api-token-revoked-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.2
+        - rule_id: identity-okta-application-lifecycle-tampering-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: identity-okta-authenticator-weak-factor-enabled
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.5
+        - rule_id: identity-okta-group-grants-admin-app
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.2
+        - rule_id: identity-okta-idp-lifecycle-changes-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: identity-okta-mfa-factor-reset-events-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.5
+        - rule_id: identity-okta-network-zone-deactivation-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: identity-okta-network-zone-delete-events-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: identity-okta-network-zone-modify-events-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: identity-okta-org2org-lifecycle-change-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: identity-okta-password-reset-or-unlock-attempt-spike-24h
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: identity-okta-password-view-events-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.5
+        - rule_id: identity-okta-policy-lifecycle-tampering-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: identity-okta-policy-rule-lifecycle-tampering
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: identity-okta-policy-rule-lifecycle-tampering-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: identity-okta-possible-dos-attack-1h
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: identity-okta-rate-limit-violations-24h
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: identity-okta-superadmin-count
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.2
+        - rule_id: identity-okta-support-session-impersonation-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.2
+        - rule_id: identity-okta-threat-insight-not-blocking
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: identity-okta-threatinsight-detected-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: identity-okta-unauthorized-app-access-attempts-7d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: identity-okta-user-reported-suspicious-activity-30d
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: identity-saas-mfa-enforced
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.5
+        - rule_id: k8s-deployment-multiple-replicas
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.14
+        - rule_id: k8s-pod-liveness-probe-required
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.14
+        - rule_id: k8s-pod-readiness-probe-required
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.14
+        - rule_id: k8s-pod-resource-limits
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.14
+        - rule_id: m365-dlp-policy-missing
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.12
+        - rule_id: okta-suspicious-login
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: security-reviewer-reported-finding
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.8
+        - rule_id: sentinelone-agent-detect-only-mode
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.7
+        - rule_id: sentinelone-agent-not-up-to-date
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: sentinelone-agent-stale
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: sentinelone-command-control
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+            - framework_name: ISO 27001:2022
+              control_id: A.8.7
+        - rule_id: sentinelone-infected-endpoint-privileged-owner
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.7
+        - rule_id: sentinelone-malware
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+            - framework_name: ISO 27001:2022
+              control_id: A.8.7
+        - rule_id: sentinelone-protection-control-tampering
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.7
+        - rule_id: sentinelone-risky-exclusion
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.9
+        - rule_id: sentinelone-threat-detected
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: threat-intel-malicious-domain-resolution
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: threat-intel-malicious-ip-connection
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
+        - rule_id: vulnview-actionable-external-finding
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.8
+        - rule_id: vulnview-external-asset-concentrated-signal
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.8
+      unmapped_controls:
+        - framework_name: ISO 27001:2022
+          control_id: A.8.10
+        - framework_name: ISO 27001:2022
+          control_id: A.8.11
+        - framework_name: ISO 27001:2022
+          control_id: A.8.17
+        - framework_name: ISO 27001:2022
+          control_id: A.8.18
+        - framework_name: ISO 27001:2022
+          control_id: A.8.21
+        - framework_name: ISO 27001:2022
+          control_id: A.8.22
+        - framework_name: ISO 27001:2022
+          control_id: A.8.23
+        - framework_name: ISO 27001:2022
+          control_id: A.8.25
+        - framework_name: ISO 27001:2022
+          control_id: A.8.26
+        - framework_name: ISO 27001:2022
+          control_id: A.8.27
+        - framework_name: ISO 27001:2022
+          control_id: A.8.28
+        - framework_name: ISO 27001:2022
+          control_id: A.8.29
+        - framework_name: ISO 27001:2022
+          control_id: A.8.3
+        - framework_name: ISO 27001:2022
+          control_id: A.8.30
+        - framework_name: ISO 27001:2022
+          control_id: A.8.31
+        - framework_name: ISO 27001:2022
+          control_id: A.8.32
+        - framework_name: ISO 27001:2022
+          control_id: A.8.33
+        - framework_name: ISO 27001:2022
+          control_id: A.8.34
+        - framework_name: ISO 27001:2022
+          control_id: A.8.4
+        - framework_name: ISO 27001:2022
+          control_id: A.8.6
+    - id: pci-operational-security
+      name: PCI Operational Security
+      description: Network, system, identity, logging, testing, and security program controls commonly used for payment-environment evidence review.
+      summary:
+        selected_controls: 49
+        mapped_controls: 18
+        unmapped_controls: 31
+        mapped_rules: 311
+      controls:
+        - framework_name: PCI DSS v4.0.1
+          family_id: "1"
+          family_name: Network Security Controls
+          control_id: "1.1"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "1"
+          family_name: Network Security Controls
+          control_id: "1.2"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "1"
+          family_name: Network Security Controls
+          control_id: "1.3"
+          mapped_rules:
+            - aws-api-gateway-no-authorization
+            - aws-bedrock-custom-model-public
+            - aws-codebuild-public-trigger
+            - aws-ec2-ami-not-public
+            - aws-ec2-ebs-snapshot-not-public
+            - aws-ec2-internet-facing-iam
+            - aws-ec2-public-ip-rdp
+            - aws-ec2-public-ip-ssh
+            - aws-ec2-sg-no-all-traffic-ingress
+            - aws-ecr-public-repository
+            - aws-ecs-secrets-in-env-vars
+            - aws-eks-public-endpoint-disabled
+            - aws-elasticache-public
+            - aws-elb-internet-facing-no-waf
+            - aws-lambda-not-publicly-accessible
+            - aws-lambda-secrets-in-env-vars
+            - aws-opensearch-public
+            - aws-rds-no-public-access
+            - aws-rds-public-snapshot
+            - aws-redshift-public
+            - aws-s3-bucket-cleartext-key
+            - aws-s3-bucket-no-public-access
+            - aws-s3-bucket-policy-public
+            - aws-s3-public-write
+            - aws-sagemaker-model-artifact-public
+            - aws-sagemaker-notebook-internet-access
+            - aws-sns-public-access
+            - aws-sqs-public-access
+            - azure-cosmosdb-public
+            - azure-cosmosdb-public-access
+            - azure-ml-workspace-public-network
+            - azure-nsg-admin-port
+            - azure-nsg-restrict-ssh
+            - azure-openai-public-network
+            - azure-sql-public-network-access
+            - azure-sqlserver-public
+            - azure-storage-blob-public-access-disabled
+            - azure-storage-public-write
+            - azure-storage-secrets-artifact
+            - azure-vm-public-ip-rdp
+            - azure-vm-public-ip-ssh
+            - bucket-public-large-files
+            - bucket-public-low-exposure
+            - cve-2023-20867
+            - cve-2023-4863
+            - cve-2024-6387
+            - efs-public-subnet
+            - gcp-bigquery-public
+            - gcp-bigquery-public-dataset
+            - gcp-bucket-public-write
+            - gcp-bucket-secrets
+            - gcp-cloudsql-no-public-ip
+            - gcp-compute-no-public-ip
+            - gcp-compute-public-ssh
+            - gcp-gke-private-cluster
+            - gcp-iam-binding-no-allUsers
+            - gcp-kms-public
+            - gcp-storage-bucket-no-public
+            - gcp-storage-no-public-allusers
+            - gcp-vertex-ai-dataset-public
+            - gcp-vertex-ai-public-endpoint
+            - github-actions-self-hosted-public
+            - github-public-repo-branch-protection
+            - github-repo-internal-exposed
+            - github-runner-group-scope
+            - github-runner-public-repo
+            - github-secret-scanning-alert
+            - k8s-ingress-public
+            - k8s-node-public-exposure
+            - k8s-service-external-ip
+            - log4shell-public
+            - m365-file-shared-externally
+            - m365-sharepoint-anonymous-link
+            - mlops-public-vuln
+            - public-resource-cleartext-admin-keys
+            - public-resource-cleartext-keys
+            - public-resource-cross-account-keys
+            - public-resource-keys-data-access
+            - public-saas-keys
+            - public-vm-cross-account-keys
+            - ray-ai-public
+            - saas-token-exposed
+            - serverless-public-admin
+            - serverless-public-high-priv
+            - serverless-unauth-privileged
+            - storage-key-exposed
+            - vm-internet-vuln-privileged
+            - vm-medium-exposure-vuln-data
+            - vm-public-admin
+            - vm-public-data-access
+            - vm-public-eol
+            - vm-public-eol-targeted
+            - vm-public-high-priv
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-common-dep
+            - vm-public-vuln-cross-account-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+        - framework_name: PCI DSS v4.0.1
+          family_id: "1"
+          family_name: Network Security Controls
+          control_id: 1.3.1
+          mapped_rules:
+            - aws-ecs-ports-restricted
+            - aws-elb-target-public-subnet
+            - aws-lambda-in-vpc
+            - aws-nacl-admin-ports-restricted
+            - aws-sagemaker-training-no-vpc
+            - k8s-ingress-no-wildcard-host
+            - k8s-network-policy-selector-present
+            - k8s-service-loadbalancer-internal
+            - k8s-service-no-nodeport
+            - k8s-workload-not-default-namespace
+            - vpc-external-peering
+        - framework_name: PCI DSS v4.0.1
+          family_id: "1"
+          family_name: Network Security Controls
+          control_id: "1.4"
+          mapped_rules:
+            - aws-api-gateway-no-authorization
+            - aws-bedrock-custom-model-public
+            - aws-codebuild-public-trigger
+            - aws-ec2-ami-not-public
+            - aws-ec2-ebs-snapshot-not-public
+            - aws-ec2-internet-facing-iam
+            - aws-ec2-public-ip-rdp
+            - aws-ec2-public-ip-ssh
+            - aws-ec2-sg-no-all-traffic-ingress
+            - aws-ecr-public-repository
+            - aws-ecs-secrets-in-env-vars
+            - aws-eks-public-endpoint-disabled
+            - aws-elasticache-public
+            - aws-elb-internet-facing-no-waf
+            - aws-lambda-not-publicly-accessible
+            - aws-lambda-secrets-in-env-vars
+            - aws-opensearch-public
+            - aws-rds-no-public-access
+            - aws-rds-public-snapshot
+            - aws-redshift-public
+            - aws-s3-bucket-cleartext-key
+            - aws-s3-bucket-no-public-access
+            - aws-s3-bucket-policy-public
+            - aws-s3-public-write
+            - aws-sagemaker-model-artifact-public
+            - aws-sagemaker-notebook-internet-access
+            - aws-sns-public-access
+            - aws-sqs-public-access
+            - azure-cosmosdb-public
+            - azure-cosmosdb-public-access
+            - azure-ml-workspace-public-network
+            - azure-nsg-admin-port
+            - azure-nsg-restrict-ssh
+            - azure-openai-public-network
+            - azure-sql-public-network-access
+            - azure-sqlserver-public
+            - azure-storage-blob-public-access-disabled
+            - azure-storage-public-write
+            - azure-storage-secrets-artifact
+            - azure-vm-public-ip-rdp
+            - azure-vm-public-ip-ssh
+            - bucket-public-large-files
+            - bucket-public-low-exposure
+            - bucket-public-sensitive
+            - cve-2023-20867
+            - cve-2023-4863
+            - cve-2024-6387
+            - efs-public-subnet
+            - gcp-bigquery-public
+            - gcp-bigquery-public-dataset
+            - gcp-bucket-public-write
+            - gcp-bucket-secrets
+            - gcp-cloudsql-no-public-ip
+            - gcp-compute-no-public-ip
+            - gcp-compute-public-ssh
+            - gcp-gke-private-cluster
+            - gcp-iam-binding-no-allUsers
+            - gcp-kms-public
+            - gcp-storage-bucket-no-public
+            - gcp-storage-no-public-allusers
+            - gcp-vertex-ai-dataset-public
+            - gcp-vertex-ai-public-endpoint
+            - github-actions-self-hosted-public
+            - github-public-repo-branch-protection
+            - github-repo-internal-exposed
+            - github-runner-group-scope
+            - github-runner-public-repo
+            - github-secret-scanning-alert
+            - k8s-ingress-public
+            - k8s-node-public-exposure
+            - k8s-service-external-ip
+            - log4shell-public
+            - m365-file-shared-externally
+            - m365-sharepoint-anonymous-link
+            - mlops-public-vuln
+            - public-resource-cleartext-admin-keys
+            - public-resource-cleartext-keys
+            - public-resource-cross-account-keys
+            - public-resource-keys-data-access
+            - public-saas-keys
+            - public-vm-cross-account-keys
+            - ray-ai-public
+            - saas-token-exposed
+            - serverless-public-admin
+            - serverless-public-high-priv
+            - serverless-unauth-privileged
+            - storage-key-exposed
+            - vm-internet-vuln-privileged
+            - vm-medium-exposure-vuln-data
+            - vm-public-admin
+            - vm-public-data-access
+            - vm-public-eol
+            - vm-public-eol-targeted
+            - vm-public-high-priv
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-common-dep
+            - vm-public-vuln-cross-account-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+        - framework_name: PCI DSS v4.0.1
+          family_id: "1"
+          family_name: Network Security Controls
+          control_id: "1.5"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "10"
+          family_name: Logging and Monitoring
+          control_id: "10.1"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "10"
+          family_name: Logging and Monitoring
+          control_id: "10.2"
+          mapped_rules:
+            - aws-cloudtrail-enabled
+            - aws-cloudwatch-alarm-missing
+            - aws-cloudwatch-log-group-encrypted
+            - aws-cloudwatch-log-group-retention
+            - aws-codebuild-public-logs
+            - aws-config-enabled-all-regions
+            - aws-ec2-detailed-monitoring-enabled
+            - aws-eks-control-plane-logging
+            - aws-rds-logging-enabled
+            - aws-s3-bucket-logging-enabled
+            - aws-vpc-flow-logs-enabled
+            - azure-keyvault-logging
+            - azure-sql-auditing-enabled
+            - gcp-audit-logging-enabled
+            - gcp-logging-disabled
+            - github-repo-secrets-exposure
+            - ml-model-registry-no-versioning
+            - s3-read-logging-disabled
+            - s3-write-logging-disabled
+            - vpc-dns-logging
+        - framework_name: PCI DSS v4.0.1
+          family_id: "10"
+          family_name: Logging and Monitoring
+          control_id: 10.2.1
+          mapped_rules:
+            - aws-cloudtrail-s3-data-events
+        - framework_name: PCI DSS v4.0.1
+          family_id: "10"
+          family_name: Logging and Monitoring
+          control_id: "10.3"
+          mapped_rules:
+            - aws-cloudtrail-enabled
+            - aws-cloudwatch-alarm-missing
+            - aws-cloudwatch-log-group-encrypted
+            - aws-cloudwatch-log-group-retention
+            - aws-codebuild-public-logs
+            - aws-config-enabled-all-regions
+            - aws-ec2-detailed-monitoring-enabled
+            - aws-eks-control-plane-logging
+            - aws-rds-logging-enabled
+            - aws-s3-bucket-logging-enabled
+            - aws-vpc-flow-logs-enabled
+            - azure-keyvault-logging
+            - azure-sql-auditing-enabled
+            - gcp-audit-logging-enabled
+            - gcp-logging-disabled
+            - github-repo-secrets-exposure
+            - ml-model-registry-no-versioning
+            - s3-read-logging-disabled
+            - s3-write-logging-disabled
+            - vpc-dns-logging
+        - framework_name: PCI DSS v4.0.1
+          family_id: "10"
+          family_name: Logging and Monitoring
+          control_id: "10.4"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "10"
+          family_name: Logging and Monitoring
+          control_id: "10.5"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "10"
+          family_name: Logging and Monitoring
+          control_id: "10.6"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "10"
+          family_name: Logging and Monitoring
+          control_id: "10.7"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "11"
+          family_name: Security Testing
+          control_id: "11.1"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "11"
+          family_name: Security Testing
+          control_id: "11.2"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "11"
+          family_name: Security Testing
+          control_id: "11.3"
+          mapped_rules:
+            - aws-ecr-scan-on-push
+            - aws-lambda-runtime-supported
+            - cisa-kev-vulnerability-present
+            - container-eol-writable
+            - container-openssl-vuln
+            - cve-2021-45046
+            - cve-2021-45105
+            - cve-2023-20867
+            - cve-2023-4863
+            - cve-2024-21626
+            - cve-2024-6387
+            - dirty-pipe-privileged
+            - gcr-unscanned
+            - github-code-scanning-critical
+            - github-dependabot-critical-alert
+            - github-dependabot-high-alert
+            - k8s-cluster-unsupported-version
+            - k8s-resource-no-deprecated-api
+            - k8s-service-external-ip
+            - log4shell-privileged
+            - log4shell-public
+            - mlops-public-vuln
+            - openssl-vuln-internal
+            - vm-internet-vuln-privileged
+            - vm-kernel-vuln-container
+            - vm-medium-exposure-vuln-data
+            - vm-public-eol
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-common-dep
+            - vm-public-vuln-cross-account-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+        - framework_name: PCI DSS v4.0.1
+          family_id: "11"
+          family_name: Security Testing
+          control_id: "11.4"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "11"
+          family_name: Security Testing
+          control_id: "11.5"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "11"
+          family_name: Security Testing
+          control_id: "11.6"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: "12.1"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: "12.10"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: 12.10.1
+          mapped_rules:
+            - compliance-ir-plan-exists
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: "12.2"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: "12.3"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: "12.4"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: "12.5"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: "12.6"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: "12.7"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: "12.8"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "12"
+          family_name: Security Program
+          control_id: "12.9"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "6"
+          family_name: Secure Systems and Software
+          control_id: "6.1"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "6"
+          family_name: Secure Systems and Software
+          control_id: "6.2"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "6"
+          family_name: Secure Systems and Software
+          control_id: "6.3"
+          mapped_rules:
+            - aws-ecr-immutable-tags
+            - aws-ecr-scan-on-push
+            - aws-lambda-runtime-supported
+            - cisa-kev-vulnerability-present
+            - container-eol-writable
+            - container-openssl-vuln
+            - cve-2021-45046
+            - cve-2021-45105
+            - cve-2023-20867
+            - cve-2023-4863
+            - cve-2024-21626
+            - cve-2024-6387
+            - dirty-pipe-privileged
+            - gcr-unscanned
+            - github-code-scanning-critical
+            - github-dependabot-critical-alert
+            - github-dependabot-high-alert
+            - gitlab-runner-unprotected-tags
+            - k8s-cluster-unsupported-version
+            - k8s-pod-image-pinned-by-digest
+            - k8s-pod-image-tag-not-latest
+            - k8s-resource-no-deprecated-api
+            - k8s-service-external-ip
+            - log4shell-privileged
+            - log4shell-public
+            - ml-model-untrusted-source
+            - mlops-public-vuln
+            - openssl-vuln-internal
+            - vm-internet-vuln-privileged
+            - vm-kernel-vuln-container
+            - vm-medium-exposure-vuln-data
+            - vm-public-eol
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-common-dep
+            - vm-public-vuln-cross-account-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+        - framework_name: PCI DSS v4.0.1
+          family_id: "6"
+          family_name: Secure Systems and Software
+          control_id: "6.4"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "6"
+          family_name: Secure Systems and Software
+          control_id: "6.5"
+          mapped_rules:
+            - aws-ecr-immutable-tags
+            - gitlab-runner-unprotected-tags
+            - k8s-pod-image-pinned-by-digest
+            - k8s-pod-image-tag-not-latest
+            - ml-model-untrusted-source
+        - framework_name: PCI DSS v4.0.1
+          family_id: "7"
+          family_name: Need-to-Know Access
+          control_id: "7.1"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "7"
+          family_name: Need-to-Know Access
+          control_id: "7.2"
+          mapped_rules:
+            - account-lateral-dormant
+            - admin-inactive-keys
+            - admin-keys-unrotated
+            - admin-keys-year-unrotated
+            - ai-agent-lambda-data-access
+            - ai-model-excessive-agency
+            - ai-model-third-party-access
+            - aws-apigateway-public
+            - aws-bedrock-custom-model-public
+            - aws-codebuild-privileged-mode
+            - aws-codebuild-public-logs
+            - aws-ec2-ami-not-public
+            - aws-ec2-ebs-snapshot-not-public
+            - aws-ec2-instance-profile-attached
+            - aws-ec2-internet-facing-iam
+            - aws-ecr-public-repository
+            - aws-eks-public-endpoint-disabled
+            - aws-iam-access-key-rotation
+            - aws-iam-no-policies-attached-user
+            - aws-iam-password-policy
+            - aws-iam-policy-no-admin-star
+            - aws-iam-role-confused-deputy-prevention
+            - aws-iam-role-cross-account-admin
+            - aws-iam-role-trust-any-principal
+            - aws-iam-role-wildcard-trust
+            - aws-iam-root-mfa-enabled
+            - aws-iam-root-no-access-keys
+            - aws-iam-saml-provider-stale
+            - aws-iam-service-account-open-assume
+            - aws-iam-user-console-inactive
+            - aws-iam-user-mfa-enabled
+            - aws-iam-user-multiple-access-keys
+            - aws-iam-user-unused-credentials
+            - aws-lambda-not-publicly-accessible
+            - aws-opensearch-public
+            - aws-rds-iam-authentication
+            - aws-rds-no-public-access
+            - aws-rds-public-snapshot
+            - aws-redshift-public
+            - aws-s3-bucket-logging-enabled
+            - aws-s3-bucket-no-public-access
+            - aws-s3-bucket-policy-public
+            - aws-s3-public-write
+            - aws-sagemaker-model-artifact-public
+            - aws-sagemaker-notebook-internet-access
+            - aws-sagemaker-notebook-root-access
+            - aws-secretsmanager-secret-used
+            - aws-security-group-restrict-rdp
+            - aws-security-group-restrict-ssh
+            - aws-sns-public-access
+            - aws-sqs-public-access
+            - aws-user-data-no-mfa
+            - aws-user-inactive-admin-no-mfa
+            - aws-user-inactive-data-no-mfa
+            - azure-ad-guest-access-restricted
+            - azure-aks-rbac-enabled
+            - azure-cosmosdb-public
+            - azure-cosmosdb-public-access
+            - azure-function-anonymous-access
+            - azure-function-public
+            - azure-ml-workspace-public-network
+            - azure-nsg-admin-port
+            - azure-nsg-restrict-ssh
+            - azure-openai-public-network
+            - azure-sql-public-network-access
+            - azure-storage-blob-public-access-disabled
+            - azure-storage-network-allow
+            - azure-storage-network-default-deny
+            - azure-storage-public-write
+            - bedrock-excessive-permissions
+            - bucket-cleartext-admin-keys
+            - bucket-cleartext-keys-data
+            - bucket-dormant-principal
+            - bucket-keys-excessive-access
+            - bucket-public-low-exposure
+            - container-cross-account-keys
+            - container-image-cleartext-keys
+            - cross-provider-dormant-privileged
+            - cross-provider-privileged-access-no-mfa
+            - cve-2024-21626
+            - data-access-keys-unrotated
+            - data-resource-excessive-access
+            - data-resource-org-access
+            - db-dormant-principal
+            - dirty-pipe-privileged
+            - gcp-bigquery-public
+            - gcp-bigquery-public-dataset
+            - gcp-bucket-public-write
+            - gcp-compute-no-default-service-account
+            - gcp-compute-serial-port-disabled
+            - gcp-external-domain-admin
+            - gcp-firewall-admin-port
+            - gcp-gke-default-sa
+            - gcp-iam-binding-no-allAuthenticatedUsers
+            - gcp-iam-binding-no-allUsers
+            - gcp-iam-minimize-user-managed-keys
+            - gcp-iam-sa-no-admin-privileges
+            - gcp-kms-public
+            - gcp-sa-admin-privileges
+            - gcp-sa-admin-user-combined
+            - gcp-sa-impersonation
+            - gcp-sa-no-full-project-access
+            - gcp-service-account-key-rotation
+            - gcp-storage-bucket-no-public
+            - gcp-storage-no-public-allusers
+            - gcp-storage-uniform-bucket-access
+            - gcp-vertex-ai-dataset-public
+            - gcp-vertex-ai-public-endpoint
+            - gcr-excessive-privileges
+            - github-admin-without-2fa
+            - github-oidc-overly-permissive
+            - github-org-workflow-permissions
+            - github-runner-group-scope
+            - github-workflow-write-permissions
+            - gke-cluster-admin
+            - gke-pod-create
+            - gke-wildcard-permissions
+            - group-excessive-admin
+            - group-excessive-data-priv
+            - group-excessive-high-priv
+            - internal-vm-cross-account-keys
+            - k8s-cluster-admin-wildcard
+            - k8s-pod-create
+            - k8s-pod-no-privileged
+            - k8s-rbac-cluster-admin-used
+            - k8s-rbac-high-risk-binding
+            - k8s-rbac-medium-risk-binding
+            - k8s-rbac-pod-create-privileges
+            - k8s-rbac-secret-read-access
+            - k8s-rbac-wildcard-permissions-assigned
+            - k8s-role-wildcard-permissions
+            - k8s-service-account-token-mount
+            - k8s-wildcard-permissions
+            - log4shell-privileged
+            - m365-file-shared-externally
+            - m365-guest-admin
+            - m365-inactive-admin
+            - m365-sharepoint-anonymous-link
+            - mlops-public-vuln
+            - notebook-excessive-agency
+            - okta-admin-dormant
+            - privileged-inactive-keys
+            - privileged-keys-unrotated
+            - public-resource-cleartext-admin-keys
+            - public-resource-cleartext-keys
+            - public-resource-cross-account-keys
+            - public-resource-keys-data-access
+            - public-vm-cross-account-keys
+            - resource-cleartext-keys-admin
+            - resource-cleartext-keys-privileged
+            - sa-external-web-identity
+            - sa-inactive-assigned
+            - sa-inactive-privileged
+            - sa-lateral-admin
+            - serverless-public-admin
+            - serverless-public-high-priv
+            - serverless-unauth-privileged
+            - terraform-cloud-no-team-access-control
+            - third-party-sa-admin
+            - third-party-sa-privileged
+            - unknown-account-trusted
+            - user-data-access-unused-password
+            - user-excessive-admin
+            - user-excessive-data-priv
+            - user-excessive-high-priv
+            - user-lateral-admin
+            - user-privileged-access-keys
+            - user-privileged-unused-password
+            - vm-cleartext-keys-cross-account
+            - vm-dormant-sa
+            - vm-internet-vuln-privileged
+            - vm-medium-exposure-vuln-data
+            - vm-public-admin
+            - vm-public-data-access
+            - vm-public-high-priv
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-cross-account-keys
+            - vm-ssh-private-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+        - framework_name: PCI DSS v4.0.1
+          family_id: "7"
+          family_name: Need-to-Know Access
+          control_id: "7.3"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "8"
+          family_name: Identity and Authentication
+          control_id: "8.1"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "8"
+          family_name: Identity and Authentication
+          control_id: 8.1.3
+          mapped_rules:
+            - identity-account-deprovision
+        - framework_name: PCI DSS v4.0.1
+          family_id: "8"
+          family_name: Identity and Authentication
+          control_id: "8.2"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "8"
+          family_name: Identity and Authentication
+          control_id: "8.3"
+          mapped_rules:
+            - aws-alb-no-authentication
+            - aws-api-gateway-no-authorization
+            - aws-appsync-no-authorization
+            - aws-iam-password-policy
+            - aws-iam-root-mfa-enabled
+            - aws-iam-user-mfa-enabled
+            - aws-iam-user-unused-credentials
+            - aws-rds-iam-authentication
+            - aws-s3-bucket-mfa-delete
+            - aws-user-data-no-mfa
+            - aws-user-inactive-admin-no-mfa
+            - aws-user-inactive-data-no-mfa
+            - azure-function-anonymous-access
+            - azure-function-public
+            - azure-sql-azure-ad-admin
+            - azure-user-mfa-disabled
+            - cross-provider-privileged-access-no-mfa
+            - gcp-cloud-run-allow-unauthenticated
+            - github-admin-without-2fa
+            - github-org-2fa-disabled
+            - k8s-ingress-no-authentication
+            - k8s-ingress-public
+            - m365-sharepoint-anonymous-link
+            - okta-app-no-mfa
+            - okta-password-policy-weak
+            - okta-user-mfa-disabled
+            - ray-ai-public
+            - serverless-unauth-privileged
+            - user-data-access-unused-password
+            - user-privileged-unused-password
+            - vm-empty-password
+        - framework_name: PCI DSS v4.0.1
+          family_id: "8"
+          family_name: Identity and Authentication
+          control_id: 8.3.6
+          mapped_rules:
+            - aws-password-policy-minimum-length
+        - framework_name: PCI DSS v4.0.1
+          family_id: "8"
+          family_name: Identity and Authentication
+          control_id: 8.3.7
+          mapped_rules:
+            - aws-password-policy-no-reuse
+        - framework_name: PCI DSS v4.0.1
+          family_id: "8"
+          family_name: Identity and Authentication
+          control_id: "8.4"
+          mapped_rules:
+            - aws-alb-no-authentication
+            - aws-api-gateway-no-authorization
+            - aws-appsync-no-authorization
+            - aws-iam-password-policy
+            - aws-iam-root-mfa-enabled
+            - aws-iam-user-mfa-enabled
+            - aws-iam-user-unused-credentials
+            - aws-rds-iam-authentication
+            - aws-s3-bucket-mfa-delete
+            - aws-user-data-no-mfa
+            - aws-user-inactive-admin-no-mfa
+            - aws-user-inactive-data-no-mfa
+            - azure-function-anonymous-access
+            - azure-function-public
+            - azure-sql-azure-ad-admin
+            - azure-user-mfa-disabled
+            - cross-provider-privileged-access-no-mfa
+            - gcp-cloud-run-allow-unauthenticated
+            - github-admin-without-2fa
+            - github-org-2fa-disabled
+            - k8s-ingress-no-authentication
+            - k8s-ingress-public
+            - m365-sharepoint-anonymous-link
+            - okta-app-no-mfa
+            - okta-password-policy-weak
+            - okta-user-mfa-disabled
+            - ray-ai-public
+            - serverless-unauth-privileged
+            - user-data-access-unused-password
+            - user-privileged-unused-password
+            - vm-empty-password
+        - framework_name: PCI DSS v4.0.1
+          family_id: "8"
+          family_name: Identity and Authentication
+          control_id: 8.4.2
+          mapped_rules:
+            - identity-saas-mfa-enforced
+        - framework_name: PCI DSS v4.0.1
+          family_id: "8"
+          family_name: Identity and Authentication
+          control_id: "8.5"
+        - framework_name: PCI DSS v4.0.1
+          family_id: "8"
+          family_name: Identity and Authentication
+          control_id: "8.6"
+          mapped_rules:
+            - admin-inactive-keys
+            - admin-keys-unrotated
+            - admin-keys-year-unrotated
+            - aws-codebuild-plaintext-secrets
+            - aws-codebuild-secrets-in-env-vars
+            - aws-codebuild-source-credential
+            - aws-dynamodb-encryption
+            - aws-ec2-instance-profile-attached
+            - aws-ecs-secrets-in-env-vars
+            - aws-eks-secrets-encryption
+            - aws-iam-access-key-rotation
+            - aws-iam-root-no-access-keys
+            - aws-iam-user-multiple-access-keys
+            - aws-iam-user-unused-credentials
+            - aws-kms-key-rotation-enabled
+            - aws-lambda-no-env-secrets
+            - aws-lambda-secrets-in-env-vars
+            - aws-s3-bucket-cleartext-key
+            - aws-secretsmanager-rotation-enabled
+            - aws-secretsmanager-secret-used
+            - azure-keyvault-key-expiry-set
+            - azure-keyvault-logging
+            - azure-keyvault-purge-protection
+            - azure-keyvault-soft-delete-enabled
+            - azure-sp-credential-expiring
+            - azure-storage-secrets-artifact
+            - bucket-cleartext-admin-keys
+            - bucket-cleartext-keys-data
+            - bucket-keys-excessive-access
+            - container-cross-account-keys
+            - container-image-cleartext-keys
+            - data-access-keys-unrotated
+            - gcp-bigquery-no-cmek
+            - gcp-bucket-secrets
+            - gcp-iam-minimize-user-managed-keys
+            - gcp-kms-admin-combined
+            - gcp-kms-public
+            - gcp-service-account-key-rotation
+            - github-actions-dangerous-trigger
+            - github-repo-secrets-exposure
+            - github-secret-scanning-alert
+            - gke-secrets-access
+            - internal-vm-cross-account-keys
+            - k8s-rbac-secret-read-access
+            - k8s-secrets-access
+            - k8s-secrets-in-secrets-not-env
+            - k8s-service-account-token-mount
+            - privileged-inactive-keys
+            - privileged-keys-unrotated
+            - public-resource-cleartext-admin-keys
+            - public-resource-cleartext-keys
+            - public-resource-cross-account-keys
+            - public-resource-keys-data-access
+            - public-saas-keys
+            - public-vm-cross-account-keys
+            - resource-cleartext-keys-admin
+            - resource-cleartext-keys-privileged
+            - saas-token-exposed
+            - ssh-key-unused
+            - storage-key-exposed
+            - telemetry-repo-secret-key
+            - user-privileged-access-keys
+            - vm-cleartext-keys-cross-account
+            - vm-public-vuln-cross-account-keys
+            - vm-ssh-private-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-keys-data-access
+      rules:
+        - rule_id: account-lateral-dormant
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: admin-inactive-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: admin-keys-unrotated
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: admin-keys-year-unrotated
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: ai-agent-lambda-data-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: ai-model-excessive-agency
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: ai-model-third-party-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-alb-no-authentication
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-api-gateway-no-authorization
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-apigateway-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-appsync-no-authorization
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-bedrock-custom-model-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-cloudtrail-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: aws-cloudtrail-s3-data-events
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 10.2.1
+        - rule_id: aws-cloudwatch-alarm-missing
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: aws-cloudwatch-log-group-encrypted
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: aws-cloudwatch-log-group-retention
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: aws-codebuild-plaintext-secrets
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-codebuild-privileged-mode
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-codebuild-public-logs
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-codebuild-public-trigger
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: aws-codebuild-secrets-in-env-vars
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-codebuild-source-credential
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-config-enabled-all-regions
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: aws-dynamodb-encryption
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-ec2-ami-not-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-ec2-detailed-monitoring-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: aws-ec2-ebs-snapshot-not-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-ec2-instance-profile-attached
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-ec2-internet-facing-iam
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-ec2-public-ip-rdp
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: aws-ec2-public-ip-ssh
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: aws-ec2-sg-no-all-traffic-ingress
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: aws-ecr-immutable-tags
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.5"
+        - rule_id: aws-ecr-public-repository
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-ecr-scan-on-push
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: aws-ecs-ports-restricted
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+        - rule_id: aws-ecs-secrets-in-env-vars
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-eks-control-plane-logging
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: aws-eks-public-endpoint-disabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-eks-secrets-encryption
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-elasticache-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: aws-elb-internet-facing-no-waf
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: aws-elb-target-public-subnet
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+        - rule_id: aws-iam-access-key-rotation
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-iam-no-policies-attached-user
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-iam-password-policy
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-iam-policy-no-admin-star
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-iam-role-confused-deputy-prevention
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-iam-role-cross-account-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-iam-role-trust-any-principal
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-iam-role-wildcard-trust
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-iam-root-mfa-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-iam-root-no-access-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-iam-saml-provider-stale
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-iam-service-account-open-assume
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-iam-user-console-inactive
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-iam-user-mfa-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-iam-user-multiple-access-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-iam-user-unused-credentials
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-kms-key-rotation-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-lambda-in-vpc
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+        - rule_id: aws-lambda-no-env-secrets
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-lambda-not-publicly-accessible
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-lambda-runtime-supported
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: aws-lambda-secrets-in-env-vars
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-nacl-admin-ports-restricted
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+        - rule_id: aws-opensearch-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-password-policy-minimum-length
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 8.3.6
+        - rule_id: aws-password-policy-no-reuse
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 8.3.7
+        - rule_id: aws-rds-iam-authentication
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-rds-logging-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: aws-rds-no-public-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-rds-public-snapshot
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-redshift-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-s3-bucket-cleartext-key
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-s3-bucket-logging-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-s3-bucket-mfa-delete
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-s3-bucket-no-public-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-s3-bucket-policy-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-s3-public-write
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-sagemaker-model-artifact-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-sagemaker-notebook-internet-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-sagemaker-notebook-root-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-sagemaker-training-no-vpc
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+        - rule_id: aws-secretsmanager-rotation-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-secretsmanager-secret-used
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: aws-security-group-restrict-rdp
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-security-group-restrict-ssh
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-sns-public-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-sqs-public-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: aws-user-data-no-mfa
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-user-inactive-admin-no-mfa
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-user-inactive-data-no-mfa
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: aws-vpc-flow-logs-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: azure-ad-guest-access-restricted
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-aks-rbac-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-cosmosdb-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-cosmosdb-public-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-function-anonymous-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: azure-function-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: azure-keyvault-key-expiry-set
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: azure-keyvault-logging
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: azure-keyvault-purge-protection
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: azure-keyvault-soft-delete-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: azure-ml-workspace-public-network
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-nsg-admin-port
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-nsg-restrict-ssh
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-openai-public-network
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-sp-credential-expiring
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: azure-sql-auditing-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: azure-sql-azure-ad-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: azure-sql-public-network-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-sqlserver-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: azure-storage-blob-public-access-disabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-storage-network-allow
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-storage-network-default-deny
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-storage-public-write
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: azure-storage-secrets-artifact
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: azure-user-mfa-disabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: azure-vm-public-ip-rdp
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: azure-vm-public-ip-ssh
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: bedrock-excessive-permissions
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: bucket-cleartext-admin-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: bucket-cleartext-keys-data
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: bucket-dormant-principal
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: bucket-keys-excessive-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: bucket-public-large-files
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: bucket-public-low-exposure
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: bucket-public-sensitive
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: cisa-kev-vulnerability-present
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: compliance-ir-plan-exists
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 12.10.1
+        - rule_id: container-cross-account-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: container-eol-writable
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: container-image-cleartext-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: container-openssl-vuln
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: cross-provider-dormant-privileged
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: cross-provider-privileged-access-no-mfa
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: cve-2021-45046
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: cve-2021-45105
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: cve-2023-20867
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: cve-2023-4863
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: cve-2024-21626
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: cve-2024-6387
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: data-access-keys-unrotated
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: data-resource-excessive-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: data-resource-org-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: db-dormant-principal
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: dirty-pipe-privileged
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: efs-public-subnet
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: gcp-audit-logging-enabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: gcp-bigquery-no-cmek
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: gcp-bigquery-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-bigquery-public-dataset
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-bucket-public-write
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-bucket-secrets
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: gcp-cloud-run-allow-unauthenticated
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: gcp-cloudsql-no-public-ip
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: gcp-compute-no-default-service-account
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-compute-no-public-ip
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: gcp-compute-public-ssh
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: gcp-compute-serial-port-disabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-external-domain-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-firewall-admin-port
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-gke-default-sa
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-gke-private-cluster
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: gcp-iam-binding-no-allAuthenticatedUsers
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-iam-binding-no-allUsers
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-iam-minimize-user-managed-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: gcp-iam-sa-no-admin-privileges
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-kms-admin-combined
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: gcp-kms-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: gcp-logging-disabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: gcp-sa-admin-privileges
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-sa-admin-user-combined
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-sa-impersonation
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-sa-no-full-project-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-service-account-key-rotation
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: gcp-storage-bucket-no-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-storage-no-public-allusers
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-storage-uniform-bucket-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-vertex-ai-dataset-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcp-vertex-ai-public-endpoint
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcr-excessive-privileges
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gcr-unscanned
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: github-actions-dangerous-trigger
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: github-actions-self-hosted-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: github-admin-without-2fa
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: github-code-scanning-critical
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: github-dependabot-critical-alert
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: github-dependabot-high-alert
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: github-oidc-overly-permissive
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: github-org-2fa-disabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: github-org-workflow-permissions
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: github-public-repo-branch-protection
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: github-repo-internal-exposed
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: github-repo-secrets-exposure
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: github-runner-group-scope
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: github-runner-public-repo
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: github-secret-scanning-alert
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: github-workflow-write-permissions
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gitlab-runner-unprotected-tags
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.5"
+        - rule_id: gke-cluster-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gke-pod-create
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: gke-secrets-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: gke-wildcard-permissions
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: group-excessive-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: group-excessive-data-priv
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: group-excessive-high-priv
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: identity-account-deprovision
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 8.1.3
+        - rule_id: identity-saas-mfa-enforced
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 8.4.2
+        - rule_id: internal-vm-cross-account-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: k8s-cluster-admin-wildcard
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: k8s-cluster-unsupported-version
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: k8s-ingress-no-authentication
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: k8s-ingress-no-wildcard-host
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+        - rule_id: k8s-ingress-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: k8s-network-policy-selector-present
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+        - rule_id: k8s-node-public-exposure
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: k8s-pod-create
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: k8s-pod-image-pinned-by-digest
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.5"
+        - rule_id: k8s-pod-image-tag-not-latest
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.5"
+        - rule_id: k8s-pod-no-privileged
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: k8s-rbac-cluster-admin-used
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: k8s-rbac-high-risk-binding
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: k8s-rbac-medium-risk-binding
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: k8s-rbac-pod-create-privileges
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: k8s-rbac-secret-read-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: k8s-rbac-wildcard-permissions-assigned
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: k8s-resource-no-deprecated-api
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: k8s-role-wildcard-permissions
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: k8s-secrets-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: k8s-secrets-in-secrets-not-env
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: k8s-service-account-token-mount
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: k8s-service-external-ip
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: k8s-service-loadbalancer-internal
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+        - rule_id: k8s-service-no-nodeport
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+        - rule_id: k8s-wildcard-permissions
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: k8s-workload-not-default-namespace
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+        - rule_id: log4shell-privileged
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: log4shell-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: m365-file-shared-externally
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: m365-guest-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: m365-inactive-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: m365-sharepoint-anonymous-link
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: ml-model-registry-no-versioning
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: ml-model-untrusted-source
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.5"
+        - rule_id: mlops-public-vuln
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: notebook-excessive-agency
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: okta-admin-dormant
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: okta-app-no-mfa
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: okta-password-policy-weak
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: okta-user-mfa-disabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: openssl-vuln-internal
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: privileged-inactive-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: privileged-keys-unrotated
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: public-resource-cleartext-admin-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: public-resource-cleartext-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: public-resource-cross-account-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: public-resource-keys-data-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: public-saas-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: public-vm-cross-account-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: ray-ai-public
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: resource-cleartext-keys-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: resource-cleartext-keys-privileged
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: s3-read-logging-disabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: s3-write-logging-disabled
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: sa-external-web-identity
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: sa-inactive-assigned
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: sa-inactive-privileged
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: sa-lateral-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: saas-token-exposed
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: serverless-public-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: serverless-public-high-priv
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: serverless-unauth-privileged
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: ssh-key-unused
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: storage-key-exposed
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: telemetry-repo-secret-key
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: terraform-cloud-no-team-access-control
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: third-party-sa-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: third-party-sa-privileged
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: unknown-account-trusted
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: user-data-access-unused-password
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: user-excessive-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: user-excessive-data-priv
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: user-excessive-high-priv
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: user-lateral-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: user-privileged-access-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: user-privileged-unused-password
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: vm-cleartext-keys-cross-account
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: vm-dormant-sa
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: vm-empty-password
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.4"
+        - rule_id: vm-internet-vuln-privileged
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: vm-kernel-vuln-container
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: vm-medium-exposure-vuln-data
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: vm-public-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: vm-public-data-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: vm-public-eol
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: vm-public-eol-targeted
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+        - rule_id: vm-public-high-priv
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: vm-public-privileged-vuln-common-dep
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: vm-public-vuln
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: vm-public-vuln-common-dep
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+        - rule_id: vm-public-vuln-cross-account-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: vm-ssh-private-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: vm-vuln-cleartext-keys
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: vm-vuln-data-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: vm-vuln-keys-data-access
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "8.6"
+        - rule_id: vm-vuln-lateral-admin
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "1.4"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "11.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "6.3"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "7.2"
+        - rule_id: vpc-dns-logging
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.2"
+            - framework_name: PCI DSS v4.0.1
+              control_id: "10.3"
+        - rule_id: vpc-external-peering
+          controls:
+            - framework_name: PCI DSS v4.0.1
+              control_id: 1.3.1
+      unmapped_controls:
+        - framework_name: PCI DSS v4.0.1
+          control_id: "1.1"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "1.2"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "1.5"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "10.1"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "10.4"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "10.5"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "10.6"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "10.7"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "11.1"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "11.2"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "11.4"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "11.5"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "11.6"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "12.1"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "12.10"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "12.2"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "12.3"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "12.4"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "12.5"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "12.6"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "12.7"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "12.8"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "12.9"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "6.1"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "6.2"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "6.4"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "7.1"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "7.3"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "8.1"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "8.2"
+        - framework_name: PCI DSS v4.0.1
+          control_id: "8.5"
+    - id: privacy-ai-governance
+      name: Privacy and AI Governance
+      description: Privacy and AI governance controls for data handling, governance accountability, and AI system oversight reviews.
+      summary:
+        selected_controls: 162
+        mapped_controls: 17
+        unmapped_controls: 145
+        mapped_rules: 14
+      controls:
+        - framework_name: CCPA
+          family_id: "1798"
+          family_name: Consumer Privacy Rights
+          control_id: "1798.100"
+          mapped_rules:
+            - compliance-data-inventory-maintained
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Art.30
+          mapped_rules:
+            - ai-data-governance
+            - compliance-inventory-data-tracking
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Art.5
+          mapped_rules:
+            - ai-data-governance
+            - compliance-gdpr-policy
+            - compliance-inventory-data-tracking
+            - compliance-ir-gdpr-addendum
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 12
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 13
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 14
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 15
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 16
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 17
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 18
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 19
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 20
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 21
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 22
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 23
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 24
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 25
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 27
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 28
+          mapped_rules:
+            - vendor-dpa-exists
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 30
+          mapped_rules:
+            - compliance-data-inventory-maintained
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 32
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 33
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 34
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 35
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 37
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 38
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 39
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 44
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 45
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 46
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 48
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 51
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 6
+        - framework_name: GDPR
+          family_id: Article
+          family_name: Articles
+          control_id: Article 7
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.2.2
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.2.3
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.2.4
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.2.5
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.2.6
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.2.7
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.2.8
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.2.9
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.3.10
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.3.11
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.3.2
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.3.3
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.3.4
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.3.5
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.3.6
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.3.7
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.3.8
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.3.9
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.4.10
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.4.2
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.4.3
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.4.4
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.4.5
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.4.6
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.4.7
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.4.8
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.4.9
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.5.2
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.5.3
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.5.4
+        - framework_name: ISO 27701:2025
+          family_id: A.1
+          family_name: A.1 Controls
+          control_id: A.1.5.5
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.2.2
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.2.3
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.2.4
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.2.5
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.2.6
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.2.7
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.3.2
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.4.2
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.4.3
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.4.4
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.5.2
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.5.3
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.5.4
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.5.5
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.5.6
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.5.7
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.5.8
+        - framework_name: ISO 27701:2025
+          family_id: A.2
+          family_name: A.2 Controls
+          control_id: A.2.5.9
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.10
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.11
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.12
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.13
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.14
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.15
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.16
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.17
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.18
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.19
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.20
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.21
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.22
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.23
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.24
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.25
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.26
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.27
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.28
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.29
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.3
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.30
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.31
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.4
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.5
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.6
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.7
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.8
+        - framework_name: ISO 27701:2025
+          family_id: A.3
+          family_name: A.3 Controls
+          control_id: A.3.9
+        - framework_name: ISO 42001
+          family_id: "10"
+          family_name: Improvement
+          control_id: "10.1"
+          mapped_rules:
+            - ai-incident-response
+        - framework_name: ISO 42001
+          family_id: "10"
+          family_name: Improvement
+          control_id: "10.2"
+          mapped_rules:
+            - ai-data-governance
+            - ai-incident-response
+        - framework_name: ISO 42001
+          family_id: "6"
+          family_name: Planning
+          control_id: "6.1"
+          mapped_rules:
+            - ai-bias-testing
+            - ai-risk-assessment
+            - aws-bedrock-model-no-guardrails
+        - framework_name: ISO 42001
+          family_id: "6"
+          family_name: Planning
+          control_id: "6.2"
+          mapped_rules:
+            - ai-human-oversight
+            - ai-risk-assessment
+            - aws-bedrock-model-no-guardrails
+        - framework_name: ISO 42001
+          family_id: "7"
+          family_name: Support
+          control_id: "7.1"
+          mapped_rules:
+            - ai-model-inventory
+        - framework_name: ISO 42001
+          family_id: "7"
+          family_name: Support
+          control_id: "7.2"
+          mapped_rules:
+            - ai-model-inventory
+        - framework_name: ISO 42001
+          family_id: "7"
+          family_name: Support
+          control_id: "7.3"
+          mapped_rules:
+            - ai-data-governance
+        - framework_name: ISO 42001
+          family_id: "8"
+          family_name: Operation
+          control_id: "8.4"
+          mapped_rules:
+            - aws-bedrock-model-no-guardrails
+        - framework_name: ISO 42001
+          family_id: "9"
+          family_name: Performance Evaluation
+          control_id: "9.1"
+          mapped_rules:
+            - ai-human-oversight
+            - ai-model-monitoring
+            - aws-bedrock-model-no-guardrails
+        - framework_name: ISO 42001
+          family_id: "9"
+          family_name: Performance Evaluation
+          control_id: "9.2"
+          mapped_rules:
+            - ai-bias-testing
+        - framework_name: ISO 42001
+          family_id: "9"
+          family_name: Performance Evaluation
+          control_id: "9.3"
+          mapped_rules:
+            - ai-model-monitoring
+        - framework_name: ISO 42001
+          family_id: "9"
+          family_name: Performance Evaluation
+          control_id: "9.4"
+          mapped_rules:
+            - ai-explainability
+        - framework_name: ISO 42001
+          family_id: A.10
+          family_name: Third-Party and Customer Relationships
+          control_id: A.10.2
+        - framework_name: ISO 42001
+          family_id: A.10
+          family_name: Third-Party and Customer Relationships
+          control_id: A.10.3
+        - framework_name: ISO 42001
+          family_id: A.10
+          family_name: Third-Party and Customer Relationships
+          control_id: A.10.4
+        - framework_name: ISO 42001
+          family_id: A.2
+          family_name: Policies
+          control_id: A.2.2
+        - framework_name: ISO 42001
+          family_id: A.2
+          family_name: Policies
+          control_id: A.2.3
+        - framework_name: ISO 42001
+          family_id: A.2
+          family_name: Policies
+          control_id: A.2.4
+        - framework_name: ISO 42001
+          family_id: A.3
+          family_name: Internal Organization
+          control_id: A.3.2
+        - framework_name: ISO 42001
+          family_id: A.3
+          family_name: Internal Organization
+          control_id: A.3.3
+        - framework_name: ISO 42001
+          family_id: A.4
+          family_name: Resources
+          control_id: A.4.2
+        - framework_name: ISO 42001
+          family_id: A.4
+          family_name: Resources
+          control_id: A.4.3
+        - framework_name: ISO 42001
+          family_id: A.4
+          family_name: Resources
+          control_id: A.4.4
+        - framework_name: ISO 42001
+          family_id: A.4
+          family_name: Resources
+          control_id: A.4.5
+        - framework_name: ISO 42001
+          family_id: A.4
+          family_name: Resources
+          control_id: A.4.6
+        - framework_name: ISO 42001
+          family_id: A.5
+          family_name: Impact Assessment
+          control_id: A.5.2
+        - framework_name: ISO 42001
+          family_id: A.5
+          family_name: Impact Assessment
+          control_id: A.5.3
+        - framework_name: ISO 42001
+          family_id: A.5
+          family_name: Impact Assessment
+          control_id: A.5.4
+        - framework_name: ISO 42001
+          family_id: A.5
+          family_name: Impact Assessment
+          control_id: A.5.5
+        - framework_name: ISO 42001
+          family_id: A.6
+          family_name: Lifecycle
+          control_id: A.6.1.2
+        - framework_name: ISO 42001
+          family_id: A.6
+          family_name: Lifecycle
+          control_id: A.6.1.3
+        - framework_name: ISO 42001
+          family_id: A.6
+          family_name: Lifecycle
+          control_id: A.6.2.2
+        - framework_name: ISO 42001
+          family_id: A.6
+          family_name: Lifecycle
+          control_id: A.6.2.3
+        - framework_name: ISO 42001
+          family_id: A.6
+          family_name: Lifecycle
+          control_id: A.6.2.4
+        - framework_name: ISO 42001
+          family_id: A.6
+          family_name: Lifecycle
+          control_id: A.6.2.5
+        - framework_name: ISO 42001
+          family_id: A.6
+          family_name: Lifecycle
+          control_id: A.6.2.6
+        - framework_name: ISO 42001
+          family_id: A.6
+          family_name: Lifecycle
+          control_id: A.6.2.7
+        - framework_name: ISO 42001
+          family_id: A.6
+          family_name: Lifecycle
+          control_id: A.6.2.8
+        - framework_name: ISO 42001
+          family_id: A.7
+          family_name: Data
+          control_id: A.7.2
+        - framework_name: ISO 42001
+          family_id: A.7
+          family_name: Data
+          control_id: A.7.3
+        - framework_name: ISO 42001
+          family_id: A.7
+          family_name: Data
+          control_id: A.7.4
+        - framework_name: ISO 42001
+          family_id: A.7
+          family_name: Data
+          control_id: A.7.5
+        - framework_name: ISO 42001
+          family_id: A.7
+          family_name: Data
+          control_id: A.7.6
+        - framework_name: ISO 42001
+          family_id: A.8
+          family_name: Information for Interested Parties
+          control_id: A.8.2
+        - framework_name: ISO 42001
+          family_id: A.8
+          family_name: Information for Interested Parties
+          control_id: A.8.3
+        - framework_name: ISO 42001
+          family_id: A.8
+          family_name: Information for Interested Parties
+          control_id: A.8.4
+        - framework_name: ISO 42001
+          family_id: A.8
+          family_name: Information for Interested Parties
+          control_id: A.8.5
+        - framework_name: ISO 42001
+          family_id: A.9
+          family_name: Use of AI Systems
+          control_id: A.9.2
+        - framework_name: ISO 42001
+          family_id: A.9
+          family_name: Use of AI Systems
+          control_id: A.9.3
+        - framework_name: ISO 42001
+          family_id: A.9
+          family_name: Use of AI Systems
+          control_id: A.9.4
+      rules:
+        - rule_id: ai-bias-testing
+          controls:
+            - framework_name: ISO 42001
+              control_id: "6.1"
+            - framework_name: ISO 42001
+              control_id: "9.2"
+        - rule_id: ai-data-governance
+          controls:
+            - framework_name: GDPR
+              control_id: Art.30
+            - framework_name: GDPR
+              control_id: Art.5
+            - framework_name: ISO 42001
+              control_id: "10.2"
+            - framework_name: ISO 42001
+              control_id: "7.3"
+        - rule_id: ai-explainability
+          controls:
+            - framework_name: ISO 42001
+              control_id: "9.4"
+        - rule_id: ai-human-oversight
+          controls:
+            - framework_name: ISO 42001
+              control_id: "6.2"
+            - framework_name: ISO 42001
+              control_id: "9.1"
+        - rule_id: ai-incident-response
+          controls:
+            - framework_name: ISO 42001
+              control_id: "10.1"
+            - framework_name: ISO 42001
+              control_id: "10.2"
+        - rule_id: ai-model-inventory
+          controls:
+            - framework_name: ISO 42001
+              control_id: "7.1"
+            - framework_name: ISO 42001
+              control_id: "7.2"
+        - rule_id: ai-model-monitoring
+          controls:
+            - framework_name: ISO 42001
+              control_id: "9.1"
+            - framework_name: ISO 42001
+              control_id: "9.3"
+        - rule_id: ai-risk-assessment
+          controls:
+            - framework_name: ISO 42001
+              control_id: "6.1"
+            - framework_name: ISO 42001
+              control_id: "6.2"
+        - rule_id: aws-bedrock-model-no-guardrails
+          controls:
+            - framework_name: ISO 42001
+              control_id: "6.1"
+            - framework_name: ISO 42001
+              control_id: "6.2"
+            - framework_name: ISO 42001
+              control_id: "8.4"
+            - framework_name: ISO 42001
+              control_id: "9.1"
+        - rule_id: compliance-data-inventory-maintained
+          controls:
+            - framework_name: CCPA
+              control_id: "1798.100"
+            - framework_name: GDPR
+              control_id: Article 30
+        - rule_id: compliance-gdpr-policy
+          controls:
+            - framework_name: GDPR
+              control_id: Art.5
+        - rule_id: compliance-inventory-data-tracking
+          controls:
+            - framework_name: GDPR
+              control_id: Art.30
+            - framework_name: GDPR
+              control_id: Art.5
+        - rule_id: compliance-ir-gdpr-addendum
+          controls:
+            - framework_name: GDPR
+              control_id: Art.5
+        - rule_id: vendor-dpa-exists
+          controls:
+            - framework_name: GDPR
+              control_id: Article 28
+      unmapped_controls:
+        - framework_name: GDPR
+          control_id: Article 12
+        - framework_name: GDPR
+          control_id: Article 13
+        - framework_name: GDPR
+          control_id: Article 14
+        - framework_name: GDPR
+          control_id: Article 15
+        - framework_name: GDPR
+          control_id: Article 16
+        - framework_name: GDPR
+          control_id: Article 17
+        - framework_name: GDPR
+          control_id: Article 18
+        - framework_name: GDPR
+          control_id: Article 19
+        - framework_name: GDPR
+          control_id: Article 20
+        - framework_name: GDPR
+          control_id: Article 21
+        - framework_name: GDPR
+          control_id: Article 22
+        - framework_name: GDPR
+          control_id: Article 23
+        - framework_name: GDPR
+          control_id: Article 24
+        - framework_name: GDPR
+          control_id: Article 25
+        - framework_name: GDPR
+          control_id: Article 27
+        - framework_name: GDPR
+          control_id: Article 32
+        - framework_name: GDPR
+          control_id: Article 33
+        - framework_name: GDPR
+          control_id: Article 34
+        - framework_name: GDPR
+          control_id: Article 35
+        - framework_name: GDPR
+          control_id: Article 37
+        - framework_name: GDPR
+          control_id: Article 38
+        - framework_name: GDPR
+          control_id: Article 39
+        - framework_name: GDPR
+          control_id: Article 44
+        - framework_name: GDPR
+          control_id: Article 45
+        - framework_name: GDPR
+          control_id: Article 46
+        - framework_name: GDPR
+          control_id: Article 48
+        - framework_name: GDPR
+          control_id: Article 51
+        - framework_name: GDPR
+          control_id: Article 6
+        - framework_name: GDPR
+          control_id: Article 7
+        - framework_name: ISO 27701:2025
+          control_id: A.1.2.2
+        - framework_name: ISO 27701:2025
+          control_id: A.1.2.3
+        - framework_name: ISO 27701:2025
+          control_id: A.1.2.4
+        - framework_name: ISO 27701:2025
+          control_id: A.1.2.5
+        - framework_name: ISO 27701:2025
+          control_id: A.1.2.6
+        - framework_name: ISO 27701:2025
+          control_id: A.1.2.7
+        - framework_name: ISO 27701:2025
+          control_id: A.1.2.8
+        - framework_name: ISO 27701:2025
+          control_id: A.1.2.9
+        - framework_name: ISO 27701:2025
+          control_id: A.1.3.10
+        - framework_name: ISO 27701:2025
+          control_id: A.1.3.11
+        - framework_name: ISO 27701:2025
+          control_id: A.1.3.2
+        - framework_name: ISO 27701:2025
+          control_id: A.1.3.3
+        - framework_name: ISO 27701:2025
+          control_id: A.1.3.4
+        - framework_name: ISO 27701:2025
+          control_id: A.1.3.5
+        - framework_name: ISO 27701:2025
+          control_id: A.1.3.6
+        - framework_name: ISO 27701:2025
+          control_id: A.1.3.7
+        - framework_name: ISO 27701:2025
+          control_id: A.1.3.8
+        - framework_name: ISO 27701:2025
+          control_id: A.1.3.9
+        - framework_name: ISO 27701:2025
+          control_id: A.1.4.10
+        - framework_name: ISO 27701:2025
+          control_id: A.1.4.2
+        - framework_name: ISO 27701:2025
+          control_id: A.1.4.3
+        - framework_name: ISO 27701:2025
+          control_id: A.1.4.4
+        - framework_name: ISO 27701:2025
+          control_id: A.1.4.5
+        - framework_name: ISO 27701:2025
+          control_id: A.1.4.6
+        - framework_name: ISO 27701:2025
+          control_id: A.1.4.7
+        - framework_name: ISO 27701:2025
+          control_id: A.1.4.8
+        - framework_name: ISO 27701:2025
+          control_id: A.1.4.9
+        - framework_name: ISO 27701:2025
+          control_id: A.1.5.2
+        - framework_name: ISO 27701:2025
+          control_id: A.1.5.3
+        - framework_name: ISO 27701:2025
+          control_id: A.1.5.4
+        - framework_name: ISO 27701:2025
+          control_id: A.1.5.5
+        - framework_name: ISO 27701:2025
+          control_id: A.2.2.2
+        - framework_name: ISO 27701:2025
+          control_id: A.2.2.3
+        - framework_name: ISO 27701:2025
+          control_id: A.2.2.4
+        - framework_name: ISO 27701:2025
+          control_id: A.2.2.5
+        - framework_name: ISO 27701:2025
+          control_id: A.2.2.6
+        - framework_name: ISO 27701:2025
+          control_id: A.2.2.7
+        - framework_name: ISO 27701:2025
+          control_id: A.2.3.2
+        - framework_name: ISO 27701:2025
+          control_id: A.2.4.2
+        - framework_name: ISO 27701:2025
+          control_id: A.2.4.3
+        - framework_name: ISO 27701:2025
+          control_id: A.2.4.4
+        - framework_name: ISO 27701:2025
+          control_id: A.2.5.2
+        - framework_name: ISO 27701:2025
+          control_id: A.2.5.3
+        - framework_name: ISO 27701:2025
+          control_id: A.2.5.4
+        - framework_name: ISO 27701:2025
+          control_id: A.2.5.5
+        - framework_name: ISO 27701:2025
+          control_id: A.2.5.6
+        - framework_name: ISO 27701:2025
+          control_id: A.2.5.7
+        - framework_name: ISO 27701:2025
+          control_id: A.2.5.8
+        - framework_name: ISO 27701:2025
+          control_id: A.2.5.9
+        - framework_name: ISO 27701:2025
+          control_id: A.3.10
+        - framework_name: ISO 27701:2025
+          control_id: A.3.11
+        - framework_name: ISO 27701:2025
+          control_id: A.3.12
+        - framework_name: ISO 27701:2025
+          control_id: A.3.13
+        - framework_name: ISO 27701:2025
+          control_id: A.3.14
+        - framework_name: ISO 27701:2025
+          control_id: A.3.15
+        - framework_name: ISO 27701:2025
+          control_id: A.3.16
+        - framework_name: ISO 27701:2025
+          control_id: A.3.17
+        - framework_name: ISO 27701:2025
+          control_id: A.3.18
+        - framework_name: ISO 27701:2025
+          control_id: A.3.19
+        - framework_name: ISO 27701:2025
+          control_id: A.3.20
+        - framework_name: ISO 27701:2025
+          control_id: A.3.21
+        - framework_name: ISO 27701:2025
+          control_id: A.3.22
+        - framework_name: ISO 27701:2025
+          control_id: A.3.23
+        - framework_name: ISO 27701:2025
+          control_id: A.3.24
+        - framework_name: ISO 27701:2025
+          control_id: A.3.25
+        - framework_name: ISO 27701:2025
+          control_id: A.3.26
+        - framework_name: ISO 27701:2025
+          control_id: A.3.27
+        - framework_name: ISO 27701:2025
+          control_id: A.3.28
+        - framework_name: ISO 27701:2025
+          control_id: A.3.29
+        - framework_name: ISO 27701:2025
+          control_id: A.3.3
+        - framework_name: ISO 27701:2025
+          control_id: A.3.30
+        - framework_name: ISO 27701:2025
+          control_id: A.3.31
+        - framework_name: ISO 27701:2025
+          control_id: A.3.4
+        - framework_name: ISO 27701:2025
+          control_id: A.3.5
+        - framework_name: ISO 27701:2025
+          control_id: A.3.6
+        - framework_name: ISO 27701:2025
+          control_id: A.3.7
+        - framework_name: ISO 27701:2025
+          control_id: A.3.8
+        - framework_name: ISO 27701:2025
+          control_id: A.3.9
+        - framework_name: ISO 42001
+          control_id: A.10.2
+        - framework_name: ISO 42001
+          control_id: A.10.3
+        - framework_name: ISO 42001
+          control_id: A.10.4
+        - framework_name: ISO 42001
+          control_id: A.2.2
+        - framework_name: ISO 42001
+          control_id: A.2.3
+        - framework_name: ISO 42001
+          control_id: A.2.4
+        - framework_name: ISO 42001
+          control_id: A.3.2
+        - framework_name: ISO 42001
+          control_id: A.3.3
+        - framework_name: ISO 42001
+          control_id: A.4.2
+        - framework_name: ISO 42001
+          control_id: A.4.3
+        - framework_name: ISO 42001
+          control_id: A.4.4
+        - framework_name: ISO 42001
+          control_id: A.4.5
+        - framework_name: ISO 42001
+          control_id: A.4.6
+        - framework_name: ISO 42001
+          control_id: A.5.2
+        - framework_name: ISO 42001
+          control_id: A.5.3
+        - framework_name: ISO 42001
+          control_id: A.5.4
+        - framework_name: ISO 42001
+          control_id: A.5.5
+        - framework_name: ISO 42001
+          control_id: A.6.1.2
+        - framework_name: ISO 42001
+          control_id: A.6.1.3
+        - framework_name: ISO 42001
+          control_id: A.6.2.2
+        - framework_name: ISO 42001
+          control_id: A.6.2.3
+        - framework_name: ISO 42001
+          control_id: A.6.2.4
+        - framework_name: ISO 42001
+          control_id: A.6.2.5
+        - framework_name: ISO 42001
+          control_id: A.6.2.6
+        - framework_name: ISO 42001
+          control_id: A.6.2.7
+        - framework_name: ISO 42001
+          control_id: A.6.2.8
+        - framework_name: ISO 42001
+          control_id: A.7.2
+        - framework_name: ISO 42001
+          control_id: A.7.3
+        - framework_name: ISO 42001
+          control_id: A.7.4
+        - framework_name: ISO 42001
+          control_id: A.7.5
+        - framework_name: ISO 42001
+          control_id: A.7.6
+        - framework_name: ISO 42001
+          control_id: A.8.2
+        - framework_name: ISO 42001
+          control_id: A.8.3
+        - framework_name: ISO 42001
+          control_id: A.8.4
+        - framework_name: ISO 42001
+          control_id: A.8.5
+        - framework_name: ISO 42001
+          control_id: A.9.2
+        - framework_name: ISO 42001
+          control_id: A.9.3
+        - framework_name: ISO 42001
+          control_id: A.9.4
+    - id: soc2-availability
+      name: SOC 2 Availability
+      description: Availability controls for uptime, capacity, continuity, and operational resilience reviews.
+      summary:
+        selected_controls: 3
+        mapped_controls: 3
+        unmapped_controls: 0
+        mapped_rules: 16
+      controls:
+        - framework_name: SOC 2
+          family_id: A1
+          family_name: Availability
+          control_id: A1.1
+          mapped_rules:
+            - aws-rds-backup-enabled
+            - aws-rds-deletion-protection
+            - aws-rds-multi-az-enabled
+            - aws-s3-bucket-versioning-enabled
+            - compliance-bcdr-plan-exists
+            - gcp-gke-auto-repair
+            - gcp-sql-backup-enabled
+            - k8s-deployment-multiple-replicas
+            - k8s-pod-liveness-probe-required
+            - k8s-pod-readiness-probe-required
+            - k8s-pod-resource-limits
+            - resolution-time-breach
+            - uptime-breach-enterprise
+            - zendesk-sla-breach
+        - framework_name: SOC 2
+          family_id: A1
+          family_name: Availability
+          control_id: A1.2
+          mapped_rules:
+            - aws-rds-backup-enabled
+            - aws-rds-deletion-protection
+            - aws-rds-multi-az-enabled
+            - aws-s3-bucket-versioning-enabled
+            - aws-s3-cross-region-replication
+            - bucket-sensitive-no-lock
+            - compliance-bcdr-plan-exists
+            - gcp-sql-backup-enabled
+            - k8s-deployment-multiple-replicas
+            - k8s-pod-liveness-probe-required
+            - k8s-pod-readiness-probe-required
+            - k8s-pod-resource-limits
+            - uptime-breach-enterprise
+        - framework_name: SOC 2
+          family_id: A1
+          family_name: Availability
+          control_id: A1.3
+          mapped_rules:
+            - aws-rds-multi-az-enabled
+            - compliance-bcdr-plan-exists
+            - k8s-deployment-multiple-replicas
+            - k8s-pod-liveness-probe-required
+            - k8s-pod-readiness-probe-required
+            - k8s-pod-resource-limits
+      rules:
+        - rule_id: aws-rds-backup-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+        - rule_id: aws-rds-deletion-protection
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+        - rule_id: aws-rds-multi-az-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+            - framework_name: SOC 2
+              control_id: A1.3
+        - rule_id: aws-s3-bucket-versioning-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+        - rule_id: aws-s3-cross-region-replication
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.2
+        - rule_id: bucket-sensitive-no-lock
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.2
+        - rule_id: compliance-bcdr-plan-exists
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+            - framework_name: SOC 2
+              control_id: A1.3
+        - rule_id: gcp-gke-auto-repair
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+        - rule_id: gcp-sql-backup-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+        - rule_id: k8s-deployment-multiple-replicas
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+            - framework_name: SOC 2
+              control_id: A1.3
+        - rule_id: k8s-pod-liveness-probe-required
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+            - framework_name: SOC 2
+              control_id: A1.3
+        - rule_id: k8s-pod-readiness-probe-required
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+            - framework_name: SOC 2
+              control_id: A1.3
+        - rule_id: k8s-pod-resource-limits
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+            - framework_name: SOC 2
+              control_id: A1.3
+        - rule_id: resolution-time-breach
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+        - rule_id: uptime-breach-enterprise
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+            - framework_name: SOC 2
+              control_id: A1.2
+        - rule_id: zendesk-sla-breach
+          controls:
+            - framework_name: SOC 2
+              control_id: A1.1
+    - id: soc2-security-core
+      name: SOC 2 Security Core
+      description: Security audit scope covering control environment, communication, risk assessment, monitoring, access, operations, change, and risk mitigation.
+      summary:
+        selected_controls: 36
+        mapped_controls: 25
+        unmapped_controls: 11
+        mapped_rules: 915
+      controls:
+        - framework_name: SOC 2
+          family_id: CC1
+          family_name: Control Environment
+          control_id: CC1.1
+          mapped_rules:
+            - aws-alb-http-to-https
+            - aws-dynamodb-pitr
+            - aws-iam-no-full-admin
+            - aws-logs-retention-365
+            - aws-rds-backup-enabled
+            - aws-rds-deletion-protection
+            - aws-s3-bucket-versioning-enabled
+            - backup-encryption
+            - backup-offsite
+            - backup-retention
+            - backup-rpo-compliance
+            - backup-testing
+            - cert-expired
+            - cert-expiry-30-days
+            - cert-self-signed
+            - cert-weak-key
+            - cert-weak-signature
+            - compliance-background-checks
+            - compliance-gdpr-policy
+            - compliance-ir-gdpr-addendum
+            - compliance-security-training
+            - container-host-network
+            - container-image-scan
+            - container-privileged
+            - container-readonly-fs
+            - container-resource-limits
+            - container-root-user
+            - db-audit-logging
+            - db-backup-enabled
+            - db-encryption-at-rest
+            - db-multi-az
+            - db-public-access
+            - db-ssl-connections
+            - endpoint-kandji-password-manager
+            - endpoint-malware-detection
+            - endpoint-mdm-enrolled
+            - endpoint-password-manager
+            - endpoint-sentinelone-active
+            - gcp-log-sink-access
+            - gcp-sql-backup-enabled
+            - github-automated-checks
+            - github-branch-protection-admin
+            - identity-cyberark-deprovision
+            - identity-duo-deprovision
+            - identity-forgerock-deprovision
+            - identity-github-deprovision
+            - identity-jumpcloud-deprovision
+            - identity-office365-deprovision
+            - identity-oracle-idcs-deprovision
+            - identity-pingidentity-deprovision
+            - identity-sailpoint-deprovision
+            - identity-saviynt-deprovision
+            - identity-slack-deprovision
+            - identity-tailscale-deprovision
+            - m365-conditional-access-disabled
+            - m365-global-admin-count
+            - m365-guest-access-review
+            - m365-inactive-users
+            - m365-legacy-auth-signins
+            - m365-mfa-required
+            - m365-privileged-roles-pim
+            - m365-risky-users
+            - m365-stale-service-principal
+            - m365-terminated-users-active
+            - network-default-deny
+            - network-dns-security
+            - network-ids-coverage
+            - network-segmentation
+            - network-unused-ports
+            - secrets-access-audit
+            - secrets-least-privilege
+            - secrets-rotation
+            - secrets-vault-storage
+            - tls-version-outdated
+            - tls-weak-ciphers
+            - vendor-auth-method
+            - vendor-pci-compliance
+            - vuln-aging-report
+            - vuln-critical-sla
+            - vuln-epss-high
+            - vuln-high-sla
+            - vuln-known-exploited
+            - vuln-medium-sla
+            - vuln-public-facing
+        - framework_name: SOC 2
+          family_id: CC1
+          family_name: Control Environment
+          control_id: CC1.2
+          mapped_rules:
+            - grc-control-missing-evidence-coverage
+            - grc-control-test-needs-attention
+        - framework_name: SOC 2
+          family_id: CC1
+          family_name: Control Environment
+          control_id: CC1.3
+        - framework_name: SOC 2
+          family_id: CC1
+          family_name: Control Environment
+          control_id: CC1.4
+          mapped_rules:
+            - ai-bias-testing
+            - ai-explainability
+        - framework_name: SOC 2
+          family_id: CC1
+          family_name: Control Environment
+          control_id: CC1.5
+        - framework_name: SOC 2
+          family_id: CC2
+          family_name: Communication and Information
+          control_id: CC2.1
+        - framework_name: SOC 2
+          family_id: CC2
+          family_name: Communication and Information
+          control_id: CC2.2
+          mapped_rules:
+            - grc-document-needs-owner-or-upload
+        - framework_name: SOC 2
+          family_id: CC2
+          family_name: Communication and Information
+          control_id: CC2.3
+        - framework_name: SOC 2
+          family_id: CC3
+          family_name: Risk Assessment
+          control_id: CC3.1
+          mapped_rules:
+            - compliance-risk-assessment-annual
+        - framework_name: SOC 2
+          family_id: CC3
+          family_name: Risk Assessment
+          control_id: CC3.2
+          mapped_rules:
+            - ai-risk-assessment
+            - compliance-risk-assessment-annual
+        - framework_name: SOC 2
+          family_id: CC3
+          family_name: Risk Assessment
+          control_id: CC3.3
+        - framework_name: SOC 2
+          family_id: CC3
+          family_name: Risk Assessment
+          control_id: CC3.4
+        - framework_name: SOC 2
+          family_id: CC4
+          family_name: Monitoring Activities
+          control_id: CC4
+          mapped_rules:
+            - aws-cloudtrail-enabled
+            - aws-cloudwatch-alarm-missing
+            - aws-cloudwatch-log-group-encrypted
+            - aws-cloudwatch-log-group-retention
+            - aws-codebuild-public-logs
+            - aws-config-enabled-all-regions
+            - aws-ec2-detailed-monitoring-enabled
+            - aws-eks-control-plane-logging
+            - aws-rds-logging-enabled
+            - aws-s3-bucket-logging-enabled
+            - aws-vpc-flow-logs-enabled
+            - azure-keyvault-logging
+            - azure-sql-auditing-enabled
+            - gcp-audit-logging-enabled
+            - gcp-logging-disabled
+            - github-repo-secrets-exposure
+            - ml-model-registry-no-versioning
+            - s3-read-logging-disabled
+            - s3-write-logging-disabled
+            - vpc-dns-logging
+        - framework_name: SOC 2
+          family_id: CC4
+          family_name: Monitoring Activities
+          control_id: CC4.1
+          mapped_rules:
+            - aws-cloudtrail-s3-data-events
+        - framework_name: SOC 2
+          family_id: CC4
+          family_name: Monitoring Activities
+          control_id: CC4.2
+        - framework_name: SOC 2
+          family_id: CC5
+          family_name: Control Activities
+          control_id: CC5.1
+        - framework_name: SOC 2
+          family_id: CC5
+          family_name: Control Activities
+          control_id: CC5.2
+          mapped_rules:
+            - same-user-approve-execute
+        - framework_name: SOC 2
+          family_id: CC5
+          family_name: Control Activities
+          control_id: CC5.3
+          mapped_rules:
+            - same-user-approve-execute
+        - framework_name: SOC 2
+          family_id: CC6
+          family_name: Logical and Physical Access
+          control_id: CC6
+          mapped_rules:
+            - account-lateral-dormant
+            - admin-inactive-keys
+            - admin-keys-unrotated
+            - admin-keys-year-unrotated
+            - ai-agent-lambda-data-access
+            - ai-model-excessive-agency
+            - ai-model-third-party-access
+            - aws-api-gateway-no-authorization
+            - aws-apigateway-public
+            - aws-bedrock-custom-model-public
+            - aws-codebuild-privileged-mode
+            - aws-codebuild-public-logs
+            - aws-codebuild-public-trigger
+            - aws-ec2-ami-not-public
+            - aws-ec2-ebs-snapshot-not-public
+            - aws-ec2-instance-profile-attached
+            - aws-ec2-internet-facing-iam
+            - aws-ec2-public-ip-rdp
+            - aws-ec2-public-ip-ssh
+            - aws-ec2-sg-no-all-traffic-ingress
+            - aws-ecr-public-repository
+            - aws-ecs-secrets-in-env-vars
+            - aws-eks-public-endpoint-disabled
+            - aws-elasticache-public
+            - aws-elb-internet-facing-no-waf
+            - aws-iam-access-key-rotation
+            - aws-iam-no-policies-attached-user
+            - aws-iam-password-policy
+            - aws-iam-policy-no-admin-star
+            - aws-iam-role-confused-deputy-prevention
+            - aws-iam-role-cross-account-admin
+            - aws-iam-role-trust-any-principal
+            - aws-iam-role-wildcard-trust
+            - aws-iam-root-mfa-enabled
+            - aws-iam-root-no-access-keys
+            - aws-iam-saml-provider-stale
+            - aws-iam-service-account-open-assume
+            - aws-iam-user-console-inactive
+            - aws-iam-user-mfa-enabled
+            - aws-iam-user-multiple-access-keys
+            - aws-iam-user-unused-credentials
+            - aws-lambda-not-publicly-accessible
+            - aws-lambda-secrets-in-env-vars
+            - aws-opensearch-public
+            - aws-rds-iam-authentication
+            - aws-rds-no-public-access
+            - aws-rds-public-snapshot
+            - aws-redshift-public
+            - aws-s3-bucket-cleartext-key
+            - aws-s3-bucket-logging-enabled
+            - aws-s3-bucket-no-public-access
+            - aws-s3-bucket-policy-public
+            - aws-s3-public-write
+            - aws-sagemaker-model-artifact-public
+            - aws-sagemaker-notebook-internet-access
+            - aws-sagemaker-notebook-root-access
+            - aws-secretsmanager-secret-used
+            - aws-security-group-restrict-rdp
+            - aws-security-group-restrict-ssh
+            - aws-sns-public-access
+            - aws-sqs-public-access
+            - aws-user-data-no-mfa
+            - aws-user-inactive-admin-no-mfa
+            - aws-user-inactive-data-no-mfa
+            - azure-ad-guest-access-restricted
+            - azure-aks-rbac-enabled
+            - azure-cosmosdb-public
+            - azure-cosmosdb-public-access
+            - azure-function-anonymous-access
+            - azure-function-public
+            - azure-ml-workspace-public-network
+            - azure-nsg-admin-port
+            - azure-nsg-restrict-ssh
+            - azure-openai-public-network
+            - azure-sql-public-network-access
+            - azure-sqlserver-public
+            - azure-storage-blob-public-access-disabled
+            - azure-storage-network-allow
+            - azure-storage-network-default-deny
+            - azure-storage-public-write
+            - azure-storage-secrets-artifact
+            - azure-vm-public-ip-rdp
+            - azure-vm-public-ip-ssh
+            - bedrock-excessive-permissions
+            - bucket-cleartext-admin-keys
+            - bucket-cleartext-keys-data
+            - bucket-dormant-principal
+            - bucket-keys-excessive-access
+            - bucket-public-large-files
+            - bucket-public-low-exposure
+            - bucket-public-sensitive
+            - container-cleartext-cloud-keys
+            - container-cross-account-keys
+            - container-image-cleartext-keys
+            - cross-provider-dormant-privileged
+            - cross-provider-privileged-access-no-mfa
+            - cve-2023-20867
+            - cve-2023-4863
+            - cve-2024-21626
+            - cve-2024-6387
+            - data-access-keys-unrotated
+            - data-resource-excessive-access
+            - data-resource-org-access
+            - db-dormant-principal
+            - dirty-pipe-privileged
+            - efs-public-subnet
+            - exposed-saas-api-token
+            - gcp-bigquery-public
+            - gcp-bigquery-public-dataset
+            - gcp-bucket-public-write
+            - gcp-bucket-secrets
+            - gcp-cloudrun-default-service-account
+            - gcp-cloudrun-public-ingress
+            - gcp-cloudsql-no-public-ip
+            - gcp-compute-no-default-service-account
+            - gcp-compute-no-public-ip
+            - gcp-compute-public-ssh
+            - gcp-compute-serial-port-disabled
+            - gcp-external-domain-admin
+            - gcp-firewall-admin-port
+            - gcp-gke-default-sa
+            - gcp-gke-private-cluster
+            - gcp-iam-binding-no-allAuthenticatedUsers
+            - gcp-iam-binding-no-allUsers
+            - gcp-iam-minimize-user-managed-keys
+            - gcp-iam-sa-no-admin-privileges
+            - gcp-kms-public
+            - gcp-sa-admin-privileges
+            - gcp-sa-admin-user-combined
+            - gcp-sa-impersonation
+            - gcp-sa-no-full-project-access
+            - gcp-service-account-key-rotation
+            - gcp-storage-bucket-no-public
+            - gcp-storage-no-public-allusers
+            - gcp-storage-uniform-bucket-access
+            - gcp-vertex-ai-dataset-public
+            - gcp-vertex-ai-public-endpoint
+            - gcr-excessive-privileges
+            - github-actions-self-hosted-public
+            - github-admin-without-2fa
+            - github-oidc-overly-permissive
+            - github-org-workflow-permissions
+            - github-public-repo-branch-protection
+            - github-repo-internal-exposed
+            - github-runner-group-scope
+            - github-runner-public-repo
+            - github-secret-scanning-alert
+            - github-workflow-write-permissions
+            - gke-cluster-admin
+            - gke-pod-create
+            - gke-wildcard-permissions
+            - group-excessive-admin
+            - group-excessive-data-priv
+            - group-excessive-high-priv
+            - iam-inactive-privileged-account
+            - iam-unknown-account-trusted
+            - internal-vm-cross-account-keys
+            - k8s-cluster-admin-wildcard
+            - k8s-ingress-public
+            - k8s-node-public-exposure
+            - k8s-pod-create
+            - k8s-pod-no-privileged
+            - k8s-rbac-cluster-admin-used
+            - k8s-rbac-high-risk-binding
+            - k8s-rbac-medium-risk-binding
+            - k8s-rbac-pod-create-privileges
+            - k8s-rbac-secret-read-access
+            - k8s-rbac-wildcard-permissions-assigned
+            - k8s-role-wildcard-permissions
+            - k8s-service-account-token-mount
+            - k8s-service-external-ip
+            - k8s-wildcard-permissions
+            - log4shell-privileged
+            - log4shell-public
+            - m365-dlp-policy-missing
+            - m365-email-security-baseline
+            - m365-file-shared-externally
+            - m365-guest-admin
+            - m365-inactive-admin
+            - m365-onedrive-sharing-restrictions
+            - m365-sensitivity-labels-missing
+            - m365-sharepoint-anonymous-link
+            - mlops-public-vuln
+            - notebook-excessive-agency
+            - okta-admin-dormant
+            - privileged-inactive-keys
+            - privileged-keys-unrotated
+            - public-resource-cleartext-admin-keys
+            - public-resource-cleartext-keys
+            - public-resource-cross-account-keys
+            - public-resource-keys-data-access
+            - public-saas-keys
+            - public-vm-cross-account-keys
+            - ray-ai-public
+            - resource-cleartext-keys-admin
+            - resource-cleartext-keys-privileged
+            - sa-external-principal-assume
+            - sa-external-web-identity
+            - sa-inactive-assigned
+            - sa-inactive-privileged
+            - sa-lateral-admin
+            - saas-token-exposed
+            - serverless-public-admin
+            - serverless-public-high-priv
+            - serverless-unauth-privileged
+            - serverless-unauthenticated-invocation
+            - storage-key-exposed
+            - terraform-cloud-no-team-access-control
+            - third-party-sa-admin
+            - third-party-sa-privileged
+            - unknown-account-trusted
+            - user-data-access-unused-password
+            - user-excessive-admin
+            - user-excessive-data-priv
+            - user-excessive-high-priv
+            - user-lateral-admin
+            - user-privileged-access-keys
+            - user-privileged-unused-password
+            - vm-cleartext-cloud-keys
+            - vm-cleartext-keys-cross-account
+            - vm-dormant-sa
+            - vm-internet-vuln-privileged
+            - vm-medium-exposure-vuln-data
+            - vm-public-admin
+            - vm-public-data-access
+            - vm-public-eol
+            - vm-public-eol-targeted
+            - vm-public-high-priv
+            - vm-public-high-privileges
+            - vm-public-privileged-vuln-common-dep
+            - vm-public-vuln
+            - vm-public-vuln-common-dep
+            - vm-public-vuln-cross-account-keys
+            - vm-ssh-private-keys
+            - vm-vuln-cleartext-keys
+            - vm-vuln-data-access
+            - vm-vuln-keys-data-access
+            - vm-vuln-lateral-admin
+        - framework_name: SOC 2
+          family_id: CC6
+          family_name: Logical and Physical Access
+          control_id: CC6.1
+          mapped_rules:
+            - ai-data-governance
+            - ai-model-inventory
+            - aws-cloudtrail-kms-encryption
+            - aws-cloudtrail-log-integrity
+            - aws-default-sg-no-rules
+            - aws-ec2-iam-instance-profile
+            - aws-ec2-public-ports-restricted
+            - aws-ecs-ports-restricted
+            - aws-ecs-ssh-denied
+            - aws-elb-target-public-subnet
+            - aws-iam-access-analyzer-enabled
+            - aws-iam-expired-certificates
+            - aws-iam-single-access-key
+            - aws-iam-users-via-groups
+            - aws-lambda-in-vpc
+            - aws-nacl-admin-ports-restricted
+            - aws-password-policy-minimum-length
+            - aws-password-policy-no-reuse
+            - aws-s3-https-only
+            - aws-sagemaker-training-no-vpc
+            - azure-vm-approved-extensions-only
+            - compliance-inventory-data-tracking
+            - compliance-inventory-owners
+            - data-sensitive-asset-risk
+            - endpoint-intune-noncompliant
+            - endpoint-jamf-screenlock
+            - endpoint-screenlock-configured
+            - gcp-compute-metadata-v1
+            - gcp-gke-metadata-server
+            - gcp-gke-secrets-kms-encryption
+            - grc-privileged-account-missing-person
+            - identity-atlassian-active-no-employee-record
+            - identity-atlassian-duplicate-email
+            - identity-atlassian-duplicate-group-name
+            - identity-atlassian-duplicate-membership-assignment
+            - identity-atlassian-empty-groups
+            - identity-atlassian-missing-email
+            - identity-atlassian-personal-email-domain
+            - identity-atlassian-privileged-personal-email
+            - identity-atlassian-terminated-active-account
+            - identity-auth0-active-no-employee-record
+            - identity-auth0-duplicate-email
+            - identity-auth0-missing-email
+            - identity-auth0-never-logged-in-30d
+            - identity-auth0-never-logged-in-90d
+            - identity-auth0-personal-email-domain
+            - identity-auth0-stale-login-180d
+            - identity-auth0-stale-login-365d
+            - identity-auth0-stale-login-90d
+            - identity-auth0-terminated-active-account
+            - identity-cyberark-active-no-employee-record
+            - identity-cyberark-duplicate-email
+            - identity-cyberark-duplicate-group-name
+            - identity-cyberark-duplicate-membership-assignment
+            - identity-cyberark-duplicate-username
+            - identity-cyberark-empty-groups
+            - identity-cyberark-group-description-missing
+            - identity-cyberark-membership-inactive-user
+            - identity-cyberark-membership-personal-email-domain
+            - identity-cyberark-missing-email
+            - identity-cyberark-orphaned-membership-group
+            - identity-cyberark-orphaned-membership-user
+            - identity-cyberark-personal-email-domain
+            - identity-cyberark-terminated-active-account
+            - identity-duo-active-no-employee-record
+            - identity-duo-duplicate-email
+            - identity-duo-duplicate-group-name
+            - identity-duo-duplicate-membership-assignment
+            - identity-duo-duplicate-username
+            - identity-duo-empty-groups
+            - identity-duo-group-description-missing
+            - identity-duo-membership-inactive-user
+            - identity-duo-missing-email
+            - identity-duo-never-logged-in-30d
+            - identity-duo-never-logged-in-90d
+            - identity-duo-orphaned-membership-group
+            - identity-duo-orphaned-membership-user
+            - identity-duo-personal-email-domain
+            - identity-duo-stale-login-180d
+            - identity-duo-stale-login-365d
+            - identity-duo-stale-login-90d
+            - identity-duo-terminated-active-account
+            - identity-entra-active-no-employee-record
+            - identity-entra-duplicate-email
+            - identity-entra-duplicate-group-name
+            - identity-entra-duplicate-username
+            - identity-entra-group-description-missing
+            - identity-entra-mfa-missing-active
+            - identity-entra-missing-email
+            - identity-entra-never-logged-in-30d
+            - identity-entra-never-logged-in-90d
+            - identity-entra-personal-email-domain
+            - identity-entra-privileged-no-mfa
+            - identity-entra-privileged-personal-email
+            - identity-entra-privileged-recently-created-7d
+            - identity-entra-privileged-stale-login-30d
+            - identity-entra-risky-active-no-employee-record
+            - identity-entra-risky-duplicate-email
+            - identity-entra-risky-duplicate-username
+            - identity-entra-risky-missing-email
+            - identity-entra-risky-personal-email-domain
+            - identity-entra-risky-terminated-active-account
+            - identity-entra-stale-login-180d
+            - identity-entra-stale-login-365d
+            - identity-entra-stale-login-90d
+            - identity-entra-terminated-active-account
+            - identity-forgerock-active-no-employee-record
+            - identity-forgerock-duplicate-email
+            - identity-forgerock-duplicate-group-name
+            - identity-forgerock-duplicate-membership-assignment
+            - identity-forgerock-duplicate-username
+            - identity-forgerock-empty-groups
+            - identity-forgerock-group-description-missing
+            - identity-forgerock-membership-inactive-user
+            - identity-forgerock-membership-personal-email-domain
+            - identity-forgerock-missing-email
+            - identity-forgerock-orphaned-membership-group
+            - identity-forgerock-orphaned-membership-user
+            - identity-forgerock-personal-email-domain
+            - identity-forgerock-terminated-active-account
+            - identity-github-active-no-employee-record
+            - identity-github-duplicate-email
+            - identity-github-duplicate-username
+            - identity-github-member-mfa
+            - identity-github-mfa-missing-active
+            - identity-github-missing-email
+            - identity-github-personal-email-domain
+            - identity-github-privileged-no-mfa
+            - identity-github-privileged-personal-email
+            - identity-github-runner-duplicate-group-name
+            - identity-github-terminated-active-account
+            - identity-gong-active-no-employee-record
+            - identity-gong-duplicate-email
+            - identity-gong-missing-email
+            - identity-gong-personal-email-domain
+            - identity-gong-terminated-active-account
+            - identity-google-workspace-active-no-employee-record
+            - identity-google-workspace-admin-mfa
+            - identity-google-workspace-duplicate-email
+            - identity-google-workspace-duplicate-group-name
+            - identity-google-workspace-duplicate-membership-assignment
+            - identity-google-workspace-empty-groups
+            - identity-google-workspace-group-description-missing
+            - identity-google-workspace-group-personal-email-domain
+            - identity-google-workspace-membership-personal-email-domain
+            - identity-google-workspace-mfa
+            - identity-google-workspace-mfa-missing-active
+            - identity-google-workspace-missing-email
+            - identity-google-workspace-never-logged-in-30d
+            - identity-google-workspace-never-logged-in-90d
+            - identity-google-workspace-orphaned-membership-group
+            - identity-google-workspace-personal-email-domain
+            - identity-google-workspace-privileged-no-mfa
+            - identity-google-workspace-privileged-personal-email
+            - identity-google-workspace-privileged-recently-created-7d
+            - identity-google-workspace-privileged-stale-login-30d
+            - identity-google-workspace-stale-login-180d
+            - identity-google-workspace-stale-login-365d
+            - identity-google-workspace-stale-login-90d
+            - identity-google-workspace-terminated-active-account
+            - identity-jamf-active-no-employee-record
+            - identity-jamf-duplicate-email
+            - identity-jamf-missing-email
+            - identity-jamf-personal-email-domain
+            - identity-jamf-privileged-personal-email
+            - identity-jamf-terminated-active-account
+            - identity-jumpcloud-active-no-employee-record
+            - identity-jumpcloud-duplicate-email
+            - identity-jumpcloud-duplicate-group-name
+            - identity-jumpcloud-duplicate-membership-assignment
+            - identity-jumpcloud-duplicate-username
+            - identity-jumpcloud-empty-groups
+            - identity-jumpcloud-group-description-missing
+            - identity-jumpcloud-group-personal-email-domain
+            - identity-jumpcloud-membership-inactive-user
+            - identity-jumpcloud-membership-personal-email-domain
+            - identity-jumpcloud-mfa
+            - identity-jumpcloud-mfa-missing-active
+            - identity-jumpcloud-missing-email
+            - identity-jumpcloud-orphaned-membership-group
+            - identity-jumpcloud-orphaned-membership-user
+            - identity-jumpcloud-personal-email-domain
+            - identity-jumpcloud-terminated-active-account
+            - identity-kandji-active-no-employee-record
+            - identity-kandji-duplicate-email
+            - identity-kandji-missing-email
+            - identity-kandji-personal-email-domain
+            - identity-kandji-privileged-personal-email
+            - identity-kandji-privileged-recently-created-7d
+            - identity-kandji-terminated-active-account
+            - identity-kolide-active-no-employee-record
+            - identity-kolide-duplicate-email
+            - identity-kolide-missing-email
+            - identity-kolide-personal-email-domain
+            - identity-kolide-privileged-personal-email
+            - identity-kolide-privileged-stale-login-30d
+            - identity-kolide-stale-login-180d
+            - identity-kolide-stale-login-365d
+            - identity-kolide-stale-login-90d
+            - identity-kolide-terminated-active-account
+            - identity-okta-active-no-employee-record
+            - identity-okta-admin-mfa
+            - identity-okta-admin-no-mfa-granular
+            - identity-okta-admin-plus-app-owner
+            - identity-okta-api-token-created-30d
+            - identity-okta-api-token-revoked-30d
+            - identity-okta-authenticator-weak-factor-enabled
+            - identity-okta-duplicate-email
+            - identity-okta-duplicate-group-name
+            - identity-okta-duplicate-username
+            - identity-okta-group-description-missing
+            - identity-okta-group-grants-admin-app
+            - identity-okta-mfa-factor-reset-events-30d
+            - identity-okta-mfa-missing-active
+            - identity-okta-missing-email
+            - identity-okta-never-logged-in-30d
+            - identity-okta-never-logged-in-90d
+            - identity-okta-oauth-public-client-review-needed
+            - identity-okta-password-view-events-30d
+            - identity-okta-personal-email-domain
+            - identity-okta-privileged-no-mfa
+            - identity-okta-privileged-personal-email
+            - identity-okta-privileged-recently-created-7d
+            - identity-okta-privileged-stale-login-30d
+            - identity-okta-stale-app-assignment-30d
+            - identity-okta-stale-app-assignment-90d
+            - identity-okta-stale-group-membership-90d
+            - identity-okta-stale-login-180d
+            - identity-okta-stale-login-365d
+            - identity-okta-stale-login-90d
+            - identity-okta-superadmin-count
+            - identity-okta-terminated-active-account
+            - identity-okta-threat-insight-not-blocking
+            - identity-okta-unauthorized-app-access-attempts-7d
+            - identity-onelogin-active-no-employee-record
+            - identity-onelogin-duplicate-email
+            - identity-onelogin-duplicate-username
+            - identity-onelogin-missing-email
+            - identity-onelogin-never-logged-in-30d
+            - identity-onelogin-never-logged-in-90d
+            - identity-onelogin-personal-email-domain
+            - identity-onelogin-stale-login-180d
+            - identity-onelogin-stale-login-365d
+            - identity-onelogin-stale-login-90d
+            - identity-onelogin-terminated-active-account
+            - identity-oracle-idcs-active-no-employee-record
+            - identity-oracle-idcs-duplicate-email
+            - identity-oracle-idcs-duplicate-group-name
+            - identity-oracle-idcs-duplicate-membership-assignment
+            - identity-oracle-idcs-duplicate-username
+            - identity-oracle-idcs-empty-groups
+            - identity-oracle-idcs-group-description-missing
+            - identity-oracle-idcs-membership-inactive-user
+            - identity-oracle-idcs-membership-personal-email-domain
+            - identity-oracle-idcs-missing-email
+            - identity-oracle-idcs-orphaned-membership-group
+            - identity-oracle-idcs-orphaned-membership-user
+            - identity-oracle-idcs-personal-email-domain
+            - identity-oracle-idcs-terminated-active-account
+            - identity-panther-active-no-employee-record
+            - identity-panther-duplicate-email
+            - identity-panther-missing-email
+            - identity-panther-personal-email-domain
+            - identity-panther-privileged-personal-email
+            - identity-panther-privileged-recently-created-7d
+            - identity-panther-terminated-active-account
+            - identity-pingidentity-active-no-employee-record
+            - identity-pingidentity-duplicate-email
+            - identity-pingidentity-duplicate-group-name
+            - identity-pingidentity-duplicate-membership-assignment
+            - identity-pingidentity-duplicate-username
+            - identity-pingidentity-empty-groups
+            - identity-pingidentity-group-description-missing
+            - identity-pingidentity-membership-inactive-user
+            - identity-pingidentity-membership-personal-email-domain
+            - identity-pingidentity-missing-email
+            - identity-pingidentity-never-logged-in-30d
+            - identity-pingidentity-never-logged-in-90d
+            - identity-pingidentity-orphaned-membership-group
+            - identity-pingidentity-orphaned-membership-user
+            - identity-pingidentity-personal-email-domain
+            - identity-pingidentity-stale-login-180d
+            - identity-pingidentity-stale-login-365d
+            - identity-pingidentity-stale-login-90d
+            - identity-pingidentity-terminated-active-account
+            - identity-ramp-active-no-employee-record
+            - identity-ramp-duplicate-email
+            - identity-ramp-missing-email
+            - identity-ramp-personal-email-domain
+            - identity-ramp-privileged-personal-email
+            - identity-ramp-terminated-active-account
+            - identity-saas-mfa-enforced
+            - identity-sailpoint-active-no-employee-record
+            - identity-sailpoint-duplicate-email
+            - identity-sailpoint-duplicate-group-name
+            - identity-sailpoint-duplicate-membership-assignment
+            - identity-sailpoint-duplicate-username
+            - identity-sailpoint-empty-groups
+            - identity-sailpoint-group-description-missing
+            - identity-sailpoint-membership-inactive-user
+            - identity-sailpoint-membership-personal-email-domain
+            - identity-sailpoint-missing-email
+            - identity-sailpoint-orphaned-membership-group
+            - identity-sailpoint-orphaned-membership-user
+            - identity-sailpoint-personal-email-domain
+            - identity-sailpoint-terminated-active-account
+            - identity-salesforce-active-no-employee-record
+            - identity-salesforce-duplicate-email
+            - identity-salesforce-duplicate-username
+            - identity-salesforce-missing-email
+            - identity-salesforce-personal-email-domain
+            - identity-salesforce-privileged-personal-email
+            - identity-salesforce-privileged-recently-created-7d
+            - identity-salesforce-terminated-active-account
+            - identity-saviynt-active-no-employee-record
+            - identity-saviynt-duplicate-email
+            - identity-saviynt-duplicate-group-name
+            - identity-saviynt-duplicate-membership-assignment
+            - identity-saviynt-duplicate-username
+            - identity-saviynt-empty-groups
+            - identity-saviynt-group-description-missing
+            - identity-saviynt-membership-inactive-user
+            - identity-saviynt-membership-personal-email-domain
+            - identity-saviynt-missing-email
+            - identity-saviynt-orphaned-membership-group
+            - identity-saviynt-orphaned-membership-user
+            - identity-saviynt-personal-email-domain
+            - identity-saviynt-terminated-active-account
+            - identity-servicenow-active-no-employee-record
+            - identity-servicenow-duplicate-email
+            - identity-servicenow-duplicate-group-name
+            - identity-servicenow-duplicate-membership-assignment
+            - identity-servicenow-duplicate-username
+            - identity-servicenow-empty-groups
+            - identity-servicenow-group-description-missing
+            - identity-servicenow-membership-inactive-user
+            - identity-servicenow-missing-email
+            - identity-servicenow-never-logged-in-30d
+            - identity-servicenow-never-logged-in-90d
+            - identity-servicenow-orphaned-membership-group
+            - identity-servicenow-orphaned-membership-user
+            - identity-servicenow-personal-email-domain
+            - identity-servicenow-stale-login-180d
+            - identity-servicenow-stale-login-365d
+            - identity-servicenow-stale-login-90d
+            - identity-servicenow-terminated-active-account
+            - identity-slack-active-no-employee-record
+            - identity-slack-duplicate-email
+            - identity-slack-mfa-missing-active
+            - identity-slack-missing-email
+            - identity-slack-personal-email-domain
+            - identity-slack-privileged-no-mfa
+            - identity-slack-privileged-personal-email
+            - identity-slack-terminated-active-account
+            - identity-splunk-active-no-employee-record
+            - identity-splunk-duplicate-email
+            - identity-splunk-missing-email
+            - identity-splunk-personal-email-domain
+            - identity-splunk-terminated-active-account
+            - identity-tailscale-active-no-employee-record
+            - identity-tailscale-duplicate-email
+            - identity-tailscale-duplicate-username
+            - identity-tailscale-missing-email
+            - identity-tailscale-never-logged-in-30d
+            - identity-tailscale-never-logged-in-90d
+            - identity-tailscale-personal-email-domain
+            - identity-tailscale-privileged-personal-email
+            - identity-tailscale-privileged-recently-created-7d
+            - identity-tailscale-privileged-stale-login-30d
+            - identity-tailscale-stale-login-180d
+            - identity-tailscale-stale-login-365d
+            - identity-tailscale-stale-login-90d
+            - identity-tailscale-terminated-active-account
+            - identity-vanta-active-no-employee-record
+            - identity-vanta-duplicate-email
+            - identity-vanta-missing-email
+            - identity-vanta-personal-email-domain
+            - identity-vanta-privileged-personal-email
+            - identity-vanta-privileged-stale-login-30d
+            - identity-vanta-stale-login-180d
+            - identity-vanta-stale-login-365d
+            - identity-vanta-stale-login-90d
+            - identity-vanta-terminated-active-account
+            - identity-workday-active-no-employee-record
+            - identity-workday-duplicate-email
+            - identity-workday-duplicate-group-name
+            - identity-workday-duplicate-membership-assignment
+            - identity-workday-duplicate-username
+            - identity-workday-empty-groups
+            - identity-workday-membership-inactive-user
+            - identity-workday-missing-email
+            - identity-workday-orphaned-membership-group
+            - identity-workday-orphaned-membership-user
+            - identity-workday-personal-email-domain
+            - identity-workday-terminated-active-account
+            - identity-zoom-active-no-employee-record
+            - identity-zoom-duplicate-email
+            - identity-zoom-duplicate-group-name
+            - identity-zoom-duplicate-membership-assignment
+            - identity-zoom-empty-groups
+            - identity-zoom-membership-inactive-user
+            - identity-zoom-membership-personal-email-domain
+            - identity-zoom-missing-email
+            - identity-zoom-never-logged-in-30d
+            - identity-zoom-never-logged-in-90d
+            - identity-zoom-orphaned-membership-group
+            - identity-zoom-orphaned-membership-user
+            - identity-zoom-personal-email-domain
+            - identity-zoom-privileged-personal-email
+            - identity-zoom-privileged-recently-created-7d
+            - identity-zoom-privileged-stale-login-30d
+            - identity-zoom-stale-login-180d
+            - identity-zoom-stale-login-365d
+            - identity-zoom-stale-login-90d
+            - identity-zoom-terminated-active-account
+            - k8s-ingress-no-wildcard-host
+            - k8s-missing-pss
+            - k8s-namespace-missing-pss-label
+            - k8s-network-policy-selector-present
+            - k8s-pod-no-hostpath-volumes
+            - k8s-pod-no-privilege-escalation
+            - k8s-pod-seccomp-runtime-default
+            - k8s-service-loadbalancer-internal
+            - k8s-service-no-nodeport
+            - k8s-workload-not-default-namespace
+            - vpc-external-peering
+        - framework_name: SOC 2
+          family_id: CC6
+          family_name: Logical and Physical Access
+          control_id: CC6.2
+          mapped_rules:
+            - github-programmatic-credential-review-needed
+            - grc-inactive-identity-active-access
+            - grc-privileged-account-missing-person
+            - identity-account-deprovision
+            - identity-admin-privilege-granted
+            - identity-api-token-or-oauth-app-created
+            - identity-auth-control-lifecycle-tampering
+            - identity-external-or-personal-group-member
+            - identity-github-active-without-okta-link
+            - identity-mfa-factor-reset-or-disabled
+            - identity-offboarding-sla
+            - identity-okta-admin-privilege-grant-events-30d
+            - identity-okta-app-access-without-assignment
+            - identity-okta-deprovisioned-active-cloud-access
+            - identity-okta-deprovisioned-active-in-github
+            - identity-okta-external-user-internal-app
+            - identity-okta-idp-lifecycle-changes-30d
+            - identity-okta-network-zone-deactivation-30d
+            - identity-okta-network-zone-delete-events-30d
+            - identity-okta-network-zone-modify-events-30d
+            - identity-okta-org2org-lifecycle-change-30d
+            - identity-okta-policy-lifecycle-tampering-30d
+            - identity-okta-policy-rule-lifecycle-tampering
+            - identity-okta-policy-rule-lifecycle-tampering-30d
+            - identity-okta-support-session-impersonation-30d
+            - identity-privileged-account-without-mfa
+            - identity-privileged-no-mfa-plus-sensitive-access
+            - identity-stale-accounts-disabled
+            - identity-stale-privileged-account
+        - framework_name: SOC 2
+          family_id: CC6
+          family_name: Logical and Physical Access
+          control_id: CC6.3
+          mapped_rules:
+            - aws-iam-access-analyzer-enabled
+            - aws-iam-users-via-groups
+            - github-org-owner-role-review-needed
+            - identity-account-deprovision
+            - identity-offboarding-sla
+        - framework_name: SOC 2
+          family_id: CC6
+          family_name: Logical and Physical Access
+          control_id: CC6.4
+        - framework_name: SOC 2
+          family_id: CC6
+          family_name: Logical and Physical Access
+          control_id: CC6.5
+        - framework_name: SOC 2
+          family_id: CC6
+          family_name: Logical and Physical Access
+          control_id: CC6.6
+          mapped_rules:
+            - aws-default-sg-no-rules
+            - aws-ec2-public-ports-restricted
+            - aws-ecs-ports-restricted
+            - aws-ecs-ssh-denied
+            - aws-eks-private-endpoint
+            - aws-elb-target-public-subnet
+            - aws-lambda-in-vpc
+            - aws-nacl-admin-ports-restricted
+            - aws-sagemaker-training-no-vpc
+            - cloud-current-public-exposure-review-needed
+            - cloud-effective-admin-permission
+            - cloud-exposed-privileged-compute-role
+            - cloud-privilege-path-granted
+            - cloud-public-exposure-privileged-principal
+            - cloud-public-resource-exposure
+            - email-domain-authentication-misconfigured
+            - gcp-dns-dnssec
+            - gcp-gke-network-policy-enabled
+            - github-app-integration-installed
+            - github-code-security-controls-disabled
+            - github-org-auth-control-modified
+            - github-org-ip-allow-list-modified
+            - github-organization-owner-added
+            - github-personal-access-token-created
+            - github-private-repository-forking-enabled
+            - github-repository-collaborator-added
+            - github-repository-ruleset-modified
+            - github-secret-scanning-alert-created
+            - github-self-hosted-runner-review-needed
+            - github-webhook-modified
+            - grc-inactive-identity-active-access
+            - identity-github-active-without-okta-link
+            - identity-okta-deprovisioned-active-cloud-access
+            - k8s-ingress-no-wildcard-host
+            - k8s-missing-pss
+            - k8s-namespace-missing-pss-label
+            - k8s-network-policy-selector-present
+            - k8s-pod-no-hostpath-volumes
+            - k8s-pod-no-privilege-escalation
+            - k8s-pod-seccomp-runtime-default
+            - k8s-service-loadbalancer-internal
+            - k8s-service-no-nodeport
+            - k8s-workload-not-default-namespace
+            - sentinelone-agent-not-up-to-date
+            - sentinelone-agent-stale
+            - sentinelone-infected-endpoint-privileged-owner
+            - vpc-external-peering
+        - framework_name: SOC 2
+          family_id: CC6
+          family_name: Logical and Physical Access
+          control_id: CC6.7
+          mapped_rules:
+            - aws-s3-https-only
+            - azure-vm-unmanaged-disk
+            - bucket-sensitive-no-lock
+            - endpoint-disk-encryption
+            - endpoint-intune-disk-encryption
+            - endpoint-jamf-disk-encryption
+            - endpoint-kandji-disk-encryption
+        - framework_name: SOC 2
+          family_id: CC6
+          family_name: Logical and Physical Access
+          control_id: CC6.8
+          mapped_rules:
+            - endpoint-edr-installed
+            - endpoint-edr-reporting
+            - endpoint-kandji-edr-installed
+            - sentinelone-agent-detect-only-mode
+            - sentinelone-command-control
+            - sentinelone-malware
+            - sentinelone-protection-control-tampering
+            - sentinelone-risky-exclusion
+        - framework_name: SOC 2
+          family_id: CC7
+          family_name: System Operations
+          control_id: CC7
+          mapped_rules:
+            - aws-cloudtrail-enabled
+            - aws-cloudwatch-alarm-missing
+            - aws-cloudwatch-log-group-encrypted
+            - aws-cloudwatch-log-group-retention
+            - aws-codebuild-public-logs
+            - aws-config-enabled-all-regions
+            - aws-ec2-detailed-monitoring-enabled
+            - aws-eks-control-plane-logging
+            - aws-rds-logging-enabled
+            - aws-s3-bucket-logging-enabled
+            - aws-vpc-flow-logs-enabled
+            - azure-keyvault-logging
+            - azure-sql-auditing-enabled
+            - gcp-audit-logging-enabled
+            - gcp-logging-disabled
+            - github-repo-secrets-exposure
+            - ml-model-registry-no-versioning
+            - s3-read-logging-disabled
+            - s3-write-logging-disabled
+            - vpc-dns-logging
+            - vpc-no-dns-resolver-logging
+        - framework_name: SOC 2
+          family_id: CC7
+          family_name: System Operations
+          control_id: CC7.1
+          mapped_rules:
+            - aws-ecr-immutable-tags
+            - aws-guardduty-c2-traffic
+            - aws-guardduty-crypto-mining
+            - aws-guardduty-malware-finding
+            - aws-lambda-runtime-supported
+            - aws-rds-auto-minor-upgrade
+            - aws-security-hub-enabled
+            - azure-defender-storage
+            - azure-vm-approved-extensions-only
+            - container-eol-writable
+            - container-runtime-exec-detected
+            - finding-isolated-open-anchor
+            - gcp-compute-shielded-vm
+            - gcp-container-vuln-critical
+            - gcp-container-vuln-high
+            - gcp-container-vuln-low
+            - gcp-container-vuln-medium
+            - gcp-gke-auto-upgrade
+            - gcr-unscanned
+            - github-code-scanning-critical
+            - github-dependabot-critical-alert
+            - github-dependabot-high-alert
+            - github-dependabot-open-alert
+            - github-vuln-low
+            - github-vuln-medium
+            - gitlab-runner-unprotected-tags
+            - graph-aws-ec2-eni-link-missing
+            - graph-orphan-nonfinding-node
+            - graph-resource-multiple-open-findings
+            - grc-failing-control-open-operational-findings
+            - grc-isolated-target-enrichment-gap
+            - grc-overdue-vulnerability-live-on-assets
+            - grc-source-integration-concentrated-open-findings
+            - grc-vulnerability-sla-overdue
+            - k8s-cluster-unsupported-version
+            - k8s-pod-image-pinned-by-digest
+            - k8s-pod-image-tag-not-latest
+            - k8s-resource-no-deprecated-api
+            - ml-model-untrusted-source
+            - okta-suspicious-login
+            - security-reviewer-reported-finding
+            - sentinelone-threat-detected
+            - sentinelone-vuln-medium
+            - threat-intel-malicious-domain-resolution
+            - threat-intel-malicious-ip-connection
+            - vulnview-actionable-external-finding
+            - vulnview-external-asset-concentrated-signal
+        - framework_name: SOC 2
+          family_id: CC7
+          family_name: System Operations
+          control_id: CC7.2
+          mapped_rules:
+            - ai-model-monitoring
+            - aws-bedrock-model-no-guardrails
+            - aws-cloudtrail-s3-data-events
+            - aws-guardduty-c2-traffic
+            - aws-guardduty-crypto-mining
+            - aws-guardduty-malware-finding
+            - aws-guardduty-notifications
+            - aws-security-hub-enabled
+            - azure-defender-storage
+            - container-runtime-exec-detected
+            - gcp-cloud-ids-notifications
+            - grc-failing-control-open-operational-findings
+            - grc-failing-control-test-unhealthy-integration
+            - grc-overdue-vulnerability-live-on-assets
+            - identity-okta-account-lock-events-24h
+            - identity-okta-application-lifecycle-tampering-30d
+            - identity-okta-password-reset-or-unlock-attempt-spike-24h
+            - identity-okta-possible-dos-attack-1h
+            - identity-okta-rate-limit-violations-24h
+            - identity-okta-threatinsight-detected-30d
+            - identity-okta-user-reported-suspicious-activity-30d
+            - okta-suspicious-login
+            - panopticon-curated-case
+            - runtime-active-threat-evidence
+            - sentinelone-command-control
+            - sentinelone-endpoint-active-infection
+            - sentinelone-infected-endpoint-privileged-owner
+            - sentinelone-malware
+            - sentinelone-threat-detected
+            - sentinelone-unmitigated-threat
+            - threat-intel-malicious-domain-resolution
+            - threat-intel-malicious-ip-connection
+        - framework_name: SOC 2
+          family_id: CC7
+          family_name: System Operations
+          control_id: CC7.3
+          mapped_rules:
+            - aws-guardduty-c2-traffic
+            - aws-guardduty-crypto-mining
+            - aws-guardduty-malware-finding
+            - aws-guardduty-notifications
+            - azure-defender-storage
+            - compliance-ir-plan-exists
+            - compliance-p1-security-issues
+            - compliance-p2-security-issues
+            - container-runtime-exec-detected
+            - gcp-cloud-ids-notifications
+            - okta-suspicious-login
+            - sentinelone-mitigation-failed
+            - sentinelone-threat-detected
+            - threat-intel-malicious-domain-resolution
+            - threat-intel-malicious-ip-connection
+        - framework_name: SOC 2
+          family_id: CC7
+          family_name: System Operations
+          control_id: CC7.4
+          mapped_rules:
+            - ai-incident-response
+            - aws-guardduty-c2-traffic
+            - aws-guardduty-crypto-mining
+            - aws-guardduty-malware-finding
+            - compliance-ir-plan-exists
+            - compliance-p1-security-issues
+            - container-runtime-exec-detected
+            - sentinelone-threat-detected
+            - threat-intel-malicious-domain-resolution
+            - threat-intel-malicious-ip-connection
+        - framework_name: SOC 2
+          family_id: CC7
+          family_name: System Operations
+          control_id: CC7.5
+          mapped_rules:
+            - aws-guardduty-c2-traffic
+            - aws-guardduty-crypto-mining
+            - aws-guardduty-malware-finding
+            - compliance-ir-plan-exists
+            - container-runtime-exec-detected
+            - sentinelone-threat-detected
+            - threat-intel-malicious-domain-resolution
+            - threat-intel-malicious-ip-connection
+        - framework_name: SOC 2
+          family_id: CC8
+          family_name: Change Management
+          control_id: CC8.1
+          mapped_rules:
+            - aws-ecr-immutable-tags
+            - gitlab-runner-unprotected-tags
+            - k8s-pod-image-pinned-by-digest
+            - k8s-pod-image-tag-not-latest
+            - ml-model-untrusted-source
+        - framework_name: SOC 2
+          family_id: CC9
+          family_name: Risk Mitigation
+          control_id: CC9.1
+        - framework_name: SOC 2
+          family_id: CC9
+          family_name: Risk Mitigation
+          control_id: CC9.2
+          mapped_rules:
+            - grc-vendor-review-overdue
+            - vendor-dpa-exists
+            - vendor-risk-assessed
+            - vendor-security-review-complete
+      rules:
+        - rule_id: account-lateral-dormant
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: admin-inactive-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: admin-keys-unrotated
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: admin-keys-year-unrotated
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: ai-agent-lambda-data-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: ai-bias-testing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.4
+        - rule_id: ai-data-governance
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: ai-explainability
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.4
+        - rule_id: ai-incident-response
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.4
+        - rule_id: ai-model-excessive-agency
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: ai-model-inventory
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: ai-model-monitoring
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: ai-model-third-party-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: ai-risk-assessment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC3.2
+        - rule_id: aws-alb-http-to-https
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: aws-api-gateway-no-authorization
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-apigateway-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-bedrock-custom-model-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-bedrock-model-no-guardrails
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: aws-cloudtrail-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: aws-cloudtrail-kms-encryption
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: aws-cloudtrail-log-integrity
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: aws-cloudtrail-s3-data-events
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: aws-cloudwatch-alarm-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: aws-cloudwatch-log-group-encrypted
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: aws-cloudwatch-log-group-retention
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: aws-codebuild-privileged-mode
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-codebuild-public-logs
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC6
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: aws-codebuild-public-trigger
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-config-enabled-all-regions
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: aws-default-sg-no-rules
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: aws-dynamodb-pitr
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: aws-ec2-ami-not-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-ec2-detailed-monitoring-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: aws-ec2-ebs-snapshot-not-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-ec2-iam-instance-profile
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: aws-ec2-instance-profile-attached
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-ec2-internet-facing-iam
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-ec2-public-ip-rdp
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-ec2-public-ip-ssh
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-ec2-public-ports-restricted
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: aws-ec2-sg-no-all-traffic-ingress
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-ecr-immutable-tags
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC8.1
+        - rule_id: aws-ecr-public-repository
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-ecs-ports-restricted
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: aws-ecs-secrets-in-env-vars
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-ecs-ssh-denied
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: aws-eks-control-plane-logging
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: aws-eks-private-endpoint
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: aws-eks-public-endpoint-disabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-elasticache-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-elb-internet-facing-no-waf
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-elb-target-public-subnet
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: aws-guardduty-c2-traffic
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+            - framework_name: SOC 2
+              control_id: CC7.4
+            - framework_name: SOC 2
+              control_id: CC7.5
+        - rule_id: aws-guardduty-crypto-mining
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+            - framework_name: SOC 2
+              control_id: CC7.4
+            - framework_name: SOC 2
+              control_id: CC7.5
+        - rule_id: aws-guardduty-malware-finding
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+            - framework_name: SOC 2
+              control_id: CC7.4
+            - framework_name: SOC 2
+              control_id: CC7.5
+        - rule_id: aws-guardduty-notifications
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+        - rule_id: aws-iam-access-analyzer-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.3
+        - rule_id: aws-iam-access-key-rotation
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-expired-certificates
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: aws-iam-no-full-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: aws-iam-no-policies-attached-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-password-policy
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-policy-no-admin-star
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-role-confused-deputy-prevention
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-role-cross-account-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-role-trust-any-principal
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-role-wildcard-trust
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-root-mfa-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-root-no-access-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-saml-provider-stale
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-service-account-open-assume
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-single-access-key
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: aws-iam-user-console-inactive
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-user-mfa-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-user-multiple-access-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-user-unused-credentials
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-iam-users-via-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.3
+        - rule_id: aws-lambda-in-vpc
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: aws-lambda-not-publicly-accessible
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-lambda-runtime-supported
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: aws-lambda-secrets-in-env-vars
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-logs-retention-365
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: aws-nacl-admin-ports-restricted
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: aws-opensearch-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-password-policy-minimum-length
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: aws-password-policy-no-reuse
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: aws-rds-auto-minor-upgrade
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: aws-rds-backup-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: aws-rds-deletion-protection
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: aws-rds-iam-authentication
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-rds-logging-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: aws-rds-no-public-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-rds-public-snapshot
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-redshift-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-s3-bucket-cleartext-key
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-s3-bucket-logging-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC6
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: aws-s3-bucket-no-public-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-s3-bucket-policy-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-s3-bucket-versioning-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: aws-s3-https-only
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.7
+        - rule_id: aws-s3-public-write
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-sagemaker-model-artifact-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-sagemaker-notebook-internet-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-sagemaker-notebook-root-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-sagemaker-training-no-vpc
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: aws-secretsmanager-secret-used
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-security-group-restrict-rdp
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-security-group-restrict-ssh
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-security-hub-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: aws-sns-public-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-sqs-public-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-user-data-no-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-user-inactive-admin-no-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-user-inactive-data-no-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: aws-vpc-flow-logs-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: azure-ad-guest-access-restricted
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-aks-rbac-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-cosmosdb-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-cosmosdb-public-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-defender-storage
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+        - rule_id: azure-function-anonymous-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-function-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-keyvault-logging
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: azure-ml-workspace-public-network
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-nsg-admin-port
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-nsg-restrict-ssh
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-openai-public-network
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-sql-auditing-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: azure-sql-public-network-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-sqlserver-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-storage-blob-public-access-disabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-storage-network-allow
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-storage-network-default-deny
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-storage-public-write
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-storage-secrets-artifact
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-vm-approved-extensions-only
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: azure-vm-public-ip-rdp
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-vm-public-ip-ssh
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: azure-vm-unmanaged-disk
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.7
+        - rule_id: backup-encryption
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: backup-offsite
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: backup-retention
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: backup-rpo-compliance
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: backup-testing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: bedrock-excessive-permissions
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: bucket-cleartext-admin-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: bucket-cleartext-keys-data
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: bucket-dormant-principal
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: bucket-keys-excessive-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: bucket-public-large-files
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: bucket-public-low-exposure
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: bucket-public-sensitive
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: bucket-sensitive-no-lock
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.7
+        - rule_id: cert-expired
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: cert-expiry-30-days
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: cert-self-signed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: cert-weak-key
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: cert-weak-signature
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: cloud-current-public-exposure-review-needed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: cloud-effective-admin-permission
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: cloud-exposed-privileged-compute-role
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: cloud-privilege-path-granted
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: cloud-public-exposure-privileged-principal
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: cloud-public-resource-exposure
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: compliance-background-checks
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: compliance-gdpr-policy
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: compliance-inventory-data-tracking
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: compliance-inventory-owners
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: compliance-ir-gdpr-addendum
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: compliance-ir-plan-exists
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.3
+            - framework_name: SOC 2
+              control_id: CC7.4
+            - framework_name: SOC 2
+              control_id: CC7.5
+        - rule_id: compliance-p1-security-issues
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.3
+            - framework_name: SOC 2
+              control_id: CC7.4
+        - rule_id: compliance-p2-security-issues
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.3
+        - rule_id: compliance-risk-assessment-annual
+          controls:
+            - framework_name: SOC 2
+              control_id: CC3.1
+            - framework_name: SOC 2
+              control_id: CC3.2
+        - rule_id: compliance-security-training
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: container-cleartext-cloud-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: container-cross-account-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: container-eol-writable
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: container-host-network
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: container-image-cleartext-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: container-image-scan
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: container-privileged
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: container-readonly-fs
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: container-resource-limits
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: container-root-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: container-runtime-exec-detected
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+            - framework_name: SOC 2
+              control_id: CC7.4
+            - framework_name: SOC 2
+              control_id: CC7.5
+        - rule_id: cross-provider-dormant-privileged
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: cross-provider-privileged-access-no-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: cve-2023-20867
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: cve-2023-4863
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: cve-2024-21626
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: cve-2024-6387
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: data-access-keys-unrotated
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: data-resource-excessive-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: data-resource-org-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: data-sensitive-asset-risk
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: db-audit-logging
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: db-backup-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: db-dormant-principal
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: db-encryption-at-rest
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: db-multi-az
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: db-public-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: db-ssl-connections
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: dirty-pipe-privileged
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: efs-public-subnet
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: email-domain-authentication-misconfigured
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: endpoint-disk-encryption
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.7
+        - rule_id: endpoint-edr-installed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.8
+        - rule_id: endpoint-edr-reporting
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.8
+        - rule_id: endpoint-intune-disk-encryption
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.7
+        - rule_id: endpoint-intune-noncompliant
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: endpoint-jamf-disk-encryption
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.7
+        - rule_id: endpoint-jamf-screenlock
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: endpoint-kandji-disk-encryption
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.7
+        - rule_id: endpoint-kandji-edr-installed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.8
+        - rule_id: endpoint-kandji-password-manager
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: endpoint-malware-detection
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: endpoint-mdm-enrolled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: endpoint-password-manager
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: endpoint-screenlock-configured
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: endpoint-sentinelone-active
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: exposed-saas-api-token
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: finding-isolated-open-anchor
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: gcp-audit-logging-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: gcp-bigquery-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-bigquery-public-dataset
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-bucket-public-write
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-bucket-secrets
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-cloud-ids-notifications
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+        - rule_id: gcp-cloudrun-default-service-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-cloudrun-public-ingress
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-cloudsql-no-public-ip
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-compute-metadata-v1
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: gcp-compute-no-default-service-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-compute-no-public-ip
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-compute-public-ssh
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-compute-serial-port-disabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-compute-shielded-vm
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: gcp-container-vuln-critical
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: gcp-container-vuln-high
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: gcp-container-vuln-low
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: gcp-container-vuln-medium
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: gcp-dns-dnssec
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: gcp-external-domain-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-firewall-admin-port
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-gke-auto-upgrade
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: gcp-gke-default-sa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-gke-metadata-server
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: gcp-gke-network-policy-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: gcp-gke-private-cluster
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-gke-secrets-kms-encryption
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: gcp-iam-binding-no-allAuthenticatedUsers
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-iam-binding-no-allUsers
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-iam-minimize-user-managed-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-iam-sa-no-admin-privileges
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-kms-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-log-sink-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: gcp-logging-disabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: gcp-sa-admin-privileges
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-sa-admin-user-combined
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-sa-impersonation
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-sa-no-full-project-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-service-account-key-rotation
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-sql-backup-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: gcp-storage-bucket-no-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-storage-no-public-allusers
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-storage-uniform-bucket-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-vertex-ai-dataset-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcp-vertex-ai-public-endpoint
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcr-excessive-privileges
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gcr-unscanned
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: github-actions-self-hosted-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: github-admin-without-2fa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: github-app-integration-installed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-automated-checks
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: github-branch-protection-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: github-code-scanning-critical
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: github-code-security-controls-disabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-dependabot-critical-alert
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: github-dependabot-high-alert
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: github-dependabot-open-alert
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: github-oidc-overly-permissive
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: github-org-auth-control-modified
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-org-ip-allow-list-modified
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-org-owner-role-review-needed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.3
+        - rule_id: github-org-workflow-permissions
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: github-organization-owner-added
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-personal-access-token-created
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-private-repository-forking-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-programmatic-credential-review-needed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: github-public-repo-branch-protection
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: github-repo-internal-exposed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: github-repo-secrets-exposure
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: github-repository-collaborator-added
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-repository-ruleset-modified
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-runner-group-scope
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: github-runner-public-repo
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: github-secret-scanning-alert
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: github-secret-scanning-alert-created
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-self-hosted-runner-review-needed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-vuln-low
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: github-vuln-medium
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: github-webhook-modified
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: github-workflow-write-permissions
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gitlab-runner-unprotected-tags
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC8.1
+        - rule_id: gke-cluster-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gke-pod-create
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: gke-wildcard-permissions
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: graph-aws-ec2-eni-link-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: graph-orphan-nonfinding-node
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: graph-resource-multiple-open-findings
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: grc-control-missing-evidence-coverage
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.2
+        - rule_id: grc-control-test-needs-attention
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.2
+        - rule_id: grc-document-needs-owner-or-upload
+          controls:
+            - framework_name: SOC 2
+              control_id: CC2.2
+        - rule_id: grc-failing-control-open-operational-findings
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: grc-failing-control-test-unhealthy-integration
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: grc-inactive-identity-active-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: grc-isolated-target-enrichment-gap
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: grc-overdue-vulnerability-live-on-assets
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: grc-privileged-account-missing-person
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: grc-source-integration-concentrated-open-findings
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: grc-vendor-review-overdue
+          controls:
+            - framework_name: SOC 2
+              control_id: CC9.2
+        - rule_id: grc-vulnerability-sla-overdue
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: group-excessive-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: group-excessive-data-priv
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: group-excessive-high-priv
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: iam-inactive-privileged-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: iam-unknown-account-trusted
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: identity-account-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+            - framework_name: SOC 2
+              control_id: CC6.3
+        - rule_id: identity-admin-privilege-granted
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-api-token-or-oauth-app-created
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-atlassian-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-atlassian-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-atlassian-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-atlassian-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-atlassian-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-atlassian-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-atlassian-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-atlassian-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-atlassian-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-auth-control-lifecycle-tampering
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-auth0-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-auth0-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-auth0-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-auth0-never-logged-in-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-auth0-never-logged-in-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-auth0-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-auth0-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-auth0-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-auth0-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-auth0-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-cyberark-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-membership-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-cyberark-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-duo-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-never-logged-in-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-never-logged-in-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-duo-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-mfa-missing-active
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-never-logged-in-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-never-logged-in-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-privileged-no-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-privileged-recently-created-7d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-privileged-stale-login-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-risky-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-risky-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-risky-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-risky-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-risky-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-risky-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-entra-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-external-or-personal-group-member
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-forgerock-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-forgerock-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-membership-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-forgerock-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-active-without-okta-link
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: identity-github-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-github-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-member-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-mfa-missing-active
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-privileged-no-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-runner-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-github-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-gong-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-gong-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-gong-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-gong-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-gong-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-admin-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-group-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-membership-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-mfa-missing-active
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-never-logged-in-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-never-logged-in-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-privileged-no-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-privileged-recently-created-7d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-privileged-stale-login-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-google-workspace-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jamf-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jamf-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jamf-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jamf-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jamf-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jamf-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-jumpcloud-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-group-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-membership-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-mfa-missing-active
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-jumpcloud-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kandji-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kandji-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kandji-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kandji-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kandji-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kandji-privileged-recently-created-7d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kandji-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kolide-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kolide-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kolide-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kolide-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kolide-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kolide-privileged-stale-login-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kolide-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kolide-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kolide-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-kolide-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-mfa-factor-reset-or-disabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-offboarding-sla
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+            - framework_name: SOC 2
+              control_id: CC6.3
+        - rule_id: identity-office365-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-okta-account-lock-events-24h
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: identity-okta-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-admin-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-admin-no-mfa-granular
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-admin-plus-app-owner
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-admin-privilege-grant-events-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-api-token-created-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-api-token-revoked-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-app-access-without-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-application-lifecycle-tampering-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: identity-okta-authenticator-weak-factor-enabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-deprovisioned-active-cloud-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: identity-okta-deprovisioned-active-in-github
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-external-user-internal-app
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-group-grants-admin-app
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-idp-lifecycle-changes-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-mfa-factor-reset-events-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-mfa-missing-active
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-network-zone-deactivation-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-network-zone-delete-events-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-network-zone-modify-events-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-never-logged-in-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-never-logged-in-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-oauth-public-client-review-needed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-org2org-lifecycle-change-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-password-reset-or-unlock-attempt-spike-24h
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: identity-okta-password-view-events-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-policy-lifecycle-tampering-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-policy-rule-lifecycle-tampering
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-policy-rule-lifecycle-tampering-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-possible-dos-attack-1h
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: identity-okta-privileged-no-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-privileged-recently-created-7d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-privileged-stale-login-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-rate-limit-violations-24h
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: identity-okta-stale-app-assignment-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-stale-app-assignment-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-stale-group-membership-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-superadmin-count
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-support-session-impersonation-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-okta-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-threat-insight-not-blocking
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-threatinsight-detected-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: identity-okta-unauthorized-app-access-attempts-7d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-okta-user-reported-suspicious-activity-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: identity-onelogin-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-onelogin-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-onelogin-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-onelogin-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-onelogin-never-logged-in-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-onelogin-never-logged-in-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-onelogin-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-onelogin-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-onelogin-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-onelogin-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-onelogin-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-oracle-idcs-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-membership-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-oracle-idcs-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-panther-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-panther-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-panther-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-panther-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-panther-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-panther-privileged-recently-created-7d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-panther-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-pingidentity-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-membership-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-never-logged-in-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-never-logged-in-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-pingidentity-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-privileged-account-without-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-privileged-no-mfa-plus-sensitive-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-ramp-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-ramp-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-ramp-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-ramp-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-ramp-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-ramp-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saas-mfa-enforced
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-sailpoint-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-membership-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-sailpoint-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-salesforce-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-salesforce-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-salesforce-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-salesforce-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-salesforce-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-salesforce-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-salesforce-privileged-recently-created-7d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-salesforce-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-saviynt-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-membership-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-saviynt-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-group-description-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-never-logged-in-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-never-logged-in-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-servicenow-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-slack-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-slack-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-slack-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-slack-mfa-missing-active
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-slack-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-slack-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-slack-privileged-no-mfa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-slack-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-slack-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-splunk-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-splunk-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-splunk-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-splunk-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-splunk-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-stale-accounts-disabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-stale-privileged-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.2
+        - rule_id: identity-tailscale-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-deprovision
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: identity-tailscale-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-never-logged-in-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-never-logged-in-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-privileged-recently-created-7d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-privileged-stale-login-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-tailscale-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-vanta-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-vanta-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-vanta-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-vanta-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-vanta-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-vanta-privileged-stale-login-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-vanta-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-vanta-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-vanta-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-vanta-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-duplicate-username
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-workday-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-active-no-employee-record
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-duplicate-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-duplicate-group-name
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-duplicate-membership-assignment
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-empty-groups
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-membership-inactive-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-membership-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-missing-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-never-logged-in-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-never-logged-in-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-orphaned-membership-group
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-orphaned-membership-user
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-personal-email-domain
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-privileged-personal-email
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-privileged-recently-created-7d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-privileged-stale-login-30d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-stale-login-180d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-stale-login-365d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-stale-login-90d
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: identity-zoom-terminated-active-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+        - rule_id: internal-vm-cross-account-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-cluster-admin-wildcard
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-cluster-unsupported-version
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: k8s-ingress-no-wildcard-host
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: k8s-ingress-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-missing-pss
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: k8s-namespace-missing-pss-label
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: k8s-network-policy-selector-present
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: k8s-node-public-exposure
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-pod-create
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-pod-image-pinned-by-digest
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC8.1
+        - rule_id: k8s-pod-image-tag-not-latest
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC8.1
+        - rule_id: k8s-pod-no-hostpath-volumes
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: k8s-pod-no-privilege-escalation
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: k8s-pod-no-privileged
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-pod-seccomp-runtime-default
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: k8s-rbac-cluster-admin-used
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-rbac-high-risk-binding
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-rbac-medium-risk-binding
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-rbac-pod-create-privileges
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-rbac-secret-read-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-rbac-wildcard-permissions-assigned
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-resource-no-deprecated-api
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: k8s-role-wildcard-permissions
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-service-account-token-mount
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-service-external-ip
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-service-loadbalancer-internal
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: k8s-service-no-nodeport
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: k8s-wildcard-permissions
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: k8s-workload-not-default-namespace
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: log4shell-privileged
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: log4shell-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: m365-conditional-access-disabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: m365-dlp-policy-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: m365-email-security-baseline
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: m365-file-shared-externally
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: m365-global-admin-count
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: m365-guest-access-review
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: m365-guest-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: m365-inactive-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: m365-inactive-users
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: m365-legacy-auth-signins
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: m365-mfa-required
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: m365-onedrive-sharing-restrictions
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: m365-privileged-roles-pim
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: m365-risky-users
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: m365-sensitivity-labels-missing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: m365-sharepoint-anonymous-link
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: m365-stale-service-principal
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: m365-terminated-users-active
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: ml-model-registry-no-versioning
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: ml-model-untrusted-source
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC8.1
+        - rule_id: mlops-public-vuln
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: network-default-deny
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: network-dns-security
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: network-ids-coverage
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: network-segmentation
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: network-unused-ports
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: notebook-excessive-agency
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: okta-admin-dormant
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: okta-suspicious-login
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+        - rule_id: panopticon-curated-case
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: privileged-inactive-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: privileged-keys-unrotated
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: public-resource-cleartext-admin-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: public-resource-cleartext-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: public-resource-cross-account-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: public-resource-keys-data-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: public-saas-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: public-vm-cross-account-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: ray-ai-public
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: resource-cleartext-keys-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: resource-cleartext-keys-privileged
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: runtime-active-threat-evidence
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: s3-read-logging-disabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: s3-write-logging-disabled
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: sa-external-principal-assume
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: sa-external-web-identity
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: sa-inactive-assigned
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: sa-inactive-privileged
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: sa-lateral-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: saas-token-exposed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: same-user-approve-execute
+          controls:
+            - framework_name: SOC 2
+              control_id: CC5.2
+            - framework_name: SOC 2
+              control_id: CC5.3
+        - rule_id: secrets-access-audit
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: secrets-least-privilege
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: secrets-rotation
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: secrets-vault-storage
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: security-reviewer-reported-finding
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: sentinelone-agent-detect-only-mode
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.8
+        - rule_id: sentinelone-agent-not-up-to-date
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: sentinelone-agent-stale
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: sentinelone-command-control
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.8
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: sentinelone-endpoint-active-infection
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: sentinelone-infected-endpoint-privileged-owner
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.6
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: sentinelone-malware
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.8
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: sentinelone-mitigation-failed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.3
+        - rule_id: sentinelone-protection-control-tampering
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.8
+        - rule_id: sentinelone-risky-exclusion
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.8
+        - rule_id: sentinelone-threat-detected
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+            - framework_name: SOC 2
+              control_id: CC7.4
+            - framework_name: SOC 2
+              control_id: CC7.5
+        - rule_id: sentinelone-unmitigated-threat
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
+        - rule_id: sentinelone-vuln-medium
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: serverless-public-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: serverless-public-high-priv
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: serverless-unauth-privileged
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: serverless-unauthenticated-invocation
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: storage-key-exposed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: terraform-cloud-no-team-access-control
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: third-party-sa-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: third-party-sa-privileged
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: threat-intel-malicious-domain-resolution
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+            - framework_name: SOC 2
+              control_id: CC7.4
+            - framework_name: SOC 2
+              control_id: CC7.5
+        - rule_id: threat-intel-malicious-ip-connection
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.2
+            - framework_name: SOC 2
+              control_id: CC7.3
+            - framework_name: SOC 2
+              control_id: CC7.4
+            - framework_name: SOC 2
+              control_id: CC7.5
+        - rule_id: tls-version-outdated
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: tls-weak-ciphers
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: unknown-account-trusted
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: user-data-access-unused-password
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: user-excessive-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: user-excessive-data-priv
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: user-excessive-high-priv
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: user-lateral-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: user-privileged-access-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: user-privileged-unused-password
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vendor-auth-method
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: vendor-dpa-exists
+          controls:
+            - framework_name: SOC 2
+              control_id: CC9.2
+        - rule_id: vendor-pci-compliance
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: vendor-risk-assessed
+          controls:
+            - framework_name: SOC 2
+              control_id: CC9.2
+        - rule_id: vendor-security-review-complete
+          controls:
+            - framework_name: SOC 2
+              control_id: CC9.2
+        - rule_id: vm-cleartext-cloud-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-cleartext-keys-cross-account
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-dormant-sa
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-internet-vuln-privileged
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-medium-exposure-vuln-data
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-public-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-public-data-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-public-eol
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-public-eol-targeted
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-public-high-priv
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-public-high-privileges
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-public-privileged-vuln-common-dep
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-public-vuln
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-public-vuln-common-dep
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-public-vuln-cross-account-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-ssh-private-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-vuln-cleartext-keys
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-vuln-data-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-vuln-keys-data-access
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vm-vuln-lateral-admin
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6
+        - rule_id: vpc-dns-logging
+          controls:
+            - framework_name: SOC 2
+              control_id: CC4
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: vpc-external-peering
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
+            - framework_name: SOC 2
+              control_id: CC6.6
+        - rule_id: vpc-no-dns-resolver-logging
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7
+        - rule_id: vuln-aging-report
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: vuln-critical-sla
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: vuln-epss-high
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: vuln-high-sla
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: vuln-known-exploited
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: vuln-medium-sla
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: vuln-public-facing
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.1
+        - rule_id: vulnview-actionable-external-finding
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+        - rule_id: vulnview-external-asset-concentrated-signal
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.1
+      unmapped_controls:
+        - framework_name: SOC 2
+          control_id: CC1.3
+        - framework_name: SOC 2
+          control_id: CC1.5
+        - framework_name: SOC 2
+          control_id: CC2.1
+        - framework_name: SOC 2
+          control_id: CC2.3
+        - framework_name: SOC 2
+          control_id: CC3.3
+        - framework_name: SOC 2
+          control_id: CC3.4
+        - framework_name: SOC 2
+          control_id: CC4.2
+        - framework_name: SOC 2
+          control_id: CC5.1
+        - framework_name: SOC 2
+          control_id: CC6.4
+        - framework_name: SOC 2
+          control_id: CC6.5
+        - framework_name: SOC 2
+          control_id: CC9.1

--- a/internal/compliance/control_profiles.yaml
+++ b/internal/compliance/control_profiles.yaml
@@ -1,0 +1,52 @@
+version: "2026-06-17"
+profiles:
+  - id: soc2-security-core
+    name: SOC 2 Security Core
+    description: Security audit scope covering control environment, communication, risk assessment, monitoring, access, operations, change, and risk mitigation.
+    frameworks:
+      - name: SOC 2
+        families: [CC1, CC2, CC3, CC4, CC5, CC6, CC7, CC8, CC9]
+  - id: soc2-availability
+    name: SOC 2 Availability
+    description: Availability controls for uptime, capacity, continuity, and operational resilience reviews.
+    frameworks:
+      - name: SOC 2
+        families: [A1]
+  - id: iso-technology-controls
+    name: ISO Technology Controls
+    description: Technology implementation controls for access, operations, logging, vulnerability management, and secure configuration evidence.
+    frameworks:
+      - name: "ISO 27001:2022"
+        families: [A.8]
+  - id: cloud-security-benchmarks
+    name: Cloud Security Benchmarks
+    description: Cloud and workload configuration controls for account management, vulnerability management, logging, network defense, and benchmark posture.
+    frameworks:
+      - name: CIS Controls v8
+        families: ["4", "5", "6", "7", "8", "12", "13"]
+      - name: CIS AWS Foundations Benchmark v2.0
+        include_all: true
+      - name: CIS Kubernetes Benchmark
+        include_all: true
+      - name: CIS GKE Benchmark v1.4
+        include_all: true
+      - name: CIS EKS Benchmark v1.3
+        include_all: true
+  - id: pci-operational-security
+    name: PCI Operational Security
+    description: Network, system, identity, logging, testing, and security program controls commonly used for payment-environment evidence review.
+    frameworks:
+      - name: PCI DSS v4.0.1
+        families: ["1", "6", "7", "8", "10", "11", "12"]
+  - id: privacy-ai-governance
+    name: Privacy and AI Governance
+    description: Privacy and AI governance controls for data handling, governance accountability, and AI system oversight reviews.
+    frameworks:
+      - name: GDPR
+        include_all: true
+      - name: CCPA
+        include_all: true
+      - name: "ISO 27701:2025"
+        families: [A.1, A.2, A.3]
+      - name: ISO 42001
+        families: ["6", "7", "8", "9", "10", A.2, A.3, A.4, A.5, A.6, A.7, A.8, A.9, A.10]

--- a/internal/compliance/profile.go
+++ b/internal/compliance/profile.go
@@ -1,0 +1,233 @@
+package compliance
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const DefaultControlProfilesPath = "internal/compliance/control_profiles.yaml"
+const DefaultControlCoverageIndexPath = "internal/compliance/control_coverage_index.yaml"
+
+type ControlProfileSet struct {
+	Version  string             `json:"version" yaml:"version"`
+	Profiles []ControlSelection `json:"profiles" yaml:"profiles"`
+}
+
+type ControlProfileResolution struct {
+	Version  string                   `json:"version" yaml:"version"`
+	Profiles []ResolvedControlProfile `json:"profiles" yaml:"profiles"`
+}
+
+type ResolvedControlProfile struct {
+	Profile    ControlSelection    `json:"profile" yaml:"profile"`
+	Resolution SelectionResolution `json:"resolution" yaml:"resolution"`
+}
+
+type ControlCoverageIndex struct {
+	Version  string                   `json:"version" yaml:"version"`
+	Profiles []ControlCoverageProfile `json:"profiles" yaml:"profiles"`
+}
+
+type ControlCoverageProfile struct {
+	ID               string                   `json:"id" yaml:"id"`
+	Name             string                   `json:"name,omitempty" yaml:"name,omitempty"`
+	Description      string                   `json:"description,omitempty" yaml:"description,omitempty"`
+	Summary          ControlCoverageSummary   `json:"summary" yaml:"summary"`
+	Controls         []ControlCoverageControl `json:"controls,omitempty" yaml:"controls,omitempty"`
+	Rules            []ControlCoverageRule    `json:"rules,omitempty" yaml:"rules,omitempty"`
+	UnmappedControls []ControlRef             `json:"unmapped_controls,omitempty" yaml:"unmapped_controls,omitempty"`
+}
+
+type ControlCoverageSummary struct {
+	SelectedControls int `json:"selected_controls" yaml:"selected_controls"`
+	MappedControls   int `json:"mapped_controls" yaml:"mapped_controls"`
+	UnmappedControls int `json:"unmapped_controls" yaml:"unmapped_controls"`
+	MappedRules      int `json:"mapped_rules" yaml:"mapped_rules"`
+}
+
+type ControlCoverageControl struct {
+	FrameworkID            string   `json:"framework_id,omitempty" yaml:"framework_id,omitempty"`
+	FrameworkName          string   `json:"framework_name" yaml:"framework_name"`
+	FrameworkVersion       string   `json:"framework_version,omitempty" yaml:"framework_version,omitempty"`
+	FamilyID               string   `json:"family_id" yaml:"family_id"`
+	FamilyName             string   `json:"family_name" yaml:"family_name"`
+	ControlID              string   `json:"control_id" yaml:"control_id"`
+	Title                  string   `json:"title,omitempty" yaml:"title,omitempty"`
+	OwnerDomain            string   `json:"owner_domain,omitempty" yaml:"owner_domain,omitempty"`
+	Tags                   []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	EvidenceExpectationIDs []string `json:"evidence_expectation_ids,omitempty" yaml:"evidence_expectation_ids,omitempty"`
+	MappedRules            []string `json:"mapped_rules,omitempty" yaml:"mapped_rules,omitempty"`
+}
+
+type ControlCoverageRule struct {
+	RuleID   string       `json:"rule_id" yaml:"rule_id"`
+	Controls []ControlRef `json:"controls" yaml:"controls"`
+}
+
+func LoadControlProfileSetFile(path string) (ControlProfileSet, error) {
+	content, err := readLocalYAMLFile(path) // #nosec G304 -- control profile path is an operator-provided local YAML file; readLocalYAMLFile rejects symlinks.
+	if err != nil {
+		return ControlProfileSet{}, err
+	}
+	return LoadControlProfileSet(content)
+}
+
+func LoadControlProfileSet(content []byte) (ControlProfileSet, error) {
+	var set ControlProfileSet
+	if err := yaml.Unmarshal(content, &set); err != nil {
+		return ControlProfileSet{}, err
+	}
+	return set, nil
+}
+
+func ResolveControlProfiles(index *CatalogIndex, set ControlProfileSet) (ControlProfileResolution, []ValidationIssue) {
+	result := ControlProfileResolution{Version: strings.TrimSpace(set.Version)}
+	issues := validateControlProfileSet(set)
+	for _, profile := range set.Profiles {
+		resolution, resolutionIssues := ResolveControlSelection(index, profile)
+		for _, issue := range resolutionIssues {
+			issue.Path = profileIssuePath(profile.ID, issue.Path)
+			issues = append(issues, issue)
+		}
+		result.Profiles = append(result.Profiles, ResolvedControlProfile{
+			Profile:    profile,
+			Resolution: resolution,
+		})
+	}
+	sort.Slice(result.Profiles, func(i, j int) bool {
+		return strings.TrimSpace(result.Profiles[i].Profile.ID) < strings.TrimSpace(result.Profiles[j].Profile.ID)
+	})
+	return result, issues
+}
+
+func BuildControlCoverageIndex(index *CatalogIndex, set ControlProfileSet, rules []RuleControlMapping) (ControlCoverageIndex, []ValidationIssue) {
+	resolution, issues := ResolveControlProfiles(index, set)
+	result := ControlCoverageIndex{Version: resolution.Version}
+	for _, profile := range resolution.Profiles {
+		coverage := ResolveRuleCoverage(profile.Resolution, rules)
+		result.Profiles = append(result.Profiles, BuildControlCoverageProfile(profile.Profile, profile.Resolution, coverage))
+	}
+	sort.Slice(result.Profiles, func(i, j int) bool {
+		return result.Profiles[i].ID < result.Profiles[j].ID
+	})
+	return result, issues
+}
+
+func BuildControlCoverageProfile(selection ControlSelection, resolution SelectionResolution, coverage RuleCoverage) ControlCoverageProfile {
+	profile := ControlCoverageProfile{
+		ID:               strings.TrimSpace(selection.ID),
+		Name:             strings.TrimSpace(selection.Name),
+		Description:      strings.TrimSpace(selection.Description),
+		UnmappedControls: append([]ControlRef(nil), coverage.UnmappedControls...),
+	}
+	for _, control := range resolution.Controls {
+		key := ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID})
+		mappedRules := sortedUniqueStrings(coverage.RulesByControl[key])
+		if len(mappedRules) != 0 {
+			profile.Summary.MappedControls++
+		}
+		expectationIDs, _ := evidenceExpectationIDs(control.Evidence)
+		profile.Controls = append(profile.Controls, ControlCoverageControl{
+			FrameworkID:            strings.TrimSpace(control.FrameworkID),
+			FrameworkName:          strings.TrimSpace(control.FrameworkName),
+			FrameworkVersion:       strings.TrimSpace(control.FrameworkVersion),
+			FamilyID:               strings.TrimSpace(control.FamilyID),
+			FamilyName:             strings.TrimSpace(control.FamilyName),
+			ControlID:              strings.TrimSpace(control.Control.ID),
+			Title:                  strings.TrimSpace(control.Control.Title),
+			OwnerDomain:            strings.TrimSpace(control.Control.OwnerDomain),
+			Tags:                   sortedUniqueStrings(control.EffectiveTags),
+			EvidenceExpectationIDs: expectationIDs,
+			MappedRules:            mappedRules,
+		})
+	}
+	profile.Rules = controlCoverageRules(coverage)
+	profile.Summary.SelectedControls = coverage.SelectedControls
+	profile.Summary.UnmappedControls = len(coverage.UnmappedControls)
+	profile.Summary.MappedRules = len(coverage.MappedRules)
+	sortControlCoverageProfile(&profile)
+	return profile
+}
+
+func validateControlProfileSet(set ControlProfileSet) []ValidationIssue {
+	issues := []ValidationIssue{}
+	if strings.TrimSpace(set.Version) == "" {
+		issues = append(issues, ValidationIssue{Path: "version", Message: "control profile set version is required"})
+	}
+	if len(set.Profiles) == 0 {
+		issues = append(issues, ValidationIssue{Path: "profiles", Message: "at least one control profile is required"})
+	}
+	ids := map[string]struct{}{}
+	for idx, profile := range set.Profiles {
+		path := profileIndexPath(idx)
+		id := strings.TrimSpace(profile.ID)
+		if id == "" {
+			issues = append(issues, ValidationIssue{Path: path + ".id", Message: "control profile id is required"})
+			continue
+		}
+		if _, ok := ids[id]; ok {
+			issues = append(issues, ValidationIssue{Path: path + ".id", Message: "control profile id is duplicated"})
+		}
+		ids[id] = struct{}{}
+		if strings.TrimSpace(profile.Name) == "" {
+			issues = append(issues, ValidationIssue{Path: path + ".name", Message: "control profile name is required"})
+		}
+	}
+	return issues
+}
+
+func controlCoverageRules(coverage RuleCoverage) []ControlCoverageRule {
+	rules := make([]ControlCoverageRule, 0, len(coverage.ControlsByRule))
+	for ruleID, refs := range coverage.ControlsByRule {
+		rules = append(rules, ControlCoverageRule{
+			RuleID:   strings.TrimSpace(ruleID),
+			Controls: sortedControlRefs(refs),
+		})
+	}
+	sort.Slice(rules, func(i, j int) bool {
+		return rules[i].RuleID < rules[j].RuleID
+	})
+	return rules
+}
+
+func sortControlCoverageProfile(profile *ControlCoverageProfile) {
+	sort.Slice(profile.UnmappedControls, func(i, j int) bool {
+		return ControlKey(profile.UnmappedControls[i]) < ControlKey(profile.UnmappedControls[j])
+	})
+	sort.Slice(profile.Controls, func(i, j int) bool {
+		left := ControlKey(ControlRef{FrameworkName: profile.Controls[i].FrameworkName, ControlID: profile.Controls[i].ControlID})
+		right := ControlKey(ControlRef{FrameworkName: profile.Controls[j].FrameworkName, ControlID: profile.Controls[j].ControlID})
+		return left < right
+	})
+	for idx := range profile.Controls {
+		profile.Controls[idx].Tags = sortedUniqueStrings(profile.Controls[idx].Tags)
+		profile.Controls[idx].EvidenceExpectationIDs = sortedUniqueStrings(profile.Controls[idx].EvidenceExpectationIDs)
+		profile.Controls[idx].MappedRules = sortedUniqueStrings(profile.Controls[idx].MappedRules)
+	}
+}
+
+func sortedControlRefs(refs []ControlRef) []ControlRef {
+	result := append([]ControlRef(nil), refs...)
+	sort.Slice(result, func(i, j int) bool {
+		return ControlKey(result[i]) < ControlKey(result[j])
+	})
+	return result
+}
+
+func profileIssuePath(id, path string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		id = "unknown"
+	}
+	if strings.TrimSpace(path) == "" {
+		return "profiles." + id
+	}
+	return "profiles." + id + "." + strings.TrimSpace(path)
+}
+
+func profileIndexPath(idx int) string {
+	return "profiles[" + strconv.Itoa(idx) + "]"
+}

--- a/internal/compliance/profile_test.go
+++ b/internal/compliance/profile_test.go
@@ -1,0 +1,91 @@
+package compliance
+
+import "testing"
+
+func TestLoadControlProfileSetReadsYAML(t *testing.T) {
+	set, err := LoadControlProfileSet([]byte(`
+version: "2026-06-17"
+profiles:
+  - id: production-access
+    name: Production Access
+    frameworks:
+      - name: Custom Framework
+        controls: [IAM-1]
+    include_tags: [identity]
+`))
+	if err != nil {
+		t.Fatalf("LoadControlProfileSet() error = %v", err)
+	}
+	if set.Version != "2026-06-17" || len(set.Profiles) != 1 || set.Profiles[0].ID != "production-access" {
+		t.Fatalf("set = %#v, want parsed profile set", set)
+	}
+}
+
+func TestResolveControlProfilesValidatesProfileMetadata(t *testing.T) {
+	_, issues := ResolveControlProfiles(testSelectionIndex(t), ControlProfileSet{
+		Profiles: []ControlSelection{
+			{ID: "duplicate", Name: "First"},
+			{ID: "duplicate", Name: "Second"},
+			{ID: "missing-name"},
+		},
+	})
+	if len(issues) < 3 {
+		t.Fatalf("issues = %#v, want version, duplicate id, and missing name issues", issues)
+	}
+	if !validationIssuesContain(issues, "control profile set version is required") {
+		t.Fatalf("issues = %#v, want version issue", issues)
+	}
+	if !validationIssuesContain(issues, "control profile id is duplicated") {
+		t.Fatalf("issues = %#v, want duplicate id issue", issues)
+	}
+	if !validationIssuesContain(issues, "control profile name is required") {
+		t.Fatalf("issues = %#v, want missing name issue", issues)
+	}
+}
+
+func TestBuildControlCoverageIndexCreditsMappedCustomControls(t *testing.T) {
+	set := ControlProfileSet{
+		Version: "2026-06-17",
+		Profiles: []ControlSelection{{
+			ID:   "customer-iam",
+			Name: "Customer IAM",
+			Frameworks: []FrameworkSelection{{
+				ID:       "custom",
+				Controls: []string{"IAM-1"},
+			}},
+		}},
+	}
+
+	index, issues := BuildControlCoverageIndex(testSelectionIndex(t), set, []RuleControlMapping{{
+		RuleID:      "identity-mfa-required",
+		ControlRefs: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+	}})
+	if len(issues) != 0 {
+		t.Fatalf("BuildControlCoverageIndex() issues = %#v, want none", issues)
+	}
+	if index.Version != "2026-06-17" || len(index.Profiles) != 1 {
+		t.Fatalf("index = %#v, want one profile", index)
+	}
+	profile := index.Profiles[0]
+	if profile.Summary.SelectedControls != 1 || profile.Summary.MappedControls != 1 || profile.Summary.MappedRules != 1 {
+		t.Fatalf("summary = %#v, want one selected/mapped control and rule", profile.Summary)
+	}
+	if len(profile.Controls) != 1 || profile.Controls[0].ControlID != "IAM-1" {
+		t.Fatalf("Controls = %#v, want custom IAM-1", profile.Controls)
+	}
+	if got := profile.Controls[0].MappedRules; len(got) != 1 || got[0] != "identity-mfa-required" {
+		t.Fatalf("MappedRules = %#v, want identity-mfa-required", got)
+	}
+	if len(profile.Rules) != 1 || len(profile.Rules[0].Controls) != 1 || profile.Rules[0].Controls[0].ControlID != "IAM-1" {
+		t.Fatalf("Rules = %#v, want rule mapped to custom IAM-1", profile.Rules)
+	}
+}
+
+func validationIssuesContain(issues []ValidationIssue, want string) bool {
+	for _, issue := range issues {
+		if issue.Message == want {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/controlindex/main.go
+++ b/tools/controlindex/main.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/writer/cerebro/internal/compliance"
+	findinganalysis "github.com/writer/cerebro/internal/findings"
+	"gopkg.in/yaml.v3"
+)
+
+type pathList []string
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	profiles := flag.String("profiles", compliance.DefaultControlProfilesPath, "control profile YAML path relative to root")
+	output := flag.String("output", compliance.DefaultControlCoverageIndexPath, "generated control coverage index YAML path relative to root")
+	write := flag.Bool("write", false, "write the generated control coverage index")
+	check := flag.Bool("check", false, "check that the generated control coverage index is fresh")
+	var catalogs pathList
+	flag.Var(&catalogs, "catalog", "control catalog YAML path relative to root; may be repeated")
+	flag.Parse()
+
+	if len(catalogs) == 0 {
+		catalogs = append(catalogs, compliance.DefaultControlCatalogPath)
+	}
+	if !*write && !*check {
+		fmt.Fprintln(os.Stderr, "controlindex: one of --write or --check is required")
+		os.Exit(2)
+	}
+
+	content, err := generateCoverageIndex(filepath.Clean(*root), catalogs, *profiles)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "controlindex: %v\n", err)
+		os.Exit(1)
+	}
+	path := filepath.Join(filepath.Clean(*root), filepath.FromSlash(*output))
+	if *write {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "controlindex: create output directory: %v\n", err)
+			os.Exit(1)
+		}
+		if err := rejectSymlink(path); err != nil {
+			fmt.Fprintf(os.Stderr, "controlindex: write %s: %v\n", *output, err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "controlindex: write %s: %v\n", *output, err)
+			os.Exit(1)
+		}
+	}
+	if *check {
+		if err := rejectSymlink(path); err != nil {
+			fmt.Fprintf(os.Stderr, "controlindex: read %s: %v\n", *output, err)
+			os.Exit(1)
+		}
+		existing, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "controlindex: read %s: %v\n", *output, err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(bytes.TrimSpace(existing), bytes.TrimSpace(content)) {
+			fmt.Fprintf(os.Stderr, "controlindex: %s is stale; run `make control-index-generate`\n", *output)
+			os.Exit(1)
+		}
+	}
+}
+
+func (p *pathList) String() string {
+	return strings.Join(*p, ",")
+}
+
+func (p *pathList) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("catalog path is required")
+	}
+	*p = append(*p, value)
+	return nil
+}
+
+func generateCoverageIndex(root string, catalogPaths []string, profilePath string) ([]byte, error) {
+	catalog, err := loadControlCatalog(root, catalogPaths)
+	if err != nil {
+		return nil, err
+	}
+	profiles, err := loadControlProfiles(root, profilePath)
+	if err != nil {
+		return nil, err
+	}
+	index, issues := compliance.BuildControlCoverageIndex(catalog, profiles, builtinRuleControlMappings())
+	if len(issues) != 0 {
+		return nil, validationIssuesError(profilePath, issues)
+	}
+	content, err := yaml.Marshal(index)
+	if err != nil {
+		return nil, fmt.Errorf("encode coverage index: %w", err)
+	}
+	return content, nil
+}
+
+func loadControlCatalog(root string, paths []string) (*compliance.CatalogIndex, error) {
+	catalogPaths := make([]string, 0, len(paths))
+	for _, path := range paths {
+		catalogPaths = append(catalogPaths, filepath.Join(root, filepath.FromSlash(strings.TrimSpace(path))))
+	}
+	catalog, err := compliance.LoadControlCatalogFiles(catalogPaths...)
+	if err != nil {
+		return nil, err
+	}
+	index, issues := compliance.BuildCatalogIndex(catalog)
+	if len(issues) != 0 {
+		return nil, validationIssuesError(strings.Join(paths, ","), issues)
+	}
+	return index, nil
+}
+
+func loadControlProfiles(root string, path string) (compliance.ControlProfileSet, error) {
+	return compliance.LoadControlProfileSetFile(filepath.Join(root, filepath.FromSlash(path)))
+}
+
+func builtinRuleControlMappings() []compliance.RuleControlMapping {
+	mappings := []compliance.RuleControlMapping{}
+	for _, metadata := range findinganalysis.BuiltinRuleMetadata() {
+		ruleID := strings.TrimSpace(metadata.ID)
+		if ruleID == "" {
+			continue
+		}
+		refs := make([]compliance.ControlRef, 0, len(metadata.ControlRefs))
+		for _, ref := range metadata.ControlRefs {
+			refs = append(refs, compliance.ControlRef{
+				FrameworkName: ref.FrameworkName,
+				ControlID:     ref.ControlID,
+			})
+		}
+		mappings = append(mappings, compliance.RuleControlMapping{
+			RuleID:      ruleID,
+			ControlRefs: refs,
+		})
+	}
+	return mappings
+}
+
+func validationIssuesError(path string, issues []compliance.ValidationIssue) error {
+	lines := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		if strings.TrimSpace(issue.Path) == "" {
+			lines = append(lines, strings.TrimSpace(path)+": "+issue.Message)
+			continue
+		}
+		lines = append(lines, strings.TrimSpace(path)+": "+issue.Path+": "+issue.Message)
+	}
+	return errors.New(strings.Join(lines, "\n"))
+}
+
+func rejectSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("symlinked generated files are not allowed")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add reusable YAML control profiles on top of ControlSelection
- add alias-aware control coverage index builder for selected controls and mapped rules
- add controlindex codegen tool and generated YAML coverage index
- wire control index generation/checking into catalog-check and docs-autogen
- document profile authoring and index generation

## Validation
- go test ./internal/compliance ./tools/controlindex ./tools/catalogcheck
- go run ./tools/controlindex --check
- make catalog-check
- make check-structural check-structural-test check-arch
- git diff --check
- python3 scripts/docs_drift_check.py
- go run ./tools/policyrulegen --check
- go run ./tools/detectioncatalog --check
- make lint
- go test ./...
- make verify