### PR TITLE
Fix EvidenceCAS case-only resource fallback

### DIFF
--- a/sources/evidencecas/source.go
+++ b/sources/evidencecas/source.go
@@ -58,7 +58,7 @@ func New() (*Source, error) {
 				Attributes: map[string]string{
 					"tenant_id":                     "metadata.tenant_id|tenant_id",
 					"evidence_id":                   "metadata.evidence_id|uri|key",
-					"resource_urn":                  "metadata.resource_urn|metadata.case_urn",
+					"resource_urn":                  "metadata.resource_urn",
 					"source_runtime_id":             "metadata.source_runtime_id|source_runtime_id",
 					"source_event_id":               "metadata.source_event_id|source_event_id|metadata.event_id|event_id",
 					"request_id":                    "metadata.request_id|request_id",
@@ -70,7 +70,7 @@ func New() (*Source, error) {
 					"case_urn":                      "metadata.case_urn",
 					"case_link_status":              "metadata.case_link_status",
 					"resource_entity_type":          "metadata.resource_entity_type",
-					"resource_id":                   "metadata.resource_id|metadata.case_id",
+					"resource_id":                   "metadata.resource_id",
 					"resource_link_status":          "metadata.resource_link_status",
 					"resource_name":                 "metadata.resource_name|metadata.filename",
 					"resource_type":                 "metadata.resource_type",

--- a/sources/evidencecas/source_test.go
+++ b/sources/evidencecas/source_test.go
@@ -219,7 +219,6 @@ func TestReadObjectRefsEmitsCanonicalCaseURNCorrelation(t *testing.T) {
 						"case_id":          "case-789",
 						"case_urn":         "urn:cerebro:tenant-789:case:case-789",
 						"case_link_status": "linked",
-						"resource_urn":     "urn:cerebro:tenant-789:case:case-789",
 					},
 				},
 			},
@@ -245,6 +244,12 @@ func TestReadObjectRefsEmitsCanonicalCaseURNCorrelation(t *testing.T) {
 	}
 	if got := pull.Events[0].Attributes["case_urn"]; got != "urn:cerebro:tenant-789:case:case-789" {
 		t.Fatalf("case_urn = %q, want urn:cerebro:tenant-789:case:case-789", got)
+	}
+	if got := pull.Events[0].Attributes["resource_urn"]; got != "" {
+		t.Fatalf("resource_urn = %q, want empty for case-only correlation", got)
+	}
+	if got := pull.Events[0].Attributes["resource_id"]; got != "" {
+		t.Fatalf("resource_id = %q, want empty for case-only correlation", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop mapping Evidence CAS case identifiers into resource identity fields
- keep case-only CAS references from fabricating resource context
- add a regression assertion that case-only correlation leaves resource_urn/resource_id empty

## Bug
The Evidence CAS source introduced in #1203 mapped `metadata.case_urn` into `resource_urn` and `metadata.case_id` into `resource_id` when explicit resource fields were absent. After #1214, blank resource link status is treated as unresolved, so a case-only linked object could be emitted as if it also had unresolved resource linkage.

## Tests
- `go test ./sources/evidencecas -run 'TestReadObjectRefsEmitsCanonicalCaseURNCorrelation|TestReadObjectRefsPreservesCanonicalCorrelationAndLegacyMetadata|TestReadObjectRefs' -count=1`\n- `go test ./internal/findings -run 'TestEvidenceCASUnresolvedLinkage' -count=1`