### PR TITLE
Add A2A work gateway for evidence packet tasks

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -102,7 +102,7 @@ paths:
   /api/v1/a2a:
     post:
       operationId: callA2AJSONRPC
-      summary: Call the authenticated A2A JSON-RPC contract endpoint
+      summary: Call the authenticated A2A JSON-RPC contract and work endpoint
       tags:
         - Platform
       requestBody:
@@ -113,7 +113,7 @@ paths:
               $ref: '#/components/schemas/A2AJSONRPCRequest'
       responses:
         '200':
-          description: JSON-RPC response. Unsupported task, streaming, and push methods return A2A UnsupportedOperationError until backed by replayable runtime adapters.
+          description: JSON-RPC response. SendMessage returns contract discovery by default and can create durable agent-evidence-packet tasks; GetTask and ListTasks read tenant-scoped A2A task records. Streaming, cancellation, and push methods return A2A UnsupportedOperationError until backed by replayable runtime adapters.
           content:
             application/json:
               schema:

--- a/docs/AGENT_PLATFORM_CONTRACT.md
+++ b/docs/AGENT_PLATFORM_CONTRACT.md
@@ -68,8 +68,10 @@ The first supported integration strategies are:
 
 - A2A protocol boundary: public discovery is limited to `/.well-known/agent-card.json` and the legacy
   `/.well-known/agent.json` alias. Authenticated JSON-RPC uses `/api/v1/a2a`; `SendMessage` returns contract
-  discovery content, `ListTasks` returns an empty task list, and task, streaming, or push-notification methods return
-  explicit unsupported-operation errors until backed by replayable runtime adapters.
+  discovery content by default and can create a durable `agent-evidence-packet` task when the message metadata
+  selects that skill. `GetTask` and `ListTasks` read the resulting tenant-scoped task records from the platform job
+  store. Streaming, cancellation, and push-notification methods return explicit unsupported-operation errors until
+  backed by replayable runtime adapters.
 - Public event subscriptions: outbound webhook triggers are exposed first as a tenant-scoped contract at
   `/api/v1/event-subscriptions/contract`, with event allow-lists, delivery IDs, `Idempotency-Key`, signing, retry, and
   dead-letter semantics. The contract intentionally does not give agents unmediated third-party egress.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -58,6 +58,6 @@ Use `Idempotency-Key` for retried mutating API requests and outbound webhook del
 
 ## A2A And Webhook Contracts
 
-`GET /.well-known/agent-card.json` publishes public-safe A2A discovery metadata. Authenticated A2A JSON-RPC calls use `POST /api/v1/a2a`; `SendMessage` returns contract discovery content, `ListTasks` returns an empty task list, and unsupported task/streaming/push methods return A2A-style unsupported-operation errors until backed by replayable runtime adapters.
+`GET /.well-known/agent-card.json` publishes public-safe A2A discovery metadata. Authenticated A2A JSON-RPC calls use `POST /api/v1/a2a`; `SendMessage` returns contract discovery content by default, or creates a durable `agent-evidence-packet` task when message or request metadata sets `skillId` to `agent-evidence-packet`. `GetTask` and `ListTasks` read those tenant-scoped A2A work tasks from the platform job store. Streaming, cancellation, and push methods still return A2A-style unsupported-operation errors until backed by replayable runtime adapters.
 
 `GET /api/v1/event-subscriptions/contract` documents outbound HTTPS webhook trigger families, delivery headers, signing schemes, retries, dead-letter behavior, and webhook delivery idempotency. Subscription metadata remains tenant-scoped and event-type allow-listed.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,6 +71,11 @@ the long-running reasoning pipeline. That deadline is owned by `net/http` and
 the response writer, so the hook belongs in bootstrap instead of the graphagent
 domain package.
 
+The budget also includes the A2A gateway adapter that maps authenticated tenant
+context, the platform job store, coverage context, and evidence authorizers into
+`internal/a2agateway`. Durable task lifecycle behavior stays in that domain
+package; bootstrap only wires the HTTP boundary into it.
+
 The agent platform graph preflight contract lives in `internal/agentplatform`.
 The bootstrap budget includes the HTTP and MCP request/response mapping needed
 to force authenticated tenant context, expose preflight to agents, and attach

--- a/internal/a2agateway/gateway.go
+++ b/internal/a2agateway/gateway.go
@@ -357,14 +357,14 @@ func matchingTenant(paramTenantID string, bodyTenantID string) (string, bool) {
 
 func (h Handler) idempotencyKey(params agentplatform.A2ASendMessageParams) (string, error) {
 	key := strings.TrimSpace(h.IdempotencyKey)
-	if key != "" && len(key) > agentplatform.Idempotency().MaxLengthBytes {
-		return "", requestError{code: -32602, message: "InvalidParams", reason: "Idempotency-Key exceeds the public contract length limit"}
-	}
 	if key == "" {
 		key = strings.TrimSpace(params.Message.MessageID)
 	}
 	if key == "" {
 		return "", nil
+	}
+	if len(key) > agentplatform.Idempotency().MaxLengthBytes {
+		return "", requestError{code: -32602, message: "InvalidParams", reason: "A2A idempotency key exceeds the public contract length limit"}
 	}
 	return "a2a:" + key, nil
 }

--- a/internal/a2agateway/gateway.go
+++ b/internal/a2agateway/gateway.go
@@ -154,6 +154,9 @@ func (h Handler) createEvidencePacketTask(ctx context.Context, params agentplatf
 		return agentplatform.A2ATask{}, err
 	}
 	if !created {
+		if !jobVisible(job, resolved) || job.Kind != agentplatform.A2AWorkJobKind {
+			return agentplatform.A2ATask{}, requestError{code: -32001, message: "TaskNotFoundError", reason: "A2A idempotent task is not visible"}
+		}
 		task, err := taskFromJob(job)
 		if err != nil {
 			return agentplatform.A2ATask{}, err
@@ -167,30 +170,35 @@ func (h Handler) createEvidencePacketTask(ctx context.Context, params agentplatf
 		Message: "A2A agent-evidence-packet task submitted.",
 		Payload: map[string]any{"skill_id": agentplatform.A2AWorkSkillAgentEvidencePacket},
 	}); err != nil {
+		h.failEvidencePacketTask(ctx, job, err)
 		return agentplatform.A2ATask{}, err
 	}
 	startedAt := now
-	if job, err = h.Store.UpdateJob(ctx, job.ID, ports.JobUpdate{
+	updatedJob, err := h.Store.UpdateJob(ctx, job.ID, ports.JobUpdate{
 		Status:          ports.JobStatusRunning,
 		Progress:        uint32Pointer(25),
 		Message:         "Building A2A agent evidence packet.",
 		StartedAt:       &startedAt,
 		AllowedStatuses: []string{ports.JobStatusQueued},
-	}); err != nil {
+	})
+	if err != nil {
+		h.failEvidencePacketTask(ctx, job, err)
 		return agentplatform.A2ATask{}, err
 	}
+	job = updatedJob
 	if _, err := h.Store.AppendJobEvent(ctx, ports.JobEvent{
 		JobID:   job.ID,
 		Type:    "a2a.task.working",
 		Status:  ports.JobStatusRunning,
 		Message: "A2A agent-evidence-packet task is building the evidence artifact.",
 	}); err != nil {
+		h.failEvidencePacketTask(ctx, job, err)
 		return agentplatform.A2ATask{}, err
 	}
 	packet := agentplatform.BuildEvidencePacket(evidenceRequest)
 	task := agentplatform.BuildA2AEvidencePacketTask(job.ID, contextID, params.Message, packet, now)
 	finishedAt := now
-	job, err = h.Store.UpdateJob(ctx, job.ID, ports.JobUpdate{
+	updatedJob, err = h.Store.UpdateJob(ctx, job.ID, ports.JobUpdate{
 		Status:          ports.JobStatusCompleted,
 		Progress:        uint32Pointer(100),
 		Message:         "A2A agent evidence packet completed.",
@@ -199,8 +207,10 @@ func (h Handler) createEvidencePacketTask(ctx context.Context, params agentplatf
 		AllowedStatuses: []string{ports.JobStatusRunning},
 	})
 	if err != nil {
+		h.failEvidencePacketTask(ctx, job, err)
 		return agentplatform.A2ATask{}, err
 	}
+	job = updatedJob
 	if _, err := h.Store.AppendJobEvent(ctx, ports.JobEvent{
 		JobID:   job.ID,
 		Type:    "a2a.task.completed",
@@ -214,6 +224,27 @@ func (h Handler) createEvidencePacketTask(ctx context.Context, params agentplatf
 		return agentplatform.A2ATask{}, err
 	}
 	return agentplatform.A2ATaskWithHistoryLimit(task, params.Configuration.HistoryLength), nil
+}
+
+func (h Handler) failEvidencePacketTask(ctx context.Context, job *ports.Job, cause error) {
+	if h.Store == nil || job == nil || cause == nil {
+		return
+	}
+	finishedAt := time.Now().UTC()
+	_, _ = h.Store.UpdateJob(context.WithoutCancel(ctx), job.ID, ports.JobUpdate{
+		Status:          ports.JobStatusFailed,
+		Message:         "A2A agent evidence packet failed.",
+		Error:           cause.Error(),
+		FinishedAt:      &finishedAt,
+		AllowedStatuses: []string{ports.JobStatusQueued, ports.JobStatusRunning},
+	})
+	_, _ = h.Store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{
+		JobID:   job.ID,
+		Type:    "a2a.task.failed",
+		Status:  ports.JobStatusFailed,
+		Message: "A2A agent-evidence-packet task failed.",
+		Payload: map[string]any{"state": agentplatform.A2ATaskStateFailed},
+	})
 }
 
 func (h Handler) getTask(ctx context.Context, request agentplatform.A2AJSONRPCRequest) agentplatform.A2AJSONRPCResponse {

--- a/internal/a2agateway/gateway.go
+++ b/internal/a2agateway/gateway.go
@@ -1,0 +1,468 @@
+package a2agateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/agentplatform"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type ResolvedContext struct {
+	TenantID          string
+	ActorID           string
+	RequestedScopes   []string
+	ScopeUnrestricted bool
+}
+
+type Resolver func(context.Context, string, string, []string) (ResolvedContext, error)
+type CoverageContextFunc func(context.Context, string) *agentplatform.AgentCoverageContext
+type EvidenceAuthorizer func(context.Context, agentplatform.EvidencePacketRequest) error
+type RequestedTenantRecorder func(context.Context, string)
+
+type Handler struct {
+	Store                 ports.JobStore
+	Card                  agentplatform.A2AAgentCard
+	Resolve               Resolver
+	CoverageContext       CoverageContextFunc
+	AuthorizeEvidence     EvidenceAuthorizer
+	RecordRequestedTenant RequestedTenantRecorder
+	IdempotencyKey        string
+}
+
+func (h Handler) Respond(ctx context.Context, request agentplatform.A2AJSONRPCRequest) agentplatform.A2AJSONRPCResponse {
+	response := agentplatform.A2AJSONRPCResponse{JSONRPC: "2.0", ID: request.ID}
+	if strings.TrimSpace(request.JSONRPC) != "2.0" {
+		response.Error = &agentplatform.A2AJSONError{Code: -32600, Message: "Invalid Request"}
+		return response
+	}
+	switch strings.TrimSpace(request.Method) {
+	case "SendMessage":
+		return h.sendMessage(ctx, request)
+	case "GetTask":
+		return h.getTask(ctx, request)
+	case "ListTasks":
+		return h.listTasks(ctx, request)
+	default:
+		return agentplatform.A2AJSONRPCResponseFor(request, h.Card)
+	}
+}
+
+func (h Handler) sendMessage(ctx context.Context, request agentplatform.A2AJSONRPCRequest) agentplatform.A2AJSONRPCResponse {
+	response := agentplatform.A2AJSONRPCResponse{JSONRPC: "2.0", ID: request.ID}
+	params, err := agentplatform.DecodeA2ASendMessageParams(request.Params)
+	if err != nil {
+		response.Error = invalidParams("SendMessage params are invalid")
+		return response
+	}
+	skillID := agentplatform.A2ARequestedSkillID(params)
+	if skillID == "" || skillID == "agent-platform-contract" || skillID == "event-subscription-contract" || skillID == "idempotency-contract" {
+		if _, err := h.resolve(ctx, params.Tenant, "", nil); err != nil {
+			response.Error = forbidden()
+			return response
+		}
+		return agentplatform.A2AJSONRPCResponseFor(request, h.Card)
+	}
+	if skillID != agentplatform.A2AWorkSkillAgentEvidencePacket {
+		response.Error = &agentplatform.A2AJSONError{
+			Code:    -32004,
+			Message: "UnsupportedOperationError",
+			Data: map[string]any{
+				"supportedSkills": []string{"agent-platform-contract", agentplatform.A2AWorkSkillAgentEvidencePacket, "event-subscription-contract", "idempotency-contract"},
+				"reason":          "The requested A2A skill is not supported by this Cerebro endpoint.",
+			},
+		}
+		return response
+	}
+	task, err := h.createEvidencePacketTask(ctx, params)
+	if err != nil {
+		response.Error = jsonRPCErrorFromError(err)
+		return response
+	}
+	response.Result = map[string]any{"task": task}
+	return response
+}
+
+func (h Handler) createEvidencePacketTask(ctx context.Context, params agentplatform.A2ASendMessageParams) (agentplatform.A2ATask, error) {
+	evidenceRequest, found, err := agentplatform.EvidencePacketRequestFromA2ASendMessage(params)
+	if err != nil {
+		return agentplatform.A2ATask{}, requestError{code: -32602, message: "InvalidParams", reason: "evidence packet request is invalid"}
+	}
+	if !found {
+		return agentplatform.A2ATask{}, requestError{code: -32602, message: "InvalidParams", reason: "agent-evidence-packet requires a text question or structured evidence packet request"}
+	}
+	requestedTenantID, ok := matchingTenant(params.Tenant, evidenceRequest.TenantID)
+	if !ok {
+		if h.RecordRequestedTenant != nil {
+			h.RecordRequestedTenant(ctx, evidenceRequest.TenantID)
+		}
+		return agentplatform.A2ATask{}, requestError{code: -32003, message: "ForbiddenError", reason: "A2A tenant values do not match"}
+	}
+	resolved, err := h.resolve(ctx, requestedTenantID, evidenceRequest.ActorID, evidenceRequest.RequestedScopes)
+	if err != nil {
+		return agentplatform.A2ATask{}, requestError{code: -32003, message: "ForbiddenError", reason: "A2A tenant is not authorized"}
+	}
+	if strings.TrimSpace(resolved.TenantID) == "" {
+		return agentplatform.A2ATask{}, requestError{code: -32602, message: "InvalidParams", reason: "A2A agent-evidence-packet tasks require a tenant"}
+	}
+	evidenceRequest.TenantID = resolved.TenantID
+	evidenceRequest.ActorID = resolved.ActorID
+	evidenceRequest.RequestedScopes = resolved.RequestedScopes
+	evidenceRequest.ScopeUnrestricted = resolved.ScopeUnrestricted
+	if h.CoverageContext != nil {
+		evidenceRequest.CoverageContext = h.CoverageContext(ctx, evidenceRequest.TenantID)
+	}
+	if h.AuthorizeEvidence != nil {
+		if err := h.AuthorizeEvidence(ctx, evidenceRequest); err != nil {
+			return agentplatform.A2ATask{}, requestError{code: -32003, message: "ForbiddenError", reason: "A2A evidence packet references are not authorized"}
+		}
+	}
+	if h.Store == nil {
+		return agentplatform.A2ATask{}, requestError{code: -32603, message: "InternalError", reason: "A2A task store is unavailable"}
+	}
+	idempotencyKey, err := h.idempotencyKey(params)
+	if err != nil {
+		return agentplatform.A2ATask{}, err
+	}
+	now := time.Now().UTC()
+	if strings.TrimSpace(evidenceRequest.GeneratedAt) == "" {
+		evidenceRequest.GeneratedAt = now.Format(time.RFC3339Nano)
+	}
+	contextID := strings.TrimSpace(params.Message.ContextID)
+	job, created, err := h.Store.CreateJob(ctx, ports.CreateJobRequest{
+		Kind:           agentplatform.A2AWorkJobKind,
+		TenantID:       evidenceRequest.TenantID,
+		SubjectType:    agentplatform.A2AWorkSkillAgentEvidencePacket,
+		SubjectID:      contextID,
+		IdempotencyKey: idempotencyKey,
+		Payload: map[string]any{
+			"skill_id":                agentplatform.A2AWorkSkillAgentEvidencePacket,
+			"context_id":              contextID,
+			"message_id":              strings.TrimSpace(params.Message.MessageID),
+			"evidence_packet_request": evidenceRequest,
+			"accepted_output_modes":   append([]string(nil), params.Configuration.AcceptedOutputModes...),
+			"return_immediately":      params.Configuration.ReturnImmediately,
+			"task_push_notifications": params.Configuration.TaskPushNotificationConfig != nil,
+			"source_protocol":         "a2a-jsonrpc",
+			"contract_version":        agentplatform.ContractVersion,
+		},
+	})
+	if err != nil {
+		return agentplatform.A2ATask{}, err
+	}
+	if !created {
+		task, err := taskFromJob(job)
+		if err != nil {
+			return agentplatform.A2ATask{}, err
+		}
+		return agentplatform.A2ATaskWithHistoryLimit(task, params.Configuration.HistoryLength), nil
+	}
+	if _, err := h.Store.AppendJobEvent(ctx, ports.JobEvent{
+		JobID:   job.ID,
+		Type:    "a2a.task.submitted",
+		Status:  ports.JobStatusQueued,
+		Message: "A2A agent-evidence-packet task submitted.",
+		Payload: map[string]any{"skill_id": agentplatform.A2AWorkSkillAgentEvidencePacket},
+	}); err != nil {
+		return agentplatform.A2ATask{}, err
+	}
+	startedAt := now
+	if job, err = h.Store.UpdateJob(ctx, job.ID, ports.JobUpdate{
+		Status:          ports.JobStatusRunning,
+		Progress:        uint32Pointer(25),
+		Message:         "Building A2A agent evidence packet.",
+		StartedAt:       &startedAt,
+		AllowedStatuses: []string{ports.JobStatusQueued},
+	}); err != nil {
+		return agentplatform.A2ATask{}, err
+	}
+	if _, err := h.Store.AppendJobEvent(ctx, ports.JobEvent{
+		JobID:   job.ID,
+		Type:    "a2a.task.working",
+		Status:  ports.JobStatusRunning,
+		Message: "A2A agent-evidence-packet task is building the evidence artifact.",
+	}); err != nil {
+		return agentplatform.A2ATask{}, err
+	}
+	packet := agentplatform.BuildEvidencePacket(evidenceRequest)
+	task := agentplatform.BuildA2AEvidencePacketTask(job.ID, contextID, params.Message, packet, now)
+	finishedAt := now
+	job, err = h.Store.UpdateJob(ctx, job.ID, ports.JobUpdate{
+		Status:          ports.JobStatusCompleted,
+		Progress:        uint32Pointer(100),
+		Message:         "A2A agent evidence packet completed.",
+		Result:          map[string]any{"task": task},
+		FinishedAt:      &finishedAt,
+		AllowedStatuses: []string{ports.JobStatusRunning},
+	})
+	if err != nil {
+		return agentplatform.A2ATask{}, err
+	}
+	if _, err := h.Store.AppendJobEvent(ctx, ports.JobEvent{
+		JobID:   job.ID,
+		Type:    "a2a.task.completed",
+		Status:  ports.JobStatusCompleted,
+		Message: "A2A agent-evidence-packet task completed.",
+		Payload: map[string]any{
+			"artifact_id": "evidence-packet",
+			"state":       agentplatform.A2ATaskStateCompleted,
+		},
+	}); err != nil {
+		return agentplatform.A2ATask{}, err
+	}
+	return agentplatform.A2ATaskWithHistoryLimit(task, params.Configuration.HistoryLength), nil
+}
+
+func (h Handler) getTask(ctx context.Context, request agentplatform.A2AJSONRPCRequest) agentplatform.A2AJSONRPCResponse {
+	response := agentplatform.A2AJSONRPCResponse{JSONRPC: "2.0", ID: request.ID}
+	params, err := agentplatform.DecodeA2AGetTaskParams(request.Params)
+	if err != nil || params.ID == "" {
+		response.Error = invalidParams("GetTask params are invalid")
+		return response
+	}
+	resolved, err := h.resolve(ctx, params.Tenant, "", nil)
+	if err != nil {
+		response.Error = forbidden()
+		return response
+	}
+	if h.Store == nil {
+		response.Error = &agentplatform.A2AJSONError{Code: -32603, Message: "InternalError", Data: map[string]any{"reason": "A2A task store is unavailable"}}
+		return response
+	}
+	job, err := h.Store.GetJob(ctx, params.ID)
+	if err != nil || !jobVisible(job, resolved) || job.Kind != agentplatform.A2AWorkJobKind {
+		response.Error = &agentplatform.A2AJSONError{Code: -32001, Message: "TaskNotFoundError"}
+		return response
+	}
+	task, err := taskFromJob(job)
+	if err != nil {
+		response.Error = jsonRPCErrorFromError(err)
+		return response
+	}
+	response.Result = agentplatform.A2ATaskWithHistoryLimit(task, params.HistoryLength)
+	return response
+}
+
+func (h Handler) listTasks(ctx context.Context, request agentplatform.A2AJSONRPCRequest) agentplatform.A2AJSONRPCResponse {
+	response := agentplatform.A2AJSONRPCResponse{JSONRPC: "2.0", ID: request.ID}
+	params, err := agentplatform.DecodeA2AListTasksParams(request.Params)
+	if err != nil {
+		response.Error = invalidParams("ListTasks params are invalid")
+		return response
+	}
+	resolved, err := h.resolve(ctx, params.Tenant, "", nil)
+	if err != nil {
+		response.Error = forbidden()
+		return response
+	}
+	if strings.TrimSpace(resolved.TenantID) == "" {
+		response.Error = invalidParams("ListTasks requires a tenant")
+		return response
+	}
+	if h.Store == nil {
+		response.Error = &agentplatform.A2AJSONError{Code: -32603, Message: "InternalError", Data: map[string]any{"reason": "A2A task store is unavailable"}}
+		return response
+	}
+	jobs, err := h.Store.ListJobs(ctx, ports.JobFilter{TenantID: resolved.TenantID, Kind: agentplatform.A2AWorkJobKind, Limit: params.Limit})
+	if err != nil {
+		response.Error = jsonRPCErrorFromError(err)
+		return response
+	}
+	tasks := make([]agentplatform.A2ATask, 0, len(jobs))
+	for _, job := range jobs {
+		if !jobVisible(job, resolved) || job.Kind != agentplatform.A2AWorkJobKind {
+			continue
+		}
+		task, err := taskFromJob(job)
+		if err != nil {
+			response.Error = jsonRPCErrorFromError(err)
+			return response
+		}
+		task.History = nil
+		tasks = append(tasks, task)
+	}
+	response.Result = map[string]any{"tasks": tasks, "totalSize": len(tasks)}
+	return response
+}
+
+func (h Handler) resolve(ctx context.Context, requestedTenantID string, requestedActorID string, requestedScopes []string) (ResolvedContext, error) {
+	if h.Resolve != nil {
+		return h.Resolve(ctx, requestedTenantID, requestedActorID, requestedScopes)
+	}
+	return ResolvedContext{
+		TenantID:        strings.TrimSpace(requestedTenantID),
+		ActorID:         strings.TrimSpace(requestedActorID),
+		RequestedScopes: append([]string(nil), requestedScopes...),
+	}, nil
+}
+
+type requestError struct {
+	code    int
+	message string
+	reason  string
+}
+
+func (e requestError) Error() string {
+	if e.reason != "" {
+		return e.reason
+	}
+	return e.message
+}
+
+func matchingTenant(paramTenantID string, bodyTenantID string) (string, bool) {
+	paramTenantID = strings.TrimSpace(paramTenantID)
+	bodyTenantID = strings.TrimSpace(bodyTenantID)
+	if paramTenantID != "" && bodyTenantID != "" && paramTenantID != bodyTenantID {
+		return "", false
+	}
+	if paramTenantID != "" {
+		return paramTenantID, true
+	}
+	return bodyTenantID, true
+}
+
+func (h Handler) idempotencyKey(params agentplatform.A2ASendMessageParams) (string, error) {
+	key := strings.TrimSpace(h.IdempotencyKey)
+	if key != "" && len(key) > agentplatform.Idempotency().MaxLengthBytes {
+		return "", requestError{code: -32602, message: "InvalidParams", reason: "Idempotency-Key exceeds the public contract length limit"}
+	}
+	if key == "" {
+		key = strings.TrimSpace(params.Message.MessageID)
+	}
+	if key == "" {
+		return "", nil
+	}
+	return "a2a:" + key, nil
+}
+
+func jobVisible(job *ports.Job, resolved ResolvedContext) bool {
+	if job == nil {
+		return false
+	}
+	tenantID := strings.TrimSpace(resolved.TenantID)
+	jobTenantID := strings.TrimSpace(job.TenantID)
+	if tenantID == "" {
+		return jobTenantID == ""
+	}
+	return jobTenantID == tenantID
+}
+
+func taskFromJob(job *ports.Job) (agentplatform.A2ATask, error) {
+	if job == nil {
+		return agentplatform.A2ATask{}, errors.New("A2A task job is nil")
+	}
+	if value, ok := job.Result["task"]; ok && value != nil {
+		task, err := decodeTaskValue(value)
+		if err != nil {
+			return agentplatform.A2ATask{}, err
+		}
+		if strings.TrimSpace(task.ID) != "" {
+			return task, nil
+		}
+	}
+	contextID := stringFromMap(job.Payload, "context_id")
+	if contextID == "" {
+		contextID = job.ID
+	}
+	state := agentplatform.A2ATaskStateSubmitted
+	switch job.Status {
+	case ports.JobStatusRunning:
+		state = agentplatform.A2ATaskStateWorking
+	case ports.JobStatusCompleted:
+		state = agentplatform.A2ATaskStateCompleted
+	case ports.JobStatusFailed:
+		state = agentplatform.A2ATaskStateFailed
+	case ports.JobStatusCancelled:
+		state = agentplatform.A2ATaskStateCanceled
+	}
+	timestamp := job.UpdatedAt
+	if timestamp.IsZero() {
+		timestamp = job.CreatedAt
+	}
+	statusText := strings.TrimSpace(job.Message)
+	if statusText == "" {
+		statusText = strings.TrimSpace(job.Error)
+	}
+	var message *agentplatform.A2AMessage
+	if statusText != "" {
+		message = &agentplatform.A2AMessage{
+			Role:      "ROLE_AGENT",
+			MessageID: job.ID + "-status",
+			ContextID: contextID,
+			TaskID:    job.ID,
+			Parts: []agentplatform.A2APart{{
+				Text:      statusText,
+				MediaType: "text/plain",
+			}},
+		}
+	}
+	task := agentplatform.A2ATask{
+		ID:        job.ID,
+		ContextID: contextID,
+		Status: agentplatform.A2ATaskStatus{
+			State:   state,
+			Message: message,
+		},
+		Metadata: map[string]any{
+			"skillId":         stringFromMap(job.Payload, "skill_id"),
+			"contractVersion": stringFromMap(job.Payload, "contract_version"),
+		},
+	}
+	if !timestamp.IsZero() {
+		task.Status.Timestamp = timestamp.UTC().Format(time.RFC3339Nano)
+	}
+	return task, nil
+}
+
+func decodeTaskValue(value any) (agentplatform.A2ATask, error) {
+	if task, ok := value.(agentplatform.A2ATask); ok {
+		return task, nil
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return agentplatform.A2ATask{}, err
+	}
+	var task agentplatform.A2ATask
+	if err := json.Unmarshal(payload, &task); err != nil {
+		return agentplatform.A2ATask{}, err
+	}
+	return task, nil
+}
+
+func stringFromMap(values map[string]any, key string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	text, _ := values[key].(string)
+	return strings.TrimSpace(text)
+}
+
+func invalidParams(reason string) *agentplatform.A2AJSONError {
+	return &agentplatform.A2AJSONError{Code: -32602, Message: "InvalidParams", Data: map[string]any{"reason": reason}}
+}
+
+func forbidden() *agentplatform.A2AJSONError {
+	return &agentplatform.A2AJSONError{Code: -32003, Message: "ForbiddenError"}
+}
+
+func jsonRPCErrorFromError(err error) *agentplatform.A2AJSONError {
+	var requestErr requestError
+	if errors.As(err, &requestErr) {
+		return &agentplatform.A2AJSONError{
+			Code:    requestErr.code,
+			Message: requestErr.message,
+			Data:    map[string]any{"reason": requestErr.reason},
+		}
+	}
+	if errors.Is(err, ports.ErrJobNotFound) {
+		return &agentplatform.A2AJSONError{Code: -32001, Message: "TaskNotFoundError"}
+	}
+	return &agentplatform.A2AJSONError{Code: -32603, Message: "InternalError", Data: map[string]any{"reason": "A2A task processing failed"}}
+}
+
+func uint32Pointer(value uint32) *uint32 {
+	return &value
+}

--- a/internal/a2agateway/gateway_test.go
+++ b/internal/a2agateway/gateway_test.go
@@ -19,7 +19,7 @@ func TestCreateEvidencePacketTaskFailsJobWhenCompletionUpdateFails(t *testing.T)
 	store.failCompleteUpdate = true
 	handler := Handler{Store: store, Resolve: gatewayTestResolver, IdempotencyKey: "task-key"}
 
-	response := handler.Respond(context.Background(), gatewayTestSendMessageRequest("writer", "message-1"))
+	response := handler.Respond(context.Background(), gatewayTestSendMessageRequest("message-1"))
 	if response.Error == nil {
 		t.Fatalf("Respond() error = nil, want transient store error")
 	}
@@ -31,7 +31,7 @@ func TestCreateEvidencePacketTaskFailsJobWhenCompletionUpdateFails(t *testing.T)
 		t.Fatal("job error is empty after compensation")
 	}
 
-	replay := handler.Respond(context.Background(), gatewayTestSendMessageRequest("writer", "message-1"))
+	replay := handler.Respond(context.Background(), gatewayTestSendMessageRequest("message-1"))
 	if replay.Error != nil {
 		t.Fatalf("replay error = %+v, want failed task result", replay.Error)
 	}
@@ -60,7 +60,7 @@ func TestCreateEvidencePacketTaskChecksVisibilityOnIdempotentReplay(t *testing.T
 	store.idempotent["writer\x00a2a:message-1"] = "job-other"
 	handler := Handler{Store: store, Resolve: gatewayTestResolver}
 
-	response := handler.Respond(context.Background(), gatewayTestSendMessageRequest("writer", "message-1"))
+	response := handler.Respond(context.Background(), gatewayTestSendMessageRequest("message-1"))
 	if response.Error == nil || response.Error.Code != -32001 {
 		t.Fatalf("cross-tenant replay response = %+v, want TaskNotFoundError", response)
 	}
@@ -71,7 +71,7 @@ func TestCreateEvidencePacketTaskRejectsLongMessageIDFallbackKey(t *testing.T) {
 	handler := Handler{Store: store, Resolve: gatewayTestResolver}
 	longMessageID := strings.Repeat("m", agentplatform.Idempotency().MaxLengthBytes+1)
 
-	response := handler.Respond(context.Background(), gatewayTestSendMessageRequest("writer", longMessageID))
+	response := handler.Respond(context.Background(), gatewayTestSendMessageRequest(longMessageID))
 	if response.Error == nil || response.Error.Code != -32602 {
 		t.Fatalf("long messageId fallback response = %+v, want InvalidParams", response)
 	}
@@ -80,7 +80,8 @@ func TestCreateEvidencePacketTaskRejectsLongMessageIDFallbackKey(t *testing.T) {
 	}
 }
 
-func gatewayTestSendMessageRequest(tenantID string, messageID string) agentplatform.A2AJSONRPCRequest {
+func gatewayTestSendMessageRequest(messageID string) agentplatform.A2AJSONRPCRequest {
+	const tenantID = "writer"
 	params := agentplatform.A2ASendMessageParams{
 		Tenant: tenantID,
 		Message: agentplatform.A2AMessage{

--- a/internal/a2agateway/gateway_test.go
+++ b/internal/a2agateway/gateway_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -62,6 +63,20 @@ func TestCreateEvidencePacketTaskChecksVisibilityOnIdempotentReplay(t *testing.T
 	response := handler.Respond(context.Background(), gatewayTestSendMessageRequest("writer", "message-1"))
 	if response.Error == nil || response.Error.Code != -32001 {
 		t.Fatalf("cross-tenant replay response = %+v, want TaskNotFoundError", response)
+	}
+}
+
+func TestCreateEvidencePacketTaskRejectsLongMessageIDFallbackKey(t *testing.T) {
+	store := newGatewayTestJobStore()
+	handler := Handler{Store: store, Resolve: gatewayTestResolver}
+	longMessageID := strings.Repeat("m", agentplatform.Idempotency().MaxLengthBytes+1)
+
+	response := handler.Respond(context.Background(), gatewayTestSendMessageRequest("writer", longMessageID))
+	if response.Error == nil || response.Error.Code != -32602 {
+		t.Fatalf("long messageId fallback response = %+v, want InvalidParams", response)
+	}
+	if len(store.jobs) != 0 {
+		t.Fatalf("jobs created = %d, want none", len(store.jobs))
 	}
 }
 

--- a/internal/a2agateway/gateway_test.go
+++ b/internal/a2agateway/gateway_test.go
@@ -1,0 +1,311 @@
+package a2agateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/agentplatform"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestCreateEvidencePacketTaskFailsJobWhenCompletionUpdateFails(t *testing.T) {
+	store := newGatewayTestJobStore()
+	store.failCompleteUpdate = true
+	handler := Handler{Store: store, Resolve: gatewayTestResolver, IdempotencyKey: "task-key"}
+
+	response := handler.Respond(context.Background(), gatewayTestSendMessageRequest("writer", "message-1"))
+	if response.Error == nil {
+		t.Fatalf("Respond() error = nil, want transient store error")
+	}
+	job := store.mustJob(t, "job-test")
+	if job.Status != ports.JobStatusFailed {
+		t.Fatalf("job status = %q, want failed after compensation", job.Status)
+	}
+	if job.Error == "" {
+		t.Fatal("job error is empty after compensation")
+	}
+
+	replay := handler.Respond(context.Background(), gatewayTestSendMessageRequest("writer", "message-1"))
+	if replay.Error != nil {
+		t.Fatalf("replay error = %+v, want failed task result", replay.Error)
+	}
+	task := gatewayTestTaskResult(t, replay.Result)
+	if task.Status.State != agentplatform.A2ATaskStateFailed {
+		t.Fatalf("replay task state = %q, want failed", task.Status.State)
+	}
+}
+
+func TestCreateEvidencePacketTaskChecksVisibilityOnIdempotentReplay(t *testing.T) {
+	store := newGatewayTestJobStore()
+	store.jobs["job-other"] = &ports.Job{
+		ID:             "job-other",
+		Kind:           agentplatform.A2AWorkJobKind,
+		Status:         ports.JobStatusCompleted,
+		TenantID:       "other",
+		IdempotencyKey: "a2a:message-1",
+		Payload: map[string]any{
+			"context_id":       "ctx-other",
+			"skill_id":         agentplatform.A2AWorkSkillAgentEvidencePacket,
+			"contract_version": agentplatform.ContractVersion,
+		},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	store.idempotent["writer\x00a2a:message-1"] = "job-other"
+	handler := Handler{Store: store, Resolve: gatewayTestResolver}
+
+	response := handler.Respond(context.Background(), gatewayTestSendMessageRequest("writer", "message-1"))
+	if response.Error == nil || response.Error.Code != -32001 {
+		t.Fatalf("cross-tenant replay response = %+v, want TaskNotFoundError", response)
+	}
+}
+
+func gatewayTestSendMessageRequest(tenantID string, messageID string) agentplatform.A2AJSONRPCRequest {
+	params := agentplatform.A2ASendMessageParams{
+		Tenant: tenantID,
+		Message: agentplatform.A2AMessage{
+			Role:      "ROLE_USER",
+			MessageID: messageID,
+			ContextID: "ctx-1",
+			Parts: []agentplatform.A2APart{{
+				Text:      "Build an evidence packet",
+				MediaType: "text/plain",
+			}},
+		},
+		Metadata: map[string]any{
+			"skillId": agentplatform.A2AWorkSkillAgentEvidencePacket,
+			"evidencePacket": map[string]any{
+				"tenant_id":      tenantID,
+				"question":       "Build an evidence packet",
+				"scope_urn":      "urn:cerebro:" + tenantID + ":finding:alert-1",
+				"capability_ids": []string{"graph-reasoning"},
+			},
+		},
+	}
+	raw, err := json.Marshal(params)
+	if err != nil {
+		panic(err)
+	}
+	return agentplatform.A2AJSONRPCRequest{JSONRPC: "2.0", ID: "request-1", Method: "SendMessage", Params: raw}
+}
+
+func gatewayTestResolver(_ context.Context, requestedTenantID string, requestedActorID string, requestedScopes []string) (ResolvedContext, error) {
+	if requestedTenantID == "" {
+		return ResolvedContext{}, errors.New("tenant required")
+	}
+	if requestedActorID == "" {
+		requestedActorID = "tester"
+	}
+	return ResolvedContext{
+		TenantID:        requestedTenantID,
+		ActorID:         requestedActorID,
+		RequestedScopes: append([]string(nil), requestedScopes...),
+	}, nil
+}
+
+func gatewayTestTaskResult(t *testing.T, result any) agentplatform.A2ATask {
+	t.Helper()
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var wrapped map[string]agentplatform.A2ATask
+	if err := json.Unmarshal(payload, &wrapped); err != nil {
+		t.Fatalf("decode task result: %v", err)
+	}
+	task, ok := wrapped["task"]
+	if !ok {
+		t.Fatalf("result = %+v, missing task", wrapped)
+	}
+	return task
+}
+
+type gatewayTestJobStore struct {
+	mu                 sync.Mutex
+	nextID             int
+	jobs               map[string]*ports.Job
+	idempotent         map[string]string
+	events             []*ports.JobEvent
+	failCompleteUpdate bool
+}
+
+func newGatewayTestJobStore() *gatewayTestJobStore {
+	return &gatewayTestJobStore{
+		nextID:     1,
+		jobs:       map[string]*ports.Job{},
+		idempotent: map[string]string{},
+	}
+}
+
+func (s *gatewayTestJobStore) Ping(context.Context) error {
+	return nil
+}
+
+func (s *gatewayTestJobStore) CreateJob(_ context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if request.IdempotencyKey != "" {
+		if id := s.idempotent[request.TenantID+"\x00"+request.IdempotencyKey]; id != "" {
+			return cloneGatewayTestJob(s.jobs[id]), false, nil
+		}
+	}
+	id := "job-test"
+	if s.nextID > 1 {
+		id = "job-test-" + strconv.Itoa(s.nextID)
+	}
+	s.nextID++
+	now := time.Now().UTC()
+	job := &ports.Job{
+		ID:             id,
+		Kind:           request.Kind,
+		Status:         ports.JobStatusQueued,
+		TenantID:       request.TenantID,
+		SubjectType:    request.SubjectType,
+		SubjectID:      request.SubjectID,
+		IdempotencyKey: request.IdempotencyKey,
+		Payload:        cloneGatewayTestMap(request.Payload),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	s.jobs[id] = cloneGatewayTestJob(job)
+	if request.IdempotencyKey != "" {
+		s.idempotent[request.TenantID+"\x00"+request.IdempotencyKey] = id
+	}
+	return cloneGatewayTestJob(job), true, nil
+}
+
+func (s *gatewayTestJobStore) GetJob(_ context.Context, id string) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job := s.jobs[id]
+	if job == nil {
+		return nil, ports.ErrJobNotFound
+	}
+	return cloneGatewayTestJob(job), nil
+}
+
+func (s *gatewayTestJobStore) ListJobs(_ context.Context, filter ports.JobFilter) ([]*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	jobs := []*ports.Job{}
+	for _, job := range s.jobs {
+		if filter.TenantID != "" && job.TenantID != filter.TenantID {
+			continue
+		}
+		if filter.Kind != "" && job.Kind != filter.Kind {
+			continue
+		}
+		jobs = append(jobs, cloneGatewayTestJob(job))
+	}
+	return jobs, nil
+}
+
+func (s *gatewayTestJobStore) UpdateJob(_ context.Context, id string, update ports.JobUpdate) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failCompleteUpdate && update.Status == ports.JobStatusCompleted {
+		return nil, errors.New("transient completion write failed")
+	}
+	job := s.jobs[id]
+	if job == nil {
+		return nil, ports.ErrJobNotFound
+	}
+	if len(update.AllowedStatuses) > 0 && !gatewayTestContainsStatus(update.AllowedStatuses, job.Status) {
+		return nil, ports.ErrJobUpdateConflict
+	}
+	if update.Status != "" {
+		job.Status = update.Status
+	}
+	if update.Progress != nil {
+		job.Progress = *update.Progress
+	}
+	if update.Message != "" {
+		job.Message = update.Message
+	}
+	if update.Error != "" {
+		job.Error = update.Error
+	}
+	if update.Result != nil {
+		job.Result = cloneGatewayTestMap(update.Result)
+	}
+	if update.StartedAt != nil {
+		job.StartedAt = *update.StartedAt
+	}
+	if update.FinishedAt != nil {
+		job.FinishedAt = *update.FinishedAt
+	}
+	job.UpdatedAt = time.Now().UTC()
+	return cloneGatewayTestJob(job), nil
+}
+
+func (s *gatewayTestJobStore) AppendJobEvent(_ context.Context, event ports.JobEvent) (*ports.JobEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	event.Sequence = uint64(len(s.events) + 1)
+	event.CreatedAt = time.Now().UTC()
+	event.Payload = cloneGatewayTestMap(event.Payload)
+	s.events = append(s.events, &event)
+	return &event, nil
+}
+
+func (s *gatewayTestJobStore) ListJobEvents(_ context.Context, jobID string, limit uint32) ([]*ports.JobEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	events := []*ports.JobEvent{}
+	for _, event := range s.events {
+		if event.JobID != jobID {
+			continue
+		}
+		cloned := *event
+		cloned.Payload = cloneGatewayTestMap(event.Payload)
+		events = append(events, &cloned)
+		if limit > 0 && len(events) >= int(limit) {
+			break
+		}
+	}
+	return events, nil
+}
+
+func (s *gatewayTestJobStore) mustJob(t *testing.T, id string) *ports.Job {
+	t.Helper()
+	job, err := s.GetJob(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetJob(%q) error = %v", id, err)
+	}
+	return job
+}
+
+func gatewayTestContainsStatus(values []string, status string) bool {
+	for _, value := range values {
+		if value == status {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneGatewayTestJob(job *ports.Job) *ports.Job {
+	if job == nil {
+		return nil
+	}
+	cloned := *job
+	cloned.Payload = cloneGatewayTestMap(job.Payload)
+	cloned.Result = cloneGatewayTestMap(job.Result)
+	return &cloned
+}
+
+func cloneGatewayTestMap(values map[string]any) map[string]any {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/internal/agentplatform/a2a_work.go
+++ b/internal/agentplatform/a2a_work.go
@@ -1,0 +1,373 @@
+package agentplatform
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"time"
+)
+
+const (
+	A2AWorkJobKind                  = "a2a_task"
+	A2AWorkSkillAgentEvidencePacket = "agent-evidence-packet"
+
+	A2ATaskStateSubmitted    = "TASK_STATE_SUBMITTED"
+	A2ATaskStateWorking      = "TASK_STATE_WORKING"
+	A2ATaskStateCompleted    = "TASK_STATE_COMPLETED"
+	A2ATaskStateFailed       = "TASK_STATE_FAILED"
+	A2ATaskStateCanceled     = "TASK_STATE_CANCELED"
+	A2ATaskStateInputNeeded  = "TASK_STATE_INPUT_REQUIRED"
+	A2ATaskStateRejected     = "TASK_STATE_REJECTED"
+	A2ATaskStateAuthRequired = "TASK_STATE_AUTH_REQUIRED"
+)
+
+type A2ASendMessageParams struct {
+	Tenant        string                      `json:"tenant,omitempty"`
+	Message       A2AMessage                  `json:"message"`
+	Configuration A2ASendMessageConfiguration `json:"configuration,omitempty"`
+	Metadata      map[string]any              `json:"metadata,omitempty"`
+}
+
+type A2ASendMessageConfiguration struct {
+	AcceptedOutputModes        []string `json:"acceptedOutputModes,omitempty"`
+	HistoryLength              *int     `json:"historyLength,omitempty"`
+	ReturnImmediately          bool     `json:"returnImmediately,omitempty"`
+	TaskPushNotificationConfig any      `json:"taskPushNotificationConfig,omitempty"`
+}
+
+type A2AGetTaskParams struct {
+	Tenant        string `json:"tenant,omitempty"`
+	ID            string `json:"id"`
+	HistoryLength *int   `json:"historyLength,omitempty"`
+}
+
+type A2AListTasksParams struct {
+	Tenant string `json:"tenant,omitempty"`
+	Limit  uint32 `json:"limit,omitempty"`
+}
+
+type A2AMessage struct {
+	Role             string         `json:"role"`
+	MessageID        string         `json:"messageId"`
+	ContextID        string         `json:"contextId,omitempty"`
+	TaskID           string         `json:"taskId,omitempty"`
+	Parts            []A2APart      `json:"parts"`
+	Metadata         map[string]any `json:"metadata,omitempty"`
+	Extensions       []string       `json:"extensions,omitempty"`
+	ReferenceTaskIDs []string       `json:"referenceTaskIds,omitempty"`
+}
+
+type A2APart struct {
+	Text      string         `json:"text,omitempty"`
+	Raw       string         `json:"raw,omitempty"`
+	URL       string         `json:"url,omitempty"`
+	Data      any            `json:"data,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+	Filename  string         `json:"filename,omitempty"`
+	MediaType string         `json:"mediaType,omitempty"`
+}
+
+type A2ATask struct {
+	ID        string         `json:"id"`
+	ContextID string         `json:"contextId,omitempty"`
+	Status    A2ATaskStatus  `json:"status"`
+	Artifacts []A2AArtifact  `json:"artifacts,omitempty"`
+	History   []A2AMessage   `json:"history,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+type A2ATaskStatus struct {
+	State     string      `json:"state"`
+	Message   *A2AMessage `json:"message,omitempty"`
+	Timestamp string      `json:"timestamp,omitempty"`
+}
+
+type A2AArtifact struct {
+	ArtifactID  string         `json:"artifactId"`
+	Name        string         `json:"name,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Parts       []A2APart      `json:"parts"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+	Extensions  []string       `json:"extensions,omitempty"`
+}
+
+func DecodeA2ASendMessageParams(raw json.RawMessage) (A2ASendMessageParams, error) {
+	var params A2ASendMessageParams
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return params, nil
+	}
+	if err := decodeA2AParams(raw, &params); err != nil {
+		return A2ASendMessageParams{}, err
+	}
+	return params, nil
+}
+
+func DecodeA2AGetTaskParams(raw json.RawMessage) (A2AGetTaskParams, error) {
+	var params A2AGetTaskParams
+	if err := decodeA2AParams(raw, &params); err != nil {
+		return A2AGetTaskParams{}, err
+	}
+	params.Tenant = strings.TrimSpace(params.Tenant)
+	params.ID = strings.TrimSpace(params.ID)
+	return params, nil
+}
+
+func DecodeA2AListTasksParams(raw json.RawMessage) (A2AListTasksParams, error) {
+	var params A2AListTasksParams
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return params, nil
+	}
+	if err := decodeA2AParams(raw, &params); err != nil {
+		return A2AListTasksParams{}, err
+	}
+	params.Tenant = strings.TrimSpace(params.Tenant)
+	return params, nil
+}
+
+func decodeA2AParams(raw json.RawMessage, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return errors.New("multiple JSON values")
+	}
+	return nil
+}
+
+func A2ARequestedSkillID(params A2ASendMessageParams) string {
+	for _, metadata := range []map[string]any{params.Metadata, params.Message.Metadata} {
+		if skillID := a2AMetadataString(metadata, "skillId", "skill_id", "cerebroSkillId", "cerebro_skill_id"); skillID != "" {
+			return strings.ToLower(skillID)
+		}
+	}
+	for _, part := range params.Message.Parts {
+		data, ok := part.Data.(map[string]any)
+		if !ok {
+			continue
+		}
+		if skillID := a2AMetadataString(data, "skillId", "skill_id", "cerebroSkillId", "cerebro_skill_id"); skillID != "" {
+			return strings.ToLower(skillID)
+		}
+	}
+	return ""
+}
+
+func EvidencePacketRequestFromA2ASendMessage(params A2ASendMessageParams) (EvidencePacketRequest, bool, error) {
+	request := EvidencePacketRequest{}
+	found := false
+	for _, metadata := range []map[string]any{params.Metadata, params.Message.Metadata} {
+		candidate, ok := a2AMetadataValue(metadata, "evidencePacket", "evidence_packet", "evidencePacketRequest", "evidence_packet_request")
+		if !ok {
+			continue
+		}
+		if err := decodeEvidencePacketCandidate(candidate, &request); err != nil {
+			return EvidencePacketRequest{}, false, err
+		}
+		found = true
+	}
+	for _, part := range params.Message.Parts {
+		data, ok := part.Data.(map[string]any)
+		if ok {
+			if candidate, exists := a2AMetadataValue(data, "evidencePacket", "evidence_packet", "evidencePacketRequest", "evidence_packet_request"); exists {
+				if err := decodeEvidencePacketCandidate(candidate, &request); err != nil {
+					return EvidencePacketRequest{}, false, err
+				}
+				found = true
+			} else if a2ALooksLikeEvidencePacketRequest(data) {
+				if err := decodeEvidencePacketCandidate(data, &request); err != nil {
+					return EvidencePacketRequest{}, false, err
+				}
+				found = true
+			}
+		}
+		if request.Question == "" {
+			request.Question = strings.TrimSpace(part.Text)
+			if request.Question != "" {
+				found = true
+			}
+		}
+	}
+	return request, found, nil
+}
+
+func BuildA2AEvidencePacketTask(taskID string, contextID string, input A2AMessage, packet AgentEvidencePacket, generatedAt time.Time) A2ATask {
+	taskID = strings.TrimSpace(taskID)
+	contextID = strings.TrimSpace(contextID)
+	if contextID == "" {
+		contextID = taskID
+	}
+	timestamp := generatedAt.UTC().Format(time.RFC3339Nano)
+	statusMessage := A2AMessage{
+		Role:      "ROLE_AGENT",
+		MessageID: taskID + "-completed",
+		ContextID: contextID,
+		TaskID:    taskID,
+		Parts: []A2APart{{
+			Text:      "Cerebro produced a tenant-scoped agent evidence packet artifact.",
+			MediaType: "text/plain",
+		}},
+	}
+	history := []A2AMessage{}
+	if strings.TrimSpace(input.MessageID) != "" || len(input.Parts) > 0 {
+		input.ContextID = contextID
+		input.TaskID = taskID
+		history = append(history, input)
+	}
+	return A2ATask{
+		ID:        taskID,
+		ContextID: contextID,
+		Status: A2ATaskStatus{
+			State:     A2ATaskStateCompleted,
+			Message:   &statusMessage,
+			Timestamp: timestamp,
+		},
+		Artifacts: []A2AArtifact{{
+			ArtifactID:  "evidence-packet",
+			Name:        "Agent evidence packet",
+			Description: "Preflight, verifier, connector-gate, eval, memory, simulation, confidence, and write-back guidance for a governed Cerebro agent run.",
+			Parts: []A2APart{{
+				Data:      packet,
+				MediaType: "application/json",
+			}},
+			Metadata: map[string]any{
+				"skillId":       A2AWorkSkillAgentEvidencePacket,
+				"capabilityIds": append([]string(nil), packet.Preflight.SelectedCapabilities...),
+			},
+		}},
+		History: history,
+		Metadata: map[string]any{
+			"skillId":         A2AWorkSkillAgentEvidencePacket,
+			"contractVersion": ContractVersion,
+			"tenantForced":    packet.Preflight.Policy.TenantForced,
+			"writeBack":       packet.RequiredWriteBack,
+		},
+	}
+}
+
+func A2ATaskWithHistoryLimit(task A2ATask, historyLength *int) A2ATask {
+	if historyLength == nil {
+		return task
+	}
+	limit := *historyLength
+	if limit <= 0 {
+		task.History = nil
+		return task
+	}
+	if len(task.History) > limit {
+		task.History = append([]A2AMessage(nil), task.History[len(task.History)-limit:]...)
+	}
+	return task
+}
+
+func a2AMetadataString(metadata map[string]any, keys ...string) string {
+	value, ok := a2AMetadataValue(metadata, keys...)
+	if !ok {
+		return ""
+	}
+	text, _ := value.(string)
+	return strings.TrimSpace(text)
+}
+
+func a2AMetadataValue(metadata map[string]any, keys ...string) (any, bool) {
+	if len(metadata) == 0 {
+		return nil, false
+	}
+	for _, key := range keys {
+		if value, ok := metadata[key]; ok {
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+func a2ALooksLikeEvidencePacketRequest(values map[string]any) bool {
+	for _, key := range []string{"question", "scope_urn", "scopeURN", "capability_ids", "capabilityIds", "action", "evidence_urns", "memory_hints"} {
+		if _, ok := values[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeEvidencePacketCandidate(candidate any, request *EvidencePacketRequest) error {
+	payload, err := json.Marshal(candidate)
+	if err != nil {
+		return err
+	}
+	var decoded EvidencePacketRequest
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return err
+	}
+	mergeEvidencePacketRequest(request, decoded)
+	return nil
+}
+
+func mergeEvidencePacketRequest(target *EvidencePacketRequest, source EvidencePacketRequest) {
+	if source.TenantID != "" {
+		target.TenantID = source.TenantID
+	}
+	if source.ActorID != "" {
+		target.ActorID = source.ActorID
+	}
+	if source.Question != "" {
+		target.Question = source.Question
+	}
+	if source.ScopeURN != "" {
+		target.ScopeURN = source.ScopeURN
+	}
+	if source.Model != "" {
+		target.Model = source.Model
+	}
+	if len(source.CapabilityIDs) > 0 {
+		target.CapabilityIDs = append([]string(nil), source.CapabilityIDs...)
+	}
+	if len(source.AgentProfileIDs) > 0 {
+		target.AgentProfileIDs = append([]string(nil), source.AgentProfileIDs...)
+	}
+	if len(source.RequestedScopes) > 0 {
+		target.RequestedScopes = append([]string(nil), source.RequestedScopes...)
+	}
+	if source.ScopeUnrestricted {
+		target.ScopeUnrestricted = true
+	}
+	if len(source.ConnectorReadiness) > 0 {
+		target.ConnectorReadiness = cloneStringMapAny(source.ConnectorReadiness)
+	}
+	if len(source.EvalStatusOverrides) > 0 {
+		target.EvalStatusOverrides = cloneStringMapAny(source.EvalStatusOverrides)
+	}
+	if source.AllowPreview {
+		target.AllowPreview = true
+	}
+	if source.Action.Stage != "" || len(source.Action.TargetURNs) > 0 || source.Action.HumanApproved {
+		target.Action = source.Action
+	}
+	if source.CoverageContext != nil {
+		target.CoverageContext = cloneCoverageContext(source.CoverageContext)
+	}
+	if len(source.EvidenceURNs) > 0 {
+		target.EvidenceURNs = append([]string(nil), source.EvidenceURNs...)
+	}
+	if len(source.MemoryHints) > 0 {
+		target.MemoryHints = append([]SecurityMemoryHint(nil), source.MemoryHints...)
+	}
+	if source.GeneratedAt != "" {
+		target.GeneratedAt = source.GeneratedAt
+	}
+}
+
+func cloneStringMapAny(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/internal/agentplatform/a2a_work.go
+++ b/internal/agentplatform/a2a_work.go
@@ -128,7 +128,6 @@ func DecodeA2AListTasksParams(raw json.RawMessage) (A2AListTasksParams, error) {
 
 func decodeA2AParams(raw json.RawMessage, target any) error {
 	decoder := json.NewDecoder(bytes.NewReader(raw))
-	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
 		return err
 	}

--- a/internal/agentplatform/a2a_work_test.go
+++ b/internal/agentplatform/a2a_work_test.go
@@ -1,0 +1,45 @@
+package agentplatform
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDecodeA2ASendMessageParamsAllowsProtocolExtensions(t *testing.T) {
+	raw := json.RawMessage(`{
+		"tenant": "writer",
+		"message": {
+			"role": "ROLE_USER",
+			"messageId": "message-1",
+			"contextId": "ctx-1",
+			"parts": [{"text": "Build an evidence packet", "mediaType": "text/plain"}],
+			"protocolExtension": {"traceId": "trace-1"}
+		},
+		"configuration": {
+			"acceptedOutputModes": ["application/json"],
+			"returnImmediately": true,
+			"streamingPreference": "poll"
+		},
+		"metadata": {"skillId": "agent-evidence-packet"},
+		"futureProtocolField": true
+	}`)
+
+	params, err := DecodeA2ASendMessageParams(raw)
+	if err != nil {
+		t.Fatalf("DecodeA2ASendMessageParams() error = %v", err)
+	}
+	if params.Message.MessageID != "message-1" {
+		t.Fatalf("messageId = %q, want message-1", params.Message.MessageID)
+	}
+	if !params.Configuration.ReturnImmediately {
+		t.Fatal("returnImmediately = false, want true")
+	}
+}
+
+func TestDecodeA2AParamsRejectsMultipleJSONValues(t *testing.T) {
+	raw := json.RawMessage(`{"id":"task-1"} {"id":"task-2"}`)
+
+	if _, err := DecodeA2AGetTaskParams(raw); err == nil {
+		t.Fatal("DecodeA2AGetTaskParams() error = nil, want multiple JSON values error")
+	}
+}

--- a/internal/agentplatform/contracts.go
+++ b/internal/agentplatform/contracts.go
@@ -5,7 +5,7 @@
 // Cerebro expects every agent-facing capability to preserve.
 package agentplatform
 
-const ContractVersion = "2026-06-16.cerebro-agent-platform"
+const ContractVersion = "2026-06-17.cerebro-agent-platform"
 
 const (
 	ScopeCosmoSecurityRead         = "cosmo.security.read"
@@ -316,15 +316,15 @@ var Capabilities = []Capability{
 		Owner:           "cerebro-platform",
 		Risk:            "medium",
 		DefaultOn:       true,
-		Summary:         "Publishes a public Agent Card and authenticated JSON-RPC contract responses for A2A-compatible clients.",
+		Summary:         "Publishes a public Agent Card and authenticated JSON-RPC contract and task responses for A2A-compatible clients.",
 		ConsoleSurfaces: []string{"Agent platform API", "OpenAPI", "A2A discovery"},
 		RequiredScopes:  []string{ScopeCosmoSecurityRead},
 		Eval: EvalStatus{
 			Required:      true,
 			Status:        "required",
 			LocalCommands: []string{"go test ./internal/agentplatform ./internal/bootstrap -run 'Test.*A2A|TestRunAgentPlatformEvalSuiteFixture'"},
-			ScenarioSets:  []string{"a2a-contract-discovery", "a2a-unsupported-methods"},
-			Rubrics:       []string{"public-safe metadata", "method honesty", "auth boundary", "contract discoverability"},
+			ScenarioSets:  []string{"a2a-contract-discovery", "a2a-work-tasks", "a2a-unsupported-methods"},
+			Rubrics:       []string{"public-safe metadata", "method honesty", "auth boundary", "contract discoverability", "durable task artifact"},
 		},
 		RuntimeEvents: []string{"agent.run.started", "agent.run.completed", "agent.run.failed"},
 		Provenance:    []string{"a2a-agent-card", "agent-run-preflight"},

--- a/internal/agentplatform/contracts_test.go
+++ b/internal/agentplatform/contracts_test.go
@@ -160,7 +160,7 @@ func TestSnapshotIncludesPublicProtocolContracts(t *testing.T) {
 	if !containsString(snapshot.A2A.DiscoveryPaths, A2AAgentCardPath) || snapshot.A2A.JSONRPCPath != A2AJSONRPCPath {
 		t.Fatalf("A2A paths = discovery:%+v jsonrpc:%q", snapshot.A2A.DiscoveryPaths, snapshot.A2A.JSONRPCPath)
 	}
-	if !containsString(snapshot.A2A.SupportedMethods, "SendMessage") || !containsString(snapshot.A2A.UnsupportedMethods, "SendStreamingMessage") {
+	if !containsString(snapshot.A2A.SupportedMethods, "SendMessage") || !containsString(snapshot.A2A.SupportedMethods, "GetTask") || !containsString(snapshot.A2A.UnsupportedMethods, "SendStreamingMessage") {
 		t.Fatalf("A2A methods = supported:%+v unsupported:%+v", snapshot.A2A.SupportedMethods, snapshot.A2A.UnsupportedMethods)
 	}
 	if len(snapshot.EventSubscriptions.EventTypes) == 0 || snapshot.EventSubscriptions.Delivery.Transport != "https_webhook" {
@@ -182,8 +182,8 @@ func TestA2AAgentCardIsPublicSafeAndHonest(t *testing.T) {
 	if card.Capabilities.Streaming || card.Capabilities.PushNotifications || card.Capabilities.ExtendedAgentCard {
 		t.Fatalf("card over-advertises unsupported capabilities: %+v", card.Capabilities)
 	}
-	if len(card.Skills) < 3 {
-		t.Fatalf("card skills = %+v, want protocol, webhook, and idempotency discovery", card.Skills)
+	if len(card.Skills) < 4 {
+		t.Fatalf("card skills = %+v, want protocol, evidence-packet, webhook, and idempotency skills", card.Skills)
 	}
 }
 
@@ -200,6 +200,10 @@ func TestA2AJSONRPCContractMethods(t *testing.T) {
 	list := A2AJSONRPCResponseFor(A2AJSONRPCRequest{JSONRPC: "2.0", Method: "ListTasks", ID: "req-3"}, card)
 	if list.Error != nil || list.Result == nil {
 		t.Fatalf("ListTasks response = %+v, want empty task listing", list)
+	}
+	get := A2AJSONRPCResponseFor(A2AJSONRPCRequest{JSONRPC: "2.0", Method: "GetTask", ID: "req-4"}, card)
+	if get.Error == nil || get.Error.Code != -32001 {
+		t.Fatalf("GetTask response = %+v, want task-not-found error without durable store context", get)
 	}
 }
 

--- a/internal/agentplatform/public_contracts.go
+++ b/internal/agentplatform/public_contracts.go
@@ -165,13 +165,12 @@ func A2AProtocol() A2AProtocolContract {
 		ProtocolVersion:  "1.0",
 		DiscoveryPaths:   []string{A2AAgentCardPath, A2ALegacyAgentCardPath},
 		JSONRPCPath:      A2AJSONRPCPath,
-		SupportedMethods: []string{"SendMessage", "ListTasks"},
+		SupportedMethods: []string{"SendMessage", "GetTask", "ListTasks"},
 		UnsupportedMethods: []string{
 			"CancelTask",
 			"CreateTaskPushNotificationConfig",
 			"DeleteTaskPushNotificationConfig",
 			"GetExtendedAgentCard",
-			"GetTask",
 			"GetTaskPushNotificationConfig",
 			"ListTaskPushNotificationConfigs",
 			"SendStreamingMessage",
@@ -180,8 +179,9 @@ func A2AProtocol() A2AProtocolContract {
 		Authentication: []string{"bearer API key", "OAuth bearer token with cerebro.cosmo.security.read"},
 		Controls: []string{
 			"public Agent Card contains no tenant, endpoint inventory, credential, or deployment labels",
-			"JSON-RPC methods force the authenticated platform tenant before returning contract data",
-			"task, streaming, and push-notification methods stay disabled until backed by replayable runtime adapters",
+			"JSON-RPC methods force the authenticated platform tenant before returning contract or task data",
+			"SendMessage can create durable agent-evidence-packet tasks backed by the platform job store",
+			"streaming, cancellation, and push-notification methods stay disabled until backed by replayable runtime adapters",
 		},
 	}
 }
@@ -238,6 +238,15 @@ func BuildA2AAgentCard(origin string) A2AAgentCard {
 				Examples:    []string{"List the public agent-platform contract endpoints."},
 				InputModes:  []string{"text/plain", "application/json"},
 				OutputModes: []string{"text/plain", "application/json"},
+			},
+			{
+				ID:          A2AWorkSkillAgentEvidencePacket,
+				Name:        "Agent evidence packet task",
+				Description: "Create a durable, tenant-scoped A2A task whose artifact contains Cerebro preflight, verifier, connector-gate, eval, memory, simulation, confidence, and write-back guidance.",
+				Tags:        []string{"security", "evidence-packet", "governed-work"},
+				Examples:    []string{"Create an evidence packet for this finding scope before an agent run."},
+				InputModes:  []string{"text/plain", "application/json"},
+				OutputModes: []string{"application/json"},
 			},
 			{
 				ID:          "event-subscription-contract",

--- a/internal/agentplatform/security_control_plane.go
+++ b/internal/agentplatform/security_control_plane.go
@@ -422,9 +422,9 @@ func agentActionLadder() []AgentActionStage {
 func agentEvalSuite() AgentEvalSuite {
 	return AgentEvalSuite{
 		ID:            "cerebro-agent-platform-eval",
-		LocalCommands: []string{"make agent-platform-eval", "go test ./internal/bootstrap -run 'TestAgentPlatformSecurityControlPlaneEndToEndWorkflow|TestHandleA2AJSONRPCSendMessage' -count=1"},
+		LocalCommands: []string{"make agent-platform-eval", "go test ./internal/bootstrap -run 'TestAgentPlatformSecurityControlPlaneEndToEndWorkflow|TestHandleA2AJSONRPC' -count=1"},
 		Scenarios: []AgentEvalScenario{
-			{ID: "a2a-contract-discovery", Purpose: "Publish public-safe A2A Agent Card metadata and authenticated JSON-RPC contract responses.", Capability: "a2a-contract-discovery", Rubrics: []string{"well-known discovery", "method honesty", "auth boundary", "public-safe metadata"}},
+			{ID: "a2a-contract-discovery", Purpose: "Publish public-safe A2A Agent Card metadata and authenticated JSON-RPC contract and task responses.", Capability: "a2a-contract-discovery", Rubrics: []string{"well-known discovery", "method honesty", "auth boundary", "public-safe metadata", "durable task artifact"}},
 			{ID: "event-subscription-contract", Purpose: "Expose outbound webhook event types, signing, retry, dead-letter, and delivery idempotency contracts.", Capability: "event-subscription-webhooks", Rubrics: []string{"event allow-list", "signature contract", "retry contract", "no sensitive metadata"}},
 			{ID: "idempotency-public-contract", Purpose: "Document Idempotency-Key semantics for mutating public APIs and outbound webhook deliveries.", Capability: "public-idempotency-contract", Rubrics: []string{"header documented", "scope documented", "409 conflict", "replay semantics"}},
 			{ID: "tenant-isolation", Purpose: "Reject cross-tenant scope hints and body tenant overrides.", Capability: "graph-reasoning", Rubrics: []string{"tenant forced", "scope rejected", "audit emitted"}},

--- a/internal/agentplatform/testdata/agent_platform_eval_cases.json
+++ b/internal/agentplatform/testdata/agent_platform_eval_cases.json
@@ -6,7 +6,7 @@
     "expect": {
       "required_capability_ids": ["a2a-contract-discovery"],
       "required_contract_paths": ["/.well-known/agent-card.json", "/.well-known/agent.json", "/api/v1/a2a"],
-      "required_a2a_methods": ["SendMessage", "ListTasks"],
+      "required_a2a_methods": ["SendMessage", "GetTask", "ListTasks"],
       "required_a2a_unsupported_methods": ["SendStreamingMessage", "CreateTaskPushNotificationConfig"],
       "required_provenance_surfaces": ["a2a-agent-card"],
       "required_integration_strategy_ids": ["a2a-protocol-boundary"]

--- a/internal/bootstrap/agent_platform.go
+++ b/internal/bootstrap/agent_platform.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/a2agateway"
 	"github.com/writer/cerebro/internal/agentplatform"
 	"github.com/writer/cerebro/internal/agentplatformcoverage"
 	"github.com/writer/cerebro/internal/ports"
@@ -34,8 +35,26 @@ func (a *App) handleA2AJSONRPC(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	response := agentplatform.A2AJSONRPCResponseFor(request, agentplatform.BuildA2AAgentCard(externalOrigin(r, a.cfg.Auth.RequestOrigin)))
+	response := a2agateway.Handler{
+		Store:                 jobStore(a.deps.StateStore),
+		Card:                  agentplatform.BuildA2AAgentCard(externalOrigin(r, a.cfg.Auth.RequestOrigin)),
+		Resolve:               a.resolveA2AGatewayContext,
+		CoverageContext:       a.agentCoverageContext,
+		AuthorizeEvidence:     authorizeAgentPlatformPacketURNs,
+		RecordRequestedTenant: recordAccessAuditRequestedTenant,
+		IdempotencyKey:        r.Header.Get("Idempotency-Key"),
+	}.Respond(r.Context(), request)
 	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *App) resolveA2AGatewayContext(ctx context.Context, tenantID string, actorID string, scopes []string) (a2agateway.ResolvedContext, error) {
+	resolved, err := resolveAgentPlatformRequestContext(ctx, tenantID, actorID, scopes)
+	return a2agateway.ResolvedContext{
+		TenantID:          resolved.TenantID,
+		ActorID:           resolved.ActorID,
+		RequestedScopes:   resolved.RequestedScopes,
+		ScopeUnrestricted: resolved.ScopeUnrestricted,
+	}, err
 }
 
 func (a *App) handleEventSubscriptionContract(w http.ResponseWriter, _ *http.Request) {

--- a/internal/bootstrap/agent_platform_test.go
+++ b/internal/bootstrap/agent_platform_test.go
@@ -2,15 +2,19 @@ package bootstrap
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/agentplatform"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -103,6 +107,201 @@ func TestHandleA2AJSONRPCSendMessage(t *testing.T) {
 	}
 	if response.Error != nil || response.Result == nil || response.ID != "request-1" {
 		t.Fatalf("A2A response = %+v, want direct message result", response)
+	}
+}
+
+func TestHandleA2AJSONRPCEvidencePacketTask(t *testing.T) {
+	store := newA2ATestJobStore()
+	app := New(agentPlatformAuthConfig(), Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"id": "request-1",
+		"method": "SendMessage",
+		"params": {
+			"message": {
+				"role": "ROLE_USER",
+				"parts": [{"text": "Triage this alert before an agent run"}],
+				"messageId": "message-1"
+			},
+			"metadata": {
+				"skillId": "agent-evidence-packet",
+				"evidencePacket": {
+					"tenant_id": "writer",
+					"scope_urn": "urn:cerebro:writer:finding:alert-1",
+					"capability_ids": ["graph-reasoning"],
+					"action": {"stage": "recommend"}
+				}
+			}
+		}
+	}`)
+	resp := postA2AJSONRPC(t, server, "test-key", "task-key-1", body)
+	defer func() { _ = resp.Body.Close() }()
+	var response agentplatform.A2AJSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Error != nil || response.Result == nil {
+		t.Fatalf("A2A response = %+v, want completed task", response)
+	}
+	task := decodeA2ATestTaskResult(t, response.Result, "task")
+	if task.Status.State != agentplatform.A2ATaskStateCompleted || len(task.Artifacts) != 1 {
+		t.Fatalf("task = %+v, want completed task with artifact", task)
+	}
+	packet := decodeA2ATestEvidencePacket(t, task.Artifacts[0].Parts[0].Data)
+	if packet.TenantID != "writer" || packet.ActorID != "tester" || !packet.Preflight.Enabled {
+		t.Fatalf("packet context/preflight = %+v, want authenticated enabled packet", packet)
+	}
+	if len(packet.VerifierResults) == 0 || len(packet.RequiredWriteBack) == 0 {
+		t.Fatalf("packet missing verifier or writeback guidance: %+v", packet)
+	}
+
+	replay := postA2AJSONRPC(t, server, "test-key", "task-key-1", body)
+	defer func() { _ = replay.Body.Close() }()
+	var replayResponse agentplatform.A2AJSONRPCResponse
+	if err := json.NewDecoder(replay.Body).Decode(&replayResponse); err != nil {
+		t.Fatalf("decode replay response: %v", err)
+	}
+	replayTask := decodeA2ATestTaskResult(t, replayResponse.Result, "task")
+	if replayTask.ID != task.ID || store.createCount != 1 {
+		t.Fatalf("replay task id/create count = %q/%d, want %q/1", replayTask.ID, store.createCount, task.ID)
+	}
+}
+
+func TestHandleA2AJSONRPCGetAndListTasks(t *testing.T) {
+	store := newA2ATestJobStore()
+	app := New(agentPlatformAuthConfig(), Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	createBody := []byte(`{
+		"jsonrpc": "2.0",
+		"id": "create",
+		"method": "SendMessage",
+		"params": {
+			"message": {
+				"role": "ROLE_USER",
+				"contextId": "ctx-1",
+				"parts": [{"text": "Build an evidence packet"}],
+				"messageId": "message-1"
+			},
+			"metadata": {
+				"skillId": "agent-evidence-packet",
+				"evidencePacket": {
+					"tenant_id": "writer",
+					"scope_urn": "urn:cerebro:writer:finding:alert-1",
+					"capability_ids": ["graph-reasoning"]
+				}
+			}
+		}
+	}`)
+	createResp := postA2AJSONRPC(t, server, "test-key", "task-key-2", createBody)
+	defer func() { _ = createResp.Body.Close() }()
+	var createResponse agentplatform.A2AJSONRPCResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&createResponse); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	created := decodeA2ATestTaskResult(t, createResponse.Result, "task")
+
+	getBody, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "get",
+		"method":  "GetTask",
+		"params": map[string]any{
+			"id":            created.ID,
+			"historyLength": 0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal get body: %v", err)
+	}
+	getResp := postA2AJSONRPC(t, server, "test-key", "", getBody)
+	defer func() { _ = getResp.Body.Close() }()
+	var getResponse agentplatform.A2AJSONRPCResponse
+	if err := json.NewDecoder(getResp.Body).Decode(&getResponse); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	got := decodeA2ATestTaskResult(t, getResponse.Result, "")
+	if got.ID != created.ID || len(got.History) != 0 || len(got.Artifacts) != 1 {
+		t.Fatalf("GetTask result = %+v, want same task without history", got)
+	}
+
+	listResp := postA2AJSONRPC(t, server, "test-key", "", []byte(`{"jsonrpc":"2.0","id":"list","method":"ListTasks","params":{"limit":10}}`))
+	defer func() { _ = listResp.Body.Close() }()
+	var listResponse agentplatform.A2AJSONRPCResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listResponse); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	var list struct {
+		Tasks     []agentplatform.A2ATask `json:"tasks"`
+		TotalSize int                     `json:"totalSize"`
+	}
+	decodeA2ATestResult(t, listResponse.Result, &list)
+	if list.TotalSize != 1 || len(list.Tasks) != 1 || list.Tasks[0].ID != created.ID {
+		t.Fatalf("ListTasks result = %+v, want created task", list)
+	}
+}
+
+func TestHandleA2AJSONRPCGetTaskHidesOtherTenantTasks(t *testing.T) {
+	store := newA2ATestJobStore()
+	cfg := agentPlatformAuthConfig()
+	cfg.Auth.APICredentials = append(cfg.Auth.APICredentials, config.APICredential{
+		ID:        "other-credential",
+		ClientID:  "other-client",
+		Key:       "other-key",
+		Principal: "other-tester",
+		TenantID:  "other",
+		Scopes:    []string{scopeCosmoSecurityRead},
+	})
+	app := New(cfg, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	createResp := postA2AJSONRPC(t, server, "test-key", "task-key-3", []byte(`{
+		"jsonrpc": "2.0",
+		"id": "create",
+		"method": "SendMessage",
+		"params": {
+			"message": {
+				"role": "ROLE_USER",
+				"parts": [{"text": "Build an evidence packet"}],
+				"messageId": "message-1"
+			},
+			"metadata": {
+				"skillId": "agent-evidence-packet",
+				"evidencePacket": {
+					"tenant_id": "writer",
+					"scope_urn": "urn:cerebro:writer:finding:alert-1",
+					"capability_ids": ["graph-reasoning"]
+				}
+			}
+		}
+	}`))
+	defer func() { _ = createResp.Body.Close() }()
+	var createResponse agentplatform.A2AJSONRPCResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&createResponse); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	created := decodeA2ATestTaskResult(t, createResponse.Result, "task")
+	getBody, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "get",
+		"method":  "GetTask",
+		"params":  map[string]any{"id": created.ID},
+	})
+	if err != nil {
+		t.Fatalf("marshal get body: %v", err)
+	}
+	getResp := postA2AJSONRPC(t, server, "other-key", "", getBody)
+	defer func() { _ = getResp.Body.Close() }()
+	var getResponse agentplatform.A2AJSONRPCResponse
+	if err := json.NewDecoder(getResp.Body).Decode(&getResponse); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if getResponse.Error == nil || getResponse.Error.Code != -32001 {
+		t.Fatalf("cross-tenant GetTask response = %+v, want TaskNotFoundError", getResponse)
 	}
 }
 
@@ -729,4 +928,267 @@ func packetActionStatus(packet agentplatform.AgentEvidencePacket, stageID string
 		}
 	}
 	return ""
+}
+
+func postA2AJSONRPC(t *testing.T, server *httptest.Server, apiKey string, idempotencyKey string, body []byte) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/a2a", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	if idempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+	}
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST A2A: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	return resp
+}
+
+func decodeA2ATestTaskResult(t *testing.T, result any, wrapperKey string) agentplatform.A2ATask {
+	t.Helper()
+	if wrapperKey == "" {
+		var task agentplatform.A2ATask
+		decodeA2ATestResult(t, result, &task)
+		return task
+	}
+	var wrapped map[string]agentplatform.A2ATask
+	decodeA2ATestResult(t, result, &wrapped)
+	task, ok := wrapped[wrapperKey]
+	if !ok {
+		t.Fatalf("A2A result = %+v, missing %q", wrapped, wrapperKey)
+	}
+	return task
+}
+
+func decodeA2ATestEvidencePacket(t *testing.T, value any) agentplatform.AgentEvidencePacket {
+	t.Helper()
+	var packet agentplatform.AgentEvidencePacket
+	decodeA2ATestResult(t, value, &packet)
+	return packet
+}
+
+func decodeA2ATestResult(t *testing.T, value any, target any) {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	if err := json.Unmarshal(payload, target); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+}
+
+type a2ATestJobStore struct {
+	mu          sync.Mutex
+	nextID      int
+	createCount int
+	jobs        map[string]*ports.Job
+	idempotent  map[string]string
+	events      []*ports.JobEvent
+}
+
+func newA2ATestJobStore() *a2ATestJobStore {
+	return &a2ATestJobStore{
+		nextID:     1,
+		jobs:       map[string]*ports.Job{},
+		idempotent: map[string]string{},
+	}
+}
+
+func (s *a2ATestJobStore) Ping(context.Context) error {
+	return nil
+}
+
+func (s *a2ATestJobStore) CreateJob(_ context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if request.IdempotencyKey != "" {
+		key := request.TenantID + "\x00" + request.IdempotencyKey
+		if id := s.idempotent[key]; id != "" {
+			return cloneA2ATestJob(s.jobs[id]), false, nil
+		}
+	}
+	id := "job-test"
+	if s.nextID > 1 {
+		id = "job-test-" + strconv.Itoa(s.nextID)
+	}
+	s.nextID++
+	s.createCount++
+	now := time.Now().UTC()
+	job := &ports.Job{
+		ID:             id,
+		Kind:           request.Kind,
+		Status:         ports.JobStatusQueued,
+		TenantID:       request.TenantID,
+		SubjectType:    request.SubjectType,
+		SubjectID:      request.SubjectID,
+		IdempotencyKey: request.IdempotencyKey,
+		Payload:        cloneA2ATestMap(request.Payload),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	s.jobs[id] = cloneA2ATestJob(job)
+	if request.IdempotencyKey != "" {
+		s.idempotent[request.TenantID+"\x00"+request.IdempotencyKey] = id
+	}
+	return cloneA2ATestJob(job), true, nil
+}
+
+func (s *a2ATestJobStore) GetJob(_ context.Context, id string) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job := s.jobs[id]
+	if job == nil {
+		return nil, ports.ErrJobNotFound
+	}
+	return cloneA2ATestJob(job), nil
+}
+
+func (s *a2ATestJobStore) ListJobs(_ context.Context, filter ports.JobFilter) ([]*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	limit := int(filter.Limit)
+	if limit == 0 {
+		limit = 50
+	}
+	jobs := []*ports.Job{}
+	for _, job := range s.jobs {
+		if filter.TenantID != "" && job.TenantID != filter.TenantID {
+			continue
+		}
+		if filter.Kind != "" && job.Kind != filter.Kind {
+			continue
+		}
+		if filter.Status != "" && job.Status != filter.Status {
+			continue
+		}
+		jobs = append(jobs, cloneA2ATestJob(job))
+		if len(jobs) >= limit {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+func (s *a2ATestJobStore) UpdateJob(_ context.Context, id string, update ports.JobUpdate) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job := s.jobs[id]
+	if job == nil {
+		return nil, ports.ErrJobNotFound
+	}
+	if len(update.AllowedStatuses) > 0 && !a2ATestContainsStatus(update.AllowedStatuses, job.Status) {
+		return nil, ports.ErrJobUpdateConflict
+	}
+	if update.Status != "" {
+		job.Status = update.Status
+	}
+	if update.Progress != nil {
+		job.Progress = *update.Progress
+	}
+	if update.Message != "" {
+		job.Message = update.Message
+	}
+	if update.Error != "" {
+		job.Error = update.Error
+	}
+	if update.Result != nil {
+		job.Result = cloneA2ATestMap(update.Result)
+	}
+	if update.ResultRefs != nil {
+		job.ResultRefs = cloneA2ATestStringMap(update.ResultRefs)
+	}
+	if update.StartedAt != nil {
+		job.StartedAt = *update.StartedAt
+	}
+	if update.FinishedAt != nil {
+		job.FinishedAt = *update.FinishedAt
+	}
+	if update.CancelRequested != nil {
+		job.CancelRequested = *update.CancelRequested
+	}
+	job.UpdatedAt = time.Now().UTC()
+	return cloneA2ATestJob(job), nil
+}
+
+func (s *a2ATestJobStore) AppendJobEvent(_ context.Context, event ports.JobEvent) (*ports.JobEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	event.Sequence = uint64(len(s.events) + 1)
+	event.CreatedAt = time.Now().UTC()
+	cloned := event
+	cloned.Payload = cloneA2ATestMap(event.Payload)
+	s.events = append(s.events, &cloned)
+	return &cloned, nil
+}
+
+func (s *a2ATestJobStore) ListJobEvents(_ context.Context, jobID string, limit uint32) ([]*ports.JobEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	max := int(limit)
+	if max == 0 {
+		max = len(s.events)
+	}
+	events := []*ports.JobEvent{}
+	for _, event := range s.events {
+		if event.JobID != jobID {
+			continue
+		}
+		cloned := *event
+		cloned.Payload = cloneA2ATestMap(event.Payload)
+		events = append(events, &cloned)
+		if len(events) >= max {
+			break
+		}
+	}
+	return events, nil
+}
+
+func a2ATestContainsStatus(values []string, status string) bool {
+	for _, value := range values {
+		if value == status {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneA2ATestJob(job *ports.Job) *ports.Job {
+	if job == nil {
+		return nil
+	}
+	cloned := *job
+	cloned.Payload = cloneA2ATestMap(job.Payload)
+	cloned.Result = cloneA2ATestMap(job.Result)
+	cloned.ResultRefs = cloneA2ATestStringMap(job.ResultRefs)
+	return &cloned
+}
+
+func cloneA2ATestMap(values map[string]any) map[string]any {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneA2ATestStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const bootstrapProductionGoLineBudget = 22257
+const bootstrapProductionGoLineBudget = 22276
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- add typed A2A task/request/artifact helpers and advertise the `agent-evidence-packet` skill
- route A2A `SendMessage` work requests into durable tenant-scoped platform job tasks with idempotent replay
- support tenant-scoped `GetTask` and `ListTasks` for A2A work tasks while keeping streaming, cancellation, and push disabled
- update OpenAPI, docs, and agent-platform eval expectations for the new work path

Closes #1128

## Validation
- `go test ./internal/agentplatform ./internal/bootstrap -count=1`
- `make agent-platform-eval`
- `make openapi-check`
- `make openapi-lint`
- `make docs-drift-check`
- `make oss-audit`