### PR TITLE
Add GRC control evidence packets

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2175,6 +2175,32 @@ paths:
       responses:
         '200':
           description: Graph neighborhood and related findings for one entity.
+  /grc/control-packets:
+    get:
+      summary: GRC control evidence packet for a compliance profile
+      tags:
+        - GRC
+      parameters:
+        - $ref: '#/components/parameters/tenantIDQuery'
+        - $ref: '#/components/parameters/limitQuery'
+        - name: profile
+          in: query
+          schema:
+            type: string
+          description: Built-in compliance profile ID. Defaults to soc2-security-core.
+        - name: framework
+          in: query
+          schema:
+            type: string
+          description: Optional framework name or ID filter.
+        - name: control
+          in: query
+          schema:
+            type: string
+          description: Optional control ID filter.
+      responses:
+        '200':
+          description: Profile metadata, posture summary, controls, findings, and evidence expectations.
   /grc/audit-packets/{packetID}:
     get:
       summary: GRC audit packet for one finding

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,6 +76,11 @@ context, the platform job store, coverage context, and evidence authorizers into
 `internal/a2agateway`. Durable task lifecycle behavior stays in that domain
 package; bootstrap only wires the HTTP boundary into it.
 
+The GRC control evidence packet route adds a small HTTP adapter that resolves
+request scope, loads findings and evidence, and hands the posture calculation to
+`internal/grccontrol`. Profile resolution, rule coverage, evidence freshness,
+and control status behavior stay behind that domain package.
+
 The agent platform graph preflight contract lives in `internal/agentplatform`.
 The bootstrap budget includes the HTTP and MCP request/response mapping needed
 to force authenticated tenant context, expose preflight to agents, and attach

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -1449,7 +1449,7 @@ func fallbackAccessAuditRoute(method string, path string) string {
 		return prefix + "/grc/audit-packets/{packetID}"
 	case strings.HasPrefix(path, "/grc/"):
 		switch path {
-		case "/grc/dashboard", "/grc/ask", "/grc/findings", "/grc/controls", "/grc/evidence":
+		case "/grc/dashboard", "/grc/ask", "/grc/findings", "/grc/controls", "/grc/evidence", "/grc/control-packets":
 			return prefix + path
 		default:
 			return prefix + "/grc/{subresource}"

--- a/internal/bootstrap/grc_control_packs.go
+++ b/internal/bootstrap/grc_control_packs.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/grccontrol"
 )
 
 func (a *App) handleGRCControlArchetypes(w http.ResponseWriter, _ *http.Request) {
@@ -34,6 +35,51 @@ func (a *App) handleGRCControlCoverage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleGRCControlEvidencePacket(w http.ResponseWriter, r *http.Request) {
+	scope, err := grcScopeFromRequest(r)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	runtimes, err := a.grcListRuntimes(r, scope)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	findings, err := a.grcListFindingRecords(r, runtimes, grcFindingFilter{Status: "open", Limit: scope.Limit})
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{Limit: scope.Limit})
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	result, err := grccontrol.BuildBuiltinEvidencePacket(grccontrol.BuildInput{
+		ProfileID: firstNonEmpty(r.URL.Query().Get("profile"), r.URL.Query().Get("profile_id")),
+		Framework: r.URL.Query().Get("framework"),
+		ControlID: r.URL.Query().Get("control"),
+		Findings:  findings,
+		Evidence:  evidence,
+		SourceIDs: grcRuntimeSourceIDs(runtimes),
+		Now:       time.Now().UTC(),
+	})
+	if err != nil {
+		if errors.Is(err, grccontrol.ErrInvalidRequest) {
+			err = errors.Join(errInvalidHTTPRequest, err)
+		}
+		writeGRCError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"profile":      result.Profile,
+		"packet":       result.Packet,
+		"controls":     result.Controls,
+		"generated_at": result.Packet.GeneratedAt,
+	})
 }
 
 func (a *App) handleGRCControlPackPreview(w http.ResponseWriter, r *http.Request) {

--- a/internal/bootstrap/grc_control_packs_test.go
+++ b/internal/bootstrap/grc_control_packs_test.go
@@ -9,8 +9,12 @@ import (
 	"testing"
 	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/grccontrol"
+	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestGRCControlArchetypesEndpointReturnsReusableControls(t *testing.T) {
@@ -79,6 +83,81 @@ func TestGRCControlPackPreviewEndpointReturnsYAMLFilesAndCoverage(t *testing.T) 
 	}
 	if !strings.Contains(payload.Preview.Files["controls.yaml"], "Customer Security Framework") {
 		t.Fatalf("controls.yaml missing generated framework:\n%s", payload.Preview.Files["controls.yaml"])
+	}
+}
+
+func TestGRCControlEvidencePacketEndpointBuildsProfilePosture(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-cc6": {
+				ID:             "finding-cc6",
+				TenantID:       "writer",
+				RuntimeID:      "writer-okta-audit",
+				RuleID:         "identity-api-token-or-oauth-app-created",
+				Title:          "Identity API token created",
+				Severity:       "HIGH",
+				Status:         "open",
+				ControlRefs:    []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+				LastObservedAt: now,
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-cc6": {
+				Id:            "evidence-cc6",
+				RuntimeId:     "writer-okta-audit",
+				RuleId:        "identity-api-token-or-oauth-app-created",
+				FindingId:     "finding-cc6",
+				GraphRootUrns: []string{"urn:cerebro:writer:okta_user:00u1"},
+				CreatedAt:     timestamppb.New(now),
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/control-packets?tenant_id=writer&profile=soc2-security-core&framework=SOC%202")
+	if err != nil {
+		t.Fatalf("GET /grc/control-packets error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/control-packets status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload struct {
+		Profile  grccontrol.Profile               `json:"profile"`
+		Packet   compliance.ControlEvidencePacket `json:"packet"`
+		Controls []grccontrol.ControlItem         `json:"controls"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode control packet: %v", err)
+	}
+	if payload.Profile.ID != "soc2-security-core" {
+		t.Fatalf("profile id = %q, want soc2-security-core", payload.Profile.ID)
+	}
+	if payload.Packet.Summary.Total < 2 {
+		t.Fatalf("packet controls = %d, want filtered CC6 family controls", payload.Packet.Summary.Total)
+	}
+	byID := map[string]grccontrol.ControlItem{}
+	for _, control := range payload.Controls {
+		byID[control.ControlID] = control
+	}
+	if got := byID["CC6.1"]; got.Status != string(compliance.ControlPostureFailing) || got.OpenFindings != 1 || got.EvidenceItems != 1 {
+		t.Fatalf("CC6.1 = %+v, want failing with finding and evidence", got)
+	}
+	var missingControl grccontrol.ControlItem
+	for _, control := range payload.Controls {
+		if control.Status == string(compliance.ControlPostureMissingEvidence) {
+			missingControl = control
+			break
+		}
+	}
+	if missingControl.ControlID == "" || missingControl.MissingEvidence == 0 || missingControl.Expectations == 0 {
+		t.Fatalf("missing control = %+v, want a selected control with missing required evidence", missingControl)
 	}
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -93,6 +93,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /grc/control-archetypes", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("control.archetypes", 5*time.Minute), app.handleGRCControlArchetypes))
 	registerHTTPRoute(mux, "GET /grc/control-profiles", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("control.profiles", 5*time.Minute), app.handleGRCControlProfiles))
 	registerHTTPRoute(mux, "GET /grc/control-coverage", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("control.coverage", 5*time.Minute), app.handleGRCControlCoverage))
+	registerHTTPRoute(mux, "GET /grc/control-packets", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("control.packets", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCControlEvidencePacket))
 	registerHTTPRoute(mux, "POST /grc/control-packs/preview", routeSurfacePlatformHTTP, app.handleGRCControlPackPreview)
 	registerHTTPRoute(mux, "POST /grc/control-packs", routeSurfacePlatformHTTP, app.handleGRCControlPackCreate)
 	registerHTTPRoute(mux, "GET /grc/inventory/categories", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.categories", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeInventory), app.handleGRCInventoryCategories))

--- a/internal/grccontrol/packets.go
+++ b/internal/grccontrol/packets.go
@@ -1,0 +1,407 @@
+package grccontrol
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const DefaultEvidenceProfileID = "soc2-security-core"
+
+var ErrInvalidRequest = errors.New("invalid grc control request")
+
+type BuildInput struct {
+	ProfileID string
+	Framework string
+	ControlID string
+	Findings  []*ports.FindingRecord
+	Evidence  []*cerebrov1.FindingEvidence
+	SourceIDs map[string]string
+	Now       time.Time
+}
+
+type PacketResult struct {
+	Profile  Profile
+	Packet   compliance.ControlEvidencePacket
+	Controls []ControlItem
+}
+
+type Profile struct {
+	ID          string `json:"id"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type ControlRef struct {
+	FrameworkName string `json:"framework_name"`
+	ControlID     string `json:"control_id"`
+}
+
+type FindingItem struct {
+	ID             string       `json:"id"`
+	Title          string       `json:"title"`
+	Severity       string       `json:"severity"`
+	Status         string       `json:"status"`
+	TenantID       string       `json:"tenant_id,omitempty"`
+	RuntimeID      string       `json:"runtime_id,omitempty"`
+	SourceID       string       `json:"source_id,omitempty"`
+	RuleID         string       `json:"rule_id,omitempty"`
+	Controls       []ControlRef `json:"controls,omitempty"`
+	EvidenceCount  int          `json:"evidence_count"`
+	Owner          string       `json:"owner"`
+	SLAStatus      string       `json:"sla_status"`
+	LastObservedAt *time.Time   `json:"last_observed_at,omitempty"`
+}
+
+type ControlItem struct {
+	FrameworkName    string        `json:"framework_name"`
+	FrameworkID      string        `json:"framework_id,omitempty"`
+	FrameworkVersion string        `json:"framework_version,omitempty"`
+	FamilyID         string        `json:"family_id,omitempty"`
+	FamilyName       string        `json:"family_name,omitempty"`
+	ControlID        string        `json:"control_id"`
+	Title            string        `json:"title,omitempty"`
+	OwnerDomain      string        `json:"owner_domain,omitempty"`
+	Status           string        `json:"status"`
+	OpenFindings     int           `json:"open_findings"`
+	CriticalFindings int           `json:"critical_findings"`
+	HighFindings     int           `json:"high_findings"`
+	EvidenceItems    int           `json:"evidence_items"`
+	MissingEvidence  int           `json:"missing_evidence_items,omitempty"`
+	StaleEvidence    int           `json:"stale_evidence_items,omitempty"`
+	Expectations     int           `json:"evidence_expectations,omitempty"`
+	MappedRules      []string      `json:"mapped_rules,omitempty"`
+	Reasons          []string      `json:"reasons,omitempty"`
+	Tags             []string      `json:"tags,omitempty"`
+	Findings         []FindingItem `json:"findings,omitempty"`
+}
+
+func BuildBuiltinEvidencePacket(input BuildInput) (PacketResult, error) {
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	profileID := strings.TrimSpace(input.ProfileID)
+	if profileID == "" {
+		profileID = DefaultEvidenceProfileID
+	}
+	profile, resolution, err := ResolveBuiltinProfile(profileID)
+	if err != nil {
+		return PacketResult{}, err
+	}
+	postureInput := compliance.ControlPostureInput{
+		Selection:    resolution,
+		RuleCoverage: compliance.ResolveRuleCoverage(resolution, compliance.BuiltinRuleControlMappings()),
+		Findings:     findingSignals(input.Findings),
+		Evidence:     evidenceSignals(input.Evidence, input.Findings, input.SourceIDs),
+		Now:          now,
+	}
+	packet := compliance.BuildControlEvidencePacket(postureInput)
+	packet.Controls = FilterPacketControls(packet.Controls, input.Framework, input.ControlID)
+	packet.Summary = SummarizePacket(packet.SelectionID, packet.Controls)
+	return PacketResult{
+		Profile:  profile,
+		Packet:   packet,
+		Controls: ControlItemsFromPacket(packet.Controls, input.Findings, input.SourceIDs),
+	}, nil
+}
+
+func ResolveBuiltinProfile(profileID string) (Profile, compliance.SelectionResolution, error) {
+	catalog, err := compliance.LoadBuiltinControlCatalog()
+	if err != nil {
+		return Profile{}, compliance.SelectionResolution{}, fmt.Errorf("load control catalog: %w", err)
+	}
+	index, issues := compliance.BuildCatalogIndex(catalog)
+	if len(issues) != 0 {
+		return Profile{}, compliance.SelectionResolution{}, fmt.Errorf("%w: builtin control catalog has validation issues", ErrInvalidRequest)
+	}
+	profiles, err := compliance.LoadBuiltinControlProfileSet()
+	if err != nil {
+		return Profile{}, compliance.SelectionResolution{}, fmt.Errorf("load control profiles: %w", err)
+	}
+	resolved, issues := compliance.ResolveControlProfiles(index, profiles)
+	if len(issues) != 0 {
+		return Profile{}, compliance.SelectionResolution{}, fmt.Errorf("%w: builtin control profiles have validation issues", ErrInvalidRequest)
+	}
+	for _, item := range resolved.Profiles {
+		if strings.TrimSpace(item.Profile.ID) == strings.TrimSpace(profileID) {
+			return Profile{
+				ID:          item.Profile.ID,
+				Name:        item.Profile.Name,
+				Description: item.Profile.Description,
+			}, item.Resolution, nil
+		}
+	}
+	return Profile{}, compliance.SelectionResolution{}, fmt.Errorf("%w: control profile %q is not declared", ErrInvalidRequest, profileID)
+}
+
+func FilterPacketControls(controls []compliance.ControlEvidencePacketControl, framework, controlID string) []compliance.ControlEvidencePacketControl {
+	framework = strings.TrimSpace(framework)
+	controlID = strings.TrimSpace(controlID)
+	if framework == "" && controlID == "" {
+		return controls
+	}
+	filtered := make([]compliance.ControlEvidencePacketControl, 0, len(controls))
+	controlQuery := strings.ToLower(controlID)
+	for _, control := range controls {
+		if framework != "" && !strings.EqualFold(control.Control.FrameworkName, framework) && !strings.EqualFold(control.Control.FrameworkID, framework) {
+			continue
+		}
+		if controlQuery != "" && !strings.Contains(strings.ToLower(control.Control.ControlID), controlQuery) {
+			continue
+		}
+		filtered = append(filtered, control)
+	}
+	return filtered
+}
+
+func SummarizePacket(selectionID string, controls []compliance.ControlEvidencePacketControl) compliance.ControlPostureSummary {
+	summary := compliance.ControlPostureSummary{
+		SelectionID: strings.TrimSpace(selectionID),
+		Total:       len(controls),
+		ByStatus:    map[compliance.ControlPostureStatus]int{},
+	}
+	for _, control := range controls {
+		summary.ByStatus[control.Status]++
+	}
+	return summary
+}
+
+func ControlItemsFromPacket(packetControls []compliance.ControlEvidencePacketControl, findings []*ports.FindingRecord, sourceIDs map[string]string) []ControlItem {
+	findingsByID := map[string]*ports.FindingRecord{}
+	for _, finding := range findings {
+		if finding != nil {
+			findingsByID[finding.ID] = finding
+		}
+	}
+	controls := make([]ControlItem, 0, len(packetControls))
+	for _, packetControl := range packetControls {
+		item := ControlItem{
+			FrameworkName:    packetControl.Control.FrameworkName,
+			FrameworkID:      packetControl.Control.FrameworkID,
+			FrameworkVersion: packetControl.Control.FrameworkVersion,
+			FamilyID:         packetControl.Control.FamilyID,
+			FamilyName:       packetControl.Control.FamilyName,
+			ControlID:        packetControl.Control.ControlID,
+			Title:            packetControl.Control.Title,
+			OwnerDomain:      packetControl.Control.OwnerDomain,
+			Status:           string(packetControl.Status),
+			EvidenceItems:    len(packetControl.Evidence.Summary.EvidenceIDs),
+			MissingEvidence:  len(packetControl.Evidence.Summary.MissingEvidenceIDs),
+			StaleEvidence:    len(packetControl.Evidence.Summary.StaleEvidenceIDs),
+			Expectations:     len(packetControl.Evidence.Expectations),
+			MappedRules:      append([]string(nil), packetControl.MappedRules...),
+			Reasons:          append([]string(nil), packetControl.Reasons...),
+			Tags:             append([]string(nil), packetControl.Tags...),
+		}
+		for _, packetFinding := range packetControl.Findings {
+			finding := findingsByID[packetFinding.ID]
+			item.Findings = append(item.Findings, findingItem(finding, packetFinding, sourceIDs))
+			if findingStatusOpen(packetFinding.Status) {
+				item.OpenFindings++
+				if strings.EqualFold(packetFinding.Severity, "CRITICAL") {
+					item.CriticalFindings++
+				}
+				if strings.EqualFold(packetFinding.Severity, "HIGH") {
+					item.HighFindings++
+				}
+			}
+		}
+		controls = append(controls, item)
+	}
+	sort.Slice(controls, func(i, j int) bool {
+		left := controls[i]
+		right := controls[j]
+		if controlStatusRank(left.Status) != controlStatusRank(right.Status) {
+			return controlStatusRank(left.Status) < controlStatusRank(right.Status)
+		}
+		if left.OpenFindings != right.OpenFindings {
+			return left.OpenFindings > right.OpenFindings
+		}
+		return left.FrameworkName+left.ControlID < right.FrameworkName+right.ControlID
+	})
+	return controls
+}
+
+func findingSignals(findings []*ports.FindingRecord) []compliance.ControlFindingSignal {
+	items := make([]compliance.ControlFindingSignal, 0, len(findings))
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		items = append(items, compliance.ControlFindingSignal{
+			ID:              finding.ID,
+			RuleID:          finding.RuleID,
+			Title:           fallbackString(finding.Title, finding.RuleID, finding.ID),
+			Status:          finding.Status,
+			Severity:        finding.Severity,
+			ControlRefs:     complianceControlRefs(finding.ControlRefs),
+			FirstObservedAt: finding.FirstObservedAt,
+			LastObservedAt:  finding.LastObservedAt,
+		})
+	}
+	return items
+}
+
+func evidenceSignals(evidence []*cerebrov1.FindingEvidence, findings []*ports.FindingRecord, sourceIDs map[string]string) []compliance.ControlEvidenceSignal {
+	findingsByID := map[string]*ports.FindingRecord{}
+	for _, finding := range findings {
+		if finding != nil {
+			findingsByID[finding.ID] = finding
+		}
+	}
+	items := make([]compliance.ControlEvidenceSignal, 0, len(evidence))
+	for _, record := range evidence {
+		if record == nil {
+			continue
+		}
+		attributes := record.GetAttributes()
+		signal := compliance.ControlEvidenceSignal{
+			ID:           record.GetId(),
+			RuleID:       record.GetRuleId(),
+			EvidenceType: fallbackString(attributes["evidence_type"], attributes["type"], "finding-evidence"),
+			Status:       fallbackString(attributes["status"], "valid"),
+			Source:       fallbackString(attributes["source"], attributes["source_id"], sourceIDs[record.GetRuntimeId()], record.GetRuntimeId()),
+			ObservedAt:   evidenceObservedAt(record),
+			ExpiresAt:    parseEvidenceTime(attributes["expires_at"]),
+			Manual:       strings.EqualFold(attributes["manual"], "true"),
+		}
+		if finding := findingsByID[record.GetFindingId()]; finding != nil {
+			signal.ControlRefs = complianceControlRefs(finding.ControlRefs)
+		}
+		items = append(items, signal)
+	}
+	return items
+}
+
+func findingItem(finding *ports.FindingRecord, packetFinding compliance.ControlEvidencePacketFinding, sourceIDs map[string]string) FindingItem {
+	if finding == nil {
+		return FindingItem{
+			ID:        packetFinding.ID,
+			Title:     fallbackString(packetFinding.Title, packetFinding.RuleID, packetFinding.ID),
+			Severity:  strings.ToUpper(strings.TrimSpace(packetFinding.Severity)),
+			Status:    normalizedFindingStatus(packetFinding.Status),
+			RuleID:    packetFinding.RuleID,
+			Owner:     "Unassigned",
+			SLAStatus: "no_due_date",
+		}
+	}
+	return FindingItem{
+		ID:             finding.ID,
+		Title:          fallbackString(finding.Title, finding.RuleID, finding.ID),
+		Severity:       strings.ToUpper(strings.TrimSpace(finding.Severity)),
+		Status:         normalizedFindingStatus(finding.Status),
+		TenantID:       finding.TenantID,
+		RuntimeID:      finding.RuntimeID,
+		SourceID:       sourceIDs[finding.RuntimeID],
+		RuleID:         finding.RuleID,
+		Controls:       controlRefs(finding.ControlRefs),
+		Owner:          fallbackString(finding.Assignee, "Unassigned"),
+		SLAStatus:      "no_due_date",
+		LastObservedAt: timePtr(finding.LastObservedAt),
+	}
+}
+
+func complianceControlRefs(refs []ports.FindingControlRef) []compliance.ControlRef {
+	items := make([]compliance.ControlRef, 0, len(refs))
+	for _, ref := range refs {
+		framework := strings.TrimSpace(ref.FrameworkName)
+		controlID := strings.TrimSpace(ref.ControlID)
+		if framework == "" || controlID == "" {
+			continue
+		}
+		items = append(items, compliance.ControlRef{FrameworkName: framework, ControlID: controlID})
+	}
+	return items
+}
+
+func controlRefs(refs []ports.FindingControlRef) []ControlRef {
+	items := make([]ControlRef, 0, len(refs))
+	for _, ref := range refs {
+		framework := strings.TrimSpace(ref.FrameworkName)
+		controlID := strings.TrimSpace(ref.ControlID)
+		if framework == "" || controlID == "" {
+			continue
+		}
+		items = append(items, ControlRef{FrameworkName: framework, ControlID: controlID})
+	}
+	return items
+}
+
+func evidenceObservedAt(record *cerebrov1.FindingEvidence) time.Time {
+	if record.GetLastObservedAt() != nil {
+		return record.GetLastObservedAt().AsTime().UTC()
+	}
+	if record.GetCreatedAt() != nil {
+		return record.GetCreatedAt().AsTime().UTC()
+	}
+	return time.Time{}
+}
+
+func parseEvidenceTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
+}
+
+func normalizedFindingStatus(status string) string {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return "UNKNOWN"
+	}
+	return strings.ToUpper(status)
+}
+
+func findingStatusOpen(status string) bool {
+	return strings.EqualFold(strings.TrimSpace(status), "open")
+}
+
+func controlStatusRank(status string) int {
+	switch compliance.ControlPostureStatus(strings.TrimSpace(status)) {
+	case compliance.ControlPostureFailing:
+		return 0
+	case compliance.ControlPostureMissingEvidence:
+		return 1
+	case compliance.ControlPostureStaleEvidence:
+		return 2
+	case compliance.ControlPostureManualReview:
+		return 3
+	case compliance.ControlPostureException:
+		return 4
+	case compliance.ControlPosturePassing:
+		return 5
+	case compliance.ControlPostureNotApplicable:
+		return 6
+	default:
+		return 7
+	}
+}
+
+func fallbackString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func timePtr(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	utc := value.UTC()
+	return &utc
+}

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const bootstrapProductionGoLineBudget = 22347
+const bootstrapProductionGoLineBudget = 22394
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- add a GET /grc/control-packets endpoint for profile-scoped control evidence packets
- move control packet posture construction into internal/grccontrol
- document the new endpoint and bootstrap budget note

## Test plan
- go test ./internal/bootstrap ./internal/grccontrol ./tools/archtests -run 'TestGRCControl|TestBootstrapProductionSurfaceDoesNotGrow|TestArchitectureDocumentsBootstrapOwnership'
- go test ./...
