### PR TITLE
Add tenant-aware telemetry drilldown

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -69,13 +69,14 @@ Expected propagated dimensions include:
 - Cross-cutting rollups: `dependency.*`, `phase.*`
 - Domain outcomes: `source_projection.*`, `finding_candidate.*`, `finding_evaluation.*`
 
-Core runtime operations emit structured spans:
+Core runtime operations emit structured spans and diagnostic events:
 
 | Span | Coverage |
 | --- | --- |
 | `source.http.request` | Hardened source HTTP transport, DNS safety checks, host pinning, retries, upstream status |
 | `source.check`, `source.discover`, `source.read` | Source CDK operations |
 | `source_runtime.sync`, `source_runtime.sync_with_lease` | Runtime sync and lease lifecycle |
+| `source_projection.project` | Per-event projection attempt, status, projected/deleted counts, and tenant/source/runtime drill-down fields |
 | `graph.ingest_runtime` | Graph ingestion runs |
 | `graphagent.http.request` | Graph-agent LLM/upstream HTTP calls |
 | `graphagent.llm.draft`, `graphagent.llm.summarize`, `graphagent.llm.probe` | Graph-agent LLM operations, model/provider metadata, counts, sizes, and safe outcomes only |
@@ -108,6 +109,13 @@ Metric attributes deliberately exclude `tenant_id`, `runtime_id`, `resource_urn`
 `evidence_id`, `request_id`, and `trace_id`. Those identifiers remain available
 in spans and wide events for drill-down, while metrics stay safe for aggregation
 and alerting.
+
+For source runtime and projection incidents, use the low-cardinality metrics to
+find the failing `source_id`, `event_kind`, `status`, or `error_kind`, then pivot
+to structured telemetry on `name="source_runtime.sync"` or
+`name="source_projection.project"`. Those diagnostic events carry `tenant_id`,
+`runtime_id`, and namespaced `source_runtime.*` / `source_projection.*` fields
+for per-tenant triage without turning tenant IDs into metric dimensions.
 
 ## Error Contract
 
@@ -180,6 +188,17 @@ stats count(*) as events,
   sum(source_runtime.invalid_event.count) as invalid_events
 by phase.last_name, phase.last_status, source_id, runtime_id, error_kind
 | sort events desc
+```
+
+Drill into tenant-level source runtime and projection failures:
+
+```sql
+fields @timestamp, name, trace_id, tenant_id, source_id, runtime_id, event_kind,
+  status, error_kind
+| filter (name = "source_runtime.sync" or name = "source_projection.project")
+  and status = "failed"
+| sort @timestamp desc
+| limit 100
 ```
 
 ## Local Verification

--- a/internal/observability/domain_context.go
+++ b/internal/observability/domain_context.go
@@ -1,0 +1,52 @@
+package observability
+
+import (
+	"strings"
+
+	"github.com/writer/cerebro/internal/telemetry"
+)
+
+// SourceRuntimeDiagnosticContext carries high-cardinality identifiers for
+// trace and wide-event drill-down. Keep these out of metric dimensions.
+type SourceRuntimeDiagnosticContext struct {
+	RuntimeID string
+	SourceID  string
+	TenantID  string
+}
+
+// SourceProjectionDiagnosticContext carries high-cardinality projection
+// identifiers for trace and wide-event drill-down.
+type SourceProjectionDiagnosticContext struct {
+	RuntimeID string
+	SourceID  string
+	TenantID  string
+	EventKind string
+}
+
+func SourceRuntimeDiagnosticAttributes(ctx SourceRuntimeDiagnosticContext) telemetry.Attributes {
+	return telemetry.Attrs(
+		diagnosticField("runtime_id", ctx.RuntimeID),
+		diagnosticField("source_id", ctx.SourceID),
+		diagnosticField("tenant_id", ctx.TenantID),
+		diagnosticField("source_runtime.id", ctx.RuntimeID),
+		diagnosticField("source_runtime.source_id", ctx.SourceID),
+		diagnosticField("source_runtime.tenant_id", ctx.TenantID),
+	)
+}
+
+func SourceProjectionDiagnosticAttributes(ctx SourceProjectionDiagnosticContext) telemetry.Attributes {
+	return telemetry.Attrs(
+		diagnosticField("runtime_id", ctx.RuntimeID),
+		diagnosticField("source_id", ctx.SourceID),
+		diagnosticField("tenant_id", ctx.TenantID),
+		diagnosticField("event_kind", ctx.EventKind),
+		diagnosticField("source_projection.runtime_id", ctx.RuntimeID),
+		diagnosticField("source_projection.source_id", ctx.SourceID),
+		diagnosticField("source_projection.tenant_id", ctx.TenantID),
+		diagnosticField("source_projection.event_kind", ctx.EventKind),
+	)
+}
+
+func diagnosticField(key string, value string) telemetry.Field {
+	return telemetry.Field{Key: key, Value: strings.TrimSpace(value)}
+}

--- a/internal/observability/domain_context_test.go
+++ b/internal/observability/domain_context_test.go
@@ -1,0 +1,61 @@
+package observability
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestSourceRuntimeDiagnosticAttributesIncludeTenantDrilldownFields(t *testing.T) {
+	attrs := SourceRuntimeDiagnosticAttributes(SourceRuntimeDiagnosticContext{
+		RuntimeID: " writer-okta-user ",
+		SourceID:  " okta ",
+		TenantID:  " writer ",
+	})
+
+	for key, want := range map[string]string{
+		"runtime_id":               "writer-okta-user",
+		"source_id":                "okta",
+		"tenant_id":                "writer",
+		"source_runtime.id":        "writer-okta-user",
+		"source_runtime.source_id": "okta",
+		"source_runtime.tenant_id": "writer",
+	} {
+		if got := attrs.OTELAttributes(); !attributeSetContains(got, key, want) {
+			t.Fatalf("diagnostic attributes missing %s=%q in %#v", key, want, got)
+		}
+	}
+}
+
+func TestSourceProjectionDiagnosticAttributesIncludeTenantDrilldownFields(t *testing.T) {
+	attrs := SourceProjectionDiagnosticAttributes(SourceProjectionDiagnosticContext{
+		RuntimeID: " writer-github-audit ",
+		SourceID:  " github ",
+		TenantID:  " writer ",
+		EventKind: " github.audit ",
+	})
+
+	for key, want := range map[string]string{
+		"runtime_id":                   "writer-github-audit",
+		"source_id":                    "github",
+		"tenant_id":                    "writer",
+		"event_kind":                   "github.audit",
+		"source_projection.runtime_id": "writer-github-audit",
+		"source_projection.source_id":  "github",
+		"source_projection.tenant_id":  "writer",
+		"source_projection.event_kind": "github.audit",
+	} {
+		if got := attrs.OTELAttributes(); !attributeSetContains(got, key, want) {
+			t.Fatalf("diagnostic attributes missing %s=%q in %#v", key, want, got)
+		}
+	}
+}
+
+func attributeSetContains(attrs []attribute.KeyValue, key string, value string) bool {
+	for _, attr := range attrs {
+		if string(attr.Key) == key && attr.Value.AsString() == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -78,6 +78,7 @@ func NewWithRegistry(state ports.ProjectionStateStore, graph ports.ProjectionGra
 
 // Project applies one source event to the configured state and graph stores.
 func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (result ports.ProjectionResult, err error) {
+	ctx = telemetry.EnsureTraceContext(ctx)
 	started := time.Now()
 	defer func() {
 		sourceID := ""
@@ -90,6 +91,21 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 		if err != nil {
 			status = "failed"
 		}
+		attrs := observability.SourceProjectionDiagnosticAttributes(sourceProjectionDiagnosticContext(event)).
+			With(telemetry.Attrs(
+				telemetry.Field{Key: "status", Value: status},
+				telemetry.Field{Key: "source_projection.status", Value: status},
+				telemetry.Field{Key: "source_projection.entities_projected", Value: result.EntitiesProjected},
+				telemetry.Field{Key: "source_projection.links_projected", Value: result.LinksProjected},
+				telemetry.Field{Key: "source_projection.entities_deleted", Value: result.EntitiesDeleted},
+				telemetry.Field{Key: "source_projection.links_deleted", Value: result.LinksDeleted},
+			))
+		if err != nil {
+			attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: sourceProjectionTelemetryErrorKind(err)})
+		}
+		telemetry.Event(ctx, "source_projection.project", attrs)
+		telemetry.AnnotateMain(ctx, attrs)
+		telemetry.AnnotateMainPhase(ctx, "source_projection.project", status, attrs)
 		observability.RecordSourceProjection(ctx, observability.SourceProjectionMetrics{
 			SourceID:          sourceID,
 			EventKind:         eventKind,
@@ -187,6 +203,32 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 		EntitiesDeleted:   entitiesDeleted,
 		LinksDeleted:      cleanupDeleted.LinksDeleted + retractedLinksDeleted,
 	}, nil
+}
+
+func sourceProjectionDiagnosticContext(event *cerebrov1.EventEnvelope) observability.SourceProjectionDiagnosticContext {
+	if event == nil {
+		return observability.SourceProjectionDiagnosticContext{}
+	}
+	return observability.SourceProjectionDiagnosticContext{
+		RuntimeID: strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID]),
+		SourceID:  event.GetSourceId(),
+		TenantID:  event.GetTenantId(),
+		EventKind: event.GetKind(),
+	}
+}
+
+func sourceProjectionTelemetryErrorKind(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "event is required"),
+		strings.Contains(message, "tenant_id is required"):
+		return "invalid_event"
+	default:
+		return "projection_failed"
+	}
 }
 
 func projectionRetractionReason(links []*ports.ProjectedLink) string {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -5871,6 +5871,53 @@ func assertProjectedLinkMissing(t *testing.T, recorder *projectionRecorder, from
 	}
 }
 
+func TestProjectTelemetryIncludesTenantRuntimeDrilldownContext(t *testing.T) {
+	service := New(nil, nil)
+	stderr := captureSourceProjectionStderr(t, func() {
+		_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+			Id:       "sensitive-event-id",
+			TenantId: "writer",
+			SourceId: "okta",
+			Kind:     "okta.user",
+			Attributes: map[string]string{
+				"source_runtime_id": "writer-okta-user",
+				"resource_urn":      "urn:cerebro:writer:okta_user:00u-sensitive",
+			},
+		})
+		if err != nil {
+			t.Fatalf("Project() error = %v", err)
+		}
+	})
+
+	payload := sourceProjectionTelemetryEventPayload(t, stderr, "source_projection.project")
+	for key, want := range map[string]any{
+		"tenant_id":                            "writer",
+		"source_id":                            "okta",
+		"runtime_id":                           "writer-okta-user",
+		"event_kind":                           "okta.user",
+		"source_projection.tenant_id":          "writer",
+		"source_projection.source_id":          "okta",
+		"source_projection.runtime_id":         "writer-okta-user",
+		"source_projection.event_kind":         "okta.user",
+		"status":                               "completed",
+		"source_projection.status":             "completed",
+		"source_projection.entities_projected": float64(0),
+		"source_projection.links_projected":    float64(0),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if payload["trace_id"] == "" || payload["span_id"] == "" {
+		t.Fatalf("projection telemetry missing trace/span ids: %#v", payload)
+	}
+	for _, prohibited := range []string{"sensitive-event-id", "00u-sensitive", "resource_urn"} {
+		if strings.Contains(stderr, prohibited) {
+			t.Fatalf("projection telemetry leaked high-cardinality value %q: %s", prohibited, stderr)
+		}
+	}
+}
+
 func captureSourceProjectionStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	oldStderr := os.Stderr
@@ -5895,7 +5942,11 @@ func captureSourceProjectionStderr(t *testing.T, fn func()) string {
 
 func sourceProjectionTelemetryPayload(t *testing.T, stderr string) map[string]any {
 	t.Helper()
-	const name = "source_projection.runtime_evidence"
+	return sourceProjectionTelemetryEventPayload(t, stderr, "source_projection.runtime_evidence")
+}
+
+func sourceProjectionTelemetryEventPayload(t *testing.T, stderr string, name string) map[string]any {
+	t.Helper()
 	lines := strings.Split(strings.TrimSpace(stderr), "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
 		if strings.TrimSpace(lines[i]) == "" {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -270,9 +270,18 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		spanAttributes = spanAttributes.
 			WithField(telemetry.Field{Key: "source_runtime.sync.contract_configured", Value: contractConfigured}).
 			WithField(telemetry.Field{Key: "source_runtime.sync.runtime_loaded", Value: runtimeLoadedForRun})
+		if runtime != nil {
+			spanAttributes = spanAttributes.With(observability.SourceRuntimeDiagnosticAttributes(observability.SourceRuntimeDiagnosticContext{
+				RuntimeID: runtime.GetId(),
+				SourceID:  runtime.GetSourceId(),
+				TenantID:  runtime.GetTenantId(),
+			}))
+		} else if runtimeID != "" {
+			spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "runtime_id", Value: runtimeID}).
+				WithField(telemetry.Field{Key: "source_runtime.id", Value: runtimeID})
+		}
 		telemetry.AnnotateMain(ctx, spanAttributes.With(telemetry.Attrs(
 			telemetry.Field{Key: "source_runtime.sync.status", Value: status},
-			telemetry.Field{Key: "source_runtime.id", Value: runtimeID},
 		)))
 		telemetry.AnnotateMainPhase(ctx, "source_runtime.sync", status, spanAttributes)
 		sourceID := ""
@@ -308,6 +317,13 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		return nil, err
 	}
 	runtimeLoadedForRun = true
+	runtimeContext := observability.SourceRuntimeDiagnosticContext{
+		RuntimeID: runtime.GetId(),
+		SourceID:  runtime.GetSourceId(),
+		TenantID:  runtime.GetTenantId(),
+	}
+	spanAttributes = spanAttributes.With(observability.SourceRuntimeDiagnosticAttributes(runtimeContext))
+	telemetry.AnnotateMain(ctx, observability.SourceRuntimeDiagnosticAttributes(runtimeContext))
 	source, err := s.lookupSource(runtime.GetSourceId())
 	if err != nil {
 		return nil, err
@@ -316,13 +332,6 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	if err != nil {
 		return nil, err
 	}
-	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()})
-	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()})
-	telemetry.AnnotateMain(ctx, telemetry.Attrs(
-		telemetry.Field{Key: "source_runtime.id", Value: runtime.GetId()},
-		telemetry.Field{Key: "source_runtime.source_id", Value: runtime.GetSourceId()},
-		telemetry.Field{Key: "source_runtime.tenant_id", Value: runtime.GetTenantId()},
-	))
 	refreshRuntimeProgressConfig(runtime, runtimeConfig)
 	pageLimit, err := normalizePageLimit(req.GetPageLimit())
 	if err != nil {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1264,6 +1264,46 @@ func TestSyncRuntimeTelemetryClassifiesErrorsWithoutRawSecret(t *testing.T) {
 	}
 }
 
+func TestSyncRuntimeTelemetryKeepsTenantContextOnEarlyFailure(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-missing-source": {
+				Id:       "writer-missing-source",
+				SourceId: "missing_source",
+				TenantId: "writer",
+			},
+		},
+	}
+	service := New(registry, store, &appendLog{}, nil)
+
+	stderr := captureSourceRuntimeStderr(t, func() {
+		_, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-missing-source"})
+		if err == nil {
+			t.Fatal("Sync() error = nil, want missing source error")
+		}
+	})
+
+	payload := sourceRuntimeTelemetryPayload(t, stderr, "source_runtime.sync")
+	for key, want := range map[string]any{
+		"runtime_id":                         "writer-missing-source",
+		"source_id":                          "missing_source",
+		"tenant_id":                          "writer",
+		"source_runtime.id":                  "writer-missing-source",
+		"source_runtime.source_id":           "missing_source",
+		"source_runtime.tenant_id":           "writer",
+		"source_runtime.sync.status":         "failed",
+		"source_runtime.sync.runtime_loaded": true,
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+}
+
 func TestSyncRuntimeTelemetryIncludesBoundedFreshnessMetadata(t *testing.T) {
 	checkpoint := sourcecdk.FamilyFreshnessCheckpoint("github", "audit", nil, sourcecdk.FamilyFreshnessProbe{
 		Kind:       "audit_log_latest_event",


### PR DESCRIPTION
## Summary
- add shared diagnostic attribute helpers for tenant/source/runtime drilldown outside metric dimensions
- keep source runtime terminal telemetry populated with tenant/source/runtime context on early failures
- emit source_projection.project diagnostic events with tenant/source/runtime context and bounded status/error fields
- document the aggregate-metric to tenant-diagnostic pivot

## Tests
- go test ./internal/observability ./internal/sourceruntime ./internal/sourceprojection