### PR TITLE
Fix AWS collector const duplicate matching

### DIFF
--- a/tools/awscollectorgen/generator_test.go
+++ b/tools/awscollectorgen/generator_test.go
@@ -138,6 +138,37 @@ const familyEC2Instance = "ec2_instance"
 	}
 }
 
+func TestEnsureNotAlreadyWiredAllowsConstNamePrefix(t *testing.T) {
+	root := t.TempDir()
+	awsDir := filepath.Join(root, "sources", "aws")
+	if err := os.MkdirAll(awsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "internal", "sourceprojection"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(awsDir, "source.go"), `package aws
+const familyEC2Instance = "ec2_instance"
+`)
+	write(filepath.Join(awsDir, "fixture.go"), "package aws\n")
+	write(filepath.Join(awsDir, "catalog.yaml"), "")
+	write(filepath.Join(awsDir, "deploy.yaml"), "")
+	write(filepath.Join(root, "internal", "sourceprojection", "registry.go"), "package sourceprojection\n")
+	n, err := deriveNames("ec2_gateway", "", "familyEC2", "awsEC2Gateway", "listEC2Gateways", "ec2GatewayEvent", "", "record.ID", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureNotAlreadyWired(root, awsDir, n); err != nil {
+		t.Fatalf("ensureNotAlreadyWired error = %v, want nil", err)
+	}
+}
+
 func TestValidateFixtures(t *testing.T) {
 	root := t.TempDir()
 	testdata := filepath.Join(root, "sources", "aws", "testdata")

--- a/tools/awscollectorgen/main.go
+++ b/tools/awscollectorgen/main.go
@@ -140,27 +140,38 @@ func safeChildPath(dir, name string) (string, error) {
 
 func ensureNotAlreadyWired(root, awsDir string, n names) error {
 	checks := []struct {
-		path string
-		want string
+		path  string
+		match func(string) bool
 	}{
-		{filepath.Join(awsDir, "source.go"), "= " + strconv.Quote(n.Family)},
-		{filepath.Join(awsDir, "source.go"), n.FamilyConst},
-		{filepath.Join(awsDir, "fixture.go"), n.FamilyConst},
-		{filepath.Join(root, "internal", "sourceprojection", "registry.go"), strconv.Quote(n.Kind) + ":"},
-		{filepath.Join(awsDir, "catalog.yaml"), "- " + n.Kind},
-		{filepath.Join(awsDir, "catalog.yaml"), "- " + n.Family},
-		{filepath.Join(awsDir, "deploy.yaml"), "family: " + n.Family},
+		{filepath.Join(awsDir, "source.go"), containsStringMatcher("= " + strconv.Quote(n.Family))},
+		{filepath.Join(awsDir, "source.go"), containsGoIdentifierMatcher(n.FamilyConst)},
+		{filepath.Join(awsDir, "fixture.go"), containsGoIdentifierMatcher(n.FamilyConst)},
+		{filepath.Join(root, "internal", "sourceprojection", "registry.go"), containsStringMatcher(strconv.Quote(n.Kind) + ":")},
+		{filepath.Join(awsDir, "catalog.yaml"), containsStringMatcher("- " + n.Kind)},
+		{filepath.Join(awsDir, "catalog.yaml"), containsStringMatcher("- " + n.Family)},
+		{filepath.Join(awsDir, "deploy.yaml"), containsStringMatcher("family: " + n.Family)},
 	}
 	for _, check := range checks {
 		body, err := os.ReadFile(check.path)
 		if err != nil {
 			return fmt.Errorf("read %s: %w", check.path, err)
 		}
-		if strings.Contains(string(body), check.want) {
+		if check.match(string(body)) {
 			return fmt.Errorf("family %q already appears in %s", n.Family, check.path)
 		}
 	}
 	return nil
+}
+
+func containsStringMatcher(want string) func(string) bool {
+	return func(body string) bool {
+		return strings.Contains(body, want)
+	}
+}
+
+func containsGoIdentifierMatcher(ident string) func(string) bool {
+	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(ident) + `\b`)
+	return re.MatchString
 }
 
 func validateFixtures(root string, n names) error {


### PR DESCRIPTION
## Summary

Follow-up to #1150. Droid review finished right as #1150 merged and found one real P1: `ensureNotAlreadyWired` used raw substring matching for family const names, so a requested const like `familyEC2` could falsely collide with an existing `familyEC2Instance`.

This changes only the duplicate detection path:
- String-valued family/kind/catalog/deploy checks still use exact string containment.
- Go family const checks now use whole-identifier regex matching.
- Adds a regression test proving `familyEC2` does not falsely collide with `familyEC2Instance` while existing family values are still rejected.

## Test Plan

- `go test ./tools/awscollectorgen -count=1`
- `go test ./tools/awscollectorgen ./tools/archtests -count=1`
- `make lint`
- `make droid-review-sast` (0 changed-line findings)
- `make build`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- This is a narrow follow-up for Droid's P1 on #1150.
- Fast local preflight: `make droid-review-preflight`.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
