### PR TITLE
Fix Droid post-merge health race

### DIFF
--- a/scripts/droid_post_merge_health.py
+++ b/scripts/droid_post_merge_health.py
@@ -13,9 +13,10 @@ import urllib.request
 from pathlib import Path
 
 COMMENT_MARKER = "<!-- droid-post-merge-health -->"
+DROID_POST_MERGE_HEALTH_WORKFLOW = "Droid Post-Merge Health"
 DROID_BOT_LOGIN = "factory-droid[bot]"
 DROID_FINISHED_MARKERS = ("Droid finished", "Review complete for PR")
-TERMINAL_DROID_STATUSES = {"ok", "skipped"}
+DROID_REVIEW_FAILURE_STATUSES = {"error", "missing"}
 DROID_REVIEW_REQUIRED_EXACT = {"go.mod", "go.sum", "Makefile"}
 DROID_REVIEW_REQUIRED_PREFIXES = (
     ".github/workflows/",
@@ -330,10 +331,14 @@ def summarize(
         for run in runs
         if (not head_sha or run.get("head_sha") == head_sha)
         and (not current_run_id or str(run.get("id") or "") != current_run_id)
+        and run.get("workflow_name") != DROID_POST_MERGE_HEALTH_WORKFLOW
     ]
     if not relevant:
         relevant = [
-            run for run in runs[:5] if not current_run_id or str(run.get("id") or "") != current_run_id
+            run
+            for run in runs[:5]
+            if (not current_run_id or str(run.get("id") or "") != current_run_id)
+            and run.get("workflow_name") != DROID_POST_MERGE_HEALTH_WORKFLOW
         ]
     failures = [
         run
@@ -342,7 +347,7 @@ def summarize(
     ]
     pending = [run for run in relevant if run.get("status") != "completed"]
     reviews = droid_reviews or []
-    failed_reviews = [review for review in reviews if review.get("status") not in TERMINAL_DROID_STATUSES]
+    failed_reviews = [review for review in reviews if review.get("status") in DROID_REVIEW_FAILURE_STATUSES]
     return {
         "kind": "droid_post_merge_health",
         "branch": branch,

--- a/scripts/tests/test_droid_post_merge_health.py
+++ b/scripts/tests/test_droid_post_merge_health.py
@@ -29,6 +29,25 @@ class DroidPostMergeHealthTests(unittest.TestCase):
         self.assertTrue(context["healthy"])
         self.assertEqual(len(context["pending_runs"]), 0)
 
+    def test_summarize_ignores_prior_post_merge_health_failures(self):
+        context = pm.summarize(
+            branch="main",
+            head_sha="abc",
+            runs=[
+                {
+                    "id": 1,
+                    "workflow_name": "Droid Post-Merge Health",
+                    "head_sha": "abc",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "url": "https://health",
+                },
+                {"id": 2, "workflow_name": "CI", "head_sha": "abc", "status": "completed", "conclusion": "success"},
+            ],
+        )
+        self.assertTrue(context["healthy"])
+        self.assertEqual(len(context["failed_runs"]), 0)
+
     def test_summarize_does_not_fail_for_pending_sibling_runs(self):
         context = pm.summarize(
             branch="main",
@@ -312,6 +331,19 @@ class DroidPostMergeHealthTests(unittest.TestCase):
         )
         self.assertFalse(context["healthy"])
         self.assertEqual(len(context["failed_droid_reviews"]), 1)
+
+    def test_summarize_keeps_in_progress_droid_review_non_blocking(self):
+        context = pm.summarize(
+            branch="main",
+            head_sha="abc",
+            runs=[
+                {"workflow_name": "CI", "head_sha": "abc", "status": "completed", "conclusion": "success", "url": "https://ci"},
+            ],
+            pull_requests=[{"number": 42, "url": "https://pr"}],
+            droid_reviews=[{"number": 42, "status": "in_progress", "reason": "Droid is still reviewing."}],
+        )
+        self.assertTrue(context["healthy"])
+        self.assertEqual(len(context["failed_droid_reviews"]), 0)
 
     def test_render_markdown_mentions_droid_review_status(self):
         markdown = pm.render_markdown(


### PR DESCRIPTION
## Summary
- keep Droid Post-Merge Health from counting earlier health-check failures on the same head
- treat active Droid review progress as non-blocking health context while preserving hard failures for missing/error reviews
- add regression coverage for both cases

## Root cause
The post-merge health workflow runs seconds after a main push. It failed #1166 because Droid had an unsuperseded in-progress review comment even though the app CI was green, and reruns could then self-poison by counting the previous Droid Post-Merge Health failure as a failed workflow.

## Verification
- python3 -m unittest scripts.tests.test_droid_post_merge_health
- python3 -m unittest discover scripts/tests
- GH_TOKEN=... GITHUB_REPOSITORY=writer/cerebro GITHUB_RUN_ID=0 DROID_POST_MERGE_HEAD=a0894703fc03f223d48b7db5a7e7cb0d3c726072 python3 scripts/droid_post_merge_health.py --head a0894703fc03f223d48b7db5a7e7cb0d3c726072 --strict --markdown-out tmp/health-fixed.md --json-out tmp/health-fixed.json