### PR TITLE
Fix EvidenceCAS blank link status handling

### DIFF
--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -170,7 +170,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 1051 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 1052 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/internal/compliance/control_coverage_index.yaml
+++ b/internal/compliance/control_coverage_index.yaml
@@ -61095,7 +61095,7 @@ profiles:
         selected_controls: 36
         mapped_controls: 25
         unmapped_controls: 11
-        mapped_rules: 928
+        mapped_rules: 929
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 36

--- a/internal/findings/evidence_cas_unresolved_linkage_rule.go
+++ b/internal/findings/evidence_cas_unresolved_linkage_rule.go
@@ -187,7 +187,7 @@ func evidenceCASResourceLinkUnresolved(attributes map[string]string) bool {
 	if parseBoolAttribute(attributes, "unresolved_resource_context") {
 		return true
 	}
-	return strings.EqualFold(strings.TrimSpace(attributes["resource_link_status"]), "missing")
+	return !strings.EqualFold(strings.TrimSpace(attributes["resource_link_status"]), "linked")
 }
 
 func evidenceCASCaseLinkUnresolved(attributes map[string]string) bool {
@@ -197,7 +197,7 @@ func evidenceCASCaseLinkUnresolved(attributes map[string]string) bool {
 	if parseBoolAttribute(attributes, "unresolved_case_context") {
 		return true
 	}
-	return strings.EqualFold(strings.TrimSpace(attributes["case_link_status"]), "missing")
+	return !strings.EqualFold(strings.TrimSpace(attributes["case_link_status"]), "linked")
 }
 
 func evidenceCASResourceContextSupplied(attributes map[string]string) bool {

--- a/internal/findings/evidence_cas_unresolved_linkage_rule_test.go
+++ b/internal/findings/evidence_cas_unresolved_linkage_rule_test.go
@@ -108,6 +108,48 @@ func TestEvidenceCASUnresolvedLinkageIgnoresResolvedAndBareEvidence(t *testing.T
 	}
 }
 
+func TestEvidenceCASUnresolvedLinkageOpensOnSuppliedContextWithBlankLinkStatus(t *testing.T) {
+	rule := newEvidenceCASUnresolvedLinkageRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-evidence-cas", SourceId: "evidence_cas", TenantId: "writer"}
+	occurredAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name  string
+		attrs map[string]string
+		scope string
+	}{
+		{
+			name: "case",
+			attrs: map[string]string{
+				"case_id":          "case-blank-status",
+				"case_link_status": "",
+			},
+			scope: "case",
+		},
+		{
+			name: "resource",
+			attrs: map[string]string{
+				"resource_id":          "resource-blank-status",
+				"resource_link_status": "",
+			},
+			scope: "resource",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			records, err := rule.Evaluate(context.Background(), runtime, evidenceCASObjectEvent("evidence-"+tc.name+"-blank-status", tc.attrs, occurredAt))
+			if err != nil {
+				t.Fatalf("Evaluate(%s) error = %v", tc.name, err)
+			}
+			if len(records) != 1 {
+				t.Fatalf("Evaluate(%s) emitted %d findings, want 1", tc.name, len(records))
+			}
+			if got := records[0].Attributes["unresolved_linkage"]; got != tc.scope {
+				t.Fatalf("unresolved_linkage = %q, want %q", got, tc.scope)
+			}
+		})
+	}
+}
+
 func TestEvidenceCASUnresolvedLinkageContextlessFollowupKeepsFindingOpen(t *testing.T) {
 	rule := newEvidenceCASUnresolvedLinkageRule()
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-evidence-cas", SourceId: "evidence_cas", TenantId: "writer"}

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -88,8 +88,8 @@ func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
 
 func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	packs := builtinRulePacks()
-	if got := len(packs); got != 22 {
-		t.Fatalf("len(builtinRulePacks()) = %d, want 22", got)
+	if got := len(packs); got != 23 {
+		t.Fatalf("len(builtinRulePacks()) = %d, want 23", got)
 	}
 	rules := flattenRulePacks(packs)
 	if got := len(rules); got < 10 {

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -825,7 +825,7 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 49; got != want {
+	if got, want := len(keepRules), 50; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -5293,6 +5293,37 @@ func TestProjectEvidenceCASStampsNormalizedLinkState(t *testing.T) {
 		t.Fatalf("unresolved evidence_link_state = %q, want unresolved", got)
 	}
 
+	blankCaseStatusState := &projectionRecorder{}
+	service = New(blankCaseStatusState, nil)
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "iris-evidence-blank-case-status",
+		TenantId: "writer",
+		SourceId: "evidence_cas",
+		Kind:     "evidence_cas.object",
+		Attributes: map[string]string{
+			"case_id":               "case-blank-status",
+			"evidence_cas_digest":   "sha256blankstatus",
+			"evidence_cas_ref_type": "evidencecas.manifest.v2",
+			"evidence_cas_uri":      "evidencecas://cases/case-blank-status/evidence/evidence-blank-status",
+			"evidence_id":           "evidence-blank-status",
+			"source_event_id":       "iris-event-blank-status",
+			"source_runtime_id":     "iris-runtime",
+			"source_system":         "iris",
+		},
+	}); err != nil {
+		t.Fatalf("Project(blank case status) error = %v", err)
+	}
+	blankCaseStatus := blankCaseStatusState.entities["urn:cerebro:writer:runtime_evidence:evidence-blank-status"]
+	if blankCaseStatus == nil {
+		t.Fatal("blank case status runtime evidence entity missing")
+	}
+	if got := blankCaseStatus.Attributes["case_link_status"]; got != "missing" {
+		t.Fatalf("blank case status case_link_status = %q, want missing", got)
+	}
+	if got := blankCaseStatus.Attributes["evidence_link_state"]; got != "unresolved" {
+		t.Fatalf("blank case status evidence_link_state = %q, want unresolved", got)
+	}
+
 	bareState := &projectionRecorder{}
 	service = New(bareState, nil)
 	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{


### PR DESCRIPTION
## Summary
- Treat supplied EvidenceCAS case/resource context as unresolved unless its link status is explicitly linked
- Add regressions for blank case/resource link statuses and projection link-state stamping
- Refresh rule-pack/control-index audit counts against current main

## Validation
- go test ./internal/findings ./internal/sourceprojection ./sources/evidencecas -count=1
- make lint
- ./scripts/pre_commit_checks.sh