### PR TITLE
Add OpenAI admin key preflight guidance

### DIFF
--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -71,6 +71,7 @@ const (
 	anthropicCredentialKindComplianceAccessKey = "compliance_access_key"
 	anthropicCredentialKindOrgAdminOAuth       = "org_admin_oauth"      // #nosec G101 -- credential kind label, not credential material.
 	anthropicCredentialKindScopedAdminAPIKey   = "scoped_admin_api_key" // #nosec G101 -- credential kind label, not credential material.
+	openAICredentialKindAdminAPIKey            = "admin_api_key"
 )
 
 var errConnectorAccessRestricted = errors.New("connector access restricted")
@@ -1649,8 +1650,11 @@ var connectorSchemas = map[string]connectorSchema{
 			"actor_emails",
 			"actor_ids",
 			"api_key_ids",
+			"base_url",
 			"batch",
 			"bucket_width",
+			"credential_kind",
+			"credential_scopes",
 			"effective_at_gt",
 			"effective_at_gte",
 			"effective_at_lt",
@@ -1661,6 +1665,7 @@ var connectorSchemas = map[string]connectorSchema{
 			"group_by",
 			"group_id",
 			"models",
+			"per_page",
 			"project_id",
 			"project_ids",
 			"start_time",
@@ -2469,11 +2474,34 @@ func connectorProviderPreflightChecks(sourceID string, authMethod string, config
 			})
 		}
 		return checks
+	case "openai":
+		return openAIProviderPreflightChecks(config, policy)
 	case "anthropic":
 		return anthropicProviderPreflightChecks(config, policy)
 	default:
 		return nil
 	}
+}
+
+func openAIProviderPreflightChecks(config map[string]string, policy resourcescope.Policy) []connectorPreflightCheckView {
+	family := strings.TrimSpace(config["family"])
+	if family == "" {
+		family = "user"
+	}
+	if policy.ExcludesFamily("openai", family) {
+		return nil
+	}
+	if normalizedCredentialHint(config["credential_kind"]) == openAICredentialKindAdminAPIKey {
+		return nil
+	}
+	return []connectorPreflightCheckView{{
+		ID:         "openai_admin_api_key",
+		Label:      "OpenAI Admin API key",
+		Status:     "warning",
+		Severity:   "warning",
+		Detail:     "OpenAI governance families read Admin API endpoints and require an Admin API key; record credential_kind=admin_api_key when configuring this runtime.",
+		NextAction: "use_openai_admin_api_key",
+	}}
 }
 
 func anthropicProviderPreflightChecks(config map[string]string, policy resourcescope.Policy) []connectorPreflightCheckView {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -1296,6 +1296,26 @@ func TestConnectorSchemaForGenerateableCatalogDefinition(t *testing.T) {
 	if got := strings.Join(jenkinsSchema.RequiredCredentials, ","); got != "password,username" {
 		t.Fatalf("jenkins required credentials = %q, want password,username", got)
 	}
+	openAISchema, ok := connectorSchemaForSource("openai")
+	if !ok {
+		t.Fatal("connectorSchemaForSource(openai) = false, want builtin schema")
+	}
+	for _, key := range []string{"base_url", "credential_kind", "credential_scopes", "per_page"} {
+		if _, ok := openAISchema.ConfigKeys[key]; !ok {
+			t.Fatalf("openai config keys missing %q: %#v", key, sortedSetKeys(openAISchema.ConfigKeys))
+		}
+	}
+	err = validateConnectorConfigFields("openai", connectorAuthMethodExternalReference, map[string]string{ // #nosec G101 -- Test-only credential reference placeholders, not live secrets.
+		"api_key":         "env:CEREBRO_SOURCE_OPENAI_API_KEY",
+		"credential_kind": openAICredentialKindAdminAPIKey,
+		"family":          "audit_log",
+		"per_page":        "100",
+	}, map[string]string{
+		"api_key": "env:CEREBRO_SOURCE_OPENAI_API_KEY",
+	})
+	if err != nil {
+		t.Fatalf("validateConnectorConfigFields(openai credential hints) error = %v", err)
+	}
 	anthropicSchema, ok := connectorSchemaForSource("anthropic")
 	if !ok {
 		t.Fatal("connectorSchemaForSource(anthropic) = false, want builtin schema")
@@ -1315,6 +1335,48 @@ func TestConnectorSchemaForGenerateableCatalogDefinition(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("validateConnectorConfigFields(anthropic credential hints) error = %v", err)
+	}
+}
+
+func TestOpenAIProviderPreflightChecksCredentialRequirements(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]string
+	}{
+		{
+			name:   "default family needs admin key hint",
+			config: map[string]string{},
+		},
+		{
+			name:   "audit log needs admin key hint",
+			config: map[string]string{"credential_kind": "project_token", "family": "audit_log"},
+		},
+		{
+			name:   "project access needs admin key hint",
+			config: map[string]string{"credential_kind": "user_token", "family": "project_user"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checks := connectorProviderPreflightChecks("openai", connectorAuthMethodExternalReference, test.config, resourcescope.Policy{})
+			check := findConnectorPreflightCheck(checks, "openai_admin_api_key")
+			if check == nil {
+				t.Fatalf("openai_admin_api_key check missing from %#v", checks)
+			}
+			if check.Status != "warning" || check.NextAction != "use_openai_admin_api_key" {
+				t.Fatalf("check = %#v, want warning action use_openai_admin_api_key", check)
+			}
+		})
+	}
+}
+
+func TestOpenAIProviderPreflightChecksPassWithAdminKeyHint(t *testing.T) {
+	checks := connectorProviderPreflightChecks("openai", connectorAuthMethodExternalReference, map[string]string{
+		"credential_kind": openAICredentialKindAdminAPIKey,
+		"family":          "audit_log",
+	}, resourcescope.Policy{})
+	if len(checks) != 0 {
+		t.Fatalf("checks = %#v, want none", checks)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow OpenAI connector setup to record non-secret credential hints plus base_url and per_page
- warn during provider preflight when OpenAI governance families are configured without credential_kind=admin_api_key
- add bootstrap tests for OpenAI schema validation and preflight pass/warn paths

## Verification
- go test ./internal/bootstrap
- make lint
- ./scripts/pre_commit_checks.sh