### PR TITLE
Validate GRC inventory asset URNs

### DIFF
--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -25,6 +25,22 @@ const (
 	maxGRCInventoryAssetReportBodyBytes = 32 << 10
 )
 
+func validateGRCInventoryAssetURN(assetURN string) error {
+	parts := strings.Split(assetURN, ":")
+	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
+		return fmt.Errorf("%w: asset_urn must be of the form urn:cerebro:<tenant>:<entity_type>:<id>", errInvalidHTTPRequest)
+	}
+	if parts[len(parts)-1] == "" {
+		return fmt.Errorf("%w: asset_urn must be of the form urn:cerebro:<tenant>:<entity_type>:<id>", errInvalidHTTPRequest)
+	}
+	for index, part := range parts[2:] {
+		if strings.TrimSpace(part) != part || (index < 3 && part == "") {
+			return fmt.Errorf("%w: asset_urn must be of the form urn:cerebro:<tenant>:<entity_type>:<id>", errInvalidHTTPRequest)
+		}
+	}
+	return nil
+}
+
 type grcInventoryCategoriesResponse struct {
 	Categories  []graphquery.InventoryCategory `json:"categories"`
 	GeneratedAt time.Time                      `json:"generated_at"`
@@ -360,6 +376,10 @@ func (a *App) handleUpdateGRCResourceScope(w http.ResponseWriter, r *http.Reques
 		writeGRCError(w, fmt.Errorf("%w: asset_urn is required", errInvalidHTTPRequest))
 		return
 	}
+	if err := validateGRCInventoryAssetURN(request.AssetURN); err != nil {
+		writeGRCError(w, err)
+		return
+	}
 	if err := authorizeCerebroURNTenant(r.Context(), request.AssetURN); err != nil {
 		writeGRCError(w, err)
 		return
@@ -421,6 +441,10 @@ func (a *App) handleUpdateGRCInventoryAccountability(w http.ResponseWriter, r *h
 		writeGRCError(w, fmt.Errorf("%w: asset_urn is required", errInvalidHTTPRequest))
 		return
 	}
+	if err := validateGRCInventoryAssetURN(request.AssetURN); err != nil {
+		writeGRCError(w, err)
+		return
+	}
 	if err := authorizeCerebroURNTenant(r.Context(), request.AssetURN); err != nil {
 		writeGRCError(w, err)
 		return
@@ -458,6 +482,9 @@ func upsertGRCInventoryAccountability(ctx context.Context, store ports.GRCInvent
 	request.Reason = strings.TrimSpace(request.Reason)
 	if request.AssetURN == "" {
 		return nil, fmt.Errorf("%w: asset_urn is required", errInvalidHTTPRequest)
+	}
+	if err := validateGRCInventoryAssetURN(request.AssetURN); err != nil {
+		return nil, err
 	}
 	existing, err := loadGRCInventoryScopeRecord(ctx, store, tenantID, request.AssetURN)
 	if err != nil {
@@ -666,6 +693,10 @@ func (a *App) handleCreateGRCInventoryAssetReport(w http.ResponseWriter, r *http
 	request.Reason = strings.TrimSpace(request.Reason)
 	if request.AssetURN == "" {
 		writeGRCError(w, fmt.Errorf("%w: asset_urn is required", errInvalidHTTPRequest))
+		return
+	}
+	if err := validateGRCInventoryAssetURN(request.AssetURN); err != nil {
+		writeGRCError(w, err)
 		return
 	}
 	if request.Reason == "" {

--- a/internal/bootstrap/grc_inventory_reports_test.go
+++ b/internal/bootstrap/grc_inventory_reports_test.go
@@ -192,6 +192,26 @@ func TestGRCInventoryAssetReportRejectsInvalidStatus(t *testing.T) {
 	}
 }
 
+func TestGRCInventoryAssetReportRejectsMalformedAssetURN(t *testing.T) {
+	store := &memoryGRCInventoryAssetReportStore{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"tenant_id":"writer","asset_urn":"not-a-cerebro-urn","reason":"bad identifier"}`)
+	resp, err := server.Client().Post(server.URL+"/grc/inventory/asset-reports", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /grc/inventory/asset-reports error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("POST status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if len(store.reports) != 0 {
+		t.Fatalf("asset reports = %#v, want malformed asset_urn rejected before persistence", store.reports)
+	}
+}
+
 func TestGRCInventoryAssetReportSummaryPreservesCountsAcrossListCap(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	store := &memoryGRCInventoryAssetReportStore{reports: map[string]*ports.GRCInventoryAssetReportRecord{}}

--- a/internal/bootstrap/grc_inventory_test.go
+++ b/internal/bootstrap/grc_inventory_test.go
@@ -1,10 +1,15 @@
 package bootstrap
 
 import (
+	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/grcinventory"
 	"github.com/writer/cerebro/internal/ports"
@@ -121,6 +126,46 @@ func TestGRCInventoryAccountabilityUpdatePreservesExistingScope(t *testing.T) {
 	}
 	if got := record.Attributes["existing"]; got != "kept" {
 		t.Fatalf("existing attribute = %q, want kept", got)
+	}
+}
+
+func TestGRCInventoryResourceScopeRejectsMalformedAssetURN(t *testing.T) {
+	store := &stubInventoryScopeStore{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"tenant_id":"writer","asset_urn":"not-a-cerebro-urn","scope_state":"out_of_scope","reason":"test"}`)
+	resp, err := server.Client().Post(server.URL+"/grc/inventory/resource-scope", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /grc/inventory/resource-scope error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("POST status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if len(store.records) != 0 {
+		t.Fatalf("scope records = %#v, want malformed asset_urn rejected before persistence", store.records)
+	}
+}
+
+func TestGRCInventoryAccountabilityRejectsMalformedAssetURN(t *testing.T) {
+	store := &stubInventoryScopeStore{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"tenant_id":"writer","asset_urn":"not-a-cerebro-urn","state":"known","owner":"security@example.com"}`)
+	resp, err := server.Client().Post(server.URL+"/grc/inventory/accountability", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /grc/inventory/accountability error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("POST status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if len(store.records) != 0 {
+		t.Fatalf("scope records = %#v, want malformed asset_urn rejected before persistence", store.records)
 	}
 }
 


### PR DESCRIPTION
## Summary
- enforce the canonical GRC asset identifier shape before tenant authorization or persistence
- reject malformed asset identifiers on resource-scope, accountability, and asset-report creation paths
- add regressions proving malformed identifiers return 400 and never reach GRC inventory persistence stores

## Tests
- `go test ./internal/bootstrap -run 'TestGRCInventory(ResourceScope|Accountability|AssetReport)RejectsMalformedAssetURN' -count=1 -v`
- `go test ./internal/bootstrap -run 'TestGRCInventory|TestGRCInventoryAssetReport' -count=1`
- `go test ./internal/bootstrap -count=1`
- `$(go env GOPATH)/bin/golangci-lint run --timeout 10m ./internal/bootstrap`
- `make cover`
- `make check-structural check-structural-test check-arch`
- `make docs-drift-check catalog-check detection-catalog-check`