### PR TITLE
Address missed review feedback from recent PRs

### DIFF
--- a/internal/a2agateway/gateway.go
+++ b/internal/a2agateway/gateway.go
@@ -297,7 +297,13 @@ func (h Handler) listTasks(ctx context.Context, request agentplatform.A2AJSONRPC
 		response.Error = &agentplatform.A2AJSONError{Code: -32603, Message: "InternalError", Data: map[string]any{"reason": "A2A task store is unavailable"}}
 		return response
 	}
-	jobs, err := h.Store.ListJobs(ctx, ports.JobFilter{TenantID: resolved.TenantID, Kind: agentplatform.A2AWorkJobKind, Limit: params.Limit})
+	filter := ports.JobFilter{TenantID: resolved.TenantID, Kind: agentplatform.A2AWorkJobKind, Limit: params.Limit}
+	jobs, err := h.Store.ListJobs(ctx, filter)
+	if err != nil {
+		response.Error = jsonRPCErrorFromError(err)
+		return response
+	}
+	totalSize, err := h.Store.CountJobs(ctx, filter)
 	if err != nil {
 		response.Error = jsonRPCErrorFromError(err)
 		return response
@@ -315,7 +321,7 @@ func (h Handler) listTasks(ctx context.Context, request agentplatform.A2AJSONRPC
 		task.History = nil
 		tasks = append(tasks, task)
 	}
-	response.Result = map[string]any{"tasks": tasks, "totalSize": len(tasks)}
+	response.Result = map[string]any{"tasks": tasks, "totalSize": totalSize, "returnedSize": len(tasks), "hasMore": totalSize > uint64(len(tasks))}
 	return response
 }
 

--- a/internal/a2agateway/gateway_test.go
+++ b/internal/a2agateway/gateway_test.go
@@ -80,6 +80,55 @@ func TestCreateEvidencePacketTaskRejectsLongMessageIDFallbackKey(t *testing.T) {
 	}
 }
 
+func TestListTasksReportsTotalSizeBeyondReturnedPage(t *testing.T) {
+	store := newGatewayTestJobStore()
+	now := time.Now().UTC()
+	for index := 1; index <= 3; index++ {
+		id := "job-" + strconv.Itoa(index)
+		store.jobs[id] = &ports.Job{
+			ID:        id,
+			Kind:      agentplatform.A2AWorkJobKind,
+			Status:    ports.JobStatusCompleted,
+			TenantID:  "writer",
+			Payload:   map[string]any{"context_id": "ctx-" + strconv.Itoa(index)},
+			CreatedAt: now.Add(time.Duration(index) * time.Second),
+			UpdatedAt: now.Add(time.Duration(index) * time.Second),
+		}
+	}
+	handler := Handler{Store: store, Resolve: gatewayTestResolver}
+	response := handler.Respond(context.Background(), agentplatform.A2AJSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      "list",
+		Method:  "ListTasks",
+		Params:  json.RawMessage(`{"tenant":"writer","limit":2}`),
+	})
+	if response.Error != nil {
+		t.Fatalf("ListTasks error = %+v", response.Error)
+	}
+	var result struct {
+		Tasks        []agentplatform.A2ATask `json:"tasks"`
+		TotalSize    int                     `json:"totalSize"`
+		ReturnedSize int                     `json:"returnedSize"`
+		HasMore      bool                    `json:"hasMore"`
+	}
+	raw, err := json.Marshal(response.Result)
+	if err != nil {
+		t.Fatalf("marshal ListTasks result: %v", err)
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("decode ListTasks result: %v", err)
+	}
+	if result.TotalSize != 3 {
+		t.Fatalf("totalSize = %d, want 3", result.TotalSize)
+	}
+	if result.ReturnedSize != 2 || len(result.Tasks) != 2 {
+		t.Fatalf("returned tasks = %d/%d, want 2", result.ReturnedSize, len(result.Tasks))
+	}
+	if !result.HasMore {
+		t.Fatal("hasMore = false, want true")
+	}
+}
+
 func gatewayTestSendMessageRequest(messageID string) agentplatform.A2AJSONRPCRequest {
 	const tenantID = "writer"
 	params := agentplatform.A2ASendMessageParams{
@@ -216,9 +265,34 @@ func (s *gatewayTestJobStore) ListJobs(_ context.Context, filter ports.JobFilter
 		if filter.Kind != "" && job.Kind != filter.Kind {
 			continue
 		}
+		if filter.Status != "" && job.Status != filter.Status {
+			continue
+		}
 		jobs = append(jobs, cloneGatewayTestJob(job))
+		if filter.Limit > 0 && len(jobs) >= int(filter.Limit) {
+			break
+		}
 	}
 	return jobs, nil
+}
+
+func (s *gatewayTestJobStore) CountJobs(_ context.Context, filter ports.JobFilter) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var count uint64
+	for _, job := range s.jobs {
+		if filter.TenantID != "" && job.TenantID != filter.TenantID {
+			continue
+		}
+		if filter.Kind != "" && job.Kind != filter.Kind {
+			continue
+		}
+		if filter.Status != "" && job.Status != filter.Status {
+			continue
+		}
+		count++
+	}
+	return count, nil
 }
 
 func (s *gatewayTestJobStore) UpdateJob(_ context.Context, id string, update ports.JobUpdate) (*ports.Job, error) {

--- a/internal/agentplatform/a2a_work.go
+++ b/internal/agentplatform/a2a_work.go
@@ -178,10 +178,9 @@ func EvidencePacketRequestFromA2ASendMessage(params A2ASendMessageParams) (Evide
 				}
 				found = true
 			} else if a2ALooksLikeEvidencePacketRequest(data) {
-				if err := decodeEvidencePacketCandidate(data, &request); err != nil {
-					return EvidencePacketRequest{}, false, err
+				if err := decodeEvidencePacketCandidate(data, &request); err == nil {
+					found = true
 				}
-				found = true
 			}
 		}
 		if request.Question == "" {

--- a/internal/agentplatform/a2a_work_test.go
+++ b/internal/agentplatform/a2a_work_test.go
@@ -43,3 +43,25 @@ func TestDecodeA2AParamsRejectsMultipleJSONValues(t *testing.T) {
 		t.Fatal("DecodeA2AGetTaskParams() error = nil, want multiple JSON values error")
 	}
 }
+
+func TestEvidencePacketRequestHeuristicIgnoresNonStructAction(t *testing.T) {
+	request, found, err := EvidencePacketRequestFromA2ASendMessage(A2ASendMessageParams{
+		Message: A2AMessage{
+			Parts: []A2APart{{
+				Text: "Build an evidence packet",
+				Data: map[string]any{
+					"action": "message/send",
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("EvidencePacketRequestFromA2ASendMessage() error = %v", err)
+	}
+	if !found {
+		t.Fatal("found = false, want text part to produce a request")
+	}
+	if request.Question != "Build an evidence packet" {
+		t.Fatalf("Question = %q, want text part question", request.Question)
+	}
+}

--- a/internal/agentplatform/public_contracts.go
+++ b/internal/agentplatform/public_contracts.go
@@ -280,7 +280,7 @@ func A2AJSONRPCResponseFor(request A2AJSONRPCRequest, card A2AAgentCard) A2AJSON
 	case "SendMessage":
 		response.Result = map[string]any{"message": a2AContractMessage(card)}
 	case "ListTasks":
-		response.Result = map[string]any{"tasks": []any{}, "totalSize": 0}
+		response.Result = map[string]any{"tasks": []any{}, "totalSize": 0, "returnedSize": 0, "hasMore": false}
 	case "GetTask":
 		response.Error = &A2AJSONError{Code: -32001, Message: "TaskNotFoundError"}
 	case "":

--- a/internal/bootstrap/agent_graph_reasoning_test.go
+++ b/internal/bootstrap/agent_graph_reasoning_test.go
@@ -86,6 +86,56 @@ func TestHandleAgentPlatformGraphReasonRejectsTenantOverride(t *testing.T) {
 	}
 }
 
+func TestHandleAgentPlatformGraphReasonAllowsAllowedTenantPrincipal(t *testing.T) {
+	graphStore := &stubGraphStore{
+		cypherRows: [][]ports.CypherRow{{
+			{Values: map[string]any{
+				"entity_urn":  "urn:cerebro:writer:asset:alpha",
+				"entity_type": "asset",
+				"label":       "alpha",
+			}},
+		}},
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APICredentials: []config.APICredential{{
+				Key:            "test-key",
+				Principal:      "tester",
+				AllowedTenants: []string{"writer"},
+			}},
+		},
+	}, Dependencies{
+		GraphStore: graphStore,
+		GraphAgentLLM: &graphagent.StubLLMClient{
+			DraftResponse: &graphagent.DraftResponse{
+				Rationale: "Reasoning over scoped graph rows.",
+				Cypher: `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS entity_urn, e.entity_type AS entity_type, e.label AS label
+LIMIT 25`,
+			},
+			Summary: "Review `urn:cerebro:writer:asset:alpha` first.",
+		},
+	}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp := postAgentGraphReason(t, server, `{"tenant_id":"writer","question":"Which scoped asset should I review?"}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var response graphagent.ReasonResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		t.Fatalf("decode graph reason response: %v", err)
+	}
+	if response.TenantID != "writer" {
+		t.Fatalf("tenant_id = %q, want writer", response.TenantID)
+	}
+}
+
 func TestHandleAgentPlatformGraphReasonMissingTenantWithoutAuthIsBadRequest(t *testing.T) {
 	app := New(config.Config{
 		HTTPAddr:        "127.0.0.1:0",

--- a/internal/bootstrap/agent_platform.go
+++ b/internal/bootstrap/agent_platform.go
@@ -220,7 +220,7 @@ func resolveAgentPlatformRequestContext(ctx context.Context, requestedTenantID s
 		return resolved, nil
 	}
 	resolved.Authenticated = true
-	tenantID := strings.TrimSpace(auth.principal.TenantID)
+	tenantID := firstNonEmpty(auth.principal.TenantID, resolved.TenantID)
 	if tenantID == "" {
 		return agentPlatformResolvedContext{}, errTenantForbidden
 	}

--- a/internal/bootstrap/agent_platform_test.go
+++ b/internal/bootstrap/agent_platform_test.go
@@ -1077,6 +1077,25 @@ func (s *a2ATestJobStore) ListJobs(_ context.Context, filter ports.JobFilter) ([
 	return jobs, nil
 }
 
+func (s *a2ATestJobStore) CountJobs(_ context.Context, filter ports.JobFilter) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var count uint64
+	for _, job := range s.jobs {
+		if filter.TenantID != "" && job.TenantID != filter.TenantID {
+			continue
+		}
+		if filter.Kind != "" && job.Kind != filter.Kind {
+			continue
+		}
+		if filter.Status != "" && job.Status != filter.Status {
+			continue
+		}
+		count++
+	}
+	return count, nil
+}
+
 func (s *a2ATestJobStore) UpdateJob(_ context.Context, id string, update ports.JobUpdate) (*ports.Job, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/bootstrap/grc_cache.go
+++ b/internal/bootstrap/grc_cache.go
@@ -290,7 +290,7 @@ func copyHeaders(dst http.Header, src http.Header) {
 func setGRCQueryCacheHeaders(header http.Header, cacheState string, policy grcCachePolicy) {
 	header.Set("X-Cerebro-Cache", cacheState)
 	header.Set("Vary", appendVary(header.Get("Vary"), "Authorization", "X-Cerebro-API-Key", "X-Cerebro-Tenant"))
-	if policy.TTL > 0 {
+	if cacheState != "bypass" && policy.TTL > 0 {
 		maxAge := int(policy.TTL / time.Second)
 		if maxAge < 1 {
 			maxAge = 1

--- a/internal/bootstrap/grc_cache_test.go
+++ b/internal/bootstrap/grc_cache_test.go
@@ -61,8 +61,31 @@ func TestGRCQueryCacheBypassesNoCacheRequest(t *testing.T) {
 	if resp.Header().Get("X-Cerebro-Cache") != "bypass" {
 		t.Fatalf("X-Cerebro-Cache = %q, want bypass", resp.Header().Get("X-Cerebro-Cache"))
 	}
+	if got := resp.Header().Get("Cache-Control"); got != "" {
+		t.Fatalf("Cache-Control = %q, want empty on bypass", got)
+	}
 	if calls != 1 {
 		t.Fatalf("handler calls = %d, want 1", calls)
+	}
+}
+
+func TestGRCQueryCacheDoesNotEmitCacheControlForErrorResponse(t *testing.T) {
+	app := &App{
+		cfg:  config.Config{Cache: config.CacheConfig{DefaultTTL: time.Minute, StaleTTL: time.Minute}},
+		deps: Dependencies{QueryCache: querycache.NewMemory(querycache.Options{Namespace: "test"})},
+	}
+	handler := app.cacheGRCJSON(app.grcCachePolicy("test", time.Minute), func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "backend failed", http.StatusInternalServerError)
+	})
+
+	resp := httptest.NewRecorder()
+	handler(resp, httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=writer", nil))
+
+	if resp.Header().Get("X-Cerebro-Cache") != "bypass" {
+		t.Fatalf("X-Cerebro-Cache = %q, want bypass", resp.Header().Get("X-Cerebro-Cache"))
+	}
+	if got := resp.Header().Get("Cache-Control"); got != "" {
+		t.Fatalf("Cache-Control = %q, want empty for uncached error response", got)
 	}
 }
 

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -1582,12 +1582,9 @@ func (app *App) mcpInvestigationContext(r *http.Request, args map[string]any) (a
 	neighborhoods := []any{}
 	partialErrors := []string{}
 	includeGraph := !mcpBoolArg(args, "skip_graph")
-	resourceURNs := make([]string, 0, assetLimit)
+	resourceURNs := make([]string, 0, len(finding.ResourceURNs))
 	seenResourceURNs := map[string]struct{}{}
 	for _, resourceURN := range finding.ResourceURNs {
-		if len(resourceURNs) >= assetLimit {
-			break
-		}
 		resourceURN = strings.TrimSpace(resourceURN)
 		if resourceURN == "" {
 			continue
@@ -1599,6 +1596,9 @@ func (app *App) mcpInvestigationContext(r *http.Request, args map[string]any) (a
 		resourceURNs = append(resourceURNs, resourceURN)
 	}
 	for _, result := range app.fetchMCPInvestigationResources(r.Context(), r, resourceURNs, includeGraph) {
+		if len(assets) >= assetLimit {
+			continue
+		}
 		if result.asset != nil {
 			assets = append(assets, *result.asset)
 		} else if result.assetErr != nil {

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -103,13 +103,13 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	var draft *DraftResponse
 	var conversion conversionResult
 	var rationale string
+	conversionStarted := time.Now()
 	if fastConversion, fastRationale, ok := deterministicFastPathConversion(request, s.options.EnableDeterministicFastPath); ok {
+		timings.ConversionMS = time.Since(conversionStarted).Milliseconds()
 		if err := emitProgress(emit, started, "planning_query", "Selecting a deterministic read-only graph query template."); err != nil {
 			return err
 		}
-		conversionStarted := time.Now()
 		conversion = fastConversion
-		timings.ConversionMS = time.Since(conversionStarted).Milliseconds()
 		rationale = fastRationale
 	} else {
 		if err := emitProgress(emit, started, "drafting_query", "Drafting a read-only graph query."); err != nil {

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -176,6 +176,10 @@ func (s *memoryJobStore) ListJobs(context.Context, ports.JobFilter) ([]*ports.Jo
 	return nil, nil
 }
 
+func (s *memoryJobStore) CountJobs(context.Context, ports.JobFilter) (uint64, error) {
+	return 0, nil
+}
+
 func (s *memoryJobStore) UpdateJob(_ context.Context, id string, update ports.JobUpdate) (*ports.Job, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/ports/jobs.go
+++ b/internal/ports/jobs.go
@@ -91,6 +91,7 @@ type JobStore interface {
 	CreateJob(context.Context, CreateJobRequest) (*Job, bool, error)
 	GetJob(context.Context, string) (*Job, error)
 	ListJobs(context.Context, JobFilter) ([]*Job, error)
+	CountJobs(context.Context, JobFilter) (uint64, error)
 	UpdateJob(context.Context, string, JobUpdate) (*Job, error)
 	AppendJobEvent(context.Context, JobEvent) (*JobEvent, error)
 	ListJobEvents(context.Context, string, uint32) ([]*JobEvent, error)

--- a/internal/querycache/cache.go
+++ b/internal/querycache/cache.go
@@ -46,6 +46,7 @@ type Cache interface {
 type Options struct {
 	Namespace       string
 	MaxPayloadBytes int
+	MaxEntries      int
 }
 
 func normalizeOptions(options Options) Options {
@@ -55,6 +56,9 @@ func normalizeOptions(options Options) Options {
 	}
 	if options.MaxPayloadBytes <= 0 {
 		options.MaxPayloadBytes = 1 << 20
+	}
+	if options.MaxEntries <= 0 {
+		options.MaxEntries = 4096
 	}
 	return options
 }

--- a/internal/querycache/memory.go
+++ b/internal/querycache/memory.go
@@ -27,9 +27,11 @@ func (c *MemoryCache) Get(_ context.Context, key string) (Entry, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	now := time.Now().UTC()
+	c.deleteExpiredLocked(now)
 	fullKey := cacheKey(c.options.Namespace, key)
 	entry, ok := c.entries[fullKey]
-	if !ok || entry.State(time.Now().UTC()) == StateMiss {
+	if !ok || entry.State(now) == StateMiss {
 		delete(c.entries, fullKey)
 		return Entry{}, ErrMiss
 	}
@@ -56,7 +58,9 @@ func (c *MemoryCache) Set(_ context.Context, key string, payload []byte, ttl tim
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.deleteExpiredLocked(now)
 	c.entries[cacheKey(c.options.Namespace, key)] = entry
+	c.evictOverflowLocked()
 	return nil
 }
 
@@ -80,4 +84,33 @@ func (c *MemoryCache) Ping(context.Context) error {
 
 func (c *MemoryCache) Close(context.Context) error {
 	return nil
+}
+
+func (c *MemoryCache) deleteExpiredLocked(now time.Time) {
+	for key, entry := range c.entries {
+		if entry.State(now) == StateMiss {
+			delete(c.entries, key)
+		}
+	}
+}
+
+func (c *MemoryCache) evictOverflowLocked() {
+	for c.options.MaxEntries > 0 && len(c.entries) > c.options.MaxEntries {
+		var oldestKey string
+		var oldestAt time.Time
+		for key, entry := range c.entries {
+			candidate := entry.CreatedAt
+			if candidate.IsZero() {
+				candidate = entry.StaleUntil
+			}
+			if oldestKey == "" || candidate.Before(oldestAt) {
+				oldestKey = key
+				oldestAt = candidate
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(c.entries, oldestKey)
+	}
 }

--- a/internal/querycache/memory_test.go
+++ b/internal/querycache/memory_test.go
@@ -1,0 +1,56 @@
+package querycache
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMemoryCacheSweepsExpiredEntriesOnSet(t *testing.T) {
+	cache := NewMemory(Options{Namespace: "test", MaxEntries: 10})
+	cache.entries[cacheKey("test", "expired")] = Entry{
+		Payload:    []byte("old"),
+		CreatedAt:  time.Now().Add(-2 * time.Second),
+		ExpiresAt:  time.Now().Add(-2 * time.Second),
+		StaleUntil: time.Now().Add(-time.Second),
+	}
+
+	if err := cache.Set(context.Background(), "fresh", []byte("new"), time.Minute, time.Minute); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	if _, ok := cache.entries[cacheKey("test", "expired")]; ok {
+		t.Fatal("expired entry was not swept")
+	}
+	if _, ok := cache.entries[cacheKey("test", "fresh")]; !ok {
+		t.Fatal("fresh entry missing after Set")
+	}
+}
+
+func TestMemoryCacheEvictsOldestEntryWhenCapped(t *testing.T) {
+	cache := NewMemory(Options{Namespace: "test", MaxEntries: 2})
+
+	if err := cache.Set(context.Background(), "oldest", []byte("a"), time.Minute, time.Minute); err != nil {
+		t.Fatalf("Set(oldest) error = %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	if err := cache.Set(context.Background(), "middle", []byte("b"), time.Minute, time.Minute); err != nil {
+		t.Fatalf("Set(middle) error = %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	if err := cache.Set(context.Background(), "newest", []byte("c"), time.Minute, time.Minute); err != nil {
+		t.Fatalf("Set(newest) error = %v", err)
+	}
+
+	if len(cache.entries) != 2 {
+		t.Fatalf("entry count = %d, want 2", len(cache.entries))
+	}
+	if _, ok := cache.entries[cacheKey("test", "oldest")]; ok {
+		t.Fatal("oldest entry was not evicted")
+	}
+	for _, key := range []string{"middle", "newest"} {
+		if _, ok := cache.entries[cacheKey("test", key)]; !ok {
+			t.Fatalf("entry %q missing after eviction", key)
+		}
+	}
+}

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -1867,7 +1867,7 @@ func oktaIdentityProviderProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 			"status":               strings.TrimSpace(attributes["status"]),
 			"type":                 strings.TrimSpace(firstNonEmpty(attributes["type"], attributes["idp_type"])),
 		}
-		for _, key := range []string{"audience", "client_id", "issuer", "kid", "protocol_type", "sso_binding", "sso_url_host"} {
+		for _, key := range []string{"acs_type", "audience", "client_id", "issuer", "kid", "protocol_type", "sso_binding", "sso_url_host"} {
 			addProjectedAttribute(idpAttrs, key, attributes[key])
 		}
 		addEntity(entities, &ports.ProjectedEntity{

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -833,6 +833,7 @@ func TestProjectOktaDurableConfigurationEntities(t *testing.T) {
 			kind: "okta.identity_provider",
 			attributes: map[string]string{
 				"domain":        "writer.okta.com",
+				"acs_type":      "HTTP-POST",
 				"idp_id":        "idp-saml",
 				"issuer":        "https://idp.example.com",
 				"name":          "Partner SAML IdP",
@@ -844,6 +845,7 @@ func TestProjectOktaDurableConfigurationEntities(t *testing.T) {
 			wantEntityType: "okta.identity_provider",
 			wantLabel:      "Partner SAML IdP",
 			wantAttrs: map[string]string{
+				"acs_type":      "HTTP-POST",
 				"idp_id":        "idp-saml",
 				"issuer":        "https://idp.example.com",
 				"name":          "Partner SAML IdP",

--- a/internal/statestore/postgres/jobs.go
+++ b/internal/statestore/postgres/jobs.go
@@ -137,11 +137,7 @@ func (s *Store) ListJobs(ctx context.Context, filter ports.JobFilter) ([]*ports.
 	if err := s.ensureJobTables(ctx); err != nil {
 		return nil, err
 	}
-	clauses := []string{"1=1"}
-	args := []any{}
-	addTextFilter(&clauses, &args, "tenant_id", filter.TenantID)
-	addTextFilter(&clauses, &args, "kind", filter.Kind)
-	addTextFilter(&clauses, &args, "status", filter.Status)
+	clauses, args := jobFilterClauses(filter)
 	limit := filter.Limit
 	if limit == 0 || limit > 200 {
 		limit = 50
@@ -170,6 +166,39 @@ LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
 		jobs = append(jobs, job)
 	}
 	return jobs, rows.Err()
+}
+
+// CountJobs returns the total platform jobs matching the supplied filter.
+func (s *Store) CountJobs(ctx context.Context, filter ports.JobFilter) (uint64, error) {
+	if s == nil || s.db == nil {
+		return 0, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return 0, err
+	}
+	clauses, args := jobFilterClauses(filter)
+	// #nosec G201 -- clauses are fixed column predicates built by jobFilterClauses.
+	query := fmt.Sprintf(`
+	SELECT COUNT(*)
+	FROM platform_jobs
+	WHERE %s`, strings.Join(clauses, " AND "))
+	var count int64
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count platform jobs: %w", err)
+	}
+	if count < 0 {
+		return 0, nil
+	}
+	return uint64(count), nil
+}
+
+func jobFilterClauses(filter ports.JobFilter) ([]string, []any) {
+	clauses := []string{"1=1"}
+	args := []any{}
+	addTextFilter(&clauses, &args, "tenant_id", filter.TenantID)
+	addTextFilter(&clauses, &args, "kind", filter.Kind)
+	addTextFilter(&clauses, &args, "status", filter.Status)
+	return clauses, args
 }
 
 // UpdateJob applies a partial job state update.

--- a/scripts/droid_post_merge_health.py
+++ b/scripts/droid_post_merge_health.py
@@ -152,7 +152,7 @@ def is_post_merge_checkout_error(pr: dict[str, object], comment: dict[str, objec
     if not merged_at:
         return False
     created_at = str(comment.get("created_at") or "")
-    return not created_at or created_at >= merged_at
+    return bool(created_at) and created_at >= merged_at
 
 
 def requires_droid_review(file: str) -> bool:

--- a/scripts/tests/test_droid_post_merge_health.py
+++ b/scripts/tests/test_droid_post_merge_health.py
@@ -175,6 +175,26 @@ class DroidPostMergeHealthTests(unittest.TestCase):
         self.assertEqual(review["post_merge_checkout_error_count"], 1)
         self.assertEqual(review["latest_comment_url"], "https://finished-comment")
 
+    def test_classify_droid_review_keeps_missing_created_at_checkout_error_active(self):
+        review = pm.classify_droid_review(
+            {
+                "number": 42,
+                "author": "alice",
+                "url": "https://pr",
+                "merged_at": "2026-06-17T04:47:49Z",
+            },
+            [
+                {
+                    "user": {"login": "factory-droid[bot]"},
+                    "body": "**Droid encountered an error**\n\nFailed to checkout PR #42 branch for review",
+                    "html_url": "https://checkout-error",
+                }
+            ],
+        )
+        self.assertEqual(review["status"], "error")
+        self.assertEqual(review["active_error_count"], 1)
+        self.assertEqual(review["post_merge_checkout_error_count"], 0)
+
     def test_classify_droid_review_accepts_superseded_error_plus_finished_comment(self):
         review = pm.classify_droid_review(
             {"number": 42, "author": "alice", "url": "https://pr"},


### PR DESCRIPTION
## Summary

This follow-up addresses review feedback from the last 48 hours that was still present on `main` after the recent merges, including post-merge Droid comments and last-minute comments that landed immediately before merge. The control-pack export feedback is now covered by merged PR #1138, so this branch contains the remaining missed items.

Fixes include:
- measure deterministic graph-agent conversion time around the actual fast-path conversion
- apply MCP investigation `asset_limit` to resolved assets instead of candidate URNs
- bound/sweep the in-memory query cache under versioned-key invalidation
- stop emitting synthetic `Cache-Control` on GRC cache bypass/error responses
- keep timestamp-less Droid checkout errors active instead of suppressing them as post-merge checkout races
- preserve Okta IDP `acs_type` in source projection
- make A2A heuristic evidence-packet detection tolerate non-struct `action` fields
- report true A2A `ListTasks.totalSize` and add `returnedSize`/`hasMore`
- allow graph reasoning for principals with `allowed_tenants` and an authorized requested tenant

## Verification

- `go test ./...`
- `python3 -m unittest scripts.tests.test_droid_post_merge_health`
- `git diff --check`
