### PR TITLE
Add Anthropic compliance role permissions

### DIFF
--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -1598,6 +1598,7 @@ var connectorSchemas = map[string]connectorSchema{
 			"organization_ids",
 			"per_page",
 			"periods",
+			"role_id",
 			"service_tiers",
 			"speeds",
 			"starting_at",

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -1321,7 +1321,7 @@ func TestConnectorSchemaForGenerateableCatalogDefinition(t *testing.T) {
 	if !ok {
 		t.Fatal("connectorSchemaForSource(anthropic) = false, want builtin schema")
 	}
-	for _, key := range []string{"credential_kind", "credential_scopes", "group_id", "organization_uuid", "per_page"} {
+	for _, key := range []string{"credential_kind", "credential_scopes", "group_id", "organization_uuid", "per_page", "role_id"} {
 		if _, ok := anthropicSchema.ConfigKeys[key]; !ok {
 			t.Fatalf("anthropic config keys missing %q: %#v", key, sortedSetKeys(anthropicSchema.ConfigKeys))
 		}
@@ -1336,6 +1336,19 @@ func TestConnectorSchemaForGenerateableCatalogDefinition(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("validateConnectorConfigFields(anthropic credential hints) error = %v", err)
+	}
+	err = validateConnectorConfigFields("anthropic", connectorAuthMethodExternalReference, map[string]string{ // #nosec G101 -- Test-only credential reference placeholders, not live secrets.
+		"api_key":           "env:CEREBRO_SOURCE_ANTHROPIC_API_KEY",
+		"credential_kind":   connectorpreflight.AnthropicCredentialKindComplianceAccessKey,
+		"credential_scopes": "read:compliance_org_data",
+		"family":            "compliance_role_permission",
+		"organization_uuid": "org-uuid-1",
+		"role_id":           "rbac_role_123",
+	}, map[string]string{
+		"api_key": "env:CEREBRO_SOURCE_ANTHROPIC_API_KEY",
+	})
+	if err != nil {
+		t.Fatalf("validateConnectorConfigFields(anthropic role permission config) error = %v", err)
 	}
 }
 
@@ -1401,8 +1414,8 @@ func TestAnthropicProviderPreflightChecksCredentialRequirements(t *testing.T) {
 			wantAction: "confirm_anthropic_compliance_scope",
 		},
 		{
-			name:       "compliance directory needs org data scope",
-			config:     map[string]string{"credential_kind": connectorpreflight.AnthropicCredentialKindAdminAPIKey, "family": "compliance_group", "credential_scopes": "read:compliance_activities"},
+			name:       "compliance role permissions need org data scope",
+			config:     map[string]string{"credential_kind": connectorpreflight.AnthropicCredentialKindAdminAPIKey, "family": "compliance_role_permission", "credential_scopes": "read:compliance_activities"},
 			wantCheck:  "anthropic_compliance_org_data_scope",
 			wantAction: "confirm_anthropic_compliance_scope",
 		},
@@ -1459,8 +1472,8 @@ func TestAnthropicProviderPreflightChecksPassWithCredentialHints(t *testing.T) {
 			config: map[string]string{"credential_kind": connectorpreflight.AnthropicCredentialKindComplianceAccessKey, "credential_scopes": "read:compliance_activities", "family": "compliance_activity"},
 		},
 		{
-			name:   "compliance directory scoped key",
-			config: map[string]string{"credential_kind": connectorpreflight.AnthropicCredentialKindComplianceAccessKey, "credential_scopes": "read:compliance_org_data", "family": "compliance_group"},
+			name:   "compliance role permissions scoped key",
+			config: map[string]string{"credential_kind": connectorpreflight.AnthropicCredentialKindComplianceAccessKey, "credential_scopes": "read:compliance_org_data", "family": "compliance_role_permission"},
 		},
 		{
 			name:   "compliance user data scoped key",

--- a/internal/connectorpreflight/provider.go
+++ b/internal/connectorpreflight/provider.go
@@ -128,12 +128,12 @@ func anthropicProviderChecks(config map[string]string, policy resourcescope.Poli
 				NextAction: "confirm_anthropic_compliance_scope",
 			})
 		}
-	case "compliance_organization", "compliance_role", "compliance_group":
+	case "compliance_organization", "compliance_role", "compliance_role_permission", "compliance_group":
 		checks = append(checks, anthropicComplianceAccessKeyCheck(authModel, credentialKind, scopes, anthropicCompliancePreflight{
 			RequiredScope: "read:compliance_org_data",
 			ID:            "anthropic_compliance_org_data_scope",
 			Label:         "Anthropic compliance org-data scope",
-			Detail:        "Compliance organization, role, and group families use x-api-key and require read:compliance_org_data on a Compliance Access Key; record credential_kind=compliance_access_key and credential_scopes=read:compliance_org_data.",
+			Detail:        "Compliance organization, role, role-permission, and group families use x-api-key and require read:compliance_org_data on a Compliance Access Key; record credential_kind=compliance_access_key and credential_scopes=read:compliance_org_data.",
 		})...)
 	case "compliance_organization_user", "compliance_group_member":
 		checks = append(checks, anthropicComplianceAccessKeyCheck(authModel, credentialKind, scopes, anthropicCompliancePreflight{

--- a/internal/sourceprojection/ai_access.go
+++ b/internal/sourceprojection/ai_access.go
@@ -84,6 +84,10 @@ func anthropicComplianceRoleProjections(event *cerebrov1.EventEnvelope) ([]*port
 	return aiScopedRoleProjections(event, anthropicAccessProfile)
 }
 
+func anthropicComplianceRolePermissionProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiRolePermissionProjections(event, anthropicAccessProfile)
+}
+
 func openAIUserRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiSubjectRoleProjections(event, openAIAccessProfile, "user", "organization")
 }
@@ -446,6 +450,57 @@ func aiGroupRoleAssignmentProjections(event *cerebrov1.EventEnvelope, profile ai
 		aiLinkRoleToScope(links, tenantID, event, roleURN, orgURN, roleID, "group_role_scope")
 	}
 	aiLinkPrincipalRolesToScope(links, tenantID, event, groupURN, orgURN, roleIDs, "group_organization_role_access")
+	return identityProjectionResult(entities, links)
+}
+
+func aiRolePermissionProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	roleID := aiRoleID(attrs)
+	permissionID := aiRolePermissionID(attrs, event.GetId())
+	if roleID == "" || permissionID == "" {
+		return identityProjectionResult(entities, links)
+	}
+	scopeURN := aiEnsureOrganization(entities, tenantID, event.GetSourceId(), profile, attrs)
+	roleURN := aiEnsureRole(entities, tenantID, event.GetSourceId(), profile, attrs, "organization")
+	entitlementURN := projectionURN(tenantID, profile.Provider+"_entitlement", "role_permission", roleID, permissionID)
+	entitlementAttrs := cloneAttributes(attrs)
+	entitlementAttrs["entitlement_id"] = "role_permission:" + roleID + ":" + permissionID
+	entitlementAttrs["entitlement_type"] = "role_permission"
+	entitlementAttrs["permission_id"] = permissionID
+	entitlementAttrs["role_id"] = roleID
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        entitlementURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: profile.Provider + ".entitlement",
+		Label:      firstNonEmpty(attrs["permission_name"], attrs["permission"], permissionID),
+		Attributes: entitlementAttrs,
+	})
+	linkAttrs := aiEventLinkAttributes(event, "role_permission")
+	addProjectedAttribute(linkAttrs, "role_id", roleID)
+	addProjectedAttribute(linkAttrs, "permission_id", permissionID)
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), roleURN, entitlementURN, relationGrantsEntitlement, linkAttrs))
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), entitlementURN, scopeURN, relationBelongsTo, aiEventLinkAttributes(event, "role_permission_scope")))
+	aiLinkRoleToScope(links, tenantID, event, roleURN, scopeURN, roleID, "role_permission_scope_access")
+	capabilityID := aiRolePermissionCapabilityID(attrs)
+	capabilityURN := projectionURN(tenantID, "privileged_capability", capabilityID)
+	if capabilityURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        capabilityURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "privileged.capability",
+			Label:      strings.ReplaceAll(capabilityID, "_", " "),
+			Attributes: map[string]string{"capability_id": capabilityID},
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), entitlementURN, capabilityURN, relationConfersCapability, aiEventLinkAttributes(event, "role_permission_capability")))
+	}
 	return identityProjectionResult(entities, links)
 }
 
@@ -959,6 +1014,32 @@ func aiAuditTargetURN(entities map[string]*ports.ProjectedEntity, tenantID strin
 
 func aiRoleID(attrs map[string]string) string {
 	return firstNonEmpty(attrs["role_id"], attrs["role"], attrs["name"], attrs["role_name"], attrs["predefined_role"])
+}
+
+func aiRolePermissionID(attrs map[string]string, fallback string) string {
+	return firstNonEmpty(attrs["permission_id"], attrs["permission"], attrs["permission_name"], attrs["name"], fallback)
+}
+
+func aiRolePermissionCapabilityID(attrs map[string]string) string {
+	normalized := normalizeIdentifier(strings.Join([]string{
+		attrs["permission_id"],
+		attrs["permission"],
+		attrs["permission_name"],
+		attrs["action"],
+		attrs["resource_type"],
+		attrs["scope"],
+		attrs["category"],
+	}, " "))
+	switch {
+	case strings.Contains(normalized, "delete") || strings.Contains(normalized, "destroy") || strings.Contains(normalized, "purge"):
+		return "ai_data_delete"
+	case strings.Contains(normalized, "admin") || strings.Contains(normalized, "manage") || strings.Contains(normalized, "write") || strings.Contains(normalized, "create") || strings.Contains(normalized, "update"):
+		return "ai_admin"
+	case strings.Contains(normalized, "read") || strings.Contains(normalized, "view") || strings.Contains(normalized, "list") || strings.Contains(normalized, "export"):
+		return "ai_data_read"
+	default:
+		return "ai_compliance_access"
+	}
 }
 
 func aiRoleIDsFromAttribute(value string) []string {

--- a/internal/sourceprojection/ai_access_test.go
+++ b/internal/sourceprojection/ai_access_test.go
@@ -306,6 +306,23 @@ func TestProjectAnthropicComplianceDirectoryGroupMembership(t *testing.T) {
 			},
 		},
 		{
+			Id:         "anthropic-compliance-role-permission",
+			TenantId:   "writer",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.compliance_role_permission",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"action":                 "read",
+				"family":                 "compliance_role_permission",
+				"organization_uuid":      "org-uuid-1",
+				"permission_description": "Read retained chat content.",
+				"permission_id":          "perm_read_chats",
+				"permission_name":        "Read chats",
+				"resource_type":          "chat",
+				"role_id":                "rbac_role_123",
+			},
+		},
+		{
 			Id:         "anthropic-compliance-role",
 			TenantId:   "writer",
 			SourceId:   "anthropic",
@@ -329,6 +346,8 @@ func TestProjectAnthropicComplianceDirectoryGroupMembership(t *testing.T) {
 	userURN := "urn:cerebro:writer:anthropic_user:user_789"
 	groupURN := "urn:cerebro:writer:anthropic_group:rbac_group_123"
 	roleURN := "urn:cerebro:writer:anthropic_role:organization:rbac_role_123"
+	entitlementURN := "urn:cerebro:writer:anthropic_entitlement:role_permission:rbac_role_123:perm_read_chats"
+	capabilityURN := "urn:cerebro:writer:privileged_capability:ai_data_read"
 	orgURN := "urn:cerebro:writer:anthropic_org:org-uuid-1"
 	identityURN := "urn:cerebro:writer:identity:email:carol@example.com"
 
@@ -338,9 +357,15 @@ func TestProjectAnthropicComplianceDirectoryGroupMembership(t *testing.T) {
 	if entity := state.entities[roleURN]; entity == nil || entity.EntityType != "anthropic.role" || entity.Label != "Compliance Reviewer" || entity.Attributes["role_id"] != "rbac_role_123" || entity.Attributes["scope_kind"] != "organization" {
 		t.Fatalf("role entity missing or wrong: %#v", entity)
 	}
+	if entity := state.entities[entitlementURN]; entity == nil || entity.EntityType != "anthropic.entitlement" || entity.Label != "Read chats" || entity.Attributes["permission_id"] != "perm_read_chats" {
+		t.Fatalf("entitlement entity missing or wrong: %#v", entity)
+	}
 	assertProjectedLink(t, state, groupURN, relationBelongsTo, orgURN)
 	assertProjectedLink(t, state, roleURN, relationBelongsTo, orgURN)
 	assertProjectedLink(t, state, roleURN, relationGrantsEntitlement, orgURN)
+	assertProjectedLink(t, state, roleURN, relationGrantsEntitlement, entitlementURN)
+	assertProjectedLink(t, state, entitlementURN, relationBelongsTo, orgURN)
+	assertProjectedLink(t, state, entitlementURN, relationConfersCapability, capabilityURN)
 	assertProjectedLink(t, state, groupURN, relationAssignedTo, roleURN)
 	assertProjectedLink(t, state, groupURN, relationCanPerform, orgURN)
 	assertProjectedLink(t, state, userURN, relationRepresentsIdentity, identityURN)

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -447,6 +447,7 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"anthropic.compliance_organization_setting":     anthropicGovernanceControlProjections,
 	"anthropic.compliance_organization_user":        anthropicUserProjections,
 	"anthropic.compliance_role":                     anthropicComplianceRoleProjections,
+	"anthropic.compliance_role_permission":          anthropicComplianceRolePermissionProjections,
 	"anthropic.cost_report":                         genericInventoryProjections,
 	"anthropic.external_key":                        anthropicCredentialProjections,
 	"anthropic.federation_issuer":                   anthropicFederationIssuerProjections,

--- a/sources/anthropic/catalog.yaml
+++ b/sources/anthropic/catalog.yaml
@@ -24,6 +24,7 @@ emitted_kinds:
   - anthropic.compliance_organization
   - anthropic.compliance_organization_user
   - anthropic.compliance_role
+  - anthropic.compliance_role_permission
   - anthropic.compliance_group
   - anthropic.compliance_group_member
   - anthropic.compliance_organization_setting
@@ -45,8 +46,8 @@ coverage_contract:
       high_value: true
     - id: compliance_directory
       type: app_entitlement
-      title: Compliance organizations, users, roles, groups, and group members
-      families: [compliance_organization, compliance_organization_user, compliance_role, compliance_group, compliance_group_member]
+      title: Compliance organizations, users, roles, role permissions, groups, and group members
+      families: [compliance_organization, compliance_organization_user, compliance_role, compliance_role_permission, compliance_group, compliance_group_member]
       support: supported
       high_value: true
     - id: compliance_settings
@@ -185,6 +186,9 @@ event_contracts:
     schema_ref: anthropic/compliance_role/v1
     required_attributes: [organization_uuid, role_id]
     required_payload_fields: [id]
+  - kind: anthropic.compliance_role_permission
+    schema_ref: anthropic/compliance_role_permission/v1
+    required_attributes: [organization_uuid, role_id, permission_id]
   - kind: anthropic.compliance_group
     schema_ref: anthropic/compliance_group/v1
     required_attributes: [group_id]

--- a/sources/anthropic/source.go
+++ b/sources/anthropic/source.go
@@ -93,6 +93,7 @@ func anthropicFamilies() []jsonapi.Family {
 		anthropicListFamily("compliance_organization", "/compliance/organizations", "anthropic_compliance_organization", []string{"uuid", "id"}, []string{"created_at"}, map[string]string{"organization_uuid": "uuid", "organization_id": "id|organization_id", "name": "name", "created_at": "created_at"}, withoutPagination()),
 		anthropicListFamily("compliance_organization_user", "/compliance/organizations/{organization_uuid}/users", "anthropic_compliance_organization_user", []string{"id", "user_id"}, []string{"created_at"}, map[string]string{"organization_uuid": "organization_uuid", "user_id": "id|user_id", "name": "full_name|name", "email": "email", "role": "organization_role|role", "organization_role": "organization_role|role", "created_at": "created_at"}, withPathParams("organization_uuid"), withPageCursor()),
 		anthropicListFamily("compliance_role", "/compliance/organizations/{organization_uuid}/roles", "anthropic_compliance_role", []string{"id", "role_id"}, []string{"created_at", "updated_at"}, map[string]string{"organization_uuid": "organization_uuid", "role_id": "id|role_id", "name": "name", "description": "description", "created_at": "created_at", "updated_at": "updated_at"}, withPathParams("organization_uuid"), withPageCursor()),
+		anthropicListFamily("compliance_role_permission", "/compliance/organizations/{organization_uuid}/roles/{role_id}/permissions", "anthropic_compliance_role_permission", []string{"id", "permission_id", "permission", "name"}, []string{"created_at", "updated_at"}, rolePermissionAttributes(), withPathParams("organization_uuid", "role_id"), withPageCursor()),
 		anthropicListFamily("compliance_group", "/compliance/groups", "anthropic_compliance_group", []string{"id", "group_id"}, []string{"created_at", "updated_at"}, map[string]string{"group_id": "id|group_id", "group_name": "name", "name": "name", "description": "description", "source_type": "source_type", "roles": "roles", "created_at": "created_at", "updated_at": "updated_at"}, withPageCursor()),
 		anthropicListFamily("compliance_group_member", "/compliance/groups/{group_id}/members", "anthropic_compliance_group_member", []string{"user_id", "id", "email"}, []string{"created_at", "updated_at"}, map[string]string{"group_id": "group_id", "user_id": "user_id|id", "email": "email", "created_at": "created_at", "updated_at": "updated_at"}, withPathParams("group_id"), withPageCursor()),
 		anthropicListFamily("compliance_organization_setting", "/compliance/organizations/{organization_uuid}/settings", "anthropic_compliance_organization_setting", []string{"name"}, nil, map[string]string{"organization_uuid": "organization_uuid", "setting_name": "name", "setting_type": "type", "setting_value": "value"}, withPathParams("organization_uuid"), withListKeys("settings"), withoutPagination()),
@@ -159,6 +160,23 @@ func rateLimitAttributes() map[string]string {
 		"input_tokens":        "input_tokens",
 		"output_tokens":       "output_tokens",
 		"updated_at":          "updated_at",
+	}
+}
+
+func rolePermissionAttributes() map[string]string {
+	return map[string]string{
+		"organization_uuid":      "organization_uuid",
+		"role_id":                "role_id",
+		"permission_id":          "id|permission_id|permission|name",
+		"permission":             "permission|permission_id|id|name",
+		"permission_name":        "name|permission|permission_id|id",
+		"permission_description": "description",
+		"action":                 "action",
+		"resource_type":          "resource_type|resource",
+		"scope":                  "scope",
+		"category":               "category|type",
+		"created_at":             "created_at",
+		"updated_at":             "updated_at",
 	}
 }
 

--- a/sources/anthropic/source_test.go
+++ b/sources/anthropic/source_test.go
@@ -251,6 +251,98 @@ func TestReadComplianceOrganizationUsersUsesComplianceKeyAndPageCursor(t *testin
 	}
 }
 
+func TestReadComplianceRolePermissionsUsesRolePathAndPageCursor(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); got != "/compliance/organizations/org-uuid-1/roles/rbac_role_123/permissions" {
+			t.Fatalf("request path = %q, want /compliance/organizations/org-uuid-1/roles/rbac_role_123/permissions", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got != "2023-06-01" {
+			t.Fatalf("anthropic-version = %q, want 2023-06-01", got)
+		}
+		if got := r.Header.Get("x-api-key"); got != "fixture-compliance-key" {
+			t.Fatalf("x-api-key = %q, want fixture-compliance-key", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("limit = %q, want 2", got)
+		}
+		switch r.URL.Query().Get("page") {
+		case "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{
+					"id":            "perm_read_chats",
+					"name":          "Read chats",
+					"description":   "Read retained chat content.",
+					"action":        "read",
+					"resource_type": "chat",
+				}},
+				"has_more":  true,
+				"next_page": "page-2",
+			})
+		case "page-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{
+					"id":            "perm_delete_files",
+					"name":          "Delete files",
+					"action":        "delete",
+					"resource_type": "file",
+				}},
+				"has_more": false,
+			})
+		default:
+			t.Fatalf("page = %q, want empty or page-2", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test-only placeholder key.
+		"api_key":           "fixture-compliance-key",
+		"base_url":          server.URL,
+		"family":            "compliance_role_permission",
+		"organization_uuid": "org-uuid-1",
+		"per_page":          "2",
+		"role_id":           "rbac_role_123",
+		"tenant_id":         "writer",
+	})
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if first.NextCursor.GetOpaque() != "page-2" {
+		t.Fatalf("first NextCursor = %q, want page-2", first.NextCursor.GetOpaque())
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
+	}
+	event := first.Events[0]
+	if event.Kind != "anthropic.compliance_role_permission" {
+		t.Fatalf("Kind = %q, want anthropic.compliance_role_permission", event.Kind)
+	}
+	if got := event.Attributes["organization_uuid"]; got != "org-uuid-1" {
+		t.Fatalf("organization_uuid = %q, want org-uuid-1", got)
+	}
+	if got := event.Attributes["role_id"]; got != "rbac_role_123" {
+		t.Fatalf("role_id = %q, want rbac_role_123", got)
+	}
+	if got := event.Attributes["permission_id"]; got != "perm_read_chats" {
+		t.Fatalf("permission_id = %q, want perm_read_chats", got)
+	}
+	if got := event.Attributes["resource_type"]; got != "chat" {
+		t.Fatalf("resource_type = %q, want chat", got)
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second NextCursor = %#v, want nil", second.NextCursor)
+	}
+}
+
 func TestReadComplianceOrganizationSettingsUsesSettingsListKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.EscapedPath(); got != "/compliance/organizations/org-uuid-1/settings" {


### PR DESCRIPTION
## Summary
- add the Anthropic Compliance API role-permissions family for `/v1/compliance/organizations/{org_uuid}/roles/{role_id}/permissions`
- project role permissions as Anthropic entitlement nodes, link roles to permissions, organizations, and coarse privileged capabilities
- allow `role_id` config and extend Anthropic compliance preflight guidance to the role-permission family

## Verification
- go test ./sources/anthropic ./internal/sourceprojection ./internal/bootstrap ./internal/connectorpreflight
- make lint
- ./scripts/pre_commit_checks.sh
- make check-structural
- make check-arch