### PR TITLE
Deepen Cerebro access projections

### DIFF
--- a/internal/sourceprojection/cerebro.go
+++ b/internal/sourceprojection/cerebro.go
@@ -35,6 +35,10 @@ func cerebroAPIAccessProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	})
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), serviceURN, accessURN, relationHasEvidence, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), accessURN, serviceURN, relationObservedOn, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
+	routeURN := cerebroRouteURN(tenantID, attrs)
+	if routeURN != "" {
+		addCerebroRouteEntities(entities, links, tenantID, event, attrs, serviceURN, accessURN, routeURN)
+	}
 	if principalURN := cerebroPrincipalURN(tenantID, attrs); principalURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        principalURN,
@@ -48,13 +52,21 @@ func cerebroAPIAccessProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 		if actor := strings.TrimSpace(firstNonEmpty(attrs["actor_user"], attrs["principal"])); actor != "" {
 			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), principalURN, actor, event.GetOccurredAt())
 		}
+		if routeURN != "" {
+			cerebroLinkPrincipalRouteAccess(links, tenantID, event, attrs, principalURN, routeURN)
+		}
+		credentialURN := cerebroCredentialURN(tenantID, attrs)
+		if credentialURN != "" {
+			addCerebroCredentialEntities(entities, links, tenantID, event, attrs, principalURN, credentialURN, routeURN)
+		}
+		addCerebroScopeEntities(entities, links, tenantID, event, attrs, principalURN, credentialURN, routeURN)
 	}
 	return identityProjectionResult(entities, links)
 }
 
 func cerebroAccessEntityAttributes(event *cerebrov1.EventEnvelope, attrs map[string]string) map[string]string {
 	out := map[string]string{"event_id": event.GetId(), "source_product": "cerebro", "at": eventObservedAt(event)}
-	for _, key := range []string{"auth_mode", "client_ip", "connect_code", "connect_procedure", "denial_reason", "device_id", "duration_ms", "effective_status_code", "method", "operation_family", "operation_type", "outcome_result", "remote_ip", "request_id", "risk_level", "risk_score", "route", "source_ip", "status_code", "tenant_mismatch"} {
+	for _, key := range []string{"auth_mode", "client_id", "client_ip", "connect_code", "connect_procedure", "credential_id", "denial_reason", "device_id", "duration_ms", "effective_status_code", "effective_tenant_id", "matched_scope", "method", "missing_scopes", "operation_family", "operation_type", "outcome_result", "principal_tenant_id", "remote_ip", "request_id", "requested_tenant_id", "required_scopes", "risk_level", "risk_score", "route", "scopes", "sensitive_action", "source_ip", "status", "status_code", "tenant_mismatch"} {
 		addProjectedAttribute(out, key, attrs[key])
 	}
 	return out
@@ -74,8 +86,206 @@ func cerebroPrincipalLabel(attrs map[string]string) string {
 
 func cerebroPrincipalAttributes(attrs map[string]string) map[string]string {
 	out := map[string]string{"source_product": "cerebro"}
-	for _, key := range []string{"auth_mode", "client_id", "credential_id", "device_id", "principal", "principal_tenant_id", "risk_level", "risk_score"} {
+	for _, key := range []string{"auth_mode", "client_id", "credential_id", "device_id", "effective_tenant_id", "principal", "principal_tenant_id", "risk_level", "risk_score", "scopes"} {
 		addProjectedAttribute(out, key, attrs[key])
+	}
+	return out
+}
+
+func addCerebroRouteEntities(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, attrs map[string]string, serviceURN string, accessURN string, routeURN string) {
+	operationFamilyURN := cerebroOperationFamilyURN(tenantID, attrs)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        routeURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "cerebro.route",
+		Label:      firstNonEmpty(attrs["route"], attrs["connect_procedure"], attrs["operation_family"]),
+		Attributes: cerebroRouteAttributes(attrs),
+	})
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), serviceURN, routeURN, relationSupports, cerebroEventLinkAttributes(event, "service_route")))
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), routeURN, serviceURN, relationBelongsTo, cerebroEventLinkAttributes(event, "route_service")))
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), routeURN, accessURN, relationHasEvidence, cerebroEventLinkAttributes(event, "route_access_observation")))
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), accessURN, routeURN, relationObservedOn, cerebroEventLinkAttributes(event, "access_route")))
+	if operationFamilyURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        operationFamilyURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "cerebro.operation_family",
+		Label:      strings.TrimSpace(attrs["operation_family"]),
+		Attributes: map[string]string{
+			"operation_family": strings.TrimSpace(attrs["operation_family"]),
+			"operation_type":   strings.TrimSpace(attrs["operation_type"]),
+			"source_product":   "cerebro",
+		},
+	})
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), routeURN, operationFamilyURN, relationBelongsTo, cerebroEventLinkAttributes(event, "route_operation_family")))
+}
+
+func cerebroLinkPrincipalRouteAccess(links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, attrs map[string]string, principalURN string, routeURN string) {
+	if cerebroAccessAllowed(attrs) {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), principalURN, routeURN, relationCanPerform, cerebroAccessLinkAttributes(event, attrs, "observed_allowed_route")))
+		if operationFamilyURN := cerebroOperationFamilyURN(tenantID, attrs); operationFamilyURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), principalURN, operationFamilyURN, relationCanPerform, cerebroAccessLinkAttributes(event, attrs, "observed_allowed_operation_family")))
+		}
+		return
+	}
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), principalURN, routeURN, relationActedOn, cerebroAccessLinkAttributes(event, attrs, "observed_route_attempt")))
+}
+
+func addCerebroCredentialEntities(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, attrs map[string]string, principalURN string, credentialURN string, routeURN string) {
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        credentialURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "cerebro.credential",
+		Label:      firstNonEmpty(attrs["credential_id"], attrs["client_id"], attrs["device_id"]),
+		Attributes: cerebroCredentialAttributes(attrs),
+	})
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), principalURN, credentialURN, relationAssignedTo, cerebroAccessLinkAttributes(event, attrs, "principal_credential")))
+	if routeURN != "" && cerebroAccessAllowed(attrs) {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), credentialURN, routeURN, relationCanPerform, cerebroAccessLinkAttributes(event, attrs, "credential_allowed_route")))
+	}
+}
+
+func addCerebroScopeEntities(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, attrs map[string]string, principalURN string, credentialURN string, routeURN string) {
+	for _, scope := range splitCerebroList(firstNonEmpty(attrs["required_scopes"], attrs["matched_scope"], attrs["scopes"])) {
+		scopeURN := cerebroScopeURN(tenantID, scope)
+		addCerebroScopeEntity(entities, tenantID, event.GetSourceId(), scopeURN, scope)
+		if routeURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), scopeURN, routeURN, relationSupports, cerebroAccessLinkAttributes(event, attrs, "scope_route")))
+		}
+		if cerebroAccessAllowed(attrs) {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), principalURN, scopeURN, relationCanPerform, cerebroAccessLinkAttributes(event, attrs, "principal_scope")))
+			if credentialURN != "" {
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), credentialURN, scopeURN, relationCanPerform, cerebroAccessLinkAttributes(event, attrs, "credential_scope")))
+			}
+		}
+	}
+	for _, scope := range splitCerebroList(attrs["missing_scopes"]) {
+		addCerebroScopeEntity(entities, tenantID, event.GetSourceId(), cerebroScopeURN(tenantID, scope), scope)
+	}
+}
+
+func addCerebroScopeEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, scopeURN string, scope string) {
+	if scopeURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        scopeURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "cerebro.scope",
+		Label:      scope,
+		Attributes: map[string]string{"scope": scope, "source_product": "cerebro"},
+	})
+}
+
+func cerebroRouteURN(tenantID string, attrs map[string]string) string {
+	routeID := firstNonEmpty(attrs["route"], attrs["connect_procedure"])
+	if routeID == "" && (strings.TrimSpace(attrs["operation_family"]) != "" || strings.TrimSpace(attrs["operation_type"]) != "") {
+		routeID = strings.Join([]string{strings.TrimSpace(attrs["operation_family"]), strings.TrimSpace(attrs["operation_type"])}, ":")
+	}
+	if routeID == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "cerebro_route", normalizeCerebroRouteID(routeID))
+}
+
+func cerebroOperationFamilyURN(tenantID string, attrs map[string]string) string {
+	family := strings.TrimSpace(attrs["operation_family"])
+	if family == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "cerebro_operation_family", normalizeIdentifier(family))
+}
+
+func cerebroCredentialURN(tenantID string, attrs map[string]string) string {
+	value := firstNonEmpty(attrs["credential_id"], attrs["client_id"], attrs["device_id"])
+	if value == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "cerebro_credential", normalizeIdentifier(value))
+}
+
+func cerebroScopeURN(tenantID string, scope string) string {
+	if strings.TrimSpace(scope) == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "cerebro_scope", normalizeIdentifier(scope))
+}
+
+func cerebroRouteAttributes(attrs map[string]string) map[string]string {
+	out := map[string]string{"source_product": "cerebro"}
+	for _, key := range []string{"connect_procedure", "method", "operation_family", "operation_type", "route", "sensitive_action"} {
+		addProjectedAttribute(out, key, attrs[key])
+	}
+	return out
+}
+
+func cerebroCredentialAttributes(attrs map[string]string) map[string]string {
+	out := map[string]string{"source_product": "cerebro"}
+	for _, key := range []string{"auth_mode", "client_id", "credential_id", "device_id", "effective_tenant_id", "principal", "principal_tenant_id", "risk_level", "risk_score", "scopes"} {
+		addProjectedAttribute(out, key, attrs[key])
+	}
+	return out
+}
+
+func cerebroAccessLinkAttributes(event *cerebrov1.EventEnvelope, attrs map[string]string, matchType string) map[string]string {
+	out := cerebroEventLinkAttributes(event, matchType)
+	for _, key := range []string{"auth_mode", "denial_reason", "effective_status_code", "effective_tenant_id", "missing_scopes", "outcome_result", "requested_tenant_id", "risk_level", "risk_score", "sensitive_action", "status_code", "tenant_mismatch"} {
+		addProjectedAttribute(out, key, attrs[key])
+	}
+	return out
+}
+
+func cerebroEventLinkAttributes(event *cerebrov1.EventEnvelope, matchType string) map[string]string {
+	out := map[string]string{"event_id": event.GetId()}
+	addProjectedAttribute(out, "at", eventObservedAt(event))
+	addProjectedAttribute(out, "match_type", matchType)
+	return out
+}
+
+func cerebroAccessAllowed(attrs map[string]string) bool {
+	outcome := normalizeIdentifier(firstNonEmpty(attrs["outcome_result"], attrs["status"]))
+	if outcome == "allowed" || outcome == "allow" || outcome == "success" || outcome == "ok" {
+		return true
+	}
+	status := strings.TrimSpace(firstNonEmpty(attrs["effective_status_code"], attrs["status_code"]))
+	return strings.HasPrefix(status, "2")
+}
+
+func normalizeCerebroRouteID(value string) string {
+	normalized := normalizeIdentifier(value)
+	normalized = strings.ReplaceAll(normalized, " ", ":")
+	for strings.Contains(normalized, "::") {
+		normalized = strings.ReplaceAll(normalized, "::", ":")
+	}
+	return strings.Trim(normalized, ":")
+}
+
+func splitCerebroList(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
+	})
+	out := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, part := range parts {
+		trimmed := strings.Trim(strings.TrimSpace(part), "[]\"'")
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
 	}
 	return out
 }

--- a/internal/sourceprojection/cerebro_test.go
+++ b/internal/sourceprojection/cerebro_test.go
@@ -19,15 +19,23 @@ func TestProjectCerebroAPIAccessLinksPrincipalAndService(t *testing.T) {
 		Kind:       "cerebro.api_access",
 		OccurredAt: timestamppb.New(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)),
 		Attributes: map[string]string{
-			"actor_user":     "ci@example.com",
-			"auth_mode":      "api_key",
-			"method":         "GET",
-			"outcome_result": "allowed",
-			"principal":      "ci@example.com",
-			"request_id":     "audit-request-1",
-			"route":          "GET /sources",
-			"source_ip":      "198.51.100.7",
-			"status_code":    "200",
+			"actor_user":          "ci@example.com",
+			"auth_mode":           "api_key",
+			"client_id":           "ci-client",
+			"credential_id":       "cred-api",
+			"effective_tenant_id": "writer",
+			"method":              "GET",
+			"operation_family":    "source",
+			"operation_type":      "read",
+			"outcome_result":      "allowed",
+			"principal":           "ci@example.com",
+			"required_scopes":     "cerebro.cosmo.security.read",
+			"request_id":          "audit-request-1",
+			"route":               "GET /sources",
+			"scopes":              "cerebro.cosmo.security.read",
+			"sensitive_action":    "false",
+			"source_ip":           "198.51.100.7",
+			"status_code":         "200",
 		},
 	}
 	if _, err := service.Project(context.Background(), event); err != nil {
@@ -37,6 +45,10 @@ func TestProjectCerebroAPIAccessLinksPrincipalAndService(t *testing.T) {
 	accessURN := "urn:cerebro:writer:cerebro_api_access:audit-request-1"
 	principalURN := "urn:cerebro:writer:cerebro_principal:ci@example.com"
 	identityURN := "urn:cerebro:writer:identity:email:ci@example.com"
+	routeURN := "urn:cerebro:writer:cerebro_route:get:/sources"
+	operationFamilyURN := "urn:cerebro:writer:cerebro_operation_family:source"
+	credentialURN := "urn:cerebro:writer:cerebro_credential:cred-api" // #nosec G101 -- test graph URN, not credential material.
+	scopeURN := "urn:cerebro:writer:cerebro_scope:cerebro.cosmo.security.read"
 	if entity := state.entities[serviceURN]; entity == nil || entity.EntityType != "service" {
 		t.Fatalf("service entity missing or wrong: %#v", entity)
 	}
@@ -47,4 +59,47 @@ func TestProjectCerebroAPIAccessLinksPrincipalAndService(t *testing.T) {
 	assertProjectedLink(t, state, accessURN, relationObservedOn, serviceURN)
 	assertProjectedLink(t, state, principalURN, relationHasEvidence, accessURN)
 	assertProjectedLink(t, state, principalURN, relationRepresentsIdentity, identityURN)
+	assertProjectedLink(t, state, serviceURN, relationSupports, routeURN)
+	assertProjectedLink(t, state, routeURN, relationBelongsTo, operationFamilyURN)
+	assertProjectedLink(t, state, principalURN, relationCanPerform, routeURN)
+	assertProjectedLink(t, state, principalURN, relationCanPerform, operationFamilyURN)
+	assertProjectedLink(t, state, principalURN, relationAssignedTo, credentialURN)
+	assertProjectedLink(t, state, credentialURN, relationCanPerform, routeURN)
+	assertProjectedLink(t, state, principalURN, relationCanPerform, scopeURN)
+	assertProjectedLink(t, state, credentialURN, relationCanPerform, scopeURN)
+	assertProjectedLink(t, state, scopeURN, relationSupports, routeURN)
+}
+
+func TestProjectCerebroAPIAccessDeniedDoesNotGrantRoute(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	event := &cerebrov1.EventEnvelope{
+		Id:         "cerebro-api-access-denied",
+		TenantId:   "writer",
+		SourceId:   "cerebro",
+		Kind:       "cerebro.api_access",
+		OccurredAt: timestamppb.New(time.Date(2026, 6, 9, 12, 1, 0, 0, time.UTC)),
+		Attributes: map[string]string{
+			"auth_mode":        "api_key",
+			"credential_id":    "cred-limited",
+			"method":           "POST",
+			"missing_scopes":   "cerebro.findings.write",
+			"operation_family": "finding",
+			"operation_type":   "write",
+			"outcome_result":   "denied",
+			"principal":        "ci@example.com",
+			"required_scopes":  "cerebro.findings.write",
+			"request_id":       "denied-request-1",
+			"route":            "POST /findings/{findingID}/notes",
+			"sensitive_action": "true",
+			"status_code":      "403",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	principalURN := "urn:cerebro:writer:cerebro_principal:ci@example.com"
+	routeURN := "urn:cerebro:writer:cerebro_route:post:/findings/{findingid}/notes"
+	assertProjectedLink(t, state, principalURN, relationActedOn, routeURN)
+	assertProjectedLinkMissing(t, state, principalURN, relationCanPerform, routeURN)
 }

--- a/sources/cerebro/source.go
+++ b/sources/cerebro/source.go
@@ -224,7 +224,7 @@ func accessAttributes(body map[string]any) map[string]string {
 		"actor_user":     stringField(body, "principal"),
 		"resource_type":  "cerebro_api_route",
 	}
-	for _, key := range []string{"auth_mode", "client_id", "connect_code", "connect_procedure", "credential_id", "denial_reason", "device_id", "duration_ms", "effective_status_code", "effective_tenant_id", "operation_family", "operation_type", "principal", "principal_tenant_id", "remote_ip", "request_id", "requested_tenant_id", "risk_level", "risk_score", "sensitive_action", "status", "status_code", "tenant_id", "tenant_mismatch"} {
+	for _, key := range []string{"auth_mode", "client_id", "connect_code", "connect_procedure", "credential_id", "denial_reason", "device_id", "duration_ms", "effective_status_code", "effective_tenant_id", "matched_scope", "missing_scopes", "operation_family", "operation_type", "principal", "principal_tenant_id", "remote_ip", "request_id", "requested_tenant_id", "required_scopes", "risk_level", "risk_score", "scopes", "sensitive_action", "status", "status_code", "tenant_id", "tenant_mismatch"} {
 		if value := stringField(body, key); value != "" {
 			attrs[key] = value
 		}
@@ -265,6 +265,27 @@ func stringField(body map[string]any, key string) string {
 		return strconv.FormatFloat(value, 'f', -1, 64)
 	case bool:
 		return strconv.FormatBool(value)
+	case []any:
+		parts := make([]string, 0, len(value))
+		for _, item := range value {
+			if rendered := scalarString(item); rendered != "" {
+				parts = append(parts, rendered)
+			}
+		}
+		return strings.Join(parts, ",")
+	default:
+		return ""
+	}
+}
+
+func scalarString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(typed)
 	default:
 		return ""
 	}

--- a/sources/cerebro/source_test.go
+++ b/sources/cerebro/source_test.go
@@ -114,6 +114,9 @@ func TestReadAccessTelemetryArchives(t *testing.T) {
 	if pull.Events[0].GetAttributes()["actor_user"] != "ci@example.com" || pull.Events[0].GetAttributes()["source_ip"] != "198.51.100.7" {
 		t.Fatalf("first event attrs = %#v", pull.Events[0].GetAttributes())
 	}
+	if pull.Events[0].GetAttributes()["credential_id"] != "cred-audit-request-1" || pull.Events[0].GetAttributes()["scopes"] != "cerebro.cosmo.security.read,cerebro.findings.write" {
+		t.Fatalf("first event access attrs = %#v", pull.Events[0].GetAttributes())
+	}
 	if pull.Events[1].GetAttributes()["outcome_result"] != "denied" || pull.Events[1].GetAttributes()["sensitive_action"] != "true" {
 		t.Fatalf("second event attrs = %#v", pull.Events[1].GetAttributes())
 	}
@@ -203,8 +206,12 @@ func accessTelemetry(requestID string, tenantID string, outcome string, route st
 		"requested_tenant_id":   tenantID,
 		"principal":             principal,
 		"auth_mode":             "api_key",
+		"client_id":             "client-" + requestID,
 		"client_ip":             "198.51.100.7",
+		"credential_id":         "cred-" + requestID,
 		"request_id":            requestID,
+		"required_scopes":       []any{"cerebro.cosmo.security.read"},
+		"scopes":                []any{"cerebro.cosmo.security.read", "cerebro.findings.write"},
 		"sensitive_action":      strings.HasPrefix(route, "POST"),
 	}
 }


### PR DESCRIPTION
## Summary
- project Cerebro access telemetry into route, operation-family, credential, and scope graph entities
- create allowed-route and allowed-scope can_perform edges while preserving denied attempts as acted_on evidence
- preserve credential/client/scope fields from exported access telemetry, including JSON array fields

## Verification
- go test ./internal/sourceprojection ./sources/cerebro
- ./scripts/pre_commit_checks.sh