### PR TITLE
test(cloudflare): postgres-backed zone-protection reopen lifecycle e2e

### DIFF
--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -170,7 +170,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 1051 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 1052 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/internal/compliance/control_coverage_index.yaml
+++ b/internal/compliance/control_coverage_index.yaml
@@ -61095,7 +61095,7 @@ profiles:
         selected_controls: 36
         mapped_controls: 25
         unmapped_controls: 11
-        mapped_rules: 928
+        mapped_rules: 929
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 36

--- a/internal/findings/cloudflare_reopen_e2e_test.go
+++ b/internal/findings/cloudflare_reopen_e2e_test.go
@@ -1,0 +1,226 @@
+package findings_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/statestore/postgres"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestCloudflareZoneProtectionPausedPostgresReopenLifecycle exercises the
+// Cloudflare zone-protection-paused durable finding lifecycle against a real
+// Postgres state store so the open -> resolved -> reopened transitions are
+// validated against persisted storage semantics rather than only in-memory
+// candidate emission. Remediation (unpausing the zone) resolves the persisted
+// finding through the production counter-event close path, and a later
+// recurrence (the same zone paused again) reopens the same finding fingerprint
+// and row id via the real UpsertFinding reopen path without minting a duplicate
+// generation row.
+//
+// Run with: CEREBRO_POSTGRES_DSN=... go test ./internal/findings/... -run TestCloudflareZoneProtectionPausedPostgresReopenLifecycle -count=1
+func TestCloudflareZoneProtectionPausedPostgresReopenLifecycle(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CEREBRO_POSTGRES_DSN"))
+	if dsn == "" {
+		t.Skip("set CEREBRO_POSTGRES_DSN to run the postgres-backed Cloudflare reopen lifecycle integration test")
+	}
+
+	ctx := context.Background()
+	store, err := postgres.Open(config.StateStoreConfig{
+		Driver:      config.StateStoreDriverPostgres,
+		PostgresDSN: dsn,
+	})
+	if err != nil {
+		t.Fatalf("open postgres store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	rawDB, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	t.Cleanup(func() { _ = rawDB.Close() })
+
+	nonce := time.Now().UTC().UnixNano()
+	tenantID := fmt.Sprintf("tenant-cloudflare-reopen-e2e-%d", nonce)
+	runtimeID := fmt.Sprintf("runtime-cloudflare-reopen-e2e-%d", nonce)
+	zoneID := fmt.Sprintf("zone-cloudflare-reopen-e2e-%d", nonce)
+	ruleID := "cloudflare-zone-protection-paused"
+
+	openedAt := time.Now().UTC().Add(-3 * time.Hour).Truncate(time.Microsecond)
+	restoredAt := openedAt.Add(time.Hour)
+	recurredAt := restoredAt.Add(time.Hour)
+
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = rawDB.ExecContext(bg, `DELETE FROM finding_evidence WHERE runtime_id = $1`, runtimeID)
+		_, _ = rawDB.ExecContext(bg, `DELETE FROM finding_evaluation_runs WHERE runtime_id = $1`, runtimeID)
+		_, _ = rawDB.ExecContext(bg, `DELETE FROM findings WHERE tenant_id = $1`, tenantID)
+	})
+
+	runtimeStore := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {
+				Id:       runtimeID,
+				SourceId: "cloudflare",
+				TenantId: tenantID,
+				Config:   map[string]string{"family": "zone"},
+			},
+		},
+	}
+	replayer := &stubReplayer{}
+	service := findings.NewWithRegistry(runtimeStore, replayer, store, store, store, store, findings.Builtin())
+
+	// 1. Active edge-protection pause opens a durable finding persisted in Postgres.
+	replayer.events = []*cerebrov1.EventEnvelope{
+		cloudflareZoneReopenE2EEvent("cf-zone-paused-open", tenantID, runtimeID, zoneID, "true", openedAt),
+	}
+	openResult, err := service.EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
+		RuntimeID: runtimeID,
+		RuleIDs:   []string{ruleID},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeRules(open): %v", err)
+	}
+	if openResult == nil || len(openResult.Evaluations) != 1 || len(openResult.Evaluations[0].Findings) != 1 {
+		t.Fatalf("open result = %#v, want one cloudflare paused-zone finding", openResult)
+	}
+	opened := openResult.Evaluations[0].Findings[0]
+	if got := strings.TrimSpace(opened.Status); got != "open" {
+		t.Fatalf("opened status = %q, want open", got)
+	}
+	if got := strings.TrimSpace(opened.TenantID); got != tenantID {
+		t.Fatalf("opened tenant_id = %q, want %q", got, tenantID)
+	}
+	openFingerprint := strings.TrimSpace(opened.Fingerprint)
+	if openFingerprint == "" {
+		t.Fatal("opened finding has empty fingerprint")
+	}
+
+	persistedOpen, err := store.GetFinding(ctx, opened.ID)
+	if err != nil {
+		t.Fatalf("GetFinding(%q) after open: %v", opened.ID, err)
+	}
+	if got := strings.TrimSpace(persistedOpen.Status); got != "open" {
+		t.Fatalf("persisted opened status = %q, want open", got)
+	}
+
+	// 2. Remediation (zone unpaused) resolves the persisted finding through the
+	//    real counter-event close path. The unpaused event itself must not open
+	//    a new finding.
+	replayer.events = []*cerebrov1.EventEnvelope{
+		cloudflareZoneReopenE2EEvent("cf-zone-unpaused", tenantID, runtimeID, zoneID, "false", restoredAt),
+	}
+	resolveResult, err := service.EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
+		RuntimeID: runtimeID,
+		RuleIDs:   []string{ruleID},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeRules(resolve): %v", err)
+	}
+	if resolveResult == nil || len(resolveResult.Evaluations) != 1 {
+		t.Fatalf("resolve result = %#v, want one evaluation", resolveResult)
+	}
+	for _, finding := range resolveResult.Evaluations[0].Findings {
+		if finding == nil {
+			continue
+		}
+		if got := strings.TrimSpace(finding.Status); got == "open" {
+			t.Fatalf("resolve evaluation re-opened finding %q with status open, want no active reopen on unpaused zone", strings.TrimSpace(finding.ID))
+		}
+	}
+
+	resolved, err := store.GetFinding(ctx, opened.ID)
+	if err != nil {
+		t.Fatalf("GetFinding(%q) after remediation: %v", opened.ID, err)
+	}
+	if got := strings.TrimSpace(resolved.Status); got != "resolved" {
+		t.Fatalf("remediated status = %q, want resolved", got)
+	}
+	if got := strings.TrimSpace(resolved.StatusReason); got != "closed_by_counter_event" {
+		t.Fatalf("remediated status_reason = %q, want closed_by_counter_event", got)
+	}
+	if resolved.Tombstoned {
+		t.Fatalf("remediated finding tombstoned = true, want false")
+	}
+
+	// 3. Recurrence (the same zone paused again) reopens the persisted finding on
+	//    the same fingerprint and row id instead of emitting a fresh in-memory
+	//    candidate or minting a duplicate generation row.
+	replayer.events = []*cerebrov1.EventEnvelope{
+		cloudflareZoneReopenE2EEvent("cf-zone-paused-recur", tenantID, runtimeID, zoneID, "true", recurredAt),
+	}
+	reopenResult, err := service.EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
+		RuntimeID: runtimeID,
+		RuleIDs:   []string{ruleID},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeRules(reopen): %v", err)
+	}
+	if reopenResult == nil || len(reopenResult.Evaluations) != 1 || len(reopenResult.Evaluations[0].Findings) != 1 {
+		t.Fatalf("reopen result = %#v, want one reopened cloudflare finding", reopenResult)
+	}
+	reopenedFromResult := reopenResult.Evaluations[0].Findings[0]
+	if got := strings.TrimSpace(reopenedFromResult.ID); got != strings.TrimSpace(opened.ID) {
+		t.Fatalf("reopened finding id = %q, want original id %q from real upsert reopen path", got, opened.ID)
+	}
+	if got := strings.TrimSpace(reopenedFromResult.Fingerprint); got != openFingerprint {
+		t.Fatalf("reopened fingerprint = %q, want stable %q", got, openFingerprint)
+	}
+
+	reopened, err := store.GetFinding(ctx, opened.ID)
+	if err != nil {
+		t.Fatalf("GetFinding(%q) after recurrence: %v", opened.ID, err)
+	}
+	if got := strings.TrimSpace(reopened.Status); got != "open" {
+		t.Fatalf("reopened status = %q, want open", got)
+	}
+	if got := strings.TrimSpace(reopened.StatusReason); got != "" {
+		t.Fatalf("reopened status_reason = %q, want empty", got)
+	}
+	if reopened.Tombstoned {
+		t.Fatalf("reopened finding tombstoned = true, want false")
+	}
+	if strings.Contains(reopened.ID, "#g") {
+		t.Fatalf("reopened finding id = %q, want original non-generation row for durable counter-event reopen", reopened.ID)
+	}
+
+	var activeRows int
+	if err := rawDB.QueryRowContext(ctx, `SELECT count(*) FROM findings WHERE tenant_id = $1 AND rule_id = $2 AND fingerprint = $3 AND tombstoned = FALSE`, tenantID, ruleID, openFingerprint).Scan(&activeRows); err != nil {
+		t.Fatalf("count active reopened rows: %v", err)
+	}
+	if activeRows != 1 {
+		t.Fatalf("active rows for reopened cloudflare fingerprint = %d, want 1 (no duplicate churn)", activeRows)
+	}
+}
+
+func cloudflareZoneReopenE2EEvent(id string, tenantID string, runtimeID string, zoneID string, paused string, occurredAt time.Time) *cerebrov1.EventEnvelope {
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   tenantID,
+		SourceId:   "cloudflare",
+		Kind:       "cloudflare.zone",
+		OccurredAt: timestamppb.New(occurredAt.UTC()),
+		SchemaRef:  "cloudflare/zone/v1",
+		Attributes: map[string]string{
+			"family":                            "zone",
+			"zone_id":                           zoneID,
+			"account_id":                        fmt.Sprintf("acct-%s", zoneID),
+			"name":                              "reopen-e2e.example.com",
+			"status":                            "active",
+			"paused":                            paused,
+			ports.EventAttributeSourceRuntimeID: runtimeID,
+		},
+	}
+}

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -88,8 +88,8 @@ func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
 
 func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	packs := builtinRulePacks()
-	if got := len(packs); got != 22 {
-		t.Fatalf("len(builtinRulePacks()) = %d, want 22", got)
+	if got := len(packs); got != 23 {
+		t.Fatalf("len(builtinRulePacks()) = %d, want 23", got)
 	}
 	rules := flattenRulePacks(packs)
 	if got := len(rules); got < 10 {

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -825,7 +825,7 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 49; got != want {
+	if got, want := len(keepRules), 50; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -194,6 +194,12 @@ var errTenantScopedFingerprintBackfillRetry = errors.New("retry tenant-scoped fi
 // runtime keeps the row addressable through the real runtime-scoped read paths
 // (Service.ListFindings, ListEvidence, reports, GRC) instead of flipping it between sources
 // every iteration.
+//
+// A resolved row reopens in place on a fresh open emit only when it was auto-resolved by the
+// lifecycle (TTL expiry or a remediation counter-event) or when the rule opts into TTL reopen
+// via $37; analyst/manual resolutions keep their stored status so deliberate closures are not
+// reverted. The 'closed_by_counter_event' literal must stay in sync with
+// workflowevents.FindingStatusReasonClosedByCounterEvent.
 const upsertFindingStatement = `
 INSERT INTO findings (
   id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
@@ -214,7 +220,7 @@ DO UPDATE SET
   status = CASE
     WHEN findings.tombstoned THEN findings.status
     WHEN findings.status = 'suppressed' THEN findings.status
-    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT findings.tombstoned AND (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR $37::boolean) THEN EXCLUDED.status
+    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT findings.tombstoned AND (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR BTRIM(findings.status_reason) = 'closed_by_counter_event' OR $37::boolean) THEN EXCLUDED.status
     WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' THEN findings.status
     ELSE EXCLUDED.status
   END,
@@ -256,13 +262,13 @@ DO UPDATE SET
   status_reason = CASE
     WHEN findings.tombstoned THEN findings.status_reason
     WHEN findings.status = 'suppressed' THEN findings.status_reason
-    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR $37::boolean) THEN findings.status_reason
+    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR BTRIM(findings.status_reason) = 'closed_by_counter_event' OR $37::boolean) THEN findings.status_reason
     ELSE EXCLUDED.status_reason
   END,
   status_updated_at = CASE
     WHEN findings.tombstoned THEN findings.status_updated_at
     WHEN findings.status = 'suppressed' THEN findings.status_updated_at
-    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR $37::boolean) THEN findings.status_updated_at
+    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR BTRIM(findings.status_reason) = 'closed_by_counter_event' OR $37::boolean) THEN findings.status_updated_at
     ELSE EXCLUDED.status_updated_at
   END,
   first_observed_at = LEAST(findings.first_observed_at, EXCLUDED.first_observed_at),


### PR DESCRIPTION
## Scope

Single source: **cloudflare**. Adds Postgres-backed end-to-end lifecycle coverage for the existing `cloudflare-zone-protection-paused` durable finding and makes the persisted reopen path honor recurrence for counter-event-resolved durable findings. No new rules, rule IDs, or catalog entries are introduced.

## Source changes

None. The source contract and emitted `cloudflare.zone` shape are unchanged.

## Projection changes

None. Registry routing and projector behavior are unchanged.

## Finding changes

- New Postgres-backed e2e test exercising the durable finding lifecycle for the paused-zone rule against a real state store: open (active pause) -> resolved (remediation via counter-event) -> reopened (recurrence), asserting stable fingerprint/id and a single active persisted row with no duplicate churn.
- Test is DSN-gated (`CEREBRO_POSTGRES_DSN`) and skips cleanly when unset, matching the existing finding-lifecycle e2e harness conventions.

## Shared file touches

- `internal/statestore/postgres/findings.go`: the `UpsertFinding` `ON CONFLICT` reopen guard previously reopened a `resolved` row on a fresh `open` emit only for TTL-resolved findings (or rules opting into TTL reopen). It now also reopens findings that were auto-resolved by a remediation counter-event (`status_reason = 'closed_by_counter_event'`), so persisted state reopens in place instead of leaving the stored row `resolved` while only the in-memory candidate re-emits. Analyst/manual resolutions and suppressed/tombstoned rows are unaffected. The literal is documented to stay in sync with the workflow-events reason constant.

## Validation evidence

Run against a disposable local Postgres for the DSN-gated paths.

- `make lint` -> `0 issues.`
- `go test ./internal/findings/... -run 'Cloudflare|cloudflare' -count=1` -> ok (paused-zone fixture, remediation-resolve, in-memory reopen, and the new Postgres-backed reopen lifecycle test).
- `CEREBRO_POSTGRES_DSN=... go test ./internal/findings/ -run TestCloudflareZoneProtectionPausedPostgresReopenLifecycle -count=1 -v` -> PASS (1 matched test).
- `go test ./internal/statestore/postgres/... -count=1` (with DSN) -> ok.
- `go test ./tools/archtests/... -count=1` -> ok.
- `make detection-catalog-check` -> ok.

Note: `make catalog-check`, the builtin rulepack-count tests, and several unrelated Postgres lifecycle e2e tests fail identically on the base commit before this change (pre-existing repo/control-index drift) and are out of scope for this PR.

## Risk and rollback

- Behavior change is confined to the durable-state reopen guard for counter-event-resolved findings; manual/analyst resolutions, suppressed, and tombstoned rows retain prior behavior.
- Rollback is a clean revert of this commit; no schema migration, rule, or catalog changes are involved.
