### PR TITLE
Harden compliance scaffold writes

### DIFF
--- a/tools/controlindex/main.go
+++ b/tools/controlindex/main.go
@@ -254,17 +254,21 @@ func writeControlExtensionScaffold(root string, options controlExtensionScaffold
 		"profiles.yaml":  controlExtensionScaffoldProfiles(options),
 	}
 	names := []string{"extension.yaml", "controls.yaml", "profiles.yaml"}
+	return writeScaffoldYAMLFiles(rootFS, dir, files, names, writeScaffoldYAMLFile)
+}
+
+func writeScaffoldYAMLFiles(root *os.Root, dir string, files map[string]any, names []string, writeFile func(*os.Root, string, any) error) error {
 	for _, name := range names {
-		if err := rejectExistingScaffoldFile(rootFS, filepath.Join(dir, name)); err != nil {
+		if err := rejectExistingScaffoldFile(root, filepath.Join(dir, name)); err != nil {
 			return err
 		}
 	}
 	written := []string{}
 	for _, name := range names {
 		path := filepath.Join(dir, name)
-		if err := writeScaffoldYAMLFile(rootFS, path, files[name]); err != nil {
-			for _, createdPath := range written {
-				_ = rootFS.Remove(createdPath)
+		if err := writeFile(root, path, files[name]); err != nil {
+			if cleanupErr := removeScaffoldFiles(root, written); cleanupErr != nil {
+				return fmt.Errorf("%w; cleanup partial scaffold: %v", err, cleanupErr)
 			}
 			return err
 		}
@@ -400,6 +404,20 @@ func writeScaffoldYAMLFile(root *os.Root, path string, value any) error {
 func removeScaffoldFile(root *os.Root, path string) error {
 	if err := root.Remove(path); err != nil && !os.IsNotExist(err) {
 		return err
+	}
+	return nil
+}
+
+func removeScaffoldFiles(root *os.Root, paths []string) error {
+	var cleanupErrors []string
+	for idx := len(paths) - 1; idx >= 0; idx-- {
+		path := paths[idx]
+		if err := removeScaffoldFile(root, path); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Sprintf("%s: %v", path, err))
+		}
+	}
+	if len(cleanupErrors) != 0 {
+		return errors.New(strings.Join(cleanupErrors, "; "))
 	}
 	return nil
 }

--- a/tools/controlindex/main_test.go
+++ b/tools/controlindex/main_test.go
@@ -210,6 +210,34 @@ func TestWriteScaffoldYAMLFileRemovesPartialFileOnWriteError(t *testing.T) {
 	}
 }
 
+func TestWriteControlExtensionScaffoldCleansUpEarlierFilesOnLaterWriteError(t *testing.T) {
+	root := t.TempDir()
+	options := newControlExtensionScaffoldOptions("customer-controls", "", "", "", "", "", "")
+	injected := errors.New("injected second write failure")
+	calls := 0
+	originalWrite := writeScaffoldFileContent
+	writeScaffoldFileContent = func(file *os.File, content []byte) (int, error) {
+		calls++
+		if calls == 2 {
+			return 0, injected
+		}
+		return file.Write(content)
+	}
+	t.Cleanup(func() {
+		writeScaffoldFileContent = originalWrite
+	})
+
+	err := writeControlExtensionScaffold(root, options)
+	if !errors.Is(err, injected) {
+		t.Fatalf("writeControlExtensionScaffold() error = %v, want injected second write failure", err)
+	}
+	for _, path := range []string{"customer-controls/extension.yaml", "customer-controls/controls.yaml", "customer-controls/profiles.yaml"} {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(path))); !os.IsNotExist(err) {
+			t.Fatalf("%s stat error = %v, want not exist after rollback", path, err)
+		}
+	}
+}
+
 func TestValidateControlExtensionScaffoldFlags(t *testing.T) {
 	options := newControlExtensionScaffoldOptions("customer-controls", "", "", "", "", "", "")
 	if err := validateControlExtensionScaffoldFlags(false, false, nil, options); err != nil {


### PR DESCRIPTION
## Summary
- create scaffold directories component-by-component while rejecting symlinked generated directories
- write scaffold YAML via temp files plus no-overwrite hard links so failed writes do not leave final orphan files
- add regression tests for existing-file preflight and symlinked scaffold directories

## Verification
- `go test ./tools/controlindex ./internal/compliance ./tools/catalogcheck`
- `go run ./tools/controlindex --check`
- `make catalog-check policy-rule-check detection-catalog-check`
- `git diff --check`
- `make check-structural`
- `make lint`