### PR TITLE
Accept agent Ask envelope metadata

### DIFF
--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -15,18 +15,26 @@ import (
 
 const maxGRCAskBodyBytes = 128 << 10
 
+type grcAskRequestEnvelope struct {
+	graphagent.AskRequest
+	Context        json.RawMessage `json:"context,omitempty"`
+	Surface        string          `json:"surface,omitempty"`
+	ConversationID string          `json:"conversation_id,omitempty"`
+}
+
 func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 	started := time.Now()
 	evt := askWideEvent{provider: a.cfg.GraphAgentLLM.Provider}
 
-	var request graphagent.AskRequest
+	var envelope grcAskRequestEnvelope
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxGRCAskBodyBytes))
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&request); err != nil {
+	if err := decoder.Decode(&envelope); err != nil {
 		evt.finish(r, started, http.StatusBadRequest, err)
 		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
 		return
 	}
+	request := envelope.AskRequest
 	evt.tenantID = request.TenantID
 	evt.question = request.Question
 	evt.scopeURN = request.ScopeURN

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -72,6 +72,41 @@ LIMIT 25`,
 	}
 }
 
+func TestGRCAskAcceptsAgentEnvelopeMetadata(t *testing.T) {
+	graphStore := &stubGraphStore{
+		cypherRows: [][]ports.CypherRow{{
+			{Values: map[string]any{
+				"entity_urn":  "urn:cerebro:example:asset:alpha",
+				"entity_type": "asset",
+				"label":       "alpha",
+			}},
+		}},
+	}
+	llm := &graphagent.StubLLMClient{
+		DraftResponse: &graphagent.DraftResponse{
+			Rationale: "Finding scoped graph rows.",
+			Cypher: `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS entity_urn, e.entity_type AS entity_type, e.label AS label
+LIMIT 25`,
+		},
+		Summary: "Review `urn:cerebro:example:asset:alpha` first.",
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphAgentLLM: llm}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := []byte(`{"tenant_id":"example","question":"What is risky?","context":{"route":"/risk-inbox","chips":[{"label":"Severity","value":"High"}]},"surface":"agent","conversation_id":"thread-1"}`)
+	resp, err := server.Client().Post(server.URL+"/grc/ask", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /grc/ask error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /grc/ask status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	assertSSEEventNames(t, readSSEEvents(t, resp), []string{"progress", "graph_probe", "progress", "rationale", "query_plan", "progress", "cypher", "progress", "rows", "progress", "summary", "done"})
+}
+
 func TestGRCAskTelemetryIncludesQueryPlanDiagnostics(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
 		GraphStore: &stubGraphStore{},


### PR DESCRIPTION
Summary
- accept web-agent envelope metadata on the graph Ask route while preserving strict request validation
- add regression coverage for agent-shaped Ask requests

Verification
- make lint-bootstrap
- go test ./internal/bootstrap -run 'TestGRCAsk(StreamsSSE|AcceptsAgentEnvelopeMetadata|MissingTenantReturnsBadRequest|MissingStartupLLMReturnsUnavailable)' -count=1\n- make verify