### PR TITLE
Deepen Cerebro wide events

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -220,6 +220,10 @@ func runtimeTelemetryMetadataFromEnv() telemetry.RuntimeMetadata {
 			os.Getenv("ECS_CONTAINER_METADATA_URI"),
 		),
 		AWSExecutionEnvironment: os.Getenv("AWS_EXECUTION_ENV"),
+		ECSCluster:              os.Getenv("ECS_CLUSTER"),
+		ECSServiceName:          os.Getenv("ECS_SERVICE_NAME"),
+		ECSTaskFamily:           os.Getenv("ECS_TASK_FAMILY"),
+		ECSTaskRevision:         os.Getenv("ECS_TASK_REVISION"),
 	}
 }
 
@@ -272,6 +276,8 @@ func startGRCReadModelWarmup(ctx context.Context, stateStore ports.StateStore, l
 		defer close(done)
 		_, hasPreparer := stateStore.(grcReadModelPreparer)
 		ctx, span := telemetry.StartMain(ctx, "grc.read_model_warmup", telemetry.Attrs(
+			telemetry.Field{Key: "operation.type", Value: "startup_job"},
+			telemetry.Field{Key: "job.name", Value: "grc.read_model_warmup"},
 			telemetry.Field{Key: "preparer_present", Value: hasPreparer},
 		))
 		status := "completed"
@@ -280,6 +286,7 @@ func startGRCReadModelWarmup(ctx context.Context, stateStore ports.StateStore, l
 			status = "skipped"
 		}
 		defer func() {
+			telemetry.AnnotateMainPhase(ctx, "grc.read_model_warmup", status, attrs)
 			telemetry.End(span, status, attrs)
 		}()
 		if err := prepareGRCReadModels(ctx, stateStore); err != nil && ctx.Err() == nil {
@@ -296,21 +303,28 @@ func startGRCReadModelWarmup(ctx context.Context, stateStore ports.StateStore, l
 func startFindingRiskBackfill(ctx context.Context, backfiller findingRiskBackfiller, logf func(string, ...any)) <-chan struct{} {
 	done := make(chan struct{})
 	if backfiller == nil {
-		_, span := telemetry.StartMain(ctx, "finding.risk_backfill", telemetry.Attrs(
+		attrs := telemetry.Attrs(
+			telemetry.Field{Key: "operation.type", Value: "startup_job"},
+			telemetry.Field{Key: "job.name", Value: "finding.risk_backfill"},
 			telemetry.Field{Key: "backfiller_present", Value: false},
-		))
-		telemetry.End(span, "skipped", telemetry.Attrs(telemetry.Field{Key: "backfiller_present", Value: false}))
+		)
+		_, span := telemetry.StartMain(ctx, "finding.risk_backfill", attrs)
+		telemetry.AnnotateMainPhase(ctx, "finding.risk_backfill", "skipped", attrs)
+		telemetry.End(span, "skipped", attrs)
 		close(done)
 		return done
 	}
 	go func() {
 		defer close(done)
 		ctx, span := telemetry.StartMain(ctx, "finding.risk_backfill", telemetry.Attrs(
+			telemetry.Field{Key: "operation.type", Value: "startup_job"},
+			telemetry.Field{Key: "job.name", Value: "finding.risk_backfill"},
 			telemetry.Field{Key: "backfiller_present", Value: true},
 		))
 		status := "completed"
 		attrs := telemetry.Attrs(telemetry.Field{Key: "backfiller_present", Value: true})
 		defer func() {
+			telemetry.AnnotateMainPhase(ctx, "finding.risk_backfill", status, attrs)
 			telemetry.End(span, status, attrs)
 		}()
 		if err := backfiller.BackfillFindingRisk(ctx); err != nil && ctx.Err() == nil {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -222,6 +222,9 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 	}
 	defer shutdownTelemetry(orchestratorShutdownContext(options, ctx), closeTelemetry, cfg.ShutdownTimeout)
 	ctx, span := telemetry.StartMain(ctx, "orchestrator.run", telemetry.Attrs(
+		telemetryField("operation.type", "background_job"),
+		telemetryField("workload.kind", "orchestrator"),
+		telemetryField("job.name", "orchestrator.run"),
 		telemetryField("runtime_id", options.Filter.RuntimeID),
 		telemetryField("tenant_id", options.Filter.TenantID),
 		telemetryField("source_id", options.Filter.SourceID),
@@ -416,6 +419,7 @@ func runOrchestratorIteration(
 	status := "failed"
 	spanAttributes := telemetry.Attrs()
 	defer func() {
+		telemetry.AnnotateMainPhase(ctx, "orchestrator.iteration", status, spanAttributes.WithField(telemetryField("iteration", iteration)))
 		telemetry.End(span, status, spanAttributes)
 	}()
 	targetLimit := options.Filter.Limit
@@ -469,6 +473,7 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_stage", "lease")
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_kind", telemetry.ErrorKind(err))
 			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "lease", err)
+			annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
 			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		}
@@ -477,6 +482,7 @@ func runOrchestratorIteration(
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			runtimeStatus = "skipped"
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reason", "lease_not_acquired")
+			annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
 			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		}
@@ -506,6 +512,7 @@ func runOrchestratorIteration(
 				captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "release_lease", releaseErr)
 			}
 			result.Runtimes = append(result.Runtimes, runtimeResult)
+			annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
 			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		} else {
@@ -604,6 +611,7 @@ func runOrchestratorIteration(
 		if runtimeResult.Error != "" {
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "runtime_error_present", true)
 		}
+		annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
 		telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 	}
 	status = "completed"
@@ -652,8 +660,48 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 		}
 		captureOrchestratorError(phaseCtx, name+".error", iteration, runtime, name, err)
 	}
+	telemetry.AnnotateMainPhase(phaseCtx, name, status, endAttrs.
+		WithField(telemetryField("phase.iteration", iteration)).
+		WithField(telemetryField("phase.runtime_id", runtime.GetId())).
+		WithField(telemetryField("phase.source_id", runtime.GetSourceId())).
+		WithField(telemetryField("phase.tenant_id", runtime.GetTenantId())))
 	telemetry.End(span, status, endAttrs)
 	return result, err
+}
+
+func annotateOrchestratorRuntimeMain(ctx context.Context, result *orchestratorRuntimeResult, status string, attrs telemetry.Attributes) {
+	if result == nil {
+		return
+	}
+	telemetry.IncrementMain(ctx, "orchestrator.runtime.count", 1)
+	switch status {
+	case "completed":
+		telemetry.IncrementMain(ctx, "orchestrator.runtime.completed.count", 1)
+	case "skipped":
+		telemetry.IncrementMain(ctx, "orchestrator.runtime.skipped.count", 1)
+	case "failed":
+		telemetry.IncrementMain(ctx, "orchestrator.runtime.failed.count", 1)
+	}
+	mainAttrs := attrs.With(telemetry.Attrs(
+		telemetryField("orchestrator.runtime.last_status", status),
+		telemetryField("orchestrator.runtime.last_runtime_id", result.RuntimeID),
+		telemetryField("orchestrator.runtime.last_source_id", result.SourceID),
+		telemetryField("orchestrator.runtime.last_tenant_id", result.TenantID),
+		telemetryField("orchestrator.runtime.last_sync_status", result.Sync),
+		telemetryField("orchestrator.runtime.last_graph_ingest_status", result.GraphIngest),
+		telemetryField("orchestrator.runtime.last_finding_rules_status", result.FindingRules),
+		telemetryField("orchestrator.runtime.last_graph_rules_status", result.GraphRules),
+		telemetryField("orchestrator.runtime.last_pages_read", result.PagesRead),
+		telemetryField("orchestrator.runtime.last_events_appended", result.EventsAppended),
+		telemetryField("orchestrator.runtime.last_events_evaluated", result.EventsEvaluated),
+		telemetryField("orchestrator.runtime.last_entities_projected", result.EntitiesProjected),
+		telemetryField("orchestrator.runtime.last_links_projected", result.LinksProjected),
+		telemetryField("orchestrator.runtime.last_finding_evaluations", result.FindingEvaluations),
+		telemetryField("orchestrator.runtime.last_graph_rule_evaluations", result.GraphRuleEvaluations),
+		telemetryField("orchestrator.runtime.last_graph_rule_findings", result.GraphRuleFindings),
+		telemetryField("orchestrator.runtime.last_graph_rule_rows_read", result.GraphRuleRowsRead),
+	))
+	telemetry.AnnotateMainPhase(ctx, "orchestrator.runtime", status, mainAttrs)
 }
 
 func captureOrchestratorError(ctx context.Context, name string, iteration uint32, runtime *cerebrov1.SourceRuntime, stage string, err error) {

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -17,11 +17,15 @@ unit of work emits one canonical span/event with:
 
 - `main=true`
 - `wide_event=true`
+- `wide_event.schema.version`
+- `telemetry.schema.version`, `telemetry.signal.kind`, `event.dataset`, `event.type`, `event.outcome`
 - service, deployment, runtime, host, cloud, and container metadata
+- ECS metadata when deployed on Fargate: `aws.ecs.cluster.name`, `aws.ecs.service.name`, `aws.ecs.task.family`, and `cloud.platform`
+- process/headroom hints such as `process.uptime_ms`, `process.cpu.count`, `process.gomaxprocs`, `go.goroutine.count`, and Go heap/GC fields
 - request/job shape
 - auth/customer posture
 - downstream cache, database, queue, graph, source, LLM, MCP, and domain counts
-- final status, duration, and bounded error kind
+- final status, `operation.status`, `duration_ms`, `duration.bucket`, and bounded error kind
 
 Use `main=true` as the primary query predicate when asking "what happened to
 this request/job?" Child spans remain available for drill-down, but shared
@@ -30,9 +34,15 @@ shape.
 
 During headroom incidents, start with `main=true`, then group by `http.route`,
 `service.version`, replica/container identity, `tenant_id`, `source_id`,
-`runtime_id`, dependency counters, and bounded `error_kind`. That keeps the
+`runtime_id`, `dependency.last_system`, `dependency.last_status`, `phase.last_name`,
+`phase.last_status`, dependency counters, and bounded `error_kind`. That keeps the
 first query broad enough to find saturation without jumping between logs,
 metrics, traces, and deployment tooling.
+
+Main spans include two generic rollup families:
+
+- `dependency.*`: counts and last-seen status for Postgres, Neo4j, Redis, JetStream, outbound HTTP, and graph-agent LLM calls. Use this when you do not yet know which dependency is guilty.
+- `phase.*`: counts and last-seen status for orchestration phases, source sync, graph ingest, GRC dashboard subtasks, and source operations. Use this when one logical job has several internal steps.
 
 Inbound HTTP requests create a main OTEL `http.server` span. The route label is
 normalized before emission. Unknown or dynamic paths are collapsed to route
@@ -42,11 +52,11 @@ errors are not emitted.
 
 Expected HTTP dimensions include:
 
-- `http.request.method`, `http.route`, `url.path_depth`, `url.query.param_count`, `url.query.keys`
+- `http.request.method`, `http.route`, `http.route.family`, `http.route.healthcheck`, `url.path_depth`, `url.query.param_count`, `url.query.keys`
 - `url.scheme`, `server.address`, `server.port`, `network.protocol.version`
-- `http.request.body.size`, selected safe request header values, header-presence booleans
+- `http.request.body.size`, `http.request.id.present`, `http.request.id_hash`, selected safe request header values, header-presence booleans
 - `user_agent.family`, `client.address_hash`
-- `http.response.status_code`, `http.response.body.size`, selected safe response header values
+- `http.response.status_code`, `http.response.status_class`, `http.response.body.size`, selected safe response header values
 
 Expected propagated dimensions include:
 
@@ -56,6 +66,7 @@ Expected propagated dimensions include:
 - Graph-agent LLM: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`, `graphagent.*.count`, `graphagent.*.bytes`, refusal/plan/Cypher presence flags
 - Stores: `cache.redis.*.count`, `db.postgres.*.count`, `db.neo4j.*.count`
 - Messaging/source/graph: `messaging.jetstream.*.count`, `source_runtime.*`, `source.operation.*`, `graph.ingest.*`
+- Cross-cutting rollups: `dependency.*`, `phase.*`
 - Domain outcomes: `source_projection.*`, `finding_candidate.*`, `finding_evaluation.*`
 
 Core runtime operations emit structured spans:
@@ -106,12 +117,47 @@ Cerebro enables OTEL export when `CEREBRO_OTEL_ENABLED=true` or when an OTLP end
 | `OTEL_RESOURCE_ATTRIBUTES` | Standard resource attributes, for example `deployment.environment.name=sec-dev` |
 | `CEREBRO_ENVIRONMENT` / `CEREBRO_DEPLOYMENT_ENVIRONMENT` | Environment value used by structured wide events |
 | `AWS_REGION` / `AWS_DEFAULT_REGION` | AWS region used by structured wide events when running on ECS |
+| `ECS_CLUSTER` / `ECS_SERVICE_NAME` / `ECS_TASK_FAMILY` / `ECS_TASK_REVISION` | Optional ECS identity used by structured wide events |
 
 Structured wide events also read `OTEL_RESOURCE_ATTRIBUTES` so CloudWatch JSON
 logs and exported OTEL spans share the same `service.namespace`,
-`deployment.environment.name`, `cloud.provider`, and `cloud.region` dimensions.
+`deployment.environment.name`, `cloud.provider`, `cloud.region`, and ECS dimensions.
 The deployment-specific env vars take precedence over generic resource
 attributes when both are present.
+
+## Useful Queries
+
+Start every incident with wide events only:
+
+```sql
+fields @timestamp, name, service.version, event.outcome, duration_ms, duration.bucket,
+  http.route, runtime_id, source_id, tenant_id,
+  dependency.last_system, dependency.last_status,
+  phase.last_name, phase.last_status, error_kind
+| filter wide_event = true and kind = "span_end"
+| sort @timestamp desc
+| limit 100
+```
+
+Find the dependency correlated with slow or failed work:
+
+```sql
+stats count(*) as events,
+  pct(duration_ms, 95) as p95_ms,
+  max(duration_ms) as max_ms
+by dependency.last_system, dependency.last_status, service.version, deployment.environment.name
+| sort p95_ms desc
+```
+
+Find the phase where orchestrator jobs are failing:
+
+```sql
+stats count(*) as events,
+  sum(orchestrator.runtime.failed.count) as failed_runtimes,
+  sum(source_runtime.invalid_event.count) as invalid_events
+by phase.last_name, phase.last_status, source_id, runtime_id, error_kind
+| sort events desc
+```
 
 ## Local Verification
 

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -395,10 +395,13 @@ func jetstreamAnnotateMain(ctx context.Context, operation string, status string)
 	if status == "failed" {
 		telemetry.IncrementMain(ctx, "messaging.jetstream.error.count", 1)
 	}
-	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "messaging.jetstream.last_operation", Value: strings.TrimSpace(operation)},
 		telemetry.Field{Key: "messaging.jetstream.last_status", Value: strings.TrimSpace(status)},
-	))
+		telemetry.Field{Key: "messaging.system", Value: "nats"},
+	)
+	telemetry.AnnotateMain(ctx, attrs)
+	telemetry.AnnotateMainDependency(ctx, "messaging.jetstream", "appendlog.jetstream", operation, status, attrs)
 }
 
 func countAtLeastUint32(count int, limit uint32) bool {

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -181,6 +181,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 			telemetry.Field{Key: "grc.dashboard.status", Value: status},
 			telemetry.Field{Key: "grc.dashboard.status_code", Value: statusCode},
 		)))
+		telemetry.AnnotateMainPhase(dashboardCtx, "grc.dashboard", status, endAttrs)
 		telemetry.End(span, status, endAttrs)
 	}()
 	scope, err := grcScopeFromRequest(r)
@@ -196,7 +197,9 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	ctx, runtimesSpan := telemetry.Start(r.Context(), "grc.dashboard.runtimes", grcDashboardScopeTelemetryAttrs(scope))
 	runtimesRequest := r.WithContext(ctx)
 	runtimes, err := a.grcListRuntimes(runtimesRequest, scope)
-	telemetry.End(runtimesSpan, grcTelemetryStatus(err), telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}))
+	runtimeAttrs := telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)})
+	telemetry.AnnotateMainPhase(ctx, "grc.dashboard.runtimes", grcTelemetryStatus(err), runtimeAttrs)
+	telemetry.End(runtimesSpan, grcTelemetryStatus(err), runtimeAttrs)
 	if err != nil {
 		statusCode = grcHTTPStatusCode(err)
 		status, endAttrs = grcTelemetryError(endAttrs, err)
@@ -206,7 +209,9 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	ctx, findingsSpan := telemetry.Start(r.Context(), "grc.dashboard.findings", grcDashboardScopeTelemetryAttrs(scope))
 	findingsRequest := r.WithContext(ctx)
 	findings, err := a.grcListFindingRecords(findingsRequest, runtimes, grcFindingFilter{Status: "open", Limit: previewLimit})
-	telemetry.End(findingsSpan, grcTelemetryStatus(err), telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findings)}))
+	findingAttrs := telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findings)})
+	telemetry.AnnotateMainPhase(ctx, "grc.dashboard.findings", grcTelemetryStatus(err), findingAttrs)
+	telemetry.End(findingsSpan, grcTelemetryStatus(err), findingAttrs)
 	if err != nil {
 		statusCode = grcHTTPStatusCode(err)
 		status, endAttrs = grcTelemetryError(endAttrs, err)
@@ -229,7 +234,9 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		ctx, evidenceSpan := telemetry.Start(parent, "grc.dashboard.evidence", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}))
 		evidenceRequest := r.WithContext(ctx)
 		evidence, err = a.grcListEvidenceRecords(evidenceRequest, runtimes, grcEvidenceFilter{FindingIDs: findingIDs, Limit: previewLimit})
-		telemetry.End(evidenceSpan, grcTelemetryStatus(err), telemetry.Attrs(telemetry.Field{Key: "evidence_count", Value: len(evidence)}))
+		evidenceAttrs := telemetry.Attrs(telemetry.Field{Key: "evidence_count", Value: len(evidence)})
+		telemetry.AnnotateMainPhase(ctx, "grc.dashboard.evidence", grcTelemetryStatus(err), evidenceAttrs)
+		telemetry.End(evidenceSpan, grcTelemetryStatus(err), evidenceAttrs)
 		if err != nil {
 			errs <- err
 		}
@@ -251,6 +258,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 			attrs = attrs.WithField(telemetry.Field{Key: "evidence_count", Value: aggregate.EvidenceCount})
 			attrs = attrs.WithField(telemetry.Field{Key: "open_findings", Value: aggregate.FindingSummary.OpenFindings})
 		}
+		telemetry.AnnotateMainPhase(ctx, "grc.dashboard.aggregate", grcTelemetryStatus(err), attrs)
 		telemetry.End(aggregateSpan, grcTelemetryStatus(err), attrs)
 		if err != nil {
 			errs <- err

--- a/internal/bootstrap/http_doer.go
+++ b/internal/bootstrap/http_doer.go
@@ -24,38 +24,53 @@ func NewHTTPDoer() graphagent.HTTPDoer {
 }
 
 func (d *stdHTTPDoer) Post(ctx context.Context, endpoint string, headers map[string]string, body []byte) (int, []byte, error) {
+	host := endpointHost(endpoint)
+	scheme := endpointScheme(endpoint)
 	ctx, span := telemetry.Start(ctx, "graphagent.http.request", telemetry.Attrs(
 		telemetry.Field{Key: "component", Value: "graphagent.http_doer"},
 		telemetry.Field{Key: "http.request.method", Value: http.MethodPost},
-		telemetry.Field{Key: "server.address", Value: endpointHost(endpoint)},
-		telemetry.Field{Key: "url.scheme", Value: endpointScheme(endpoint)},
+		telemetry.Field{Key: "server.address", Value: host},
+		telemetry.Field{Key: "url.scheme", Value: scheme},
 	))
 	finish := func(statusCode int, err error) {
-		attrs := telemetry.Attrs(telemetry.Field{Key: "http.response.status_code", Value: statusCode})
+		status := "completed"
+		if err != nil || statusCode >= http.StatusInternalServerError {
+			status = "failed"
+		}
+		attrs := telemetry.Attrs(
+			telemetry.Field{Key: "http.response.status_code", Value: statusCode},
+			telemetry.Field{Key: "http.response.status_class", Value: telemetry.HTTPStatusClass(statusCode)},
+		)
 		telemetry.IncrementMain(ctx, "outbound.http.request.count", 1)
-		telemetry.AnnotateMain(ctx, telemetry.Attrs(
+		mainAttrs := telemetry.Attrs(
 			telemetry.Field{Key: "outbound.http.last_component", Value: "graphagent.http_doer"},
-			telemetry.Field{Key: "outbound.http.last_host", Value: endpointHost(endpoint)},
+			telemetry.Field{Key: "outbound.http.last_host", Value: host},
 			telemetry.Field{Key: "outbound.http.last_method", Value: http.MethodPost},
-			telemetry.Field{Key: "outbound.http.last_scheme", Value: endpointScheme(endpoint)},
+			telemetry.Field{Key: "outbound.http.last_scheme", Value: scheme},
 			telemetry.Field{Key: "outbound.http.last_status_code", Value: statusCode},
-		))
+			telemetry.Field{Key: "outbound.http.last_status_class", Value: telemetry.HTTPStatusClass(statusCode)},
+		)
+		telemetry.AnnotateMain(ctx, mainAttrs)
 		if err != nil {
 			telemetry.IncrementMain(ctx, "outbound.http.error.count", 1)
 			attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+			mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 			telemetry.CaptureError(ctx, "graphagent.http.error", err, telemetry.Attrs(
 				telemetry.Field{Key: "component", Value: "graphagent.http_doer"},
 				telemetry.Field{Key: "operation", Value: "post"},
 			))
+			telemetry.AnnotateMainDependency(ctx, "outbound.http", "graphagent.http_doer", "post", status, mainAttrs)
 			telemetry.End(span, "failed", attrs)
 			return
 		}
 		if statusCode >= http.StatusInternalServerError {
 			telemetry.IncrementMain(ctx, "outbound.http.server_error.count", 1)
+			telemetry.AnnotateMainDependency(ctx, "outbound.http", "graphagent.http_doer", "post", status, mainAttrs)
 			telemetry.End(span, "failed", attrs.WithField(telemetry.Field{Key: "status_detail", Value: "server_error"}))
 			return
 		}
 		telemetry.IncrementMain(ctx, "outbound.http.success.count", 1)
+		telemetry.AnnotateMainDependency(ctx, "outbound.http", "graphagent.http_doer", "post", status, mainAttrs)
 		telemetry.End(span, "completed", attrs)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))

--- a/internal/graphagent/llm_telemetry.go
+++ b/internal/graphagent/llm_telemetry.go
@@ -46,6 +46,7 @@ func (c *instrumentedLLMClient) DraftCypher(ctx context.Context, req DraftReques
 			WithField(telemetry.Field{Key: "graphagent.cypher.present", Value: strings.TrimSpace(response.Cypher) != ""}).
 			WithField(telemetry.Field{Key: "graphagent.cypher.bytes", Value: len(response.Cypher)})
 	}
+	c.annotateMain(ctx, "draft", status, attrs.With(endAttrs))
 	telemetry.End(span, status, endAttrs)
 	return response, err
 }
@@ -68,6 +69,7 @@ func (c *instrumentedLLMClient) Summarize(ctx context.Context, req SummarizeRequ
 	} else {
 		endAttrs = endAttrs.WithField(telemetry.Field{Key: "graphagent.summary.bytes", Value: len(summary)})
 	}
+	c.annotateMain(ctx, "summarize", status, attrs.With(endAttrs))
 	telemetry.End(span, status, endAttrs)
 	return summary, err
 }
@@ -87,6 +89,7 @@ func (c *instrumentedLLMClient) Probe(ctx context.Context) error {
 		endAttrs = endAttrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 		telemetry.CaptureError(ctx, "graphagent.llm.error", err, attrs)
 	}
+	c.annotateMain(ctx, "probe", status, attrs.With(endAttrs))
 	telemetry.End(span, status, endAttrs)
 	return err
 }
@@ -98,4 +101,19 @@ func (c *instrumentedLLMClient) operationAttrs(operation string, model string, t
 		telemetry.Field{Key: "gen_ai.request.model", Value: normalizeModel(model)},
 		telemetry.Field{Key: "tenant_id", Value: strings.TrimSpace(tenantID)},
 	)
+}
+
+func (c *instrumentedLLMClient) annotateMain(ctx context.Context, operation string, status string, attrs telemetry.Attributes) {
+	telemetry.IncrementMain(ctx, "gen_ai.operation.count", 1)
+	if status == "failed" {
+		telemetry.IncrementMain(ctx, "gen_ai.error.count", 1)
+	}
+	mainAttrs := attrs.With(telemetry.Attrs(
+		telemetry.Field{Key: "gen_ai.last_provider.name", Value: strings.TrimSpace(c.provider)},
+		telemetry.Field{Key: "gen_ai.last_operation.name", Value: strings.TrimSpace(operation)},
+		telemetry.Field{Key: "gen_ai.last_status", Value: strings.TrimSpace(status)},
+	))
+	telemetry.AnnotateMain(ctx, mainAttrs)
+	telemetry.AnnotateMainDependency(ctx, "gen_ai", "graphagent.llm", operation, status, mainAttrs)
+	telemetry.AnnotateMainPhase(ctx, "graphagent.llm."+strings.TrimSpace(operation), status, mainAttrs)
 }

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -177,6 +177,7 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (resul
 			telemetry.Field{Key: "graph.ingest.runtime_id", Value: strings.TrimSpace(request.RuntimeID)},
 			telemetry.Field{Key: "graph.ingest.trigger", Value: strings.TrimSpace(request.Trigger)},
 		)))
+		telemetry.AnnotateMainPhase(ctx, "graph.ingest_runtime", status, spanAttributes)
 		telemetry.End(span, status, spanAttributes)
 	}()
 	if s == nil || s.runtimeStore == nil || s.graphStore == nil || s.projector == nil {
@@ -388,6 +389,7 @@ func (s *Service) Health(ctx context.Context, limit uint32) (result *HealthResul
 				WithField(telemetry.Field{Key: "failed_count", Value: result.FailedCount}).
 				WithField(telemetry.Field{Key: "running_count", Value: result.RunningCount})
 		}
+		telemetry.AnnotateMainPhase(ctx, "graph.ingest_health", status, attrs)
 		telemetry.End(span, status, attrs)
 	}()
 	runStore, err := s.runStore()

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1354,11 +1354,15 @@ func neo4jAnnotateMain(ctx context.Context, database string, operation string, s
 	if status == "failed" {
 		telemetry.IncrementMain(ctx, "db.neo4j.error.count", 1)
 	}
-	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "db.neo4j.last_database", Value: strings.TrimSpace(database)},
 		telemetry.Field{Key: "db.neo4j.last_operation", Value: strings.TrimSpace(operation)},
 		telemetry.Field{Key: "db.neo4j.last_status", Value: strings.TrimSpace(status)},
-	))
+		telemetry.Field{Key: "db.system.name", Value: "neo4j"},
+		telemetry.Field{Key: "db.namespace", Value: strings.TrimSpace(database)},
+	)
+	telemetry.AnnotateMain(ctx, attrs)
+	telemetry.AnnotateMainDependency(ctx, "db.neo4j", "graphstore.neo4j", operation, status, attrs)
 }
 
 func consume(ctx context.Context, tx neo4jdriver.ManagedTransaction, query string, params map[string]any) (any, error) {

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -194,6 +194,8 @@ func httpRequestWideAttributes(r *http.Request, method string, route string) tel
 		telemetry.Field{Key: "operation", Value: method},
 		telemetry.Field{Key: "http.request.method", Value: method},
 		telemetry.Field{Key: "http.route", Value: route},
+		telemetry.Field{Key: "http.route.family", Value: routeFamily(route)},
+		telemetry.Field{Key: "http.route.healthcheck", Value: routeIsHealthcheck(route)},
 		telemetry.Field{Key: "url.path_family", Value: route},
 		telemetry.Field{Key: "url.path_depth", Value: pathDepth},
 		telemetry.Field{Key: "url.query.param_count", Value: queryParamCount(r)},
@@ -203,7 +205,10 @@ func httpRequestWideAttributes(r *http.Request, method string, route string) tel
 		telemetry.Field{Key: "server.port", Value: requestPort(r)},
 		telemetry.Field{Key: "network.protocol.version", Value: requestProto(r)},
 		telemetry.Field{Key: "http.request.body.size", Value: requestBodySize(r)},
+		telemetry.Field{Key: "http.request.id.present", Value: requestID(r) != ""},
+		telemetry.Field{Key: "http.request.id_hash", Value: requestIDHash(r)},
 		telemetry.Field{Key: "http.request.header.traceparent.present", Value: requestHeader(r, "Traceparent") != ""},
+		telemetry.Field{Key: "http.request.header.x_amzn_trace_id.present", Value: requestHeader(r, "X-Amzn-Trace-Id") != ""},
 		telemetry.Field{Key: "http.request.header.x_request_id.present", Value: requestHeader(r, "X-Request-Id") != ""},
 		telemetry.Field{Key: "http.request.auth_header.present", Value: requestHeader(r, "Authorization") != ""},
 		telemetry.Field{Key: "http.request.header.accept", Value: requestHeader(r, "Accept")},
@@ -221,11 +226,60 @@ func httpResponseWideAttributes(recorder *statusRecorder) telemetry.Attributes {
 	}
 	return telemetry.RuntimeAttributes().With(telemetry.Attrs(
 		telemetry.Field{Key: "http.response.status_code", Value: recorder.status},
+		telemetry.Field{Key: "http.response.status_class", Value: telemetry.HTTPStatusClass(recorder.status)},
 		telemetry.Field{Key: "http.response.body.size", Value: recorder.bytes},
 		telemetry.Field{Key: "http.response.header.cache_control", Value: recorder.Header().Get("Cache-Control")},
 		telemetry.Field{Key: "http.response.header.content_type", Value: recorder.Header().Get("Content-Type")},
 		telemetry.Field{Key: "http.response.header.retry_after", Value: recorder.Header().Get("Retry-After")},
 	))
+}
+
+func routeFamily(route string) string {
+	route = strings.TrimSpace(route)
+	if route == "" || route == "/" {
+		return "root"
+	}
+	parts := strings.Split(strings.Trim(route, "/"), "/")
+	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
+		return "root"
+	}
+	if len(parts) >= 2 && parts[0] == "api" {
+		return strings.Join(parts[:2], "/")
+	}
+	if len(parts) >= 2 && parts[0] == "cerebro.v1.BootstrapService" {
+		return "grpc/bootstrap"
+	}
+	return parts[0]
+}
+
+func routeIsHealthcheck(route string) bool {
+	switch strings.TrimSpace(route) {
+	case "/health", "/healthz", "/livez":
+		return true
+	default:
+		return false
+	}
+}
+
+func requestID(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	for _, header := range []string{"X-Request-Id", "X-Amzn-Trace-Id", "X-Correlation-Id"} {
+		if value := strings.TrimSpace(r.Header.Get(header)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func requestIDHash(r *http.Request) string {
+	id := requestID(r)
+	if id == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(id))
+	return hex.EncodeToString(sum[:8])
 }
 
 func requestHeader(r *http.Request, key string) string {

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -95,6 +95,7 @@ func TestMiddlewareEmitsHTTPWideEventFields(t *testing.T) {
 		request.Header.Set("Authorization", "Bearer definitely-not-emitted")
 		request.Header.Set("Content-Type", "application/json")
 		request.Header.Set("Traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+		request.Header.Set("X-Request-Id", "request-123")
 		request.Header.Set("User-Agent", "curl/8.0")
 
 		handler.ServeHTTP(httptest.NewRecorder(), request)
@@ -107,6 +108,8 @@ func TestMiddlewareEmitsHTTPWideEventFields(t *testing.T) {
 		"tenant_id":                "tenant-a",
 		"http.request.method":      http.MethodPost,
 		"http.route":               "/platform/jobs/{jobID}/events",
+		"http.route.family":        "platform",
+		"http.route.healthcheck":   false,
 		"url.path_depth":           float64(4),
 		"url.query.param_count":    float64(2),
 		"url.query.keys":           "cursor,limit",
@@ -115,17 +118,20 @@ func TestMiddlewareEmitsHTTPWideEventFields(t *testing.T) {
 		"server.port":              float64(8443),
 		"network.protocol.version": "1.1",
 		"http.request.body.size":   float64(4),
-		"http.request.header.traceparent.present": true,
-		"http.request.header.accept":              "application/json",
-		"http.request.header.accept_encoding":     "gzip",
-		"http.request.header.content_type":        "application/json",
-		"http.request.header.user_agent":          "curl/8.0",
-		"http.request.auth_header.present":        true,
-		"user_agent.family":                       "curl",
-		"cache.redis.hit.count":                   float64(1),
-		"http.response.status_code":               float64(http.StatusOK),
-		"http.response.body.size":                 float64(len(`{"ok":true}`)),
-		"http.response.header.content_type":       "application/json",
+		"http.request.id.present":  true,
+		"http.request.header.traceparent.present":     true,
+		"http.request.header.x_amzn_trace_id.present": false,
+		"http.request.header.accept":                  "application/json",
+		"http.request.header.accept_encoding":         "gzip",
+		"http.request.header.content_type":            "application/json",
+		"http.request.header.user_agent":              "curl/8.0",
+		"http.request.auth_header.present":            true,
+		"user_agent.family":                           "curl",
+		"cache.redis.hit.count":                       float64(1),
+		"http.response.status_code":                   float64(http.StatusOK),
+		"http.response.status_class":                  "2xx",
+		"http.response.body.size":                     float64(len(`{"ok":true}`)),
+		"http.response.header.content_type":           "application/json",
 	}
 	for key, want := range expected {
 		if got := payload[key]; got != want {
@@ -134,6 +140,9 @@ func TestMiddlewareEmitsHTTPWideEventFields(t *testing.T) {
 	}
 	if strings.Contains(stderr, "definitely-not-emitted") {
 		t.Fatalf("authorization header leaked into telemetry: %s", stderr)
+	}
+	if got, ok := payload["http.request.id_hash"].(string); !ok || got == "" || strings.Contains(got, "request-123") {
+		t.Fatalf("request id hash = %#v, want non-empty hash without raw id; payload=%#v", payload["http.request.id_hash"], payload)
 	}
 }
 

--- a/internal/querycache/redis.go
+++ b/internal/querycache/redis.go
@@ -164,9 +164,12 @@ func redisAnnotateMain(ctx context.Context, namespace string, operation string, 
 	case "skipped":
 		telemetry.IncrementMain(ctx, "cache.redis.skipped.count", 1)
 	}
-	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "cache.redis.last_namespace", Value: strings.TrimSpace(namespace)},
 		telemetry.Field{Key: "cache.redis.last_operation", Value: strings.TrimSpace(operation)},
 		telemetry.Field{Key: "cache.redis.last_status", Value: strings.TrimSpace(status)},
-	))
+		telemetry.Field{Key: "cache.namespace", Value: strings.TrimSpace(namespace)},
+	)
+	telemetry.AnnotateMain(ctx, attrs)
+	telemetry.AnnotateMainDependency(ctx, "cache.redis", "querycache.redis", operation, status, attrs)
 }

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -214,41 +214,57 @@ func (rt SafeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		base = http.DefaultTransport
 	}
 	if req != nil {
+		method := strings.ToUpper(strings.TrimSpace(req.Method))
+		host := requestHost(req)
+		scheme := requestScheme(req)
 		ctx, span := telemetry.Start(req.Context(), "source.http.request", telemetry.Attrs(
 			telemetry.Field{Key: "component", Value: "sourcehttp"},
 			telemetry.Field{Key: "source_id", Value: rt.SourceID},
-			telemetry.Field{Key: "http.request.method", Value: strings.ToUpper(strings.TrimSpace(req.Method))},
-			telemetry.Field{Key: "server.address", Value: requestHost(req)},
-			telemetry.Field{Key: "url.scheme", Value: requestScheme(req)},
+			telemetry.Field{Key: "http.request.method", Value: method},
+			telemetry.Field{Key: "server.address", Value: host},
+			telemetry.Field{Key: "url.scheme", Value: scheme},
 		))
 		finish := func(statusCode int, err error) {
-			attrs := telemetry.Attrs(telemetry.Field{Key: "http.response.status_code", Value: statusCode})
+			status := "completed"
+			if err != nil || statusCode >= http.StatusInternalServerError {
+				status = "failed"
+			}
+			attrs := telemetry.Attrs(
+				telemetry.Field{Key: "http.response.status_code", Value: statusCode},
+				telemetry.Field{Key: "http.response.status_class", Value: telemetry.HTTPStatusClass(statusCode)},
+			)
 			telemetry.IncrementMain(ctx, "outbound.http.request.count", 1)
-			telemetry.AnnotateMain(ctx, telemetry.Attrs(
+			mainAttrs := telemetry.Attrs(
 				telemetry.Field{Key: "outbound.http.last_component", Value: "sourcehttp"},
 				telemetry.Field{Key: "outbound.http.last_source_id", Value: rt.SourceID},
-				telemetry.Field{Key: "outbound.http.last_host", Value: requestHost(req)},
-				telemetry.Field{Key: "outbound.http.last_method", Value: strings.ToUpper(strings.TrimSpace(req.Method))},
-				telemetry.Field{Key: "outbound.http.last_scheme", Value: requestScheme(req)},
+				telemetry.Field{Key: "outbound.http.last_host", Value: host},
+				telemetry.Field{Key: "outbound.http.last_method", Value: method},
+				telemetry.Field{Key: "outbound.http.last_scheme", Value: scheme},
 				telemetry.Field{Key: "outbound.http.last_status_code", Value: statusCode},
-			))
+				telemetry.Field{Key: "outbound.http.last_status_class", Value: telemetry.HTTPStatusClass(statusCode)},
+			)
+			telemetry.AnnotateMain(ctx, mainAttrs)
 			if err != nil {
 				telemetry.IncrementMain(ctx, "outbound.http.error.count", 1)
 				attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+				mainAttrs = mainAttrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 				telemetry.CaptureError(ctx, "source.http.error", err, telemetry.Attrs(
 					telemetry.Field{Key: "component", Value: "sourcehttp"},
 					telemetry.Field{Key: "source_id", Value: rt.SourceID},
 					telemetry.Field{Key: "operation", Value: "round_trip"},
 				))
+				telemetry.AnnotateMainDependency(ctx, "outbound.http", "sourcehttp", "round_trip", status, mainAttrs)
 				telemetry.End(span, "failed", attrs)
 				return
 			}
 			if statusCode >= http.StatusInternalServerError {
 				telemetry.IncrementMain(ctx, "outbound.http.server_error.count", 1)
+				telemetry.AnnotateMainDependency(ctx, "outbound.http", "sourcehttp", "round_trip", status, mainAttrs)
 				telemetry.End(span, "failed", attrs.WithField(telemetry.Field{Key: "status_detail", Value: "server_error"}))
 				return
 			}
 			telemetry.IncrementMain(ctx, "outbound.http.success.count", 1)
+			telemetry.AnnotateMainDependency(ctx, "outbound.http", "sourcehttp", "round_trip", status, mainAttrs)
 			telemetry.End(span, "completed", attrs)
 		}
 		req = req.Clone(ctx)

--- a/internal/sourcehttp/safe_test.go
+++ b/internal/sourcehttp/safe_test.go
@@ -123,8 +123,7 @@ func TestNewRequestNormalizesOriginPathQueryAndBody(t *testing.T) {
 
 func TestSafeRoundTripperPropagatesTraceWithoutLeakingURLQuery(t *testing.T) {
 	var propagated string
-	ctx, parent := telemetry.Start(context.Background(), "test.parent", telemetry.Attrs())
-	defer telemetry.End(parent, "completed", telemetry.Attrs())
+	ctx, parent := telemetry.StartMain(context.Background(), "test.parent", telemetry.Attrs())
 	req := httptest.NewRequest(http.MethodGet, "https://93.184.216.34/v1/items?token=secret", nil).WithContext(ctx)
 	_, stderr := captureSourceHTTPStderr(t, func() {
 		resp, err := SafeRoundTripper{
@@ -145,6 +144,7 @@ func TestSafeRoundTripperPropagatesTraceWithoutLeakingURLQuery(t *testing.T) {
 		if resp != nil {
 			_ = resp.Body.Close()
 		}
+		telemetry.End(parent, "completed", telemetry.Attrs())
 	})
 	if propagated == "" {
 		t.Fatal("traceparent was not propagated")
@@ -154,6 +154,17 @@ func TestSafeRoundTripperPropagatesTraceWithoutLeakingURLQuery(t *testing.T) {
 	}
 	if !strings.Contains(stderr, `"name":"source.http.request"`) {
 		t.Fatalf("source HTTP span missing from telemetry: %s", stderr)
+	}
+	for _, expected := range []string{
+		`"dependency.outbound_http.operation.count":1`,
+		`"dependency.last_component":"sourcehttp"`,
+		`"dependency.last_operation":"round_trip"`,
+		`"dependency.last_status":"completed"`,
+		`"http.response.status_class":"2xx"`,
+	} {
+		if !strings.Contains(stderr, expected) {
+			t.Fatalf("telemetry missing %s: %s", expected, stderr)
+		}
 	}
 }
 

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -226,10 +226,12 @@ func annotateMainSourceOperation(ctx context.Context, operation string, status s
 	if status == "failed" {
 		telemetry.IncrementMain(ctx, "source.operation.error.count", 1)
 	}
-	telemetry.AnnotateMain(ctx, attrs.With(telemetry.Attrs(
+	mainAttrs := attrs.With(telemetry.Attrs(
 		telemetry.Field{Key: "source.operation", Value: operation},
 		telemetry.Field{Key: "source.operation.status", Value: status},
-	)))
+	))
+	telemetry.AnnotateMain(ctx, mainAttrs)
+	telemetry.AnnotateMainPhase(ctx, "source."+strings.TrimSpace(operation), status, mainAttrs)
 }
 
 func sourceOperationTelemetryErrorKind(err error) string {

--- a/internal/sourceruntime/lease.go
+++ b/internal/sourceruntime/lease.go
@@ -86,6 +86,7 @@ func (s *Service) SyncWithLease(ctx context.Context, req *cerebrov1.SyncSourceRu
 		}
 		telemetry.IncrementMain(ctx, "source_runtime.lease.count", 1)
 		telemetry.AnnotateMain(ctx, attrs.WithField(telemetry.Field{Key: "source_runtime.lease.status", Value: status}))
+		telemetry.AnnotateMainPhase(ctx, "source_runtime.sync_with_lease", status, attrs)
 		telemetry.End(span, status, attrs)
 	}()
 	if s == nil {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -239,6 +239,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	ctx, span := telemetry.Start(ctx, "source_runtime.sync", telemetry.Attrs(
 		telemetry.Field{Key: "runtime_id", Value: runtimeID},
 		telemetry.Field{Key: "page_limit", Value: req.GetPageLimit()},
+		telemetry.Field{Key: "operation.type", Value: "source_runtime_sync"},
 	))
 	status := "failed"
 	spanAttributes := telemetry.Attrs()
@@ -258,10 +259,14 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			}
 		}
 		telemetry.IncrementMain(ctx, "source_runtime.sync.count", 1)
+		spanAttributes = spanAttributes.
+			WithField(telemetry.Field{Key: "source_runtime.sync.contract_configured", Value: contractConfigured}).
+			WithField(telemetry.Field{Key: "source_runtime.sync.runtime_loaded", Value: runtimeLoadedForRun})
 		telemetry.AnnotateMain(ctx, spanAttributes.With(telemetry.Attrs(
 			telemetry.Field{Key: "source_runtime.sync.status", Value: status},
 			telemetry.Field{Key: "source_runtime.id", Value: runtimeID},
 		)))
+		telemetry.AnnotateMainPhase(ctx, "source_runtime.sync", status, spanAttributes)
 		telemetry.End(span, status, spanAttributes)
 	}()
 	if s == nil || s.store == nil || s.appendLog == nil {
@@ -336,6 +341,12 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "reconciliation_reason", Value: pageReconciliationReason},
 		), pull.Checkpoint)
 		telemetry.Event(ctx, "source_runtime.page_read", pageReadAttrs)
+		telemetry.IncrementMain(ctx, "source_runtime.page.read.count", 1)
+		telemetry.AnnotateMain(ctx, pageReadAttrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "source_runtime.page.last_number", Value: pageNumber},
+			telemetry.Field{Key: "source_runtime.page.last_events_read", Value: eventsRead},
+			telemetry.Field{Key: "source_runtime.page.last_has_next_cursor", Value: pull.NextCursor != nil},
+		)))
 		if pull.Checkpoint != nil {
 			advanceRuntimeCheckpoint(runtime, pull.Checkpoint)
 		}
@@ -360,6 +371,11 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 						telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()},
 						telemetry.Field{Key: "failure_category", Value: category},
 						telemetry.Field{Key: "retryable", Value: false},
+					))
+					telemetry.IncrementMain(ctx, "source_runtime.invalid_event.count", 1)
+					telemetry.AnnotateMain(ctx, telemetry.Attrs(
+						telemetry.Field{Key: "source_runtime.invalid_event.last_failure_category", Value: category},
+						telemetry.Field{Key: "source_runtime.invalid_event.last_retryable", Value: false},
 					))
 					continue
 				}
@@ -410,6 +426,13 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "reconciliation_reason", Value: pageReconciliationReason},
 		), runtime.GetCheckpoint())
 		telemetry.Event(ctx, "source_runtime.page_committed", pageCommittedAttrs)
+		telemetry.IncrementMain(ctx, "source_runtime.page.committed.count", 1)
+		telemetry.AnnotateMain(ctx, pageCommittedAttrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "source_runtime.page.last_committed_number", Value: pageNumber},
+			telemetry.Field{Key: "source_runtime.page.last_records_scanned", Value: recordsScanned},
+			telemetry.Field{Key: "source_runtime.page.last_records_accepted", Value: eventsAppended},
+			telemetry.Field{Key: "source_runtime.page.last_records_rejected", Value: recordsRejected},
+		)))
 		if pull.NextCursor == nil {
 			break
 		}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -146,10 +146,13 @@ func postgresAnnotateMain(ctx context.Context, operation string, status string) 
 	if status == "failed" {
 		telemetry.IncrementMain(ctx, "db.postgres.error.count", 1)
 	}
-	telemetry.AnnotateMain(ctx, telemetry.Attrs(
+	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "db.postgres.last_operation", Value: strings.TrimSpace(operation)},
 		telemetry.Field{Key: "db.postgres.last_status", Value: strings.TrimSpace(status)},
-	))
+		telemetry.Field{Key: "db.system.name", Value: "postgresql"},
+	)
+	telemetry.AnnotateMain(ctx, attrs)
+	telemetry.AnnotateMainDependency(ctx, "db.postgres", "statestore.postgres", operation, status, attrs)
 }
 
 const schemaMigrationsDDL = `

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -63,13 +63,19 @@ type RuntimeMetadata struct {
 	ContainerID             string
 	ECSContainerMetadataURI string
 	AWSExecutionEnvironment string
+	ECSCluster              string
+	ECSServiceName          string
+	ECSTaskFamily           string
+	ECSTaskRevision         string
 }
 
 const maxAttributeStringLength = 1024
+const wideEventSchemaVersion = "2026-06-18"
 
 var (
 	runtimeMetadataMu sync.RWMutex
 	runtimeMetadata   RuntimeMetadata
+	processStartedAt  = time.Now().UTC()
 )
 
 func Attrs(fields ...Field) Attributes {
@@ -122,6 +128,8 @@ func RuntimeAttributes() Attributes {
 
 func RuntimeAttributesFor(metadata RuntimeMetadata) Attributes {
 	hostname, _ := os.Hostname()
+	var memory runtime.MemStats
+	runtime.ReadMemStats(&memory)
 	resourceAttributes := parseResourceAttributes(metadata.ResourceAttributes)
 	serviceName := firstNonEmpty(
 		metadata.ServiceName,
@@ -162,13 +170,27 @@ func RuntimeAttributesFor(metadata RuntimeMetadata) Attributes {
 		Field{Key: "os.type", Value: runtime.GOOS},
 		Field{Key: "os.arch", Value: runtime.GOARCH},
 		Field{Key: "process.pid", Value: os.Getpid()},
+		Field{Key: "process.uptime_ms", Value: time.Since(processStartedAt).Milliseconds()},
 		Field{Key: "process.runtime.name", Value: "go"},
 		Field{Key: "process.runtime.version", Value: runtime.Version()},
 		Field{Key: "process.cpu.count", Value: runtime.NumCPU()},
+		Field{Key: "process.gomaxprocs", Value: runtime.GOMAXPROCS(0)},
 		Field{Key: "go.goroutine.count", Value: runtime.NumGoroutine()},
+		Field{Key: "go.gc.count", Value: memory.NumGC},
+		Field{Key: "go.memory.heap_alloc_bytes", Value: memory.HeapAlloc},
+		Field{Key: "go.memory.heap_sys_bytes", Value: memory.HeapSys},
+		Field{Key: "go.memory.heap_idle_bytes", Value: memory.HeapIdle},
+		Field{Key: "go.memory.heap_inuse_bytes", Value: memory.HeapInuse},
+		Field{Key: "go.memory.stack_inuse_bytes", Value: memory.StackInuse},
+		Field{Key: "go.memory.next_gc_bytes", Value: memory.NextGC},
 		Field{Key: "cloud.provider", Value: cloudProvider},
 		Field{Key: "cloud.region", Value: cloudRegion},
+		Field{Key: "cloud.platform", Value: cloudPlatform(metadata, cloudProvider)},
 		Field{Key: "container.id", Value: containerID},
+		Field{Key: "aws.ecs.cluster.name", Value: strings.TrimSpace(metadata.ECSCluster)},
+		Field{Key: "aws.ecs.service.name", Value: strings.TrimSpace(metadata.ECSServiceName)},
+		Field{Key: "aws.ecs.task.family", Value: strings.TrimSpace(metadata.ECSTaskFamily)},
+		Field{Key: "aws.ecs.task.revision", Value: strings.TrimSpace(metadata.ECSTaskRevision)},
 	))
 }
 
@@ -269,12 +291,25 @@ func inferredCloudProvider(metadata RuntimeMetadata) string {
 	return ""
 }
 
+func cloudPlatform(metadata RuntimeMetadata, provider string) string {
+	if strings.TrimSpace(metadata.ECSContainerMetadataURI) != "" ||
+		strings.TrimSpace(metadata.ECSCluster) != "" ||
+		strings.TrimSpace(metadata.ECSServiceName) != "" ||
+		strings.Contains(strings.ToLower(strings.TrimSpace(metadata.AWSExecutionEnvironment)), "ecs") {
+		return "aws_ecs"
+	}
+	if strings.TrimSpace(provider) == "aws" {
+		return "aws"
+	}
+	return ""
+}
+
 func Start(ctx context.Context, name string, attributes Attributes) (context.Context, *Span) {
 	return StartWithOptions(ctx, name, attributes)
 }
 
 func StartMain(ctx context.Context, name string, attributes Attributes, options ...oteltrace.SpanStartOption) (context.Context, *Span) {
-	attributes = RuntimeAttributes().With(attributes).
+	attributes = RuntimeAttributes().With(wideEventBaseAttributes(name)).With(attributes).
 		WithField(Field{Key: "main", Value: true}).
 		WithField(Field{Key: "wide_event", Value: true})
 	ctx, span := StartWithOptions(ctx, name, attributes, options...)
@@ -285,6 +320,7 @@ func StartMain(ctx context.Context, name string, attributes Attributes, options 
 }
 
 func StartWithOptions(ctx context.Context, name string, attributes Attributes, options ...oteltrace.SpanStartOption) (context.Context, *Span) {
+	attributes = spanBaseAttributes(name).With(attributes)
 	parent, _ := ctx.Value(spanContextKey{}).(spanContext)
 	traceID := parent.TraceID
 	if traceID == "" {
@@ -366,6 +402,7 @@ func ParseTraceParent(header string) (string, string, bool) {
 }
 
 func Event(ctx context.Context, name string, attributes Attributes) {
+	attributes = eventBaseAttributes(name).With(attributes)
 	current, _ := ctx.Value(spanContextKey{}).(spanContext)
 	if span := oteltrace.SpanFromContext(ctx); span.SpanContext().IsValid() {
 		span.AddEvent(name, oteltrace.WithAttributes(attributes.OTELAttributes()...))
@@ -388,6 +425,57 @@ func IncrementMain(ctx context.Context, key string, delta int64) {
 		return
 	}
 	span.increment(key, delta)
+}
+
+func AnnotateMainDependency(ctx context.Context, system string, component string, operation string, status string, attributes Attributes) {
+	system = boundedKeyPart(system)
+	if system == "" {
+		system = "unknown"
+	}
+	component = strings.TrimSpace(component)
+	operation = strings.TrimSpace(operation)
+	status = strings.TrimSpace(status)
+	if status == "" {
+		status = "unknown"
+	}
+	IncrementMain(ctx, "dependency.operation.count", 1)
+	IncrementMain(ctx, "dependency."+system+".operation.count", 1)
+	if telemetryStatus(status) == codes.Error {
+		IncrementMain(ctx, "dependency.error.count", 1)
+		IncrementMain(ctx, "dependency."+system+".error.count", 1)
+	}
+	attrs := attributes.With(Attrs(
+		Field{Key: "dependency.last_system", Value: system},
+		Field{Key: "dependency.last_component", Value: component},
+		Field{Key: "dependency.last_operation", Value: operation},
+		Field{Key: "dependency.last_status", Value: status},
+		Field{Key: "dependency." + system + ".last_component", Value: component},
+		Field{Key: "dependency." + system + ".last_operation", Value: operation},
+		Field{Key: "dependency." + system + ".last_status", Value: status},
+	))
+	AnnotateMain(ctx, attrs)
+}
+
+func AnnotateMainPhase(ctx context.Context, phase string, status string, attributes Attributes) {
+	phaseKey := boundedKeyPart(phase)
+	if phaseKey == "" {
+		phaseKey = "unknown"
+	}
+	status = strings.TrimSpace(status)
+	if status == "" {
+		status = "unknown"
+	}
+	IncrementMain(ctx, "phase.count", 1)
+	IncrementMain(ctx, "phase."+phaseKey+".count", 1)
+	if telemetryStatus(status) == codes.Error {
+		IncrementMain(ctx, "phase.error.count", 1)
+		IncrementMain(ctx, "phase."+phaseKey+".error.count", 1)
+	}
+	AnnotateMain(ctx, attributes.With(Attrs(
+		Field{Key: "phase.last_name", Value: strings.TrimSpace(phase)},
+		Field{Key: "phase.last_status", Value: status},
+		Field{Key: "phase." + phaseKey + ".status", Value: status},
+	)))
 }
 
 // CaptureError records a Sentry-style handled error event without serializing
@@ -466,7 +554,14 @@ func End(span *Span, status string, attributes Attributes) {
 	if status != "" {
 		attributes = attributes.with("status", status)
 	}
-	attributes = attributes.with("duration_ms", time.Since(span.started).Milliseconds())
+	duration := time.Since(span.started)
+	attributes = attributes.
+		with("operation.name", span.name).
+		with("operation.status", strings.TrimSpace(status)).
+		with("event.type", "end").
+		with("event.outcome", eventOutcomeForStatus(status)).
+		with("duration_ms", duration.Milliseconds()).
+		with("duration.bucket", durationBucket(duration))
 	if span.otelSpan != nil && span.otelSpan.SpanContext().IsValid() {
 		span.otelSpan.SetAttributes(attributes.OTELAttributes()...)
 		switch telemetryStatus(strings.TrimSpace(status)) {
@@ -557,6 +652,108 @@ func telemetryStatus(status string) codes.Code {
 	default:
 		return codes.Ok
 	}
+}
+
+func spanBaseAttributes(name string) Attributes {
+	return Attrs(
+		Field{Key: "telemetry.schema.version", Value: wideEventSchemaVersion},
+		Field{Key: "event.dataset", Value: "cerebro.telemetry"},
+		Field{Key: "telemetry.signal.kind", Value: "span"},
+		Field{Key: "event.category", Value: "operation"},
+		Field{Key: "event.type", Value: "start"},
+		Field{Key: "operation.name", Value: strings.TrimSpace(name)},
+	)
+}
+
+func wideEventBaseAttributes(name string) Attributes {
+	return spanBaseAttributes(name).With(Attrs(
+		Field{Key: "event.dataset", Value: "cerebro.wide_events"},
+		Field{Key: "wide_event.schema.version", Value: wideEventSchemaVersion},
+		Field{Key: "wide_event.contract", Value: "main-span"},
+	))
+}
+
+func eventBaseAttributes(name string) Attributes {
+	return Attrs(
+		Field{Key: "telemetry.schema.version", Value: wideEventSchemaVersion},
+		Field{Key: "event.dataset", Value: "cerebro.telemetry"},
+		Field{Key: "telemetry.signal.kind", Value: "event"},
+		Field{Key: "event.category", Value: "application"},
+		Field{Key: "event.type", Value: "info"},
+		Field{Key: "event.name", Value: strings.TrimSpace(name)},
+	)
+}
+
+func eventOutcomeForStatus(status string) string {
+	switch telemetryStatus(strings.TrimSpace(status)) {
+	case codes.Error:
+		return "failure"
+	case codes.Ok:
+		return "success"
+	default:
+		switch strings.ToLower(strings.TrimSpace(status)) {
+		case "skipped", "miss":
+			return "neutral"
+		default:
+			return "unknown"
+		}
+	}
+}
+
+func HTTPStatusClass(statusCode int) string {
+	switch {
+	case statusCode >= 100 && statusCode < 200:
+		return "1xx"
+	case statusCode >= 200 && statusCode < 300:
+		return "2xx"
+	case statusCode >= 300 && statusCode < 400:
+		return "3xx"
+	case statusCode >= 400 && statusCode < 500:
+		return "4xx"
+	case statusCode >= 500 && statusCode < 600:
+		return "5xx"
+	case statusCode == 0:
+		return "none"
+	default:
+		return "other"
+	}
+}
+
+func durationBucket(duration time.Duration) string {
+	switch {
+	case duration < 10*time.Millisecond:
+		return "lt_10ms"
+	case duration < 50*time.Millisecond:
+		return "lt_50ms"
+	case duration < 100*time.Millisecond:
+		return "lt_100ms"
+	case duration < 250*time.Millisecond:
+		return "lt_250ms"
+	case duration < 500*time.Millisecond:
+		return "lt_500ms"
+	case duration < time.Second:
+		return "lt_1s"
+	case duration < 5*time.Second:
+		return "lt_5s"
+	case duration < 30*time.Second:
+		return "lt_30s"
+	case duration < time.Minute:
+		return "lt_1m"
+	case duration < 5*time.Minute:
+		return "lt_5m"
+	case duration < 30*time.Minute:
+		return "lt_30m"
+	default:
+		return "gte_30m"
+	}
+}
+
+func boundedKeyPart(value string) string {
+	value = compactErrorKind(value)
+	if len(value) > 64 {
+		return value[:64]
+	}
+	return value
 }
 
 func InjectEventAttributes(ctx context.Context, attributes map[string]string) {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -169,7 +169,7 @@ func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
 		IncrementMain(ctx, "cache.redis.hit.count", 2)
 		End(span, "completed", Attrs(Field{Key: "explicit_end_attr", Value: "kept"}))
 	})
-	payload := telemetryPayloadByKindAndName(t, stderr, "span_end", "test.main")
+	payload := telemetrySpanEndPayloadByName(t, stderr, "test.main")
 	if payload["main"] != true || payload["wide_event"] != true {
 		t.Fatalf("main span flags missing: %#v", payload)
 	}
@@ -252,7 +252,7 @@ func TestRuntimeAttributesUseECSAndOTELResourceEnvironment(t *testing.T) {
 		_, span := StartMain(context.Background(), "test.runtime", Attrs())
 		End(span, "completed", Attrs())
 	})
-	payload := telemetryPayloadByKindAndName(t, stderr, "span_end", "test.runtime")
+	payload := telemetrySpanEndPayloadByName(t, stderr, "test.runtime")
 	for key, want := range map[string]any{
 		"service.name":                "cerebro-api",
 		"service.namespace":           "cerebro",
@@ -288,7 +288,7 @@ func TestMainSpanDependencyAndPhaseRollups(t *testing.T) {
 		))
 		End(span, "failed", Attrs(Field{Key: "error_kind", Value: "boom_kind"}))
 	})
-	payload := telemetryPayloadByKindAndName(t, stderr, "span_end", "test.rollups")
+	payload := telemetrySpanEndPayloadByName(t, stderr, "test.rollups")
 	expected := map[string]any{
 		"event.outcome":                            "failure",
 		"operation.status":                         "failed",
@@ -333,7 +333,7 @@ func TestRuntimeAttributesDoNotInferAWSFromOTELCloudRegion(t *testing.T) {
 		_, span := StartMain(context.Background(), "test.runtime.otel-region", Attrs())
 		End(span, "completed", Attrs())
 	})
-	payload := telemetryPayloadByKindAndName(t, stderr, "span_end", "test.runtime.otel-region")
+	payload := telemetrySpanEndPayloadByName(t, stderr, "test.runtime.otel-region")
 	for key, want := range map[string]any{
 		"cloud.provider": "unknown",
 		"cloud.region":   "europe-west1",
@@ -448,7 +448,7 @@ func TestConfigureOpenTelemetryDisabledLeavesNoopProviderUsable(t *testing.T) {
 	End(span, "completed", Attrs())
 }
 
-func telemetryPayloadByKindAndName(t *testing.T, stderr string, kind string, name string) map[string]any {
+func telemetrySpanEndPayloadByName(t *testing.T, stderr string, name string) map[string]any {
 	t.Helper()
 	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
 		if strings.TrimSpace(line) == "" {
@@ -458,11 +458,11 @@ func telemetryPayloadByKindAndName(t *testing.T, stderr string, kind string, nam
 		if err := json.Unmarshal([]byte(line), &payload); err != nil {
 			t.Fatalf("unmarshal telemetry payload %q: %v", line, err)
 		}
-		if payload["kind"] == kind && payload["name"] == name {
+		if payload["kind"] == "span_end" && payload["name"] == name {
 			return payload
 		}
 	}
-	t.Fatalf("telemetry payload kind=%q name=%q not found in stderr: %s", kind, name, stderr)
+	t.Fatalf("telemetry span_end payload name=%q not found in stderr: %s", name, stderr)
 	return nil
 }
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -191,6 +191,37 @@ func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
 	if got := payload["explicit_end_attr"]; got != "kept" {
 		t.Fatalf("explicit end attr missing: %#v", payload)
 	}
+	for key, want := range map[string]any{
+		"telemetry.schema.version":  wideEventSchemaVersion,
+		"wide_event.schema.version": wideEventSchemaVersion,
+		"event.dataset":             "cerebro.wide_events",
+		"telemetry.signal.kind":     "span",
+		"event.category":            "operation",
+		"event.type":                "end",
+		"event.outcome":             "success",
+		"operation.name":            "test.main",
+		"operation.status":          "completed",
+		"process.runtime.name":      "go",
+		"process.gomaxprocs":        float64(runtime.GOMAXPROCS(0)),
+		"process.cpu.count":         float64(runtime.NumCPU()),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	for _, key := range []string{
+		"duration.bucket",
+		"process.uptime_ms",
+		"go.goroutine.count",
+		"go.memory.heap_alloc_bytes",
+		"go.memory.heap_sys_bytes",
+		"go.memory.heap_inuse_bytes",
+		"go.memory.next_gc_bytes",
+	} {
+		if _, ok := payload[key]; !ok {
+			t.Fatalf("%s missing from wide event payload=%#v", key, payload)
+		}
+	}
 	oversized, ok := payload["oversized"].(string)
 	if !ok || len(oversized) > maxAttributeStringLength+3 || !strings.HasSuffix(oversized, "...") {
 		t.Fatalf("oversized attribute was not bounded: len=%d value=%q", len(oversized), oversized)
@@ -207,6 +238,10 @@ func TestRuntimeAttributesUseECSAndOTELResourceEnvironment(t *testing.T) {
 		DeploymentEnvironment: "sec-dev",
 		CloudRegion:           "us-east-1",
 		ContainerID:           "task-hostname",
+		ECSCluster:            "cerebro-sec-dev-cluster",
+		ECSServiceName:        "cerebro-sec-dev-api",
+		ECSTaskFamily:         "cerebro-sec-dev",
+		ECSTaskRevision:       "362",
 		ResourceAttributes:    "service.namespace=cerebro,cloud.provider=gcp,cloud.region=europe-west1,cloud.availability_zone=us-east-1a,container.id=otel-container,deployment.environment.name=ignored-by-cerebro-env",
 	})
 	t.Cleanup(func() {
@@ -225,9 +260,60 @@ func TestRuntimeAttributesUseECSAndOTELResourceEnvironment(t *testing.T) {
 		"deployment.environment.name": "sec-dev",
 		"cloud.provider":              "aws",
 		"cloud.region":                "us-east-1",
+		"cloud.platform":              "aws_ecs",
 		"cloud.availability_zone":     "us-east-1a",
 		"container.id":                "task-hostname",
+		"aws.ecs.cluster.name":        "cerebro-sec-dev-cluster",
+		"aws.ecs.service.name":        "cerebro-sec-dev-api",
+		"aws.ecs.task.family":         "cerebro-sec-dev",
+		"aws.ecs.task.revision":       "362",
 	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+}
+
+func TestMainSpanDependencyAndPhaseRollups(t *testing.T) {
+	_, stderr := captureOutput(t, func() {
+		ctx, span := StartMain(context.Background(), "test.rollups", Attrs())
+		AnnotateMainDependency(ctx, "db.postgres", "statestore.postgres", "query", "completed", Attrs(
+			Field{Key: "db.system.name", Value: "postgresql"},
+		))
+		AnnotateMainDependency(ctx, "outbound.http", "sourcehttp", "round_trip", "failed", Attrs(
+			Field{Key: "http.response.status_class", Value: "5xx"},
+		))
+		AnnotateMainPhase(ctx, "source_runtime.sync", "failed", Attrs(
+			Field{Key: "source_id", Value: "github"},
+		))
+		End(span, "failed", Attrs(Field{Key: "error_kind", Value: "boom_kind"}))
+	})
+	payload := telemetryPayloadByKindAndName(t, stderr, "span_end", "test.rollups")
+	expected := map[string]any{
+		"event.outcome":                            "failure",
+		"operation.status":                         "failed",
+		"dependency.operation.count":               float64(2),
+		"dependency.error.count":                   float64(1),
+		"dependency.db_postgres.operation.count":   float64(1),
+		"dependency.outbound_http.operation.count": float64(1),
+		"dependency.outbound_http.error.count":     float64(1),
+		"dependency.last_system":                   "outbound_http",
+		"dependency.last_component":                "sourcehttp",
+		"dependency.last_operation":                "round_trip",
+		"dependency.last_status":                   "failed",
+		"dependency.outbound_http.last_status":     "failed",
+		"phase.count":                              float64(1),
+		"phase.error.count":                        float64(1),
+		"phase.source_runtime_sync.count":          float64(1),
+		"phase.source_runtime_sync.error.count":    float64(1),
+		"phase.last_name":                          "source_runtime.sync",
+		"phase.last_status":                        "failed",
+		"phase.source_runtime_sync.status":         "failed",
+		"http.response.status_class":               "5xx",
+		"source_id":                                "github",
+		"error_kind":                               "boom_kind",
+	}
+	for key, want := range expected {
 		if got := payload[key]; got != want {
 			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
 		}


### PR DESCRIPTION
## Summary
- add a versioned wide-event contract with event outcome, operation status, duration buckets, process/runtime memory hints, and ECS metadata fields
- add main-span dependency rollups for Postgres, Neo4j, Redis, JetStream, outbound HTTP, and graph-agent LLM work
- add main-span phase rollups for orchestrator, source runtime sync, graph ingest, GRC dashboard subtasks, source operations, and startup jobs
- expand HTTP wide fields with route family, healthcheck flag, request-id hash, AWS trace header presence, and response status class
- document wide-event query patterns for dependency and phase debugging

## Validation
- go test ./internal/telemetry ./internal/observability ./internal/sourcehttp ./internal/bootstrap ./internal/graphagent ./internal/querycache ./internal/statestore/postgres ./internal/graphstore/neo4j ./internal/appendlog/jetstream ./internal/sourceops ./internal/sourceruntime ./internal/sourceprojection ./internal/graphingest ./cmd/cerebro
- go test ./...
- git diff --check