### PR TITLE
Deepen OpenAI audit access evidence

### DIFF
--- a/internal/sourceprojection/ai_access.go
+++ b/internal/sourceprojection/ai_access.go
@@ -749,36 +749,43 @@ func aiAuditProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile)
 	attrs := event.GetAttributes()
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
-	actorID := firstNonEmpty(attrs["actor_user_id"], attrs["actor_id"])
+	actorAPIKeyID := strings.TrimSpace(attrs["actor_api_key_id"])
+	actorUserID := strings.TrimSpace(attrs["actor_user_id"])
+	actorServiceAccountID := strings.TrimSpace(attrs["actor_service_account_id"])
 	actorEmail := strings.TrimSpace(attrs["actor_email"])
-	actorType := firstNonEmpty(attrs["actor_type"], "user")
-	if strings.TrimSpace(attrs["actor_api_key_id"]) != "" || aiActorTypeIsCredential(actorType) {
+	actorType := strings.TrimSpace(attrs["actor_type"])
+	actorID := firstNonEmpty(actorUserID, actorServiceAccountID, actorAPIKeyID, attrs["actor_id"])
+	if actorAPIKeyID != "" {
 		actorType = "credential"
-		actorID = firstNonEmpty(attrs["actor_api_key_id"], actorID)
+		actorID = actorAPIKeyID
+	} else if actorServiceAccountID != "" {
+		actorType = "service_account"
+		actorID = actorServiceAccountID
+	} else if actorType == "" {
+		actorType = "user"
 	}
 	actorURN := ""
 	if identityPrincipalType(actorType) == "service_account" {
-		actorURN = identityPrincipalURN(tenantID, profile.Provider, "service_account", actorID, "")
+		actorURN = aiEnsureServiceAccount(entities, tenantID, event.GetSourceId(), profile, actorID, attrs["actor_name"], "", attrs)
 	} else if actorType == "credential" {
-		actorURN = projectionURN(tenantID, profile.Provider+"_credential", actorID)
+		actorURN = aiEnsureCredential(entities, tenantID, event.GetSourceId(), profile, actorID, attrs)
 	} else {
 		actorURN = aiEnsureUser(entities, links, tenantID, event, profile, actorID, actorEmail, attrs["actor_name"], "")
 	}
-	if actorURN != "" && actorType == "credential" {
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        actorURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: profile.Provider + ".credential",
-			Label:      actorID,
-			Attributes: map[string]string{"credential_id": actorID, "principal_type": "credential"},
-		})
+	if actorURN != "" && actorAPIKeyID != "" {
+		ownerURN := aiAuditCredentialOwnerURN(entities, links, tenantID, event, profile, actorUserID, actorServiceAccountID, actorEmail)
+		if ownerURN != "" {
+			linkAttrs := aiEventLinkAttributes(event, "audit_actor_credential_owner")
+			addProjectedAttribute(linkAttrs, "credential_id", actorAPIKeyID)
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), ownerURN, actorURN, relationAssignedTo, linkAttrs))
+		}
 	}
-	targetURN := aiAuditTargetURN(entities, tenantID, event.GetSourceId(), profile, attrs)
+	targetURN := aiAuditTargetURN(entities, links, tenantID, event, profile, attrs)
 	if actorURN != "" && targetURN != "" {
 		linkAttrs := aiEventLinkAttributes(event, "audit_activity")
 		addProjectedAttribute(linkAttrs, "event_type", firstNonEmpty(attrs["event_type"], attrs["activity_type"]))
 		addProjectedAttribute(linkAttrs, "activity_type", attrs["activity_type"])
+		addProjectedAttribute(linkAttrs, "actor_type", actorType)
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, targetURN, relationActedOn, linkAttrs))
 	}
 	return identityProjectionResult(entities, links)
@@ -904,6 +911,51 @@ func aiEnsureUser(entities map[string]*ports.ProjectedEntity, links map[string]*
 	})
 	addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, email, event.GetOccurredAt())
 	return userURN
+}
+
+func aiEnsureServiceAccount(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, profile aiAccessProfile, serviceAccountID string, name string, role string, attrs map[string]string) string {
+	serviceAccountURN := identityPrincipalURN(tenantID, profile.Provider, "service_account", serviceAccountID, "")
+	if serviceAccountURN == "" {
+		return ""
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        serviceAccountURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: profile.Provider + ".service_account",
+		Label:      firstNonEmpty(name, serviceAccountID),
+		Attributes: aiPrincipalAttributes(attrs, map[string]string{
+			"principal_type":     "service_account",
+			"service_account_id": serviceAccountID,
+			"name":               strings.TrimSpace(name),
+			"role":               strings.TrimSpace(role),
+			"is_admin":           boolString(aiRoleIsAdmin(role)),
+		}),
+	})
+	return serviceAccountURN
+}
+
+func aiEnsureCredential(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, profile aiAccessProfile, credentialID string, attrs map[string]string) string {
+	credentialURN := projectionURN(tenantID, profile.Provider+"_credential", credentialID)
+	if credentialURN == "" {
+		return ""
+	}
+	credentialAttrs := aiPrincipalAttributes(attrs, map[string]string{
+		"credential_id":            strings.TrimSpace(credentialID),
+		"principal_type":           "credential",
+		"api_key_id":               strings.TrimSpace(credentialID),
+		"actor_user_id":            strings.TrimSpace(attrs["actor_user_id"]),
+		"actor_service_account_id": strings.TrimSpace(attrs["actor_service_account_id"]),
+	})
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        credentialURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: profile.Provider + ".credential",
+		Label:      credentialID,
+		Attributes: credentialAttrs,
+	})
+	return credentialURN
 }
 
 func aiEnsureRole(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, profile aiAccessProfile, attrs map[string]string, scopeKind string) string {
@@ -1037,25 +1089,129 @@ func aiRoleAssignmentRelation(role string) string {
 	return relationAssignedTo
 }
 
-func aiAuditTargetURN(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, profile aiAccessProfile, attrs map[string]string) string {
+func aiAuditTargetURN(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, profile aiAccessProfile, attrs map[string]string) string {
+	sourceID := event.GetSourceId()
+	eventType := strings.TrimSpace(firstNonEmpty(attrs["event_type"], attrs["activity_type"]))
 	switch {
+	case strings.HasPrefix(eventType, "api_key.") && strings.TrimSpace(attrs["api_key_id"]) != "":
+		return aiEnsureCredential(entities, tenantID, sourceID, profile, attrs["api_key_id"], attrs)
+	case strings.HasPrefix(eventType, "user.") && (strings.TrimSpace(attrs["user_id"]) != "" || strings.TrimSpace(attrs["email"]) != ""):
+		return aiEnsureUser(entities, links, tenantID, event, profile, attrs["user_id"], attrs["email"], attrs["name"], attrs["role"])
+	case strings.HasPrefix(eventType, "service_account.") && strings.TrimSpace(attrs["service_account_id"]) != "":
+		return aiEnsureServiceAccount(entities, tenantID, sourceID, profile, attrs["service_account_id"], attrs["name"], attrs["role"], attrs)
+	case strings.HasPrefix(eventType, "group.") && strings.TrimSpace(attrs["group_id"]) != "":
+		return aiEnsureGroup(entities, tenantID, sourceID, profile, attrs)
+	case strings.HasPrefix(eventType, "role.assignment.") && strings.TrimSpace(attrs["resource_id"]) != "":
+		return aiAuditResourceURN(entities, links, tenantID, event, profile, attrs["resource_id"], attrs["resource_type"], attrs)
+	case strings.HasPrefix(eventType, "role.assignment.") && strings.TrimSpace(attrs["principal_id"]) != "":
+		return aiAuditPrincipalURN(entities, links, tenantID, event, profile, attrs["principal_id"], attrs["principal_type"], attrs)
+	case strings.HasPrefix(eventType, "role.") && strings.TrimSpace(attrs["role_id"]) != "":
+		return aiEnsureRole(entities, tenantID, sourceID, profile, attrs, aiAuditRoleScopeKind(attrs))
+	case strings.HasPrefix(eventType, "project.") && strings.TrimSpace(attrs["project_id"]) != "":
+		return aiEnsureProject(entities, tenantID, sourceID, profile, attrs)
 	case strings.TrimSpace(attrs["project_id"]) != "":
 		return aiEnsureProject(entities, tenantID, sourceID, profile, attrs)
 	case strings.TrimSpace(attrs["api_key_id"]) != "":
-		credentialURN := projectionURN(tenantID, profile.Provider+"_credential", attrs["api_key_id"])
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        credentialURN,
-			TenantID:   tenantID,
-			SourceID:   sourceID,
-			EntityType: profile.Provider + ".credential",
-			Label:      attrs["api_key_id"],
-			Attributes: map[string]string{"credential_id": attrs["api_key_id"]},
-		})
-		return credentialURN
+		return aiEnsureCredential(entities, tenantID, sourceID, profile, attrs["api_key_id"], attrs)
+	case strings.TrimSpace(attrs["user_id"]) != "" || strings.TrimSpace(attrs["email"]) != "":
+		return aiEnsureUser(entities, links, tenantID, event, profile, attrs["user_id"], attrs["email"], attrs["name"], attrs["role"])
+	case strings.TrimSpace(attrs["service_account_id"]) != "":
+		return aiEnsureServiceAccount(entities, tenantID, sourceID, profile, attrs["service_account_id"], attrs["name"], attrs["role"], attrs)
+	case strings.TrimSpace(attrs["group_id"]) != "":
+		return aiEnsureGroup(entities, tenantID, sourceID, profile, attrs)
+	case strings.TrimSpace(attrs["role_id"]) != "":
+		return aiEnsureRole(entities, tenantID, sourceID, profile, attrs, aiAuditRoleScopeKind(attrs))
+	case strings.TrimSpace(attrs["resource_id"]) != "":
+		return aiAuditResourceURN(entities, links, tenantID, event, profile, attrs["resource_id"], attrs["resource_type"], attrs)
 	case strings.TrimSpace(attrs["organization_id"]) != "" || strings.TrimSpace(attrs["organization_uuid"]) != "":
 		return aiEnsureOrganization(entities, tenantID, sourceID, profile, attrs)
 	default:
 		return aiEnsureOrganization(entities, tenantID, sourceID, profile, attrs)
+	}
+}
+
+func aiAuditCredentialOwnerURN(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, profile aiAccessProfile, userID string, serviceAccountID string, email string) string {
+	if strings.TrimSpace(serviceAccountID) != "" {
+		return aiEnsureServiceAccount(entities, tenantID, event.GetSourceId(), profile, serviceAccountID, "", "", event.GetAttributes())
+	}
+	if strings.TrimSpace(userID) != "" || strings.TrimSpace(email) != "" {
+		return aiEnsureUser(entities, links, tenantID, event, profile, userID, email, "", "")
+	}
+	return ""
+}
+
+func aiAuditPrincipalURN(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, profile aiAccessProfile, principalID string, principalType string, attrs map[string]string) string {
+	switch identityPrincipalType(principalType) {
+	case "group":
+		groupAttrs := cloneAttributes(attrs)
+		groupAttrs["group_id"] = principalID
+		return aiEnsureGroup(entities, tenantID, event.GetSourceId(), profile, groupAttrs)
+	case "service_account":
+		return aiEnsureServiceAccount(entities, tenantID, event.GetSourceId(), profile, principalID, attrs["name"], attrs["role"], attrs)
+	case "role":
+		roleAttrs := cloneAttributes(attrs)
+		roleAttrs["role_id"] = principalID
+		return aiEnsureRole(entities, tenantID, event.GetSourceId(), profile, roleAttrs, aiAuditRoleScopeKind(attrs))
+	default:
+		return aiEnsureUser(entities, links, tenantID, event, profile, principalID, attrs["email"], attrs["name"], attrs["role"])
+	}
+}
+
+func aiAuditResourceURN(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, profile aiAccessProfile, resourceID string, resourceType string, attrs map[string]string) string {
+	switch identityPrincipalType(resourceType) {
+	case "group":
+		groupAttrs := cloneAttributes(attrs)
+		groupAttrs["group_id"] = resourceID
+		return aiEnsureGroup(entities, tenantID, event.GetSourceId(), profile, groupAttrs)
+	case "service_account":
+		return aiEnsureServiceAccount(entities, tenantID, event.GetSourceId(), profile, resourceID, attrs["name"], attrs["role"], attrs)
+	case "role":
+		roleAttrs := cloneAttributes(attrs)
+		roleAttrs["role_id"] = resourceID
+		return aiEnsureRole(entities, tenantID, event.GetSourceId(), profile, roleAttrs, aiAuditRoleScopeKind(attrs))
+	}
+	normalizedType := normalizeIdentifier(resourceType)
+	switch {
+	case strings.Contains(normalizedType, "project"):
+		projectAttrs := cloneAttributes(attrs)
+		projectAttrs["project_id"] = resourceID
+		return aiEnsureProject(entities, tenantID, event.GetSourceId(), profile, projectAttrs)
+	case strings.Contains(normalizedType, "organization") || normalizedType == "org":
+		orgAttrs := cloneAttributes(attrs)
+		orgAttrs["organization_id"] = resourceID
+		return aiEnsureOrganization(entities, tenantID, event.GetSourceId(), profile, orgAttrs)
+	case strings.Contains(normalizedType, "user"):
+		return aiEnsureUser(entities, links, tenantID, event, profile, resourceID, attrs["email"], attrs["name"], attrs["role"])
+	default:
+		resourceType = firstNonEmpty(resourceType, "resource")
+		resourceURN := projectionURN(tenantID, profile.Provider+"_resource", resourceType, resourceID)
+		if resourceURN == "" {
+			return ""
+		}
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        resourceURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: profile.Provider + ".resource",
+			Label:      firstNonEmpty(attrs["name"], resourceID),
+			Attributes: compactAttributes(map[string]string{
+				"resource_id":   resourceID,
+				"resource_type": resourceType,
+				"family":        attrs["family"],
+				"provider":      attrs["provider"],
+			}),
+		})
+		return resourceURN
+	}
+}
+
+func aiAuditRoleScopeKind(attrs map[string]string) string {
+	resourceType := normalizeIdentifier(attrs["resource_type"])
+	switch {
+	case strings.TrimSpace(attrs["project_id"]) != "" || strings.Contains(resourceType, "project"):
+		return "project"
+	default:
+		return "organization"
 	}
 }
 
@@ -1204,13 +1360,6 @@ func aiRolesIncludeAdmin(roles []string) bool {
 		}
 	}
 	return false
-}
-
-func aiActorTypeIsCredential(actorType string) bool {
-	normalized := normalizeIdentifier(actorType)
-	return strings.Contains(normalized, "api_key") ||
-		strings.Contains(normalized, "apikey") ||
-		strings.Contains(normalized, "credential")
 }
 
 func aiFamily(event *cerebrov1.EventEnvelope, profile aiAccessProfile) string {

--- a/internal/sourceprojection/ai_access_test.go
+++ b/internal/sourceprojection/ai_access_test.go
@@ -92,6 +92,87 @@ func TestProjectOpenAIProjectAccessEdges(t *testing.T) {
 	assertProjectedLink(t, state, projectURN, relationCanPerform, modelURN)
 }
 
+func TestProjectOpenAIAuditDeepAccessEvidence(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	occurred := time.Date(2026, time.June, 18, 12, 5, 0, 0, time.UTC)
+
+	events := []*cerebrov1.EventEnvelope{
+		{
+			Id:         "openai-audit-api-key",
+			TenantId:   "writer",
+			SourceId:   "openai",
+			Kind:       "openai.audit_log",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"actor_api_key_id":         "key_actor",
+				"actor_service_account_id": "sa_123",
+				"api_key_id":               "key_target",
+				"event_type":               "api_key.updated",
+				"family":                   "audit_log",
+			},
+		},
+		{
+			Id:         "openai-audit-role-assignment",
+			TenantId:   "writer",
+			SourceId:   "openai",
+			Kind:       "openai.audit_log",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"actor_email":    "admin@example.com",
+				"actor_user_id":  "user_admin",
+				"event_type":     "role.assignment.created",
+				"family":         "audit_log",
+				"principal_id":   "group_123",
+				"principal_type": "group",
+				"resource_id":    "proj_456",
+				"resource_type":  "project",
+			},
+		},
+		{
+			Id:         "openai-audit-group",
+			TenantId:   "writer",
+			SourceId:   "openai",
+			Kind:       "openai.audit_log",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"actor_email":   "admin@example.com",
+				"actor_user_id": "user_admin",
+				"event_type":    "group.updated",
+				"family":        "audit_log",
+				"group_id":      "group_123",
+				"group_name":    "Engineering",
+			},
+		},
+	}
+	for _, event := range events {
+		if _, err := service.Project(context.Background(), event); err != nil {
+			t.Fatalf("Project(%q) error = %v", event.GetId(), err)
+		}
+	}
+
+	actorCredentialURN := "urn:cerebro:writer:openai_credential:key_actor"   // #nosec G101 -- test credential URN fixture, not credential material.
+	targetCredentialURN := "urn:cerebro:writer:openai_credential:key_target" // #nosec G101 -- test credential URN fixture, not credential material.
+	serviceAccountURN := "urn:cerebro:writer:openai_service_account:sa_123"
+	userURN := "urn:cerebro:writer:openai_user:user_admin"
+	projectURN := "urn:cerebro:writer:openai_project:proj_456"
+	groupURN := "urn:cerebro:writer:openai_group:group_123"
+	identityURN := "urn:cerebro:writer:identity:email:admin@example.com"
+
+	assertProjectedLink(t, state, serviceAccountURN, relationAssignedTo, actorCredentialURN)
+	assertProjectedLink(t, state, actorCredentialURN, relationActedOn, targetCredentialURN)
+	assertProjectedLink(t, state, userURN, relationRepresentsIdentity, identityURN)
+	assertProjectedLink(t, state, userURN, relationActedOn, projectURN)
+	assertProjectedLink(t, state, userURN, relationActedOn, groupURN)
+	link := state.links[actorCredentialURN+"|"+relationActedOn+"|"+targetCredentialURN]
+	if got := link.Attributes["event_type"]; got != "api_key.updated" {
+		t.Fatalf("acted_on event_type = %q, want api_key.updated", got)
+	}
+	if got := link.Attributes["actor_type"]; got != "credential" {
+		t.Fatalf("acted_on actor_type = %q, want credential", got)
+	}
+}
+
 func TestProjectAnthropicProjectCollaboratorAccessEdges(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/sources/openai/source.go
+++ b/sources/openai/source.go
@@ -71,7 +71,7 @@ func openAIFamilies() []jsonapi.Family {
 		openAIListFamily("service_account", "/organization/projects/default/service_accounts", "openai_service_account", []string{"id"}, []string{"created_at"}, map[string]string{"service_account_id": "id", "project_id": "project_id", "name": "name", "role": "role", "created_at": "created_at"}),
 		openAIListFamily("api_key", "/organization/projects/default/api_keys", "openai_api_key", []string{"id"}, []string{"created_at", "last_used_at"}, map[string]string{"api_key_id": "id", "project_id": "project_id", "name": "name", "owner_user_id": "owner.user.id", "owner_service_account_id": "owner.service_account.id", "created_at": "created_at", "last_used_at": "last_used_at"}),
 		openAIListFamily("admin_api_key", "/organization/admin_api_keys", "openai_admin_api_key", []string{"id"}, []string{"created_at", "last_used_at"}, map[string]string{"api_key_id": "id", "name": "name", "owner_user_id": "owner.user.id", "owner_service_account_id": "owner.service_account.id", "created_at": "created_at", "last_used_at": "last_used_at"}),
-		openAIListFamily("audit_log", "/organization/audit_logs", "openai_audit_log", []string{"id"}, []string{"effective_at", "created_at"}, map[string]string{"audit_log_id": "id", "event_type": "type|event_type", "actor_id": "actor.id|actor.user.id|actor.service_account.id|actor.api_key.id", "actor_type": "actor.type", "actor_email": "actor.user.email|actor.email", "project_id": "project.id|project_id", "api_key_id": "api_key.id|api_key_id", "effective_at": "effective_at"}, withQuery(map[string]string{"actor_emails": "actor_emails", "actor_ids": "actor_ids", "effective_at[gt]": "effective_at_gt", "effective_at[gte]": "effective_at_gte", "effective_at[lt]": "effective_at_lt", "effective_at[lte]": "effective_at_lte", "event_types": "event_types", "project_ids": "project_ids"})),
+		openAIListFamily("audit_log", "/organization/audit_logs", "openai_audit_log", []string{"id"}, []string{"effective_at", "created_at"}, openAIAuditAttributes(), withQuery(map[string]string{"actor_emails": "actor_emails", "actor_ids": "actor_ids", "effective_at[gt]": "effective_at_gt", "effective_at[gte]": "effective_at_gte", "effective_at[lt]": "effective_at_lt", "effective_at[lte]": "effective_at_lte", "event_types": "event_types", "project_ids": "project_ids", "resource_ids": "resource_ids", "tenant_only": "tenant_only"})),
 		openAIListFamily("invite", "/organization/invites", "openai_invite", []string{"id"}, []string{"created_at"}, map[string]string{"invite_id": "id", "email": "email", "role": "role", "status": "status", "created_at": "created_at", "expires_at": "expires_at"}),
 		openAIListFamily("role", "/organization/roles", "openai_role", []string{"id"}, []string{"created_at", "updated_at"}, roleAttributes()),
 		openAIListFamily("user_role", "/organization/users/{user_id}/roles", "openai_user_role", []string{"id"}, []string{"created_at", "updated_at"}, roleAttributes(), withPathParams("user_id")),
@@ -156,6 +156,48 @@ func openAIUsageFamily(name string, path string) jsonapi.Family {
 		"organization_object": "object",
 	}
 	return openAIListFamily(name, path, "openai_"+name, []string{"id"}, []string{"start_time", "end_time"}, attrs, withCursor("page", "next_page", ""), withQuery(usageQuery))
+}
+
+func openAIAuditAttributes() map[string]string {
+	return map[string]string{
+		"api_key_id":               "api_key.created.id|api_key.updated.id|api_key.deleted.id|api_key.id|api_key_id",
+		"audit_log_id":             "id",
+		"actor_api_key_id":         "actor.api_key.id",
+		"actor_city":               "actor.session.ip_address_details.city",
+		"actor_country":            "actor.session.ip_address_details.country",
+		"actor_email":              "actor.session.user.email|actor.api_key.user.email|actor.user.email|actor.email",
+		"actor_id":                 "actor.session.user.id|actor.api_key.user.id|actor.api_key.service_account.id|actor.api_key.id|actor.user.id|actor.service_account.id|actor.id",
+		"actor_ip_address":         "actor.session.ip_address",
+		"actor_region":             "actor.session.ip_address_details.region",
+		"actor_service_account_id": "actor.api_key.service_account.id|actor.service_account.id",
+		"actor_type":               "actor.type|actor.api_key.type",
+		"actor_user_agent":         "actor.session.user_agent",
+		"actor_user_id":            "actor.session.user.id|actor.api_key.user.id|actor.user.id",
+		"certificate_id":           "certificate.created.id|certificate.updated.id|certificate.deleted.id",
+		"certificate_name":         "certificate.created.name|certificate.updated.name|certificate.deleted.name",
+		"effective_at":             "effective_at",
+		"event_type":               "type|event_type",
+		"external_key_id":          "external_key.registered.id|external_key.removed.id",
+		"group_id":                 "group.created.id|group.updated.id|group.deleted.id",
+		"group_name":               "group.created.data.group_name|group.updated.changes_requested.group_name",
+		"invite_email":             "invite.sent.data.email",
+		"invite_id":                "invite.sent.id|invite.accepted.id|invite.deleted.id",
+		"invite_role":              "invite.sent.data.role",
+		"ip_allowlist_id":          "ip_allowlist.created.id|ip_allowlist.updated.id|ip_allowlist.deleted.id",
+		"ip_allowlist_name":        "ip_allowlist.created.name|ip_allowlist.deleted.name",
+		"organization_id":          "organization.updated.id|organization_id|org_id",
+		"principal_id":             "role.assignment.created.principal_id|role.assignment.deleted.principal_id",
+		"principal_type":           "role.assignment.created.principal_type|role.assignment.deleted.principal_type",
+		"project_id":               "project.created.id|project.updated.id|project.archived.id|project.deleted.id|checkpoint.permission.created.data.project_id|project.id|project_id",
+		"rate_limit_id":            "rate_limit.updated.id|rate_limit.deleted.id",
+		"resource_id":              "role.assignment.created.resource_id|role.assignment.deleted.resource_id|role.bound_to_resource.resource_id|role.unbound_from_resource.resource_id|resource.deleted.id",
+		"resource_type":            "role.assignment.created.resource_type|role.assignment.deleted.resource_type|role.bound_to_resource.resource_type|role.unbound_from_resource.resource_type|resource.deleted.type",
+		"role_assignment_id":       "role.assignment.created.id|role.assignment.deleted.id",
+		"role_id":                  "role.created.id|role.updated.id|role.deleted.id|role.bound_to_resource.role_id|role.unbound_from_resource.role_id",
+		"role_name":                "role.created.data.role_name|role.updated.changes_requested.role_name|role.bound_to_resource.role_name|role.unbound_from_resource.role_name",
+		"service_account_id":       "service_account.created.id|service_account.updated.id|service_account.deleted.id",
+		"user_id":                  "user.added.id|user.updated.id|user.deleted.id",
+	}
 }
 
 func roleAttributes() map[string]string {

--- a/sources/openai/source_test.go
+++ b/sources/openai/source_test.go
@@ -35,10 +35,16 @@ func TestReadAuditLogMapsQueryAndUnixTimestamp(t *testing.T) {
 		if got := r.URL.Query().Get("limit"); got != "2" {
 			t.Fatalf("limit = %q, want 2", got)
 		}
+		if got := r.URL.Query().Get("resource_ids"); got != "proj_123" {
+			t.Fatalf("resource_ids = %q, want proj_123", got)
+		}
+		if got := r.URL.Query().Get("tenant_only"); got != "true" {
+			t.Fatalf("tenant_only = %q, want true", got)
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data": []map[string]any{{
 				"id":           "audit-1",
-				"type":         "project.created",
+				"type":         "project.archived",
 				"effective_at": 1711471533,
 				"actor": map[string]any{
 					"type": "user",
@@ -47,6 +53,7 @@ func TestReadAuditLogMapsQueryAndUnixTimestamp(t *testing.T) {
 						"email": "alice@example.com",
 					},
 				},
+				"project.archived": map[string]any{"id": "proj_123"},
 			}},
 			"has_more": false,
 		})
@@ -64,7 +71,9 @@ func TestReadAuditLogMapsQueryAndUnixTimestamp(t *testing.T) {
 		"effective_at_gte": "1711471533",
 		"family":           "audit_log",
 		"per_page":         "2",
+		"resource_ids":     "proj_123",
 		"tenant_id":        "writer",
+		"tenant_only":      "true",
 	}), nil)
 	if err != nil {
 		t.Fatalf("Read() error = %v", err)
@@ -76,15 +85,110 @@ func TestReadAuditLogMapsQueryAndUnixTimestamp(t *testing.T) {
 	if event.Kind != "openai.audit_log" {
 		t.Fatalf("Kind = %q, want openai.audit_log", event.Kind)
 	}
-	if got := event.Attributes["event_type"]; got != "project.created" {
-		t.Fatalf("event_type = %q, want project.created", got)
+	if got := event.Attributes["event_type"]; got != "project.archived" {
+		t.Fatalf("event_type = %q, want project.archived", got)
 	}
 	if got := event.Attributes["actor_email"]; got != "alice@example.com" {
 		t.Fatalf("actor_email = %q, want alice@example.com", got)
 	}
+	if got := event.Attributes["project_id"]; got != "proj_123" {
+		t.Fatalf("project_id = %q, want proj_123", got)
+	}
 	want := time.Unix(1711471533, 0).UTC()
 	if got := event.OccurredAt.AsTime(); !got.Equal(want) {
 		t.Fatalf("OccurredAt = %s, want %s", got.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+}
+
+func TestReadAuditLogMapsNestedActorAndTargetDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{
+				"id":           "audit-2",
+				"type":         "api_key.updated",
+				"effective_at": 1711471544,
+				"actor": map[string]any{
+					"type": "api_key",
+					"api_key": map[string]any{
+						"id":   "key_actor",
+						"type": "service_account",
+						"service_account": map[string]any{
+							"id": "sa_123",
+						},
+					},
+				},
+				"api_key.updated": map[string]any{
+					"id": "key_target",
+					"changes_requested": map[string]any{
+						"scopes": []string{"api.model.request"},
+					},
+				},
+			}, {
+				"id":           "audit-3",
+				"type":         "role.assignment.created",
+				"effective_at": 1711471555,
+				"actor": map[string]any{
+					"type": "session",
+					"session": map[string]any{
+						"user": map[string]any{
+							"id":    "user-admin",
+							"email": "admin@example.com",
+						},
+						"ip_address": "203.0.113.10",
+					},
+				},
+				"role.assignment.created": map[string]any{
+					"id":             "assign_123",
+					"principal_id":   "group_123",
+					"principal_type": "group",
+					"resource_id":    "proj_456",
+					"resource_type":  "project",
+				},
+			}},
+			"has_more": false,
+		})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"api_key":   "admin-key",
+		"base_url":  server.URL,
+		"family":    "audit_log",
+		"tenant_id": "writer",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(Events) = %d, want 2", len(pull.Events))
+	}
+	keyEvent := pull.Events[0]
+	if got := keyEvent.Attributes["actor_api_key_id"]; got != "key_actor" {
+		t.Fatalf("actor_api_key_id = %q, want key_actor", got)
+	}
+	if got := keyEvent.Attributes["actor_service_account_id"]; got != "sa_123" {
+		t.Fatalf("actor_service_account_id = %q, want sa_123", got)
+	}
+	if got := keyEvent.Attributes["api_key_id"]; got != "key_target" {
+		t.Fatalf("api_key_id = %q, want key_target", got)
+	}
+	roleEvent := pull.Events[1]
+	if got := roleEvent.Attributes["actor_user_id"]; got != "user-admin" {
+		t.Fatalf("actor_user_id = %q, want user-admin", got)
+	}
+	if got := roleEvent.Attributes["actor_ip_address"]; got != "203.0.113.10" {
+		t.Fatalf("actor_ip_address = %q, want 203.0.113.10", got)
+	}
+	if got := roleEvent.Attributes["principal_type"]; got != "group" {
+		t.Fatalf("principal_type = %q, want group", got)
+	}
+	if got := roleEvent.Attributes["resource_id"]; got != "proj_456" {
+		t.Fatalf("resource_id = %q, want proj_456", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- expand OpenAI audit-log extraction for documented actor.session / actor.api_key details and event-specific target objects
- add audit query support for resource_ids and tenant_only
- project richer audit evidence: API-key actors, API-key owner links, typed targets for projects, credentials, users, groups, service accounts, roles, and role-assignment resources

## Docs
- https://developers.openai.com/api/reference/resources/admin/subresources/organization/subresources/audit_logs/methods/list

## Tests
- go test ./sources/openai ./internal/sourceprojection
- make lint
- make check-structural
- make check-arch
- ./scripts/pre_commit_checks.sh