### PR TITLE
Harden vulnerability feed fetches

### DIFF
--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/writer/cerebro/internal/sourcehttp"
 	"github.com/writer/cerebro/internal/vulndb"
 )
 
@@ -29,7 +30,7 @@ func TestVulnDBInputClientRejectsLoopbackRemoteFeed(t *testing.T) {
 	if err == nil {
 		t.Fatal("Open(loopback HTTP feed) error = nil, want unsafe destination rejection")
 	}
-	if !strings.Contains(err.Error(), "must not target loopback, private, or link-local") {
+	if !errors.Is(err, sourcehttp.ErrUnsafeHostAddress) {
 		t.Fatalf("Open(loopback HTTP feed) error = %v, want unsafe destination rejection", err)
 	}
 	if targetHit {

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,25 +14,26 @@ import (
 	"github.com/writer/cerebro/internal/vulndb"
 )
 
-func TestVulnDBInputClientOpenTreatsRemoteSchemeCaseInsensitive(t *testing.T) {
+func TestVulnDBInputClientRejectsLoopbackRemoteFeed(t *testing.T) {
+	targetHit := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetHit = true
 		_, _ = w.Write([]byte("ok"))
 	}))
 	defer server.Close()
 	source := "HTTP" + strings.TrimPrefix(server.URL, "http")
 	reader, err := (vulndbInputClient{}).Open(context.Background(), source, true)
-	if err != nil {
-		t.Fatalf("open uppercase-scheme feed: %v", err)
-	}
-	defer func() {
+	if reader != nil {
 		_ = reader.Close()
-	}()
-	body, err := io.ReadAll(reader)
-	if err != nil {
-		t.Fatalf("read uppercase-scheme feed: %v", err)
 	}
-	if string(body) != "ok" {
-		t.Fatalf("body = %q, want ok", string(body))
+	if err == nil {
+		t.Fatal("Open(loopback HTTP feed) error = nil, want unsafe destination rejection")
+	}
+	if !strings.Contains(err.Error(), "must not target loopback, private, or link-local") {
+		t.Fatalf("Open(loopback HTTP feed) error = %v, want unsafe destination rejection", err)
+	}
+	if targetHit {
+		t.Fatal("Open(loopback HTTP feed) connected to loopback destination")
 	}
 }
 

--- a/internal/bootstrap/vulndbfeed.go
+++ b/internal/bootstrap/vulndbfeed.go
@@ -8,11 +8,20 @@ import (
 	"strings"
 	"time"
 
+	"github.com/writer/cerebro/internal/sourcehttp"
 	"github.com/writer/cerebro/internal/vulndb"
 )
 
+type vulndbFeedOptions struct {
+	allowLoopback bool
+}
+
 // OpenVulnDBFeed fetches a remote vulnerability feed with Cerebro's feed transport policy.
 func OpenVulnDBFeed(ctx context.Context, rawURL string, allowInsecureHTTP bool) (io.ReadCloser, error) {
+	return openVulnDBFeed(ctx, rawURL, allowInsecureHTTP, vulndbFeedOptions{})
+}
+
+func openVulnDBFeed(ctx context.Context, rawURL string, allowInsecureHTTP bool, options vulndbFeedOptions) (io.ReadCloser, error) {
 	if err := vulndb.ValidateFeedURL(rawURL, allowInsecureHTTP); err != nil {
 		return nil, err
 	}
@@ -22,7 +31,7 @@ func OpenVulnDBFeed(ctx context.Context, rawURL string, allowInsecureHTTP bool) 
 	}
 	initialScheme := strings.ToLower(request.URL.Scheme)
 	client := &http.Client{
-		Transport: vulndbFeedTransport(),
+		Transport: vulndbFeedTransport(options),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if initialScheme == "https" && strings.EqualFold(req.URL.Scheme, "http") {
 				return fmt.Errorf("refusing vulnerability feed redirect from https to http")
@@ -41,12 +50,20 @@ func OpenVulnDBFeed(ctx context.Context, rawURL string, allowInsecureHTTP bool) 
 	return response.Body, nil
 }
 
-func vulndbFeedTransport() http.RoundTripper {
+func vulndbFeedTransport(options vulndbFeedOptions) http.RoundTripper {
 	transport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
-		return http.DefaultTransport
+		return sourcehttp.SafeRoundTripper{
+			Base:          http.DefaultTransport,
+			SourceID:      "vulndb",
+			AllowLoopback: options.allowLoopback,
+		}
 	}
 	clone := transport.Clone()
 	clone.ResponseHeaderTimeout = 30 * time.Second
-	return clone
+	return sourcehttp.SafeRoundTripper{
+		Base:          clone,
+		SourceID:      "vulndb",
+		AllowLoopback: options.allowLoopback,
+	}
 }

--- a/internal/bootstrap/vulndbfeed_test.go
+++ b/internal/bootstrap/vulndbfeed_test.go
@@ -2,10 +2,10 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -67,7 +67,7 @@ func TestOpenVulnDBFeedRejectsLoopbackDestination(t *testing.T) {
 	if err == nil {
 		t.Fatal("OpenVulnDBFeed() error = nil, want unsafe destination rejection")
 	}
-	if !strings.Contains(err.Error(), "must not target loopback, private, or link-local") {
+	if !errors.Is(err, sourcehttp.ErrUnsafeHostAddress) {
 		t.Fatalf("OpenVulnDBFeed() error = %v, want unsafe destination rejection", err)
 	}
 	if targetHit {

--- a/internal/bootstrap/vulndbfeed_test.go
+++ b/internal/bootstrap/vulndbfeed_test.go
@@ -5,18 +5,25 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
 func TestVulnDBFeedTransportUsesHeaderTimeoutWithoutBodyTimeout(t *testing.T) {
-	client := &http.Client{Transport: vulndbFeedTransport()}
+	client := &http.Client{Transport: vulndbFeedTransport(vulndbFeedOptions{})}
 	if client.Timeout != 0 {
 		t.Fatalf("client.Timeout = %v, want no whole-body timeout", client.Timeout)
 	}
-	transport, ok := client.Transport.(*http.Transport)
+	safe, ok := client.Transport.(sourcehttp.SafeRoundTripper)
 	if !ok {
-		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+		t.Fatalf("transport type = %T, want sourcehttp.SafeRoundTripper", client.Transport)
+	}
+	transport, ok := safe.Base.(*http.Transport)
+	if !ok {
+		t.Fatalf("base transport type = %T, want *http.Transport", safe.Base)
 	}
 	if transport.ResponseHeaderTimeout != 30*time.Second {
 		t.Fatalf("ResponseHeaderTimeout = %v, want 30s", transport.ResponseHeaderTimeout)
@@ -29,7 +36,7 @@ func TestOpenVulnDBFeedFetchesSuccessfulHTTPWhenExplicitlyAllowed(t *testing.T) 
 	}))
 	defer server.Close()
 
-	body, err := OpenVulnDBFeed(context.Background(), server.URL, true)
+	body, err := openVulnDBFeed(context.Background(), server.URL, true, vulndbFeedOptions{allowLoopback: true})
 	if err != nil {
 		t.Fatalf("OpenVulnDBFeed() error = %v", err)
 	}
@@ -45,13 +52,36 @@ func TestOpenVulnDBFeedFetchesSuccessfulHTTPWhenExplicitlyAllowed(t *testing.T) 
 	}
 }
 
+func TestOpenVulnDBFeedRejectsLoopbackDestination(t *testing.T) {
+	targetHit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetHit = true
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	body, err := OpenVulnDBFeed(context.Background(), server.URL, true)
+	if body != nil {
+		_ = body.Close()
+	}
+	if err == nil {
+		t.Fatal("OpenVulnDBFeed() error = nil, want unsafe destination rejection")
+	}
+	if !strings.Contains(err.Error(), "must not target loopback, private, or link-local") {
+		t.Fatalf("OpenVulnDBFeed() error = %v, want unsafe destination rejection", err)
+	}
+	if targetHit {
+		t.Fatal("OpenVulnDBFeed() connected to loopback destination")
+	}
+}
+
 func TestOpenVulnDBFeedRejectsNonSuccessStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "nope", http.StatusTeapot)
 	}))
 	defer server.Close()
 
-	_, err := OpenVulnDBFeed(context.Background(), server.URL, true)
+	_, err := openVulnDBFeed(context.Background(), server.URL, true, vulndbFeedOptions{allowLoopback: true})
 	if err == nil {
 		t.Fatal("OpenVulnDBFeed() error = nil, want status error")
 	}
@@ -63,7 +93,7 @@ func TestOpenVulnDBFeedValidatesRedirectTargets(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := OpenVulnDBFeed(context.Background(), server.URL, true)
+	_, err := openVulnDBFeed(context.Background(), server.URL, true, vulndbFeedOptions{allowLoopback: true})
 	if err == nil {
 		t.Fatal("OpenVulnDBFeed() error = nil, want redirect policy error")
 	}
@@ -88,7 +118,7 @@ func TestOpenVulnDBFeedRejectsHTTPSDowngradeRedirect(t *testing.T) {
 		http.DefaultTransport = previousTransport
 	}()
 
-	body, err := OpenVulnDBFeed(context.Background(), server.URL, true)
+	body, err := openVulnDBFeed(context.Background(), server.URL, true, vulndbFeedOptions{allowLoopback: true})
 	if body != nil {
 		_ = body.Close()
 	}

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -23,6 +23,7 @@ const DefaultRetryBackoff = 250 * time.Millisecond
 const MaxRetryAfter = 5 * time.Second
 
 var ErrTransportPinningUnsupported = errors.New("source transport must support pinned host dialing")
+var ErrUnsafeHostAddress = errors.New("source host must not target unsafe addresses")
 
 type ClientOptions struct {
 	SourceID                 string
@@ -284,7 +285,7 @@ func SafeResolvedHostAddrsWithOptions(ctx context.Context, sourceID string, host
 	}
 	if ip := net.ParseIP(strings.Trim(normalized, "[]")); ip != nil {
 		if unsafeIP(ip, options.AllowLoopback) {
-			return nil, fmt.Errorf("%s host must not target loopback, private, or link-local addresses", sourceID)
+			return nil, fmt.Errorf("%s host must not target loopback, private, or link-local addresses: %w", sourceID, ErrUnsafeHostAddress)
 		}
 		return nil, nil
 	}
@@ -302,7 +303,7 @@ func SafeResolvedHostAddrsWithOptions(ctx context.Context, sourceID string, host
 	allowPrivate := privateEndpointHostAllowed(normalized, options.PrivateEndpointAllowlist)
 	for _, addr := range addrs {
 		if unsafeResolvedIP(addr.IP, options.AllowLoopback, allowPrivate) {
-			return nil, fmt.Errorf("%s host must not resolve to loopback, private, or link-local addresses", sourceID)
+			return nil, fmt.Errorf("%s host must not resolve to loopback, private, or link-local addresses: %w", sourceID, ErrUnsafeHostAddress)
 		}
 	}
 	return addrs, nil


### PR DESCRIPTION
## Summary
- route remote vulnerability feed fetches through the hardened source HTTP transport
- keep streaming feed reads without a whole-body client timeout
- add regression coverage for unsafe destination rejection and existing redirect/status behavior

## Tests
- `go test ./internal/bootstrap -run 'Test(VulnDBFeed|OpenVulnDBFeed)' -count=1 -v`
- `go test ./cmd/cerebro -run 'TestVulnDB' -count=1 -v`
- `go test ./internal/vulndb -run 'TestValidateFeedURL|TestSync' -count=1 -v`
- `go test ./internal/bootstrap ./cmd/cerebro ./internal/vulndb -count=1`
- `$(go env GOPATH)/bin/golangci-lint run --timeout 10m ./internal/bootstrap ./cmd/cerebro ./internal/vulndb`
