### PR TITLE
Project OpenAI invite project memberships

### DIFF
--- a/internal/sourceprojection/ai_access.go
+++ b/internal/sourceprojection/ai_access.go
@@ -1,6 +1,7 @@
 package sourceprojection
 
 import (
+	"encoding/json"
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -9,6 +10,11 @@ import (
 
 type aiAccessProfile struct {
 	Provider string
+}
+
+type aiInviteProjectMembership struct {
+	ProjectID string
+	Role      string
 }
 
 var (
@@ -254,6 +260,38 @@ func aiInviteProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), inviteURN, roleURN, aiRoleAssignmentRelation(role), linkAttrs))
 			aiLinkRoleToScope(links, tenantID, event, roleURN, orgURN, role, "invite_role_scope")
 		}
+	}
+	for _, projectMembership := range aiInviteProjectMemberships(event) {
+		projectAttrs := cloneAttributes(attrs)
+		projectAttrs["project_id"] = projectMembership.ProjectID
+		projectURN := aiEnsureProject(entities, tenantID, event.GetSourceId(), profile, projectAttrs)
+		if projectURN == "" {
+			continue
+		}
+		projectRole := firstNonEmpty(projectMembership.Role, role)
+		if projectRole != "" {
+			roleAttrs := aiScopedRoleAttributes(projectAttrs, projectRole)
+			roleAttrs["role"] = projectRole
+			roleAttrs["role_id"] = projectRole
+			roleURN := aiEnsureRole(entities, tenantID, event.GetSourceId(), profile, roleAttrs, "project")
+			if roleURN != "" {
+				linkAttrs := aiEventLinkAttributes(event, "invite_project_role")
+				addProjectedAttribute(linkAttrs, "project_id", projectMembership.ProjectID)
+				addProjectedAttribute(linkAttrs, "role", projectRole)
+				addProjectedAttribute(linkAttrs, "status", status)
+				addProjectedAttribute(linkAttrs, "access_state", aiInviteAccessState(status))
+				addProjectedAttribute(linkAttrs, "is_admin", boolString(aiRoleIsAdmin(projectRole)))
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), inviteURN, roleURN, aiRoleAssignmentRelation(projectRole), linkAttrs))
+				aiLinkRoleToScope(links, tenantID, event, roleURN, projectURN, projectRole, "invite_project_role_scope")
+			}
+		}
+		linkAttrs := aiEventLinkAttributes(event, "invite_project_access_intent")
+		addProjectedAttribute(linkAttrs, "project_id", projectMembership.ProjectID)
+		addProjectedAttribute(linkAttrs, "role", projectRole)
+		addProjectedAttribute(linkAttrs, "status", status)
+		addProjectedAttribute(linkAttrs, "access_state", aiInviteAccessState(status))
+		addProjectedAttribute(linkAttrs, "is_admin", boolString(aiRoleIsAdmin(projectRole)))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), inviteURN, projectURN, aiScopeAccessRelation([]string{projectRole}), linkAttrs))
 	}
 	linkAttrs := aiEventLinkAttributes(event, "invite_access_intent")
 	addProjectedAttribute(linkAttrs, "role", role)
@@ -1313,6 +1351,37 @@ func aiInviteAccessIntentActive(status string) bool {
 	default:
 		return false
 	}
+}
+
+func aiInviteProjectMemberships(event *cerebrov1.EventEnvelope) []aiInviteProjectMembership {
+	if len(event.GetPayload()) == 0 {
+		return nil
+	}
+	var payload struct {
+		Projects []struct {
+			ID   string `json:"id"`
+			Role string `json:"role"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(event.GetPayload(), &payload); err != nil {
+		return nil
+	}
+	memberships := make([]aiInviteProjectMembership, 0, len(payload.Projects))
+	seen := map[string]struct{}{}
+	for _, project := range payload.Projects {
+		projectID := strings.TrimSpace(project.ID)
+		if projectID == "" {
+			continue
+		}
+		role := strings.TrimSpace(project.Role)
+		key := projectID + "\x00" + role
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		memberships = append(memberships, aiInviteProjectMembership{ProjectID: projectID, Role: role})
+	}
+	return memberships
 }
 
 func aiRoleID(attrs map[string]string) string {

--- a/internal/sourceprojection/ai_access_test.go
+++ b/internal/sourceprojection/ai_access_test.go
@@ -185,6 +185,16 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 			SourceId:   "openai",
 			Kind:       "openai.invite",
 			OccurredAt: timestamppb.New(occurred),
+			Payload: []byte(`{
+				"id": "invite_openai_123",
+				"email": "future-owner@example.com",
+				"role": "owner",
+				"status": "pending",
+				"projects": [
+					{"id": "proj_123", "role": "owner"},
+					{"id": "proj_456", "role": "member"}
+				]
+			}`),
 			Attributes: map[string]string{
 				"email":      "future-owner@example.com",
 				"family":     "invite",
@@ -193,6 +203,29 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 				"status":     "pending",
 				"created_at": "2026-06-18T12:10:00Z",
 				"expires_at": "2026-06-25T12:10:00Z",
+			},
+		},
+		{
+			Id:         "openai-expired-invite",
+			TenantId:   "writer",
+			SourceId:   "openai",
+			Kind:       "openai.invite",
+			OccurredAt: timestamppb.New(occurred),
+			Payload: []byte(`{
+				"id": "invite_openai_expired",
+				"email": "expired-owner@example.com",
+				"role": "owner",
+				"status": "expired",
+				"projects": [
+					{"id": "proj_expired", "role": "owner"}
+				]
+			}`),
+			Attributes: map[string]string{
+				"email":     "expired-owner@example.com",
+				"family":    "invite",
+				"invite_id": "invite_openai_expired",
+				"role":      "owner",
+				"status":    "expired",
 			},
 		},
 		{
@@ -233,8 +266,14 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 	}
 
 	openAIInviteURN := "urn:cerebro:writer:openai_invite:invite_openai_123"
+	openAIExpiredInviteURN := "urn:cerebro:writer:openai_invite:invite_openai_expired"
 	openAIOrgURN := "urn:cerebro:writer:openai_org:openai"
 	openAIRoleURN := "urn:cerebro:writer:openai_role:organization:owner"
+	openAIProjectOwnerRoleURN := "urn:cerebro:writer:openai_role:project:owner"
+	openAIProjectMemberRoleURN := "urn:cerebro:writer:openai_role:project:member"
+	openAIProjectOwnerURN := "urn:cerebro:writer:openai_project:proj_123"
+	openAIProjectMemberURN := "urn:cerebro:writer:openai_project:proj_456"
+	openAIExpiredProjectURN := "urn:cerebro:writer:openai_project:proj_expired"
 	anthropicInviteURN := "urn:cerebro:writer:anthropic_invite:invite_anthropic_123"
 	anthropicExpiredInviteURN := "urn:cerebro:writer:anthropic_invite:invite_anthropic_expired"
 	anthropicOrgURN := "urn:cerebro:writer:anthropic_org:anthropic"
@@ -253,6 +292,13 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 	assertProjectedLink(t, state, openAIInviteURN, relationCanAdmin, openAIRoleURN)
 	assertProjectedLink(t, state, openAIRoleURN, relationGrantsEntitlement, openAIOrgURN)
 	assertProjectedLink(t, state, openAIInviteURN, relationCanAdmin, openAIOrgURN)
+	assertProjectedLink(t, state, openAIInviteURN, relationCanAdmin, openAIProjectOwnerRoleURN)
+	assertProjectedLink(t, state, openAIProjectOwnerRoleURN, relationGrantsEntitlement, openAIProjectOwnerURN)
+	assertProjectedLink(t, state, openAIInviteURN, relationCanAdmin, openAIProjectOwnerURN)
+	assertProjectedLink(t, state, openAIInviteURN, relationAssignedTo, openAIProjectMemberRoleURN)
+	assertProjectedLink(t, state, openAIProjectMemberRoleURN, relationGrantsEntitlement, openAIProjectMemberURN)
+	assertProjectedLink(t, state, openAIInviteURN, relationCanPerform, openAIProjectMemberURN)
+	assertProjectedLinkMissing(t, state, openAIExpiredInviteURN, relationCanAdmin, openAIExpiredProjectURN)
 	assertProjectedLink(t, state, anthropicInviteURN, relationBelongsTo, anthropicOrgURN)
 	assertProjectedLink(t, state, anthropicInviteURN, relationRepresentsIdentity, anthropicIdentityURN)
 	assertProjectedLink(t, state, anthropicInviteURN, relationAssignedTo, anthropicRoleURN)


### PR DESCRIPTION
## Summary
- project OpenAI invite `projects` payload entries into project entities, project-scoped role edges, and pending invite access intent edges
- preserve inactive invite behavior so expired project invites do not create active access intent
- cover owner/member project invite roles in source projection tests

## Verification
- go test ./internal/sourceprojection
- make lint
- make check-structural
- make check-arch
- ./scripts/pre_commit_checks.sh

## Docs
- OpenAI organization invite list API: https://developers.openai.com/api/reference/resources/admin/subresources/organization/subresources/invites/methods/list/