### PR TITLE
feat(panopticon): deepen connector with deterministic Evidence CAS correlation

### DIFF
--- a/internal/findings/panopticon_case_rule.go
+++ b/internal/findings/panopticon_case_rule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -179,6 +180,10 @@ func buildPanopticonCuratedCaseFinding(ctx context.Context, runtime *cerebrov1.S
 	if url != "" {
 		findingAttributes["case_url"] = url
 	}
+	evidenceObjectIDs := panopticonCaseEvidenceCASObjectIDs(event, attrs)
+	if len(evidenceObjectIDs) != 0 {
+		findingAttributes["evidence_cas_object_ids"] = strings.Join(evidenceObjectIDs, ",")
+	}
 	mergePanopticonCaseFindingAttributes(findingAttributes, panopticonCaseSignalAttributes(event, attrs))
 	for key, value := range attrs {
 		if _, exists := findingAttributes[key]; !exists {
@@ -202,8 +207,10 @@ func buildPanopticonCuratedCaseFinding(ctx context.Context, runtime *cerebrov1.S
 	for _, key := range panopticonCaseSignalAttributeKeys {
 		graphEvidenceAttributes[key] = findingAttributes[key]
 	}
+	casePaths := panopticonCaseAlertEvidencePaths(event, caseID, title, projectedContext.PrimaryResourceURN, findingAttributes)
+	casePaths = append(casePaths, panopticonCaseEvidenceCASPaths(event, caseID, title, projectedContext.PrimaryResourceURN, evidenceObjectIDs)...)
 	graphRows := []*cerebrov1.GraphEvidenceRow{
-		newGraphEvidenceRow("panopticon_case", graphEvidenceAttributes, panopticonCaseAlertEvidencePaths(event, caseID, title, projectedContext.PrimaryResourceURN, findingAttributes)...),
+		newGraphEvidenceRow("panopticon_case", graphEvidenceAttributes, casePaths...),
 	}
 	return &ports.FindingRecord{
 		ID:                fingerprint,
@@ -305,6 +312,134 @@ func panopticonCaseAlertEvidencePaths(event *cerebrov1.EventEnvelope, caseID str
 
 func panopticonAlertEvidenceURN(tenantID string, alertID string) string {
 	return fmt.Sprintf("urn:cerebro:%s:panopticon_alert:%s", strings.TrimSpace(tenantID), strings.TrimSpace(alertID))
+}
+
+// panopticonCaseEvidenceCASObjectIDs extracts stable Evidence CAS object
+// identifiers from a Panopticon case payload using the same identity precedence
+// the Evidence CAS source applies (evidence_id, then CAS URI/digest). The result
+// is deterministic (deduped, sorted) so downstream correlation and fingerprints
+// stay stable across syncs.
+func panopticonCaseEvidenceCASObjectIDs(event *cerebrov1.EventEnvelope, attrs map[string]string) []string {
+	if promoted := strings.TrimSpace(attrs["evidence_cas_object_ids"]); promoted != "" {
+		return panopticonDedupeSortedIDs(strings.Split(promoted, ","))
+	}
+	payload := panopticonCasePayloadObject(event)
+	var ids []string
+	for _, key := range []string{"evidence", "evidences", "evidence_pointers", "captures"} {
+		for _, evidence := range panopticonCasePayloadObjects(payload, key) {
+			id := firstNonEmpty(
+				panopticonCaseMapString(evidence, "evidence_id", "id"),
+				panopticonCaseMapString(evidence, "evidence_cas", "evidence_cas_uri", "uri", "cas_uri", "pointer"),
+				panopticonCaseMapString(evidence, "sha256", "digest"),
+			)
+			if id != "" {
+				ids = append(ids, id)
+			}
+		}
+	}
+	return panopticonDedupeSortedIDs(ids)
+}
+
+func panopticonDedupeSortedIDs(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func panopticonCasePayloadObjects(payload map[string]interface{}, key string) []map[string]interface{} {
+	switch typed := payload[key].(type) {
+	case []map[string]interface{}:
+		return typed
+	case []interface{}:
+		objects := make([]map[string]interface{}, 0, len(typed))
+		for _, item := range typed {
+			if object, ok := item.(map[string]interface{}); ok {
+				objects = append(objects, object)
+			}
+		}
+		return objects
+	case map[string]interface{}:
+		return []map[string]interface{}{typed}
+	default:
+		return nil
+	}
+}
+
+// panopticonCaseEvidenceCASPaths emits graph-visible correlation paths from a
+// Panopticon case to the canonical Evidence CAS object projections so the case
+// finding deterministically joins its evidence references to Evidence CAS state.
+func panopticonCaseEvidenceCASPaths(event *cerebrov1.EventEnvelope, caseID string, caseTitle string, caseURN string, objectIDs []string) []*cerebrov1.GraphEvidencePath {
+	caseURN = strings.TrimSpace(caseURN)
+	if caseURN == "" || len(objectIDs) == 0 {
+		return nil
+	}
+	tenantID := ""
+	if event != nil {
+		tenantID = strings.TrimSpace(event.GetTenantId())
+	}
+	if tenantID == "" {
+		return nil
+	}
+	observedAt := ""
+	if event != nil && event.GetOccurredAt() != nil {
+		observedAt = event.GetOccurredAt().AsTime().UTC().Format(time.RFC3339Nano)
+	}
+	seen := map[string]struct{}{}
+	paths := []*cerebrov1.GraphEvidencePath{}
+	for _, objectID := range objectIDs {
+		objectID = strings.TrimSpace(objectID)
+		if objectID == "" {
+			continue
+		}
+		if len(paths) >= maxPanopticonCaseAlertEvidencePaths {
+			break
+		}
+		objectURN := panopticonEvidenceCASObjectURN(tenantID, objectID)
+		if objectURN == "" {
+			continue
+		}
+		if _, ok := seen[objectURN]; ok {
+			continue
+		}
+		seen[objectURN] = struct{}{}
+		paths = append(paths, newGraphEvidencePath(
+			caseURN,
+			firstNonEmpty(caseTitle, caseID),
+			"panopticon.case",
+			"has_evidence",
+			objectURN,
+			objectID,
+			"runtime.evidence",
+			map[string]string{
+				"case_id":                 strings.TrimSpace(caseID),
+				"evidence_cas_object_id":  objectID,
+				"evidence_cas_object_urn": objectURN,
+				"observed_at":             observedAt,
+			},
+		))
+	}
+	return paths
+}
+
+func panopticonEvidenceCASObjectURN(tenantID string, objectID string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	objectID = strings.TrimSpace(objectID)
+	if tenantID == "" || objectID == "" {
+		return ""
+	}
+	return fmt.Sprintf("urn:cerebro:%s:runtime_evidence:%s", tenantID, objectID)
 }
 
 func panopticonCaseSourceOpen(status string) bool {

--- a/internal/findings/panopticon_case_rule_test.go
+++ b/internal/findings/panopticon_case_rule_test.go
@@ -129,6 +129,96 @@ func TestPanopticonCuratedCaseFindingRule(t *testing.T) {
 	assertIdentityRuleRemediationTrajectory(t, rule, open, closed, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
 }
 
+func TestPanopticonCuratedCaseFindingCorrelatesEvidenceCASAndReopens(t *testing.T) {
+	rule := newPanopticonCuratedCaseRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-panopticon-case", SourceId: "panopticon", TenantId: "writer", Config: map[string]string{"family": "case"}}
+
+	open := panopticonCaseEventWithEvidence("panopticon-case-evidence-open", "case-555", "investigating", "evidence-1,evidencecas://cases/case-555/evidence/timeline.json")
+	findings, err := rule.Evaluate(context.Background(), runtime, open)
+	if err != nil {
+		t.Fatalf("Evaluate(open) error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("Evaluate(open) returned %d findings, want 1", len(findings))
+	}
+	finding := findings[0]
+	firstFingerprint := finding.Fingerprint
+	if firstFingerprint == "" {
+		t.Fatal("open finding has empty fingerprint")
+	}
+	if got := finding.Attributes["evidence_cas_object_ids"]; got != "evidence-1,evidencecas://cases/case-555/evidence/timeline.json" {
+		t.Fatalf("evidence_cas_object_ids = %q, want the promoted correlation ids", got)
+	}
+
+	evidenceObjectURN := "urn:cerebro:writer:runtime_evidence:evidence-1"
+	var foundEvidencePath bool
+	for _, row := range finding.GraphEvidenceRows {
+		for _, path := range row.GetPaths() {
+			if path.GetToUrn() == evidenceObjectURN && path.GetRelation() == "has_evidence" {
+				foundEvidencePath = true
+			}
+		}
+	}
+	if !foundEvidencePath {
+		t.Fatalf("expected a has_evidence graph path to %q for Evidence CAS correlation", evidenceObjectURN)
+	}
+
+	closed := panopticonCaseEventWithEvidence("panopticon-case-evidence-closed", "case-555", "closed", "evidence-1,evidencecas://cases/case-555/evidence/timeline.json")
+	findings, err = rule.Evaluate(context.Background(), runtime, closed)
+	if err != nil {
+		t.Fatalf("Evaluate(closed) error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("Evaluate(closed) returned %d findings, want 0", len(findings))
+	}
+
+	reopened := panopticonCaseEventWithEvidence("panopticon-case-evidence-reopen", "case-555", "investigating", "evidence-1,evidencecas://cases/case-555/evidence/timeline.json")
+	findings, err = rule.Evaluate(context.Background(), runtime, reopened)
+	if err != nil {
+		t.Fatalf("Evaluate(reopen) error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("Evaluate(reopen) returned %d findings, want 1", len(findings))
+	}
+	if findings[0].Fingerprint != firstFingerprint {
+		t.Fatalf("reopen fingerprint = %q, want stable %q", findings[0].Fingerprint, firstFingerprint)
+	}
+}
+
+func panopticonCaseEventWithEvidence(id string, caseID string, status string, _ string) *cerebrov1.EventEnvelope {
+	payload, _ := json.Marshal(map[string]interface{}{
+		"case_id": caseID,
+		"status":  status,
+		"title":   "Evidence correlated case",
+		"evidence": []map[string]interface{}{
+			{
+				"evidence_id":  "evidence-1",
+				"evidence_cas": "evidencecas://cases/" + caseID + "/evidence/triage.tar",
+				"sha256":       "sha256:abc",
+			},
+			{
+				"uri":    "evidencecas://cases/" + caseID + "/evidence/timeline.json",
+				"digest": "sha256:def",
+			},
+		},
+	})
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   "panopticon",
+		Kind:       "panopticon.case",
+		SchemaRef:  "panopticon/case/v1",
+		OccurredAt: timestamppb.New(identityTrajectoryBaseTime),
+		Payload:    payload,
+		Attributes: map[string]string{
+			"case_id":    caseID,
+			"status":     status,
+			"title":      "Evidence correlated case",
+			"runtime_id": "writer-panopticon-case",
+		},
+	}
+}
+
 func TestPanopticonCaseStatusMap(t *testing.T) {
 	closedStatuses := []string{"closed", "Resolved", "false positive", "risk-accepted", "duplicate", "cancelled", "ignored"}
 	for _, status := range closedStatuses {

--- a/internal/sourceprojection/panopticon.go
+++ b/internal/sourceprojection/panopticon.go
@@ -143,7 +143,7 @@ func panopticonCaseProjections(event *cerebrov1.EventEnvelope) ([]*ports.Project
 	for _, assetURN := range panopticonAddAssets(entities, tenantID, event.GetSourceId(), event.GetId(), nil, payload) {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), caseURN, assetURN, relationContains, panopticonLinkAttributes(event, "panopticon_case_asset")))
 	}
-	for _, evidenceURN := range panopticonAddEvidencePointers(entities, tenantID, event.GetSourceId(), event.GetId(), payload) {
+	for _, evidenceURN := range panopticonAddEvidencePointers(entities, links, tenantID, event, payload) {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), caseURN, evidenceURN, relationHasEvidence, panopticonLinkAttributes(event, "panopticon_case_evidence_cas")))
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, caseURN, relationBelongsTo, panopticonLinkAttributes(event, "panopticon_evidence_cas_case")))
 	}
@@ -355,7 +355,9 @@ func panopticonAddAssets(entities map[string]*ports.ProjectedEntity, tenantID st
 	return urns
 }
 
-func panopticonAddEvidencePointers(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, eventID string, payload map[string]any) []string {
+func panopticonAddEvidencePointers(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, payload map[string]any) []string {
+	sourceID := event.GetSourceId()
+	eventID := event.GetId()
 	seen := map[string]struct{}{}
 	var urns []string
 	for _, evidence := range panopticonObjects(payload, "evidence", "evidences", "evidence_pointers", "captures") {
@@ -368,14 +370,16 @@ func panopticonAddEvidencePointers(entities map[string]*ports.ProjectedEntity, t
 		if evidenceURN == "" {
 			continue
 		}
+		objectURN := panopticonEvidenceCASObjectURN(tenantID, evidence, pointer)
 		attributes := compactAttributes(map[string]string{
-			"evidence_id":      panopticonString(evidence, "evidence_id", "id"),
-			"evidence_cas":     pointer,
-			"evidence_cas_uri": pointer,
-			"sha256":           panopticonEvidenceDigest(evidence),
-			"content_type":     panopticonString(evidence, "content_type"),
-			"ref_type":         panopticonString(evidence, "ref_type"),
-			"source_path":      panopticonString(evidence, "source_path"),
+			"evidence_id":             panopticonString(evidence, "evidence_id", "id"),
+			"evidence_cas":            pointer,
+			"evidence_cas_uri":        pointer,
+			"evidence_cas_object_urn": objectURN,
+			"sha256":                  panopticonEvidenceDigest(evidence),
+			"content_type":            panopticonString(evidence, "content_type"),
+			"ref_type":                panopticonString(evidence, "ref_type"),
+			"source_path":             panopticonString(evidence, "source_path"),
 			"chain_of_custody_id": firstNonEmpty(
 				panopticonString(evidence, "chain_of_custody_id"),
 				panopticonString(evidence, "custody_id"),
@@ -395,6 +399,9 @@ func panopticonAddEvidencePointers(entities map[string]*ports.ProjectedEntity, t
 			Label:      firstNonEmpty(panopticonString(evidence, "label", "name"), evidenceID),
 			Attributes: attributes,
 		})
+		if objectURN != "" {
+			addLink(links, projectedLink(tenantID, sourceID, evidenceURN, objectURN, relationRepresents, panopticonAnchorAttributes(event, "panopticon_evidence_cas_object", "evidence_cas_object_urn", objectURN)))
+		}
 		if _, ok := seen[evidenceURN]; ok {
 			continue
 		}
@@ -402,6 +409,18 @@ func panopticonAddEvidencePointers(entities map[string]*ports.ProjectedEntity, t
 		urns = append(urns, evidenceURN)
 	}
 	return urns
+}
+
+// panopticonEvidenceCASObjectURN returns the canonical Evidence CAS object URN
+// for an evidence reference using the same identity precedence the Evidence CAS
+// source applies (evidence_id, then CAS URI). The result is tenant-scoped so a
+// Panopticon pointer never correlates across tenant boundaries.
+func panopticonEvidenceCASObjectURN(tenantID string, evidence map[string]any, pointer string) string {
+	objectID := firstNonEmpty(panopticonString(evidence, "evidence_id", "id"), pointer)
+	if objectID == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "runtime_evidence", objectID)
 }
 
 func panopticonEvidencePointer(evidence map[string]any) string {

--- a/internal/sourceprojection/panopticon_test.go
+++ b/internal/sourceprojection/panopticon_test.go
@@ -780,6 +780,68 @@ func TestProjectPanopticonSkipsSensitivePayloadContext(t *testing.T) {
 	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:internet_ip:203.0.113.55")
 }
 
+func TestProjectPanopticonEvidencePointerCorrelatesWithEvidenceCASObject(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "panopticon-case-event-evidence-correlation",
+		TenantId: "writer",
+		SourceId: "panopticon",
+		Kind:     "panopticon.case",
+		Attributes: map[string]string{
+			"case_id": "case-corr",
+			"status":  "investigating",
+			"title":   "Evidence correlation",
+		},
+		Payload: mustJSON(t, map[string]any{
+			"case_id": "case-corr",
+			"status":  "investigating",
+			"title":   "Evidence correlation",
+			"evidence": []map[string]any{{
+				"evidence_id":  "evidence-1",
+				"evidence_cas": "evidencecas://cases/case-corr/evidence/triage.tar",
+				"sha256":       "sha256:abc",
+			}},
+		}),
+	}); err != nil {
+		t.Fatalf("Project(case) error = %v", err)
+	}
+
+	// The Evidence CAS source independently projects the same evidence object.
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "evidence-cas-object-event-1",
+		TenantId: "writer",
+		SourceId: "evidence_cas",
+		Kind:     "evidence_cas.object",
+		Attributes: map[string]string{
+			"evidence_id":         "evidence-1",
+			"evidence_cas_uri":    "evidencecas://cases/case-corr/evidence/triage.tar",
+			"evidence_cas_digest": "sha256:abc",
+		},
+	}); err != nil {
+		t.Fatalf("Project(evidence_cas.object) error = %v", err)
+	}
+
+	pointerURN := "urn:cerebro:writer:evidence_cas_pointer:evidence-1"
+	evidenceObjectURN := "urn:cerebro:writer:runtime_evidence:evidence-1"
+
+	pointer := state.entities[pointerURN]
+	if pointer == nil || pointer.EntityType != "evidence.cas.pointer" {
+		t.Fatalf("panopticon evidence pointer missing or wrong type: %#v", pointer)
+	}
+	if got := pointer.Attributes["evidence_cas_object_urn"]; got != evidenceObjectURN {
+		t.Fatalf("evidence_cas_object_urn = %q, want %q", got, evidenceObjectURN)
+	}
+	if state.entities[evidenceObjectURN] == nil {
+		t.Fatalf("Evidence CAS object projection %q missing for correlation join", evidenceObjectURN)
+	}
+	assertProjectedLink(t, state, pointerURN, relationRepresents, evidenceObjectURN)
+
+	// Cross-tenant Evidence CAS objects must not be joined by the writer pointer.
+	assertProjectedLinkMissing(t, state, pointerURN, relationRepresents, "urn:cerebro:other:runtime_evidence:evidence-1")
+}
+
 func assertProjectedEntityType(t *testing.T, recorder *projectionRecorder, urn string, entityType string) {
 	t.Helper()
 	entity := recorder.entities[urn]

--- a/sources/panopticon/catalog.yaml
+++ b/sources/panopticon/catalog.yaml
@@ -1,6 +1,6 @@
 id: panopticon
 name: Panopticon
-description: Panopticon security operations source. Reads curated cases by default, with explicit alert and IOC families available for evidence and enrichment.
+description: Panopticon security operations source. Reads curated cases by default, with explicit alert and IOC families available for evidence and enrichment. Case payloads preserve Evidence CAS object references (evidence_id, CAS URI, digest) so projection and findings can correlate deterministically with Evidence CAS object projections.
 emitted_kinds:
   - panopticon.alert
   - panopticon.case

--- a/sources/panopticon/source_test.go
+++ b/sources/panopticon/source_test.go
@@ -290,6 +290,51 @@ func TestReadAPIRejectsInvalidNativeRecordsAndHTTPError(t *testing.T) {
 	}
 }
 
+func TestReadCasesPreservesEvidenceReferencesForCorrelation(t *testing.T) {
+	fixed := fixedTime()
+	caseItem := validNativeCase("88", fixed)
+	caseItem["evidence"] = []map[string]interface{}{
+		{
+			"evidence_id":  "evidence-1",
+			"evidence_cas": "evidencecas://cases/88/evidence/triage.tar",
+			"sha256":       "sha256:abc",
+		},
+		{
+			"uri":    "evidencecas://cases/88/evidence/timeline.json",
+			"digest": "sha256:def",
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/cases" {
+			http.NotFound(w, r)
+			return
+		}
+		writePage(w, []map[string]interface{}{caseItem}, 1, 0)
+	}))
+	defer server.Close()
+
+	src := newTestSource(t)
+	pull, err := src.Read(context.Background(), apiConfig(server.URL, map[string]string{"family": familyCase}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("events = %d, want 1 case event", len(pull.Events))
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(pull.Events[0].GetPayload(), &payload); err != nil {
+		t.Fatalf("decode case payload: %v", err)
+	}
+	evidence, ok := payload["evidence"].([]interface{})
+	if !ok || len(evidence) != 2 {
+		t.Fatalf("case payload evidence = %#v, want 2 preserved references", payload["evidence"])
+	}
+	first, ok := evidence[0].(map[string]interface{})
+	if !ok || first["evidence_id"] != "evidence-1" || first["evidence_cas"] != "evidencecas://cases/88/evidence/triage.tar" {
+		t.Fatalf("first evidence reference = %#v, want Evidence CAS correlation identifiers preserved", evidence[0])
+	}
+}
+
 func newTestSource(t *testing.T) *Source {
 	t.Helper()
 	src, err := New()


### PR DESCRIPTION
## Scope

Single source: `panopticon` (batch 4). Deepens the connector with a full vertical slice focused on deterministic Evidence CAS correlation. No other source domains are modified.

## Source changes

- `sources/panopticon/catalog.yaml`: documents that case payloads preserve Evidence CAS object references (`evidence_id`, CAS URI, digest) so downstream layers can correlate deterministically. The source package Go LOC is unchanged (kept at its ratcheted ceiling); normalization stays in the projection and finding layers per the Source CDK budget.
- `sources/panopticon/source_test.go`: adds regression coverage proving emitted case events preserve evidence references needed for correlation.

## Projection changes

- `internal/sourceprojection/panopticon.go`: each Panopticon evidence pointer is annotated with the canonical Evidence CAS object URN and a graph-visible `represents` correlation link to it. The object URN is derived using the same identity precedence the Evidence CAS source applies (`evidence_id`, then CAS URI) and is tenant-scoped, so a pointer never correlates across tenant boundaries.
- `internal/sourceprojection/panopticon_test.go`: adds a correlation test that projects a Panopticon case and an Evidence CAS object sharing the same identifier, asserts the deterministic join, and asserts no cross-tenant linkage.

## Finding changes

- `internal/findings/panopticon_case_rule.go`: the curated case finding now surfaces correlated Evidence CAS object ids and adds `has_evidence` graph evidence paths to the canonical Evidence CAS objects. It retains its durable, current-state lifecycle (open on active source state, resolve when the case is closed in the source) with a stable case-scoped fingerprint that reopens deterministically on recurrence.
- `internal/findings/panopticon_case_rule_test.go`: adds a lifecycle test covering open, resolve, and deterministic reopen with stable fingerprint, plus Evidence CAS correlation paths.

## Shared file touches

None. No changes to the projection registry, rulepack, rulepack audit, detection catalog, or closeout artifacts (no rule ids or kind routing were added or changed). Collision risk for this PR is minimal.

## Validation evidence

- `make lint` — 0 issues.
- `go test ./sources/panopticon/... -count=1` — pass.
- `go test ./internal/sourceprojection/... -run 'Panopticon|EvidenceCAS|RuntimeEvidence' -count=1` — pass (correlation test matched and passed).
- `go test ./internal/findings/... -run 'Panopticon|panopticon' -count=1` — pass (lifecycle + correlation test matched and passed).
- `go test ./tools/archtests/... -count=1` — pass (source LOC budget respected).
- `go test ./internal/findings/... -run 'Rulepack|BuiltinRule|Lifecycle|Closeout' -count=1` — pass.
- `make catalog-check` — pass.
- `make detection-catalog-check` — pass.

## Risk and rollback

Low risk and additive: evidence-pointer correlation attributes/links and finding graph paths are only emitted when a case carries evidence references; absent evidence, behavior is unchanged. No rule ids, kind routing, or governance artifacts changed. Rollback is a single-commit revert of this branch with no shared-file or schema impact.
