### PR TITLE
feat(archetype): wire findings through graph ingest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
-version: "3.9"
-
 services:
   nats:
     image: nats:2.10-alpine
-    command: ["-js", "-sd", "/data"]
+    command: ["-js", "-sd", "/data", "-m", "8222"]
     ports:
       - "4222:4222"
       - "8222:8222"
@@ -14,6 +12,25 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
+
+  nats-init:
+    image: natsio/nats-box:0.18.0
+    command:
+      - sh
+      - -lc
+      - |
+        nats --server nats://nats:4222 stream info CEREBRO_EVENTS >/dev/null 2>&1 || \
+          nats --server nats://nats:4222 stream add CEREBRO_EVENTS \
+            --subjects "events.>" \
+            --storage file \
+            --retention limits \
+            --discard old \
+            --replicas 1 \
+            --dupe-window 2m \
+            --defaults
+    depends_on:
+      nats:
+        condition: service_healthy
 
   postgres:
     image: postgres:16-alpine
@@ -64,6 +81,8 @@ services:
     depends_on:
       nats:
         condition: service_healthy
+      nats-init:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       neo4j:

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -44,6 +45,7 @@ import (
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/workflowevents"
 	"github.com/writer/cerebro/internal/workflowprojection"
+	archetypesource "github.com/writer/cerebro/sources/archetype"
 	githubsource "github.com/writer/cerebro/sources/github"
 	oktasource "github.com/writer/cerebro/sources/okta"
 	sdksource "github.com/writer/cerebro/sources/sdk"
@@ -63,6 +65,14 @@ func sourceGet(t *testing.T, server *httptest.Server, path string, config map[st
 		req.Header.Set("X-Cerebro-Source-Config", string(payload))
 	}
 	return server.Client().Do(req)
+}
+
+func writeTestJSON(t *testing.T, w http.ResponseWriter, payload any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode test JSON: %v", err)
+	}
 }
 
 func TestSourceConfigFromRequestRejectsSensitiveQueryKeys(t *testing.T) {
@@ -4906,6 +4916,138 @@ func TestGraphIngestEndpoints(t *testing.T) {
 	}
 }
 
+func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
+	var sawAuth bool
+	archetypeAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer test-token" {
+			sawAuth = true
+		}
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeTestJSON(t, w, []map[string]any{{
+				"id":            1,
+				"repository_id": 7,
+				"status":        "completed",
+				"completed_at":  "2026-06-17T12:05:00Z",
+			}})
+		case "/api/v1/repositories":
+			writeTestJSON(t, w, []map[string]any{{
+				"id":    7,
+				"owner": "WriterInternal",
+				"name":  "Archetype",
+			}})
+		case "/api/v1/scans/1/vulnerabilities":
+			writeTestJSON(t, w, []map[string]any{{
+				"id":             10,
+				"scan_id":        1,
+				"line_number":    42,
+				"file_path":      "backend/app/core/security.py",
+				"category":       "ssrf",
+				"severity":       "high",
+				"description":    "Server-side request forgery in outbound fetch path",
+				"analyzer_score": 0.91,
+				"analyzer_label": "high-confidence",
+				"created_at":     "2026-06-17T12:06:00Z",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer archetypeAPI.Close()
+
+	source, err := archetypesource.NewFixture()
+	if err != nil {
+		t.Fatalf("archetype NewFixture() error = %v", err)
+	}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry(archetype) error = %v", err)
+	}
+	runtimeStore := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-archetype-vulnerabilities": {
+			Id:       "writer-archetype-vulnerabilities",
+			SourceId: "archetype",
+			TenantId: "writer",
+			Config: map[string]string{
+				"base_url": archetypeAPI.URL,
+				"family":   "vulnerability",
+				"token":    "test-token",
+			},
+		},
+	}}
+	graphStore := &stubGraphStore{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		StateStore: runtimeStore,
+		GraphStore: graphStore,
+	}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	runResp, err := server.Client().Post(server.URL+"/source-runtimes/writer-archetype-vulnerabilities/graph-ingest-runs?page_limit=1&checkpoint_id=graph-archetype", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/graph-ingest-runs error = %v", err)
+	}
+	defer func() { _ = runResp.Body.Close() }()
+	if runResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(runResp.Body)
+		t.Fatalf("graph ingest status = %d, want 200: %s", runResp.StatusCode, body)
+	}
+	var runPayload map[string]any
+	if err := json.NewDecoder(runResp.Body).Decode(&runPayload); err != nil {
+		t.Fatalf("decode graph ingest response: %v", err)
+	}
+	resultPayload, ok := runPayload["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("graph ingest result = %#v, want object", runPayload["result"])
+	}
+	ingestPayload, ok := resultPayload["ingest"].(map[string]any)
+	if !ok {
+		t.Fatalf("graph ingest details = %#v, want object", resultPayload["ingest"])
+	}
+	if got := ingestPayload["events_read"]; got != float64(2) {
+		t.Fatalf("events_read = %#v, want 2", got)
+	}
+	if got := ingestPayload["entities_projected"]; got != float64(3) {
+		t.Fatalf("entities_projected = %#v, want 3", got)
+	}
+	if got := ingestPayload["links_projected"]; got != float64(5) {
+		t.Fatalf("links_projected = %#v, want 5", got)
+	}
+	if !sawAuth {
+		t.Fatal("Archetype API did not receive bearer token")
+	}
+
+	repoURN := "urn:cerebro:writer:github_code_repository:WriterInternal/Archetype"
+	scanURN := "urn:cerebro:writer:archetype_scan:1"
+	findingURN := "urn:cerebro:writer:archetype_finding:10"
+	if entity := graphStore.entities[findingURN]; entity == nil || entity.EntityType != "archetype.finding" {
+		t.Fatalf("projected finding entity = %#v, want archetype.finding", entity)
+	}
+	if entity := graphStore.entities[scanURN]; entity == nil || entity.EntityType != "archetype.scan" {
+		t.Fatalf("projected scan entity = %#v, want archetype.scan", entity)
+	}
+	if entity := graphStore.entities[repoURN]; entity == nil || entity.EntityType != "github.code.repository" {
+		t.Fatalf("projected repository entity = %#v, want github.code.repository", entity)
+	}
+	assertBootstrapProjectedLink(t, graphStore, repoURN, "has_evidence", scanURN)
+	assertBootstrapProjectedLink(t, graphStore, repoURN, "has_evidence", findingURN)
+	assertBootstrapProjectedLink(t, graphStore, findingURN, "belongs_to", scanURN)
+	assertBootstrapProjectedLink(t, graphStore, findingURN, "affects", repoURN)
+
+	neighborhoodResp, err := server.Client().Get(server.URL + "/platform/graph/neighborhood?root_urn=" + url.QueryEscape(findingURN) + "&limit=10")
+	if err != nil {
+		t.Fatalf("GET /platform/graph/neighborhood error = %v", err)
+	}
+	defer func() { _ = neighborhoodResp.Body.Close() }()
+	if neighborhoodResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(neighborhoodResp.Body)
+		t.Fatalf("graph neighborhood status = %d, want 200: %s", neighborhoodResp.StatusCode, body)
+	}
+	if graphStore.neighborhoodRootURN != findingURN {
+		t.Fatalf("graph neighborhood root = %q, want %q", graphStore.neighborhoodRootURN, findingURN)
+	}
+}
+
 func TestGraphIngestResolvesConnectorCredentialRuntimeConfig(t *testing.T) {
 	source := &bootstrapTokenSource{id: "bootstrap_token"}
 	registry, err := sourcecdk.NewRegistry(source)
@@ -7066,6 +7208,17 @@ func newFixtureRegistry() (*sourcecdk.Registry, error) {
 		return nil, err
 	}
 	return sourcecdk.NewRegistry(source, okta, sdk)
+}
+
+func assertBootstrapProjectedLink(t *testing.T, graph *stubGraphStore, fromURN string, relation string, toURN string) {
+	t.Helper()
+	if graph == nil {
+		t.Fatal("graph store is nil")
+	}
+	key := fromURN + "|" + relation + "|" + toURN
+	if _, ok := graph.links[key]; !ok {
+		t.Fatalf("missing projected link %s; links = %#v", key, graph.links)
+	}
 }
 
 func TestFindingMessageIncludesRiskFactors(t *testing.T) {

--- a/sources/archetype/fixture.go
+++ b/sources/archetype/fixture.go
@@ -1,0 +1,13 @@
+package archetype
+
+import "github.com/writer/cerebro/internal/sourcecdk"
+
+// NewFixture constructs the Archetype source used by integration tests.
+func NewFixture() (sourcecdk.Source, error) {
+	source, err := New()
+	if err != nil {
+		return nil, err
+	}
+	source.allowLoopbackBaseURL = true
+	return source, nil
+}

--- a/sources/archetype/source.go
+++ b/sources/archetype/source.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,7 +31,14 @@ type Source struct {
 	allowLoopbackBaseURL bool
 }
 
-type settings struct{ tenantID, family, baseURL, token, apiPrefix string }
+type settings struct {
+	tenantID                 string
+	family                   string
+	baseURL                  string
+	token                    string
+	apiPrefix                string
+	privateEndpointAllowlist []string
+}
 type scanRecord struct {
 	ID           int    `json:"id"`
 	RepositoryID int    `json:"repository_id"`
@@ -70,12 +78,12 @@ func New() (*Source, error) {
 }
 func (s *Source) Spec() *cerebrov1.SourceSpec { return s.spec }
 func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
-	st, err := parseSettings(cfg)
+	st, err := parseSettings(cfg, s != nil && s.allowLoopbackBaseURL)
 	if err != nil {
 		return err
 	}
 	var scans []scanRecord
-	return s.get(ctx, st, "/scans", &scans)
+	return s.get(ctx, st, "/scans", nil, &scans)
 }
 func (s *Source) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
 	return nil, nil
@@ -84,12 +92,12 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 	return s.ReadWithCheckpoint(ctx, cfg, cursor, nil)
 }
 func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
-	st, err := parseSettings(cfg)
+	st, err := parseSettings(cfg, s != nil && s.allowLoopbackBaseURL)
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
 	var scans []scanRecord
-	if err := s.get(ctx, st, "/scans", &scans); err != nil {
+	if err := s.get(ctx, st, "/scans", nil, &scans); err != nil {
 		return sourcecdk.Pull{}, err
 	}
 	sort.Slice(scans, func(i, j int) bool { return scans[i].ID < scans[j].ID })
@@ -108,7 +116,7 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 			continue
 		}
 		var vulns []vulnerabilityRecord
-		if err := s.get(ctx, st, fmt.Sprintf("/scans/%d/vulnerabilities", scan.ID), &vulns); err != nil {
+		if err := s.get(ctx, st, fmt.Sprintf("/scans/%d/vulnerabilities", scan.ID), nil, &vulns); err != nil {
 			return sourcecdk.Pull{}, err
 		}
 		for _, vuln := range vulns {
@@ -121,7 +129,7 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 	next := strconv.Itoa(maxScanID(scans))
 	return sourcecdk.Pull{Events: events, Checkpoint: &cerebrov1.SourceCheckpoint{CursorOpaque: next, Watermark: events[len(events)-1].OccurredAt}}, nil
 }
-func parseSettings(cfg sourcecdk.Config) (settings, error) {
+func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 	st := settings{
 		tenantID:  first(configValue(cfg, "tenant_id"), configValue(cfg, sourceconfig.RuntimeTenantIDKey)),
 		family:    first(configValue(cfg, "family"), "vulnerability"),
@@ -135,10 +143,36 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if st.family != "scan" && st.family != "vulnerability" {
 		return st, fmt.Errorf("%w: archetype family must be scan or vulnerability", sourcecdk.ErrInvalidConfig)
 	}
+	privateEndpointAllowlist, err := sourcehttp.ParsePrivateEndpointAllowlist(sourceID, configValue(cfg, "private_endpoint_allowlist"))
+	if err != nil {
+		return st, err
+	}
+	baseURL, _, err := sourcehttp.NormalizeBaseURLWithOptions(sourceID, st.baseURL, sourcehttp.URLValidationOptions{
+		AllowLoopback:            allowLoopback,
+		PrivateEndpointAllowlist: privateEndpointAllowlist,
+	})
+	if err != nil {
+		return st, err
+	}
+	apiPrefix, err := sourcehttp.NormalizeRequestPath(sourceID, st.apiPrefix)
+	if err != nil {
+		return st, err
+	}
+	st.baseURL = baseURL
+	st.apiPrefix = strings.TrimRight(apiPrefix, "/")
+	st.privateEndpointAllowlist = privateEndpointAllowlist
 	return st, nil
 }
-func (s *Source) get(ctx context.Context, st settings, path string, out any) error {
-	req, err := sourcehttp.NewRequest(ctx, sourceID, st.baseURL, s.allowLoopbackBaseURL, http.MethodGet, st.apiPrefix+path, nil, nil)
+func (s *Source) get(ctx context.Context, st settings, path string, query url.Values, out any) error {
+	requestPath, err := sourcehttp.NormalizeRequestPath(sourceID, st.apiPrefix+path)
+	if err != nil {
+		return err
+	}
+	endpoint := st.baseURL + requestPath
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return err
 	}
@@ -146,7 +180,11 @@ func (s *Source) get(ctx context.Context, st settings, path string, out any) err
 		req.Header.Set("Authorization", "Bearer "+st.token)
 	}
 	req.Header.Set("Accept", "application/json")
-	resp, err := sourcehttp.DoWithRetry(ctx, sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: sourceID, AllowLoopback: s.allowLoopbackBaseURL}), req, sourcehttp.RetryOptions{})
+	resp, err := sourcehttp.DoWithRetry(ctx, sourcehttp.NewClient(sourcehttp.ClientOptions{
+		SourceID:                 sourceID,
+		AllowLoopback:            s != nil && s.allowLoopbackBaseURL,
+		PrivateEndpointAllowlist: st.privateEndpointAllowlist,
+	}), req, sourcehttp.RetryOptions{})
 	if err != nil {
 		return err
 	}
@@ -157,7 +195,7 @@ func (s *Source) get(ctx context.Context, st settings, path string, out any) err
 }
 func (s *Source) repositories(ctx context.Context, st settings) map[int]repositoryRecord {
 	var repos []repositoryRecord
-	if err := s.get(ctx, st, "/repositories", &repos); err != nil {
+	if err := s.get(ctx, st, "/repositories", nil, &repos); err != nil {
 		return nil
 	}
 	out := map[int]repositoryRecord{}

--- a/sources/archetype/source.go
+++ b/sources/archetype/source.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -83,7 +82,7 @@ func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 		return err
 	}
 	var scans []scanRecord
-	return s.get(ctx, st, "/scans", nil, &scans)
+	return s.get(ctx, st, "/scans", &scans)
 }
 func (s *Source) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
 	return nil, nil
@@ -97,7 +96,7 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 		return sourcecdk.Pull{}, err
 	}
 	var scans []scanRecord
-	if err := s.get(ctx, st, "/scans", nil, &scans); err != nil {
+	if err := s.get(ctx, st, "/scans", &scans); err != nil {
 		return sourcecdk.Pull{}, err
 	}
 	sort.Slice(scans, func(i, j int) bool { return scans[i].ID < scans[j].ID })
@@ -116,7 +115,7 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 			continue
 		}
 		var vulns []vulnerabilityRecord
-		if err := s.get(ctx, st, fmt.Sprintf("/scans/%d/vulnerabilities", scan.ID), nil, &vulns); err != nil {
+		if err := s.get(ctx, st, fmt.Sprintf("/scans/%d/vulnerabilities", scan.ID), &vulns); err != nil {
 			return sourcecdk.Pull{}, err
 		}
 		for _, vuln := range vulns {
@@ -163,16 +162,12 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 	st.privateEndpointAllowlist = privateEndpointAllowlist
 	return st, nil
 }
-func (s *Source) get(ctx context.Context, st settings, path string, query url.Values, out any) error {
+func (s *Source) get(ctx context.Context, st settings, path string, out any) error {
 	requestPath, err := sourcehttp.NormalizeRequestPath(sourceID, st.apiPrefix+path)
 	if err != nil {
 		return err
 	}
-	endpoint := st.baseURL + requestPath
-	if encoded := query.Encode(); encoded != "" {
-		endpoint += "?" + encoded
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, st.baseURL+requestPath, nil)
 	if err != nil {
 		return err
 	}
@@ -195,7 +190,7 @@ func (s *Source) get(ctx context.Context, st settings, path string, query url.Va
 }
 func (s *Source) repositories(ctx context.Context, st settings) map[int]repositoryRecord {
 	var repos []repositoryRecord
-	if err := s.get(ctx, st, "/repositories", nil, &repos); err != nil {
+	if err := s.get(ctx, st, "/repositories", &repos); err != nil {
 		return nil
 	}
 	out := map[int]repositoryRecord{}

--- a/sources/archetype/source_test.go
+++ b/sources/archetype/source_test.go
@@ -107,6 +107,34 @@ func TestSourceCheckRejectsBadFamily(t *testing.T) {
 	}
 }
 
+func TestParseSettingsSupportsPrivateEndpointAllowlist(t *testing.T) {
+	settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"tenant_id":                  "writer",
+		"base_url":                   "https://archetype.internal.example",
+		"private_endpoint_allowlist": "archetype.internal.example",
+	}), false)
+	if err != nil {
+		t.Fatalf("parseSettings() error = %v", err)
+	}
+	if settings.baseURL != "https://archetype.internal.example" {
+		t.Fatalf("baseURL = %q, want normalized private endpoint origin", settings.baseURL)
+	}
+	if got := settings.privateEndpointAllowlist; len(got) != 1 || got[0] != "archetype.internal.example" {
+		t.Fatalf("privateEndpointAllowlist = %#v, want archetype.internal.example", got)
+	}
+}
+
+func TestParseSettingsRejectsPrivateEndpointAllowlistMismatch(t *testing.T) {
+	_, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"tenant_id":                  "writer",
+		"base_url":                   "https://archetype.internal.example",
+		"private_endpoint_allowlist": "other.internal.example",
+	}), false)
+	if err == nil {
+		t.Fatal("parseSettings() error = nil, want mismatch error")
+	}
+}
+
 func writeJSON(t *testing.T, w http.ResponseWriter, payload any) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- Add Archetype private endpoint allowlist handling while keeping loopback access isolated to tests.
- Add HTTP-level graph-ingest regression coverage for Archetype scan and vulnerability projection.
- Fix local Docker Compose startup so NATS health and the required JetStream stream are ready before Cerebro starts.

## Validation
- Focused Archetype/source-projection/bootstrap regression tests passed.
- Full `go test ./...` passed.
- `make build` passed.
- `docker compose config` passed.
- Rebuilt the local durable stack and verified `/health` reported append log, state store, and graph store ready.
- Ran a live synthetic Archetype source preview and fresh runtime sync; it appended scan and vulnerability events, projected graph entities and links, and returned no invalid events.
- Queried the projected graph neighborhood and verified the synthetic finding was connected to its scan and repository evidence nodes.