### PR TITLE
Harden Trusted Endpoint trust-gate findings

### DIFF
--- a/internal/endpointtelemetry/normalizer.go
+++ b/internal/endpointtelemetry/normalizer.go
@@ -234,8 +234,15 @@ func trustGateAction(raw map[string]any, eventType string) string {
 	if action := firstString(raw, "action", "gated_action", "operation"); action != "" {
 		return action
 	}
-	if _, after, ok := strings.Cut(strings.TrimSpace(eventType), "."); ok && strings.TrimSpace(after) != "" {
-		return after
+	if _, after, ok := strings.Cut(strings.TrimSpace(eventType), "."); ok {
+		after = strings.TrimSpace(after)
+		switch normalizeDecision(after) {
+		case "deny", "allow", "error":
+			return "trust_gate"
+		}
+		if after != "" {
+			return after
+		}
 	}
 	return "trust_gate"
 }

--- a/internal/endpointtelemetry/normalizer_test.go
+++ b/internal/endpointtelemetry/normalizer_test.go
@@ -67,6 +67,31 @@ func TestNormalizeBuildsSecurityFindingEvent(t *testing.T) {
 	}
 }
 
+func TestNormalizeTrustGateDecisionSuffixDoesNotBecomeAction(t *testing.T) {
+	body := []byte(`{"events":[
+		{"type":"trust_gate.deny","reason":"posture_failed"},
+		{"type":"trust_gate.allow","reason":"posture_remediated"}
+	]}`)
+	events, err := Normalize(body, Principal{TenantID: "writer", DeviceID: "dev_123"}, time.Now())
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	for i, event := range events {
+		if got := event.GetAttributes()["action"]; got != "trust_gate" {
+			t.Fatalf("event[%d] action = %q, want stable trust_gate action", i, got)
+		}
+	}
+	if got := events[0].GetAttributes()["decision"]; got != "deny" {
+		t.Fatalf("deny event decision = %q, want deny", got)
+	}
+	if got := events[1].GetAttributes()["decision"]; got != "allow" {
+		t.Fatalf("allow event decision = %q, want allow", got)
+	}
+}
+
 func TestNormalizeRequiresTenantAndDeviceIdentity(t *testing.T) {
 	if _, err := Normalize([]byte(`{"events":[]}`), Principal{DeviceID: "dev"}, time.Now()); err == nil {
 		t.Fatal("Normalize() without tenant error = nil, want error")

--- a/internal/findings/testdata/rules/trusted-endpoint-active-trust-gate-failure.json
+++ b/internal/findings/testdata/rules/trusted-endpoint-active-trust-gate-failure.json
@@ -68,16 +68,28 @@
         "primary_resource_urn": "urn:cerebro:writer:trusted_endpoint_agent:dev-risky",
         "rule_required_attributes": "agent_id,action,decision"
       }
+    },
+    {
+      "rule_id": "trusted-endpoint-active-trust-gate-failure",
+      "severity": "HIGH",
+      "status": "open",
+      "summary": "Trusted Endpoint agent dev-offboarded is failing the trust gate for action git_push",
+      "event_ids": ["trusted-endpoint-gate-deprovisioned"],
+      "attributes": {
+        "trusted_endpoint_gate_urn": "urn:cerebro:writer:trusted_endpoint_trust_gate:dev-offboarded:git_push",
+        "trusted_endpoint_agent_urn": "urn:cerebro:writer:trusted_endpoint_agent:dev-offboarded",
+        "agent_id": "dev-offboarded",
+        "action": "git_push",
+        "decision": "deny",
+        "primary_resource_urn": "urn:cerebro:writer:trusted_endpoint_agent:dev-offboarded",
+        "rule_required_attributes": "agent_id,action,decision"
+      }
     }
   ],
   "expected_no_match": [
     {
       "event_id": "trusted-endpoint-gate-allow",
       "reason": "allow decision means the agent currently passes the trust gate"
-    },
-    {
-      "event_id": "trusted-endpoint-gate-deprovisioned",
-      "reason": "deprovisioned agent must not open a stale trust-gate finding"
     }
   ]
 }

--- a/internal/findings/trusted_endpoint_active_trust_gate_failure_rule.go
+++ b/internal/findings/trusted_endpoint_active_trust_gate_failure_rule.go
@@ -75,16 +75,16 @@ func (r *trustedEndpointActiveTrustGateFailureRule) OpenAnchor(attributes map[st
 	return trustedEndpointActiveTrustGateFailureAnchor(attributes)
 }
 
-// CloseOnEvent resolves an open finding when a later trust-gate decision for the
-// same agent/action allows the action (posture remediated) or when the agent is
-// no longer managed (deprovisioned/offboarded), so resolved or removed agents do
-// not leave stale open findings.
+// CloseOnEvent resolves an open finding only when a later trust-gate decision
+// for the same agent/action allows the action. Endpoint-reported lifecycle
+// fields are retained as context but are not authoritative enough to close or
+// suppress a current trust-gate failure.
 func (r *trustedEndpointActiveTrustGateFailureRule) CloseOnEvent(event Event) (string, bool) {
 	if !trustedEndpointTrustGateKindMatcher(event) || !hasRequiredAttributes(event, trustedEndpointActiveTrustGateFailureDefinition.RequiredAttributes...) {
 		return "", false
 	}
 	attributes := eventAttributes(event)
-	if !trustedEndpointGateRemediated(attributes) && !trustedEndpointAgentDeprovisioned(attributes) {
+	if !trustedEndpointGateRemediated(attributes) {
 		return "", false
 	}
 	gateURN := trustedEndpointTrustGateURN(event.GetTenantId(), attributes["agent_id"], attributes["action"])
@@ -110,7 +110,7 @@ func trustedEndpointActiveTrustGateFailureFinding(event *cerebrov1.EventEnvelope
 		return nil, nil
 	}
 	decision := trustedEndpointNormalizeDecisionValue(attrs["decision"])
-	severity := firstNonEmpty(normalizeFindingSeverity(attrs["severity"]), "HIGH")
+	severity := normalizeFindingSeverity(firstNonEmpty(attrs["severity"], trustedEndpointActiveTrustGateFailureDefinition.Severity))
 	label := firstNonEmpty(strings.TrimSpace(attrs["hostname"]), agentID)
 	attributes := map[string]string{
 		"trusted_endpoint_gate_urn":  gateURN,
@@ -157,9 +157,6 @@ func trustedEndpointActiveTrustGateFailureFinding(event *cerebrov1.EventEnvelope
 }
 
 func trustedEndpointGateDenied(attributes map[string]string) bool {
-	if trustedEndpointAgentDeprovisioned(attributes) {
-		return false
-	}
 	switch trustedEndpointNormalizeDecisionValue(attributes["decision"]) {
 	case "deny", "error":
 		return true
@@ -170,30 +167,6 @@ func trustedEndpointGateDenied(attributes map[string]string) bool {
 
 func trustedEndpointGateRemediated(attributes map[string]string) bool {
 	return trustedEndpointNormalizeDecisionValue(attributes["decision"]) == "allow"
-}
-
-// trustedEndpointAgentDeprovisioned reports whether the agent is no longer
-// managed based on the normalized lifecycle state propagated by the source
-// normalizer, so offboarded agents resolve stale trust-gate findings instead of
-// relying on inconsistent raw attribute values.
-func trustedEndpointAgentDeprovisioned(attributes map[string]string) bool {
-	if managed, ok := parseOptionalBoolAttribute(attributes, "managed"); ok && !managed {
-		return true
-	}
-	return trustedEndpointNormalizeAgentStatus(attributes["agent_status"]) == "deprovisioned"
-}
-
-func trustedEndpointNormalizeAgentStatus(value string) string {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "":
-		return ""
-	case "deprovisioned", "deleted", "removed", "offboarded", "off-boarded", "off boarded", "unenrolled", "un-enrolled", "deactivated", "inactive", "retired", "decommissioned", "disabled", "terminated", "revoked":
-		return "deprovisioned"
-	case "active", "enrolled", "managed", "enabled", "provisioned", "online":
-		return "active"
-	default:
-		return strings.ToLower(strings.TrimSpace(value))
-	}
 }
 
 func trustedEndpointNormalizeDecisionValue(value string) string {

--- a/internal/findings/trusted_endpoint_active_trust_gate_failure_rule_test.go
+++ b/internal/findings/trusted_endpoint_active_trust_gate_failure_rule_test.go
@@ -42,66 +42,65 @@ func TestTrustedEndpointActiveTrustGateFailureRemediationResolves(t *testing.T) 
 	assertIdentityRuleRemediationTrajectory(t, newTrustedEndpointActiveTrustGateFailureRule(), open, resolved, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
 }
 
-func TestTrustedEndpointActiveTrustGateFailureDeprovisionResolves(t *testing.T) {
-	open := trustedEndpointGateEvent("te-open", map[string]string{"decision": "deny", "severity": "high"}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
-	deprovisioned := trustedEndpointGateEvent("te-deprovisioned", map[string]string{"decision": "deny", "agent_status": "deprovisioned"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
-	assertIdentityRuleRemediationTrajectory(t, newTrustedEndpointActiveTrustGateFailureRule(), open, deprovisioned, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
-}
-
-func TestTrustedEndpointActiveTrustGateFailureUnmanagedAgentResolves(t *testing.T) {
-	open := trustedEndpointGateEvent("te-open", map[string]string{"decision": "deny", "severity": "high"}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
-	unmanaged := trustedEndpointGateEvent("te-unmanaged", map[string]string{"decision": "deny", "managed": "false"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
-	assertIdentityRuleRemediationTrajectory(t, newTrustedEndpointActiveTrustGateFailureRule(), open, unmanaged, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
-}
-
-func TestTrustedEndpointActiveTrustGateFailureReopensAfterDeprovision(t *testing.T) {
+func TestTrustedEndpointActiveTrustGateFailureDefaultsBlankSeverityToHigh(t *testing.T) {
 	rule := newTrustedEndpointActiveTrustGateFailureRule()
 	runtime := &cerebrov1.SourceRuntime{
 		Id:       "writer-trusted-endpoint",
 		SourceId: "trusted_endpoint",
 		TenantId: "writer",
 	}
-
-	emitOpen := func(event *cerebrov1.EventEnvelope) *ports.FindingRecord {
-		t.Helper()
-		records, err := rule.Evaluate(context.Background(), runtime, event)
-		if err != nil {
-			t.Fatalf("Evaluate(%q) error = %v", event.GetId(), err)
-		}
-		if len(records) != 1 {
-			t.Fatalf("Evaluate(%q) emitted %d findings, want 1", event.GetId(), len(records))
-		}
-		if got := strings.TrimSpace(records[0].Status); got != findingStatusOpen {
-			t.Fatalf("Evaluate(%q) status = %q, want open", event.GetId(), got)
-		}
-		return records[0]
+	event := trustedEndpointGateEvent("te-open", map[string]string{"decision": "deny"}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	records, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
 	}
-
-	opened := emitOpen(trustedEndpointGateEvent("te-deny-1", map[string]string{"decision": "deny", "severity": "high"}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)))
-	openFingerprint := strings.TrimSpace(opened.Fingerprint)
-	if openFingerprint == "" {
-		t.Fatal("opened finding has empty fingerprint")
+	if len(records) != 1 {
+		t.Fatalf("Evaluate() emitted %d findings, want 1", len(records))
 	}
+	if got := records[0].Severity; got != "HIGH" {
+		t.Fatalf("Severity = %q, want HIGH", got)
+	}
+	if got := records[0].Attributes["severity"]; got != "HIGH" {
+		t.Fatalf("Attributes[severity] = %q, want HIGH", got)
+	}
+}
 
+func TestTrustedEndpointActiveTrustGateFailureSelfReportedDeprovisionDoesNotResolveOrSuppress(t *testing.T) {
+	assertTrustedEndpointSelfReportedLifecycleDoesNotResolveOrSuppress(t, map[string]string{
+		"decision":     "deny",
+		"agent_status": "deprovisioned",
+	})
+}
+
+func TestTrustedEndpointActiveTrustGateFailureSelfReportedUnmanagedDoesNotResolveOrSuppress(t *testing.T) {
+	assertTrustedEndpointSelfReportedLifecycleDoesNotResolveOrSuppress(t, map[string]string{
+		"decision": "deny",
+		"managed":  "false",
+	})
+}
+
+func assertTrustedEndpointSelfReportedLifecycleDoesNotResolveOrSuppress(t *testing.T, attrs map[string]string) {
+	t.Helper()
+	rule := newTrustedEndpointActiveTrustGateFailureRule()
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "writer-trusted-endpoint",
+		SourceId: "trusted_endpoint",
+		TenantId: "writer",
+	}
+	event := trustedEndpointGateEvent("te-self-reported-lifecycle", attrs, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	records, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Evaluate() emitted %d findings, want 1", len(records))
+	}
 	counterRule, ok := rule.(CounterEventRule)
 	if !ok {
 		t.Fatal("rule does not implement CounterEventRule")
 	}
-	deprovisionedEvent := trustedEndpointGateEvent("te-deprovisioned", map[string]string{"decision": "deny", "agent_status": "offboarded"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
-	closeAnchor, closes := counterRule.CloseOnEvent(deprovisionedEvent)
-	if !closes || closeAnchor == "" {
-		t.Fatalf("CloseOnEvent(deprovisioned) = (%q, %v), want a non-empty closing anchor", closeAnchor, closes)
-	}
-	if openAnchor := counterRule.OpenAnchor(opened.Attributes); openAnchor != closeAnchor {
-		t.Fatalf("OpenAnchor(open finding) = %q, want match close anchor %q", openAnchor, closeAnchor)
-	}
-
-	reopened := emitOpen(trustedEndpointGateEvent("te-deny-2", map[string]string{"decision": "deny", "severity": "high", "agent_status": "active"}, time.Date(2026, 5, 1, 14, 0, 0, 0, time.UTC)))
-	if got := strings.TrimSpace(reopened.Fingerprint); got != openFingerprint {
-		t.Fatalf("recurrence fingerprint = %q, want stable %q", got, openFingerprint)
-	}
-	if got := strings.TrimSpace(reopened.ID); got != strings.TrimSpace(opened.ID) {
-		t.Fatalf("recurrence finding id = %q, want stable %q", got, strings.TrimSpace(opened.ID))
+	if closeAnchor, closes := counterRule.CloseOnEvent(event); closes || closeAnchor != "" {
+		t.Fatalf("CloseOnEvent(self-reported lifecycle) = (%q, %v), want no close", closeAnchor, closes)
 	}
 }
 

--- a/sources/trustedendpoint/telemetry_test.go
+++ b/sources/trustedendpoint/telemetry_test.go
@@ -84,6 +84,29 @@ func TestNormalizeTrustGateDecisionAttributes(t *testing.T) {
 	}
 }
 
+func TestNormalizeTrustGateDecisionTypeSuffixUsesStableFallbackAction(t *testing.T) {
+	principal := endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev_123"}
+	body := []byte(`{"events":[{"type":"trust_gate.deny","reason":"posture_failed"},{"type":"trust_gate.allow","reason":"posture_remediated"}]}`)
+	events, err := endpointtelemetry.Normalize(body, principal, time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	for i, event := range events {
+		if got := event.GetAttributes()["action"]; got != "trust_gate" {
+			t.Fatalf("event[%d] action = %q, want trust_gate", i, got)
+		}
+	}
+	if got := events[0].GetAttributes()["decision"]; got != "deny" {
+		t.Fatalf("events[0] decision = %q, want deny", got)
+	}
+	if got := events[1].GetAttributes()["decision"]; got != "allow" {
+		t.Fatalf("events[1] decision = %q, want allow", got)
+	}
+}
+
 func TestNormalizeTrustGatePropagatesDeprovisionState(t *testing.T) {
 	principal := endpointtelemetry.Principal{TenantID: "writer", DeviceID: "dev_123"}
 	body := []byte(`{"events":[{"type":"trust_gate.deny","action":"git_push","reason":"posture_failed","agent_status":"Off-boarded","managed":false}]}`)


### PR DESCRIPTION
## Summary
- stabilize type-encoded trust-gate events so `trust_gate.deny` / `trust_gate.allow` use the same fallback action when no explicit action is present
- default blank Trusted Endpoint trust-gate severities to the rule-declared HIGH severity
- stop closing or suppressing trust-gate failure findings based on endpoint self-reported lifecycle/managed fields

## Validation
- go test ./internal/endpointtelemetry ./sources/trustedendpoint ./internal/findings -run 'TrustedEndpoint|trusted_endpoint|TrustGate|trust_gate|Normalize' -count=1\n- make docs-drift-check detection-catalog-check control-index-check\n- make lint