### PR TITLE
feat: Add shared Cerebro Go API SDK

### DIFF
--- a/sdk/go/cerebroapi/claims/claims.go
+++ b/sdk/go/cerebroapi/claims/claims.go
@@ -30,10 +30,10 @@ func Ref(tenantID, runtimeID, entityType, externalID, label string) cerebroapi.E
 		URN: strings.Join([]string{
 			"urn",
 			"cerebro",
-			strings.TrimSpace(tenantID),
+			EncodeExternalID(strings.TrimSpace(tenantID)),
 			"runtime",
-			strings.TrimSpace(runtimeID),
-			strings.TrimSpace(entityType),
+			EncodeExternalID(strings.TrimSpace(runtimeID)),
+			EncodeExternalID(strings.TrimSpace(entityType)),
 			encodedExternalID,
 		}, ":"),
 		EntityType: strings.TrimSpace(entityType),
@@ -59,10 +59,6 @@ func EncodeExternalID(value string) string {
 			character == '(' ||
 			character == ')' {
 			builder.WriteByte(character)
-			continue
-		}
-		if character == ' ' {
-			builder.WriteByte('-')
 			continue
 		}
 		builder.WriteByte('%')

--- a/sdk/go/cerebroapi/claims/claims.go
+++ b/sdk/go/cerebroapi/claims/claims.go
@@ -1,0 +1,123 @@
+package claims
+
+import (
+	"strings"
+
+	"github.com/writer/cerebro/sdk/go/cerebroapi"
+)
+
+const (
+	StatusAsserted = "asserted"
+
+	TypeExistence = "existence"
+	TypeAttribute = "attribute"
+	TypeRelation  = "relation"
+
+	PredicateExists = "exists"
+)
+
+type Source struct {
+	SourceEventID string
+	ObservedAt    string
+	ValidFrom     string
+	ValidTo       string
+	Attributes    map[string]string
+}
+
+func Ref(tenantID, runtimeID, entityType, externalID, label string) cerebroapi.EntityRef {
+	encodedExternalID := EncodeExternalID(externalID)
+	return cerebroapi.EntityRef{
+		URN: strings.Join([]string{
+			"urn",
+			"cerebro",
+			strings.TrimSpace(tenantID),
+			"runtime",
+			strings.TrimSpace(runtimeID),
+			strings.TrimSpace(entityType),
+			encodedExternalID,
+		}, ":"),
+		EntityType: strings.TrimSpace(entityType),
+		Label:      label,
+	}
+}
+
+func EncodeExternalID(value string) string {
+	const upperHex = "0123456789ABCDEF"
+	var builder strings.Builder
+	for index := 0; index < len(value); index++ {
+		character := value[index]
+		if (character >= 'A' && character <= 'Z') ||
+			(character >= 'a' && character <= 'z') ||
+			(character >= '0' && character <= '9') ||
+			character == '-' ||
+			character == '_' ||
+			character == '.' ||
+			character == '!' ||
+			character == '~' ||
+			character == '*' ||
+			character == '\'' ||
+			character == '(' ||
+			character == ')' {
+			builder.WriteByte(character)
+			continue
+		}
+		if character == ' ' {
+			builder.WriteByte('-')
+			continue
+		}
+		builder.WriteByte('%')
+		builder.WriteByte(upperHex[character>>4])
+		builder.WriteByte(upperHex[character&0x0f])
+	}
+	return builder.String()
+}
+
+func Exists(subject cerebroapi.EntityRef, source Source) cerebroapi.Claim {
+	claim := base(subject, source)
+	claim.Predicate = PredicateExists
+	claim.ClaimType = TypeExistence
+	return claim
+}
+
+func Attribute(subject cerebroapi.EntityRef, predicate string, value string, source Source) cerebroapi.Claim {
+	claim := base(subject, source)
+	claim.Predicate = predicate
+	claim.ObjectValue = value
+	claim.ClaimType = TypeAttribute
+	return claim
+}
+
+func Relation(subject cerebroapi.EntityRef, predicate string, object cerebroapi.EntityRef, source Source) cerebroapi.Claim {
+	claim := base(subject, source)
+	claim.Predicate = predicate
+	claim.ObjectURN = object.URN
+	claim.ObjectRef = &object
+	claim.ClaimType = TypeRelation
+	return claim
+}
+
+func base(subject cerebroapi.EntityRef, source Source) cerebroapi.Claim {
+	return cerebroapi.Claim{
+		SubjectURN:    subject.URN,
+		SubjectRef:    subject,
+		Status:        StatusAsserted,
+		SourceEventID: strings.TrimSpace(source.SourceEventID),
+		ObservedAt:    strings.TrimSpace(source.ObservedAt),
+		ValidFrom:     strings.TrimSpace(source.ValidFrom),
+		ValidTo:       strings.TrimSpace(source.ValidTo),
+		Attributes:    copyAttributes(source.Attributes),
+	}
+}
+
+func copyAttributes(attributes map[string]string) map[string]string {
+	if len(attributes) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(attributes))
+	for key, value := range attributes {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out[key] = trimmed
+		}
+	}
+	return out
+}

--- a/sdk/go/cerebroapi/claims/claims.go
+++ b/sdk/go/cerebroapi/claims/claims.go
@@ -111,6 +111,10 @@ func copyAttributes(attributes map[string]string) map[string]string {
 	}
 	out := make(map[string]string, len(attributes))
 	for key, value := range attributes {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
 		if trimmed := strings.TrimSpace(value); trimmed != "" {
 			out[key] = trimmed
 		}

--- a/sdk/go/cerebroapi/claims/claims.go
+++ b/sdk/go/cerebroapi/claims/claims.go
@@ -119,5 +119,8 @@ func copyAttributes(attributes map[string]string) map[string]string {
 			out[key] = trimmed
 		}
 	}
+	if len(out) == 0 {
+		return nil
+	}
 	return out
 }

--- a/sdk/go/cerebroapi/claims/claims_test.go
+++ b/sdk/go/cerebroapi/claims/claims_test.go
@@ -85,3 +85,13 @@ func TestClaimConstructorsUseCanonicalClaimShapes(t *testing.T) {
 		})
 	}
 }
+
+func TestCopyAttributesReturnsNilWhenAllEntriesFiltered(t *testing.T) {
+	attributes := copyAttributes(map[string]string{
+		"empty": "",
+		" ":     "ignored",
+	})
+	if attributes != nil {
+		t.Fatalf("attributes = %#v, want nil", attributes)
+	}
+}

--- a/sdk/go/cerebroapi/claims/claims_test.go
+++ b/sdk/go/cerebroapi/claims/claims_test.go
@@ -49,8 +49,9 @@ func TestClaimConstructorsUseCanonicalClaimShapes(t *testing.T) {
 		SourceEventID: "evt-1",
 		ObservedAt:    "2026-06-16T12:00:00Z",
 		Attributes: map[string]string{
-			"provider": "github",
-			"empty":    "",
+			" provider ": " github ",
+			"empty":      "",
+			" ":          "ignored",
 		},
 	}
 
@@ -74,6 +75,12 @@ func TestClaimConstructorsUseCanonicalClaimShapes(t *testing.T) {
 			}
 			if _, ok := tc.claim.Attributes["empty"]; ok {
 				t.Fatalf("empty attribute was retained: %#v", tc.claim.Attributes)
+			}
+			if tc.claim.Attributes["provider"] != "github" {
+				t.Fatalf("provider attribute = %#v", tc.claim.Attributes)
+			}
+			if _, ok := tc.claim.Attributes[" provider "]; ok {
+				t.Fatalf("untrimmed attribute key was retained: %#v", tc.claim.Attributes)
 			}
 		})
 	}

--- a/sdk/go/cerebroapi/claims/claims_test.go
+++ b/sdk/go/cerebroapi/claims/claims_test.go
@@ -1,0 +1,58 @@
+package claims
+
+import (
+	"testing"
+
+	"github.com/writer/cerebro/sdk/go/cerebroapi"
+)
+
+func TestRefEncodesExternalIDLikeCerebroURNPathSegment(t *testing.T) {
+	ref := Ref(
+		"tenant-a",
+		"runtime-main",
+		"finding",
+		"finding:id with spaces!*'()~:/?#[]@é",
+		"Encoded finding",
+	)
+	want := "urn:cerebro:tenant-a:runtime:runtime-main:finding:finding%3Aid-with-spaces!*'()~%3A%2F%3F%23%5B%5D%40%C3%A9"
+	if ref.URN != want {
+		t.Fatalf("URN = %q, want %q", ref.URN, want)
+	}
+}
+
+func TestClaimConstructorsUseCanonicalClaimShapes(t *testing.T) {
+	finding := Ref("tenant-a", "runtime-main", "finding", "finding-1", "Finding 1")
+	asset := Ref("tenant-a", "runtime-main", "asset", "asset-1", "Asset 1")
+	source := Source{
+		SourceEventID: "evt-1",
+		ObservedAt:    "2026-06-16T12:00:00Z",
+		Attributes: map[string]string{
+			"provider": "github",
+			"empty":    "",
+		},
+	}
+
+	cases := []struct {
+		name      string
+		predicate string
+		claimType string
+		claim     cerebroapi.Claim
+	}{
+		{name: "exists", predicate: PredicateExists, claimType: TypeExistence, claim: Exists(finding, source)},
+		{name: "attribute", predicate: "severity", claimType: TypeAttribute, claim: Attribute(finding, "severity", "HIGH", source)},
+		{name: "relation", predicate: "affects", claimType: TypeRelation, claim: Relation(finding, "affects", asset, source)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.claim.Predicate != tc.predicate || tc.claim.ClaimType != tc.claimType {
+				t.Fatalf("claim = %#v", tc.claim)
+			}
+			if tc.claim.SubjectURN != finding.URN || tc.claim.Status != StatusAsserted || tc.claim.SourceEventID != "evt-1" {
+				t.Fatalf("claim source fields = %#v", tc.claim)
+			}
+			if _, ok := tc.claim.Attributes["empty"]; ok {
+				t.Fatalf("empty attribute was retained: %#v", tc.claim.Attributes)
+			}
+		})
+	}
+}

--- a/sdk/go/cerebroapi/claims/claims_test.go
+++ b/sdk/go/cerebroapi/claims/claims_test.go
@@ -14,9 +14,31 @@ func TestRefEncodesExternalIDLikeCerebroURNPathSegment(t *testing.T) {
 		"finding:id with spaces!*'()~:/?#[]@é",
 		"Encoded finding",
 	)
-	want := "urn:cerebro:tenant-a:runtime:runtime-main:finding:finding%3Aid-with-spaces!*'()~%3A%2F%3F%23%5B%5D%40%C3%A9"
+	want := "urn:cerebro:tenant-a:runtime:runtime-main:finding:finding%3Aid%20with%20spaces!*'()~%3A%2F%3F%23%5B%5D%40%C3%A9"
 	if ref.URN != want {
 		t.Fatalf("URN = %q, want %q", ref.URN, want)
+	}
+}
+
+func TestRefEncodesAllVariableURNSegments(t *testing.T) {
+	ref := Ref("tenant:a", "runtime:main", "finding:type", "external id", "Finding")
+	want := "urn:cerebro:tenant%3Aa:runtime:runtime%3Amain:finding%3Atype:external%20id"
+	if ref.URN != want {
+		t.Fatalf("URN = %q, want %q", ref.URN, want)
+	}
+	if ref.EntityType != "finding:type" {
+		t.Fatalf("EntityType = %q", ref.EntityType)
+	}
+}
+
+func TestEncodeExternalIDAvoidsSpaceHyphenCollision(t *testing.T) {
+	withSpace := EncodeExternalID("external id")
+	withHyphen := EncodeExternalID("external-id")
+	if withSpace == withHyphen {
+		t.Fatalf("space and hyphen encodings collided: %q", withSpace)
+	}
+	if withSpace != "external%20id" || withHyphen != "external-id" {
+		t.Fatalf("encodings = %q, %q", withSpace, withHyphen)
 	}
 }
 

--- a/sdk/go/cerebroapi/client.go
+++ b/sdk/go/cerebroapi/client.go
@@ -13,7 +13,10 @@ import (
 	"strings"
 )
 
-const defaultUserAgent = "cerebro-go-sdk"
+const (
+	defaultUserAgent     = "cerebro-go-sdk"
+	maxResponseBodyBytes = 4 << 20
+)
 
 type Client struct {
 	baseURL    *url.URL
@@ -67,11 +70,9 @@ func New(config Config, options ...Option) (*Client, error) {
 	for _, option := range options {
 		option(client)
 	}
-	if client.httpClient.CheckRedirect == nil {
-		transportClient := *client.httpClient
-		transportClient.CheckRedirect = blockRedirects
-		client.httpClient = &transportClient
-	}
+	transportClient := *client.httpClient
+	transportClient.CheckRedirect = blockRedirects
+	client.httpClient = &transportClient
 	return client, nil
 }
 
@@ -212,11 +213,14 @@ func (c *Client) doJSON(ctx context.Context, method string, endpoint string, bod
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return newHTTPError(resp)
 	}
+	bodyBytes, err := readSuccessfulBody(resp.Body)
+	if err != nil {
+		return err
+	}
 	if target == nil {
-		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil
 	}
-	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(target); err != nil {
 		return fmt.Errorf("decode cerebro response: %w", err)
 	}
 	return nil
@@ -342,4 +346,16 @@ func newHTTPError(resp *http.Response) error {
 		Status:     strings.TrimSpace(resp.Status),
 		Body:       strings.TrimSpace(string(body)),
 	}
+}
+
+func readSuccessfulBody(body io.Reader) ([]byte, error) {
+	limited := io.LimitReader(body, maxResponseBodyBytes+1)
+	bodyBytes, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(bodyBytes)) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("cerebro response body exceeds %d bytes", maxResponseBodyBytes)
+	}
+	return bodyBytes, nil
 }

--- a/sdk/go/cerebroapi/client.go
+++ b/sdk/go/cerebroapi/client.go
@@ -71,6 +71,7 @@ func New(config Config, options ...Option) (*Client, error) {
 		option(client)
 	}
 	transportClient := *client.httpClient
+	transportClient.Timeout = timeout
 	transportClient.CheckRedirect = blockRedirects
 	client.httpClient = &transportClient
 	return client, nil

--- a/sdk/go/cerebroapi/client.go
+++ b/sdk/go/cerebroapi/client.go
@@ -1,0 +1,345 @@
+package cerebroapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const defaultUserAgent = "cerebro-go-sdk"
+
+type Client struct {
+	baseURL    *url.URL
+	apiKey     string
+	tenantID   string
+	userAgent  string
+	httpClient *http.Client
+}
+
+type Option func(*Client)
+
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(c *Client) {
+		if httpClient != nil {
+			c.httpClient = httpClient
+		}
+	}
+}
+
+func New(config Config, options ...Option) (*Client, error) {
+	baseURL, err := parseBaseURL(config.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	apiKey := strings.TrimSpace(config.APIKey)
+	if apiKey == "" {
+		return nil, errors.New("cerebro API key is required")
+	}
+	tenantID := strings.TrimSpace(config.TenantID)
+	if tenantID == "" {
+		return nil, errors.New("cerebro tenant id is required")
+	}
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = DefaultHTTPTimeout
+	}
+	userAgent := strings.TrimSpace(config.UserAgent)
+	if userAgent == "" {
+		userAgent = defaultUserAgent
+	}
+	client := &Client{
+		baseURL:   baseURL,
+		apiKey:    apiKey,
+		tenantID:  tenantID,
+		userAgent: userAgent,
+		httpClient: &http.Client{
+			Timeout:       timeout,
+			CheckRedirect: blockRedirects,
+		},
+	}
+	for _, option := range options {
+		option(client)
+	}
+	if client.httpClient.CheckRedirect == nil {
+		transportClient := *client.httpClient
+		transportClient.CheckRedirect = blockRedirects
+		client.httpClient = &transportClient
+	}
+	return client, nil
+}
+
+func (c Config) MCPServerURL() string {
+	if strings.TrimSpace(c.MCPURL) != "" {
+		mcpURL, err := parseBaseURL(c.MCPURL)
+		if err != nil {
+			return ""
+		}
+		return mcpURL.String()
+	}
+	baseURL, err := parseBaseURL(c.BaseURL)
+	if err != nil {
+		return ""
+	}
+	value := *baseURL
+	value.Path, value.RawPath = mcpPathFromBase(value.Path, value.EscapedPath())
+	value.RawQuery = ""
+	value.Fragment = ""
+	return value.String()
+}
+
+func (c *Client) GetSourceRuntime(ctx context.Context, runtimeID string) (*SourceRuntime, error) {
+	runtimeID = strings.TrimSpace(runtimeID)
+	if runtimeID == "" {
+		return nil, errors.New("cerebro runtime id is required")
+	}
+	var response sourceRuntimeResponse
+	if err := c.doJSON(ctx, http.MethodGet, c.runtimeURL(runtimeID), nil, &response); err != nil {
+		return nil, err
+	}
+	return runtimeFromResponse(response)
+}
+
+func (c *Client) PutSourceRuntime(ctx context.Context, runtime SourceRuntime) (*SourceRuntime, error) {
+	runtime.ID = strings.TrimSpace(runtime.ID)
+	if runtime.ID == "" {
+		return nil, errors.New("cerebro runtime id is required")
+	}
+	if strings.TrimSpace(runtime.TenantID) == "" {
+		runtime.TenantID = c.tenantID
+	}
+	if strings.TrimSpace(runtime.SourceID) == "" {
+		return nil, errors.New("cerebro source id is required")
+	}
+	var response sourceRuntimeResponse
+	body := map[string]SourceRuntime{"runtime": runtime}
+	if err := c.doJSON(ctx, http.MethodPut, c.runtimeURL(runtime.ID), body, &response); err != nil {
+		return nil, err
+	}
+	return runtimeFromResponse(response)
+}
+
+func (c *Client) EnsureDefaultRuntime(ctx context.Context, config Config) (*SourceRuntime, error) {
+	return c.PutSourceRuntime(ctx, config.DefaultRuntime())
+}
+
+func (c *Client) ListClaims(ctx context.Context, request ListClaimsRequest) (*ListClaimsResponse, error) {
+	request.RuntimeID = strings.TrimSpace(request.RuntimeID)
+	if request.RuntimeID == "" {
+		return nil, errors.New("cerebro runtime id is required")
+	}
+	query := url.Values{}
+	addQuery(query, "claim_id", request.ClaimID)
+	addQuery(query, "subject_urn", request.SubjectURN)
+	addQuery(query, "predicate", request.Predicate)
+	addQuery(query, "object_urn", request.ObjectURN)
+	addQuery(query, "object_value", request.ObjectValue)
+	addQuery(query, "claim_type", request.ClaimType)
+	addQuery(query, "status", request.Status)
+	addQuery(query, "source_event_id", request.SourceEventID)
+	if request.Limit > 0 {
+		query.Set("limit", strconv.FormatUint(uint64(request.Limit), 10))
+	}
+	var response ListClaimsResponse
+	if err := c.doJSON(ctx, http.MethodGet, withQuery(c.runtimeURL(request.RuntimeID, "claims"), query), nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) WriteClaims(ctx context.Context, request WriteClaimsRequest) (*WriteClaimsResponse, error) {
+	request.RuntimeID = strings.TrimSpace(request.RuntimeID)
+	if request.RuntimeID == "" {
+		return nil, errors.New("cerebro runtime id is required")
+	}
+	if len(request.Claims) == 0 {
+		return nil, errors.New("at least one cerebro claim is required")
+	}
+	var response WriteClaimsResponse
+	if err := c.doJSON(ctx, http.MethodPost, c.runtimeURL(request.RuntimeID, "claims"), request, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) GetEntityNeighborhood(ctx context.Context, rootURN string, limit uint32) (*EntityNeighborhood, error) {
+	rootURN = strings.TrimSpace(rootURN)
+	if rootURN == "" {
+		return nil, errors.New("cerebro graph root urn is required")
+	}
+	query := url.Values{"root_urn": []string{rootURN}}
+	if limit > 0 {
+		query.Set("limit", strconv.FormatUint(uint64(limit), 10))
+	}
+	var response EntityNeighborhood
+	if err := c.doJSON(ctx, http.MethodGet, withQuery(c.urlFor("platform", "graph", "neighborhood"), query), nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) doJSON(ctx context.Context, method string, endpoint string, body any, target any) error {
+	var bodyReader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		bodyReader = bytes.NewReader(encoded)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bodyReader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("X-Cerebro-Tenant", c.tenantID)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return newHTTPError(resp)
+	}
+	if target == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		return fmt.Errorf("decode cerebro response: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) runtimeURL(runtimeID string, suffix ...string) string {
+	segments := []string{"source-runtimes", strings.TrimSpace(runtimeID)}
+	segments = append(segments, suffix...)
+	return c.urlFor(segments...)
+}
+
+func (c *Client) urlFor(segments ...string) string {
+	value := *c.baseURL
+	pathPrefix := strings.TrimRight(value.Path, "/")
+	rawPathPrefix := strings.TrimRight(value.EscapedPath(), "/")
+	escaped := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		escaped = append(escaped, url.PathEscape(segment))
+	}
+	value.Path = pathPrefix + "/" + strings.Join(segments, "/")
+	value.RawPath = rawPathPrefix + "/" + strings.Join(escaped, "/")
+	value.RawQuery = ""
+	value.Fragment = ""
+	return value.String()
+}
+
+func parseBaseURL(raw string) (*url.URL, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, errors.New("cerebro base url is required")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("parse cerebro base url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, errors.New("cerebro base url must use http or https")
+	}
+	if parsed.Host == "" {
+		return nil, errors.New("cerebro base url must include a host")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, errors.New("cerebro base url must not include credentials, query, or fragment")
+	}
+	return parsed, nil
+}
+
+func mcpPathFromBase(path string, rawPath string) (string, string) {
+	path = strings.TrimRight(path, "/")
+	rawPath = strings.TrimRight(rawPath, "/")
+	suffix := "/api/v1/mcp"
+	if strings.HasSuffix(path, "/api") {
+		suffix = "/v1/mcp"
+	} else if hasVersionedAPISuffix(path) {
+		suffix = "/mcp"
+	}
+	return path + suffix, rawPath + suffix
+}
+
+func hasVersionedAPISuffix(path string) bool {
+	versionStart := strings.LastIndex(path, "/")
+	if versionStart < 0 || !strings.HasSuffix(path[:versionStart], "/api") {
+		return false
+	}
+	version := path[versionStart+1:]
+	if len(version) < 2 || version[0] != 'v' {
+		return false
+	}
+	for _, ch := range version[1:] {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func addQuery(query url.Values, key string, value string) {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		query.Set(key, trimmed)
+	}
+}
+
+func withQuery(endpoint string, query url.Values) string {
+	if len(query) == 0 {
+		return endpoint
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return endpoint
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+func blockRedirects(*http.Request, []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+func runtimeFromResponse(response sourceRuntimeResponse) (*SourceRuntime, error) {
+	if response.Runtime == nil {
+		return nil, errors.New("cerebro response missing runtime")
+	}
+	return response.Runtime, nil
+}
+
+type HTTPError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e HTTPError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("cerebro http error: %d %s", e.StatusCode, e.Status)
+	}
+	return fmt.Sprintf("cerebro http error: %d %s: %s", e.StatusCode, e.Status, e.Body)
+}
+
+func newHTTPError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	return HTTPError{
+		StatusCode: resp.StatusCode,
+		Status:     strings.TrimSpace(resp.Status),
+		Body:       strings.TrimSpace(string(body)),
+	}
+}

--- a/sdk/go/cerebroapi/client_test.go
+++ b/sdk/go/cerebroapi/client_test.go
@@ -169,6 +169,25 @@ func TestWithHTTPClientStillBlocksRedirects(t *testing.T) {
 	}
 }
 
+func TestWithHTTPClientAppliesConfiguredTimeout(t *testing.T) {
+	httpClient := &http.Client{}
+	client, err := New(Config{
+		BaseURL:  "https://cerebro.example.com",
+		APIKey:   "secret-key",
+		TenantID: "tenant-a",
+		Timeout:  3 * time.Second,
+	}, WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if client.httpClient.Timeout != 3*time.Second {
+		t.Fatalf("Timeout = %s, want 3s", client.httpClient.Timeout)
+	}
+	if httpClient.Timeout != 0 {
+		t.Fatalf("caller HTTP client was mutated: Timeout = %s", httpClient.Timeout)
+	}
+}
+
 func TestWriteClaimsSendsReplaceExistingAndParsesCounts(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/sdk/go/cerebroapi/client_test.go
+++ b/sdk/go/cerebroapi/client_test.go
@@ -134,6 +134,41 @@ func TestPutSourceRuntimeSendsTenantScopedBearerRequest(t *testing.T) {
 	}
 }
 
+func TestWithHTTPClientStillBlocksRedirects(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/source-runtimes/runtime-1" {
+			http.Redirect(w, r, "/redirected", http.StatusFound)
+			return
+		}
+		t.Fatalf("unexpected redirected request path: %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	httpClient := server.Client()
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return nil
+	}
+	client, err := New(Config{
+		BaseURL:  server.URL,
+		APIKey:   "secret-key",
+		TenantID: "tenant-a",
+	}, WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = client.GetSourceRuntime(context.Background(), "runtime-1")
+	if err == nil {
+		t.Fatal("GetSourceRuntime() error = nil")
+	}
+	var httpErr HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error type = %T, want HTTPError", err)
+	}
+	if httpErr.StatusCode != http.StatusFound {
+		t.Fatalf("StatusCode = %d, want %d", httpErr.StatusCode, http.StatusFound)
+	}
+}
+
 func TestWriteClaimsSendsReplaceExistingAndParsesCounts(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -193,6 +228,29 @@ func TestWriteClaimsSendsReplaceExistingAndParsesCounts(t *testing.T) {
 	}
 	if response.ClaimsWritten != 1 || response.ClaimsRetracted != 2 {
 		t.Fatalf("response = %#v", response)
+	}
+}
+
+func TestSuccessfulResponseBodyIsBounded(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", maxResponseBodyBytes+1)))
+	}))
+	defer server.Close()
+
+	client, err := New(Config{
+		BaseURL:  server.URL,
+		APIKey:   "secret-key",
+		TenantID: "tenant-a",
+	}, WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = client.GetSourceRuntime(context.Background(), "runtime-1")
+	if err == nil {
+		t.Fatal("GetSourceRuntime() error = nil")
+	}
+	if !strings.Contains(err.Error(), "response body exceeds") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/sdk/go/cerebroapi/client_test.go
+++ b/sdk/go/cerebroapi/client_test.go
@@ -1,0 +1,290 @@
+package cerebroapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConfigFromEnvDefaultsAndTrims(t *testing.T) {
+	t.Setenv("CEREBRO_BASE_URL", " https://cerebro.example.com ")
+	t.Setenv("CEREBRO_MCP_URL", " https://cerebro.example.com/custom/mcp ")
+	t.Setenv("CEREBRO_API_KEY", " api-key ")
+	t.Setenv("CEREBRO_TOKEN", "ignored-token")
+	t.Setenv("CEREBRO_TENANT_ID", " tenant-a ")
+	t.Setenv("CEREBRO_SOURCE_RUNTIME_ID", " runtime-a ")
+	t.Setenv("CEREBRO_SOURCE_ID", " source-a ")
+	t.Setenv("CEREBRO_HTTP_TIMEOUT_SECONDS", "7")
+
+	config := ConfigFromEnv()
+	if config.BaseURL != "https://cerebro.example.com" {
+		t.Fatalf("BaseURL = %q", config.BaseURL)
+	}
+	if config.MCPURL != "https://cerebro.example.com/custom/mcp" {
+		t.Fatalf("MCPURL = %q", config.MCPURL)
+	}
+	if config.APIKey != "api-key" {
+		t.Fatalf("APIKey = %q", config.APIKey)
+	}
+	if config.TenantID != "tenant-a" {
+		t.Fatalf("TenantID = %q", config.TenantID)
+	}
+	if config.RuntimeID != "runtime-a" {
+		t.Fatalf("RuntimeID = %q", config.RuntimeID)
+	}
+	if config.SourceID != "source-a" {
+		t.Fatalf("SourceID = %q", config.SourceID)
+	}
+	if config.Timeout != 7*time.Second {
+		t.Fatalf("Timeout = %s, want 7s", config.Timeout)
+	}
+	if !config.Enabled() {
+		t.Fatal("Enabled() = false, want true")
+	}
+	if config.MCPServerURL() != "https://cerebro.example.com/custom/mcp" {
+		t.Fatalf("MCPServerURL() = %q", config.MCPServerURL())
+	}
+}
+
+func TestMCPServerURLDerivesFromBaseURL(t *testing.T) {
+	cases := []struct {
+		name string
+		base string
+		want string
+	}{
+		{name: "origin", base: "https://cerebro.example.com", want: "https://cerebro.example.com/api/v1/mcp"},
+		{name: "api prefix", base: "https://cerebro.example.com/api", want: "https://cerebro.example.com/api/v1/mcp"},
+		{name: "versioned api prefix", base: "https://proxy.example.com/api/v1", want: "https://proxy.example.com/api/v1/mcp"},
+		{name: "nested versioned api prefix", base: "https://proxy.example.com/cerebro/api/v2", want: "https://proxy.example.com/cerebro/api/v2/mcp"},
+		{name: "tenant prefix", base: "https://proxy.example.com/cerebro", want: "https://proxy.example.com/cerebro/api/v1/mcp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := (Config{BaseURL: tc.base}).MCPServerURL()
+			if got != tc.want {
+				t.Fatalf("MCPServerURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPutSourceRuntimeSendsTenantScopedBearerRequest(t *testing.T) {
+	var seenBody map[string]SourceRuntime
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/api/source-runtimes/runtime-1" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret-key" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("X-Cerebro-Tenant"); got != "tenant-a" {
+			t.Fatalf("X-Cerebro-Tenant = %q", got)
+		}
+		if got := r.Header.Get("User-Agent"); got != "cerebro-test-client" {
+			t.Fatalf("User-Agent = %q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&seenBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"runtime": map[string]any{
+				"id":        "runtime-1",
+				"source_id": "source-a",
+				"tenant_id": "tenant-a",
+				"config": map[string]string{
+					"surface": "sdk-test",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := New(Config{
+		BaseURL:   server.URL + "/api",
+		APIKey:    "secret-key",
+		TenantID:  "tenant-a",
+		UserAgent: "cerebro-test-client",
+	}, WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	runtime, err := client.PutSourceRuntime(context.Background(), SourceRuntime{
+		ID:       "runtime-1",
+		SourceID: "source-a",
+		Config: map[string]string{
+			"surface": "sdk-test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("PutSourceRuntime() error = %v", err)
+	}
+	if runtime == nil || runtime.ID != "runtime-1" {
+		t.Fatalf("runtime = %#v", runtime)
+	}
+	if seenBody["runtime"].TenantID != "tenant-a" {
+		t.Fatalf("request runtime tenant = %q, want tenant-a", seenBody["runtime"].TenantID)
+	}
+}
+
+func TestWriteClaimsSendsReplaceExistingAndParsesCounts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.EscapedPath() != "/source-runtimes/runtime%2Fwith%20space/claims" {
+			t.Fatalf("path = %s", r.URL.EscapedPath())
+		}
+		var request WriteClaimsRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if request.RuntimeID != "runtime/with space" {
+			t.Fatalf("RuntimeID = %q", request.RuntimeID)
+		}
+		if !request.ReplaceExisting {
+			t.Fatal("ReplaceExisting = false, want true")
+		}
+		if len(request.Claims) != 1 || request.Claims[0].Predicate != "exists" {
+			t.Fatalf("Claims = %#v", request.Claims)
+		}
+		_ = json.NewEncoder(w).Encode(WriteClaimsResponse{
+			ClaimsWritten:          1,
+			EntitiesUpserted:       1,
+			RelationLinksProjected: 0,
+			ClaimsRetracted:        2,
+		})
+	}))
+	defer server.Close()
+
+	client, err := New(Config{
+		BaseURL:  server.URL,
+		APIKey:   "secret-key",
+		TenantID: "tenant-a",
+	}, WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	response, err := client.WriteClaims(context.Background(), WriteClaimsRequest{
+		RuntimeID:       "runtime/with space",
+		ReplaceExisting: true,
+		Claims: []Claim{{
+			SubjectURN: "urn:cerebro:tenant-a:runtime:runtime-1:finding:f-1",
+			SubjectRef: EntityRef{
+				URN:        "urn:cerebro:tenant-a:runtime:runtime-1:finding:f-1",
+				EntityType: "finding",
+				Label:      "Finding",
+			},
+			Predicate:  "exists",
+			ClaimType:  "existence",
+			Status:     "asserted",
+			ObservedAt: "2026-06-16T00:00:00Z",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("WriteClaims() error = %v", err)
+	}
+	if response.ClaimsWritten != 1 || response.ClaimsRetracted != 2 {
+		t.Fatalf("response = %#v", response)
+	}
+}
+
+func TestGetEntityNeighborhoodSendsGraphQueryAndParsesResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.EscapedPath() != "/api/platform/graph/neighborhood" {
+			t.Fatalf("path = %s", r.URL.EscapedPath())
+		}
+		query := r.URL.Query()
+		if query.Get("root_urn") != "urn:cerebro:tenant-a:runtime:runtime-1:finding:f-1" || query.Get("limit") != "10" {
+			t.Fatalf("query = %#v", query)
+		}
+		_ = json.NewEncoder(w).Encode(EntityNeighborhood{
+			Root: &GraphEntity{
+				URN:        "urn:cerebro:tenant-a:runtime:runtime-1:finding:f-1",
+				EntityType: "finding",
+				Label:      "Public repository created",
+			},
+			Neighbors: []GraphEntity{{
+				URN:        "urn:cerebro:tenant-a:runtime:runtime-1:asset:repo",
+				EntityType: "asset",
+				Label:      "writer/aperio",
+			}},
+			Relations: []GraphRelation{{
+				FromURN:  "urn:cerebro:tenant-a:runtime:runtime-1:finding:f-1",
+				Relation: "affects",
+				ToURN:    "urn:cerebro:tenant-a:runtime:runtime-1:asset:repo",
+			}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := New(Config{
+		BaseURL:  server.URL + "/api",
+		APIKey:   "secret-key",
+		TenantID: "tenant-a",
+	}, WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	response, err := client.GetEntityNeighborhood(context.Background(), " urn:cerebro:tenant-a:runtime:runtime-1:finding:f-1 ", 10)
+	if err != nil {
+		t.Fatalf("GetEntityNeighborhood() error = %v", err)
+	}
+	if response.Root == nil || response.Root.EntityType != "finding" || len(response.Neighbors) != 1 || len(response.Relations) != 1 {
+		t.Fatalf("neighborhood = %#v", response)
+	}
+}
+
+func TestHTTPErrorDoesNotExposeRequestCredential(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "tenant mismatch", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client, err := New(Config{
+		BaseURL:  server.URL,
+		APIKey:   "super-secret-key",
+		TenantID: "tenant-a",
+	}, WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = client.GetSourceRuntime(context.Background(), "runtime-1")
+	if err == nil {
+		t.Fatal("GetSourceRuntime() error = nil")
+	}
+	var httpErr HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error type = %T, want HTTPError", err)
+	}
+	if httpErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("StatusCode = %d", httpErr.StatusCode)
+	}
+	if strings.Contains(err.Error(), "super-secret-key") {
+		t.Fatalf("error exposed API key: %s", err)
+	}
+}
+
+func TestNewRejectsUnsafeBaseURL(t *testing.T) {
+	_, err := New(Config{
+		BaseURL:  "https://user:pass@cerebro.example.com?token=abc",
+		APIKey:   "secret-key",
+		TenantID: "tenant-a",
+	})
+	if err == nil {
+		t.Fatal("New() error = nil")
+	}
+	if !strings.Contains(err.Error(), "must not include credentials") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/sdk/go/cerebroapi/config.go
+++ b/sdk/go/cerebroapi/config.go
@@ -1,0 +1,91 @@
+package cerebroapi
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const DefaultHTTPTimeout = 15 * time.Second
+
+type Config struct {
+	BaseURL       string
+	MCPURL        string
+	APIKey        string
+	TenantID      string
+	RuntimeID     string
+	SourceID      string
+	RuntimeConfig map[string]string
+	Timeout       time.Duration
+	UserAgent     string
+}
+
+func ConfigFromEnv() Config {
+	return Config{
+		BaseURL:  trimEnv("CEREBRO_BASE_URL"),
+		MCPURL:   trimEnv("CEREBRO_MCP_URL"),
+		APIKey:   firstEnv("CEREBRO_API_KEY", "CEREBRO_TOKEN"),
+		TenantID: trimEnv("CEREBRO_TENANT_ID"),
+		RuntimeID: firstEnv(
+			"CEREBRO_SOURCE_RUNTIME_ID",
+			"CEREBRO_RUNTIME_ID",
+		),
+		SourceID: firstEnv(
+			"CEREBRO_SOURCE_ID",
+			"CEREBRO_CONNECTOR_SOURCE_ID",
+		),
+		Timeout: durationEnv("CEREBRO_HTTP_TIMEOUT_SECONDS", DefaultHTTPTimeout),
+	}
+}
+
+func (c Config) Enabled() bool {
+	return strings.TrimSpace(c.BaseURL) != "" &&
+		strings.TrimSpace(c.APIKey) != "" &&
+		strings.TrimSpace(c.TenantID) != ""
+}
+
+func (c Config) DefaultRuntime() SourceRuntime {
+	return SourceRuntime{
+		ID:       strings.TrimSpace(c.RuntimeID),
+		SourceID: strings.TrimSpace(c.SourceID),
+		TenantID: strings.TrimSpace(c.TenantID),
+		Config:   copyStringMap(c.RuntimeConfig),
+	}
+}
+
+func trimEnv(key string) string {
+	return strings.TrimSpace(os.Getenv(key))
+}
+
+func firstEnv(keys ...string) string {
+	for _, key := range keys {
+		if value := trimEnv(key); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func durationEnv(key string, fallback time.Duration) time.Duration {
+	value := trimEnv(key)
+	if value == "" {
+		return fallback
+	}
+	seconds, err := strconv.Atoi(value)
+	if err != nil || seconds <= 0 {
+		return fallback
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func copyStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}

--- a/sdk/go/cerebroapi/go.mod
+++ b/sdk/go/cerebroapi/go.mod
@@ -1,0 +1,3 @@
+module github.com/writer/cerebro/sdk/go/cerebroapi
+
+go 1.25.0

--- a/sdk/go/cerebroapi/types.go
+++ b/sdk/go/cerebroapi/types.go
@@ -1,0 +1,83 @@
+package cerebroapi
+
+type SourceRuntime struct {
+	ID       string            `json:"id,omitempty"`
+	SourceID string            `json:"source_id"`
+	TenantID string            `json:"tenant_id"`
+	Config   map[string]string `json:"config,omitempty"`
+}
+
+type EntityRef struct {
+	URN        string `json:"urn"`
+	EntityType string `json:"entity_type"`
+	Label      string `json:"label"`
+}
+
+type Claim struct {
+	ID            string            `json:"id,omitempty"`
+	SubjectURN    string            `json:"subject_urn"`
+	SubjectRef    EntityRef         `json:"subject_ref"`
+	Predicate     string            `json:"predicate"`
+	ObjectURN     string            `json:"object_urn,omitempty"`
+	ObjectRef     *EntityRef        `json:"object_ref,omitempty"`
+	ObjectValue   string            `json:"object_value,omitempty"`
+	ClaimType     string            `json:"claim_type"`
+	Status        string            `json:"status"`
+	SourceEventID string            `json:"source_event_id,omitempty"`
+	ObservedAt    string            `json:"observed_at,omitempty"`
+	ValidFrom     string            `json:"valid_from,omitempty"`
+	ValidTo       string            `json:"valid_to,omitempty"`
+	Attributes    map[string]string `json:"attributes,omitempty"`
+}
+
+type ListClaimsRequest struct {
+	RuntimeID     string
+	ClaimID       string
+	SubjectURN    string
+	Predicate     string
+	ObjectURN     string
+	ObjectValue   string
+	ClaimType     string
+	Status        string
+	SourceEventID string
+	Limit         uint32
+}
+
+type ListClaimsResponse struct {
+	Claims []Claim `json:"claims"`
+}
+
+type WriteClaimsRequest struct {
+	RuntimeID       string  `json:"runtime_id"`
+	Claims          []Claim `json:"claims"`
+	ReplaceExisting bool    `json:"replace_existing,omitempty"`
+}
+
+type WriteClaimsResponse struct {
+	ClaimsWritten          uint32 `json:"claims_written"`
+	EntitiesUpserted       uint32 `json:"entities_upserted"`
+	RelationLinksProjected uint32 `json:"relation_links_projected"`
+	ClaimsRetracted        uint32 `json:"claims_retracted"`
+}
+
+type sourceRuntimeResponse struct {
+	Runtime *SourceRuntime `json:"runtime"`
+}
+
+type GraphEntity struct {
+	URN        string `json:"urn"`
+	EntityType string `json:"entity_type"`
+	Label      string `json:"label"`
+}
+
+type GraphRelation struct {
+	FromURN  string `json:"from_urn"`
+	Relation string `json:"relation"`
+	ToURN    string `json:"to_urn"`
+}
+
+type EntityNeighborhood struct {
+	Root      *GraphEntity    `json:"root,omitempty"`
+	Neighbors []GraphEntity   `json:"neighbors,omitempty"`
+	Relations []GraphRelation `json:"relations,omitempty"`
+}


### PR DESCRIPTION
## Summary

Adds a standalone Go SDK module under `sdk/go/cerebroapi` for shared Cerebro API consumers.

- Provides typed config, source-runtime, claims, and graph-neighborhood models.
- Adds a bounded HTTP client for source runtime, claim, and graph neighborhood APIs.
- Adds shared claim helpers for Cerebro URN encoding and existence/attribute/relation claim construction.

## Test Plan

- `go -C sdk/go/cerebroapi test ./...`
- `go -C sdk/go/cerebroapi vet ./...`
- `make sdk-test`
- `make test`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
