### PR TITLE
fix: Harden AWS collector generator validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ new-aws-collector: ## Wire an implemented AWS collector (FAMILY=foo_bar RECORD_T
 	@test -n "$(LIST_FUNC)" || (echo "LIST_FUNC is required" && exit 1)
 	@test -n "$(EVENT_FUNC)" || (echo "EVENT_FUNC is required" && exit 1)
 	@test -n "$(URN_EXPR)" || (echo "URN_EXPR is required" && exit 1)
-	go run ./tools/awscollectorgen --family="$(FAMILY)" --title="$(TITLE)" --label="$(LABEL)" --const-name="$(CONST_NAME)" --record-type="$(RECORD_TYPE)" --list-func="$(LIST_FUNC)" --event-func="$(EVENT_FUNC)" --urn-expr="$(URN_EXPR)" --cursor-expr="$(CURSOR_EXPR)" --projector="$(PROJECTOR)" $(if $(DRY_RUN),--dry-run,)
+	go run ./tools/awscollectorgen --family="$(FAMILY)" --title="$(TITLE)" --label="$(LABEL)" --const-name="$(CONST_NAME)" --record-type="$(RECORD_TYPE)" --list-func="$(LIST_FUNC)" --event-func="$(EVENT_FUNC)" --urn-type="$(URN_TYPE)" --urn-expr="$(URN_EXPR)" --cursor-expr="$(CURSOR_EXPR)" --projector="$(PROJECTOR)" $(if $(DRY_RUN),--dry-run,)
 
 docs-autogen: openapi-sync proto-generate policy-rule-generate control-index-generate detection-catalog-generate ## Regenerate checked-in generated docs and catalogs.
 

--- a/tools/awscollectorgen/generator.go
+++ b/tools/awscollectorgen/generator.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"go/parser"
 	"regexp"
 	"strconv"
 	"strings"
@@ -9,10 +10,9 @@ import (
 )
 
 var (
-	familyPattern   = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
-	goIdentPattern  = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
-	goTypePattern   = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$`)
-	goExprDenyChars = regexp.MustCompile(`[\r\n;]`)
+	familyPattern  = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
+	goIdentPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	goTypePattern  = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$`)
 )
 
 const (
@@ -37,6 +37,7 @@ type names struct {
 	EventFunc   string
 	Kind        string
 	SchemaRef   string
+	URNType     string
 	Label       string
 	Title       string
 	TitleYAML   string
@@ -45,7 +46,7 @@ type names struct {
 	Projector   string
 }
 
-func deriveNames(family, title, constName, recordType, listFunc, eventFunc, label, urnExpr, cursorExpr, projector string) (names, error) {
+func deriveNames(family, title, constName, recordType, listFunc, eventFunc, label, urnType, urnExpr, cursorExpr, projector string) (names, error) {
 	family = strings.TrimSpace(family)
 	if !familyPattern.MatchString(family) {
 		return names{}, fmt.Errorf("family %q must be lower_snake_case matching %s", family, familyPattern.String())
@@ -66,14 +67,23 @@ func deriveNames(family, title, constName, recordType, listFunc, eventFunc, labe
 	if eventFunc = strings.TrimSpace(eventFunc); !goIdentPattern.MatchString(eventFunc) {
 		return names{}, fmt.Errorf("event func %q must be a Go identifier", eventFunc)
 	}
-	if urnExpr = strings.TrimSpace(urnExpr); urnExpr == "" || goExprDenyChars.MatchString(urnExpr) {
-		return names{}, fmt.Errorf("urn expr must be a non-empty single Go expression")
+	if urnType = strings.TrimSpace(urnType); urnType == "" {
+		urnType = "aws_" + family
+	}
+	if !familyPattern.MatchString(urnType) {
+		return names{}, fmt.Errorf("urn type %q must be lower_snake_case matching %s", urnType, familyPattern.String())
+	}
+	var err error
+	urnExpr, err = validateGoExpr("urn expr", urnExpr)
+	if err != nil {
+		return names{}, err
 	}
 	if cursorExpr = strings.TrimSpace(cursorExpr); cursorExpr == "" {
 		cursorExpr = urnExpr
 	}
-	if goExprDenyChars.MatchString(cursorExpr) {
-		return names{}, fmt.Errorf("cursor expr must be a single Go expression")
+	cursorExpr, err = validateGoExpr("cursor expr", cursorExpr)
+	if err != nil {
+		return names{}, err
 	}
 	if projector = strings.TrimSpace(projector); projector == "" {
 		projector = "awsCloudResourceProjections"
@@ -100,6 +110,7 @@ func deriveNames(family, title, constName, recordType, listFunc, eventFunc, labe
 		EventFunc:   eventFunc,
 		Kind:        "aws." + family,
 		SchemaRef:   "aws/" + family + "/v1",
+		URNType:     urnType,
 		Label:       label,
 		Title:       title,
 		TitleYAML:   strconv.Quote(title),
@@ -107,6 +118,17 @@ func deriveNames(family, title, constName, recordType, listFunc, eventFunc, labe
 		CursorExpr:  cursorExpr,
 		Projector:   projector,
 	}, nil
+}
+
+func validateGoExpr(name, expr string) (string, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return "", fmt.Errorf("%s must be a non-empty Go expression", name)
+	}
+	if _, err := parser.ParseExpr(expr); err != nil {
+		return "", fmt.Errorf("%s must be a valid Go expression: %w", name, err)
+	}
+	return expr, nil
 }
 
 func pascalCase(family string) string {
@@ -124,7 +146,7 @@ var registerTemplate = template.Must(template.New("register").Parse(`		awsFamily
 			List:  {{.ListFunc}},
 			Event: {{.EventFunc}},
 			URN: func(settings settings, record {{.RecordType}}) (string, error) {
-				return fmt.Sprintf("urn:cerebro:%s:{{.Family}}:%s", settings.accountID, {{.URNExpr}}), nil
+				return fmt.Sprintf("urn:cerebro:%s:{{.URNType}}:%s", settings.accountID, {{.URNExpr}}), nil
 			},
 			CursorFallback: func(record {{.RecordType}}) string { return {{.CursorExpr}} },
 		}),`))

--- a/tools/awscollectorgen/generator_test.go
+++ b/tools/awscollectorgen/generator_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDeriveNames(t *testing.T) {
-	n, err := deriveNames("ec2_transit_gateway", "AWS EC2: Transit gateways", "familyEC2TransitGateway", "awsEC2TransitGateway", "listEC2TransitGateways", "ec2TransitGatewayEvent", "aws ec2 transit gateways", "record.ID", "record.Name", "")
+	n, err := deriveNames("ec2_transit_gateway", "AWS EC2: Transit gateways", "familyEC2TransitGateway", "awsEC2TransitGateway", "listEC2TransitGateways", "ec2TransitGatewayEvent", "aws ec2 transit gateways", "", "record.ID", "record.Name", "")
 	if err != nil {
 		t.Fatalf("deriveNames error = %v", err)
 	}
@@ -20,6 +20,7 @@ func TestDeriveNames(t *testing.T) {
 		"EventFunc":   "ec2TransitGatewayEvent",
 		"Kind":        "aws.ec2_transit_gateway",
 		"SchemaRef":   "aws/ec2_transit_gateway/v1",
+		"URNType":     "aws_ec2_transit_gateway",
 		"TitleYAML":   `"AWS EC2: Transit gateways"`,
 		"CursorExpr":  "record.Name",
 		"Projector":   "awsCloudResourceProjections",
@@ -27,7 +28,7 @@ func TestDeriveNames(t *testing.T) {
 	got := map[string]string{
 		"Pascal": n.Pascal, "FamilyConst": n.FamilyConst, "RecordType": n.RecordType,
 		"ListFunc": n.ListFunc, "EventFunc": n.EventFunc, "Kind": n.Kind,
-		"SchemaRef": n.SchemaRef, "TitleYAML": n.TitleYAML, "CursorExpr": n.CursorExpr,
+		"SchemaRef": n.SchemaRef, "URNType": n.URNType, "TitleYAML": n.TitleYAML, "CursorExpr": n.CursorExpr,
 		"Projector": n.Projector,
 	}
 	for field, want := range cases {
@@ -42,14 +43,16 @@ func TestDeriveNamesRejectsInvalid(t *testing.T) {
 		name string
 		args []string
 	}{
-		{name: "family", args: []string{"EC2", "title", "familyEC2", "awsRecord", "listRecords", "recordEvent", "label", "record.ID", "", ""}},
-		{name: "record type", args: []string{"ec2_gateway", "title", "familyEC2Gateway", "aws-record", "listRecords", "recordEvent", "label", "record.ID", "", ""}},
-		{name: "list func", args: []string{"ec2_gateway", "title", "familyEC2Gateway", "awsRecord", "list-records", "recordEvent", "label", "record.ID", "", ""}},
-		{name: "urn expr", args: []string{"ec2_gateway", "title", "familyEC2Gateway", "awsRecord", "listRecords", "recordEvent", "label", "record.ID; panic()", "", ""}},
-		{name: "title newline", args: []string{"ec2_gateway", "bad\ntitle", "familyEC2Gateway", "awsRecord", "listRecords", "recordEvent", "label", "record.ID", "", ""}},
+		{name: "family", args: []string{"EC2", "title", "familyEC2", "awsRecord", "listRecords", "recordEvent", "label", "", "record.ID", "", ""}},
+		{name: "record type", args: []string{"ec2_gateway", "title", "familyEC2Gateway", "aws-record", "listRecords", "recordEvent", "label", "", "record.ID", "", ""}},
+		{name: "list func", args: []string{"ec2_gateway", "title", "familyEC2Gateway", "awsRecord", "list-records", "recordEvent", "label", "", "record.ID", "", ""}},
+		{name: "urn type", args: []string{"ec2_gateway", "title", "familyEC2Gateway", "awsRecord", "listRecords", "recordEvent", "label", "aws-ec2-gateway", "record.ID", "", ""}},
+		{name: "urn expr", args: []string{"ec2_gateway", "title", "familyEC2Gateway", "awsRecord", "listRecords", "recordEvent", "label", "", "record.ID; panic()", "", ""}},
+		{name: "cursor expr", args: []string{"ec2_gateway", "title", "familyEC2Gateway", "awsRecord", "listRecords", "recordEvent", "label", "", "record.ID", "record.ID, record.Name", ""}},
+		{name: "title newline", args: []string{"ec2_gateway", "bad\ntitle", "familyEC2Gateway", "awsRecord", "listRecords", "recordEvent", "label", "", "record.ID", "", ""}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := deriveNames(tt.args[0], tt.args[1], tt.args[2], tt.args[3], tt.args[4], tt.args[5], tt.args[6], tt.args[7], tt.args[8], tt.args[9]); err == nil {
+			if _, err := deriveNames(tt.args[0], tt.args[1], tt.args[2], tt.args[3], tt.args[4], tt.args[5], tt.args[6], tt.args[7], tt.args[8], tt.args[9], tt.args[10]); err == nil {
 				t.Fatal("expected error, got nil")
 			}
 		})
@@ -67,7 +70,7 @@ func TestRenderRegisterSnippet(t *testing.T) {
 		"Name:  familyDemoWidget,",
 		"List:  listDemoWidgets,",
 		"Event: demoWidgetEvent,",
-		`urn:cerebro:%s:demo_widget:%s`,
+		`urn:cerebro:%s:aws_demo_widget:%s`,
 		"record.ID",
 		"CursorFallback: func(record awsDemoWidget) string { return record.Name }",
 	} {
@@ -129,7 +132,7 @@ const familyEC2Instance = "ec2_instance"
 	write(filepath.Join(awsDir, "catalog.yaml"), "")
 	write(filepath.Join(awsDir, "deploy.yaml"), "")
 	write(filepath.Join(root, "internal", "sourceprojection", "registry.go"), "package sourceprojection\n")
-	n, err := deriveNames("ec2_instance", "", "familyEc2Instance", "awsEC2Instance", "listEC2Instances", "ec2InstanceEvent", "", "record.ID", "", "")
+	n, err := deriveNames("ec2_instance", "", "familyEc2Instance", "awsEC2Instance", "listEC2Instances", "ec2InstanceEvent", "", "", "record.ID", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +163,49 @@ const familyEC2Instance = "ec2_instance"
 	write(filepath.Join(awsDir, "catalog.yaml"), "")
 	write(filepath.Join(awsDir, "deploy.yaml"), "")
 	write(filepath.Join(root, "internal", "sourceprojection", "registry.go"), "package sourceprojection\n")
-	n, err := deriveNames("ec2_gateway", "", "familyEC2", "awsEC2Gateway", "listEC2Gateways", "ec2GatewayEvent", "", "record.ID", "", "")
+	n, err := deriveNames("ec2_gateway", "", "familyEC2", "awsEC2Gateway", "listEC2Gateways", "ec2GatewayEvent", "", "", "record.ID", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureNotAlreadyWired(root, awsDir, n); err != nil {
+		t.Fatalf("ensureNotAlreadyWired error = %v, want nil", err)
+	}
+}
+
+func TestEnsureNotAlreadyWiredAllowsYAMLPrefixValues(t *testing.T) {
+	root := t.TempDir()
+	awsDir := filepath.Join(root, "sources", "aws")
+	if err := os.MkdirAll(awsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "internal", "sourceprojection"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(awsDir, "source.go"), `package aws
+const familyS3Bucket = "s3_bucket"
+`)
+	write(filepath.Join(awsDir, "fixture.go"), "package aws\n")
+	write(filepath.Join(awsDir, "catalog.yaml"), `emitted:
+  - aws.s3_bucket
+runtime:
+  - s3_bucket
+`)
+	write(filepath.Join(awsDir, "deploy.yaml"), `sources:
+  - localId: s3-bucket
+    config:
+      family: s3_bucket
+`)
+	write(filepath.Join(root, "internal", "sourceprojection", "registry.go"), `package sourceprojection
+var registry = map[string]any{
+	"aws.s3_bucket": projector,
+}`)
+	n, err := deriveNames("s3", "", "familyS3", "awsS3", "listS3", "s3Event", "", "", "record.ID", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,16 +226,35 @@ func TestValidateFixtures(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	write("discover_demo_widget.json", `["urn:cerebro:123456789012:demo_widget:demo-1"]`)
+	write("discover_demo_widget.json", `["urn:cerebro:123456789012:aws_demo_widget:demo-1"]`)
 	write("read_demo_widget.json", `[{"id":"aws-demo-widget-demo-1","tenant_id":"123456789012","source_id":"aws","kind":"aws.demo_widget","occurred_at":"2025-01-01T00:00:00Z","schema_ref":"aws/demo_widget/v1","payload":{"id":"demo-1"},"attributes":{"resource_id":"demo-1"}}]`)
 	if err := validateFixtures(root, mustNames(t)); err != nil {
 		t.Fatalf("validateFixtures error = %v", err)
 	}
 }
 
+func TestValidateFixturesRejectsUnexpectedURNType(t *testing.T) {
+	root := t.TempDir()
+	testdata := filepath.Join(root, "sources", "aws", "testdata")
+	if err := os.MkdirAll(testdata, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(testdata, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("discover_demo_widget.json", `["urn:cerebro:123456789012:demo_widget:demo-1"]`)
+	write("read_demo_widget.json", `[{"id":"aws-demo-widget-demo-1","tenant_id":"123456789012","source_id":"aws","kind":"aws.demo_widget","occurred_at":"2025-01-01T00:00:00Z","schema_ref":"aws/demo_widget/v1","payload":{"id":"demo-1"},"attributes":{"resource_id":"demo-1"}}]`)
+	if err := validateFixtures(root, mustNames(t)); err == nil || !strings.Contains(err.Error(), "resource type") {
+		t.Fatalf("validateFixtures error = %v, want resource type", err)
+	}
+}
+
 func mustNames(t *testing.T) names {
 	t.Helper()
-	n, err := deriveNames("demo_widget", "AWS Demo: widgets", "familyDemoWidget", "awsDemoWidget", "listDemoWidgets", "demoWidgetEvent", "aws demo widgets", "record.ID", "record.Name", "")
+	n, err := deriveNames("demo_widget", "AWS Demo: widgets", "familyDemoWidget", "awsDemoWidget", "listDemoWidgets", "demoWidgetEvent", "aws demo widgets", "", "record.ID", "record.Name", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/awscollectorgen/main.go
+++ b/tools/awscollectorgen/main.go
@@ -42,6 +42,7 @@ func run(args []string) error {
 	recordType := flags.String("record-type", "", "record type used by awsFamilyOptions[T]")
 	listFunc := flags.String("list-func", "", "implemented list function name")
 	eventFunc := flags.String("event-func", "", "implemented event function name")
+	urnType := flags.String("urn-type", "", "URN resource type; defaults to aws_<family>")
 	urnExpr := flags.String("urn-expr", "", "Go expression that returns the record resource id string, evaluated with record/settings in scope")
 	cursorExpr := flags.String("cursor-expr", "", "Go expression for CursorFallback; defaults to --urn-expr")
 	projector := flags.String("projector", "awsCloudResourceProjections", "sourceprojection projector function")
@@ -50,7 +51,7 @@ func run(args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
-	n, err := deriveNames(*family, *title, *constName, *recordType, *listFunc, *eventFunc, *label, *urnExpr, *cursorExpr, *projector)
+	n, err := deriveNames(*family, *title, *constName, *recordType, *listFunc, *eventFunc, *label, *urnType, *urnExpr, *cursorExpr, *projector)
 	if err != nil {
 		return err
 	}
@@ -147,9 +148,9 @@ func ensureNotAlreadyWired(root, awsDir string, n names) error {
 		{filepath.Join(awsDir, "source.go"), containsGoIdentifierMatcher(n.FamilyConst)},
 		{filepath.Join(awsDir, "fixture.go"), containsGoIdentifierMatcher(n.FamilyConst)},
 		{filepath.Join(root, "internal", "sourceprojection", "registry.go"), containsStringMatcher(strconv.Quote(n.Kind) + ":")},
-		{filepath.Join(awsDir, "catalog.yaml"), containsStringMatcher("- " + n.Kind)},
-		{filepath.Join(awsDir, "catalog.yaml"), containsStringMatcher("- " + n.Family)},
-		{filepath.Join(awsDir, "deploy.yaml"), containsStringMatcher("family: " + n.Family)},
+		{filepath.Join(awsDir, "catalog.yaml"), containsYAMLListEntryMatcher(n.Kind)},
+		{filepath.Join(awsDir, "catalog.yaml"), containsYAMLListEntryMatcher(n.Family)},
+		{filepath.Join(awsDir, "deploy.yaml"), containsYAMLMappingValueMatcher("family", n.Family)},
 	}
 	for _, check := range checks {
 		body, err := os.ReadFile(check.path)
@@ -174,6 +175,16 @@ func containsGoIdentifierMatcher(ident string) func(string) bool {
 	return re.MatchString
 }
 
+func containsYAMLListEntryMatcher(value string) func(string) bool {
+	re := regexp.MustCompile(`(?m)^\s*-\s+` + regexp.QuoteMeta(value) + `\s*(?:#.*)?$`)
+	return re.MatchString
+}
+
+func containsYAMLMappingValueMatcher(key, value string) func(string) bool {
+	re := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(key) + `:\s+` + regexp.QuoteMeta(value) + `\s*(?:#.*)?$`)
+	return re.MatchString
+}
+
 func validateFixtures(root string, n names) error {
 	fsys := os.DirFS(root)
 	discoverPath := filepath.ToSlash(filepath.Join("sources", "aws", "testdata", "discover_"+n.Family+".json"))
@@ -184,6 +195,12 @@ func validateFixtures(root string, n names) error {
 	}
 	if len(urns) == 0 {
 		return fmt.Errorf("%s must contain at least one URN", discoverPath)
+	}
+	expectedURNType := ":" + n.URNType + ":"
+	for _, urn := range urns {
+		if !strings.Contains(urn.String(), expectedURNType) {
+			return fmt.Errorf("%s urn %q must use resource type %q", discoverPath, urn, n.URNType)
+		}
 	}
 	events, err := sourcecdk.LoadFixtureEvents(fsys, readPath)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Default AWS collector generator URNs to the established `aws_<family>` resource type, with an optional `--urn-type` override.
- Validate `--urn-expr` and `--cursor-expr` with Go expression parsing instead of character deny-lists.
- Tighten duplicate detection for YAML list/mapping entries and validate discover fixture URNs use the configured resource type.

## Test Plan

- `go test ./tools/awscollectorgen -count=1`
- `make droid-review-sast`
- `go run ./tools/catalogcheck`
- `go test ./tools/awscollectorgen ./tools/archtests -count=1`
- `make lint`
- `make test`
- `make build`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
