### PR TITLE
chore: harden PR landing gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ DROID_SAST_POST_COMMENT ?= false
 LAND_PR_REPO ?= writer/cerebro
 LAND_PR_ADMIN ?= false
 LAND_PR_KEEP_BRANCH ?= false
+LAND_PR_ALLOW_LARGE ?= false
 
 help: ## Show this help message.
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n"} /^##@/ {printf "\n%s\n", substr($$0, 5); next} /^[A-Za-z0-9_.-]+:.*##/ {printf "  %-34s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -336,9 +337,9 @@ droid-feedback: ## Fetch and normalize Droid feedback for DROID_PR.
 	@if [ -z "$(DROID_PR)" ]; then echo "DROID_PR is required, e.g. make droid-feedback DROID_PR=719" >&2; exit 2; fi
 	python3 scripts/droid_feedback_harness.py "$(DROID_PR)" $(if $(DROID_FEEDBACK_OUT),--markdown-out "$(DROID_FEEDBACK_OUT)") --json-out "$(DROID_FEEDBACK_JSON_OUT)"
 
-land-pr: ## Wait for leak/Droid gates, merge PR, then delete the PR branch.
+land-pr: ## Wait for core/Droid gates, merge PR, then delete the PR branch.
 	@if [ -z "$(PR)" ]; then echo "PR is required, e.g. make land-pr PR=719" >&2; exit 2; fi
-	python3 scripts/land_pr.py "$(PR)" --repo "$(LAND_PR_REPO)" $(if $(filter true,$(LAND_PR_ADMIN)),--admin,) $(if $(filter true,$(LAND_PR_KEEP_BRANCH)),--keep-branch,)
+	python3 scripts/land_pr.py "$(PR)" --repo "$(LAND_PR_REPO)" $(if $(filter true,$(LAND_PR_ADMIN)),--admin,) $(if $(filter true,$(LAND_PR_KEEP_BRANCH)),--keep-branch,) $(if $(filter true,$(LAND_PR_ALLOW_LARGE)),--allow-large-pr,)
 
 # ==== Project Hygiene ====
 ##@ Project Hygiene

--- a/scripts/land_pr.py
+++ b/scripts/land_pr.py
@@ -2,8 +2,8 @@
 """Conservative PR landing helper for Cerebro.
 
 The helper exists to keep automated review branches alive until Droid has
-finished. It intentionally merges first and deletes the branch only after the
-review gates and merge have succeeded.
+finished. It intentionally waits for core checks, then merges and deletes the
+branch only after the review gates and merge have succeeded.
 """
 
 from __future__ import annotations
@@ -16,6 +16,35 @@ import time
 
 
 PASS_BUCKETS = {"pass"}
+DEFAULT_REQUIRED_CHECKS = (
+    "tenant-data leak check",
+    "gitleaks",
+    "semgrep",
+    "Semgrep OSS",
+    "build",
+    "test",
+    "race",
+    "coverage",
+    "sdk",
+    "sdk-dependency-audit",
+    "mcp",
+    "lint",
+    "proto",
+    "openapi",
+    "catalog",
+    "docs-drift",
+    "readme",
+    "oss-audit",
+    "govulncheck",
+    "release-smoke",
+    "docker-smoke",
+    "structural",
+    "droid-review-preflight",
+    "droid-review",
+    "verify",
+)
+DEFAULT_MAX_CHANGED_LINES = 5000
+DEFAULT_MAX_CHANGED_FILES = 50
 DROID_BOT_LOGIN = "factory-droid[bot]"
 DROID_FINISHED_MARKERS = ("Droid finished", "Review complete for PR")
 
@@ -35,7 +64,7 @@ def fetch_pr(pr_number: int, repo: str) -> dict[str, object]:
             "view",
             str(pr_number),
             "--json",
-            "number,state,headRefName,headRefOid,headRepository,headRepositoryOwner,url",
+            "number,state,headRefName,headRefOid,headRepository,headRepositoryOwner,url,additions,deletions,changedFiles,files",
         ],
         repo,
     )
@@ -86,6 +115,45 @@ def check_named_status(checks: list[dict[str, object]], name: str) -> tuple[bool
     if latest.get("bucket") in PASS_BUCKETS:
         return True, ""
     return False, f"{name!r} is {latest.get('bucket') or latest.get('state')}: {latest.get('link') or ''}"
+
+
+def check_required_statuses(checks: list[dict[str, object]], required: tuple[str, ...]) -> tuple[bool, str]:
+    failures = []
+    for name in required:
+        ok, reason = check_named_status(checks, name)
+        if not ok:
+            failures.append(reason)
+    if failures:
+        return False, "; ".join(failures[:8])
+    return True, ""
+
+
+def pr_change_count(pr: dict[str, object], key: str) -> int:
+    value = pr.get(key)
+    return int(value) if isinstance(value, int) else 0
+
+
+def check_pr_size(
+    pr: dict[str, object],
+    *,
+    max_changed_lines: int,
+    max_changed_files: int,
+    allow_large_pr: bool,
+) -> tuple[bool, str]:
+    changed_lines = pr_change_count(pr, "additions") + pr_change_count(pr, "deletions")
+    changed_files = pr_change_count(pr, "changedFiles")
+    failures = []
+    if changed_lines > max_changed_lines:
+        failures.append(f"{changed_lines} changed lines exceeds {max_changed_lines}")
+    if changed_files > max_changed_files:
+        failures.append(f"{changed_files} changed files exceeds {max_changed_files}")
+    if not failures:
+        return True, ""
+    reason = "; ".join(failures)
+    if allow_large_pr:
+        print(f"large PR override: {reason}")
+        return True, ""
+    return False, f"{reason}; rerun with --allow-large-pr after confirming the diff is intentionally large"
 
 
 def is_droid_comment(comment: dict[str, object]) -> bool:
@@ -188,17 +256,41 @@ def main() -> int:
     parser.add_argument("--interval-seconds", type=int, default=20)
     parser.add_argument("--admin", action="store_true", help="Pass --admin to gh pr merge.")
     parser.add_argument("--keep-branch", action="store_true", help="Do not delete the PR branch after merge.")
+    parser.add_argument(
+        "--required-check",
+        action="append",
+        default=[],
+        help="Required check name. Defaults to Cerebro's core PR checks when omitted.",
+    )
+    parser.add_argument(
+        "--allow-large-pr",
+        action="store_true",
+        help="Allow landing PRs above the default size guardrail after manual diff inspection.",
+    )
+    parser.add_argument("--max-changed-lines", type=int, default=DEFAULT_MAX_CHANGED_LINES)
+    parser.add_argument("--max-changed-files", type=int, default=DEFAULT_MAX_CHANGED_FILES)
     args = parser.parse_args()
 
     pr = fetch_pr(args.pr_number, args.repo)
     if pr.get("state") != "OPEN":
         raise RuntimeError(f"PR #{args.pr_number} is {pr.get('state')}, not OPEN.")
+    ok, reason = check_pr_size(
+        pr,
+        max_changed_lines=args.max_changed_lines,
+        max_changed_files=args.max_changed_files,
+        allow_large_pr=args.allow_large_pr,
+    )
+    if not ok:
+        raise RuntimeError(f"PR size guard failed: {reason}")
 
     wait_for_gate(
-        "tenant-data leak check",
+        "core PR checks",
         args.timeout_seconds,
         args.interval_seconds,
-        lambda: check_named_status(fetch_checks(args.pr_number, args.repo), "tenant-data leak check"),
+        lambda: check_required_statuses(
+            fetch_checks(args.pr_number, args.repo),
+            tuple(args.required_check) if args.required_check else DEFAULT_REQUIRED_CHECKS,
+        ),
     )
     wait_for_gate(
         "Droid review",

--- a/scripts/tests/test_land_pr.py
+++ b/scripts/tests/test_land_pr.py
@@ -18,6 +18,49 @@ class LandPRTests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("missing", reason)
 
+    def test_check_required_statuses_accepts_all_required_checks(self):
+        ok, reason = land_pr.check_required_statuses(
+            [
+                {"name": "build", "bucket": "pass"},
+                {"name": "test", "bucket": "pass"},
+            ],
+            ("build", "test"),
+        )
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
+    def test_check_required_statuses_rejects_failed_or_missing_checks(self):
+        ok, reason = land_pr.check_required_statuses(
+            [
+                {"name": "build", "bucket": "pass"},
+                {"name": "catalog", "bucket": "fail", "link": "https://check"},
+            ],
+            ("build", "catalog", "verify"),
+        )
+        self.assertFalse(ok)
+        self.assertIn("catalog", reason)
+        self.assertIn("verify", reason)
+
+    def test_check_pr_size_rejects_large_pr_without_override(self):
+        ok, reason = land_pr.check_pr_size(
+            {"additions": 5001, "deletions": 0, "changedFiles": 3},
+            max_changed_lines=5000,
+            max_changed_files=50,
+            allow_large_pr=False,
+        )
+        self.assertFalse(ok)
+        self.assertIn("--allow-large-pr", reason)
+
+    def test_check_pr_size_allows_large_pr_with_override(self):
+        ok, reason = land_pr.check_pr_size(
+            {"additions": 5001, "deletions": 0, "changedFiles": 3},
+            max_changed_lines=5000,
+            max_changed_files=50,
+            allow_large_pr=True,
+        )
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
     def test_check_droid_finished_accepts_finished_review(self):
         ok, reason = land_pr.check_droid_finished(
             [


### PR DESCRIPTION
## Summary

- require the local PR landing helper to wait for the core CI, security, and Droid checks before merging
- add PR size guardrails to catch very large diffs before landing, with an explicit override for intentional large changes
- expose the large-PR override through the `make land-pr` wrapper

## Test Plan

- `python3 -m unittest scripts.tests.test_land_pr`
- `make changed-check DROID_REVIEW_BASE=origin/main DROID_REVIEW_HEAD=HEAD`
- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
