### PR TITLE
Add Anthropic credential preflight guidance

### DIFF
--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -66,6 +66,13 @@ const (
 	connectorReadinessStageRuntimeUnknown      = "runtime_unknown"
 )
 
+const (
+	anthropicCredentialKindAdminAPIKey         = "admin_api_key"
+	anthropicCredentialKindComplianceAccessKey = "compliance_access_key"
+	anthropicCredentialKindOrgAdminOAuth       = "org_admin_oauth"      // #nosec G101 -- credential kind label, not credential material.
+	anthropicCredentialKindScopedAdminAPIKey   = "scoped_admin_api_key" // #nosec G101 -- credential kind label, not credential material.
+)
+
 var errConnectorAccessRestricted = errors.New("connector access restricted")
 
 type connectorCatalogEntry struct {
@@ -1583,6 +1590,8 @@ var connectorSchemas = map[string]connectorSchema{
 			"created_at_gte",
 			"created_at_lt",
 			"created_at_lte",
+			"credential_kind",
+			"credential_scopes",
 			"ending_at",
 			"family",
 			"group_by",
@@ -2457,9 +2466,95 @@ func connectorProviderPreflightChecks(sourceID string, authMethod string, config
 			})
 		}
 		return checks
+	case "anthropic":
+		return anthropicProviderPreflightChecks(config, policy)
 	default:
 		return nil
 	}
+}
+
+func anthropicProviderPreflightChecks(config map[string]string, policy resourcescope.Policy) []connectorPreflightCheckView {
+	family := strings.TrimSpace(config["family"])
+	if family == "" {
+		family = "user"
+	}
+	if policy.ExcludesFamily("anthropic", family) {
+		return nil
+	}
+	authModel := strings.ToLower(strings.TrimSpace(config["auth_model"]))
+	if authModel == "" {
+		authModel = "legacy_token"
+	}
+	credentialKind := normalizedCredentialHint(config["credential_kind"])
+	scopes := connectorTokenSet(config["credential_scopes"])
+	checks := []connectorPreflightCheckView{}
+	switch family {
+	case "service_account", "federation_issuer", "federation_rule":
+		if authModel != "bearer_token" || (credentialKind != "" && credentialKind != anthropicCredentialKindOrgAdminOAuth) || !setContains(scopes, "org:admin") {
+			checks = append(checks, connectorPreflightCheckView{
+				ID:         "anthropic_org_admin_oauth",
+				Label:      "Anthropic org admin OAuth",
+				Status:     "warning",
+				Severity:   "warning",
+				Detail:     "Service account and workload identity federation families require an org:admin OAuth bearer token; set auth_model=bearer_token and record credential_scopes=org:admin when configuring this runtime.",
+				NextAction: "use_anthropic_org_admin_oauth",
+			})
+		}
+	case "compliance_activity":
+		if authModel == "bearer_token" || (credentialKind != "" && credentialKind != anthropicCredentialKindAdminAPIKey && credentialKind != anthropicCredentialKindComplianceAccessKey) || !setContains(scopes, "read:compliance_activities") {
+			checks = append(checks, connectorPreflightCheckView{
+				ID:         "anthropic_compliance_scope",
+				Label:      "Anthropic compliance scope",
+				Status:     "warning",
+				Severity:   "warning",
+				Detail:     "Compliance Activity Feed reads use x-api-key and require read:compliance_activities on an Admin API key or Compliance Access Key; record credential_kind and credential_scopes to make that explicit.",
+				NextAction: "confirm_anthropic_compliance_scope",
+			})
+		}
+	case "spend_limit", "spend_limit_increase_request":
+		if authModel == "bearer_token" || (credentialKind != "" && credentialKind != anthropicCredentialKindScopedAdminAPIKey) || !setContains(scopes, "read:spend_limits") {
+			checks = append(checks, connectorPreflightCheckView{
+				ID:         "anthropic_spend_limit_scope",
+				Label:      "Anthropic spend-limit scope",
+				Status:     "warning",
+				Severity:   "warning",
+				Detail:     "Read-only spend-limit families require an Enterprise scoped Admin API key with read:spend_limits in x-api-key; record credential_kind=scoped_admin_api_key and credential_scopes=read:spend_limits.",
+				NextAction: "confirm_anthropic_spend_limit_scope",
+			})
+		}
+	}
+	return checks
+}
+
+func normalizedCredentialHint(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	replacer := strings.NewReplacer("-", "_", " ", "_")
+	value = replacer.Replace(value)
+	switch value {
+	case "oauth", "oauth_bearer", "org_admin", "org_admin_token":
+		return anthropicCredentialKindOrgAdminOAuth
+	case "admin", "admin_key", "admin_api":
+		return anthropicCredentialKindAdminAPIKey
+	case "compliance", "compliance_key":
+		return anthropicCredentialKindComplianceAccessKey
+	case "spend_limit_admin_key", "spend_limits_admin_key":
+		return anthropicCredentialKindScopedAdminAPIKey
+	default:
+		return value
+	}
+}
+
+func connectorTokenSet(value string) map[string]struct{} {
+	tokens := map[string]struct{}{}
+	for _, token := range strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\n' || r == '\t'
+	}) {
+		token = strings.ToLower(strings.TrimSpace(token))
+		if token != "" {
+			tokens[token] = struct{}{}
+		}
+	}
+	return tokens
 }
 
 func connectorPreflightErrorDetail(err error) string {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -1296,6 +1296,102 @@ func TestConnectorSchemaForGenerateableCatalogDefinition(t *testing.T) {
 	if got := strings.Join(jenkinsSchema.RequiredCredentials, ","); got != "password,username" {
 		t.Fatalf("jenkins required credentials = %q, want password,username", got)
 	}
+	anthropicSchema, ok := connectorSchemaForSource("anthropic")
+	if !ok {
+		t.Fatal("connectorSchemaForSource(anthropic) = false, want builtin schema")
+	}
+	for _, key := range []string{"credential_kind", "credential_scopes"} {
+		if _, ok := anthropicSchema.ConfigKeys[key]; !ok {
+			t.Fatalf("anthropic config keys missing %q: %#v", key, sortedSetKeys(anthropicSchema.ConfigKeys))
+		}
+	}
+	err = validateConnectorConfigFields("anthropic", connectorAuthMethodExternalReference, map[string]string{ // #nosec G101 -- Test-only credential reference placeholders, not live secrets.
+		"api_key":           "env:CEREBRO_SOURCE_ANTHROPIC_API_KEY",
+		"credential_kind":   anthropicCredentialKindScopedAdminAPIKey,
+		"credential_scopes": "read:spend_limits",
+		"family":            "spend_limit",
+	}, map[string]string{
+		"api_key": "env:CEREBRO_SOURCE_ANTHROPIC_API_KEY",
+	})
+	if err != nil {
+		t.Fatalf("validateConnectorConfigFields(anthropic credential hints) error = %v", err)
+	}
+}
+
+func TestAnthropicProviderPreflightChecksCredentialRequirements(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     map[string]string
+		wantCheck  string
+		wantAction string
+	}{
+		{
+			name:       "service account needs org admin OAuth",
+			config:     map[string]string{"family": "service_account"},
+			wantCheck:  "anthropic_org_admin_oauth",
+			wantAction: "use_anthropic_org_admin_oauth",
+		},
+		{
+			name:       "compliance activity needs read compliance scope",
+			config:     map[string]string{"credential_kind": anthropicCredentialKindAdminAPIKey, "family": "compliance_activity"},
+			wantCheck:  "anthropic_compliance_scope",
+			wantAction: "confirm_anthropic_compliance_scope",
+		},
+		{
+			name:       "spend limits need scoped admin key",
+			config:     map[string]string{"credential_kind": anthropicCredentialKindAdminAPIKey, "family": "spend_limit", "credential_scopes": "read:usage"},
+			wantCheck:  "anthropic_spend_limit_scope",
+			wantAction: "confirm_anthropic_spend_limit_scope",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checks := connectorProviderPreflightChecks("anthropic", connectorAuthMethodExternalReference, test.config, resourcescope.Policy{})
+			check := findConnectorPreflightCheck(checks, test.wantCheck)
+			if check == nil {
+				t.Fatalf("check %q missing from %#v", test.wantCheck, checks)
+			}
+			if check.Status != "warning" || check.NextAction != test.wantAction {
+				t.Fatalf("check = %#v, want warning action %q", check, test.wantAction)
+			}
+		})
+	}
+}
+
+func TestAnthropicProviderPreflightChecksPassWithCredentialHints(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]string
+	}{
+		{
+			name:   "service account org admin oauth",
+			config: map[string]string{"auth_model": "bearer_token", "credential_kind": anthropicCredentialKindOrgAdminOAuth, "credential_scopes": "org:admin", "family": "service_account"},
+		},
+		{
+			name:   "compliance activity scoped key",
+			config: map[string]string{"credential_kind": anthropicCredentialKindComplianceAccessKey, "credential_scopes": "read:compliance_activities", "family": "compliance_activity"},
+		},
+		{
+			name:   "spend limit scoped key",
+			config: map[string]string{"credential_kind": anthropicCredentialKindScopedAdminAPIKey, "credential_scopes": "read:spend_limits", "family": "spend_limit"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if checks := connectorProviderPreflightChecks("anthropic", connectorAuthMethodExternalReference, test.config, resourcescope.Policy{}); len(checks) != 0 {
+				t.Fatalf("checks = %#v, want none", checks)
+			}
+		})
+	}
+}
+
+func findConnectorPreflightCheck(checks []connectorPreflightCheckView, id string) *connectorPreflightCheckView {
+	for i := range checks {
+		if checks[i].ID == id {
+			return &checks[i]
+		}
+	}
+	return nil
 }
 
 func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {


### PR DESCRIPTION
## Summary
- add optional Anthropic credential_kind and credential_scopes setup hints
- warn during connector preflight when selected Anthropic families require org:admin OAuth, Compliance Activity Feed scope, or spend-limit scoped admin keys
- suppress gosec false positives for AI-access test graph URNs

## Verification
- go test ./internal/bootstrap ./internal/sourceprojection
- make lint
- ./scripts/pre_commit_checks.sh