### PR TITLE
Fix OAuth client credentials token cache isolation

### DIFF
--- a/internal/sourcehttp/oauth_client_credentials.go
+++ b/internal/sourcehttp/oauth_client_credentials.go
@@ -2,6 +2,8 @@ package sourcehttp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,9 +28,13 @@ type ClientCredentialsOptions struct {
 	Timeout          time.Duration
 }
 
-// ClientCredentialsCache caches one access token until shortly before expiry.
+// ClientCredentialsCache caches access tokens until shortly before expiry.
 type ClientCredentialsCache struct {
-	mu        sync.Mutex
+	mu      sync.Mutex
+	entries map[string]clientCredentialsCacheEntry
+}
+
+type clientCredentialsCacheEntry struct {
 	value     string
 	expiresAt time.Time
 }
@@ -37,12 +43,6 @@ type ClientCredentialsCache struct {
 func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config, options ClientCredentialsOptions) (string, error) {
 	if c == nil {
 		return "", fmt.Errorf("%s oauth token cache is required", sourceID(options.SourceID))
-	}
-	now := time.Now()
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.value != "" && now.Before(c.expiresAt) {
-		return c.value, nil
 	}
 	tokenURL, err := renderTemplate(firstNonEmpty(configValue(cfg, "token_url"), options.TokenURLTemplate), cfg, options)
 	if err != nil {
@@ -70,6 +70,13 @@ func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config
 			return "", err
 		}
 		form.Set(key, value)
+	}
+	cacheKey := clientCredentialsCacheKey(sourceID(options.SourceID), tokenURL, form)
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cached, ok := c.entries[cacheKey]; ok && cached.value != "" && now.Before(cached.expiresAt) {
+		return cached.value, nil
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
@@ -103,12 +110,24 @@ func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config
 	if expiresIn <= 0 {
 		expiresIn = 300
 	}
-	c.value = token
-	c.expiresAt = now.Add(time.Duration(expiresIn)*time.Second - firstNonZeroDuration(options.ExpirationBuffer, time.Minute))
-	if !c.expiresAt.After(now) {
-		c.expiresAt = now.Add(time.Minute)
+	entry := clientCredentialsCacheEntry{
+		value:     token,
+		expiresAt: now.Add(time.Duration(expiresIn)*time.Second - firstNonZeroDuration(options.ExpirationBuffer, time.Minute)),
 	}
-	return c.value, nil
+	if !entry.expiresAt.After(now) {
+		entry.expiresAt = now.Add(time.Minute)
+	}
+	if c.entries == nil {
+		c.entries = make(map[string]clientCredentialsCacheEntry)
+	}
+	c.entries[cacheKey] = entry
+	return entry.value, nil
+}
+
+func clientCredentialsCacheKey(sourceID string, tokenURL string, form url.Values) string {
+	material := strings.Join([]string{sourceID, tokenURL, form.Encode()}, "\x00")
+	sum := sha256.Sum256([]byte(material))
+	return hex.EncodeToString(sum[:])
 }
 
 func renderTemplate(template string, cfg sourcecdk.Config, options ClientCredentialsOptions) (string, error) {

--- a/internal/sourcehttp/oauth_client_credentials_test.go
+++ b/internal/sourcehttp/oauth_client_credentials_test.go
@@ -1,0 +1,178 @@
+package sourcehttp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+func TestClientCredentialsCacheSeparatesResolvedOAuthRequest(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	calls := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		calls[r.URL.Path]++
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case "/tenant-a/token":
+			if r.Form.Get("client_id") != "client-a" || r.Form.Get("client_secret") != "secret-a" {
+				http.Error(w, "unexpected tenant-a credentials", http.StatusBadRequest)
+				return
+			}
+			writeOAuthToken(t, w, "token-a")
+		case "/tenant-b/token":
+			if r.Form.Get("client_id") != "client-b" || r.Form.Get("client_secret") != "secret-b" {
+				http.Error(w, "unexpected tenant-b credentials", http.StatusBadRequest)
+				return
+			}
+			writeOAuthToken(t, w, "token-b")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	var cache ClientCredentialsCache
+	options := ClientCredentialsOptions{SourceID: "test", AllowLoopback: true}
+	tokenA, err := cache.Token(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"token_url":     server.URL + "/tenant-a/token",
+		"client_id":     "client-a",
+		"client_secret": "secret-a",
+	}), options)
+	if err != nil {
+		t.Fatalf("tenant-a token: %v", err)
+	}
+	if tokenA != "token-a" {
+		t.Fatalf("tenant-a token = %q, want token-a", tokenA)
+	}
+
+	tokenB, err := cache.Token(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"token_url":     server.URL + "/tenant-b/token",
+		"client_id":     "client-b",
+		"client_secret": "secret-b",
+	}), options)
+	if err != nil {
+		t.Fatalf("tenant-b token: %v", err)
+	}
+	if tokenB != "token-b" {
+		t.Fatalf("tenant-b token = %q, want token-b", tokenB)
+	}
+
+	tokenAAgain, err := cache.Token(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"token_url":     server.URL + "/tenant-a/token",
+		"client_id":     "client-a",
+		"client_secret": "secret-a",
+	}), options)
+	if err != nil {
+		t.Fatalf("tenant-a cached token: %v", err)
+	}
+	if tokenAAgain != "token-a" {
+		t.Fatalf("tenant-a cached token = %q, want token-a", tokenAAgain)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls["/tenant-a/token"] != 1 {
+		t.Fatalf("tenant-a token endpoint calls = %d, want 1", calls["/tenant-a/token"])
+	}
+	if calls["/tenant-b/token"] != 1 {
+		t.Fatalf("tenant-b token endpoint calls = %d, want 1", calls["/tenant-b/token"])
+	}
+}
+
+func TestClientCredentialsCacheSeparatesRenderedTokenParams(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	calls := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		audience := r.Form.Get("audience")
+		if audience == "" {
+			http.Error(w, "missing audience", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		calls[audience]++
+		mu.Unlock()
+		writeOAuthToken(t, w, "token-"+audience)
+	}))
+	defer server.Close()
+
+	var cache ClientCredentialsCache
+	options := ClientCredentialsOptions{
+		SourceID:      "test",
+		TokenParams:   map[string]string{"audience": "${config.audience}"},
+		TemplateKeys:  []string{"audience"},
+		AllowLoopback: true,
+	}
+	cfg := func(audience string) sourcecdk.Config {
+		return sourcecdk.NewConfig(map[string]string{
+			"token_url":     server.URL + "/oauth/token",
+			"client_id":     "client",
+			"client_secret": "secret",
+			"audience":      audience,
+		})
+	}
+
+	tokenOne, err := cache.Token(context.Background(), cfg("audience-one"), options)
+	if err != nil {
+		t.Fatalf("audience-one token: %v", err)
+	}
+	if tokenOne != "token-audience-one" {
+		t.Fatalf("audience-one token = %q, want token-audience-one", tokenOne)
+	}
+	tokenTwo, err := cache.Token(context.Background(), cfg("audience-two"), options)
+	if err != nil {
+		t.Fatalf("audience-two token: %v", err)
+	}
+	if tokenTwo != "token-audience-two" {
+		t.Fatalf("audience-two token = %q, want token-audience-two", tokenTwo)
+	}
+	tokenOneAgain, err := cache.Token(context.Background(), cfg("audience-one"), options)
+	if err != nil {
+		t.Fatalf("audience-one cached token: %v", err)
+	}
+	if tokenOneAgain != "token-audience-one" {
+		t.Fatalf("audience-one cached token = %q, want token-audience-one", tokenOneAgain)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls["audience-one"] != 1 {
+		t.Fatalf("audience-one token endpoint calls = %d, want 1", calls["audience-one"])
+	}
+	if calls["audience-two"] != 1 {
+		t.Fatalf("audience-two token endpoint calls = %d, want 1", calls["audience-two"])
+	}
+}
+
+func writeOAuthToken(t *testing.T, w http.ResponseWriter, token string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"access_token": token,
+		"expires_in":   3600,
+	}); err != nil {
+		t.Fatalf("encode token response: %v", err)
+	}
+}

--- a/internal/sourcehttp/oauth_client_credentials_test.go
+++ b/internal/sourcehttp/oauth_client_credentials_test.go
@@ -17,6 +17,7 @@ func TestClientCredentialsCacheSeparatesResolvedOAuthRequest(t *testing.T) {
 	var mu sync.Mutex
 	calls := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -102,6 +103,7 @@ func TestClientCredentialsCacheSeparatesRenderedTokenParams(t *testing.T) {
 	var mu sync.Mutex
 	calls := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 		if err := r.ParseForm(); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
## Summary
- key shared OAuth client-credentials token caching by the resolved token request instead of a singleton value
- cover distinct token endpoints and rendered token parameters with focused regression tests

## Tests
- `go test ./internal/sourcehttp -run 'TestClientCredentialsCache' -count=1 -v`
- `go test ./sources/auth0 ./internal/sourcegen -count=1`
- `go test ./internal/sourcehttp ./sources/auth0 ./internal/sourcegen -count=1`
