### PR TITLE
Normalize direct ID lookup auth errors

### DIFF
--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -725,7 +725,7 @@ func (a *App) handleGetReportRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := authorizeReportRunTenant(r.Context(), response.GetRun()); err != nil {
-		writeReportError(w, err)
+		writeReportError(w, normalizeIDLookupError(err, ports.ErrReportRunNotFound))
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, response)
@@ -1209,7 +1209,7 @@ func (a *App) handleGetGraphIngestRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := authorizeTenantID(r.Context(), run.TenantID); err != nil {
-		writeGraphIngestError(w, err)
+		writeGraphIngestError(w, normalizeIDLookupError(err, graphingest.ErrRunNotFound))
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.GetGraphIngestRunResponse{
@@ -1934,7 +1934,7 @@ func (s *bootstrapService) GetReportRun(ctx context.Context, req *connect.Reques
 		return nil, reportConnectError(err)
 	}
 	if err := authorizeReportRunTenant(ctx, response.GetRun()); err != nil {
-		return nil, reportConnectError(err)
+		return nil, reportConnectError(normalizeIDLookupError(err, ports.ErrReportRunNotFound))
 	}
 	return connect.NewResponse(response), nil
 }
@@ -2555,7 +2555,7 @@ func (s *bootstrapService) GetGraphIngestRun(ctx context.Context, req *connect.R
 		return nil, graphIngestConnectError(err)
 	}
 	if err := authorizeTenantID(ctx, run.TenantID); err != nil {
-		return nil, graphIngestConnectError(err)
+		return nil, graphIngestConnectError(normalizeIDLookupError(err, graphingest.ErrRunNotFound))
 	}
 	return connect.NewResponse(&cerebrov1.GetGraphIngestRunResponse{
 		Run: graphIngestRunMessage(run),

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -3587,15 +3587,15 @@ func TestAuthMiddlewareEnforcesTenantOnReportRunLookups(t *testing.T) {
 		t.Fatalf("GET /report-runs/other-report-run error = %v", err)
 	}
 	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("GET /report-runs/other-report-run status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET /report-runs/other-report-run status = %d, want %d", resp.StatusCode, http.StatusNotFound)
 	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	getReq := connect.NewRequest(&cerebrov1.GetReportRunRequest{Id: "other-report-run"})
 	getReq.Header().Set("Authorization", "Bearer writer-key")
-	if _, err := client.GetReportRun(context.Background(), getReq); connect.CodeOf(err) != connect.CodePermissionDenied {
-		t.Fatalf("GetReportRun(other tenant) code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodePermissionDenied, err)
+	if _, err := client.GetReportRun(context.Background(), getReq); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("GetReportRun(other tenant) code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodeNotFound, err)
 	}
 }
 
@@ -3909,6 +3909,53 @@ func TestAuthMiddlewareRejectsUnscopedGraphIngestRunListings(t *testing.T) {
 	listReq.Header().Set("Authorization", "Bearer writer-key")
 	if _, err := client.ListGraphIngestRuns(context.Background(), listReq); connect.CodeOf(err) != connect.CodePermissionDenied {
 		t.Fatalf("ListGraphIngestRuns(unscoped) code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodePermissionDenied, err)
+	}
+}
+
+func TestAuthMiddlewareNormalizesForeignGraphIngestRunLookup(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APIKeys: []config.APIKey{{
+				Key:      "writer-key",
+				TenantID: "writer",
+			}},
+		},
+	}
+	store := &stubGraphStore{ingestRuns: map[string]graphstore.IngestRun{
+		"other-run": {
+			ID:        "other-run",
+			RuntimeID: "runtime-other",
+			SourceID:  "okta",
+			TenantID:  "other",
+			Status:    graphstore.IngestRunStatusCompleted,
+		},
+	}}
+	app := New(cfg, Dependencies{GraphStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/ingest-runs/other-run", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer writer-key")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /platform/graph/ingest-runs/other-run error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET /platform/graph/ingest-runs/other-run status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	getReq := connect.NewRequest(&cerebrov1.GetGraphIngestRunRequest{Id: "other-run"})
+	getReq.Header().Set("Authorization", "Bearer writer-key")
+	if _, err := client.GetGraphIngestRun(context.Background(), getReq); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("GetGraphIngestRun(other tenant) code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodeNotFound, err)
 	}
 }
 

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -887,7 +887,7 @@ func (a *App) handleGetConnectorCredential(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if err := authorizeTenantID(r.Context(), record.TenantID); err != nil {
-		writeConnectorError(w, err)
+		writeConnectorError(w, normalizeIDLookupError(err, ports.ErrConnectorCredentialNotFound))
 		return
 	}
 	events, err := broker.AuditEvents(r.Context(), credentialID, 50)

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -701,6 +701,49 @@ func TestConnectorCredentialBrokerRejectsCrossTenantRequest(t *testing.T) {
 	}
 }
 
+func TestConnectorCredentialDetailNormalizesForeignTenantLookup(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &connectorTestStore{
+		stubRuntimeStore: &stubRuntimeStore{},
+		credentials: map[string]*ports.ConnectorCredentialRecord{
+			"credential-other": {
+				ID:                "credential-other",
+				TenantID:          "tenant-b",
+				SourceID:          "bootstrap_token",
+				RuntimeID:         "runtime-b",
+				CredentialStoreID: defaultConnectorCredentialStoreID,
+				AuthMethod:        "encrypted_submission",
+				Status:            connectorcredentials.StatusValid,
+				Fields:            []string{"token"},
+			},
+		},
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+
+	req := httptest.NewRequest(http.MethodGet, "/connectors/bootstrap_token/credentials/credential-other", nil)
+	req.SetPathValue("sourceID", "bootstrap_token")
+	req.SetPathValue("credentialID", "credential-other")
+	req = req.WithContext(context.WithValue(req.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{TenantID: "tenant-a"},
+	}))
+	recorder := httptest.NewRecorder()
+	app.handleGetConnectorCredential(recorder, req)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("GET credential detail status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}
+
 func TestConnectorCredentialBrokerRejectsExistingRuntimeTenantMismatch(t *testing.T) {
 	source := &bootstrapTokenSource{id: "bootstrap_token"}
 	registry, err := sourcecdk.NewRegistry(source)

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -810,11 +810,11 @@ func (a *App) handleGetGRCInventoryAssetReport(w http.ResponseWriter, r *http.Re
 		return
 	}
 	if err := authorizeTenantID(r.Context(), record.TenantID); err != nil {
-		writeGRCError(w, err)
+		writeGRCError(w, normalizeIDLookupError(err, ports.ErrGRCInventoryAssetReportNotFound))
 		return
 	}
 	if err := authorizeCerebroURNTenant(r.Context(), record.AssetURN); err != nil {
-		writeGRCError(w, err)
+		writeGRCError(w, normalizeIDLookupError(err, ports.ErrGRCInventoryAssetReportNotFound))
 		return
 	}
 	writeJSON(w, http.StatusOK, grcInventoryAssetReportResponse{Report: record, GeneratedAt: time.Now().UTC()})

--- a/internal/bootstrap/grc_inventory_reports_test.go
+++ b/internal/bootstrap/grc_inventory_reports_test.go
@@ -212,6 +212,30 @@ func TestGRCInventoryAssetReportRejectsMalformedAssetURN(t *testing.T) {
 	}
 }
 
+func TestGRCInventoryAssetReportNormalizesForeignTenantLookup(t *testing.T) {
+	store := &memoryGRCInventoryAssetReportStore{reports: map[string]*ports.GRCInventoryAssetReportRecord{
+		"report-other": {
+			ID:           "report-other",
+			TenantID:     "tenant-b",
+			AssetURN:     "urn:cerebro:tenant-b:aws_s3_bucket:bucket-a",
+			Reason:       "foreign report",
+			Reporter:     "security@example.com",
+			TriageStatus: "open",
+		},
+	}}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	request := httptest.NewRequest(http.MethodGet, "/grc/inventory/asset-reports/report-other", nil)
+	request.SetPathValue("reportID", "report-other")
+	request = request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{TenantID: "tenant-a"},
+	}))
+	recorder := httptest.NewRecorder()
+	app.handleGetGRCInventoryAssetReport(recorder, request)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("GET asset report status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}
+
 func TestGRCInventoryAssetReportSummaryPreservesCountsAcrossListCap(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	store := &memoryGRCInventoryAssetReportStore{reports: map[string]*ports.GRCInventoryAssetReportRecord{}}

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -137,7 +137,7 @@ func (a *App) handleGetJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := authorizeTenantID(r.Context(), job.TenantID); err != nil {
-		writeJobError(w, err)
+		writeJobError(w, normalizeIDLookupError(err, ports.ErrJobNotFound))
 		return
 	}
 	writeJSON(w, http.StatusOK, jobResponse{Job: job})
@@ -150,7 +150,7 @@ func (a *App) handleListJobEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := authorizeTenantID(r.Context(), job.TenantID); err != nil {
-		writeJobError(w, err)
+		writeJobError(w, normalizeIDLookupError(err, ports.ErrJobNotFound))
 		return
 	}
 	limit, err := uint32QueryParam(r, "limit")
@@ -173,7 +173,7 @@ func (a *App) handleCancelJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := authorizeTenantID(r.Context(), existing.TenantID); err != nil {
-		writeJobError(w, err)
+		writeJobError(w, normalizeIDLookupError(err, ports.ErrJobNotFound))
 		return
 	}
 	job, err := a.jobService().Cancel(r.Context(), existing.ID)

--- a/internal/bootstrap/jobs_test.go
+++ b/internal/bootstrap/jobs_test.go
@@ -12,6 +12,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	platformjobs "github.com/writer/cerebro/internal/jobs"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func TestAuthorizeJobCreateAllowsSourceRuntimeOrchestrate(t *testing.T) {
@@ -40,6 +41,40 @@ func TestNewCachesJobServiceForAsyncLifecycle(t *testing.T) {
 	second := app.jobService()
 	if first != second {
 		t.Fatal("jobService() returned different instances")
+	}
+}
+
+func TestJobDirectIDHandlersNormalizeForeignTenantLookup(t *testing.T) {
+	store := newA2ATestJobStore()
+	store.jobs["foreign-job"] = &ports.Job{
+		ID:       "foreign-job",
+		TenantID: "tenant-b",
+		Status:   ports.JobStatusRunning,
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0"}, Dependencies{StateStore: store}, nil)
+
+	for _, tt := range []struct {
+		name    string
+		method  string
+		target  string
+		handler http.HandlerFunc
+	}{
+		{name: "get", method: http.MethodGet, target: "/platform/jobs/foreign-job", handler: app.handleGetJob},
+		{name: "events", method: http.MethodGet, target: "/platform/jobs/foreign-job/events", handler: app.handleListJobEvents},
+		{name: "cancel", method: http.MethodPost, target: "/platform/jobs/foreign-job/cancel", handler: app.handleCancelJob},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(tt.method, tt.target, nil)
+			request.SetPathValue("jobID", "foreign-job")
+			request = request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{
+				principal: authPrincipal{TenantID: "tenant-a"},
+			}))
+			recorder := httptest.NewRecorder()
+			tt.handler(recorder, request)
+			if recorder.Code != http.StatusNotFound {
+				t.Fatalf("%s status = %d, want %d", tt.name, recorder.Code, http.StatusNotFound)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Normalize tenant-denied direct resource lookups to each resource type's existing not-found response
- Cover jobs, report runs, graph ingest runs, connector credential details, and GRC inventory asset reports
- Add regressions for HTTP and Connect lookup paths that previously exposed a forbidden/not-found distinction

## Validation
- go test ./internal/bootstrap -run 'Test(JobDirectIDHandlersNormalizeForeignTenantLookup|AuthMiddlewareEnforcesTenantOnReportRunLookups|AuthMiddlewareNormalizesForeignGraphIngestRunLookup|ConnectorCredentialDetailNormalizesForeignTenantLookup|GRCInventoryAssetReportNormalizesForeignTenantLookup)' -count=1 -v\n- go test ./internal/bootstrap -count=1\n- golangci-lint run --timeout 10m ./internal/bootstrap\n- make check-structural check-structural-test check-arch\n- make cover\n- make catalog-check\n- make docs-drift-check