### PR TITLE
Fix AI access review feedback

### DIFF
--- a/internal/sourceprojection/ai_access.go
+++ b/internal/sourceprojection/ai_access.go
@@ -589,7 +589,7 @@ func aiRolePermissionProjections(event *cerebrov1.EventEnvelope, profile aiAcces
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 	roleID := aiRoleID(attrs)
-	permissionID := aiRolePermissionID(attrs, event.GetId())
+	permissionID := aiRolePermissionID(attrs, "")
 	if roleID == "" || permissionID == "" {
 		return identityProjectionResult(entities, links)
 	}
@@ -617,17 +617,15 @@ func aiRolePermissionProjections(event *cerebrov1.EventEnvelope, profile aiAcces
 	aiLinkRoleToScope(links, tenantID, event, roleURN, scopeURN, roleID, "role_permission_scope_access")
 	capabilityID := aiRolePermissionCapabilityID(attrs)
 	capabilityURN := projectionURN(tenantID, "privileged_capability", capabilityID)
-	if capabilityURN != "" {
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        capabilityURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: "privileged.capability",
-			Label:      strings.ReplaceAll(capabilityID, "_", " "),
-			Attributes: map[string]string{"capability_id": capabilityID},
-		})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), entitlementURN, capabilityURN, relationConfersCapability, aiEventLinkAttributes(event, "role_permission_capability")))
-	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        capabilityURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "privileged.capability",
+		Label:      strings.ReplaceAll(capabilityID, "_", " "),
+		Attributes: map[string]string{"capability_id": capabilityID},
+	})
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), entitlementURN, capabilityURN, relationConfersCapability, aiEventLinkAttributes(event, "role_permission_capability")))
 	return identityProjectionResult(entities, links)
 }
 
@@ -936,7 +934,7 @@ func aiAuditProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile)
 	actorServiceAccountID := strings.TrimSpace(attrs["actor_service_account_id"])
 	actorEmail := strings.TrimSpace(attrs["actor_email"])
 	actorType := strings.TrimSpace(attrs["actor_type"])
-	actorID := firstNonEmpty(actorUserID, actorServiceAccountID, actorAPIKeyID, attrs["actor_id"])
+	actorID := firstNonEmpty(actorUserID, attrs["actor_id"])
 	if actorAPIKeyID != "" {
 		actorType = "credential"
 		actorID = actorAPIKeyID
@@ -962,13 +960,14 @@ func aiAuditProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile)
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), ownerURN, actorURN, relationAssignedTo, linkAttrs))
 		}
 	}
-	targetURN := aiAuditTargetURN(entities, links, tenantID, event, profile, attrs)
-	if actorURN != "" && targetURN != "" {
-		linkAttrs := aiEventLinkAttributes(event, "audit_activity")
-		addProjectedAttribute(linkAttrs, "event_type", firstNonEmpty(attrs["event_type"], attrs["activity_type"]))
-		addProjectedAttribute(linkAttrs, "activity_type", attrs["activity_type"])
-		addProjectedAttribute(linkAttrs, "actor_type", actorType)
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, targetURN, relationActedOn, linkAttrs))
+	for _, targetURN := range aiAuditTargetURNs(entities, links, tenantID, event, profile, attrs) {
+		if actorURN != "" && targetURN != "" {
+			linkAttrs := aiEventLinkAttributes(event, "audit_activity")
+			addProjectedAttribute(linkAttrs, "event_type", firstNonEmpty(attrs["event_type"], attrs["activity_type"]))
+			addProjectedAttribute(linkAttrs, "activity_type", attrs["activity_type"])
+			addProjectedAttribute(linkAttrs, "actor_type", actorType)
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, targetURN, relationActedOn, linkAttrs))
+		}
 	}
 	return identityProjectionResult(entities, links)
 }
@@ -1122,13 +1121,16 @@ func aiEnsureCredential(entities map[string]*ports.ProjectedEntity, tenantID str
 	if credentialURN == "" {
 		return ""
 	}
-	credentialAttrs := aiPrincipalAttributes(attrs, map[string]string{
-		"credential_id":            strings.TrimSpace(credentialID),
-		"principal_type":           "credential",
-		"api_key_id":               strings.TrimSpace(credentialID),
-		"actor_user_id":            strings.TrimSpace(attrs["actor_user_id"]),
-		"actor_service_account_id": strings.TrimSpace(attrs["actor_service_account_id"]),
-	})
+	baseAttrs := map[string]string{
+		"credential_id":  strings.TrimSpace(credentialID),
+		"principal_type": "credential",
+		"api_key_id":     strings.TrimSpace(credentialID),
+	}
+	if credentialID == strings.TrimSpace(firstNonEmpty(attrs["actor_api_key_id"], attrs["actor_admin_api_key_id"])) {
+		baseAttrs["actor_user_id"] = strings.TrimSpace(attrs["actor_user_id"])
+		baseAttrs["actor_service_account_id"] = strings.TrimSpace(attrs["actor_service_account_id"])
+	}
+	credentialAttrs := aiPrincipalAttributes(attrs, baseAttrs)
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        credentialURN,
 		TenantID:   tenantID,
@@ -1271,6 +1273,28 @@ func aiRoleAssignmentRelation(role string) string {
 	return relationAssignedTo
 }
 
+func aiAuditTargetURNs(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, profile aiAccessProfile, attrs map[string]string) []string {
+	targetURNs := []string{}
+	appendTarget := func(targetURN string) {
+		if targetURN == "" {
+			return
+		}
+		for _, existing := range targetURNs {
+			if existing == targetURN {
+				return
+			}
+		}
+		targetURNs = append(targetURNs, targetURN)
+	}
+	appendTarget(aiAuditTargetURN(entities, links, tenantID, event, profile, attrs))
+
+	eventType := strings.TrimSpace(firstNonEmpty(attrs["event_type"], attrs["activity_type"]))
+	if strings.HasPrefix(eventType, "role.assignment.") && strings.TrimSpace(attrs["principal_id"]) != "" {
+		appendTarget(aiAuditPrincipalURN(entities, links, tenantID, event, profile, attrs["principal_id"], attrs["principal_type"], attrs))
+	}
+	return targetURNs
+}
+
 func aiAuditTargetURN(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, profile aiAccessProfile, attrs map[string]string) string {
 	sourceID := event.GetSourceId()
 	eventType := strings.TrimSpace(firstNonEmpty(attrs["event_type"], attrs["activity_type"]))
@@ -1357,19 +1381,22 @@ func aiAuditActivityResourceURN(entities map[string]*ports.ProjectedEntity, link
 }
 
 func aiAuditPrincipalURN(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, profile aiAccessProfile, principalID string, principalType string, attrs map[string]string) string {
-	switch identityPrincipalType(principalType) {
-	case "group":
+	normalizedType := normalizeIdentifier(principalType)
+	switch {
+	case strings.Contains(normalizedType, "group"):
 		groupAttrs := cloneAttributes(attrs)
 		groupAttrs["group_id"] = principalID
 		return aiEnsureGroup(entities, tenantID, event.GetSourceId(), profile, groupAttrs)
-	case "service_account":
+	case strings.Contains(normalizedType, "service_account") || strings.Contains(normalizedType, "serviceaccount"):
 		return aiEnsureServiceAccount(entities, tenantID, event.GetSourceId(), profile, principalID, attrs["name"], attrs["role"], attrs)
-	case "role":
+	case strings.Contains(normalizedType, "role"):
 		roleAttrs := cloneAttributes(attrs)
 		roleAttrs["role_id"] = principalID
 		return aiEnsureRole(entities, tenantID, event.GetSourceId(), profile, roleAttrs, aiAuditRoleScopeKind(attrs))
-	default:
+	case normalizedType == "" || strings.Contains(normalizedType, "user"):
 		return aiEnsureUser(entities, links, tenantID, event, profile, principalID, attrs["email"], attrs["name"], attrs["role"])
+	default:
+		return aiAuditResourceURN(entities, links, tenantID, event, profile, principalID, principalType, attrs)
 	}
 }
 
@@ -1456,7 +1483,7 @@ func aiInviteAccessState(status string) string {
 
 func aiInviteAccessIntentActive(status string) bool {
 	switch aiInviteAccessState(status) {
-	case "invited":
+	case "invited", "accepted":
 		return true
 	default:
 		return false
@@ -1659,7 +1686,8 @@ func aiGovernanceControlID(family string, attrs map[string]string, fallback stri
 	case "project_data_retention":
 		return firstNonEmpty(joinProjectionIdentity(attrs, "project_id", "retention_type", "object"), fallback)
 	case "data_retention":
-		return firstNonEmpty(joinProjectionIdentity(attrs, "organization_id", "organization_uuid", "retention_type", "object"), joinProjectionIdentity(attrs, "retention_type", "object"), fallback)
+		orgID := firstNonEmpty(attrs["organization_id"], attrs["organization_uuid"])
+		return firstNonEmpty(joinScopedProjectionIdentity(orgID, attrs, "retention_type", "object"), joinProjectionIdentity(attrs, "retention_type", "object"), fallback)
 	case "project_spend_alert":
 		return firstNonEmpty(joinProjectionIdentity(attrs, "project_id", "spend_alert_id", "name"), fallback)
 	case "spend_alert":
@@ -1673,9 +1701,23 @@ func aiGovernanceControlID(family string, attrs map[string]string, fallback stri
 	case "spend_limit_increase_request":
 		return firstNonEmpty(attrs["request_id"], attrs["id"], joinProjectionIdentity(attrs, "user_id", "period", "amount"), fallback)
 	case "compliance_organization_setting":
-		return firstNonEmpty(joinProjectionIdentity(attrs, "organization_uuid", "organization_id", "setting_name", "name"), fallback)
+		orgID := firstNonEmpty(attrs["organization_uuid"], attrs["organization_id"])
+		return firstNonEmpty(joinScopedProjectionIdentity(orgID, attrs, "setting_name", "name"), fallback)
 	}
 	return firstNonEmpty(inventoryEntityID("", family, attrs), fallback)
+}
+
+func joinScopedProjectionIdentity(scopeID string, attrs map[string]string, keys ...string) string {
+	values := []string{}
+	if scopeID = strings.TrimSpace(scopeID); scopeID != "" {
+		values = append(values, scopeID)
+	}
+	for _, key := range keys {
+		if value := strings.TrimSpace(attrs[key]); value != "" {
+			values = append(values, value)
+		}
+	}
+	return strings.Join(values, "|")
 }
 
 func aiGovernanceControlType(family string) string {

--- a/internal/sourceprojection/ai_access_test.go
+++ b/internal/sourceprojection/ai_access_test.go
@@ -140,7 +140,7 @@ func TestProjectOpenAIAuditDeepAccessEvidence(t *testing.T) {
 				"actor_user_id": "user_admin",
 				"event_type":    "group.updated",
 				"family":        "audit_log",
-				"group_id":      "group_123",
+				"group_id":      "group_999",
 				"group_name":    "Engineering",
 			},
 		},
@@ -164,6 +164,12 @@ func TestProjectOpenAIAuditDeepAccessEvidence(t *testing.T) {
 	assertProjectedLink(t, state, userURN, relationRepresentsIdentity, identityURN)
 	assertProjectedLink(t, state, userURN, relationActedOn, projectURN)
 	assertProjectedLink(t, state, userURN, relationActedOn, groupURN)
+	if got := state.entities[actorCredentialURN].Attributes["actor_service_account_id"]; got != "sa_123" {
+		t.Fatalf("actor credential actor_service_account_id = %q, want sa_123", got)
+	}
+	if got := state.entities[targetCredentialURN].Attributes["actor_service_account_id"]; got != "" {
+		t.Fatalf("target credential actor_service_account_id = %q, want empty", got)
+	}
 	link := state.links[actorCredentialURN+"|"+relationActedOn+"|"+targetCredentialURN]
 	if got := link.Attributes["event_type"]; got != "api_key.updated" {
 		t.Fatalf("acted_on event_type = %q, want api_key.updated", got)
@@ -292,6 +298,30 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 			},
 		},
 		{
+			Id:         "openai-accepted-invite",
+			TenantId:   "writer",
+			SourceId:   "openai",
+			Kind:       "openai.invite",
+			OccurredAt: timestamppb.New(occurred),
+			Payload: []byte(`{
+				"id": "invite_openai_accepted",
+				"email": "accepted-member@example.com",
+				"role": "member",
+				"status": "accepted",
+				"projects": [
+					{"id": "proj_accepted", "role": "member"}
+				]
+			}`),
+			Attributes: map[string]string{
+				"email":       "accepted-member@example.com",
+				"family":      "invite",
+				"invite_id":   "invite_openai_accepted",
+				"role":        "member",
+				"status":      "accepted",
+				"accepted_at": "2026-06-18T12:12:00Z",
+			},
+		},
+		{
 			Id:         "anthropic-pending-invite",
 			TenantId:   "writer",
 			SourceId:   "anthropic",
@@ -337,6 +367,8 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 	openAIProjectOwnerURN := "urn:cerebro:writer:openai_project:proj_123"
 	openAIProjectMemberURN := "urn:cerebro:writer:openai_project:proj_456"
 	openAIExpiredProjectURN := "urn:cerebro:writer:openai_project:proj_expired"
+	openAIAcceptedInviteURN := "urn:cerebro:writer:openai_invite:invite_openai_accepted"
+	openAIAcceptedProjectURN := "urn:cerebro:writer:openai_project:proj_accepted"
 	anthropicInviteURN := "urn:cerebro:writer:anthropic_invite:invite_anthropic_123"
 	anthropicExpiredInviteURN := "urn:cerebro:writer:anthropic_invite:invite_anthropic_expired"
 	anthropicOrgURN := "urn:cerebro:writer:anthropic_org:anthropic"
@@ -350,6 +382,9 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 	if entity := state.entities[anthropicExpiredInviteURN]; entity == nil || entity.Attributes["access_state"] != "expired" {
 		t.Fatalf("expired invite entity missing or wrong: %#v", entity)
 	}
+	if entity := state.entities[openAIAcceptedInviteURN]; entity == nil || entity.Attributes["access_state"] != "accepted" {
+		t.Fatalf("accepted invite entity missing or wrong: %#v", entity)
+	}
 	assertProjectedLink(t, state, openAIInviteURN, relationBelongsTo, openAIOrgURN)
 	assertProjectedLink(t, state, openAIInviteURN, relationRepresentsIdentity, openAIIdentityURN)
 	assertProjectedLink(t, state, openAIInviteURN, relationCanAdmin, openAIRoleURN)
@@ -362,6 +397,8 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 	assertProjectedLink(t, state, openAIProjectMemberRoleURN, relationGrantsEntitlement, openAIProjectMemberURN)
 	assertProjectedLink(t, state, openAIInviteURN, relationCanPerform, openAIProjectMemberURN)
 	assertProjectedLinkMissing(t, state, openAIExpiredInviteURN, relationCanAdmin, openAIExpiredProjectURN)
+	assertProjectedLink(t, state, openAIAcceptedInviteURN, relationCanPerform, openAIOrgURN)
+	assertProjectedLink(t, state, openAIAcceptedInviteURN, relationCanPerform, openAIAcceptedProjectURN)
 	assertProjectedLink(t, state, anthropicInviteURN, relationBelongsTo, anthropicOrgURN)
 	assertProjectedLink(t, state, anthropicInviteURN, relationRepresentsIdentity, anthropicIdentityURN)
 	assertProjectedLink(t, state, anthropicInviteURN, relationAssignedTo, anthropicRoleURN)
@@ -521,6 +558,48 @@ func TestProjectAIGovernanceControlEdges(t *testing.T) {
 				"setting_value":     "true",
 			},
 		},
+		{
+			Id:         "anthropic-compliance-setting-with-org-id",
+			TenantId:   "writer",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.compliance_organization_setting",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"family":            "compliance_organization_setting",
+				"organization_id":   "org-id-1",
+				"organization_uuid": "org-uuid-1",
+				"setting_name":      "data_retention",
+				"setting_type":      "boolean",
+				"setting_value":     "false",
+			},
+		},
+		{
+			Id:         "openai-data-retention",
+			TenantId:   "writer",
+			SourceId:   "openai",
+			Kind:       "openai.data_retention",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"family":          "data_retention",
+				"object":          "chat",
+				"organization_id": "org_123",
+				"retention_type":  "30d",
+			},
+		},
+		{
+			Id:         "openai-data-retention-with-org-uuid",
+			TenantId:   "writer",
+			SourceId:   "openai",
+			Kind:       "openai.data_retention",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"family":            "data_retention",
+				"object":            "chat",
+				"organization_id":   "org_123",
+				"organization_uuid": "org_uuid_123",
+				"retention_type":    "30d",
+			},
+		},
 	}
 	for _, event := range events {
 		if _, err := service.Project(context.Background(), event); err != nil {
@@ -535,13 +614,25 @@ func TestProjectAIGovernanceControlEdges(t *testing.T) {
 	anthropicWorkspaceURN := "urn:cerebro:writer:anthropic_workspace:ws_123"
 	anthropicModelURN := "urn:cerebro:writer:anthropic_model:claude-sonnet-4-20250514"
 	anthropicSettingURN := "urn:cerebro:writer:anthropic_compliance_organization_setting:org-uuid-1:data_retention"
+	anthropicUnstableSettingURN := "urn:cerebro:writer:anthropic_compliance_organization_setting:org-uuid-1:org-id-1:data_retention"
 	anthropicOrgURN := "urn:cerebro:writer:anthropic_org:org-uuid-1"
+	openAIDataRetentionURN := "urn:cerebro:writer:openai_data_retention:org_123:30d:chat"
+	openAIUnstableDataRetentionURN := "urn:cerebro:writer:openai_data_retention:org_123:org_uuid_123:30d:chat"
 
 	if entity := state.entities[openAIControlURN]; entity == nil || entity.EntityType != "openai.project_rate_limit" || entity.Attributes["control_type"] != "rate_limit" || entity.Attributes["scope_kind"] != "project" {
 		t.Fatalf("openai control entity missing or wrong: %#v", entity)
 	}
 	if entity := state.entities[anthropicSettingURN]; entity == nil || entity.EntityType != "anthropic.compliance_organization_setting" || entity.Attributes["control_type"] != "setting" {
 		t.Fatalf("anthropic setting entity missing or wrong: %#v", entity)
+	}
+	if entity := state.entities[anthropicUnstableSettingURN]; entity != nil {
+		t.Fatalf("anthropic setting projected unstable dual-org URN: %#v", entity)
+	}
+	if entity := state.entities[openAIDataRetentionURN]; entity == nil || entity.EntityType != "openai.data_retention" || entity.Attributes["control_type"] != "data_retention" {
+		t.Fatalf("openai data retention entity missing or wrong: %#v", entity)
+	}
+	if entity := state.entities[openAIUnstableDataRetentionURN]; entity != nil {
+		t.Fatalf("openai data retention projected unstable dual-org URN: %#v", entity)
 	}
 	assertProjectedLink(t, state, openAIControlURN, relationBelongsTo, openAIProjectURN)
 	assertProjectedLink(t, state, openAIControlURN, relationAssociatedWith, openAIModelURN)
@@ -786,6 +877,18 @@ func TestProjectAnthropicComplianceDirectoryGroupMembership(t *testing.T) {
 			},
 		},
 		{
+			Id:         "anthropic-compliance-role-permission-sparse",
+			TenantId:   "writer",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.compliance_role_permission",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"family":            "compliance_role_permission",
+				"organization_uuid": "org-uuid-1",
+				"role_id":           "rbac_role_123",
+			},
+		},
+		{
 			Id:         "anthropic-compliance-role",
 			TenantId:   "writer",
 			SourceId:   "anthropic",
@@ -810,6 +913,7 @@ func TestProjectAnthropicComplianceDirectoryGroupMembership(t *testing.T) {
 	groupURN := "urn:cerebro:writer:anthropic_group:rbac_group_123"
 	roleURN := "urn:cerebro:writer:anthropic_role:organization:rbac_role_123"
 	entitlementURN := "urn:cerebro:writer:anthropic_entitlement:role_permission:rbac_role_123:perm_read_chats"
+	sparseEntitlementURN := "urn:cerebro:writer:anthropic_entitlement:role_permission:rbac_role_123:anthropic-compliance-role-permission-sparse"
 	capabilityURN := "urn:cerebro:writer:privileged_capability:ai_data_read"
 	orgURN := "urn:cerebro:writer:anthropic_org:org-uuid-1"
 	identityURN := "urn:cerebro:writer:identity:email:carol@example.com"
@@ -822,6 +926,9 @@ func TestProjectAnthropicComplianceDirectoryGroupMembership(t *testing.T) {
 	}
 	if entity := state.entities[entitlementURN]; entity == nil || entity.EntityType != "anthropic.entitlement" || entity.Label != "Read chats" || entity.Attributes["permission_id"] != "perm_read_chats" {
 		t.Fatalf("entitlement entity missing or wrong: %#v", entity)
+	}
+	if entity := state.entities[sparseEntitlementURN]; entity != nil {
+		t.Fatalf("sparse role permission projected unstable entitlement: %#v", entity)
 	}
 	assertProjectedLink(t, state, groupURN, relationBelongsTo, orgURN)
 	assertProjectedLink(t, state, roleURN, relationBelongsTo, orgURN)

--- a/sources/anthropic/catalog.yaml
+++ b/sources/anthropic/catalog.yaml
@@ -197,6 +197,7 @@ event_contracts:
   - kind: anthropic.compliance_role_permission
     schema_ref: anthropic/compliance_role_permission/v1
     required_attributes: [organization_uuid, role_id, permission_id]
+    required_payload_fields: [id]
   - kind: anthropic.compliance_group
     schema_ref: anthropic/compliance_group/v1
     required_attributes: [group_id]

--- a/sources/anthropic/source.go
+++ b/sources/anthropic/source.go
@@ -234,8 +234,8 @@ func projectCollaboratorAttributes() map[string]string {
 		"organization_id":   "organization.id|organization_id",
 		"organization_uuid": "organization.uuid|organization_uuid|organization.id|organization_id",
 		"role_id":           "role.id|role_id|role",
-		"role":              "role.name|role|role_id",
-		"role_name":         "role.name|role_name|role",
+		"role":              "role.name|role.id|role_id",
+		"role_name":         "role.name|role_name|role.id|role_id",
 		"created_at":        "created_at",
 		"updated_at":        "updated_at",
 	}

--- a/sources/anthropic/source_test.go
+++ b/sources/anthropic/source_test.go
@@ -605,6 +605,19 @@ func TestReadComplianceProjectCollaboratorsUsesProjectPathAndPageCursor(t *testi
 	if second.NextCursor != nil {
 		t.Fatalf("second NextCursor = %#v, want nil", second.NextCursor)
 	}
+	if len(second.Events) != 1 {
+		t.Fatalf("len(second.Events) = %d, want 1", len(second.Events))
+	}
+	secondEvent := second.Events[0]
+	if got := secondEvent.Attributes["role_id"]; got != "project_viewer" {
+		t.Fatalf("second role_id = %q, want project_viewer", got)
+	}
+	if got := secondEvent.Attributes["role"]; got != "project_viewer" {
+		t.Fatalf("second role = %q, want project_viewer", got)
+	}
+	if got := secondEvent.Attributes["role_name"]; got != "project_viewer" {
+		t.Fatalf("second role_name = %q, want project_viewer", got)
+	}
 }
 
 func TestReadComplianceOrganizationSettingsUsesSettingsListKey(t *testing.T) {


### PR DESCRIPTION
## Summary
- keep accepted OpenAI/Anthropic invites active for access-intent edges
- project role-assignment audit events to both resource and principal targets
- avoid copying actor owner attributes onto target credential entities
- skip sparse role-permission records instead of event-id fallback URNs
- stabilize org-scoped governance control IDs when both org identifiers are present
- fix Anthropic project collaborator role fallback extraction and role-permission contract requirements

## Verification
- go test ./internal/sourceprojection
- go test ./sources/anthropic
- go test ./...
- make lint
- make check-structural
- make check-arch
- ./scripts/pre_commit_checks.sh