### PR TITLE
Require explicit trusted proxy CIDRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Core runtime and store variables:
 | `CEREBRO_CAPABILITY_TOKEN_SECRETS` | comma-separated HMAC secrets for capability-token auth | unset |
 | `CEREBRO_CAPABILITY_TOKEN_AUDIENCE` | expected capability-token audience | `cerebro-api` |
 | `CEREBRO_PUBLIC_ORIGIN` | canonical external origin for DPoP and proxy-aware URL reconstruction | request host |
-| `CEREBRO_TRUSTED_PROXY_CIDRS` | comma-separated trusted proxy/load-balancer CIDRs for forwarded headers | private/link-local remotes |
+| `CEREBRO_TRUSTED_PROXY_CIDRS` | comma-separated trusted proxy/load-balancer CIDRs for forwarded headers | unset |
 | `CEREBRO_TRUSTED_PROXY_COUNT` | trusted trailing `X-Forwarded-For` hops | `0` |
 | `CEREBRO_RATE_LIMIT_ENABLED` | enable global API rate limiting | `true` outside acknowledged dev mode |
 | `CEREBRO_RATE_LIMIT_RPS` | global API rate-limit refill rate | `100` |

--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -10,7 +10,7 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_API_KEYS` | unset | Comma-separated `key[:principal[:tenant_id]]` entries. Required when auth is enabled. |
 | `CEREBRO_ALLOWED_TENANTS` | unset | Optional comma-separated tenant allowlist for unscoped API keys. |
 | `CEREBRO_PUBLIC_ORIGIN` | request host | Canonical external origin, for example `https://cerebro.example.com`, used for DPoP `htu` and public URL reconstruction. Must not include a path, query, or fragment. |
-| `CEREBRO_TRUSTED_PROXY_CIDRS` | private/link-local remotes | Optional comma-separated CIDRs whose forwarded headers are trusted. Set this explicitly in production to the load-balancer/proxy network. |
+| `CEREBRO_TRUSTED_PROXY_CIDRS` | unset | Optional comma-separated CIDRs whose forwarded headers are trusted. Set this explicitly in production to the load-balancer/proxy network. |
 | `CEREBRO_TRUSTED_PROXY_COUNT` | `0` | Optional count of trusted trailing `X-Forwarded-For` hops. Use `1` for a single ALB/proxy hop. |
 | `CEREBRO_RATE_LIMIT_ENABLED` | `true` outside acknowledged dev mode | Enable global API rate limiting. |
 | `CEREBRO_RATE_LIMIT_RPS` | `100` | Global API rate-limit refill rate. |

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2060,6 +2060,10 @@ func TestAuthMiddlewareEmitsAccessAuditEvents(t *testing.T) {
 				Principal: "ci",
 				TenantID:  "writer",
 			}},
+			RequestOrigin: config.RequestOriginConfig{
+				TrustedProxyCIDRs: []string{"127.0.0.0/8"},
+				TrustedProxyCount: 1,
+			},
 		},
 	}
 	app := New(cfg, Dependencies{}, registry)
@@ -2320,20 +2324,6 @@ func TestAccessAuditRemoteIPDropsPort(t *testing.T) {
 	}
 }
 
-func TestAccessAuditClientIPTrustsForwardedForFromPrivateRemote(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
-	req.RemoteAddr = "10.0.0.5:54321"
-	req.Header.Set("X-Forwarded-For", "198.51.100.10, 10.0.0.5")
-	if got := accessAuditClientIP(req); got != "198.51.100.10" {
-		t.Fatalf("accessAuditClientIP(private remote) = %q, want forwarded client", got)
-	}
-
-	req.RemoteAddr = "203.0.113.20:54321"
-	if got := accessAuditClientIP(req); got != "" {
-		t.Fatalf("accessAuditClientIP(public remote) = %q, want empty", got)
-	}
-}
-
 func TestResolveRequestOriginUsesConfiguredPublicOrigin(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://internal.local/platform/devices/token?rotate=true", nil)
 	req.RemoteAddr = "10.0.0.5:54321"
@@ -2376,10 +2366,18 @@ func TestResolveRequestOriginDoesNotTrustCallerSuppliedForwardedFor(t *testing.T
 	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
 	req.RemoteAddr = "10.0.1.20:443"
 	req.Header.Set("X-Forwarded-For", "198.51.100.99, 203.0.113.200")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "attacker.example")
 
 	origin := resolveRequestOrigin(req, config.RequestOriginConfig{})
-	if got := origin.ClientIP; got != "203.0.113.200" {
-		t.Fatalf("ClientIP = %q, want proxy-appended client IP", got)
+	if origin.TrustedProxy {
+		t.Fatal("TrustedProxy = true, want false without explicit trusted proxy CIDRs")
+	}
+	if got := origin.ClientIP; got != "10.0.1.20" {
+		t.Fatalf("ClientIP = %q, want remote address", got)
+	}
+	if got := origin.PublicURL; got != "http://example.com/sources" {
+		t.Fatalf("PublicURL = %q, want request origin", got)
 	}
 }
 
@@ -2388,7 +2386,7 @@ func TestResolveRequestOriginRejectsMalformedForwardedHost(t *testing.T) {
 	req.RemoteAddr = "10.0.1.20:443"
 	req.Header.Set("X-Forwarded-Host", "user@evil.example")
 
-	origin := resolveRequestOrigin(req, config.RequestOriginConfig{})
+	origin := resolveRequestOrigin(req, config.RequestOriginConfig{TrustedProxyCIDRs: []string{"10.0.0.0/8"}})
 	if got := origin.PublicURL; got != "http://example.com/sources" {
 		t.Fatalf("PublicURL = %q, want request host when forwarded host is malformed", got)
 	}
@@ -2401,7 +2399,7 @@ func TestResolveRequestOriginRejectsMalformedTrailingForwardedOrigin(t *testing.
 	req.Header.Set("X-Forwarded-Proto", "https, gopher")
 	req.Header.Set("X-Forwarded-Host", "stale.example, user@evil.example")
 
-	origin := resolveRequestOrigin(req, config.RequestOriginConfig{})
+	origin := resolveRequestOrigin(req, config.RequestOriginConfig{TrustedProxyCIDRs: []string{"10.0.0.0/8"}})
 	if got := origin.PublicURL; got != "http://internal.local/sources" {
 		t.Fatalf("PublicURL = %q, want request origin when trailing forwarded origin is malformed", got)
 	}
@@ -2414,7 +2412,7 @@ func TestResolveRequestOriginDoesNotMixForwardedOriginWithFallback(t *testing.T)
 	req.Header.Set("X-Forwarded-Proto", "https, gopher")
 	req.Header.Set("X-Forwarded-Host", "api.writer.com, api.writer.com")
 
-	origin := resolveRequestOrigin(req, config.RequestOriginConfig{})
+	origin := resolveRequestOrigin(req, config.RequestOriginConfig{TrustedProxyCIDRs: []string{"10.0.0.0/8"}})
 	if got := origin.PublicURL; got != "http://internal.local/sources" {
 		t.Fatalf("PublicURL = %q, want request origin when forwarded proto is malformed", got)
 	}

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -1076,32 +1076,6 @@ func accessAuditRemoteIP(remoteAddr string) string {
 	return ""
 }
 
-func accessAuditClientIP(r *http.Request) string {
-	if r == nil {
-		return ""
-	}
-	remoteIP := net.ParseIP(accessAuditRemoteIP(r.RemoteAddr))
-	if remoteIP == nil || !accessAuditTrustsForwardedFor(remoteIP) {
-		return ""
-	}
-	parts := strings.Split(r.Header.Get("X-Forwarded-For"), ",")
-	for i := len(parts) - 1; i >= 0; i-- {
-		ip := net.ParseIP(strings.TrimSpace(parts[i]))
-		if ip == nil {
-			continue
-		}
-		if accessAuditTrustsForwardedFor(ip) {
-			continue
-		}
-		return ip.String()
-	}
-	return ""
-}
-
-func accessAuditTrustsForwardedFor(remoteIP net.IP) bool {
-	return remoteIP != nil && (remoteIP.IsLoopback() || remoteIP.IsPrivate() || remoteIP.IsLinkLocalUnicast())
-}
-
 func accessAuditRequestID(r *http.Request) string {
 	if r == nil {
 		return ""

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -526,12 +526,12 @@ func TestRemoteIPForRateLimitIgnoresClientForwardedFor(t *testing.T) {
 	}
 }
 
-func TestRemoteIPForRateLimitTrustsForwardedForFromPrivateProxy(t *testing.T) {
+func TestRemoteIPForRateLimitIgnoresForwardedForFromPrivateRemote(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", nil)
 	req.RemoteAddr = "10.0.1.20:443"
 	req.Header.Set("X-Forwarded-For", "203.0.113.200, 10.0.1.20")
-	if got := remoteIPForRateLimit(req); got != "203.0.113.200" {
-		t.Fatalf("remoteIPForRateLimit = %q, want forwarded client IP", got)
+	if got := remoteIPForRateLimit(req); got != "10.0.1.20" {
+		t.Fatalf("remoteIPForRateLimit = %q, want RemoteAddr host", got)
 	}
 }
 
@@ -539,8 +539,8 @@ func TestRemoteIPForRateLimitIgnoresSpoofedLeftmostForwardedFor(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", nil)
 	req.RemoteAddr = "10.0.1.20:443"
 	req.Header.Set("X-Forwarded-For", "198.51.100.99, 203.0.113.200, 10.0.1.20")
-	if got := remoteIPForRateLimit(req); got != "203.0.113.200" {
-		t.Fatalf("remoteIPForRateLimit = %q, want rightmost untrusted client IP", got)
+	if got := remoteIPForRateLimit(req); got != "10.0.1.20" {
+		t.Fatalf("remoteIPForRateLimit = %q, want RemoteAddr host", got)
 	}
 }
 

--- a/internal/bootstrap/request_origin.go
+++ b/internal/bootstrap/request_origin.go
@@ -70,10 +70,7 @@ func requestOriginTrustsProxy(remoteIP net.IP, cfg config.RequestOriginConfig) b
 			return true
 		}
 	}
-	if len(cfg.TrustedProxyCIDRs) > 0 {
-		return false
-	}
-	return remoteIP.IsLoopback() || remoteIP.IsPrivate() || remoteIP.IsLinkLocalUnicast()
+	return false
 }
 
 func normalizedPublicOrigin(raw string) *url.URL {
@@ -143,7 +140,7 @@ func forwardedClientIP(header string, cfg config.RequestOriginConfig) string {
 	}
 	for i := len(parts) - 1; i >= 0; i-- {
 		ip := net.ParseIP(strings.TrimSpace(parts[i]))
-		if ip != nil && !accessAuditTrustsForwardedFor(ip) {
+		if ip != nil && !forwardedHopTrusted(ip, cfg) {
 			return ip.String()
 		}
 	}
@@ -172,8 +169,5 @@ func forwardedHopTrusted(ip net.IP, cfg config.RequestOriginConfig) bool {
 			return true
 		}
 	}
-	if len(cfg.TrustedProxyCIDRs) > 0 {
-		return false
-	}
-	return accessAuditTrustsForwardedFor(ip)
+	return false
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -260,7 +260,7 @@ type MCPOAuthUpstreamConfig struct {
 }
 
 // RequestOriginConfig controls how bootstrap reconstructs client IPs and public
-// request URLs when requests traverse reverse proxies.
+// request URLs when requests traverse explicitly trusted reverse proxies.
 type RequestOriginConfig struct {
 	PublicOrigin      string
 	TrustedProxyCIDRs []string


### PR DESCRIPTION
## Summary
- ignore forwarded headers unless the remote address matches configured trusted proxy CIDRs
- keep forwarded-header behavior for explicitly trusted proxy deployments
- update config documentation to show the safer unset default

## Tests
- `go test ./internal/bootstrap -run 'Test(AuthMiddlewareEmitsAccessAuditEvents|ResolveRequestOrigin|RemoteIPForRateLimit|RateLimiterUsesConfiguredRequestOriginTrust)' -count=1 -v`
- `go test ./internal/config -run 'TestLoadRejectsInvalidRequestOriginConfig|TestLoadReadsAuthAndRequestOriginConfig' -count=1 -v`
- `go test ./internal/bootstrap ./internal/config -count=1`
- `make oss-audit`
- `make docs-drift-check`
