### PR TITLE
Restrict metrics endpoint to operator credentials

### DIFF
--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -37,7 +37,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/evidence-packets", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/graph/reason", Scope: scopeCosmoSecurityRead, Static: true},
 	{Exact: "/api/v1/mcp", Scope: scopeCosmoSecurityRead, Static: true},
-	{Method: http.MethodGet, Exact: "/metrics", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/metrics", Static: true, AdminOnly: true},
 	{Method: http.MethodPost, Prefix: "/reports/", Suffix: "/runs", Static: true, AdminOnly: true},
 	{Method: http.MethodPost, Exact: "/platform/knowledge/decisions", Static: true, AdminOnly: true},
 	{Method: http.MethodPost, Exact: "/platform/knowledge/actions", Static: true, AdminOnly: true},

--- a/internal/bootstrap/auth_route_policy_test.go
+++ b/internal/bootstrap/auth_route_policy_test.go
@@ -1,7 +1,9 @@
 package bootstrap
 
 import (
+	"errors"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -108,6 +110,24 @@ func TestConnectorCredentialBrokerHTTPRouteRequiresWriteScope(t *testing.T) {
 	writer := authPrincipal{Scopes: []string{scopeConnectorCredentialsWrite}}
 	if err := authorizePrincipalScope(writer, scopeConnectorCredentialsWrite); err != nil {
 		t.Fatalf("connector credential writer rejected: %v", err)
+	}
+}
+
+func TestMetricsHTTPRouteRequiresAdminOnly(t *testing.T) {
+	policy := httpRoutePolicyFor(http.MethodGet, "/metrics")
+	if policy.Scope != "" || !policy.AdminOnly {
+		t.Fatalf("GET /metrics policy = %#v, want admin-only", policy)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	readOnly := authContext{principal: authPrincipal{Scopes: []string{scopeCosmoSecurityRead}}}
+	if err := authorizeHTTPRequestScope(readOnly, request); !errors.Is(err, errScopeForbidden) {
+		t.Fatalf("read-only authorizeHTTPRequestScope(/metrics) error = %v, want scope forbidden", err)
+	}
+
+	operator := authContext{principal: authPrincipal{AuthMode: "api_key"}}
+	if err := authorizeHTTPRequestScope(operator, request); err != nil {
+		t.Fatalf("operator authorizeHTTPRequestScope(/metrics) error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make GET /metrics use the existing admin-only HTTP route policy
- add regression coverage proving read-scoped credentials are denied while operator credentials remain allowed

## Validation
- go test ./internal/bootstrap -run 'TestMetricsHTTPRouteRequiresAdminOnly' -count=1 -v (fails before the fix; passes after)\n- go test ./internal/bootstrap -run 'Test(MetricsHTTPRouteRequiresAdminOnly|PlatformHTTPRoutesHaveAuthPolicies|ConnectorCredentialBrokerHTTPRouteRequiresWriteScope|FindingLifecycleHTTPRoutesRequireWriteScope)$' -count=1 -v\n- go test ./internal/bootstrap -run 'Test.*Auth|Test.*Route|Test.*Scope|Test.*Tenant' -count=1\n- go test ./internal/bootstrap -count=1\n- make check-structural check-structural-test check-arch\n- $(go env GOPATH)/bin/golangci-lint run --timeout 10m ./internal/bootstrap