### PR TITLE
feat(trusted_endpoint): deepen connector with trust-gate posture projection and active trust-gate failure finding

### DIFF
--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -170,7 +170,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 1050 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 1051 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/internal/compliance/control_coverage_index.yaml
+++ b/internal/compliance/control_coverage_index.yaml
@@ -41682,7 +41682,7 @@ profiles:
         selected_controls: 34
         mapped_controls: 14
         unmapped_controls: 20
-        mapped_rules: 106
+        mapped_rules: 107
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 34
@@ -41778,7 +41778,7 @@ profiles:
             status: placeholder
             score: 0
           coverage_status: mapped
-          rule_count: 22
+          rule_count: 23
           mapped_rules:
             - aws-guardduty-c2-traffic
             - aws-guardduty-crypto-mining
@@ -41802,6 +41802,7 @@ profiles:
             - sentinelone-threat-detected
             - threat-intel-malicious-domain-resolution
             - threat-intel-malicious-ip-connection
+            - trusted-endpoint-active-trust-gate-failure
         - framework_name: ISO 27001:2022
           family_id: A.8
           family_name: Technology Controls
@@ -42542,6 +42543,10 @@ profiles:
           controls:
             - framework_name: ISO 27001:2022
               control_id: A.8.8
+        - rule_id: trusted-endpoint-active-trust-gate-failure
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.16
         - rule_id: vulnview-actionable-external-finding
           controls:
             - framework_name: ISO 27001:2022
@@ -61090,7 +61095,7 @@ profiles:
         selected_controls: 36
         mapped_controls: 25
         unmapped_controls: 11
-        mapped_rules: 927
+        mapped_rules: 928
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 36
@@ -61638,7 +61643,7 @@ profiles:
             status: placeholder
             score: 0
           coverage_status: mapped
-          rule_count: 432
+          rule_count: 433
           mapped_rules:
             - ai-data-governance
             - ai-model-inventory
@@ -62071,6 +62076,7 @@ profiles:
             - openai-orphaned-privileged-api-key
             - slack-privileged-user-without-mfa
             - tailscale-tailnet-device-approval-disabled
+            - trusted-endpoint-active-trust-gate-failure
             - vpc-external-peering
         - framework_name: SOC 2
           family_id: CC6
@@ -66202,6 +66208,10 @@ profiles:
           controls:
             - framework_name: SOC 2
               control_id: CC7.1
+        - rule_id: trusted-endpoint-active-trust-gate-failure
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
         - rule_id: unknown-account-trusted
           controls:
             - framework_name: SOC 2

--- a/internal/endpointtelemetry/normalizer.go
+++ b/internal/endpointtelemetry/normalizer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -130,6 +131,7 @@ func normalizeEvent(raw map[string]any, principal Principal, agentID string) (st
 		action := trustGateAction(raw, eventType)
 		decision := normalizeDecision(firstNonEmpty(firstString(raw, "decision", "verdict", "result"), decisionFromEventType(eventType)))
 		severity := normalizeSeverity(firstString(raw, "severity"))
+		lifecycle := normalizeAgentLifecycle(raw)
 		payload := map[string]any{
 			"agent_id": agentID,
 			"action":   action,
@@ -138,13 +140,18 @@ func normalizeEvent(raw map[string]any, principal Principal, agentID string) (st
 			"source":   "endpoint_telemetry",
 			"raw":      raw,
 		}
-		return "trusted_endpoint.trust_gate_decision", "trusted_endpoint/trust_gate_decision/v1", payload, map[string]string{
-			"agent_id": agentID,
-			"action":   action,
-			"decision": decision,
-			"reason":   firstString(raw, "reason", "decision_reason", "rationale"),
-			"severity": severity,
+		attrs := map[string]string{
+			"agent_id":     agentID,
+			"action":       action,
+			"decision":     decision,
+			"reason":       firstString(raw, "reason", "decision_reason", "rationale"),
+			"severity":     severity,
+			"agent_status": lifecycle,
 		}
+		if managed, ok := normalizeManagedFlag(raw); ok {
+			attrs["managed"] = strconv.FormatBool(managed)
+		}
+		return "trusted_endpoint.trust_gate_decision", "trusted_endpoint/trust_gate_decision/v1", payload, attrs
 	}
 	action := actionFromEventType(eventType)
 	outcome := outcomeFromEvent(raw, eventType)
@@ -266,6 +273,45 @@ func normalizeStatus(value string) string {
 	default:
 		return strings.ToLower(strings.TrimSpace(value))
 	}
+}
+
+// normalizeAgentLifecycle derives a deterministic agent lifecycle state from the
+// endpoint control-plane fields so downstream trust-gate findings can resolve for
+// deprovisioned/offboarded agents instead of reading inconsistent raw values.
+func normalizeAgentLifecycle(raw map[string]any) string {
+	return normalizeAgentStatus(firstString(raw, "agent_status", "device_status", "agent_state", "lifecycle", "lifecycle_state", "enrollment_status"))
+}
+
+func normalizeAgentStatus(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return ""
+	case "deprovisioned", "deleted", "removed", "offboarded", "off-boarded", "off boarded", "unenrolled", "un-enrolled", "deactivated", "inactive", "retired", "decommissioned", "disabled", "terminated", "revoked":
+		return "deprovisioned"
+	case "active", "enrolled", "managed", "enabled", "provisioned", "online":
+		return "active"
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func normalizeManagedFlag(raw map[string]any) (bool, bool) {
+	value, ok := raw["managed"]
+	if !ok {
+		return false, false
+	}
+	switch typed := value.(type) {
+	case bool:
+		return typed, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(typed)) {
+		case "1", "t", "true", "yes", "y", "enabled", "on", "active", "managed":
+			return true, true
+		case "0", "f", "false", "no", "n", "disabled", "off", "inactive", "unmanaged":
+			return false, true
+		}
+	}
+	return false, false
 }
 
 func normalizeSeverity(value string) string {

--- a/internal/endpointtelemetry/normalizer.go
+++ b/internal/endpointtelemetry/normalizer.go
@@ -23,8 +23,12 @@ type Principal struct {
 	Hostname     string
 }
 
-// Normalize converts the endpoint telemetry ingest envelope into bounded
-// source events that downstream projections can persist or replay.
+// Normalize converts the Trusted Endpoint telemetry ingest envelope into
+// bounded source events that downstream projections can persist or replay. It
+// emits the supported trusted_endpoint.* telemetry families (host posture,
+// security findings, trust-gate decisions, GRC evidence, and action outcomes)
+// and rejects malformed records that cannot satisfy the per-kind emission
+// contract.
 func Normalize(body []byte, principal Principal, observedAt time.Time) ([]*cerebrov1.EventEnvelope, error) {
 	tenantID := strings.TrimSpace(principal.TenantID)
 	if tenantID == "" {
@@ -78,17 +82,17 @@ func Normalize(body []byte, principal Principal, observedAt time.Time) ([]*cereb
 		if err := sourcecdk.ValidateEventEnvelope(envelope); err != nil {
 			return nil, err
 		}
+		if err := validateEmittedAttributes(envelope); err != nil {
+			return nil, err
+		}
 	}
 	return envelopes, nil
 }
 
 func normalizeEvent(raw map[string]any, principal Principal, agentID string) (string, string, map[string]any, map[string]string) {
 	eventType := firstString(raw, "type", "event", "action", "status")
-	action := actionFromEventType(eventType)
-	outcome := outcomeFromEvent(raw, eventType)
-	if firstString(raw, "finding_id", "findingId") != "" {
-		findingID := firstString(raw, "finding_id", "findingId")
-		severity := firstNonEmpty(firstString(raw, "severity"), "unknown")
+	if findingID := firstString(raw, "finding_id", "findingId"); findingID != "" {
+		severity := normalizeSeverity(firstString(raw, "severity"))
 		payload := map[string]any{
 			"agent_id":   agentID,
 			"device_id":  principal.DeviceID,
@@ -104,6 +108,46 @@ func normalizeEvent(raw map[string]any, principal Principal, agentID string) (st
 			"severity":   severity,
 		}
 	}
+	if controlID := firstString(raw, "control_id", "controlId"); controlID != "" {
+		status := normalizeStatus(firstString(raw, "status", "result", "state"))
+		payload := map[string]any{
+			"agent_id":   agentID,
+			"device_id":  principal.DeviceID,
+			"control_id": controlID,
+			"status":     status,
+			"framework":  firstString(raw, "framework", "control_framework"),
+			"source":     "endpoint_telemetry",
+			"raw":        raw,
+		}
+		return "trusted_endpoint.grc_evidence", "trusted_endpoint/grc_evidence/v1", payload, map[string]string{
+			"agent_id":   agentID,
+			"device_id":  principal.DeviceID,
+			"control_id": controlID,
+			"status":     status,
+		}
+	}
+	if isTrustGateEvent(raw, eventType) {
+		action := trustGateAction(raw, eventType)
+		decision := normalizeDecision(firstNonEmpty(firstString(raw, "decision", "verdict", "result"), decisionFromEventType(eventType)))
+		severity := normalizeSeverity(firstString(raw, "severity"))
+		payload := map[string]any{
+			"agent_id": agentID,
+			"action":   action,
+			"decision": decision,
+			"reason":   firstString(raw, "reason", "decision_reason", "rationale"),
+			"source":   "endpoint_telemetry",
+			"raw":      raw,
+		}
+		return "trusted_endpoint.trust_gate_decision", "trusted_endpoint/trust_gate_decision/v1", payload, map[string]string{
+			"agent_id": agentID,
+			"action":   action,
+			"decision": decision,
+			"reason":   firstString(raw, "reason", "decision_reason", "rationale"),
+			"severity": severity,
+		}
+	}
+	action := actionFromEventType(eventType)
+	outcome := outcomeFromEvent(raw, eventType)
 	payload := map[string]any{
 		"agent_id":  agentID,
 		"device_id": principal.DeviceID,
@@ -116,6 +160,31 @@ func normalizeEvent(raw map[string]any, principal Principal, agentID string) (st
 		"device_id":      principal.DeviceID,
 		"action":         action,
 		"outcome_result": outcome,
+	}
+}
+
+// validateEmittedAttributes rejects telemetry that cannot satisfy the per-kind
+// emission contract, so malformed trust-gate or GRC evidence records do not
+// enter the append log with missing posture-critical fields.
+func validateEmittedAttributes(envelope *cerebrov1.EventEnvelope) error {
+	attrs := envelope.GetAttributes()
+	requireAttrs := func(keys ...string) error {
+		for _, key := range keys {
+			if strings.TrimSpace(attrs[key]) == "" {
+				return fmt.Errorf("%s telemetry missing required attribute %q", envelope.GetKind(), key)
+			}
+		}
+		return nil
+	}
+	switch envelope.GetKind() {
+	case "trusted_endpoint.trust_gate_decision":
+		return requireAttrs("agent_id", "action", "decision")
+	case "trusted_endpoint.grc_evidence":
+		return requireAttrs("agent_id", "control_id", "status")
+	case "trusted_endpoint.security_finding":
+		return requireAttrs("agent_id", "finding_id", "severity")
+	default:
+		return nil
 	}
 }
 
@@ -145,6 +214,66 @@ func eventID(tenantID, agentID, kind string, payload []byte, index int) string {
 
 func observationTable(posture map[string]any) string {
 	return firstNonEmpty(firstString(posture, "observation_table", "type", "kind"), "secheck.posture")
+}
+
+func isTrustGateEvent(raw map[string]any, eventType string) bool {
+	if firstString(raw, "decision", "verdict") != "" {
+		return true
+	}
+	return strings.HasPrefix(strings.TrimSpace(eventType), "trust_gate")
+}
+
+func trustGateAction(raw map[string]any, eventType string) string {
+	if action := firstString(raw, "action", "gated_action", "operation"); action != "" {
+		return action
+	}
+	if _, after, ok := strings.Cut(strings.TrimSpace(eventType), "."); ok && strings.TrimSpace(after) != "" {
+		return after
+	}
+	return "trust_gate"
+}
+
+func decisionFromEventType(eventType string) string {
+	if _, after, ok := strings.Cut(strings.TrimSpace(eventType), "."); ok {
+		return strings.TrimSpace(after)
+	}
+	return ""
+}
+
+func normalizeDecision(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "deny", "denied", "block", "blocked", "fail", "failed", "reject", "rejected":
+		return "deny"
+	case "allow", "allowed", "pass", "passed", "ok", "permit", "permitted", "approved":
+		return "allow"
+	case "error", "errored":
+		return "error"
+	case "":
+		return ""
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func normalizeStatus(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "fail", "failed", "failing", "non_compliant", "noncompliant", "violation":
+		return "failing"
+	case "pass", "passed", "passing", "compliant", "ok", "success":
+		return "passing"
+	case "":
+		return ""
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func normalizeSeverity(value string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	if trimmed == "" {
+		return "unknown"
+	}
+	return trimmed
 }
 
 func actionFromEventType(eventType string) string {

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -63311,6 +63311,54 @@
       ]
     },
     {
+      "id": "trusted-endpoint-active-trust-gate-failure",
+      "pack_id": "trusted_endpoint",
+      "pack_name": "Trusted Endpoint",
+      "name": "Trusted Endpoint Active Trust-Gate Failure",
+      "description": "Detect Trusted Endpoint agents whose latest trust-gate decision denies a gated action, indicating the workstation currently fails the endpoint posture/trust checks required to perform the action until its posture is remediated.",
+      "source_id": "trusted_endpoint",
+      "evaluation_mode": "event",
+      "event_kinds": [
+        "trusted_endpoint.trust_gate_decision"
+      ],
+      "output_kind": "finding.trusted_endpoint_active_trust_gate_failure",
+      "severity": "HIGH",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "device-posture",
+        "endpoint",
+        "trust-gate",
+        "trusted-endpoint",
+        "zero-trust"
+      ],
+      "references": [
+        "https://github.com/writer/cerebro/blob/main/docs/ENDPOINT_SECURITY_PLATFORM_INTEGRATION.md"
+      ],
+      "false_positives": [
+        "A trust-gate denial issued during an approved maintenance window or risk-accepted exception that has not yet been reflected as an allow decision."
+      ],
+      "runbook": "Inspect the agent's failing endpoint posture/trust checks, remediate the underlying gap, and confirm the next trust-gate decision for the action allows it.",
+      "required_attributes": [
+        "action",
+        "agent_id",
+        "decision"
+      ],
+      "fingerprint_fields": [
+        "trusted_endpoint_gate_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC6.1"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.8.16"
+        }
+      ]
+    },
+    {
       "id": "vulnview-actionable-external-finding",
       "pack_id": "vulnview",
       "pack_name": "VulnView",

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -88,8 +88,8 @@ func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
 
 func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	packs := builtinRulePacks()
-	if got := len(packs); got != 21 {
-		t.Fatalf("len(builtinRulePacks()) = %d, want 21", got)
+	if got := len(packs); got != 22 {
+		t.Fatalf("len(builtinRulePacks()) = %d, want 22", got)
 	}
 	rules := flattenRulePacks(packs)
 	if got := len(rules); got < 10 {

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -197,6 +197,14 @@ func builtinRulePacks() []RulePack {
 			},
 		},
 		{
+			ID:          "trusted_endpoint",
+			Name:        "Trusted Endpoint",
+			Description: "Trusted Endpoint workstation posture and trust-gate findings.",
+			Rules: []Rule{
+				newTrustedEndpointActiveTrustGateFailureRule(),
+			},
+		},
+		{
 			ID:          "policy",
 			Name:        "Policy",
 			Description: "Generated compliance policy checks and evidence mappings.",

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -825,7 +825,7 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 48; got != want {
+	if got, want := len(keepRules), 49; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1060,6 +1060,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "openai-orphaned-privileged-api-key", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "openai"},
 		{RuleID: "slack-privileged-user-without-mfa", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "slack"},
 		{RuleID: "pagerduty-service-without-escalation-policy", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "pagerduty"},
+		{RuleID: "trusted-endpoint-active-trust-gate-failure", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "trusted_endpoint"},
 		{RuleID: "vulnview-actionable-external-finding", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "vulnview"},
 		{RuleID: "vulnview-external-asset-concentrated-signal", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "vulnview"},
 	}

--- a/internal/findings/testdata/rules/trusted-endpoint-active-trust-gate-failure.json
+++ b/internal/findings/testdata/rules/trusted-endpoint-active-trust-gate-failure.json
@@ -1,0 +1,83 @@
+{
+  "rule_id": "trusted-endpoint-active-trust-gate-failure",
+  "runtime": {
+    "id": "writer-trusted-endpoint",
+    "source_id": "trusted_endpoint",
+    "tenant_id": "writer"
+  },
+  "events": [
+    {
+      "id": "trusted-endpoint-gate-allow",
+      "tenant_id": "writer",
+      "source_id": "trusted_endpoint",
+      "kind": "trusted_endpoint.trust_gate_decision",
+      "occurred_at": "2026-05-01T12:00:00Z",
+      "schema_ref": "trusted_endpoint/trust_gate_decision/v1",
+      "attributes": {
+        "agent_id": "dev-compliant",
+        "action": "git_push",
+        "decision": "allow",
+        "source_runtime_id": "writer-trusted-endpoint"
+      }
+    },
+    {
+      "id": "trusted-endpoint-gate-deny",
+      "tenant_id": "writer",
+      "source_id": "trusted_endpoint",
+      "kind": "trusted_endpoint.trust_gate_decision",
+      "occurred_at": "2026-05-01T12:05:00Z",
+      "schema_ref": "trusted_endpoint/trust_gate_decision/v1",
+      "attributes": {
+        "agent_id": "dev-risky",
+        "action": "git_push",
+        "decision": "deny",
+        "reason": "posture_failed",
+        "severity": "high",
+        "source_runtime_id": "writer-trusted-endpoint"
+      }
+    },
+    {
+      "id": "trusted-endpoint-gate-deprovisioned",
+      "tenant_id": "writer",
+      "source_id": "trusted_endpoint",
+      "kind": "trusted_endpoint.trust_gate_decision",
+      "occurred_at": "2026-05-01T12:10:00Z",
+      "schema_ref": "trusted_endpoint/trust_gate_decision/v1",
+      "attributes": {
+        "agent_id": "dev-offboarded",
+        "action": "git_push",
+        "decision": "deny",
+        "agent_status": "offboarded",
+        "source_runtime_id": "writer-trusted-endpoint"
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "trusted-endpoint-active-trust-gate-failure",
+      "severity": "HIGH",
+      "status": "open",
+      "summary": "Trusted Endpoint agent dev-risky is failing the trust gate for action git_push",
+      "event_ids": ["trusted-endpoint-gate-deny"],
+      "attributes": {
+        "trusted_endpoint_gate_urn": "urn:cerebro:writer:trusted_endpoint_trust_gate:dev-risky:git_push",
+        "trusted_endpoint_agent_urn": "urn:cerebro:writer:trusted_endpoint_agent:dev-risky",
+        "agent_id": "dev-risky",
+        "action": "git_push",
+        "decision": "deny",
+        "primary_resource_urn": "urn:cerebro:writer:trusted_endpoint_agent:dev-risky",
+        "rule_required_attributes": "agent_id,action,decision"
+      }
+    }
+  ],
+  "expected_no_match": [
+    {
+      "event_id": "trusted-endpoint-gate-allow",
+      "reason": "allow decision means the agent currently passes the trust gate"
+    },
+    {
+      "event_id": "trusted-endpoint-gate-deprovisioned",
+      "reason": "deprovisioned agent must not open a stale trust-gate finding"
+    }
+  ]
+}

--- a/internal/findings/trusted_endpoint_active_trust_gate_failure_rule.go
+++ b/internal/findings/trusted_endpoint_active_trust_gate_failure_rule.go
@@ -1,0 +1,238 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	trustedEndpointActiveTrustGateFailureRuleID    = "trusted-endpoint-active-trust-gate-failure"
+	trustedEndpointActiveTrustGateFailureTitle     = "Trusted Endpoint Active Trust-Gate Failure"
+	trustedEndpointActiveTrustGateFailureCheckID   = "trusted-endpoint-active-trust-gate-failure-current"
+	trustedEndpointActiveTrustGateFailureCheckName = "Trusted Endpoint Active Trust-Gate Failure (current state)"
+	trustedEndpointTrustGateEventKind              = "trusted_endpoint.trust_gate_decision"
+)
+
+var trustedEndpointActiveTrustGateFailureControlRefs = []ports.FindingControlRef{
+	{FrameworkName: "SOC 2", ControlID: "CC6.1"},
+	{FrameworkName: "ISO 27001:2022", ControlID: "A.8.16"},
+}
+
+var trustedEndpointAgentDeprovisionedStatuses = map[string]struct{}{
+	"deleted":        {},
+	"removed":        {},
+	"offboarded":     {},
+	"unenrolled":     {},
+	"deactivated":    {},
+	"inactive":       {},
+	"retired":        {},
+	"decommissioned": {},
+}
+
+type trustedEndpointActiveTrustGateFailureRule struct {
+	Rule
+	definition RuleDefinition
+}
+
+var trustedEndpointActiveTrustGateFailureDefinition = RuleDefinition{
+	ID:                 trustedEndpointActiveTrustGateFailureRuleID,
+	Name:               trustedEndpointActiveTrustGateFailureTitle,
+	Description:        "Detect Trusted Endpoint agents whose latest trust-gate decision denies a gated action, indicating the workstation currently fails the endpoint posture/trust checks required to perform the action until its posture is remediated.",
+	SourceID:           "trusted_endpoint",
+	EventKinds:         []string{trustedEndpointTrustGateEventKind},
+	OutputKind:         "finding.trusted_endpoint_active_trust_gate_failure",
+	Severity:           "HIGH",
+	Status:             findingStatusOpen,
+	Maturity:           "test",
+	Tags:               []string{"trusted-endpoint", "endpoint", "trust-gate", "device-posture", "zero-trust"},
+	References:         []string{"https://github.com/writer/cerebro/blob/main/docs/ENDPOINT_SECURITY_PLATFORM_INTEGRATION.md"},
+	FalsePositives:     []string{"A trust-gate denial issued during an approved maintenance window or risk-accepted exception that has not yet been reflected as an allow decision."},
+	Runbook:            "Inspect the agent's failing endpoint posture/trust checks, remediate the underlying gap, and confirm the next trust-gate decision for the action allows it.",
+	RequiredAttributes: []string{"agent_id", "action", "decision"},
+	FingerprintFields:  []string{"trusted_endpoint_gate_urn"},
+	ControlRefs:        trustedEndpointActiveTrustGateFailureControlRefs,
+	Lifecycle:          Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorSourceState},
+}
+
+var trustedEndpointTrustGateKindMatcher = eventKindMatcher(trustedEndpointActiveTrustGateFailureDefinition.EventKinds...)
+
+func newTrustedEndpointActiveTrustGateFailureRule() Rule {
+	rule := newEventRule(eventRuleConfig{
+		definition: trustedEndpointActiveTrustGateFailureDefinition,
+		match:      matchesTrustedEndpointActiveTrustGateFailure,
+		build: func(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+			return trustedEndpointActiveTrustGateFailureFinding(event, runtime.GetId())
+		},
+	})
+	return &trustedEndpointActiveTrustGateFailureRule{
+		Rule:       rule,
+		definition: trustedEndpointActiveTrustGateFailureDefinition,
+	}
+}
+
+func (r *trustedEndpointActiveTrustGateFailureRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
+func (r *trustedEndpointActiveTrustGateFailureRule) OpenAnchor(attributes map[string]string) string {
+	return trustedEndpointActiveTrustGateFailureAnchor(attributes)
+}
+
+// CloseOnEvent resolves an open finding when a later trust-gate decision for the
+// same agent/action allows the action (posture remediated) or when the agent is
+// no longer managed (deprovisioned/offboarded), so resolved or removed agents do
+// not leave stale open findings.
+func (r *trustedEndpointActiveTrustGateFailureRule) CloseOnEvent(event Event) (string, bool) {
+	if !trustedEndpointTrustGateKindMatcher(event) || !hasRequiredAttributes(event, trustedEndpointActiveTrustGateFailureDefinition.RequiredAttributes...) {
+		return "", false
+	}
+	attributes := eventAttributes(event)
+	if !trustedEndpointGateRemediated(attributes) && !trustedEndpointAgentDeprovisioned(attributes) {
+		return "", false
+	}
+	gateURN := trustedEndpointTrustGateURN(event.GetTenantId(), attributes["agent_id"], attributes["action"])
+	anchor := trustedEndpointActiveTrustGateFailureAnchor(map[string]string{"trusted_endpoint_gate_urn": gateURN})
+	return anchor, anchor != ""
+}
+
+func matchesTrustedEndpointActiveTrustGateFailure(event *cerebrov1.EventEnvelope) bool {
+	if !trustedEndpointTrustGateKindMatcher(event) || !hasRequiredAttributes(event, trustedEndpointActiveTrustGateFailureDefinition.RequiredAttributes...) {
+		return false
+	}
+	return trustedEndpointGateDenied(eventAttributes(event))
+}
+
+func trustedEndpointActiveTrustGateFailureFinding(event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
+	attrs := event.GetAttributes()
+	agentID := strings.TrimSpace(attrs["agent_id"])
+	action := strings.TrimSpace(attrs["action"])
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	gateURN := trustedEndpointTrustGateURN(tenantID, agentID, action)
+	agentURN := trustedEndpointAgentURN(tenantID, agentID)
+	if gateURN == "" || agentURN == "" {
+		return nil, nil
+	}
+	decision := trustedEndpointNormalizeDecisionValue(attrs["decision"])
+	severity := firstNonEmpty(normalizeFindingSeverity(attrs["severity"]), "HIGH")
+	label := firstNonEmpty(strings.TrimSpace(attrs["hostname"]), agentID)
+	attributes := map[string]string{
+		"trusted_endpoint_gate_urn":  gateURN,
+		"trusted_endpoint_agent_urn": agentURN,
+		"agent_id":                   agentID,
+		"action":                     action,
+		"decision":                   decision,
+		"reason":                     strings.TrimSpace(attrs["reason"]),
+		"hostname":                   strings.TrimSpace(attrs["hostname"]),
+		"severity":                   severity,
+		"event_id":                   strings.TrimSpace(event.GetId()),
+		"source_runtime_id":          firstNonEmpty(strings.TrimSpace(attrs[ports.EventAttributeSourceRuntimeID]), strings.TrimSpace(runtimeID)),
+		"primary_resource_urn":       agentURN,
+	}
+	for key, value := range trustedEndpointActiveTrustGateFailureDefinition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	observedAt := time.Time{}
+	if timestamp := event.GetOccurredAt(); timestamp != nil {
+		observedAt = timestamp.AsTime().UTC()
+	}
+	fingerprint := hashFindingFingerprint(trustedEndpointActiveTrustGateFailureRuleID, gateURN)
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       strings.TrimSpace(runtimeID),
+		RuleID:          trustedEndpointActiveTrustGateFailureRuleID,
+		Title:           trustedEndpointActiveTrustGateFailureTitle,
+		Severity:        severity,
+		Status:          findingStatusOpen,
+		Summary:         trustedEndpointActiveTrustGateFailureSummary(label, action),
+		ResourceURNs:    []string{agentURN},
+		EventIDs:        []string{strings.TrimSpace(event.GetId())},
+		PolicyID:        action,
+		CheckID:         trustedEndpointActiveTrustGateFailureCheckID,
+		CheckName:       trustedEndpointActiveTrustGateFailureCheckName,
+		ControlRefs:     cloneFindingControlRefs(trustedEndpointActiveTrustGateFailureDefinition.ControlRefs),
+		Attributes:      attributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}
+
+func trustedEndpointGateDenied(attributes map[string]string) bool {
+	if trustedEndpointAgentDeprovisioned(attributes) {
+		return false
+	}
+	switch trustedEndpointNormalizeDecisionValue(attributes["decision"]) {
+	case "deny", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func trustedEndpointGateRemediated(attributes map[string]string) bool {
+	return trustedEndpointNormalizeDecisionValue(attributes["decision"]) == "allow"
+}
+
+func trustedEndpointAgentDeprovisioned(attributes map[string]string) bool {
+	if managed, ok := parseOptionalBoolAttribute(attributes, "managed"); ok && !managed {
+		return true
+	}
+	status := strings.ToLower(strings.TrimSpace(attributes["agent_status"]))
+	if status == "" {
+		status = strings.ToLower(strings.TrimSpace(attributes["status"]))
+	}
+	_, deprovisioned := trustedEndpointAgentDeprovisionedStatuses[status]
+	return deprovisioned
+}
+
+func trustedEndpointNormalizeDecisionValue(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "deny", "denied", "block", "blocked", "fail", "failed", "reject", "rejected":
+		return "deny"
+	case "allow", "allowed", "pass", "passed", "ok", "permit", "permitted", "approved":
+		return "allow"
+	case "error", "errored":
+		return "error"
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func trustedEndpointTrustGateURN(tenantID string, agentID string, action string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	agentID = strings.TrimSpace(agentID)
+	action = strings.TrimSpace(action)
+	if tenantID == "" || agentID == "" || action == "" {
+		return ""
+	}
+	return fmt.Sprintf("urn:cerebro:%s:trusted_endpoint_trust_gate:%s:%s", tenantID, agentID, action)
+}
+
+func trustedEndpointAgentURN(tenantID string, agentID string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	agentID = strings.TrimSpace(agentID)
+	if tenantID == "" || agentID == "" {
+		return ""
+	}
+	return fmt.Sprintf("urn:cerebro:%s:trusted_endpoint_agent:%s", tenantID, agentID)
+}
+
+func trustedEndpointActiveTrustGateFailureAnchor(attributes map[string]string) string {
+	return identityCounterEventAnchor(map[string]string{
+		"trusted_endpoint_gate_urn": strings.TrimSpace(attributes["trusted_endpoint_gate_urn"]),
+	}, "trusted_endpoint_gate_urn")
+}
+
+func trustedEndpointActiveTrustGateFailureSummary(label string, action string) string {
+	return fmt.Sprintf("Trusted Endpoint agent %s is failing the trust gate for action %s", firstNonEmpty(label, "unknown agent"), firstNonEmpty(action, "unknown action"))
+}

--- a/internal/findings/trusted_endpoint_active_trust_gate_failure_rule.go
+++ b/internal/findings/trusted_endpoint_active_trust_gate_failure_rule.go
@@ -23,17 +23,6 @@ var trustedEndpointActiveTrustGateFailureControlRefs = []ports.FindingControlRef
 	{FrameworkName: "ISO 27001:2022", ControlID: "A.8.16"},
 }
 
-var trustedEndpointAgentDeprovisionedStatuses = map[string]struct{}{
-	"deleted":        {},
-	"removed":        {},
-	"offboarded":     {},
-	"unenrolled":     {},
-	"deactivated":    {},
-	"inactive":       {},
-	"retired":        {},
-	"decommissioned": {},
-}
-
 type trustedEndpointActiveTrustGateFailureRule struct {
 	Rule
 	definition RuleDefinition
@@ -183,16 +172,28 @@ func trustedEndpointGateRemediated(attributes map[string]string) bool {
 	return trustedEndpointNormalizeDecisionValue(attributes["decision"]) == "allow"
 }
 
+// trustedEndpointAgentDeprovisioned reports whether the agent is no longer
+// managed based on the normalized lifecycle state propagated by the source
+// normalizer, so offboarded agents resolve stale trust-gate findings instead of
+// relying on inconsistent raw attribute values.
 func trustedEndpointAgentDeprovisioned(attributes map[string]string) bool {
 	if managed, ok := parseOptionalBoolAttribute(attributes, "managed"); ok && !managed {
 		return true
 	}
-	status := strings.ToLower(strings.TrimSpace(attributes["agent_status"]))
-	if status == "" {
-		status = strings.ToLower(strings.TrimSpace(attributes["status"]))
+	return trustedEndpointNormalizeAgentStatus(attributes["agent_status"]) == "deprovisioned"
+}
+
+func trustedEndpointNormalizeAgentStatus(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return ""
+	case "deprovisioned", "deleted", "removed", "offboarded", "off-boarded", "off boarded", "unenrolled", "un-enrolled", "deactivated", "inactive", "retired", "decommissioned", "disabled", "terminated", "revoked":
+		return "deprovisioned"
+	case "active", "enrolled", "managed", "enabled", "provisioned", "online":
+		return "active"
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
 	}
-	_, deprovisioned := trustedEndpointAgentDeprovisionedStatuses[status]
-	return deprovisioned
 }
 
 func trustedEndpointNormalizeDecisionValue(value string) string {

--- a/internal/findings/trusted_endpoint_active_trust_gate_failure_rule_test.go
+++ b/internal/findings/trusted_endpoint_active_trust_gate_failure_rule_test.go
@@ -1,0 +1,115 @@
+package findings
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func trustedEndpointGateEvent(id string, attrs map[string]string, occurredAt time.Time) *cerebrov1.EventEnvelope {
+	base := map[string]string{
+		"agent_id":          "dev-1",
+		"action":            "git_push",
+		"source_runtime_id": "writer-trusted-endpoint",
+	}
+	for key, value := range attrs {
+		base[key] = value
+	}
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   "trusted_endpoint",
+		Kind:       "trusted_endpoint.trust_gate_decision",
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  "trusted_endpoint/trust_gate_decision/v1",
+		Attributes: base,
+	}
+}
+
+func TestTrustedEndpointActiveTrustGateFailureFixture(t *testing.T) {
+	assertRuleFixture(t, newTrustedEndpointActiveTrustGateFailureRule(), "testdata/rules/trusted-endpoint-active-trust-gate-failure.json")
+}
+
+func TestTrustedEndpointActiveTrustGateFailureRemediationResolves(t *testing.T) {
+	open := trustedEndpointGateEvent("te-open", map[string]string{"decision": "deny", "severity": "high"}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	resolved := trustedEndpointGateEvent("te-resolved", map[string]string{"decision": "allow"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	assertIdentityRuleRemediationTrajectory(t, newTrustedEndpointActiveTrustGateFailureRule(), open, resolved, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
+}
+
+func TestTrustedEndpointActiveTrustGateFailureReopensOnRecurrence(t *testing.T) {
+	rule := newTrustedEndpointActiveTrustGateFailureRule()
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "writer-trusted-endpoint",
+		SourceId: "trusted_endpoint",
+		TenantId: "writer",
+	}
+
+	emitOpen := func(event *cerebrov1.EventEnvelope) *ports.FindingRecord {
+		t.Helper()
+		records, err := rule.Evaluate(context.Background(), runtime, event)
+		if err != nil {
+			t.Fatalf("Evaluate(%q) error = %v", event.GetId(), err)
+		}
+		if len(records) != 1 {
+			t.Fatalf("Evaluate(%q) emitted %d findings, want 1", event.GetId(), len(records))
+		}
+		if got := strings.TrimSpace(records[0].Status); got != findingStatusOpen {
+			t.Fatalf("Evaluate(%q) status = %q, want open", event.GetId(), got)
+		}
+		return records[0]
+	}
+
+	opened := emitOpen(trustedEndpointGateEvent("te-deny-1", map[string]string{"decision": "deny", "severity": "high"}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)))
+	openFingerprint := strings.TrimSpace(opened.Fingerprint)
+	if openFingerprint == "" {
+		t.Fatal("opened finding has empty fingerprint")
+	}
+
+	counterRule, ok := rule.(CounterEventRule)
+	if !ok {
+		t.Fatal("rule does not implement CounterEventRule")
+	}
+	resolvedEvent := trustedEndpointGateEvent("te-allow", map[string]string{"decision": "allow"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	closeAnchor, closes := counterRule.CloseOnEvent(resolvedEvent)
+	if !closes || closeAnchor == "" {
+		t.Fatalf("CloseOnEvent(allow) = (%q, %v), want a non-empty closing anchor", closeAnchor, closes)
+	}
+	if openAnchor := counterRule.OpenAnchor(opened.Attributes); openAnchor != closeAnchor {
+		t.Fatalf("OpenAnchor(open finding) = %q, want match close anchor %q", openAnchor, closeAnchor)
+	}
+
+	reopened := emitOpen(trustedEndpointGateEvent("te-deny-2", map[string]string{"decision": "deny", "severity": "high"}, time.Date(2026, 5, 1, 14, 0, 0, 0, time.UTC)))
+	if got := strings.TrimSpace(reopened.Fingerprint); got != openFingerprint {
+		t.Fatalf("recurrence fingerprint = %q, want stable %q", got, openFingerprint)
+	}
+	if got := strings.TrimSpace(reopened.ID); got != strings.TrimSpace(opened.ID) {
+		t.Fatalf("recurrence finding id = %q, want stable %q", got, strings.TrimSpace(opened.ID))
+	}
+}
+
+func TestTrustedEndpointActiveTrustGateFailureIgnoresActionOutcome(t *testing.T) {
+	rule := newTrustedEndpointActiveTrustGateFailureRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-trusted-endpoint", SourceId: "trusted_endpoint", TenantId: "writer"}
+	event := &cerebrov1.EventEnvelope{
+		Id:         "te-action",
+		TenantId:   "writer",
+		SourceId:   "trusted_endpoint",
+		Kind:       "trusted_endpoint.action_outcome",
+		OccurredAt: timestamppb.New(time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)),
+		SchemaRef:  "trusted_endpoint/action_outcome/v1",
+		Attributes: map[string]string{"agent_id": "dev-1", "action": "remediation", "outcome_result": "success"},
+	}
+	records, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("action_outcome produced %d findings, want 0 (temporal events must not become durable findings)", len(records))
+	}
+}

--- a/internal/findings/trusted_endpoint_active_trust_gate_failure_rule_test.go
+++ b/internal/findings/trusted_endpoint_active_trust_gate_failure_rule_test.go
@@ -42,6 +42,69 @@ func TestTrustedEndpointActiveTrustGateFailureRemediationResolves(t *testing.T) 
 	assertIdentityRuleRemediationTrajectory(t, newTrustedEndpointActiveTrustGateFailureRule(), open, resolved, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
 }
 
+func TestTrustedEndpointActiveTrustGateFailureDeprovisionResolves(t *testing.T) {
+	open := trustedEndpointGateEvent("te-open", map[string]string{"decision": "deny", "severity": "high"}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	deprovisioned := trustedEndpointGateEvent("te-deprovisioned", map[string]string{"decision": "deny", "agent_status": "deprovisioned"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	assertIdentityRuleRemediationTrajectory(t, newTrustedEndpointActiveTrustGateFailureRule(), open, deprovisioned, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
+}
+
+func TestTrustedEndpointActiveTrustGateFailureUnmanagedAgentResolves(t *testing.T) {
+	open := trustedEndpointGateEvent("te-open", map[string]string{"decision": "deny", "severity": "high"}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	unmanaged := trustedEndpointGateEvent("te-unmanaged", map[string]string{"decision": "deny", "managed": "false"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	assertIdentityRuleRemediationTrajectory(t, newTrustedEndpointActiveTrustGateFailureRule(), open, unmanaged, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
+}
+
+func TestTrustedEndpointActiveTrustGateFailureReopensAfterDeprovision(t *testing.T) {
+	rule := newTrustedEndpointActiveTrustGateFailureRule()
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "writer-trusted-endpoint",
+		SourceId: "trusted_endpoint",
+		TenantId: "writer",
+	}
+
+	emitOpen := func(event *cerebrov1.EventEnvelope) *ports.FindingRecord {
+		t.Helper()
+		records, err := rule.Evaluate(context.Background(), runtime, event)
+		if err != nil {
+			t.Fatalf("Evaluate(%q) error = %v", event.GetId(), err)
+		}
+		if len(records) != 1 {
+			t.Fatalf("Evaluate(%q) emitted %d findings, want 1", event.GetId(), len(records))
+		}
+		if got := strings.TrimSpace(records[0].Status); got != findingStatusOpen {
+			t.Fatalf("Evaluate(%q) status = %q, want open", event.GetId(), got)
+		}
+		return records[0]
+	}
+
+	opened := emitOpen(trustedEndpointGateEvent("te-deny-1", map[string]string{"decision": "deny", "severity": "high"}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)))
+	openFingerprint := strings.TrimSpace(opened.Fingerprint)
+	if openFingerprint == "" {
+		t.Fatal("opened finding has empty fingerprint")
+	}
+
+	counterRule, ok := rule.(CounterEventRule)
+	if !ok {
+		t.Fatal("rule does not implement CounterEventRule")
+	}
+	deprovisionedEvent := trustedEndpointGateEvent("te-deprovisioned", map[string]string{"decision": "deny", "agent_status": "offboarded"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	closeAnchor, closes := counterRule.CloseOnEvent(deprovisionedEvent)
+	if !closes || closeAnchor == "" {
+		t.Fatalf("CloseOnEvent(deprovisioned) = (%q, %v), want a non-empty closing anchor", closeAnchor, closes)
+	}
+	if openAnchor := counterRule.OpenAnchor(opened.Attributes); openAnchor != closeAnchor {
+		t.Fatalf("OpenAnchor(open finding) = %q, want match close anchor %q", openAnchor, closeAnchor)
+	}
+
+	reopened := emitOpen(trustedEndpointGateEvent("te-deny-2", map[string]string{"decision": "deny", "severity": "high", "agent_status": "active"}, time.Date(2026, 5, 1, 14, 0, 0, 0, time.UTC)))
+	if got := strings.TrimSpace(reopened.Fingerprint); got != openFingerprint {
+		t.Fatalf("recurrence fingerprint = %q, want stable %q", got, openFingerprint)
+	}
+	if got := strings.TrimSpace(reopened.ID); got != strings.TrimSpace(opened.ID) {
+		t.Fatalf("recurrence finding id = %q, want stable %q", got, strings.TrimSpace(opened.ID))
+	}
+}
+
 func TestTrustedEndpointActiveTrustGateFailureReopensOnRecurrence(t *testing.T) {
 	rule := newTrustedEndpointActiveTrustGateFailureRule()
 	runtime := &cerebrov1.SourceRuntime{

--- a/internal/sourceprojection/trusted_endpoint.go
+++ b/internal/sourceprojection/trusted_endpoint.go
@@ -42,18 +42,22 @@ func trustedEndpointProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 		},
 	})
 
+	decision := trustedEndpointNormalizeDecision(attrs["decision"])
 	eventURN := projectionURN(tenantID, "trusted_endpoint_event", event.GetKind(), event.GetId())
 	eventAttrs := map[string]string{
-		"action":            strings.TrimSpace(attrs["action"]),
-		"control_id":        strings.TrimSpace(attrs["control_id"]),
-		"event_id":          event.GetId(),
-		"finding_id":        strings.TrimSpace(attrs["finding_id"]),
-		"kind":              event.GetKind(),
-		"observation_table": strings.TrimSpace(attrs["observation_table"]),
-		"outcome_result":    strings.TrimSpace(attrs["outcome_result"]),
-		"severity":          strings.TrimSpace(attrs["severity"]),
-		"source_product":    "trusted_endpoint",
-		"at":                eventObservedAt(event),
+		"action":              strings.TrimSpace(attrs["action"]),
+		"control_id":          strings.TrimSpace(attrs["control_id"]),
+		"decision":            decision,
+		"event_id":            event.GetId(),
+		"finding_id":          strings.TrimSpace(attrs["finding_id"]),
+		"kind":                event.GetKind(),
+		"observation_table":   strings.TrimSpace(attrs["observation_table"]),
+		"outcome_result":      strings.TrimSpace(attrs["outcome_result"]),
+		"severity":            strings.TrimSpace(attrs["severity"]),
+		"severity_normalized": trustedEndpointNormalizeSeverity(attrs["severity"]),
+		"status_normalized":   trustedEndpointNormalizeStatus(event.GetKind(), attrs, decision),
+		"source_product":      "trusted_endpoint",
+		"at":                  eventObservedAt(event),
 	}
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        eventURN,
@@ -100,4 +104,76 @@ func trustedEndpointEventLabel(event *cerebrov1.EventEnvelope, attrs map[string]
 		attrs["observation_table"],
 		event.GetKind(),
 	)
+}
+
+func trustedEndpointNormalizeDecision(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "deny", "denied", "block", "blocked", "fail", "failed", "reject", "rejected":
+		return "deny"
+	case "allow", "allowed", "pass", "passed", "ok", "permit", "permitted", "approved":
+		return "allow"
+	case "error", "errored":
+		return "error"
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func trustedEndpointNormalizeSeverity(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "critical", "crit", "p0", "sev0":
+		return "CRITICAL"
+	case "high", "p1", "sev1":
+		return "HIGH"
+	case "medium", "med", "moderate", "p2", "sev2":
+		return "MEDIUM"
+	case "low", "p3", "sev3":
+		return "LOW"
+	case "info", "informational", "none", "p4", "sev4":
+		return "INFO"
+	case "":
+		return "UNKNOWN"
+	default:
+		return strings.ToUpper(strings.TrimSpace(value))
+	}
+}
+
+func trustedEndpointNormalizeStatus(kind string, attrs map[string]string, decision string) string {
+	switch strings.TrimSpace(kind) {
+	case "trusted_endpoint.trust_gate_decision":
+		switch decision {
+		case "deny", "error":
+			return "failing"
+		case "allow":
+			return "passing"
+		}
+	case "trusted_endpoint.security_finding":
+		if trustedEndpointResolved(attrs) {
+			return "passing"
+		}
+		return "failing"
+	}
+	return trustedEndpointStatusValue(firstNonEmpty(attrs["status"], attrs["outcome_result"]))
+}
+
+func trustedEndpointStatusValue(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "fail", "failed", "failing", "non_compliant", "noncompliant", "violation", "open":
+		return "failing"
+	case "pass", "passed", "passing", "compliant", "ok", "success", "resolved", "closed":
+		return "passing"
+	case "":
+		return "unknown"
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func trustedEndpointResolved(attrs map[string]string) bool {
+	status := strings.ToLower(strings.TrimSpace(attrs["status"]))
+	switch status {
+	case "resolved", "closed", "remediated", "fixed":
+		return true
+	}
+	return strings.TrimSpace(attrs["resolved_at"]) != ""
 }

--- a/internal/sourceprojection/trusted_endpoint_test.go
+++ b/internal/sourceprojection/trusted_endpoint_test.go
@@ -1,0 +1,131 @@
+package sourceprojection
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func trustedEndpointEvent(id string, kind string, attrs map[string]string) *cerebrov1.EventEnvelope {
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   "trusted_endpoint",
+		Kind:       kind,
+		Attributes: attrs,
+	}
+}
+
+func findProjectedEntityByType(recorder *projectionRecorder, entityType string) *ports.ProjectedEntity {
+	for _, entity := range recorder.entities {
+		if entity.EntityType == entityType {
+			return entity
+		}
+	}
+	return nil
+}
+
+func TestProjectTrustedEndpointTrustGateDecision(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	event := trustedEndpointEvent("te-trust-gate", "trusted_endpoint.trust_gate_decision", map[string]string{
+		"agent_id": "dev_123",
+		"hostname": "workstation",
+		"action":   "git_push",
+		"decision": "deny",
+		"severity": "high",
+	})
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	agentURN := "urn:cerebro:writer:trusted_endpoint_agent:dev_123"
+	agent := state.entities[agentURN]
+	if agent == nil || agent.EntityType != "trusted_endpoint.agent" {
+		t.Fatalf("trusted_endpoint.agent entity missing or wrong: %#v", agent)
+	}
+
+	gate := findProjectedEntityByType(state, "trusted_endpoint.trust_gate_decision")
+	if gate == nil {
+		t.Fatalf("trusted_endpoint.trust_gate_decision entity missing; entities=%#v", state.entities)
+	}
+	for key, want := range map[string]string{
+		"decision":            "deny",
+		"severity_normalized": "HIGH",
+		"status_normalized":   "failing",
+	} {
+		if got := gate.Attributes[key]; got != want {
+			t.Fatalf("trust gate attribute %q = %q, want %q", key, got, want)
+		}
+	}
+
+	assertProjectedLink(t, state, agentURN, relationHasEvidence, gate.URN)
+	assertProjectedLink(t, state, gate.URN, relationObservedOn, agentURN)
+}
+
+func TestProjectTrustedEndpointGRCEvidenceNormalizesStatus(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	event := trustedEndpointEvent("te-grc", "trusted_endpoint.grc_evidence", map[string]string{
+		"agent_id":   "dev_123",
+		"control_id": "AC-2",
+		"status":     "failing",
+	})
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	evidence := findProjectedEntityByType(state, "trusted_endpoint.grc_evidence")
+	if evidence == nil {
+		t.Fatalf("trusted_endpoint.grc_evidence entity missing; entities=%#v", state.entities)
+	}
+	if got := evidence.Attributes["status_normalized"]; got != "failing" {
+		t.Fatalf("grc status_normalized = %q, want failing", got)
+	}
+	if got := evidence.Attributes["control_id"]; got != "AC-2" {
+		t.Fatalf("grc control_id = %q, want AC-2", got)
+	}
+}
+
+func TestRegistryRoutesTrustedEndpointKinds(t *testing.T) {
+	kinds := []string{
+		"trusted_endpoint.agent_identity",
+		"trusted_endpoint.host_posture",
+		"trusted_endpoint.repo_worktree_context",
+		"trusted_endpoint.ai_session_summary",
+		"trusted_endpoint.ai_workflow_risk",
+		"trusted_endpoint.security_finding",
+		"trusted_endpoint.grc_evidence",
+		"trusted_endpoint.trust_gate_decision",
+		"trusted_endpoint.action_outcome",
+	}
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			event := trustedEndpointEvent("te-"+kind, kind, map[string]string{
+				"agent_id": "dev_123",
+				"action":   "git_push",
+				"decision": "deny",
+			})
+			entities, links, err := BuiltinRegistry().Project(event)
+			if err != nil {
+				t.Fatalf("Project(%s) error = %v", kind, err)
+			}
+			foundAgent := false
+			for _, entity := range entities {
+				if entity.EntityType == "trusted_endpoint.agent" {
+					foundAgent = true
+					break
+				}
+			}
+			if !foundAgent {
+				t.Fatalf("kind %q did not route to trusted_endpoint projector; entities=%#v", kind, entities)
+			}
+			if len(links) == 0 {
+				t.Fatalf("kind %q produced no projected links", kind)
+			}
+		})
+	}
+}

--- a/sources/trustedendpoint/telemetry_test.go
+++ b/sources/trustedendpoint/telemetry_test.go
@@ -1,0 +1,169 @@
+package trustedendpoint
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/endpointtelemetry"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+func sampleTelemetryBody() []byte {
+	return []byte(`{
+		"posture": {"observation_table": "secheck.heartbeat", "status": "ok"},
+		"events": [
+			{"type": "remediation.remediated", "package": "openssl", "result": "success"},
+			{"type": "verification.vulnerable", "finding_id": "finding-1", "severity": "high"},
+			{"type": "trust_gate.deny", "action": "git_push", "reason": "posture_failed", "severity": "high"},
+			{"control_id": "AC-2", "status": "failing", "framework": "SOC2"}
+		]
+	}`)
+}
+
+func TestNormalizeEmitsSupportedTrustedEndpointKinds(t *testing.T) {
+	principal := endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev_123", HardwareUUID: "hw-123", Hostname: "workstation"}
+	events, err := endpointtelemetry.Normalize(sampleTelemetryBody(), principal, time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	gotKinds := map[string]int{}
+	for _, event := range events {
+		gotKinds[event.GetKind()]++
+	}
+	for _, kind := range []string{
+		"trusted_endpoint.host_posture",
+		"trusted_endpoint.action_outcome",
+		"trusted_endpoint.security_finding",
+		"trusted_endpoint.trust_gate_decision",
+		"trusted_endpoint.grc_evidence",
+	} {
+		if gotKinds[kind] == 0 {
+			t.Fatalf("Normalize() did not emit kind %q; got kinds %v", kind, gotKinds)
+		}
+	}
+
+	contracts := loadTelemetryEventContracts(t)
+	for _, event := range events {
+		if err := sourcecdk.ValidateEventEnvelopeWithContracts(event, contracts); err != nil {
+			t.Fatalf("event kind %q failed contract validation: %v", event.GetKind(), err)
+		}
+	}
+}
+
+func TestNormalizeTrustGateDecisionAttributes(t *testing.T) {
+	principal := endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev_123"}
+	body := []byte(`{"events":[{"type":"trust_gate.deny","action":"git_push","reason":"posture_failed","severity":"high"}]}`)
+	events, err := endpointtelemetry.Normalize(body, principal, time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	event := events[0]
+	if event.GetKind() != "trusted_endpoint.trust_gate_decision" {
+		t.Fatalf("Kind = %q, want trust_gate_decision", event.GetKind())
+	}
+	for key, want := range map[string]string{
+		"agent_id": "dev_123",
+		"action":   "git_push",
+		"decision": "deny",
+		"severity": "high",
+	} {
+		if got := event.GetAttributes()[key]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", key, got, want)
+		}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(event.GetPayload(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["decision"] != "deny" || payload["action"] != "git_push" {
+		t.Fatalf("payload action/decision = %v/%v, want git_push/deny", payload["action"], payload["decision"])
+	}
+}
+
+func TestNormalizeGRCEvidenceAttributes(t *testing.T) {
+	principal := endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev_123"}
+	body := []byte(`{"events":[{"control_id":"AC-2","status":"failing","framework":"SOC2"}]}`)
+	events, err := endpointtelemetry.Normalize(body, principal, time.Now())
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	event := events[0]
+	if event.GetKind() != "trusted_endpoint.grc_evidence" {
+		t.Fatalf("Kind = %q, want grc_evidence", event.GetKind())
+	}
+	if event.GetAttributes()["control_id"] != "AC-2" {
+		t.Fatalf("control_id attr = %q, want AC-2", event.GetAttributes()["control_id"])
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(event.GetPayload(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["status"] != "failing" {
+		t.Fatalf("payload status = %v, want failing", payload["status"])
+	}
+}
+
+func TestNormalizeProducesStableEventIdentities(t *testing.T) {
+	principal := endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev_123", HardwareUUID: "hw-123"}
+	at := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	first, err := endpointtelemetry.Normalize(sampleTelemetryBody(), principal, at)
+	if err != nil {
+		t.Fatalf("Normalize() first error = %v", err)
+	}
+	second, err := endpointtelemetry.Normalize(sampleTelemetryBody(), principal, at)
+	if err != nil {
+		t.Fatalf("Normalize() second error = %v", err)
+	}
+	if len(first) != len(second) {
+		t.Fatalf("event count drift: first=%d second=%d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i].GetId() != second[i].GetId() {
+			t.Fatalf("event[%d] id drift: %q != %q", i, first[i].GetId(), second[i].GetId())
+		}
+		if first[i].GetId() == "" {
+			t.Fatalf("event[%d] id is empty", i)
+		}
+	}
+}
+
+func TestNormalizeRejectsMalformedTelemetry(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      []byte
+		principal endpointtelemetry.Principal
+	}{
+		{"missing tenant", []byte(`{"events":[]}`), endpointtelemetry.Principal{DeviceID: "dev"}},
+		{"missing device", []byte(`{"events":[]}`), endpointtelemetry.Principal{TenantID: "writer"}},
+		{"invalid json", []byte(`{not-json`), endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev"}},
+		{"trust gate without decision", []byte(`{"events":[{"type":"trust_gate"}]}`), endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev"}},
+		{"grc evidence without status", []byte(`{"events":[{"control_id":"AC-2"}]}`), endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := endpointtelemetry.Normalize(tc.body, tc.principal, time.Now()); err == nil {
+				t.Fatalf("Normalize() error = nil, want rejection for %s", tc.name)
+			}
+		})
+	}
+}
+
+func loadTelemetryEventContracts(t *testing.T) []sourcecdk.EventContract {
+	t.Helper()
+	specBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		t.Fatalf("read catalog.yaml error = %v", err)
+	}
+	catalog, err := sourcecdk.LoadSourceCatalog(specBytes)
+	if err != nil {
+		t.Fatalf("LoadSourceCatalog() error = %v", err)
+	}
+	return catalog.EventContracts
+}

--- a/sources/trustedendpoint/telemetry_test.go
+++ b/sources/trustedendpoint/telemetry_test.go
@@ -84,6 +84,44 @@ func TestNormalizeTrustGateDecisionAttributes(t *testing.T) {
 	}
 }
 
+func TestNormalizeTrustGatePropagatesDeprovisionState(t *testing.T) {
+	principal := endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev_123"}
+	body := []byte(`{"events":[{"type":"trust_gate.deny","action":"git_push","reason":"posture_failed","agent_status":"Off-boarded","managed":false}]}`)
+	events, err := endpointtelemetry.Normalize(body, principal, time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	attrs := events[0].GetAttributes()
+	if got := attrs["agent_status"]; got != "deprovisioned" {
+		t.Fatalf("agent_status attr = %q, want deprovisioned", got)
+	}
+	if got := attrs["managed"]; got != "false" {
+		t.Fatalf("managed attr = %q, want false", got)
+	}
+}
+
+func TestNormalizeTrustGateMarksManagedAgentActive(t *testing.T) {
+	principal := endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev_123"}
+	body := []byte(`{"events":[{"type":"trust_gate.deny","action":"git_push","agent_status":"active","managed":true}]}`)
+	events, err := endpointtelemetry.Normalize(body, principal, time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	attrs := events[0].GetAttributes()
+	if got := attrs["agent_status"]; got != "active" {
+		t.Fatalf("agent_status attr = %q, want active", got)
+	}
+	if got := attrs["managed"]; got != "true" {
+		t.Fatalf("managed attr = %q, want true", got)
+	}
+}
+
 func TestNormalizeGRCEvidenceAttributes(t *testing.T) {
 	principal := endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev_123"}
 	body := []byte(`{"events":[{"control_id":"AC-2","status":"failing","framework":"SOC2"}]}`)


### PR DESCRIPTION
## Scope

Single source: **`trusted_endpoint`**. Deepens the connector to a full vertical slice (source emission, graph projection, finding semantics, tests) without touching other source domains.

## Source changes

- Enriched the Trusted Endpoint telemetry normalizer to emit the supported `trusted_endpoint.*` families, adding `trusted_endpoint.trust_gate_decision` and `trusted_endpoint.grc_evidence` alongside the existing posture/finding/action-outcome events.
- Normalized decision, status, and severity values, and added per-kind emission guards so malformed records (e.g. a trust-gate event with no decision, GRC evidence with no status) are rejected before entering the append log.
- Source-package tests validate emitted events against the source `catalog.yaml` event contracts and assert stable, deterministic event identities plus input-validation rejections.

## Projection changes

- The projector now stamps normalized `decision`, `severity_normalized`, and `status_normalized` attributes onto the observation entity and keeps the agent/observation entities with directional `has_evidence` / `observed_on` links.
- Added projection tests covering the trust-gate and GRC observation behavior and confirming complete registry routing for every declared `trusted_endpoint` kind.

## Finding changes

- New durable, current-state rule that opens when an agent's latest trust-gate decision denies a gated action (active posture/trust failure).
- Resolves when a later decision for the same agent/action allows it (remediation) or when the agent is deprovisioned, and reopens deterministically on recurrence using a stable agent/action fingerprint.
- Pure temporal action-outcome events do not produce findings.

## Shared file touches (approved integration points)

- `internal/findings/rulepack.go` — registered the new source rulepack.
- `internal/findings/rulepack_audit_test.go` — added the rule classification fallback entry.
- `internal/findings/public_detection_catalog.json` — regenerated via `make detection-catalog-generate`.
- `internal/findings/registry_test.go` — updated the expected rulepack count.
- `internal/compliance/control_coverage_index.yaml` — regenerated via `make control-index-generate` for the new control refs.

## Validation evidence

- `make lint` → `0 issues.`
- `go test ./sources/trustedendpoint/... -count=1` → ok (emission + contract + rejection tests)
- `go test ./internal/sourceprojection/... -run 'TrustedEndpoint|trusted_endpoint' -count=1` → ok (matched tests > 0)
- `go test ./internal/findings/... -run 'TrustedEndpoint|trusted_endpoint' -count=1` → ok (open/resolve/reopen lifecycle, matched tests > 0)
- `go test ./tools/archtests/... -count=1` → ok
- `make catalog-check` → ok
- `make detection-catalog-check` → ok

## Risk and rollback

- Low blast radius: changes are scoped to the Trusted Endpoint source plus approved shared governance artifacts. The bootstrap ingest path keeps its existing `endpointtelemetry.Normalize` call site and remains backward compatible.
- Rollback by reverting this single commit; generated artifacts (detection catalog, control index) revert with it and pass their `*-check` targets at the prior revision.
