### PR TITLE
Harden MCP OAuth upstream OIDC fetches

### DIFF
--- a/internal/bootstrap/mcp_oauth_test.go
+++ b/internal/bootstrap/mcp_oauth_test.go
@@ -354,6 +354,77 @@ func TestMCPOAuthClientCredentialsIssuesMCPOnlyToken(t *testing.T) {
 	}
 }
 
+func TestMCPOAuthOIDCDiscoveryDoesNotFollowRedirects(t *testing.T) {
+	redirectTargetHit := false
+	var redirectTarget *httptest.Server
+	redirectTarget = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectTargetHit = true
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 "placeholder",
+			"authorization_endpoint": redirectTarget.URL + "/authorize",
+			"token_endpoint":         redirectTarget.URL + "/token",
+			"jwks_uri":               redirectTarget.URL + "/jwks",
+		})
+	}))
+	defer redirectTarget.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Redirect(w, r, redirectTarget.URL+"/openid-configuration", http.StatusFound)
+	}))
+	defer upstream.Close()
+
+	client := newMCPOAuthOIDCClient(config.MCPOAuthUpstreamConfig{
+		Issuer:       upstream.URL,
+		ClientID:     "writer-client",
+		ClientSecret: "writer-secret",
+		RedirectURI:  "https://cerebro.example/oauth/callback",
+	})
+	endpoint, err := client.AuthorizationEndpoint(context.Background())
+	if err == nil {
+		t.Fatalf("AuthorizationEndpoint = %q, want upstream discovery redirect rejection", endpoint)
+	}
+	if redirectTargetHit {
+		t.Fatal("OIDC discovery followed a server-side redirect target")
+	}
+}
+
+func TestMCPOAuthOIDCTokenExchangeDoesNotFollowRedirects(t *testing.T) {
+	redirectTargetHit := false
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectTargetHit = true
+		_ = json.NewEncoder(w).Encode(map[string]any{"id_token": "redirected"})
+	}))
+	defer redirectTarget.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Redirect(w, r, redirectTarget.URL+"/capture", http.StatusFound)
+	}))
+	defer upstream.Close()
+
+	client := newMCPOAuthOIDCClient(config.MCPOAuthUpstreamConfig{
+		Issuer:        "https://writer-sso.example",
+		TokenEndpoint: upstream.URL + "/token",
+		ClientID:      "writer-client",
+		ClientSecret:  "writer-secret",
+		RedirectURI:   "https://cerebro.example/oauth/callback",
+	})
+	_, err := client.ExchangeCode(context.Background(), "upstream-code", "nonce")
+	if err == nil {
+		t.Fatal("ExchangeCode succeeded through an upstream token redirect")
+	}
+	if redirectTargetHit {
+		t.Fatal("OIDC token exchange followed a server-side redirect target")
+	}
+}
+
 func TestMCPOAuthCallbackRejectsMissingSecurityGroup(t *testing.T) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/internal/bootstrap/oauth_oidc.go
+++ b/internal/bootstrap/oauth_oidc.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/mcpoauth"
+	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
 const (
@@ -44,8 +45,33 @@ type mcpOAuthOIDCClient struct {
 func newMCPOAuthOIDCClient(cfg config.MCPOAuthUpstreamConfig) *mcpOAuthOIDCClient {
 	return &mcpOAuthOIDCClient{
 		cfg:        cfg,
-		httpClient: &http.Client{Timeout: 15 * time.Second},
+		httpClient: newMCPOAuthOIDCHTTPClient(cfg),
 	}
+}
+
+func newMCPOAuthOIDCHTTPClient(cfg config.MCPOAuthUpstreamConfig) *http.Client {
+	return sourcehttp.NewClient(sourcehttp.ClientOptions{
+		SourceID:      "mcp-oauth-oidc",
+		Timeout:       15 * time.Second,
+		AllowLoopback: mcpOAuthOIDCAllowsLoopback(cfg),
+	})
+}
+
+func mcpOAuthOIDCAllowsLoopback(cfg config.MCPOAuthUpstreamConfig) bool {
+	for _, raw := range []string{cfg.Issuer, cfg.TokenEndpoint, cfg.JWKSURI} {
+		if mcpOAuthOIDCURLUsesLoopback(raw) {
+			return true
+		}
+	}
+	return false
+}
+
+func mcpOAuthOIDCURLUsesLoopback(raw string) bool {
+	parsed, err := url.Parse(strings.TrimRight(strings.TrimSpace(raw), "/"))
+	if err != nil {
+		return false
+	}
+	return sourcehttp.IsLoopbackHost(parsed.Hostname())
 }
 
 func (c *mcpOAuthOIDCClient) AuthorizationEndpoint(ctx context.Context) (string, error) {


### PR DESCRIPTION
## Summary
- route MCP OAuth upstream OIDC discovery, token exchange, and JWKS fetches through the hardened source HTTP client
- preserve explicit loopback upstream support for local/dev configurations
- add regressions that ensure upstream discovery and token exchange redirects are not followed server-side

## Validation
- go test ./internal/bootstrap -run 'TestMCPOAuthOIDCDiscoveryDoesNotFollowRedirects' -count=1 -v (failed before fix)\n- go test ./internal/bootstrap -run 'TestMCPOAuthOIDC.*DoesNotFollowRedirects' -count=1 -v\n- go test ./internal/bootstrap -run 'TestMCPOAuth' -count=1\n- go test ./internal/bootstrap -count=1\n- make check-structural check-structural-test check-arch\n- golangci-lint run --timeout 10m ./internal/bootstrap