### PR TITLE
Accept Trivy ImageID as image digest fallback

### DIFF
--- a/sources/internal/trivy/source.go
+++ b/sources/internal/trivy/source.go
@@ -348,6 +348,9 @@ func imageDigest(report report) string {
 	if idx := strings.LastIndex(report.ArtifactName, "@sha256:"); idx >= 0 {
 		return report.ArtifactName[idx+1:]
 	}
+	if imageID := strings.TrimSpace(report.Metadata.ImageID); imageID != "" {
+		return imageID
+	}
 	return ""
 }
 

--- a/sources/internal/trivy/source_test.go
+++ b/sources/internal/trivy/source_test.go
@@ -6,6 +6,25 @@ import (
 	"time"
 )
 
+func TestLoadReportAcceptsMetadataImageID(t *testing.T) {
+	source := &Source{
+		readFile: func(string) ([]byte, error) {
+			return []byte(`{
+				"ArtifactName": "registry.example/app:latest",
+				"Metadata": {"ImageID": "sha256:cccc"},
+				"Results": []
+			}`), nil
+		},
+	}
+	report, err := source.loadReport(settings{tenantID: "writer", family: familyImageScan, path: "report.json"})
+	if err != nil {
+		t.Fatalf("loadReport() error = %v", err)
+	}
+	if got := imageDigest(report); got != "sha256:cccc" {
+		t.Fatalf("imageDigest() = %q, want sha256:cccc", got)
+	}
+}
+
 func TestFixEventIDsIncludeImageDigest(t *testing.T) {
 	source := &Source{now: func() time.Time { return time.Unix(0, 0).UTC() }}
 	st := settings{tenantID: "writer", family: familyFix}


### PR DESCRIPTION
## Summary
- use `Metadata.ImageID` as the Trivy image digest fallback when `RepoDigests` and `ArtifactName@sha256` are unavailable
- add a regression test covering `loadReport` acceptance for ImageID-only reports

## Bug
PR #1191 added offline Trivy report ingestion, and discovery already considered `Metadata.ImageID` a valid report identity. But `loadReport` rejected the same report because `imageDigest` ignored `Metadata.ImageID`. Valid Trivy image reports that only contain `Metadata.ImageID` therefore failed before Cerebro could create graph projections or vulnerability findings.

## Tests
- `go test ./sources/internal/trivy ./sources/trivy -count=1`
- `go test ./internal/sourceprojection ./internal/findings -run 'TestProjectTrivy|TestTrivyImageVulnerability' -count=1`
- `go test ./sources/internal/trivy ./sources/trivy ./internal/sourceprojection ./internal/findings -count=1`
