### PR TITLE
Fix Panopticon EvidenceCAS candidate correlation

### DIFF
--- a/internal/findings/panopticon_case_rule.go
+++ b/internal/findings/panopticon_case_rule.go
@@ -315,10 +315,11 @@ func panopticonAlertEvidenceURN(tenantID string, alertID string) string {
 }
 
 // panopticonCaseEvidenceCASObjectIDs extracts stable Evidence CAS object
-// identifiers from a Panopticon case payload using the same identity precedence
-// the Evidence CAS source applies (evidence_id, then CAS URI/digest). The result
-// is deterministic (deduped, sorted) so downstream correlation and fingerprints
-// stay stable across syncs.
+// identifiers from a Panopticon case payload. EvidenceCAS may project the
+// canonical runtime evidence under legacy metadata.evidence_id or the CAS URI,
+// so keep both candidates when Panopticon supplies both values. The result is
+// deterministic (deduped, sorted) so downstream correlation stays stable across
+// syncs.
 func panopticonCaseEvidenceCASObjectIDs(event *cerebrov1.EventEnvelope, attrs map[string]string) []string {
 	if promoted := strings.TrimSpace(attrs["evidence_cas_object_ids"]); promoted != "" {
 		return panopticonDedupeSortedIDs(strings.Split(promoted, ","))
@@ -327,13 +328,13 @@ func panopticonCaseEvidenceCASObjectIDs(event *cerebrov1.EventEnvelope, attrs ma
 	var ids []string
 	for _, key := range []string{"evidence", "evidences", "evidence_pointers", "captures"} {
 		for _, evidence := range panopticonCasePayloadObjects(payload, key) {
-			id := firstNonEmpty(
+			localID := firstNonEmpty(
 				panopticonCaseMapString(evidence, "evidence_id", "id"),
-				panopticonCaseMapString(evidence, "evidence_cas", "evidence_cas_uri", "uri", "cas_uri", "pointer"),
-				panopticonCaseMapString(evidence, "sha256", "digest"),
 			)
-			if id != "" {
-				ids = append(ids, id)
+			pointer := panopticonCaseMapString(evidence, "evidence_cas", "evidence_cas_uri", "uri", "cas_uri", "pointer")
+			ids = append(ids, localID, pointer)
+			if pointer == "" {
+				ids = append(ids, panopticonCaseMapString(evidence, "sha256", "digest"))
 			}
 		}
 	}

--- a/internal/findings/panopticon_case_rule_test.go
+++ b/internal/findings/panopticon_case_rule_test.go
@@ -146,21 +146,27 @@ func TestPanopticonCuratedCaseFindingCorrelatesEvidenceCASAndReopens(t *testing.
 	if firstFingerprint == "" {
 		t.Fatal("open finding has empty fingerprint")
 	}
-	if got := finding.Attributes["evidence_cas_object_ids"]; got != "evidence-1,evidencecas://cases/case-555/evidence/timeline.json" {
+	wantObjectIDs := "evidence-1,evidencecas://cases/case-555/evidence/timeline.json,evidencecas://cases/case-555/evidence/triage.tar"
+	if got := finding.Attributes["evidence_cas_object_ids"]; got != wantObjectIDs {
 		t.Fatalf("evidence_cas_object_ids = %q, want the promoted correlation ids", got)
 	}
 
-	evidenceObjectURN := "urn:cerebro:writer:runtime_evidence:evidence-1"
-	var foundEvidencePath bool
+	expectedEvidenceURNs := map[string]bool{
+		"urn:cerebro:writer:runtime_evidence:evidence-1":                                          false,
+		"urn:cerebro:writer:runtime_evidence:evidencecas://cases/case-555/evidence/triage.tar":    false,
+		"urn:cerebro:writer:runtime_evidence:evidencecas://cases/case-555/evidence/timeline.json": false,
+	}
 	for _, row := range finding.GraphEvidenceRows {
 		for _, path := range row.GetPaths() {
-			if path.GetToUrn() == evidenceObjectURN && path.GetRelation() == "has_evidence" {
-				foundEvidencePath = true
+			if _, ok := expectedEvidenceURNs[path.GetToUrn()]; ok && path.GetRelation() == "has_evidence" {
+				expectedEvidenceURNs[path.GetToUrn()] = true
 			}
 		}
 	}
-	if !foundEvidencePath {
-		t.Fatalf("expected a has_evidence graph path to %q for Evidence CAS correlation", evidenceObjectURN)
+	for urn, found := range expectedEvidenceURNs {
+		if !found {
+			t.Fatalf("expected a has_evidence graph path to %q for Evidence CAS correlation", urn)
+		}
 	}
 
 	closed := panopticonCaseEventWithEvidence("panopticon-case-evidence-closed", "case-555", "closed", "evidence-1,evidencecas://cases/case-555/evidence/timeline.json")

--- a/internal/sourceprojection/panopticon.go
+++ b/internal/sourceprojection/panopticon.go
@@ -370,16 +370,18 @@ func panopticonAddEvidencePointers(entities map[string]*ports.ProjectedEntity, l
 		if evidenceURN == "" {
 			continue
 		}
-		objectURN := panopticonEvidenceCASObjectURN(tenantID, evidence, pointer)
+		objectURNs := panopticonEvidenceCASObjectURNs(tenantID, evidence, pointer)
+		objectURN := firstNonEmpty(objectURNs...)
 		attributes := compactAttributes(map[string]string{
-			"evidence_id":             panopticonString(evidence, "evidence_id", "id"),
-			"evidence_cas":            pointer,
-			"evidence_cas_uri":        pointer,
-			"evidence_cas_object_urn": objectURN,
-			"sha256":                  panopticonEvidenceDigest(evidence),
-			"content_type":            panopticonString(evidence, "content_type"),
-			"ref_type":                panopticonString(evidence, "ref_type"),
-			"source_path":             panopticonString(evidence, "source_path"),
+			"evidence_id":              panopticonString(evidence, "evidence_id", "id"),
+			"evidence_cas":             pointer,
+			"evidence_cas_uri":         pointer,
+			"evidence_cas_object_urn":  objectURN,
+			"evidence_cas_object_urns": strings.Join(objectURNs, ","),
+			"sha256":                   panopticonEvidenceDigest(evidence),
+			"content_type":             panopticonString(evidence, "content_type"),
+			"ref_type":                 panopticonString(evidence, "ref_type"),
+			"source_path":              panopticonString(evidence, "source_path"),
 			"chain_of_custody_id": firstNonEmpty(
 				panopticonString(evidence, "chain_of_custody_id"),
 				panopticonString(evidence, "custody_id"),
@@ -399,7 +401,7 @@ func panopticonAddEvidencePointers(entities map[string]*ports.ProjectedEntity, l
 			Label:      firstNonEmpty(panopticonString(evidence, "label", "name"), evidenceID),
 			Attributes: attributes,
 		})
-		if objectURN != "" {
+		for _, objectURN := range objectURNs {
 			addLink(links, projectedLink(tenantID, sourceID, evidenceURN, objectURN, relationRepresents, panopticonAnchorAttributes(event, "panopticon_evidence_cas_object", "evidence_cas_object_urn", objectURN)))
 		}
 		if _, ok := seen[evidenceURN]; ok {
@@ -411,16 +413,44 @@ func panopticonAddEvidencePointers(entities map[string]*ports.ProjectedEntity, l
 	return urns
 }
 
-// panopticonEvidenceCASObjectURN returns the canonical Evidence CAS object URN
-// for an evidence reference using the same identity precedence the Evidence CAS
-// source applies (evidence_id, then CAS URI). The result is tenant-scoped so a
-// Panopticon pointer never correlates across tenant boundaries.
-func panopticonEvidenceCASObjectURN(tenantID string, evidence map[string]any, pointer string) string {
-	objectID := firstNonEmpty(panopticonString(evidence, "evidence_id", "id"), pointer)
-	if objectID == "" {
-		return ""
+// panopticonEvidenceCASObjectURNs returns tenant-scoped candidate Evidence CAS
+// object URNs for an evidence reference. EvidenceCAS may project the canonical
+// runtime evidence under either legacy metadata.evidence_id or the CAS URI, so
+// Panopticon preserves both graph-visible joins when both identifiers are
+// present.
+func panopticonEvidenceCASObjectURNs(tenantID string, evidence map[string]any, pointer string) []string {
+	objectIDs := panopticonEvidenceCASObjectIDs(evidence, pointer)
+	urns := make([]string, 0, len(objectIDs))
+	for _, objectID := range objectIDs {
+		if urn := projectionURN(tenantID, "runtime_evidence", objectID); urn != "" {
+			urns = append(urns, urn)
+		}
 	}
-	return projectionURN(tenantID, "runtime_evidence", objectID)
+	return urns
+}
+
+func panopticonEvidenceCASObjectIDs(evidence map[string]any, pointer string) []string {
+	candidates := []string{
+		panopticonString(evidence, "evidence_id", "id"),
+		pointer,
+	}
+	if pointer == "" {
+		candidates = append(candidates, panopticonEvidenceDigest(evidence))
+	}
+	seen := map[string]struct{}{}
+	ids := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		ids = append(ids, candidate)
+	}
+	return ids
 }
 
 func panopticonEvidencePointer(evidence map[string]any) string {

--- a/internal/sourceprojection/panopticon_test.go
+++ b/internal/sourceprojection/panopticon_test.go
@@ -822,9 +822,23 @@ func TestProjectPanopticonEvidencePointerCorrelatesWithEvidenceCASObject(t *test
 	}); err != nil {
 		t.Fatalf("Project(evidence_cas.object) error = %v", err)
 	}
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "evidence-cas-object-event-uri",
+		TenantId: "writer",
+		SourceId: "evidence_cas",
+		Kind:     "evidence_cas.object",
+		Attributes: map[string]string{
+			"evidence_id":         "evidencecas://cases/case-corr/evidence/triage.tar",
+			"evidence_cas_uri":    "evidencecas://cases/case-corr/evidence/triage.tar",
+			"evidence_cas_digest": "sha256:abc",
+		},
+	}); err != nil {
+		t.Fatalf("Project(uri identity evidence_cas.object) error = %v", err)
+	}
 
 	pointerURN := "urn:cerebro:writer:evidence_cas_pointer:evidence-1"
 	evidenceObjectURN := "urn:cerebro:writer:runtime_evidence:evidence-1"
+	uriEvidenceObjectURN := "urn:cerebro:writer:runtime_evidence:evidencecas://cases/case-corr/evidence/triage.tar"
 
 	pointer := state.entities[pointerURN]
 	if pointer == nil || pointer.EntityType != "evidence.cas.pointer" {
@@ -833,10 +847,17 @@ func TestProjectPanopticonEvidencePointerCorrelatesWithEvidenceCASObject(t *test
 	if got := pointer.Attributes["evidence_cas_object_urn"]; got != evidenceObjectURN {
 		t.Fatalf("evidence_cas_object_urn = %q, want %q", got, evidenceObjectURN)
 	}
+	if got, want := pointer.Attributes["evidence_cas_object_urns"], evidenceObjectURN+","+uriEvidenceObjectURN; got != want {
+		t.Fatalf("evidence_cas_object_urns = %q, want %q", got, want)
+	}
 	if state.entities[evidenceObjectURN] == nil {
 		t.Fatalf("Evidence CAS object projection %q missing for correlation join", evidenceObjectURN)
 	}
+	if state.entities[uriEvidenceObjectURN] == nil {
+		t.Fatalf("Evidence CAS URI object projection %q missing for correlation join", uriEvidenceObjectURN)
+	}
 	assertProjectedLink(t, state, pointerURN, relationRepresents, evidenceObjectURN)
+	assertProjectedLink(t, state, pointerURN, relationRepresents, uriEvidenceObjectURN)
 
 	// Cross-tenant Evidence CAS objects must not be joined by the writer pointer.
 	assertProjectedLinkMissing(t, state, pointerURN, relationRepresents, "urn:cerebro:other:runtime_evidence:evidence-1")


### PR DESCRIPTION
## Summary
- preserve both Panopticon local evidence IDs and CAS URI candidates when building EvidenceCAS graph correlation
- add multiple `represents` links from Panopticon evidence pointers to candidate `runtime_evidence` objects while keeping the legacy singular object URN attribute
- include all candidate EvidenceCAS IDs in Panopticon curated case finding graph evidence rows

## Bug
PR #1199 added Panopticon curated case/EvidenceCAS correlation, but it collapsed a Panopticon evidence reference to the first available identifier. When Panopticon supplied a local `evidence_id` and a CAS URI, Cerebro only emitted paths to `runtime_evidence:<local-id>`. EvidenceCAS itself can project the canonical object under the CAS URI when no legacy metadata evidence ID is present, so those findings and pointer entities could point at a graph node that never exists and miss the actual EvidenceCAS object.

## Tests
- `go test ./internal/sourceprojection -run 'TestProjectPanopticonEvidencePointerCorrelatesWithEvidenceCASObject|TestProjectPanopticonCaseBuildsLinkedGraphAndEvidencePointers|TestProjectPanopticonGeneratedCaseArchivePreservesEvidenceCASPointer' -count=1`
- `go test ./internal/findings -run 'TestPanopticonCuratedCaseFindingCorrelatesEvidenceCASAndReopens|TestPanopticonCuratedCase' -count=1`
- `go test ./internal/sourceprojection ./internal/findings -count=1`
- `go test ./sources/panopticon ./sources/evidencecas ./internal/sourceprojection ./internal/findings -count=1`
