### PR TITLE
Fix auditor control packet markdown review issues

### DIFF
--- a/internal/bootstrap/grc_control_packs.go
+++ b/internal/bootstrap/grc_control_packs.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -203,7 +203,7 @@ func writeGRCMarkdownExport(w http.ResponseWriter, filename, body string) {
 	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	_, _ = w.Write([]byte(html.EscapeString(body)))
+	_, _ = io.Copy(w, strings.NewReader(body))
 }
 
 func (a *App) handleGRCControlPackPreview(w http.ResponseWriter, r *http.Request) {

--- a/internal/bootstrap/grc_control_packs_test.go
+++ b/internal/bootstrap/grc_control_packs_test.go
@@ -216,6 +216,23 @@ func TestGRCControlEvidencePacketExportEndpointReturnsMarkdown(t *testing.T) {
 	}
 }
 
+func TestWriteGRCMarkdownExportPreservesMarkdownBytes(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	body := "# Control & Evidence <Packet>\n\n- Link text: [literal](https://example.invalid)\n"
+
+	writeGRCMarkdownExport(recorder, "packet.md", body)
+
+	if got := recorder.Body.String(); got != body {
+		t.Fatalf("markdown body = %q, want raw %q", got, body)
+	}
+	if strings.Contains(recorder.Body.String(), "&amp;") || strings.Contains(recorder.Body.String(), "&lt;") {
+		t.Fatalf("markdown export was HTML-escaped: %q", recorder.Body.String())
+	}
+	if got := recorder.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+}
+
 func TestGRCCustomControlEvidencePacketEndpointBuildsGeneratedProfilePacket(t *testing.T) {
 	server := newGRCControlPacketTestServer(t)
 	defer server.Close()

--- a/internal/compliance/evidence_packet.go
+++ b/internal/compliance/evidence_packet.go
@@ -305,15 +305,42 @@ func controlPacketReadiness(control ControlEvidencePacketControl) ControlEvidenc
 	}
 	if readiness.OpenFindings > 0 && readiness.Score > 40 {
 		readiness.Score = 40
-		readiness.Rating = ControlEvidenceQualityPartial
+		if readiness.Rating == ControlEvidenceQualityStrong {
+			readiness.Rating = ControlEvidenceQualityPartial
+		}
 		readiness.Summary = "Evidence may be present, but open findings must be remediated before control reliance."
 	}
-	if control.Status == ControlPostureException && readiness.Score > 50 {
-		readiness.Score = 50
-		readiness.Rating = ControlEvidenceQualityPartial
-		readiness.Summary = "An active exception limits auditor reliance for this control."
+	if control.Status == ControlPostureException {
+		if readiness.Score > 50 {
+			readiness.Score = 50
+		}
+		if readiness.Rating == ControlEvidenceQualityStrong {
+			readiness.Rating = ControlEvidenceQualityPartial
+		}
+		readiness.Summary = controlPacketExceptionSummary(readiness)
 	}
 	return readiness
+}
+
+func controlPacketExceptionSummary(readiness ControlEvidencePacketReadiness) string {
+	conditions := make([]string, 0, 4)
+	if readiness.MissingEvidence > 0 || (readiness.EvidenceItems == 0 && readiness.RequiredExpectations > 0) {
+		conditions = append(conditions, "required evidence is missing")
+	}
+	if readiness.StaleEvidence > 0 {
+		conditions = append(conditions, "evidence is stale")
+	}
+	if readiness.ManualEvidence > 0 {
+		conditions = append(conditions, "manual evidence requires human assessment")
+	}
+	if readiness.OpenFindings > 0 {
+		conditions = append(conditions, "open findings remain visible for remediation tracking")
+	}
+	if len(conditions) == 0 {
+		return "An active exception limits auditor reliance for this control."
+	}
+	summary := strings.Join(conditions, "; ")
+	return strings.ToUpper(summary[:1]) + summary[1:] + "; an active exception limits auditor reliance for this control."
 }
 
 func requiredExpectationCount(expectations []ControlEvidenceExpectationPosture) int {

--- a/internal/compliance/evidence_packet_test.go
+++ b/internal/compliance/evidence_packet_test.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -138,6 +139,82 @@ func TestBuildControlEvidencePacketMarksOptionalExpectations(t *testing.T) {
 	expectation := packet.Controls[0].Evidence.Expectations[0]
 	if expectation.ID != "quarterly-access-review" || expectation.Status != ControlEvidenceExpectationOptional || expectation.Quality != ControlEvidenceQualityOptional || expectation.Required {
 		t.Fatalf("expectation = %#v, want optional quarterly-access-review", expectation)
+	}
+}
+
+func TestControlPacketReadinessReportsExceptionWithOpenFindings(t *testing.T) {
+	readiness := controlPacketReadiness(ControlEvidencePacketControl{
+		Status: ControlPostureException,
+		Findings: []ControlEvidencePacketFinding{{
+			ID:     "finding-1",
+			Status: "open",
+		}},
+		Evidence: ControlEvidencePacketEvidence{
+			Items: []ControlEvidencePacketEvidenceItem{{ID: "evidence-1"}},
+		},
+	})
+
+	if readiness.Score != 40 {
+		t.Fatalf("Score = %d, want open-finding cap at 40", readiness.Score)
+	}
+	if readiness.Rating != ControlEvidenceQualityPartial {
+		t.Fatalf("Rating = %q, want partial", readiness.Rating)
+	}
+	normalizedSummary := strings.ToLower(readiness.Summary)
+	if !strings.Contains(normalizedSummary, "active exception") || !strings.Contains(normalizedSummary, "open findings") {
+		t.Fatalf("Summary = %q, want exception and open-finding context", readiness.Summary)
+	}
+}
+
+func TestControlPacketReadinessDoesNotUpgradeMissingEvidenceForException(t *testing.T) {
+	readiness := controlPacketReadiness(ControlEvidencePacketControl{
+		Status: ControlPostureException,
+		Evidence: ControlEvidencePacketEvidence{
+			Summary: ControlPostureEvidence{
+				MissingEvidenceIDs: []string{"evidence-1"},
+			},
+		},
+	})
+
+	if readiness.Score != 25 {
+		t.Fatalf("Score = %d, want missing-evidence score 25", readiness.Score)
+	}
+	if readiness.Rating != ControlEvidenceQualityMissing {
+		t.Fatalf("Rating = %q, want missing", readiness.Rating)
+	}
+	if !strings.Contains(readiness.Summary, "Required evidence is missing") || !strings.Contains(readiness.Summary, "active exception") {
+		t.Fatalf("Summary = %q, want missing evidence and exception context", readiness.Summary)
+	}
+}
+
+func TestControlPacketReadinessReportsExceptionWithStaleEvidenceAndOpenFindings(t *testing.T) {
+	readiness := controlPacketReadiness(ControlEvidencePacketControl{
+		Status: ControlPostureException,
+		Findings: []ControlEvidencePacketFinding{{
+			ID:     "finding-1",
+			Status: "open",
+		}},
+		Evidence: ControlEvidencePacketEvidence{
+			Summary: ControlPostureEvidence{
+				StaleEvidenceIDs: []string{"evidence-1"},
+			},
+			Items: []ControlEvidencePacketEvidenceItem{{
+				ID: "evidence-1",
+			}},
+		},
+	})
+
+	if readiness.Score != 40 {
+		t.Fatalf("Score = %d, want open-finding cap at 40", readiness.Score)
+	}
+	if readiness.Rating != ControlEvidenceQualityStale {
+		t.Fatalf("Rating = %q, want stale evidence to remain visible", readiness.Rating)
+	}
+	normalizedSummary := strings.ToLower(readiness.Summary)
+	for _, want := range []string{"evidence is stale", "open findings", "active exception"} {
+		if !strings.Contains(normalizedSummary, want) {
+			t.Fatalf("Summary = %q, want %q context", readiness.Summary, want)
+		}
 	}
 }
 

--- a/internal/grccontrol/packets.go
+++ b/internal/grccontrol/packets.go
@@ -327,7 +327,7 @@ func RenderMarkdown(result PacketResult) string {
 		writeMarkdownLine(&builder, "## "+markdownHeading(control.Control.FrameworkName+" "+control.Control.ControlID))
 		if title := strings.TrimSpace(control.Control.Title); title != "" {
 			writeMarkdownLine(&builder, "")
-			writeMarkdownLine(&builder, title)
+			writeMarkdownLine(&builder, markdownValue(title))
 		}
 		writeMarkdownLine(&builder, "")
 		writeMarkdownLine(&builder, "- Status: "+markdownValue(string(control.Status)))
@@ -353,9 +353,8 @@ func RenderMarkdown(result PacketResult) string {
 
 func RenderCustomMarkdown(result CustomPacketResult) string {
 	return RenderMarkdown(PacketResult{
-		Profile:  result.Profile,
-		Packet:   result.Packet,
-		Controls: result.Controls,
+		Profile: result.Profile,
+		Packet:  result.Packet,
 	})
 }
 
@@ -436,29 +435,44 @@ func writeMarkdownRow(builder *strings.Builder, cells ...string) {
 }
 
 func markdownHeading(value string) string {
-	value = strings.TrimSpace(value)
+	value = markdownSingleLine(value)
 	if value == "" {
 		return "Control"
 	}
-	return strings.ReplaceAll(value, "\n", " ")
+	return escapeMarkdownText(value)
 }
 
 func markdownCell(value string) string {
-	value = strings.TrimSpace(value)
+	value = markdownSingleLine(value)
 	if value == "" {
 		return "-"
 	}
-	value = strings.ReplaceAll(value, "\n", " ")
-	value = strings.ReplaceAll(value, "|", "\\|")
-	return value
+	return escapeMarkdownText(value)
 }
 
 func markdownValue(value string) string {
-	value = strings.TrimSpace(value)
+	value = markdownSingleLine(value)
 	if value == "" {
 		return "Not specified"
 	}
-	return strings.ReplaceAll(value, "\n", " ")
+	return escapeMarkdownText(value)
+}
+
+func markdownSingleLine(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+}
+
+func escapeMarkdownText(value string) string {
+	var builder strings.Builder
+	builder.Grow(len(value))
+	for _, char := range value {
+		switch char {
+		case '\\', '`', '*', '_', '~', '[', ']', '(', ')', '#', '!', '<', '>', '|':
+			builder.WriteByte('\\')
+		}
+		builder.WriteRune(char)
+	}
+	return builder.String()
 }
 
 func markdownTime(value time.Time) string {

--- a/internal/grccontrol/packets_test.go
+++ b/internal/grccontrol/packets_test.go
@@ -1,0 +1,92 @@
+package grccontrol
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+func TestRenderMarkdownEscapesUserSuppliedMarkdownSyntax(t *testing.T) {
+	generatedAt := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	result := PacketResult{
+		Profile: Profile{
+			ID:   "customer-profile",
+			Name: "Customer [Audit](https://evil.example) ~~strike~~",
+		},
+		Packet: compliance.ControlEvidencePacket{
+			GeneratedAt: generatedAt,
+			Summary: compliance.ControlPostureSummary{
+				Total:    1,
+				ByStatus: map[compliance.ControlPostureStatus]int{},
+			},
+			Controls: []compliance.ControlEvidencePacketControl{{
+				Control: compliance.ControlPostureControl{
+					FrameworkName: "Customer [Framework](https://evil.example)",
+					ControlID:     "IAM-1",
+					Title:         "Click [here](https://evil.example) <script>",
+					OwnerDomain:   "security|platform",
+				},
+				Status: compliance.ControlPosturePassing,
+				Readiness: compliance.ControlEvidencePacketReadiness{
+					Score:   100,
+					Rating:  compliance.ControlEvidenceQualityStrong,
+					Summary: "Ready [now](https://evil.example)",
+				},
+				Evidence: compliance.ControlEvidencePacketEvidence{
+					Expectations: []compliance.ControlEvidenceExpectationPosture{{
+						ID:           "evidence-1",
+						Title:        "Proof [link](https://evil.example)",
+						Type:         "system|state",
+						Required:     true,
+						Status:       compliance.ControlEvidenceExpectationSatisfied,
+						Quality:      compliance.ControlEvidenceQualityStrong,
+						FreshnessSLA: "30d",
+					}},
+					Items: []compliance.ControlEvidencePacketEvidenceItem{{
+						ID:           "item-1",
+						EvidenceType: "runtime|config",
+						Status:       "passing",
+						Quality:      compliance.ControlEvidenceQualityStrong,
+						Source:       "collector|agent",
+					}},
+				},
+				Findings: []compliance.ControlEvidencePacketFinding{{
+					ID:       "finding-1",
+					Severity: "high",
+					Status:   "open",
+					RuleID:   "rule-1",
+					Title:    "Finding [link](https://evil.example)",
+				}},
+			}},
+		},
+	}
+
+	markdown := RenderMarkdown(result)
+
+	for _, disallowed := range []string{
+		"[Audit](https://evil.example)",
+		"[Framework](https://evil.example)",
+		"[here](https://evil.example)",
+		"[now](https://evil.example)",
+		"~~strike~~",
+		"<script>",
+	} {
+		if strings.Contains(markdown, disallowed) {
+			t.Fatalf("markdown contains unescaped fragment %q:\n%s", disallowed, markdown)
+		}
+	}
+	for _, required := range []string{
+		`Customer \[Audit\]\(https://evil.example\)`,
+		`\~\~strike\~\~`,
+		`Customer \[Framework\]\(https://evil.example\) IAM-1`,
+		`Click \[here\]\(https://evil.example\) \<script\>`,
+		`security\|platform`,
+		`collector\|agent`,
+	} {
+		if !strings.Contains(markdown, required) {
+			t.Fatalf("markdown missing escaped fragment %q:\n%s", required, markdown)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- serve markdown exports as raw markdown attachments instead of HTML-escaped text
- escape user-supplied markdown syntax in auditor packet headings, values, and tables
- preserve active-exception audit readiness when open findings are also present

## Verification
- go test ./internal/compliance ./internal/grccontrol ./internal/bootstrap ./tools/archtests
- make lint
- go test ./...

Addresses Droid review feedback from #1142.