### PR TITLE
Validate tenant scope for projected Cerebro URNs

### DIFF
--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -406,6 +406,9 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 	if entityType == "" {
 		return errors.New("projected entity type is required")
 	}
+	if err := ports.ValidateProjectedEntityTenantScope(entity); err != nil {
+		return err
+	}
 	if err := s.requireConfigured(); err != nil {
 		return err
 	}
@@ -1497,6 +1500,9 @@ func validateProjectedLink(link *ports.ProjectedLink) (fromURN string, toURN str
 	sourceID = strings.TrimSpace(link.SourceID)
 	if sourceID == "" {
 		return "", "", "", "", "", errors.New("projected link source id is required")
+	}
+	if err := ports.ValidateProjectedLinkTenantScope(link); err != nil {
+		return "", "", "", "", "", err
 	}
 	return fromURN, toURN, relation, tenantID, sourceID, nil
 }

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -36,6 +36,39 @@ func TestProjectedEntityMergePreservesExistingLabelsForFallbackLabels(t *testing
 	}
 }
 
+func TestUpsertProjectedEntityRejectsCrossTenantCerebroURNBeforeConnection(t *testing.T) {
+	store := &Store{}
+	err := store.UpsertProjectedEntity(context.Background(), &ports.ProjectedEntity{
+		URN:        "urn:cerebro:victim:github_user:alice",
+		TenantID:   "writer",
+		SourceID:   "github",
+		EntityType: "github.user",
+	})
+	if err == nil {
+		t.Fatal("UpsertProjectedEntity() error = nil, want cross-tenant Cerebro URN error")
+	}
+	if got := err.Error(); !strings.Contains(got, "urn:cerebro:victim:github_user:alice") || !strings.Contains(got, "not projection tenant") {
+		t.Fatalf("UpsertProjectedEntity() error = %q", got)
+	}
+}
+
+func TestUpsertProjectedLinkRejectsCrossTenantCerebroURNBeforeConnection(t *testing.T) {
+	store := &Store{}
+	err := store.UpsertProjectedLink(context.Background(), &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "github",
+		FromURN:  "urn:cerebro:writer:github_user:alice",
+		ToURN:    "urn:cerebro:victim:github_code_repository:writer/cerebro",
+		Relation: "owns",
+	})
+	if err == nil {
+		t.Fatal("UpsertProjectedLink() error = nil, want cross-tenant Cerebro URN error")
+	}
+	if got := err.Error(); !strings.Contains(got, "urn:cerebro:victim:github_code_repository:writer/cerebro") || !strings.Contains(got, "not projection tenant") {
+		t.Fatalf("UpsertProjectedLink() error = %q", got)
+	}
+}
+
 func TestEndpointOwnerIDLinkCleanupQueryOrdersLimitedBatch(t *testing.T) {
 	_, conditions, err := endpointOwnerIDLinkCleanupParams(ports.ProjectionLinkCleanupRequest{
 		TenantID: "writer",

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -2,9 +2,13 @@ package ports
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
+
+const cerebroURNPrefix = "urn:cerebro:"
 
 // ProjectedEntity is the normalized current-state and graph entity shape.
 type ProjectedEntity struct {
@@ -26,6 +30,61 @@ type ProjectedLink struct {
 	ToURN      string
 	Relation   string
 	Attributes map[string]string
+}
+
+// ValidateProjectedTenantScopes rejects Cerebro-owned projection URNs that do
+// not belong to the projection tenant. Provider-native identifiers remain valid.
+func ValidateProjectedTenantScopes(entities []*ProjectedEntity, links []*ProjectedLink) error {
+	for _, entity := range entities {
+		if err := ValidateProjectedEntityTenantScope(entity); err != nil {
+			return err
+		}
+	}
+	for _, link := range links {
+		if err := ValidateProjectedLinkTenantScope(link); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateProjectedEntityTenantScope enforces that a Cerebro-owned entity URN
+// cannot be projected under a different tenant_id.
+func ValidateProjectedEntityTenantScope(entity *ProjectedEntity) error {
+	if entity == nil {
+		return nil
+	}
+	return validateProjectedCerebroURNScope("projected entity urn", entity.URN, entity.TenantID)
+}
+
+// ValidateProjectedLinkTenantScope enforces that Cerebro-owned link endpoints
+// cannot be projected under a different tenant_id.
+func ValidateProjectedLinkTenantScope(link *ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	if err := validateProjectedCerebroURNScope("projected link from urn", link.FromURN, link.TenantID); err != nil {
+		return err
+	}
+	return validateProjectedCerebroURNScope("projected link to urn", link.ToURN, link.TenantID)
+}
+
+func validateProjectedCerebroURNScope(field string, rawURN string, rawTenantID string) error {
+	urn := strings.TrimSpace(rawURN)
+	tenantID := strings.TrimSpace(rawTenantID)
+	if urn == "" || tenantID == "" || !strings.HasPrefix(urn, cerebroURNPrefix) {
+		return nil
+	}
+	remainder := strings.TrimPrefix(urn, cerebroURNPrefix)
+	urnTenantID, _, ok := strings.Cut(remainder, ":")
+	urnTenantID = strings.TrimSpace(urnTenantID)
+	if !ok || urnTenantID == "" {
+		return fmt.Errorf("%s %q is missing a Cerebro tenant scope", field, urn)
+	}
+	if urnTenantID != tenantID {
+		return fmt.Errorf("%s %q is scoped to tenant %q, not projection tenant %q", field, urn, urnTenantID, tenantID)
+	}
+	return nil
 }
 
 // ProjectionResult reports how many workflow events, entities, and links were materialized or pruned.

--- a/internal/ports/projection_test.go
+++ b/internal/ports/projection_test.go
@@ -1,0 +1,58 @@
+package ports
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateProjectedTenantScopesRejectsCrossTenantCerebroURNs(t *testing.T) {
+	err := ValidateProjectedTenantScopes(
+		[]*ProjectedEntity{
+			{URN: "urn:cerebro:writer:asset:ok", TenantID: "writer"},
+			{URN: "arn:aws:s3:::shared-bucket", TenantID: "writer"},
+			{URN: "urn:cerebro:victim:asset:stolen", TenantID: "writer"},
+		},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("ValidateProjectedTenantScopes() error = nil, want cross-tenant Cerebro URN error")
+	}
+	if got := err.Error(); !strings.Contains(got, "urn:cerebro:victim:asset:stolen") || !strings.Contains(got, "not projection tenant") {
+		t.Fatalf("ValidateProjectedTenantScopes() error = %q", got)
+	}
+}
+
+func TestValidateProjectedTenantScopesAllowsSameTenantAndExternalURNs(t *testing.T) {
+	err := ValidateProjectedTenantScopes(
+		[]*ProjectedEntity{
+			{URN: "urn:cerebro:writer:asset:ok", TenantID: "writer"},
+			{URN: "arn:aws:s3:::shared-bucket", TenantID: "writer"},
+		},
+		[]*ProjectedLink{
+			{
+				TenantID: "writer",
+				FromURN:  "urn:cerebro:writer:asset:ok",
+				ToURN:    "https://example.test/resource",
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ValidateProjectedTenantScopes() error = %v", err)
+	}
+}
+
+func TestValidateProjectedTenantScopesRejectsCrossTenantLinkEndpoint(t *testing.T) {
+	err := ValidateProjectedTenantScopes(nil, []*ProjectedLink{
+		{
+			TenantID: "writer",
+			FromURN:  "urn:cerebro:writer:asset:ok",
+			ToURN:    "urn:cerebro:victim:asset:target",
+		},
+	})
+	if err == nil {
+		t.Fatal("ValidateProjectedTenantScopes() error = nil, want cross-tenant link endpoint error")
+	}
+	if got := err.Error(); !strings.Contains(got, "projected link to urn") || !strings.Contains(got, "not projection tenant") {
+		t.Fatalf("ValidateProjectedTenantScopes() error = %q", got)
+	}
+}

--- a/internal/sourceprojection/cloud_resource_test.go
+++ b/internal/sourceprojection/cloud_resource_test.go
@@ -2,6 +2,7 @@ package sourceprojection
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -53,6 +54,34 @@ func TestProjectGCPCloudResourceMetadataLinksAccountExposureOwnerClassificationA
 	assertProjectedLink(t, state, resourceURN, relationRunsAs, serviceAccountURN)
 	if link := state.links[resourceURN+"|"+relationRunsAs+"|"+serviceAccountURN]; link == nil || link.Attributes["match_type"] != "gcp_runtime_service_account" {
 		t.Fatalf("runs_as link = %#v, want gcp runtime service account match", link)
+	}
+}
+
+func TestProjectCloudResourceRejectsCrossTenantCerebroResourceURN(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "aws-cross-tenant-resource",
+		TenantId: "writer",
+		SourceId: "aws",
+		Kind:     "aws.s3_bucket",
+		Attributes: map[string]string{
+			"account_id":        "123456789012",
+			"resource_id":       "bucket-1",
+			"resource_name":     "bucket-1",
+			"resource_provider": "aws",
+			"resource_type":     "s3_bucket",
+			"resource_urn":      "urn:cerebro:victim:aws_s3_bucket:bucket-1",
+		},
+	})
+	if err == nil {
+		t.Fatal("Project() error = nil, want cross-tenant Cerebro URN error")
+	}
+	if got := err.Error(); !strings.Contains(got, "urn:cerebro:victim:aws_s3_bucket:bucket-1") || !strings.Contains(got, "not projection tenant") {
+		t.Fatalf("Project() error = %q", got)
+	}
+	if len(state.entities) != 0 || len(state.links) != 0 {
+		t.Fatalf("Project() wrote entities=%d links=%d despite cross-tenant resource_urn", len(state.entities), len(state.links))
 	}
 }
 

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -4900,6 +4900,61 @@ func TestProjectEvidenceCASPreservesRuntimeIdentityAndSourceCorrelation(t *testi
 	}
 }
 
+func TestProjectRuntimeEvidenceRejectsCrossTenantCerebroContextURNs(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		attrs      map[string]string
+		wantInErr  string
+		wantInErr2 string
+	}{
+		{
+			name: "resource_urn",
+			attrs: map[string]string{
+				"evidence_id":          "evidence-cross-resource",
+				"resource_entity_type": "aws.bucket",
+				"resource_id":          "bucket-1",
+				"resource_link_status": "linked",
+				"resource_type":        "bucket",
+				"resource_urn":         "urn:cerebro:victim:aws_bucket:bucket-1",
+			},
+			wantInErr:  "urn:cerebro:victim:aws_bucket:bucket-1",
+			wantInErr2: "not projection tenant",
+		},
+		{
+			name: "case_urn",
+			attrs: map[string]string{
+				"case_id":          "case-1",
+				"case_link_status": "linked",
+				"case_urn":         "urn:cerebro:victim:case:case-1",
+				"evidence_id":      "evidence-cross-case",
+			},
+			wantInErr:  "urn:cerebro:victim:case:case-1",
+			wantInErr2: "not projection tenant",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &projectionRecorder{}
+			service := New(state, nil)
+			_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+				Id:         "runtime-" + tt.name,
+				TenantId:   "writer",
+				SourceId:   "evidence_cas",
+				Kind:       "runtime.evidence",
+				Attributes: tt.attrs,
+			})
+			if err == nil {
+				t.Fatal("Project() error = nil, want cross-tenant Cerebro URN error")
+			}
+			if got := err.Error(); !strings.Contains(got, tt.wantInErr) || !strings.Contains(got, tt.wantInErr2) {
+				t.Fatalf("Project() error = %q", got)
+			}
+			if len(state.entities) != 0 || len(state.links) != 0 {
+				t.Fatalf("Project() wrote entities=%d links=%d despite cross-tenant URN", len(state.entities), len(state.links))
+			}
+		})
+	}
+}
+
 func TestProjectEvidenceCASReplayIsIdempotentAndConflictsAreRejected(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -622,7 +622,14 @@ func (r *Registry) Project(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEn
 	if !ok {
 		return nil, nil, nil
 	}
-	return project(event)
+	entities, links, err := project(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := ports.ValidateProjectedTenantScopes(entities, links); err != nil {
+		return nil, nil, err
+	}
+	return entities, links, nil
 }
 
 // ProjectEvent projects one event through the built-in registry without stores.

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -373,6 +373,9 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 	if entityType == "" {
 		return errors.New("projected entity type is required")
 	}
+	if err := ports.ValidateProjectedEntityTenantScope(entity); err != nil {
+		return err
+	}
 	if s == nil || s.db == nil {
 		return errors.New("postgres is not configured")
 	}
@@ -506,6 +509,9 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	sourceID := strings.TrimSpace(link.SourceID)
 	if sourceID == "" {
 		return errors.New("projected link source id is required")
+	}
+	if err := ports.ValidateProjectedLinkTenantScope(link); err != nil {
+		return err
 	}
 	if s == nil || s.db == nil {
 		return errors.New("postgres is not configured")

--- a/internal/statestore/postgres/projection_test.go
+++ b/internal/statestore/postgres/projection_test.go
@@ -33,6 +33,22 @@ func TestUpsertProjectedEntityRejectsUnconfiguredStore(t *testing.T) {
 	}
 }
 
+func TestUpsertProjectedEntityRejectsCrossTenantCerebroURNBeforeDatabase(t *testing.T) {
+	store := &Store{}
+	err := store.UpsertProjectedEntity(context.Background(), &ports.ProjectedEntity{
+		URN:        "urn:cerebro:victim:github_user:alice",
+		TenantID:   "writer",
+		SourceID:   "github",
+		EntityType: "github.user",
+	})
+	if err == nil {
+		t.Fatal("UpsertProjectedEntity() error = nil, want cross-tenant Cerebro URN error")
+	}
+	if got := err.Error(); !strings.Contains(got, "urn:cerebro:victim:github_user:alice") || !strings.Contains(got, "not projection tenant") {
+		t.Fatalf("UpsertProjectedEntity() error = %q", got)
+	}
+}
+
 func TestUpsertProjectedLinkRejectsMissingRelation(t *testing.T) {
 	store := &Store{}
 	err := store.UpsertProjectedLink(context.Background(), &ports.ProjectedLink{
@@ -43,6 +59,23 @@ func TestUpsertProjectedLinkRejectsMissingRelation(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("UpsertProjectedLink() error = nil, want non-nil")
+	}
+}
+
+func TestUpsertProjectedLinkRejectsCrossTenantCerebroURNBeforeDatabase(t *testing.T) {
+	store := &Store{}
+	err := store.UpsertProjectedLink(context.Background(), &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "github",
+		FromURN:  "urn:cerebro:writer:github_user:alice",
+		ToURN:    "urn:cerebro:victim:github_code_repository:writer/cerebro",
+		Relation: "owns",
+	})
+	if err == nil {
+		t.Fatal("UpsertProjectedLink() error = nil, want cross-tenant Cerebro URN error")
+	}
+	if got := err.Error(); !strings.Contains(got, "urn:cerebro:victim:github_code_repository:writer/cerebro") || !strings.Contains(got, "not projection tenant") {
+		t.Fatalf("UpsertProjectedLink() error = %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject source-projected internal entity/link identifiers when their embedded tenant scope does not match the projection tenant
- enforce the check at the sourceprojection registry boundary and again in Postgres and Neo4j projection upserts
- add regression coverage for tainted runtime and cloud context identifiers, pure validator behavior, and both store barriers

## Security
Fixes CAND-DEEP-005: source-controlled projection context attributes could name another tenant's internal graph identifier while the event carried the attacker tenant, allowing graph entity/link contamination at upsert time.

## Validation
- focused validator, sourceprojection, Postgres, and Neo4j regression tests
- touched-package test suite
- full `go test ./...`
- focused `golangci-lint run`
- `make cover`
- `make check-structural check-structural-test check-arch`
- `scripts/leak_check.sh staged`