### PR TITLE
Fix control pack export follow-ups

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1938,8 +1938,8 @@ paths:
                   items:
                     type: string
       responses:
-        '201':
-          description: Generated extension, controls, profiles, coverage summary, and YAML file payloads.
+        '200':
+          description: Generated extension, controls, profiles, coverage summary, and YAML file payloads for a stateless export. No resource is persisted.
         '400':
           description: Invalid custom framework request or unresolved archetype.
   /grc/inventory/categories:

--- a/internal/bootstrap/grc_control_packs.go
+++ b/internal/bootstrap/grc_control_packs.go
@@ -41,7 +41,7 @@ func (a *App) handleGRCControlPackPreview(w http.ResponseWriter, r *http.Request
 }
 
 func (a *App) handleGRCControlPackCreate(w http.ResponseWriter, r *http.Request) {
-	a.writeGRCControlPackPreview(w, r, http.StatusCreated)
+	a.writeGRCControlPackPreview(w, r, http.StatusOK)
 }
 
 func (a *App) writeGRCControlPackPreview(w http.ResponseWriter, r *http.Request, status int) {

--- a/internal/bootstrap/grc_control_packs_test.go
+++ b/internal/bootstrap/grc_control_packs_test.go
@@ -82,6 +82,31 @@ func TestGRCControlPackPreviewEndpointReturnsYAMLFilesAndCoverage(t *testing.T) 
 	}
 }
 
+func TestGRCControlPackCreateEndpointReturnsStatelessExport(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := strings.NewReader(`{
+		"framework_id":"customer-security",
+		"framework_name":"Customer Security Framework",
+		"profile_id":"customer-security-audit",
+		"profile_name":"Customer Security Audit",
+		"archetype_ids":["privileged-mfa"]
+	}`)
+	resp, err := server.Client().Post(server.URL+"/grc/control-packs", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /grc/control-packs error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /grc/control-packs status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if location := resp.Header.Get("Location"); location != "" {
+		t.Fatalf("Location header = %q, want none for stateless export", location)
+	}
+}
+
 func TestGRCControlPackPreviewEndpointReturnsValidationIssues(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, nil)
 	server := httptest.NewServer(app.Handler())
@@ -103,5 +128,8 @@ func TestGRCControlPackPreviewEndpointReturnsValidationIssues(t *testing.T) {
 	}
 	if len(payload.Issues) == 0 {
 		t.Fatal("issues = 0, want validation issue")
+	}
+	if payload.Issues[0].Path == "" || payload.Issues[0].Message == "" {
+		t.Fatalf("issue = %#v, want JSON-decoded path and message fields", payload.Issues[0])
 	}
 }

--- a/internal/compliance/catalog.go
+++ b/internal/compliance/catalog.go
@@ -13,8 +13,8 @@ import (
 const DefaultControlCatalogPath = "internal/compliance/control_families.yaml"
 
 type ValidationIssue struct {
-	Path    string
-	Message string
+	Path    string `json:"path,omitempty" yaml:"path,omitempty"`
+	Message string `json:"message" yaml:"message"`
 }
 
 func (i ValidationIssue) Error() string {

--- a/internal/compliance/control_pack_codegen.go
+++ b/internal/compliance/control_pack_codegen.go
@@ -138,7 +138,7 @@ func normalizeControlPackBuildRequest(request ControlPackBuildRequest) ControlPa
 		FrameworkVersion: strings.TrimSpace(firstNonEmpty(request.FrameworkVersion, "2026")),
 		ProfileID:        profileID,
 		ProfileName:      profileName,
-		ArchetypeIDs:     sortedUniqueStrings(request.ArchetypeIDs),
+		ArchetypeIDs:     trimmedStrings(request.ArchetypeIDs),
 		IncludeProfiles:  sortedUniqueStrings(request.IncludeProfiles),
 		Tags:             sortedUniqueStrings(append([]string{"custom_framework"}, request.Tags...)),
 	}
@@ -190,6 +190,17 @@ func selectControlArchetypes(set ControlArchetypeSet, ids []string) ([]ControlAr
 		issues = append(issues, ValidationIssue{Path: "archetype_ids", Message: "at least one archetype is required"})
 	}
 	return selected, issues
+}
+
+func trimmedStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed = append(trimmed, strings.TrimSpace(value))
+	}
+	return trimmed
 }
 
 func normalizeControlArchetype(archetype ControlArchetype) ControlArchetype {

--- a/internal/compliance/control_pack_codegen_test.go
+++ b/internal/compliance/control_pack_codegen_test.go
@@ -112,3 +112,31 @@ func TestBuildControlPackPreviewRejectsUnknownArchetype(t *testing.T) {
 		t.Fatalf("issue = %#v, want precise unknown archetype issue", issues[0])
 	}
 }
+
+func TestBuildControlPackPreviewRejectsBlankArchetype(t *testing.T) {
+	archetypes, err := LoadBuiltinControlArchetypeSet()
+	if err != nil {
+		t.Fatalf("load archetypes: %v", err)
+	}
+	baseCatalog, err := LoadBuiltinControlCatalog()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	baseProfiles, err := LoadBuiltinControlProfileSet()
+	if err != nil {
+		t.Fatalf("load profiles: %v", err)
+	}
+	preview, issues, err := BuildControlPackPreview(ControlPackBuildRequest{ArchetypeIDs: []string{" "}}, archetypes, baseCatalog, baseProfiles, nil)
+	if err != nil {
+		t.Fatalf("BuildControlPackPreview error = %v", err)
+	}
+	if preview.Summary.Controls != 0 {
+		t.Fatalf("controls = %d, want no default controls for explicit blank archetype", preview.Summary.Controls)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %#v, want only the blank archetype issue", issues)
+	}
+	if issues[0].Path != "archetype_ids[0]" || issues[0].Message != "archetype id is required" {
+		t.Fatalf("issue = %#v, want precise blank archetype issue", issues[0])
+	}
+}


### PR DESCRIPTION
## Summary
- return 200 OK for stateless control pack export requests and update OpenAPI
- preserve explicit blank archetype IDs through validation instead of falling back to defaults
- serialize validation issues as path/message JSON fields
- add regression coverage for stateless export, validation issue shape, and blank archetype IDs

## Verification
- go test ./internal/compliance ./internal/bootstrap ./api
- go test ./tools/archtests
- make catalog-check policy-rule-check detection-catalog-check docs-drift-check
- go test ./...