### PR TITLE
Add inventory review accountability posture

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1980,9 +1980,21 @@ paths:
           schema:
             type: string
             enum: [in_scope, out_of_scope, all]
+        - name: review_state
+          in: query
+          description: Derived GRC review disposition for the asset.
+          schema:
+            type: string
+            enum: [baseline, needs_review, reported_issue, out_of_scope, all]
+        - name: accountability_state
+          in: query
+          description: Derived accountability requirement for the asset.
+          schema:
+            type: string
+            enum: [not_required, known, candidate, required_missing, disputed, all]
       responses:
         '200':
-          description: Inventory asset list with risk, ownership, and GRC purview state.
+          description: Inventory asset list with risk, review disposition, accountability, and GRC purview state.
   /grc/inventory/assets/detail:
     get:
       summary: Inventory asset detail
@@ -2044,6 +2056,9 @@ paths:
                   type: string
                 source_id:
                   type: string
+                runtime_id:
+                  type: string
+                  description: Source runtime to update with the concrete resource exclusion. If omitted, matching runtimes for the source may be updated.
                 scope_state:
                   type: string
                   enum: [in_scope, out_of_scope]
@@ -2055,7 +2070,7 @@ paths:
                     type: string
       responses:
         '200':
-          description: Updated GRC purview state for one inventory asset.
+          description: Updated GRC purview state for one inventory asset and propagated any concrete resource exclusion to source-runtime incremental fetch policy.
   /grc/inventory/asset-reports:
     get:
       summary: Inventory asset reports

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -10,8 +11,11 @@ import (
 	"strings"
 	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/resourcescope"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -20,6 +24,15 @@ const (
 	maxGRCInventoryAssetReportBodyBytes = 32 << 10
 	grcInventoryScopeStateInScope       = ports.GRCInventoryScopeStateIn
 	grcInventoryScopeStateOutScope      = ports.GRCInventoryScopeStateOut
+	grcInventoryReviewBaseline          = "baseline"
+	grcInventoryReviewNeedsReview       = "needs_review"
+	grcInventoryReviewOutOfScope        = "out_of_scope"
+	grcInventoryReviewReportedIssue     = "reported_issue"
+	grcInventoryAccountabilityKnown     = "known"
+	grcInventoryAccountabilityCandidate = "candidate"
+	grcInventoryAccountabilityRequired  = "required_missing"
+	grcInventoryAccountabilityDisputed  = "disputed"
+	grcInventoryAccountabilityNone      = "not_required"
 )
 
 type grcInventoryCategoriesResponse struct {
@@ -53,6 +66,11 @@ type grcInventorySummary struct {
 	OutOfScopeAssets    int `json:"out_of_scope_assets"`
 	HighRiskAssets      int `json:"high_risk_assets"`
 	UnassignedAssets    int `json:"unassigned_assets"`
+	BaselineAssets      int `json:"baseline_assets"`
+	NeedsReviewAssets   int `json:"needs_review_assets"`
+	OwnerRequiredAssets int `json:"owner_required_assets"`
+	AccountableAssets   int `json:"accountable_assets"`
+	ReportedIssueAssets int `json:"reported_issue_assets"`
 	OrgGroups           int `json:"org_groups"`
 	PublicAssets        int `json:"public_assets"`
 	ScopedCoveragePct   int `json:"scoped_coverage_pct"`
@@ -106,14 +124,24 @@ type grcInventoryScopeUpdateRequest struct {
 	TenantID   string            `json:"tenant_id,omitempty"`
 	AssetURN   string            `json:"asset_urn"`
 	SourceID   string            `json:"source_id,omitempty"`
+	RuntimeID  string            `json:"runtime_id,omitempty"`
 	ScopeState string            `json:"scope_state"`
 	Reason     string            `json:"reason,omitempty"`
 	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
 type grcInventoryScopeUpdateResponse struct {
-	Scope       *ports.GRCInventoryScopeRecord `json:"scope"`
-	GeneratedAt time.Time                      `json:"generated_at"`
+	Scope       *ports.GRCInventoryScopeRecord       `json:"scope"`
+	Propagation []grcInventoryScopePropagationResult `json:"propagation,omitempty"`
+	GeneratedAt time.Time                            `json:"generated_at"`
+}
+
+type grcInventoryScopePropagationResult struct {
+	RuntimeID        string `json:"runtime_id,omitempty"`
+	SourceID         string `json:"source_id,omitempty"`
+	Status           string `json:"status"`
+	ExclusionApplied bool   `json:"exclusion_applied"`
+	Reason           string `json:"reason,omitempty"`
 }
 
 type grcInventoryAssetReportCreateRequest struct {
@@ -192,8 +220,10 @@ func (a *App) handleGRCInventoryAssets(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	summary := summarizeGRCInventoryAssets(assets)
 	assets = filterGRCInventoryAssetsByScope(assets, strings.TrimSpace(r.URL.Query().Get("scope_state")))
+	assets = filterGRCInventoryAssetsByReviewDisposition(assets, strings.TrimSpace(r.URL.Query().Get("review_state")))
+	assets = filterGRCInventoryAssetsByAccountability(assets, strings.TrimSpace(r.URL.Query().Get("accountability_state")))
+	summary := summarizeGRCInventoryAssets(assets)
 	writeJSON(w, http.StatusOK, grcInventoryAssetsResponse{Assets: assets, Summary: summary, GeneratedAt: time.Now().UTC()})
 }
 
@@ -251,6 +281,7 @@ func (a *App) handleGRCInventoryAssetDetail(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	asset = applyFindingRiskToInventoryAsset(asset, findingItems, tests, vulnerabilities)
+	applyGRCInventoryReviewPosture(&asset)
 	reports, err := a.listGRCInventoryAssetReportsForAsset(r, scope, asset.URN, scope.Limit)
 	if err != nil {
 		writeGRCError(w, err)
@@ -358,6 +389,10 @@ func (a *App) handleUpdateGRCResourceScope(w http.ResponseWriter, r *http.Reques
 		writeGRCError(w, fmt.Errorf("%w: scope_state must be in_scope or out_of_scope", errInvalidHTTPRequest))
 		return
 	}
+	request.ScopeState = state
+	request.SourceID = strings.TrimSpace(request.SourceID)
+	request.RuntimeID = strings.TrimSpace(request.RuntimeID)
+	request.Reason = strings.TrimSpace(request.Reason)
 	store := grcInventoryScopeStore(a.deps.StateStore)
 	if store == nil {
 		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
@@ -366,9 +401,9 @@ func (a *App) handleUpdateGRCResourceScope(w http.ResponseWriter, r *http.Reques
 	record, err := store.UpsertGRCInventoryScope(r.Context(), ports.GRCInventoryScopeRecord{
 		TenantID:   tenantID,
 		AssetURN:   request.AssetURN,
-		SourceID:   strings.TrimSpace(request.SourceID),
+		SourceID:   request.SourceID,
 		ScopeState: state,
-		Reason:     strings.TrimSpace(request.Reason),
+		Reason:     request.Reason,
 		UpdatedBy:  grcInventoryUpdatedBy(r),
 		Attributes: request.Attributes,
 	})
@@ -376,8 +411,116 @@ func (a *App) handleUpdateGRCResourceScope(w http.ResponseWriter, r *http.Reques
 		writeGRCError(w, err)
 		return
 	}
+	propagation, err := a.applyGRCInventoryScopeToSourceRuntimes(r.Context(), tenantID, request)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
 	a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeInventory)
-	writeJSON(w, http.StatusOK, grcInventoryScopeUpdateResponse{Scope: record, GeneratedAt: time.Now().UTC()})
+	writeJSON(w, http.StatusOK, grcInventoryScopeUpdateResponse{Scope: record, Propagation: propagation, GeneratedAt: time.Now().UTC()})
+}
+
+func (a *App) applyGRCInventoryScopeToSourceRuntimes(ctx context.Context, tenantID string, request grcInventoryScopeUpdateRequest) ([]grcInventoryScopePropagationResult, error) {
+	store := sourceRuntimeStore(a.deps.StateStore)
+	if store == nil {
+		return nil, nil
+	}
+	request.AssetURN = strings.TrimSpace(request.AssetURN)
+	request.SourceID = strings.TrimSpace(request.SourceID)
+	request.RuntimeID = strings.TrimSpace(request.RuntimeID)
+	if request.AssetURN == "" || (request.RuntimeID == "" && request.SourceID == "") {
+		return nil, nil
+	}
+	runtimes, skipped, err := grcInventoryScopeTargetRuntimes(ctx, store, tenantID, request)
+	if err != nil {
+		return nil, err
+	}
+	results := append([]grcInventoryScopePropagationResult{}, skipped...)
+	selector := resourcescope.SelectorFromURN(request.AssetURN, request.Reason)
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		if tenantID != "" && runtime.GetTenantId() != tenantID {
+			return nil, errTenantForbidden
+		}
+		if request.SourceID != "" && runtime.GetSourceId() != request.SourceID {
+			return nil, fmt.Errorf("%w: source_id does not match runtime", errInvalidHTTPRequest)
+		}
+		next := proto.Clone(runtime).(*cerebrov1.SourceRuntime)
+		if next.Config == nil {
+			next.Config = map[string]string{}
+		}
+		policy, err := resourcescope.FromConfig(next.Config)
+		if err != nil {
+			return nil, fmt.Errorf("%w: source runtime resource scope policy", errInvalidHTTPRequest)
+		}
+		switch request.ScopeState {
+		case grcInventoryScopeStateOutScope:
+			policy, err = resourcescope.AddExcludedResource(policy, selector)
+		case grcInventoryScopeStateInScope:
+			policy, err = resourcescope.RemoveExcludedResource(policy, selector)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("%w: update source runtime resource scope policy: %w", errInvalidHTTPRequest, err)
+		}
+		value, err := resourcescope.ConfigValue(policy)
+		if err != nil {
+			return nil, fmt.Errorf("%w: encode source runtime resource scope policy: %w", errInvalidHTTPRequest, err)
+		}
+		if value == "" {
+			delete(next.Config, resourcescope.ConfigKey)
+		} else {
+			next.Config[resourcescope.ConfigKey] = value
+		}
+		if err := store.PutSourceRuntime(ctx, next); err != nil {
+			return nil, err
+		}
+		results = append(results, grcInventoryScopePropagationResult{
+			RuntimeID:        next.GetId(),
+			SourceID:         next.GetSourceId(),
+			Status:           "updated",
+			ExclusionApplied: request.ScopeState == grcInventoryScopeStateOutScope,
+		})
+	}
+	return results, nil
+}
+
+func grcInventoryScopeTargetRuntimes(ctx context.Context, store ports.SourceRuntimeStore, tenantID string, request grcInventoryScopeUpdateRequest) ([]*cerebrov1.SourceRuntime, []grcInventoryScopePropagationResult, error) {
+	if request.RuntimeID != "" {
+		runtime, err := store.GetSourceRuntime(ctx, request.RuntimeID)
+		if err != nil {
+			return nil, nil, err
+		}
+		return []*cerebrov1.SourceRuntime{runtime}, nil, nil
+	}
+	if request.SourceID == "" {
+		return nil, nil, nil
+	}
+	listStore, ok := store.(ports.SourceRuntimeListStore)
+	if !ok {
+		return nil, []grcInventoryScopePropagationResult{{
+			SourceID: request.SourceID,
+			Status:   "skipped",
+			Reason:   "source runtime listing is unavailable",
+		}}, nil
+	}
+	runtimes, err := listStore.ListSourceRuntimes(ctx, ports.SourceRuntimeFilter{
+		TenantID: tenantID,
+		SourceID: request.SourceID,
+		Limit:    500,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(runtimes) == 0 {
+		return nil, []grcInventoryScopePropagationResult{{
+			SourceID: request.SourceID,
+			Status:   "skipped",
+			Reason:   "no matching source runtimes",
+		}}, nil
+	}
+	return runtimes, nil, nil
 }
 
 func (a *App) handleCreateGRCInventoryAssetReport(w http.ResponseWriter, r *http.Request) {
@@ -677,7 +820,14 @@ func (a *App) enrichGRCInventoryAssets(r *http.Request, scope grcScope, assets [
 			applyGRCInventoryScope(&assets[index], byURN[assets[index].URN])
 		}
 	}
-	return a.enrichGRCInventoryAssetsWithReports(r, scope, assets)
+	assets, err := a.enrichGRCInventoryAssetsWithReports(r, scope, assets)
+	if err != nil {
+		return nil, err
+	}
+	for index := range assets {
+		applyGRCInventoryReviewPosture(&assets[index])
+	}
+	return assets, nil
 }
 
 func (a *App) enrichGRCInventoryAsset(r *http.Request, scope grcScope, asset graphquery.InventoryAsset) (graphquery.InventoryAsset, error) {
@@ -761,6 +911,116 @@ func applyGRCInventoryAssetReportSummary(asset *graphquery.InventoryAsset, summa
 	}
 }
 
+func applyGRCInventoryReviewPosture(asset *graphquery.InventoryAsset) {
+	if asset == nil {
+		return
+	}
+	if strings.TrimSpace(asset.ScopeState) == "" {
+		asset.ScopeState = grcInventoryScopeStateInScope
+	}
+	owner := inventoryAssetOwnerPrincipal(*asset)
+	accountabilityReasons := inventoryAccountabilityReasons(*asset)
+	if asset.ScopeState == grcInventoryScopeStateOutScope {
+		reason := graphquery.InventoryReviewReason{Code: "scope_exclusion", Label: "Scoped out of GRC review"}
+		asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
+			State:   grcInventoryReviewOutOfScope,
+			Label:   "Scoped out",
+			Detail:  fallbackString(asset.ScopeReason, "Excluded from controls, evidence collection, and review until scoped back in."),
+			Reasons: []graphquery.InventoryReviewReason{reason},
+		}
+		asset.Accountability = &graphquery.InventoryAccountability{
+			State:   grcInventoryAccountabilityNone,
+			Label:   "Owner not required",
+			Reasons: []graphquery.InventoryReviewReason{reason},
+		}
+		return
+	}
+
+	if owner != "" {
+		asset.Accountability = &graphquery.InventoryAccountability{
+			State:     grcInventoryAccountabilityKnown,
+			Label:     "Owner known",
+			Principal: owner,
+		}
+	} else if inventoryAssetOwnerRequired(*asset) {
+		asset.Accountability = &graphquery.InventoryAccountability{
+			State:   grcInventoryAccountabilityRequired,
+			Label:   "Owner required",
+			Reasons: accountabilityReasons,
+		}
+	} else {
+		asset.Accountability = &graphquery.InventoryAccountability{
+			State:   grcInventoryAccountabilityNone,
+			Label:   "Owner not required",
+			Reasons: []graphquery.InventoryReviewReason{{Code: "baseline_no_action", Label: "No active GRC action"}},
+		}
+	}
+
+	if inventoryAssetHasActiveReport(*asset) {
+		asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
+			State:   grcInventoryReviewReportedIssue,
+			Label:   "Reported issue",
+			Detail:  fallbackString(asset.LatestAssetReportReason, "A reviewer reported this asset for triage."),
+			Reasons: []graphquery.InventoryReviewReason{{Code: "reported_issue", Label: "Reviewer report"}},
+		}
+		return
+	}
+	if asset.Accountability != nil && asset.Accountability.State == grcInventoryAccountabilityRequired {
+		asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
+			State:   grcInventoryReviewNeedsReview,
+			Label:   "Needs review",
+			Detail:  "GRC-relevant evidence indicates this asset needs an accountable owner.",
+			Reasons: accountabilityReasons,
+		}
+		return
+	}
+	asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
+		State:   grcInventoryReviewBaseline,
+		Label:   "Baseline",
+		Detail:  "No immediate GRC action required.",
+		Reasons: []graphquery.InventoryReviewReason{{Code: "baseline_no_action", Label: "No active GRC action"}},
+	}
+}
+
+func inventoryAssetHasActiveReport(asset graphquery.InventoryAsset) bool {
+	if asset.AssetReportCount <= 0 {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(asset.LatestAssetReportStatus)) {
+	case ports.GRCInventoryAssetReportStatusRejected, ports.GRCInventoryAssetReportStatusResolved:
+		return false
+	default:
+		return true
+	}
+}
+
+func inventoryAssetOwnerRequired(asset graphquery.InventoryAsset) bool {
+	if asset.ScopeState == grcInventoryScopeStateOutScope || inventoryAssetOwnerPrincipal(asset) != "" {
+		return false
+	}
+	if inventoryAttributeTruthy(asset, "owner_required", "requires_owner", "accountability_required") {
+		return true
+	}
+	return asset.RiskScore >= 70 || inventoryAssetPublic(asset)
+}
+
+func inventoryAccountabilityReasons(asset graphquery.InventoryAsset) []graphquery.InventoryReviewReason {
+	reasons := []graphquery.InventoryReviewReason{}
+	if asset.RiskScore >= 70 {
+		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "high_risk", Label: "High risk"})
+	}
+	if inventoryAssetPublic(asset) {
+		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "public_exposure", Label: "Public exposure"})
+	}
+	if inventoryAttributeTruthy(asset, "owner_required", "requires_owner", "accountability_required") {
+		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "accountability_required", Label: "Accountability required"})
+	}
+	if len(reasons) == 0 {
+		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "accountability_missing", Label: "Owner missing where required"})
+	}
+	return reasons
+}
+
 func filterGRCInventoryAssetsByScope(assets []graphquery.InventoryAsset, state string) []graphquery.InventoryAsset {
 	state = strings.TrimSpace(state)
 	if state == "" || state == "all" {
@@ -779,10 +1039,41 @@ func filterGRCInventoryAssetsByScope(assets []graphquery.InventoryAsset, state s
 	return filtered
 }
 
+func filterGRCInventoryAssetsByReviewDisposition(assets []graphquery.InventoryAsset, state string) []graphquery.InventoryAsset {
+	state = strings.TrimSpace(state)
+	if state == "" || state == "all" {
+		return assets
+	}
+	filtered := make([]graphquery.InventoryAsset, 0, len(assets))
+	for _, asset := range assets {
+		applyGRCInventoryReviewPosture(&asset)
+		if asset.ReviewDisposition != nil && asset.ReviewDisposition.State == state {
+			filtered = append(filtered, asset)
+		}
+	}
+	return filtered
+}
+
+func filterGRCInventoryAssetsByAccountability(assets []graphquery.InventoryAsset, state string) []graphquery.InventoryAsset {
+	state = strings.TrimSpace(state)
+	if state == "" || state == "all" {
+		return assets
+	}
+	filtered := make([]graphquery.InventoryAsset, 0, len(assets))
+	for _, asset := range assets {
+		applyGRCInventoryReviewPosture(&asset)
+		if asset.Accountability != nil && asset.Accountability.State == state {
+			filtered = append(filtered, asset)
+		}
+	}
+	return filtered
+}
+
 func summarizeGRCInventoryAssets(assets []graphquery.InventoryAsset) grcInventorySummary {
 	summary := grcInventorySummary{TotalAssets: len(assets)}
 	orgs := map[string]struct{}{}
 	for _, asset := range assets {
+		applyGRCInventoryReviewPosture(&asset)
 		state := strings.TrimSpace(asset.ScopeState)
 		if state == "" || state == grcInventoryScopeStateInScope {
 			summary.InScopeAssets++
@@ -795,6 +1086,24 @@ func summarizeGRCInventoryAssets(assets []graphquery.InventoryAsset) grcInventor
 		}
 		if inventoryAssetOwner(asset) == "Unassigned" {
 			summary.UnassignedAssets++
+		}
+		if asset.ReviewDisposition != nil {
+			switch asset.ReviewDisposition.State {
+			case grcInventoryReviewBaseline:
+				summary.BaselineAssets++
+			case grcInventoryReviewNeedsReview:
+				summary.NeedsReviewAssets++
+			case grcInventoryReviewReportedIssue:
+				summary.ReportedIssueAssets++
+			}
+		}
+		if asset.Accountability != nil {
+			switch asset.Accountability.State {
+			case grcInventoryAccountabilityKnown:
+				summary.AccountableAssets++
+			case grcInventoryAccountabilityRequired:
+				summary.OwnerRequiredAssets++
+			}
 		}
 		if inventoryAssetPublic(asset) {
 			summary.PublicAssets++
@@ -894,12 +1203,13 @@ func grcInventoryTimeline(asset graphquery.InventoryAsset, findings []grcFinding
 }
 
 func grcInventoryActions(asset graphquery.InventoryAsset, findings []grcFindingItem, controls []grcControlItem, tests []grcInventoryTestItem, vulnerabilities []grcInventoryVulnerability) []grcInventoryAction {
+	applyGRCInventoryReviewPosture(&asset)
 	actions := []grcInventoryAction{}
 	if asset.ScopeState == grcInventoryScopeStateOutScope {
 		actions = append(actions, grcInventoryAction{Title: "Confirm GRC purview", Description: "This asset is scoped out. Scope it back in if it should participate in controls, tests, and evidence review.", Priority: "high"})
 	}
-	if inventoryAssetOwner(asset) == "Unassigned" {
-		actions = append(actions, grcInventoryAction{Title: "Assign an owner", Description: "Add ownership metadata so findings and control evidence route to an accountable team.", Priority: "high"})
+	if asset.Accountability != nil && asset.Accountability.State == grcInventoryAccountabilityRequired {
+		actions = append(actions, grcInventoryAction{Title: "Assign accountable owner", Description: "Add ownership metadata for this GRC-relevant asset so evidence, findings, and remediation work have a responsible team.", Priority: "high"})
 	}
 	if criticalHighGRCInventoryVulnerabilities(vulnerabilities) > 0 {
 		actions = append(actions, grcInventoryAction{Title: "Remediate critical or high vulnerabilities", Description: "Review linked findings and confirm active remediation plans for severe vulnerability exposure.", Priority: "high"})
@@ -911,7 +1221,7 @@ func grcInventoryActions(asset graphquery.InventoryAsset, findings []grcFindingI
 		actions = append(actions, grcInventoryAction{Title: "Map framework scope", Description: "Attach affected findings to framework controls to make audit impact explicit.", Priority: "medium"})
 	}
 	if len(actions) == 0 {
-		actions = append(actions, grcInventoryAction{Title: "Keep monitoring", Description: "No immediate scope, ownership, vulnerability, or test gaps were detected for this asset.", Priority: "low"})
+		actions = append(actions, grcInventoryAction{Title: "Keep monitoring", Description: "No immediate scope, accountability, vulnerability, or test gaps were detected for this asset.", Priority: "low"})
 	}
 	return actions
 }
@@ -939,7 +1249,11 @@ func criticalHighGRCInventoryVulnerabilities(items []grcInventoryVulnerability) 
 }
 
 func inventoryAssetOwner(asset graphquery.InventoryAsset) string {
-	return fallbackString(asset.Attributes["owner"], asset.Attributes["owner_email"], asset.Attributes["assignee"], asset.Attributes["account_manager_email"], asset.Attributes["owner_login"], "Unassigned")
+	return fallbackString(inventoryAssetOwnerPrincipal(asset), "Unassigned")
+}
+
+func inventoryAssetOwnerPrincipal(asset graphquery.InventoryAsset) string {
+	return fallbackString(asset.Attributes["owner"], asset.Attributes["owner_email"], asset.Attributes["assignee"], asset.Attributes["account_manager_email"], asset.Attributes["owner_login"])
 }
 
 func inventoryAssetOrg(asset graphquery.InventoryAsset) string {
@@ -947,7 +1261,11 @@ func inventoryAssetOrg(asset graphquery.InventoryAsset) string {
 }
 
 func inventoryAssetPublic(asset graphquery.InventoryAsset) bool {
-	for _, key := range []string{"public", "publicly_accessible", "internet_exposed", "external"} {
+	return inventoryAttributeTruthy(asset, "public", "publicly_accessible", "internet_exposed", "external")
+}
+
+func inventoryAttributeTruthy(asset graphquery.InventoryAsset, keys ...string) bool {
+	for _, key := range keys {
 		switch strings.ToLower(strings.TrimSpace(asset.Attributes[key])) {
 		case "1", "t", "true", "yes", "y":
 			return true

--- a/internal/bootstrap/grc_inventory_test.go
+++ b/internal/bootstrap/grc_inventory_test.go
@@ -1,6 +1,14 @@
 package bootstrap
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/resourcescope"
+)
 
 func TestGRCInventoryVulnerabilitiesReturnsEmptySlice(t *testing.T) {
 	got := grcInventoryVulnerabilities([]grcFindingItem{{ID: "finding-1", Title: "Owner missing", Status: "OPEN"}})
@@ -9,5 +17,110 @@ func TestGRCInventoryVulnerabilitiesReturnsEmptySlice(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("grcInventoryVulnerabilities() len = %d, want 0", len(got))
+	}
+}
+
+func TestGRCInventoryReviewPostureKeepsOrdinaryUnownedAssetsInBaseline(t *testing.T) {
+	asset := graphquery.InventoryAsset{
+		URN:        "urn:cerebro:writer:github_code_repository:writer/app",
+		ScopeState: grcInventoryScopeStateInScope,
+		Attributes: map[string]string{},
+	}
+	applyGRCInventoryReviewPosture(&asset)
+	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcInventoryReviewBaseline {
+		t.Fatalf("review_disposition = %#v, want baseline", asset.ReviewDisposition)
+	}
+	if asset.Accountability == nil || asset.Accountability.State != grcInventoryAccountabilityNone {
+		t.Fatalf("accountability = %#v, want not_required", asset.Accountability)
+	}
+}
+
+func TestGRCInventoryReviewPostureRequiresOwnerForHighRiskUnownedAssets(t *testing.T) {
+	asset := graphquery.InventoryAsset{
+		URN:        "urn:cerebro:writer:aws_s3_bucket:bucket-a",
+		RiskScore:  80,
+		ScopeState: grcInventoryScopeStateInScope,
+		Attributes: map[string]string{},
+	}
+	applyGRCInventoryReviewPosture(&asset)
+	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcInventoryReviewNeedsReview {
+		t.Fatalf("review_disposition = %#v, want needs_review", asset.ReviewDisposition)
+	}
+	if asset.Accountability == nil || asset.Accountability.State != grcInventoryAccountabilityRequired {
+		t.Fatalf("accountability = %#v, want required_missing", asset.Accountability)
+	}
+}
+
+func TestGRCInventoryReviewPostureReportsActiveIssues(t *testing.T) {
+	asset := graphquery.InventoryAsset{
+		URN:                     "urn:cerebro:writer:aws_s3_bucket:bucket-a",
+		ScopeState:              grcInventoryScopeStateInScope,
+		AssetReportCount:        1,
+		LatestAssetReportStatus: ports.GRCInventoryAssetReportStatusAccepted,
+		Attributes:              map[string]string{},
+	}
+	applyGRCInventoryReviewPosture(&asset)
+	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcInventoryReviewReportedIssue {
+		t.Fatalf("review_disposition = %#v, want reported_issue", asset.ReviewDisposition)
+	}
+}
+
+func TestGRCInventoryScopePropagationUpdatesRuntimeResourcePolicy(t *testing.T) {
+	const assetURN = "urn:cerebro:writer:aws_s3_bucket:bucket-a"
+	store := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-a": {Id: "runtime-a", TenantId: "writer", SourceId: "aws", Config: map[string]string{}},
+	}}
+	app := &App{deps: Dependencies{StateStore: store}}
+
+	results, err := app.applyGRCInventoryScopeToSourceRuntimes(context.Background(), "writer", grcInventoryScopeUpdateRequest{
+		AssetURN:   assetURN,
+		SourceID:   "aws",
+		RuntimeID:  "runtime-a",
+		ScopeState: grcInventoryScopeStateOutScope,
+		Reason:     "Not in audit scope",
+	})
+	if err != nil {
+		t.Fatalf("applyGRCInventoryScopeToSourceRuntimes(out) error = %v", err)
+	}
+	if len(results) != 1 || !results[0].ExclusionApplied {
+		t.Fatalf("propagation results = %#v, want one applied result", results)
+	}
+	runtime, err := store.GetSourceRuntime(context.Background(), "runtime-a")
+	if err != nil {
+		t.Fatalf("GetSourceRuntime(out) error = %v", err)
+	}
+	policy, err := resourcescope.FromConfig(runtime.GetConfig())
+	if err != nil {
+		t.Fatalf("FromConfig(out) error = %v", err)
+	}
+	if !policy.ExcludesEvent("aws_s3_bucket", "bucket-a", map[string]string{"resource_urn": assetURN}) {
+		t.Fatalf("scope policy did not exclude %s", assetURN)
+	}
+
+	results, err = app.applyGRCInventoryScopeToSourceRuntimes(context.Background(), "writer", grcInventoryScopeUpdateRequest{
+		AssetURN:   assetURN,
+		SourceID:   "aws",
+		RuntimeID:  "runtime-a",
+		ScopeState: grcInventoryScopeStateInScope,
+	})
+	if err != nil {
+		t.Fatalf("applyGRCInventoryScopeToSourceRuntimes(in) error = %v", err)
+	}
+	if len(results) != 1 || results[0].ExclusionApplied {
+		t.Fatalf("propagation results = %#v, want one removal result", results)
+	}
+	runtime, err = store.GetSourceRuntime(context.Background(), "runtime-a")
+	if err != nil {
+		t.Fatalf("GetSourceRuntime(in) error = %v", err)
+	}
+	policy, err = resourcescope.FromConfig(runtime.GetConfig())
+	if err != nil {
+		t.Fatalf("FromConfig(in) error = %v", err)
+	}
+	if policy.ExcludesEvent("aws_s3_bucket", "bucket-a", map[string]string{"resource_urn": assetURN}) {
+		t.Fatalf("scope policy still excludes %s", assetURN)
+	}
+	if _, ok := runtime.GetConfig()[resourcescope.ConfigKey]; ok {
+		t.Fatalf("runtime config retained empty %s", resourcescope.ConfigKey)
 	}
 }

--- a/internal/graphquery/inventory.go
+++ b/internal/graphquery/inventory.go
@@ -43,22 +43,50 @@ type InventoryCategory struct {
 }
 
 type InventoryAsset struct {
-	URN                        string            `json:"urn"`
-	EntityType                 string            `json:"entity_type"`
-	Label                      string            `json:"label"`
-	SourceID                   string            `json:"source_id,omitempty"`
-	RuntimeID                  string            `json:"runtime_id,omitempty"`
-	RiskScore                  int               `json:"risk_score,omitempty"`
-	RiskLevel                  string            `json:"risk_level,omitempty"`
-	RiskReasons                []string          `json:"risk_reasons,omitempty"`
-	ScopeState                 string            `json:"scope_state,omitempty"`
-	ScopeReason                string            `json:"scope_reason,omitempty"`
-	ScopeUpdatedAt             string            `json:"scope_updated_at,omitempty"`
-	AssetReportCount           int               `json:"asset_report_count,omitempty"`
-	LatestAssetReportStatus    string            `json:"latest_asset_report_status,omitempty"`
-	LatestAssetReportReason    string            `json:"latest_asset_report_reason,omitempty"`
-	LatestAssetReportUpdatedAt string            `json:"latest_asset_report_updated_at,omitempty"`
-	Attributes                 map[string]string `json:"attributes,omitempty"`
+	URN                        string                      `json:"urn"`
+	EntityType                 string                      `json:"entity_type"`
+	Label                      string                      `json:"label"`
+	SourceID                   string                      `json:"source_id,omitempty"`
+	RuntimeID                  string                      `json:"runtime_id,omitempty"`
+	RiskScore                  int                         `json:"risk_score,omitempty"`
+	RiskLevel                  string                      `json:"risk_level,omitempty"`
+	RiskReasons                []string                    `json:"risk_reasons,omitempty"`
+	ScopeState                 string                      `json:"scope_state,omitempty"`
+	ScopeReason                string                      `json:"scope_reason,omitempty"`
+	ScopeUpdatedAt             string                      `json:"scope_updated_at,omitempty"`
+	AssetReportCount           int                         `json:"asset_report_count,omitempty"`
+	LatestAssetReportStatus    string                      `json:"latest_asset_report_status,omitempty"`
+	LatestAssetReportReason    string                      `json:"latest_asset_report_reason,omitempty"`
+	LatestAssetReportUpdatedAt string                      `json:"latest_asset_report_updated_at,omitempty"`
+	ReviewDisposition          *InventoryReviewDisposition `json:"review_disposition,omitempty"`
+	Accountability             *InventoryAccountability    `json:"accountability,omitempty"`
+	Attributes                 map[string]string           `json:"attributes,omitempty"`
+}
+
+type InventoryReviewDisposition struct {
+	State   string                  `json:"state"`
+	Label   string                  `json:"label"`
+	Detail  string                  `json:"detail,omitempty"`
+	Reasons []InventoryReviewReason `json:"reasons,omitempty"`
+}
+
+type InventoryReviewReason struct {
+	Code  string `json:"code"`
+	Label string `json:"label"`
+}
+
+type InventoryAccountability struct {
+	State      string                    `json:"state"`
+	Label      string                    `json:"label"`
+	Principal  string                    `json:"principal,omitempty"`
+	Candidates []InventoryOwnerCandidate `json:"candidates,omitempty"`
+	Reasons    []InventoryReviewReason   `json:"reasons,omitempty"`
+}
+
+type InventoryOwnerCandidate struct {
+	Principal  string `json:"principal"`
+	Confidence string `json:"confidence,omitempty"`
+	Source     string `json:"source,omitempty"`
 }
 
 type InventoryAssetDetail struct {
@@ -254,10 +282,6 @@ func inventoryRisk(attrs map[string]string) (int, []string) {
 	if strings.EqualFold(attrs["environment"], "prod") || strings.EqualFold(attrs["environment"], "production") {
 		score += 15
 		reasons = append(reasons, "production")
-	}
-	if firstInventoryString(attrs["owner"], attrs["owner_email"], attrs["owner_login"], attrs["assignee"]) == "" {
-		score += 10
-		reasons = append(reasons, "missing owner")
 	}
 	return clampInventoryRisk(score), reasons
 }

--- a/internal/resourcescope/policy.go
+++ b/internal/resourcescope/policy.go
@@ -115,6 +115,60 @@ func (p Policy) Empty() bool {
 		len(p.ExcludedResources) == 0
 }
 
+// SelectorFromURN returns the exact-resource selector represented by a
+// Cerebro inventory URN. The URN itself is the source of truth; type/id are
+// added so runtimes can filter raw events before projection when they expose
+// provider identifiers instead of a projected URN.
+func SelectorFromURN(urn string, reason string) ResourceSelector {
+	urn = strings.TrimSpace(urn)
+	selector := ResourceSelector{URN: urn, Reason: strings.TrimSpace(reason)}
+	parts := strings.Split(urn, ":")
+	if strings.HasPrefix(urn, "urn:cerebro:") && len(parts) >= 5 {
+		selector.Type = parts[len(parts)-2]
+		selector.ID = parts[len(parts)-1]
+	}
+	return selector
+}
+
+// AddExcludedResource returns a policy that excludes the concrete resource.
+func AddExcludedResource(policy Policy, selector ResourceSelector) (Policy, error) {
+	if strings.TrimSpace(selector.URN) != "" {
+		policy.ExcludedResourceURNs = append(policy.ExcludedResourceURNs, selector.URN)
+	}
+	policy.ExcludedResources = append(policy.ExcludedResources, selector)
+	return Normalize(policy)
+}
+
+// RemoveExcludedResource returns a policy with the concrete resource exclusion removed.
+func RemoveExcludedResource(policy Policy, selector ResourceSelector) (Policy, error) {
+	normalized, err := Normalize(Policy{ExcludedResources: []ResourceSelector{selector}})
+	if err != nil {
+		return Policy{}, err
+	}
+	if len(normalized.ExcludedResources) == 0 {
+		return Normalize(policy)
+	}
+	target := normalized.ExcludedResources[0]
+	targetURN := strings.TrimSpace(target.URN)
+	urns := make([]string, 0, len(policy.ExcludedResourceURNs))
+	for _, urn := range policy.ExcludedResourceURNs {
+		if strings.TrimSpace(urn) == targetURN {
+			continue
+		}
+		urns = append(urns, urn)
+	}
+	resources := make([]ResourceSelector, 0, len(policy.ExcludedResources))
+	for _, resource := range policy.ExcludedResources {
+		if sameResourceSelector(resource, target) {
+			continue
+		}
+		resources = append(resources, resource)
+	}
+	policy.ExcludedResourceURNs = urns
+	policy.ExcludedResources = resources
+	return Normalize(policy)
+}
+
 // ExcludesFamily returns true when a runtime family should be skipped before source IO.
 func (p Policy) ExcludesFamily(sourceID string, family string) bool {
 	if p.Empty() {
@@ -253,6 +307,23 @@ func normalizeResources(values []ResourceSelector) ([]ResourceSelector, error) {
 		return left < right
 	})
 	return out, nil
+}
+
+func sameResourceSelector(left ResourceSelector, right ResourceSelector) bool {
+	leftNormalized, err := normalizeResources([]ResourceSelector{left})
+	if err != nil || len(leftNormalized) == 0 {
+		return false
+	}
+	rightNormalized, err := normalizeResources([]ResourceSelector{right})
+	if err != nil || len(rightNormalized) == 0 {
+		return false
+	}
+	left = leftNormalized[0]
+	right = rightNormalized[0]
+	if left.URN != "" && right.URN != "" {
+		return left.URN == right.URN
+	}
+	return left.Type != "" && left.ID != "" && left.Type == right.Type && left.ID == right.ID
 }
 
 func familyCandidates(sourceID string, family string) map[string]bool {


### PR DESCRIPTION
## Summary
- Adds derived inventory review disposition and accountability fields to asset API responses and summaries.
- Adds API filters for review state and accountability state.
- Propagates inventory scope exclusions into source-runtime resource scope policy so incremental fetches honor scoped-out resources.
- Stops treating missing ownership alone as inventory risk.

## Tests
- go test ./internal/resourcescope ./internal/bootstrap ./internal/graphquery

## Related
- Companion web PR updates the inventory UI to consume these fields.