### PR TITLE
Add compliance control extension packs

### DIFF
--- a/docs/COMPLIANCE_CONTROLS.md
+++ b/docs/COMPLIANCE_CONTROLS.md
@@ -24,6 +24,15 @@ frameworks:
             intent: Reduce account takeover risk for administrative access.
             applicability: [production, privileged_access]
             assessment_methods: [examine, test]
+            implementation_guidance:
+              - Require privileged identities to enroll MFA before production access is granted.
+            audit_procedure:
+              - Compare privileged account inventory with current MFA enrollment evidence.
+            failure_modes:
+              - Privileged user has active production access without enrolled MFA.
+            remediation_guidance:
+              - Remove privileged access until MFA enrollment is complete.
+            exception_guidance: Time-bound exceptions require compensating monitoring and approval.
             owner_domain: identity
             automatable: true
             manual_evidence_allowed: true
@@ -42,7 +51,7 @@ frameworks:
                 control_id: CC6.1
 ```
 
-Required fields are intentionally small for compatibility: catalog `version`, framework `name`, family `id` and `name`, and control `id`. Rich controls should add `title`, `objective`, `intent`, `assessment_methods`, `evidence_expectations`, and `maps_to` as soon as they are known.
+Required fields are intentionally small for compatibility: catalog `version`, framework `name`, family `id` and `name`, and control `id`. Rich controls should add `title`, `objective`, `intent`, `assessment_methods`, `implementation_guidance`, `audit_procedure`, `failure_modes`, `remediation_guidance`, `evidence_expectations`, and `maps_to` as soon as they are known.
 
 Assessment methods are limited to `examine`, `interview`, and `test`. Evidence expectations require `id` and `type` when present. `maps_to` entries must reference controls that exist in the merged catalog.
 
@@ -59,6 +68,32 @@ index, issues := compliance.BuildCatalogIndex(catalog)
 ```
 
 Use `maps_to` to connect custom controls to controls already covered by generated policy rules. Rule coverage resolution credits the selected custom control when a rule maps to any equivalent control in `maps_to`.
+
+## Control Extension Packs
+
+Control extension packs are YAML manifests that package custom catalog and profile files together. This gives custom framework work a single generated-coverage entrypoint while keeping the actual control catalog YAML separate and reviewable.
+
+```yaml
+version: "2026-06-17"
+id: customer-controls
+name: Customer Controls
+description: Custom framework and reusable audit selections.
+catalogs:
+  - controls.yaml
+profiles:
+  - profiles.yaml
+```
+
+Manifest paths are resolved relative to the manifest file. Use an extension pack when a customer, business unit, or product surface needs its own control IDs and profile selections:
+
+```bash
+go run ./tools/controlindex \
+  --extension customer-controls/extension.yaml \
+  --output customer-controls/coverage.yaml \
+  --write
+```
+
+The generator merges extension catalogs with the built-in catalog, merges extension profile sets with the built-in profiles, validates all `maps_to` references, and emits a coverage index for every selected profile.
 
 ## Control Selections
 
@@ -112,7 +147,7 @@ Coverage is resolved in two steps:
 
 The result reports selected control count, mapped rule IDs, controls without rule coverage, rules by control, and controls by rule. This is the foundation for later control posture and auditor evidence packets.
 
-`BuildControlCoverageIndex` applies this process to a full profile set. The checked-in `internal/compliance/control_coverage_index.yaml` is generated from the built-in profiles and builtin rule metadata. It gives reviewers a stable YAML view of selected controls, mapped rules, unmapped controls, and per-profile coverage summaries.
+`BuildControlCoverageIndex` applies this process to a full profile set. The checked-in `internal/compliance/control_coverage_index.yaml` is generated from the built-in profiles and builtin rule metadata. It gives reviewers a stable YAML view of selected controls, coverage status, rule counts, mapped rules, mapped equivalent controls, evidence expectations, unmapped controls, and per-profile coverage summaries.
 
 Regenerate and verify the index with:
 
@@ -173,6 +208,9 @@ The packet builder uses the same matching rules as posture evaluation. Evidence 
 - `ResolveControlSelection`
 - `ResolveRuleCoverage`
 - `LoadControlProfileSet`
+- `LoadControlExtensionPack`
+- `ValidateControlExtensionPack`
+- `MergeControlProfileSets`
 - `ResolveControlProfiles`
 - `BuildControlCoverageIndex`
 - `EvaluateControlPosture`

--- a/internal/compliance/catalog.go
+++ b/internal/compliance/catalog.go
@@ -47,19 +47,24 @@ type Family struct {
 }
 
 type Control struct {
-	ID                    string                `json:"id" yaml:"id"`
-	Title                 string                `json:"title,omitempty" yaml:"title,omitempty"`
-	Objective             string                `json:"objective,omitempty" yaml:"objective,omitempty"`
-	Intent                string                `json:"intent,omitempty" yaml:"intent,omitempty"`
-	Applicability         []string              `json:"applicability,omitempty" yaml:"applicability,omitempty"`
-	AssessmentMethods     []string              `json:"assessment_methods,omitempty" yaml:"assessment_methods,omitempty"`
-	EvidenceExpectations  []EvidenceExpectation `json:"evidence_expectations,omitempty" yaml:"evidence_expectations,omitempty"`
-	FreshnessSLA          string                `json:"freshness_sla,omitempty" yaml:"freshness_sla,omitempty"`
-	OwnerDomain           string                `json:"owner_domain,omitempty" yaml:"owner_domain,omitempty"`
-	Automatable           *bool                 `json:"automatable,omitempty" yaml:"automatable,omitempty"`
-	ManualEvidenceAllowed *bool                 `json:"manual_evidence_allowed,omitempty" yaml:"manual_evidence_allowed,omitempty"`
-	Tags                  []string              `json:"tags,omitempty" yaml:"tags,omitempty"`
-	MapsTo                []ControlRef          `json:"maps_to,omitempty" yaml:"maps_to,omitempty"`
+	ID                     string                `json:"id" yaml:"id"`
+	Title                  string                `json:"title,omitempty" yaml:"title,omitempty"`
+	Objective              string                `json:"objective,omitempty" yaml:"objective,omitempty"`
+	Intent                 string                `json:"intent,omitempty" yaml:"intent,omitempty"`
+	Applicability          []string              `json:"applicability,omitempty" yaml:"applicability,omitempty"`
+	AssessmentMethods      []string              `json:"assessment_methods,omitempty" yaml:"assessment_methods,omitempty"`
+	ImplementationGuidance []string              `json:"implementation_guidance,omitempty" yaml:"implementation_guidance,omitempty"`
+	AuditProcedure         []string              `json:"audit_procedure,omitempty" yaml:"audit_procedure,omitempty"`
+	FailureModes           []string              `json:"failure_modes,omitempty" yaml:"failure_modes,omitempty"`
+	RemediationGuidance    []string              `json:"remediation_guidance,omitempty" yaml:"remediation_guidance,omitempty"`
+	ExceptionGuidance      string                `json:"exception_guidance,omitempty" yaml:"exception_guidance,omitempty"`
+	EvidenceExpectations   []EvidenceExpectation `json:"evidence_expectations,omitempty" yaml:"evidence_expectations,omitempty"`
+	FreshnessSLA           string                `json:"freshness_sla,omitempty" yaml:"freshness_sla,omitempty"`
+	OwnerDomain            string                `json:"owner_domain,omitempty" yaml:"owner_domain,omitempty"`
+	Automatable            *bool                 `json:"automatable,omitempty" yaml:"automatable,omitempty"`
+	ManualEvidenceAllowed  *bool                 `json:"manual_evidence_allowed,omitempty" yaml:"manual_evidence_allowed,omitempty"`
+	Tags                   []string              `json:"tags,omitempty" yaml:"tags,omitempty"`
+	MapsTo                 []ControlRef          `json:"maps_to,omitempty" yaml:"maps_to,omitempty"`
 }
 
 type EvidenceExpectation struct {
@@ -403,6 +408,11 @@ func validateControl(path string, control Control) []ValidationIssue {
 	var issues []ValidationIssue
 	issues = append(issues, validateAssessmentMethods(path+".assessment_methods", control.AssessmentMethods)...)
 	issues = append(issues, validateTags(path+".tags", control.Tags)...)
+	issues = append(issues, validateStringList(path+".applicability", control.Applicability)...)
+	issues = append(issues, validateStringList(path+".implementation_guidance", control.ImplementationGuidance)...)
+	issues = append(issues, validateStringList(path+".audit_procedure", control.AuditProcedure)...)
+	issues = append(issues, validateStringList(path+".failure_modes", control.FailureModes)...)
+	issues = append(issues, validateStringList(path+".remediation_guidance", control.RemediationGuidance)...)
 	for expectationIdx, expectation := range control.EvidenceExpectations {
 		expectationPath := fmt.Sprintf("%s.evidence_expectations[%d]", path, expectationIdx)
 		if strings.TrimSpace(expectation.ID) == "" {
@@ -530,6 +540,10 @@ func cloneResolvedControl(control ResolvedControl) ResolvedControl {
 func cloneControl(control Control) Control {
 	control.Applicability = append([]string(nil), control.Applicability...)
 	control.AssessmentMethods = append([]string(nil), control.AssessmentMethods...)
+	control.ImplementationGuidance = append([]string(nil), control.ImplementationGuidance...)
+	control.AuditProcedure = append([]string(nil), control.AuditProcedure...)
+	control.FailureModes = append([]string(nil), control.FailureModes...)
+	control.RemediationGuidance = append([]string(nil), control.RemediationGuidance...)
 	control.EvidenceExpectations = cloneEvidenceExpectations(control.EvidenceExpectations)
 	control.Tags = append([]string(nil), control.Tags...)
 	control.MapsTo = append([]ControlRef(nil), control.MapsTo...)

--- a/internal/compliance/catalog_test.go
+++ b/internal/compliance/catalog_test.go
@@ -38,6 +38,15 @@ frameworks:
             intent: Reduce the likelihood of account takeover for administrative access.
             owner_domain: identity
             assessment_methods: [examine, test]
+            implementation_guidance:
+              - Require privileged identities to enroll phishing-resistant MFA before production access is granted.
+            audit_procedure:
+              - Compare privileged account inventory with current MFA enrollment evidence.
+            failure_modes:
+              - Privileged user has active production access without enrolled MFA.
+            remediation_guidance:
+              - Remove privileged access until MFA enrollment is complete.
+            exception_guidance: Time-bound exceptions require compensating monitoring and approval.
             evidence_expectations:
               - id: privileged-mfa-state
                 type: identity_configuration
@@ -57,6 +66,9 @@ frameworks:
 	}
 	if control.Control.Objective == "" || control.Control.Intent == "" {
 		t.Fatalf("rich control fields were not retained: %#v", control.Control)
+	}
+	if len(control.Control.AuditProcedure) != 1 || control.Control.ExceptionGuidance == "" {
+		t.Fatalf("auditor guidance fields were not retained: %#v", control.Control)
 	}
 	if !stringSliceContains(control.EffectiveTags, "identity") {
 		t.Fatalf("EffectiveTags = %#v, want inherited identity tag", control.EffectiveTags)

--- a/internal/compliance/control_coverage_index.yaml
+++ b/internal/compliance/control_coverage_index.yaml
@@ -19,6 +19,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SA-9
+            - framework_name: NIST 800-53 r5
+              control_id: SR-6
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - vendor-risk-assessed
             - vendor-security-review-complete
@@ -32,6 +39,15 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-13
+            - framework_name: NIST 800-53 r5
+              control_id: SC-7
+            - framework_name: NIST 800-53 r5
+              control_id: SC-8
+          coverage_status: mapped
+          rule_count: 159
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -202,6 +218,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CA-7
+            - framework_name: SOC 2
+              control_id: CC4
+          coverage_status: mapped
+          rule_count: 22
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudwatch-alarm-missing
@@ -235,6 +258,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: PS-4
+            - framework_name: SOC 2
+              control_id: CC1.4
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
@@ -251,6 +281,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-6
+            - framework_name: NIST 800-53 r5
+              control_id: CM-7
+          coverage_status: mapped
+          rule_count: 207
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -469,6 +506,15 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-3
+            - framework_name: NIST 800-53 r5
+              control_id: SA-9
+            - framework_name: NIST 800-53 r5
+              control_id: SR-6
+          coverage_status: mapped
+          rule_count: 3
           mapped_rules:
             - aws-rds-auto-minor-upgrade
             - vendor-risk-assessed
@@ -483,6 +529,15 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SI-2
+            - framework_name: NIST 800-53 r5
+              control_id: SI-3
+            - framework_name: NIST 800-53 r5
+              control_id: SI-7
+          coverage_status: mapped
+          rule_count: 57
           mapped_rules:
             - aws-cloudtrail-log-integrity
             - aws-ecr-immutable-tags
@@ -551,6 +606,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-7
+            - framework_name: NIST 800-53 r5
+              control_id: SI-2
+          coverage_status: mapped
+          rule_count: 55
           mapped_rules:
             - aws-ecr-immutable-tags
             - aws-ecr-scan-on-push
@@ -617,6 +679,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-2
+            - framework_name: NIST 800-53 r5
+              control_id: IR-1
+          coverage_status: mapped
+          rule_count: 7
           mapped_rules:
             - aws-rds-multi-az-enabled
             - compliance-bcdr-plan-exists
@@ -635,6 +704,15 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-10
+            - framework_name: NIST 800-53 r5
+              control_id: CP-2
+            - framework_name: NIST 800-53 r5
+              control_id: CP-9
+          coverage_status: mapped
+          rule_count: 12
           mapped_rules:
             - aws-rds-backup-enabled
             - aws-rds-deletion-protection
@@ -658,6 +736,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: RA-3
+            - framework_name: NIST 800-53 r5
+              control_id: RA-5
+          coverage_status: mapped
+          rule_count: 44
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-lambda-runtime-supported
@@ -713,6 +798,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: ISO 27001:2022
+              control_id: A.6.5
+            - framework_name: SOC 2
+              control_id: CC1.4
+          coverage_status: mapped
+          rule_count: 4
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
@@ -728,6 +820,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+            - framework_name: NIST 800-53 r5
+              control_id: IR-8
+          coverage_status: mapped
+          rule_count: 14
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -753,6 +852,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AU-12
+            - framework_name: NIST 800-53 r5
+              control_id: AU-2
+          coverage_status: mapped
+          rule_count: 22
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudtrail-s3-data-events
@@ -786,6 +892,15 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-2
+            - framework_name: NIST 800-53 r5
+              control_id: AC-3
+            - framework_name: NIST 800-53 r5
+              control_id: AC-6
+          coverage_status: mapped
+          rule_count: 250
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -1047,6 +1162,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IA-2
+            - framework_name: NIST 800-53 r5
+              control_id: IA-5
+          coverage_status: mapped
+          rule_count: 109
           mapped_rules:
             - admin-inactive-keys
             - admin-keys-unrotated
@@ -1167,6 +1289,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-3
+            - framework_name: NIST 800-53 r5
+              control_id: CM-7
+          coverage_status: mapped
+          rule_count: 13
           mapped_rules:
             - aws-ecr-immutable-tags
             - aws-rds-auto-minor-upgrade
@@ -1191,6 +1320,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: MP-4
+            - framework_name: NIST 800-53 r5
+              control_id: SC-28
+          coverage_status: mapped
+          rule_count: 43
           mapped_rules:
             - aws-cloudfront-http
             - aws-cloudtrail-kms-encryption
@@ -1245,6 +1381,13 @@ profiles:
             - criminal-justice
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: SOC 2
+              control_id: CC6
+            - framework_name: SOC 2
+              control_id: CC6.6
+          coverage_status: mapped
+          rule_count: 285
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -5089,12 +5232,16 @@ profiles:
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.10"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-iam-password-policy
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.12"
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-iam-user-console-inactive
             - aws-iam-user-unused-credentials
@@ -5102,18 +5249,24 @@ profiles:
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.13"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-iam-single-access-key
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.14"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-iam-access-key-rotation
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.15"
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-iam-no-policies-attached-user
             - aws-iam-users-via-groups
@@ -5121,6 +5274,8 @@ profiles:
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.16"
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-ec2-iam-instance-profile
             - aws-iam-policy-no-admin-star
@@ -5128,24 +5283,32 @@ profiles:
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.19"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-iam-expired-certificates
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.20"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-iam-support-role
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.21"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-iam-access-analyzer-enabled
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.4"
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-iam-root-no-access-keys
             - aws-iam-user-mfa-enabled
@@ -5153,12 +5316,16 @@ profiles:
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.5"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-iam-root-mfa-enabled
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.8"
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-iam-password-policy
             - aws-password-policy-minimum-length
@@ -5166,6 +5333,8 @@ profiles:
           family_id: "1"
           family_name: Identity and Access Management
           control_id: "1.9"
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-iam-password-policy
             - aws-password-policy-no-reuse
@@ -5173,12 +5342,16 @@ profiles:
           family_id: "2"
           family_name: Storage
           control_id: 2.1.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-s3-bucket-encryption-enabled
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "2"
           family_name: Storage
           control_id: 2.1.2
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-s3-bucket-ssl-only
             - aws-s3-https-only
@@ -5186,6 +5359,8 @@ profiles:
           family_id: "2"
           family_name: Storage
           control_id: 2.1.5
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-s3-bucket-no-public-access
             - aws-s3-bucket-policy-public
@@ -5193,6 +5368,8 @@ profiles:
           family_id: "2"
           family_name: Storage
           control_id: 2.2.1
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-ebs-encryption-default
             - aws-ec2-ebs-volume-encrypted
@@ -5200,6 +5377,8 @@ profiles:
           family_id: "2"
           family_name: Storage
           control_id: 2.3.1
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-rds-encryption-enabled
             - aws-redshift-public
@@ -5207,102 +5386,136 @@ profiles:
           family_id: "2"
           family_name: Storage
           control_id: 2.3.2
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-redshift-no-encryption
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "2"
           family_name: Storage
           control_id: 2.3.3
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-rds-no-public-access
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "2"
           family_name: Storage
           control_id: "2.6"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-apigateway-public
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "3"
           family_name: Logging
           control_id: "3.1"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-cloudtrail-enabled
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "3"
           family_name: Logging
           control_id: "3.10"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-cloudtrail-s3-data-events
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "3"
           family_name: Logging
           control_id: "3.11"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-cloudtrail-s3-data-events
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "3"
           family_name: Logging
           control_id: "3.2"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-cloudtrail-log-integrity
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "3"
           family_name: Logging
           control_id: "3.5"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-config-enabled-all-regions
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "3"
           family_name: Logging
           control_id: "3.6"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-s3-bucket-logging-enabled
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "3"
           family_name: Logging
           control_id: "3.7"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-cloudtrail-kms-encryption
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "3"
           family_name: Logging
           control_id: "3.8"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-kms-key-rotation-enabled
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "3"
           family_name: Logging
           control_id: "3.9"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-vpc-flow-logs-enabled
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "4"
           family_name: Monitoring
           control_id: "4.1"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-cloudwatch-alarm-missing
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "4"
           family_name: Monitoring
           control_id: "4.15"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-guardduty-disabled
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "4"
           family_name: Monitoring
           control_id: "4.16"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-security-hub-enabled
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "5"
           family_name: Networking
           control_id: "5.1"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-nacl-admin-ports-restricted
         - framework_name: CIS AWS Foundations Benchmark v2.0
           family_id: "5"
           family_name: Networking
           control_id: "5.2"
+          coverage_status: mapped
+          rule_count: 4
           mapped_rules:
             - aws-ec2-public-ip-ssh
             - aws-ec2-public-ports-restricted
@@ -5312,6 +5525,8 @@ profiles:
           family_id: "5"
           family_name: Networking
           control_id: "5.3"
+          coverage_status: mapped
+          rule_count: 3
           mapped_rules:
             - aws-ec2-public-ip-rdp
             - aws-ec2-public-ports-restricted
@@ -5320,6 +5535,8 @@ profiles:
           family_id: "5"
           family_name: Networking
           control_id: "5.4"
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-default-sg-no-rules
             - aws-ec2-sg-no-all-traffic-ingress
@@ -5327,12 +5544,16 @@ profiles:
           family_id: "5"
           family_name: Networking
           control_id: "5.6"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-ec2-imdsv2-required
         - framework_name: CIS Controls v8
           family_id: "12"
           family_name: Network Infrastructure Management
           control_id: "12"
+          coverage_status: mapped
+          rule_count: 116
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -5454,6 +5675,8 @@ profiles:
           family_id: "13"
           family_name: Network Monitoring and Defense
           control_id: "13"
+          coverage_status: mapped
+          rule_count: 112
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -5571,12 +5794,16 @@ profiles:
           family_id: "4"
           family_name: Secure Configuration of Enterprise Assets and Software
           control_id: "4"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - azure-vm-approved-extensions-only
         - framework_name: CIS Controls v8
           family_id: "4"
           family_name: Secure Configuration of Enterprise Assets and Software
           control_id: "4.3"
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - endpoint-jamf-screenlock
             - endpoint-screenlock-configured
@@ -5584,6 +5811,8 @@ profiles:
           family_id: "5"
           family_name: Account Management
           control_id: "5"
+          coverage_status: mapped
+          rule_count: 189
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -5778,12 +6007,16 @@ profiles:
           family_id: "5"
           family_name: Account Management
           control_id: "5.3"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - identity-stale-accounts-disabled
         - framework_name: CIS Controls v8
           family_id: "6"
           family_name: Access Control Management
           control_id: "6"
+          coverage_status: mapped
+          rule_count: 204
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -5993,18 +6226,24 @@ profiles:
           family_id: "6"
           family_name: Access Control Management
           control_id: "6.3"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - identity-saas-mfa-enforced
         - framework_name: CIS Controls v8
           family_id: "6"
           family_name: Access Control Management
           control_id: "6.4"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - identity-saas-mfa-enforced
         - framework_name: CIS Controls v8
           family_id: "7"
           family_name: Continuous Vulnerability Management
           control_id: "7"
+          coverage_status: mapped
+          rule_count: 42
           mapped_rules:
             - aws-ecr-immutable-tags
             - aws-ecr-scan-on-push
@@ -6052,6 +6291,8 @@ profiles:
           family_id: "8"
           family_name: Audit Log Management
           control_id: "8"
+          coverage_status: mapped
+          rule_count: 30
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudwatch-alarm-missing
@@ -6087,66 +6328,88 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.4.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-eks-private-endpoint
         - framework_name: CIS GKE Benchmark v1.4
           family_id: "5"
           family_name: Policies
           control_id: 5.1.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-gke-no-alpha-clusters
         - framework_name: CIS GKE Benchmark v1.4
           family_id: "5"
           family_name: Policies
           control_id: 5.2.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-gke-metadata-server
         - framework_name: CIS GKE Benchmark v1.4
           family_id: "5"
           family_name: Policies
           control_id: 5.3.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-gke-secrets-kms-encryption
         - framework_name: CIS GKE Benchmark v1.4
           family_id: "5"
           family_name: Policies
           control_id: 5.5.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-gke-shielded-nodes
         - framework_name: CIS GKE Benchmark v1.4
           family_id: "5"
           family_name: Policies
           control_id: 5.5.2
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-gke-auto-repair
         - framework_name: CIS GKE Benchmark v1.4
           family_id: "5"
           family_name: Policies
           control_id: 5.5.3
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-gke-auto-upgrade
         - framework_name: CIS GKE Benchmark v1.4
           family_id: "5"
           family_name: Policies
           control_id: 5.5.4
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-gke-cos-containerd
         - framework_name: CIS GKE Benchmark v1.4
           family_id: "5"
           family_name: Policies
           control_id: 5.6.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-gke-dashboard-disabled
         - framework_name: CIS GKE Benchmark v1.4
           family_id: "5"
           family_name: Policies
           control_id: 5.6.3
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-gke-network-policy-enabled
         - framework_name: CIS Kubernetes Benchmark
           family_id: "5"
           family_name: Policies
           control_id: 5.1.1
+          coverage_status: mapped
+          rule_count: 8
           mapped_rules:
             - gke-cluster-admin
             - k8s-rbac-cluster-admin-used
@@ -6160,6 +6423,8 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.1.3
+          coverage_status: mapped
+          rule_count: 9
           mapped_rules:
             - gke-cluster-admin
             - k8s-cluster-admin-wildcard
@@ -6174,6 +6439,8 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.1.4
+          coverage_status: mapped
+          rule_count: 8
           mapped_rules:
             - gke-cluster-admin
             - k8s-rbac-cluster-admin-used
@@ -6187,12 +6454,16 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.1.6
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - k8s-service-account-token-mount
         - framework_name: CIS Kubernetes Benchmark
           family_id: "5"
           family_name: Policies
           control_id: 5.2.1
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - k8s-missing-pss
             - k8s-namespace-missing-pss-label
@@ -6204,6 +6475,8 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.2.2
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - k8s-missing-pss
             - k8s-namespace-missing-pss-label
@@ -6215,6 +6488,8 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.2.3
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - k8s-missing-pss
             - k8s-namespace-missing-pss-label
@@ -6225,6 +6500,8 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.2.4
+          coverage_status: mapped
+          rule_count: 7
           mapped_rules:
             - k8s-missing-pss
             - k8s-namespace-missing-pss-label
@@ -6237,6 +6514,8 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.2.5
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - k8s-missing-pss
             - k8s-namespace-missing-pss-label
@@ -6247,6 +6526,8 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.2.6
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - k8s-missing-pss
             - k8s-namespace-missing-pss-label
@@ -6258,6 +6539,8 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.2.7
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - k8s-missing-pss
             - k8s-namespace-missing-pss-label
@@ -6269,6 +6552,8 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.2.8
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - k8s-missing-pss
             - k8s-namespace-missing-pss-label
@@ -6279,6 +6564,8 @@ profiles:
           family_id: "5"
           family_name: Policies
           control_id: 5.3.2
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - k8s-network-policy-default-deny
       rules:
@@ -8682,6 +8969,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-2
+            - framework_name: NIST 800-53 r5
+              control_id: AC-3
+          coverage_status: mapped
+          rule_count: 242
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -8936,6 +9230,17 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-17
+            - framework_name: NIST 800-53 r5
+              control_id: AC-2
+            - framework_name: NIST 800-53 r5
+              control_id: AC-3
+            - framework_name: NIST 800-53 r5
+              control_id: AC-6
+          coverage_status: mapped
+          rule_count: 251
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -9199,6 +9504,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: ISO 27001:2022
+              control_id: A.6.5
+            - framework_name: SOC 2
+              control_id: CC1.4
+          coverage_status: mapped
+          rule_count: 4
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
@@ -9215,6 +9527,15 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AU-12
+            - framework_name: NIST 800-53 r5
+              control_id: AU-2
+            - framework_name: NIST 800-53 r5
+              control_id: AU-3
+          coverage_status: mapped
+          rule_count: 22
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudtrail-s3-data-events
@@ -9249,6 +9570,11 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CA-7
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-iam-access-analyzer-enabled
             - aws-security-hub-enabled
@@ -9263,6 +9589,17 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-3
+            - framework_name: NIST 800-53 r5
+              control_id: CM-5
+            - framework_name: NIST 800-53 r5
+              control_id: CM-7
+            - framework_name: NIST 800-53 r5
+              control_id: CM-8
+          coverage_status: mapped
+          rule_count: 15
           mapped_rules:
             - aws-ecr-immutable-tags
             - aws-rds-auto-minor-upgrade
@@ -9290,6 +9627,11 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IA-2
+          coverage_status: mapped
+          rule_count: 36
           mapped_rules:
             - aws-alb-no-authentication
             - aws-api-gateway-no-authorization
@@ -9338,6 +9680,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IA-2
+            - framework_name: NIST 800-53 r5
+              control_id: IA-5
+          coverage_status: mapped
+          rule_count: 109
           mapped_rules:
             - admin-inactive-keys
             - admin-keys-unrotated
@@ -9459,6 +9808,15 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+            - framework_name: NIST 800-53 r5
+              control_id: IR-5
+            - framework_name: NIST 800-53 r5
+              control_id: IR-8
+          coverage_status: mapped
+          rule_count: 14
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -9485,6 +9843,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+            - framework_name: NIST 800-53 r5
+              control_id: IR-5
+          coverage_status: mapped
+          rule_count: 13
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -9510,6 +9875,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-7
+            - framework_name: NIST 800-53 r5
+              control_id: SI-2
+          coverage_status: mapped
+          rule_count: 55
           mapped_rules:
             - aws-ecr-immutable-tags
             - aws-ecr-scan-on-push
@@ -9577,6 +9949,11 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: MP-4
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - m365-sensitivity-labels-missing
         - framework_id: cmmc-2
@@ -9590,6 +9967,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: MP-4
+            - framework_name: NIST 800-53 r5
+              control_id: SC-28
+          coverage_status: mapped
+          rule_count: 43
           mapped_rules:
             - aws-cloudfront-http
             - aws-cloudtrail-kms-encryption
@@ -9645,6 +10029,11 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: SOC 2
+              control_id: CC6.6
+          coverage_status: mapped
+          rule_count: 47
           mapped_rules:
             - aws-default-sg-no-rules
             - aws-ec2-public-ports-restricted
@@ -9704,6 +10093,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: SOC 2
+              control_id: CC6
+            - framework_name: SOC 2
+              control_id: CC6.6
+          coverage_status: mapped
+          rule_count: 285
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -10001,6 +10397,11 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: PS-4
+          coverage_status: mapped
+          rule_count: 3
           mapped_rules:
             - identity-account-deprovision
             - identity-offboarding-sla
@@ -10016,6 +10417,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: RA-3
+            - framework_name: NIST 800-53 r5
+              control_id: RA-5
+          coverage_status: mapped
+          rule_count: 44
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-lambda-runtime-supported
@@ -10072,6 +10480,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: RA-3
+            - framework_name: NIST 800-53 r5
+              control_id: RA-5
+          coverage_status: mapped
+          rule_count: 44
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-lambda-runtime-supported
@@ -10128,6 +10543,11 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-7
+          coverage_status: mapped
+          rule_count: 128
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -10268,6 +10688,19 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-12
+            - framework_name: NIST 800-53 r5
+              control_id: SC-13
+            - framework_name: NIST 800-53 r5
+              control_id: SC-28
+            - framework_name: NIST 800-53 r5
+              control_id: SC-7
+            - framework_name: NIST 800-53 r5
+              control_id: SC-8
+          coverage_status: mapped
+          rule_count: 214
           mapped_rules:
             - admin-inactive-keys
             - admin-keys-unrotated
@@ -10494,6 +10927,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-7
+            - framework_name: NIST 800-53 r5
+              control_id: SC-8
+          coverage_status: mapped
+          rule_count: 129
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -10635,6 +11075,11 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SI-2
+          coverage_status: mapped
+          rule_count: 43
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-lambda-runtime-supported
@@ -10690,6 +11135,17 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SI-2
+            - framework_name: NIST 800-53 r5
+              control_id: SI-3
+            - framework_name: NIST 800-53 r5
+              control_id: SI-4
+            - framework_name: NIST 800-53 r5
+              control_id: SI-7
+          coverage_status: mapped
+          rule_count: 71
           mapped_rules:
             - aws-cloudtrail-log-integrity
             - aws-ecr-immutable-tags
@@ -10773,6 +11229,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SI-4
+            - framework_name: NIST 800-53 r5
+              control_id: SI-7
+          coverage_status: mapped
+          rule_count: 26
           mapped_rules:
             - aws-cloudtrail-log-integrity
             - aws-ecr-immutable-tags
@@ -10811,6 +11274,13 @@ profiles:
             - defense
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SR-11
+            - framework_name: NIST 800-53 r5
+              control_id: SR-6
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - aws-ecr-immutable-tags
             - gitlab-runner-unprotected-tags
@@ -15433,6 +15903,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AU-12
+            - framework_name: NIST 800-53 r5
+              control_id: AU-2
+            - framework_name: NIST 800-53 r5
+              control_id: SI-4
+          coverage_status: mapped
+          rule_count: 38
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudtrail-s3-data-events
@@ -15483,6 +15962,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-10
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+            - framework_name: NIST 800-53 r5
+              control_id: IR-5
+          coverage_status: mapped
+          rule_count: 18
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -15513,6 +16001,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-10
+            - framework_name: NIST 800-53 r5
+              control_id: CP-9
+            - framework_name: NIST 800-53 r5
+              control_id: SC-28
+          coverage_status: mapped
+          rule_count: 47
           mapped_rules:
             - aws-cloudfront-http
             - aws-cloudtrail-kms-encryption
@@ -15572,6 +16069,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CA-7
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+            - framework_name: NIST 800-53 r5
+              control_id: RA-5
+          coverage_status: mapped
+          rule_count: 57
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-guardduty-c2-traffic
@@ -15641,6 +16147,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AU-12
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+            - framework_name: NIST 800-53 r5
+              control_id: IR-5
+          coverage_status: mapped
+          rule_count: 34
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudtrail-s3-data-events
@@ -15687,6 +16202,13 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-5
+            - framework_name: NIST 800-53 r5
+              control_id: SI-4
+          coverage_status: mapped
+          rule_count: 18
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -15717,6 +16239,13 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-8
+            - framework_name: SOC 2
+              control_id: CC7.4
+          coverage_status: mapped
+          rule_count: 10
           mapped_rules:
             - ai-incident-response
             - aws-guardduty-c2-traffic
@@ -15739,6 +16268,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CA-7
+            - framework_name: NIST 800-53 r5
+              control_id: RA-5
+            - framework_name: NIST 800-53 r5
+              control_id: SI-2
+          coverage_status: mapped
+          rule_count: 47
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-iam-access-analyzer-enabled
@@ -15798,6 +16336,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CA-7
+            - framework_name: NIST 800-53 r5
+              control_id: SI-3
+            - framework_name: NIST 800-53 r5
+              control_id: SI-7
+          coverage_status: mapped
+          rule_count: 16
           mapped_rules:
             - aws-cloudtrail-log-integrity
             - aws-ecr-immutable-tags
@@ -15826,6 +16373,13 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CA-7
+            - framework_name: NIST 800-53 r5
+              control_id: RA-5
+          coverage_status: mapped
+          rule_count: 44
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-iam-access-analyzer-enabled
@@ -15882,6 +16436,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SA-9
+            - framework_name: NIST 800-53 r5
+              control_id: SR-11
+            - framework_name: NIST 800-53 r5
+              control_id: SR-6
+          coverage_status: mapped
+          rule_count: 7
           mapped_rules:
             - aws-ecr-immutable-tags
             - gitlab-runner-unprotected-tags
@@ -15901,6 +16464,13 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SA-9
+            - framework_name: NIST 800-53 r5
+              control_id: SR-6
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - vendor-risk-assessed
             - vendor-security-review-complete
@@ -15915,6 +16485,13 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SR-11
+            - framework_name: NIST 800-53 r5
+              control_id: SR-6
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - aws-ecr-immutable-tags
             - gitlab-runner-unprotected-tags
@@ -15933,6 +16510,13 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+            - framework_name: NIST 800-53 r5
+              control_id: RA-3
+          coverage_status: mapped
+          rule_count: 15
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -15960,6 +16544,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: ISO 27001:2022
+              control_id: A.5.1
+            - framework_name: SOC 2
+              control_id: CC1.1
+            - framework_name: SOC 2
+              control_id: CC3.1
+          coverage_status: mapped
+          rule_count: 87
           mapped_rules:
             - aws-alb-http-to-https
             - aws-dynamodb-pitr
@@ -16059,6 +16652,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-1
+            - framework_name: NIST 800-53 r5
+              control_id: RA-3
+            - framework_name: SOC 2
+              control_id: CC3.1
+          coverage_status: mapped
+          rule_count: 34
           mapped_rules:
             - aws-alb-http-to-https
             - aws-dynamodb-pitr
@@ -16105,6 +16707,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-8
+            - framework_name: NIST 800-53 r5
+              control_id: RA-2
+            - framework_name: NIST 800-53 r5
+              control_id: RA-3
+          coverage_status: mapped
+          rule_count: 4
           mapped_rules:
             - compliance-inventory-data-tracking
             - compliance-inventory-owners
@@ -16121,6 +16732,15 @@ profiles:
             - financial-services
             - operational-resilience
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-3
+            - framework_name: NIST 800-53 r5
+              control_id: CM-7
+            - framework_name: NIST 800-53 r5
+              control_id: SC-7
+          coverage_status: mapped
+          rule_count: 136
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -18198,6 +18818,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-1
+          coverage_status: mapped
+          rule_count: 32
           mapped_rules:
             - aws-alb-http-to-https
             - aws-dynamodb-pitr
@@ -18241,6 +18866,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-11
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - endpoint-jamf-screenlock
             - endpoint-screenlock-configured
@@ -18254,6 +18884,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-17
+          coverage_status: mapped
+          rule_count: 3
           mapped_rules:
             - aws-ecs-ssh-denied
             - iam-unknown-account-trusted
@@ -18268,6 +18903,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-2
+          coverage_status: mapped
+          rule_count: 198
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -18477,6 +19117,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-3
+          coverage_status: mapped
+          rule_count: 105
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -18593,6 +19238,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-4
+          coverage_status: mapped
+          rule_count: 14
           mapped_rules:
             - aws-default-sg-no-rules
             - aws-ecs-ports-restricted
@@ -18618,6 +19268,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-6
+          coverage_status: mapped
+          rule_count: 200
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -18829,6 +19484,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AU-12
+          coverage_status: mapped
+          rule_count: 21
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudtrail-s3-data-events
@@ -18861,6 +19521,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AU-2
+          coverage_status: mapped
+          rule_count: 22
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudtrail-s3-data-events
@@ -18894,6 +19559,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AU-3
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - vpc-no-dns-resolver-logging
         - framework_id: fedramp-rev5
@@ -18906,6 +19576,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AU-9
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-cloudtrail-kms-encryption
             - aws-cloudtrail-log-integrity
@@ -18919,6 +19594,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CA-7
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - aws-iam-access-analyzer-enabled
             - aws-security-hub-enabled
@@ -18932,6 +19612,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-3
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-rds-auto-minor-upgrade
         - framework_id: fedramp-rev5
@@ -18944,6 +19629,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-5
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - aws-ecr-immutable-tags
             - gitlab-runner-unprotected-tags
@@ -18960,6 +19650,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-7
+          coverage_status: mapped
+          rule_count: 12
           mapped_rules:
             - aws-ecr-immutable-tags
             - azure-vm-approved-extensions-only
@@ -18983,6 +19678,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-8
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - compliance-inventory-data-tracking
             - compliance-inventory-owners
@@ -18996,6 +19696,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-10
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - aws-rds-backup-enabled
             - aws-rds-deletion-protection
@@ -19012,6 +19717,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-2
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - aws-rds-multi-az-enabled
             - compliance-bcdr-plan-exists
@@ -19029,6 +19739,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-4
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - aws-rds-multi-az-enabled
             - compliance-bcdr-plan-exists
@@ -19046,6 +19761,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-9
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - aws-rds-backup-enabled
             - aws-rds-deletion-protection
@@ -19063,6 +19783,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IA-2
+          coverage_status: mapped
+          rule_count: 36
           mapped_rules:
             - aws-alb-no-authentication
             - aws-api-gateway-no-authorization
@@ -19110,6 +19835,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IA-5
+          coverage_status: mapped
+          rule_count: 105
           mapped_rules:
             - admin-inactive-keys
             - admin-keys-unrotated
@@ -19226,6 +19956,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - compliance-ir-plan-exists
         - framework_id: fedramp-rev5
@@ -19238,6 +19973,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+          coverage_status: mapped
+          rule_count: 13
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -19262,6 +20002,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-5
+          coverage_status: mapped
+          rule_count: 8
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -19281,6 +20026,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-8
+          coverage_status: mapped
+          rule_count: 8
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -19300,6 +20050,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: MP-4
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - m365-sensitivity-labels-missing
         - framework_id: fedramp-rev5
@@ -19312,6 +20067,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: PS-4
+          coverage_status: mapped
+          rule_count: 3
           mapped_rules:
             - identity-account-deprovision
             - identity-offboarding-sla
@@ -19326,6 +20086,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: RA-2
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - compliance-inventory-data-tracking
         - framework_id: fedramp-rev5
@@ -19338,6 +20103,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: RA-3
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - compliance-risk-assessment-annual
             - vendor-risk-assessed
@@ -19351,6 +20121,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: RA-5
+          coverage_status: mapped
+          rule_count: 42
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-lambda-runtime-supported
@@ -19404,6 +20179,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SA-9
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - vendor-risk-assessed
             - vendor-security-review-complete
@@ -19417,6 +20197,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-12
+          coverage_status: mapped
+          rule_count: 96
           mapped_rules:
             - admin-inactive-keys
             - admin-keys-unrotated
@@ -19524,6 +20309,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-13
+          coverage_status: mapped
+          rule_count: 31
           mapped_rules:
             - aws-cloudfront-http
             - aws-cloudwatch-log-group-encrypted
@@ -19566,6 +20356,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-17
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-iam-expired-certificates
         - framework_id: fedramp-rev5
@@ -19578,6 +20373,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-20
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-dns-dnssec
         - framework_id: fedramp-rev5
@@ -19590,6 +20390,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-21
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - gcp-dns-dnssec
         - framework_id: fedramp-rev5
@@ -19602,6 +20407,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-23
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-s3-https-only
         - framework_id: fedramp-rev5
@@ -19614,6 +20424,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-28
+          coverage_status: mapped
+          rule_count: 42
           mapped_rules:
             - aws-cloudfront-http
             - aws-cloudtrail-kms-encryption
@@ -19667,6 +20482,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-7
+          coverage_status: mapped
+          rule_count: 128
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -19806,6 +20626,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-8
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-s3-https-only
         - framework_id: fedramp-rev5
@@ -19818,6 +20643,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SI-2
+          coverage_status: mapped
+          rule_count: 43
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-lambda-runtime-supported
@@ -19872,6 +20702,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SI-3
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - endpoint-edr-installed
             - endpoint-edr-reporting
@@ -19888,6 +20723,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SI-4
+          coverage_status: mapped
+          rule_count: 17
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -19916,6 +20756,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SI-7
+          coverage_status: mapped
+          rule_count: 9
           mapped_rules:
             - aws-cloudtrail-log-integrity
             - aws-ecr-immutable-tags
@@ -19936,6 +20781,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SI-8
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - m365-email-security-baseline
         - framework_id: fedramp-rev5
@@ -19948,6 +20798,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SR-11
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - aws-ecr-immutable-tags
             - gitlab-runner-unprotected-tags
@@ -19964,6 +20819,11 @@ profiles:
             - cloud
             - federal
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SR-6
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - vendor-security-review-complete
       rules:
@@ -23414,6 +24274,8 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.1
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - endpoint-jamf-screenlock
             - endpoint-screenlock-configured
@@ -23421,20 +24283,28 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.10
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.11
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.12
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - m365-dlp-policy-missing
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.13
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - aws-rds-backup-enabled
             - aws-rds-deletion-protection
@@ -23446,6 +24316,8 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.14
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - aws-rds-multi-az-enabled
             - k8s-deployment-multiple-replicas
@@ -23456,12 +24328,16 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.15
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - grc-failing-control-test-unhealthy-integration
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.16
+          coverage_status: mapped
+          rule_count: 22
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -23489,20 +24365,28 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.17
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.18
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.19
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-rds-auto-minor-upgrade
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.2
+          coverage_status: mapped
+          rule_count: 8
           mapped_rules:
             - github-org-owner-role-review-needed
             - identity-okta-admin-plus-app-owner
@@ -23516,6 +24400,8 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.20
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - cloud-current-public-exposure-review-needed
             - cloud-effective-admin-permission
@@ -23527,18 +24413,26 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.21
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.22
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.23
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.24
+          coverage_status: mapped
+          rule_count: 7
           mapped_rules:
             - aws-cloudtrail-kms-encryption
             - azure-vm-unmanaged-disk
@@ -23551,54 +24445,80 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.25
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.26
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.27
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.28
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.29
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.30
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.31
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.32
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.33
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.34
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.5
+          coverage_status: mapped
+          rule_count: 7
           mapped_rules:
             - identity-google-workspace-admin-mfa
             - identity-okta-admin-mfa
@@ -23611,10 +24531,14 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.7
+          coverage_status: mapped
+          rule_count: 7
           mapped_rules:
             - endpoint-edr-installed
             - endpoint-kandji-edr-installed
@@ -23627,6 +24551,8 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.8
+          coverage_status: mapped
+          rule_count: 8
           mapped_rules:
             - aws-rds-auto-minor-upgrade
             - grc-isolated-target-enrichment-gap
@@ -23640,6 +24566,8 @@ profiles:
           family_id: A.8
           family_name: Technology Controls
           control_id: A.8.9
+          coverage_status: mapped
+          rule_count: 21
           mapped_rules:
             - github-app-integration-installed
             - github-code-security-controls-disabled
@@ -24124,6 +25052,15 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: ISO 27001:2022
+              control_id: A.5.1
+            - framework_name: SOC 2
+              control_id: CC1.1
+            - framework_name: SOC 2
+              control_id: CC3.1
+          coverage_status: mapped
+          rule_count: 87
           mapped_rules:
             - aws-alb-http-to-https
             - aws-dynamodb-pitr
@@ -24223,6 +25160,15 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: ISO 27001:2022
+              control_id: A.5.1
+            - framework_name: NIST 800-53 r5
+              control_id: AC-1
+            - framework_name: NIST 800-53 r5
+              control_id: RA-3
+          coverage_status: mapped
+          rule_count: 77
           mapped_rules:
             - aws-alb-http-to-https
             - aws-dynamodb-pitr
@@ -24312,6 +25258,13 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+            - framework_name: NIST 800-53 r5
+              control_id: IR-5
+          coverage_status: mapped
+          rule_count: 13
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -24337,6 +25290,15 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-10
+            - framework_name: NIST 800-53 r5
+              control_id: CP-2
+            - framework_name: NIST 800-53 r5
+              control_id: CP-9
+          coverage_status: mapped
+          rule_count: 12
           mapped_rules:
             - aws-rds-backup-enabled
             - aws-rds-deletion-protection
@@ -24361,6 +25323,15 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SA-9
+            - framework_name: NIST 800-53 r5
+              control_id: SR-11
+            - framework_name: NIST 800-53 r5
+              control_id: SR-6
+          coverage_status: mapped
+          rule_count: 7
           mapped_rules:
             - aws-ecr-immutable-tags
             - gitlab-runner-unprotected-tags
@@ -24380,6 +25351,15 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-3
+            - framework_name: NIST 800-53 r5
+              control_id: CM-7
+            - framework_name: NIST 800-53 r5
+              control_id: RA-5
+          coverage_status: mapped
+          rule_count: 55
           mapped_rules:
             - aws-ecr-immutable-tags
             - aws-ecr-scan-on-push
@@ -24447,6 +25427,13 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CA-7
+            - framework_name: SOC 2
+              control_id: CC4
+          coverage_status: mapped
+          rule_count: 22
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudwatch-alarm-missing
@@ -24481,6 +25468,13 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: ISO 27001:2022
+              control_id: A.6.5
+            - framework_name: SOC 2
+              control_id: CC1.4
+          coverage_status: mapped
+          rule_count: 4
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
@@ -24497,6 +25491,15 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-12
+            - framework_name: NIST 800-53 r5
+              control_id: SC-13
+            - framework_name: NIST 800-53 r5
+              control_id: SC-28
+          coverage_status: mapped
+          rule_count: 103
           mapped_rules:
             - admin-inactive-keys
             - admin-keys-unrotated
@@ -24612,6 +25615,17 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-2
+            - framework_name: NIST 800-53 r5
+              control_id: AC-6
+            - framework_name: NIST 800-53 r5
+              control_id: CM-8
+            - framework_name: NIST 800-53 r5
+              control_id: PS-4
+          coverage_status: mapped
+          rule_count: 211
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -24835,6 +25849,17 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IA-2
+            - framework_name: NIST 800-53 r5
+              control_id: IA-5
+            - framework_name: NIST 800-53 r5
+              control_id: SC-23
+            - framework_name: NIST 800-53 r5
+              control_id: SC-8
+          coverage_status: mapped
+          rule_count: 110
           mapped_rules:
             - admin-inactive-keys
             - admin-keys-unrotated
@@ -24957,6 +25982,13 @@ profiles:
             - cybersecurity
             - eu
             - regulatory
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-8
+            - framework_name: SOC 2
+              control_id: CC7.4
+          coverage_status: mapped
+          rule_count: 10
           mapped_rules:
             - ai-incident-response
             - aws-guardduty-c2-traffic
@@ -27329,6 +28361,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-5
+            - framework_name: NIST 800-53 r5
+              control_id: SI-4
+          coverage_status: mapped
+          rule_count: 18
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -27359,6 +28398,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AU-12
+            - framework_name: NIST 800-53 r5
+              control_id: SI-4
+          coverage_status: mapped
+          rule_count: 38
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudtrail-s3-data-events
@@ -27409,6 +28455,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: ISO 27001:2022
+              control_id: A.5.1
+            - framework_name: SOC 2
+              control_id: CC3.1
+          coverage_status: mapped
+          rule_count: 58
           mapped_rules:
             - aws-dynamodb-pitr
             - aws-logs-retention-365
@@ -27479,6 +28532,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CA-7
+            - framework_name: SOC 2
+              control_id: CC4
+          coverage_status: mapped
+          rule_count: 22
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudwatch-alarm-missing
@@ -27513,6 +28573,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: ISO 27001:2022
+              control_id: A.5.1
+            - framework_name: NIST 800-53 r5
+              control_id: AC-1
+          coverage_status: mapped
+          rule_count: 75
           mapped_rules:
             - aws-alb-http-to-https
             - aws-dynamodb-pitr
@@ -27600,6 +28667,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: RA-3
+            - framework_name: SOC 2
+              control_id: CC3.2
+          coverage_status: mapped
+          rule_count: 3
           mapped_rules:
             - ai-risk-assessment
             - compliance-risk-assessment-annual
@@ -27615,6 +28689,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: SOC 2
+              control_id: CC1.1
+            - framework_name: SOC 2
+              control_id: CC1.4
+          coverage_status: mapped
+          rule_count: 86
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
@@ -27713,6 +28794,15 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SA-9
+            - framework_name: NIST 800-53 r5
+              control_id: SR-11
+            - framework_name: NIST 800-53 r5
+              control_id: SR-6
+          coverage_status: mapped
+          rule_count: 7
           mapped_rules:
             - aws-ecr-immutable-tags
             - gitlab-runner-unprotected-tags
@@ -27732,6 +28822,11 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-8
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - compliance-inventory-data-tracking
             - compliance-inventory-owners
@@ -27746,6 +28841,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CA-7
+            - framework_name: SOC 2
+              control_id: CC4
+          coverage_status: mapped
+          rule_count: 22
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudwatch-alarm-missing
@@ -27780,6 +28882,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: RA-3
+            - framework_name: NIST 800-53 r5
+              control_id: RA-5
+          coverage_status: mapped
+          rule_count: 44
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-lambda-runtime-supported
@@ -27836,6 +28945,17 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AC-2
+            - framework_name: NIST 800-53 r5
+              control_id: AC-3
+            - framework_name: NIST 800-53 r5
+              control_id: AC-6
+            - framework_name: NIST 800-53 r5
+              control_id: IA-2
+          coverage_status: mapped
+          rule_count: 265
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -28113,6 +29233,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: ISO 27001:2022
+              control_id: A.6.5
+            - framework_name: SOC 2
+              control_id: CC1.4
+          coverage_status: mapped
+          rule_count: 4
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
@@ -28129,6 +29256,15 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: SC-12
+            - framework_name: NIST 800-53 r5
+              control_id: SC-28
+            - framework_name: NIST 800-53 r5
+              control_id: SC-8
+          coverage_status: mapped
+          rule_count: 104
           mapped_rules:
             - admin-inactive-keys
             - admin-keys-unrotated
@@ -28245,6 +29381,15 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-10
+            - framework_name: NIST 800-53 r5
+              control_id: CP-9
+            - framework_name: NIST 800-53 r5
+              control_id: SC-7
+          coverage_status: mapped
+          rule_count: 134
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -28391,6 +29536,15 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CM-3
+            - framework_name: NIST 800-53 r5
+              control_id: CM-7
+            - framework_name: NIST 800-53 r5
+              control_id: SI-7
+          coverage_status: mapped
+          rule_count: 16
           mapped_rules:
             - aws-cloudtrail-log-integrity
             - aws-ecr-immutable-tags
@@ -28419,6 +29573,11 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-8
+          coverage_status: mapped
+          rule_count: 8
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -28439,6 +29598,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: CP-10
+            - framework_name: NIST 800-53 r5
+              control_id: CP-9
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - aws-rds-backup-enabled
             - aws-rds-deletion-protection
@@ -28457,6 +29623,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: AU-3
+            - framework_name: NIST 800-53 r5
+              control_id: IR-5
+          coverage_status: mapped
+          rule_count: 9
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -28478,6 +29651,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-8
+            - framework_name: SOC 2
+              control_id: CC7.4
+          coverage_status: mapped
+          rule_count: 10
           mapped_rules:
             - ai-incident-response
             - aws-guardduty-c2-traffic
@@ -28500,6 +29680,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+            - framework_name: NIST 800-53 r5
+              control_id: IR-5
+          coverage_status: mapped
+          rule_count: 13
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -28525,6 +29712,13 @@ profiles:
             - cybersecurity
             - framework
             - risk-management
+          mapped_control_refs:
+            - framework_name: NIST 800-53 r5
+              control_id: IR-4
+            - framework_name: NIST 800-53 r5
+              control_id: SI-2
+          coverage_status: mapped
+          rule_count: 56
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-guardduty-c2-traffic
@@ -31596,14 +32790,20 @@ profiles:
           family_id: "1"
           family_name: Network Security Controls
           control_id: "1.1"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "1"
           family_name: Network Security Controls
           control_id: "1.2"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "1"
           family_name: Network Security Controls
           control_id: "1.3"
+          coverage_status: mapped
+          rule_count: 101
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -31710,6 +32910,8 @@ profiles:
           family_id: "1"
           family_name: Network Security Controls
           control_id: 1.3.1
+          coverage_status: mapped
+          rule_count: 11
           mapped_rules:
             - aws-ecs-ports-restricted
             - aws-elb-target-public-subnet
@@ -31726,6 +32928,8 @@ profiles:
           family_id: "1"
           family_name: Network Security Controls
           control_id: "1.4"
+          coverage_status: mapped
+          rule_count: 102
           mapped_rules:
             - aws-api-gateway-no-authorization
             - aws-bedrock-custom-model-public
@@ -31833,14 +33037,20 @@ profiles:
           family_id: "1"
           family_name: Network Security Controls
           control_id: "1.5"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "10"
           family_name: Logging and Monitoring
           control_id: "10.1"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "10"
           family_name: Logging and Monitoring
           control_id: "10.2"
+          coverage_status: mapped
+          rule_count: 20
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudwatch-alarm-missing
@@ -31866,12 +33076,16 @@ profiles:
           family_id: "10"
           family_name: Logging and Monitoring
           control_id: 10.2.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-cloudtrail-s3-data-events
         - framework_name: PCI DSS v4.0.1
           family_id: "10"
           family_name: Logging and Monitoring
           control_id: "10.3"
+          coverage_status: mapped
+          rule_count: 20
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudwatch-alarm-missing
@@ -31897,30 +33111,44 @@ profiles:
           family_id: "10"
           family_name: Logging and Monitoring
           control_id: "10.4"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "10"
           family_name: Logging and Monitoring
           control_id: "10.5"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "10"
           family_name: Logging and Monitoring
           control_id: "10.6"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "10"
           family_name: Logging and Monitoring
           control_id: "10.7"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "11"
           family_name: Security Testing
           control_id: "11.1"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "11"
           family_name: Security Testing
           control_id: "11.2"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "11"
           family_name: Security Testing
           control_id: "11.3"
+          coverage_status: mapped
+          rule_count: 35
           mapped_rules:
             - aws-ecr-scan-on-push
             - aws-lambda-runtime-supported
@@ -31961,72 +33189,106 @@ profiles:
           family_id: "11"
           family_name: Security Testing
           control_id: "11.4"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "11"
           family_name: Security Testing
           control_id: "11.5"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "11"
           family_name: Security Testing
           control_id: "11.6"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: "12.1"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: "12.10"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: 12.10.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - compliance-ir-plan-exists
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: "12.2"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: "12.3"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: "12.4"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: "12.5"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: "12.6"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: "12.7"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: "12.8"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "12"
           family_name: Security Program
           control_id: "12.9"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "6"
           family_name: Secure Systems and Software
           control_id: "6.1"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "6"
           family_name: Secure Systems and Software
           control_id: "6.2"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "6"
           family_name: Secure Systems and Software
           control_id: "6.3"
+          coverage_status: mapped
+          rule_count: 40
           mapped_rules:
             - aws-ecr-immutable-tags
             - aws-ecr-scan-on-push
@@ -32072,10 +33334,14 @@ profiles:
           family_id: "6"
           family_name: Secure Systems and Software
           control_id: "6.4"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "6"
           family_name: Secure Systems and Software
           control_id: "6.5"
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - aws-ecr-immutable-tags
             - gitlab-runner-unprotected-tags
@@ -32086,10 +33352,14 @@ profiles:
           family_id: "7"
           family_name: Need-to-Know Access
           control_id: "7.1"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "7"
           family_name: Need-to-Know Access
           control_id: "7.2"
+          coverage_status: mapped
+          rule_count: 183
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -32278,24 +33548,34 @@ profiles:
           family_id: "7"
           family_name: Need-to-Know Access
           control_id: "7.3"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "8"
           family_name: Identity and Authentication
           control_id: "8.1"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "8"
           family_name: Identity and Authentication
           control_id: 8.1.3
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - identity-account-deprovision
         - framework_name: PCI DSS v4.0.1
           family_id: "8"
           family_name: Identity and Authentication
           control_id: "8.2"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "8"
           family_name: Identity and Authentication
           control_id: "8.3"
+          coverage_status: mapped
+          rule_count: 31
           mapped_rules:
             - aws-alb-no-authentication
             - aws-api-gateway-no-authorization
@@ -32332,18 +33612,24 @@ profiles:
           family_id: "8"
           family_name: Identity and Authentication
           control_id: 8.3.6
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-password-policy-minimum-length
         - framework_name: PCI DSS v4.0.1
           family_id: "8"
           family_name: Identity and Authentication
           control_id: 8.3.7
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-password-policy-no-reuse
         - framework_name: PCI DSS v4.0.1
           family_id: "8"
           family_name: Identity and Authentication
           control_id: "8.4"
+          coverage_status: mapped
+          rule_count: 31
           mapped_rules:
             - aws-alb-no-authentication
             - aws-api-gateway-no-authorization
@@ -32380,16 +33666,22 @@ profiles:
           family_id: "8"
           family_name: Identity and Authentication
           control_id: 8.4.2
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - identity-saas-mfa-enforced
         - framework_name: PCI DSS v4.0.1
           family_id: "8"
           family_name: Identity and Authentication
           control_id: "8.5"
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: PCI DSS v4.0.1
           family_id: "8"
           family_name: Identity and Authentication
           control_id: "8.6"
+          coverage_status: mapped
+          rule_count: 67
           mapped_rules:
             - admin-inactive-keys
             - admin-keys-unrotated
@@ -34461,12 +35753,16 @@ profiles:
           family_id: "1798"
           family_name: Consumer Privacy Rights
           control_id: "1798.100"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - compliance-data-inventory-maintained
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Art.30
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - ai-data-governance
             - compliance-inventory-data-tracking
@@ -34474,6 +35770,8 @@ profiles:
           family_id: Article
           family_name: Articles
           control_id: Art.5
+          coverage_status: mapped
+          rule_count: 4
           mapped_rules:
             - ai-data-governance
             - compliance-gdpr-policy
@@ -34483,452 +35781,674 @@ profiles:
           family_id: Article
           family_name: Articles
           control_id: Article 12
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 13
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 14
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 15
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 16
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 17
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 18
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 19
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 20
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 21
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 22
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 23
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 24
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 25
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 27
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 28
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - vendor-dpa-exists
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 30
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - compliance-data-inventory-maintained
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 32
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 33
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 34
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 35
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 37
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 38
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 39
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 44
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 45
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 46
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 48
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 51
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: GDPR
           family_id: Article
           family_name: Articles
           control_id: Article 7
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.2.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.2.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.2.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.2.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.2.6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.2.7
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.2.8
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.2.9
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.3.10
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.3.11
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.3.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.3.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.3.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.3.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.3.6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.3.7
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.3.8
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.3.9
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.4.10
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.4.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.4.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.4.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.4.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.4.6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.4.7
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.4.8
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.4.9
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.5.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.5.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.5.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.1
           family_name: A.1 Controls
           control_id: A.1.5.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.2.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.2.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.2.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.2.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.2.6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.2.7
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.3.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.4.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.4.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.4.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.5.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.5.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.5.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.5.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.5.6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.5.7
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.5.8
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.2
           family_name: A.2 Controls
           control_id: A.2.5.9
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.10
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.11
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.12
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.13
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.14
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.15
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.16
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.17
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.18
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.19
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.20
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.21
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.22
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.23
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.24
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.25
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.26
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.27
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.28
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.29
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.30
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.31
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.7
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.8
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 27701:2025
           family_id: A.3
           family_name: A.3 Controls
           control_id: A.3.9
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: "10"
           family_name: Improvement
           control_id: "10.1"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - ai-incident-response
         - framework_name: ISO 42001
           family_id: "10"
           family_name: Improvement
           control_id: "10.2"
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - ai-data-governance
             - ai-incident-response
@@ -34936,6 +36456,8 @@ profiles:
           family_id: "6"
           family_name: Planning
           control_id: "6.1"
+          coverage_status: mapped
+          rule_count: 3
           mapped_rules:
             - ai-bias-testing
             - ai-risk-assessment
@@ -34944,6 +36466,8 @@ profiles:
           family_id: "6"
           family_name: Planning
           control_id: "6.2"
+          coverage_status: mapped
+          rule_count: 3
           mapped_rules:
             - ai-human-oversight
             - ai-risk-assessment
@@ -34952,30 +36476,40 @@ profiles:
           family_id: "7"
           family_name: Support
           control_id: "7.1"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - ai-model-inventory
         - framework_name: ISO 42001
           family_id: "7"
           family_name: Support
           control_id: "7.2"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - ai-model-inventory
         - framework_name: ISO 42001
           family_id: "7"
           family_name: Support
           control_id: "7.3"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - ai-data-governance
         - framework_name: ISO 42001
           family_id: "8"
           family_name: Operation
           control_id: "8.4"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-bedrock-model-no-guardrails
         - framework_name: ISO 42001
           family_id: "9"
           family_name: Performance Evaluation
           control_id: "9.1"
+          coverage_status: mapped
+          rule_count: 3
           mapped_rules:
             - ai-human-oversight
             - ai-model-monitoring
@@ -34984,172 +36518,254 @@ profiles:
           family_id: "9"
           family_name: Performance Evaluation
           control_id: "9.2"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - ai-bias-testing
         - framework_name: ISO 42001
           family_id: "9"
           family_name: Performance Evaluation
           control_id: "9.3"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - ai-model-monitoring
         - framework_name: ISO 42001
           family_id: "9"
           family_name: Performance Evaluation
           control_id: "9.4"
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - ai-explainability
         - framework_name: ISO 42001
           family_id: A.10
           family_name: Third-Party and Customer Relationships
           control_id: A.10.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.10
           family_name: Third-Party and Customer Relationships
           control_id: A.10.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.10
           family_name: Third-Party and Customer Relationships
           control_id: A.10.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.2
           family_name: Policies
           control_id: A.2.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.2
           family_name: Policies
           control_id: A.2.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.2
           family_name: Policies
           control_id: A.2.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.3
           family_name: Internal Organization
           control_id: A.3.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.3
           family_name: Internal Organization
           control_id: A.3.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.4
           family_name: Resources
           control_id: A.4.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.4
           family_name: Resources
           control_id: A.4.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.4
           family_name: Resources
           control_id: A.4.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.4
           family_name: Resources
           control_id: A.4.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.4
           family_name: Resources
           control_id: A.4.6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.5
           family_name: Impact Assessment
           control_id: A.5.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.5
           family_name: Impact Assessment
           control_id: A.5.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.5
           family_name: Impact Assessment
           control_id: A.5.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.5
           family_name: Impact Assessment
           control_id: A.5.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.6
           family_name: Lifecycle
           control_id: A.6.1.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.6
           family_name: Lifecycle
           control_id: A.6.1.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.6
           family_name: Lifecycle
           control_id: A.6.2.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.6
           family_name: Lifecycle
           control_id: A.6.2.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.6
           family_name: Lifecycle
           control_id: A.6.2.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.6
           family_name: Lifecycle
           control_id: A.6.2.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.6
           family_name: Lifecycle
           control_id: A.6.2.6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.6
           family_name: Lifecycle
           control_id: A.6.2.7
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.6
           family_name: Lifecycle
           control_id: A.6.2.8
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.7
           family_name: Data
           control_id: A.7.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.7
           family_name: Data
           control_id: A.7.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.7
           family_name: Data
           control_id: A.7.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.7
           family_name: Data
           control_id: A.7.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.7
           family_name: Data
           control_id: A.7.6
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.8
           family_name: Information for Interested Parties
           control_id: A.8.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.8
           family_name: Information for Interested Parties
           control_id: A.8.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.8
           family_name: Information for Interested Parties
           control_id: A.8.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.8
           family_name: Information for Interested Parties
           control_id: A.8.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.9
           family_name: Use of AI Systems
           control_id: A.9.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.9
           family_name: Use of AI Systems
           control_id: A.9.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: ISO 42001
           family_id: A.9
           family_name: Use of AI Systems
           control_id: A.9.4
+          coverage_status: unmapped
+          rule_count: 0
       rules:
         - rule_id: ai-bias-testing
           controls:
@@ -35539,6 +37155,8 @@ profiles:
           family_id: A1
           family_name: Availability
           control_id: A1.1
+          coverage_status: mapped
+          rule_count: 14
           mapped_rules:
             - aws-rds-backup-enabled
             - aws-rds-deletion-protection
@@ -35558,6 +37176,8 @@ profiles:
           family_id: A1
           family_name: Availability
           control_id: A1.2
+          coverage_status: mapped
+          rule_count: 13
           mapped_rules:
             - aws-rds-backup-enabled
             - aws-rds-deletion-protection
@@ -35576,6 +37196,8 @@ profiles:
           family_id: A1
           family_name: Availability
           control_id: A1.3
+          coverage_status: mapped
+          rule_count: 6
           mapped_rules:
             - aws-rds-multi-az-enabled
             - compliance-bcdr-plan-exists
@@ -35695,6 +37317,8 @@ profiles:
           family_id: CC1
           family_name: Control Environment
           control_id: CC1.1
+          coverage_status: mapped
+          rule_count: 84
           mapped_rules:
             - aws-alb-http-to-https
             - aws-dynamodb-pitr
@@ -35784,6 +37408,8 @@ profiles:
           family_id: CC1
           family_name: Control Environment
           control_id: CC1.2
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - grc-control-missing-evidence-coverage
             - grc-control-test-needs-attention
@@ -35791,10 +37417,14 @@ profiles:
           family_id: CC1
           family_name: Control Environment
           control_id: CC1.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC1
           family_name: Control Environment
           control_id: CC1.4
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
@@ -35802,30 +37432,42 @@ profiles:
           family_id: CC1
           family_name: Control Environment
           control_id: CC1.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC2
           family_name: Communication and Information
           control_id: CC2.1
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC2
           family_name: Communication and Information
           control_id: CC2.2
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - grc-document-needs-owner-or-upload
         - framework_name: SOC 2
           family_id: CC2
           family_name: Communication and Information
           control_id: CC2.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC3
           family_name: Risk Assessment
           control_id: CC3.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - compliance-risk-assessment-annual
         - framework_name: SOC 2
           family_id: CC3
           family_name: Risk Assessment
           control_id: CC3.2
+          coverage_status: mapped
+          rule_count: 2
           mapped_rules:
             - ai-risk-assessment
             - compliance-risk-assessment-annual
@@ -35833,14 +37475,20 @@ profiles:
           family_id: CC3
           family_name: Risk Assessment
           control_id: CC3.3
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC3
           family_name: Risk Assessment
           control_id: CC3.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC4
           family_name: Monitoring Activities
           control_id: CC4
+          coverage_status: mapped
+          rule_count: 20
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudwatch-alarm-missing
@@ -35866,32 +37514,44 @@ profiles:
           family_id: CC4
           family_name: Monitoring Activities
           control_id: CC4.1
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - aws-cloudtrail-s3-data-events
         - framework_name: SOC 2
           family_id: CC4
           family_name: Monitoring Activities
           control_id: CC4.2
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC5
           family_name: Control Activities
           control_id: CC5.1
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC5
           family_name: Control Activities
           control_id: CC5.2
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - same-user-approve-execute
         - framework_name: SOC 2
           family_id: CC5
           family_name: Control Activities
           control_id: CC5.3
+          coverage_status: mapped
+          rule_count: 1
           mapped_rules:
             - same-user-approve-execute
         - framework_name: SOC 2
           family_id: CC6
           family_name: Logical and Physical Access
           control_id: CC6
+          coverage_status: mapped
+          rule_count: 238
           mapped_rules:
             - account-lateral-dormant
             - admin-inactive-keys
@@ -36135,6 +37795,8 @@ profiles:
           family_id: CC6
           family_name: Logical and Physical Access
           control_id: CC6.1
+          coverage_status: mapped
+          rule_count: 426
           mapped_rules:
             - ai-data-governance
             - ai-model-inventory
@@ -36566,6 +38228,8 @@ profiles:
           family_id: CC6
           family_name: Logical and Physical Access
           control_id: CC6.2
+          coverage_status: mapped
+          rule_count: 29
           mapped_rules:
             - github-programmatic-credential-review-needed
             - grc-inactive-identity-active-access
@@ -36600,6 +38264,8 @@ profiles:
           family_id: CC6
           family_name: Logical and Physical Access
           control_id: CC6.3
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - aws-iam-access-analyzer-enabled
             - aws-iam-users-via-groups
@@ -36610,14 +38276,20 @@ profiles:
           family_id: CC6
           family_name: Logical and Physical Access
           control_id: CC6.4
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC6
           family_name: Logical and Physical Access
           control_id: CC6.5
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC6
           family_name: Logical and Physical Access
           control_id: CC6.6
+          coverage_status: mapped
+          rule_count: 47
           mapped_rules:
             - aws-default-sg-no-rules
             - aws-ec2-public-ports-restricted
@@ -36670,6 +38342,8 @@ profiles:
           family_id: CC6
           family_name: Logical and Physical Access
           control_id: CC6.7
+          coverage_status: mapped
+          rule_count: 7
           mapped_rules:
             - aws-s3-https-only
             - azure-vm-unmanaged-disk
@@ -36682,6 +38356,8 @@ profiles:
           family_id: CC6
           family_name: Logical and Physical Access
           control_id: CC6.8
+          coverage_status: mapped
+          rule_count: 8
           mapped_rules:
             - endpoint-edr-installed
             - endpoint-edr-reporting
@@ -36695,6 +38371,8 @@ profiles:
           family_id: CC7
           family_name: System Operations
           control_id: CC7
+          coverage_status: mapped
+          rule_count: 21
           mapped_rules:
             - aws-cloudtrail-enabled
             - aws-cloudwatch-alarm-missing
@@ -36721,6 +38399,8 @@ profiles:
           family_id: CC7
           family_name: System Operations
           control_id: CC7.1
+          coverage_status: mapped
+          rule_count: 47
           mapped_rules:
             - aws-ecr-immutable-tags
             - aws-guardduty-c2-traffic
@@ -36773,6 +38453,8 @@ profiles:
           family_id: CC7
           family_name: System Operations
           control_id: CC7.2
+          coverage_status: mapped
+          rule_count: 32
           mapped_rules:
             - ai-model-monitoring
             - aws-bedrock-model-no-guardrails
@@ -36810,6 +38492,8 @@ profiles:
           family_id: CC7
           family_name: System Operations
           control_id: CC7.3
+          coverage_status: mapped
+          rule_count: 15
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -36830,6 +38514,8 @@ profiles:
           family_id: CC7
           family_name: System Operations
           control_id: CC7.4
+          coverage_status: mapped
+          rule_count: 10
           mapped_rules:
             - ai-incident-response
             - aws-guardduty-c2-traffic
@@ -36845,6 +38531,8 @@ profiles:
           family_id: CC7
           family_name: System Operations
           control_id: CC7.5
+          coverage_status: mapped
+          rule_count: 8
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -36858,6 +38546,8 @@ profiles:
           family_id: CC8
           family_name: Change Management
           control_id: CC8.1
+          coverage_status: mapped
+          rule_count: 5
           mapped_rules:
             - aws-ecr-immutable-tags
             - gitlab-runner-unprotected-tags
@@ -36868,10 +38558,14 @@ profiles:
           family_id: CC9
           family_name: Risk Mitigation
           control_id: CC9.1
+          coverage_status: unmapped
+          rule_count: 0
         - framework_name: SOC 2
           family_id: CC9
           family_name: Risk Mitigation
           control_id: CC9.2
+          coverage_status: mapped
+          rule_count: 4
           mapped_rules:
             - grc-vendor-review-overdue
             - vendor-dpa-exists

--- a/internal/compliance/extension.go
+++ b/internal/compliance/extension.go
@@ -1,0 +1,75 @@
+package compliance
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ControlExtensionPack is a small manifest for shipping custom control catalogs
+// and reusable profile selections together.
+type ControlExtensionPack struct {
+	Version     string   `json:"version" yaml:"version"`
+	ID          string   `json:"id" yaml:"id"`
+	Name        string   `json:"name" yaml:"name"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Catalogs    []string `json:"catalogs,omitempty" yaml:"catalogs,omitempty"`
+	Profiles    []string `json:"profiles,omitempty" yaml:"profiles,omitempty"`
+}
+
+func LoadControlExtensionPackFile(path string) (ControlExtensionPack, error) {
+	content, err := readLocalYAMLFile(path) // #nosec G304 -- control extension path is an operator-provided local YAML file; readLocalYAMLFile rejects symlinks.
+	if err != nil {
+		return ControlExtensionPack{}, err
+	}
+	return LoadControlExtensionPack(content)
+}
+
+func LoadControlExtensionPack(content []byte) (ControlExtensionPack, error) {
+	var pack ControlExtensionPack
+	if err := yaml.Unmarshal(content, &pack); err != nil {
+		return ControlExtensionPack{}, err
+	}
+	return pack, nil
+}
+
+func ValidateControlExtensionPack(pack ControlExtensionPack) []ValidationIssue {
+	var issues []ValidationIssue
+	if strings.TrimSpace(pack.Version) == "" {
+		issues = append(issues, ValidationIssue{Path: "version", Message: "control extension version is required"})
+	}
+	if strings.TrimSpace(pack.ID) == "" {
+		issues = append(issues, ValidationIssue{Path: "id", Message: "control extension id is required"})
+	}
+	if strings.TrimSpace(pack.Name) == "" {
+		issues = append(issues, ValidationIssue{Path: "name", Message: "control extension name is required"})
+	}
+	if len(pack.Catalogs) == 0 && len(pack.Profiles) == 0 {
+		issues = append(issues, ValidationIssue{Path: "catalogs", Message: "control extension requires at least one catalog or profile path"})
+	}
+	issues = append(issues, validateExtensionPaths("catalogs", pack.Catalogs)...)
+	issues = append(issues, validateExtensionPaths("profiles", pack.Profiles)...)
+	return issues
+}
+
+func MergeControlProfileSets(sets ...ControlProfileSet) ControlProfileSet {
+	var merged ControlProfileSet
+	for _, set := range sets {
+		if strings.TrimSpace(merged.Version) == "" {
+			merged.Version = strings.TrimSpace(set.Version)
+		}
+		merged.Profiles = append(merged.Profiles, set.Profiles...)
+	}
+	return merged
+}
+
+func validateExtensionPaths(path string, values []string) []ValidationIssue {
+	var issues []ValidationIssue
+	for idx, value := range values {
+		if strings.TrimSpace(value) == "" {
+			issues = append(issues, ValidationIssue{Path: fmt.Sprintf("%s[%d]", path, idx), Message: "path is required"})
+		}
+	}
+	return issues
+}

--- a/internal/compliance/extension_test.go
+++ b/internal/compliance/extension_test.go
@@ -1,0 +1,64 @@
+package compliance
+
+import "testing"
+
+func TestLoadControlExtensionPackReadsYAML(t *testing.T) {
+	pack, err := LoadControlExtensionPack([]byte(`
+version: "2026-06-17"
+id: customer-controls
+name: Customer Controls
+description: Custom control framework and profile selections.
+catalogs:
+  - controls.yaml
+profiles:
+  - profiles.yaml
+`))
+	if err != nil {
+		t.Fatalf("LoadControlExtensionPack() error = %v", err)
+	}
+	if pack.ID != "customer-controls" || len(pack.Catalogs) != 1 || len(pack.Profiles) != 1 {
+		t.Fatalf("pack = %#v, want parsed extension manifest", pack)
+	}
+}
+
+func TestValidateControlExtensionPackRequiresMetadataAndPaths(t *testing.T) {
+	issues := ValidateControlExtensionPack(ControlExtensionPack{
+		Catalogs: []string{""},
+		Profiles: []string{""},
+	})
+	for _, want := range []string{
+		"control extension version is required",
+		"control extension id is required",
+		"control extension name is required",
+		"path is required",
+	} {
+		if !validationIssuesContain(issues, want) {
+			t.Fatalf("issues = %#v, want %q", issues, want)
+		}
+	}
+}
+
+func TestMergeControlProfileSetsAppendsCustomProfiles(t *testing.T) {
+	merged := MergeControlProfileSets(
+		ControlProfileSet{
+			Version: "2026-06-17",
+			Profiles: []ControlSelection{{
+				ID:   "base",
+				Name: "Base",
+			}},
+		},
+		ControlProfileSet{
+			Version: "customer",
+			Profiles: []ControlSelection{{
+				ID:   "custom",
+				Name: "Custom",
+			}},
+		},
+	)
+	if merged.Version != "2026-06-17" {
+		t.Fatalf("Version = %q, want first non-empty version", merged.Version)
+	}
+	if len(merged.Profiles) != 2 || merged.Profiles[1].ID != "custom" {
+		t.Fatalf("Profiles = %#v, want base and custom profiles", merged.Profiles)
+	}
+}

--- a/internal/compliance/posture.go
+++ b/internal/compliance/posture.go
@@ -670,3 +670,18 @@ func sortedUniqueStrings(values []string) []string {
 	sort.Strings(unique)
 	return unique
 }
+
+func orderedUniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	unique := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		unique = appendUniqueString(unique, value)
+	}
+	return unique
+}

--- a/internal/compliance/profile.go
+++ b/internal/compliance/profile.go
@@ -49,22 +49,57 @@ type ControlCoverageSummary struct {
 }
 
 type ControlCoverageControl struct {
-	FrameworkID            string   `json:"framework_id,omitempty" yaml:"framework_id,omitempty"`
-	FrameworkName          string   `json:"framework_name" yaml:"framework_name"`
-	FrameworkVersion       string   `json:"framework_version,omitempty" yaml:"framework_version,omitempty"`
-	FamilyID               string   `json:"family_id" yaml:"family_id"`
-	FamilyName             string   `json:"family_name" yaml:"family_name"`
-	ControlID              string   `json:"control_id" yaml:"control_id"`
-	Title                  string   `json:"title,omitempty" yaml:"title,omitempty"`
-	OwnerDomain            string   `json:"owner_domain,omitempty" yaml:"owner_domain,omitempty"`
-	Tags                   []string `json:"tags,omitempty" yaml:"tags,omitempty"`
-	EvidenceExpectationIDs []string `json:"evidence_expectation_ids,omitempty" yaml:"evidence_expectation_ids,omitempty"`
-	MappedRules            []string `json:"mapped_rules,omitempty" yaml:"mapped_rules,omitempty"`
+	FrameworkID            string                       `json:"framework_id,omitempty" yaml:"framework_id,omitempty"`
+	FrameworkName          string                       `json:"framework_name" yaml:"framework_name"`
+	FrameworkVersion       string                       `json:"framework_version,omitempty" yaml:"framework_version,omitempty"`
+	FamilyID               string                       `json:"family_id" yaml:"family_id"`
+	FamilyName             string                       `json:"family_name" yaml:"family_name"`
+	ControlID              string                       `json:"control_id" yaml:"control_id"`
+	Title                  string                       `json:"title,omitempty" yaml:"title,omitempty"`
+	OwnerDomain            string                       `json:"owner_domain,omitempty" yaml:"owner_domain,omitempty"`
+	Tags                   []string                     `json:"tags,omitempty" yaml:"tags,omitempty"`
+	EvidenceExpectationIDs []string                     `json:"evidence_expectation_ids,omitempty" yaml:"evidence_expectation_ids,omitempty"`
+	AuditPlan              *ControlCoverageAuditPlan    `json:"audit_plan,omitempty" yaml:"audit_plan,omitempty"`
+	EvidencePlan           *ControlCoverageEvidencePlan `json:"evidence_plan,omitempty" yaml:"evidence_plan,omitempty"`
+	MappedControlRefs      []ControlRef                 `json:"mapped_control_refs,omitempty" yaml:"mapped_control_refs,omitempty"`
+	CoverageStatus         string                       `json:"coverage_status" yaml:"coverage_status"`
+	RuleCount              int                          `json:"rule_count" yaml:"rule_count"`
+	MappedRules            []string                     `json:"mapped_rules,omitempty" yaml:"mapped_rules,omitempty"`
+}
+
+type ControlCoverageAuditPlan struct {
+	Objective              string   `json:"objective,omitempty" yaml:"objective,omitempty"`
+	Intent                 string   `json:"intent,omitempty" yaml:"intent,omitempty"`
+	FreshnessSLA           string   `json:"freshness_sla,omitempty" yaml:"freshness_sla,omitempty"`
+	Applicability          []string `json:"applicability,omitempty" yaml:"applicability,omitempty"`
+	AssessmentMethods      []string `json:"assessment_methods,omitempty" yaml:"assessment_methods,omitempty"`
+	ImplementationGuidance []string `json:"implementation_guidance,omitempty" yaml:"implementation_guidance,omitempty"`
+	AuditProcedure         []string `json:"audit_procedure,omitempty" yaml:"audit_procedure,omitempty"`
+	FailureModes           []string `json:"failure_modes,omitempty" yaml:"failure_modes,omitempty"`
+	RemediationGuidance    []string `json:"remediation_guidance,omitempty" yaml:"remediation_guidance,omitempty"`
+	ExceptionGuidance      string   `json:"exception_guidance,omitempty" yaml:"exception_guidance,omitempty"`
+	Automatable            *bool    `json:"automatable,omitempty" yaml:"automatable,omitempty"`
+	ManualEvidenceAllowed  *bool    `json:"manual_evidence_allowed,omitempty" yaml:"manual_evidence_allowed,omitempty"`
+}
+
+type ControlCoverageEvidencePlan struct {
+	Expectations []ControlCoverageEvidenceExpectation `json:"expectations,omitempty" yaml:"expectations,omitempty"`
 }
 
 type ControlCoverageRule struct {
 	RuleID   string       `json:"rule_id" yaml:"rule_id"`
 	Controls []ControlRef `json:"controls" yaml:"controls"`
+}
+
+type ControlCoverageEvidenceExpectation struct {
+	ID                string   `json:"id" yaml:"id"`
+	Title             string   `json:"title,omitempty" yaml:"title,omitempty"`
+	Type              string   `json:"type" yaml:"type"`
+	Required          bool     `json:"required" yaml:"required"`
+	Description       string   `json:"description,omitempty" yaml:"description,omitempty"`
+	AssessmentMethods []string `json:"assessment_methods,omitempty" yaml:"assessment_methods,omitempty"`
+	FreshnessSLA      string   `json:"freshness_sla,omitempty" yaml:"freshness_sla,omitempty"`
+	AcceptedFrom      []string `json:"accepted_from,omitempty" yaml:"accepted_from,omitempty"`
 }
 
 func LoadControlProfileSetFile(path string) (ControlProfileSet, error) {
@@ -130,6 +165,10 @@ func BuildControlCoverageProfile(selection ControlSelection, resolution Selectio
 			profile.Summary.MappedControls++
 		}
 		expectationIDs, _ := evidenceExpectationIDs(control.Evidence)
+		coverageStatus := "unmapped"
+		if len(mappedRules) != 0 {
+			coverageStatus = "mapped"
+		}
 		profile.Controls = append(profile.Controls, ControlCoverageControl{
 			FrameworkID:            strings.TrimSpace(control.FrameworkID),
 			FrameworkName:          strings.TrimSpace(control.FrameworkName),
@@ -141,6 +180,11 @@ func BuildControlCoverageProfile(selection ControlSelection, resolution Selectio
 			OwnerDomain:            strings.TrimSpace(control.Control.OwnerDomain),
 			Tags:                   sortedUniqueStrings(control.EffectiveTags),
 			EvidenceExpectationIDs: expectationIDs,
+			AuditPlan:              controlCoverageAuditPlan(control.Control),
+			EvidencePlan:           controlCoverageEvidencePlan(control.Evidence, control.Control.FreshnessSLA),
+			MappedControlRefs:      sortedControlRefs(control.Control.MapsTo),
+			CoverageStatus:         coverageStatus,
+			RuleCount:              len(mappedRules),
 			MappedRules:            mappedRules,
 		})
 	}
@@ -205,6 +249,9 @@ func sortControlCoverageProfile(profile *ControlCoverageProfile) {
 	for idx := range profile.Controls {
 		profile.Controls[idx].Tags = sortedUniqueStrings(profile.Controls[idx].Tags)
 		profile.Controls[idx].EvidenceExpectationIDs = sortedUniqueStrings(profile.Controls[idx].EvidenceExpectationIDs)
+		normalizeControlCoverageAuditPlan(profile.Controls[idx].AuditPlan)
+		sortControlCoverageEvidencePlan(profile.Controls[idx].EvidencePlan)
+		profile.Controls[idx].MappedControlRefs = sortedControlRefs(profile.Controls[idx].MappedControlRefs)
 		profile.Controls[idx].MappedRules = sortedUniqueStrings(profile.Controls[idx].MappedRules)
 	}
 }
@@ -215,6 +262,95 @@ func sortedControlRefs(refs []ControlRef) []ControlRef {
 		return ControlKey(result[i]) < ControlKey(result[j])
 	})
 	return result
+}
+
+func controlCoverageAuditPlan(control Control) *ControlCoverageAuditPlan {
+	plan := ControlCoverageAuditPlan{
+		Objective:              strings.TrimSpace(control.Objective),
+		Intent:                 strings.TrimSpace(control.Intent),
+		FreshnessSLA:           strings.TrimSpace(control.FreshnessSLA),
+		Applicability:          orderedUniqueStrings(control.Applicability),
+		AssessmentMethods:      orderedUniqueStrings(control.AssessmentMethods),
+		ImplementationGuidance: orderedUniqueStrings(control.ImplementationGuidance),
+		AuditProcedure:         orderedUniqueStrings(control.AuditProcedure),
+		FailureModes:           orderedUniqueStrings(control.FailureModes),
+		RemediationGuidance:    orderedUniqueStrings(control.RemediationGuidance),
+		ExceptionGuidance:      strings.TrimSpace(control.ExceptionGuidance),
+		Automatable:            cloneBool(control.Automatable),
+		ManualEvidenceAllowed:  cloneBool(control.ManualEvidenceAllowed),
+	}
+	if controlCoverageAuditPlanEmpty(plan) {
+		return nil
+	}
+	return &plan
+}
+
+func controlCoverageEvidencePlan(expectations []EvidenceExpectation, fallbackFreshnessSLA string) *ControlCoverageEvidencePlan {
+	values := make([]ControlCoverageEvidenceExpectation, 0, len(expectations))
+	for _, expectation := range expectations {
+		expectation = expectationWithControlFreshness(expectation, fallbackFreshnessSLA)
+		values = append(values, ControlCoverageEvidenceExpectation{
+			ID:                strings.TrimSpace(expectation.ID),
+			Title:             strings.TrimSpace(expectation.Title),
+			Type:              strings.TrimSpace(expectation.Type),
+			Required:          evidenceExpectationRequired(expectation),
+			Description:       strings.TrimSpace(expectation.Description),
+			AssessmentMethods: sortedUniqueStrings(expectation.AssessmentMethods),
+			FreshnessSLA:      strings.TrimSpace(expectation.FreshnessSLA),
+			AcceptedFrom:      sortedUniqueStrings(expectation.AcceptedFrom),
+		})
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return values[i].ID < values[j].ID
+	})
+	if len(values) == 0 {
+		return nil
+	}
+	return &ControlCoverageEvidencePlan{Expectations: values}
+}
+
+func normalizeControlCoverageAuditPlan(plan *ControlCoverageAuditPlan) {
+	if plan == nil {
+		return
+	}
+	plan.Applicability = orderedUniqueStrings(plan.Applicability)
+	plan.AssessmentMethods = orderedUniqueStrings(plan.AssessmentMethods)
+	plan.ImplementationGuidance = orderedUniqueStrings(plan.ImplementationGuidance)
+	plan.AuditProcedure = orderedUniqueStrings(plan.AuditProcedure)
+	plan.FailureModes = orderedUniqueStrings(plan.FailureModes)
+	plan.RemediationGuidance = orderedUniqueStrings(plan.RemediationGuidance)
+}
+
+func sortControlCoverageEvidencePlan(plan *ControlCoverageEvidencePlan) {
+	if plan == nil {
+		return
+	}
+	sort.Slice(plan.Expectations, func(i, j int) bool {
+		return plan.Expectations[i].ID < plan.Expectations[j].ID
+	})
+}
+
+func controlCoverageAuditPlanEmpty(plan ControlCoverageAuditPlan) bool {
+	return plan.Objective == "" &&
+		plan.Intent == "" &&
+		plan.FreshnessSLA == "" &&
+		len(plan.Applicability) == 0 &&
+		len(plan.AssessmentMethods) == 0 &&
+		len(plan.ImplementationGuidance) == 0 &&
+		len(plan.AuditProcedure) == 0 &&
+		len(plan.FailureModes) == 0 &&
+		len(plan.RemediationGuidance) == 0 &&
+		plan.ExceptionGuidance == "" &&
+		plan.Automatable == nil &&
+		plan.ManualEvidenceAllowed == nil
+}
+
+func cloneBool(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func profileIssuePath(id, path string) string {

--- a/internal/compliance/profile_test.go
+++ b/internal/compliance/profile_test.go
@@ -73,6 +73,28 @@ func TestBuildControlCoverageIndexCreditsMappedCustomControls(t *testing.T) {
 	if len(profile.Controls) != 1 || profile.Controls[0].ControlID != "IAM-1" {
 		t.Fatalf("Controls = %#v, want custom IAM-1", profile.Controls)
 	}
+	control := profile.Controls[0]
+	if control.CoverageStatus != "mapped" || control.RuleCount != 1 {
+		t.Fatalf("coverage fields = status %q rule_count %d, want mapped/1", control.CoverageStatus, control.RuleCount)
+	}
+	if control.AuditPlan == nil || control.AuditPlan.Objective == "" || len(control.AuditPlan.AuditProcedure) != 2 || control.AuditPlan.ExceptionGuidance == "" {
+		t.Fatalf("auditor guidance fields = %#v, want objective, audit procedure, and exception guidance", control)
+	}
+	wantProcedure := []string{
+		"Review privileged production access approvals before checking MFA enrollment.",
+		"Compare privileged account inventory against MFA enrollment evidence.",
+	}
+	for idx, want := range wantProcedure {
+		if got := control.AuditPlan.AuditProcedure[idx]; got != want {
+			t.Fatalf("AuditProcedure[%d] = %q, want %q", idx, got, want)
+		}
+	}
+	if control.EvidencePlan == nil || len(control.EvidencePlan.Expectations) != 1 || control.EvidencePlan.Expectations[0].ID != "privileged-mfa-state" || !control.EvidencePlan.Expectations[0].Required {
+		t.Fatalf("EvidencePlan = %#v, want required privileged-mfa-state", control.EvidencePlan)
+	}
+	if len(control.MappedControlRefs) != 1 || control.MappedControlRefs[0].FrameworkName != "SOC 2" || control.MappedControlRefs[0].ControlID != "CC6.1" {
+		t.Fatalf("MappedControlRefs = %#v, want SOC 2 CC6.1", control.MappedControlRefs)
+	}
 	if got := profile.Controls[0].MappedRules; len(got) != 1 || got[0] != "identity-mfa-required" {
 		t.Fatalf("MappedRules = %#v, want identity-mfa-required", got)
 	}

--- a/internal/compliance/selection_test.go
+++ b/internal/compliance/selection_test.go
@@ -142,16 +142,33 @@ frameworks:
         name: Identity Controls
         controls:
           - id: IAM-1
+            title: Privileged access requires MFA
+            objective: Privileged production access requires strong authentication evidence.
+            intent: Reduce account takeover risk for privileged production identities.
             owner_domain: identity
+            freshness_sla: 30d
             applicability: [production, privileged_access]
             assessment_methods: [test]
+            implementation_guidance:
+              - Enforce MFA before privileged production access is granted.
+            audit_procedure:
+              - Review privileged production access approvals before checking MFA enrollment.
+              - Compare privileged account inventory against MFA enrollment evidence.
+            failure_modes:
+              - Privileged account has production access without MFA evidence.
+            remediation_guidance:
+              - Remove privileged access until MFA is enrolled.
+            exception_guidance: Exceptions require compensating monitoring and approval.
             automatable: true
             manual_evidence_allowed: false
             tags: [identity]
             evidence_expectations:
               - id: privileged-mfa-state
+                title: Privileged MFA state
                 type: identity_configuration
+                required: true
                 assessment_methods: [examine]
+                accepted_from: [okta]
             maps_to:
               - framework_id: soc2
                 control_id: CC6.1

--- a/tools/controlindex/main.go
+++ b/tools/controlindex/main.go
@@ -23,7 +23,9 @@ func main() {
 	write := flag.Bool("write", false, "write the generated control coverage index")
 	check := flag.Bool("check", false, "check that the generated control coverage index is fresh")
 	var catalogs pathList
+	var extensions pathList
 	flag.Var(&catalogs, "catalog", "control catalog YAML path relative to root; may be repeated")
+	flag.Var(&extensions, "extension", "control extension manifest path relative to root; may be repeated")
 	flag.Parse()
 
 	if len(catalogs) == 0 {
@@ -34,7 +36,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	content, err := generateCoverageIndex(filepath.Clean(*root), catalogs, *profiles)
+	content, err := generateCoverageIndex(filepath.Clean(*root), catalogs, *profiles, extensions)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "controlindex: %v\n", err)
 		os.Exit(1)
@@ -84,7 +86,17 @@ func (p *pathList) Set(value string) error {
 	return nil
 }
 
-func generateCoverageIndex(root string, catalogPaths []string, profilePath string) ([]byte, error) {
+func generateCoverageIndex(root string, catalogPaths []string, profilePath string, extensionPaths []string) ([]byte, error) {
+	absoluteRoot, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return nil, fmt.Errorf("resolve root: %w", err)
+	}
+	root = absoluteRoot
+	extensionCatalogs, extensionProfiles, err := loadControlExtensions(root, extensionPaths)
+	if err != nil {
+		return nil, err
+	}
+	catalogPaths = append(catalogPaths, extensionCatalogs...)
 	catalog, err := loadControlCatalog(root, catalogPaths)
 	if err != nil {
 		return nil, err
@@ -92,6 +104,17 @@ func generateCoverageIndex(root string, catalogPaths []string, profilePath strin
 	profiles, err := loadControlProfiles(root, profilePath)
 	if err != nil {
 		return nil, err
+	}
+	if len(extensionProfiles) != 0 {
+		profileSets := []compliance.ControlProfileSet{profiles}
+		for _, path := range extensionProfiles {
+			extensionProfile, err := loadControlProfiles(root, path)
+			if err != nil {
+				return nil, err
+			}
+			profileSets = append(profileSets, extensionProfile)
+		}
+		profiles = compliance.MergeControlProfileSets(profileSets...)
 	}
 	index, issues := compliance.BuildControlCoverageIndex(catalog, profiles, builtinRuleControlMappings())
 	if len(issues) != 0 {
@@ -107,7 +130,7 @@ func generateCoverageIndex(root string, catalogPaths []string, profilePath strin
 func loadControlCatalog(root string, paths []string) (*compliance.CatalogIndex, error) {
 	catalogPaths := make([]string, 0, len(paths))
 	for _, path := range paths {
-		catalogPaths = append(catalogPaths, filepath.Join(root, filepath.FromSlash(strings.TrimSpace(path))))
+		catalogPaths = append(catalogPaths, resolveRootPath(root, strings.TrimSpace(path)))
 	}
 	catalog, err := compliance.LoadControlCatalogFiles(catalogPaths...)
 	if err != nil {
@@ -121,7 +144,46 @@ func loadControlCatalog(root string, paths []string) (*compliance.CatalogIndex, 
 }
 
 func loadControlProfiles(root string, path string) (compliance.ControlProfileSet, error) {
-	return compliance.LoadControlProfileSetFile(filepath.Join(root, filepath.FromSlash(path)))
+	return compliance.LoadControlProfileSetFile(resolveRootPath(root, path))
+}
+
+func loadControlExtensions(root string, paths []string) ([]string, []string, error) {
+	catalogPaths := []string{}
+	profilePaths := []string{}
+	for _, path := range paths {
+		manifestPath := resolveRootPath(root, path)
+		pack, err := compliance.LoadControlExtensionPackFile(manifestPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load extension %s: %w", path, err)
+		}
+		if issues := compliance.ValidateControlExtensionPack(pack); len(issues) != 0 {
+			return nil, nil, validationIssuesError(path, issues)
+		}
+		manifestDir := filepath.Dir(manifestPath)
+		for _, catalog := range pack.Catalogs {
+			catalogPaths = append(catalogPaths, resolveExtensionPath(manifestDir, catalog))
+		}
+		for _, profiles := range pack.Profiles {
+			profilePaths = append(profilePaths, resolveExtensionPath(manifestDir, profiles))
+		}
+	}
+	return catalogPaths, profilePaths, nil
+}
+
+func resolveRootPath(root string, path string) string {
+	path = strings.TrimSpace(path)
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(root, filepath.FromSlash(path))
+}
+
+func resolveExtensionPath(manifestDir string, path string) string {
+	path = strings.TrimSpace(path)
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(manifestDir, filepath.FromSlash(path))
 }
 
 func builtinRuleControlMappings() []compliance.RuleControlMapping {

--- a/tools/controlindex/main_test.go
+++ b/tools/controlindex/main_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+func TestGenerateCoverageIndexLoadsExtensionCatalogsAndProfiles(t *testing.T) {
+	root := t.TempDir()
+	writeControlExtensionFixture(t, root)
+
+	content, err := generateCoverageIndex(root, []string{compliance.DefaultControlCatalogPath}, compliance.DefaultControlProfilesPath, []string{"extensions/customer/extension.yaml"})
+	if err != nil {
+		t.Fatalf("generateCoverageIndex() error = %v", err)
+	}
+	assertGeneratedCoverageIndexContainsExtension(t, content)
+}
+
+func TestGenerateCoverageIndexLoadsExtensionsWithRelativeRoot(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "repo")
+	writeControlExtensionFixture(t, root)
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	if err := os.Chdir(parent); err != nil {
+		t.Fatalf("Chdir(%s) error = %v", parent, err)
+	}
+	defer func() {
+		if err := os.Chdir(currentDir); err != nil {
+			t.Fatalf("Chdir(%s) error = %v", currentDir, err)
+		}
+	}()
+
+	content, err := generateCoverageIndex("repo", []string{compliance.DefaultControlCatalogPath}, compliance.DefaultControlProfilesPath, []string{"extensions/customer/extension.yaml"})
+	if err != nil {
+		t.Fatalf("generateCoverageIndex() error = %v", err)
+	}
+	assertGeneratedCoverageIndexContainsExtension(t, content)
+}
+
+func writeControlExtensionFixture(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, root, compliance.DefaultControlCatalogPath, `
+version: "2026-06-17"
+frameworks:
+  - name: SOC 2
+    families:
+      - id: CC6
+        name: Logical and Physical Access
+        controls:
+          - id: CC6.1
+`)
+	writeTestFile(t, root, compliance.DefaultControlProfilesPath, `
+version: "2026-06-17"
+profiles:
+  - id: base-soc2
+    name: Base SOC 2
+    frameworks:
+      - name: SOC 2
+        controls: [CC6.1]
+`)
+	writeTestFile(t, root, "extensions/customer/extension.yaml", `
+version: "2026-06-17"
+id: customer-controls
+name: Customer Controls
+catalogs:
+  - controls.yaml
+profiles:
+  - profiles.yaml
+`)
+	writeTestFile(t, root, "extensions/customer/controls.yaml", `
+version: "2026-06-17"
+frameworks:
+  - id: customer
+    name: Customer Framework
+    families:
+      - id: IAM
+        name: Identity Controls
+        controls:
+          - id: IAM-1
+            title: Privileged access requires MFA
+            objective: Privileged production access requires strong authentication evidence.
+            audit_procedure:
+              - Compare privileged account inventory against MFA enrollment evidence.
+            evidence_expectations:
+              - id: privileged-mfa-state
+                type: identity_configuration
+                required: true
+            maps_to:
+              - framework_name: SOC 2
+                control_id: CC6.1
+`)
+	writeTestFile(t, root, "extensions/customer/profiles.yaml", `
+version: "2026-06-17"
+profiles:
+  - id: customer-iam
+    name: Customer IAM
+    frameworks:
+      - id: customer
+        controls: [IAM-1]
+`)
+}
+
+func assertGeneratedCoverageIndexContainsExtension(t *testing.T, content []byte) {
+	t.Helper()
+	output := string(content)
+	for _, want := range []string{
+		"id: customer-iam",
+		"framework_name: Customer Framework",
+		"control_id: IAM-1",
+		"evidence_plan:",
+		"mapped_control_refs:",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("generated coverage index missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func writeTestFile(t *testing.T, root string, path string, content string) {
+	t.Helper()
+	fullPath := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(fullPath), err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", fullPath, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add YAML control extension manifests for packaging custom control catalogs and profile sets
- enrich control catalog semantics with auditor-facing guidance fields
- expand generated control coverage rows with coverage status, rule counts, mapped refs, audit plans, and evidence plans
- document custom framework extension workflow and regenerate the coverage index

## Validation
- go test ./internal/compliance ./tools/controlindex ./tools/catalogcheck
- go run ./tools/controlindex --check
- git diff --check
- make check-structural
- make lint
- make catalog-check
- make verify