### PR TITLE
Add Archetype source and graph projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-
 | Source ID | Description | Emitted kinds / families |
 | --- | --- | --- |
 | `anthropic` | Anthropic organization governance source | organization, users, invites, workspaces and members, API keys, service accounts, federation, external keys, usage/cost reports, rate/spend limits, compliance activity |
+| `archetype` | Archetype repository vulnerability scan source | scans, vulnerabilities |
 | `aurelius` | SaaS/business-operation export source | configured catalog families |
 | `auth0` | Auth0 Management API source | users, roles, audit events |
 | `aws` | AWS IAM, cloud, workload, network exposure, and CloudTrail source | access keys, IAM users/groups/roles/trust, EC2, ECS, EKS, Lambda, public endpoints, resource exposure, CloudTrail |

--- a/internal/sourceprojection/archetype.go
+++ b/internal/sourceprojection/archetype.go
@@ -1,0 +1,124 @@
+package sourceprojection
+
+import (
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func archetypeScanProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	scanID := firstNonEmpty(attrs["scan_id"], stringValue(payloadMap(event), "id"))
+	if scanID == "" {
+		return nil, nil, nil
+	}
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	scanURN := projectionURN(tenantID, "archetype_scan", scanID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        scanURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "archetype.scan",
+		Label:      "Archetype scan " + scanID,
+		Attributes: compactAttributes(map[string]string{
+			"repository_id":  attrs["repository_id"],
+			"scan_id":        scanID,
+			"source_product": "archetype",
+			"status":         attrs["status"],
+			"at":             eventObservedAt(event),
+		}),
+	})
+	if repoURN := archetypeRepoURN(tenantID, attrs); repoURN != "" {
+		addArchetypeRepo(entities, tenantID, event.GetSourceId(), repoURN, attrs)
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), repoURN, scanURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), scanURN, repoURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func archetypeVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	vulnID := firstNonEmpty(attrs["vulnerability_id"], stringValue(payloadMap(event), "id"))
+	if vulnID == "" {
+		return nil, nil, nil
+	}
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	findingURN := projectionURN(tenantID, "archetype_finding", vulnID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        findingURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "archetype.finding",
+		Label:      archetypeFindingLabel(attrs),
+		Attributes: compactAttributes(map[string]string{
+			"category":         attrs["category"],
+			"file_path":        attrs["file_path"],
+			"line_number":      attrs["line_number"],
+			"repository_id":    attrs["repository_id"],
+			"scan_id":          attrs["scan_id"],
+			"severity":         attrs["severity"],
+			"source_product":   "archetype",
+			"vulnerability_id": vulnID,
+			"at":               eventObservedAt(event),
+		}),
+	})
+	if scanURN := projectionURN(tenantID, "archetype_scan", attrs["scan_id"]); scanURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{URN: scanURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "archetype.scan", Label: "Archetype scan " + attrs["scan_id"], Attributes: map[string]string{"scan_id": attrs["scan_id"]}})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, scanURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+	}
+	if repoURN := archetypeRepoURN(tenantID, attrs); repoURN != "" {
+		addArchetypeRepo(entities, tenantID, event.GetSourceId(), repoURN, attrs)
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), repoURN, findingURN, relationHasEvidence, map[string]string{"event_id": event.GetId(), "severity": attrs["severity"]}))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, repoURN, relationAffects, map[string]string{"event_id": event.GetId()}))
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func archetypeRepoURN(tenantID string, attrs map[string]string) string {
+	repository := firstNonEmpty(attrs["repository"], joinRepo(attrs["owner"], attrs["repo"]))
+	return projectionURN(tenantID, "github_code_repository", repository)
+}
+
+func addArchetypeRepo(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, repoURN string, attrs map[string]string) {
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        repoURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "github.code.repository",
+		Label:      firstNonEmpty(attrs["repo"], attrs["repository"], repoURN),
+		Attributes: compactAttributes(map[string]string{
+			"owner_login":    attrs["owner"],
+			"repository":     firstNonEmpty(attrs["repository"], joinRepo(attrs["owner"], attrs["repo"])),
+			"resource_type":  "code_repository",
+			"source_product": "archetype",
+		}),
+	})
+}
+
+func archetypeFindingLabel(attrs map[string]string) string {
+	location := strings.TrimSpace(attrs["file_path"])
+	if line := strings.TrimSpace(attrs["line_number"]); line != "" {
+		location += ":" + line
+	}
+	return firstNonEmpty(attrs["category"]+" "+location, attrs["vulnerability_id"], "Archetype finding")
+}
+
+func joinRepo(owner string, repo string) string {
+	if strings.TrimSpace(owner) == "" || strings.TrimSpace(repo) == "" {
+		return ""
+	}
+	return strings.TrimSpace(owner) + "/" + strings.TrimSpace(repo)
+}

--- a/internal/sourceprojection/archetype_test.go
+++ b/internal/sourceprojection/archetype_test.go
@@ -1,0 +1,75 @@
+package sourceprojection
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestProjectArchetypeVulnerabilityLinksRepoScanAndFinding(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "archetype-vulnerability-10",
+		TenantId: "writer",
+		SourceId: "archetype",
+		Kind:     "archetype.vulnerability",
+		Attributes: map[string]string{
+			"vulnerability_id": "10",
+			"scan_id":          "1",
+			"repository_id":    "7",
+			"owner":            "WriterInternal",
+			"repo":             "Archetype",
+			"severity":         "high",
+			"category":         "ssrf",
+			"file_path":        "app/main.py",
+			"line_number":      "42",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesProjected != 3 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 3 {
+		t.Fatalf("Project().LinksProjected = %d, want 3", result.LinksProjected)
+	}
+	repoURN := "urn:cerebro:writer:github_code_repository:WriterInternal/Archetype"
+	scanURN := "urn:cerebro:writer:archetype_scan:1"
+	findingURN := "urn:cerebro:writer:archetype_finding:10"
+	if entity := state.entities[findingURN]; entity == nil || entity.EntityType != "archetype.finding" {
+		t.Fatalf("finding entity missing: %#v", entity)
+	}
+	assertProjectedLink(t, state, findingURN, relationBelongsTo, scanURN)
+	assertProjectedLink(t, state, repoURN, relationHasEvidence, findingURN)
+	assertProjectedLink(t, state, findingURN, relationAffects, repoURN)
+}
+
+func TestProjectArchetypeScanLinksRepositoryEvidence(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "archetype-scan-1",
+		TenantId: "writer",
+		SourceId: "archetype",
+		Kind:     "archetype.scan",
+		Attributes: map[string]string{
+			"scan_id":       "1",
+			"repository_id": "7",
+			"owner":         "WriterInternal",
+			"repo":          "Archetype",
+			"status":        "completed",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	repoURN := "urn:cerebro:writer:github_code_repository:WriterInternal/Archetype"
+	scanURN := "urn:cerebro:writer:archetype_scan:1"
+	assertProjectedLink(t, state, repoURN, relationHasEvidence, scanURN)
+	assertProjectedLink(t, state, scanURN, relationObservedOn, repoURN)
+}

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -47,6 +47,8 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"auth0.audit_events":                            auth0AuditEventsProjections,
 	"auth0.roles":                                   auth0RolesProjections,
 	"auth0.users":                                   auth0UsersProjections,
+	"archetype.scan":                                archetypeScanProjections,
+	"archetype.vulnerability":                       archetypeVulnerabilityProjections,
 	"aurelius.catalog_promotion":                    aureliusCatalogPromotionProjections,
 	"aurelius.finding":                              aureliusFindingProjections,
 	"aurelius.image_scan":                           aureliusImageScanProjections,

--- a/internal/sourceregistry/registry.go
+++ b/internal/sourceregistry/registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/writer/cerebro/internal/connectorcatalog"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	anthropicsource "github.com/writer/cerebro/sources/anthropic"
+	archetypesource "github.com/writer/cerebro/sources/archetype"
 	aureliussource "github.com/writer/cerebro/sources/aurelius"
 	auth0source "github.com/writer/cerebro/sources/auth0"
 	awssource "github.com/writer/cerebro/sources/aws"
@@ -61,6 +62,12 @@ var builtinSourceLoaders = []builtinSourceLoader{
 		name: "anthropic",
 		load: func() (sourcecdk.Source, error) {
 			return anthropicsource.New()
+		},
+	},
+	{
+		name: "archetype",
+		load: func() (sourcecdk.Source, error) {
+			return archetypesource.New()
 		},
 	},
 	{

--- a/sources/archetype/catalog.yaml
+++ b/sources/archetype/catalog.yaml
@@ -1,0 +1,31 @@
+id: archetype
+name: Archetype
+description: Archetype code security scan lifecycle and vulnerability findings.
+emitted_kinds:
+  - archetype.scan
+  - archetype.vulnerability
+coverage_contract:
+  owner_domain: code_security
+  authority_domain: archetype
+  dimensions:
+    - id: scans
+      type: lifecycle_state
+      title: Archetype scan lifecycle
+      families: [scan]
+      support: supported
+      high_value: true
+    - id: vulnerabilities
+      type: entity_family
+      title: Archetype code vulnerabilities
+      families: [vulnerability]
+      support: supported
+      high_value: true
+event_contracts:
+  - kind: archetype.scan
+    schema_ref: archetype/scan/v1
+    required_attributes: [scan_id, repository_id, status]
+    required_payload_fields: [id, repository_id, status]
+  - kind: archetype.vulnerability
+    schema_ref: archetype/vulnerability/v1
+    required_attributes: [vulnerability_id, scan_id, severity, category, file_path]
+    required_payload_fields: [id, scan_id, severity, category, file_path]

--- a/sources/archetype/source.go
+++ b/sources/archetype/source.go
@@ -1,0 +1,225 @@
+package archetype
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/sourcehttp"
+)
+
+//go:embed catalog.yaml
+var catalogFS embed.FS
+
+const sourceID = "archetype"
+
+type Source struct {
+	spec                 *cerebrov1.SourceSpec
+	allowLoopbackBaseURL bool
+}
+
+type settings struct{ tenantID, family, baseURL, token, apiPrefix string }
+type scanRecord struct {
+	ID           int    `json:"id"`
+	RepositoryID int    `json:"repository_id"`
+	Status       string `json:"status"`
+	StartedAt    string `json:"started_at"`
+	CompletedAt  string `json:"completed_at"`
+	CreatedAt    string `json:"created_at"`
+}
+type vulnerabilityRecord struct {
+	ID            int     `json:"id"`
+	ScanID        int     `json:"scan_id"`
+	LineNumber    int     `json:"line_number"`
+	FilePath      string  `json:"file_path"`
+	Category      string  `json:"category"`
+	Severity      string  `json:"severity"`
+	Description   string  `json:"description"`
+	AnalyzerScore float64 `json:"analyzer_score"`
+	AnalyzerLabel string  `json:"analyzer_label"`
+	CreatedAt     string  `json:"created_at"`
+}
+type repositoryRecord struct {
+	ID    int    `json:"id"`
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
+}
+
+func New() (*Source, error) {
+	specBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read catalog: %w", err)
+	}
+	spec, err := sourcecdk.LoadCatalog(specBytes)
+	if err != nil {
+		return nil, fmt.Errorf("load catalog: %w", err)
+	}
+	return &Source{spec: spec}, nil
+}
+func (s *Source) Spec() *cerebrov1.SourceSpec { return s.spec }
+func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
+	st, err := parseSettings(cfg)
+	if err != nil {
+		return err
+	}
+	var scans []scanRecord
+	return s.get(ctx, st, "/scans", nil, &scans)
+}
+func (s *Source) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return s.ReadWithCheckpoint(ctx, cfg, cursor, nil)
+}
+func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	st, err := parseSettings(cfg)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	var scans []scanRecord
+	if err := s.get(ctx, st, "/scans", nil, &scans); err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	sort.Slice(scans, func(i, j int) bool { return scans[i].ID < scans[j].ID })
+	last := lastScanID(cursor, checkpoint)
+	repos := map[int]repositoryRecord{}
+	events := []*primitives.Event{}
+	for _, scan := range scans {
+		if scan.ID <= last {
+			continue
+		}
+		if len(repos) == 0 {
+			repos = s.repositories(ctx, st)
+		}
+		events = append(events, scanEvent(st, scan, repos[scan.RepositoryID]))
+		if st.family == "scan" {
+			continue
+		}
+		var vulns []vulnerabilityRecord
+		if err := s.get(ctx, st, fmt.Sprintf("/scans/%d/vulnerabilities", scan.ID), nil, &vulns); err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		for _, vuln := range vulns {
+			events = append(events, vulnerabilityEvent(st, scan, vuln, repos[scan.RepositoryID]))
+		}
+	}
+	if len(events) == 0 {
+		return sourcecdk.NotModifiedPull(checkpoint), nil
+	}
+	next := strconv.Itoa(maxScanID(scans))
+	return sourcecdk.Pull{Events: events, Checkpoint: &cerebrov1.SourceCheckpoint{CursorOpaque: next, Watermark: events[len(events)-1].OccurredAt}}, nil
+}
+func parseSettings(cfg sourcecdk.Config) (settings, error) {
+	st := settings{
+		tenantID:  first(configValue(cfg, "tenant_id"), configValue(cfg, sourceconfig.RuntimeTenantIDKey)),
+		family:    first(configValue(cfg, "family"), "vulnerability"),
+		baseURL:   strings.TrimRight(configValue(cfg, "base_url"), "/"),
+		token:     first(configValue(cfg, "token"), configValue(cfg, "api_token")),
+		apiPrefix: first(configValue(cfg, "api_prefix"), "/api/v1"),
+	}
+	if st.tenantID == "" || st.baseURL == "" {
+		return st, fmt.Errorf("%w: archetype tenant_id and base_url are required", sourcecdk.ErrInvalidConfig)
+	}
+	if st.family != "scan" && st.family != "vulnerability" {
+		return st, fmt.Errorf("%w: archetype family must be scan or vulnerability", sourcecdk.ErrInvalidConfig)
+	}
+	return st, nil
+}
+func (s *Source) get(ctx context.Context, st settings, path string, query url.Values, out any) error {
+	req, err := sourcehttp.NewRequest(ctx, sourceID, st.baseURL, s.allowLoopbackBaseURL, http.MethodGet, st.apiPrefix+path, query, nil)
+	if err != nil {
+		return err
+	}
+	if st.token != "" {
+		req.Header.Set("Authorization", "Bearer "+st.token)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := sourcehttp.DoWithRetry(ctx, sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: sourceID, AllowLoopback: s.allowLoopbackBaseURL}), req, sourcehttp.RetryOptions{})
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("archetype GET %s failed with status %d", path, resp.StatusCode)
+	}
+	return json.Unmarshal(resp.Body, out)
+}
+func (s *Source) repositories(ctx context.Context, st settings) map[int]repositoryRecord {
+	var repos []repositoryRecord
+	if err := s.get(ctx, st, "/repositories", nil, &repos); err != nil {
+		return nil
+	}
+	out := map[int]repositoryRecord{}
+	for _, repo := range repos {
+		out[repo.ID] = repo
+	}
+	return out
+}
+func scanEvent(st settings, scan scanRecord, repo repositoryRecord) *primitives.Event {
+	attrs := map[string]string{"scan_id": itoa(scan.ID), "repository_id": itoa(scan.RepositoryID), "status": scan.Status, "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}
+	return event(st, "archetype.scan", "archetype-scan-"+itoa(scan.ID), "archetype/scan/v1", scanTime(scan), attrs, scan)
+}
+func vulnerabilityEvent(st settings, scan scanRecord, vuln vulnerabilityRecord, repo repositoryRecord) *primitives.Event {
+	attrs := map[string]string{"vulnerability_id": itoa(vuln.ID), "scan_id": itoa(vuln.ScanID), "repository_id": itoa(scan.RepositoryID), "severity": vuln.Severity, "category": vuln.Category, "file_path": vuln.FilePath, "line_number": itoa(vuln.LineNumber), "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}
+	return event(st, "archetype.vulnerability", "archetype-vulnerability-"+itoa(vuln.ID), "archetype/vulnerability/v1", parseTime(vuln.CreatedAt, scanTime(scan)), attrs, vuln)
+}
+func event(st settings, kind, id, schema string, at time.Time, attrs map[string]string, payload any) *primitives.Event {
+	body, _ := json.Marshal(payload)
+	return &cerebrov1.EventEnvelope{Id: id, TenantId: st.tenantID, SourceId: sourceID, Kind: kind, SchemaRef: schema, OccurredAt: timestamppb.New(at), Payload: body, Attributes: compact(attrs)}
+}
+func lastScanID(cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) int {
+	value := first(sourcecdk.CursorToken(cursor), checkpoint.GetCursorOpaque())
+	id, _ := strconv.Atoi(value)
+	return id
+}
+func maxScanID(scans []scanRecord) int {
+	max := 0
+	for _, scan := range scans {
+		if scan.ID > max {
+			max = scan.ID
+		}
+	}
+	return max
+}
+func scanTime(scan scanRecord) time.Time {
+	return parseTime(first(scan.CompletedAt, scan.StartedAt, scan.CreatedAt), time.Now().UTC())
+}
+func parseTime(value string, fallback time.Time) time.Time {
+	if at, err := time.Parse(time.RFC3339, strings.TrimSpace(value)); err == nil {
+		return at.UTC()
+	}
+	return fallback.UTC()
+}
+func configValue(cfg sourcecdk.Config, key string) string {
+	value, _ := cfg.Lookup(key)
+	return strings.TrimSpace(value)
+}
+func first(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+func compact(attrs map[string]string) map[string]string {
+	for key, value := range attrs {
+		if strings.TrimSpace(value) == "" {
+			delete(attrs, key)
+		}
+	}
+	return attrs
+}
+func itoa(value int) string { return strconv.Itoa(value) }

--- a/sources/archetype/source_test.go
+++ b/sources/archetype/source_test.go
@@ -1,0 +1,116 @@
+package archetype
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+func TestSourceReadEmitsScanAndVulnerabilityEvents(t *testing.T) {
+	var sawAuth bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer token" {
+			sawAuth = true
+		}
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"}})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		case "/api/v1/scans/1/vulnerabilities":
+			body, err := os.ReadFile("testdata/sample_vulnerability.json")
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[" + string(body) + "]"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"__cerebro_runtime_tenant_id": "writer",
+		"base_url":                    server.URL,
+		"token":                       "token",
+	}), nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if !sawAuth {
+		t.Fatal("server did not receive bearer token")
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(Events) = %d, want 2", len(pull.Events))
+	}
+	if pull.Events[0].GetKind() != "archetype.scan" || pull.Events[1].GetKind() != "archetype.vulnerability" {
+		t.Fatalf("event kinds = %q, %q", pull.Events[0].GetKind(), pull.Events[1].GetKind())
+	}
+	if got := pull.Events[1].GetAttributes()["repo"]; got != "Archetype" {
+		t.Fatalf("vulnerability repo attr = %q, want Archetype", got)
+	}
+	if got := pull.Checkpoint.GetCursorOpaque(); got != "1" {
+		t.Fatalf("checkpoint cursor = %q, want 1", got)
+	}
+}
+
+func TestSourceReadHonorsCheckpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/scans" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		writeJSON(t, w, []map[string]any{{"id": 1, "repository_id": 7, "status": "completed"}})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+	}), nil, &cerebrov1.SourceCheckpoint{CursorOpaque: "1"})
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 0 {
+		t.Fatalf("len(Events) = %d, want 0", len(pull.Events))
+	}
+}
+
+func TestSourceCheckRejectsBadFamily(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	err = source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  "https://archetype.example.com",
+		"family":    "repository",
+	}))
+	if err == nil {
+		t.Fatal("Check() error = nil, want error")
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, payload any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/sources/archetype/testdata/sample_vulnerability.json
+++ b/sources/archetype/testdata/sample_vulnerability.json
@@ -1,0 +1,12 @@
+{
+  "id": 10,
+  "scan_id": 1,
+  "file_path": "app/main.py",
+  "line_number": 42,
+  "category": "ssrf",
+  "severity": "high",
+  "description": "Potential SSRF detected.",
+  "analyzer_score": 0.91,
+  "analyzer_label": "confirmed",
+  "created_at": "2026-06-17T12:04:00Z"
+}


### PR DESCRIPTION
## Summary
- add a first-class `archetype` source for scan and vulnerability events from the Archetype API
- register the source in the built-in source registry
- project Archetype scans/findings into repository-linked graph entities

## Validation
- go test ./sources/archetype ./internal/sourceprojection ./internal/sourceregistry
- go test ./tools/archtests ./tools/catalogcheck
- go test ./sources/...