### PR TITLE
Add product OTEL domain metrics

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -86,6 +86,29 @@ Core runtime operations emit structured spans:
 
 Outbound HTTP uses W3C `traceparent`. The source transport and graph-agent HTTP doer inject child trace context, but they do not emit full URLs, query strings, request bodies, authorization headers, or API keys. Graph-agent LLM spans also do not emit prompt text, completion text, raw Cypher, raw tool arguments, rows, or headers.
 
+## Product OTEL Metrics
+
+The app exports explicit low-cardinality OTEL metrics for the domain operations
+that decide whether Cerebro is useful, not just reachable. These metrics are
+safe to aggregate in CloudWatch, Prometheus, or a vendor backend.
+
+| Metric | Unit | Primary dimensions | Meaning |
+| --- | --- | --- | --- |
+| `cerebro.http.server.requests` | `{request}` | `http.request.method`, `http.route`, `http.response.status_code` | API request rate and error-rate denominator |
+| `cerebro.http.server.request.duration` | `s` | `http.request.method`, `http.route`, `http.response.status_code` | API latency distribution |
+| `cerebro.source_runtime.sync.runs` | `{run}` | `source_id`, `status`, `error_kind`, `contract_configured` | Source sync success/failure rate |
+| `cerebro.source_runtime.sync.duration` | `s` | `source_id`, `status`, `error_kind`, `contract_configured` | Source sync duration distribution |
+| `cerebro.source_runtime.records` | `{record}` | `source_id`, `status`, `error_kind`, `contract_configured`, `record.kind` | Pages, scanned records, accepted/rejected events, appended events, and projected entities/links |
+| `cerebro.source_runtime.watermark.lag` | `s` | `source_id`, `status`, `error_kind`, `contract_configured` | Observed source freshness lag when a checkpoint watermark exists |
+| `cerebro.source_projection.runs` | `{projection}` | `source_id`, `event_kind`, `status` | Projection success/failure rate |
+| `cerebro.source_projection.duration` | `s` | `source_id`, `event_kind`, `status` | Projection latency distribution |
+| `cerebro.source_projection.records` | `{record}` | `source_id`, `event_kind`, `status`, `record.kind` | Graph/current-state records projected or deleted |
+
+Metric attributes deliberately exclude `tenant_id`, `runtime_id`, `resource_urn`,
+`evidence_id`, `request_id`, and `trace_id`. Those identifiers remain available
+in spans and wide events for drill-down, while metrics stay safe for aggregation
+and alerting.
+
 ## Error Contract
 
 Use `telemetry.CaptureError(ctx, name, err, attrs)` for Sentry-style handled errors. It emits:

--- a/internal/observability/domain_metrics.go
+++ b/internal/observability/domain_metrics.go
@@ -1,0 +1,199 @@
+package observability
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+func otelSourceRuntimeRuns() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.source_runtime.sync.runs",
+		otelmetric.WithDescription("Total source runtime sync attempts."),
+	)
+	return instrument
+}
+
+func otelSourceRuntimeDuration() otelmetric.Float64Histogram {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Float64Histogram(
+		"cerebro.source_runtime.sync.duration",
+		otelmetric.WithDescription("Source runtime sync duration."),
+		otelmetric.WithUnit("s"),
+	)
+	return instrument
+}
+
+func otelSourceRuntimeRecords() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.source_runtime.records",
+		otelmetric.WithDescription("Source runtime records read, accepted, rejected, appended, or projected."),
+	)
+	return instrument
+}
+
+func otelSourceRuntimeWatermarkLag() otelmetric.Float64Histogram {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Float64Histogram(
+		"cerebro.source_runtime.watermark.lag",
+		otelmetric.WithDescription("Observed source runtime checkpoint watermark lag."),
+		otelmetric.WithUnit("s"),
+	)
+	return instrument
+}
+
+func otelSourceProjectionRuns() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.source_projection.runs",
+		otelmetric.WithDescription("Total source projection attempts."),
+	)
+	return instrument
+}
+
+func otelSourceProjectionDuration() otelmetric.Float64Histogram {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Float64Histogram(
+		"cerebro.source_projection.duration",
+		otelmetric.WithDescription("Source projection duration."),
+		otelmetric.WithUnit("s"),
+	)
+	return instrument
+}
+
+func otelSourceProjectionRecords() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.source_projection.records",
+		otelmetric.WithDescription("Source projection records materialized or deleted."),
+	)
+	return instrument
+}
+
+// SourceRuntimeSyncMetrics is intentionally shaped for low-cardinality OTEL
+// metrics. Runtime IDs, tenant IDs, resource URNs, evidence IDs, request IDs,
+// and trace IDs belong in spans/wide events, not metric labels.
+type SourceRuntimeSyncMetrics struct {
+	SourceID            string
+	Status              string
+	ErrorKind           string
+	ContractConfigured  bool
+	Duration            time.Duration
+	PagesRead           uint32
+	RecordsScanned      uint32
+	RecordsAccepted     uint32
+	RecordsRejected     uint32
+	EventsAppended      uint32
+	EntitiesProjected   uint32
+	LinksProjected      uint32
+	WatermarkLagSeconds int64
+	HasWatermarkLag     bool
+}
+
+// SourceProjectionMetrics is intentionally scoped to bounded event dimensions.
+type SourceProjectionMetrics struct {
+	SourceID          string
+	EventKind         string
+	Status            string
+	Duration          time.Duration
+	EntitiesProjected uint32
+	LinksProjected    uint32
+	EntitiesDeleted   uint32
+	LinksDeleted      uint32
+}
+
+func RecordSourceRuntimeSync(ctx context.Context, metrics SourceRuntimeSyncMetrics) {
+	status := boundedMetricValue(metrics.Status, "unknown")
+	attrs := []attribute.KeyValue{
+		attribute.String("source_id", boundedMetricValue(metrics.SourceID, "unknown")),
+		attribute.String("status", status),
+		attribute.String("error_kind", boundedMetricValue(metrics.ErrorKind, "none")),
+		attribute.Bool("contract_configured", metrics.ContractConfigured),
+	}
+	otelSourceRuntimeRuns().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+	if metrics.Duration >= 0 {
+		otelSourceRuntimeDuration().Record(ctx, metrics.Duration.Seconds(), otelmetric.WithAttributes(attrs...))
+	}
+	recordSourceRuntimeRecordCount(ctx, attrs, "page", int64(metrics.PagesRead))
+	recordSourceRuntimeRecordCount(ctx, attrs, "scanned", int64(metrics.RecordsScanned))
+	recordSourceRuntimeRecordCount(ctx, attrs, "accepted", int64(metrics.RecordsAccepted))
+	recordSourceRuntimeRecordCount(ctx, attrs, "rejected", int64(metrics.RecordsRejected))
+	recordSourceRuntimeRecordCount(ctx, attrs, "appended", int64(metrics.EventsAppended))
+	recordSourceRuntimeRecordCount(ctx, attrs, "entity_projected", int64(metrics.EntitiesProjected))
+	recordSourceRuntimeRecordCount(ctx, attrs, "link_projected", int64(metrics.LinksProjected))
+	if metrics.HasWatermarkLag {
+		otelSourceRuntimeWatermarkLag().Record(ctx, float64(maxInt64(metrics.WatermarkLagSeconds, 0)), otelmetric.WithAttributes(attrs...))
+	}
+}
+
+func RecordSourceProjection(ctx context.Context, metrics SourceProjectionMetrics) {
+	attrs := []attribute.KeyValue{
+		attribute.String("source_id", boundedMetricValue(metrics.SourceID, "unknown")),
+		attribute.String("event_kind", boundedMetricValue(metrics.EventKind, "unknown")),
+		attribute.String("status", boundedMetricValue(metrics.Status, "unknown")),
+	}
+	otelSourceProjectionRuns().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+	if metrics.Duration >= 0 {
+		otelSourceProjectionDuration().Record(ctx, metrics.Duration.Seconds(), otelmetric.WithAttributes(attrs...))
+	}
+	recordSourceProjectionRecordCount(ctx, attrs, "entity_projected", int64(metrics.EntitiesProjected))
+	recordSourceProjectionRecordCount(ctx, attrs, "link_projected", int64(metrics.LinksProjected))
+	recordSourceProjectionRecordCount(ctx, attrs, "entity_deleted", int64(metrics.EntitiesDeleted))
+	recordSourceProjectionRecordCount(ctx, attrs, "link_deleted", int64(metrics.LinksDeleted))
+}
+
+func recordSourceRuntimeRecordCount(ctx context.Context, base []attribute.KeyValue, kind string, count int64) {
+	if count <= 0 {
+		return
+	}
+	attrs := append(cloneMetricAttributes(base), attribute.String("record.kind", kind))
+	otelSourceRuntimeRecords().Add(ctx, count, otelmetric.WithAttributes(attrs...))
+}
+
+func recordSourceProjectionRecordCount(ctx context.Context, base []attribute.KeyValue, kind string, count int64) {
+	if count <= 0 {
+		return
+	}
+	attrs := append(cloneMetricAttributes(base), attribute.String("record.kind", kind))
+	otelSourceProjectionRecords().Add(ctx, count, otelmetric.WithAttributes(attrs...))
+}
+
+func cloneMetricAttributes(values []attribute.KeyValue) []attribute.KeyValue {
+	copied := make([]attribute.KeyValue, len(values))
+	copy(copied, values)
+	return copied
+}
+
+func boundedMetricValue(value string, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = fallback
+	}
+	value = strings.ToLower(value)
+	var out strings.Builder
+	for _, char := range value {
+		switch {
+		case char >= 'a' && char <= 'z':
+			out.WriteRune(char)
+		case char >= '0' && char <= '9':
+			out.WriteRune(char)
+		case char == '.', char == '_', char == '-':
+			out.WriteRune(char)
+		default:
+			out.WriteRune('_')
+		}
+		if out.Len() >= 96 {
+			break
+		}
+	}
+	if strings.Trim(out.String(), "_-.") == "" {
+		return fallback
+	}
+	return out.String()
+}
+
+func maxInt64(value int64, minimum int64) int64 {
+	if value < minimum {
+		return minimum
+	}
+	return value
+}

--- a/internal/observability/domain_metrics_test.go
+++ b/internal/observability/domain_metrics_test.go
@@ -1,0 +1,174 @@
+package observability
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestRecordSourceRuntimeSyncMetricsAreLowCardinality(t *testing.T) {
+	reader, shutdown := installManualMetricReader(t)
+	RecordSourceRuntimeSync(context.Background(), SourceRuntimeSyncMetrics{
+		SourceID:            "GitHub",
+		Status:              "completed",
+		ContractConfigured:  true,
+		Duration:            150 * time.Millisecond,
+		PagesRead:           2,
+		RecordsScanned:      10,
+		RecordsAccepted:     9,
+		RecordsRejected:     1,
+		EventsAppended:      9,
+		EntitiesProjected:   7,
+		LinksProjected:      4,
+		WatermarkLagSeconds: 42,
+		HasWatermarkLag:     true,
+	})
+	t.Cleanup(shutdown)
+
+	metrics := collectMetrics(t, reader)
+	for _, name := range []string{
+		"cerebro.source_runtime.sync.runs",
+		"cerebro.source_runtime.sync.duration",
+		"cerebro.source_runtime.records",
+		"cerebro.source_runtime.watermark.lag",
+	} {
+		if _, ok := metrics[name]; !ok {
+			t.Fatalf("metric %q missing from %#v", name, metricNames(metrics))
+		}
+	}
+	assertNoForbiddenMetricAttributes(t, metrics["cerebro.source_runtime.records"])
+	assertMetricHasAttribute(t, metrics["cerebro.source_runtime.records"], "record.kind", "accepted")
+	assertMetricHasAttribute(t, metrics["cerebro.source_runtime.records"], "source_id", "github")
+}
+
+func TestRecordSourceProjectionMetricsAreLowCardinality(t *testing.T) {
+	reader, shutdown := installManualMetricReader(t)
+	RecordSourceProjection(context.Background(), SourceProjectionMetrics{
+		SourceID:          "evidence_cas",
+		EventKind:         "evidence_cas.object",
+		Status:            "failed",
+		Duration:          20 * time.Millisecond,
+		EntitiesProjected: 3,
+		LinksProjected:    2,
+		EntitiesDeleted:   1,
+	})
+	t.Cleanup(shutdown)
+
+	metrics := collectMetrics(t, reader)
+	for _, name := range []string{
+		"cerebro.source_projection.runs",
+		"cerebro.source_projection.duration",
+		"cerebro.source_projection.records",
+	} {
+		if _, ok := metrics[name]; !ok {
+			t.Fatalf("metric %q missing from %#v", name, metricNames(metrics))
+		}
+	}
+	assertNoForbiddenMetricAttributes(t, metrics["cerebro.source_projection.records"])
+	assertMetricHasAttribute(t, metrics["cerebro.source_projection.records"], "event_kind", "evidence_cas.object")
+	assertMetricHasAttribute(t, metrics["cerebro.source_projection.records"], "record.kind", "entity_deleted")
+}
+
+func TestBoundedMetricValueNormalizesAndBoundsLabels(t *testing.T) {
+	got := boundedMetricValue("Runtime ID With Spaces And / Weird # Chars", "unknown")
+	if got != "runtime_id_with_spaces_and___weird___chars" {
+		t.Fatalf("bounded metric value = %q", got)
+	}
+	if got := boundedMetricValue("!!!", "unknown"); got != "unknown" {
+		t.Fatalf("punctuation-only value = %q, want fallback", got)
+	}
+	if got := boundedMetricValue("source-"+strings.Repeat("x", 200), "unknown"); len(got) > 96 {
+		t.Fatalf("bounded metric value length = %d, want <= 96", len(got))
+	}
+}
+
+func installManualMetricReader(t *testing.T) (*sdkmetric.ManualReader, func()) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	oldProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	return reader, func() {
+		otel.SetMeterProvider(oldProvider)
+		_ = provider.Shutdown(context.Background())
+	}
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Metrics {
+	t.Helper()
+	var data metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &data); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	metrics := map[string]metricdata.Metrics{}
+	for _, scope := range data.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			metrics[metric.Name] = metric
+		}
+	}
+	return metrics
+}
+
+func metricNames(metrics map[string]metricdata.Metrics) []string {
+	names := make([]string, 0, len(metrics))
+	for name := range metrics {
+		names = append(names, name)
+	}
+	return names
+}
+
+func assertNoForbiddenMetricAttributes(t *testing.T, metric metricdata.Metrics) {
+	t.Helper()
+	for _, attrs := range metricAttributeSets(metric) {
+		forbidden := map[attribute.Key]bool{
+			"tenant_id":    true,
+			"runtime_id":   true,
+			"resource_urn": true,
+			"evidence_id":  true,
+			"request_id":   true,
+			"trace_id":     true,
+		}
+		for _, kv := range attrs.ToSlice() {
+			if forbidden[kv.Key] {
+				t.Fatalf("metric %q contains forbidden attribute %q", metric.Name, kv.Key)
+			}
+		}
+	}
+}
+
+func assertMetricHasAttribute(t *testing.T, metric metricdata.Metrics, key attribute.Key, value string) {
+	t.Helper()
+	for _, attrs := range metricAttributeSets(metric) {
+		for _, kv := range attrs.ToSlice() {
+			if kv.Key == key && kv.Value.AsString() == value {
+				return
+			}
+		}
+	}
+	t.Fatalf("metric %q missing attribute %s=%q", metric.Name, key, value)
+}
+
+func metricAttributeSets(metric metricdata.Metrics) []attribute.Set {
+	switch data := metric.Data.(type) {
+	case metricdata.Sum[int64]:
+		sets := make([]attribute.Set, 0, len(data.DataPoints))
+		for _, point := range data.DataPoints {
+			sets = append(sets, point.Attributes)
+		}
+		return sets
+	case metricdata.Histogram[float64]:
+		sets := make([]attribute.Set, 0, len(data.DataPoints))
+		for _, point := range data.DataPoints {
+			sets = append(sets, point.Attributes)
+		}
+		return sets
+	default:
+		return nil
+	}
+}

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/telemetry"
 )
@@ -76,7 +77,30 @@ func NewWithRegistry(state ports.ProjectionStateStore, graph ports.ProjectionGra
 }
 
 // Project applies one source event to the configured state and graph stores.
-func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
+func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (result ports.ProjectionResult, err error) {
+	started := time.Now()
+	defer func() {
+		sourceID := ""
+		eventKind := ""
+		if event != nil {
+			sourceID = event.GetSourceId()
+			eventKind = event.GetKind()
+		}
+		status := "completed"
+		if err != nil {
+			status = "failed"
+		}
+		observability.RecordSourceProjection(ctx, observability.SourceProjectionMetrics{
+			SourceID:          sourceID,
+			EventKind:         eventKind,
+			Status:            status,
+			Duration:          time.Since(started),
+			EntitiesProjected: result.EntitiesProjected,
+			LinksProjected:    result.LinksProjected,
+			EntitiesDeleted:   result.EntitiesDeleted,
+			LinksDeleted:      result.LinksDeleted,
+		})
+	}()
 	if event == nil {
 		return ports.ProjectionResult{}, fmt.Errorf("event is required")
 	}

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -241,6 +242,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		telemetry.Field{Key: "page_limit", Value: req.GetPageLimit()},
 		telemetry.Field{Key: "operation.type", Value: "source_runtime_sync"},
 	))
+	started := time.Now()
 	status := "failed"
 	spanAttributes := telemetry.Attrs()
 	var (
@@ -248,6 +250,12 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		eventContracts      []sourcecdk.EventContract
 		contractConfigured  bool
 		runtimeLoadedForRun bool
+		eventsAppended      uint32
+		pagesRead           uint32
+		recordsScanned      uint32
+		recordsRejected     uint32
+		entitiesProjected   uint32
+		linksProjected      uint32
 	)
 	defer func() {
 		if err != nil {
@@ -267,6 +275,29 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "source_runtime.id", Value: runtimeID},
 		)))
 		telemetry.AnnotateMainPhase(ctx, "source_runtime.sync", status, spanAttributes)
+		sourceID := ""
+		watermarkLagSeconds := int64(0)
+		hasWatermarkLag := false
+		if runtime != nil {
+			sourceID = runtime.GetSourceId()
+			_, watermarkLagSeconds, hasWatermarkLag = runtimeWatermarkLag(runtime, time.Now().UTC())
+		}
+		observability.RecordSourceRuntimeSync(ctx, observability.SourceRuntimeSyncMetrics{
+			SourceID:            sourceID,
+			Status:              status,
+			ErrorKind:           sourceRuntimeTelemetryErrorKind(err),
+			ContractConfigured:  contractConfigured,
+			Duration:            time.Since(started),
+			PagesRead:           pagesRead,
+			RecordsScanned:      recordsScanned,
+			RecordsAccepted:     eventsAppended,
+			RecordsRejected:     recordsRejected,
+			EventsAppended:      eventsAppended,
+			EntitiesProjected:   entitiesProjected,
+			LinksProjected:      linksProjected,
+			WatermarkLagSeconds: watermarkLagSeconds,
+			HasWatermarkLag:     hasWatermarkLag,
+		})
 		telemetry.End(span, status, spanAttributes)
 	}()
 	if s == nil || s.store == nil || s.appendLog == nil {
@@ -298,14 +329,6 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		return nil, err
 	}
 	cursor := runtimeStartCursor(runtime)
-	var (
-		eventsAppended    uint32
-		pagesRead         uint32
-		recordsScanned    uint32
-		recordsRejected   uint32
-		entitiesProjected uint32
-		linksProjected    uint32
-	)
 	if provider, ok := source.(sourcecdk.EventContractProvider); ok {
 		eventContracts = provider.EventContracts()
 	}
@@ -465,6 +488,9 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 }
 
 func sourceRuntimeTelemetryErrorKind(err error) string {
+	if err == nil {
+		return ""
+	}
 	switch {
 	case errors.Is(err, ErrInvalidRequest):
 		return "invalid_request"


### PR DESCRIPTION
## Summary
- add explicit low-cardinality OTEL metrics for source-runtime syncs and source projection outcomes
- wire source sync/projection execution paths into the new metrics
- document the product metric contract and refresh stale finding catalog count guards from current main

## Validation
- go test ./internal/observability ./internal/sourceruntime ./internal/sourceprojection
- go test ./internal/findings
- go test ./...
- git diff --check