### PR TITLE
Persist GRC inventory accountability decisions

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2071,6 +2071,41 @@ paths:
       responses:
         '200':
           description: Updated GRC purview state for one inventory asset and propagated any concrete resource exclusion to source-runtime incremental fetch policy.
+  /grc/inventory/accountability:
+    post:
+      summary: Update inventory accountability
+      tags:
+        - GRC
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [asset_urn, state]
+              properties:
+                tenant_id:
+                  type: string
+                asset_urn:
+                  type: string
+                source_id:
+                  type: string
+                runtime_id:
+                  type: string
+                  description: Source runtime associated with this inventory asset.
+                state:
+                  type: string
+                  enum: [known, not_required, clear]
+                  description: Owner decision to persist for derived GRC review posture.
+                owner:
+                  type: string
+                  description: Required when state is known.
+                reason:
+                  type: string
+                  description: Reviewer rationale for the accountability decision.
+      responses:
+        '200':
+          description: Updated accountability metadata for one inventory asset while preserving any existing scope exclusion.
   /grc/inventory/asset-reports:
     get:
       summary: Inventory asset reports

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -88,6 +88,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Exact: "/grc/control-packets/export", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Prefix: "/grc/control-packs", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/inventory/resource-scope", Scope: scopeGRCInventoryWrite, Static: true},
+	{Method: http.MethodPost, Exact: "/grc/inventory/accountability", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/inventory/asset-reports", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPatch, Prefix: "/grc/inventory/asset-reports/", Suffix: "/triage", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodGet, Exact: "/platform/runtime-freshness", Scope: scopeCosmoSecurityRead, Static: true},

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -75,12 +75,22 @@ type grcFindingItem struct {
 	PolicyName   string          `json:"policy_name,omitempty"`
 	Controls     []grcControlRef `json:"controls,omitempty"`
 	GRCFindingRisk
+	GRCFindingWorkflowMetadata
 	EvidenceCount   int        `json:"evidence_count"`
 	Owner           string     `json:"owner"`
 	SLAStatus       string     `json:"sla_status"`
-	DueAt           *time.Time `json:"due_at,omitempty"`
 	FirstObservedAt *time.Time `json:"first_observed_at,omitempty"`
 	LastObservedAt  *time.Time `json:"last_observed_at,omitempty"`
+}
+
+type GRCFindingWorkflowMetadata struct {
+	StatusReason    string                     `json:"status_reason,omitempty"`
+	Assignee        string                     `json:"assignee,omitempty"`
+	DueAt           *time.Time                 `json:"due_at,omitempty"`
+	StatusUpdatedAt *time.Time                 `json:"status_updated_at,omitempty"`
+	Notes           []ports.FindingNote        `json:"notes,omitempty"`
+	Tickets         []ports.FindingTicket      `json:"tickets,omitempty"`
+	ExternalRefs    []ports.FindingExternalRef `json:"external_refs,omitempty"`
 }
 
 type GRCFindingRisk struct {
@@ -1204,10 +1214,18 @@ func grcFindingItems(findings []*ports.FindingRecord, sourceIDs map[string]strin
 				RiskReasons:     append([]string(nil), finding.RiskReasons...),
 				RiskModel:       finding.RiskModelVersion,
 			},
+			GRCFindingWorkflowMetadata: GRCFindingWorkflowMetadata{
+				StatusReason:    finding.StatusReason,
+				Assignee:        finding.Assignee,
+				DueAt:           timePtr(finding.DueAt),
+				StatusUpdatedAt: timePtr(finding.StatusUpdatedAt),
+				Notes:           append([]ports.FindingNote(nil), finding.Notes...),
+				Tickets:         append([]ports.FindingTicket(nil), finding.Tickets...),
+				ExternalRefs:    append([]ports.FindingExternalRef(nil), finding.ExternalRefs...),
+			},
 			EvidenceCount:   evidenceCounts[finding.ID],
 			Owner:           fallbackString(finding.Assignee, "Unassigned"),
 			SLAStatus:       grcSLAStatus(finding),
-			DueAt:           timePtr(finding.DueAt),
 			FirstObservedAt: timePtr(finding.FirstObservedAt),
 			LastObservedAt:  timePtr(finding.LastObservedAt),
 		})

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -103,10 +103,25 @@ type grcInventoryScopeUpdateRequest struct {
 	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
+type grcInventoryAccountabilityUpdateRequest struct {
+	TenantID  string `json:"tenant_id,omitempty"`
+	AssetURN  string `json:"asset_urn"`
+	SourceID  string `json:"source_id,omitempty"`
+	RuntimeID string `json:"runtime_id,omitempty"`
+	State     string `json:"state"`
+	Owner     string `json:"owner,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
 type grcInventoryScopeUpdateResponse struct {
 	Scope       *ports.GRCInventoryScopeRecord       `json:"scope"`
 	Propagation []grcInventoryScopePropagationResult `json:"propagation,omitempty"`
 	GeneratedAt time.Time                            `json:"generated_at"`
+}
+
+type grcInventoryAccountabilityUpdateResponse struct {
+	Scope       *ports.GRCInventoryScopeRecord `json:"scope"`
+	GeneratedAt time.Time                      `json:"generated_at"`
 }
 
 type grcInventoryScopePropagationResult struct {
@@ -391,6 +406,149 @@ func (a *App) handleUpdateGRCResourceScope(w http.ResponseWriter, r *http.Reques
 	}
 	a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeInventory)
 	writeJSON(w, http.StatusOK, grcInventoryScopeUpdateResponse{Scope: record, Propagation: propagation, GeneratedAt: time.Now().UTC()})
+}
+
+func (a *App) handleUpdateGRCInventoryAccountability(w http.ResponseWriter, r *http.Request) {
+	var request grcInventoryAccountabilityUpdateRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxGRCInventoryScopeBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeGRCError(w, fmt.Errorf("%w: decode inventory accountability request: %w", errInvalidHTTPRequest, err))
+		return
+	}
+	request.AssetURN = strings.TrimSpace(request.AssetURN)
+	if request.AssetURN == "" {
+		writeGRCError(w, fmt.Errorf("%w: asset_urn is required", errInvalidHTTPRequest))
+		return
+	}
+	if err := authorizeCerebroURNTenant(r.Context(), request.AssetURN); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		tenantID = tenantIDFromCerebroURN(request.AssetURN)
+	}
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	store := grcInventoryScopeStore(a.deps.StateStore)
+	if store == nil {
+		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
+		return
+	}
+	record, err := upsertGRCInventoryAccountability(r.Context(), store, tenantID, grcInventoryUpdatedBy(r), request)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeInventory)
+	writeJSON(w, http.StatusOK, grcInventoryAccountabilityUpdateResponse{Scope: record, GeneratedAt: time.Now().UTC()})
+}
+
+func upsertGRCInventoryAccountability(ctx context.Context, store ports.GRCInventoryScopeStore, tenantID string, updatedBy string, request grcInventoryAccountabilityUpdateRequest) (*ports.GRCInventoryScopeRecord, error) {
+	if store == nil {
+		return nil, graphquery.ErrRuntimeUnavailable
+	}
+	request.AssetURN = strings.TrimSpace(request.AssetURN)
+	request.SourceID = strings.TrimSpace(request.SourceID)
+	request.State = strings.TrimSpace(request.State)
+	request.Owner = strings.TrimSpace(request.Owner)
+	request.Reason = strings.TrimSpace(request.Reason)
+	if request.AssetURN == "" {
+		return nil, fmt.Errorf("%w: asset_urn is required", errInvalidHTTPRequest)
+	}
+	existing, err := loadGRCInventoryScopeRecord(ctx, store, tenantID, request.AssetURN)
+	if err != nil {
+		return nil, err
+	}
+	scopeState := grcinventory.ScopeStateInScope
+	scopeReason := ""
+	sourceID := request.SourceID
+	attributes := map[string]string{}
+	if existing != nil {
+		if strings.TrimSpace(existing.ScopeState) != "" {
+			scopeState = existing.ScopeState
+		}
+		scopeReason = existing.Reason
+		if sourceID == "" {
+			sourceID = existing.SourceID
+		}
+		for key, value := range existing.Attributes {
+			if strings.TrimSpace(key) != "" && strings.TrimSpace(value) != "" {
+				attributes[key] = value
+			}
+		}
+	}
+	switch request.State {
+	case grcinventory.AccountabilityKnown:
+		if request.Owner == "" {
+			return nil, fmt.Errorf("%w: owner is required when state is known", errInvalidHTTPRequest)
+		}
+		attributes[grcinventory.AttributeAccountabilityState] = grcinventory.AccountabilityKnown
+		attributes[grcinventory.AttributeAccountabilityPrincipal] = request.Owner
+		attributes["owner"] = request.Owner
+		attributes[grcinventory.AttributeOwnerSource] = grcinventory.AttributeOwnerSourceCerebro
+		attributes["accountability_required"] = "true"
+		delete(attributes, grcinventory.AttributeOwnerNotRequired)
+	case grcinventory.AccountabilityNone:
+		attributes[grcinventory.AttributeAccountabilityState] = grcinventory.AccountabilityNone
+		attributes[grcinventory.AttributeOwnerNotRequired] = "true"
+		delete(attributes, grcinventory.AttributeAccountabilityPrincipal)
+		delete(attributes, "owner")
+		delete(attributes, grcinventory.AttributeOwnerSource)
+		delete(attributes, "accountability_required")
+	case "clear":
+		delete(attributes, grcinventory.AttributeAccountabilityState)
+		delete(attributes, grcinventory.AttributeAccountabilityPrincipal)
+		delete(attributes, grcinventory.AttributeAccountabilityReason)
+		delete(attributes, grcinventory.AttributeOwnerNotRequired)
+		delete(attributes, grcinventory.AttributeOwnerSource)
+		delete(attributes, "owner")
+		delete(attributes, "accountability_required")
+		delete(attributes, "accountability_updated_by")
+		delete(attributes, "accountability_updated_at")
+	default:
+		return nil, fmt.Errorf("%w: state must be known, not_required, or clear", errInvalidHTTPRequest)
+	}
+	if request.State != "clear" {
+		attributes[grcinventory.AttributeAccountabilityReason] = fallbackString(request.Reason, accountabilityDefaultReason(request.State))
+		attributes["accountability_updated_by"] = strings.TrimSpace(updatedBy)
+		attributes["accountability_updated_at"] = time.Now().UTC().Format(time.RFC3339)
+	}
+	return store.UpsertGRCInventoryScope(ctx, ports.GRCInventoryScopeRecord{
+		TenantID:   tenantID,
+		AssetURN:   request.AssetURN,
+		SourceID:   sourceID,
+		ScopeState: scopeState,
+		Reason:     scopeReason,
+		UpdatedBy:  updatedBy,
+		Attributes: attributes,
+	})
+}
+
+func loadGRCInventoryScopeRecord(ctx context.Context, store ports.GRCInventoryScopeStore, tenantID string, assetURN string) (*ports.GRCInventoryScopeRecord, error) {
+	records, err := store.ListGRCInventoryScopes(ctx, ports.GRCInventoryScopeFilter{
+		TenantID:  tenantID,
+		AssetURNs: []string{assetURN},
+		Limit:     1,
+	})
+	if err != nil || len(records) == 0 {
+		return nil, err
+	}
+	return records[0], nil
+}
+
+func accountabilityDefaultReason(state string) string {
+	switch state {
+	case grcinventory.AccountabilityKnown:
+		return "Owner assigned from inventory"
+	case grcinventory.AccountabilityNone:
+		return "Owner not required for GRC review"
+	default:
+		return ""
+	}
 }
 
 func (a *App) applyGRCInventoryScopeToSourceRuntimes(ctx context.Context, tenantID string, request grcInventoryScopeUpdateRequest) ([]grcInventoryScopePropagationResult, error) {

--- a/internal/bootstrap/grc_inventory_test.go
+++ b/internal/bootstrap/grc_inventory_test.go
@@ -52,6 +52,32 @@ func TestGRCInventoryReviewPostureRequiresOwnerForHighRiskUnownedAssets(t *testi
 	}
 }
 
+func TestGRCInventoryAccountabilityOverrideMarksOwnerNotRequired(t *testing.T) {
+	asset := graphquery.InventoryAsset{
+		URN:        "urn:cerebro:writer:aws_s3_bucket:bucket-a",
+		RiskScore:  90,
+		ScopeState: grcinventory.ScopeStateInScope,
+		Attributes: map[string]string{},
+	}
+	grcinventory.ApplyScope(&asset, &ports.GRCInventoryScopeRecord{
+		TenantID:   "writer",
+		AssetURN:   asset.URN,
+		ScopeState: grcinventory.ScopeStateInScope,
+		Attributes: map[string]string{
+			grcinventory.AttributeAccountabilityState:  grcinventory.AccountabilityNone,
+			grcinventory.AttributeOwnerNotRequired:     "true",
+			grcinventory.AttributeAccountabilityReason: "Ephemeral build artifact",
+		},
+	})
+	grcinventory.ApplyReviewPosture(&asset)
+	if asset.Accountability == nil || asset.Accountability.State != grcinventory.AccountabilityNone {
+		t.Fatalf("accountability = %#v, want not_required", asset.Accountability)
+	}
+	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcinventory.ReviewBaseline {
+		t.Fatalf("review_disposition = %#v, want baseline", asset.ReviewDisposition)
+	}
+}
+
 func TestGRCInventoryReviewPostureReportsActiveIssues(t *testing.T) {
 	asset := graphquery.InventoryAsset{
 		URN:                     "urn:cerebro:writer:aws_s3_bucket:bucket-a",
@@ -63,6 +89,38 @@ func TestGRCInventoryReviewPostureReportsActiveIssues(t *testing.T) {
 	grcinventory.ApplyReviewPosture(&asset)
 	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcinventory.ReviewReportedIssue {
 		t.Fatalf("review_disposition = %#v, want reported_issue", asset.ReviewDisposition)
+	}
+}
+
+func TestGRCInventoryAccountabilityUpdatePreservesExistingScope(t *testing.T) {
+	const assetURN = "urn:cerebro:writer:aws_s3_bucket:bucket-a"
+	store := &stubInventoryScopeStore{records: map[string]*ports.GRCInventoryScopeRecord{
+		"writer\x00" + assetURN: {
+			TenantID:   "writer",
+			AssetURN:   assetURN,
+			SourceID:   "aws",
+			ScopeState: grcinventory.ScopeStateOutScope,
+			Reason:     "Not part of audit scope",
+			Attributes: map[string]string{"existing": "kept"},
+		},
+	}}
+	record, err := upsertGRCInventoryAccountability(context.Background(), store, "writer", "tester", grcInventoryAccountabilityUpdateRequest{
+		AssetURN: assetURN,
+		State:    grcinventory.AccountabilityKnown,
+		Owner:    "platform@example.com",
+		Reason:   "Service owner",
+	})
+	if err != nil {
+		t.Fatalf("upsertGRCInventoryAccountability error = %v", err)
+	}
+	if record.ScopeState != grcinventory.ScopeStateOutScope || record.Reason != "Not part of audit scope" {
+		t.Fatalf("record scope = %q reason = %q, want preserved scope exclusion", record.ScopeState, record.Reason)
+	}
+	if got := record.Attributes[grcinventory.AttributeAccountabilityPrincipal]; got != "platform@example.com" {
+		t.Fatalf("accountability principal = %q, want platform@example.com", got)
+	}
+	if got := record.Attributes["existing"]; got != "kept" {
+		t.Fatalf("existing attribute = %q, want kept", got)
 	}
 }
 
@@ -124,4 +182,66 @@ func TestGRCInventoryScopePropagationUpdatesRuntimeResourcePolicy(t *testing.T) 
 	if _, ok := runtime.GetConfig()[resourcescope.ConfigKey]; ok {
 		t.Fatalf("runtime config retained empty %s", resourcescope.ConfigKey)
 	}
+}
+
+type stubInventoryScopeStore struct {
+	records map[string]*ports.GRCInventoryScopeRecord
+}
+
+func (s *stubInventoryScopeStore) Ping(context.Context) error { return nil }
+
+func (s *stubInventoryScopeStore) UpsertGRCInventoryScope(_ context.Context, record ports.GRCInventoryScopeRecord) (*ports.GRCInventoryScopeRecord, error) {
+	if s.records == nil {
+		s.records = map[string]*ports.GRCInventoryScopeRecord{}
+	}
+	cloned := cloneInventoryScopeRecord(&record)
+	s.records[inventoryScopeRecordKey(cloned.TenantID, cloned.AssetURN)] = cloned
+	return cloneInventoryScopeRecord(cloned), nil
+}
+
+func (s *stubInventoryScopeStore) ListGRCInventoryScopes(_ context.Context, filter ports.GRCInventoryScopeFilter) ([]*ports.GRCInventoryScopeRecord, error) {
+	if s.records == nil {
+		return nil, nil
+	}
+	urns := map[string]struct{}{}
+	for _, urn := range filter.AssetURNs {
+		urns[urn] = struct{}{}
+	}
+	records := []*ports.GRCInventoryScopeRecord{}
+	for _, record := range s.records {
+		if filter.TenantID != "" && record.TenantID != filter.TenantID {
+			continue
+		}
+		if filter.SourceID != "" && record.SourceID != filter.SourceID {
+			continue
+		}
+		if filter.ScopeState != "" && record.ScopeState != filter.ScopeState {
+			continue
+		}
+		if len(urns) > 0 {
+			if _, ok := urns[record.AssetURN]; !ok {
+				continue
+			}
+		}
+		records = append(records, cloneInventoryScopeRecord(record))
+	}
+	return records, nil
+}
+
+func inventoryScopeRecordKey(tenantID string, assetURN string) string {
+	return tenantID + "\x00" + assetURN
+}
+
+func cloneInventoryScopeRecord(record *ports.GRCInventoryScopeRecord) *ports.GRCInventoryScopeRecord {
+	if record == nil {
+		return nil
+	}
+	cloned := *record
+	if record.Attributes != nil {
+		cloned.Attributes = map[string]string{}
+		for key, value := range record.Attributes {
+			cloned.Attributes[key] = value
+		}
+	}
+	return &cloned
 }

--- a/internal/bootstrap/grc_workflow_test.go
+++ b/internal/bootstrap/grc_workflow_test.go
@@ -1,0 +1,66 @@
+package bootstrap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestGRCFindingItemsCarryWorkflowMetadata(t *testing.T) {
+	now := time.Date(2026, 6, 18, 15, 30, 0, 0, time.UTC)
+	findings := []*ports.FindingRecord{{
+		ID:        "finding-1",
+		Title:     "Privileged access without review",
+		Severity:  "high",
+		Status:    "OPEN",
+		TenantID:  "writer",
+		RuntimeID: "runtime-1",
+		FindingWorkflow: ports.FindingWorkflow{
+			Assignee:        "identity-team",
+			DueAt:           now.Add(24 * time.Hour),
+			StatusReason:    "Investigating with IAM owners",
+			StatusUpdatedAt: now,
+			Notes: []ports.FindingNote{{
+				ID:        "note-1",
+				Body:      "Escalated from GRC workbench.",
+				CreatedAt: now,
+			}},
+			Tickets: []ports.FindingTicket{{
+				URL:        "https://jira.example/browse/SEC-1",
+				Name:       "SEC-1",
+				ExternalID: "SEC-1",
+				LinkedAt:   now,
+			}},
+			ExternalRefs: []ports.FindingExternalRef{{
+				System:         "siem",
+				Kind:           "case",
+				ExternalID:     "case-1",
+				URL:            "https://siem.example/cases/case-1",
+				ExternalStatus: "open",
+				ObservedAt:     now,
+			}},
+		},
+	}}
+
+	items := grcFindingItems(findings, map[string]string{"runtime-1": "okta"}, map[string]int{"finding-1": 2})
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	item := items[0]
+	if item.Owner != "identity-team" || item.Assignee != "identity-team" {
+		t.Fatalf("owner/assignee = %q/%q, want identity-team", item.Owner, item.Assignee)
+	}
+	if item.StatusReason != "Investigating with IAM owners" || item.StatusUpdatedAt == nil || !item.StatusUpdatedAt.Equal(now) {
+		t.Fatalf("status metadata = %q/%v", item.StatusReason, item.StatusUpdatedAt)
+	}
+	if len(item.Notes) != 1 || item.Notes[0].Body != "Escalated from GRC workbench." {
+		t.Fatalf("notes = %#v", item.Notes)
+	}
+	if len(item.Tickets) != 1 || item.Tickets[0].ExternalID != "SEC-1" {
+		t.Fatalf("tickets = %#v", item.Tickets)
+	}
+	if len(item.ExternalRefs) != 1 || item.ExternalRefs[0].ExternalID != "case-1" {
+		t.Fatalf("external refs = %#v", item.ExternalRefs)
+	}
+}

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -105,6 +105,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /grc/inventory/assets/detail", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.asset.detail", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeInventory, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCInventoryAssetDetail))
 	registerHTTPRoute(mux, "GET /grc/inventory/resource-scope", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.resource_scope", time.Minute, grcCacheScopeInventory, grcCacheScopeGraph), app.handleGRCResourceScope))
 	registerHTTPRoute(mux, "POST /grc/inventory/resource-scope", routeSurfacePlatformHTTP, app.handleUpdateGRCResourceScope)
+	registerHTTPRoute(mux, "POST /grc/inventory/accountability", routeSurfacePlatformHTTP, app.handleUpdateGRCInventoryAccountability)
 	registerHTTPRoute(mux, "GET /grc/inventory/asset-reports", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.asset_reports", time.Minute, grcCacheScopeInventory), app.handleListGRCInventoryAssetReports))
 	registerHTTPRoute(mux, "POST /grc/inventory/asset-reports", routeSurfacePlatformHTTP, app.handleCreateGRCInventoryAssetReport)
 	registerHTTPRoute(mux, "GET /grc/inventory/asset-reports/{reportID}", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.asset_report", time.Minute, grcCacheScopeInventory), app.handleGetGRCInventoryAssetReport))

--- a/internal/bootstrap/tenant_filter_test.go
+++ b/internal/bootstrap/tenant_filter_test.go
@@ -97,6 +97,7 @@ func TestGRCInventoryScopeMutationRequiresWriteScope(t *testing.T) {
 		path   string
 	}{
 		{method: http.MethodPost, path: "/grc/inventory/resource-scope"},
+		{method: http.MethodPost, path: "/grc/inventory/accountability"},
 		{method: http.MethodPost, path: "/grc/inventory/asset-reports"},
 		{method: http.MethodPatch, path: "/grc/inventory/asset-reports/report-1/triage"},
 	} {

--- a/internal/grcinventory/posture.go
+++ b/internal/grcinventory/posture.go
@@ -20,6 +20,13 @@ const (
 	AccountabilityKnown    = "known"
 	AccountabilityRequired = "required_missing"
 	AccountabilityNone     = "not_required"
+
+	AttributeAccountabilityState     = "accountability_state"
+	AttributeAccountabilityPrincipal = "accountability_principal"
+	AttributeAccountabilityReason    = "accountability_reason"
+	AttributeOwnerNotRequired        = "owner_not_required"
+	AttributeOwnerSource             = "owner_source"
+	AttributeOwnerSourceCerebro      = "cerebro_inventory_accountability"
 )
 
 type Summary struct {
@@ -54,6 +61,7 @@ func ApplyScope(asset *graphquery.InventoryAsset, record *ports.GRCInventoryScop
 	if !record.UpdatedAt.IsZero() {
 		asset.ScopeUpdatedAt = record.UpdatedAt.UTC().Format(time.RFC3339)
 	}
+	applyAccountabilityAttributes(asset, record.Attributes)
 }
 
 func ApplyAssetReportSummary(asset *graphquery.InventoryAsset, summary *ports.GRCInventoryAssetReportSummary) {
@@ -93,7 +101,13 @@ func ApplyReviewPosture(asset *graphquery.InventoryAsset) {
 		return
 	}
 
-	if owner != "" {
+	if ownerNotRequired(*asset) {
+		asset.Accountability = &graphquery.InventoryAccountability{
+			State:   AccountabilityNone,
+			Label:   "Owner not required",
+			Reasons: []graphquery.InventoryReviewReason{{Code: "accountability_not_required", Label: fallback(asset.Attributes[AttributeAccountabilityReason], "Owner not required")}},
+		}
+	} else if owner != "" {
 		asset.Accountability = &graphquery.InventoryAccountability{
 			State:     AccountabilityKnown,
 			Label:     "Owner known",
@@ -285,7 +299,7 @@ func AssetOwner(asset graphquery.InventoryAsset) string {
 }
 
 func AssetOwnerPrincipal(asset graphquery.InventoryAsset) string {
-	return fallback(asset.Attributes["owner"], asset.Attributes["owner_email"], asset.Attributes["assignee"], asset.Attributes["account_manager_email"], asset.Attributes["owner_login"])
+	return fallback(asset.Attributes[AttributeAccountabilityPrincipal], asset.Attributes["owner"], asset.Attributes["owner_email"], asset.Attributes["assignee"], asset.Attributes["account_manager_email"], asset.Attributes["owner_login"])
 }
 
 func AssetOrg(asset graphquery.InventoryAsset) string {
@@ -312,6 +326,9 @@ func ownerRequired(asset graphquery.InventoryAsset) bool {
 	if asset.ScopeState == ScopeStateOutScope || AssetOwnerPrincipal(asset) != "" {
 		return false
 	}
+	if ownerNotRequired(asset) {
+		return false
+	}
 	if attributeTruthy(asset, "owner_required", "requires_owner", "accountability_required") {
 		return true
 	}
@@ -333,6 +350,42 @@ func accountabilityReasons(asset graphquery.InventoryAsset) []graphquery.Invento
 		reasons = append(reasons, graphquery.InventoryReviewReason{Code: "accountability_missing", Label: "Owner missing where required"})
 	}
 	return reasons
+}
+
+func applyAccountabilityAttributes(asset *graphquery.InventoryAsset, attributes map[string]string) {
+	if asset == nil || len(attributes) == 0 {
+		return
+	}
+	if asset.Attributes == nil {
+		asset.Attributes = map[string]string{}
+	}
+	for key, value := range attributes {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			asset.Attributes[key] = trimmed
+		}
+	}
+	state := strings.TrimSpace(attributes[AttributeAccountabilityState])
+	switch state {
+	case AccountabilityKnown:
+		principal := fallback(attributes[AttributeAccountabilityPrincipal], attributes["owner"])
+		if principal != "" {
+			asset.Attributes[AttributeAccountabilityPrincipal] = principal
+			asset.Attributes["owner"] = principal
+			asset.Attributes[AttributeOwnerSource] = AttributeOwnerSourceCerebro
+			asset.Attributes["accountability_required"] = "true"
+		}
+	case AccountabilityNone:
+		asset.Attributes[AttributeOwnerNotRequired] = "true"
+	}
+}
+
+func ownerNotRequired(asset graphquery.InventoryAsset) bool {
+	return strings.TrimSpace(asset.Attributes[AttributeAccountabilityState]) == AccountabilityNone ||
+		attributeTruthy(asset, AttributeOwnerNotRequired)
 }
 
 func attributeTruthy(asset graphquery.InventoryAsset, keys ...string) bool {

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -222,6 +222,7 @@ var exactRouteLabels = map[string]struct{}{
 	"/grc/inventory/assets":                                               {},
 	"/grc/inventory/assets/detail":                                        {},
 	"/grc/inventory/resource-scope":                                       {},
+	"/grc/inventory/accountability":                                       {},
 	"/finding-rules":                                                      {},
 	"/endpoint-vulnerability-findings":                                    {},
 	"/sources":                                                            {},


### PR DESCRIPTION
## Summary
- add POST /grc/inventory/accountability for owner, owner-not-required, and clear decisions
- persist accountability decisions on inventory scope records while preserving existing scope exclusions
- apply accountability attributes before deriving inventory review posture
- require inventory-write scope for accountability mutations
- carry finding workflow metadata in GRC finding items

## Verification
- go test ./...

## Frontend pairing
Pairs with writer/cerebro-web PR for the Inventory UI and workflow writes.