### PR TITLE
Add compliance profile composition

### DIFF
--- a/docs/COMPLIANCE_CONTROLS.md
+++ b/docs/COMPLIANCE_CONTROLS.md
@@ -129,6 +129,7 @@ profiles:
   - id: customer-production-access
     name: Customer Production Access
     description: Production identity and privileged-access scope for customer audit evidence.
+    include_profiles: [soc2-security-core]
     frameworks:
       - name: Customer Audit 2026
         controls: [IAM-1]
@@ -137,6 +138,26 @@ profiles:
 ```
 
 Use profiles for common auditor views, control subsets, custom framework launches, or product-packaged compliance views. Custom frameworks can ship their own profile YAML beside their control pack and use the same resolver APIs.
+
+Profiles can compose other profiles with `include_profiles`. Included profiles are resolved independently and unioned with the including profile, so each reusable selection keeps its own framework, tag, owner, evidence, applicability, and assessment-method semantics. The including profile's `exclude_controls` and `exclude_tags` are applied after the union, which lets teams build broad audit packets and then remove customer-irrelevant controls without copying the source profile definitions.
+
+```yaml
+version: "2026-06-17"
+profiles:
+  - id: customer-security-audit
+    name: Customer Security Audit
+    include_profiles:
+      - soc2-security-core
+      - cloud-security-benchmarks
+    frameworks:
+      - name: Customer Audit 2026
+        controls: [IAM-1]
+    exclude_controls:
+      - framework_name: SOC 2
+        control_id: CC6.2
+```
+
+Use composition for customer audit packets, internal control programs, product-specific compliance views, or custom framework launches that need to combine several built-in control groups with customer-specific controls.
 
 ## Coverage Resolution
 

--- a/internal/compliance/profile.go
+++ b/internal/compliance/profile.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -121,8 +122,9 @@ func LoadControlProfileSet(content []byte) (ControlProfileSet, error) {
 func ResolveControlProfiles(index *CatalogIndex, set ControlProfileSet) (ControlProfileResolution, []ValidationIssue) {
 	result := ControlProfileResolution{Version: strings.TrimSpace(set.Version)}
 	issues := validateControlProfileSet(set)
+	profilesByID := controlProfilesByID(set.Profiles)
 	for _, profile := range set.Profiles {
-		resolution, resolutionIssues := ResolveControlSelection(index, profile)
+		resolution, resolutionIssues := resolveControlProfile(index, profilesByID, profile, nil)
 		for _, issue := range resolutionIssues {
 			issue.Path = profileIssuePath(profile.ID, issue.Path)
 			issues = append(issues, issue)
@@ -138,6 +140,57 @@ func ResolveControlProfiles(index *CatalogIndex, set ControlProfileSet) (Control
 	return result, issues
 }
 
+func resolveControlProfile(index *CatalogIndex, profilesByID map[string]ControlSelection, profile ControlSelection, stack []string) (SelectionResolution, []ValidationIssue) {
+	id := strings.TrimSpace(profile.ID)
+	if profileIDInStack(stack, id) {
+		return SelectionResolution{SelectionID: id}, []ValidationIssue{{
+			Path:    "include_profiles",
+			Message: "profile include cycle detected: " + strings.Join(append(stack, id), " -> "),
+		}}
+	}
+	stack = append(stack, id)
+	selected := map[string]ResolvedControl{}
+	issues := []ValidationIssue{}
+
+	direct := profile
+	direct.IncludeProfiles = nil
+	direct.ExcludeControls = nil
+	direct.ExcludeTags = nil
+	if !selectionEmpty(direct) || len(profile.IncludeProfiles) == 0 {
+		resolution, resolutionIssues := ResolveControlSelection(index, direct)
+		issues = append(issues, resolutionIssues...)
+		addResolvedControls(selected, resolution.Controls)
+	}
+
+	for idx, includeID := range profile.IncludeProfiles {
+		includeID = strings.TrimSpace(includeID)
+		path := fmt.Sprintf("include_profiles[%d]", idx)
+		if includeID == "" {
+			issues = append(issues, ValidationIssue{Path: path, Message: "profile id is required"})
+			continue
+		}
+		if profileIDInStack(stack, includeID) {
+			cycle := append(append([]string(nil), stack...), includeID)
+			issues = append(issues, ValidationIssue{Path: path, Message: "profile include cycle detected: " + strings.Join(cycle, " -> ")})
+			continue
+		}
+		included, ok := profilesByID[includeID]
+		if !ok {
+			issues = append(issues, ValidationIssue{Path: path, Message: fmt.Sprintf("profile %q is not declared", includeID)})
+			continue
+		}
+		resolution, resolutionIssues := resolveControlProfile(index, profilesByID, included, stack)
+		for _, issue := range resolutionIssues {
+			issue.Path = nestedProfileIssuePath(path, issue.Path)
+			issues = append(issues, issue)
+		}
+		addResolvedControls(selected, resolution.Controls)
+	}
+
+	issues = append(issues, applyControlSelectionExclusions(index, selected, profile)...)
+	return controlSelectionResolution(id, selected), issues
+}
+
 func BuildControlCoverageIndex(index *CatalogIndex, set ControlProfileSet, rules []RuleControlMapping) (ControlCoverageIndex, []ValidationIssue) {
 	resolution, issues := ResolveControlProfiles(index, set)
 	result := ControlCoverageIndex{Version: resolution.Version}
@@ -149,6 +202,51 @@ func BuildControlCoverageIndex(index *CatalogIndex, set ControlProfileSet, rules
 		return result.Profiles[i].ID < result.Profiles[j].ID
 	})
 	return result, issues
+}
+
+func controlProfilesByID(profiles []ControlSelection) map[string]ControlSelection {
+	result := map[string]ControlSelection{}
+	for _, profile := range profiles {
+		id := strings.TrimSpace(profile.ID)
+		if id == "" {
+			continue
+		}
+		if _, ok := result[id]; ok {
+			continue
+		}
+		result[id] = profile
+	}
+	return result
+}
+
+func addResolvedControls(selected map[string]ResolvedControl, controls []ResolvedControl) {
+	for _, control := range controls {
+		selected[ControlKey(ControlRef{FrameworkName: control.FrameworkName, ControlID: control.Control.ID})] = control
+	}
+}
+
+func profileIDInStack(stack []string, id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, existing := range stack {
+		if existing == id {
+			return true
+		}
+	}
+	return false
+}
+
+func nestedProfileIssuePath(prefix, path string) string {
+	prefix = strings.TrimSpace(prefix)
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return prefix
+	}
+	if prefix == "" {
+		return path
+	}
+	return prefix + "." + path
 }
 
 func BuildControlCoverageProfile(selection ControlSelection, resolution SelectionResolution, coverage RuleCoverage) ControlCoverageProfile {

--- a/internal/compliance/profile_test.go
+++ b/internal/compliance/profile_test.go
@@ -8,6 +8,7 @@ version: "2026-06-17"
 profiles:
   - id: production-access
     name: Production Access
+    include_profiles: [identity-core]
     frameworks:
       - name: Custom Framework
         controls: [IAM-1]
@@ -16,7 +17,7 @@ profiles:
 	if err != nil {
 		t.Fatalf("LoadControlProfileSet() error = %v", err)
 	}
-	if set.Version != "2026-06-17" || len(set.Profiles) != 1 || set.Profiles[0].ID != "production-access" {
+	if set.Version != "2026-06-17" || len(set.Profiles) != 1 || set.Profiles[0].ID != "production-access" || len(set.Profiles[0].IncludeProfiles) != 1 {
 		t.Fatalf("set = %#v, want parsed profile set", set)
 	}
 }
@@ -101,6 +102,91 @@ func TestBuildControlCoverageIndexCreditsMappedCustomControls(t *testing.T) {
 	if len(profile.Rules) != 1 || len(profile.Rules[0].Controls) != 1 || profile.Rules[0].Controls[0].ControlID != "IAM-1" {
 		t.Fatalf("Rules = %#v, want rule mapped to custom IAM-1", profile.Rules)
 	}
+}
+
+func TestResolveControlProfilesComposesIncludedProfiles(t *testing.T) {
+	set := ControlProfileSet{
+		Version: "2026-06-17",
+		Profiles: []ControlSelection{
+			{
+				ID:   "soc2-access",
+				Name: "SOC 2 Access",
+				Frameworks: []FrameworkSelection{{
+					Name:     "SOC 2",
+					Controls: []string{"CC6.1"},
+				}},
+			},
+			{
+				ID:   "custom-identity",
+				Name: "Custom Identity",
+				Frameworks: []FrameworkSelection{{
+					ID:       "custom",
+					Controls: []string{"IAM-1"},
+				}},
+			},
+			{
+				ID:              "customer-audit",
+				Name:            "Customer Audit",
+				IncludeProfiles: []string{"soc2-access", "custom-identity"},
+				ExcludeControls: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+			},
+		},
+	}
+
+	resolution, issues := ResolveControlProfiles(testSelectionIndex(t), set)
+	if len(issues) != 0 {
+		t.Fatalf("ResolveControlProfiles() issues = %#v, want none", issues)
+	}
+	profile := resolvedProfileByID(t, resolution, "customer-audit")
+	if len(profile.Resolution.Controls) != 1 {
+		t.Fatalf("Controls = %#v, want one custom identity control after exclusion", profile.Resolution.Controls)
+	}
+	control := profile.Resolution.Controls[0]
+	if control.FrameworkName != "Custom Framework" || control.Control.ID != "IAM-1" {
+		t.Fatalf("Control = %#v, want Custom Framework IAM-1", control)
+	}
+}
+
+func TestResolveControlProfilesReportsUnknownIncludedProfile(t *testing.T) {
+	set := ControlProfileSet{
+		Version: "2026-06-17",
+		Profiles: []ControlSelection{{
+			ID:              "customer-audit",
+			Name:            "Customer Audit",
+			IncludeProfiles: []string{"missing-profile"},
+		}},
+	}
+
+	_, issues := ResolveControlProfiles(testSelectionIndex(t), set)
+	if !validationIssuesContain(issues, `profile "missing-profile" is not declared`) {
+		t.Fatalf("issues = %#v, want missing profile issue", issues)
+	}
+}
+
+func TestResolveControlProfilesReportsIncludeCycles(t *testing.T) {
+	set := ControlProfileSet{
+		Version: "2026-06-17",
+		Profiles: []ControlSelection{
+			{ID: "profile-a", Name: "Profile A", IncludeProfiles: []string{"profile-b"}},
+			{ID: "profile-b", Name: "Profile B", IncludeProfiles: []string{"profile-a"}},
+		},
+	}
+
+	_, issues := ResolveControlProfiles(testSelectionIndex(t), set)
+	if !validationIssuesContain(issues, "profile include cycle detected: profile-a -> profile-b -> profile-a") {
+		t.Fatalf("issues = %#v, want include cycle issue", issues)
+	}
+}
+
+func resolvedProfileByID(t *testing.T, resolution ControlProfileResolution, id string) ResolvedControlProfile {
+	t.Helper()
+	for _, profile := range resolution.Profiles {
+		if profile.Profile.ID == id {
+			return profile
+		}
+	}
+	t.Fatalf("profile %q not found in %#v", id, resolution.Profiles)
+	return ResolvedControlProfile{}
 }
 
 func validationIssuesContain(issues []ValidationIssue, want string) bool {

--- a/internal/compliance/selection.go
+++ b/internal/compliance/selection.go
@@ -12,6 +12,7 @@ type ControlSelection struct {
 	ID                    string               `json:"id" yaml:"id"`
 	Name                  string               `json:"name" yaml:"name"`
 	Description           string               `json:"description,omitempty" yaml:"description,omitempty"`
+	IncludeProfiles       []string             `json:"include_profiles,omitempty" yaml:"include_profiles,omitempty"`
 	Frameworks            []FrameworkSelection `json:"frameworks,omitempty" yaml:"frameworks,omitempty"`
 	IncludeControls       []ControlRef         `json:"include_controls,omitempty" yaml:"include_controls,omitempty"`
 	ExcludeControls       []ControlRef         `json:"exclude_controls,omitempty" yaml:"exclude_controls,omitempty"`
@@ -73,6 +74,9 @@ func ResolveControlSelection(index *CatalogIndex, selection ControlSelection) (S
 	if index == nil {
 		return SelectionResolution{SelectionID: strings.TrimSpace(selection.ID)}, []ValidationIssue{{Message: "control catalog index is required"}}
 	}
+	if len(selection.IncludeProfiles) != 0 {
+		issues = append(issues, ValidationIssue{Path: "include_profiles", Message: "include_profiles can only be resolved by ResolveControlProfiles"})
+	}
 	selected := map[string]ResolvedControl{}
 	if selectionEmpty(selection) {
 		for _, control := range index.Controls() {
@@ -103,6 +107,18 @@ func ResolveControlSelection(index *CatalogIndex, selection ControlSelection) (S
 			}
 		}
 	}
+	issues = append(issues, applyControlSelectionExclusions(index, selected, selection)...)
+	return controlSelectionResolution(strings.TrimSpace(selection.ID), selected), issues
+}
+
+func applyControlSelectionExclusions(index *CatalogIndex, selected map[string]ResolvedControl, selection ControlSelection) []ValidationIssue {
+	var issues []ValidationIssue
+	if index == nil {
+		if len(selection.ExcludeControls) != 0 {
+			return []ValidationIssue{{Path: "exclude_controls", Message: "control catalog index is required"}}
+		}
+		return nil
+	}
 	for idx, ref := range selection.ExcludeControls {
 		control, ok := index.Control(ref)
 		if !ok {
@@ -117,14 +133,18 @@ func ResolveControlSelection(index *CatalogIndex, selection ControlSelection) (S
 			delete(selected, key)
 		}
 	}
-	result := SelectionResolution{SelectionID: strings.TrimSpace(selection.ID)}
+	return issues
+}
+
+func controlSelectionResolution(selectionID string, selected map[string]ResolvedControl) SelectionResolution {
+	result := SelectionResolution{SelectionID: strings.TrimSpace(selectionID)}
 	for key, control := range selected {
 		result.ControlKeys = append(result.ControlKeys, key)
 		result.Controls = append(result.Controls, control)
 	}
 	sort.Strings(result.ControlKeys)
 	sortResolvedControls(result.Controls)
-	return result, issues
+	return result
 }
 
 func ResolveRuleCoverage(resolution SelectionResolution, rules []RuleControlMapping) RuleCoverage {
@@ -246,7 +266,8 @@ func resolveFrameworkSelection(index *CatalogIndex, idx int, selection Framework
 }
 
 func selectionEmpty(selection ControlSelection) bool {
-	return len(selection.Frameworks) == 0 &&
+	return len(selection.IncludeProfiles) == 0 &&
+		len(selection.Frameworks) == 0 &&
 		len(selection.IncludeControls) == 0 &&
 		len(selection.IncludeTags) == 0 &&
 		len(selection.IncludeOwnerDomains) == 0 &&

--- a/internal/compliance/selection_test.go
+++ b/internal/compliance/selection_test.go
@@ -76,6 +76,19 @@ func TestResolveControlSelectionSupportsControlPostureFilters(t *testing.T) {
 	}
 }
 
+func TestResolveControlSelectionRejectsProfileIncludes(t *testing.T) {
+	resolution, issues := ResolveControlSelection(testSelectionIndex(t), ControlSelection{
+		ID:              "composed",
+		IncludeProfiles: []string{"identity-core"},
+	})
+	if len(resolution.Controls) != 0 {
+		t.Fatalf("Controls = %#v, want none without profile-set resolver", resolution.Controls)
+	}
+	if !validationIssuesContain(issues, "include_profiles can only be resolved by ResolveControlProfiles") {
+		t.Fatalf("issues = %#v, want include_profiles resolver issue", issues)
+	}
+}
+
 func TestResolveControlSelectionMatchesEvidenceAssessmentMethods(t *testing.T) {
 	index := testSelectionIndex(t)
 	resolution, issues := ResolveControlSelection(index, ControlSelection{


### PR DESCRIPTION
## Summary
- add `include_profiles` to control profiles so reusable selections can be composed into customer or program audit views
- resolve included profiles independently, union selected controls, apply the including profile exclusions after the union, and detect missing/cyclic includes
- document composition for custom framework/control-pack authors

## Verification
- `go test ./internal/compliance ./tools/controlindex ./tools/catalogcheck`
- `go run ./tools/controlindex --check`
- `make check-structural`
- `make lint`
- `make catalog-check detection-catalog-check`