### PR TITLE
Honor explicit EvidenceCAS unresolved context

### DIFF
--- a/internal/findings/evidence_cas_unresolved_linkage_rule.go
+++ b/internal/findings/evidence_cas_unresolved_linkage_rule.go
@@ -201,11 +201,13 @@ func evidenceCASCaseLinkUnresolved(attributes map[string]string) bool {
 }
 
 func evidenceCASResourceContextSupplied(attributes map[string]string) bool {
-	return firstNonEmpty(attributes["resource_urn"], attributes["resource_id"]) != ""
+	return firstNonEmpty(attributes["resource_urn"], attributes["resource_id"]) != "" ||
+		parseBoolAttribute(attributes, "unresolved_resource_context")
 }
 
 func evidenceCASCaseContextSupplied(attributes map[string]string) bool {
-	return firstNonEmpty(attributes["case_id"], attributes["case_urn"]) != ""
+	return firstNonEmpty(attributes["case_id"], attributes["case_urn"]) != "" ||
+		parseBoolAttribute(attributes, "unresolved_case_context")
 }
 
 func evidenceCASUnresolvedLinkageScope(attributes map[string]string) string {

--- a/internal/findings/evidence_cas_unresolved_linkage_rule_test.go
+++ b/internal/findings/evidence_cas_unresolved_linkage_rule_test.go
@@ -150,6 +150,51 @@ func TestEvidenceCASUnresolvedLinkageOpensOnSuppliedContextWithBlankLinkStatus(t
 	}
 }
 
+func TestEvidenceCASUnresolvedLinkageOpensOnExplicitUnresolvedContextWithoutIdentifiers(t *testing.T) {
+	rule := newEvidenceCASUnresolvedLinkageRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-evidence-cas", SourceId: "evidence_cas", TenantId: "writer"}
+	occurredAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name  string
+		attrs map[string]string
+		scope string
+	}{
+		{
+			name: "case marker",
+			attrs: map[string]string{
+				"case_id":                 "",
+				"case_link_status":        "",
+				"unresolved_case_context": "true",
+			},
+			scope: "case",
+		},
+		{
+			name: "resource marker",
+			attrs: map[string]string{
+				"resource_id":                 "",
+				"resource_urn":                "",
+				"resource_link_status":        "",
+				"unresolved_resource_context": "true",
+			},
+			scope: "resource",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			records, err := rule.Evaluate(context.Background(), runtime, evidenceCASObjectEvent("evidence-"+strings.ReplaceAll(tc.name, " ", "-"), tc.attrs, occurredAt))
+			if err != nil {
+				t.Fatalf("Evaluate(%s) error = %v", tc.name, err)
+			}
+			if len(records) != 1 {
+				t.Fatalf("Evaluate(%s) emitted %d findings, want 1", tc.name, len(records))
+			}
+			if got := records[0].Attributes["unresolved_linkage"]; got != tc.scope {
+				t.Fatalf("unresolved_linkage = %q, want %q", got, tc.scope)
+			}
+		})
+	}
+}
+
 func TestEvidenceCASUnresolvedLinkageContextlessFollowupKeepsFindingOpen(t *testing.T) {
 	rule := newEvidenceCASUnresolvedLinkageRule()
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-evidence-cas", SourceId: "evidence_cas", TenantId: "writer"}


### PR DESCRIPTION
## Summary
- treat `unresolved_resource_context=true` as supplied resource context for the EvidenceCAS unresolved-linkage rule
- treat `unresolved_case_context=true` as supplied case context for the same rule
- add regression tests for explicit unresolved context markers without target identifiers

## Bug
PR #1203 added EvidenceCAS unresolved-linkage findings, but the finding rule only considered case/resource context supplied when a case/resource ID or URN was present. The source/projection path can explicitly mark unresolved context with `unresolved_resource_context=true` or `unresolved_case_context=true`; the projector records that evidence as unresolved, but the finding rule ignored it and emitted no finding. This left graph-visible unresolved EvidenceCAS objects without the durable finding meant to track them.

## Tests
- `go test ./internal/findings -run 'TestEvidenceCASUnresolvedLinkage' -count=1`
- `go test ./internal/sourceprojection -run 'TestProjectEvidenceCAS' -count=1`
- `go test ./sources/evidencecas -count=1`
- `go test ./sources/evidencecas ./internal/sourceprojection ./internal/findings -count=1`
