### PR TITLE
feat(evidence_cas): deepen connector with case-URN correlation, link-state projection, and unresolved-linkage finding

### DIFF
--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -170,7 +170,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 1050 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 1051 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/internal/compliance/control_coverage_index.yaml
+++ b/internal/compliance/control_coverage_index.yaml
@@ -61090,7 +61090,7 @@ profiles:
         selected_controls: 36
         mapped_controls: 25
         unmapped_controls: 11
-        mapped_rules: 927
+        mapped_rules: 928
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 36
@@ -62335,7 +62335,7 @@ profiles:
             status: placeholder
             score: 0
           coverage_status: mapped
-          rule_count: 32
+          rule_count: 33
           mapped_rules:
             - ai-model-monitoring
             - aws-bedrock-model-no-guardrails
@@ -62347,6 +62347,7 @@ profiles:
             - aws-security-hub-enabled
             - azure-defender-storage
             - container-runtime-exec-detected
+            - evidence-cas-unresolved-linkage
             - gcp-cloud-ids-notifications
             - grc-failing-control-open-operational-findings
             - grc-failing-control-test-unhealthy-integration
@@ -63472,6 +63473,10 @@ profiles:
           controls:
             - framework_name: SOC 2
               control_id: CC1.1
+        - rule_id: evidence-cas-unresolved-linkage
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7.2
         - rule_id: exposed-saas-api-token
           controls:
             - framework_name: SOC 2

--- a/internal/findings/evidence_cas_unresolved_linkage_rule.go
+++ b/internal/findings/evidence_cas_unresolved_linkage_rule.go
@@ -1,0 +1,228 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	evidenceCASUnresolvedLinkageRuleID    = "evidence-cas-unresolved-linkage"
+	evidenceCASUnresolvedLinkageTitle     = "Evidence CAS Object With Unresolved Linkage"
+	evidenceCASUnresolvedLinkageSeverity  = "MEDIUM"
+	evidenceCASUnresolvedLinkageCheckID   = "evidence-cas-unresolved-linkage-current"
+	evidenceCASUnresolvedLinkageCheckName = "Evidence CAS Object With Unresolved Linkage (current state)"
+	evidenceCASObjectEventKind            = "evidence_cas.object"
+)
+
+var evidenceCASUnresolvedLinkageControlRefs = []ports.FindingControlRef{
+	{FrameworkName: "SOC 2", ControlID: "CC7.2"},
+	{FrameworkName: "ISO 27001:2022", ControlID: "A.5.28"},
+}
+
+type evidenceCASUnresolvedLinkageRule struct {
+	Rule
+	definition RuleDefinition
+}
+
+var evidenceCASUnresolvedLinkageDefinition = RuleDefinition{
+	ID:                 evidenceCASUnresolvedLinkageRuleID,
+	Name:               evidenceCASUnresolvedLinkageTitle,
+	Description:        "Detect Evidence CAS objects whose latest reference cannot resolve the case or resource it claims to document, leaving stored evidence detached from the asset, identity, or case it is meant to support and breaking its chain of custody until the linkage is repaired.",
+	SourceID:           "evidence_cas",
+	EventKinds:         []string{evidenceCASObjectEventKind},
+	OutputKind:         "finding.evidence_cas_unresolved_linkage",
+	Severity:           evidenceCASUnresolvedLinkageSeverity,
+	Status:             findingStatusOpen,
+	Maturity:           "test",
+	Tags:               []string{"evidence-cas", "evidence", "chain-of-custody", "data-integrity", "correlation"},
+	References:         []string{"https://github.com/writer/cerebro/blob/main/docs/ARCHITECTURE.md"},
+	FalsePositives:     []string{"Evidence captured slightly ahead of the case or resource it references, where the linkage resolves on the next sync once the referenced context is ingested."},
+	Runbook:            "Confirm whether the referenced case or resource exists, repair the evidence reference or ingest the missing context, and verify the next Evidence CAS sync resolves the linkage.",
+	RequiredAttributes: []string{"evidence_id"},
+	FingerprintFields:  []string{"evidence_cas_evidence_urn"},
+	ControlRefs:        evidenceCASUnresolvedLinkageControlRefs,
+	Lifecycle:          Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorSourceState},
+}
+
+var evidenceCASObjectKindMatcher = eventKindMatcher(evidenceCASUnresolvedLinkageDefinition.EventKinds...)
+
+func newEvidenceCASUnresolvedLinkageRule() Rule {
+	rule := newEventRule(eventRuleConfig{
+		definition: evidenceCASUnresolvedLinkageDefinition,
+		match:      matchesEvidenceCASUnresolvedLinkage,
+		build: func(_ context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+			return evidenceCASUnresolvedLinkageFinding(event, runtime.GetId())
+		},
+	})
+	return &evidenceCASUnresolvedLinkageRule{
+		Rule:       rule,
+		definition: evidenceCASUnresolvedLinkageDefinition,
+	}
+}
+
+func (r *evidenceCASUnresolvedLinkageRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
+func (r *evidenceCASUnresolvedLinkageRule) OpenAnchor(attributes map[string]string) string {
+	return evidenceCASUnresolvedLinkageAnchor(attributes)
+}
+
+// CloseOnEvent resolves an open finding when a later reference for the same
+// evidence object resolves its case and resource linkage, so evidence whose
+// context has since been ingested or repaired does not leave a stale open
+// finding.
+func (r *evidenceCASUnresolvedLinkageRule) CloseOnEvent(event Event) (string, bool) {
+	if !evidenceCASObjectKindMatcher(event) || !hasRequiredAttributes(event, evidenceCASUnresolvedLinkageDefinition.RequiredAttributes...) {
+		return "", false
+	}
+	attributes := eventAttributes(event)
+	if evidenceCASLinkageUnresolved(attributes) {
+		return "", false
+	}
+	evidenceURN := evidenceCASEvidenceURN(event.GetTenantId(), attributes["evidence_id"])
+	anchor := evidenceCASUnresolvedLinkageAnchor(map[string]string{"evidence_cas_evidence_urn": evidenceURN})
+	return anchor, anchor != ""
+}
+
+func matchesEvidenceCASUnresolvedLinkage(event *cerebrov1.EventEnvelope) bool {
+	if !evidenceCASObjectKindMatcher(event) || !hasRequiredAttributes(event, evidenceCASUnresolvedLinkageDefinition.RequiredAttributes...) {
+		return false
+	}
+	return evidenceCASLinkageUnresolved(eventAttributes(event))
+}
+
+func evidenceCASUnresolvedLinkageFinding(event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
+	attrs := event.GetAttributes()
+	evidenceID := strings.TrimSpace(attrs["evidence_id"])
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	evidenceURN := evidenceCASEvidenceURN(tenantID, evidenceID)
+	if evidenceURN == "" {
+		return nil, nil
+	}
+	label := firstNonEmpty(strings.TrimSpace(attrs["resource_name"]), evidenceID)
+	attributes := map[string]string{
+		"evidence_cas_evidence_urn": evidenceURN,
+		"evidence_id":               evidenceID,
+		"evidence_type":             strings.TrimSpace(attrs["evidence_type"]),
+		"source_system":             strings.TrimSpace(attrs["source_system"]),
+		"unresolved_linkage":        evidenceCASUnresolvedLinkageScope(attrs),
+		"case_id":                   strings.TrimSpace(attrs["case_id"]),
+		"case_urn":                  strings.TrimSpace(attrs["case_urn"]),
+		"case_link_status":          strings.TrimSpace(attrs["case_link_status"]),
+		"resource_urn":              strings.TrimSpace(attrs["resource_urn"]),
+		"resource_link_status":      strings.TrimSpace(attrs["resource_link_status"]),
+		"evidence_cas_uri":          strings.TrimSpace(attrs["evidence_cas_uri"]),
+		"evidence_cas_digest":       strings.TrimSpace(attrs["evidence_cas_digest"]),
+		"event_id":                  strings.TrimSpace(event.GetId()),
+		"source_runtime_id":         firstNonEmpty(strings.TrimSpace(attrs[ports.EventAttributeSourceRuntimeID]), strings.TrimSpace(runtimeID)),
+		"primary_resource_urn":      evidenceURN,
+	}
+	for key, value := range evidenceCASUnresolvedLinkageDefinition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	observedAt := time.Time{}
+	if timestamp := event.GetOccurredAt(); timestamp != nil {
+		observedAt = timestamp.AsTime().UTC()
+	}
+	fingerprint := hashFindingFingerprint(evidenceCASUnresolvedLinkageRuleID, evidenceURN)
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       strings.TrimSpace(runtimeID),
+		RuleID:          evidenceCASUnresolvedLinkageRuleID,
+		Title:           evidenceCASUnresolvedLinkageTitle,
+		Severity:        evidenceCASUnresolvedLinkageSeverity,
+		Status:          findingStatusOpen,
+		Summary:         evidenceCASUnresolvedLinkageSummary(label),
+		ResourceURNs:    []string{evidenceURN},
+		EventIDs:        []string{strings.TrimSpace(event.GetId())},
+		PolicyID:        evidenceID,
+		CheckID:         evidenceCASUnresolvedLinkageCheckID,
+		CheckName:       evidenceCASUnresolvedLinkageCheckName,
+		ControlRefs:     cloneFindingControlRefs(evidenceCASUnresolvedLinkageDefinition.ControlRefs),
+		Attributes:      attributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}
+
+// evidenceCASLinkageUnresolved reports whether an Evidence CAS object that
+// supplied a case or resource context could not resolve that context. Evidence
+// with no declared context, or whose declared context resolves, is not a
+// linkage risk so ordinary inventory does not surface as a finding.
+func evidenceCASLinkageUnresolved(attributes map[string]string) bool {
+	return evidenceCASResourceLinkUnresolved(attributes) || evidenceCASCaseLinkUnresolved(attributes)
+}
+
+func evidenceCASResourceLinkUnresolved(attributes map[string]string) bool {
+	if !evidenceCASResourceContextSupplied(attributes) {
+		return false
+	}
+	if parseBoolAttribute(attributes, "unresolved_resource_context") {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(attributes["resource_link_status"]), "missing")
+}
+
+func evidenceCASCaseLinkUnresolved(attributes map[string]string) bool {
+	if !evidenceCASCaseContextSupplied(attributes) {
+		return false
+	}
+	if parseBoolAttribute(attributes, "unresolved_case_context") {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(attributes["case_link_status"]), "missing")
+}
+
+func evidenceCASResourceContextSupplied(attributes map[string]string) bool {
+	return firstNonEmpty(attributes["resource_urn"], attributes["resource_id"]) != ""
+}
+
+func evidenceCASCaseContextSupplied(attributes map[string]string) bool {
+	return firstNonEmpty(attributes["case_id"], attributes["case_urn"]) != ""
+}
+
+func evidenceCASUnresolvedLinkageScope(attributes map[string]string) string {
+	resource := evidenceCASResourceLinkUnresolved(attributes)
+	caseLink := evidenceCASCaseLinkUnresolved(attributes)
+	switch {
+	case resource && caseLink:
+		return "resource_and_case"
+	case resource:
+		return "resource"
+	case caseLink:
+		return "case"
+	default:
+		return ""
+	}
+}
+
+func evidenceCASEvidenceURN(tenantID string, evidenceID string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	evidenceID = strings.TrimSpace(evidenceID)
+	if tenantID == "" || evidenceID == "" {
+		return ""
+	}
+	return fmt.Sprintf("urn:cerebro:%s:runtime_evidence:%s", tenantID, evidenceID)
+}
+
+func evidenceCASUnresolvedLinkageAnchor(attributes map[string]string) string {
+	return identityCounterEventAnchor(map[string]string{
+		"evidence_cas_evidence_urn": strings.TrimSpace(attributes["evidence_cas_evidence_urn"]),
+	}, "evidence_cas_evidence_urn")
+}
+
+func evidenceCASUnresolvedLinkageSummary(label string) string {
+	return fmt.Sprintf("Evidence CAS object %s cannot resolve its case or resource linkage", firstNonEmpty(label, "unknown evidence"))
+}

--- a/internal/findings/evidence_cas_unresolved_linkage_rule.go
+++ b/internal/findings/evidence_cas_unresolved_linkage_rule.go
@@ -76,16 +76,18 @@ func (r *evidenceCASUnresolvedLinkageRule) OpenAnchor(attributes map[string]stri
 	return evidenceCASUnresolvedLinkageAnchor(attributes)
 }
 
-// CloseOnEvent resolves an open finding when a later reference for the same
-// evidence object resolves its case and resource linkage, so evidence whose
-// context has since been ingested or repaired does not leave a stale open
-// finding.
+// CloseOnEvent resolves an open finding only when a later reference for the
+// same evidence object supplies case or resource context that explicitly
+// resolves, so evidence whose context has since been ingested or repaired does
+// not leave a stale open finding. A context-less follow-up event that omits
+// case and resource linkage entirely must not close the finding: the absence
+// of unresolved markers is not evidence that the linkage was repaired.
 func (r *evidenceCASUnresolvedLinkageRule) CloseOnEvent(event Event) (string, bool) {
 	if !evidenceCASObjectKindMatcher(event) || !hasRequiredAttributes(event, evidenceCASUnresolvedLinkageDefinition.RequiredAttributes...) {
 		return "", false
 	}
 	attributes := eventAttributes(event)
-	if evidenceCASLinkageUnresolved(attributes) {
+	if !evidenceCASLinkageResolved(attributes) {
 		return "", false
 	}
 	evidenceURN := evidenceCASEvidenceURN(event.GetTenantId(), attributes["evidence_id"])
@@ -163,6 +165,19 @@ func evidenceCASUnresolvedLinkageFinding(event *cerebrov1.EventEnvelope, runtime
 // linkage risk so ordinary inventory does not surface as a finding.
 func evidenceCASLinkageUnresolved(attributes map[string]string) bool {
 	return evidenceCASResourceLinkUnresolved(attributes) || evidenceCASCaseLinkUnresolved(attributes)
+}
+
+// evidenceCASLinkageResolved reports whether an Evidence CAS object explicitly
+// supplies case or resource context that resolves. It requires positive
+// evidence of a repaired linkage: at least one declared context must be present
+// and none of the declared contexts may be unresolved. Evidence that declares
+// no case or resource context carries no resolved-linkage signal and therefore
+// does not resolve an open finding.
+func evidenceCASLinkageResolved(attributes map[string]string) bool {
+	if !evidenceCASResourceContextSupplied(attributes) && !evidenceCASCaseContextSupplied(attributes) {
+		return false
+	}
+	return !evidenceCASLinkageUnresolved(attributes)
 }
 
 func evidenceCASResourceLinkUnresolved(attributes map[string]string) bool {

--- a/internal/findings/evidence_cas_unresolved_linkage_rule_test.go
+++ b/internal/findings/evidence_cas_unresolved_linkage_rule_test.go
@@ -108,6 +108,52 @@ func TestEvidenceCASUnresolvedLinkageIgnoresResolvedAndBareEvidence(t *testing.T
 	}
 }
 
+func TestEvidenceCASUnresolvedLinkageContextlessFollowupKeepsFindingOpen(t *testing.T) {
+	rule := newEvidenceCASUnresolvedLinkageRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-evidence-cas", SourceId: "evidence_cas", TenantId: "writer"}
+
+	opened, err := rule.Evaluate(context.Background(), runtime, evidenceCASObjectEvent("evidence-open-1", map[string]string{
+		"case_id":                 "case-1",
+		"case_link_status":        "missing",
+		"unresolved_case_context": "true",
+	}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)))
+	if err != nil {
+		t.Fatalf("Evaluate(open) error = %v", err)
+	}
+	if len(opened) != 1 || strings.TrimSpace(opened[0].Status) != findingStatusOpen {
+		t.Fatalf("Evaluate(open) = %d findings, want 1 open", len(opened))
+	}
+
+	counterRule, ok := rule.(CounterEventRule)
+	if !ok {
+		t.Fatal("rule does not implement CounterEventRule")
+	}
+
+	// A later event sharing the same evidence_id that supplies no case or
+	// resource context at all must not close the finding: the absence of
+	// unresolved markers is not evidence that the linkage was repaired.
+	contextless := evidenceCASObjectEvent("evidence-followup", map[string]string{
+		"case_id":                 "",
+		"case_urn":                "",
+		"case_link_status":        "",
+		"unresolved_case_context": "",
+		"resource_urn":            "",
+		"resource_id":             "",
+		"resource_link_status":    "",
+	}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	if anchor, closes := counterRule.CloseOnEvent(contextless); closes || anchor != "" {
+		t.Fatalf("CloseOnEvent(contextless) = (%q, %v), want no close", anchor, closes)
+	}
+
+	records, err := rule.Evaluate(context.Background(), runtime, contextless)
+	if err != nil {
+		t.Fatalf("Evaluate(contextless) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("Evaluate(contextless) emitted %d findings, want 0", len(records))
+	}
+}
+
 func TestEvidenceCASUnresolvedLinkageRemediationResolves(t *testing.T) {
 	open := evidenceCASObjectEvent("evidence-open", map[string]string{
 		"case_id":                 "case-1",

--- a/internal/findings/evidence_cas_unresolved_linkage_rule_test.go
+++ b/internal/findings/evidence_cas_unresolved_linkage_rule_test.go
@@ -1,0 +1,200 @@
+package findings
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func evidenceCASObjectEvent(id string, attrs map[string]string, occurredAt time.Time) *cerebrov1.EventEnvelope {
+	base := map[string]string{
+		"family":            "object",
+		"evidence_id":       "evidence-1",
+		"evidence_type":     "evidence_cas.artifact",
+		"source_system":     "iris",
+		"source_runtime_id": "writer-evidence-cas",
+	}
+	for key, value := range attrs {
+		if value == "" {
+			delete(base, key)
+			continue
+		}
+		base[key] = value
+	}
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   "evidence_cas",
+		Kind:       "evidence_cas.object",
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  "evidence_cas/object/v1",
+		Attributes: base,
+	}
+}
+
+func TestEvidenceCASUnresolvedLinkageFixture(t *testing.T) {
+	assertRuleFixture(t, newEvidenceCASUnresolvedLinkageRule(), "testdata/rules/evidence-cas-unresolved-linkage.json")
+}
+
+func TestEvidenceCASUnresolvedLinkageOpensOnUnresolvedContext(t *testing.T) {
+	rule := newEvidenceCASUnresolvedLinkageRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-evidence-cas", SourceId: "evidence_cas", TenantId: "writer"}
+
+	unresolved := evidenceCASObjectEvent("evidence-unresolved", map[string]string{
+		"evidence_id":             "evidence-unresolved",
+		"case_id":                 "case-1",
+		"case_link_status":        "missing",
+		"unresolved_case_context": "true",
+		"resource_urn":            "urn:cerebro:writer:case:case-1",
+		"resource_link_status":    "missing",
+	}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	records, err := rule.Evaluate(context.Background(), runtime, unresolved)
+	if err != nil {
+		t.Fatalf("Evaluate(unresolved) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Evaluate(unresolved) emitted %d findings, want 1", len(records))
+	}
+	finding := records[0]
+	if got := strings.TrimSpace(finding.Status); got != findingStatusOpen {
+		t.Fatalf("status = %q, want open", got)
+	}
+	if got := finding.Severity; got != "MEDIUM" {
+		t.Fatalf("severity = %q, want MEDIUM", got)
+	}
+	assertFindingResourceURN(t, finding.ResourceURNs, "urn:cerebro:writer:runtime_evidence:evidence-unresolved")
+	if got := finding.Attributes["unresolved_linkage"]; got != "resource_and_case" {
+		t.Fatalf("unresolved_linkage = %q, want resource_and_case", got)
+	}
+}
+
+func TestEvidenceCASUnresolvedLinkageIgnoresResolvedAndBareEvidence(t *testing.T) {
+	rule := newEvidenceCASUnresolvedLinkageRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-evidence-cas", SourceId: "evidence_cas", TenantId: "writer"}
+
+	resolved := evidenceCASObjectEvent("evidence-linked", map[string]string{
+		"case_id":              "case-1",
+		"case_link_status":     "linked",
+		"resource_urn":         "urn:cerebro:writer:case:case-1",
+		"resource_link_status": "linked",
+	}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	records, err := rule.Evaluate(context.Background(), runtime, resolved)
+	if err != nil {
+		t.Fatalf("Evaluate(resolved) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("Evaluate(resolved) emitted %d findings, want 0", len(records))
+	}
+
+	// Evidence that declares no case or resource context is not a linkage risk
+	// and must not surface as a finding even though no context resolved.
+	bare := evidenceCASObjectEvent("evidence-bare", map[string]string{
+		"case_id":              "",
+		"resource_urn":         "",
+		"resource_link_status": "missing",
+	}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	records, err = rule.Evaluate(context.Background(), runtime, bare)
+	if err != nil {
+		t.Fatalf("Evaluate(bare) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("Evaluate(bare) emitted %d findings, want 0", len(records))
+	}
+}
+
+func TestEvidenceCASUnresolvedLinkageRemediationResolves(t *testing.T) {
+	open := evidenceCASObjectEvent("evidence-open", map[string]string{
+		"case_id":                 "case-1",
+		"case_link_status":        "missing",
+		"unresolved_case_context": "true",
+	}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	resolved := evidenceCASObjectEvent("evidence-resolved", map[string]string{
+		"case_id":          "case-1",
+		"case_urn":         "urn:cerebro:writer:case:case-1",
+		"case_link_status": "linked",
+	}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	assertIdentityRuleRemediationTrajectory(t, newEvidenceCASUnresolvedLinkageRule(), open, resolved, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
+}
+
+func TestEvidenceCASUnresolvedLinkageReopensOnRecurrence(t *testing.T) {
+	rule := newEvidenceCASUnresolvedLinkageRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-evidence-cas", SourceId: "evidence_cas", TenantId: "writer"}
+
+	emitOpen := func(event *cerebrov1.EventEnvelope) *ports.FindingRecord {
+		t.Helper()
+		records, err := rule.Evaluate(context.Background(), runtime, event)
+		if err != nil {
+			t.Fatalf("Evaluate(%q) error = %v", event.GetId(), err)
+		}
+		if len(records) != 1 {
+			t.Fatalf("Evaluate(%q) emitted %d findings, want 1", event.GetId(), len(records))
+		}
+		if got := strings.TrimSpace(records[0].Status); got != findingStatusOpen {
+			t.Fatalf("Evaluate(%q) status = %q, want open", event.GetId(), got)
+		}
+		return records[0]
+	}
+
+	opened := emitOpen(evidenceCASObjectEvent("evidence-open-1", map[string]string{
+		"case_id":                 "case-1",
+		"case_link_status":        "missing",
+		"unresolved_case_context": "true",
+	}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)))
+	openFingerprint := strings.TrimSpace(opened.Fingerprint)
+	if openFingerprint == "" {
+		t.Fatal("opened finding has empty fingerprint")
+	}
+
+	counterRule, ok := rule.(CounterEventRule)
+	if !ok {
+		t.Fatal("rule does not implement CounterEventRule")
+	}
+	resolvedEvent := evidenceCASObjectEvent("evidence-resolved", map[string]string{
+		"case_id":          "case-1",
+		"case_urn":         "urn:cerebro:writer:case:case-1",
+		"case_link_status": "linked",
+	}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	closeAnchor, closes := counterRule.CloseOnEvent(resolvedEvent)
+	if !closes || closeAnchor == "" {
+		t.Fatalf("CloseOnEvent(resolved) = (%q, %v), want a non-empty closing anchor", closeAnchor, closes)
+	}
+	if openAnchor := counterRule.OpenAnchor(opened.Attributes); openAnchor != closeAnchor {
+		t.Fatalf("OpenAnchor(open finding) = %q, want match close anchor %q", openAnchor, closeAnchor)
+	}
+
+	reopened := emitOpen(evidenceCASObjectEvent("evidence-open-2", map[string]string{
+		"case_id":                 "case-1",
+		"case_link_status":        "missing",
+		"unresolved_case_context": "true",
+	}, time.Date(2026, 5, 1, 14, 0, 0, 0, time.UTC)))
+	if got := strings.TrimSpace(reopened.Fingerprint); got != openFingerprint {
+		t.Fatalf("recurrence fingerprint = %q, want stable %q", got, openFingerprint)
+	}
+	if got := strings.TrimSpace(reopened.ID); got != strings.TrimSpace(opened.ID) {
+		t.Fatalf("recurrence finding id = %q, want stable %q", got, strings.TrimSpace(opened.ID))
+	}
+}
+
+func TestEvidenceCASUnresolvedLinkageLifecycleMetadata(t *testing.T) {
+	rule := newEvidenceCASUnresolvedLinkageRule()
+	metadataRule, ok := rule.(MetadataRule)
+	if !ok {
+		t.Fatal("rule does not expose RuleMetadata")
+	}
+	definition := metadataRule.RuleMetadata()
+	if err := definition.Validate(); err != nil {
+		t.Fatalf("RuleDefinition.Validate() error = %v", err)
+	}
+	if definition.Lifecycle.Kind != LifecycleDurableState {
+		t.Fatalf("Lifecycle.Kind = %q, want %q", definition.Lifecycle.Kind, LifecycleDurableState)
+	}
+	if definition.Lifecycle.Anchor != AnchorSourceState {
+		t.Fatalf("Lifecycle.Anchor = %q, want %q", definition.Lifecycle.Anchor, AnchorSourceState)
+	}
+}

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -653,6 +653,52 @@
       ]
     },
     {
+      "id": "evidence-cas-unresolved-linkage",
+      "pack_id": "evidence_cas",
+      "pack_name": "Evidence CAS",
+      "name": "Evidence CAS Object With Unresolved Linkage",
+      "description": "Detect Evidence CAS objects whose latest reference cannot resolve the case or resource it claims to document, leaving stored evidence detached from the asset, identity, or case it is meant to support and breaking its chain of custody until the linkage is repaired.",
+      "source_id": "evidence_cas",
+      "evaluation_mode": "event",
+      "event_kinds": [
+        "evidence_cas.object"
+      ],
+      "output_kind": "finding.evidence_cas_unresolved_linkage",
+      "severity": "MEDIUM",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "chain-of-custody",
+        "correlation",
+        "data-integrity",
+        "evidence",
+        "evidence-cas"
+      ],
+      "references": [
+        "https://github.com/writer/cerebro/blob/main/docs/ARCHITECTURE.md"
+      ],
+      "false_positives": [
+        "Evidence captured slightly ahead of the case or resource it references, where the linkage resolves on the next sync once the referenced context is ingested."
+      ],
+      "runbook": "Confirm whether the referenced case or resource exists, repair the evidence reference or ingest the missing context, and verify the next Evidence CAS sync resolves the linkage.",
+      "required_attributes": [
+        "evidence_id"
+      ],
+      "fingerprint_fields": [
+        "evidence_cas_evidence_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC7.2"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.5.28"
+        }
+      ]
+    },
+    {
       "id": "github-app-integration-installed",
       "pack_id": "github",
       "pack_name": "GitHub",

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -88,8 +88,8 @@ func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
 
 func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	packs := builtinRulePacks()
-	if got := len(packs); got != 21 {
-		t.Fatalf("len(builtinRulePacks()) = %d, want 21", got)
+	if got := len(packs); got != 22 {
+		t.Fatalf("len(builtinRulePacks()) = %d, want 22", got)
 	}
 	rules := flattenRulePacks(packs)
 	if got := len(rules); got < 10 {

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -60,6 +60,14 @@ func builtinRulePacks() []RulePack {
 			Rules:       []Rule{newRuntimeActiveThreatEvidenceRule()},
 		},
 		{
+			ID:          "evidence_cas",
+			Name:        "Evidence CAS",
+			Description: "Evidence CAS object integrity and chain-of-custody linkage findings.",
+			Rules: []Rule{
+				newEvidenceCASUnresolvedLinkageRule(),
+			},
+		},
+		{
 			ID:          "panopticon",
 			Name:        "Panopticon",
 			Description: "Panopticon curated security operations cases.",

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -825,7 +825,7 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 48; got != want {
+	if got, want := len(keepRules), 49; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -994,6 +994,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "cloudflare-zone-protection-paused", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "cloudflare"},
 		{RuleID: "data-sensitive-asset-risk", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "asset"},
 		{RuleID: "email-domain-authentication-misconfigured", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "email_domain_health"},
+		{RuleID: "evidence-cas-unresolved-linkage", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "evidence_cas"},
 		{RuleID: "github-app-integration-installed", Classification: "RETIRE", BulkCloseoutThreshold: ">24h", Source: "github"},
 		{RuleID: "github-code-security-controls-disabled", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "github-dependabot-open-alert", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},

--- a/internal/findings/testdata/rules/evidence-cas-unresolved-linkage.json
+++ b/internal/findings/testdata/rules/evidence-cas-unresolved-linkage.json
@@ -1,0 +1,90 @@
+{
+  "rule_id": "evidence-cas-unresolved-linkage",
+  "runtime": {
+    "id": "writer-evidence-cas",
+    "source_id": "evidence_cas",
+    "tenant_id": "writer"
+  },
+  "events": [
+    {
+      "id": "evidence-cas-linked",
+      "tenant_id": "writer",
+      "source_id": "evidence_cas",
+      "kind": "evidence_cas.object",
+      "occurred_at": "2026-05-01T12:00:00Z",
+      "schema_ref": "evidence_cas/object/v1",
+      "attributes": {
+        "evidence_id": "evidence-linked",
+        "evidence_type": "evidence_cas.artifact",
+        "source_system": "iris",
+        "source_runtime_id": "writer-evidence-cas",
+        "case_id": "case-linked",
+        "case_urn": "urn:cerebro:writer:case:case-linked",
+        "case_link_status": "linked",
+        "resource_urn": "urn:cerebro:writer:case:case-linked",
+        "resource_link_status": "linked"
+      }
+    },
+    {
+      "id": "evidence-cas-unresolved",
+      "tenant_id": "writer",
+      "source_id": "evidence_cas",
+      "kind": "evidence_cas.object",
+      "occurred_at": "2026-05-01T12:05:00Z",
+      "schema_ref": "evidence_cas/object/v1",
+      "attributes": {
+        "evidence_id": "evidence-orphan",
+        "evidence_type": "evidence_cas.artifact",
+        "source_system": "iris",
+        "source_runtime_id": "writer-evidence-cas",
+        "case_id": "case-missing",
+        "case_link_status": "missing",
+        "unresolved_case_context": "true",
+        "resource_urn": "urn:cerebro:writer:case:case-missing",
+        "resource_link_status": "missing"
+      }
+    },
+    {
+      "id": "evidence-cas-bare",
+      "tenant_id": "writer",
+      "source_id": "evidence_cas",
+      "kind": "evidence_cas.object",
+      "occurred_at": "2026-05-01T12:10:00Z",
+      "schema_ref": "evidence_cas/object/v1",
+      "attributes": {
+        "evidence_id": "evidence-bare",
+        "evidence_type": "evidence_cas.artifact",
+        "source_system": "iris",
+        "source_runtime_id": "writer-evidence-cas",
+        "resource_link_status": "missing"
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "evidence-cas-unresolved-linkage",
+      "severity": "MEDIUM",
+      "status": "open",
+      "summary": "Evidence CAS object evidence-orphan cannot resolve its case or resource linkage",
+      "event_ids": ["evidence-cas-unresolved"],
+      "policy_id": "evidence-orphan",
+      "attributes": {
+        "evidence_cas_evidence_urn": "urn:cerebro:writer:runtime_evidence:evidence-orphan",
+        "evidence_id": "evidence-orphan",
+        "unresolved_linkage": "resource_and_case",
+        "primary_resource_urn": "urn:cerebro:writer:runtime_evidence:evidence-orphan",
+        "rule_required_attributes": "evidence_id"
+      }
+    }
+  ],
+  "expected_no_match": [
+    {
+      "event_id": "evidence-cas-linked",
+      "reason": "evidence whose case and resource linkage resolves is not a chain-of-custody risk"
+    },
+    {
+      "event_id": "evidence-cas-bare",
+      "reason": "evidence that declares no case or resource context cannot have unresolved linkage"
+    }
+  ]
+}

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -5230,6 +5230,70 @@ func TestProjectEvidenceCASTenantScopedLinksForCollidingIdentifiers(t *testing.T
 	assertProjectedLinkMissing(t, state, "urn:cerebro:tenant-b:case:case-1", relationHasEvidence, "urn:cerebro:tenant-a:runtime_evidence:evidence-1")
 }
 
+func TestProjectEvidenceCASStampsNormalizedLinkState(t *testing.T) {
+	linkedState := &projectionRecorder{}
+	service := New(linkedState, nil)
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "iris-evidence-linked",
+		TenantId: "writer",
+		SourceId: "evidence_cas",
+		Kind:     "evidence_cas.object",
+		Attributes: map[string]string{
+			"case_id":               "case-linked",
+			"case_link_status":      "linked",
+			"evidence_cas_digest":   "sha256linked",
+			"evidence_cas_ref_type": "evidencecas.manifest.v2",
+			"evidence_cas_uri":      "evidencecas://cases/case-linked/evidence/evidence-linked",
+			"evidence_id":           "evidence-linked",
+			"resource_entity_type":  "case",
+			"resource_link_status":  "linked",
+			"resource_urn":          "urn:cerebro:writer:case:case-linked",
+			"source_event_id":       "iris-event-linked",
+			"source_runtime_id":     "iris-runtime",
+			"source_system":         "iris",
+		},
+	}); err != nil {
+		t.Fatalf("Project(linked) error = %v", err)
+	}
+	linked := linkedState.entities["urn:cerebro:writer:runtime_evidence:evidence-linked"]
+	if linked == nil {
+		t.Fatal("linked runtime evidence entity missing")
+	}
+	if got := linked.Attributes["evidence_link_state"]; got != "linked" {
+		t.Fatalf("linked evidence_link_state = %q, want linked", got)
+	}
+
+	unresolvedState := &projectionRecorder{}
+	service = New(unresolvedState, nil)
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "iris-evidence-unresolved",
+		TenantId: "writer",
+		SourceId: "evidence_cas",
+		Kind:     "evidence_cas.object",
+		Attributes: map[string]string{
+			"case_id":                 "case-unresolved",
+			"evidence_cas_digest":     "sha256unresolved",
+			"evidence_cas_ref_type":   "evidencecas.manifest.v2",
+			"evidence_cas_uri":        "evidencecas://cases/case-unresolved/evidence/evidence-unresolved",
+			"evidence_id":             "evidence-unresolved",
+			"resource_urn":            "urn:cerebro:writer:case:case-unresolved",
+			"source_event_id":         "iris-event-unresolved",
+			"source_runtime_id":       "iris-runtime",
+			"source_system":           "iris",
+			"unresolved_case_context": "true",
+		},
+	}); err != nil {
+		t.Fatalf("Project(unresolved) error = %v", err)
+	}
+	unresolved := unresolvedState.entities["urn:cerebro:writer:runtime_evidence:evidence-unresolved"]
+	if unresolved == nil {
+		t.Fatal("unresolved runtime evidence entity missing")
+	}
+	if got := unresolved.Attributes["evidence_link_state"]; got != "unresolved" {
+		t.Fatalf("unresolved evidence_link_state = %q, want unresolved", got)
+	}
+}
+
 func TestProjectKubernetesWorkloadBuildsClusterAndCloudAccountLinks(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -5292,6 +5292,34 @@ func TestProjectEvidenceCASStampsNormalizedLinkState(t *testing.T) {
 	if got := unresolved.Attributes["evidence_link_state"]; got != "unresolved" {
 		t.Fatalf("unresolved evidence_link_state = %q, want unresolved", got)
 	}
+
+	bareState := &projectionRecorder{}
+	service = New(bareState, nil)
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "iris-evidence-bare",
+		TenantId: "writer",
+		SourceId: "evidence_cas",
+		Kind:     "evidence_cas.object",
+		Attributes: map[string]string{
+			"evidence_cas_digest":   "sha256bare",
+			"evidence_cas_ref_type": "evidencecas.manifest.v2",
+			"evidence_cas_uri":      "evidencecas://evidence/evidence-bare",
+			"evidence_id":           "evidence-bare",
+			"resource_link_status":  "missing",
+			"source_event_id":       "iris-event-bare",
+			"source_runtime_id":     "iris-runtime",
+			"source_system":         "iris",
+		},
+	}); err != nil {
+		t.Fatalf("Project(bare) error = %v", err)
+	}
+	bare := bareState.entities["urn:cerebro:writer:runtime_evidence:evidence-bare"]
+	if bare == nil {
+		t.Fatal("bare runtime evidence entity missing")
+	}
+	if got := bare.Attributes["evidence_link_state"]; got != "linked" {
+		t.Fatalf("bare evidence_link_state = %q, want linked", got)
+	}
 }
 
 func TestProjectKubernetesWorkloadBuildsClusterAndCloudAccountLinks(t *testing.T) {

--- a/internal/sourceprojection/runtime.go
+++ b/internal/sourceprojection/runtime.go
@@ -21,6 +21,8 @@ func runtimeEvidenceProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 	resourceURN := firstNonEmpty(attributes["resource_urn"], attributes["workload_urn"])
 	explicitResourceURN := resourceURN != ""
 	resourceLinkStatusInput := strings.ToLower(strings.TrimSpace(attributes["resource_link_status"]))
+	resourceContextSupplied := firstNonEmpty(attributes["resource_urn"], attributes["workload_urn"], attributes["resource_id"]) != "" ||
+		strings.EqualFold(strings.TrimSpace(attributes["unresolved_resource_context"]), "true")
 	resourceUnresolved := strings.EqualFold(strings.TrimSpace(attributes["unresolved_resource_context"]), "true") || resourceLinkStatusInput == "missing"
 	if resourceURN == "" && !isEvidenceCAS && !resourceUnresolved {
 		resourceURN = projectionURN(tenantID, "runtime_"+normalizeCloudType(firstNonEmpty(attributes["resource_type"], "resource")), firstNonEmpty(attributes["resource_id"], attributes["resource_name"], evidenceID))
@@ -43,7 +45,8 @@ func runtimeEvidenceProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 		}
 	}
 	evidenceLinkState := "linked"
-	if resourceLinkStatus == "missing" || caseLinkStatus == "missing" {
+	resourceLinkUnresolved := resourceLinkStatus == "missing" && (!isEvidenceCAS || resourceContextSupplied)
+	if resourceLinkUnresolved || caseLinkStatus == "missing" {
 		evidenceLinkState = "unresolved"
 	}
 	if evidenceURN != "" {

--- a/internal/sourceprojection/runtime.go
+++ b/internal/sourceprojection/runtime.go
@@ -42,6 +42,10 @@ func runtimeEvidenceProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 			caseURN = firstNonEmpty(attributes["case_urn"], projectionURN(tenantID, "case", caseID))
 		}
 	}
+	evidenceLinkState := "linked"
+	if resourceLinkStatus == "missing" || caseLinkStatus == "missing" {
+		evidenceLinkState = "unresolved"
+	}
 	if evidenceURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        evidenceURN,
@@ -52,6 +56,7 @@ func runtimeEvidenceProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 			Attributes: map[string]string{
 				"case_id":                       caseID,
 				"case_link_status":              caseLinkStatus,
+				"evidence_link_state":           evidenceLinkState,
 				"confidence":                    strings.TrimSpace(attributes["confidence"]),
 				"detector_id":                   strings.TrimSpace(attributes["detector_id"]),
 				"evidence_cas_blocks_count":     strings.TrimSpace(attributes["evidence_cas_blocks_count"]),

--- a/sources/evidencecas/source.go
+++ b/sources/evidencecas/source.go
@@ -67,6 +67,7 @@ func New() (*Source, error) {
 					"occurred_at":                   "metadata.occurred_at|occurred_at",
 					"observed_at":                   "metadata.observed_at|observed_at|updated_at",
 					"case_id":                       "metadata.case_id",
+					"case_urn":                      "metadata.case_urn",
 					"case_link_status":              "metadata.case_link_status",
 					"resource_entity_type":          "metadata.resource_entity_type",
 					"resource_id":                   "metadata.resource_id|metadata.case_id",

--- a/sources/evidencecas/source_test.go
+++ b/sources/evidencecas/source_test.go
@@ -201,6 +201,53 @@ func TestReadObjectRefsPreservesCanonicalCorrelationAndLegacyMetadata(t *testing
 	}
 }
 
+func TestReadObjectRefsEmitsCanonicalCaseURNCorrelation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"objects": []map[string]any{
+				{
+					"ref_type":         "evidencecas.manifest.v2",
+					"uri":              "evidencecas://cases/case-789/evidence/evidence-789",
+					"digest":           "sha256case",
+					"manifest_version": 2,
+					"updated_at":       "2026-06-06T00:00:00Z",
+					"metadata": map[string]any{
+						"tenant_id":        "tenant-789",
+						"source_system":    "iris",
+						"source_event_id":  "iris-event-789",
+						"evidence_id":      "evidence-789",
+						"case_id":          "case-789",
+						"case_urn":         "urn:cerebro:tenant-789:case:case-789",
+						"case_link_status": "linked",
+						"resource_urn":     "urn:cerebro:tenant-789:case:case-789",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "tenant-789",
+		"base_url":  server.URL,
+		"token":     "cache-token",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+	if got := pull.Events[0].Attributes["case_urn"]; got != "urn:cerebro:tenant-789:case:case-789" {
+		t.Fatalf("case_urn = %q, want urn:cerebro:tenant-789:case:case-789", got)
+	}
+}
+
 func TestSourceCatalogRequiresSourceSystem(t *testing.T) {
 	specBytes, err := catalogFS.ReadFile("catalog.yaml")
 	if err != nil {


### PR DESCRIPTION
## Scope

Single source: `evidence_cas`. Deepens the Evidence CAS connector to full-depth quality with a complete vertical slice (source enrichment, graph projection, durable finding, tests/fixtures). No other source domains are modified.

## Source changes

- Map the canonical `case_urn` correlation attribute on emitted `evidence_cas.object` events (`sources/evidencecas/source.go`), so downstream consumers can resolve case linkage deterministically instead of always reconstructing a URN from `case_id`. This strengthens cross-source correlation joins.
- Added source test asserting `case_urn` flows through from object metadata.

## Projection changes

- The runtime-evidence projector (`internal/sourceprojection/runtime.go`) now stamps a normalized `evidence_link_state` attribute (`linked` / `unresolved`) on the projected `runtime.evidence` entity, derived from the resolved resource/case link statuses. Existing unresolved-link guardrails (no synthetic entities/links when context is unresolved, tenant-safe identity, replay idempotency, conflict rejection) are preserved.
- Added projection test asserting `evidence_link_state` is `linked` for resolved context and `unresolved` when declared context cannot resolve.

## Finding changes

- New durable, current-state rule `evidence-cas-unresolved-linkage` (`MEDIUM`) that opens when an Evidence CAS object supplies a case or resource context that cannot be resolved (broken chain of custody), keeping stored evidence detached from the asset/identity/case it documents.
- Lifecycle is `durable_state` anchored on `source_state`: a later reference for the same evidence that resolves its linkage closes the finding; recurrence reopens the same evidence-URN fingerprint without churn. Evidence that declares no case/resource context does not produce a finding (no temporal noise).
- Added rule unit tests (open/resolve/reopen lifecycle, bare-evidence negative case, lifecycle metadata) and a JSON rule fixture.

## Shared file touches

- `internal/findings/rulepack.go` — register a new `evidence_cas` rule pack.
- `internal/findings/rulepack_audit_test.go` — add fallback classification (`KEEP_AS_IS`) for the new rule.
- `internal/findings/registry_test.go` — bump expected rule-pack count.
- `internal/findings/public_detection_catalog.json` — regenerated (`make detection-catalog-generate`), adds the new detection only.
- `internal/compliance/control_coverage_index.yaml` — regenerated (`make control-index-generate`), adds the new rule's control mappings only.

No new projection retraction reasons were introduced, and no closeout rule-id artifacts changed (the new rule is `KEEP_AS_IS`).

## Validation evidence

All commands run on the PR head commit:

- `make lint` — `0 issues.`
- `go test ./sources/evidencecas/... -count=1` — ok (8 matched tests)
- `go test ./internal/sourceprojection/... -run 'EvidenceCAS|RuntimeEvidence|evidence_cas' -count=1` — ok (8 matched tests)
- `go test ./internal/sourceprojection/... -run 'Panopticon|EvidenceCAS|RuntimeEvidence' -count=1` — ok (19 matched tests, correlation join)
- `go test ./internal/findings/... -run 'EvidenceCAS|RuntimeEvidence|evidence_cas' -count=1` — ok (6 matched tests)
- `go test ./internal/findings/... -run 'Rulepack|BuiltinRule|Lifecycle|Closeout|Classification' -count=1` — ok (rulepack governance)
- `go test ./tools/archtests/... -count=1` — ok
- `make catalog-check` — ok
- `make detection-catalog-check` — ok

## Risk and rollback

Low risk and additive. The source change adds one optional attribute mapping; the projection change adds one deterministic derived attribute; the finding rule is current-state and conservative (only fires on context that was supplied but unresolved). Rollback by reverting this single commit; the regenerated catalog/control-index artifacts revert with it and remain consistent.
