### PR TITLE
Move inventory posture derivation out of bootstrap

### DIFF
--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -13,6 +13,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/grcinventory"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/resourcescope"
 	"google.golang.org/protobuf/proto"
@@ -22,17 +23,6 @@ const (
 	grcRuntimeStatusConfigKey           = "__cerebro_runtime_status"
 	maxGRCInventoryScopeBodyBytes       = 32 << 10
 	maxGRCInventoryAssetReportBodyBytes = 32 << 10
-	grcInventoryScopeStateInScope       = ports.GRCInventoryScopeStateIn
-	grcInventoryScopeStateOutScope      = ports.GRCInventoryScopeStateOut
-	grcInventoryReviewBaseline          = "baseline"
-	grcInventoryReviewNeedsReview       = "needs_review"
-	grcInventoryReviewOutOfScope        = "out_of_scope"
-	grcInventoryReviewReportedIssue     = "reported_issue"
-	grcInventoryAccountabilityKnown     = "known"
-	grcInventoryAccountabilityCandidate = "candidate"
-	grcInventoryAccountabilityRequired  = "required_missing"
-	grcInventoryAccountabilityDisputed  = "disputed"
-	grcInventoryAccountabilityNone      = "not_required"
 )
 
 type grcInventoryCategoriesResponse struct {
@@ -42,7 +32,7 @@ type grcInventoryCategoriesResponse struct {
 
 type grcInventoryAssetsResponse struct {
 	Assets      []graphquery.InventoryAsset `json:"assets"`
-	Summary     grcInventorySummary         `json:"summary"`
+	Summary     grcinventory.Summary        `json:"summary"`
 	GeneratedAt time.Time                   `json:"generated_at"`
 }
 
@@ -58,23 +48,6 @@ type grcInventoryAssetDetailResponse struct {
 	Timeline        []grcInventoryTimelineEvent            `json:"timeline"`
 	Actions         []grcInventoryAction                   `json:"actions"`
 	GeneratedAt     time.Time                              `json:"generated_at"`
-}
-
-type grcInventorySummary struct {
-	TotalAssets         int `json:"total_assets"`
-	InScopeAssets       int `json:"in_scope_assets"`
-	OutOfScopeAssets    int `json:"out_of_scope_assets"`
-	HighRiskAssets      int `json:"high_risk_assets"`
-	UnassignedAssets    int `json:"unassigned_assets"`
-	BaselineAssets      int `json:"baseline_assets"`
-	NeedsReviewAssets   int `json:"needs_review_assets"`
-	OwnerRequiredAssets int `json:"owner_required_assets"`
-	AccountableAssets   int `json:"accountable_assets"`
-	ReportedIssueAssets int `json:"reported_issue_assets"`
-	OrgGroups           int `json:"org_groups"`
-	PublicAssets        int `json:"public_assets"`
-	ScopedCoveragePct   int `json:"scoped_coverage_pct"`
-	AssignedCoveragePct int `json:"assigned_coverage_pct"`
 }
 
 type grcInventoryTimelineEvent struct {
@@ -116,7 +89,7 @@ type grcResourceScopeResponse struct {
 	SourceID    string                      `json:"source_id"`
 	Runtimes    []grcResourceScopeRuntime   `json:"runtimes"`
 	Resources   []graphquery.InventoryAsset `json:"resources"`
-	Summary     grcInventorySummary         `json:"summary"`
+	Summary     grcinventory.Summary        `json:"summary"`
 	GeneratedAt time.Time                   `json:"generated_at"`
 }
 
@@ -220,10 +193,10 @@ func (a *App) handleGRCInventoryAssets(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	assets = filterGRCInventoryAssetsByScope(assets, strings.TrimSpace(r.URL.Query().Get("scope_state")))
-	assets = filterGRCInventoryAssetsByReviewDisposition(assets, strings.TrimSpace(r.URL.Query().Get("review_state")))
-	assets = filterGRCInventoryAssetsByAccountability(assets, strings.TrimSpace(r.URL.Query().Get("accountability_state")))
-	summary := summarizeGRCInventoryAssets(assets)
+	assets = grcinventory.FilterByScope(assets, strings.TrimSpace(r.URL.Query().Get("scope_state")))
+	assets = grcinventory.FilterByReviewDisposition(assets, strings.TrimSpace(r.URL.Query().Get("review_state")))
+	assets = grcinventory.FilterByAccountability(assets, strings.TrimSpace(r.URL.Query().Get("accountability_state")))
+	summary := grcinventory.Summarize(assets)
 	writeJSON(w, http.StatusOK, grcInventoryAssetsResponse{Assets: assets, Summary: summary, GeneratedAt: time.Now().UTC()})
 }
 
@@ -281,7 +254,7 @@ func (a *App) handleGRCInventoryAssetDetail(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	asset = applyFindingRiskToInventoryAsset(asset, findingItems, tests, vulnerabilities)
-	applyGRCInventoryReviewPosture(&asset)
+	grcinventory.ApplyReviewPosture(&asset)
 	reports, err := a.listGRCInventoryAssetReportsForAsset(r, scope, asset.URN, scope.Limit)
 	if err != nil {
 		writeGRCError(w, err)
@@ -354,7 +327,7 @@ func (a *App) handleGRCResourceScope(w http.ResponseWriter, r *http.Request) {
 		SourceID:    sourceID,
 		Runtimes:    items,
 		Resources:   resources,
-		Summary:     summarizeGRCInventoryAssets(resources),
+		Summary:     grcinventory.Summarize(resources),
 		GeneratedAt: time.Now().UTC(),
 	})
 }
@@ -385,7 +358,7 @@ func (a *App) handleUpdateGRCResourceScope(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	state := strings.TrimSpace(request.ScopeState)
-	if state != grcInventoryScopeStateInScope && state != grcInventoryScopeStateOutScope {
+	if state != grcinventory.ScopeStateInScope && state != grcinventory.ScopeStateOutScope {
 		writeGRCError(w, fmt.Errorf("%w: scope_state must be in_scope or out_of_scope", errInvalidHTTPRequest))
 		return
 	}
@@ -456,9 +429,9 @@ func (a *App) applyGRCInventoryScopeToSourceRuntimes(ctx context.Context, tenant
 			return nil, fmt.Errorf("%w: source runtime resource scope policy", errInvalidHTTPRequest)
 		}
 		switch request.ScopeState {
-		case grcInventoryScopeStateOutScope:
+		case grcinventory.ScopeStateOutScope:
 			policy, err = resourcescope.AddExcludedResource(policy, selector)
-		case grcInventoryScopeStateInScope:
+		case grcinventory.ScopeStateInScope:
 			policy, err = resourcescope.RemoveExcludedResource(policy, selector)
 		}
 		if err != nil {
@@ -480,7 +453,7 @@ func (a *App) applyGRCInventoryScopeToSourceRuntimes(ctx context.Context, tenant
 			RuntimeID:        next.GetId(),
 			SourceID:         next.GetSourceId(),
 			Status:           "updated",
-			ExclusionApplied: request.ScopeState == grcInventoryScopeStateOutScope,
+			ExclusionApplied: request.ScopeState == grcinventory.ScopeStateOutScope,
 		})
 	}
 	return results, nil
@@ -817,7 +790,7 @@ func (a *App) enrichGRCInventoryAssets(r *http.Request, scope grcScope, assets [
 			}
 		}
 		for index := range assets {
-			applyGRCInventoryScope(&assets[index], byURN[assets[index].URN])
+			grcinventory.ApplyScope(&assets[index], byURN[assets[index].URN])
 		}
 	}
 	assets, err := a.enrichGRCInventoryAssetsWithReports(r, scope, assets)
@@ -825,7 +798,7 @@ func (a *App) enrichGRCInventoryAssets(r *http.Request, scope grcScope, assets [
 		return nil, err
 	}
 	for index := range assets {
-		applyGRCInventoryReviewPosture(&assets[index])
+		grcinventory.ApplyReviewPosture(&assets[index])
 	}
 	return assets, nil
 }
@@ -864,7 +837,7 @@ func (a *App) enrichGRCInventoryAssetsWithReports(r *http.Request, scope grcScop
 		byURN[summary.AssetURN] = summary
 	}
 	for index := range assets {
-		applyGRCInventoryAssetReportSummary(&assets[index], byURN[assets[index].URN])
+		grcinventory.ApplyAssetReportSummary(&assets[index], byURN[assets[index].URN])
 	}
 	return assets, nil
 }
@@ -880,244 +853,6 @@ func (a *App) listGRCInventoryAssetReportsForAsset(r *http.Request, scope grcSco
 		SourceID:  scope.SourceID,
 		Limit:     limit,
 	})
-}
-
-func applyGRCInventoryScope(asset *graphquery.InventoryAsset, record *ports.GRCInventoryScopeRecord) {
-	if asset == nil {
-		return
-	}
-	if strings.TrimSpace(asset.ScopeState) == "" {
-		asset.ScopeState = grcInventoryScopeStateInScope
-	}
-	if record == nil {
-		return
-	}
-	asset.ScopeState = record.ScopeState
-	asset.ScopeReason = record.Reason
-	if !record.UpdatedAt.IsZero() {
-		asset.ScopeUpdatedAt = record.UpdatedAt.UTC().Format(time.RFC3339)
-	}
-}
-
-func applyGRCInventoryAssetReportSummary(asset *graphquery.InventoryAsset, summary *ports.GRCInventoryAssetReportSummary) {
-	if asset == nil || summary == nil {
-		return
-	}
-	asset.AssetReportCount = summary.ReportCount
-	asset.LatestAssetReportStatus = summary.TriageStatus
-	asset.LatestAssetReportReason = summary.Reason
-	if !summary.UpdatedAt.IsZero() {
-		asset.LatestAssetReportUpdatedAt = summary.UpdatedAt.UTC().Format(time.RFC3339)
-	}
-}
-
-func applyGRCInventoryReviewPosture(asset *graphquery.InventoryAsset) {
-	if asset == nil {
-		return
-	}
-	if strings.TrimSpace(asset.ScopeState) == "" {
-		asset.ScopeState = grcInventoryScopeStateInScope
-	}
-	owner := inventoryAssetOwnerPrincipal(*asset)
-	accountabilityReasons := inventoryAccountabilityReasons(*asset)
-	if asset.ScopeState == grcInventoryScopeStateOutScope {
-		reason := graphquery.InventoryReviewReason{Code: "scope_exclusion", Label: "Scoped out of GRC review"}
-		asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
-			State:   grcInventoryReviewOutOfScope,
-			Label:   "Scoped out",
-			Detail:  fallbackString(asset.ScopeReason, "Excluded from controls, evidence collection, and review until scoped back in."),
-			Reasons: []graphquery.InventoryReviewReason{reason},
-		}
-		asset.Accountability = &graphquery.InventoryAccountability{
-			State:   grcInventoryAccountabilityNone,
-			Label:   "Owner not required",
-			Reasons: []graphquery.InventoryReviewReason{reason},
-		}
-		return
-	}
-
-	if owner != "" {
-		asset.Accountability = &graphquery.InventoryAccountability{
-			State:     grcInventoryAccountabilityKnown,
-			Label:     "Owner known",
-			Principal: owner,
-		}
-	} else if inventoryAssetOwnerRequired(*asset) {
-		asset.Accountability = &graphquery.InventoryAccountability{
-			State:   grcInventoryAccountabilityRequired,
-			Label:   "Owner required",
-			Reasons: accountabilityReasons,
-		}
-	} else {
-		asset.Accountability = &graphquery.InventoryAccountability{
-			State:   grcInventoryAccountabilityNone,
-			Label:   "Owner not required",
-			Reasons: []graphquery.InventoryReviewReason{{Code: "baseline_no_action", Label: "No active GRC action"}},
-		}
-	}
-
-	if inventoryAssetHasActiveReport(*asset) {
-		asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
-			State:   grcInventoryReviewReportedIssue,
-			Label:   "Reported issue",
-			Detail:  fallbackString(asset.LatestAssetReportReason, "A reviewer reported this asset for triage."),
-			Reasons: []graphquery.InventoryReviewReason{{Code: "reported_issue", Label: "Reviewer report"}},
-		}
-		return
-	}
-	if asset.Accountability != nil && asset.Accountability.State == grcInventoryAccountabilityRequired {
-		asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
-			State:   grcInventoryReviewNeedsReview,
-			Label:   "Needs review",
-			Detail:  "GRC-relevant evidence indicates this asset needs an accountable owner.",
-			Reasons: accountabilityReasons,
-		}
-		return
-	}
-	asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
-		State:   grcInventoryReviewBaseline,
-		Label:   "Baseline",
-		Detail:  "No immediate GRC action required.",
-		Reasons: []graphquery.InventoryReviewReason{{Code: "baseline_no_action", Label: "No active GRC action"}},
-	}
-}
-
-func inventoryAssetHasActiveReport(asset graphquery.InventoryAsset) bool {
-	if asset.AssetReportCount <= 0 {
-		return false
-	}
-	switch strings.ToLower(strings.TrimSpace(asset.LatestAssetReportStatus)) {
-	case ports.GRCInventoryAssetReportStatusRejected, ports.GRCInventoryAssetReportStatusResolved:
-		return false
-	default:
-		return true
-	}
-}
-
-func inventoryAssetOwnerRequired(asset graphquery.InventoryAsset) bool {
-	if asset.ScopeState == grcInventoryScopeStateOutScope || inventoryAssetOwnerPrincipal(asset) != "" {
-		return false
-	}
-	if inventoryAttributeTruthy(asset, "owner_required", "requires_owner", "accountability_required") {
-		return true
-	}
-	return asset.RiskScore >= 70 || inventoryAssetPublic(asset)
-}
-
-func inventoryAccountabilityReasons(asset graphquery.InventoryAsset) []graphquery.InventoryReviewReason {
-	reasons := []graphquery.InventoryReviewReason{}
-	if asset.RiskScore >= 70 {
-		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "high_risk", Label: "High risk"})
-	}
-	if inventoryAssetPublic(asset) {
-		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "public_exposure", Label: "Public exposure"})
-	}
-	if inventoryAttributeTruthy(asset, "owner_required", "requires_owner", "accountability_required") {
-		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "accountability_required", Label: "Accountability required"})
-	}
-	if len(reasons) == 0 {
-		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "accountability_missing", Label: "Owner missing where required"})
-	}
-	return reasons
-}
-
-func filterGRCInventoryAssetsByScope(assets []graphquery.InventoryAsset, state string) []graphquery.InventoryAsset {
-	state = strings.TrimSpace(state)
-	if state == "" || state == "all" {
-		return assets
-	}
-	filtered := make([]graphquery.InventoryAsset, 0, len(assets))
-	for _, asset := range assets {
-		assetState := strings.TrimSpace(asset.ScopeState)
-		if assetState == "" {
-			assetState = grcInventoryScopeStateInScope
-		}
-		if assetState == state {
-			filtered = append(filtered, asset)
-		}
-	}
-	return filtered
-}
-
-func filterGRCInventoryAssetsByReviewDisposition(assets []graphquery.InventoryAsset, state string) []graphquery.InventoryAsset {
-	state = strings.TrimSpace(state)
-	if state == "" || state == "all" {
-		return assets
-	}
-	filtered := make([]graphquery.InventoryAsset, 0, len(assets))
-	for _, asset := range assets {
-		applyGRCInventoryReviewPosture(&asset)
-		if asset.ReviewDisposition != nil && asset.ReviewDisposition.State == state {
-			filtered = append(filtered, asset)
-		}
-	}
-	return filtered
-}
-
-func filterGRCInventoryAssetsByAccountability(assets []graphquery.InventoryAsset, state string) []graphquery.InventoryAsset {
-	state = strings.TrimSpace(state)
-	if state == "" || state == "all" {
-		return assets
-	}
-	filtered := make([]graphquery.InventoryAsset, 0, len(assets))
-	for _, asset := range assets {
-		applyGRCInventoryReviewPosture(&asset)
-		if asset.Accountability != nil && asset.Accountability.State == state {
-			filtered = append(filtered, asset)
-		}
-	}
-	return filtered
-}
-
-func summarizeGRCInventoryAssets(assets []graphquery.InventoryAsset) grcInventorySummary {
-	summary := grcInventorySummary{TotalAssets: len(assets)}
-	orgs := map[string]struct{}{}
-	for _, asset := range assets {
-		applyGRCInventoryReviewPosture(&asset)
-		state := strings.TrimSpace(asset.ScopeState)
-		if state == "" || state == grcInventoryScopeStateInScope {
-			summary.InScopeAssets++
-		}
-		if state == grcInventoryScopeStateOutScope {
-			summary.OutOfScopeAssets++
-		}
-		if asset.RiskScore >= 70 {
-			summary.HighRiskAssets++
-		}
-		if inventoryAssetOwner(asset) == "Unassigned" {
-			summary.UnassignedAssets++
-		}
-		if asset.ReviewDisposition != nil {
-			switch asset.ReviewDisposition.State {
-			case grcInventoryReviewBaseline:
-				summary.BaselineAssets++
-			case grcInventoryReviewNeedsReview:
-				summary.NeedsReviewAssets++
-			case grcInventoryReviewReportedIssue:
-				summary.ReportedIssueAssets++
-			}
-		}
-		if asset.Accountability != nil {
-			switch asset.Accountability.State {
-			case grcInventoryAccountabilityKnown:
-				summary.AccountableAssets++
-			case grcInventoryAccountabilityRequired:
-				summary.OwnerRequiredAssets++
-			}
-		}
-		if inventoryAssetPublic(asset) {
-			summary.PublicAssets++
-		}
-		if org := inventoryAssetOrg(asset); org != "" {
-			orgs[org] = struct{}{}
-		}
-	}
-	summary.OrgGroups = len(orgs)
-	if summary.TotalAssets > 0 {
-		summary.ScopedCoveragePct = int(float64(summary.InScopeAssets) / float64(summary.TotalAssets) * 100)
-		summary.AssignedCoveragePct = int(float64(summary.TotalAssets-summary.UnassignedAssets) / float64(summary.TotalAssets) * 100)
-	}
-	return summary
 }
 
 func applyFindingRiskToInventoryAsset(asset graphquery.InventoryAsset, findings []grcFindingItem, tests []grcInventoryTestItem, vulnerabilities []grcInventoryVulnerability) graphquery.InventoryAsset {
@@ -1139,12 +874,12 @@ func applyFindingRiskToInventoryAsset(asset graphquery.InventoryAsset, findings 
 		score += 15
 		reasons = append(reasons, "critical or high vulnerabilities")
 	}
-	if asset.ScopeState == grcInventoryScopeStateOutScope {
+	if asset.ScopeState == grcinventory.ScopeStateOutScope {
 		reasons = append(reasons, "out of GRC purview")
 	}
-	asset.RiskScore = clampGRCInventoryRisk(score)
-	asset.RiskLevel = grcInventoryRiskLevel(asset.RiskScore)
-	asset.RiskReasons = uniqueGRCInventoryStrings(reasons)
+	asset.RiskScore = grcinventory.ClampRisk(score)
+	asset.RiskLevel = grcinventory.RiskLevel(asset.RiskScore)
+	asset.RiskReasons = grcinventory.UniqueStrings(reasons)
 	return asset
 }
 
@@ -1203,12 +938,12 @@ func grcInventoryTimeline(asset graphquery.InventoryAsset, findings []grcFinding
 }
 
 func grcInventoryActions(asset graphquery.InventoryAsset, findings []grcFindingItem, controls []grcControlItem, tests []grcInventoryTestItem, vulnerabilities []grcInventoryVulnerability) []grcInventoryAction {
-	applyGRCInventoryReviewPosture(&asset)
+	grcinventory.ApplyReviewPosture(&asset)
 	actions := []grcInventoryAction{}
-	if asset.ScopeState == grcInventoryScopeStateOutScope {
+	if asset.ScopeState == grcinventory.ScopeStateOutScope {
 		actions = append(actions, grcInventoryAction{Title: "Confirm GRC purview", Description: "This asset is scoped out. Scope it back in if it should participate in controls, tests, and evidence review.", Priority: "high"})
 	}
-	if asset.Accountability != nil && asset.Accountability.State == grcInventoryAccountabilityRequired {
+	if asset.Accountability != nil && asset.Accountability.State == grcinventory.AccountabilityRequired {
 		actions = append(actions, grcInventoryAction{Title: "Assign accountable owner", Description: "Add ownership metadata for this GRC-relevant asset so evidence, findings, and remediation work have a responsible team.", Priority: "high"})
 	}
 	if criticalHighGRCInventoryVulnerabilities(vulnerabilities) > 0 {
@@ -1248,32 +983,6 @@ func criticalHighGRCInventoryVulnerabilities(items []grcInventoryVulnerability) 
 	return count
 }
 
-func inventoryAssetOwner(asset graphquery.InventoryAsset) string {
-	return fallbackString(inventoryAssetOwnerPrincipal(asset), "Unassigned")
-}
-
-func inventoryAssetOwnerPrincipal(asset graphquery.InventoryAsset) string {
-	return fallbackString(asset.Attributes["owner"], asset.Attributes["owner_email"], asset.Attributes["assignee"], asset.Attributes["account_manager_email"], asset.Attributes["owner_login"])
-}
-
-func inventoryAssetOrg(asset graphquery.InventoryAsset) string {
-	return fallbackString(asset.Attributes["org"], asset.Attributes["owner_login"], asset.Attributes["account_id"], asset.Attributes["project_id"], asset.SourceID)
-}
-
-func inventoryAssetPublic(asset graphquery.InventoryAsset) bool {
-	return inventoryAttributeTruthy(asset, "public", "publicly_accessible", "internet_exposed", "external")
-}
-
-func inventoryAttributeTruthy(asset graphquery.InventoryAsset, keys ...string) bool {
-	for _, key := range keys {
-		switch strings.ToLower(strings.TrimSpace(asset.Attributes[key])) {
-		case "1", "t", "true", "yes", "y":
-			return true
-		}
-	}
-	return false
-}
-
 func parseGRCInventoryTime(value string) *time.Time {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -1287,48 +996,6 @@ func parseGRCInventoryTime(value string) *time.Time {
 		}
 	}
 	return nil
-}
-
-func clampGRCInventoryRisk(score int) int {
-	if score < 0 {
-		return 0
-	}
-	if score > 100 {
-		return 100
-	}
-	return score
-}
-
-func grcInventoryRiskLevel(score int) string {
-	switch {
-	case score >= 85:
-		return "critical"
-	case score >= 70:
-		return "high"
-	case score >= 40:
-		return "medium"
-	case score > 0:
-		return "low"
-	default:
-		return "unknown"
-	}
-}
-
-func uniqueGRCInventoryStrings(values []string) []string {
-	seen := map[string]struct{}{}
-	result := []string{}
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		result = append(result, value)
-	}
-	return result
 }
 
 func grcInventoryUpdatedBy(r *http.Request) string {

--- a/internal/bootstrap/grc_inventory_test.go
+++ b/internal/bootstrap/grc_inventory_test.go
@@ -6,6 +6,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/grcinventory"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/resourcescope"
 )
@@ -23,14 +24,14 @@ func TestGRCInventoryVulnerabilitiesReturnsEmptySlice(t *testing.T) {
 func TestGRCInventoryReviewPostureKeepsOrdinaryUnownedAssetsInBaseline(t *testing.T) {
 	asset := graphquery.InventoryAsset{
 		URN:        "urn:cerebro:writer:github_code_repository:writer/app",
-		ScopeState: grcInventoryScopeStateInScope,
+		ScopeState: grcinventory.ScopeStateInScope,
 		Attributes: map[string]string{},
 	}
-	applyGRCInventoryReviewPosture(&asset)
-	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcInventoryReviewBaseline {
+	grcinventory.ApplyReviewPosture(&asset)
+	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcinventory.ReviewBaseline {
 		t.Fatalf("review_disposition = %#v, want baseline", asset.ReviewDisposition)
 	}
-	if asset.Accountability == nil || asset.Accountability.State != grcInventoryAccountabilityNone {
+	if asset.Accountability == nil || asset.Accountability.State != grcinventory.AccountabilityNone {
 		t.Fatalf("accountability = %#v, want not_required", asset.Accountability)
 	}
 }
@@ -39,14 +40,14 @@ func TestGRCInventoryReviewPostureRequiresOwnerForHighRiskUnownedAssets(t *testi
 	asset := graphquery.InventoryAsset{
 		URN:        "urn:cerebro:writer:aws_s3_bucket:bucket-a",
 		RiskScore:  80,
-		ScopeState: grcInventoryScopeStateInScope,
+		ScopeState: grcinventory.ScopeStateInScope,
 		Attributes: map[string]string{},
 	}
-	applyGRCInventoryReviewPosture(&asset)
-	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcInventoryReviewNeedsReview {
+	grcinventory.ApplyReviewPosture(&asset)
+	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcinventory.ReviewNeedsReview {
 		t.Fatalf("review_disposition = %#v, want needs_review", asset.ReviewDisposition)
 	}
-	if asset.Accountability == nil || asset.Accountability.State != grcInventoryAccountabilityRequired {
+	if asset.Accountability == nil || asset.Accountability.State != grcinventory.AccountabilityRequired {
 		t.Fatalf("accountability = %#v, want required_missing", asset.Accountability)
 	}
 }
@@ -54,13 +55,13 @@ func TestGRCInventoryReviewPostureRequiresOwnerForHighRiskUnownedAssets(t *testi
 func TestGRCInventoryReviewPostureReportsActiveIssues(t *testing.T) {
 	asset := graphquery.InventoryAsset{
 		URN:                     "urn:cerebro:writer:aws_s3_bucket:bucket-a",
-		ScopeState:              grcInventoryScopeStateInScope,
+		ScopeState:              grcinventory.ScopeStateInScope,
 		AssetReportCount:        1,
 		LatestAssetReportStatus: ports.GRCInventoryAssetReportStatusAccepted,
 		Attributes:              map[string]string{},
 	}
-	applyGRCInventoryReviewPosture(&asset)
-	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcInventoryReviewReportedIssue {
+	grcinventory.ApplyReviewPosture(&asset)
+	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcinventory.ReviewReportedIssue {
 		t.Fatalf("review_disposition = %#v, want reported_issue", asset.ReviewDisposition)
 	}
 }
@@ -76,7 +77,7 @@ func TestGRCInventoryScopePropagationUpdatesRuntimeResourcePolicy(t *testing.T) 
 		AssetURN:   assetURN,
 		SourceID:   "aws",
 		RuntimeID:  "runtime-a",
-		ScopeState: grcInventoryScopeStateOutScope,
+		ScopeState: grcinventory.ScopeStateOutScope,
 		Reason:     "Not in audit scope",
 	})
 	if err != nil {
@@ -101,7 +102,7 @@ func TestGRCInventoryScopePropagationUpdatesRuntimeResourcePolicy(t *testing.T) 
 		AssetURN:   assetURN,
 		SourceID:   "aws",
 		RuntimeID:  "runtime-a",
-		ScopeState: grcInventoryScopeStateInScope,
+		ScopeState: grcinventory.ScopeStateInScope,
 	})
 	if err != nil {
 		t.Fatalf("applyGRCInventoryScopeToSourceRuntimes(in) error = %v", err)

--- a/internal/grcinventory/posture.go
+++ b/internal/grcinventory/posture.go
@@ -193,7 +193,7 @@ func Summarize(assets []graphquery.InventoryAsset) Summary {
 	for _, asset := range assets {
 		ApplyReviewPosture(&asset)
 		state := strings.TrimSpace(asset.ScopeState)
-		if state == "" || state == ScopeStateInScope {
+		if state == ScopeStateInScope {
 			summary.InScopeAssets++
 		}
 		if state == ScopeStateOutScope {

--- a/internal/grcinventory/posture.go
+++ b/internal/grcinventory/posture.go
@@ -1,0 +1,355 @@
+package grcinventory
+
+import (
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	ScopeStateInScope  = ports.GRCInventoryScopeStateIn
+	ScopeStateOutScope = ports.GRCInventoryScopeStateOut
+
+	ReviewBaseline      = "baseline"
+	ReviewNeedsReview   = "needs_review"
+	ReviewOutOfScope    = "out_of_scope"
+	ReviewReportedIssue = "reported_issue"
+
+	AccountabilityKnown    = "known"
+	AccountabilityRequired = "required_missing"
+	AccountabilityNone     = "not_required"
+)
+
+type Summary struct {
+	TotalAssets         int `json:"total_assets"`
+	InScopeAssets       int `json:"in_scope_assets"`
+	OutOfScopeAssets    int `json:"out_of_scope_assets"`
+	HighRiskAssets      int `json:"high_risk_assets"`
+	UnassignedAssets    int `json:"unassigned_assets"`
+	BaselineAssets      int `json:"baseline_assets"`
+	NeedsReviewAssets   int `json:"needs_review_assets"`
+	OwnerRequiredAssets int `json:"owner_required_assets"`
+	AccountableAssets   int `json:"accountable_assets"`
+	ReportedIssueAssets int `json:"reported_issue_assets"`
+	OrgGroups           int `json:"org_groups"`
+	PublicAssets        int `json:"public_assets"`
+	ScopedCoveragePct   int `json:"scoped_coverage_pct"`
+	AssignedCoveragePct int `json:"assigned_coverage_pct"`
+}
+
+func ApplyScope(asset *graphquery.InventoryAsset, record *ports.GRCInventoryScopeRecord) {
+	if asset == nil {
+		return
+	}
+	if strings.TrimSpace(asset.ScopeState) == "" {
+		asset.ScopeState = ScopeStateInScope
+	}
+	if record == nil {
+		return
+	}
+	asset.ScopeState = record.ScopeState
+	asset.ScopeReason = record.Reason
+	if !record.UpdatedAt.IsZero() {
+		asset.ScopeUpdatedAt = record.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+}
+
+func ApplyAssetReportSummary(asset *graphquery.InventoryAsset, summary *ports.GRCInventoryAssetReportSummary) {
+	if asset == nil || summary == nil {
+		return
+	}
+	asset.AssetReportCount = summary.ReportCount
+	asset.LatestAssetReportStatus = summary.TriageStatus
+	asset.LatestAssetReportReason = summary.Reason
+	if !summary.UpdatedAt.IsZero() {
+		asset.LatestAssetReportUpdatedAt = summary.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+}
+
+func ApplyReviewPosture(asset *graphquery.InventoryAsset) {
+	if asset == nil {
+		return
+	}
+	if strings.TrimSpace(asset.ScopeState) == "" {
+		asset.ScopeState = ScopeStateInScope
+	}
+	owner := AssetOwnerPrincipal(*asset)
+	accountabilityReasons := accountabilityReasons(*asset)
+	if asset.ScopeState == ScopeStateOutScope {
+		reason := graphquery.InventoryReviewReason{Code: "scope_exclusion", Label: "Scoped out of GRC review"}
+		asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
+			State:   ReviewOutOfScope,
+			Label:   "Scoped out",
+			Detail:  fallback(asset.ScopeReason, "Excluded from controls, evidence collection, and review until scoped back in."),
+			Reasons: []graphquery.InventoryReviewReason{reason},
+		}
+		asset.Accountability = &graphquery.InventoryAccountability{
+			State:   AccountabilityNone,
+			Label:   "Owner not required",
+			Reasons: []graphquery.InventoryReviewReason{reason},
+		}
+		return
+	}
+
+	if owner != "" {
+		asset.Accountability = &graphquery.InventoryAccountability{
+			State:     AccountabilityKnown,
+			Label:     "Owner known",
+			Principal: owner,
+		}
+	} else if ownerRequired(*asset) {
+		asset.Accountability = &graphquery.InventoryAccountability{
+			State:   AccountabilityRequired,
+			Label:   "Owner required",
+			Reasons: accountabilityReasons,
+		}
+	} else {
+		asset.Accountability = &graphquery.InventoryAccountability{
+			State:   AccountabilityNone,
+			Label:   "Owner not required",
+			Reasons: []graphquery.InventoryReviewReason{{Code: "baseline_no_action", Label: "No active GRC action"}},
+		}
+	}
+
+	if hasActiveReport(*asset) {
+		asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
+			State:   ReviewReportedIssue,
+			Label:   "Reported issue",
+			Detail:  fallback(asset.LatestAssetReportReason, "A reviewer reported this asset for triage."),
+			Reasons: []graphquery.InventoryReviewReason{{Code: "reported_issue", Label: "Reviewer report"}},
+		}
+		return
+	}
+	if asset.Accountability != nil && asset.Accountability.State == AccountabilityRequired {
+		asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
+			State:   ReviewNeedsReview,
+			Label:   "Needs review",
+			Detail:  "GRC-relevant evidence indicates this asset needs an accountable owner.",
+			Reasons: accountabilityReasons,
+		}
+		return
+	}
+	asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
+		State:   ReviewBaseline,
+		Label:   "Baseline",
+		Detail:  "No immediate GRC action required.",
+		Reasons: []graphquery.InventoryReviewReason{{Code: "baseline_no_action", Label: "No active GRC action"}},
+	}
+}
+
+func FilterByScope(assets []graphquery.InventoryAsset, state string) []graphquery.InventoryAsset {
+	state = strings.TrimSpace(state)
+	if state == "" || state == "all" {
+		return assets
+	}
+	filtered := make([]graphquery.InventoryAsset, 0, len(assets))
+	for _, asset := range assets {
+		assetState := strings.TrimSpace(asset.ScopeState)
+		if assetState == "" {
+			assetState = ScopeStateInScope
+		}
+		if assetState == state {
+			filtered = append(filtered, asset)
+		}
+	}
+	return filtered
+}
+
+func FilterByReviewDisposition(assets []graphquery.InventoryAsset, state string) []graphquery.InventoryAsset {
+	state = strings.TrimSpace(state)
+	if state == "" || state == "all" {
+		return assets
+	}
+	filtered := make([]graphquery.InventoryAsset, 0, len(assets))
+	for _, asset := range assets {
+		ApplyReviewPosture(&asset)
+		if asset.ReviewDisposition != nil && asset.ReviewDisposition.State == state {
+			filtered = append(filtered, asset)
+		}
+	}
+	return filtered
+}
+
+func FilterByAccountability(assets []graphquery.InventoryAsset, state string) []graphquery.InventoryAsset {
+	state = strings.TrimSpace(state)
+	if state == "" || state == "all" {
+		return assets
+	}
+	filtered := make([]graphquery.InventoryAsset, 0, len(assets))
+	for _, asset := range assets {
+		ApplyReviewPosture(&asset)
+		if asset.Accountability != nil && asset.Accountability.State == state {
+			filtered = append(filtered, asset)
+		}
+	}
+	return filtered
+}
+
+func Summarize(assets []graphquery.InventoryAsset) Summary {
+	summary := Summary{TotalAssets: len(assets)}
+	orgs := map[string]struct{}{}
+	for _, asset := range assets {
+		ApplyReviewPosture(&asset)
+		state := strings.TrimSpace(asset.ScopeState)
+		if state == "" || state == ScopeStateInScope {
+			summary.InScopeAssets++
+		}
+		if state == ScopeStateOutScope {
+			summary.OutOfScopeAssets++
+		}
+		if asset.RiskScore >= 70 {
+			summary.HighRiskAssets++
+		}
+		if AssetOwner(asset) == "Unassigned" {
+			summary.UnassignedAssets++
+		}
+		if asset.ReviewDisposition != nil {
+			switch asset.ReviewDisposition.State {
+			case ReviewBaseline:
+				summary.BaselineAssets++
+			case ReviewNeedsReview:
+				summary.NeedsReviewAssets++
+			case ReviewReportedIssue:
+				summary.ReportedIssueAssets++
+			}
+		}
+		if asset.Accountability != nil {
+			switch asset.Accountability.State {
+			case AccountabilityKnown:
+				summary.AccountableAssets++
+			case AccountabilityRequired:
+				summary.OwnerRequiredAssets++
+			}
+		}
+		if AssetPublic(asset) {
+			summary.PublicAssets++
+		}
+		if org := AssetOrg(asset); org != "" {
+			orgs[org] = struct{}{}
+		}
+	}
+	summary.OrgGroups = len(orgs)
+	if summary.TotalAssets > 0 {
+		summary.ScopedCoveragePct = int(float64(summary.InScopeAssets) / float64(summary.TotalAssets) * 100)
+		summary.AssignedCoveragePct = int(float64(summary.TotalAssets-summary.UnassignedAssets) / float64(summary.TotalAssets) * 100)
+	}
+	return summary
+}
+
+func ClampRisk(score int) int {
+	if score < 0 {
+		return 0
+	}
+	if score > 100 {
+		return 100
+	}
+	return score
+}
+
+func RiskLevel(score int) string {
+	switch {
+	case score >= 85:
+		return "critical"
+	case score >= 70:
+		return "high"
+	case score >= 40:
+		return "medium"
+	case score > 0:
+		return "low"
+	default:
+		return "unknown"
+	}
+}
+
+func UniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	result := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func AssetOwner(asset graphquery.InventoryAsset) string {
+	return fallback(AssetOwnerPrincipal(asset), "Unassigned")
+}
+
+func AssetOwnerPrincipal(asset graphquery.InventoryAsset) string {
+	return fallback(asset.Attributes["owner"], asset.Attributes["owner_email"], asset.Attributes["assignee"], asset.Attributes["account_manager_email"], asset.Attributes["owner_login"])
+}
+
+func AssetOrg(asset graphquery.InventoryAsset) string {
+	return fallback(asset.Attributes["org"], asset.Attributes["owner_login"], asset.Attributes["account_id"], asset.Attributes["project_id"], asset.SourceID)
+}
+
+func AssetPublic(asset graphquery.InventoryAsset) bool {
+	return attributeTruthy(asset, "public", "publicly_accessible", "internet_exposed", "external")
+}
+
+func hasActiveReport(asset graphquery.InventoryAsset) bool {
+	if asset.AssetReportCount <= 0 {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(asset.LatestAssetReportStatus)) {
+	case ports.GRCInventoryAssetReportStatusRejected, ports.GRCInventoryAssetReportStatusResolved:
+		return false
+	default:
+		return true
+	}
+}
+
+func ownerRequired(asset graphquery.InventoryAsset) bool {
+	if asset.ScopeState == ScopeStateOutScope || AssetOwnerPrincipal(asset) != "" {
+		return false
+	}
+	if attributeTruthy(asset, "owner_required", "requires_owner", "accountability_required") {
+		return true
+	}
+	return asset.RiskScore >= 70 || AssetPublic(asset)
+}
+
+func accountabilityReasons(asset graphquery.InventoryAsset) []graphquery.InventoryReviewReason {
+	reasons := []graphquery.InventoryReviewReason{}
+	if asset.RiskScore >= 70 {
+		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "high_risk", Label: "High risk"})
+	}
+	if AssetPublic(asset) {
+		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "public_exposure", Label: "Public exposure"})
+	}
+	if attributeTruthy(asset, "owner_required", "requires_owner", "accountability_required") {
+		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "accountability_required", Label: "Accountability required"})
+	}
+	if len(reasons) == 0 {
+		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "accountability_missing", Label: "Owner missing where required"})
+	}
+	return reasons
+}
+
+func attributeTruthy(asset graphquery.InventoryAsset, keys ...string) bool {
+	for _, key := range keys {
+		switch strings.ToLower(strings.TrimSpace(asset.Attributes[key])) {
+		case "1", "t", "true", "yes", "y":
+			return true
+		}
+	}
+	return false
+}
+
+func fallback(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- Moves inventory review, accountability, summary, and risk helper logic into internal/grcinventory.
- Keeps bootstrap focused on request handling and store orchestration.
- Restores the bootstrap production line budget that is currently failing on main.

## Tests
- go test ./internal/grcinventory ./internal/bootstrap ./tools/archtests

## Main failure addressed
- Fixes TestBootstrapProductionSurfaceDoesNotGrow failing after #1145.