### PR TITLE
Bind device refresh tokens to DPoP keys

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2747,9 +2747,12 @@ paths:
       description: |
         Consumes a single-use bootstrap token and provisions a device
         identity. The bootstrap token is delivered out-of-band by MDM and
-        is bound to the device's hardware_uuid. Returns a short-lived
-        access token (EdDSA JWT) and a long-lived refresh token. Replay
-        of an already-consumed bootstrap token returns 401.
+        is bound to the device's hardware_uuid. Enrollment must bind a
+        DPoP key through verified attestation, an agent-supplied
+        `device_key`, or an existing active device binding before the
+        service returns a short-lived access token (EdDSA JWT) and
+        single-use refresh token. Replay of an already-consumed bootstrap
+        token returns 401.
       tags:
         - Devices
       security: []
@@ -2781,24 +2784,24 @@ paths:
         consumed refresh token revokes the entire token family per RFC 6819
         §5.2.2.3.
 
-        When the device was enrolled with a hardware-bound key (App Attest
-        or TPM 2.0), the request MUST carry an RFC 9449 DPoP proof JWT in
-        the `DPoP` header signed by the bound key, with `htm` matching the
+        The request MUST carry an RFC 9449 DPoP proof JWT in the `DPoP`
+        header signed by the device's bound key, with `htm` matching the
         request method, `htu` matching the canonical request URL, a unique
         `jti`, and a fresh `iat`. The proof's JWK SHA-256 thumbprint
-        (RFC 7638) must equal the device's stored `dpop_jkt`.
+        (RFC 7638) must equal the device's stored `dpop_jkt`; devices
+        without a stored binding are rejected and must re-enroll.
       tags:
         - Devices
       security: []
       parameters:
         - in: header
           name: DPoP
-          required: false
+          required: true
           schema:
             type: string
           description: |
-            RFC 9449 DPoP proof JWT. Required when the device was enrolled
-            with a hardware-bound key. Algorithms: ES256, ES384, EdDSA.
+            RFC 9449 DPoP proof JWT signed by the enrolled device key.
+            Algorithms: ES256, ES384, EdDSA.
       requestBody:
         required: true
         content:
@@ -5788,6 +5791,15 @@ components:
             present and verified, the server binds a DPoP key (RFC 9449) to
             subsequent refresh-token rotations and the response includes
             assurance_level=hardware.
+        device_key:
+          type: object
+          additionalProperties: true
+          description: |
+            Agent-supplied public JWK used to bind the device's access and
+            refresh tokens to RFC 9449 DPoP proofs when attestation does not
+            provide a public key. Required unless verified attestation or an
+            existing active device record supplies the binding. Allowed keys:
+            EC P-256, EC P-384, or OKP Ed25519. RSA is rejected.
     DeviceTokenRequest:
       type: object
       required: [grant_type, refresh_token]

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -99,8 +99,9 @@ func buildDeviceAuthService(cfg config.DeviceAuthConfig, store deviceauth.Store,
 // buildAttestationRegistry constructs the attestation registry from
 // configuration. When the operator has not configured Apple or TPM
 // verifiers, the registry runs in non-required mode -- enroll requests
-// without an attestation statement get a software-assurance result, and
-// the device gets a software-only access token (no DPoP binding).
+// without an attestation statement get a software-assurance result, but
+// still need device_key or an existing binding before refresh tokens are
+// issued.
 func buildAttestationRegistry(cfg config.DeviceAuthConfig) (*attestation.Registry, error) {
 	verifiers := make([]attestation.Verifier, 0, 2)
 	if cfg.Attestation.Apple.TeamID != "" && len(cfg.Attestation.Apple.BundleIDs) > 0 {
@@ -162,11 +163,12 @@ type enrollRequestBody struct {
 	// Windows. Required when CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED=true.
 	Attestation string `json:"attestation,omitempty"`
 	// DeviceKey is the agent-supplied public JWK that the agent will sign
-	// DPoP proofs with. When present, cnf.jkt on the access token is set
-	// to the RFC 7638 thumbprint of this key, and every refresh and
-	// DPoP-protected resource call must carry a proof signed by the
-	// matching private key. Allowed kty/crv values: EC P-256, EC P-384,
-	// OKP Ed25519. RSA is rejected. Maximum encoded size: 4 KiB.
+	// DPoP proofs with. It is required unless verified attestation or an
+	// existing device record supplies the binding. cnf.jkt on the access
+	// token is set to the RFC 7638 thumbprint of this key, and every
+	// refresh and DPoP-protected resource call must carry a proof signed by
+	// the matching private key. Allowed kty/crv values: EC P-256, EC
+	// P-384, OKP Ed25519. RSA is rejected. Maximum encoded size: 4 KiB.
 	DeviceKey json.RawMessage `json:"device_key,omitempty"`
 }
 

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -105,6 +106,7 @@ func encodePEMPrivate(t *testing.T, priv ed25519.PrivateKey) string {
 func TestDeviceAuthEndToEnd(t *testing.T) {
 	app := newAppForDeviceTest(t)
 	handler := app.Handler()
+	deviceKey := newTestDeviceDPoPKey(t)
 
 	// Issue bootstrap token as an operator using the API key.
 	bootstrapBody := bytes.NewBufferString(`{"hardware_uuid":"hw-1","tenant_id":"writer","ttl_seconds":3600}`)
@@ -128,7 +130,7 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 	}
 
 	// Enroll the device (no auth header; route is public).
-	enrollBody := []byte(`{"bootstrap_token":"` + bootstrap.Token + `","hardware_uuid":"hw-1","hostname":"laptop-1","os_type":"darwin"}`)
+	enrollBody := []byte(`{"bootstrap_token":"` + bootstrap.Token + `","hardware_uuid":"hw-1","hostname":"laptop-1","os_type":"darwin","device_key":` + deviceKey.jwkJSON + `}`)
 	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewReader(enrollBody))
 	req.Header.Set("Content-Type", "application/json")
 	resp = httptest.NewRecorder()
@@ -158,6 +160,7 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+enroll.AccessToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Idempotency-Key", "abc-123")
+	setDPoPHeader(t, req, deviceKey, "ingest-1", enroll.AccessToken)
 	resp = httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusAccepted {
@@ -170,6 +173,7 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+enroll.AccessToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Idempotency-Key", "abc-123")
+	setDPoPHeader(t, req, deviceKey, "ingest-2", enroll.AccessToken)
 	handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusAccepted {
 		t.Fatalf("idempotent ingest status = %d", resp.Code)
@@ -188,6 +192,7 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+enroll.AccessToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Idempotency-Key", "abc-123")
+	setDPoPHeader(t, req, deviceKey, "ingest-3", enroll.AccessToken)
 	handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusConflict {
 		t.Fatalf("conflicting ingest status = %d, body=%s", resp.Code, resp.Body.String())
@@ -197,6 +202,7 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 	rotateBody := []byte(`{"grant_type":"refresh_token","refresh_token":"` + enroll.RefreshToken + `"}`)
 	req = httptest.NewRequest(http.MethodPost, "/platform/devices/token", bytes.NewReader(rotateBody))
 	req.Header.Set("Content-Type", "application/json")
+	setDPoPHeader(t, req, deviceKey, "token-1", "")
 	resp = httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusOK {
@@ -207,6 +213,7 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 	resp = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/platform/devices/token", bytes.NewReader(rotateBody))
 	req.Header.Set("Content-Type", "application/json")
+	setDPoPHeader(t, req, deviceKey, "token-2", "")
 	handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusUnauthorized {
 		t.Fatalf("replay status = %d, want 401", resp.Code)
@@ -220,6 +227,7 @@ func TestDeviceAuthRevokeAuthorizesTargetDeviceTenant(t *testing.T) {
 	app := newAppForDeviceTest(t)
 	handler := app.Handler()
 	ctx := context.Background()
+	deviceKey := newTestDeviceDPoPKey(t)
 
 	bootstrap, err := app.deviceService.IssueBootstrapToken(ctx, deviceauth.IssueBootstrapTokenRequest{
 		HardwareUUID: "hw-security",
@@ -231,6 +239,7 @@ func TestDeviceAuthRevokeAuthorizesTargetDeviceTenant(t *testing.T) {
 	enroll, err := app.deviceService.Enroll(ctx, deviceauth.EnrollRequest{
 		BootstrapToken: bootstrap.Token,
 		HardwareUUID:   "hw-security",
+		DeviceJWK:      json.RawMessage(deviceKey.jwkJSON),
 	})
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
@@ -489,6 +498,7 @@ func TestAuthMiddlewarePreservesDPoPErrorCodes(t *testing.T) {
 func TestTelemetryIngestRejectsMalformedBodies(t *testing.T) {
 	app := newAppForDeviceTest(t)
 	handler := app.Handler()
+	deviceKey := newTestDeviceDPoPKey(t)
 	bootstrap, err := app.deviceService.IssueBootstrapToken(context.Background(), deviceauth.IssueBootstrapTokenRequest{
 		HardwareUUID: "hw-json",
 		TenantID:     "writer",
@@ -499,16 +509,18 @@ func TestTelemetryIngestRejectsMalformedBodies(t *testing.T) {
 	enroll, err := app.deviceService.Enroll(context.Background(), deviceauth.EnrollRequest{
 		BootstrapToken: bootstrap.Token,
 		HardwareUUID:   "hw-json",
+		DeviceJWK:      json.RawMessage(deviceKey.jwkJSON),
 	})
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
 
-	for _, body := range []string{"", "not-json", "[]", "null"} {
+	for i, body := range []string{"", "not-json", "[]", "null"} {
 		req := httptest.NewRequest(http.MethodPost, "/platform/telemetry/ingest", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer "+enroll.AccessToken)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Idempotency-Key", "telemetry-json-"+body)
+		setDPoPHeader(t, req, deviceKey, fmt.Sprintf("telemetry-json-%d", i), enroll.AccessToken)
 		resp := httptest.NewRecorder()
 		handler.ServeHTTP(resp, req)
 		if resp.Code != http.StatusBadRequest {
@@ -547,6 +559,7 @@ func TestRemoteIPForRateLimitIgnoresSpoofedLeftmostForwardedFor(t *testing.T) {
 func TestDeviceAuthTokenLimiterUsesStableDeviceKey(t *testing.T) {
 	app := newAppForDeviceTest(t)
 	handler := app.Handler()
+	deviceKey := newTestDeviceDPoPKey(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/platform/devices/bootstrap-tokens", bytes.NewBufferString(`{"hardware_uuid":"hw-1","tenant_id":"writer","ttl_seconds":3600}`))
 	req.Header.Set("Authorization", "Bearer operator-key")
@@ -563,7 +576,7 @@ func TestDeviceAuthTokenLimiterUsesStableDeviceKey(t *testing.T) {
 		t.Fatalf("decode bootstrap response: %v", err)
 	}
 
-	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewBufferString(`{"bootstrap_token":"`+bootstrap.Token+`","hardware_uuid":"hw-1"}`))
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewBufferString(`{"bootstrap_token":"`+bootstrap.Token+`","hardware_uuid":"hw-1","device_key":`+deviceKey.jwkJSON+`}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp = httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
@@ -585,6 +598,7 @@ func TestDeviceAuthTokenLimiterUsesStableDeviceKey(t *testing.T) {
 	rotateBody := []byte(`{"grant_type":"refresh_token","refresh_token":"` + enroll.RefreshToken + `"}`)
 	req = httptest.NewRequest(http.MethodPost, "/platform/devices/token", bytes.NewReader(rotateBody))
 	req.Header.Set("Content-Type", "application/json")
+	setDPoPHeader(t, req, deviceKey, "limit-token-1", "")
 	resp = httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusOK {
@@ -599,6 +613,7 @@ func TestDeviceAuthTokenLimiterUsesStableDeviceKey(t *testing.T) {
 	rotateBody = []byte(`{"grant_type":"refresh_token","refresh_token":"` + rotated.RefreshToken + `"}`)
 	req = httptest.NewRequest(http.MethodPost, "/platform/devices/token", bytes.NewReader(rotateBody))
 	req.Header.Set("Content-Type", "application/json")
+	setDPoPHeader(t, req, deviceKey, "limit-token-2", "")
 	resp = httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusTooManyRequests {
@@ -683,6 +698,7 @@ func containsString(values []string, target string) bool {
 func TestDeviceAuthEnrollAndTokenSetNoStoreHeaders(t *testing.T) {
 	app := newAppForDeviceTest(t)
 	handler := app.Handler()
+	deviceKey := newTestDeviceDPoPKey(t)
 
 	bootstrapBody := bytes.NewBufferString(`{"hardware_uuid":"hw-no-store","tenant_id":"writer","ttl_seconds":3600}`)
 	req := httptest.NewRequest(http.MethodPost, "/platform/devices/bootstrap-tokens", bootstrapBody)
@@ -701,7 +717,7 @@ func TestDeviceAuthEnrollAndTokenSetNoStoreHeaders(t *testing.T) {
 		t.Fatalf("decode bootstrap response: %v", err)
 	}
 
-	enrollBody := []byte(`{"bootstrap_token":"` + bootstrap.Token + `","hardware_uuid":"hw-no-store","os_type":"darwin"}`)
+	enrollBody := []byte(`{"bootstrap_token":"` + bootstrap.Token + `","hardware_uuid":"hw-no-store","os_type":"darwin","device_key":` + deviceKey.jwkJSON + `}`)
 	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewReader(enrollBody))
 	req.Header.Set("Content-Type", "application/json")
 	resp = httptest.NewRecorder()
@@ -720,6 +736,7 @@ func TestDeviceAuthEnrollAndTokenSetNoStoreHeaders(t *testing.T) {
 	rotateBody := []byte(`{"grant_type":"refresh_token","refresh_token":"` + enroll.RefreshToken + `"}`)
 	req = httptest.NewRequest(http.MethodPost, "/platform/devices/token", bytes.NewReader(rotateBody))
 	req.Header.Set("Content-Type", "application/json")
+	setDPoPHeader(t, req, deviceKey, "no-store-token", "")
 	resp = httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusOK {
@@ -740,8 +757,8 @@ func assertNoStoreHeaders(t *testing.T, where string, h http.Header) {
 
 // TestDeviceAuthEnrollAcceptsAgentDeviceKey verifies that an agent that
 // supplies a device_key in the enrollment body gets a sender-constrained
-// access token whose cnf.jkt matches the supplied key. Without device_key
-// the access token has no DPoP binding (software-bearer mode).
+// access token whose cnf.jkt matches the supplied key, while malformed
+// device_key input is rejected without consuming the bootstrap token.
 func TestDeviceAuthEnrollAcceptsAgentDeviceKey(t *testing.T) {
 	app := newAppForDeviceTest(t)
 	handler := app.Handler()
@@ -832,6 +849,80 @@ func TestDeviceAuthEnrollAcceptsAgentDeviceKey(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("retry enroll status = %d, want 200 (bootstrap should not have been consumed); body=%s", resp.Code, resp.Body.String())
 	}
+}
+
+type testDeviceDPoPKey struct {
+	jwkJSON string
+	jwk     map[string]string
+	private ed25519.PrivateKey
+}
+
+func newTestDeviceDPoPKey(t *testing.T) testDeviceDPoPKey {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	jwk := map[string]string{
+		"crv": "Ed25519",
+		"kty": "OKP",
+		"x":   base64Raw(pub),
+	}
+	raw, err := json.Marshal(jwk)
+	if err != nil {
+		t.Fatalf("marshal jwk: %v", err)
+	}
+	return testDeviceDPoPKey{jwkJSON: string(raw), jwk: jwk, private: priv}
+}
+
+func setDPoPHeader(t *testing.T, req *http.Request, key testDeviceDPoPKey, jti string, accessToken string) {
+	t.Helper()
+	req.Header.Set("DPoP", makeTestDPoPProof(t, key, req.Method, testRequestHTU(req), jti, accessToken))
+}
+
+func testRequestHTU(req *http.Request) string {
+	if req.URL.IsAbs() {
+		return req.URL.String()
+	}
+	scheme := "http"
+	if req.TLS != nil {
+		scheme = "https"
+	}
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+	return scheme + "://" + host + req.URL.RequestURI()
+}
+
+func makeTestDPoPProof(t *testing.T, key testDeviceDPoPKey, method string, htu string, jti string, accessToken string) string {
+	t.Helper()
+	header := map[string]any{
+		"typ": "dpop+jwt",
+		"alg": "EdDSA",
+		"jwk": key.jwk,
+	}
+	payload := map[string]any{
+		"htm": method,
+		"htu": htu,
+		"iat": time.Now().UTC().Unix(),
+		"jti": jti,
+	}
+	if accessToken != "" {
+		sum := sha256.Sum256([]byte(accessToken))
+		payload["ath"] = base64.RawURLEncoding.EncodeToString(sum[:])
+	}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal DPoP header: %v", err)
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal DPoP payload: %v", err)
+	}
+	signingInput := base64Raw(headerJSON) + "." + base64Raw(payloadJSON)
+	signature := ed25519.Sign(key.private, []byte(signingInput))
+	return signingInput + "." + base64Raw(signature)
 }
 
 func base64Raw(b []byte) string {

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -393,8 +393,7 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	// Pin dpop_jkt in priority order: attestation-bound key (hardware
 	// proven), then an existing hardware-bound key, then agent-supplied
 	// key (software assurance), then prior non-hardware enrollment key.
-	// Empty result means the device is in pure-Bearer mode -- audit logs
-	// will mark it as such.
+	// Enrollment must produce a binding before any refresh token is minted.
 	switch {
 	case attestationJKT != "":
 		metadata["dpop_jkt"] = attestationJKT
@@ -408,6 +407,9 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 		metadata["dpop_jkt"] = agentJKT
 	case priorJKT != "":
 		metadata["dpop_jkt"] = priorJKT
+	}
+	if strings.TrimSpace(metadata["dpop_jkt"]) == "" {
+		return EnrollResponse{}, fmt.Errorf("%w: device_key or attestation is required to bind refresh tokens", ErrInvalidRequest)
 	}
 	if attResult.KeyID != "" {
 		metadata["attestation_keyid"] = attResult.KeyID
@@ -578,7 +580,7 @@ func (s *Service) RefreshTokenRateLimitKey(ctx context.Context, refreshToken str
 func (s *Service) verifyDPoPForRefresh(device DeviceRecord, request TokenRequest) error {
 	jkt := strings.TrimSpace(device.Metadata["dpop_jkt"])
 	if jkt == "" {
-		return nil
+		return fmt.Errorf("%w: device has no DPoP binding", ErrDPoPMissing)
 	}
 	if s.cfg.DPoP == nil {
 		return ErrDPoPVerifierUnavailable
@@ -854,9 +856,8 @@ func (s *Service) mintAccess(device DeviceRecord, scopes []string) (string, time
 // and returns its RFC 7638 SHA-256 thumbprint. The function reuses the
 // package-internal parseJWK helper, so the same kty / curve allowlist that
 // applies to DPoP proofs (EC P-256, EC P-384, OKP Ed25519; **no RSA**)
-// applies here too. An empty input returns ("", nil) so callers can treat
-// "no key supplied" as a non-error condition (software assurance, no DPoP
-// binding requested).
+// applies here too. An empty input returns ("", nil); Enroll rejects that
+// unless attestation or an existing device record supplies a DPoP binding.
 func parseEnrollDeviceJWK(raw json.RawMessage) (string, error) {
 	if len(raw) == 0 {
 		return "", nil
@@ -926,8 +927,8 @@ func subtleByteEqual(a, b []byte) bool {
 // computeJKTFromPublicKeyDER returns the RFC 7638 JWK SHA-256 thumbprint of
 // the supplied SubjectPublicKeyInfo. Only EC (P-256, P-384) and Ed25519
 // keys are supported; other types fall through with an empty result so the
-// caller can decide whether attestation succeeded without binding a DPoP
-// key (e.g. a software-only attestation result).
+// caller can bind an agent-supplied key or reject enrollment before issuing
+// refresh tokens.
 func computeJKTFromPublicKeyDER(pubDER []byte) (string, error) {
 	if len(pubDER) == 0 {
 		return "", nil

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -50,6 +50,13 @@ func newServiceForTest(t *testing.T) (*Service, *MemStore, time.Time) {
 func TestServiceEnrollAndIssueToken(t *testing.T) {
 	ctx := context.Background()
 	service, _, now := newServiceForTest(t)
+	service.cfg.DPoP = NewDPoPVerifier(time.Minute, time.Minute)
+	service.cfg.DPoP.SetClock(service.cfg.Now)
+	signer := newDPoPSignerEd25519(t)
+	deviceJWK, err := json.Marshal(signer.jwk())
+	if err != nil {
+		t.Fatalf("marshal device JWK: %v", err)
+	}
 
 	bootstrapResp, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
 		HardwareUUID: "hw-1",
@@ -70,6 +77,7 @@ func TestServiceEnrollAndIssueToken(t *testing.T) {
 		Hostname:       "laptop-1",
 		OSType:         "darwin",
 		AgentVersion:   "1.0.0",
+		DeviceJWK:      deviceJWK,
 	})
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
@@ -92,6 +100,9 @@ func TestServiceEnrollAndIssueToken(t *testing.T) {
 	rotated, err := service.IssueToken(ctx, TokenRequest{
 		GrantType:    "refresh_token",
 		RefreshToken: enroll.RefreshToken,
+		DPoPProof:    makeDPoPProof(t, signer, "POST", "https://cerebro.test/platform/devices/token", now, "jti-refresh-1"),
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
 	})
 	if err != nil {
 		t.Fatalf("IssueToken: %v", err)
@@ -103,16 +114,113 @@ func TestServiceEnrollAndIssueToken(t *testing.T) {
 	if _, err := service.IssueToken(ctx, TokenRequest{
 		GrantType:    "refresh_token",
 		RefreshToken: enroll.RefreshToken,
+		DPoPProof:    makeDPoPProof(t, signer, "POST", "https://cerebro.test/platform/devices/token", now, "jti-refresh-2"),
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
 	}); !errors.Is(err, ErrRefreshReplay) {
 		t.Fatalf("replay err = %v, want ErrRefreshReplay", err)
 	}
 	if _, err := service.IssueToken(ctx, TokenRequest{
 		GrantType:    "refresh_token",
 		RefreshToken: rotated.RefreshToken,
+		DPoPProof:    makeDPoPProof(t, signer, "POST", "https://cerebro.test/platform/devices/token", now, "jti-refresh-3"),
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
 	}); !errors.Is(err, ErrRefreshReplay) {
 		t.Fatalf("post-replay rotated err = %v, want ErrRefreshReplay", err)
 	}
 	_ = now
+}
+
+func TestServiceEnrollRejectsUnboundRefreshTokenMinting(t *testing.T) {
+	ctx := context.Background()
+	service, store, _ := newServiceForTest(t)
+
+	bootstrap, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-unbound",
+		TenantID:     "writer",
+		TTL:          time.Hour,
+		IssuedBy:     "operator",
+	})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken: %v", err)
+	}
+
+	if _, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-unbound",
+		OSType:         "darwin",
+	}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Enroll without DPoP binding err = %v, want ErrInvalidRequest", err)
+	}
+	if _, err := store.LookupDeviceByHardware(ctx, "writer", "hw-unbound"); !errors.Is(err, ErrDeviceNotFound) {
+		t.Fatalf("LookupDeviceByHardware after rejected unbound enroll err = %v, want ErrDeviceNotFound", err)
+	}
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	boundBootstrap, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-unbound",
+		TenantID:     "writer",
+		TTL:          time.Hour,
+		IssuedBy:     "operator",
+	})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken(bound): %v", err)
+	}
+	deviceJWK, _ := makeEd25519JWK(t, pub)
+	enroll, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: boundBootstrap.Token,
+		HardwareUUID:   "hw-unbound",
+		OSType:         "darwin",
+		DeviceJWK:      deviceJWK,
+	})
+	if err != nil {
+		t.Fatalf("Enroll after rejected unbound attempt: %v", err)
+	}
+	if enroll.AccessToken == "" || enroll.RefreshToken == "" {
+		t.Fatal("bound enrollment returned empty tokens")
+	}
+}
+
+func TestServiceIssueTokenRejectsLegacyUnboundDeviceRefresh(t *testing.T) {
+	ctx := context.Background()
+	service, store, now := newServiceForTest(t)
+	device := DeviceRecord{
+		DeviceID:     "dev-legacy",
+		HardwareUUID: "hw-legacy",
+		TenantID:     "writer",
+		Status:       "active",
+		EnrolledAt:   now,
+		LastSeenAt:   now,
+		Metadata: map[string]string{
+			"assurance_level": "software",
+		},
+	}
+	if _, err := store.EnrollDevice(ctx, device); err != nil {
+		t.Fatalf("EnrollDevice legacy row: %v", err)
+	}
+	refresh, _, err := service.mintRefresh(ctx, device.DeviceID, DefaultDeviceScopes, "", 0, now)
+	if err != nil {
+		t.Fatalf("mintRefresh legacy row: %v", err)
+	}
+	if _, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: refresh,
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
+	}); !errors.Is(err, ErrDPoPMissing) {
+		t.Fatalf("IssueToken legacy unbound err = %v, want ErrDPoPMissing", err)
+	}
+	row, err := store.LookupRefreshToken(ctx, HashToken(refresh), now)
+	if err != nil {
+		t.Fatalf("LookupRefreshToken after rejected legacy refresh: %v", err)
+	}
+	if !row.ConsumedAt.IsZero() {
+		t.Fatal("legacy unbound refresh was consumed before DPoP rejection")
+	}
 }
 
 func TestServiceEnrollRequiresMatchingHardware(t *testing.T) {
@@ -171,7 +279,15 @@ func (v *checkingAttestationVerifier) Verify(_ context.Context, in attestation.I
 func TestServiceEnrollAttestationClientHashBindsHardwareUUID(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)
-	verifier := &checkingAttestationVerifier{wantHardwareUUID: "hw-1"}
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	verifier := &checkingAttestationVerifier{wantHardwareUUID: "hw-1", publicKey: pubDER}
 	service.cfg.Attestations = attestation.NewRegistry(true, verifier)
 
 	bootstrap, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
@@ -256,8 +372,9 @@ func TestServiceIssueTokenRejectsBoundDeviceWhenDPoPVerifierUnavailable(t *testi
 func TestServiceRevokeBlocksRefresh(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)
+	deviceJWK := newEnrollDeviceJWK(t)
 	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
-	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1", DeviceJWK: deviceJWK})
 	if err := service.Revoke(ctx, enroll.DeviceID, "test"); err != nil {
 		t.Fatalf("Revoke: %v", err)
 	}
@@ -269,16 +386,17 @@ func TestServiceRevokeBlocksRefresh(t *testing.T) {
 func TestServiceEnrollRejectsRevokedHardware(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)
+	deviceJWK := newEnrollDeviceJWK(t)
 	firstBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
 	secondBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
-	enroll, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: firstBootstrap.Token, HardwareUUID: "hw-1"})
+	enroll, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: firstBootstrap.Token, HardwareUUID: "hw-1", DeviceJWK: deviceJWK})
 	if err != nil {
 		t.Fatalf("Enroll(first): %v", err)
 	}
 	if err := service.Revoke(ctx, enroll.DeviceID, "lost"); err != nil {
 		t.Fatalf("Revoke: %v", err)
 	}
-	if _, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: secondBootstrap.Token, HardwareUUID: "hw-1"}); !errors.Is(err, ErrDeviceInactive) {
+	if _, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: secondBootstrap.Token, HardwareUUID: "hw-1", DeviceJWK: deviceJWK}); !errors.Is(err, ErrDeviceInactive) {
 		t.Fatalf("Enroll(second) err = %v, want ErrDeviceInactive", err)
 	}
 }
@@ -286,20 +404,34 @@ func TestServiceEnrollRejectsRevokedHardware(t *testing.T) {
 func TestServiceReenrollActiveHardwarePreservesRefreshLineage(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)
+	service.cfg.DPoP = NewDPoPVerifier(time.Minute, time.Minute)
+	service.cfg.DPoP.SetClock(service.cfg.Now)
+	signer := newDPoPSignerEd25519(t)
+	deviceJWK, err := json.Marshal(signer.jwk())
+	if err != nil {
+		t.Fatalf("marshal device JWK: %v", err)
+	}
+	now := service.cfg.Now()
 	firstBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
 	secondBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
-	first, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: firstBootstrap.Token, HardwareUUID: "hw-1"})
+	first, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: firstBootstrap.Token, HardwareUUID: "hw-1", DeviceJWK: deviceJWK})
 	if err != nil {
 		t.Fatalf("Enroll(first): %v", err)
 	}
-	second, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: secondBootstrap.Token, HardwareUUID: "hw-1"})
+	second, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: secondBootstrap.Token, HardwareUUID: "hw-1", DeviceJWK: deviceJWK})
 	if err != nil {
 		t.Fatalf("Enroll(second): %v", err)
 	}
 	if second.DeviceID != first.DeviceID {
 		t.Fatalf("second device_id = %q, want existing %q", second.DeviceID, first.DeviceID)
 	}
-	if _, err := service.IssueToken(ctx, TokenRequest{GrantType: "refresh_token", RefreshToken: first.RefreshToken}); err != nil {
+	if _, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: first.RefreshToken,
+		DPoPProof:    makeDPoPProof(t, signer, "POST", "https://cerebro.test/platform/devices/token", now, "jti-lineage"),
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
+	}); err != nil {
 		t.Fatalf("IssueToken with first refresh after re-enroll: %v", err)
 	}
 }
@@ -342,7 +474,12 @@ func TestServiceReenrollActiveHardwarePreservesDPoPBinding(t *testing.T) {
 
 	service.cfg.Attestations = attestation.NewRegistry(false)
 	secondBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
-	second, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: secondBootstrap.Token, HardwareUUID: "hw-1"})
+	matchingJWK, _ := makeEd25519JWK(t, pub)
+	second, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: secondBootstrap.Token,
+		HardwareUUID:   "hw-1",
+		DeviceJWK:      json.RawMessage(matchingJWK),
+	})
 	if err != nil {
 		t.Fatalf("second Enroll: %v", err)
 	}
@@ -452,9 +589,11 @@ func TestServiceReenrollPreservesHardwareAssuranceToBlockTwoStepDowngrade(t *tes
 
 	service.cfg.Attestations = attestation.NewRegistry(false)
 	secondBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-two-step", TenantID: "writer"})
+	matchingJWK, _ := makeEd25519JWK(t, pub)
 	second, err := service.Enroll(ctx, EnrollRequest{
 		BootstrapToken: secondBootstrap.Token,
 		HardwareUUID:   "hw-two-step",
+		DeviceJWK:      json.RawMessage(matchingJWK),
 	})
 	if err != nil {
 		t.Fatalf("second Enroll: %v", err)
@@ -497,12 +636,26 @@ func TestServiceReenrollPreservesHardwareAssuranceToBlockTwoStepDowngrade(t *tes
 func TestRefreshTokenRateLimitKeyRejectsConsumedTokens(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)
+	service.cfg.DPoP = NewDPoPVerifier(time.Minute, time.Minute)
+	service.cfg.DPoP.SetClock(service.cfg.Now)
+	signer := newDPoPSignerEd25519(t)
+	deviceJWK, err := json.Marshal(signer.jwk())
+	if err != nil {
+		t.Fatalf("marshal device JWK: %v", err)
+	}
+	now := service.cfg.Now()
 	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
-	enroll, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+	enroll, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1", DeviceJWK: deviceJWK})
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
-	rotated, err := service.IssueToken(ctx, TokenRequest{GrantType: "refresh_token", RefreshToken: enroll.RefreshToken})
+	rotated, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: enroll.RefreshToken,
+		DPoPProof:    makeDPoPProof(t, signer, "POST", "https://cerebro.test/platform/devices/token", now, "jti-rate-limit"),
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
+	})
 	if err != nil {
 		t.Fatalf("IssueToken: %v", err)
 	}
@@ -517,8 +670,9 @@ func TestRefreshTokenRateLimitKeyRejectsConsumedTokens(t *testing.T) {
 func TestServiceIngestTelemetryRequiresIdempotencyKey(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)
+	deviceJWK := newEnrollDeviceJWK(t)
 	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
-	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1", DeviceJWK: deviceJWK})
 	if _, err := service.IngestTelemetry(ctx, IngestPayload{DeviceID: enroll.DeviceID, Body: []byte(`{"events":[]}`)}); !errors.Is(err, ErrInvalidRequest) {
 		t.Fatalf("IngestTelemetry without key err = %v, want ErrInvalidRequest", err)
 	}
@@ -527,8 +681,9 @@ func TestServiceIngestTelemetryRequiresIdempotencyKey(t *testing.T) {
 func TestServiceIngestTelemetryIdempotent(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)
+	deviceJWK := newEnrollDeviceJWK(t)
 	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
-	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1", DeviceJWK: deviceJWK})
 
 	body := []byte(`{"events":[{"type":"login"}]}`)
 	first, err := service.IngestTelemetry(ctx, IngestPayload{DeviceID: enroll.DeviceID, IdempotencyKey: "abc-123", Body: body})
@@ -558,8 +713,9 @@ func TestServiceIngestTelemetryIdempotent(t *testing.T) {
 func TestServiceIngestTelemetryIdempotencyPreservesBodyWhitespace(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)
+	deviceJWK := newEnrollDeviceJWK(t)
 	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
-	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1", DeviceJWK: deviceJWK})
 
 	if _, err := service.IngestTelemetry(ctx, IngestPayload{DeviceID: enroll.DeviceID, IdempotencyKey: "raw-body", Body: []byte(`{}`)}); err != nil {
 		t.Fatalf("first IngestTelemetry: %v", err)
@@ -647,7 +803,7 @@ func TestEnrollFiltersLegacyBootstrapAdminScopes(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("CreateBootstrapToken: %v", err)
 	}
-	enroll, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: plaintext, HardwareUUID: "hw-1"})
+	enroll, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: plaintext, HardwareUUID: "hw-1", DeviceJWK: newEnrollDeviceJWK(t)})
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -709,6 +865,16 @@ func makeEd25519JWK(t *testing.T, pub ed25519.PublicKey) ([]byte, string) {
 	jwk := []byte(`{"crv":"Ed25519","kty":"OKP","x":"` + x + `"}`)
 	sum := sha256.Sum256(jwk)
 	return jwk, base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func newEnrollDeviceJWK(t *testing.T) json.RawMessage {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	jwk, _ := makeEd25519JWK(t, pub)
+	return json.RawMessage(jwk)
 }
 
 func TestServiceEnrollAcceptsAgentSuppliedJWKAndPinsCnfJKT(t *testing.T) {


### PR DESCRIPTION
## Summary
- require successful device enrollment to have a DPoP binding from attestation, an existing device record, or an agent-supplied device_key before refresh tokens are minted
- reject refresh rotation for legacy unbound devices before consuming the refresh token
- update OpenAPI plus HTTP/service tests for DPoP-bound refresh and telemetry flows

## Security
Fixes CAND-DEEP-004.

## Validation
- go test ./internal/deviceauth -count=1
- go test ./internal/bootstrap -run 'TestDeviceAuth|TestAuthMiddleware.*DPoP|TestWriteDeviceAuth|TestBuildAttestation' -count=1\n- go test ./internal/bootstrap ./internal/deviceauth -count=1\n- golangci-lint run --timeout 10m ./internal/deviceauth ./internal/bootstrap\n- make cover\n- make check-structural check-structural-test check-arch\n- make docs-drift-check catalog-check\n- make openapi-check openapi-lint\n- go test ./...\n- scripts/leak_check.sh staged\n