### PR TITLE
feat(tailscale): preserve device blocks-incoming retraction reason in projection telemetry

### DIFF
--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -195,6 +195,7 @@ func boundedProjectionRetractionReason(value string) string {
 		"cloudflare_dns_record_zone_reassigned",
 		"trivy_vulnerability_resolved",
 		"tailscale_device_deauthorized",
+		"tailscale_device_blocks_incoming",
 		"tailscale_grant_disabled":
 		return strings.TrimSpace(value)
 	default:

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -211,6 +211,13 @@ func TestProjectionRetractionReason(t *testing.T) {
 			want: "tailscale_grant_disabled",
 		},
 		{
+			name: "tailscale device blocks incoming",
+			links: []*ports.ProjectedLink{{
+				Attributes: map[string]string{"retraction": "tailscale_device_blocks_incoming"},
+			}},
+			want: "tailscale_device_blocks_incoming",
+		},
+		{
 			name: "mixed",
 			links: []*ports.ProjectedLink{
 				{Attributes: map[string]string{"retraction": "endpoint_owner_id"}},

--- a/internal/sourceprojection/tailscale.go
+++ b/internal/sourceprojection/tailscale.go
@@ -183,7 +183,7 @@ func tailscaleDeviceProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 			"at":         eventObservedAt(event),
 			"match_type": "tailscale_device_owner",
 		}))
-		if tailscaleBoolIsTrue(attrs["authorized"]) {
+		if tailscaleBoolIsTrue(attrs["authorized"]) && !tailscaleBoolIsTrue(attrs["blocks_incoming_connections"]) {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), ownerURN, deviceURN, relationCanReach, map[string]string{
 				"event_id":   event.GetId(),
 				"at":         eventObservedAt(event),
@@ -349,9 +349,9 @@ func tailscaleGrantProjections(event *cerebrov1.EventEnvelope) ([]*ports.Project
 }
 
 // tailscaleAccessRetractions clears obsolete access edges when Tailscale evidence
-// shows that access has been revoked: a deauthorized device must no longer be
-// reachable by its owner, and a disabled ACL grant must no longer confer source
-// entitlements or destination reachability.
+// shows that access has been revoked: a deauthorized device, or one that blocks
+// incoming connections, must no longer be reachable by its owner, and a disabled
+// ACL grant must no longer confer source entitlements or destination reachability.
 func tailscaleAccessRetractions(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedLink, error) {
 	switch event.GetKind() {
 	case "tailscale.device":
@@ -365,7 +365,9 @@ func tailscaleAccessRetractions(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 
 func tailscaleDeviceAccessRetractions(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedLink, error) {
 	attrs := event.GetAttributes()
-	if !tailscaleBoolIsFalse(attrs["authorized"]) {
+	deauthorized := tailscaleBoolIsFalse(attrs["authorized"])
+	blocksIncoming := tailscaleBoolIsTrue(attrs["blocks_incoming_connections"])
+	if !deauthorized && !blocksIncoming {
 		return nil, nil
 	}
 	tenantID, err := tenantID(event)
@@ -377,12 +379,16 @@ func tailscaleDeviceAccessRetractions(event *cerebrov1.EventEnvelope) ([]*ports.
 	if deviceID == "" || strings.TrimSpace(ownerID) == "" {
 		return nil, nil
 	}
+	reason := "tailscale_device_blocks_incoming"
+	if deauthorized {
+		reason = "tailscale_device_deauthorized"
+	}
 	deviceURN := tailscaleDeviceURN(tenantID, deviceID)
 	ownerURN := tailscaleUserURN(tenantID, ownerID)
 	links := map[string]*ports.ProjectedLink{}
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), ownerURN, deviceURN, relationCanReach, map[string]string{
 		"event_id":   event.GetId(),
-		"retraction": "tailscale_device_deauthorized",
+		"retraction": reason,
 	}))
 	_, projectedLinks := entitiesAndLinks(nil, links)
 	return projectedLinks, nil

--- a/internal/sourceprojection/tailscale_test.go
+++ b/internal/sourceprojection/tailscale_test.go
@@ -146,6 +146,49 @@ func TestProjectTailscaleDeviceDeauthorizationRetraction(t *testing.T) {
 	}
 }
 
+func TestProjectTailscaleDeviceBlocksIncomingRetraction(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	event := tailscaleTestEvent("ts-device-blocks-incoming", "tailscale.device", map[string]string{
+		"device_id": "device-1", "user_id": "user-1", "authorized": "true", "blocks_incoming_connections": "true",
+	})
+	links, err := service.ProjectRetractions(event)
+	if err != nil {
+		t.Fatalf("ProjectRetractions() error = %v", err)
+	}
+	deviceURN := "urn:cerebro:writer:tailscale_device:device-1"
+	userURN := "urn:cerebro:writer:tailscale_user:user-1"
+	var retracted *struct{ reason string }
+	for _, link := range links {
+		if link.FromURN == userURN && link.ToURN == deviceURN && link.Relation == relationCanReach {
+			retracted = &struct{ reason string }{reason: link.Attributes["retraction"]}
+		}
+	}
+	if retracted == nil {
+		t.Fatalf("expected user->device can_reach retracted; links=%#v", links)
+	}
+	if retracted.reason != "tailscale_device_blocks_incoming" {
+		t.Fatalf("retraction reason = %q, want tailscale_device_blocks_incoming", retracted.reason)
+	}
+	if got := projectionRetractionReason(links); got != "tailscale_device_blocks_incoming" {
+		t.Fatalf("projectionRetractionReason() = %q, want tailscale_device_blocks_incoming", got)
+	}
+
+	entities, projectedLinks, err := BuiltinRegistry().Project(event)
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if len(entities) == 0 {
+		t.Fatalf("expected device entity to project; entities=%#v", entities)
+	}
+	for _, link := range projectedLinks {
+		if link.FromURN == userURN && link.ToURN == deviceURN && link.Relation == relationCanReach {
+			t.Fatalf("expected no owner can_reach edge for device blocking incoming connections; links=%#v", projectedLinks)
+		}
+	}
+}
+
 func TestProjectTailscaleGrantDisabledRetraction(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)


### PR DESCRIPTION
## Scope

Follow-up that extends the tailscale projection retraction reason allowlist so a bounded, tailscale-specific retraction reason is preserved in projection telemetry instead of collapsing to `unknown`. Source-scoped to tailscale projection and the shared bounded-reason helper.

## Source changes

None. The tailscale source already emits the device `blocks_incoming_connections` attribute consumed here.

## Projection changes

- Added `tailscale_device_blocks_incoming` to the `boundedProjectionRetractionReason` allowlist in `internal/sourceprojection/projector.go` so the reason survives telemetry bounding.
- A device that blocks incoming connections no longer projects an owner reachability edge, and any existing owner reachability edge is retracted with the bounded reason.
- Reused the existing device retraction code path; deauthorization retains precedence when both conditions are present.

## Finding changes

None. No finding rules, rulepack, audit, or detection catalog artifacts were touched.

## Shared file touches

- `internal/sourceprojection/projector.go` (bounded retraction reason allowlist only).

## Validation evidence

- `make lint` -> 0 issues.
- `go test ./sources/tailscale/... -count=1` -> ok.
- `go test ./internal/sourceprojection/... -count=1` -> ok (new tests matched and passed).
- `go test ./tools/archtests/... -count=1` -> ok.
- `make catalog-check` -> ok.
- `make detection-catalog-check` -> ok.

## Rollback notes

Revert this commit. The change is additive to the bounded-reason allowlist plus a single projection gating condition; no schema, rule, or catalog migrations are involved.