### PR TITLE
Restrict graph agent model routing

### DIFF
--- a/internal/bootstrap/agent_graph_reasoning_test.go
+++ b/internal/bootstrap/agent_graph_reasoning_test.go
@@ -161,6 +161,25 @@ func TestHandleAgentPlatformGraphReasonMissingTenantWithoutAuthIsBadRequest(t *t
 	}
 }
 
+func TestHandleAgentPlatformGraphReasonRejectsUnsupportedModelBeforeLLM(t *testing.T) {
+	llm := &graphagent.StubLLMClient{}
+	app := New(graphReasoningAuthConfig(), Dependencies{
+		GraphStore:    &stubGraphStore{},
+		GraphAgentLLM: llm,
+	}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp := postAgentGraphReason(t, server, `{"question":"hello","model":"attacker-selected-provider-model"}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if len(llm.DraftRequests) != 0 {
+		t.Fatalf("draft requests = %#v, want unsupported model rejected before LLM", llm.DraftRequests)
+	}
+}
+
 func TestHandleAgentPlatformGraphReasonRequiresLLM(t *testing.T) {
 	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: &stubGraphStore{}}, nil)
 	server := httptest.NewServer(app.Handler())

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -183,6 +183,25 @@ func TestGRCAskMissingTenantReturnsBadRequest(t *testing.T) {
 	}
 }
 
+func TestGRCAskRejectsUnsupportedModelBeforeLLM(t *testing.T) {
+	llm := &graphagent.StubLLMClient{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: &stubGraphStore{}, GraphAgentLLM: llm}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Post(server.URL+"/grc/ask", "application/json", strings.NewReader(`{"tenant_id":"example","question":"hello","model":"attacker-selected-provider-model"}`))
+	if err != nil {
+		t.Fatalf("POST /grc/ask error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if len(llm.DraftRequests) != 0 {
+		t.Fatalf("draft requests = %#v, want unsupported model rejected before LLM", llm.DraftRequests)
+	}
+}
+
 func TestGRCAskMissingStartupLLMReturnsUnavailable(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: &stubGraphStore{}}, nil)
 	server := httptest.NewServer(app.Handler())

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -1923,6 +1923,33 @@ LIMIT 25`,
 	}
 }
 
+func TestMCPGraphReasonRejectsUnsupportedModelBeforeLLM(t *testing.T) {
+	llm := &graphagent.StubLLMClient{}
+	server := newMCPTestServerWithGraphReasoning(t, &stubRuntimeStore{}, &stubGraphStore{}, llm)
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.graph.reason",
+			"arguments": map[string]any{
+				"question": "Which asset should I review first?",
+				"model":    "attacker-selected-provider-model",
+			},
+		},
+	})
+	result := response["result"].(map[string]any)
+	content := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	if result["isError"] != true || !strings.Contains(content, "unsupported graph agent model") {
+		t.Fatalf("graph.reason unsupported model response = %#v", response)
+	}
+	if len(llm.DraftRequests) != 0 {
+		t.Fatalf("draft requests = %#v, want unsupported model rejected before LLM", llm.DraftRequests)
+	}
+}
+
 func TestMCPGraphReasonMissingTenantWithoutAuthReportsInvalidRequest(t *testing.T) {
 	app := New(config.Config{
 		HTTPAddr:        "127.0.0.1:0",

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -317,6 +317,9 @@ func ValidateRequest(request AskRequest) error {
 	if len(question) > 4096 {
 		return fmt.Errorf("%w: question exceeds 4096 characters", ErrInvalidRequest)
 	}
+	if err := validateModel(request.Model); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -131,6 +131,35 @@ func TestServiceUsesDeterministicFastPathForCommonTopRiskAsk(t *testing.T) {
 	}
 }
 
+func TestValidateRequestRejectsUnsupportedModel(t *testing.T) {
+	err := ValidateRequest(AskRequest{
+		TenantID: "writer",
+		Question: "Show risky assets",
+		Model:    "openrouter/private-model",
+	})
+	if err == nil {
+		t.Fatal("ValidateRequest() error = nil, want unsupported model error")
+	}
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("ValidateRequest() error = %v, want ErrInvalidRequest", err)
+	}
+}
+
+func TestValidateRequestAllowsConfiguredModelAliases(t *testing.T) {
+	for _, model := range []string{"", DefaultModel, "claude-opus-4-7", "claude-haiku-4-5-20251001"} {
+		t.Run(model, func(t *testing.T) {
+			err := ValidateRequest(AskRequest{
+				TenantID: "writer",
+				Question: "Show risky assets",
+				Model:    model,
+			})
+			if err != nil {
+				t.Fatalf("ValidateRequest() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestCollectGraphProbeCachesTenantCounts(t *testing.T) {
 	resetGraphProbeCountsCacheForTest()
 	defer resetGraphProbeCountsCacheForTest()

--- a/internal/graphagent/llm.go
+++ b/internal/graphagent/llm.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 )
 
-const DefaultModel = "claude-sonnet-4-6"
+const (
+	DefaultModel = "claude-sonnet-4-6"
+	OpusModel    = "claude-opus-4-7"
+	HaikuModel   = "claude-haiku-4-5-20251001"
+)
 
 type HistoryMessage struct {
 	Role    string `json:"role"`
@@ -130,4 +134,37 @@ func normalizeModel(model string) string {
 		return DefaultModel
 	}
 	return strings.TrimSpace(model)
+}
+
+func validateModel(model string) error {
+	if graphAgentModelAllowed(model) {
+		return nil
+	}
+	return unsupportedGraphAgentModelError()
+}
+
+func graphAgentModelAllowed(model string) bool {
+	switch normalizeModel(model) {
+	case DefaultModel, OpusModel, HaikuModel:
+		return true
+	default:
+		return false
+	}
+}
+
+func configuredModelID(requested string, defaultModel string, sonnetModel string, opusModel string, haikuModel string) (string, error) {
+	switch normalizeModel(requested) {
+	case DefaultModel:
+		return firstNonEmpty(sonnetModel, defaultModel), nil
+	case OpusModel:
+		return firstNonEmpty(opusModel, defaultModel), nil
+	case HaikuModel:
+		return firstNonEmpty(haikuModel, defaultModel), nil
+	default:
+		return "", unsupportedGraphAgentModelError()
+	}
+}
+
+func unsupportedGraphAgentModelError() error {
+	return fmt.Errorf("%w: unsupported graph agent model; supported models are %s, %s, %s", ErrInvalidRequest, DefaultModel, OpusModel, HaikuModel)
 }

--- a/internal/graphagent/llm_bedrock.go
+++ b/internal/graphagent/llm_bedrock.go
@@ -85,7 +85,7 @@ func NewBedrockLLMClient(ctx context.Context, llmConfig BedrockConfig) (*Bedrock
 		}
 		client = bedrockruntime.NewFromConfig(awsConfig)
 	}
-	if llmConfig.DefaultModel == "" {
+	if strings.TrimSpace(llmConfig.DefaultModel) == "" {
 		llmConfig.DefaultModel = DefaultModel
 	}
 	if llmConfig.MaxTokens <= 0 {
@@ -104,7 +104,11 @@ func NewBedrockLLMClient(ctx context.Context, llmConfig BedrockConfig) (*Bedrock
 
 func (c *BedrockLLMClient) DraftCypher(ctx context.Context, req DraftRequest) (*DraftResponse, error) {
 	prompt := draftPrompt(req)
-	text, err := c.invokeMessages(ctx, c.modelID(req.Model), prompt, c.maxTokens)
+	modelID, err := c.modelID(req.Model)
+	if err != nil {
+		return nil, err
+	}
+	text, err := c.invokeMessages(ctx, modelID, prompt, c.maxTokens)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +129,11 @@ func (c *BedrockLLMClient) DraftCypher(ctx context.Context, req DraftRequest) (*
 }
 
 func (c *BedrockLLMClient) Summarize(ctx context.Context, req SummarizeRequest) (string, error) {
-	return c.invokeMessages(ctx, c.modelID(req.Model), summarizePrompt(req), c.maxTokens)
+	modelID, err := c.modelID(req.Model)
+	if err != nil {
+		return "", err
+	}
+	return c.invokeMessages(ctx, modelID, summarizePrompt(req), c.maxTokens)
 }
 
 func (c *BedrockLLMClient) Probe(ctx context.Context) error {
@@ -133,20 +141,8 @@ func (c *BedrockLLMClient) Probe(ctx context.Context) error {
 	return err
 }
 
-func (c *BedrockLLMClient) modelID(requested string) string {
-	switch normalizeModel(requested) {
-	case "claude-sonnet-4-6":
-		return firstNonEmpty(c.sonnetModel, c.defaultModel)
-	case "claude-opus-4-7":
-		return firstNonEmpty(c.opusModel, c.defaultModel)
-	case "claude-haiku-4-5-20251001":
-		return firstNonEmpty(c.haikuModel, c.defaultModel)
-	default:
-		if strings.TrimSpace(requested) != "" {
-			return strings.TrimSpace(requested)
-		}
-		return c.defaultModel
-	}
+func (c *BedrockLLMClient) modelID(requested string) (string, error) {
+	return configuredModelID(requested, c.defaultModel, c.sonnetModel, c.opusModel, c.haikuModel)
 }
 
 func (c *BedrockLLMClient) invokeMessages(ctx context.Context, modelID string, prompt string, maxTokens int) (string, error) {

--- a/internal/graphagent/llm_bedrock_test.go
+++ b/internal/graphagent/llm_bedrock_test.go
@@ -91,6 +91,32 @@ func TestBedrockLLMClient_DraftCypherUsesInferenceProfile(t *testing.T) {
 	}
 }
 
+func TestBedrockLLMClient_RejectsUnsupportedRequestedModel(t *testing.T) {
+	runtime := &stubBedrockRuntime{text: `{"rationale":"ok","cypher":"MATCH (n) RETURN n LIMIT 5","refusal":""}`}
+	client, err := NewBedrockLLMClient(context.Background(), BedrockConfig{
+		DefaultModel: "us.anthropic.claude-sonnet-4-6",
+		Runtime:      runtime,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.DraftCypher(context.Background(), DraftRequest{
+		TenantID: "test",
+		Question: "Show risky assets",
+		Model:    "arn:aws:bedrock:us-east-1:123456789012:inference-profile/private-model",
+	})
+	if err == nil {
+		t.Fatal("DraftCypher() error = nil, want unsupported model error")
+	}
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("DraftCypher() error = %v, want ErrInvalidRequest", err)
+	}
+	if runtime.lastInput != nil {
+		t.Fatalf("Bedrock Converse was called for unsupported model: %q", aws.ToString(runtime.lastInput.ModelId))
+	}
+}
+
 func TestBedrockLLMClient_Probe(t *testing.T) {
 	runtime := &stubBedrockRuntime{text: "OK"}
 	client, err := NewBedrockLLMClient(context.Background(), BedrockConfig{DefaultModel: "us.anthropic.claude-sonnet-4-6", Runtime: runtime})

--- a/internal/graphagent/llm_openrouter.go
+++ b/internal/graphagent/llm_openrouter.go
@@ -68,7 +68,7 @@ func NewOpenRouterLLMClient(cfg OpenRouterConfig) (*OpenRouterLLMClient, error) 
 	if cfg.HTTPDoer == nil {
 		return nil, fmt.Errorf("%w: HTTPDoer is required for the openrouter LLM provider", ErrRuntimeUnavailable)
 	}
-	if cfg.DefaultModel == "" {
+	if strings.TrimSpace(cfg.DefaultModel) == "" {
 		cfg.DefaultModel = defaultOpenRouterModel
 	}
 	if cfg.MaxTokens <= 0 {
@@ -88,7 +88,11 @@ func NewOpenRouterLLMClient(cfg OpenRouterConfig) (*OpenRouterLLMClient, error) 
 
 func (c *OpenRouterLLMClient) DraftCypher(ctx context.Context, req DraftRequest) (*DraftResponse, error) {
 	prompt := draftPrompt(req)
-	text, err := c.chat(ctx, c.modelID(req.Model), prompt, c.maxTokens)
+	modelID, err := c.modelID(req.Model)
+	if err != nil {
+		return nil, err
+	}
+	text, err := c.chat(ctx, modelID, prompt, c.maxTokens)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +113,11 @@ func (c *OpenRouterLLMClient) DraftCypher(ctx context.Context, req DraftRequest)
 }
 
 func (c *OpenRouterLLMClient) Summarize(ctx context.Context, req SummarizeRequest) (string, error) {
-	return c.chat(ctx, c.modelID(req.Model), summarizePrompt(req), c.maxTokens)
+	modelID, err := c.modelID(req.Model)
+	if err != nil {
+		return "", err
+	}
+	return c.chat(ctx, modelID, summarizePrompt(req), c.maxTokens)
 }
 
 func (c *OpenRouterLLMClient) Probe(ctx context.Context) error {
@@ -117,20 +125,8 @@ func (c *OpenRouterLLMClient) Probe(ctx context.Context) error {
 	return err
 }
 
-func (c *OpenRouterLLMClient) modelID(requested string) string {
-	switch normalizeModel(requested) {
-	case "claude-sonnet-4-6":
-		return firstNonEmpty(c.sonnetModel, c.defaultModel)
-	case "claude-opus-4-7":
-		return firstNonEmpty(c.opusModel, c.defaultModel)
-	case "claude-haiku-4-5-20251001":
-		return firstNonEmpty(c.haikuModel, c.defaultModel)
-	default:
-		if strings.TrimSpace(requested) != "" {
-			return strings.TrimSpace(requested)
-		}
-		return c.defaultModel
-	}
+func (c *OpenRouterLLMClient) modelID(requested string) (string, error) {
+	return configuredModelID(requested, c.defaultModel, c.sonnetModel, c.opusModel, c.haikuModel)
 }
 
 func (c *OpenRouterLLMClient) chat(ctx context.Context, model string, prompt string, maxTokens int) (string, error) {

--- a/internal/graphagent/llm_openrouter_test.go
+++ b/internal/graphagent/llm_openrouter_test.go
@@ -113,6 +113,37 @@ func TestOpenRouterLLMClient_MapsAnthropicAliasToOpenRouterModel(t *testing.T) {
 	assertOpenRouterRequestModel(t, doer.lastBody, "anthropic/claude-sonnet-4.6")
 }
 
+func TestOpenRouterLLMClient_RejectsUnsupportedRequestedModel(t *testing.T) {
+	respBody, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{{
+			"message": map[string]string{
+				"content": `{"rationale":"ok","cypher":"MATCH (n) RETURN n","refusal":""}`,
+			},
+		}},
+	})
+	doer := &stubHTTPDoer{statusCode: 200, body: respBody}
+
+	client, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: "test-key", HTTPDoer: doer})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.DraftCypher(context.Background(), DraftRequest{
+		TenantID: "test",
+		Question: "Show nodes",
+		Model:    "openrouter/private-model",
+	})
+	if err == nil {
+		t.Fatal("DraftCypher() error = nil, want unsupported model error")
+	}
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("DraftCypher() error = %v, want ErrInvalidRequest", err)
+	}
+	if len(doer.lastBody) != 0 {
+		t.Fatalf("OpenRouter request body was sent for unsupported model: %s", string(doer.lastBody))
+	}
+}
+
 func TestOpenRouterLLMClient_Summarize(t *testing.T) {
 	respBody, _ := json.Marshal(map[string]any{
 		"choices": []map[string]any{{


### PR DESCRIPTION
## Summary
- validate graph-agent model selectors against the supported server-side aliases before any graph reasoning LLM call
- resolve Bedrock and OpenRouter provider model ids only from configured aliases/defaults
- add regressions for /grc/ask, agent-platform graph reasoning, MCP graph.reason, and provider clients proving unsupported selectors do not reach the LLM

## Tests
- go test ./internal/graphagent -run 'TestValidateRequest.*Model|TestOpenRouterLLMClient_RejectsUnsupportedRequestedModel|TestBedrockLLMClient_RejectsUnsupportedRequestedModel' -count=1 -v\n- go test ./internal/bootstrap -run 'TestGRCAskRejectsUnsupportedModelBeforeLLM|TestHandleAgentPlatformGraphReasonRejectsUnsupportedModelBeforeLLM|TestMCPGraphReasonRejectsUnsupportedModelBeforeLLM' -count=1 -v\n- go test ./internal/graphagent ./internal/bootstrap -count=1\n- $(go env GOPATH)/bin/golangci-lint run --timeout 10m ./internal/graphagent ./internal/bootstrap\n- make cover\n- make check-structural check-structural-test check-arch\n- make docs-drift-check catalog-check detection-catalog-check