### PR TITLE
Add compliance extension scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **Operations data platform for cloud, SaaS, identity, workflow, finding, and graph signals.**
 
-Cerebro is Writer's original operations platform repository. The current `main` branch is centered on a Go bootstrap service with Connect and JSON HTTP APIs, built-in source integrations, source runtime sync, finding and report workflows, append-log replay, MCP access, device-authenticated telemetry, and optional graph projection/query tooling.
+Cerebro is Writer's original operations platform repository. The current `main` branch is centered on a Go bootstrap service with Connect and JSON HTTP APIs, built-in source integrations, source runtime sync, finding and report workflows, compliance-control coverage, append-log replay, MCP access, device-authenticated telemetry, and optional graph projection/query tooling.
 
-In practical terms, Cerebro ingests source and runtime signals, turns them into claims, findings, reports, workflow events, and graph context, then exposes that substrate through the CLI, JSON HTTP, Connect RPC, SDK helpers, and MCP.
+In practical terms, Cerebro ingests source and runtime signals, turns them into claims, findings, reports, workflow events, compliance evidence, and graph context, then exposes that substrate through the CLI, JSON HTTP, Connect RPC, SDK helpers, and MCP.
 
 [![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
@@ -22,7 +22,7 @@ In practical terms, Cerebro ingests source and runtime signals, turns them into 
 - **Graph operations** — Neo4j/Aura-backed graph counts, relation counts, neighborhoods, path summaries, impact queries, graph health, source/runtime ingest, ingest run status, repair/cleanup helpers, and isolated dry-run rebuilds.
 - **MCP and graph-agent surfaces** — an authenticated MCP endpoint, optional OAuth 2.1 authorization-server flow for MCP clients, and an optional graph agent LLM adapter.
 - **Device telemetry surface** — optional first-party device enrollment, token, telemetry ingest, and device vulnerability finding routes.
-- **Policy catalog** — JSON policy definitions under `policies/` for cloud, identity, GitHub, Kubernetes, SaaS, runtime, vulnerability, compliance, and business-operation checks.
+- **Policy and compliance catalogs** — JSON policy definitions under `policies/`, generated detection catalogs, compliance control profiles, coverage indexes, evidence/posture packet helpers, and extension packs for custom control frameworks.
 
 Cerebro has historical and forward-looking docs in `docs/`. For current runtime behavior, treat `cmd/cerebro`, `internal/config`, `internal/bootstrap`, `proto/cerebro/v1/bootstrap.proto`, and the Makefile as the source of truth.
 
@@ -124,6 +124,7 @@ The compose stack starts Cerebro with NATS JetStream, Postgres, Neo4j, and a loc
 | Explore the API | `GET /openapi.yaml` or `api/openapi.yaml` | JSON HTTP routes are generated and checked against the OpenAPI contract. |
 | Call the Connect API | `proto/cerebro/v1/bootstrap.proto` and `gen/cerebro/v1` | Connect RPCs are served under `/cerebro.v1.BootstrapService/{Method}`. |
 | Use SDK helpers | `sdk/python/README.md`, `sdk/typescript/README.md`, and `sources/sdk` | Maintained helpers target current bootstrap routes; the historical Agent SDK gateway is retired. |
+| Map compliance controls and evidence coverage | `docs/COMPLIANCE_CONTROLS.md`, `make control-index-check`, and `go run ./tools/controlindex --init-extension ...` | Built-in profiles cover SOC 2, ISO, CIS, PCI, DORA, FedRAMP, NIS2, CMMC, CJIS, NIST CSF, privacy, and AI governance scopes. Control extension packs scaffold custom `extension.yaml`, `controls.yaml`, and `profiles.yaml` files, then `--extension`, `--profile`, `--output`, and `--write` generate filtered coverage packets. |
 | Ingest Panopticon cases | `sources/panopticon`, source runtime config, and `sdk/python/examples/panopticon_push_claims.py` | API runtimes read curated `case` events by default; explicit `alert` and `ioc` families are available when raw signal evidence or IOC enrichment is needed. |
 | Preview a source | `./bin/cerebro source check/discover/read ...` | Source config is passed as `key=value` pairs or HTTP query parameters. |
 | Persist and sync a runtime | `docs/SOURCE_RUNTIME_GUIDE.md` and `source-runtime put/get/list/sync` | Requires Postgres; sync also requires JetStream. |
@@ -134,7 +135,7 @@ The compose stack starts Cerebro with NATS JetStream, Postgres, Neo4j, and a loc
 | Integrate MCP clients | `docs/MCP_DROID_SETUP.md` and `/api/v1/mcp` | Covers stateless Streamable HTTP, OAuth discovery, and compatibility checks. |
 | Shape agent-facing platform contracts | `docs/AGENT_PLATFORM_CONTRACT.md` and `internal/agentplatform` | Cerebro-native runtime, eval, capability, execution, replay, connector, and knowledge principles. |
 | Integrate endpoint telemetry | `docs/ENDPOINT_SECURITY_PLATFORM_INTEGRATION.md` | Covers device-authenticated telemetry, trusted endpoint claims, and trust-gate evidence. |
-| Author policies or finding rules | `policies/`, `internal/findings`, and catalog checks | Run the relevant catalog and finding-rule tests before opening a PR. |
+| Author policies, control mappings, or finding rules | `policies/`, `docs/COMPLIANCE_CONTROLS.md`, `internal/compliance`, `internal/findings`, and catalog checks | Run the relevant catalog, policy-rule, control-index, detection-catalog, and finding-rule checks before opening a PR. |
 | Contribute code or docs | `docs/DEVELOPMENT.md`, `docs/NON_GOALS.md`, and the Makefile | Prefer focused `make` targets while iterating; use `make verify` for broad PR preflight. |
 
 ---
@@ -354,6 +355,8 @@ Policy definitions live under `policies/` as JSON files. The catalog includes cl
 
 Useful directories include `policies/aws/`, `policies/azure/`, `policies/gcp/`, `policies/github/`, `policies/identity/`, `policies/kubernetes/`, `policies/okta/`, `policies/runtime/`, and `policies/vulnerability/`.
 
+Compliance control metadata lives under `internal/compliance/`. `internal/compliance/control_families.yaml` is the built-in control catalog, `internal/compliance/control_profiles.yaml` defines reusable audit scopes, and `internal/compliance/control_coverage_index.yaml` is generated by `make control-index-generate`. Use `docs/COMPLIANCE_CONTROLS.md` for custom framework authoring, extension pack scaffolding with `--init-extension`, and filtered coverage generation with `--extension` and `--profile`.
+
 ---
 
 ## Development
@@ -375,7 +378,7 @@ make oss-audit      # public repository hygiene scan
 make clean          # remove bin/
 ```
 
-Focused validation and utility targets include `make openapi-check`, `make openapi-lint`, `make catalog-check`, `make detection-catalog-check`, `make workflow-e2e-test`, `make workflow-replay-test`, `make finding-rule-test`, `make graph-rebuild-dryrun`, `make workflow-replay`, and `make workflow-neighborhood`.
+Focused validation and utility targets include `make openapi-check`, `make openapi-lint`, `make catalog-check`, `make policy-rule-check`, `make control-index-check`, `make detection-catalog-check`, `make workflow-e2e-test`, `make workflow-replay-test`, `make finding-rule-test`, `make graph-rebuild-dryrun`, `make workflow-replay`, and `make workflow-neighborhood`.
 
 Public-facing docs, config, or example changes should run:
 
@@ -391,9 +394,14 @@ Choose validators by change type:
 | Go runtime/API change | `make test` plus focused package tests |
 | OpenAPI route or handler change | `make openapi-check openapi-lint` |
 | Proto change | `make proto-lint` and generated contract checks when applicable |
-| Source catalog or policy change | `make catalog-check detection-catalog-check` |
+| Source catalog or policy change | `make catalog-check policy-rule-check detection-catalog-check` |
+| Compliance control/profile/scaffold change | `make catalog-check policy-rule-check control-index-check detection-catalog-check` |
 | Public docs/config/examples | `make docs-drift-check` when generated docs are touched, plus `make oss-audit` |
 | Broad PR preflight | `make verify` |
+
+### README freshness
+
+The README is maintained by `make readme-check`, which is part of CI and local changed-path validation. It compares the built-in source table with `internal/sourceregistry`, top-level CLI commands with `cmd/cerebro`, the documented Go toolchain with `go.mod`, selected config names with `internal/config` and `.env.example`, and README anchors for compliance control extension workflows. When a public capability, source, CLI command, config family, or control-index workflow changes, update the README and extend `scripts/readme_check.py` with the new source-of-truth assertion.
 
 ---
 
@@ -428,6 +436,7 @@ Some files in `docs/` describe broader or historical architecture and may be ahe
 | [Source runtime guide](docs/SOURCE_RUNTIME_GUIDE.md) | source preview, runtime persistence, sync, secrets, health, and scheduling |
 | [Auth and tenancy](docs/AUTH_TENANCY.md) | API keys, structured credentials, tenant scoping, public origin, proxy trust, and rotation |
 | [Graph operations](docs/GRAPH_OPERATIONS.md) | graph health, ingest, rebuild, cleanup, query safety, and troubleshooting |
+| [Compliance controls](docs/COMPLIANCE_CONTROLS.md) | control catalog schema, profiles, extension packs, coverage resolution, posture, and evidence packets |
 | [Release contract](docs/RELEASE_CONTRACT.md) | release artifacts, runtime deploy contract schema, source manifests, and verification |
 | [PR landing](docs/PR_LANDING.md) | merge ordering, Droid review gates, and branch deletion safety |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | symptom-driven cookbook for health, auth, source runtime, graph, MCP, and device-auth issues |
@@ -452,8 +461,8 @@ Some files in `docs/` describe broader or historical architecture and may be ahe
 | Append log | NATS JetStream |
 | State store | Postgres |
 | Graph store | Neo4j/Aura |
-| Source integrations | Aurelius, AWS, Azure, Backstage, Cosmo, EvidenceCAS, GCP, GitHub, Google Workspace, GRC, Kandji, Kolide, Okta, Panopticon, SDK, SentinelOne, Security Tooling Map, Trusted Endpoint, VulnView |
-| Validation | `go test`, `golangci-lint`, Buf, Spectral, catalog checks, OSS audit, custom structural linters, arch tests |
+| Source integrations | Built-in source registry under `sources/`; see the Built-in sources table above for the checked list |
+| Validation | `go test`, `golangci-lint`, Buf, Spectral, catalog checks, policy-rule checks, control-index checks, README drift checks, OSS audit, custom structural linters, arch tests |
 
 ---
 

--- a/docs/COMPLIANCE_CONTROLS.md
+++ b/docs/COMPLIANCE_CONTROLS.md
@@ -73,6 +73,19 @@ Use `maps_to` to connect custom controls to controls already covered by generate
 
 Control extension packs are YAML manifests that package custom catalog and profile files together. This gives custom framework work a single generated-coverage entrypoint while keeping the actual control catalog YAML separate and reviewable.
 
+Start a custom pack with the scaffold command:
+
+```bash
+go run ./tools/controlindex \
+  --init-extension customer-controls \
+  --extension-id customer-controls \
+  --framework-id customer \
+  --framework-name "Customer Audit 2026" \
+  --profile-id customer-security-audit
+```
+
+The scaffold writes `extension.yaml`, `controls.yaml`, and `profiles.yaml` into the target directory and refuses to overwrite existing files. The starter control is intentionally rich: it includes objective, intent, applicability, assessment methods, audit procedure, failure modes, remediation guidance, exception guidance, evidence expectations, freshness SLA, owner domain, automation flags, and `maps_to` aliases that can be edited for the custom framework.
+
 ```yaml
 version: "2026-06-17"
 id: customer-controls

--- a/scripts/changed_checks.py
+++ b/scripts/changed_checks.py
@@ -92,6 +92,9 @@ def select_commands(files: list[str], repo: Path) -> list[CommandPlan]:
         add_command(commands, seen, "policy-rule-check", ["make", "policy-rule-check"], "Policy authoring or generated rule enrichment changed.")
         add_command(commands, seen, "detection-catalog-check", ["make", "detection-catalog-check"], "Policy rule changes affect the public detection catalog.")
 
+    if any(path_matches(path, prefixes=("internal/compliance/", "tools/controlindex/")) for path in files):
+        add_command(commands, seen, "control-index-check", ["make", "control-index-check"], "Compliance controls, profiles, or control-index tooling changed.")
+
     if any(path_matches(path, prefixes=("proto/",), suffixes=(".proto",)) for path in files):
         add_command(commands, seen, "proto-generate-check", ["make", "proto-generate-check"], "Protobuf contracts changed.")
         add_command(commands, seen, "proto-breaking", ["make", "proto-breaking"], "Protobuf compatibility must be checked.")
@@ -102,8 +105,22 @@ def select_commands(files: list[str], repo: Path) -> list[CommandPlan]:
 
     if any(path_matches(path, prefixes=("docs/",), exact=("README.md",)) for path in files):
         add_command(commands, seen, "docs-drift-check", ["make", "docs-drift-check"], "Documentation changed.")
-    if "README.md" in files:
-        add_command(commands, seen, "readme-check", ["make", "readme-check"], "README changed.")
+    if any(
+        path_matches(
+            path,
+            prefixes=("internal/config/",),
+            exact=(
+                ".env.example",
+                "README.md",
+                "cmd/cerebro/main.go",
+                "docs/COMPLIANCE_CONTROLS.md",
+                "internal/sourceregistry/registry.go",
+                "tools/controlindex/main.go",
+            ),
+        )
+        for path in files
+    ):
+        add_command(commands, seen, "readme-check", ["make", "readme-check"], "README source-of-truth path changed.")
 
     if any(path_matches(path, prefixes=("scripts/", ".github/workflows/", ".factory/")) for path in files):
         add_command(commands, seen, "python-script-tests", ["python3", "-m", "unittest", "discover", "-s", "scripts/tests"], "Automation, review context, or workflow-adjacent files changed.")

--- a/scripts/readme_check.py
+++ b/scripts/readme_check.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
+CONTROL_INDEX_DOC_FLAGS = {"init-extension", "extension", "profile", "output", "write", "check"}
+CONTROL_INDEX_README_FLAGS = {"init-extension", "extension", "profile", "output", "write"}
 
 
 def read(path: Path) -> str:
@@ -52,6 +54,29 @@ def readme_commands(readme: str) -> list[str]:
     if not match:
         fail("README is missing top-level command sentence")
     return sorted(re.findall(r"`([^`]+)`", match.group(1)))
+
+
+def controlindex_flags() -> set[str]:
+    body = read(ROOT / "tools" / "controlindex" / "main.go")
+    flags = set(re.findall(r'flag\.(?:String|Bool)\("([^"]+)"', body))
+    flags.update(re.findall(r'flag\.Var\([^,\n]+,\s*"([^"]+)"', body))
+    return flags
+
+
+def require_controlindex_docs(readme: str) -> None:
+    flags = controlindex_flags()
+    missing_code_flags = sorted(CONTROL_INDEX_DOC_FLAGS - flags)
+    if missing_code_flags:
+        fail("controlindex lost README-tracked flags: " + ", ".join(f"--{flag}" for flag in missing_code_flags))
+
+    compliance_docs = read(ROOT / "docs" / "COMPLIANCE_CONTROLS.md")
+    missing_doc_flags = sorted(f"--{flag}" for flag in CONTROL_INDEX_DOC_FLAGS if f"--{flag}" not in compliance_docs)
+    if missing_doc_flags:
+        fail("COMPLIANCE_CONTROLS.md missing controlindex flags: " + ", ".join(missing_doc_flags))
+
+    missing_readme_flags = sorted(f"--{flag}" for flag in CONTROL_INDEX_README_FLAGS if f"--{flag}" not in readme)
+    if missing_readme_flags:
+        fail("README missing controlindex workflow flags: " + ", ".join(missing_readme_flags))
 
 
 def repository_env_vars() -> set[str]:
@@ -98,6 +123,8 @@ def main() -> int:
     if missing_env_vars:
         fail("README documents env vars not found in config sources: " + ", ".join(missing_env_vars))
 
+    require_controlindex_docs(readme)
+
     require_contains(
         readme,
         [
@@ -111,6 +138,12 @@ def main() -> int:
             "sdk/typescript/README.md",
             "docs/MCP_DROID_SETUP.md",
             "docs/ENDPOINT_SECURITY_PLATFORM_INTEGRATION.md",
+            "docs/COMPLIANCE_CONTROLS.md",
+            "make control-index-check",
+            "make policy-rule-check",
+            "make detection-catalog-check",
+            "Control extension packs",
+            "make readme-check",
         ],
     )
 

--- a/scripts/tests/test_changed_checks.py
+++ b/scripts/tests/test_changed_checks.py
@@ -30,6 +30,11 @@ class ChangedChecksTests(unittest.TestCase):
         names = self.command_names(["scripts/droid_review_context.py"])
         self.assertIn("python-script-tests", names)
 
+    def test_readme_source_paths_select_readme_check(self):
+        names = self.command_names(["tools/controlindex/main.go"])
+        self.assertIn("readme-check", names)
+        self.assertIn("control-index-check", names)
+
     def test_go_files_select_package_tests(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tools/controlindex/main.go
+++ b/tools/controlindex/main.go
@@ -17,10 +17,19 @@ import (
 type pathList []string
 type profileList []string
 
+const controlExtensionScaffoldVersion = "2026-06-17"
+
 func main() {
 	root := flag.String("root", ".", "repository root")
 	profiles := flag.String("profiles", compliance.DefaultControlProfilesPath, "control profile YAML path relative to root")
 	output := flag.String("output", compliance.DefaultControlCoverageIndexPath, "generated control coverage index YAML path relative to root")
+	initExtension := flag.String("init-extension", "", "write a starter control extension pack to this directory relative to root")
+	extensionID := flag.String("extension-id", "", "control extension id for --init-extension")
+	extensionName := flag.String("extension-name", "", "control extension name for --init-extension")
+	frameworkID := flag.String("framework-id", "", "custom framework id for --init-extension")
+	frameworkName := flag.String("framework-name", "", "custom framework name for --init-extension")
+	profileID := flag.String("profile-id", "", "starter control profile id for --init-extension")
+	profileName := flag.String("profile-name", "", "starter control profile name for --init-extension")
 	write := flag.Bool("write", false, "write the generated control coverage index")
 	check := flag.Bool("check", false, "check that the generated control coverage index is fresh")
 	var catalogs pathList
@@ -30,6 +39,19 @@ func main() {
 	flag.Var(&extensions, "extension", "control extension manifest path relative to root; may be repeated")
 	flag.Var(&selectedProfiles, "profile", "control profile id to include in the generated index; may be repeated")
 	flag.Parse()
+
+	if strings.TrimSpace(*initExtension) != "" {
+		options := newControlExtensionScaffoldOptions(*initExtension, *extensionID, *extensionName, *frameworkID, *frameworkName, *profileID, *profileName)
+		if err := validateControlExtensionScaffoldFlags(*write, *check, []string(selectedProfiles), options); err != nil {
+			fmt.Fprintf(os.Stderr, "controlindex: %v\n", err)
+			os.Exit(2)
+		}
+		if err := writeControlExtensionScaffold(filepath.Clean(*root), options); err != nil {
+			fmt.Fprintf(os.Stderr, "controlindex: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	if len(catalogs) == 0 {
 		catalogs = append(catalogs, compliance.DefaultControlCatalogPath)
@@ -114,6 +136,272 @@ func validateControlIndexFlags(write bool, check bool, output string, selectedPr
 
 func isDefaultCoverageOutput(path string) bool {
 	return filepath.ToSlash(filepath.Clean(strings.TrimSpace(path))) == filepath.ToSlash(filepath.Clean(compliance.DefaultControlCoverageIndexPath))
+}
+
+type controlExtensionScaffoldOptions struct {
+	Dir           string
+	Version       string
+	ExtensionID   string
+	ExtensionName string
+	FrameworkID   string
+	FrameworkName string
+	ProfileID     string
+	ProfileName   string
+}
+
+func newControlExtensionScaffoldOptions(dir, extensionID, extensionName, frameworkID, frameworkName, profileID, profileName string) controlExtensionScaffoldOptions {
+	dir = strings.TrimSpace(dir)
+	baseID := scaffoldSlugValue(firstNonEmpty(extensionID, filepath.Base(filepath.Clean(filepath.FromSlash(dir)))))
+	if baseID == "" {
+		baseID = "custom-controls"
+	}
+	frameworkBaseID := strings.TrimSuffix(baseID, "-controls")
+	if frameworkBaseID == "" {
+		frameworkBaseID = baseID
+	}
+	options := controlExtensionScaffoldOptions{
+		Dir:           dir,
+		Version:       controlExtensionScaffoldVersion,
+		ExtensionID:   baseID,
+		ExtensionName: scaffoldTitle(baseID),
+		FrameworkID:   frameworkBaseID,
+		FrameworkName: scaffoldTitle(frameworkBaseID) + " Framework",
+		ProfileID:     frameworkBaseID + "-audit",
+		ProfileName:   scaffoldTitle(frameworkBaseID) + " Audit",
+	}
+	if value := scaffoldSlugValue(extensionID); value != "" {
+		options.ExtensionID = value
+	}
+	if value := strings.TrimSpace(extensionName); value != "" {
+		options.ExtensionName = value
+	}
+	if value := scaffoldSlugValue(frameworkID); value != "" {
+		options.FrameworkID = value
+	}
+	if value := strings.TrimSpace(frameworkName); value != "" {
+		options.FrameworkName = value
+	}
+	if value := scaffoldSlugValue(profileID); value != "" {
+		options.ProfileID = value
+	}
+	if value := strings.TrimSpace(profileName); value != "" {
+		options.ProfileName = value
+	}
+	return options
+}
+
+func validateControlExtensionScaffoldFlags(write bool, check bool, selectedProfileIDs []string, options controlExtensionScaffoldOptions) error {
+	if write || check {
+		return fmt.Errorf("--init-extension cannot be combined with --write or --check")
+	}
+	if len(selectedProfileIDs) != 0 {
+		return fmt.Errorf("--init-extension cannot be combined with --profile")
+	}
+	if strings.TrimSpace(options.Dir) == "" {
+		return fmt.Errorf("--init-extension directory is required")
+	}
+	for label, value := range map[string]string{
+		"extension id":   options.ExtensionID,
+		"extension name": options.ExtensionName,
+		"framework id":   options.FrameworkID,
+		"framework name": options.FrameworkName,
+		"profile id":     options.ProfileID,
+		"profile name":   options.ProfileName,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", label)
+		}
+	}
+	return nil
+}
+
+func writeControlExtensionScaffold(root string, options controlExtensionScaffoldOptions) error {
+	dir := resolveRootPath(root, options.Dir)
+	if err := rejectSymlink(dir); err != nil {
+		return fmt.Errorf("create extension directory: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create extension directory: %w", err)
+	}
+	files := map[string]any{
+		"extension.yaml": controlExtensionScaffoldPack(options),
+		"controls.yaml":  controlExtensionScaffoldCatalog(options),
+		"profiles.yaml":  controlExtensionScaffoldProfiles(options),
+	}
+	names := []string{"extension.yaml", "controls.yaml", "profiles.yaml"}
+	for _, name := range names {
+		if err := rejectExistingScaffoldFile(filepath.Join(dir, name)); err != nil {
+			return err
+		}
+	}
+	for _, name := range names {
+		if err := writeScaffoldYAMLFile(filepath.Join(dir, name), files[name]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func controlExtensionScaffoldPack(options controlExtensionScaffoldOptions) compliance.ControlExtensionPack {
+	return compliance.ControlExtensionPack{
+		Version:     strings.TrimSpace(options.Version),
+		ID:          strings.TrimSpace(options.ExtensionID),
+		Name:        strings.TrimSpace(options.ExtensionName),
+		Description: "Custom control framework and reusable audit selections.",
+		Catalogs:    []string{"controls.yaml"},
+		Profiles:    []string{"profiles.yaml"},
+	}
+}
+
+func controlExtensionScaffoldCatalog(options controlExtensionScaffoldOptions) compliance.ControlCatalog {
+	automatable := true
+	manualEvidenceAllowed := true
+	required := true
+	return compliance.ControlCatalog{
+		Version: strings.TrimSpace(options.Version),
+		Frameworks: []compliance.Framework{{
+			ID:          strings.TrimSpace(options.FrameworkID),
+			Name:        strings.TrimSpace(options.FrameworkName),
+			Version:     "2026",
+			Description: "Custom auditor-facing controls for this compliance scope.",
+			Tags:        []string{"custom_framework"},
+			Families: []compliance.Family{{
+				ID:          "IAM",
+				Name:        "Identity and Access Management",
+				Description: "Access controls that protect production systems and privileged actions.",
+				Tags:        []string{"identity", "access"},
+				Controls: []compliance.Control{{
+					ID:                     "IAM-1",
+					Title:                  "Privileged access requires MFA",
+					Objective:              "Privileged users authenticate with phishing-resistant MFA before production access is granted.",
+					Intent:                 "Reduce account takeover risk for administrative and production access paths.",
+					Applicability:          []string{"production", "privileged_access"},
+					AssessmentMethods:      []string{"examine", "test"},
+					ImplementationGuidance: []string{"Require privileged identities to enroll MFA before production access is granted."},
+					AuditProcedure:         []string{"Compare privileged account inventory with current MFA enrollment evidence."},
+					FailureModes:           []string{"Privileged user has active production access without enrolled MFA."},
+					RemediationGuidance:    []string{"Remove privileged access until MFA enrollment is complete."},
+					ExceptionGuidance:      "Time-bound exceptions require compensating monitoring and approval.",
+					EvidenceExpectations: []compliance.EvidenceExpectation{{
+						ID:                "privileged-mfa-state",
+						Title:             "Privileged MFA enrollment",
+						Type:              "identity_configuration",
+						Description:       "Current MFA posture for privileged users.",
+						Required:          &required,
+						AssessmentMethods: []string{"examine", "test"},
+						FreshnessSLA:      "30d",
+						AcceptedFrom:      []string{"identity_provider", "source_snapshot"},
+					}},
+					FreshnessSLA:          "30d",
+					OwnerDomain:           "identity",
+					Automatable:           &automatable,
+					ManualEvidenceAllowed: &manualEvidenceAllowed,
+					Tags:                  []string{"mfa", "privileged_access"},
+					MapsTo: []compliance.ControlRef{{
+						FrameworkName: "SOC 2",
+						ControlID:     "CC6.1",
+					}},
+				}},
+			}},
+		}},
+	}
+}
+
+func controlExtensionScaffoldProfiles(options controlExtensionScaffoldOptions) compliance.ControlProfileSet {
+	return compliance.ControlProfileSet{
+		Version: strings.TrimSpace(options.Version),
+		Profiles: []compliance.ControlSelection{{
+			ID:          strings.TrimSpace(options.ProfileID),
+			Name:        strings.TrimSpace(options.ProfileName),
+			Description: "Starter audit profile for the custom framework.",
+			Frameworks: []compliance.FrameworkSelection{{
+				ID:       strings.TrimSpace(options.FrameworkID),
+				Controls: []string{"IAM-1"},
+			}},
+			IncludeApplicability: []string{"production"},
+			IncludeAssessments:   []string{"examine", "test"},
+		}},
+	}
+}
+
+func writeScaffoldYAMLFile(path string, value any) error {
+	if err := rejectSymlink(path); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	content, err := yaml.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", path, err)
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("write %s: file already exists", path)
+		}
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	defer file.Close()
+	if _, err := file.Write(content); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func rejectExistingScaffoldFile(path string) error {
+	if err := rejectSymlink(path); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	_, err := os.Lstat(path)
+	if err == nil {
+		return fmt.Errorf("write %s: file already exists", path)
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return fmt.Errorf("write %s: %w", path, err)
+}
+
+func scaffoldSlugValue(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	lastHyphen := false
+	for _, char := range value {
+		isAlphaNumeric := (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9')
+		if isAlphaNumeric {
+			builder.WriteRune(char)
+			lastHyphen = false
+			continue
+		}
+		if builder.Len() == 0 || lastHyphen {
+			continue
+		}
+		builder.WriteByte('-')
+		lastHyphen = true
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func scaffoldTitle(id string) string {
+	parts := strings.Split(scaffoldSlugValue(id), "-")
+	words := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		words = append(words, strings.ToUpper(part[:1])+part[1:])
+	}
+	if len(words) == 0 {
+		return "Custom Controls"
+	}
+	return strings.Join(words, " ")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func generateCoverageIndex(root string, catalogPaths []string, profilePath string, extensionPaths []string, selectedProfileIDs []string) ([]byte, error) {

--- a/tools/controlindex/main_test.go
+++ b/tools/controlindex/main_test.go
@@ -104,6 +104,110 @@ func TestValidateControlIndexFlagsRequiresMode(t *testing.T) {
 	}
 }
 
+func TestWriteControlExtensionScaffoldBuildsCoverageIndex(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, compliance.DefaultControlCatalogPath, `
+version: "2026-06-17"
+frameworks:
+  - name: SOC 2
+    families:
+      - id: CC6
+        name: Logical and Physical Access
+        controls:
+          - id: CC6.1
+`)
+	writeTestFile(t, root, compliance.DefaultControlProfilesPath, `
+version: "2026-06-17"
+profiles:
+  - id: base-soc2
+    name: Base SOC 2
+    frameworks:
+      - name: SOC 2
+        controls: [CC6.1]
+`)
+	options := newControlExtensionScaffoldOptions("customer-controls", "customer-controls", "Customer Controls", "customer", "Customer Framework", "customer-audit", "Customer Audit")
+	if err := writeControlExtensionScaffold(root, options); err != nil {
+		t.Fatalf("writeControlExtensionScaffold() error = %v", err)
+	}
+
+	pack, err := compliance.LoadControlExtensionPackFile(filepath.Join(root, "customer-controls/extension.yaml"))
+	if err != nil {
+		t.Fatalf("LoadControlExtensionPackFile() error = %v", err)
+	}
+	if issues := compliance.ValidateControlExtensionPack(pack); len(issues) != 0 {
+		t.Fatalf("ValidateControlExtensionPack() issues = %#v, want none", issues)
+	}
+	content, err := generateCoverageIndex(root, []string{compliance.DefaultControlCatalogPath}, compliance.DefaultControlProfilesPath, []string{"customer-controls/extension.yaml"}, []string{"customer-audit"})
+	if err != nil {
+		t.Fatalf("generateCoverageIndex() error = %v", err)
+	}
+	output := string(content)
+	for _, want := range []string{
+		"id: customer-audit",
+		"framework_name: Customer Framework",
+		"control_id: IAM-1",
+		"privileged-mfa-state",
+		"mapped_control_refs:",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("generated coverage index missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestWriteControlExtensionScaffoldRejectsExistingFiles(t *testing.T) {
+	root := t.TempDir()
+	options := newControlExtensionScaffoldOptions("customer-controls", "", "", "", "", "", "")
+	if err := writeControlExtensionScaffold(root, options); err != nil {
+		t.Fatalf("writeControlExtensionScaffold() error = %v", err)
+	}
+	err := writeControlExtensionScaffold(root, options)
+	if err == nil || !strings.Contains(err.Error(), "file already exists") {
+		t.Fatalf("writeControlExtensionScaffold() error = %v, want existing file error", err)
+	}
+}
+
+func TestValidateControlExtensionScaffoldFlags(t *testing.T) {
+	options := newControlExtensionScaffoldOptions("customer-controls", "", "", "", "", "", "")
+	if err := validateControlExtensionScaffoldFlags(false, false, nil, options); err != nil {
+		t.Fatalf("validateControlExtensionScaffoldFlags() error = %v, want nil", err)
+	}
+	for name, test := range map[string]struct {
+		write    bool
+		check    bool
+		profiles []string
+		options  controlExtensionScaffoldOptions
+		want     string
+	}{
+		"write": {
+			write:   true,
+			options: options,
+			want:    "cannot be combined with --write",
+		},
+		"check": {
+			check:   true,
+			options: options,
+			want:    "cannot be combined with --write or --check",
+		},
+		"profile": {
+			profiles: []string{"customer-audit"},
+			options:  options,
+			want:     "cannot be combined with --profile",
+		},
+		"directory": {
+			options: newControlExtensionScaffoldOptions("", "", "", "", "", "", ""),
+			want:    "directory is required",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := validateControlExtensionScaffoldFlags(test.write, test.check, test.profiles, test.options)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validateControlExtensionScaffoldFlags() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func writeControlExtensionFixture(t *testing.T, root string) {
 	t.Helper()
 	writeTestFile(t, root, compliance.DefaultControlCatalogPath, `


### PR DESCRIPTION
## Summary
- add `tools/controlindex --init-extension` to scaffold custom control extension packs
- generate rich starter `extension.yaml`, `controls.yaml`, and `profiles.yaml` with audit objectives, evidence expectations, profile selection, and SOC 2 mapping aliases
- document the scaffold workflow for custom frameworks and add tests that load the generated pack into coverage generation

## Verification
- `go test ./tools/controlindex ./internal/compliance ./tools/catalogcheck`
- `go run ./tools/controlindex --check`
- `make catalog-check policy-rule-check detection-catalog-check`
- `git diff --check`
- `make check-structural`
- `make lint`