### PR TITLE
Rate limit dependency readiness checks

### DIFF
--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -15,7 +15,7 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_RATE_LIMIT_ENABLED` | `true` outside acknowledged dev mode | Enable global API rate limiting. |
 | `CEREBRO_RATE_LIMIT_RPS` | `100` | Global API rate-limit refill rate. |
 | `CEREBRO_RATE_LIMIT_BURST` | `150` | Global API rate-limit burst size. |
-| `CEREBRO_RATE_LIMIT_EXEMPT_PATHS` | health, metrics, and well-known metadata paths | Optional comma-separated path prefixes that bypass rate limiting. |
+| `CEREBRO_RATE_LIMIT_EXEMPT_PATHS` | liveness, metrics, and well-known metadata paths | Optional comma-separated path prefixes that bypass rate limiting. |
 | `CEREBRO_APPEND_LOG_DRIVER` | inferred | Append-log driver. Supported: `jetstream`. |
 | `CEREBRO_JETSTREAM_URL` | unset | NATS JetStream URL. Setting this infers `jetstream`. |
 | `CEREBRO_JETSTREAM_SUBJECT_PREFIX` | `events` | Subject prefix for append-log events. |

--- a/internal/bootstrap/ratelimit.go
+++ b/internal/bootstrap/ratelimit.go
@@ -12,7 +12,7 @@ import (
 )
 
 // rateLimiter implements per-IP token bucket rate limiting with configurable
-// exemptions for health and metadata endpoints.
+// exemptions for liveness and metadata endpoints.
 type rateLimiter struct {
 	config          config.RateLimitConfig
 	originConfig    config.RequestOriginConfig

--- a/internal/bootstrap/ratelimit_test.go
+++ b/internal/bootstrap/ratelimit_test.go
@@ -57,6 +57,38 @@ func TestRateLimiterExemptsHealthPaths(t *testing.T) {
 	}
 }
 
+func TestRateLimiterChargesReadinessWhenNotExempt(t *testing.T) {
+	cfg := config.RateLimitConfig{
+		Enabled:           true,
+		RequestsPerSecond: 1,
+		BurstSize:         1,
+		ExemptPaths:       []string{"/healthz", "/livez", "/metrics", "/.well-known/"},
+	}
+	rl := newRateLimiter(cfg, config.RequestOriginConfig{})
+
+	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i, want := range []int{http.StatusOK, http.StatusTooManyRequests} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/health", nil)
+		handler.ServeHTTP(rec, req)
+		if rec.Code != want {
+			t.Fatalf("readiness request %d status = %d, want %d", i+1, rec.Code, want)
+		}
+	}
+
+	for i := 0; i < 10; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/healthz", nil)
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("liveness request %d status = %d, want 200", i+1, rec.Code)
+		}
+	}
+}
+
 func TestRateLimiterExemptsWellKnownPaths(t *testing.T) {
 	cfg := config.RateLimitConfig{
 		Enabled:           true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,7 @@ type RateLimitConfig struct {
 	Enabled           bool
 	RequestsPerSecond float64
 	BurstSize         int
-	// ExemptPaths are route patterns that bypass rate limiting (e.g., health, metrics)
+	// ExemptPaths are route patterns that bypass rate limiting (e.g., liveness, metrics)
 	ExemptPaths []string
 }
 
@@ -657,7 +657,7 @@ func Load() (Config, error) {
 	}
 	cfg.RateLimit.ExemptPaths = parseCSV(os.Getenv("CEREBRO_RATE_LIMIT_EXEMPT_PATHS"))
 	if len(cfg.RateLimit.ExemptPaths) == 0 {
-		cfg.RateLimit.ExemptPaths = []string{"/health", "/healthz", "/livez", "/metrics", "/.well-known/"}
+		cfg.RateLimit.ExemptPaths = []string{"/healthz", "/livez", "/metrics", "/.well-known/"}
 	}
 
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -105,6 +105,15 @@ func TestLoadDefaults(t *testing.T) {
 	if !cfg.RateLimit.Enabled {
 		t.Fatal("RateLimit.Enabled = false, want true safe default")
 	}
+	wantExemptPaths := []string{"/healthz", "/livez", "/metrics", "/.well-known/"}
+	if len(cfg.RateLimit.ExemptPaths) != len(wantExemptPaths) {
+		t.Fatalf("RateLimit.ExemptPaths = %#v, want %#v", cfg.RateLimit.ExemptPaths, wantExemptPaths)
+	}
+	for i, want := range wantExemptPaths {
+		if cfg.RateLimit.ExemptPaths[i] != want {
+			t.Fatalf("RateLimit.ExemptPaths = %#v, want %#v", cfg.RateLimit.ExemptPaths, wantExemptPaths)
+		}
+	}
 	if cfg.StateStore.PostgresMaxOpenConns != defaultPostgresMaxOpenConns || cfg.StateStore.PostgresMaxIdleConns != defaultPostgresMaxIdleConns || cfg.StateStore.PostgresConnMaxLifetime != defaultPostgresConnMaxLifetime || cfg.StateStore.PostgresConnMaxIdleTime != defaultPostgresConnMaxIdleTime {
 		t.Fatalf("StateStore Postgres pool defaults = %#v", cfg.StateStore)
 	}


### PR DESCRIPTION
## Summary
- remove dependency-aware readiness from the built-in rate-limit exemptions
- keep liveness and metadata paths exempt by default
- add regression coverage for the default exemption list and readiness throttling behavior

## Tests
- `go test ./internal/config -run 'TestLoadDefaults|TestLoadFromEnv' -count=1 -v`
- `go test ./internal/bootstrap -run 'TestRateLimiter(ChargesReadinessWhenNotExempt|ExemptsHealthPaths|ExemptsWellKnownPaths|AllowsRequestsUnderLimit)' -count=1 -v`
- `go test ./internal/bootstrap ./internal/config -count=1`
- `make oss-audit`
- `make docs-drift-check`
