### PR TITLE
Remove Slack MFA dead branch

### DIFF
--- a/internal/findings/slack_privileged_user_without_mfa_rule.go
+++ b/internal/findings/slack_privileged_user_without_mfa_rule.go
@@ -171,16 +171,7 @@ func slackUserAccountPrivileged(attributes map[string]string) bool {
 }
 
 func slackUserMFAEnabled(attributes map[string]string) bool {
-	if parseBoolAttribute(attributes, "has_2fa") || parseBoolAttribute(attributes, "has_mfa") {
-		return true
-	}
-	if value, ok := parseOptionalBoolAttribute(attributes, "has_2fa"); ok {
-		return value
-	}
-	if value, ok := parseOptionalBoolAttribute(attributes, "has_mfa"); ok {
-		return value
-	}
-	return false
+	return parseBoolAttribute(attributes, "has_2fa") || parseBoolAttribute(attributes, "has_mfa")
 }
 
 func slackUserAccountDeactivated(attributes map[string]string) bool {


### PR DESCRIPTION
## Summary
- simplify slackUserMFAEnabled to remove unreachable optional-bool branches
- closes the remaining Droid P2 from #1197

## Verification
- go test ./internal/findings -run 'TestSlackPrivilegedUserWithoutMFA|TestRulePackAudit|TestPublicDetectionCatalog'\n- go test ./internal/findings\n- make lint\n- make check-structural\n- make check-arch\n- ./scripts/pre_commit_checks.sh