### PR TITLE
Wire Cerebro runtime observability metadata

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -58,6 +58,7 @@ func main() {
 }
 
 func run(args []string) error {
+	telemetry.ConfigureRuntimeMetadata(runtimeTelemetryMetadataFromEnv())
 	command := "serve"
 	if len(args) > 0 {
 		command = args[0]
@@ -191,6 +192,36 @@ func firstNonEmptyString(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func runtimeTelemetryMetadataFromEnv() telemetry.RuntimeMetadata {
+	return telemetry.RuntimeMetadata{
+		ResourceAttributes: os.Getenv("OTEL_RESOURCE_ATTRIBUTES"),
+		ServiceName: firstNonEmptyString(
+			os.Getenv("CEREBRO_OTEL_SERVICE_NAME"),
+			os.Getenv("OTEL_SERVICE_NAME"),
+		),
+		DeploymentEnvironment: firstNonEmptyString(
+			os.Getenv("CEREBRO_DEPLOYMENT_ENVIRONMENT"),
+			os.Getenv("CEREBRO_ENVIRONMENT"),
+			os.Getenv("OTEL_ENVIRONMENT_NAME"),
+			os.Getenv("ENVIRONMENT"),
+			os.Getenv("APP_ENV"),
+		),
+		CloudRegion: firstNonEmptyString(
+			os.Getenv("AWS_REGION"),
+			os.Getenv("AWS_DEFAULT_REGION"),
+		),
+		ContainerID: firstNonEmptyString(
+			os.Getenv("ECS_CONTAINER_ID"),
+			os.Getenv("HOSTNAME"),
+		),
+		ECSContainerMetadataURI: firstNonEmptyString(
+			os.Getenv("ECS_CONTAINER_METADATA_URI_V4"),
+			os.Getenv("ECS_CONTAINER_METADATA_URI"),
+		),
+		AWSExecutionEnvironment: os.Getenv("AWS_EXECUTION_ENV"),
+	}
 }
 
 func shutdownTelemetry(ctx context.Context, closeTelemetry telemetry.ShutdownFunc, timeout time.Duration) {

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -104,6 +104,14 @@ Cerebro enables OTEL export when `CEREBRO_OTEL_ENABLED=true` or when an OTLP end
 | `CEREBRO_OTEL_TRACES_SAMPLE_RATE` | Float from `0` to `1` |
 | `CEREBRO_OTEL_METRICS_EXPORT_INTERVAL` | Duration such as `30s` or `1m` |
 | `OTEL_RESOURCE_ATTRIBUTES` | Standard resource attributes, for example `deployment.environment.name=sec-dev` |
+| `CEREBRO_ENVIRONMENT` / `CEREBRO_DEPLOYMENT_ENVIRONMENT` | Environment value used by structured wide events |
+| `AWS_REGION` / `AWS_DEFAULT_REGION` | AWS region used by structured wide events when running on ECS |
+
+Structured wide events also read `OTEL_RESOURCE_ATTRIBUTES` so CloudWatch JSON
+logs and exported OTEL spans share the same `service.namespace`,
+`deployment.environment.name`, `cloud.provider`, and `cloud.region` dimensions.
+The deployment-specific env vars take precedence over generic resource
+attributes when both are present.
 
 ## Local Verification
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -90,12 +90,48 @@ func (a Attributes) with(key string, value any) Attributes {
 
 func RuntimeAttributes() Attributes {
 	hostname, _ := os.Hostname()
-	return Attrs(
-		Field{Key: "service.name", Value: buildinfo.ServiceName},
+	resourceAttributes := parseResourceAttributes(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"))
+	serviceName := firstNonEmpty(
+		strings.TrimSpace(os.Getenv("CEREBRO_OTEL_SERVICE_NAME")),
+		strings.TrimSpace(os.Getenv("OTEL_SERVICE_NAME")),
+		resourceAttributes["service.name"],
+		buildinfo.ServiceName,
+	)
+	deploymentEnvironment := firstNonEmpty(
+		strings.TrimSpace(os.Getenv("CEREBRO_DEPLOYMENT_ENVIRONMENT")),
+		strings.TrimSpace(os.Getenv("CEREBRO_ENVIRONMENT")),
+		strings.TrimSpace(os.Getenv("OTEL_ENVIRONMENT_NAME")),
+		resourceAttributes["deployment.environment.name"],
+		resourceAttributes["deployment.environment"],
+		resourceAttributes["environment"],
+		strings.TrimSpace(os.Getenv("ENVIRONMENT")),
+		strings.TrimSpace(os.Getenv("APP_ENV")),
+		"unknown",
+	)
+	cloudRegion := firstNonEmpty(
+		resourceAttributes["cloud.region"],
+		strings.TrimSpace(os.Getenv("AWS_REGION")),
+		strings.TrimSpace(os.Getenv("AWS_DEFAULT_REGION")),
+	)
+	cloudProvider := firstNonEmpty(
+		resourceAttributes["cloud.provider"],
+		inferredCloudProvider(cloudRegion),
+		"unknown",
+	)
+	containerID := firstNonEmpty(
+		resourceAttributes["container.id"],
+		strings.TrimSpace(os.Getenv("ECS_CONTAINER_ID")),
+		strings.TrimSpace(os.Getenv("HOSTNAME")),
+		hostname,
+	)
+	attributes := resourceAttributesToTelemetry(resourceAttributes)
+	return attributes.With(Attrs(
+		Field{Key: "service.name", Value: serviceName},
 		Field{Key: "service.version", Value: buildinfo.Version},
 		Field{Key: "service.commit", Value: buildinfo.Commit},
 		Field{Key: "service.build_date", Value: buildinfo.BuildDate},
-		Field{Key: "deployment.environment.name", Value: "unknown"},
+		Field{Key: "deployment.environment", Value: deploymentEnvironment},
+		Field{Key: "deployment.environment.name", Value: deploymentEnvironment},
 		Field{Key: "host.name", Value: hostname},
 		Field{Key: "os.type", Value: runtime.GOOS},
 		Field{Key: "os.arch", Value: runtime.GOARCH},
@@ -104,10 +140,107 @@ func RuntimeAttributes() Attributes {
 		Field{Key: "process.runtime.version", Value: runtime.Version()},
 		Field{Key: "process.cpu.count", Value: runtime.NumCPU()},
 		Field{Key: "go.goroutine.count", Value: runtime.NumGoroutine()},
-		Field{Key: "cloud.provider", Value: "unknown"},
-		Field{Key: "cloud.region", Value: ""},
-		Field{Key: "container.id", Value: hostname},
-	)
+		Field{Key: "cloud.provider", Value: cloudProvider},
+		Field{Key: "cloud.region", Value: cloudRegion},
+		Field{Key: "container.id", Value: containerID},
+	))
+}
+
+func parseResourceAttributes(raw string) map[string]string {
+	attributes := map[string]string{}
+	for _, item := range splitResourceAttributePairs(raw) {
+		key, value, ok := cutResourceAttributePair(strings.TrimSpace(item))
+		key = strings.TrimSpace(unescapeResourceAttribute(key))
+		value = strings.TrimSpace(unescapeResourceAttribute(value))
+		if !ok || key == "" || value == "" {
+			continue
+		}
+		attributes[key] = strings.Trim(value, `"`)
+	}
+	return attributes
+}
+
+func splitResourceAttributePairs(raw string) []string {
+	var pairs []string
+	var current strings.Builder
+	escaped := false
+	for _, char := range raw {
+		if escaped {
+			current.WriteRune('\\')
+			current.WriteRune(char)
+			escaped = false
+			continue
+		}
+		if char == '\\' {
+			escaped = true
+			continue
+		}
+		if char == ',' {
+			pairs = append(pairs, current.String())
+			current.Reset()
+			continue
+		}
+		current.WriteRune(char)
+	}
+	if escaped {
+		current.WriteRune('\\')
+	}
+	pairs = append(pairs, current.String())
+	return pairs
+}
+
+func cutResourceAttributePair(raw string) (string, string, bool) {
+	escaped := false
+	for index, char := range raw {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if char == '\\' {
+			escaped = true
+			continue
+		}
+		if char == '=' {
+			return raw[:index], raw[index+1:], true
+		}
+	}
+	return raw, "", false
+}
+
+func unescapeResourceAttribute(raw string) string {
+	var value strings.Builder
+	escaped := false
+	for _, char := range raw {
+		if escaped {
+			value.WriteRune(char)
+			escaped = false
+			continue
+		}
+		if char == '\\' {
+			escaped = true
+			continue
+		}
+		value.WriteRune(char)
+	}
+	if escaped {
+		value.WriteRune('\\')
+	}
+	return value.String()
+}
+
+func resourceAttributesToTelemetry(values map[string]string) Attributes {
+	attributes := Attrs()
+	for key, value := range values {
+		attributes = attributes.WithField(Field{Key: key, Value: value})
+	}
+	return attributes
+}
+
+func inferredCloudProvider(region string) string {
+	if strings.TrimSpace(region) != "" || strings.TrimSpace(os.Getenv("ECS_CONTAINER_METADATA_URI_V4")) != "" || strings.TrimSpace(os.Getenv("ECS_CONTAINER_METADATA_URI")) != "" || strings.Contains(strings.ToLower(strings.TrimSpace(os.Getenv("AWS_EXECUTION_ENV"))), "aws") {
+		return "aws"
+	}
+	return ""
 }
 
 func Start(ctx context.Context, name string, attributes Attributes) (context.Context, *Span) {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -54,7 +54,23 @@ type Field struct {
 	Value any
 }
 
+type RuntimeMetadata struct {
+	ResourceAttributes      string
+	ServiceName             string
+	DeploymentEnvironment   string
+	CloudRegion             string
+	CloudProvider           string
+	ContainerID             string
+	ECSContainerMetadataURI string
+	AWSExecutionEnvironment string
+}
+
 const maxAttributeStringLength = 1024
+
+var (
+	runtimeMetadataMu sync.RWMutex
+	runtimeMetadata   RuntimeMetadata
+)
 
 func Attrs(fields ...Field) Attributes {
 	attributes := Attributes{values: map[string]any{}}
@@ -88,40 +104,50 @@ func (a Attributes) with(key string, value any) Attributes {
 	return a
 }
 
+func ConfigureRuntimeMetadata(metadata RuntimeMetadata) {
+	runtimeMetadataMu.Lock()
+	defer runtimeMetadataMu.Unlock()
+	runtimeMetadata = metadata
+}
+
+func configuredRuntimeMetadata() RuntimeMetadata {
+	runtimeMetadataMu.RLock()
+	defer runtimeMetadataMu.RUnlock()
+	return runtimeMetadata
+}
+
 func RuntimeAttributes() Attributes {
+	return RuntimeAttributesFor(configuredRuntimeMetadata())
+}
+
+func RuntimeAttributesFor(metadata RuntimeMetadata) Attributes {
 	hostname, _ := os.Hostname()
-	resourceAttributes := parseResourceAttributes(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"))
+	resourceAttributes := parseResourceAttributes(metadata.ResourceAttributes)
 	serviceName := firstNonEmpty(
-		strings.TrimSpace(os.Getenv("CEREBRO_OTEL_SERVICE_NAME")),
-		strings.TrimSpace(os.Getenv("OTEL_SERVICE_NAME")),
+		metadata.ServiceName,
 		resourceAttributes["service.name"],
 		buildinfo.ServiceName,
 	)
 	deploymentEnvironment := firstNonEmpty(
-		strings.TrimSpace(os.Getenv("CEREBRO_DEPLOYMENT_ENVIRONMENT")),
-		strings.TrimSpace(os.Getenv("CEREBRO_ENVIRONMENT")),
-		strings.TrimSpace(os.Getenv("OTEL_ENVIRONMENT_NAME")),
+		metadata.DeploymentEnvironment,
 		resourceAttributes["deployment.environment.name"],
 		resourceAttributes["deployment.environment"],
 		resourceAttributes["environment"],
-		strings.TrimSpace(os.Getenv("ENVIRONMENT")),
-		strings.TrimSpace(os.Getenv("APP_ENV")),
 		"unknown",
 	)
 	cloudRegion := firstNonEmpty(
 		resourceAttributes["cloud.region"],
-		strings.TrimSpace(os.Getenv("AWS_REGION")),
-		strings.TrimSpace(os.Getenv("AWS_DEFAULT_REGION")),
+		metadata.CloudRegion,
 	)
 	cloudProvider := firstNonEmpty(
 		resourceAttributes["cloud.provider"],
-		inferredCloudProvider(cloudRegion),
+		metadata.CloudProvider,
+		inferredCloudProvider(metadata, cloudRegion),
 		"unknown",
 	)
 	containerID := firstNonEmpty(
 		resourceAttributes["container.id"],
-		strings.TrimSpace(os.Getenv("ECS_CONTAINER_ID")),
-		strings.TrimSpace(os.Getenv("HOSTNAME")),
+		metadata.ContainerID,
 		hostname,
 	)
 	attributes := resourceAttributesToTelemetry(resourceAttributes)
@@ -236,8 +262,8 @@ func resourceAttributesToTelemetry(values map[string]string) Attributes {
 	return attributes
 }
 
-func inferredCloudProvider(region string) string {
-	if strings.TrimSpace(region) != "" || strings.TrimSpace(os.Getenv("ECS_CONTAINER_METADATA_URI_V4")) != "" || strings.TrimSpace(os.Getenv("ECS_CONTAINER_METADATA_URI")) != "" || strings.Contains(strings.ToLower(strings.TrimSpace(os.Getenv("AWS_EXECUTION_ENV"))), "aws") {
+func inferredCloudProvider(metadata RuntimeMetadata, region string) string {
+	if strings.TrimSpace(region) != "" || strings.TrimSpace(metadata.ECSContainerMetadataURI) != "" || strings.Contains(strings.ToLower(strings.TrimSpace(metadata.AWSExecutionEnvironment)), "aws") {
 		return "aws"
 	}
 	return ""

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -200,6 +200,48 @@ func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
 	}
 }
 
+func TestRuntimeAttributesUseECSAndOTELResourceEnvironment(t *testing.T) {
+	t.Setenv("CEREBRO_OTEL_SERVICE_NAME", "cerebro-api")
+	t.Setenv("CEREBRO_ENVIRONMENT", "sec-dev")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("HOSTNAME", "task-hostname")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.namespace=cerebro,cloud.availability_zone=us-east-1a,deployment.environment.name=ignored-by-cerebro-env")
+
+	_, stderr := captureOutput(t, func() {
+		_, span := StartMain(context.Background(), "test.runtime", Attrs())
+		End(span, "completed", Attrs())
+	})
+	payload := telemetryPayloadByKindAndName(t, stderr, "span_end", "test.runtime")
+	for key, want := range map[string]any{
+		"service.name":                "cerebro-api",
+		"service.namespace":           "cerebro",
+		"deployment.environment":      "sec-dev",
+		"deployment.environment.name": "sec-dev",
+		"cloud.provider":              "aws",
+		"cloud.region":                "us-east-1",
+		"cloud.availability_zone":     "us-east-1a",
+		"container.id":                "task-hostname",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+}
+
+func TestParseResourceAttributesHandlesEscapedSeparators(t *testing.T) {
+	got := parseResourceAttributes(`service.namespace=cerebro,custom.note=hello\,world,custom.expression=a\=b,custom.path=c:\\tmp`)
+	for key, want := range map[string]string{
+		"service.namespace": "cerebro",
+		"custom.note":       "hello,world",
+		"custom.expression": "a=b",
+		"custom.path":       `c:\tmp`,
+	} {
+		if got[key] != want {
+			t.Fatalf("%s = %q, want %q; attrs=%#v", key, got[key], want, got)
+		}
+	}
+}
+
 func TestEndMapsErrorStatusesToOpenTelemetryErrors(t *testing.T) {
 	for _, status := range []string{"failed", "error"} {
 		t.Run(status, func(t *testing.T) {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -201,11 +201,17 @@ func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
 }
 
 func TestRuntimeAttributesUseECSAndOTELResourceEnvironment(t *testing.T) {
-	t.Setenv("CEREBRO_OTEL_SERVICE_NAME", "cerebro-api")
-	t.Setenv("CEREBRO_ENVIRONMENT", "sec-dev")
-	t.Setenv("AWS_REGION", "us-east-1")
-	t.Setenv("HOSTNAME", "task-hostname")
-	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.namespace=cerebro,cloud.availability_zone=us-east-1a,deployment.environment.name=ignored-by-cerebro-env")
+	previous := configuredRuntimeMetadata()
+	ConfigureRuntimeMetadata(RuntimeMetadata{
+		ServiceName:           "cerebro-api",
+		DeploymentEnvironment: "sec-dev",
+		CloudRegion:           "us-east-1",
+		ContainerID:           "task-hostname",
+		ResourceAttributes:    "service.namespace=cerebro,cloud.availability_zone=us-east-1a,deployment.environment.name=ignored-by-cerebro-env",
+	})
+	t.Cleanup(func() {
+		ConfigureRuntimeMetadata(previous)
+	})
 
 	_, stderr := captureOutput(t, func() {
 		_, span := StartMain(context.Background(), "test.runtime", Attrs())


### PR DESCRIPTION
## Summary
- populate structured wide events from Cerebro/OTEL/ECS deployment metadata
- propagate OTEL_RESOURCE_ATTRIBUTES into CloudWatch JSON wide-event payloads
- document the runtime env vars that align structured logs with OTEL spans

## Tests
- go test ./internal/config ./internal/telemetry ./cmd/cerebro
- go test ./...
- git diff --check