### PR TITLE
Normalize GRC audit packet lookup errors

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -522,7 +522,7 @@ func (a *App) buildGRCAuditPacket(r *http.Request) (grcAuditPacketResponse, erro
 		return grcAuditPacketResponse{}, findings.ErrRuntimeUnavailable
 	}
 	if err := authorizeFindingIDTenant(r.Context(), store, findingID); err != nil {
-		return grcAuditPacketResponse{}, err
+		return grcAuditPacketResponse{}, normalizeIDLookupError(err, ports.ErrFindingNotFound)
 	}
 	finding, err := a.findingService().GetFinding(r.Context(), findingID)
 	if err != nil {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -926,6 +926,34 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 	}
 }
 
+func TestGRCAuditPacketNormalizesForeignFindingLookup(t *testing.T) {
+	store := &stubRuntimeStore{
+		findings: map[string]*ports.FindingRecord{
+			"foreign-finding": {
+				ID:        "foreign-finding",
+				TenantID:  "other",
+				RuntimeID: "other-runtime",
+				Title:     "Foreign finding",
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	request := httptest.NewRequest(http.MethodGet, "/grc/audit-packets/foreign-finding", nil)
+	request.SetPathValue("packetID", "foreign-finding")
+	request = request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{
+		cfg:       config.AuthConfig{},
+		principal: authPrincipal{TenantID: "writer"},
+	}))
+
+	_, err := app.buildGRCAuditPacket(request)
+	if !errors.Is(err, ports.ErrFindingNotFound) {
+		t.Fatalf("buildGRCAuditPacket() error = %v, want finding not found", err)
+	}
+	if got := grcHTTPStatusCode(err); got != http.StatusNotFound {
+		t.Fatalf("grcHTTPStatusCode(buildGRCAuditPacket error) = %d, want %d", got, http.StatusNotFound)
+	}
+}
+
 type stubGRCAggregateStore struct {
 	*stubRuntimeStore
 	aggregateCalls int


### PR DESCRIPTION
## Summary
- normalize tenant-scoped audit-packet lookup failures to the existing not-found sentinel
- add regression coverage for foreign finding IDs so the endpoint does not distinguish them from missing findings

## Validation
- go test ./internal/bootstrap -run 'TestGRCAuditPacketNormalizesForeignFindingLookup' -count=1 -v (fails before the fix; passes after)\n- go test ./internal/bootstrap -run 'Test(GRCAuditPacketNormalizesForeignFindingLookup|GRCEntityImpactAndAuditPacket)$' -count=1 -v\n- go test ./internal/bootstrap -count=1\n- make check-structural check-structural-test check-arch\n- $(go env GOPATH)/bin/golangci-lint run --timeout 10m ./internal/bootstrap