### PR TITLE
Fix remaining Droid feedback

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -204,7 +204,6 @@ func runtimeTelemetryMetadataFromEnv() telemetry.RuntimeMetadata {
 		DeploymentEnvironment: firstNonEmptyString(
 			os.Getenv("CEREBRO_DEPLOYMENT_ENVIRONMENT"),
 			os.Getenv("CEREBRO_ENVIRONMENT"),
-			os.Getenv("OTEL_ENVIRONMENT_NAME"),
 			os.Getenv("ENVIRONMENT"),
 			os.Getenv("APP_ENV"),
 		),

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -4917,10 +4918,10 @@ func TestGraphIngestEndpoints(t *testing.T) {
 }
 
 func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
-	var sawAuth bool
+	var sawAuth atomic.Bool
 	archetypeAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "Bearer test-token" {
-			sawAuth = true
+			sawAuth.Store(true)
 		}
 		switch r.URL.Path {
 		case "/api/v1/scans":
@@ -5013,7 +5014,7 @@ func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
 	if got := ingestPayload["links_projected"]; got != float64(5) {
 		t.Fatalf("links_projected = %#v, want 5", got)
 	}
-	if !sawAuth {
+	if !sawAuth.Load() {
 		t.Fatal("Archetype API did not receive bearer token")
 	}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -136,18 +136,18 @@ func RuntimeAttributesFor(metadata RuntimeMetadata) Attributes {
 		"unknown",
 	)
 	cloudRegion := firstNonEmpty(
-		resourceAttributes["cloud.region"],
 		metadata.CloudRegion,
+		resourceAttributes["cloud.region"],
 	)
 	cloudProvider := firstNonEmpty(
-		resourceAttributes["cloud.provider"],
 		metadata.CloudProvider,
-		inferredCloudProvider(metadata, cloudRegion),
+		inferredCloudProvider(metadata),
+		resourceAttributes["cloud.provider"],
 		"unknown",
 	)
 	containerID := firstNonEmpty(
-		resourceAttributes["container.id"],
 		metadata.ContainerID,
+		resourceAttributes["container.id"],
 		hostname,
 	)
 	attributes := resourceAttributesToTelemetry(resourceAttributes)
@@ -262,8 +262,8 @@ func resourceAttributesToTelemetry(values map[string]string) Attributes {
 	return attributes
 }
 
-func inferredCloudProvider(metadata RuntimeMetadata, region string) string {
-	if strings.TrimSpace(region) != "" || strings.TrimSpace(metadata.ECSContainerMetadataURI) != "" || strings.Contains(strings.ToLower(strings.TrimSpace(metadata.AWSExecutionEnvironment)), "aws") {
+func inferredCloudProvider(metadata RuntimeMetadata) string {
+	if strings.TrimSpace(metadata.CloudRegion) != "" || strings.TrimSpace(metadata.ECSContainerMetadataURI) != "" || strings.Contains(strings.ToLower(strings.TrimSpace(metadata.AWSExecutionEnvironment)), "aws") {
 		return "aws"
 	}
 	return ""

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -207,7 +207,7 @@ func TestRuntimeAttributesUseECSAndOTELResourceEnvironment(t *testing.T) {
 		DeploymentEnvironment: "sec-dev",
 		CloudRegion:           "us-east-1",
 		ContainerID:           "task-hostname",
-		ResourceAttributes:    "service.namespace=cerebro,cloud.availability_zone=us-east-1a,deployment.environment.name=ignored-by-cerebro-env",
+		ResourceAttributes:    "service.namespace=cerebro,cloud.provider=gcp,cloud.region=europe-west1,cloud.availability_zone=us-east-1a,container.id=otel-container,deployment.environment.name=ignored-by-cerebro-env",
 	})
 	t.Cleanup(func() {
 		ConfigureRuntimeMetadata(previous)
@@ -227,6 +227,31 @@ func TestRuntimeAttributesUseECSAndOTELResourceEnvironment(t *testing.T) {
 		"cloud.region":                "us-east-1",
 		"cloud.availability_zone":     "us-east-1a",
 		"container.id":                "task-hostname",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+}
+
+func TestRuntimeAttributesDoNotInferAWSFromOTELCloudRegion(t *testing.T) {
+	previous := configuredRuntimeMetadata()
+	ConfigureRuntimeMetadata(RuntimeMetadata{
+		ResourceAttributes: "cloud.region=europe-west1,container.id=otel-container",
+	})
+	t.Cleanup(func() {
+		ConfigureRuntimeMetadata(previous)
+	})
+
+	_, stderr := captureOutput(t, func() {
+		_, span := StartMain(context.Background(), "test.runtime.otel-region", Attrs())
+		End(span, "completed", Attrs())
+	})
+	payload := telemetryPayloadByKindAndName(t, stderr, "span_end", "test.runtime.otel-region")
+	for key, want := range map[string]any{
+		"cloud.provider": "unknown",
+		"cloud.region":   "europe-west1",
+		"container.id":   "otel-container",
 	} {
 		if got := payload[key]; got != want {
 			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)

--- a/sources/internal/oktaasset/asset.go
+++ b/sources/internal/oktaasset/asset.go
@@ -292,6 +292,7 @@ func apiTokenAttributes(settings Settings, record Record) map[string]string {
 
 func authorizationServerAttributes(settings Settings, record Record) map[string]string {
 	signing := nestedMap(record.mapValue("credentials"), "signing")
+	metadataLink := nestedMap(record.mapValue("_links"), "metadata")
 	audiences := nonEmptyAnyStrings(record.anySlice("audiences"))
 	attrs := map[string]string{
 		"audience_count":          strconv.Itoa(len(audiences)),
@@ -304,7 +305,7 @@ func authorizationServerAttributes(settings Settings, record Record) map[string]
 		"issuer":                  record.String("issuer"),
 		"issuer_host":             urlHost(record.String("issuer")),
 		"issuer_mode":             record.String("issuerMode"),
-		"jwks_uri_host":           urlHost(record.String("jwks_uri")),
+		"jwks_uri_host":           urlHost(firstNonEmpty(record.String("jwks_uri"), stringMap(metadataLink, "href"))),
 		"kid":                     stringMap(signing, "kid"),
 		"last_updated_at":         record.String("lastUpdated"),
 		"name":                    record.String("name"),

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -946,6 +946,12 @@ func TestReadLiveOktaIdentityJoinFamilies(t *testing.T) {
 			want:   "login.example.com",
 		},
 		{
+			family: "authorization_server",
+			kind:   "okta.authorization_server",
+			attr:   "jwks_uri_host",
+			want:   "login.example.com",
+		},
+		{
 			family: "brand",
 			kind:   "okta.brand",
 			attr:   "custom_privacy_policy_host",
@@ -1952,6 +1958,11 @@ func newOktaAPIHandler(t *testing.T) http.Handler {
 		"created":     "2026-04-20T00:00:00Z",
 		"lastUpdated": "2026-04-23T00:00:00Z",
 		"credentials": map[string]any{"signing": map[string]any{"kid": "kid-1", "rotationMode": "AUTO", "lastRotated": "2026-04-20T00:00:00Z"}},
+		"_links": map[string]any{
+			"metadata": map[string]any{
+				"href": "https://login.example.com/oauth2/aus-api/.well-known/openid-configuration",
+			},
+		},
 	}}
 	brandRecords := []map[string]any{{
 		"id":                     "brand-prod",

--- a/sources/okta/testdata/read_authorization_server.json
+++ b/sources/okta/testdata/read_authorization_server.json
@@ -22,6 +22,7 @@
       "issuer": "https://login.example.com/oauth2/aus-api",
       "issuer_host": "login.example.com",
       "issuer_mode": "CUSTOM_URL",
+      "jwks_uri_host": "login.example.com",
       "kid": "kid-1",
       "last_updated_at": "2026-04-23T00:00:00Z",
       "name": "API Gateway",


### PR DESCRIPTION
## Summary
- fix runtime telemetry precedence so ECS/AWS metadata wins over conflicting OTEL resource attrs
- stop inferring AWS provider from OTEL-only cloud.region and remove nonstandard OTEL_ENVIRONMENT_NAME
- remove the Archetype graph-ingest test race with atomic.Bool
- derive Okta authorization-server JWKS host from the metadata link and cover it in fixtures

## Verification
- go test ./internal/telemetry ./cmd/cerebro
- go test ./sources/internal/oktaasset ./sources/okta
- go test ./internal/bootstrap
- go test -race ./internal/bootstrap -run TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd -count=1
- go test ./...
- make lint
- make check-structural
- make check-arch
- ./scripts/pre_commit_checks.sh