### PR TITLE
Fix source lint findings

### DIFF
--- a/sources/anthropic/source.go
+++ b/sources/anthropic/source.go
@@ -77,7 +77,7 @@ func anthropicFamilies() []jsonapi.Family {
 		anthropicListFamily("workspace", "/organizations/workspaces", "anthropic_workspace", []string{"id"}, []string{"created_at", "archived_at"}, map[string]string{"workspace_id": "id", "name": "name", "display_color": "display_color", "created_at": "created_at", "archived_at": "archived_at"}, withQuery(map[string]string{"include_archived": "include_archived"})),
 		anthropicListFamily("workspace_member", "/organizations/workspaces/{workspace_id}/members", "anthropic_workspace_member", []string{"id", "user_id"}, []string{"added_at", "created_at"}, map[string]string{"workspace_id": "workspace_id", "user_id": "id|user_id", "email": "email", "name": "name", "workspace_role": "workspace_role|role", "added_at": "added_at"}, withPathParams("workspace_id")),
 		anthropicListFamily("api_key", "/organizations/api_keys", "anthropic_api_key", []string{"id"}, []string{"created_at", "last_used_at"}, map[string]string{"api_key_id": "id", "name": "name", "status": "status", "workspace_id": "workspace_id|workspace.id", "owner_user_id": "created_by.id|owner.id|user_id", "created_at": "created_at", "last_used_at": "last_used_at"}, withQuery(map[string]string{"status": "status", "workspace_id": "workspace_id"})),
-		anthropicListFamily("external_key", "/organizations/external_keys", "anthropic_external_key", []string{"id"}, []string{"created_at", "last_used_at"}, map[string]string{"external_key_id": "id", "name": "name", "status": "status", "provider": "provider", "workspace_id": "workspace_id|workspace.id", "created_at": "created_at", "last_used_at": "last_used_at"}, withCursor("page", "next_page", "")),
+		anthropicListFamily("external_key", "/organizations/external_keys", "anthropic_external_key", []string{"id"}, []string{"created_at", "last_used_at"}, map[string]string{"external_key_id": "id", "name": "name", "status": "status", "provider": "provider", "workspace_id": "workspace_id|workspace.id", "created_at": "created_at", "last_used_at": "last_used_at"}, withPageCursor()),
 		anthropicListFamily("service_account", "/organizations/service_accounts", "anthropic_service_account", []string{"id"}, []string{"created_at"}, map[string]string{"service_account_id": "id", "name": "name", "status": "status", "description": "description", "created_at": "created_at"}),
 		anthropicListFamily("federation_issuer", "/organizations/federation_issuers", "anthropic_federation_issuer", []string{"id"}, []string{"created_at", "updated_at"}, map[string]string{"federation_issuer_id": "id", "issuer": "issuer", "name": "name", "status": "status", "created_at": "created_at", "updated_at": "updated_at"}),
 		anthropicListFamily("federation_rule", "/organizations/federation_rules", "anthropic_federation_rule", []string{"id"}, []string{"created_at", "updated_at"}, map[string]string{"federation_rule_id": "id", "issuer_id": "issuer_id|federation_issuer_id", "service_account_id": "service_account_id", "subject": "subject", "scopes": "scopes", "created_at": "created_at", "updated_at": "updated_at"}),
@@ -85,10 +85,10 @@ func anthropicFamilies() []jsonapi.Family {
 		anthropicReportFamily("usage_report_claude_code", "/organizations/usage_report/claude_code"),
 		anthropicReportFamily("cost_report", "/organizations/cost_report"),
 		anthropicReportFamily("analytics_cost", "/organizations/analytics/cost"),
-		anthropicListFamily("rate_limit", "/organizations/rate_limits", "anthropic_rate_limit", []string{"id", "group_type", "model", "name"}, []string{"updated_at"}, rateLimitAttributes(), withQuery(map[string]string{"model": "model"}), withCursor("page", "next_page", "")),
-		anthropicListFamily("workspace_rate_limit", "/organizations/workspaces/{workspace_id}/rate_limits", "anthropic_workspace_rate_limit", []string{"id", "group_type", "model", "name"}, []string{"updated_at"}, rateLimitAttributes(), withPathParams("workspace_id"), withCursor("page", "next_page", "")),
-		anthropicListFamily("spend_limit", "/organizations/spend_limits/effective", "anthropic_spend_limit", []string{"spend_limit_id", "id", "scope.user_id", "actor.user_id"}, []string{"created_at", "updated_at"}, map[string]string{"spend_limit_id": "spend_limit_id|id", "scope_type": "scope.type", "user_id": "scope.user_id|actor.user_id", "actor_email": "actor.email_address|actor.email", "amount": "amount", "currency": "currency", "period": "period", "source_type": "source.type", "period_to_date_spend": "period_to_date_spend", "created_at": "created_at", "updated_at": "updated_at"}, withCursor("page", "next_page", ""), withQuery(map[string]string{"actor_ids[]": "actor_ids", "period[]": "periods", "user_ids[]": "user_ids"})),
-		anthropicListFamily("spend_limit_increase_request", "/organizations/spend_limit_increase_requests", "anthropic_spend_limit_increase_request", []string{"id"}, []string{"created_at", "updated_at"}, map[string]string{"request_id": "id", "user_id": "scope.user_id|actor.user_id", "actor_email": "actor.email_address|actor.email", "status": "status", "amount": "amount", "currency": "currency", "period": "period", "created_at": "created_at", "updated_at": "updated_at"}, withCursor("page", "next_page", ""), withQuery(map[string]string{"actor_ids[]": "actor_ids", "status[]": "status"})),
+		anthropicListFamily("rate_limit", "/organizations/rate_limits", "anthropic_rate_limit", []string{"id", "group_type", "model", "name"}, []string{"updated_at"}, rateLimitAttributes(), withQuery(map[string]string{"model": "model"}), withPageCursor()),
+		anthropicListFamily("workspace_rate_limit", "/organizations/workspaces/{workspace_id}/rate_limits", "anthropic_workspace_rate_limit", []string{"id", "group_type", "model", "name"}, []string{"updated_at"}, rateLimitAttributes(), withPathParams("workspace_id"), withPageCursor()),
+		anthropicListFamily("spend_limit", "/organizations/spend_limits/effective", "anthropic_spend_limit", []string{"spend_limit_id", "id", "scope.user_id", "actor.user_id"}, []string{"created_at", "updated_at"}, map[string]string{"spend_limit_id": "spend_limit_id|id", "scope_type": "scope.type", "user_id": "scope.user_id|actor.user_id", "actor_email": "actor.email_address|actor.email", "amount": "amount", "currency": "currency", "period": "period", "source_type": "source.type", "period_to_date_spend": "period_to_date_spend", "created_at": "created_at", "updated_at": "updated_at"}, withPageCursor(), withQuery(map[string]string{"actor_ids[]": "actor_ids", "period[]": "periods", "user_ids[]": "user_ids"})),
+		anthropicListFamily("spend_limit_increase_request", "/organizations/spend_limit_increase_requests", "anthropic_spend_limit_increase_request", []string{"id"}, []string{"created_at", "updated_at"}, map[string]string{"request_id": "id", "user_id": "scope.user_id|actor.user_id", "actor_email": "actor.email_address|actor.email", "status": "status", "amount": "amount", "currency": "currency", "period": "period", "created_at": "created_at", "updated_at": "updated_at"}, withPageCursor(), withQuery(map[string]string{"actor_ids[]": "actor_ids", "status[]": "status"})),
 		anthropicListFamily("compliance_activity", "/compliance/activities", "anthropic_compliance_activity", []string{"id"}, []string{"created_at"}, map[string]string{"activity_id": "id", "activity_type": "type", "organization_id": "organization_id", "organization_uuid": "organization_uuid", "actor_type": "actor.type", "actor_user_id": "actor.user_id", "actor_api_key_id": "actor.api_key_id", "actor_email": "actor.email_address|actor.email", "created_at": "created_at"}, withQuery(map[string]string{"activity_types[]": "activity_types", "actor_ids[]": "actor_ids", "created_at.gt": "created_at_gt", "created_at.gte": "created_at_gte", "created_at.lt": "created_at_lt", "created_at.lte": "created_at_lte", "organization_ids[]": "organization_ids"})),
 	}
 }
@@ -136,11 +136,11 @@ func anthropicReportFamily(name string, path string) jsonapi.Family {
 		"output_tokens":   "output_tokens",
 		"request_count":   "request_count|requests",
 		"organization_id": "organization_id",
-	}, withCursor("page", "next_page", ""), withQuery(reportQuery))
+	}, withPageCursor(), withQuery(reportQuery))
 }
 
 func rateLimitAttributes() map[string]string {
-	return map[string]string{
+	return map[string]string{ // #nosec G101 -- provider field names only, not credentials.
 		"rate_limit_id":       "id",
 		"group_type":          "group_type",
 		"name":                "name",
@@ -168,11 +168,11 @@ func withQuery(query map[string]string) familyOption {
 	}
 }
 
-func withCursor(param string, nextKey string, hasMoreKey string) familyOption {
+func withPageCursor() familyOption {
 	return func(f *jsonapi.Family) {
-		f.CursorParam = param
-		f.NextCursorKeys = []string{nextKey}
-		f.HasMoreKey = hasMoreKey
+		f.CursorParam = "page"
+		f.NextCursorKeys = []string{"next_page"}
+		f.HasMoreKey = ""
 	}
 }
 

--- a/sources/anthropic/source_test.go
+++ b/sources/anthropic/source_test.go
@@ -111,8 +111,8 @@ func TestReadServiceAccountCanUseBearerToken(t *testing.T) {
 		if got := r.URL.EscapedPath(); got != "/organizations/service_accounts" {
 			t.Fatalf("request path = %q, want /organizations/service_accounts", got)
 		}
-		if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
-			t.Fatalf("Authorization = %q, want Bearer oauth-token", got)
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-value" {
+			t.Fatalf("Authorization = %q, want Bearer oauth-value", got)
 		}
 		if got := r.Header.Get("x-api-key"); got != "" {
 			t.Fatalf("x-api-key = %q, want empty", got)
@@ -136,12 +136,12 @@ func TestReadServiceAccountCanUseBearerToken(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 	source.inner.AllowLoopbackBaseURL = true
-	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test placeholder auth config only.
 		"auth_model": "bearer_token",
 		"base_url":   server.URL,
 		"family":     "service_account",
 		"tenant_id":  "writer",
-		"token":      "oauth-token",
+		"token":      "oauth-value",
 	}), nil)
 	if err != nil {
 		t.Fatalf("Read() error = %v", err)

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -785,12 +785,12 @@ func TestConfigurableBearerAuthUsesAuthorizationHeader(t *testing.T) {
 			if got := r.Header.Get("x-api-key"); got != "admin-key" {
 				t.Fatalf("x-api-key = %q, want admin-key", got)
 			}
-		case "Bearer oauth-token":
+		case "Bearer oauth-value":
 			if got := r.Header.Get("x-api-key"); got != "" {
 				t.Fatalf("x-api-key = %q, want empty for bearer auth", got)
 			}
 		default:
-			t.Fatalf("Authorization = %q, want empty or Bearer oauth-token", r.Header.Get("Authorization"))
+			t.Fatalf("Authorization = %q, want empty or Bearer oauth-value", r.Header.Get("Authorization"))
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{{"id": "device-1"}}})
 	}))
@@ -820,10 +820,10 @@ func TestConfigurableBearerAuthUsesAuthorizationHeader(t *testing.T) {
 	}), nil); err != nil {
 		t.Fatalf("Read(default auth) error = %v", err)
 	}
-	if _, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+	if _, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test placeholder auth config only.
 		"tenant_id":  "writer",
 		"auth_model": "bearer_token",
-		"token":      "oauth-token",
+		"token":      "oauth-value",
 	}), nil); err != nil {
 		t.Fatalf("Read(bearer auth) error = %v", err)
 	}

--- a/sources/openai/source.go
+++ b/sources/openai/source.go
@@ -96,7 +96,7 @@ func openAIFamilies() []jsonapi.Family {
 		openAIListFamily("project_user_role", "/projects/{project_id}/users/{user_id}/roles", "openai_project_user_role", []string{"id"}, []string{"created_at", "updated_at"}, roleAttributes(), withPathParams("project_id", "user_id"), withCursor("after", "next", "has_more")),
 		openAIListFamily("project_service_account", "/organization/projects/{project_id}/service_accounts", "openai_project_service_account", []string{"id"}, []string{"created_at"}, map[string]string{"project_id": "project_id", "service_account_id": "id", "name": "name", "role": "role", "created_at": "created_at"}, withPathParams("project_id")),
 		openAIListFamily("project_api_key", "/organization/projects/{project_id}/api_keys", "openai_project_api_key", []string{"id"}, []string{"created_at", "last_used_at"}, map[string]string{"project_id": "project_id", "api_key_id": "id", "name": "name", "owner_user_id": "owner.user.id", "owner_service_account_id": "owner.service_account.id", "created_at": "created_at", "last_used_at": "last_used_at"}, withPathParams("project_id")),
-		openAIListFamily("project_rate_limit", "/organization/projects/{project_id}/rate_limits", "openai_project_rate_limit", []string{"id", "model"}, []string{"updated_at", "created_at"}, map[string]string{"project_id": "project_id", "rate_limit_id": "id", "model": "model", "max_requests_per_1_minute": "max_requests_per_1_minute", "max_tokens_per_1_minute": "max_tokens_per_1_minute", "max_images_per_1_minute": "max_images_per_1_minute", "max_requests_per_1_day": "max_requests_per_1_day", "batch_1_day_max_input_tokens": "batch_1_day_max_input_tokens"}, withPathParams("project_id")),
+		openAIListFamily("project_rate_limit", "/organization/projects/{project_id}/rate_limits", "openai_project_rate_limit", []string{"id", "model"}, []string{"updated_at", "created_at"}, projectRateLimitAttributes(), withPathParams("project_id")),
 		openAISingletonFamily("project_model_permission", "/organization/projects/{project_id}/model_permissions", "openai_project_model_permission", map[string]string{"project_id": "project_id", "mode": "mode", "model_ids": "model_ids"}, withPathParams("project_id")),
 		openAISingletonFamily("project_hosted_tool_permission", "/organization/projects/{project_id}/hosted_tool_permissions", "openai_project_hosted_tool_permission", map[string]string{"project_id": "project_id", "code_interpreter_enabled": "code_interpreter.enabled", "file_search_enabled": "file_search.enabled", "image_generation_enabled": "image_generation.enabled", "mcp_enabled": "mcp.enabled", "web_search_enabled": "web_search.enabled"}, withPathParams("project_id")),
 		openAIListFamily("project_group", "/organization/projects/{project_id}/groups", "openai_project_group", []string{"id"}, []string{"created_at", "updated_at"}, map[string]string{"project_id": "project_id", "group_id": "id", "name": "name", "created_at": "created_at", "updated_at": "updated_at"}, withPathParams("project_id")),
@@ -169,6 +169,19 @@ func roleAttributes() map[string]string {
 		"created_at":      "created_at",
 		"updated_at":      "updated_at",
 		"created_by":      "created_by",
+	}
+}
+
+func projectRateLimitAttributes() map[string]string {
+	return map[string]string{ // #nosec G101 -- provider field names only, not credentials.
+		"project_id":                   "project_id",
+		"rate_limit_id":                "id",
+		"model":                        "model",
+		"max_requests_per_1_minute":    "max_requests_per_1_minute",
+		"max_tokens_per_1_minute":      "max_tokens_per_1_minute",
+		"max_images_per_1_minute":      "max_images_per_1_minute",
+		"max_requests_per_1_day":       "max_requests_per_1_day",
+		"batch_1_day_max_input_tokens": "batch_1_day_max_input_tokens",
 	}
 }
 


### PR DESCRIPTION
## Summary
- suppress gosec only for provider field-name maps and test placeholder auth config
- simplify Anthropic page cursor option to satisfy unparam
- keep source behavior unchanged

## Verification
- go test ./sources/internal/jsonapi ./sources/openai ./sources/anthropic
- make lint
