### PR TITLE
Harden OTEL runtime telemetry

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -246,6 +246,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 	}()
 	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
 	if err != nil {
+		captureOrchestratorError(ctx, "orchestrator.error", 0, nil, "open_dependencies", err)
 		return nil, fmt.Errorf("open dependencies: %w", err)
 	}
 	defer func() {
@@ -255,15 +256,20 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 	}()
 	registry, err := sourceregistry.Builtin()
 	if err != nil {
+		captureOrchestratorError(ctx, "orchestrator.error", 0, nil, "source_registry", err)
 		return nil, fmt.Errorf("open source registry: %w", err)
 	}
 	lister, ok := sourceRuntimeStore(deps.StateStore).(ports.SourceRuntimeListStore)
 	if !ok {
-		return nil, sourceruntime.ErrRuntimeUnavailable
+		err := sourceruntime.ErrRuntimeUnavailable
+		captureOrchestratorError(ctx, "orchestrator.error", 0, nil, "runtime_list_store", err)
+		return nil, err
 	}
 	leaser, ok := lister.(ports.SourceRuntimeLeaseStore)
 	if !ok {
-		return nil, sourceruntime.ErrRuntimeUnavailable
+		err := sourceruntime.ErrRuntimeUnavailable
+		captureOrchestratorError(ctx, "orchestrator.error", 0, nil, "runtime_lease_store", err)
+		return nil, err
 	}
 	leaseOwner := orchestratorLeaseOwner()
 	runtimeService := newOrchestratorRuntimeService(registry, lister, deps.AppendLog, deps.StateStore)
@@ -417,6 +423,7 @@ func runOrchestratorIteration(
 	result := &orchestratorIterationResult{Iteration: iteration, StartedAt: time.Now().UTC()}
 	if err != nil {
 		spanAttributes = withTelemetryField(spanAttributes, "error_kind", telemetry.ErrorKind(err))
+		captureOrchestratorError(ctx, "orchestrator.iteration.error", iteration, nil, "list_runtimes", err)
 		return result, err
 	}
 	telemetry.Event(ctx, "orchestrator.runtimes_listed", telemetry.Attrs(
@@ -461,6 +468,7 @@ func runOrchestratorIteration(
 			runErr = err
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_stage", "lease")
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_kind", telemetry.ErrorKind(err))
+			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "lease", err)
 			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		}
@@ -483,16 +491,19 @@ func runOrchestratorIteration(
 			runErr = err
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_stage", "sync")
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_kind", telemetry.ErrorKind(err))
+			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "sync", err)
 			cancelRuntime()
 			if renewalErr := stopLeaseRenewal(); renewalErr != nil {
 				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", renewalErr)
 				runErr = renewalErr
 				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error_kind", telemetry.ErrorKind(renewalErr))
+				captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "renew_lease", renewalErr)
 			}
 			if releaseErr := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); releaseErr != nil {
 				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", releaseErr)
 				runErr = releaseErr
 				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error_kind", telemetry.ErrorKind(releaseErr))
+				captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "release_lease", releaseErr)
 			}
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
@@ -578,11 +589,13 @@ func runOrchestratorIteration(
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", err)
 			runErr = err
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error_kind", telemetry.ErrorKind(err))
+			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "renew_lease", err)
 		}
 		if err := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); err != nil {
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", err)
 			runErr = err
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error_kind", telemetry.ErrorKind(err))
+			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "release_lease", err)
 		}
 		result.Runtimes = append(result.Runtimes, runtimeResult)
 		if runtimeResult.Error == "" {
@@ -637,9 +650,27 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(phaseCtx.Err(), context.DeadlineExceeded) {
 			endAttrs = withTelemetryField(endAttrs, "timeout_exceeded", true)
 		}
+		captureOrchestratorError(phaseCtx, name+".error", iteration, runtime, name, err)
 	}
 	telemetry.End(span, status, endAttrs)
 	return result, err
+}
+
+func captureOrchestratorError(ctx context.Context, name string, iteration uint32, runtime *cerebrov1.SourceRuntime, stage string, err error) {
+	if err == nil {
+		return
+	}
+	attrs := telemetry.Attrs(
+		telemetryField("iteration", iteration),
+		telemetryField("stage", stage),
+	)
+	if runtime != nil {
+		attrs = attrs.
+			WithField(telemetryField("runtime_id", runtime.GetId())).
+			WithField(telemetryField("source_id", runtime.GetSourceId())).
+			WithField(telemetryField("tenant_id", runtime.GetTenantId()))
+	}
+	telemetry.CaptureError(ctx, name, err, attrs)
 }
 
 func applyGraphIngestCounters(runtimeResult *orchestratorRuntimeResult, graphResult *graphingest.RunResult, attrs telemetry.Attributes) telemetry.Attributes {

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -45,6 +45,7 @@ Expected propagated dimensions include:
 - Auth: `tenant_id`, `auth.outcome`, `auth.mode`, `auth.credential_tier`, `auth.risk_level`, `auth.denial_reason`
 - MCP/OAuth: `mcp.method`, `mcp.tool`, `mcp.tool_family`, `mcp.outcome`, `oauth.operation`, `oauth.grant_type`
 - GRC/LLM: `grc.ask.llm.provider`, `grc.ask.query_plan.intent`, `grc.ask.row_count`, stage timing fields
+- Graph-agent LLM: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`, `graphagent.*.count`, `graphagent.*.bytes`, refusal/plan/Cypher presence flags
 - Stores: `cache.redis.*.count`, `db.postgres.*.count`, `db.neo4j.*.count`
 - Messaging/source/graph: `messaging.jetstream.*.count`, `source_runtime.*`, `source.operation.*`, `graph.ingest.*`
 - Domain outcomes: `source_projection.*`, `finding_candidate.*`, `finding_evaluation.*`
@@ -58,12 +59,13 @@ Core runtime operations emit structured spans:
 | `source_runtime.sync`, `source_runtime.sync_with_lease` | Runtime sync and lease lifecycle |
 | `graph.ingest_runtime` | Graph ingestion runs |
 | `graphagent.http.request` | Graph-agent LLM/upstream HTTP calls |
+| `graphagent.llm.draft`, `graphagent.llm.summarize`, `graphagent.llm.probe` | Graph-agent LLM operations, model/provider metadata, counts, sizes, and safe outcomes only |
 | `postgres.ping`, `postgres.ensure_statements` | Postgres readiness and schema setup |
 | `neo4j.read`, `neo4j.write` | Graph store transactions |
 | `redis.cache.*`, `redis.ping` | Query cache operations, hits/misses, version bumps |
 | `jetstream.ping`, `jetstream.append`, `jetstream.replay` | Append-log health, publish, and replay |
 
-Outbound HTTP uses W3C `traceparent`. The source transport and graph-agent HTTP doer inject child trace context, but they do not emit full URLs, query strings, request bodies, authorization headers, or API keys.
+Outbound HTTP uses W3C `traceparent`. The source transport and graph-agent HTTP doer inject child trace context, but they do not emit full URLs, query strings, request bodies, authorization headers, or API keys. Graph-agent LLM spans also do not emit prompt text, completion text, raw Cypher, raw tool arguments, rows, or headers.
 
 ## Error Contract
 
@@ -90,10 +92,10 @@ Cerebro enables OTEL export when `CEREBRO_OTEL_ENABLED=true` or when an OTLP end
 | `CEREBRO_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Trace endpoint override |
 | `CEREBRO_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Metric endpoint override |
 | `CEREBRO_OTEL_EXPORTER_OTLP_HEADERS` | Comma-separated OTLP auth headers; mount from secrets only |
-| `CEREBRO_OTEL_EXPORTER_OTLP_INSECURE` | Allow insecure transport for local collectors |
+| `CEREBRO_OTEL_EXPORTER_OTLP_INSECURE` | Allow insecure transport only for loopback collectors |
 | `CEREBRO_OTEL_TRACES_SAMPLE_RATE` | Float from `0` to `1` |
 | `CEREBRO_OTEL_METRICS_EXPORT_INTERVAL` | Duration such as `30s` or `1m` |
-| `OTEL_RESOURCE_ATTRIBUTES` | Standard resource attributes, for example `deployment.environment=sec-dev` |
+| `OTEL_RESOURCE_ATTRIBUTES` | Standard resource attributes, for example `deployment.environment.name=sec-dev` |
 
 ## Local Verification
 
@@ -118,6 +120,8 @@ CEREBRO_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
 CEREBRO_OTEL_EXPORTER_OTLP_INSECURE=true \
 go run ./cmd/cerebro serve
 ```
+
+Remote OTLP endpoints must use `https://` without `CEREBRO_OTEL_EXPORTER_OTLP_INSECURE=true`. Plain HTTP is accepted only for loopback collector endpoints such as `http://127.0.0.1:4318`.
 
 Then hit `/health` and one API route. Confirm:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,8 +36,10 @@ const (
 )
 
 var (
-	errConfigValueConflict = errors.New("config value and file are both set")
-	errLegacyKuzuPath      = errors.New("CEREBRO_KUZU_PATH is no longer supported")
+	errConfigValueConflict     = errors.New("config value and file are both set")
+	errInvalidOTLPEndpoint     = errors.New("invalid otlp endpoint")
+	errLegacyKuzuPath          = errors.New("CEREBRO_KUZU_PATH is no longer supported")
+	errUnsafeOTLPTransportMode = errors.New("unsafe otlp transport mode")
 )
 
 // Config is the minimal bootstrap configuration for the rewrite skeleton.
@@ -482,6 +484,9 @@ func Load() (Config, error) {
 	default:
 		return Config{}, fmt.Errorf("unsupported CEREBRO_OTEL_EXPORTER_OTLP_PROTOCOL %q", cfg.OTEL.Protocol)
 	}
+	if err := validateOpenTelemetryEndpoints(cfg.OTEL); err != nil {
+		return Config{}, err
+	}
 	if cfg.Auth.RequestOrigin.TrustedProxyCount, err = parseIntEnv("CEREBRO_TRUSTED_PROXY_COUNT", 0); err != nil {
 		return Config{}, err
 	}
@@ -729,6 +734,49 @@ func validateRequestOriginConfig(cfg RequestOriginConfig) error {
 
 func (cfg OpenTelemetryConfig) hasExporterConfig() bool {
 	return strings.TrimSpace(cfg.Endpoint) != "" || strings.TrimSpace(cfg.TracesEndpoint) != "" || strings.TrimSpace(cfg.MetricsEndpoint) != ""
+}
+
+func validateOpenTelemetryEndpoints(cfg OpenTelemetryConfig) error {
+	for _, endpoint := range []struct {
+		name  string
+		value string
+	}{
+		{name: "CEREBRO_OTEL_EXPORTER_OTLP_ENDPOINT", value: cfg.Endpoint},
+		{name: "CEREBRO_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", value: cfg.TracesEndpoint},
+		{name: "CEREBRO_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", value: cfg.MetricsEndpoint},
+	} {
+		raw := strings.TrimSpace(endpoint.value)
+		if raw == "" {
+			continue
+		}
+		parsed, err := url.Parse(raw)
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Hostname() == "" {
+			return fmt.Errorf("%w: %s must be an absolute http(s) URL", errInvalidOTLPEndpoint, endpoint.name)
+		}
+		if parsed.User != nil {
+			return fmt.Errorf("%w: %s must not include user info", errInvalidOTLPEndpoint, endpoint.name)
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return fmt.Errorf("%w: %s must use http or https", errInvalidOTLPEndpoint, endpoint.name)
+		}
+		loopback := isLoopbackHost(parsed.Hostname())
+		if parsed.Scheme == "http" && (!cfg.Insecure || !loopback) {
+			return fmt.Errorf("%w: %s plain HTTP OTLP endpoints are only allowed for loopback collectors with CEREBRO_OTEL_EXPORTER_OTLP_INSECURE=true", errUnsafeOTLPTransportMode, endpoint.name)
+		}
+		if cfg.Insecure && (parsed.Scheme != "http" || !loopback) {
+			return fmt.Errorf("%w: CEREBRO_OTEL_EXPORTER_OTLP_INSECURE is only allowed with loopback HTTP OTLP endpoints", errUnsafeOTLPTransportMode)
+		}
+	}
+	return nil
+}
+
+func isLoopbackHost(host string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(host))
+	if normalized == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(normalized)
+	return ip != nil && ip.IsLoopback()
 }
 
 func envHasValue(name string) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -162,7 +162,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://otel-collector.example.com:4317/v1/traces")
 	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://otel-collector.example.com:4317/v1/metrics")
 	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_HEADERS", "x-scope=security,tenant=writer")
-	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_INSECURE", "true")
+	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_INSECURE", "false")
 	t.Setenv("CEREBRO_OTEL_TRACES_SAMPLE_RATE", "0.25")
 	t.Setenv("CEREBRO_OTEL_METRICS_EXPORT_INTERVAL", "15s")
 	t.Setenv("CEREBRO_KUZU_PATH", "")
@@ -259,7 +259,7 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.OTEL.Headers["x-scope"] != "security" || cfg.OTEL.Headers["tenant"] != "writer" {
 		t.Fatalf("OTEL headers = %#v", cfg.OTEL.Headers)
 	}
-	if !cfg.OTEL.Insecure || cfg.OTEL.TraceSampleRate != 0.25 || cfg.OTEL.MetricInterval != 15*time.Second {
+	if cfg.OTEL.Insecure || cfg.OTEL.TraceSampleRate != 0.25 || cfg.OTEL.MetricInterval != 15*time.Second {
 		t.Fatalf("OTEL exporter options = %#v", cfg.OTEL)
 	}
 	if !cfg.Auth.Enabled {
@@ -401,6 +401,7 @@ func TestLoadParsesMCPOAuthJSONFiles(t *testing.T) {
 func TestLoadEnablesOTELWhenEndpointConfigured(t *testing.T) {
 	clearDependencyEnv(t)
 	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
+	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_INSECURE", "true")
 
 	cfg, err := Load()
 	if err != nil {
@@ -408,6 +409,52 @@ func TestLoadEnablesOTELWhenEndpointConfigured(t *testing.T) {
 	}
 	if !cfg.OTEL.Enabled {
 		t.Fatal("OTEL.Enabled = false, want true when endpoint is configured")
+	}
+}
+
+func TestLoadRejectsPlainHTTPRemoteOTELEndpoint(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_OTEL_ENABLED", "true")
+	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.example.com:4318")
+	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_INSECURE", "true")
+
+	_, err := Load()
+	if !errors.Is(err, errUnsafeOTLPTransportMode) {
+		t.Fatalf("Load() error = %v, want remote plain HTTP OTLP rejection", err)
+	}
+}
+
+func TestLoadRejectsLoopbackHTTPOTELEndpointWithoutInsecure(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_OTEL_ENABLED", "true")
+	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+
+	_, err := Load()
+	if !errors.Is(err, errUnsafeOTLPTransportMode) {
+		t.Fatalf("Load() error = %v, want loopback HTTP to require insecure flag", err)
+	}
+}
+
+func TestLoadRejectsInsecureFlagForHTTPSOTELEndpoint(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_OTEL_ENABLED", "true")
+	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel-collector.example.com:4318")
+	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_INSECURE", "true")
+
+	_, err := Load()
+	if !errors.Is(err, errUnsafeOTLPTransportMode) {
+		t.Fatalf("Load() error = %v, want insecure HTTPS OTLP rejection", err)
+	}
+}
+
+func TestLoadRejectsMalformedOTELEndpoint(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_OTEL_ENABLED", "true")
+	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_ENDPOINT", "otel-collector.example.com:4318")
+
+	_, err := Load()
+	if !errors.Is(err, errInvalidOTLPEndpoint) {
+		t.Fatalf("Load() error = %v, want malformed OTLP endpoint rejection", err)
 	}
 }
 

--- a/internal/graphagent/llm.go
+++ b/internal/graphagent/llm.go
@@ -81,7 +81,7 @@ func NewLLMClientWithSecrets(ctx context.Context, cfg LLMConfigWithSecrets) (LLM
 	case "stub":
 		return NewStubLLMClient(), nil
 	case "bedrock":
-		return NewBedrockLLMClient(ctx, BedrockConfig{
+		client, err := NewBedrockLLMClient(ctx, BedrockConfig{
 			DefaultModel: cfg.Model,
 			SonnetModel:  cfg.SonnetModel,
 			OpusModel:    cfg.OpusModel,
@@ -90,8 +90,12 @@ func NewLLMClientWithSecrets(ctx context.Context, cfg LLMConfigWithSecrets) (LLM
 			MaxTokens:    cfg.MaxTokens,
 			Temperature:  cfg.Temperature,
 		})
+		if err != nil {
+			return nil, err
+		}
+		return instrumentLLMClient(provider, client), nil
 	case "openrouter":
-		return NewOpenRouterLLMClient(OpenRouterConfig{
+		client, err := NewOpenRouterLLMClient(OpenRouterConfig{
 			APIKey:       cfg.OpenRouterAPIKey,
 			HTTPDoer:     cfg.HTTPDoer,
 			DefaultModel: cfg.Model,
@@ -101,6 +105,10 @@ func NewLLMClientWithSecrets(ctx context.Context, cfg LLMConfigWithSecrets) (LLM
 			MaxTokens:    cfg.MaxTokens,
 			Temperature:  cfg.Temperature,
 		})
+		if err != nil {
+			return nil, err
+		}
+		return instrumentLLMClient(provider, client), nil
 	default:
 		return nil, fmt.Errorf("%w: unsupported graph agent llm provider %q", ErrInvalidRequest, provider)
 	}

--- a/internal/graphagent/llm_telemetry.go
+++ b/internal/graphagent/llm_telemetry.go
@@ -1,0 +1,101 @@
+package graphagent
+
+import (
+	"context"
+	"strings"
+
+	"github.com/writer/cerebro/internal/telemetry"
+)
+
+type instrumentedLLMClient struct {
+	provider string
+	client   LLMClient
+}
+
+func instrumentLLMClient(provider string, client LLMClient) LLMClient {
+	if client == nil {
+		return nil
+	}
+	return &instrumentedLLMClient{
+		provider: strings.TrimSpace(provider),
+		client:   client,
+	}
+}
+
+func (c *instrumentedLLMClient) DraftCypher(ctx context.Context, req DraftRequest) (*DraftResponse, error) {
+	attrs := c.operationAttrs("draft", req.Model, req.TenantID).
+		WithField(telemetry.Field{Key: "graphagent.scope_urn.present", Value: strings.TrimSpace(req.ScopeURN) != ""}).
+		WithField(telemetry.Field{Key: "graphagent.question.bytes", Value: len(req.Question)}).
+		WithField(telemetry.Field{Key: "graphagent.schema.bytes", Value: len(req.Schema)}).
+		WithField(telemetry.Field{Key: "graphagent.guardrail.bytes", Value: len(req.Guardrail)}).
+		WithField(telemetry.Field{Key: "graphagent.history.count", Value: len(req.History)}).
+		WithField(telemetry.Field{Key: "graphagent.max_rows", Value: req.MaxRows}).
+		WithField(telemetry.Field{Key: "graphagent.probe.present", Value: req.Probe != nil})
+	ctx, span := telemetry.Start(ctx, "graphagent.llm.draft", attrs)
+	response, err := c.client.DraftCypher(ctx, req)
+	endAttrs := telemetry.Attrs()
+	status := "completed"
+	if err != nil {
+		status = "failed"
+		endAttrs = endAttrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+		telemetry.CaptureError(ctx, "graphagent.llm.error", err, attrs)
+	} else if response != nil {
+		endAttrs = endAttrs.
+			WithField(telemetry.Field{Key: "graphagent.refusal", Value: strings.TrimSpace(response.Refusal) != ""}).
+			WithField(telemetry.Field{Key: "graphagent.plan.present", Value: response.Plan != nil}).
+			WithField(telemetry.Field{Key: "graphagent.cypher.present", Value: strings.TrimSpace(response.Cypher) != ""}).
+			WithField(telemetry.Field{Key: "graphagent.cypher.bytes", Value: len(response.Cypher)})
+	}
+	telemetry.End(span, status, endAttrs)
+	return response, err
+}
+
+func (c *instrumentedLLMClient) Summarize(ctx context.Context, req SummarizeRequest) (string, error) {
+	attrs := c.operationAttrs("summarize", req.Model, req.TenantID).
+		WithField(telemetry.Field{Key: "graphagent.scope_urn.present", Value: strings.TrimSpace(req.ScopeURN) != ""}).
+		WithField(telemetry.Field{Key: "graphagent.question.bytes", Value: len(req.Question)}).
+		WithField(telemetry.Field{Key: "graphagent.cypher.bytes", Value: len(req.Cypher)}).
+		WithField(telemetry.Field{Key: "graphagent.rows.count", Value: len(req.Rows)}).
+		WithField(telemetry.Field{Key: "graphagent.history.count", Value: len(req.History)})
+	ctx, span := telemetry.Start(ctx, "graphagent.llm.summarize", attrs)
+	summary, err := c.client.Summarize(ctx, req)
+	endAttrs := telemetry.Attrs()
+	status := "completed"
+	if err != nil {
+		status = "failed"
+		endAttrs = endAttrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+		telemetry.CaptureError(ctx, "graphagent.llm.error", err, attrs)
+	} else {
+		endAttrs = endAttrs.WithField(telemetry.Field{Key: "graphagent.summary.bytes", Value: len(summary)})
+	}
+	telemetry.End(span, status, endAttrs)
+	return summary, err
+}
+
+func (c *instrumentedLLMClient) Probe(ctx context.Context) error {
+	prober, ok := c.client.(LLMProber)
+	if !ok {
+		return nil
+	}
+	attrs := c.operationAttrs("probe", "", "")
+	ctx, span := telemetry.Start(ctx, "graphagent.llm.probe", attrs)
+	err := prober.Probe(ctx)
+	endAttrs := telemetry.Attrs()
+	status := "completed"
+	if err != nil {
+		status = "failed"
+		endAttrs = endAttrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+		telemetry.CaptureError(ctx, "graphagent.llm.error", err, attrs)
+	}
+	telemetry.End(span, status, endAttrs)
+	return err
+}
+
+func (c *instrumentedLLMClient) operationAttrs(operation string, model string, tenantID string) telemetry.Attributes {
+	return telemetry.Attrs(
+		telemetry.Field{Key: "gen_ai.provider.name", Value: strings.TrimSpace(c.provider)},
+		telemetry.Field{Key: "gen_ai.operation.name", Value: strings.TrimSpace(operation)},
+		telemetry.Field{Key: "gen_ai.request.model", Value: normalizeModel(model)},
+		telemetry.Field{Key: "tenant_id", Value: strings.TrimSpace(tenantID)},
+	)
+}

--- a/internal/graphagent/llm_telemetry_test.go
+++ b/internal/graphagent/llm_telemetry_test.go
@@ -1,0 +1,69 @@
+package graphagent
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestInstrumentedLLMClientDraftDoesNotEmitPromptOrCypherText(t *testing.T) {
+	question := "Which assets mention secret-token-shaped evidence?"
+	cypher := "MATCH (e:Entity {secret: 'token-shaped'}) RETURN e LIMIT 1"
+	client := instrumentLLMClient("openrouter", &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Cypher: cypher,
+		},
+	})
+
+	stderr := captureGraphAgentStderr(t, func() {
+		response, err := client.DraftCypher(context.Background(), DraftRequest{
+			TenantID: "tenant-a",
+			Question: question,
+			ScopeURN: "urn:cerebro:example:scope",
+			Model:    "claude-sonnet-4-6",
+			Schema:   "(:Entity)-[:RELATES_TO]->(:Entity)",
+			MaxRows:  25,
+		})
+		if err != nil {
+			t.Fatalf("DraftCypher() error = %v", err)
+		}
+		if response == nil || response.Cypher != cypher {
+			t.Fatalf("DraftCypher() response = %#v", response)
+		}
+	})
+
+	if !strings.Contains(stderr, `"name":"graphagent.llm.draft"`) {
+		t.Fatalf("telemetry missing graphagent llm draft span: %s", stderr)
+	}
+	if !strings.Contains(stderr, `"gen_ai.provider.name":"openrouter"`) || !strings.Contains(stderr, `"gen_ai.operation.name":"draft"`) {
+		t.Fatalf("telemetry missing safe gen_ai attrs: %s", stderr)
+	}
+	if strings.Contains(stderr, question) || strings.Contains(stderr, cypher) {
+		t.Fatalf("telemetry leaked prompt or cypher text: %s", stderr)
+	}
+}
+
+func captureGraphAgentStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = writer
+	t.Cleanup(func() {
+		os.Stderr = original
+	})
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	os.Stderr = original
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	return string(data)
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -95,7 +95,7 @@ func RuntimeAttributes() Attributes {
 		Field{Key: "service.version", Value: buildinfo.Version},
 		Field{Key: "service.commit", Value: buildinfo.Commit},
 		Field{Key: "service.build_date", Value: buildinfo.BuildDate},
-		Field{Key: "deployment.environment", Value: "unknown"},
+		Field{Key: "deployment.environment.name", Value: "unknown"},
 		Field{Key: "host.name", Value: hostname},
 		Field{Key: "os.type", Value: runtime.GOOS},
 		Field{Key: "os.arch", Value: runtime.GOARCH},

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -49,7 +49,15 @@ func TestTelemetryFieldsDoNotUseRawErrorKey(t *testing.T) {
 		t.Fatal("runtime.Caller failed")
 	}
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
-	pattern := regexp.MustCompile(`telemetry\.Field\s*\{\s*Key:\s*"` + `error"`)
+	patterns := []struct {
+		name string
+		re   *regexp.Regexp
+	}{
+		{name: `telemetry.Field Key "error"`, re: regexp.MustCompile(`telemetry\.Field\s*\{[\s\S]{0,240}?Key:\s*"error"`)},
+		{name: `withTelemetryField key "error"`, re: regexp.MustCompile(`withTelemetryField\s*\([\s\S]{0,240}?"error"\s*,`)},
+		{name: `telemetry.Field Value err.Error()`, re: regexp.MustCompile(`telemetry\.Field\s*\{[\s\S]{0,240}?Value:\s*[^}\n]*\.Error\s*\(`)},
+		{name: `withTelemetryField err.Error()`, re: regexp.MustCompile(`withTelemetryField\s*\([\s\S]{0,240}?\.Error\s*\(`)},
+	}
 	var matches []string
 	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -65,16 +73,21 @@ func TestTelemetryFieldsDoNotUseRawErrorKey(t *testing.T) {
 		if filepath.Ext(path) != ".go" {
 			return nil
 		}
+		if filepath.Clean(path) == filepath.Clean(currentFile) {
+			return nil
+		}
 		contents, err := os.ReadFile(path) // #nosec G304 G122 -- path comes from WalkDir under the repository root in a repository-static lint test.
 		if err != nil {
 			return err
 		}
-		if pattern.Match(contents) {
-			rel, err := filepath.Rel(repoRoot, path)
-			if err != nil {
-				rel = path
+		for _, pattern := range patterns {
+			if pattern.re.Match(contents) {
+				rel, err := filepath.Rel(repoRoot, path)
+				if err != nil {
+					rel = path
+				}
+				matches = append(matches, rel+" ("+pattern.name+")")
 			}
-			matches = append(matches, rel)
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary
- reject unsafe OTLP endpoint configs at runtime: remote plain HTTP, malformed URLs, and insecure mode on non-loopback endpoints
- modernize resource attrs to deployment.environment.name and strengthen the no-raw-error telemetry lint
- add bounded orchestrator CaptureError events and safe graph-agent LLM spans for provider/model/outcome metadata only

## Tests
- go test ./internal/config ./internal/telemetry ./internal/graphagent ./cmd/cerebro
- go test ./...