### PR TITLE
Add GRC report packet metadata

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3424,6 +3424,36 @@ paths:
       responses:
         '200':
           description: Projection provenance for one graph entity, including projection class, source/runtime identifiers, attributes, and freshness signals.
+  /grc/audit-packets/{packetID}/export:
+    get:
+      operationId: exportGRCAuditPacket
+      summary: Export a GRC audit packet
+      tags:
+        - GRC
+      parameters:
+        - name: packetID
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: format
+          in: query
+          schema:
+            type: string
+            enum:
+              - markdown
+              - json
+          description: Optional export format. Defaults to markdown.
+      responses:
+        '200':
+          description: Exported audit packet content.
+          content:
+            text/markdown:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: object
 
 components:
   securitySchemes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,12 +76,13 @@ context, the platform job store, coverage context, and evidence authorizers into
 `internal/a2agateway`. Durable task lifecycle behavior stays in that domain
 package; bootstrap only wires the HTTP boundary into it.
 
-The GRC control evidence packet routes add small HTTP adapters that resolve
-request scope, load findings and evidence, decode generated custom control-pack
-requests, and hand posture calculation or markdown rendering to
-`internal/grccontrol`. Profile resolution, rule coverage, evidence freshness,
-control status behavior, custom profile resolution, and export rendering stay
-behind that domain package.
+The GRC report packet routes add small HTTP adapters that resolve request scope,
+load findings, evidence, and graph proof, decode generated custom control-pack
+requests, and hand readiness, posture calculation, scope metadata, redaction
+metadata, and markdown rendering to `internal/grccontrol`. Profile resolution,
+rule coverage, evidence freshness, control status behavior, custom profile
+resolution, report metadata construction, and export rendering stay behind that
+domain package.
 
 The agent platform graph preflight contract lives in `internal/agentplatform`.
 The bootstrap budget includes the HTTP and MCP request/response mapping needed

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/grccontrol"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourceruntime"
@@ -149,6 +150,7 @@ type grcAuditPacketResponse struct {
 	Graph             *ports.EntityNeighborhood `json:"graph,omitempty"`
 	Controls          []grcControlRef           `json:"controls,omitempty"`
 	RecommendedAction string                    `json:"recommended_action"`
+	Metadata          grccontrol.ReportMetadata `json:"metadata"`
 	GeneratedAt       time.Time                 `json:"generated_at"`
 }
 
@@ -466,39 +468,56 @@ func (a *App) handleGRCEntityImpact(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleGRCAuditPacket(w http.ResponseWriter, r *http.Request) {
+	packet, err := a.buildGRCAuditPacket(r)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, packet)
+}
+
+func (a *App) handleGRCAuditPacketExport(w http.ResponseWriter, r *http.Request) {
+	packet, err := a.buildGRCAuditPacket(r)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	if strings.EqualFold(r.URL.Query().Get("format"), "json") {
+		writeJSON(w, http.StatusOK, packet)
+		return
+	}
+	writeGRCMarkdownExport(w, "finding-audit-packet.md", grccontrol.RenderFindingAuditPacketMarkdown(grcFindingAuditMarkdownInput(packet)))
+}
+
+func (a *App) buildGRCAuditPacket(r *http.Request) (grcAuditPacketResponse, error) {
 	findingID := strings.TrimSpace(r.PathValue("packetID"))
 	if findingID == "" {
-		writeGRCError(w, fmt.Errorf("%w: finding id is required", errInvalidHTTPRequest))
-		return
+		return grcAuditPacketResponse{}, fmt.Errorf("%w: finding id is required", errInvalidHTTPRequest)
 	}
 	limit, err := grcLimitFromRequest(r)
 	if err != nil {
-		writeGRCError(w, err)
-		return
+		return grcAuditPacketResponse{}, err
 	}
 	store := findingStore(a.deps.StateStore)
 	if store == nil {
-		writeGRCError(w, findings.ErrRuntimeUnavailable)
-		return
+		return grcAuditPacketResponse{}, findings.ErrRuntimeUnavailable
 	}
 	if err := authorizeFindingIDTenant(r.Context(), store, findingID); err != nil {
-		writeGRCError(w, err)
-		return
+		return grcAuditPacketResponse{}, err
 	}
 	finding, err := a.findingService().GetFinding(r.Context(), findingID)
 	if err != nil {
-		writeGRCError(w, err)
-		return
+		return grcAuditPacketResponse{}, err
 	}
-	runtimes, err := a.grcListRuntimes(r, grcScope{TenantID: finding.TenantID, RuntimeID: finding.RuntimeID, Limit: limit})
+	scope := grcScope{TenantID: finding.TenantID, RuntimeID: finding.RuntimeID, Limit: limit}
+	runtimes, err := a.grcListRuntimes(r, scope)
 	if err != nil {
-		writeGRCError(w, err)
-		return
+		return grcAuditPacketResponse{}, err
 	}
+	reportScopeRuntimes := a.grcReportScopeRuntimes(r, scope, runtimes)
 	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingID: finding.ID, Limit: limit})
 	if err != nil {
-		writeGRCError(w, err)
-		return
+		return grcAuditPacketResponse{}, err
 	}
 	var graph *ports.EntityNeighborhood
 	if len(finding.ResourceURNs) > 0 {
@@ -508,18 +527,66 @@ func (a *App) handleGRCAuditPacket(w http.ResponseWriter, r *http.Request) {
 	}
 	items := grcFindingItems([]*ports.FindingRecord{finding}, grcRuntimeSourceIDs(runtimes), grcEvidenceCounts(evidence))
 	if len(items) == 0 {
-		writeGRCError(w, ports.ErrFindingNotFound)
-		return
+		return grcAuditPacketResponse{}, ports.ErrFindingNotFound
 	}
-	writeJSON(w, http.StatusOK, grcAuditPacketResponse{
+	generatedAt := time.Now().UTC()
+	controls := grcControlRefs(finding.ControlRefs)
+	packet := grcAuditPacketResponse{
 		ID:                finding.ID,
 		Finding:           items[0],
 		Evidence:          grcEvidenceItems(evidence, map[string]string{finding.ID: finding.Title}),
 		Graph:             graph,
-		Controls:          grcControlRefs(finding.ControlRefs),
+		Controls:          controls,
 		RecommendedAction: grcRecommendedAction(items[0]),
-		GeneratedAt:       time.Now().UTC(),
+		GeneratedAt:       generatedAt,
+	}
+	packet.Metadata = grccontrol.BuildReportMetadata(grccontrol.ReportMetadataInput{
+		ReportType:    "finding",
+		GeneratedAt:   generatedAt,
+		ControlCount:  len(controls),
+		FindingCount:  1,
+		EvidenceCount: len(evidence),
+		Readiness: grccontrol.BuildFindingAuditReadiness(grccontrol.FindingAuditReadinessInput{
+			Owner:          packet.Finding.Owner,
+			ControlCount:   len(controls),
+			EvidenceCount:  len(evidence),
+			HasImpactProof: packet.Graph != nil && packet.Graph.Root != nil,
+		}),
+		Runtimes: reportScopeRuntimes,
 	})
+	return packet, nil
+}
+
+func grcFindingAuditMarkdownInput(packet grcAuditPacketResponse) grccontrol.FindingAuditMarkdownInput {
+	controls := make([]grccontrol.ControlRef, 0, len(packet.Controls))
+	for _, control := range packet.Controls {
+		controls = append(controls, grccontrol.ControlRef{FrameworkName: control.FrameworkName, ControlID: control.ControlID})
+	}
+	evidence := make([]grccontrol.FindingAuditMarkdownEvidence, 0, len(packet.Evidence))
+	for _, item := range packet.Evidence {
+		evidence = append(evidence, grccontrol.FindingAuditMarkdownEvidence{
+			ID:        item.ID,
+			RuleID:    item.RuleID,
+			CreatedAt: item.CreatedAt,
+		})
+	}
+	return grccontrol.FindingAuditMarkdownInput{
+		Finding: grccontrol.FindingAuditMarkdownFinding{
+			ID:        packet.Finding.ID,
+			Title:     packet.Finding.Title,
+			Severity:  packet.Finding.Severity,
+			Status:    packet.Finding.Status,
+			Summary:   packet.Finding.Summary,
+			RiskScore: packet.Finding.RiskScore,
+			Owner:     packet.Finding.Owner,
+			SLAStatus: packet.Finding.SLAStatus,
+		},
+		Controls:          controls,
+		Evidence:          evidence,
+		RecommendedAction: packet.RecommendedAction,
+		Metadata:          packet.Metadata,
+		GeneratedAt:       packet.GeneratedAt,
+	}
 }
 
 type grcFindingFilter struct {
@@ -693,6 +760,24 @@ func (a *App) grcListRuntimes(r *http.Request, scope grcScope) ([]*cerebrov1.Sou
 		return nil, err
 	}
 	return runtimes, nil
+}
+
+func (a *App) grcReportScopeRuntimes(r *http.Request, scope grcScope, fallback []*cerebrov1.SourceRuntime) []*cerebrov1.SourceRuntime {
+	store, ok := a.deps.StateStore.(ports.SourceRuntimeListStore)
+	if !ok {
+		return grccontrol.ReportScopeRuntimeSnapshots(fallback)
+	}
+	runtimes, err := store.ListSourceRuntimes(r.Context(), ports.SourceRuntimeFilter{
+		RuntimeID:  scope.RuntimeID,
+		RuntimeIDs: scope.RuntimeIDs,
+		TenantID:   scope.TenantID,
+		SourceID:   scope.SourceID,
+		Limit:      scope.Limit,
+	})
+	if err != nil {
+		return grccontrol.ReportScopeRuntimeSnapshots(fallback)
+	}
+	return grccontrol.ReportScopeRuntimeSnapshots(runtimes)
 }
 
 func (a *App) grcListFindingRecords(r *http.Request, runtimes []*cerebrov1.SourceRuntime, filter grcFindingFilter) ([]*ports.FindingRecord, error) {

--- a/internal/bootstrap/grc_control_packs.go
+++ b/internal/bootstrap/grc_control_packs.go
@@ -94,6 +94,7 @@ func (a *App) handleGRCCustomControlEvidencePacket(w http.ResponseWriter, r *htt
 		"packet":       result.Packet,
 		"controls":     result.Controls,
 		"preview":      result.Preview,
+		"metadata":     result.Metadata,
 		"generated_at": result.Packet.GeneratedAt,
 	})
 }
@@ -114,6 +115,7 @@ func (a *App) handleGRCCustomControlEvidencePacketExport(w http.ResponseWriter, 
 			"packet":       result.Packet,
 			"controls":     result.Controls,
 			"preview":      result.Preview,
+			"metadata":     result.Metadata,
 			"generated_at": result.Packet.GeneratedAt,
 		})
 		return
@@ -130,6 +132,7 @@ func (a *App) buildGRCControlEvidencePacket(r *http.Request) (grccontrol.PacketR
 	if err != nil {
 		return grccontrol.PacketResult{}, err
 	}
+	reportScopeRuntimes := a.grcReportScopeRuntimes(r, scope, runtimes)
 	findings, err := a.grcListFindingRecords(r, runtimes, grcFindingFilter{Status: "open", Limit: scope.Limit})
 	if err != nil {
 		return grccontrol.PacketResult{}, err
@@ -145,6 +148,7 @@ func (a *App) buildGRCControlEvidencePacket(r *http.Request) (grccontrol.PacketR
 		Findings:  findings,
 		Evidence:  evidence,
 		SourceIDs: grcRuntimeSourceIDs(runtimes),
+		Runtimes:  reportScopeRuntimes,
 		Now:       time.Now().UTC(),
 	})
 }
@@ -164,6 +168,7 @@ func (a *App) buildGRCCustomControlEvidencePacket(w http.ResponseWriter, r *http
 	if err != nil {
 		return grccontrol.CustomPacketResult{}, nil, err
 	}
+	reportScopeRuntimes := a.grcReportScopeRuntimes(r, scope, runtimes)
 	findings, err := a.grcListFindingRecords(r, runtimes, grcFindingFilter{Status: "open", Limit: scope.Limit})
 	if err != nil {
 		return grccontrol.CustomPacketResult{}, nil, err
@@ -179,6 +184,7 @@ func (a *App) buildGRCCustomControlEvidencePacket(w http.ResponseWriter, r *http
 		Findings:  findings,
 		Evidence:  evidence,
 		SourceIDs: grcRuntimeSourceIDs(runtimes),
+		Runtimes:  reportScopeRuntimes,
 		Now:       time.Now().UTC(),
 	})
 }
@@ -188,6 +194,7 @@ func writeGRCControlPacketJSON(w http.ResponseWriter, result grccontrol.PacketRe
 		"profile":      result.Profile,
 		"packet":       result.Packet,
 		"controls":     result.Controls,
+		"metadata":     result.Metadata,
 		"generated_at": result.Packet.GeneratedAt,
 	})
 }

--- a/internal/bootstrap/grc_control_packs_test.go
+++ b/internal/bootstrap/grc_control_packs_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/grccontrol"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/resourcescope"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -89,9 +90,21 @@ func TestGRCControlPackPreviewEndpointReturnsYAMLFilesAndCoverage(t *testing.T) 
 
 func TestGRCControlEvidencePacketEndpointBuildsProfilePosture(t *testing.T) {
 	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	scopePolicy, err := resourcescope.ConfigValue(resourcescope.Policy{
+		ExcludedFamilies:     []string{"okta.audit"},
+		ExcludedResourceURNs: []string{"urn:cerebro:writer:okta_user:excluded"},
+	})
+	if err != nil {
+		t.Fatalf("scope policy: %v", err)
+	}
 	store := &stubRuntimeStore{
 		runtimes: map[string]*cerebrov1.SourceRuntime{
-			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+			"writer-okta-audit": {
+				Id:       "writer-okta-audit",
+				SourceId: "okta",
+				TenantId: "writer",
+				Config:   map[string]string{resourcescope.ConfigKey: scopePolicy},
+			},
 		},
 		findings: map[string]*ports.FindingRecord{
 			"finding-cc6": {
@@ -133,6 +146,7 @@ func TestGRCControlEvidencePacketEndpointBuildsProfilePosture(t *testing.T) {
 		Profile  grccontrol.Profile               `json:"profile"`
 		Packet   compliance.ControlEvidencePacket `json:"packet"`
 		Controls []grccontrol.ControlItem         `json:"controls"`
+		Metadata grccontrol.ReportMetadata        `json:"metadata"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode control packet: %v", err)
@@ -159,6 +173,15 @@ func TestGRCControlEvidencePacketEndpointBuildsProfilePosture(t *testing.T) {
 	}
 	if missingControl.ControlID == "" || missingControl.MissingEvidence == 0 || missingControl.Expectations == 0 {
 		t.Fatalf("missing control = %+v, want a selected control with missing required evidence", missingControl)
+	}
+	if payload.Metadata.Readiness.Status == "" || payload.Metadata.Readiness.Score == 0 {
+		t.Fatalf("metadata readiness = %#v, want packet readiness", payload.Metadata.Readiness)
+	}
+	if payload.Metadata.Scope.Exclusions.Total != 2 {
+		t.Fatalf("scope exclusions = %#v, want two configured exclusions", payload.Metadata.Scope.Exclusions)
+	}
+	if !payload.Metadata.Scope.Exclusions.AppliedToIncrementalFetch || !payload.Metadata.Scope.IncrementalFetch.PolicyAppliedBeforeRead {
+		t.Fatalf("scope incremental metadata = %#v, want exclusions carried before incremental fetch", payload.Metadata.Scope)
 	}
 }
 

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -897,6 +898,31 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 	}
 	if packet.RecommendedAction == "" {
 		t.Fatalf("packet recommended action is empty")
+	}
+	if packet.Metadata.Readiness.Status == "" || packet.Metadata.Provenance.ReportType != "finding" {
+		t.Fatalf("packet metadata = %#v, want finding readiness and provenance", packet.Metadata)
+	}
+	if packet.Metadata.Redaction.DefaultMode != "share_safe" {
+		t.Fatalf("redaction metadata = %#v, want share-safe default", packet.Metadata.Redaction)
+	}
+
+	exportResp, err := server.Client().Get(server.URL + "/grc/audit-packets/finding-high/export")
+	if err != nil {
+		t.Fatalf("GET /grc/audit-packets export error = %v", err)
+	}
+	defer func() { _ = exportResp.Body.Close() }()
+	if exportResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/audit-packets export status = %d, want %d", exportResp.StatusCode, http.StatusOK)
+	}
+	body, err := io.ReadAll(exportResp.Body)
+	if err != nil {
+		t.Fatalf("read packet export: %v", err)
+	}
+	markdown := string(body)
+	for _, want := range []string{"# Finding Audit Packet", "Recommended Action", "Readiness"} {
+		if !strings.Contains(markdown, want) {
+			t.Fatalf("finding export missing %q:\n%s", want, markdown)
+		}
 	}
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -111,6 +111,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "PATCH /grc/inventory/asset-reports/{reportID}/triage", routeSurfacePlatformHTTP, app.handleUpdateGRCInventoryAssetReportTriage)
 	registerHTTPRoute(mux, "GET /grc/entities/{entityID}/impact", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("entity.impact", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCEntityImpact))
 	registerHTTPRoute(mux, "GET /grc/audit-packets/{packetID}", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("audit.packet", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCAuditPacket))
+	registerHTTPRoute(mux, "GET /grc/audit-packets/{packetID}/export", routeSurfacePlatformHTTP, app.handleGRCAuditPacketExport)
 }
 
 func (app *App) registerFindingRoutes(mux *http.ServeMux) {

--- a/internal/grccontrol/finding_reports.go
+++ b/internal/grccontrol/finding_reports.go
@@ -1,0 +1,156 @@
+package grccontrol
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/resourcescope"
+)
+
+type FindingAuditReadinessInput struct {
+	Owner          string
+	ControlCount   int
+	EvidenceCount  int
+	HasImpactProof bool
+}
+
+type FindingAuditMarkdownInput struct {
+	Finding           FindingAuditMarkdownFinding
+	Controls          []ControlRef
+	Evidence          []FindingAuditMarkdownEvidence
+	RecommendedAction string
+	Metadata          ReportMetadata
+	GeneratedAt       time.Time
+}
+
+type FindingAuditMarkdownFinding struct {
+	ID        string
+	Title     string
+	Severity  string
+	Status    string
+	Summary   string
+	RiskScore int
+	Owner     string
+	SLAStatus string
+}
+
+type FindingAuditMarkdownEvidence struct {
+	ID        string
+	RuleID    string
+	CreatedAt time.Time
+}
+
+func BuildFindingAuditReadiness(input FindingAuditReadinessInput) ReportReadiness {
+	readiness := ReportReadiness{
+		Status:  "ready",
+		Score:   100,
+		Summary: "Finding packet has owner, controls, evidence, and impact proof.",
+	}
+	addBlocker := func(code string, label string, count int, penalty int) {
+		if count <= 0 {
+			return
+		}
+		readiness.Blockers = append(readiness.Blockers, ReportReadinessBlocker{Code: code, Label: label, Count: count})
+		readiness.Score -= penalty
+	}
+	if strings.TrimSpace(input.Owner) == "" || strings.EqualFold(input.Owner, "Unassigned") {
+		addBlocker("missing_owner", "No accountable owner", 1, 20)
+	}
+	if input.ControlCount == 0 {
+		addBlocker("missing_controls", "No mapped controls", 1, 25)
+	}
+	if input.EvidenceCount == 0 {
+		addBlocker("missing_evidence", "No evidence attached", 1, 30)
+	}
+	if !input.HasImpactProof {
+		addBlocker("missing_impact_proof", "No impact graph proof", 1, 20)
+	}
+	if readiness.Score < 0 {
+		readiness.Score = 0
+	}
+	if len(readiness.Blockers) != 0 {
+		readiness.Status = "needs_attention"
+		readiness.Summary = "Packet can be reviewed, but the listed gaps should be resolved or accepted before auditor reliance."
+	}
+	if input.EvidenceCount == 0 || input.ControlCount == 0 {
+		readiness.Status = "blocked"
+		readiness.Summary = "Packet is not audit-ready until evidence and control mappings are present."
+	}
+	return readiness
+}
+
+func RenderFindingAuditPacketMarkdown(input FindingAuditMarkdownInput) string {
+	var builder strings.Builder
+	writeMarkdownLine(&builder, "# Finding Audit Packet")
+	writeMarkdownLine(&builder, "")
+	writeMarkdownLine(&builder, "- Finding: "+markdownValue(input.Finding.Title))
+	writeMarkdownLine(&builder, "- Finding ID: "+markdownValue(input.Finding.ID))
+	writeMarkdownLine(&builder, "- Severity: "+markdownValue(input.Finding.Severity))
+	writeMarkdownLine(&builder, "- Status: "+markdownValue(input.Finding.Status))
+	writeMarkdownLine(&builder, "- Risk score: "+fmt.Sprintf("%d", input.Finding.RiskScore))
+	writeMarkdownLine(&builder, "- Owner: "+markdownValue(input.Finding.Owner))
+	writeMarkdownLine(&builder, "- SLA: "+markdownValue(input.Finding.SLAStatus))
+	writeMarkdownLine(&builder, "- Generated: "+markdownTime(input.GeneratedAt))
+	writeMarkdownLine(&builder, "- Readiness: "+markdownValue(input.Metadata.Readiness.Status)+" ("+fmt.Sprintf("%d", input.Metadata.Readiness.Score)+"/100)")
+	writeMarkdownLine(&builder, "- Collection exclusions: "+fmt.Sprintf("%d", input.Metadata.Scope.Exclusions.Total))
+	if input.RecommendedAction != "" {
+		writeMarkdownLine(&builder, "")
+		writeMarkdownLine(&builder, "## Recommended Action")
+		writeMarkdownLine(&builder, "")
+		writeMarkdownLine(&builder, markdownValue(input.RecommendedAction))
+	}
+	if input.Finding.Summary != "" {
+		writeMarkdownLine(&builder, "")
+		writeMarkdownLine(&builder, "## Summary")
+		writeMarkdownLine(&builder, "")
+		writeMarkdownLine(&builder, markdownValue(input.Finding.Summary))
+	}
+	if len(input.Controls) != 0 {
+		writeMarkdownLine(&builder, "")
+		writeMarkdownLine(&builder, "## Controls")
+		writeMarkdownLine(&builder, "")
+		for _, control := range input.Controls {
+			writeMarkdownLine(&builder, "- "+markdownValue(control.FrameworkName+" "+control.ControlID))
+		}
+	}
+	if len(input.Evidence) != 0 {
+		writeMarkdownLine(&builder, "")
+		writeMarkdownLine(&builder, "## Evidence")
+		writeMarkdownLine(&builder, "")
+		writeMarkdownLine(&builder, "| ID | Rule | Created |")
+		writeMarkdownLine(&builder, "| --- | --- | --- |")
+		for _, evidence := range input.Evidence {
+			writeMarkdownLine(&builder, "| "+markdownCell(evidence.ID)+" | "+markdownCell(evidence.RuleID)+" | "+markdownCell(markdownTime(evidence.CreatedAt))+" |")
+		}
+	}
+	if len(input.Metadata.Readiness.Blockers) != 0 {
+		writeMarkdownLine(&builder, "")
+		writeMarkdownLine(&builder, "## Readiness Blockers")
+		writeMarkdownLine(&builder, "")
+		for _, blocker := range input.Metadata.Readiness.Blockers {
+			writeMarkdownLine(&builder, "- "+markdownValue(blocker.Label)+" ("+fmt.Sprintf("%d", blocker.Count)+")")
+		}
+	}
+	return strings.TrimRight(builder.String(), "\n") + "\n"
+}
+
+func ReportScopeRuntimeSnapshots(runtimes []*cerebrov1.SourceRuntime) []*cerebrov1.SourceRuntime {
+	snapshots := make([]*cerebrov1.SourceRuntime, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		snapshot := &cerebrov1.SourceRuntime{
+			Id:       runtime.GetId(),
+			SourceId: runtime.GetSourceId(),
+			TenantId: runtime.GetTenantId(),
+		}
+		if value := strings.TrimSpace(runtime.GetConfig()[resourcescope.ConfigKey]); value != "" {
+			snapshot.Config = map[string]string{resourcescope.ConfigKey: value}
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	return snapshots
+}

--- a/internal/grccontrol/packets.go
+++ b/internal/grccontrol/packets.go
@@ -10,6 +10,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/resourcescope"
 )
 
 const DefaultEvidenceProfileID = "soc2-security-core"
@@ -23,6 +24,7 @@ type BuildInput struct {
 	Findings  []*ports.FindingRecord
 	Evidence  []*cerebrov1.FindingEvidence
 	SourceIDs map[string]string
+	Runtimes  []*cerebrov1.SourceRuntime
 	Now       time.Time
 }
 
@@ -33,6 +35,7 @@ type CustomBuildInput struct {
 	Findings  []*ports.FindingRecord
 	Evidence  []*cerebrov1.FindingEvidence
 	SourceIDs map[string]string
+	Runtimes  []*cerebrov1.SourceRuntime
 	Now       time.Time
 }
 
@@ -40,6 +43,7 @@ type PacketResult struct {
 	Profile  Profile
 	Packet   compliance.ControlEvidencePacket
 	Controls []ControlItem
+	Metadata ReportMetadata
 }
 
 type CustomPacketResult struct {
@@ -47,6 +51,7 @@ type CustomPacketResult struct {
 	Packet   compliance.ControlEvidencePacket `json:"packet"`
 	Controls []ControlItem                    `json:"controls"`
 	Preview  compliance.ControlPackPreview    `json:"preview"`
+	Metadata ReportMetadata                   `json:"metadata,omitempty"`
 }
 
 type Profile struct {
@@ -102,6 +107,84 @@ type ControlItem struct {
 	Findings         []FindingItem `json:"findings,omitempty"`
 }
 
+type ReportMetadata struct {
+	Readiness  ReportReadiness  `json:"readiness"`
+	Provenance ReportProvenance `json:"provenance"`
+	Scope      ReportScope      `json:"scope"`
+	Redaction  ReportRedaction  `json:"redaction"`
+}
+
+type ReportReadiness struct {
+	Status   string                   `json:"status"`
+	Score    int                      `json:"score"`
+	Summary  string                   `json:"summary,omitempty"`
+	Blockers []ReportReadinessBlocker `json:"blockers,omitempty"`
+}
+
+type ReportReadinessBlocker struct {
+	Code  string `json:"code"`
+	Label string `json:"label"`
+	Count int    `json:"count,omitempty"`
+}
+
+type ReportProvenance struct {
+	ReportType    string    `json:"report_type"`
+	ProfileID     string    `json:"profile_id,omitempty"`
+	ProfileName   string    `json:"profile_name,omitempty"`
+	PacketVersion string    `json:"packet_version,omitempty"`
+	GeneratedAt   time.Time `json:"generated_at"`
+	ControlCount  int       `json:"control_count,omitempty"`
+	FindingCount  int       `json:"finding_count,omitempty"`
+	EvidenceCount int       `json:"evidence_count,omitempty"`
+	RuntimeCount  int       `json:"runtime_count,omitempty"`
+	SourceIDs     []string  `json:"source_ids,omitempty"`
+}
+
+type ReportScope struct {
+	SourceIDs        []string               `json:"source_ids,omitempty"`
+	RuntimeIDs       []string               `json:"runtime_ids,omitempty"`
+	Exclusions       ReportScopeExclusions  `json:"exclusions"`
+	IncrementalFetch ReportIncrementalFetch `json:"incremental_fetch"`
+}
+
+type ReportScopeExclusions struct {
+	Total                         int                              `json:"total"`
+	RuntimeIDs                    []string                         `json:"runtime_ids,omitempty"`
+	ExcludedFamilies              []string                         `json:"excluded_families,omitempty"`
+	ExcludedAssetClasses          []string                         `json:"excluded_asset_classes,omitempty"`
+	ExcludedKinds                 []string                         `json:"excluded_kinds,omitempty"`
+	ExcludedResourceURNs          []string                         `json:"excluded_resource_urns,omitempty"`
+	ExcludedResources             []resourcescope.ResourceSelector `json:"excluded_resources,omitempty"`
+	AppliedToIncrementalFetch     bool                             `json:"applied_to_incremental_fetch"`
+	FilteredBeforeGraphProjection bool                             `json:"filtered_before_graph_projection"`
+}
+
+type ReportIncrementalFetch struct {
+	Status                         string `json:"status"`
+	PolicyAppliedBeforeRead        bool   `json:"policy_applied_before_read"`
+	EventFilteringBeforeProjection bool   `json:"event_filtering_before_projection"`
+	Summary                        string `json:"summary,omitempty"`
+}
+
+type ReportRedaction struct {
+	DefaultMode     string   `json:"default_mode"`
+	AvailableModes  []string `json:"available_modes,omitempty"`
+	SensitiveFields []string `json:"sensitive_fields,omitempty"`
+	Summary         string   `json:"summary,omitempty"`
+}
+
+type ReportMetadataInput struct {
+	ReportType    string
+	Profile       Profile
+	PacketVersion string
+	GeneratedAt   time.Time
+	ControlCount  int
+	FindingCount  int
+	EvidenceCount int
+	Readiness     ReportReadiness
+	Runtimes      []*cerebrov1.SourceRuntime
+}
+
 func BuildBuiltinEvidencePacket(input BuildInput) (PacketResult, error) {
 	now := input.Now
 	if now.IsZero() {
@@ -125,10 +208,22 @@ func BuildBuiltinEvidencePacket(input BuildInput) (PacketResult, error) {
 	packet := compliance.BuildControlEvidencePacket(postureInput)
 	packet.Controls = FilterPacketControls(packet.Controls, input.Framework, input.ControlID)
 	packet.Summary = SummarizePacket(packet.SelectionID, packet.Controls)
+	controls := ControlItemsFromPacket(packet.Controls, input.Findings, input.SourceIDs)
 	return PacketResult{
 		Profile:  profile,
 		Packet:   packet,
-		Controls: ControlItemsFromPacket(packet.Controls, input.Findings, input.SourceIDs),
+		Controls: controls,
+		Metadata: BuildReportMetadata(ReportMetadataInput{
+			ReportType:    "control",
+			Profile:       profile,
+			PacketVersion: packet.Version,
+			GeneratedAt:   packet.GeneratedAt,
+			ControlCount:  packet.Summary.Total,
+			FindingCount:  len(input.Findings),
+			EvidenceCount: len(input.Evidence),
+			Readiness:     PacketReadiness(packet.Controls),
+			Runtimes:      input.Runtimes,
+		}),
 	}, nil
 }
 
@@ -177,6 +272,7 @@ func BuildCustomEvidencePacket(input CustomBuildInput) (CustomPacketResult, []co
 		packet := compliance.BuildControlEvidencePacket(postureInput)
 		packet.Controls = FilterPacketControls(packet.Controls, input.Framework, input.ControlID)
 		packet.Summary = SummarizePacket(packet.SelectionID, packet.Controls)
+		controls := ControlItemsFromPacket(packet.Controls, input.Findings, input.SourceIDs)
 		return CustomPacketResult{
 			Profile: Profile{
 				ID:          item.Profile.ID,
@@ -184,8 +280,19 @@ func BuildCustomEvidencePacket(input CustomBuildInput) (CustomPacketResult, []co
 				Description: item.Profile.Description,
 			},
 			Packet:   packet,
-			Controls: ControlItemsFromPacket(packet.Controls, input.Findings, input.SourceIDs),
+			Controls: controls,
 			Preview:  preview,
+			Metadata: BuildReportMetadata(ReportMetadataInput{
+				ReportType:    "control",
+				Profile:       Profile{ID: item.Profile.ID, Name: item.Profile.Name, Description: item.Profile.Description},
+				PacketVersion: packet.Version,
+				GeneratedAt:   packet.GeneratedAt,
+				ControlCount:  packet.Summary.Total,
+				FindingCount:  len(input.Findings),
+				EvidenceCount: len(input.Evidence),
+				Readiness:     PacketReadiness(packet.Controls),
+				Runtimes:      input.Runtimes,
+			}),
 		}, nil, nil
 	}
 	return CustomPacketResult{}, []compliance.ValidationIssue{{Path: "profile_id", Message: fmt.Sprintf("generated profile %q was not resolved", profileID)}}, nil
@@ -311,6 +418,158 @@ func ControlItemsFromPacket(packetControls []compliance.ControlEvidencePacketCon
 	return controls
 }
 
+func PacketReadiness(controls []compliance.ControlEvidencePacketControl) ReportReadiness {
+	if len(controls) == 0 {
+		return ReportReadiness{
+			Status:  "blocked",
+			Score:   0,
+			Summary: "No controls matched the selected packet filters.",
+			Blockers: []ReportReadinessBlocker{{
+				Code:  "no_controls",
+				Label: "No controls matched",
+				Count: 1,
+			}},
+		}
+	}
+	readiness := ReportReadiness{
+		Status:  "ready",
+		Score:   100,
+		Summary: "Packet is ready for auditor review.",
+	}
+	scoreTotal := 0
+	counts := map[string]int{}
+	for _, control := range controls {
+		scoreTotal += control.Readiness.Score
+		switch control.Status {
+		case compliance.ControlPostureFailing:
+			counts["open_findings"] += maxInt(1, len(control.Findings))
+		case compliance.ControlPostureMissingEvidence:
+			counts["missing_evidence"] += maxInt(1, control.Readiness.MissingEvidence)
+		case compliance.ControlPostureStaleEvidence:
+			counts["stale_evidence"] += maxInt(1, control.Readiness.StaleEvidence)
+		case compliance.ControlPostureManualReview:
+			counts["manual_review"] += 1
+		case compliance.ControlPostureException:
+			counts["exceptions"] += 1
+		}
+	}
+	readiness.Score = scoreTotal / len(controls)
+	addBlocker := func(code string, label string) {
+		if count := counts[code]; count > 0 {
+			readiness.Blockers = append(readiness.Blockers, ReportReadinessBlocker{Code: code, Label: label, Count: count})
+		}
+	}
+	addBlocker("open_findings", "Open findings remain mapped")
+	addBlocker("missing_evidence", "Required evidence is missing")
+	addBlocker("stale_evidence", "Evidence is stale")
+	addBlocker("manual_review", "Manual evidence needs review")
+	addBlocker("exceptions", "Exceptions limit reliance")
+	if len(readiness.Blockers) != 0 {
+		readiness.Status = "needs_attention"
+		readiness.Summary = "Packet is useful, but blockers must be resolved or accepted before auditor reliance."
+	}
+	if counts["open_findings"] > 0 || counts["missing_evidence"] > 0 {
+		readiness.Status = "blocked"
+		readiness.Summary = "Packet is not audit-ready until open findings or missing evidence are addressed."
+	}
+	return readiness
+}
+
+func BuildReportMetadata(input ReportMetadataInput) ReportMetadata {
+	generatedAt := input.GeneratedAt
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+	scope := ReportScopeFromRuntimes(input.Runtimes)
+	sourceIDs := scope.SourceIDs
+	if len(sourceIDs) == 0 {
+		sourceIDs = uniqueSortedRuntimeSourceIDs(input.Runtimes)
+	}
+	return ReportMetadata{
+		Readiness: input.Readiness,
+		Provenance: ReportProvenance{
+			ReportType:    fallbackString(input.ReportType, "packet"),
+			ProfileID:     input.Profile.ID,
+			ProfileName:   input.Profile.Name,
+			PacketVersion: input.PacketVersion,
+			GeneratedAt:   generatedAt,
+			ControlCount:  input.ControlCount,
+			FindingCount:  input.FindingCount,
+			EvidenceCount: input.EvidenceCount,
+			RuntimeCount:  len(input.Runtimes),
+			SourceIDs:     sourceIDs,
+		},
+		Scope: scope,
+		Redaction: ReportRedaction{
+			DefaultMode:    "share_safe",
+			AvailableModes: []string{"share_safe", "internal"},
+			SensitiveFields: []string{
+				"finding IDs",
+				"resource URNs",
+				"runtime IDs",
+				"source-specific identifiers",
+				"identity labels",
+			},
+			Summary: "Use share-safe mode before sending packets outside the operating team.",
+		},
+	}
+}
+
+func ReportScopeFromRuntimes(runtimes []*cerebrov1.SourceRuntime) ReportScope {
+	scope := ReportScope{
+		SourceIDs:  uniqueSortedRuntimeSourceIDs(runtimes),
+		RuntimeIDs: uniqueSortedRuntimeIDs(runtimes),
+		IncrementalFetch: ReportIncrementalFetch{
+			Status:                         "all_collected",
+			PolicyAppliedBeforeRead:        true,
+			EventFilteringBeforeProjection: true,
+			Summary:                        "No collection exclusions are configured for the selected source runtimes.",
+		},
+	}
+	excludedRuntimeIDs := []string{}
+	families := []string{}
+	assetClasses := []string{}
+	kinds := []string{}
+	resourceURNs := []string{}
+	resources := []resourcescope.ResourceSelector{}
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		policy, err := resourcescope.FromConfig(runtime.GetConfig())
+		if err != nil || policy.Empty() {
+			continue
+		}
+		excludedRuntimeIDs = append(excludedRuntimeIDs, runtime.GetId())
+		families = append(families, policy.ExcludedFamilies...)
+		assetClasses = append(assetClasses, policy.ExcludedAssetClasses...)
+		kinds = append(kinds, policy.ExcludedKinds...)
+		resourceURNs = append(resourceURNs, policy.ExcludedResourceURNs...)
+		resources = append(resources, policy.ExcludedResources...)
+	}
+	scope.Exclusions = ReportScopeExclusions{
+		RuntimeIDs:           uniqueSortedStrings(excludedRuntimeIDs),
+		ExcludedFamilies:     uniqueSortedStrings(families),
+		ExcludedAssetClasses: uniqueSortedStrings(assetClasses),
+		ExcludedKinds:        uniqueSortedStrings(kinds),
+		ExcludedResourceURNs: uniqueSortedStrings(resourceURNs),
+		ExcludedResources:    uniqueSortedResources(resources),
+	}
+	scope.Exclusions.Total =
+		len(scope.Exclusions.ExcludedFamilies) +
+			len(scope.Exclusions.ExcludedAssetClasses) +
+			len(scope.Exclusions.ExcludedKinds) +
+			len(scope.Exclusions.ExcludedResourceURNs) +
+			len(scope.Exclusions.ExcludedResources)
+	if scope.Exclusions.Total > 0 {
+		scope.Exclusions.AppliedToIncrementalFetch = true
+		scope.Exclusions.FilteredBeforeGraphProjection = true
+		scope.IncrementalFetch.Status = "exclusions_applied"
+		scope.IncrementalFetch.Summary = "Configured exclusions are evaluated before source reads where possible and again before graph projection."
+	}
+	return scope
+}
+
 func RenderMarkdown(result PacketResult) string {
 	var builder strings.Builder
 	writeMarkdownLine(&builder, "# Control Evidence Packet")
@@ -322,6 +581,8 @@ func RenderMarkdown(result PacketResult) string {
 	writeMarkdownLine(&builder, "- Failing controls: "+fmt.Sprintf("%d", result.Packet.Summary.ByStatus[compliance.ControlPostureFailing]))
 	writeMarkdownLine(&builder, "- Missing-evidence controls: "+fmt.Sprintf("%d", result.Packet.Summary.ByStatus[compliance.ControlPostureMissingEvidence]))
 	writeMarkdownLine(&builder, "- Stale-evidence controls: "+fmt.Sprintf("%d", result.Packet.Summary.ByStatus[compliance.ControlPostureStaleEvidence]))
+	writeMarkdownLine(&builder, "- Readiness: "+markdownValue(result.Metadata.Readiness.Status)+" ("+fmt.Sprintf("%d", result.Metadata.Readiness.Score)+"/100)")
+	writeMarkdownLine(&builder, "- Collection exclusions: "+fmt.Sprintf("%d", result.Metadata.Scope.Exclusions.Total))
 	for _, control := range result.Packet.Controls {
 		writeMarkdownLine(&builder, "")
 		writeMarkdownLine(&builder, "## "+markdownHeading(control.Control.FrameworkName+" "+control.Control.ControlID))
@@ -649,6 +910,74 @@ func fallbackString(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func uniqueSortedRuntimeSourceIDs(runtimes []*cerebrov1.SourceRuntime) []string {
+	values := make([]string, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime != nil {
+			values = append(values, runtime.GetSourceId())
+		}
+	}
+	return uniqueSortedStrings(values)
+}
+
+func uniqueSortedRuntimeIDs(runtimes []*cerebrov1.SourceRuntime) []string {
+	values := make([]string, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime != nil {
+			values = append(values, runtime.GetId())
+		}
+	}
+	return uniqueSortedStrings(values)
+}
+
+func uniqueSortedStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, trimmed)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func uniqueSortedResources(values []resourcescope.ResourceSelector) []resourcescope.ResourceSelector {
+	out := make([]resourcescope.ResourceSelector, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		key := strings.TrimSpace(value.URN) + "\x00" + strings.ToLower(strings.TrimSpace(value.Type)) + "\x00" + strings.TrimSpace(value.ID)
+		if key == "\x00\x00" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := out[i].URN + out[i].Type + out[i].ID
+		right := out[j].URN + out[j].Type + out[j].ID
+		return left < right
+	})
+	return out
+}
+
+func maxInt(left, right int) int {
+	if left > right {
+		return left
+	}
+	return right
 }
 
 func timePtr(value time.Time) *time.Time {

--- a/internal/sourcecdk/family_scope_test.go
+++ b/internal/sourcecdk/family_scope_test.go
@@ -303,3 +303,57 @@ func TestFamilyEngineAppliesIncrementalWatermarkFallback(t *testing.T) {
 		t.Fatalf("NextCursor opaque = %q, want resumable envelope", pull.NextCursor.GetOpaque())
 	}
 }
+
+func TestFamilyEngineCarriesResourceScopeThroughIncrementalWatermark(t *testing.T) {
+	watermark := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	checkpoint := IncrementalWatermarkCheckpoint("aws", "cloudtrail", []*primitives.Event{
+		{Id: "known", OccurredAt: timestamppb.New(watermark)},
+	}, IncrementalWatermarkState{})
+	engine, err := NewFamilyEngineWithSourceID("aws", func(cfg Config) (string, error) {
+		family, _ := cfg.Lookup("family")
+		return family, nil
+	}, func(settings string) string { return settings }, Family[string]{
+		Name:                 "cloudtrail",
+		IncrementalWatermark: true,
+		Read: func(context.Context, string, *cerebrov1.SourceCursor) (Pull, error) {
+			return Pull{
+				Events: []*primitives.Event{
+					{
+						Id:         "keep",
+						Kind:       "aws.cloudtrail",
+						OccurredAt: timestamppb.New(watermark.Add(time.Minute)),
+						Attributes: map[string]string{"resource_urn": "urn:cerebro:tenant:aws_s3_bucket:kept"},
+					},
+					{
+						Id:         "drop",
+						Kind:       "aws.cloudtrail",
+						OccurredAt: timestamppb.New(watermark.Add(2 * time.Minute)),
+						Attributes: map[string]string{"resource_urn": "urn:cerebro:tenant:aws_s3_bucket:excluded"},
+					},
+				},
+				NextCursor: &cerebrov1.SourceCursor{Opaque: "2"},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFamilyEngineWithSourceID() error = %v", err)
+	}
+	rawPolicy, err := resourcescope.ConfigValue(resourcescope.Policy{ExcludedResourceURNs: []string{"urn:cerebro:tenant:aws_s3_bucket:excluded"}})
+	if err != nil {
+		t.Fatalf("ConfigValue() error = %v", err)
+	}
+
+	pull, err := engine.ReadWithCheckpoint(context.Background(), NewConfig(map[string]string{
+		"family":                "cloudtrail",
+		resourcescope.ConfigKey: rawPolicy,
+	}), nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 1 || pull.Events[0].GetId() != "keep" {
+		t.Fatalf("events = %#v, want resource-scope exclusion applied after incremental filtering", pull.Events)
+	}
+	if pull.NextCursor == nil || !ResumableCursorOpaque(pull.NextCursor.GetOpaque()) {
+		t.Fatalf("NextCursor = %#v, want resumable incremental cursor", pull.NextCursor)
+	}
+}

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const bootstrapProductionGoLineBudget = 22891
+const bootstrapProductionGoLineBudget = 22984
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- Add report packet metadata for readiness, provenance, scope, incremental collection, and redaction state.
- Add export support for report packet output.
- Add regression coverage for scoped incremental reads.

## Tests
- go test ./internal/grccontrol ./internal/sourcecdk ./internal/bootstrap -count=1

## Compatibility
- Packet metadata is additive for existing consumers.