### PR TITLE
Treat missing Slack MFA visibility as unknown

### DIFF
--- a/internal/findings/slack_privileged_user_without_mfa_rule.go
+++ b/internal/findings/slack_privileged_user_without_mfa_rule.go
@@ -84,7 +84,7 @@ func (r *slackPrivilegedUserWithoutMFARule) CloseOnEvent(event Event) (string, b
 		return "", false
 	}
 	attributes := eventAttributes(event)
-	if slackUserMFANotEnforced(attributes) {
+	if !slackUserMFAFindingResolved(attributes) {
 		return "", false
 	}
 	userURN := slackUserFindingURN(event.GetTenantId(), attributes["user_id"])
@@ -161,7 +161,19 @@ func slackUserMFANotEnforced(attributes map[string]string) bool {
 	if !slackUserAccountPrivileged(attributes) {
 		return false
 	}
-	return !slackUserMFAEnabled(attributes)
+	enabled, observed := slackUserMFAObserved(attributes)
+	return observed && !enabled
+}
+
+func slackUserMFAFindingResolved(attributes map[string]string) bool {
+	if slackUserAccountDeactivated(attributes) || parseBoolAttribute(attributes, "is_bot") {
+		return true
+	}
+	if !slackUserAccountPrivileged(attributes) {
+		return true
+	}
+	enabled, observed := slackUserMFAObserved(attributes)
+	return observed && enabled
 }
 
 func slackUserAccountPrivileged(attributes map[string]string) bool {
@@ -171,7 +183,20 @@ func slackUserAccountPrivileged(attributes map[string]string) bool {
 }
 
 func slackUserMFAEnabled(attributes map[string]string) bool {
-	return parseBoolAttribute(attributes, "has_2fa") || parseBoolAttribute(attributes, "has_mfa")
+	enabled, _ := slackUserMFAObserved(attributes)
+	return enabled
+}
+
+func slackUserMFAObserved(attributes map[string]string) (bool, bool) {
+	has2FA, observed2FA := parseOptionalBoolAttribute(attributes, "has_2fa")
+	hasMFA, observedMFA := parseOptionalBoolAttribute(attributes, "has_mfa")
+	if (observed2FA && has2FA) || (observedMFA && hasMFA) {
+		return true, true
+	}
+	if observed2FA || observedMFA {
+		return false, true
+	}
+	return false, false
 }
 
 func slackUserAccountDeactivated(attributes map[string]string) bool {

--- a/internal/findings/slack_privileged_user_without_mfa_rule.go
+++ b/internal/findings/slack_privileged_user_without_mfa_rule.go
@@ -182,11 +182,6 @@ func slackUserAccountPrivileged(attributes map[string]string) bool {
 		parseBoolAttribute(attributes, "is_primary_owner")
 }
 
-func slackUserMFAEnabled(attributes map[string]string) bool {
-	enabled, _ := slackUserMFAObserved(attributes)
-	return enabled
-}
-
 func slackUserMFAObserved(attributes map[string]string) (bool, bool) {
 	has2FA, observed2FA := parseOptionalBoolAttribute(attributes, "has_2fa")
 	hasMFA, observedMFA := parseOptionalBoolAttribute(attributes, "has_mfa")

--- a/internal/findings/slack_privileged_user_without_mfa_rule_test.go
+++ b/internal/findings/slack_privileged_user_without_mfa_rule_test.go
@@ -60,6 +60,36 @@ func TestSlackPrivilegedUserWithoutMFADeactivationResolves(t *testing.T) {
 	assertIdentityRuleRemediationTrajectory(t, newSlackPrivilegedUserWithoutMFARule(), open, deleted, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
 }
 
+func TestSlackPrivilegedUserWithoutMFAMissingVisibilityIsUnknown(t *testing.T) {
+	rule := newSlackPrivilegedUserWithoutMFARule()
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "writer-slack-user",
+		SourceId: "slack",
+		TenantId: "writer",
+		Config:   map[string]string{"family": "user"},
+	}
+	unknown := slackUserEvent("slack-mfa-unknown", map[string]string{
+		"has_2fa": "",
+		"has_mfa": "",
+	}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+
+	records, err := rule.Evaluate(context.Background(), runtime, unknown)
+	if err != nil {
+		t.Fatalf("Evaluate(unknown MFA) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("Evaluate(unknown MFA) emitted %d findings, want 0", len(records))
+	}
+
+	counterRule, ok := rule.(CounterEventRule)
+	if !ok {
+		t.Fatal("rule does not implement CounterEventRule")
+	}
+	if anchor, closes := counterRule.CloseOnEvent(unknown); closes || anchor != "" {
+		t.Fatalf("CloseOnEvent(unknown MFA) = (%q, %v), want no close", anchor, closes)
+	}
+}
+
 func TestSlackPrivilegedUserWithoutMFAReopensOnRecurrence(t *testing.T) {
 	rule := newSlackPrivilegedUserWithoutMFARule()
 	runtime := &cerebrov1.SourceRuntime{


### PR DESCRIPTION
## Summary
- do not open Slack privileged-user MFA findings when MFA visibility is missing
- do not close existing findings on unknown MFA visibility for still-privileged active users
- keep explicit MFA enablement, role removal, and deactivation as closing signals

## Bug
#1197 treats a missing `has_2fa`/`has_mfa` field as `false`. Slack documents `has_2fa` as visible only when the user executing the call is an admin, so field absence is an unknown state, not proof MFA is disabled. The old behavior could false-positive privileged users and could also close/reopen findings incorrectly if token visibility changed.

## Tests
- `go test ./internal/findings -run 'TestSlackPrivilegedUserWithoutMFA' -count=1`\n- `go test ./sources/slack -run TestReadSlackIdentityWorkspacePostureKinds -count=1`\n- `go test ./internal/sourceprojection -run 'TestProjectSlack|Slack' -count=1`