### PR TITLE
Add Anthropic project collaborator access

### DIFF
--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -1598,6 +1598,7 @@ var connectorSchemas = map[string]connectorSchema{
 			"organization_ids",
 			"per_page",
 			"periods",
+			"project_id",
 			"role_id",
 			"service_tiers",
 			"speeds",

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -1321,7 +1321,7 @@ func TestConnectorSchemaForGenerateableCatalogDefinition(t *testing.T) {
 	if !ok {
 		t.Fatal("connectorSchemaForSource(anthropic) = false, want builtin schema")
 	}
-	for _, key := range []string{"credential_kind", "credential_scopes", "group_id", "organization_uuid", "per_page", "role_id"} {
+	for _, key := range []string{"credential_kind", "credential_scopes", "group_id", "organization_uuid", "per_page", "project_id", "role_id"} {
 		if _, ok := anthropicSchema.ConfigKeys[key]; !ok {
 			t.Fatalf("anthropic config keys missing %q: %#v", key, sortedSetKeys(anthropicSchema.ConfigKeys))
 		}
@@ -1349,6 +1349,18 @@ func TestConnectorSchemaForGenerateableCatalogDefinition(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("validateConnectorConfigFields(anthropic role permission config) error = %v", err)
+	}
+	err = validateConnectorConfigFields("anthropic", connectorAuthMethodExternalReference, map[string]string{ // #nosec G101 -- Test-only credential reference placeholders, not live secrets.
+		"api_key":           "env:CEREBRO_SOURCE_ANTHROPIC_API_KEY",
+		"credential_kind":   connectorpreflight.AnthropicCredentialKindComplianceAccessKey,
+		"credential_scopes": "read:compliance_user_data",
+		"family":            "compliance_project_collaborator",
+		"project_id":        "claude_proj_123",
+	}, map[string]string{
+		"api_key": "env:CEREBRO_SOURCE_ANTHROPIC_API_KEY",
+	})
+	if err != nil {
+		t.Fatalf("validateConnectorConfigFields(anthropic project collaborator config) error = %v", err)
 	}
 }
 
@@ -1426,6 +1438,12 @@ func TestAnthropicProviderPreflightChecksCredentialRequirements(t *testing.T) {
 			wantAction: "confirm_anthropic_compliance_scope",
 		},
 		{
+			name:       "compliance projects need user data scope",
+			config:     map[string]string{"credential_kind": connectorpreflight.AnthropicCredentialKindComplianceAccessKey, "family": "compliance_project_collaborator", "credential_scopes": "read:compliance_org_data"},
+			wantCheck:  "anthropic_compliance_user_data_scope",
+			wantAction: "confirm_anthropic_compliance_scope",
+		},
+		{
 			name:       "compliance settings need settings scope",
 			config:     map[string]string{"auth_model": "bearer_token", "credential_kind": connectorpreflight.AnthropicCredentialKindOrgAdminOAuth, "family": "compliance_organization_setting", "credential_scopes": "org:admin"},
 			wantCheck:  "anthropic_compliance_org_settings_scope",
@@ -1478,6 +1496,10 @@ func TestAnthropicProviderPreflightChecksPassWithCredentialHints(t *testing.T) {
 		{
 			name:   "compliance user data scoped key",
 			config: map[string]string{"credential_kind": connectorpreflight.AnthropicCredentialKindComplianceAccessKey, "credential_scopes": "read:compliance_user_data", "family": "compliance_organization_user"},
+		},
+		{
+			name:   "compliance project collaborator scoped key",
+			config: map[string]string{"credential_kind": connectorpreflight.AnthropicCredentialKindComplianceAccessKey, "credential_scopes": "read:compliance_user_data", "family": "compliance_project_collaborator"},
 		},
 		{
 			name:   "compliance settings scoped key",

--- a/internal/connectorpreflight/provider.go
+++ b/internal/connectorpreflight/provider.go
@@ -135,12 +135,12 @@ func anthropicProviderChecks(config map[string]string, policy resourcescope.Poli
 			Label:         "Anthropic compliance org-data scope",
 			Detail:        "Compliance organization, role, role-permission, and group families use x-api-key and require read:compliance_org_data on a Compliance Access Key; record credential_kind=compliance_access_key and credential_scopes=read:compliance_org_data.",
 		})...)
-	case "compliance_organization_user", "compliance_group_member":
+	case "compliance_organization_user", "compliance_group_member", "compliance_project", "compliance_project_collaborator":
 		checks = append(checks, anthropicComplianceAccessKeyCheck(authModel, credentialKind, scopes, anthropicCompliancePreflight{
 			RequiredScope: "read:compliance_user_data",
 			ID:            "anthropic_compliance_user_data_scope",
 			Label:         "Anthropic compliance user-data scope",
-			Detail:        "Compliance user and group-member families use x-api-key and require read:compliance_user_data on a Compliance Access Key; record credential_kind=compliance_access_key and credential_scopes=read:compliance_user_data.",
+			Detail:        "Compliance user, group-member, project, and project-collaborator families use x-api-key and require read:compliance_user_data on a Compliance Access Key; record credential_kind=compliance_access_key and credential_scopes=read:compliance_user_data.",
 		})...)
 	case "compliance_organization_setting":
 		checks = append(checks, anthropicComplianceAccessKeyCheck(authModel, credentialKind, scopes, anthropicCompliancePreflight{

--- a/internal/sourceprojection/ai_access.go
+++ b/internal/sourceprojection/ai_access.go
@@ -28,6 +28,14 @@ func openAIProjectProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projecte
 	return aiProjectProjections(event, openAIAccessProfile)
 }
 
+func anthropicProjectProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiProjectProjections(event, anthropicAccessProfile)
+}
+
+func anthropicProjectCollaboratorProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiProjectCollaboratorProjections(event, anthropicAccessProfile)
+}
+
 func anthropicOrganizationProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiOrganizationProjections(event, anthropicAccessProfile)
 }
@@ -501,6 +509,45 @@ func aiRolePermissionProjections(event *cerebrov1.EventEnvelope, profile aiAcces
 		})
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), entitlementURN, capabilityURN, relationConfersCapability, aiEventLinkAttributes(event, "role_permission_capability")))
 	}
+	return identityProjectionResult(entities, links)
+}
+
+func aiProjectCollaboratorProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	projectURN := aiEnsureProject(entities, tenantID, event.GetSourceId(), profile, attrs)
+	orgURN := aiEnsureOrganization(entities, tenantID, event.GetSourceId(), profile, attrs)
+	if projectURN != "" && orgURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), projectURN, orgURN, relationBelongsTo, aiEventLinkAttributes(event, "project_organization")))
+	}
+	roleID := aiRoleID(attrs)
+	if roleID == "" {
+		return identityProjectionResult(entities, links)
+	}
+	roleName := firstNonEmpty(attrs["role_name"], attrs["role"], roleID)
+	roleAttrs := aiScopedRoleAttributes(attrs, roleID)
+	roleAttrs["name"] = roleName
+	roleAttrs["role_name"] = roleName
+	roleURN := aiEnsureRole(entities, tenantID, event.GetSourceId(), profile, roleAttrs, "project")
+	principalType := aiProjectCollaboratorPrincipalType(attrs)
+	principalID := aiProjectCollaboratorPrincipalID(attrs, principalType)
+	principalURN := aiEnsureProjectCollaboratorPrincipal(entities, links, tenantID, event, profile, principalType, principalID, roleName)
+	if principalURN != "" && roleURN != "" {
+		linkAttrs := aiEventLinkAttributes(event, "project_collaborator_role")
+		addProjectedAttribute(linkAttrs, "principal_type", principalType)
+		addProjectedAttribute(linkAttrs, "principal_id", principalID)
+		addProjectedAttribute(linkAttrs, "role_id", roleID)
+		addProjectedAttribute(linkAttrs, "role", roleName)
+		addProjectedAttribute(linkAttrs, "is_admin", boolString(aiRoleIsAdmin(firstNonEmpty(roleName, roleID))))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), principalURN, roleURN, aiRoleAssignmentRelation(firstNonEmpty(roleName, roleID)), linkAttrs))
+	}
+	aiLinkRoleToScope(links, tenantID, event, roleURN, projectURN, firstNonEmpty(roleName, roleID), "project_collaborator_role_scope")
+	aiLinkPrincipalToScope(links, tenantID, event, principalURN, projectURN, firstNonEmpty(roleName, roleID), "project_collaborator_project_access")
 	return identityProjectionResult(entities, links)
 }
 
@@ -1039,6 +1086,77 @@ func aiRolePermissionCapabilityID(attrs map[string]string) string {
 		return "ai_data_read"
 	default:
 		return "ai_compliance_access"
+	}
+}
+
+func aiProjectCollaboratorPrincipalType(attrs map[string]string) string {
+	raw := firstNonEmpty(attrs["principal_type"], attrs["collaborator_type"], attrs["type"])
+	normalized := normalizeIdentifier(raw)
+	switch {
+	case strings.Contains(normalized, "organization") || normalized == "org" || strings.Contains(normalized, "everyone"):
+		return "organization"
+	case strings.TrimSpace(raw) != "":
+		return identityPrincipalType(raw)
+	case strings.TrimSpace(attrs["group_id"]) != "":
+		return "group"
+	case strings.TrimSpace(attrs["user_id"]) != "" || strings.TrimSpace(attrs["email"]) != "":
+		return "user"
+	case strings.TrimSpace(attrs["organization_uuid"]) != "" || strings.TrimSpace(attrs["organization_id"]) != "":
+		return "organization"
+	default:
+		return identityPrincipalType(raw)
+	}
+}
+
+func aiProjectCollaboratorPrincipalID(attrs map[string]string, principalType string) string {
+	switch principalType {
+	case "group":
+		return firstNonEmpty(attrs["group_id"], attrs["principal_id"])
+	case "organization":
+		return firstNonEmpty(attrs["organization_uuid"], attrs["organization_id"], attrs["principal_id"])
+	case "service_account":
+		return firstNonEmpty(attrs["service_account_id"], attrs["principal_id"])
+	default:
+		return firstNonEmpty(attrs["user_id"], attrs["principal_id"])
+	}
+}
+
+func aiEnsureProjectCollaboratorPrincipal(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, profile aiAccessProfile, principalType string, principalID string, role string) string {
+	attrs := event.GetAttributes()
+	switch principalType {
+	case "group":
+		groupAttrs := cloneAttributes(attrs)
+		groupAttrs["group_id"] = firstNonEmpty(attrs["group_id"], principalID)
+		groupAttrs["group_name"] = firstNonEmpty(attrs["group_name"], attrs["name"], principalID)
+		return aiEnsureGroup(entities, tenantID, event.GetSourceId(), profile, groupAttrs)
+	case "organization":
+		orgAttrs := cloneAttributes(attrs)
+		if strings.TrimSpace(orgAttrs["organization_uuid"]) == "" && strings.TrimSpace(orgAttrs["organization_id"]) == "" {
+			orgAttrs["organization_uuid"] = principalID
+		}
+		return aiEnsureOrganization(entities, tenantID, event.GetSourceId(), profile, orgAttrs)
+	case "service_account":
+		serviceAccountID := firstNonEmpty(attrs["service_account_id"], principalID)
+		serviceAccountURN := identityPrincipalURN(tenantID, profile.Provider, "service_account", serviceAccountID, "")
+		if serviceAccountURN != "" {
+			addEntity(entities, &ports.ProjectedEntity{
+				URN:        serviceAccountURN,
+				TenantID:   tenantID,
+				SourceID:   event.GetSourceId(),
+				EntityType: profile.Provider + ".service_account",
+				Label:      firstNonEmpty(attrs["name"], serviceAccountID),
+				Attributes: aiPrincipalAttributes(attrs, map[string]string{
+					"principal_type":     "service_account",
+					"service_account_id": serviceAccountID,
+					"name":               strings.TrimSpace(attrs["name"]),
+					"role":               strings.TrimSpace(role),
+					"is_admin":           boolString(aiRoleIsAdmin(role)),
+				}),
+			})
+		}
+		return serviceAccountURN
+	default:
+		return aiEnsureUser(entities, links, tenantID, event, profile, firstNonEmpty(attrs["user_id"], principalID), attrs["email"], attrs["name"], role)
 	}
 }
 

--- a/internal/sourceprojection/ai_access_test.go
+++ b/internal/sourceprojection/ai_access_test.go
@@ -92,6 +92,109 @@ func TestProjectOpenAIProjectAccessEdges(t *testing.T) {
 	assertProjectedLink(t, state, projectURN, relationCanPerform, modelURN)
 }
 
+func TestProjectAnthropicProjectCollaboratorAccessEdges(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	occurred := time.Date(2026, time.June, 18, 12, 15, 0, 0, time.UTC)
+
+	events := []*cerebrov1.EventEnvelope{
+		{
+			Id:         "anthropic-project",
+			TenantId:   "writer",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.compliance_project",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"family":            "compliance_project",
+				"name":              "Legal review",
+				"organization_uuid": "org-uuid-1",
+				"project_id":        "claude_proj_123",
+				"status":            "active",
+			},
+		},
+		{
+			Id:         "anthropic-project-user-collaborator",
+			TenantId:   "writer",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.compliance_project_collaborator",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"email":          "alice@example.com",
+				"family":         "compliance_project_collaborator",
+				"name":           "Alice Example",
+				"principal_id":   "user_123",
+				"principal_type": "user",
+				"project_id":     "claude_proj_123",
+				"role_id":        "project_admin",
+				"role_name":      "Project admin",
+				"user_id":        "user_123",
+			},
+		},
+		{
+			Id:         "anthropic-project-group-collaborator",
+			TenantId:   "writer",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.compliance_project_collaborator",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"family":         "compliance_project_collaborator",
+				"group_id":       "rbac_group_123",
+				"name":           "Legal",
+				"principal_id":   "rbac_group_123",
+				"principal_type": "group",
+				"project_id":     "claude_proj_123",
+				"role_id":        "project_viewer",
+				"role_name":      "Project viewer",
+			},
+		},
+		{
+			Id:         "anthropic-project-org-collaborator",
+			TenantId:   "writer",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.compliance_project_collaborator",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"family":            "compliance_project_collaborator",
+				"organization_uuid": "org-uuid-1",
+				"principal_id":      "org-uuid-1",
+				"principal_type":    "organization",
+				"project_id":        "claude_proj_123",
+				"role_id":           "project_viewer",
+				"role_name":         "Project viewer",
+			},
+		},
+	}
+	for _, event := range events {
+		if _, err := service.Project(context.Background(), event); err != nil {
+			t.Fatalf("Project(%q) error = %v", event.GetId(), err)
+		}
+	}
+
+	userURN := "urn:cerebro:writer:anthropic_user:user_123"
+	groupURN := "urn:cerebro:writer:anthropic_group:rbac_group_123"
+	orgURN := "urn:cerebro:writer:anthropic_org:org-uuid-1"
+	projectURN := "urn:cerebro:writer:anthropic_project:claude_proj_123"
+	adminRoleURN := "urn:cerebro:writer:anthropic_role:project:project_admin"
+	viewerRoleURN := "urn:cerebro:writer:anthropic_role:project:project_viewer"
+	identityURN := "urn:cerebro:writer:identity:email:alice@example.com"
+
+	if entity := state.entities[projectURN]; entity == nil || entity.EntityType != "anthropic.project" {
+		t.Fatalf("project entity missing or wrong: %#v", entity)
+	}
+	if entity := state.entities[adminRoleURN]; entity == nil || entity.EntityType != "anthropic.role" || entity.Label != "Project admin" || entity.Attributes["scope_kind"] != "project" {
+		t.Fatalf("admin role entity missing or wrong: %#v", entity)
+	}
+	assertProjectedLink(t, state, projectURN, relationBelongsTo, orgURN)
+	assertProjectedLink(t, state, userURN, relationRepresentsIdentity, identityURN)
+	assertProjectedLink(t, state, userURN, relationCanAdmin, adminRoleURN)
+	assertProjectedLink(t, state, userURN, relationCanAdmin, projectURN)
+	assertProjectedLink(t, state, adminRoleURN, relationGrantsEntitlement, projectURN)
+	assertProjectedLink(t, state, groupURN, relationAssignedTo, viewerRoleURN)
+	assertProjectedLink(t, state, groupURN, relationCanPerform, projectURN)
+	assertProjectedLink(t, state, orgURN, relationAssignedTo, viewerRoleURN)
+	assertProjectedLink(t, state, orgURN, relationCanPerform, projectURN)
+}
+
 func TestProjectAIGovernanceControlEdges(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -446,6 +446,8 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"anthropic.compliance_organization":             anthropicOrganizationProjections,
 	"anthropic.compliance_organization_setting":     anthropicGovernanceControlProjections,
 	"anthropic.compliance_organization_user":        anthropicUserProjections,
+	"anthropic.compliance_project":                  anthropicProjectProjections,
+	"anthropic.compliance_project_collaborator":     anthropicProjectCollaboratorProjections,
 	"anthropic.compliance_role":                     anthropicComplianceRoleProjections,
 	"anthropic.compliance_role_permission":          anthropicComplianceRolePermissionProjections,
 	"anthropic.cost_report":                         genericInventoryProjections,

--- a/sources/anthropic/catalog.yaml
+++ b/sources/anthropic/catalog.yaml
@@ -1,6 +1,6 @@
 id: anthropic
 name: Anthropic
-description: Anthropic organization governance source covering organization identity, users, invites, workspaces, workspace members, API keys, service accounts, federation, external keys, usage and cost reports, rate limits, spend limits, compliance activity, compliance directory metadata, and effective organization settings.
+description: Anthropic organization governance source covering organization identity, users, invites, workspaces, workspace members, API keys, service accounts, federation, external keys, usage and cost reports, rate limits, spend limits, compliance activity, compliance directory metadata, project collaborators, and effective organization settings.
 emitted_kinds:
   - anthropic.organization
   - anthropic.user
@@ -27,6 +27,8 @@ emitted_kinds:
   - anthropic.compliance_role_permission
   - anthropic.compliance_group
   - anthropic.compliance_group_member
+  - anthropic.compliance_project
+  - anthropic.compliance_project_collaborator
   - anthropic.compliance_organization_setting
 coverage_contract:
   owner_domain: ai
@@ -54,6 +56,12 @@ coverage_contract:
       type: lifecycle_state
       title: Effective compliance organization settings
       families: [compliance_organization_setting]
+      support: supported
+      high_value: true
+    - id: compliance_projects
+      type: app_entitlement
+      title: Claude projects and active collaborator role assignments
+      families: [compliance_project, compliance_project_collaborator]
       support: supported
       high_value: true
     - id: external_keys
@@ -197,6 +205,13 @@ event_contracts:
     schema_ref: anthropic/compliance_group_member/v1
     required_attributes: [group_id, user_id]
     required_payload_fields: [user_id]
+  - kind: anthropic.compliance_project
+    schema_ref: anthropic/compliance_project/v1
+    required_attributes: [project_id]
+    required_payload_fields: [id]
+  - kind: anthropic.compliance_project_collaborator
+    schema_ref: anthropic/compliance_project_collaborator/v1
+    required_attributes: [project_id, principal_type, principal_id, role_id]
   - kind: anthropic.compliance_organization_setting
     schema_ref: anthropic/compliance_organization_setting/v1
     required_attributes: [organization_uuid, setting_name]

--- a/sources/anthropic/source.go
+++ b/sources/anthropic/source.go
@@ -96,6 +96,8 @@ func anthropicFamilies() []jsonapi.Family {
 		anthropicListFamily("compliance_role_permission", "/compliance/organizations/{organization_uuid}/roles/{role_id}/permissions", "anthropic_compliance_role_permission", []string{"id", "permission_id", "permission", "name"}, []string{"created_at", "updated_at"}, rolePermissionAttributes(), withPathParams("organization_uuid", "role_id"), withPageCursor()),
 		anthropicListFamily("compliance_group", "/compliance/groups", "anthropic_compliance_group", []string{"id", "group_id"}, []string{"created_at", "updated_at"}, map[string]string{"group_id": "id|group_id", "group_name": "name", "name": "name", "description": "description", "source_type": "source_type", "roles": "roles", "created_at": "created_at", "updated_at": "updated_at"}, withPageCursor()),
 		anthropicListFamily("compliance_group_member", "/compliance/groups/{group_id}/members", "anthropic_compliance_group_member", []string{"user_id", "id", "email"}, []string{"created_at", "updated_at"}, map[string]string{"group_id": "group_id", "user_id": "user_id|id", "email": "email", "created_at": "created_at", "updated_at": "updated_at"}, withPathParams("group_id"), withPageCursor()),
+		anthropicListFamily("compliance_project", "/compliance/apps/projects", "anthropic_compliance_project", []string{"id", "project_id"}, []string{"created_at", "updated_at", "archived_at"}, projectAttributes(), withPageCursor()),
+		anthropicListFamily("compliance_project_collaborator", "/compliance/apps/projects/{project_id}/collaborators", "anthropic_compliance_project_collaborator", []string{"id", "assignment_id", "principal.id", "user.id", "group.id", "organization.id"}, []string{"created_at", "updated_at"}, projectCollaboratorAttributes(), withPathParams("project_id"), withPageCursor()),
 		anthropicListFamily("compliance_organization_setting", "/compliance/organizations/{organization_uuid}/settings", "anthropic_compliance_organization_setting", []string{"name"}, nil, map[string]string{"organization_uuid": "organization_uuid", "setting_name": "name", "setting_type": "type", "setting_value": "value"}, withPathParams("organization_uuid"), withListKeys("settings"), withoutPagination()),
 	}
 }
@@ -177,6 +179,43 @@ func rolePermissionAttributes() map[string]string {
 		"category":               "category|type",
 		"created_at":             "created_at",
 		"updated_at":             "updated_at",
+	}
+}
+
+func projectAttributes() map[string]string {
+	return map[string]string{
+		"project_id":        "id|project_id",
+		"name":              "name|title",
+		"description":       "description",
+		"organization_id":   "organization.id|organization_id",
+		"organization_uuid": "organization.uuid|organization_uuid|organization.id|organization_id",
+		"creator_user_id":   "created_by.id|creator.id|owner.id|created_by_user_id|user_id",
+		"creator_email":     "created_by.email|creator.email|owner.email|email",
+		"status":            "status",
+		"visibility":        "visibility",
+		"created_at":        "created_at",
+		"updated_at":        "updated_at",
+		"archived_at":       "archived_at",
+	}
+}
+
+func projectCollaboratorAttributes() map[string]string {
+	return map[string]string{
+		"project_id":        "project_id",
+		"assignment_id":     "id|assignment_id",
+		"principal_type":    "principal.type|principal_type|type|collaborator_type",
+		"principal_id":      "principal.id|principal.user_id|principal.group_id|user.id|user_id|group.id|group_id|organization.id|organization_uuid|organization_id|id",
+		"user_id":           "user.id|user_id|principal.user_id",
+		"group_id":          "group.id|group_id|principal.group_id",
+		"email":             "principal.email|user.email|email",
+		"name":              "principal.name|user.name|group.name|name",
+		"organization_id":   "organization.id|organization_id",
+		"organization_uuid": "organization.uuid|organization_uuid|organization.id|organization_id",
+		"role_id":           "role.id|role_id|role",
+		"role":              "role.name|role|role_id",
+		"role_name":         "role.name|role_name|role",
+		"created_at":        "created_at",
+		"updated_at":        "updated_at",
 	}
 }
 

--- a/sources/anthropic/source_test.go
+++ b/sources/anthropic/source_test.go
@@ -343,6 +343,194 @@ func TestReadComplianceRolePermissionsUsesRolePathAndPageCursor(t *testing.T) {
 	}
 }
 
+func TestReadComplianceProjectsUsesComplianceKeyAndPageCursor(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); got != "/compliance/apps/projects" {
+			t.Fatalf("request path = %q, want /compliance/apps/projects", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got != "2023-06-01" {
+			t.Fatalf("anthropic-version = %q, want 2023-06-01", got)
+		}
+		if got := r.Header.Get("x-api-key"); got != "fixture-compliance-key" {
+			t.Fatalf("x-api-key = %q, want fixture-compliance-key", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("limit = %q, want 2", got)
+		}
+		switch r.URL.Query().Get("page") {
+		case "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{
+					"id":          "claude_proj_123",
+					"name":        "Legal review",
+					"description": "Matter review workspace",
+					"organization": map[string]any{
+						"uuid": "org-uuid-1",
+					},
+					"created_at": "2026-01-02T03:04:05Z",
+				}},
+				"has_more":  true,
+				"next_page": "page-2",
+			})
+		case "page-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{
+					"id":     "claude_proj_456",
+					"name":   "Engineering docs",
+					"status": "archived",
+				}},
+				"has_more": false,
+			})
+		default:
+			t.Fatalf("page = %q, want empty or page-2", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test-only placeholder key.
+		"api_key":   "fixture-compliance-key",
+		"base_url":  server.URL,
+		"family":    "compliance_project",
+		"per_page":  "2",
+		"tenant_id": "writer",
+	})
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if first.NextCursor.GetOpaque() != "page-2" {
+		t.Fatalf("first NextCursor = %q, want page-2", first.NextCursor.GetOpaque())
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
+	}
+	event := first.Events[0]
+	if event.Kind != "anthropic.compliance_project" {
+		t.Fatalf("Kind = %q, want anthropic.compliance_project", event.Kind)
+	}
+	if got := event.Attributes["project_id"]; got != "claude_proj_123" {
+		t.Fatalf("project_id = %q, want claude_proj_123", got)
+	}
+	if got := event.Attributes["organization_uuid"]; got != "org-uuid-1" {
+		t.Fatalf("organization_uuid = %q, want org-uuid-1", got)
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second NextCursor = %#v, want nil", second.NextCursor)
+	}
+}
+
+func TestReadComplianceProjectCollaboratorsUsesProjectPathAndPageCursor(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); got != "/compliance/apps/projects/claude_proj_123/collaborators" {
+			t.Fatalf("request path = %q, want /compliance/apps/projects/claude_proj_123/collaborators", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got != "2023-06-01" {
+			t.Fatalf("anthropic-version = %q, want 2023-06-01", got)
+		}
+		if got := r.Header.Get("x-api-key"); got != "fixture-compliance-key" {
+			t.Fatalf("x-api-key = %q, want fixture-compliance-key", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("limit = %q, want 2", got)
+		}
+		switch r.URL.Query().Get("page") {
+		case "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{
+					"id": "assignment_1",
+					"principal": map[string]any{
+						"type":  "user",
+						"id":    "user_123",
+						"email": "alice@example.com",
+						"name":  "Alice Example",
+					},
+					"role": map[string]any{
+						"id":   "project_admin",
+						"name": "Project admin",
+					},
+					"created_at": "2026-01-02T03:04:05Z",
+				}},
+				"has_more":  true,
+				"next_page": "page-2",
+			})
+		case "page-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{
+					"id": "assignment_2",
+					"principal": map[string]any{
+						"type": "group",
+						"id":   "rbac_group_123",
+						"name": "Legal",
+					},
+					"role": map[string]any{
+						"id": "project_viewer",
+					},
+				}},
+				"has_more": false,
+			})
+		default:
+			t.Fatalf("page = %q, want empty or page-2", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test-only placeholder key.
+		"api_key":    "fixture-compliance-key",
+		"base_url":   server.URL,
+		"family":     "compliance_project_collaborator",
+		"per_page":   "2",
+		"project_id": "claude_proj_123",
+		"tenant_id":  "writer",
+	})
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if first.NextCursor.GetOpaque() != "page-2" {
+		t.Fatalf("first NextCursor = %q, want page-2", first.NextCursor.GetOpaque())
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
+	}
+	event := first.Events[0]
+	if event.Kind != "anthropic.compliance_project_collaborator" {
+		t.Fatalf("Kind = %q, want anthropic.compliance_project_collaborator", event.Kind)
+	}
+	if got := event.Attributes["project_id"]; got != "claude_proj_123" {
+		t.Fatalf("project_id = %q, want claude_proj_123", got)
+	}
+	if got := event.Attributes["principal_type"]; got != "user" {
+		t.Fatalf("principal_type = %q, want user", got)
+	}
+	if got := event.Attributes["principal_id"]; got != "user_123" {
+		t.Fatalf("principal_id = %q, want user_123", got)
+	}
+	if got := event.Attributes["role_id"]; got != "project_admin" {
+		t.Fatalf("role_id = %q, want project_admin", got)
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second NextCursor = %#v, want nil", second.NextCursor)
+	}
+}
+
 func TestReadComplianceOrganizationSettingsUsesSettingsListKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.EscapedPath(); got != "/compliance/organizations/org-uuid-1/settings" {


### PR DESCRIPTION
## Summary
- add Anthropic Compliance API project and project-collaborator source families
- project project collaborators as user/group/org-wide role assignments on Claude project nodes
- extend Anthropic config validation and preflight guidance for project_id and read:compliance_user_data

## Source docs
- https://platform.claude.com/docs/en/api/compliance/apps/projects/list
- https://platform.claude.com/docs/en/api/compliance/apps/projects/collaborators/list

## Verification
- go test ./sources/anthropic ./internal/sourceprojection ./internal/bootstrap ./internal/connectorpreflight
- make lint
- ./scripts/pre_commit_checks.sh
- make check-structural
- make check-arch