### PR TITLE
Harden telemetry field governance

### DIFF
--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -333,12 +333,7 @@ func (e *askWideEvent) finish(r *http.Request, started time.Time, status int, er
 	if r != nil {
 		attrs = attrs.WithField(telemetry.Field{Key: "http.method", Value: r.Method})
 		attrs = attrs.WithField(telemetry.Field{Key: "http.route", Value: "POST /grc/ask"})
-		if ua := r.Header.Get("User-Agent"); ua != "" {
-			if len(ua) > 128 {
-				ua = ua[:128]
-			}
-			attrs = attrs.WithField(telemetry.Field{Key: "http.user_agent", Value: ua})
-		}
+		attrs = attrs.WithField(telemetry.Field{Key: "http.user_agent.present", Value: strings.TrimSpace(r.Header.Get("User-Agent")) != ""})
 	}
 	telemetry.Event(r.Context(), "cerebro.grc.ask", attrs)
 	telemetry.IncrementMain(r.Context(), "grc.ask.count", 1)

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -209,7 +209,7 @@ func httpRequestWideAttributes(r *http.Request, method string, route string) tel
 		telemetry.Field{Key: "http.request.header.accept", Value: requestHeader(r, "Accept")},
 		telemetry.Field{Key: "http.request.header.accept_encoding", Value: requestHeader(r, "Accept-Encoding")},
 		telemetry.Field{Key: "http.request.header.content_type", Value: requestHeader(r, "Content-Type")},
-		telemetry.Field{Key: "http.request.header.user_agent", Value: requestHeader(r, "User-Agent")},
+		telemetry.Field{Key: "http.request.header.user_agent.present", Value: requestHeader(r, "User-Agent") != ""},
 		telemetry.Field{Key: "user_agent.family", Value: userAgentFamily(requestHeader(r, "User-Agent"))},
 		telemetry.Field{Key: "client.address_hash", Value: remoteAddressHash(r)},
 	))

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -119,7 +119,7 @@ func TestMiddlewareEmitsHTTPWideEventFields(t *testing.T) {
 		"http.request.header.accept":              "application/json",
 		"http.request.header.accept_encoding":     "gzip",
 		"http.request.header.content_type":        "application/json",
-		"http.request.header.user_agent":          "curl/8.0",
+		"http.request.header.user_agent.present":  true,
 		"http.request.auth_header.present":        true,
 		"user_agent.family":                       "curl",
 		"cache.redis.hit.count":                   float64(1),
@@ -134,6 +134,9 @@ func TestMiddlewareEmitsHTTPWideEventFields(t *testing.T) {
 	}
 	if strings.Contains(stderr, "definitely-not-emitted") {
 		t.Fatalf("authorization header leaked into telemetry: %s", stderr)
+	}
+	if strings.Contains(stderr, "curl/8.0") {
+		t.Fatalf("raw user-agent leaked into telemetry: %s", stderr)
 	}
 }
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -99,6 +99,59 @@ func TestTelemetryFieldsDoNotUseRawErrorKey(t *testing.T) {
 	}
 }
 
+func TestTelemetryFieldsDoNotEmitRawUserAgent(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+	patterns := []struct {
+		name string
+		re   *regexp.Regexp
+	}{
+		{name: `raw user-agent telemetry key`, re: regexp.MustCompile(`Key:\s*"(http\.request\.header\.user_agent|http\.user_agent)"`)},
+	}
+	var matches []string
+	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", ".idea", ".vscode", "bin", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+		if filepath.Clean(path) == filepath.Clean(currentFile) {
+			return nil
+		}
+		contents, err := os.ReadFile(path) // #nosec G304 G122 -- path comes from WalkDir under the repository root in a repository-static lint test.
+		if err != nil {
+			return err
+		}
+		for _, pattern := range patterns {
+			if pattern.re.Match(contents) {
+				rel, err := filepath.Rel(repoRoot, path)
+				if err != nil {
+					rel = path
+				}
+				matches = append(matches, rel+" ("+pattern.name+")")
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("telemetry raw user-agent fields are forbidden; emit presence/family only: %s", strings.Join(matches, ", "))
+	}
+}
+
 func TestParseTraceParentValidatesTraceFlags(t *testing.T) {
 	traceID, spanID, ok := ParseTraceParent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
 	if !ok {


### PR DESCRIPTION
## Summary
- stop emitting raw User-Agent values in HTTP and GRC telemetry
- emit User-Agent presence/family instead
- add a repo-wide telemetry test blocking raw User-Agent keys from returning

## Verification
- go test ./internal/telemetry ./internal/observability ./internal/bootstrap
- go test ./...
- git diff --check