### PR TITLE
Add Cerebro headroom guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
             command: make sdk-test
           - name: sdk-dependency-audit
             command: make sdk-dependency-audit
+          - name: script-test
+            command: make script-test
           - name: mcp
             command: make mcp-contract-check mcp-sdk-compat
           - name: lint

--- a/.github/workflows/load-smoke.yml
+++ b/.github/workflows/load-smoke.yml
@@ -1,0 +1,90 @@
+name: Cerebro Load Smoke
+
+on:
+  schedule:
+    # Run daily after the compose smoke. The job skips cleanly unless a live target secret is configured.
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Cerebro origin to exercise; falls back to CEREBRO_LOAD_SMOKE_BASE_URL secret when empty'
+        required: false
+        type: string
+      duration_seconds:
+        description: 'Smoke duration in seconds'
+        required: false
+        default: '60'
+        type: string
+      rps:
+        description: 'Target requests per second'
+        required: false
+        default: '3'
+        type: string
+      concurrency:
+        description: 'Maximum in-flight requests'
+        required: false
+        default: '6'
+        type: string
+      max_p95_ms:
+        description: 'Fail when p95 latency is above this threshold'
+        required: false
+        default: '750'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  load-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    env:
+      INPUT_BASE_URL: ${{ github.event.inputs.base_url }}
+      INPUT_DURATION_SECONDS: ${{ github.event.inputs.duration_seconds }}
+      INPUT_RPS: ${{ github.event.inputs.rps }}
+      INPUT_CONCURRENCY: ${{ github.event.inputs.concurrency }}
+      INPUT_MAX_P95_MS: ${{ github.event.inputs.max_p95_ms }}
+      SECRET_BASE_URL: ${{ secrets.CEREBRO_LOAD_SMOKE_BASE_URL }}
+      CEREBRO_LOAD_SMOKE_BEARER_TOKEN: ${{ secrets.CEREBRO_LOAD_SMOKE_BEARER_TOKEN }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Resolve target
+        id: target
+        shell: bash
+        run: |
+          target_url="${INPUT_BASE_URL:-$SECRET_BASE_URL}"
+          if [ -z "$target_url" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No load-smoke target configured; set the CEREBRO_LOAD_SMOKE_BASE_URL secret or pass base_url manually."
+            exit 0
+          fi
+          echo "::add-mask::$target_url"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "CEREBRO_BASE_URL=$target_url"
+            echo "LOAD_SMOKE_DURATION=${INPUT_DURATION_SECONDS:-60}"
+            echo "LOAD_SMOKE_RPS=${INPUT_RPS:-3}"
+            echo "LOAD_SMOKE_CONCURRENCY=${INPUT_CONCURRENCY:-6}"
+            echo "LOAD_SMOKE_MAX_P95_MS=${INPUT_MAX_P95_MS:-750}"
+            echo "LOAD_SMOKE_JSON_OUT=tmp/load-smoke.json"
+            echo "LOAD_SMOKE_MARKDOWN_OUT=tmp/load-smoke.md"
+          } >> "$GITHUB_ENV"
+
+      - name: Run load smoke
+        if: steps.target.outputs.skip != 'true'
+        run: make load-smoke
+
+      - name: Upload load-smoke artifacts
+        if: steps.target.outputs.skip != 'true' && always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cerebro-load-smoke
+          path: |
+            tmp/load-smoke.json
+            tmp/load-smoke.md
+          if-no-files-found: warn

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit workflow-e2e-test workflow-replay-test finding-rule-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check policy-rule-generate policy-rule-check detection-catalog-generate detection-catalog-check new-aws-collector docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check docker-smoke release-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check policy-rule-generate policy-rule-check detection-catalog-generate detection-catalog-check new-aws-collector docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -46,6 +46,16 @@ GRAPH_REBUILD_PAGE_LIMIT ?= 1
 GRAPH_REBUILD_EVENT_LIMIT ?= 100
 GRAPH_REBUILD_PREVIEW_LIMIT ?= 10
 CANDIDATE_SMOKE_EVENT_LIMIT ?= 25
+LOAD_SMOKE_DURATION ?= 30
+LOAD_SMOKE_RPS ?= 2
+LOAD_SMOKE_CONCURRENCY ?= 4
+LOAD_SMOKE_TIMEOUT ?= 5
+LOAD_SMOKE_PATHS ?= /health
+LOAD_SMOKE_MAX_P95_MS ?= 750
+LOAD_SMOKE_MAX_ERROR_RATE ?= 0.01
+LOAD_SMOKE_MAX_5XX_RATE ?= 0
+LOAD_SMOKE_JSON_OUT ?= tmp/load-smoke.json
+LOAD_SMOKE_MARKDOWN_OUT ?= tmp/load-smoke.md
 MCP_SDK_ROOT ?= tmp/mcp-sdk-compat
 MCP_SDK_PACKAGE ?= @modelcontextprotocol/sdk@latest
 MCP_SDK_TEST_TOKEN ?= mcp-sdk-test-key
@@ -119,6 +129,9 @@ sdk-dependency-audit: ## Audit SDK dependencies for known vulnerabilities.
 	$(PYTHON) -m venv "$(SDK_AUDIT_VENV)"
 	"$(SDK_AUDIT_VENV)/bin/python" -m pip install --upgrade pip pip-audit
 	"$(SDK_AUDIT_VENV)/bin/python" scripts/sdk_dependency_audit.py
+
+script-test: ## Run Python utility tests.
+	$(PYTHON) -m unittest discover scripts/tests
 
 # ==== Focused Tests ====
 ##@ Focused Tests
@@ -316,6 +329,20 @@ docker-smoke: ## Build and smoke-test the runtime Docker image.
 release-smoke: ## Validate GoReleaser configuration.
 	$(GORELEASER) check
 
+load-smoke: ## Run bounded capacity/load smoke checks against CEREBRO_BASE_URL.
+	$(PYTHON) scripts/load_smoke.py \
+		--base-url "$(CEREBRO_BASE_URL)" \
+		$(foreach path,$(LOAD_SMOKE_PATHS),--path "$(path)") \
+		--duration "$(LOAD_SMOKE_DURATION)" \
+		--rps "$(LOAD_SMOKE_RPS)" \
+		--concurrency "$(LOAD_SMOKE_CONCURRENCY)" \
+		--timeout "$(LOAD_SMOKE_TIMEOUT)" \
+		--max-p95-ms "$(LOAD_SMOKE_MAX_P95_MS)" \
+		--max-error-rate "$(LOAD_SMOKE_MAX_ERROR_RATE)" \
+		--max-5xx-rate "$(LOAD_SMOKE_MAX_5XX_RATE)" \
+		--json-out "$(LOAD_SMOKE_JSON_OUT)" \
+		--markdown-out "$(LOAD_SMOKE_MARKDOWN_OUT)"
+
 doctor: ## Check local development toolchain availability.
 	@command -v git >/dev/null || { echo "missing required tool: git" >&2; exit 2; }
 	@command -v go >/dev/null || { echo "missing required tool: go" >&2; exit 2; }
@@ -365,7 +392,7 @@ hooks: ## Install repository git hooks.
 pre-commit: ## Run local pre-commit checks.
 	./scripts/pre_commit_checks.sh
 
-check: build test sdk-test lint proto-lint proto-generate-check policy-rule-check docs-drift-check check-structural check-structural-test check-arch ## Run the main local validation suite.
+check: build test script-test sdk-test lint proto-lint proto-generate-check policy-rule-check docs-drift-check check-structural check-structural-test check-arch ## Run the main local validation suite.
 
 check-structural: check-structural-build ## Run custom structural lints.
 	@$(LINTER_BIN) $(APP_PACKAGES)
@@ -381,4 +408,4 @@ check-arch: ## Run architectural guardrail tests.
 
 check-hook-integrity: check-arch ## Verify hook-integrity guardrails.
 
-verify: build test test-race cover sdk-test sdk-dependency-audit mcp-contract-check mcp-sdk-compat lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check policy-rule-check detection-catalog-check docs-drift-check readme-check oss-audit release-smoke check-structural check-structural-test check-arch ## Run full CI-equivalent validation suite.
+verify: build test test-race cover script-test sdk-test sdk-dependency-audit mcp-contract-check mcp-sdk-compat lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check policy-rule-check detection-catalog-check docs-drift-check readme-check oss-audit release-smoke check-structural check-structural-test check-arch ## Run full CI-equivalent validation suite.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The compose stack starts Cerebro with NATS JetStream, Postgres, Neo4j, and a loc
 | Run the lightweight server | `make serve-dev` | Starts the API without external stores using an acknowledged local-only auth/rate-limit opt-out; useful for health, source catalog, and OpenAPI checks. |
 | Run the durable local stack | `docker compose up --build` | Starts Cerebro with NATS JetStream, Postgres, Neo4j, and the local bearer key `local-dev-key`. |
 | Host Cerebro | `docs/HOSTING.md`, `docs/DEPLOYMENT_EXAMPLES.md`, and `docs/OPERATIONS_RUNBOOK.md` | Deployment guidance, example platform shapes, health checks, operations, and rollout. |
+| Preserve production headroom | `docs/HEADROOM.md`, `docs/OBSERVABILITY.md`, and `make load-smoke` | Capacity SLOs, saturation alerts, autoscaling signals, wide-event incident queries, and bounded live load smoke checks. |
 | Try a local end-to-end path | `docs/GETTING_STARTED.md` | Creates an SDK source runtime, writes a synthetic claim, and reads it back. |
 | Explore the API | `GET /openapi.yaml` or `api/openapi.yaml` | JSON HTTP routes are generated and checked against the OpenAPI contract. |
 | Call the Connect API | `proto/cerebro/v1/bootstrap.proto` and `gen/cerebro/v1` | Connect RPCs are served under `/cerebro.v1.BootstrapService/{Method}`. |

--- a/docs/HEADROOM.md
+++ b/docs/HEADROOM.md
@@ -1,0 +1,372 @@
+# Cerebro Headroom and Capacity Guardrails
+
+This document defines how Cerebro operators keep enough spare capacity to absorb traffic spikes, source-runtime catch-up, graph ingest bursts, dependency slowness, and deploy churn without user-visible choking. It is intentionally portable: this public repo owns the runtime contract, telemetry shape, smoke tooling, and operator checklist. Environment-specific replica counts, hostnames, account IDs, stack config, and autoscaling resources live in deployment repositories.
+
+Use this with:
+
+- [`docs/OBSERVABILITY.md`](./OBSERVABILITY.md) for OTEL, structured telemetry, and wide-event contracts.
+- [`docs/OPERATIONS_RUNBOOK.md`](./OPERATIONS_RUNBOOK.md) for startup, readiness, dependency, rollout, rollback, and incident basics.
+- [`docs/CONFIG_ENV_VARS.md`](./CONFIG_ENV_VARS.md) for runtime knobs.
+- [`docs/DEPLOYMENT_EXAMPLES.md`](./DEPLOYMENT_EXAMPLES.md) for portable hosting patterns.
+- [`scripts/load_smoke.py`](../scripts/load_smoke.py) and `make load-smoke` for bounded live checks.
+
+## Principles
+
+1. **Headroom is a product property, not an instance property.** CPU, memory, replicas, database pools, append-log lag, graph write latency, source provider rate limits, and downstream LLM latency all count.
+2. **Scale on pressure, not only CPU.** CPU can look healthy while requests queue behind Postgres, JetStream, Neo4j, Redis/Valkey, source providers, or outbound LLM calls.
+3. **Page on user-visible or data-loss risk.** Warnings should create tickets or Slack noise; pages should map to degraded readiness, sustained 5xx, saturation at max replicas, data freshness risk, or unrecoverable queue growth.
+4. **Every top-level unit of work needs one queryable wide event.** `main=true` and `wide_event=true` are the starting point for incident slicing.
+5. **Release checks should prove margin.** A release that merely starts is not enough. It should pass bounded smoke under small concurrency and preserve latency/error budgets.
+6. **Be explicit about freshness.** Source runtime and graph freshness are capacity signals. A quiet HTTP surface can still be unhealthy when sync, replay, or projection falls behind.
+
+## Capacity SLOs
+
+These are default budgets for a shared Cerebro deployment. Tighten them for user-facing production, loosen them for single-user development, and document environment-specific overrides in the deployment repo.
+
+| Layer | Steady target | Warning | Critical/page | Why it matters | First action |
+| --- | --- | --- | --- | --- | --- |
+| HTTP availability | `99.9%` successful non-maintenance requests | 5xx rate above `0.25%` for 10m | 5xx rate above `1%` for 5m or `/health` 503 for 5m | Users and agents feel this immediately | Check recent deploy, dependency health, and per-route wide events |
+| HTTP p95 latency | below `500ms` for light routes, route-specific for heavy graph/source routes | p95 above `750ms` for 10m | p95 above `1500ms` for 5m or p99 above timeout budget | Latency usually rises before errors | Slice by `http.route`, status, version, replica, and dependency counters |
+| Replica CPU | below `70%` average with no single replica pinned | above `80%` for 15m | above `90%` for 5m, or CPU throttling with latency | CPU saturation elongates all work | Add replicas, raise task CPU, or reduce background concurrency |
+| Replica memory | below `70%` working set | above `80%` for 15m | above `90%`, OOM kill, or restart loop | Memory pressure causes retries and cold starts | Scale out/up, inspect heap/goroutines, reduce payload/concurrency |
+| Request concurrency | queueing stays flat; in-flight below `70%` of worker capacity | sustained in-flight growth | in-flight remains high while RPS is flat or falling | Queueing means capacity is gone even before errors | Scale out and find the slow route/dependency |
+| Postgres pool | wait count near zero, idle connections available | wait duration rising for 10m | pool exhausted, health degraded, or write errors | Durable runtime, claims, findings, OAuth, and reports depend on it | Increase pool/DB capacity or reduce request/background concurrency |
+| Redis/Valkey cache | low error rate, stable latency, hit ratio within baseline | miss spike or latency above baseline | cache unavailable plus DB/LLM pressure | Cache failures amplify expensive reads | Verify cache health, namespace, payload caps, and fallback load |
+| NATS JetStream | consumer lag drains faster than it grows | lag grows for 15m or storage pressure | lag grows for 30m, append failures, stream storage critical | Replay and runtime sync durability depend on it | Pause producers, scale consumers, inspect stream limits/storage |
+| Neo4j/Aura | graph reads/writes within route budgets | query latency or timeouts rising | graph health degraded, write failures, stale ingest | Graph projection/query and agent context depend on it | Identify read vs write saturation, reduce ingest, check Aura capacity |
+| Source runtime freshness | runtime-specific lag below freshness expectation | lag above expectation for 1 interval | lag above expectation for 3 intervals or lease churn | Quiet sync failure silently erodes data quality | Check provider rate limits, leases, runtime errors, append-log health |
+| Graph ingest freshness | ingest runs complete and freshness advances | stale-running runs or zero projections | repeated failures or stale graph-dependent workflows | Findings/impact paths can become misleading | Run ingest health, pause broad rebuilds, inspect failed runtime |
+| Outbound providers/LLMs | provider errors within baseline | latency/error spike by provider/model/source | provider outage blocks core workflow | External saturation can look like app saturation | Fail closed, reduce concurrency, switch provider/model if configured |
+| Deployment rollout | new version reaches readiness inside rollout window | slow readiness or one replica unhealthy | max unavailable exceeded or rollback required | Deploy churn consumes headroom | Pause rollout, compare `service.version`, rollback if needed |
+
+## Dashboards
+
+Every shared Cerebro environment should have a dashboard with these sections. The exact backend can be Prometheus, CloudWatch, Grafana, Datadog, Honeycomb, Sentry, or an OTEL collector pipeline, but the dimensions should stay stable.
+
+### 1. Executive Headroom Strip
+
+Show this at the top:
+
+- Current availability and 5xx rate.
+- HTTP p50/p95/p99 by route.
+- Request rate by route and status class.
+- Replica count, desired count, max count, CPU, memory, restart count.
+- `/health` status and dependency readiness status.
+- Source runtime freshness summary.
+- Graph ingest health summary.
+- Postgres pool wait and DB CPU/storage.
+- JetStream lag/storage.
+- Neo4j/Aura latency/error/freshness.
+- Last deploy version and deploy age.
+
+### 2. HTTP Pressure
+
+Panels:
+
+- `rate(cerebro_http_requests_total[5m])` by `route`, `method`, `status_code`.
+- 5xx rate by `route`.
+- Average latency from `/metrics` using `cerebro_http_request_duration_seconds_sum` divided by `cerebro_http_request_duration_seconds_count`.
+- Tail latency from OTEL histogram `cerebro.http.server.request.duration` when exported to a backend that supports quantiles.
+- Top routes by request body size and response body size from wide events.
+- Top routes by `url.query.keys` and `user_agent.family` when traffic shape changes.
+
+### 3. Dependency Pressure
+
+Panels:
+
+- Postgres open, idle, in-use, wait count, wait duration, query errors, slow queries, locks, storage, CPU.
+- Redis/Valkey command latency, error rate, hit/miss counts, evictions, memory pressure.
+- JetStream append failures, replay failures, consumer lag, stream bytes/messages, storage pressure.
+- Neo4j/Aura read/write duration, timeout count, connection failures, transaction retries, graph ingest failures.
+- Source provider error rate by `source_id`, `runtime_id`, upstream status class, and bounded `error_kind`.
+- Graph-agent/LLM duration and error rate by provider, model, operation, and refusal/outcome.
+
+### 4. Background Work and Freshness
+
+Panels:
+
+- Source runtime sync attempts, success/failure, duration, page/event counts, lease acquisition/renewal failures.
+- Runtime freshness by `tenant_id`, `source_id`, and `runtime_id`.
+- Graph ingest run status, age of oldest running ingest, projection counts, zero-projection runs.
+- Finding evaluation run duration/error/candidate counts.
+- Workflow replay request count, duration, event count, and failure kind.
+
+### 5. Version and Rollout Correlation
+
+Panels:
+
+- Error rate grouped by `service.version`.
+- p95 latency grouped by `service.version`.
+- Request count grouped by replica/task/container ID.
+- Restarts and readiness failures by version.
+- Deploy age distribution.
+
+These version panels answer "did something just go out?" without leaving the observability tool.
+
+## Alert Policy
+
+Default routing:
+
+- **Page** when user-visible availability is degraded, data freshness is at risk, a durable dependency is failing, or the service is saturated at max capacity.
+- **Ticket or Slack warning** when a trend will become a page if ignored, such as rising latency, rising pool wait, or source runtime lag.
+- **No alert** for one-off dependency blips that recover inside the retry/backoff window and do not burn error budget.
+
+Suggested alerts:
+
+| Alert | Severity | Window | Condition | Triage anchor |
+| --- | --- | --- | --- | --- |
+| `CerebroHealthDegraded` | page | 5m | `/health` returns 503 or readiness fails | `/health`, dependency panel |
+| `CerebroHigh5xxRate` | page | 5m | 5xx rate above `1%` and request volume above low-traffic floor | wide events by `http.route`, `service.version` |
+| `CerebroLatencySaturation` | page | 10m | p95/p99 above route budget and RPS not dropping to zero | latency heatmap by route/version/replica |
+| `CerebroAtMaxReplicas` | page | 10m | desired replicas equals max and CPU/memory/concurrency/queue pressure remains high | autoscaler and platform metrics |
+| `CerebroPostgresPoolSaturated` | page | 5m | pool wait rises and request latency/errors rise | Postgres pool panel, `db.postgres.*` fields |
+| `CerebroJetStreamLagGrowing` | page | 30m | consumer lag grows faster than drain rate | JetStream lag, source runtime freshness |
+| `CerebroGraphIngestStale` | page | 30m | graph ingest failures or stale-running runs | graph ingest health and `graph.ingest.*` |
+| `CerebroSourceFreshnessBreached` | page/ticket by source | source-specific | runtime lag exceeds freshness expectation | `source_runtime.*`, provider errors |
+| `CerebroProviderErrorSpike` | ticket/page if core | 15m | source provider or LLM errors exceed baseline | `source_id`, provider/model, `error_kind` |
+| `CerebroRestartsOrOOM` | page | 5m | restart loop, OOM kill, crash-loop, SIGKILL | container/task events and runtime memory |
+| `CerebroLoadSmokeFailed` | page/ticket by env | one run | scheduled live load smoke fails thresholds | workflow artifact JSON/Markdown |
+
+Use multi-window burn-rate alerts for high-traffic environments:
+
+- Fast burn: 5xx/error budget burn over 5m and 30m.
+- Slow burn: 5xx/error budget burn over 1h and 6h.
+- Low-traffic floor: require enough requests to avoid paging on one request.
+
+Example alert queries live in [`docs/observability/headroom-alerts.promql`](./observability/headroom-alerts.promql). Treat them as templates: adapt label names and platform metric names to the deployed collector.
+
+## Autoscaling
+
+Autoscaling should combine platform metrics and application pressure. CPU-only scaling misses important Cerebro failure modes.
+
+Recommended scaling signals:
+
+| Signal | Scale out when | Scale in when | Notes |
+| --- | --- | --- | --- |
+| CPU utilization | above `65-70%` for 5m | below `35%` for 30m | Keep scale-in slower than scale-out |
+| Memory utilization | above `70-75%` for 10m | below `45%` for 30m | Use max memory, not only average, when replicas differ |
+| Request concurrency | in-flight per replica above target for 5m | below target for 30m | Requires platform/LB/app metric |
+| HTTP latency | p95 above route budget and RPS stable | below budget for 30m | Do not scale solely on latency if dependency is clearly saturated |
+| JetStream lag | lag growing for 10m | lag drains and stays low for 30m | Scale consumers/background workers, not necessarily API replicas |
+| Source runtime backlog | lag above freshness expectation | lag drains | Avoid stampeding provider rate limits |
+| Postgres pool wait | wait duration rising | wait near zero | If DB is saturated, scale the DB or reduce app concurrency instead of adding app replicas |
+| Graph ingest queue/failures | ingest age/failures rise | stable completion | Scale graph workers only if graph backend has room |
+
+Guardrails:
+
+- Keep at least two healthy replicas for shared deployments, unless the platform is explicitly single-user.
+- Set max replicas high enough to absorb normal peaks, but low enough to protect Postgres, JetStream, Neo4j, and provider APIs.
+- Use pod/task disruption budgets or equivalent so maintenance does not remove all headroom.
+- Keep scale-in cooldowns long enough to avoid oscillation during source sync and graph ingest bursts.
+- Pin background concurrency per replica so scaling out does not multiply provider/API pressure beyond limits.
+- During incidents, prefer temporary max-replica increases only when dependencies have room.
+
+## Load Smoke Testing
+
+`make load-smoke` runs a bounded HTTP smoke using only Python's standard library. It is not a replacement for full load testing. It is a release and environment confidence check that answers:
+
+- Can a live Cerebro origin serve repeated requests without immediate 5xx?
+- Is p95 latency inside the configured smoke threshold?
+- Do protected routes still work when a bearer token is supplied?
+- Did a recent deploy or infra change remove obvious headroom?
+
+Default local usage:
+
+```bash
+make load-smoke CEREBRO_BASE_URL=http://127.0.0.1:8080
+```
+
+Shared environment usage:
+
+```bash
+CEREBRO_LOAD_SMOKE_BEARER_TOKEN="${CEREBRO_API_KEY}" \
+make load-smoke \
+  CEREBRO_BASE_URL=https://cerebro.example.com \
+  LOAD_SMOKE_PATHS="/health /livez" \
+  LOAD_SMOKE_DURATION=60 \
+  LOAD_SMOKE_RPS=3 \
+  LOAD_SMOKE_CONCURRENCY=6 \
+  LOAD_SMOKE_MAX_P95_MS=750 \
+  LOAD_SMOKE_MAX_ERROR_RATE=0.01
+```
+
+Outputs:
+
+- `tmp/load-smoke.json`: machine-readable summary with request counts, latency percentiles, status counts, and threshold failures.
+- `tmp/load-smoke.md`: human-readable artifact for release notes, incidents, or PR comments.
+
+The GitHub Actions workflow [`load-smoke.yml`](../.github/workflows/load-smoke.yml) supports:
+
+- daily scheduled execution when `CEREBRO_LOAD_SMOKE_BASE_URL` is configured as a repository secret;
+- manual `workflow_dispatch` with `base_url`, duration, RPS, concurrency, and p95 threshold inputs;
+- optional `CEREBRO_LOAD_SMOKE_BEARER_TOKEN` secret for protected paths;
+- uploaded JSON and Markdown artifacts.
+
+Recommended release gate:
+
+1. Deploy canary or first production task.
+2. Run `make load-smoke` against `/health` and one protected cheap route.
+3. Confirm p95, error rate, 5xx rate, readiness, and dependency dashboards.
+4. Continue rollout only if the smoke passes and dependency headroom remains inside target.
+
+## CI and Test Coverage
+
+The repo-level checks now include `make script-test`, which runs unit tests for Python utility scripts, including `scripts/load_smoke.py`.
+
+Coverage expectations:
+
+- **Unit tests**: scheduling, success/failure thresholds, latency threshold failure, URL safety.
+- **CI**: `make script-test` on every PR and push through the `script-test` shard.
+- **Scheduled smoke**: daily live smoke when secrets are present.
+- **Release smoke**: manual or automated `make load-smoke` after deploy/canary.
+- **Game day**: intentionally lower task CPU/memory or inject dependency latency in a non-prod stack, then verify alerts fire and runbook steps work.
+
+Do not put live-environment smoke into required PR CI. PRs should not depend on private hostnames, credentials, or account state.
+
+## Wide Events for Headroom
+
+Cerebro's wide-event convention comes from the "one top-level unit of work with many queryable dimensions" pattern. Use `main=true` and `wide_event=true` to find the canonical event, then slice by route, version, source, runtime, tenant, dependency, and outcome.
+
+Headroom-relevant fields that should be present where safe:
+
+| Field family | Examples | Use |
+| --- | --- | --- |
+| Unit-of-work marker | `main`, `wide_event`, `component`, `operation` | Find the canonical event quickly |
+| Service/deploy | `service.name`, `service.version`, `deployment.environment.name`, `service.build.git_hash` | Correlate incidents with deploys |
+| Runtime host | `host.name`, `container.id`, `cloud.region`, `cloud.availability_zone`, `instance.cpu_count`, `instance.memory_mb` | Explain replica-specific saturation |
+| HTTP shape | `http.route`, `http.request.method`, `http.response.status_code`, `duration_ms`, `http.request.body.size`, `http.response.body.size` | Identify route and payload pressure |
+| Caller/client | `tenant_id`, `auth.mode`, `auth.outcome`, `user_agent.family`, `client.address_hash` | Scope to tenant/client segments without leaking secrets |
+| Store counters | `db.postgres.*.count`, `cache.redis.*.count`, `db.neo4j.*.count` | Identify dependency fan-out |
+| Messaging counters | `messaging.jetstream.*.count`, replay counts, append counts | Explain queue and durability pressure |
+| Source runtime | `source_runtime.*`, `source_id`, `runtime_id`, event/page counts, lease outcome | Debug freshness and provider pressure |
+| Graph ingest | `graph.ingest.*`, projection counts, failure counts | Debug graph staleness and write pressure |
+| LLM/provider | `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.operation.name`, bounded outcome/error kind | Separate model/provider slowness from app slowness |
+| Errors | `error_kind`, `error_fingerprint`, `handled`, bounded component/operation | Group safely without raw error leakage |
+
+Useful queries:
+
+```sql
+-- Which routes are slow right now?
+SELECT P95(duration_ms), COUNT(*)
+WHERE main = true AND service.name = "cerebro"
+GROUP BY http.route
+ORDER BY P95(duration_ms) DESC
+```
+
+```sql
+-- Did the newest version introduce errors?
+SELECT COUNT(*)
+WHERE main = true AND service.name = "cerebro"
+GROUP BY service.version, http.response.status_code
+```
+
+```sql
+-- Is one dependency fan-out pattern causing tail latency?
+SELECT P99(duration_ms), MAX(db.postgres.query.count), MAX(db.neo4j.write.count), MAX(messaging.jetstream.append.count)
+WHERE main = true AND http.route = "/source-runtimes/{runtimeID}/sync"
+GROUP BY source_id, runtime_id
+ORDER BY P99(duration_ms) DESC
+```
+
+```sql
+-- Which runtime/source is falling behind?
+SELECT COUNT(*), P95(duration_ms)
+WHERE main = true AND source_runtime.sync.outcome != "success"
+GROUP BY tenant_id, source_id, runtime_id, error_kind
+```
+
+```sql
+-- Is graph ingest pressure tied to zero-projection runs?
+SELECT COUNT(*), P95(duration_ms)
+WHERE main = true AND graph.ingest.run.count > 0
+GROUP BY service.version, graph.ingest.outcome, graph.ingest.zero_projection
+```
+
+## Saturation Incident Runbook
+
+Use this when Cerebro "feels choked": slow requests, readiness flaps, source/runtime lag, graph staleness, queue growth, or dependency pool exhaustion.
+
+### First 5 Minutes
+
+1. Check whether `/livez` fails, `/health` fails, or only specific routes are slow.
+2. Check 5xx rate, p95/p99 latency, request rate, and current replica count.
+3. Confirm whether a deploy, config change, secret rotation, dependency migration, or source schedule change just happened.
+4. Slice wide events by `http.route`, `service.version`, `tenant_id`, `source_id`, `runtime_id`, and `error_kind`.
+5. Check Postgres pool wait, JetStream lag, Neo4j/Aura health, Redis/Valkey health, and provider/LLM error panels.
+6. If the service is at max replicas and dependencies have room, raise max replicas or task size.
+7. If a dependency is saturated, avoid blindly adding app replicas; reduce background concurrency, pause broad sync/ingest/rebuild work, or scale the dependency.
+
+### First 15 Minutes
+
+1. Decide whether the incident is HTTP, source runtime, graph, append-log, state-store, cache, provider, or deploy-specific.
+2. If deploy-specific, pause rollout and compare old/new `service.version` in wide events.
+3. If source-runtime-specific, pause or lower cadence for the offending runtime and keep other runtimes running.
+4. If graph-ingest-specific, pause broad rebuilds and keep read-only graph health checks running.
+5. If Postgres pool waits are high, reduce app/background concurrency before increasing replicas.
+6. If JetStream lag is growing, identify producers and consumers; scale consumers only if storage and downstream stores have room.
+7. If Redis/Valkey is down, estimate cache miss amplification into Postgres, LLM, or graph queries.
+8. If provider or LLM latency is the cause, reduce concurrency and use configured fallback/provider routing when available.
+
+### Mitigation Choices
+
+| Symptom | Safer mitigation | Risky mitigation |
+| --- | --- | --- |
+| CPU high, dependencies healthy | add replicas or task CPU | only raising timeouts |
+| memory high/OOM | add memory, inspect heap/payloads, reduce concurrency | retrying failing requests aggressively |
+| Postgres pool wait high | reduce app/background concurrency, tune pool/DB capacity | adding many replicas |
+| JetStream lag growing | scale consumers carefully, pause noisy producers | increasing producer concurrency |
+| graph writes slow | reduce ingest/rebuild concurrency, check Aura capacity | broad graph rebuild during incident |
+| one source provider rate-limited | pause/lower that runtime schedule | global service restart |
+| new version errors | pause/rollback deploy | scaling broken code |
+
+### After Recovery
+
+1. Save the dashboard time range, load-smoke artifact, and representative trace/log links.
+2. Record the lowest observed headroom: max CPU/memory, max pool wait, max lag, max p95/p99, max replicas, and dependency bottleneck.
+3. Add or adjust an alert if the incident was detected by humans before automation.
+4. Add or adjust a wide-event field if the first useful query required guessing.
+5. Update environment-specific autoscaling limits and background concurrency.
+6. Run `make load-smoke` against the recovered environment and attach the artifact to the incident or release notes.
+
+## Capacity Planning
+
+Run this weekly for shared deployments and before major source onboarding:
+
+1. Review p95/p99 latency by route for the last 7 and 30 days.
+2. Review peak RPS, peak replica count, CPU/memory max, and scale-out time.
+3. Review Postgres pool wait, slow queries, locks, storage growth, and CPU.
+4. Review JetStream lag/storage and replay throughput.
+5. Review Neo4j/Aura query duration, ingest duration, graph size, and failed/stale runs.
+6. Review top source runtimes by duration, event count, provider errors, and freshness lag.
+7. Review cache hit ratio, miss amplification, evictions, and payload rejection counts.
+8. Compare actual peak load with configured max replicas and dependency limits.
+9. Run a controlled non-prod load smoke or scenario test against the next planned source/runtime shape.
+10. File capacity work before warnings become pages.
+
+Planning questions:
+
+- What is the expected peak RPS for the next 30 days?
+- What is the expected source-runtime event/page volume by source?
+- Which runtime has the lowest freshness margin?
+- Which dependency saturates first when RPS doubles?
+- Which dependency saturates first when source sync doubles?
+- How long does scale-out take from alert threshold to healthy capacity?
+- Are max replicas and DB/JetStream/Neo4j/provider limits aligned?
+- Can we roll back without replay or graph-rebuild amplification?
+
+## Environment Handoff
+
+Deployment repositories should carry the concrete answers for each environment:
+
+- min/desired/max replicas;
+- task/container CPU and memory;
+- autoscaling target metrics and cooldowns;
+- Postgres class, storage, pool limits, and alert thresholds;
+- Redis/Valkey class/memory and alert thresholds;
+- JetStream storage/retention/consumer limits and alert thresholds;
+- Neo4j/Aura tier and graph ingest concurrency;
+- source-runtime schedule volumes and freshness expectations;
+- live load-smoke target URL and token secret names;
+- alert destinations and escalation policy.
+
+Keep those values out of this public runtime repo unless they are generic examples. Link back to this document so every deployment keeps the same operating contract.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -8,6 +8,8 @@ Cerebro emits three layers of operational signal:
 
 The structured JSON and OTEL spans share the same trace context where possible. HTTP responses include `X-Cerebro-Trace-Id` so operators can pivot from the web UI or API response to logs and traces.
 
+For capacity SLOs, saturation dashboards, alert templates, autoscaling signals, and live load-smoke checks, use [`docs/HEADROOM.md`](./HEADROOM.md). This observability contract supplies the event and metric shape; the headroom guide defines how operators turn those signals into prevention, paging, and release gates.
+
 ## Wide Event Contract
 
 Cerebro follows a wide-event model for request and job debugging. Each top-level
@@ -25,6 +27,12 @@ Use `main=true` as the primary query predicate when asking "what happened to
 this request/job?" Child spans remain available for drill-down, but shared
 service methods annotate the active main span so the first query has the full
 shape.
+
+During headroom incidents, start with `main=true`, then group by `http.route`,
+`service.version`, replica/container identity, `tenant_id`, `source_id`,
+`runtime_id`, dependency counters, and bounded `error_kind`. That keeps the
+first query broad enough to find saturation without jumping between logs,
+metrics, traces, and deployment tooling.
 
 Inbound HTTP requests create a main OTEL `http.server` span. The route label is
 normalized before emission. Unknown or dynamic paths are collapsed to route
@@ -109,6 +117,18 @@ Run the full suite before release:
 
 ```sh
 go test ./...
+```
+
+Run Python utility tests, including the load-smoke harness:
+
+```sh
+make script-test
+```
+
+Run a bounded live headroom smoke against a local or deployed service:
+
+```sh
+make load-smoke CEREBRO_BASE_URL=http://127.0.0.1:8080
 ```
 
 For local OTLP export, run a collector listening on `4318` and start Cerebro with:

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -7,6 +7,7 @@ Use it with:
 - [`docs/HOSTING.md`](./HOSTING.md) for the hosting baseline.
 - [`docs/DEPLOYMENT_EXAMPLES.md`](./DEPLOYMENT_EXAMPLES.md) for portable deployment patterns.
 - [`docs/TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) for symptom-driven debugging.
+- [`docs/HEADROOM.md`](./HEADROOM.md) for capacity SLOs, saturation alerts, autoscaling signals, load-smoke gates, and capacity incident playbooks.
 - [`docs/CONFIG_ENV_VARS.md`](./CONFIG_ENV_VARS.md) for current environment variables.
 - [`api/openapi.yaml`](../api/openapi.yaml) for the HTTP route contract.
 
@@ -245,6 +246,16 @@ Use this sequence for most incidents:
 
 Escalate only after you can say which layer is failing.
 
+For saturation or headroom incidents, immediately add:
+
+1. Compare current replica count with configured max capacity.
+2. Check CPU, memory, restart count, readiness failures, and request concurrency.
+3. Check route-level 5xx, average latency from `/metrics`, and p95/p99 latency from OTEL if available.
+4. Slice wide events with `main=true` by `http.route`, `service.version`, `tenant_id`, `source_id`, `runtime_id`, and bounded `error_kind`.
+5. Check whether Postgres pool wait, JetStream lag, Neo4j/Aura latency, Redis/Valkey errors, source provider throttling, or LLM latency is the first saturated dependency.
+6. If dependencies have room, scale Cerebro out or up. If a dependency is saturated, reduce app/background concurrency or pause the specific runtime/ingest/rebuild path before adding replicas.
+7. After mitigation, run `make load-smoke` against the recovered origin and save `tmp/load-smoke.json` with the incident notes.
+
 ## Alert suggestions
 
 Useful alerts for any shared deployment:
@@ -252,6 +263,8 @@ Useful alerts for any shared deployment:
 - process not serving `/livez`
 - `/health` degraded for longer than a short rollout window
 - sustained HTTP `5xx`
+- sustained HTTP p95/p99 latency above the route budget
+- API replicas at max capacity while CPU, memory, concurrency, or queue pressure remains high
 - unusual HTTP `401` or `403` increase
 - Postgres connection saturation
 - Postgres query failures
@@ -261,5 +274,6 @@ Useful alerts for any shared deployment:
 - source runtime sync failures
 - repeated process restarts
 - missing metrics scrape
+- scheduled live load-smoke failure
 
-Keep exact thresholds environment-specific.
+Keep exact thresholds environment-specific. Use [`docs/HEADROOM.md`](./HEADROOM.md) and [`docs/observability/headroom-alerts.promql`](./observability/headroom-alerts.promql) as the portable baseline.

--- a/docs/observability/headroom-alerts.promql
+++ b/docs/observability/headroom-alerts.promql
@@ -1,0 +1,135 @@
+# Cerebro headroom alert query templates.
+#
+# These are starting points for Prometheus-compatible backends. Adapt label
+# names to the deployed scrape pipeline, collector, and platform exporter.
+# Cerebro's built-in /metrics endpoint currently emits:
+#
+#   cerebro_http_requests_total{method,route,status_code}
+#   cerebro_http_request_duration_seconds_sum{method,route,status_code}
+#   cerebro_http_request_duration_seconds_count{method,route,status_code}
+#
+# Tail latency needs OTEL histogram export from:
+#
+#   cerebro.http.server.request.duration
+#
+# Resource and dependency metrics usually come from the platform exporter
+# or managed-service integrations, not directly from this public runtime repo.
+
+# Sustained HTTP 5xx rate above 1%, with a low-traffic floor.
+(
+  sum(rate(cerebro_http_requests_total{status_code=~"5.."}[5m]))
+  /
+  clamp_min(sum(rate(cerebro_http_requests_total[5m])), 1)
+) > 0.01
+and
+sum(rate(cerebro_http_requests_total[5m])) > 0.05
+
+# Route-specific 5xx rate above 1%.
+(
+  sum by (route) (rate(cerebro_http_requests_total{status_code=~"5.."}[5m]))
+  /
+  clamp_min(sum by (route) (rate(cerebro_http_requests_total[5m])), 1)
+) > 0.01
+and
+sum by (route) (rate(cerebro_http_requests_total[5m])) > 0.02
+
+# Average latency above 500ms from built-in /metrics.
+# Use this as a warning. Page on p95/p99 from OTEL histograms when available.
+(
+  sum(rate(cerebro_http_request_duration_seconds_sum[5m]))
+  /
+  clamp_min(sum(rate(cerebro_http_request_duration_seconds_count[5m])), 1)
+) > 0.5
+
+# Route-specific average latency above 750ms.
+(
+  sum by (route) (rate(cerebro_http_request_duration_seconds_sum[5m]))
+  /
+  clamp_min(sum by (route) (rate(cerebro_http_request_duration_seconds_count[5m])), 1)
+) > 0.75
+and
+sum by (route) (rate(cerebro_http_request_duration_seconds_count[5m])) > 0.02
+
+# OTEL p95 latency when the collector exports histogram buckets.
+# Rename the metric to match the collector's Prometheus mapping.
+histogram_quantile(
+  0.95,
+  sum by (le, route) (rate(cerebro_http_server_request_duration_seconds_bucket[5m]))
+) > 0.75
+
+# OTEL p99 latency when the collector exports histogram buckets.
+histogram_quantile(
+  0.99,
+  sum by (le, route) (rate(cerebro_http_server_request_duration_seconds_bucket[5m]))
+) > 1.5
+
+# Readiness degradation from a blackbox probe or load balancer health metric.
+# Replace probe_success labels with the deployed probe labels.
+avg_over_time(probe_success{job="cerebro-health"}[5m]) < 1
+
+# ECS/Container Insights-style CPU saturation.
+# Replace metric and label names to match the environment exporter.
+(
+  avg by (service) (aws_ecs_containerinsights_cpu_utilized{service=~"cerebro.*"})
+  /
+  clamp_min(avg by (service) (aws_ecs_containerinsights_cpu_reserved{service=~"cerebro.*"}), 1)
+) > 0.85
+
+# ECS/Container Insights-style memory saturation.
+(
+  avg by (service) (aws_ecs_containerinsights_memory_utilized{service=~"cerebro.*"})
+  /
+  clamp_min(avg by (service) (aws_ecs_containerinsights_memory_reserved{service=~"cerebro.*"}), 1)
+) > 0.85
+
+# Desired task count at max capacity while CPU is still high.
+# Replace max_capacity with the autoscaler/exporter metric used by deployment.
+aws_applicationautoscaling_desired_capacity{resource_label=~".*cerebro.*"}
+  >= aws_applicationautoscaling_max_capacity{resource_label=~".*cerebro.*"}
+and
+(
+  avg by (service) (aws_ecs_containerinsights_cpu_utilized{service=~"cerebro.*"})
+  /
+  clamp_min(avg by (service) (aws_ecs_containerinsights_cpu_reserved{service=~"cerebro.*"}), 1)
+) > 0.75
+
+# Postgres connection pressure.
+# Replace with RDS/pg_exporter metric names available in the environment.
+(
+  sum(pg_stat_database_numbackends{datname=~"cerebro.*"})
+  /
+  clamp_min(sum(pg_settings_max_connections), 1)
+) > 0.8
+
+# Postgres pool wait pressure from app or pgx/pool exporter.
+# Replace metric names if the deployment uses a different pool collector.
+rate(cerebro_postgres_pool_wait_seconds_sum[5m])
+  / clamp_min(rate(cerebro_postgres_pool_wait_seconds_count[5m]), 1)
+> 0.05
+
+# JetStream consumer lag growing.
+# Replace metric names with the NATS exporter labels used by deployment.
+deriv(nats_jetstream_consumer_num_pending{consumer=~".*cerebro.*"}[15m]) > 0
+and
+nats_jetstream_consumer_num_pending{consumer=~".*cerebro.*"} > 100
+
+# JetStream storage pressure.
+nats_jetstream_stream_bytes{stream=~".*cerebro.*"}
+  / clamp_min(nats_jetstream_stream_bytes_limit{stream=~".*cerebro.*"}, 1)
+> 0.8
+
+# Neo4j/Aura query latency from a managed-service exporter.
+# Replace names to match the Aura/Neo4j integration.
+histogram_quantile(
+  0.95,
+  sum by (le, operation) (rate(neo4j_query_duration_seconds_bucket{database=~".*cerebro.*"}[5m]))
+) > 1.0
+
+# Scheduled live load smoke failed in GitHub Actions.
+# This requires ingesting workflow run conclusions into the metrics backend.
+github_actions_workflow_run_conclusion{
+  repository="writer/cerebro",
+  workflow="Cerebro Load Smoke",
+  conclusion!="success",
+  conclusion!="skipped"
+} > 0

--- a/scripts/load_smoke.py
+++ b/scripts/load_smoke.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Run a bounded load smoke against a Cerebro HTTP deployment."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import dataclasses
+import json
+import os
+import pathlib
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import Counter
+from typing import Sequence
+
+
+USER_AGENT = "cerebro-load-smoke/0"
+
+
+@dataclasses.dataclass(frozen=True)
+class RequestResult:
+    path: str
+    status_code: int | None
+    latency_ms: float
+    response_bytes: int
+    error_kind: str
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = build_parser().parse_args(argv)
+        summary = execute(args)
+        write_outputs(summary, args)
+        print(render_console_summary(summary))
+        return 0 if summary["healthy"] else 1
+    except SmokeUsageError as exc:
+        print(f"load_smoke: {exc}", file=sys.stderr)
+        return 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default=first_env("CEREBRO_LOAD_SMOKE_BASE_URL", "CEREBRO_BASE_URL"), help="Cerebro origin, for example https://cerebro.example.com")
+    parser.add_argument("--path", action="append", default=[], help="Path to exercise; repeatable. Defaults to /health")
+    parser.add_argument("--duration", type=positive_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_DURATION", "30")), help="Smoke duration in seconds")
+    parser.add_argument("--rps", type=positive_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_RPS", "2")), help="Target request rate per second")
+    parser.add_argument("--concurrency", type=positive_int, default=int(os.environ.get("CEREBRO_LOAD_SMOKE_CONCURRENCY", "4")), help="Maximum in-flight requests")
+    parser.add_argument("--timeout", type=positive_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_TIMEOUT", "5")), help="Per-request timeout in seconds")
+    parser.add_argument("--success-status-min", type=int, default=200, help="Minimum HTTP status counted as success")
+    parser.add_argument("--success-status-max", type=int, default=399, help="Maximum HTTP status counted as success")
+    parser.add_argument("--max-p95-ms", type=positive_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_MAX_P95_MS", "750")), help="Fail when p95 latency exceeds this value")
+    parser.add_argument("--max-error-rate", type=non_negative_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_MAX_ERROR_RATE", "0.01")), help="Fail when non-success or transport errors exceed this fraction")
+    parser.add_argument("--max-5xx-rate", type=non_negative_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_MAX_5XX_RATE", "0")), help="Fail when 5xx responses exceed this fraction")
+    parser.add_argument("--min-requests", type=positive_int, default=1, help="Fail when fewer requests completed")
+    parser.add_argument("--header", action="append", default=[], help="Extra HTTP header as 'Name: value'; repeatable")
+    parser.add_argument("--bearer-token", default=first_env("CEREBRO_LOAD_SMOKE_BEARER_TOKEN", "CEREBRO_MCP_BEARER_TOKEN"), help="Optional bearer/API token; never printed")
+    parser.add_argument("--max-read-bytes", type=positive_int, default=65536, help="Maximum response bytes read per request")
+    parser.add_argument("--json-out", default=os.environ.get("CEREBRO_LOAD_SMOKE_JSON_OUT", ""), help="Optional JSON summary path")
+    parser.add_argument("--markdown-out", default=os.environ.get("CEREBRO_LOAD_SMOKE_MARKDOWN_OUT", ""), help="Optional Markdown summary path")
+    return parser
+
+
+def execute(args: argparse.Namespace) -> dict:
+    base_url = normalize_base_url(args.base_url)
+    paths = normalize_paths(args.path)
+    headers = parse_headers(args.header)
+    if args.bearer_token:
+        headers["Authorization"] = f"Bearer {args.bearer_token}"
+
+    started_at = time.time()
+    results = run_schedule(
+        base_url=base_url,
+        paths=paths,
+        headers=headers,
+        duration_seconds=args.duration,
+        rps=args.rps,
+        concurrency=args.concurrency,
+        timeout_seconds=args.timeout,
+        max_read_bytes=args.max_read_bytes,
+    )
+    finished_at = time.time()
+    summary = summarize(
+        base_url=base_url,
+        paths=paths,
+        results=results,
+        args=args,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+    return summary
+
+
+def run_schedule(
+    *,
+    base_url: str,
+    paths: list[str],
+    headers: dict[str, str],
+    duration_seconds: float,
+    rps: float,
+    concurrency: int,
+    timeout_seconds: float,
+    max_read_bytes: int,
+) -> list[RequestResult]:
+    interval = 1.0 / rps
+    started = time.monotonic()
+    deadline = started + duration_seconds
+    next_request_at = started
+    request_index = 0
+    results: list[RequestResult] = []
+    pending: set[concurrent.futures.Future[RequestResult]] = set()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
+        while time.monotonic() < deadline:
+            now = time.monotonic()
+            if now < next_request_at:
+                drain_ready(pending, results, timeout=next_request_at - now)
+                continue
+            if len(pending) >= concurrency:
+                drain_ready(pending, results, timeout=0.05)
+                continue
+            path = paths[request_index % len(paths)]
+            pending.add(pool.submit(fetch_once, base_url, path, dict(headers), timeout_seconds, max_read_bytes))
+            request_index += 1
+            next_request_at += interval
+
+        while pending:
+            drain_ready(pending, results, timeout=0.1)
+    return results
+
+
+def drain_ready(pending: set[concurrent.futures.Future[RequestResult]], results: list[RequestResult], *, timeout: float) -> None:
+    if not pending:
+        if timeout > 0:
+            time.sleep(timeout)
+        return
+    done, still_pending = concurrent.futures.wait(pending, timeout=max(0.0, timeout), return_when=concurrent.futures.FIRST_COMPLETED)
+    pending.clear()
+    pending.update(still_pending)
+    for future in done:
+        results.append(future.result())
+
+
+def fetch_once(base_url: str, path: str, headers: dict[str, str], timeout_seconds: float, max_read_bytes: int) -> RequestResult:
+    url = urllib.parse.urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+    request_headers = {
+        "Accept": "application/json, text/plain, */*",
+        "User-Agent": USER_AGENT,
+        **headers,
+    }
+    req = urllib.request.Request(url, headers=request_headers, method="GET")
+    started = time.perf_counter()
+    status_code: int | None = None
+    response_bytes = 0
+    error_kind = ""
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_seconds) as response:
+            status_code = response.status
+            response_bytes = len(response.read(max_read_bytes))
+    except urllib.error.HTTPError as exc:
+        status_code = exc.code
+        try:
+            response_bytes = len(exc.read(max_read_bytes))
+        finally:
+            exc.close()
+    except TimeoutError:
+        error_kind = "timeout"
+    except urllib.error.URLError as exc:
+        error_kind = classify_url_error(exc)
+    except OSError as exc:
+        error_kind = exc.__class__.__name__
+    latency_ms = (time.perf_counter() - started) * 1000.0
+    return RequestResult(path=path, status_code=status_code, latency_ms=latency_ms, response_bytes=response_bytes, error_kind=error_kind)
+
+
+def summarize(*, base_url: str, paths: list[str], results: list[RequestResult], args: argparse.Namespace, started_at: float, finished_at: float) -> dict:
+    total = len(results)
+    status_counts: Counter[str] = Counter()
+    path_counts: Counter[str] = Counter()
+    error_kind_counts: Counter[str] = Counter()
+    success_count = 0
+    http_5xx_count = 0
+    transport_error_count = 0
+    latencies = sorted(result.latency_ms for result in results)
+    for result in results:
+        path_counts[result.path] += 1
+        if result.status_code is None:
+            status_counts["transport_error"] += 1
+            transport_error_count += 1
+            error_kind_counts[result.error_kind or "transport_error"] += 1
+            continue
+        status_counts[str(result.status_code)] += 1
+        if 500 <= result.status_code <= 599:
+            http_5xx_count += 1
+        if args.success_status_min <= result.status_code <= args.success_status_max:
+            success_count += 1
+    error_count = total - success_count
+    failures = evaluate_failures(
+        total=total,
+        p95_ms=percentile(latencies, 95),
+        error_rate=rate(error_count, total),
+        http_5xx_rate=rate(http_5xx_count, total),
+        args=args,
+    )
+    return {
+        "kind": "cerebro_load_smoke",
+        "healthy": not failures,
+        "failures": failures,
+        "base_url": safe_base_url(base_url),
+        "paths": paths,
+        "started_at_unix": started_at,
+        "finished_at_unix": finished_at,
+        "duration_seconds": round(finished_at - started_at, 3),
+        "target": {
+            "duration_seconds": args.duration,
+            "rps": args.rps,
+            "concurrency": args.concurrency,
+            "timeout_seconds": args.timeout,
+            "success_status_min": args.success_status_min,
+            "success_status_max": args.success_status_max,
+        },
+        "thresholds": {
+            "min_requests": args.min_requests,
+            "max_p95_ms": args.max_p95_ms,
+            "max_error_rate": args.max_error_rate,
+            "max_5xx_rate": args.max_5xx_rate,
+        },
+        "request_count": total,
+        "success_count": success_count,
+        "error_count": error_count,
+        "error_rate": rate(error_count, total),
+        "http_5xx_count": http_5xx_count,
+        "http_5xx_rate": rate(http_5xx_count, total),
+        "transport_error_count": transport_error_count,
+        "status_counts": dict(sorted(status_counts.items())),
+        "path_counts": dict(sorted(path_counts.items())),
+        "error_kind_counts": dict(sorted(error_kind_counts.items())),
+        "latency_ms": {
+            "min": round(latencies[0], 3) if latencies else None,
+            "p50": percentile(latencies, 50),
+            "p95": percentile(latencies, 95),
+            "p99": percentile(latencies, 99),
+            "max": round(latencies[-1], 3) if latencies else None,
+        },
+    }
+
+
+def evaluate_failures(*, total: int, p95_ms: float | None, error_rate: float, http_5xx_rate: float, args: argparse.Namespace) -> list[str]:
+    failures: list[str] = []
+    if total < args.min_requests:
+        failures.append(f"completed {total} requests, below minimum {args.min_requests}")
+    if p95_ms is None:
+        failures.append("no latency samples recorded")
+    elif p95_ms > args.max_p95_ms:
+        failures.append(f"p95 latency {p95_ms:.1f}ms exceeds {args.max_p95_ms:.1f}ms")
+    if error_rate > args.max_error_rate:
+        failures.append(f"error rate {error_rate:.4f} exceeds {args.max_error_rate:.4f}")
+    if http_5xx_rate > args.max_5xx_rate:
+        failures.append(f"5xx rate {http_5xx_rate:.4f} exceeds {args.max_5xx_rate:.4f}")
+    return failures
+
+
+def write_outputs(summary: dict, args: argparse.Namespace) -> None:
+    if args.json_out:
+        write_text(args.json_out, json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    if args.markdown_out:
+        write_text(args.markdown_out, render_markdown(summary))
+
+
+def write_text(path: str, body: str) -> None:
+    out = pathlib.Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(body, encoding="utf-8")
+
+
+def render_console_summary(summary: dict) -> str:
+    status = "passed" if summary["healthy"] else "failed"
+    latency = summary["latency_ms"]
+    return (
+        f"load_smoke: {status}; "
+        f"requests={summary['request_count']} "
+        f"error_rate={summary['error_rate']:.4f} "
+        f"5xx_rate={summary['http_5xx_rate']:.4f} "
+        f"p95_ms={latency['p95']}"
+    )
+
+
+def render_markdown(summary: dict) -> str:
+    latency = summary["latency_ms"]
+    failures = summary["failures"] or ["none"]
+    lines = [
+        "# Cerebro Load Smoke",
+        "",
+        f"- Status: {'passed' if summary['healthy'] else 'failed'}",
+        f"- Target: `{summary['base_url']}`",
+        f"- Paths: `{', '.join(summary['paths'])}`",
+        f"- Requests: {summary['request_count']}",
+        f"- Error rate: {summary['error_rate']:.4f}",
+        f"- 5xx rate: {summary['http_5xx_rate']:.4f}",
+        f"- Latency ms: p50={latency['p50']}, p95={latency['p95']}, p99={latency['p99']}, max={latency['max']}",
+        "",
+        "## Failures",
+        "",
+    ]
+    lines.extend(f"- {failure}" for failure in failures)
+    lines.extend([
+        "",
+        "## Status Counts",
+        "",
+    ])
+    lines.extend(f"- `{status}`: {count}" for status, count in summary["status_counts"].items())
+    lines.append("")
+    return "\n".join(lines)
+
+
+def normalize_base_url(value: str) -> str:
+    value = value.strip().rstrip("/")
+    if not value:
+        raise SmokeUsageError("provide --base-url or CEREBRO_LOAD_SMOKE_BASE_URL")
+    parsed = urllib.parse.urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise SmokeUsageError(f"invalid base URL {safe_base_url(value)!r}; expected http(s)://host")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise SmokeUsageError("base URL must be an origin without path, query, or fragment")
+    return value
+
+
+def normalize_paths(values: Sequence[str]) -> list[str]:
+    paths = [value.strip() for value in values if value.strip()]
+    if not paths:
+        paths = ["/health"]
+    normalized: list[str] = []
+    for path in paths:
+        parsed = urllib.parse.urlparse(path)
+        if parsed.scheme or parsed.netloc:
+            raise SmokeUsageError("--path must be a path, not a full URL")
+        if not path.startswith("/"):
+            path = "/" + path
+        normalized.append(path)
+    return normalized
+
+
+def parse_headers(values: Sequence[str]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for raw in values:
+        name, sep, value = raw.partition(":")
+        name = name.strip()
+        if sep != ":" or not name:
+            raise SmokeUsageError(f"invalid header {raw!r}; expected 'Name: value'")
+        headers[name] = value.strip()
+    return headers
+
+
+def percentile(sorted_values: list[float], pct: int) -> float | None:
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return round(sorted_values[0], 3)
+    rank = (pct / 100.0) * (len(sorted_values) - 1)
+    lower = int(rank)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    fraction = rank - lower
+    value = sorted_values[lower] + ((sorted_values[upper] - sorted_values[lower]) * fraction)
+    return round(value, 3)
+
+
+def rate(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+def classify_url_error(exc: urllib.error.URLError) -> str:
+    reason = getattr(exc, "reason", None)
+    if isinstance(reason, TimeoutError):
+        return "timeout"
+    if reason is None:
+        return "url_error"
+    return reason.__class__.__name__
+
+
+def safe_base_url(value: str) -> str:
+    parsed = urllib.parse.urlparse(value)
+    if not parsed.scheme or not parsed.netloc:
+        return value.strip()
+    return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+
+
+def first_env(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name, "")
+        if value:
+            return value
+    return ""
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def non_negative_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be non-negative")
+    return parsed
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+class SmokeUsageError(RuntimeError):
+    pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_load_smoke.py
+++ b/scripts/tests/test_load_smoke.py
@@ -1,0 +1,138 @@
+import json
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import scripts.load_smoke as load_smoke
+
+
+class LoadSmokeTests(unittest.TestCase):
+    def test_passes_against_healthy_endpoint_and_writes_outputs(self):
+        with load_smoke_server() as base_url, tempfile.TemporaryDirectory() as tmp:
+            json_out = Path(tmp) / "summary.json"
+            markdown_out = Path(tmp) / "summary.md"
+
+            code = load_smoke.main([
+                "--base-url",
+                base_url,
+                "--duration",
+                "0.4",
+                "--rps",
+                "6",
+                "--concurrency",
+                "2",
+                "--json-out",
+                str(json_out),
+                "--markdown-out",
+                str(markdown_out),
+            ])
+
+            self.assertEqual(code, 0)
+            summary = json.loads(json_out.read_text(encoding="utf-8"))
+            self.assertTrue(summary["healthy"])
+            self.assertGreaterEqual(summary["request_count"], 1)
+            self.assertEqual(summary["error_count"], 0)
+            self.assertIn("Status: passed", markdown_out.read_text(encoding="utf-8"))
+
+    def test_fails_when_5xx_rate_exceeds_threshold(self):
+        with load_smoke_server() as base_url:
+            code = load_smoke.main([
+                "--base-url",
+                base_url,
+                "--path",
+                "/fail",
+                "--duration",
+                "0.3",
+                "--rps",
+                "5",
+                "--concurrency",
+                "2",
+                "--max-error-rate",
+                "0",
+            ])
+
+            self.assertEqual(code, 1)
+
+    def test_fails_when_p95_latency_exceeds_threshold(self):
+        with load_smoke_server() as base_url:
+            code = load_smoke.main([
+                "--base-url",
+                base_url,
+                "--path",
+                "/slow",
+                "--duration",
+                "0.3",
+                "--rps",
+                "4",
+                "--concurrency",
+                "1",
+                "--max-p95-ms",
+                "1",
+                "--max-error-rate",
+                "1",
+                "--max-5xx-rate",
+                "1",
+            ])
+
+            self.assertEqual(code, 1)
+
+    def test_rejects_full_url_path(self):
+        code = load_smoke.main([
+            "--base-url",
+            "http://127.0.0.1:1",
+            "--path",
+            "https://example.com/health",
+        ])
+
+        self.assertEqual(code, 2)
+
+    def test_redacts_query_and_path_from_base_url_in_summary(self):
+        args = load_smoke.build_parser().parse_args([
+            "--base-url",
+            "https://example.com/private?token=secret",
+            "--duration",
+            "0.1",
+        ])
+
+        with self.assertRaises(load_smoke.SmokeUsageError):
+            load_smoke.normalize_base_url(args.base_url)
+
+        self.assertEqual(load_smoke.safe_base_url("https://example.com/private?token=secret"), "https://example.com")
+
+
+class load_smoke_server:
+    def __enter__(self):
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), LoadSmokeHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        host, port = self.server.server_address
+        return f"http://{host}:{port}"
+
+    def __exit__(self, exc_type, exc, tb):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+class LoadSmokeHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/fail":
+            self.send_response(503)
+            self.end_headers()
+            self.wfile.write(b"unavailable")
+            return
+        if self.path == "/slow":
+            time.sleep(0.04)
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, format, *args):
+        return
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `docs/HEADROOM.md` with capacity SLOs, dashboard sections, alert policy, autoscaling signals, wide-event incident queries, load-smoke release gates, and saturation runbook steps
- add Prometheus-compatible headroom alert templates under `docs/observability/headroom-alerts.promql`
- add a dependency-free `scripts/load_smoke.py` harness with JSON/Markdown artifacts, `make load-smoke`, and a scheduled/manual `Cerebro Load Smoke` workflow
- add `make script-test` and wire it into CI so Python utility tests, including the load-smoke harness, run on PRs
- cross-link headroom guidance from README, observability docs, and the operations runbook

## Validation

- `python3 -m unittest scripts.tests.test_load_smoke`
- `make script-test`
- `make docs-drift-check`
- `make readme-check`
- `git diff --check`
- `make -n load-smoke`
- `make load-smoke` against a local test HTTP server
