### PR TITLE
Sign Duo Admin API requests

### DIFF
--- a/sources/duo/source.go
+++ b/sources/duo/source.go
@@ -31,7 +31,7 @@ func New() (*Source, error) {
 		DefaultBaseURL:  defaultBaseURL,
 		DefaultFamily:   defaultFamily,
 		RequireTenantID: true,
-		TokenScheme:     "Basic",
+		AuthModel:       "duo_hmac",
 		Families: []jsonapi.Family{
 			{Name: "user", Path: "/users", URNKind: "duo_user", IDKeys: []string{"user_id"}, ListKeys: []string{"response"}, TimestampKeys: []string{"created", "last_login"}, Attributes: map[string]string{"user_id": "user_id", "username": "username", "email": "email", "realname": "realname", "status": "status", "last_login_at": "last_login", "is_enrolled": "is_enrolled", "lockout_reason": "lockout_reason", "last_directory_sync": "last_directory_sync"}, StaticAttributes: map[string]string{"source_product": "duo"}},
 			{Name: "group", Path: "/groups", URNKind: "duo_group", IDKeys: []string{"group_id"}, ListKeys: []string{"response"}, TimestampKeys: []string{"created"}, Attributes: map[string]string{"group_id": "group_id", "name": "name", "description": "desc|description", "status": "status"}, StaticAttributes: map[string]string{"source_product": "duo"}},

--- a/sources/duo/source_test.go
+++ b/sources/duo/source_test.go
@@ -2,9 +2,14 @@ package duo
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -99,6 +104,7 @@ func TestReadDuoIdentityAndMFAPostureKinds(t *testing.T) {
 				if got := r.URL.EscapedPath(); got != tt.path {
 					t.Fatalf("request path = %q, want %s", got, tt.path)
 				}
+				assertDuoHMACAuth(t, r, "DIXXXXXXXXXXXXXXXXXX", "deadbeefsecret")
 				_ = json.NewEncoder(w).Encode(tt.response)
 			}))
 			defer server.Close()
@@ -108,7 +114,7 @@ func TestReadDuoIdentityAndMFAPostureKinds(t *testing.T) {
 				t.Fatalf("New() error = %v", err)
 			}
 			source.inner.AllowLoopbackBaseURL = true
-			config := map[string]string{"base_url": server.URL, "family": tt.family, "tenant_id": "writer", "token": "duo-token"}
+			config := map[string]string{"base_url": server.URL, "client_id": "DIXXXXXXXXXXXXXXXXXX", "client_secret": "deadbeefsecret", "family": tt.family, "tenant_id": "writer"}
 			pull, err := source.Read(context.Background(), sourcecdk.NewConfig(config), nil)
 			if err != nil {
 				t.Fatalf("Read() error = %v", err)
@@ -126,5 +132,40 @@ func TestReadDuoIdentityAndMFAPostureKinds(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func assertDuoHMACAuth(t *testing.T, r *http.Request, integrationKey string, secretKey string) {
+	t.Helper()
+	date := r.Header.Get("Date")
+	if date == "" {
+		t.Fatal("Date header is empty; Duo HMAC auth requires it")
+	}
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Basic ") {
+		t.Fatalf("Authorization = %q, want Basic auth", auth)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
+	if err != nil {
+		t.Fatalf("decode Authorization: %v", err)
+	}
+	username, signature, ok := strings.Cut(string(decoded), ":")
+	if !ok {
+		t.Fatalf("Authorization payload = %q, want username:signature", decoded)
+	}
+	if username != integrationKey {
+		t.Fatalf("Duo integration key = %q, want %q", username, integrationKey)
+	}
+	canonical := strings.Join([]string{
+		date,
+		r.Method,
+		r.Host,
+		r.URL.EscapedPath(),
+		r.URL.Query().Encode(),
+	}, "\n")
+	mac := hmac.New(sha1.New, []byte(secretKey))
+	_, _ = mac.Write([]byte(canonical))
+	if want := hex.EncodeToString(mac.Sum(nil)); signature != want {
+		t.Fatalf("Duo HMAC signature = %q, want %q", signature, want)
 	}
 }

--- a/sources/duo/source_test.go
+++ b/sources/duo/source_test.go
@@ -3,7 +3,7 @@ package duo
 import (
 	"context"
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- Duo Admin API HMAC auth requires HMAC-SHA1.
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- Duo Admin API HMAC auth requires HMAC-SHA1.
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -603,11 +603,10 @@ func setDuoHMACAuth(req *http.Request, settings settings, sourceID string) error
 	}
 	date := time.Now().UTC().Format(time.RFC1123Z)
 	req.Header.Set("Date", date)
-	req.Header.Set("Host", req.URL.Host)
 	canonical := strings.Join([]string{
 		date,
 		strings.ToUpper(req.Method),
-		req.URL.Host,
+		strings.ToLower(req.URL.Host),
 		req.URL.EscapedPath(),
 		req.URL.Query().Encode(),
 	}, "\n")

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -3,6 +3,8 @@ package jsonapi
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -562,6 +564,8 @@ func (s *Source) authorizeRequest(ctx context.Context, settings settings, req *h
 			return nil
 		}
 		return setTokenHeader(req, "Authorization", "Basic", settings.token, s.options.SourceID)
+	case "duo_hmac":
+		return setDuoHMACAuth(req, settings, s.options.SourceID)
 	case "oauth_client_credentials":
 		token := settings.token
 		if token == "" {
@@ -589,6 +593,29 @@ func (s *Source) authorizeRequest(ctx context.Context, settings settings, req *h
 	default:
 		return fmt.Errorf("%s auth model %q is not supported by jsonapi", s.options.SourceID, authModel)
 	}
+}
+
+func setDuoHMACAuth(req *http.Request, settings settings, sourceID string) error {
+	integrationKey := firstNonEmpty(settings.clientID, settings.username)
+	secretKey := firstNonEmpty(settings.clientSecret, settings.password)
+	if integrationKey == "" || secretKey == "" {
+		return fmt.Errorf("%s client_id and client_secret are required for Duo HMAC auth", sourceID)
+	}
+	date := time.Now().UTC().Format(time.RFC1123Z)
+	req.Header.Set("Date", date)
+	req.Header.Set("Host", req.URL.Host)
+	canonical := strings.Join([]string{
+		date,
+		strings.ToUpper(req.Method),
+		req.URL.Host,
+		req.URL.EscapedPath(),
+		req.URL.Query().Encode(),
+	}, "\n")
+	mac := hmac.New(sha1.New, []byte(secretKey))
+	_, _ = mac.Write([]byte(canonical))
+	signature := hex.EncodeToString(mac.Sum(nil))
+	req.SetBasicAuth(integrationKey, signature)
+	return nil
 }
 
 func setTokenHeader(req *http.Request, header string, scheme string, token string, sourceID string) error {
@@ -1245,7 +1272,7 @@ func normalizedAuthModel(value string) string {
 		return "bearer_token"
 	case "api_key", "api_token":
 		return "api_key"
-	case "basic", "oauth_client_credentials", "oauth_authorization_code", "jwt", "signature", "none":
+	case "basic", "duo_hmac", "oauth_client_credentials", "oauth_authorization_code", "jwt", "signature", "none":
 		return value
 	default:
 		return value

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -2,12 +2,16 @@ package jsonapi
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha1" // #nosec G505 -- Duo Admin API HMAC auth requires HMAC-SHA1.
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -141,6 +145,50 @@ func TestReadUsesBasicAuth(t *testing.T) {
 	}
 	if len(pull.Events) != 1 {
 		t.Fatalf("events = %d, want 1", len(pull.Events))
+	}
+}
+
+func TestDuoHMACAuthLowercasesCanonicalHost(t *testing.T) {
+	request, err := http.NewRequest(http.MethodGet, "https://API-ABC.DUOSECURITY.COM/admin/v1/users?limit=1", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	err = setDuoHMACAuth(request, settings{
+		clientID:     "DIXXXXXXXXXXXXXXXXXX",
+		clientSecret: "deadbeefsecret",
+	}, "duo")
+	if err != nil {
+		t.Fatalf("setDuoHMACAuth: %v", err)
+	}
+	if got := request.Header.Get("Host"); got != "" {
+		t.Fatalf("Host header map value = %q, want empty", got)
+	}
+	date := request.Header.Get("Date")
+	if date == "" {
+		t.Fatal("Date header is empty")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(request.Header.Get("Authorization"), "Basic "))
+	if err != nil {
+		t.Fatalf("decode Authorization: %v", err)
+	}
+	username, signature, ok := strings.Cut(string(decoded), ":")
+	if !ok {
+		t.Fatalf("Authorization payload = %q, want username:signature", decoded)
+	}
+	if username != "DIXXXXXXXXXXXXXXXXXX" {
+		t.Fatalf("Duo integration key = %q, want DIXXXXXXXXXXXXXXXXXX", username)
+	}
+	canonical := strings.Join([]string{
+		date,
+		http.MethodGet,
+		"api-abc.duosecurity.com",
+		"/admin/v1/users",
+		"limit=1",
+	}, "\n")
+	mac := hmac.New(sha1.New, []byte("deadbeefsecret"))
+	_, _ = mac.Write([]byte(canonical))
+	if want := hex.EncodeToString(mac.Sum(nil)); signature != want {
+		t.Fatalf("Duo HMAC signature = %q, want %q", signature, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an opt-in `duo_hmac` auth model to the JSON API source adapter
- configure the Duo source to sign Admin API requests with `client_id`/`client_secret`
- assert the emitted Date and Basic HMAC signature in Duo source tests

## Bug
#1195 kept Duo on generic `Authorization: Basic <token>` auth. Duo Admin API requires a Date header and HTTP Basic auth where the username is the integration key and the password is an HMAC-SHA1 signature of the request. Without signing, real Duo Admin API reads fail authentication before any MFA posture finding can evaluate.

## Tests
- `go test ./sources/duo -run TestReadDuoIdentityAndMFAPostureKinds -count=1`
- `go test ./sources/internal/jsonapi -count=1`
- `go test ./internal/findings -run 'TestDuoActiveUserMFANotEnforced' -count=1`\n- `go test ./internal/sourceprojection -run 'TestProjectDuo|Duo' -count=1`