### PR TITLE
Deepen Cerebro wide-event telemetry

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -241,7 +241,7 @@ func startGRCReadModelWarmup(ctx context.Context, stateStore ports.StateStore, l
 	go func() {
 		defer close(done)
 		_, hasPreparer := stateStore.(grcReadModelPreparer)
-		ctx, span := telemetry.Start(ctx, "grc.read_model_warmup", telemetry.Attrs(
+		ctx, span := telemetry.StartMain(ctx, "grc.read_model_warmup", telemetry.Attrs(
 			telemetry.Field{Key: "preparer_present", Value: hasPreparer},
 		))
 		status := "completed"
@@ -266,7 +266,7 @@ func startGRCReadModelWarmup(ctx context.Context, stateStore ports.StateStore, l
 func startFindingRiskBackfill(ctx context.Context, backfiller findingRiskBackfiller, logf func(string, ...any)) <-chan struct{} {
 	done := make(chan struct{})
 	if backfiller == nil {
-		_, span := telemetry.Start(ctx, "finding.risk_backfill", telemetry.Attrs(
+		_, span := telemetry.StartMain(ctx, "finding.risk_backfill", telemetry.Attrs(
 			telemetry.Field{Key: "backfiller_present", Value: false},
 		))
 		telemetry.End(span, "skipped", telemetry.Attrs(telemetry.Field{Key: "backfiller_present", Value: false}))
@@ -275,7 +275,7 @@ func startFindingRiskBackfill(ctx context.Context, backfiller findingRiskBackfil
 	}
 	go func() {
 		defer close(done)
-		ctx, span := telemetry.Start(ctx, "finding.risk_backfill", telemetry.Attrs(
+		ctx, span := telemetry.StartMain(ctx, "finding.risk_backfill", telemetry.Attrs(
 			telemetry.Field{Key: "backfiller_present", Value: true},
 		))
 		status := "completed"

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -221,7 +221,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		return nil, fmt.Errorf("configure telemetry: %w", err)
 	}
 	defer shutdownTelemetry(orchestratorShutdownContext(options, ctx), closeTelemetry, cfg.ShutdownTimeout)
-	ctx, span := telemetry.Start(ctx, "orchestrator.run", telemetry.Attrs(
+	ctx, span := telemetry.StartMain(ctx, "orchestrator.run", telemetry.Attrs(
 		telemetryField("runtime_id", options.Filter.RuntimeID),
 		telemetryField("tenant_id", options.Filter.TenantID),
 		telemetryField("source_id", options.Filter.SourceID),
@@ -239,8 +239,9 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 	defer func() {
 		if err != nil {
 			status = "failed"
-			spanAttributes = withTelemetryField(spanAttributes, "error", err.Error())
+			spanAttributes = withTelemetryField(spanAttributes, "error_kind", telemetry.ErrorKind(err))
 		}
+		telemetry.AnnotateMain(ctx, spanAttributes.WithField(telemetry.Field{Key: "orchestrator.status", Value: status}))
 		telemetry.End(span, status, spanAttributes)
 	}()
 	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
@@ -312,7 +313,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		}
 		select {
 		case <-ctx.Done():
-			spanAttributes = withTelemetryField(spanAttributes, "error", ctx.Err().Error())
+			spanAttributes = withTelemetryField(spanAttributes, "error_kind", telemetry.ErrorKind(ctx.Err()))
 			return result, ctx.Err()
 		case <-ticker.C:
 		}
@@ -320,7 +321,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 	status = "completed"
 	if runErr != nil {
 		status = "failed"
-		spanAttributes = withTelemetryField(spanAttributes, "error", runErr.Error())
+		spanAttributes = withTelemetryField(spanAttributes, "error_kind", telemetry.ErrorKind(runErr))
 	}
 	spanAttributes = withTelemetryField(spanAttributes, "iterations_completed", iteration)
 	return result, runErr
@@ -415,7 +416,7 @@ func runOrchestratorIteration(
 	runtimes, err := lister.ListSourceRuntimes(ctx, orchestratorListFilter(options.Filter))
 	result := &orchestratorIterationResult{Iteration: iteration, StartedAt: time.Now().UTC()}
 	if err != nil {
-		spanAttributes = withTelemetryField(spanAttributes, "error", err.Error())
+		spanAttributes = withTelemetryField(spanAttributes, "error_kind", telemetry.ErrorKind(err))
 		return result, err
 	}
 	telemetry.Event(ctx, "orchestrator.runtimes_listed", telemetry.Attrs(
@@ -430,7 +431,7 @@ func runOrchestratorIteration(
 		}
 		select {
 		case <-ctx.Done():
-			spanAttributes = withTelemetryField(spanAttributes, "error", ctx.Err().Error())
+			spanAttributes = withTelemetryField(spanAttributes, "error_kind", telemetry.ErrorKind(ctx.Err()))
 			return result, ctx.Err()
 		default:
 		}
@@ -458,7 +459,8 @@ func runOrchestratorIteration(
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "lease", err)
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			runErr = err
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error", err.Error())
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_stage", "lease")
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_kind", telemetry.ErrorKind(err))
 			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		}
@@ -479,17 +481,18 @@ func runOrchestratorIteration(
 			runtimeResult.Sync = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "sync", err)
 			runErr = err
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error", err.Error())
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_stage", "sync")
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_kind", telemetry.ErrorKind(err))
 			cancelRuntime()
 			if renewalErr := stopLeaseRenewal(); renewalErr != nil {
 				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", renewalErr)
 				runErr = renewalErr
-				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error", renewalErr.Error())
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error_kind", telemetry.ErrorKind(renewalErr))
 			}
 			if releaseErr := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); releaseErr != nil {
 				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", releaseErr)
 				runErr = releaseErr
-				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error", releaseErr.Error())
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error_kind", telemetry.ErrorKind(releaseErr))
 			}
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
@@ -521,7 +524,7 @@ func runOrchestratorIteration(
 			runtimeResult.GraphIngest = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
 			runErr = err
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_error", err.Error())
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_error_kind", telemetry.ErrorKind(err))
 		} else {
 			runtimeResult.GraphIngest = "completed"
 		}
@@ -531,12 +534,12 @@ func runOrchestratorIteration(
 		if err != nil {
 			if errors.Is(err, findings.ErrRuleUnavailable) {
 				runtimeResult.FindingRules = "skipped"
-				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_rules_skip_reason", err.Error())
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_rules_skip_reason", "rule_unavailable")
 			} else {
 				runtimeResult.FindingRules = "failed"
 				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "finding_rules", err)
 				runErr = err
-				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_rules_error", err.Error())
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_rules_error_kind", telemetry.ErrorKind(err))
 			}
 		} else {
 			runtimeResult.FindingRules = "completed"
@@ -556,12 +559,12 @@ func runOrchestratorIteration(
 			if err != nil {
 				if errors.Is(err, findings.ErrGraphRuntimeUnavailable) || errors.Is(err, findings.ErrRuntimeUnavailable) {
 					runtimeResult.GraphRules = "skipped"
-					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_skip_reason", err.Error())
+					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_skip_reason", "runtime_unavailable")
 				} else {
 					runtimeResult.GraphRules = "failed"
 					runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_rules", err)
 					runErr = err
-					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_error", err.Error())
+					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_error_kind", telemetry.ErrorKind(err))
 				}
 			} else {
 				runtimeResult.GraphRules = "completed"
@@ -574,26 +577,26 @@ func runOrchestratorIteration(
 		if err := stopLeaseRenewal(); err != nil {
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", err)
 			runErr = err
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error", err.Error())
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error_kind", telemetry.ErrorKind(err))
 		}
 		if err := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); err != nil {
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", err)
 			runErr = err
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error", err.Error())
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error_kind", telemetry.ErrorKind(err))
 		}
 		result.Runtimes = append(result.Runtimes, runtimeResult)
 		if runtimeResult.Error == "" {
 			runtimeStatus = "completed"
 		}
 		if runtimeResult.Error != "" {
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error", runtimeResult.Error)
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "runtime_error_present", true)
 		}
 		telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 	}
 	status = "completed"
 	if runErr != nil {
 		status = "failed"
-		spanAttributes = withTelemetryField(spanAttributes, "error", runErr.Error())
+		spanAttributes = withTelemetryField(spanAttributes, "error_kind", telemetry.ErrorKind(runErr))
 	}
 	spanAttributes = withTelemetryField(spanAttributes, "runtimes_attempted", len(result.Runtimes))
 	spanAttributes = withTelemetryField(spanAttributes, "runtimes_acquired", acquiredCount)
@@ -630,7 +633,7 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 	endAttrs := telemetry.Attrs()
 	if err != nil {
 		status = "failed"
-		endAttrs = withTelemetryField(endAttrs, "error", err.Error())
+		endAttrs = withTelemetryField(endAttrs, "error_kind", telemetry.ErrorKind(err))
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(phaseCtx.Err(), context.DeadlineExceeded) {
 			endAttrs = withTelemetryField(endAttrs, "timeout_exceeded", true)
 		}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,6 +71,14 @@ the long-running reasoning pipeline. That deadline is owned by `net/http` and
 the response writer, so the hook belongs in bootstrap instead of the graphagent
 domain package.
 
+The budget includes request-boundary wide-event annotations for auth, OAuth,
+MCP, GRC dashboard, and GRC ask handlers. These annotations stay in bootstrap
+because they combine HTTP status, response-writer timing, route shape, and
+authenticated principal posture before control enters a domain package. Domain
+operation counts still live behind their owning source, graph, cache, store,
+and findings packages and only annotate the active main span through the shared
+telemetry helper.
+
 The budget also includes the A2A gateway adapter that maps authenticated tenant
 context, the platform job store, coverage context, and evidence authorizers into
 `internal/a2agateway`. Durable task lifecycle behavior stays in that domain

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -8,15 +8,46 @@ Cerebro emits three layers of operational signal:
 
 The structured JSON and OTEL spans share the same trace context where possible. HTTP responses include `X-Cerebro-Trace-Id` so operators can pivot from the web UI or API response to logs and traces.
 
-## Trace Contract
+## Wide Event Contract
 
-Inbound HTTP requests create an OTEL `http.server` span with bounded attributes:
+Cerebro follows a wide-event model for request and job debugging. Each top-level
+unit of work emits one canonical span/event with:
 
-- `http.request.method`
-- `http.route`
-- `http.response.status_code`
+- `main=true`
+- `wide_event=true`
+- service, deployment, runtime, host, cloud, and container metadata
+- request/job shape
+- auth/customer posture
+- downstream cache, database, queue, graph, source, LLM, MCP, and domain counts
+- final status, duration, and bounded error kind
 
-The route label is normalized before emission. Unknown or dynamic paths are collapsed to route families such as `/platform/jobs/{jobID}/events` or `/{unmatched}`.
+Use `main=true` as the primary query predicate when asking "what happened to
+this request/job?" Child spans remain available for drill-down, but shared
+service methods annotate the active main span so the first query has the full
+shape.
+
+Inbound HTTP requests create a main OTEL `http.server` span. The route label is
+normalized before emission. Unknown or dynamic paths are collapsed to route
+families such as `/platform/jobs/{jobID}/events` or `/{unmatched}`. Query values,
+authorization headers, cookies, request bodies, response bodies, DSNs, and raw
+errors are not emitted.
+
+Expected HTTP dimensions include:
+
+- `http.request.method`, `http.route`, `url.path_depth`, `url.query.param_count`, `url.query.keys`
+- `url.scheme`, `server.address`, `server.port`, `network.protocol.version`
+- `http.request.body.size`, selected safe request header values, header-presence booleans
+- `user_agent.family`, `client.address_hash`
+- `http.response.status_code`, `http.response.body.size`, selected safe response header values
+
+Expected propagated dimensions include:
+
+- Auth: `tenant_id`, `auth.outcome`, `auth.mode`, `auth.credential_tier`, `auth.risk_level`, `auth.denial_reason`
+- MCP/OAuth: `mcp.method`, `mcp.tool`, `mcp.tool_family`, `mcp.outcome`, `oauth.operation`, `oauth.grant_type`
+- GRC/LLM: `grc.ask.llm.provider`, `grc.ask.query_plan.intent`, `grc.ask.row_count`, stage timing fields
+- Stores: `cache.redis.*.count`, `db.postgres.*.count`, `db.neo4j.*.count`
+- Messaging/source/graph: `messaging.jetstream.*.count`, `source_runtime.*`, `source.operation.*`, `graph.ingest.*`
+- Domain outcomes: `source_projection.*`, `finding_candidate.*`, `finding_evaluation.*`
 
 Core runtime operations emit structured spans:
 
@@ -69,7 +100,7 @@ Cerebro enables OTEL export when `CEREBRO_OTEL_ENABLED=true` or when an OTLP end
 Run focused tests for the observability surface:
 
 ```sh
-go test ./internal/telemetry ./internal/observability ./internal/sourcehttp ./internal/bootstrap ./internal/querycache ./internal/statestore/postgres ./internal/graphstore/neo4j ./internal/appendlog/jetstream
+go test ./internal/telemetry ./internal/observability ./internal/sourcehttp ./internal/bootstrap ./internal/querycache ./internal/statestore/postgres ./internal/graphstore/neo4j ./internal/appendlog/jetstream ./internal/sourceops ./internal/sourceruntime ./internal/sourceprojection ./internal/graphingest ./internal/findings ./cmd/cerebro
 ```
 
 Run the full suite before release:
@@ -92,4 +123,5 @@ Then hit `/health` and one API route. Confirm:
 
 - the response includes `X-Cerebro-Trace-Id`;
 - stderr contains parseable JSON span/event lines;
+- the top-level request/job span has `main=true` and `wide_event=true`;
 - the collector receives `http.server` plus downstream child spans for any work performed.

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -170,6 +170,7 @@ func (l *Log) Ping(ctx context.Context) error {
 			return err
 		}
 	}
+	jetstreamAnnotateMain(ctx, "ping", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return nil
 }
@@ -221,6 +222,7 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 		jetstreamTelemetryError(ctx, span, "append", err)
 		return err
 	}
+	jetstreamAnnotateMain(ctx, "append", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs(telemetry.Field{Key: "payload_bytes", Value: len(payload)}))
 	return nil
 }
@@ -317,6 +319,7 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	}
 	candidates := make([]replayCandidate, 0, limit)
 	if stream.State.LastSeq == 0 || stream.State.LastSeq < stream.State.FirstSeq {
+		jetstreamAnnotateMain(ctx, "replay", "completed")
 		telemetry.End(span, "completed", telemetry.Attrs(telemetry.Field{Key: "events_returned", Value: 0}))
 		return nil, nil
 	}
@@ -364,6 +367,7 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	for _, candidate := range candidates {
 		events = append(events, candidate.event)
 	}
+	jetstreamAnnotateMain(ctx, "replay", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs(telemetry.Field{Key: "events_returned", Value: len(events)}))
 	return events, nil
 }
@@ -377,12 +381,24 @@ func jetstreamTelemetryAttrs(operation string) telemetry.Attributes {
 }
 
 func jetstreamTelemetryError(ctx context.Context, span *telemetry.Span, operation string, err error) {
+	jetstreamAnnotateMain(ctx, operation, "failed")
 	attrs := telemetry.Attrs(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 	telemetry.CaptureError(ctx, "jetstream.error", err, telemetry.Attrs(
 		telemetry.Field{Key: "component", Value: "appendlog.jetstream"},
 		telemetry.Field{Key: "operation", Value: operation},
 	))
 	telemetry.End(span, "failed", attrs)
+}
+
+func jetstreamAnnotateMain(ctx context.Context, operation string, status string) {
+	telemetry.IncrementMain(ctx, "messaging.jetstream.operation.count", 1)
+	if status == "failed" {
+		telemetry.IncrementMain(ctx, "messaging.jetstream.error.count", 1)
+	}
+	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+		telemetry.Field{Key: "messaging.jetstream.last_operation", Value: strings.TrimSpace(operation)},
+		telemetry.Field{Key: "messaging.jetstream.last_status", Value: strings.TrimSpace(status)},
+	))
 }
 
 func countAtLeastUint32(count int, limit uint32) bool {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -7611,9 +7611,23 @@ func decodeBootstrapTelemetryPayload(t *testing.T, stderr string) map[string]any
 	if len(lines) == 0 || strings.TrimSpace(lines[0]) == "" {
 		t.Fatal("telemetry stderr is empty")
 	}
-	payload := map[string]any{}
-	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &payload); err != nil {
-		t.Fatalf("unmarshal telemetry payload %q: %v", lines[len(lines)-1], err)
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		payload := map[string]any{}
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			t.Fatalf("unmarshal telemetry payload %q: %v", line, err)
+		}
+		if payload["name"] == "http.server" {
+			continue
+		}
+		if payload["kind"] == "span_start" {
+			continue
+		}
+		return payload
 	}
-	return payload
+	t.Fatalf("non-http telemetry payload not found in stderr: %s", stderr)
+	return nil
 }

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -1006,6 +1006,67 @@ func emitAccessAuditEvent(r *http.Request, origin requestOrigin, principal authP
 		attrs = attrs.WithField(telemetry.Field{Key: "denial_reason", Value: denialReason})
 	}
 	telemetry.Event(r.Context(), "cerebro.api.access", attrs)
+	telemetry.IncrementMain(r.Context(), "auth.access.count", 1)
+	if accessAuditOutcomeFailed(outcome) {
+		telemetry.IncrementMain(r.Context(), "auth.access.denied.count", 1)
+	}
+	mainAttrs := telemetry.Attrs(
+		telemetry.Field{Key: "auth.outcome", Value: outcome},
+		telemetry.Field{Key: "auth.status_code", Value: status},
+		telemetry.Field{Key: "auth.effective_status_code", Value: effectiveStatusCode},
+		telemetry.Field{Key: "auth.operation_family", Value: operation.Family},
+		telemetry.Field{Key: "auth.operation_type", Value: operation.Type},
+		telemetry.Field{Key: "auth.sensitive_action", Value: operation.SensitiveAction},
+		telemetry.Field{Key: "auth.duration_ms", Value: duration.Milliseconds()},
+		telemetry.Field{Key: "auth.principal.present", Value: strings.TrimSpace(principal.Name) != ""},
+		telemetry.Field{Key: "auth.client.present", Value: strings.TrimSpace(principal.ClientID) != ""},
+		telemetry.Field{Key: "auth.device.present", Value: strings.TrimSpace(principal.DeviceID) != ""},
+	)
+	if tenantID := firstNonEmpty(requestedTenantID, principalTenantID); tenantID != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "tenant_id", Value: tenantID})
+	}
+	if effectiveTenantID := firstNonEmpty(principalTenantID, requestedTenantID); effectiveTenantID != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.effective_tenant_id", Value: effectiveTenantID})
+	}
+	if requestedTenantID != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.requested_tenant_id", Value: requestedTenantID})
+	}
+	if principalTenantID != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.principal_tenant_id", Value: principalTenantID})
+	}
+	if requestedTenantID != "" && principalTenantID != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.tenant_mismatch", Value: requestedTenantID != principalTenantID})
+	}
+	if principal.AuthMode != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.mode", Value: principal.AuthMode})
+	}
+	if tier := accessAuditCredentialTier(principal); tier != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.credential_tier", Value: tier})
+	}
+	if principal.AssuranceLevel != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.assurance_level", Value: principal.AssuranceLevel})
+	}
+	if principal.RiskLevel != "" {
+		mainAttrs = mainAttrs.
+			WithField(telemetry.Field{Key: "auth.risk_level", Value: principal.RiskLevel}).
+			WithField(telemetry.Field{Key: "auth.risk_score", Value: principal.RiskScore})
+	}
+	if auditResult.ConnectCode != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.connect_code", Value: auditResult.ConnectCode})
+	}
+	if denialReason != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.denial_reason", Value: denialReason})
+	}
+	telemetry.AnnotateMain(r.Context(), mainAttrs)
+}
+
+func accessAuditOutcomeFailed(outcome string) bool {
+	switch strings.TrimSpace(outcome) {
+	case "denied", "rejected", "error":
+		return true
+	default:
+		return false
+	}
 }
 
 func accessAuditEffectiveStatusCode(status int, connectCode string) int {

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -166,12 +166,21 @@ type grcAuditPacketResponse struct {
 
 func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	ctx, span := telemetry.Start(r.Context(), "grc.dashboard", grcDashboardTelemetryAttrs())
+	dashboardCtx := ctx
 	r = r.WithContext(ctx)
 	status := "completed"
 	statusCode := http.StatusOK
 	endAttrs := grcDashboardTelemetryAttrs()
 	defer func() {
 		endAttrs = endAttrs.WithField(telemetry.Field{Key: "status_code", Value: statusCode})
+		telemetry.IncrementMain(dashboardCtx, "grc.dashboard.count", 1)
+		if status != "completed" {
+			telemetry.IncrementMain(dashboardCtx, "grc.dashboard.error.count", 1)
+		}
+		telemetry.AnnotateMain(dashboardCtx, endAttrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "grc.dashboard.status", Value: status},
+			telemetry.Field{Key: "grc.dashboard.status_code", Value: statusCode},
+		)))
 		telemetry.End(span, status, endAttrs)
 	}()
 	scope, err := grcScopeFromRequest(r)

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -333,6 +333,76 @@ func (e *askWideEvent) finish(r *http.Request, started time.Time, status int, er
 		}
 	}
 	telemetry.Event(r.Context(), "cerebro.grc.ask", attrs)
+	telemetry.IncrementMain(r.Context(), "grc.ask.count", 1)
+	if err != nil {
+		telemetry.IncrementMain(r.Context(), "grc.ask.error.count", 1)
+	}
+	mainAttrs := telemetry.Attrs(
+		telemetry.Field{Key: "grc.ask.status_code", Value: status},
+		telemetry.Field{Key: "grc.ask.outcome", Value: outcome},
+		telemetry.Field{Key: "grc.ask.duration_ms", Value: durationMs},
+		telemetry.Field{Key: "tenant_id", Value: e.tenantID},
+		telemetry.Field{Key: "grc.ask.question_len", Value: len(e.question)},
+		telemetry.Field{Key: "grc.ask.scope.present", Value: strings.TrimSpace(e.scopeURN) != ""},
+		telemetry.Field{Key: "grc.ask.model", Value: e.model},
+		telemetry.Field{Key: "grc.ask.history_len", Value: e.historyLen},
+		telemetry.Field{Key: "grc.ask.llm.provider", Value: e.provider},
+		telemetry.Field{Key: "grc.ask.llm.ok", Value: e.llmOK},
+		telemetry.Field{Key: "grc.ask.llm.pre_cached", Value: e.llmPreCached},
+		telemetry.Field{Key: "grc.ask.llm.init_ms", Value: e.llmInitMs},
+		telemetry.Field{Key: "grc.ask.graph_store.ok", Value: e.graphStoreOK},
+		telemetry.Field{Key: "grc.ask.sse_events", Value: e.sseEvents},
+		telemetry.Field{Key: "grc.ask.validator.ok", Value: e.result.validatorOK},
+		telemetry.Field{Key: "grc.ask.validator.warnings_count", Value: e.result.validatorWarningsCount},
+		telemetry.Field{Key: "grc.ask.cypher_refused", Value: e.result.cypherRefused},
+		telemetry.Field{Key: "grc.ask.row_count", Value: e.result.rowCount},
+		telemetry.Field{Key: "grc.ask.citation_count", Value: e.result.citationCount},
+		telemetry.Field{Key: "grc.ask.citation_validation.warnings_count", Value: e.result.citationWarningsCount},
+		telemetry.Field{Key: "grc.ask.graph_probe.entity_type_count", Value: e.probe.entityTypeCount},
+		telemetry.Field{Key: "grc.ask.graph_probe.relation_count", Value: e.probe.relationCount},
+		telemetry.Field{Key: "grc.ask.graph_probe.warnings_count", Value: e.probe.warningsCount},
+		telemetry.Field{Key: "grc.ask.graph_probe.scope_found", Value: e.probe.scopeFound},
+		telemetry.Field{Key: "grc.ask.stage.probe_ms", Value: e.result.timings.ProbeMS},
+		telemetry.Field{Key: "grc.ask.stage.draft_ms", Value: e.result.timings.DraftMS},
+		telemetry.Field{Key: "grc.ask.stage.conversion_ms", Value: e.result.timings.ConversionMS},
+		telemetry.Field{Key: "grc.ask.stage.validate_ms", Value: e.result.timings.ValidateMS},
+		telemetry.Field{Key: "grc.ask.stage.execute_ms", Value: e.result.timings.ExecuteMS},
+		telemetry.Field{Key: "grc.ask.stage.summarize_ms", Value: e.result.timings.SummarizeMS},
+		telemetry.Field{Key: "grc.ask.stage.citation_validation_ms", Value: e.result.timings.CitationValidationMS},
+	)
+	if e.queryPlan.intent != "" {
+		mainAttrs = mainAttrs.
+			WithField(telemetry.Field{Key: "grc.ask.query_plan.intent", Value: e.queryPlan.intent}).
+			WithField(telemetry.Field{Key: "grc.ask.query_plan.source", Value: e.queryPlan.source}).
+			WithField(telemetry.Field{Key: "grc.ask.query_plan.deterministic", Value: e.queryPlan.deterministic}).
+			WithField(telemetry.Field{Key: "grc.ask.query_plan.corrected", Value: e.queryPlan.corrected}).
+			WithField(telemetry.Field{Key: "grc.ask.query_plan.diagnostics_count", Value: e.queryPlan.diagnosticsCount})
+	}
+	if e.queryPlan.diagnosticCodes != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "grc.ask.query_plan.diagnostic_codes", Value: e.queryPlan.diagnosticCodes})
+	}
+	if e.result.terminalEvent != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "grc.ask.terminal_event", Value: e.result.terminalEvent})
+	}
+	if e.result.validatorCode != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "grc.ask.validator.code", Value: e.result.validatorCode})
+	}
+	if e.result.runtimeErrorCode != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "grc.ask.runtime_error.code", Value: e.result.runtimeErrorCode})
+	}
+	if e.result.unsupportedQueryCode != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "grc.ask.unsupported_query.code", Value: e.result.unsupportedQueryCode})
+	}
+	if e.failureStage != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "grc.ask.failure_stage", Value: e.failureStage})
+	}
+	if e.llmInitErrorKind != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "grc.ask.llm.init_error_kind", Value: e.llmInitErrorKind})
+	}
+	if err != nil {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "grc.ask.error_kind", Value: grcTelemetryErrorKind(err)})
+	}
+	telemetry.AnnotateMain(r.Context(), mainAttrs)
 
 	if err != nil {
 		providerDesc := strings.TrimSpace(e.provider)

--- a/internal/bootstrap/http_doer.go
+++ b/internal/bootstrap/http_doer.go
@@ -32,7 +32,16 @@ func (d *stdHTTPDoer) Post(ctx context.Context, endpoint string, headers map[str
 	))
 	finish := func(statusCode int, err error) {
 		attrs := telemetry.Attrs(telemetry.Field{Key: "http.response.status_code", Value: statusCode})
+		telemetry.IncrementMain(ctx, "outbound.http.request.count", 1)
+		telemetry.AnnotateMain(ctx, telemetry.Attrs(
+			telemetry.Field{Key: "outbound.http.last_component", Value: "graphagent.http_doer"},
+			telemetry.Field{Key: "outbound.http.last_host", Value: endpointHost(endpoint)},
+			telemetry.Field{Key: "outbound.http.last_method", Value: http.MethodPost},
+			telemetry.Field{Key: "outbound.http.last_scheme", Value: endpointScheme(endpoint)},
+			telemetry.Field{Key: "outbound.http.last_status_code", Value: statusCode},
+		))
 		if err != nil {
+			telemetry.IncrementMain(ctx, "outbound.http.error.count", 1)
 			attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 			telemetry.CaptureError(ctx, "graphagent.http.error", err, telemetry.Attrs(
 				telemetry.Field{Key: "component", Value: "graphagent.http_doer"},
@@ -42,9 +51,11 @@ func (d *stdHTTPDoer) Post(ctx context.Context, endpoint string, headers map[str
 			return
 		}
 		if statusCode >= http.StatusInternalServerError {
+			telemetry.IncrementMain(ctx, "outbound.http.server_error.count", 1)
 			telemetry.End(span, "failed", attrs.WithField(telemetry.Field{Key: "status_detail", Value: "server_error"}))
 			return
 		}
+		telemetry.IncrementMain(ctx, "outbound.http.success.count", 1)
 		telemetry.End(span, "completed", attrs)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -2256,6 +2256,71 @@ func mcpTelemetryEvent(r *http.Request, method string, tool string, statusCode i
 		}
 	}
 	telemetry.Event(r.Context(), "cerebro.mcp.request", attrs)
+	telemetry.IncrementMain(r.Context(), "mcp.request.count", 1)
+	if mcpTelemetryOutcomeFailed(outcome) {
+		telemetry.IncrementMain(r.Context(), "mcp.request.error.count", 1)
+	}
+	mainAttrs := telemetry.Attrs(
+		telemetry.Field{Key: "mcp.status_code", Value: statusCode},
+		telemetry.Field{Key: "mcp.request_kind", Value: requestKind},
+		telemetry.Field{Key: "mcp.method", Value: method},
+		telemetry.Field{Key: "mcp.outcome", Value: outcome},
+		telemetry.Field{Key: "mcp.protocol_version", Value: mcpSanitizeTelemetryValue(r.Header.Get("MCP-Protocol-Version"), 32)},
+		telemetry.Field{Key: "mcp.transport", Value: "stateless_http"},
+		telemetry.Field{Key: "mcp.stateless", Value: true},
+		telemetry.Field{Key: "mcp.accepts_json", Value: mcpHeaderAccepts(r.Header.Get("Accept"), "application/json")},
+		telemetry.Field{Key: "mcp.accepts_sse", Value: mcpHeaderAccepts(r.Header.Get("Accept"), "text/event-stream")},
+		telemetry.Field{Key: "mcp.session_header_present", Value: strings.TrimSpace(r.Header.Get("Mcp-Session-Id")) != ""},
+		telemetry.Field{Key: "mcp.jsonrpc_id_present", Value: detail.JSONRPCIDPresent},
+		telemetry.Field{Key: "mcp.params_present", Value: detail.ParamsPresent},
+		telemetry.Field{Key: "mcp.duration_ms", Value: duration.Milliseconds()},
+	)
+	if contentType := mcpMediaType(r.Header.Get("Content-Type")); contentType != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "mcp.content_type", Value: contentType})
+	}
+	for _, field := range mcpResponseTelemetryFields(detail.Response) {
+		mainAttrs = mainAttrs.WithField(field)
+	}
+	if tool != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "mcp.tool", Value: tool})
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "mcp.tool_known", Value: mcpKnownTool(tool)})
+		if family := mcpToolFamily(tool); family != "" {
+			mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "mcp.tool_family", Value: family})
+		}
+	}
+	if jsonRPCErrorCode != 0 {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "mcp.jsonrpc_error_code", Value: jsonRPCErrorCode})
+	}
+	if outcome == "tool_error" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "mcp.tool_error", Value: true})
+	}
+	if toolErrorKind != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "mcp.tool_error_kind", Value: toolErrorKind})
+	}
+	if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok {
+		if tenantID := strings.TrimSpace(auth.principal.TenantID); tenantID != "" {
+			mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "tenant_id", Value: mcpSanitizeTelemetryValue(tenantID, 128)})
+		}
+		if authMode := strings.TrimSpace(auth.principal.AuthMode); authMode != "" {
+			mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.mode", Value: mcpSanitizeTelemetryValue(authMode, 64)})
+		}
+		if tier := accessAuditCredentialTier(auth.principal); tier != "" {
+			mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "auth.credential_tier", Value: tier})
+		}
+		mainAttrs = mainAttrs.
+			WithField(telemetry.Field{Key: "auth.principal.present", Value: strings.TrimSpace(auth.principal.Name) != ""}).
+			WithField(telemetry.Field{Key: "auth.client.present", Value: strings.TrimSpace(auth.principal.ClientID) != ""})
+	}
+	telemetry.AnnotateMain(r.Context(), mainAttrs)
+}
+
+func mcpTelemetryOutcomeFailed(outcome string) bool {
+	switch strings.TrimSpace(outcome) {
+	case "ok", "notification", "client_message":
+		return false
+	default:
+		return true
+	}
 }
 
 func mcpTelemetryHTTPRoute(r *http.Request) string {

--- a/internal/bootstrap/oauth_handlers.go
+++ b/internal/bootstrap/oauth_handlers.go
@@ -311,6 +311,27 @@ func (app *App) emitOAuthAuditEvent(r *http.Request, operation string, status in
 		attrs = attrs.WithField(field)
 	}
 	telemetry.Event(r.Context(), "cerebro.oauth.mcp", attrs)
+	telemetry.IncrementMain(r.Context(), "oauth.mcp.count", 1)
+	if strings.TrimSpace(outcome) != "success" {
+		telemetry.IncrementMain(r.Context(), "oauth.mcp.error.count", 1)
+	}
+	mainAttrs := telemetry.Attrs(
+		telemetry.Field{Key: "oauth.operation", Value: strings.TrimSpace(operation)},
+		telemetry.Field{Key: "oauth.outcome", Value: strings.TrimSpace(outcome)},
+		telemetry.Field{Key: "oauth.status_code", Value: status},
+		telemetry.Field{Key: "oauth.duration_ms", Value: time.Since(started).Milliseconds()},
+		telemetry.Field{Key: "oauth.client.present", Value: strings.TrimSpace(clientID) != ""},
+	)
+	if reason = strings.TrimSpace(reason); reason != "" {
+		mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "oauth.reason", Value: reason})
+	}
+	for _, field := range app.oauthAuditRequestFields(r) {
+		mainAttrs = mainAttrs.WithField(field)
+	}
+	for _, field := range extraFields {
+		mainAttrs = mainAttrs.WithField(field)
+	}
+	telemetry.AnnotateMain(r.Context(), mainAttrs)
 }
 
 func (app *App) oauthAuditRequestFields(r *http.Request) []telemetry.Field {

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -711,7 +711,7 @@ func emitFindingCandidateRunTelemetry(ctx context.Context, run *ports.FindingCan
 	if !run.StartedAt.IsZero() && !run.FinishedAt.IsZero() {
 		durationMS = run.FinishedAt.Sub(run.StartedAt).Milliseconds()
 	}
-	telemetry.Event(ctx, "finding_candidate.run", telemetry.Attrs(
+	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "run_id", Value: strings.TrimSpace(run.ID)},
 		telemetry.Field{Key: "tenant_id", Value: strings.TrimSpace(run.TenantID)},
 		telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(run.RuntimeID)},
@@ -722,6 +722,22 @@ func emitFindingCandidateRunTelemetry(ctx context.Context, run *ports.FindingCan
 		telemetry.Field{Key: "events_matched", Value: run.EventsMatched},
 		telemetry.Field{Key: "candidates_emitted", Value: run.Candidates},
 		telemetry.Field{Key: "duration_ms", Value: durationMS},
+	)
+	telemetry.Event(ctx, "finding_candidate.run", attrs)
+	telemetry.IncrementMain(ctx, "finding_candidate.run.count", 1)
+	if !strings.EqualFold(strings.TrimSpace(run.Status), "completed") {
+		telemetry.IncrementMain(ctx, "finding_candidate.run.non_completed.count", 1)
+	}
+	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+		telemetry.Field{Key: "tenant_id", Value: strings.TrimSpace(run.TenantID)},
+		telemetry.Field{Key: "finding_candidate.runtime_id", Value: strings.TrimSpace(run.RuntimeID)},
+		telemetry.Field{Key: "finding_candidate.rule_id", Value: strings.TrimSpace(run.RuleID)},
+		telemetry.Field{Key: "finding_candidate.status", Value: strings.TrimSpace(run.Status)},
+		telemetry.Field{Key: "finding_candidate.event_limit", Value: run.EventLimit},
+		telemetry.Field{Key: "finding_candidate.events_evaluated", Value: run.EventsEvaluated},
+		telemetry.Field{Key: "finding_candidate.events_matched", Value: run.EventsMatched},
+		telemetry.Field{Key: "finding_candidate.candidates_emitted", Value: run.Candidates},
+		telemetry.Field{Key: "finding_candidate.duration_ms", Value: durationMS},
 	))
 }
 
@@ -745,7 +761,7 @@ func emitFindingCandidateListTelemetry(ctx context.Context, runtimeID string, ca
 			staleCount++
 		}
 	}
-	telemetry.Event(ctx, "finding_candidate.list", telemetry.Attrs(
+	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(runtimeID)},
 		telemetry.Field{Key: "rule_id", Value: strings.TrimSpace(request.RuleID)},
 		telemetry.Field{Key: "status_filter", Value: strings.TrimSpace(request.Status)},
@@ -754,6 +770,18 @@ func emitFindingCandidateListTelemetry(ctx context.Context, runtimeID string, ca
 		telemetry.Field{Key: "rejected_count", Value: rejectedCount},
 		telemetry.Field{Key: "open_candidate_count", Value: candidateCount - promotedCount - rejectedCount},
 		telemetry.Field{Key: "stale_candidate_count", Value: staleCount},
+	)
+	telemetry.Event(ctx, "finding_candidate.list", attrs)
+	telemetry.IncrementMain(ctx, "finding_candidate.list.count", 1)
+	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+		telemetry.Field{Key: "finding_candidate.runtime_id", Value: strings.TrimSpace(runtimeID)},
+		telemetry.Field{Key: "finding_candidate.rule_id", Value: strings.TrimSpace(request.RuleID)},
+		telemetry.Field{Key: "finding_candidate.status_filter", Value: strings.TrimSpace(request.Status)},
+		telemetry.Field{Key: "finding_candidate.candidate_count", Value: candidateCount},
+		telemetry.Field{Key: "finding_candidate.promoted_count", Value: promotedCount},
+		telemetry.Field{Key: "finding_candidate.rejected_count", Value: rejectedCount},
+		telemetry.Field{Key: "finding_candidate.open_candidate_count", Value: candidateCount - promotedCount - rejectedCount},
+		telemetry.Field{Key: "finding_candidate.stale_candidate_count", Value: staleCount},
 	))
 }
 
@@ -774,6 +802,8 @@ func emitFindingCandidatePromotionTelemetry(ctx context.Context, outcome string,
 		attrs = attrs.WithField(telemetry.Field{Key: "finding_id", Value: strings.TrimSpace(finding.ID)})
 	}
 	telemetry.Event(ctx, "finding_candidate.promotion", attrs)
+	telemetry.IncrementMain(ctx, "finding_candidate.promotion.count", 1)
+	telemetry.AnnotateMain(ctx, findingCandidateDecisionMainAttrs("promotion", outcome, candidate, startedAt))
 }
 
 func emitFindingCandidateRejectionTelemetry(ctx context.Context, outcome string, candidate *ports.FindingCandidateRecord, decisionID string, startedAt time.Time) {
@@ -790,6 +820,24 @@ func emitFindingCandidateRejectionTelemetry(ctx context.Context, outcome string,
 		attrs = attrs.WithField(telemetry.Field{Key: "observation_count", Value: candidate.ObservationCount})
 	}
 	telemetry.Event(ctx, "finding_candidate.rejection", attrs)
+	telemetry.IncrementMain(ctx, "finding_candidate.rejection.count", 1)
+	telemetry.AnnotateMain(ctx, findingCandidateDecisionMainAttrs("rejection", outcome, candidate, startedAt))
+}
+
+func findingCandidateDecisionMainAttrs(decision string, outcome string, candidate *ports.FindingCandidateRecord, startedAt time.Time) telemetry.Attributes {
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "finding_candidate.decision", Value: strings.TrimSpace(decision)},
+		telemetry.Field{Key: "finding_candidate.decision_outcome", Value: strings.TrimSpace(outcome)},
+		telemetry.Field{Key: "finding_candidate.decision_duration_ms", Value: time.Since(startedAt).Milliseconds()},
+	)
+	if candidate == nil {
+		return attrs
+	}
+	return attrs.
+		WithField(telemetry.Field{Key: "tenant_id", Value: strings.TrimSpace(candidate.TenantID)}).
+		WithField(telemetry.Field{Key: "finding_candidate.runtime_id", Value: strings.TrimSpace(candidate.RuntimeID)}).
+		WithField(telemetry.Field{Key: "finding_candidate.rule_id", Value: strings.TrimSpace(candidate.RuleID)}).
+		WithField(telemetry.Field{Key: "finding_candidate.observation_count", Value: candidate.ObservationCount})
 }
 
 func (s *Service) markCandidateEvaluationFailed(ctx context.Context, state *candidateRuleEvaluationState, evaluationErr error) error {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -2126,7 +2126,7 @@ func emitFindingEvaluationRunTelemetry(ctx context.Context, run *cerebrov1.Findi
 	if run == nil {
 		return
 	}
-	telemetry.Event(ctx, "finding_evaluation.run", telemetry.Attrs(
+	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "run_id", Value: strings.TrimSpace(run.GetId())},
 		telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(run.GetRuntimeId())},
 		telemetry.Field{Key: "rule_id", Value: strings.TrimSpace(run.GetRuleId())},
@@ -2137,6 +2137,22 @@ func emitFindingEvaluationRunTelemetry(ctx context.Context, run *cerebrov1.Findi
 		telemetry.Field{Key: "findings_emitted", Value: run.GetFindingsEmitted()},
 		telemetry.Field{Key: "graph_rule", Value: run.GetGraphRule()},
 		telemetry.Field{Key: "graph_rows_read", Value: run.GetGraphRowsRead()},
+	)
+	telemetry.Event(ctx, "finding_evaluation.run", attrs)
+	telemetry.IncrementMain(ctx, "finding_evaluation.run.count", 1)
+	if !strings.EqualFold(strings.TrimSpace(run.GetStatus()), "completed") {
+		telemetry.IncrementMain(ctx, "finding_evaluation.run.non_completed.count", 1)
+	}
+	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+		telemetry.Field{Key: "finding_evaluation.runtime_id", Value: strings.TrimSpace(run.GetRuntimeId())},
+		telemetry.Field{Key: "finding_evaluation.rule_id", Value: strings.TrimSpace(run.GetRuleId())},
+		telemetry.Field{Key: "finding_evaluation.status", Value: strings.TrimSpace(run.GetStatus())},
+		telemetry.Field{Key: "finding_evaluation.event_limit", Value: run.GetEventLimit()},
+		telemetry.Field{Key: "finding_evaluation.events_processed", Value: run.GetEventsProcessed()},
+		telemetry.Field{Key: "finding_evaluation.events_matched", Value: run.GetEventsMatched()},
+		telemetry.Field{Key: "finding_evaluation.findings_emitted", Value: run.GetFindingsEmitted()},
+		telemetry.Field{Key: "finding_evaluation.graph_rule", Value: run.GetGraphRule()},
+		telemetry.Field{Key: "finding_evaluation.graph_rows_read", Value: run.GetGraphRowsRead()},
 	))
 }
 

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -169,7 +169,14 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (resul
 		}
 		if err != nil {
 			spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "error_kind", Value: graphIngestTelemetryErrorKind(err)})
+			telemetry.IncrementMain(ctx, "graph.ingest.error.count", 1)
 		}
+		telemetry.IncrementMain(ctx, "graph.ingest.count", 1)
+		telemetry.AnnotateMain(ctx, spanAttributes.With(telemetry.Attrs(
+			telemetry.Field{Key: "graph.ingest.status", Value: status},
+			telemetry.Field{Key: "graph.ingest.runtime_id", Value: strings.TrimSpace(request.RuntimeID)},
+			telemetry.Field{Key: "graph.ingest.trigger", Value: strings.TrimSpace(request.Trigger)},
+		)))
 		telemetry.End(span, status, spanAttributes)
 	}()
 	if s == nil || s.runtimeStore == nil || s.graphStore == nil || s.projector == nil {
@@ -700,14 +707,19 @@ func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRe
 			deleted++
 		}
 		if len(retractedLinks) != 0 {
-			telemetry.Event(ctx, "source_projection.retractions", telemetry.Attrs(
+			attrs := telemetry.Attrs(
 				telemetry.Field{Key: "tenant_id", Value: request.TenantID},
 				telemetry.Field{Key: "source_id", Value: request.SourceID},
 				telemetry.Field{Key: "runtime_id", Value: request.RuntimeID},
 				telemetry.Field{Key: "reason", Value: "endpoint_owner_id"},
 				telemetry.Field{Key: "links_matched", Value: len(retractedLinks)},
 				telemetry.Field{Key: "links_deleted", Value: deleted},
-			))
+			)
+			telemetry.Event(ctx, "source_projection.retractions", attrs)
+			telemetry.IncrementMain(ctx, "source_projection.retraction.count", 1)
+			telemetry.AnnotateMain(ctx, attrs.With(telemetry.Attrs(
+				telemetry.Field{Key: "source_projection.retraction.present", Value: true},
+			)))
 		}
 	}
 	entityKeys := sortedMapKeys(entities)

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1301,6 +1301,7 @@ func (s *Store) read(ctx context.Context, work func(context.Context, neo4jdriver
 		neo4jTelemetryError(ctx, span, "read", err)
 		return nil, err
 	}
+	neo4jAnnotateMain(ctx, s.database, "read", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return result, nil
 }
@@ -1314,6 +1315,7 @@ func (s *Store) write(ctx context.Context, work neo4jdriver.ManagedTransactionWo
 		neo4jTelemetryError(ctx, span, "write", err)
 		return nil, err
 	}
+	neo4jAnnotateMain(ctx, s.database, "write", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return result, nil
 }
@@ -1332,12 +1334,31 @@ func neo4jTelemetryAttrs(operation string, database string, timeout time.Duratio
 }
 
 func neo4jTelemetryError(ctx context.Context, span *telemetry.Span, operation string, err error) {
+	neo4jAnnotateMain(ctx, "", operation, "failed")
 	attrs := telemetry.Attrs(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 	telemetry.CaptureError(ctx, "neo4j.error", err, telemetry.Attrs(
 		telemetry.Field{Key: "component", Value: "graphstore.neo4j"},
 		telemetry.Field{Key: "operation", Value: operation},
 	))
 	telemetry.End(span, "failed", attrs)
+}
+
+func neo4jAnnotateMain(ctx context.Context, database string, operation string, status string) {
+	telemetry.IncrementMain(ctx, "db.neo4j.operation.count", 1)
+	if operation == "read" {
+		telemetry.IncrementMain(ctx, "db.neo4j.read.count", 1)
+	}
+	if operation == "write" {
+		telemetry.IncrementMain(ctx, "db.neo4j.write.count", 1)
+	}
+	if status == "failed" {
+		telemetry.IncrementMain(ctx, "db.neo4j.error.count", 1)
+	}
+	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+		telemetry.Field{Key: "db.neo4j.last_database", Value: strings.TrimSpace(database)},
+		telemetry.Field{Key: "db.neo4j.last_operation", Value: strings.TrimSpace(operation)},
+		telemetry.Field{Key: "db.neo4j.last_status", Value: strings.TrimSpace(status)},
+	))
 }
 
 func consume(ctx context.Context, tx neo4jdriver.ManagedTransaction, query string, params map[string]any) (any, error) {

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -2,6 +2,8 @@ package observability
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"sort"
@@ -12,7 +14,6 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
@@ -88,15 +89,9 @@ func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		route := normalizeRouteLabel(r.URL.Path)
 		method := normalizeMethodLabel(r.Method)
-		ctx, span := otel.Tracer("github.com/writer/cerebro/internal/observability").Start(r.Context(), "http.server",
+		ctx, span := telemetry.StartMain(r.Context(), "http.server", httpRequestWideAttributes(r, method, route),
 			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
-			oteltrace.WithAttributes(
-				attribute.String("http.request.method", method),
-				attribute.String("http.route", route),
-			),
 		)
-		defer span.End()
-		ctx = telemetry.EnsureTraceContext(ctx)
 		r = r.WithContext(ctx)
 		if traceparent := telemetry.TraceParent(ctx); traceparent != "" {
 			traceID, _, ok := telemetry.ParseTraceParent(traceparent)
@@ -107,24 +102,28 @@ func Middleware(next http.Handler) http.Handler {
 		started := time.Now()
 		recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(recorder, r)
+		durationSeconds := time.Since(started).Seconds()
 		labels := map[string]string{
 			"method":      method,
 			"route":       route,
 			"status_code": strconv.Itoa(recorder.status),
 		}
-		span.SetAttributes(attribute.Int("http.response.status_code", recorder.status))
 		if recorder.status >= http.StatusInternalServerError {
-			span.SetStatus(codes.Error, fmt.Sprintf("http_status_%d", recorder.status))
-			span.AddEvent("http.server.error", oteltrace.WithAttributes(
-				attribute.String("http.request.method", method),
-				attribute.String("http.route", route),
-				attribute.Int("http.response.status_code", recorder.status),
+			telemetry.Event(ctx, "http.server.error", telemetry.Attrs(
+				telemetry.Field{Key: "http.request.method", Value: method},
+				telemetry.Field{Key: "http.route", Value: route},
+				telemetry.Field{Key: "http.response.status_code", Value: recorder.status},
 			))
 		}
 		Default.Inc("cerebro_http_requests_total", labels)
-		Default.Add("cerebro_http_request_duration_seconds_sum", labels, time.Since(started).Seconds())
+		Default.Add("cerebro_http_request_duration_seconds_sum", labels, durationSeconds)
 		Default.Inc("cerebro_http_request_duration_seconds_count", labels)
-		recordOTELHTTPServerRequest(ctx, labels, recorder.status, time.Since(started).Seconds())
+		recordOTELHTTPServerRequest(ctx, labels, recorder.status, durationSeconds)
+		status := "completed"
+		if recorder.status >= http.StatusInternalServerError {
+			status = "failed"
+		}
+		telemetry.End(span, status, httpResponseWideAttributes(recorder))
 	})
 }
 
@@ -142,6 +141,7 @@ type statusRecorder struct {
 	http.ResponseWriter
 	status      int
 	wroteHeader bool
+	bytes       int64
 }
 
 func (r *statusRecorder) WriteHeader(status int) {
@@ -151,6 +151,15 @@ func (r *statusRecorder) WriteHeader(status int) {
 	r.status = status
 	r.wroteHeader = true
 	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *statusRecorder) Write(data []byte) (int, error) {
+	if !r.wroteHeader {
+		r.WriteHeader(http.StatusOK)
+	}
+	n, err := r.ResponseWriter.Write(data)
+	r.bytes += int64(n)
+	return n, err
 }
 
 func (r *statusRecorder) Flush() {
@@ -170,6 +179,194 @@ func (r *statusRecorder) Unwrap() http.ResponseWriter {
 		return nil
 	}
 	return r.ResponseWriter
+}
+
+func httpRequestWideAttributes(r *http.Request, method string, route string) telemetry.Attributes {
+	pathDepth := 0
+	if r != nil && r.URL != nil {
+		pathDepth = len(strings.Split(strings.Trim(r.URL.Path, "/"), "/"))
+		if strings.Trim(r.URL.Path, "/") == "" {
+			pathDepth = 0
+		}
+	}
+	return telemetry.RuntimeAttributes().With(telemetry.Attrs(
+		telemetry.Field{Key: "component", Value: "http-middleware"},
+		telemetry.Field{Key: "operation", Value: method},
+		telemetry.Field{Key: "http.request.method", Value: method},
+		telemetry.Field{Key: "http.route", Value: route},
+		telemetry.Field{Key: "url.path_family", Value: route},
+		telemetry.Field{Key: "url.path_depth", Value: pathDepth},
+		telemetry.Field{Key: "url.query.param_count", Value: queryParamCount(r)},
+		telemetry.Field{Key: "url.query.keys", Value: queryParamKeys(r)},
+		telemetry.Field{Key: "url.scheme", Value: requestScheme(r)},
+		telemetry.Field{Key: "server.address", Value: requestHost(r)},
+		telemetry.Field{Key: "server.port", Value: requestPort(r)},
+		telemetry.Field{Key: "network.protocol.version", Value: requestProto(r)},
+		telemetry.Field{Key: "http.request.body.size", Value: requestBodySize(r)},
+		telemetry.Field{Key: "http.request.header.traceparent.present", Value: requestHeader(r, "Traceparent") != ""},
+		telemetry.Field{Key: "http.request.header.x_request_id.present", Value: requestHeader(r, "X-Request-Id") != ""},
+		telemetry.Field{Key: "http.request.auth_header.present", Value: requestHeader(r, "Authorization") != ""},
+		telemetry.Field{Key: "http.request.header.accept", Value: requestHeader(r, "Accept")},
+		telemetry.Field{Key: "http.request.header.accept_encoding", Value: requestHeader(r, "Accept-Encoding")},
+		telemetry.Field{Key: "http.request.header.content_type", Value: requestHeader(r, "Content-Type")},
+		telemetry.Field{Key: "http.request.header.user_agent", Value: requestHeader(r, "User-Agent")},
+		telemetry.Field{Key: "user_agent.family", Value: userAgentFamily(requestHeader(r, "User-Agent"))},
+		telemetry.Field{Key: "client.address_hash", Value: remoteAddressHash(r)},
+	))
+}
+
+func httpResponseWideAttributes(recorder *statusRecorder) telemetry.Attributes {
+	if recorder == nil {
+		return telemetry.Attrs()
+	}
+	return telemetry.RuntimeAttributes().With(telemetry.Attrs(
+		telemetry.Field{Key: "http.response.status_code", Value: recorder.status},
+		telemetry.Field{Key: "http.response.body.size", Value: recorder.bytes},
+		telemetry.Field{Key: "http.response.header.cache_control", Value: recorder.Header().Get("Cache-Control")},
+		telemetry.Field{Key: "http.response.header.content_type", Value: recorder.Header().Get("Content-Type")},
+		telemetry.Field{Key: "http.response.header.retry_after", Value: recorder.Header().Get("Retry-After")},
+	))
+}
+
+func requestHeader(r *http.Request, key string) string {
+	if r == nil {
+		return ""
+	}
+	return r.Header.Get(key)
+}
+
+func requestScheme(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if r.URL != nil && strings.TrimSpace(r.URL.Scheme) != "" {
+		return r.URL.Scheme
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
+		return strings.ToLower(proto)
+	}
+	return "http"
+}
+
+func requestHost(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	host := strings.TrimSpace(r.Host)
+	if host == "" && r.URL != nil {
+		host = r.URL.Host
+	}
+	if strings.Contains(host, ":") {
+		if hostname, _, ok := strings.Cut(host, ":"); ok {
+			return hostname
+		}
+	}
+	return host
+}
+
+func requestPort(r *http.Request) int {
+	if r == nil {
+		return 0
+	}
+	host := strings.TrimSpace(r.Host)
+	if host == "" && r.URL != nil {
+		host = r.URL.Host
+	}
+	if _, port, ok := strings.Cut(host, ":"); ok {
+		parsed, err := strconv.Atoi(port)
+		if err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	if requestScheme(r) == "https" {
+		return 443
+	}
+	return 80
+}
+
+func requestProto(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if r.ProtoMajor == 0 {
+		return ""
+	}
+	if r.ProtoMinor == 0 {
+		return strconv.Itoa(r.ProtoMajor)
+	}
+	return fmt.Sprintf("%d.%d", r.ProtoMajor, r.ProtoMinor)
+}
+
+func requestBodySize(r *http.Request) int64 {
+	if r == nil || r.ContentLength < 0 {
+		return 0
+	}
+	return r.ContentLength
+}
+
+func remoteAddressHash(r *http.Request) string {
+	if r == nil || strings.TrimSpace(r.RemoteAddr) == "" {
+		return ""
+	}
+	host := r.RemoteAddr
+	if strings.Contains(host, ":") {
+		if parsedHost, _, ok := strings.Cut(host, ":"); ok {
+			host = parsedHost
+		}
+	}
+	sum := sha256.Sum256([]byte(strings.TrimSpace(host)))
+	return hex.EncodeToString(sum[:8])
+}
+
+func queryParamCount(r *http.Request) int {
+	if r == nil || r.URL == nil {
+		return 0
+	}
+	return len(r.URL.Query())
+}
+
+func queryParamKeys(r *http.Request) string {
+	if r == nil || r.URL == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(r.URL.Query()))
+	for key := range r.URL.Query() {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if len(keys) > 12 {
+		keys = append(keys[:12], "...")
+	}
+	return strings.Join(keys, ",")
+}
+
+func userAgentFamily(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case normalized == "":
+		return "none"
+	case strings.Contains(normalized, "bot"), strings.Contains(normalized, "crawler"), strings.Contains(normalized, "spider"):
+		return "bot"
+	case strings.Contains(normalized, "edge"), strings.Contains(normalized, "edg/"):
+		return "edge"
+	case strings.Contains(normalized, "chrome"):
+		return "chrome"
+	case strings.Contains(normalized, "safari"):
+		return "safari"
+	case strings.Contains(normalized, "firefox"):
+		return "firefox"
+	case strings.Contains(normalized, "curl"):
+		return "curl"
+	default:
+		return "other"
+	}
 }
 
 func normalizeMethodLabel(method string) string {

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -2,8 +2,11 @@ package observability
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -71,6 +74,66 @@ func TestMiddlewareReturnsTraceIDHeader(t *testing.T) {
 
 	if got := recorder.Header().Get("X-Cerebro-Trace-Id"); len(got) != 32 {
 		t.Fatalf("X-Cerebro-Trace-Id = %q, want 32 hex chars", got)
+	}
+}
+
+func TestMiddlewareEmitsHTTPWideEventFields(t *testing.T) {
+	_, stderr := captureObservabilityOutput(t, func() {
+		handler := Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			telemetry.AnnotateMain(r.Context(), telemetry.Attrs(
+				telemetry.Field{Key: "tenant_id", Value: "tenant-a"},
+				telemetry.Field{Key: "cache.redis.hit.count", Value: 1},
+			))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		request := httptest.NewRequest(http.MethodPost, "/platform/jobs/job-123/events?cursor=abc&limit=10", strings.NewReader("body"))
+		request.Host = "api.example.test:8443"
+		request.RemoteAddr = "203.0.113.9:5678"
+		request.Header.Set("Accept", "application/json")
+		request.Header.Set("Accept-Encoding", "gzip")
+		request.Header.Set("Authorization", "Bearer definitely-not-emitted")
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("Traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+		request.Header.Set("User-Agent", "curl/8.0")
+
+		handler.ServeHTTP(httptest.NewRecorder(), request)
+	})
+
+	payload := observabilityTelemetryPayload(t, stderr, "span_end", "http.server")
+	expected := map[string]any{
+		"main":                     true,
+		"wide_event":               true,
+		"tenant_id":                "tenant-a",
+		"http.request.method":      http.MethodPost,
+		"http.route":               "/platform/jobs/{jobID}/events",
+		"url.path_depth":           float64(4),
+		"url.query.param_count":    float64(2),
+		"url.query.keys":           "cursor,limit",
+		"url.scheme":               "http",
+		"server.address":           "api.example.test",
+		"server.port":              float64(8443),
+		"network.protocol.version": "1.1",
+		"http.request.body.size":   float64(4),
+		"http.request.header.traceparent.present": true,
+		"http.request.header.accept":              "application/json",
+		"http.request.header.accept_encoding":     "gzip",
+		"http.request.header.content_type":        "application/json",
+		"http.request.header.user_agent":          "curl/8.0",
+		"http.request.auth_header.present":        true,
+		"user_agent.family":                       "curl",
+		"cache.redis.hit.count":                   float64(1),
+		"http.response.status_code":               float64(http.StatusOK),
+		"http.response.body.size":                 float64(len(`{"ok":true}`)),
+		"http.response.header.content_type":       "application/json",
+	}
+	for key, want := range expected {
+		if got := payload[key]; got != want {
+			t.Fatalf("payload[%q] = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if strings.Contains(stderr, "definitely-not-emitted") {
+		t.Fatalf("authorization header leaked into telemetry: %s", stderr)
 	}
 }
 
@@ -145,4 +208,59 @@ func (w *flushResponseWriter) WriteHeader(status int) {
 
 func (w *flushResponseWriter) Flush() {
 	w.flushed = true
+}
+
+func captureObservabilityOutput(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stdout: %v", err)
+	}
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stderr: %v", err)
+	}
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	fn()
+	if err := stdoutWriter.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	if err := stderrWriter.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	stdout, err := io.ReadAll(stdoutReader)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	stderr, err := io.ReadAll(stderrReader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	return string(stdout), string(stderr)
+}
+
+func observabilityTelemetryPayload(t *testing.T, stderr string, kind string, name string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			t.Fatalf("unmarshal telemetry payload %q: %v", line, err)
+		}
+		if payload["kind"] == kind && payload["name"] == name {
+			return payload
+		}
+	}
+	t.Fatalf("telemetry payload kind=%q name=%q not found in stderr: %s", kind, name, stderr)
+	return nil
 }

--- a/internal/querycache/redis.go
+++ b/internal/querycache/redis.go
@@ -33,22 +33,25 @@ func (c *RedisCache) Get(ctx context.Context, key string) (Entry, error) {
 	ctx, span := telemetry.Start(ctx, "redis.cache.get", redisTelemetryAttrs("get", c.options.Namespace))
 	raw, err := c.client.Get(ctx, cacheKey(c.options.Namespace, key)).Bytes()
 	if errors.Is(err, redis.Nil) {
+		redisAnnotateMain(ctx, c.options.Namespace, "get", "miss")
 		telemetry.End(span, "miss", telemetry.Attrs())
 		return Entry{}, ErrMiss
 	}
 	if err != nil {
-		redisTelemetryError(ctx, span, "get", err)
+		redisTelemetryError(ctx, span, c.options.Namespace, "get", err)
 		return Entry{}, err
 	}
 	var entry Entry
 	if err := json.Unmarshal(raw, &entry); err != nil {
-		redisTelemetryError(ctx, span, "get", err)
+		redisTelemetryError(ctx, span, c.options.Namespace, "get", err)
 		return Entry{}, err
 	}
 	if entry.State(time.Now().UTC()) == StateMiss {
+		redisAnnotateMain(ctx, c.options.Namespace, "get", "miss")
 		telemetry.End(span, "miss", telemetry.Attrs())
 		return Entry{}, ErrMiss
 	}
+	redisAnnotateMain(ctx, c.options.Namespace, "get", "hit")
 	telemetry.End(span, "hit", telemetry.Attrs())
 	return entry, nil
 }
@@ -56,6 +59,7 @@ func (c *RedisCache) Get(ctx context.Context, key string) (Entry, error) {
 func (c *RedisCache) Set(ctx context.Context, key string, payload []byte, ttl time.Duration, staleTTL time.Duration) error {
 	ctx, span := telemetry.Start(ctx, "redis.cache.set", redisTelemetryAttrs("set", c.options.Namespace))
 	if len(payload) == 0 || len(payload) > c.options.MaxPayloadBytes {
+		redisAnnotateMain(ctx, c.options.Namespace, "set", "skipped")
 		telemetry.End(span, "skipped", telemetry.Attrs(telemetry.Field{Key: "status_detail", Value: "payload_size"}))
 		return nil
 	}
@@ -74,13 +78,14 @@ func (c *RedisCache) Set(ctx context.Context, key string, payload []byte, ttl ti
 	}
 	raw, err := json.Marshal(entry)
 	if err != nil {
-		redisTelemetryError(ctx, span, "set", err)
+		redisTelemetryError(ctx, span, c.options.Namespace, "set", err)
 		return err
 	}
 	if err := c.client.Set(ctx, cacheKey(c.options.Namespace, key), raw, ttl+staleTTL).Err(); err != nil {
-		redisTelemetryError(ctx, span, "set", err)
+		redisTelemetryError(ctx, span, c.options.Namespace, "set", err)
 		return err
 	}
+	redisAnnotateMain(ctx, c.options.Namespace, "set", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return nil
 }
@@ -89,13 +94,15 @@ func (c *RedisCache) Version(ctx context.Context, scope string) (string, error) 
 	ctx, span := telemetry.Start(ctx, "redis.cache.version", redisTelemetryAttrs("version", c.options.Namespace))
 	value, err := c.client.Get(ctx, versionKey(c.options.Namespace, scope)).Result()
 	if errors.Is(err, redis.Nil) {
+		redisAnnotateMain(ctx, c.options.Namespace, "version", "miss")
 		telemetry.End(span, "miss", telemetry.Attrs())
 		return "0", nil
 	}
 	if err != nil {
-		redisTelemetryError(ctx, span, "version", err)
+		redisTelemetryError(ctx, span, c.options.Namespace, "version", err)
 		return value, err
 	}
+	redisAnnotateMain(ctx, c.options.Namespace, "version", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return value, err
 }
@@ -104,9 +111,10 @@ func (c *RedisCache) BumpVersion(ctx context.Context, scope string) (string, err
 	ctx, span := telemetry.Start(ctx, "redis.cache.bump_version", redisTelemetryAttrs("bump_version", c.options.Namespace))
 	value, err := c.client.Incr(ctx, versionKey(c.options.Namespace, scope)).Result()
 	if err != nil {
-		redisTelemetryError(ctx, span, "bump_version", err)
+		redisTelemetryError(ctx, span, c.options.Namespace, "bump_version", err)
 		return "", err
 	}
+	redisAnnotateMain(ctx, c.options.Namespace, "bump_version", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return strconv.FormatInt(value, 10), nil
 }
@@ -114,9 +122,10 @@ func (c *RedisCache) BumpVersion(ctx context.Context, scope string) (string, err
 func (c *RedisCache) Ping(ctx context.Context) error {
 	ctx, span := telemetry.Start(ctx, "redis.ping", redisTelemetryAttrs("ping", c.options.Namespace))
 	if err := c.client.Ping(ctx).Err(); err != nil {
-		redisTelemetryError(ctx, span, "ping", err)
+		redisTelemetryError(ctx, span, c.options.Namespace, "ping", err)
 		return err
 	}
+	redisAnnotateMain(ctx, c.options.Namespace, "ping", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return nil
 }
@@ -133,11 +142,31 @@ func redisTelemetryAttrs(operation string, namespace string) telemetry.Attribute
 	)
 }
 
-func redisTelemetryError(ctx context.Context, span *telemetry.Span, operation string, err error) {
+func redisTelemetryError(ctx context.Context, span *telemetry.Span, namespace string, operation string, err error) {
+	redisAnnotateMain(ctx, namespace, operation, "failed")
 	attrs := telemetry.Attrs(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 	telemetry.CaptureError(ctx, "redis.cache.error", err, telemetry.Attrs(
 		telemetry.Field{Key: "component", Value: "querycache.redis"},
 		telemetry.Field{Key: "operation", Value: operation},
 	))
 	telemetry.End(span, "failed", attrs)
+}
+
+func redisAnnotateMain(ctx context.Context, namespace string, operation string, status string) {
+	telemetry.IncrementMain(ctx, "cache.redis.operation.count", 1)
+	switch status {
+	case "hit":
+		telemetry.IncrementMain(ctx, "cache.redis.hit.count", 1)
+	case "miss":
+		telemetry.IncrementMain(ctx, "cache.redis.miss.count", 1)
+	case "failed":
+		telemetry.IncrementMain(ctx, "cache.redis.error.count", 1)
+	case "skipped":
+		telemetry.IncrementMain(ctx, "cache.redis.skipped.count", 1)
+	}
+	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+		telemetry.Field{Key: "cache.redis.last_namespace", Value: strings.TrimSpace(namespace)},
+		telemetry.Field{Key: "cache.redis.last_operation", Value: strings.TrimSpace(operation)},
+		telemetry.Field{Key: "cache.redis.last_status", Value: strings.TrimSpace(status)},
+	))
 }

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -223,7 +223,17 @@ func (rt SafeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		))
 		finish := func(statusCode int, err error) {
 			attrs := telemetry.Attrs(telemetry.Field{Key: "http.response.status_code", Value: statusCode})
+			telemetry.IncrementMain(ctx, "outbound.http.request.count", 1)
+			telemetry.AnnotateMain(ctx, telemetry.Attrs(
+				telemetry.Field{Key: "outbound.http.last_component", Value: "sourcehttp"},
+				telemetry.Field{Key: "outbound.http.last_source_id", Value: rt.SourceID},
+				telemetry.Field{Key: "outbound.http.last_host", Value: requestHost(req)},
+				telemetry.Field{Key: "outbound.http.last_method", Value: strings.ToUpper(strings.TrimSpace(req.Method))},
+				telemetry.Field{Key: "outbound.http.last_scheme", Value: requestScheme(req)},
+				telemetry.Field{Key: "outbound.http.last_status_code", Value: statusCode},
+			))
 			if err != nil {
+				telemetry.IncrementMain(ctx, "outbound.http.error.count", 1)
 				attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 				telemetry.CaptureError(ctx, "source.http.error", err, telemetry.Attrs(
 					telemetry.Field{Key: "component", Value: "sourcehttp"},
@@ -234,9 +244,11 @@ func (rt SafeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 				return
 			}
 			if statusCode >= http.StatusInternalServerError {
+				telemetry.IncrementMain(ctx, "outbound.http.server_error.count", 1)
 				telemetry.End(span, "failed", attrs.WithField(telemetry.Field{Key: "status_detail", Value: "server_error"}))
 				return
 			}
+			telemetry.IncrementMain(ctx, "outbound.http.success.count", 1)
 			telemetry.End(span, "completed", attrs)
 		}
 		req = req.Clone(ctx)

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -59,6 +59,7 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 			status = "failed"
 			attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: sourceOperationTelemetryErrorKind(err)})
 		}
+		annotateMainSourceOperation(ctx, "check", status, attrs)
 		telemetry.End(span, status, attrs)
 	}()
 	source, err := s.lookup(req.GetSourceId())
@@ -88,6 +89,7 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 			status = "failed"
 			attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: sourceOperationTelemetryErrorKind(err)})
 		}
+		annotateMainSourceOperation(ctx, "discover", status, attrs)
 		telemetry.End(span, status, attrs)
 	}()
 	source, err := s.lookup(req.GetSourceId())
@@ -123,6 +125,7 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (_
 			status = "failed"
 			attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: sourceOperationTelemetryErrorKind(err)})
 		}
+		annotateMainSourceOperation(ctx, "read", status, attrs)
 		telemetry.End(span, status, attrs)
 	}()
 	source, err := s.lookup(req.GetSourceId())
@@ -216,6 +219,17 @@ func previewEvents(events []*cerebrov1.EventEnvelope) ([]*cerebrov1.SourcePrevie
 
 func sourceOperationTelemetryAttrs(sourceID string) telemetry.Attributes {
 	return telemetry.Attrs(telemetry.Field{Key: "source_id", Value: strings.TrimSpace(sourceID)})
+}
+
+func annotateMainSourceOperation(ctx context.Context, operation string, status string, attrs telemetry.Attributes) {
+	telemetry.IncrementMain(ctx, "source.operation.count", 1)
+	if status == "failed" {
+		telemetry.IncrementMain(ctx, "source.operation.error.count", 1)
+	}
+	telemetry.AnnotateMain(ctx, attrs.With(telemetry.Attrs(
+		telemetry.Field{Key: "source.operation", Value: operation},
+		telemetry.Field{Key: "source.operation.status", Value: status},
+	)))
 }
 
 func sourceOperationTelemetryErrorKind(err error) string {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -113,7 +113,7 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 		return ports.ProjectionResult{}, err
 	}
 	if len(retractedLinks) != 0 {
-		telemetry.Event(ctx, "source_projection.retractions", telemetry.Attrs(
+		attrs := telemetry.Attrs(
 			telemetry.Field{Key: "tenant_id", Value: event.GetTenantId()},
 			telemetry.Field{Key: "source_id", Value: event.GetSourceId()},
 			telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID])},
@@ -121,7 +121,12 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 			telemetry.Field{Key: "reason", Value: "endpoint_owner_id"},
 			telemetry.Field{Key: "links_matched", Value: len(retractedLinks)},
 			telemetry.Field{Key: "links_deleted", Value: retractedLinksDeleted},
-		))
+		)
+		telemetry.Event(ctx, "source_projection.retractions", attrs)
+		telemetry.IncrementMain(ctx, "source_projection.retraction.count", 1)
+		telemetry.AnnotateMain(ctx, attrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "source_projection.retraction.present", Value: true},
+		)))
 	}
 	if conflictCategory, err := s.detectRuntimeEvidenceConflict(ctx, event, entities); err != nil {
 		emitRuntimeEvidenceTelemetry(ctx, event, entities, links, "conflict", conflictCategory)
@@ -284,7 +289,7 @@ func emitRuntimeEvidenceTelemetry(ctx context.Context, event *cerebrov1.EventEnv
 	if evidenceCount == 0 && outcome != "conflict" {
 		return
 	}
-	telemetry.Event(ctx, "source_projection.runtime_evidence", telemetry.Attrs(
+	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "source_id", Value: boundedEvidenceSourceID(event.GetSourceId())},
 		telemetry.Field{Key: "event_kind", Value: boundedEvidenceEventKind(event.GetKind())},
 		telemetry.Field{Key: "outcome", Value: boundedEvidenceOutcome(outcome)},
@@ -295,7 +300,15 @@ func emitRuntimeEvidenceTelemetry(ctx context.Context, event *cerebrov1.EventEnv
 		telemetry.Field{Key: "missing_case_count", Value: missingCaseCount},
 		telemetry.Field{Key: "entities_projected", Value: len(entities)},
 		telemetry.Field{Key: "links_projected", Value: len(links)},
-	))
+	)
+	telemetry.Event(ctx, "source_projection.runtime_evidence", attrs)
+	telemetry.IncrementMain(ctx, "source_projection.runtime_evidence.count", 1)
+	if boundedEvidenceOutcome(outcome) == "conflict" {
+		telemetry.IncrementMain(ctx, "source_projection.runtime_evidence.conflict.count", 1)
+	}
+	telemetry.AnnotateMain(ctx, attrs.With(telemetry.Attrs(
+		telemetry.Field{Key: "source_projection.runtime_evidence.present", Value: true},
+	)))
 }
 
 func boundedEvidenceSourceID(value string) string {

--- a/internal/sourceruntime/lease.go
+++ b/internal/sourceruntime/lease.go
@@ -82,7 +82,10 @@ func (s *Service) SyncWithLease(ctx context.Context, req *cerebrov1.SyncSourceRu
 				errorKind = syncWithLeaseTelemetryErrorKind(err)
 			}
 			attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: errorKind})
+			telemetry.IncrementMain(ctx, "source_runtime.lease.error.count", 1)
 		}
+		telemetry.IncrementMain(ctx, "source_runtime.lease.count", 1)
+		telemetry.AnnotateMain(ctx, attrs.WithField(telemetry.Field{Key: "source_runtime.lease.status", Value: status}))
 		telemetry.End(span, status, attrs)
 	}()
 	if s == nil {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -252,10 +252,16 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		if err != nil {
 			status = "failed"
 			spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "error_kind", Value: sourceRuntimeTelemetryErrorKind(err)})
+			telemetry.IncrementMain(ctx, "source_runtime.sync.error.count", 1)
 			if runtimeLoadedForRun {
 				_ = s.recordRuntimeSyncFailure(context.WithoutCancel(ctx), runtime, err, contractConfigured)
 			}
 		}
+		telemetry.IncrementMain(ctx, "source_runtime.sync.count", 1)
+		telemetry.AnnotateMain(ctx, spanAttributes.With(telemetry.Attrs(
+			telemetry.Field{Key: "source_runtime.sync.status", Value: status},
+			telemetry.Field{Key: "source_runtime.id", Value: runtimeID},
+		)))
 		telemetry.End(span, status, spanAttributes)
 	}()
 	if s == nil || s.store == nil || s.appendLog == nil {
@@ -276,6 +282,11 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	}
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()})
+	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+		telemetry.Field{Key: "source_runtime.id", Value: runtime.GetId()},
+		telemetry.Field{Key: "source_runtime.source_id", Value: runtime.GetSourceId()},
+		telemetry.Field{Key: "source_runtime.tenant_id", Value: runtime.GetTenantId()},
+	))
 	refreshRuntimeProgressConfig(runtime, runtimeConfig)
 	pageLimit, err := normalizePageLimit(req.GetPageLimit())
 	if err != nil {

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -92,6 +92,7 @@ func (s *Store) Ping(ctx context.Context) error {
 		postgresTelemetryError(ctx, span, "ping", err)
 		return err
 	}
+	postgresAnnotateMain(ctx, "ping", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return nil
 }
@@ -125,17 +126,30 @@ func (s *Store) ensureStatements(ctx context.Context, ready *bool, label string,
 		return err
 	}
 	*ready = true
+	postgresAnnotateMain(ctx, "ensure_statements", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return nil
 }
 
 func postgresTelemetryError(ctx context.Context, span *telemetry.Span, operation string, err error) {
+	postgresAnnotateMain(ctx, operation, "failed")
 	attrs := telemetry.Attrs(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 	telemetry.CaptureError(ctx, "postgres.error", err, telemetry.Attrs(
 		telemetry.Field{Key: "component", Value: "statestore.postgres"},
 		telemetry.Field{Key: "operation", Value: operation},
 	))
 	telemetry.End(span, "failed", attrs)
+}
+
+func postgresAnnotateMain(ctx context.Context, operation string, status string) {
+	telemetry.IncrementMain(ctx, "db.postgres.operation.count", 1)
+	if status == "failed" {
+		telemetry.IncrementMain(ctx, "db.postgres.error.count", 1)
+	}
+	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+		telemetry.Field{Key: "db.postgres.last_operation", Value: strings.TrimSpace(operation)},
+		telemetry.Field{Key: "db.postgres.last_status", Value: strings.TrimSpace(status)},
+	))
 }
 
 const schemaMigrationsDDL = `

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -10,8 +10,10 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -19,9 +21,12 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/writer/cerebro/internal/buildinfo"
 )
 
 type spanContextKey struct{}
+type mainSpanContextKey struct{}
 
 type spanContext struct {
 	TraceID string
@@ -29,12 +34,15 @@ type spanContext struct {
 }
 
 type Span struct {
-	name     string
-	traceID  string
-	spanID   string
-	parentID string
-	started  time.Time
-	otelSpan oteltrace.Span
+	mu          sync.Mutex
+	name        string
+	traceID     string
+	spanID      string
+	parentID    string
+	started     time.Time
+	otelSpan    oteltrace.Span
+	main        bool
+	annotations map[string]any
 }
 
 type Attributes struct {
@@ -45,6 +53,8 @@ type Field struct {
 	Key   string
 	Value any
 }
+
+const maxAttributeStringLength = 1024
 
 func Attrs(fields ...Field) Attributes {
 	attributes := Attributes{values: map[string]any{}}
@@ -61,6 +71,13 @@ func (a Attributes) WithField(field Field) Attributes {
 	return a.with(field.Key, field.Value)
 }
 
+func (a Attributes) With(other Attributes) Attributes {
+	for key, value := range other.values {
+		a = a.with(key, value)
+	}
+	return a
+}
+
 func (a Attributes) with(key string, value any) Attributes {
 	if a.values == nil {
 		a.values = map[string]any{}
@@ -71,8 +88,41 @@ func (a Attributes) with(key string, value any) Attributes {
 	return a
 }
 
+func RuntimeAttributes() Attributes {
+	hostname, _ := os.Hostname()
+	return Attrs(
+		Field{Key: "service.name", Value: buildinfo.ServiceName},
+		Field{Key: "service.version", Value: buildinfo.Version},
+		Field{Key: "service.commit", Value: buildinfo.Commit},
+		Field{Key: "service.build_date", Value: buildinfo.BuildDate},
+		Field{Key: "deployment.environment", Value: "unknown"},
+		Field{Key: "host.name", Value: hostname},
+		Field{Key: "os.type", Value: runtime.GOOS},
+		Field{Key: "os.arch", Value: runtime.GOARCH},
+		Field{Key: "process.pid", Value: os.Getpid()},
+		Field{Key: "process.runtime.name", Value: "go"},
+		Field{Key: "process.runtime.version", Value: runtime.Version()},
+		Field{Key: "process.cpu.count", Value: runtime.NumCPU()},
+		Field{Key: "go.goroutine.count", Value: runtime.NumGoroutine()},
+		Field{Key: "cloud.provider", Value: "unknown"},
+		Field{Key: "cloud.region", Value: ""},
+		Field{Key: "container.id", Value: hostname},
+	)
+}
+
 func Start(ctx context.Context, name string, attributes Attributes) (context.Context, *Span) {
 	return StartWithOptions(ctx, name, attributes)
+}
+
+func StartMain(ctx context.Context, name string, attributes Attributes, options ...oteltrace.SpanStartOption) (context.Context, *Span) {
+	attributes = RuntimeAttributes().With(attributes).
+		WithField(Field{Key: "main", Value: true}).
+		WithField(Field{Key: "wide_event", Value: true})
+	ctx, span := StartWithOptions(ctx, name, attributes, options...)
+	span.main = true
+	span.annotate(attributes)
+	ctx = context.WithValue(ctx, mainSpanContextKey{}, span)
+	return ctx, span
 }
 
 func StartWithOptions(ctx context.Context, name string, attributes Attributes, options ...oteltrace.SpanStartOption) (context.Context, *Span) {
@@ -164,6 +214,23 @@ func Event(ctx context.Context, name string, attributes Attributes) {
 	emit("event", &Span{name: name, traceID: current.TraceID, spanID: current.SpanID}, attributes)
 }
 
+func AnnotateMain(ctx context.Context, attributes Attributes) {
+	if span, ok := ctx.Value(mainSpanContextKey{}).(*Span); ok && span != nil {
+		span.annotate(attributes)
+	}
+}
+
+func IncrementMain(ctx context.Context, key string, delta int64) {
+	if strings.TrimSpace(key) == "" || delta == 0 {
+		return
+	}
+	span, ok := ctx.Value(mainSpanContextKey{}).(*Span)
+	if !ok || span == nil {
+		return
+	}
+	span.increment(key, delta)
+}
+
 // CaptureError records a Sentry-style handled error event without serializing
 // the raw error message. Raw messages often contain DSNs, URLs, or token-shaped
 // values, so errors are grouped with a stable kind and fingerprint instead.
@@ -232,6 +299,11 @@ func End(span *Span, status string, attributes Attributes) {
 	if span == nil {
 		return
 	}
+	for key, value := range span.snapshotAnnotations() {
+		if _, exists := attributes.values[key]; !exists {
+			attributes = attributes.with(key, value)
+		}
+	}
 	if status != "" {
 		attributes = attributes.with("status", status)
 	}
@@ -248,6 +320,73 @@ func End(span *Span, status string, attributes Attributes) {
 		span.otelSpan.End()
 	}
 	emit("span_end", span, attributes)
+}
+
+func (s *Span) annotate(attributes Attributes) {
+	if s == nil || len(attributes.values) == 0 {
+		return
+	}
+	s.mu.Lock()
+	if s.annotations == nil {
+		s.annotations = map[string]any{}
+	}
+	for key, value := range attributes.values {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		s.annotations[key] = value
+	}
+	s.mu.Unlock()
+	if s.otelSpan != nil && s.otelSpan.SpanContext().IsValid() {
+		s.otelSpan.SetAttributes(attributes.OTELAttributes()...)
+	}
+}
+
+func (s *Span) increment(key string, delta int64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.annotations == nil {
+		s.annotations = map[string]any{}
+	}
+	current := int64(0)
+	switch value := s.annotations[key].(type) {
+	case int:
+		current = int64(value)
+	case int64:
+		current = value
+	case uint32:
+		current = int64(value)
+	case uint64:
+		if value <= uint64(^uint(0)>>1) {
+			current = int64(value)
+		}
+	case float64:
+		current = int64(value)
+	}
+	next := current + delta
+	s.annotations[key] = next
+	s.mu.Unlock()
+	if s.otelSpan != nil && s.otelSpan.SpanContext().IsValid() {
+		s.otelSpan.SetAttributes(attribute.Int64(key, next))
+	}
+}
+
+func (s *Span) snapshotAnnotations() map[string]any {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.annotations) == 0 {
+		return nil
+	}
+	copied := make(map[string]any, len(s.annotations))
+	for key, value := range s.annotations {
+		copied[key] = value
+	}
+	return copied
 }
 
 func telemetryStatus(status string) codes.Code {
@@ -289,7 +428,7 @@ func (a Attributes) OTELAttributes() []attribute.KeyValue {
 		if strings.TrimSpace(key) == "" {
 			continue
 		}
-		attrs = append(attrs, otelAttribute(key, value))
+		attrs = append(attrs, otelAttribute(key, safeAttributeValue(key, value)))
 	}
 	return attrs
 }
@@ -395,7 +534,7 @@ func emit(kind string, span *Span, attributes Attributes) {
 		}
 	}
 	for key, value := range attributes.values {
-		payload[key] = value
+		payload[key] = safeAttributeValue(key, value)
 	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
@@ -406,6 +545,52 @@ func emit(kind string, span *Span, attributes Attributes) {
 	if _, err := os.Stderr.Write(encoded); err != nil {
 		log.Printf("telemetry write: %v", err)
 	}
+}
+
+func safeAttributeValue(key string, value any) any {
+	if secretLikeKey(key) {
+		return "[redacted]"
+	}
+	switch v := value.(type) {
+	case string:
+		return boundString(v, maxAttributeStringLength)
+	case fmt.Stringer:
+		return boundString(v.String(), maxAttributeStringLength)
+	default:
+		return value
+	}
+}
+
+func secretLikeKey(key string) bool {
+	lower := strings.ToLower(strings.TrimSpace(key))
+	for _, fragment := range []string{
+		"authorization",
+		"api_key",
+		"apikey",
+		"access_token",
+		"refresh_token",
+		"id_token",
+		"token_secret",
+		"secret",
+		"password",
+		"cookie",
+		"credential_id",
+		"credential_secret",
+		"credential_value",
+	} {
+		if strings.Contains(lower, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func boundString(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	return value[:limit] + "..."
 }
 
 func randomHex(bytes int) string {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -143,6 +143,50 @@ func TestStartAndEventBridgeToOpenTelemetry(t *testing.T) {
 	}
 }
 
+func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
+	_, stderr := captureOutput(t, func() {
+		ctx, span := StartMain(context.Background(), "test.main", Attrs(
+			Field{Key: "tenant_id", Value: "tenant-1"},
+			Field{Key: "auth.credential_tier", Value: "production"},
+			Field{Key: "credential_id", Value: "cred-secret"},
+			Field{Key: "oversized", Value: strings.Repeat("x", maxAttributeStringLength+256)},
+		))
+		AnnotateMain(ctx, Attrs(Field{Key: "cache.redis.last_status", Value: "hit"}))
+		IncrementMain(ctx, "cache.redis.hit.count", 1)
+		IncrementMain(ctx, "cache.redis.hit.count", 2)
+		End(span, "completed", Attrs(Field{Key: "explicit_end_attr", Value: "kept"}))
+	})
+	payload := telemetryPayloadByKindAndName(t, stderr, "span_end", "test.main")
+	if payload["main"] != true || payload["wide_event"] != true {
+		t.Fatalf("main span flags missing: %#v", payload)
+	}
+	if got := payload["tenant_id"]; got != "tenant-1" {
+		t.Fatalf("tenant_id = %#v, want tenant-1; payload=%#v", got, payload)
+	}
+	if got := payload["auth.credential_tier"]; got != "production" {
+		t.Fatalf("credential tier was unexpectedly redacted: %#v", payload)
+	}
+	if got := payload["credential_id"]; got != "[redacted]" {
+		t.Fatalf("credential_id = %#v, want redacted; payload=%#v", got, payload)
+	}
+	if got := payload["cache.redis.last_status"]; got != "hit" {
+		t.Fatalf("late annotation missing: %#v", payload)
+	}
+	if got := payload["cache.redis.hit.count"]; got != float64(3) {
+		t.Fatalf("incremented count = %#v, want 3; payload=%#v", got, payload)
+	}
+	if got := payload["explicit_end_attr"]; got != "kept" {
+		t.Fatalf("explicit end attr missing: %#v", payload)
+	}
+	oversized, ok := payload["oversized"].(string)
+	if !ok || len(oversized) > maxAttributeStringLength+3 || !strings.HasSuffix(oversized, "...") {
+		t.Fatalf("oversized attribute was not bounded: len=%d value=%q", len(oversized), oversized)
+	}
+	if got := payload["service.name"]; got != "cerebro" {
+		t.Fatalf("runtime service attr = %#v, want cerebro; payload=%#v", got, payload)
+	}
+}
+
 func TestEndMapsErrorStatusesToOpenTelemetryErrors(t *testing.T) {
 	for _, status := range []string{"failed", "error"} {
 		t.Run(status, func(t *testing.T) {
@@ -230,6 +274,24 @@ func TestConfigureOpenTelemetryDisabledLeavesNoopProviderUsable(t *testing.T) {
 	}
 	_, span := Start(context.Background(), "noop.span", Attrs())
 	End(span, "completed", Attrs())
+}
+
+func telemetryPayloadByKindAndName(t *testing.T, stderr string, kind string, name string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			t.Fatalf("unmarshal telemetry payload %q: %v", line, err)
+		}
+		if payload["kind"] == kind && payload["name"] == name {
+			return payload
+		}
+	}
+	t.Fatalf("telemetry payload kind=%q name=%q not found in stderr: %s", kind, name, stderr)
+	return nil
 }
 
 func captureOutput(t *testing.T, fn func()) (string, string) {

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const bootstrapProductionGoLineBudget = 23042
+const bootstrapProductionGoLineBudget = 23279
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- add canonical main-span wide events for HTTP requests and top-level jobs
- propagate auth, MCP/OAuth, GRC ask/dashboard, cache, DB, graph, source, queue, projection, and findings dimensions onto the active main span
- bound/redact telemetry values, document the wide-event contract, and update tests/architecture budget for request-boundary instrumentation

## Validation
- go test ./internal/telemetry ./internal/observability ./internal/sourcehttp ./internal/bootstrap ./internal/querycache ./internal/statestore/postgres ./internal/graphstore/neo4j ./internal/appendlog/jetstream ./internal/sourceops ./internal/sourceruntime ./internal/sourceprojection ./internal/graphingest ./internal/findings ./cmd/cerebro
- go test ./...
- make lint