### PR TITLE
Document GRC inventory bootstrap budget

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,6 +107,10 @@ Inventory accountability and source-connector setup remain bootstrap-boundary
 work for now. The budget includes GRC inventory request/response mapping and
 tenant authorization that compose existing inventory data for review workflows;
 durable inventory semantics stay behind the inventory and compliance packages.
+The accountability write endpoints also stay in bootstrap while they are limited
+to tenant-enforced request decoding, persistence-store wiring, and response
+mapping for operator decisions; posture classification and inventory filtering
+remain in `internal/grcinventory`.
 The budget also includes connector setup metadata for source runtime config
 validation, including richer OpenAI and Anthropic family/filter keys. That
 metadata belongs at the connector API boundary until connector setup schemas are

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const bootstrapProductionGoLineBudget = 22984
+const bootstrapProductionGoLineBudget = 23042
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- bump the bootstrap production LOC budget to the current post-GRC-inventory size
- document why the accountability write endpoint mapping remains in bootstrap while domain behavior stays in grcinventory

## Verification
- make check-structural check-structural-test check-arch