### PR TITLE
feat(anthropic): deepen connector with inventory hardening and unmanaged-key finding

### DIFF
--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -170,7 +170,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 1053 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 1054 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -170,7 +170,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 1052 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 1053 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/internal/compliance/control_coverage_index.yaml
+++ b/internal/compliance/control_coverage_index.yaml
@@ -41682,7 +41682,7 @@ profiles:
         selected_controls: 34
         mapped_controls: 14
         unmapped_controls: 20
-        mapped_rules: 107
+        mapped_rules: 108
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 34
@@ -41840,8 +41840,9 @@ profiles:
             status: placeholder
             score: 0
           coverage_status: mapped
-          rule_count: 10
+          rule_count: 11
           mapped_rules:
+            - anthropic-unmanaged-active-api-key
             - github-org-owner-role-review-needed
             - identity-okta-admin-plus-app-owner
             - identity-okta-admin-privilege-grant-events-30d
@@ -42119,6 +42120,10 @@ profiles:
             - kolide-host-failing-compliance-checks
             - sentinelone-risky-exclusion
       rules:
+        - rule_id: anthropic-unmanaged-active-api-key
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.2
         - rule_id: aws-cloudtrail-kms-encryption
           controls:
             - framework_name: ISO 27001:2022
@@ -61095,7 +61100,7 @@ profiles:
         selected_controls: 36
         mapped_controls: 25
         unmapped_controls: 11
-        mapped_rules: 929
+        mapped_rules: 930
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 36
@@ -61643,10 +61648,11 @@ profiles:
             status: placeholder
             score: 0
           coverage_status: mapped
-          rule_count: 433
+          rule_count: 434
           mapped_rules:
             - ai-data-governance
             - ai-model-inventory
+            - anthropic-unmanaged-active-api-key
             - aws-cloudtrail-kms-encryption
             - aws-cloudtrail-log-integrity
             - aws-default-sg-no-rules
@@ -62537,6 +62543,10 @@ profiles:
           controls:
             - framework_name: SOC 2
               control_id: CC3.2
+        - rule_id: anthropic-unmanaged-active-api-key
+          controls:
+            - framework_name: SOC 2
+              control_id: CC6.1
         - rule_id: aws-alb-http-to-https
           controls:
             - framework_name: SOC 2

--- a/internal/compliance/control_coverage_index.yaml
+++ b/internal/compliance/control_coverage_index.yaml
@@ -61100,7 +61100,7 @@ profiles:
         selected_controls: 36
         mapped_controls: 25
         unmapped_controls: 11
-        mapped_rules: 930
+        mapped_rules: 931
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 36

--- a/internal/findings/anthropic_unmanaged_active_api_key_rule.go
+++ b/internal/findings/anthropic_unmanaged_active_api_key_rule.go
@@ -1,0 +1,194 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	anthropicUnmanagedActiveAPIKeyRuleID    = "anthropic-unmanaged-active-api-key" // #nosec G101 -- rule identifier, not a credential.
+	anthropicUnmanagedActiveAPIKeyTitle     = "Anthropic Unmanaged Active API Key" // #nosec G101 -- rule display title, not a credential.
+	anthropicUnmanagedActiveAPIKeySeverity  = "HIGH"
+	anthropicUnmanagedActiveAPIKeyCheckID   = "anthropic-unmanaged-active-api-key-current"         // #nosec G101 -- check identifier, not a credential.
+	anthropicUnmanagedActiveAPIKeyCheckName = "Anthropic Unmanaged Active API Key (current state)" // #nosec G101 -- check display name, not a credential.
+)
+
+var anthropicUnmanagedActiveAPIKeyControlRefs = []ports.FindingControlRef{
+	{FrameworkName: "SOC 2", ControlID: "CC6.1"},
+	{FrameworkName: "ISO 27001:2022", ControlID: "A.8.2"},
+}
+
+var anthropicAPIKeyRevokedStatuses = map[string]struct{}{
+	"deleted":   {},
+	"revoked":   {},
+	"disabled":  {},
+	"inactive":  {},
+	"expired":   {},
+	"suspended": {},
+	"archived":  {},
+}
+
+type anthropicUnmanagedActiveAPIKeyRule struct {
+	Rule
+	definition RuleDefinition
+}
+
+var anthropicUnmanagedActiveAPIKeyDefinition = RuleDefinition{
+	ID:                 anthropicUnmanagedActiveAPIKeyRuleID,
+	Name:               anthropicUnmanagedActiveAPIKeyTitle,
+	Description:        "Detect active Anthropic organization API keys that have no accountable owner (no owning user or service account), leaving a live credential without a responsible identity to govern or revoke it.",
+	SourceID:           "anthropic",
+	EventKinds:         []string{"anthropic.api_key"},
+	OutputKind:         "finding.anthropic_unmanaged_active_api_key",
+	Severity:           anthropicUnmanagedActiveAPIKeySeverity,
+	Status:             findingStatusOpen,
+	Maturity:           "test",
+	Tags:               []string{"anthropic", "credential", "api-key", "ownership", "unmanaged"},
+	References:         []string{"https://docs.anthropic.com/en/api/administration-api"},
+	FalsePositives:     []string{"Keys intentionally owned by a shared break-glass identity that is tracked outside the Anthropic ownership model."},
+	Runbook:            "Identify the unmanaged Anthropic API key, assign an accountable owner, or revoke the key if it is no longer required.",
+	RequiredAttributes: []string{"api_key_id"},
+	FingerprintFields:  []string{"anthropic_credential_urn"},
+	ControlRefs:        anthropicUnmanagedActiveAPIKeyControlRefs,
+	Lifecycle:          Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorSourceState},
+}
+
+var anthropicUnmanagedActiveAPIKeyKindMatcher = eventKindMatcher(anthropicUnmanagedActiveAPIKeyDefinition.EventKinds...)
+
+func newAnthropicUnmanagedActiveAPIKeyRule() Rule {
+	rule := newEventRule(eventRuleConfig{
+		definition: anthropicUnmanagedActiveAPIKeyDefinition,
+		match:      matchesAnthropicUnmanagedActiveAPIKey,
+		build: func(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+			return anthropicUnmanagedActiveAPIKeyFinding(event, runtime.GetId())
+		},
+	})
+	return &anthropicUnmanagedActiveAPIKeyRule{
+		Rule:       rule,
+		definition: anthropicUnmanagedActiveAPIKeyDefinition,
+	}
+}
+
+func (r *anthropicUnmanagedActiveAPIKeyRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
+func (r *anthropicUnmanagedActiveAPIKeyRule) OpenAnchor(attributes map[string]string) string {
+	return anthropicUnmanagedActiveAPIKeyAnchor(attributes)
+}
+
+// CloseOnEvent resolves an open finding when a later snapshot of the same API
+// key shows an accountable owner (remediation) or shows the key revoked or
+// inactive (no longer a live credential), so resolved keys do not leave stale
+// open findings.
+func (r *anthropicUnmanagedActiveAPIKeyRule) CloseOnEvent(event Event) (string, bool) {
+	if !anthropicUnmanagedActiveAPIKeyKindMatcher(event) || !hasRequiredAttributes(event, anthropicUnmanagedActiveAPIKeyDefinition.RequiredAttributes...) {
+		return "", false
+	}
+	attributes := eventAttributes(event)
+	if !anthropicAPIKeyHasOwner(attributes) && !anthropicAPIKeyRevoked(attributes) {
+		return "", false
+	}
+	credentialURN := anthropicCredentialURN(event.GetTenantId(), attributes["api_key_id"])
+	anchor := anthropicUnmanagedActiveAPIKeyAnchor(map[string]string{"anthropic_credential_urn": credentialURN})
+	return anchor, anchor != ""
+}
+
+func matchesAnthropicUnmanagedActiveAPIKey(event *cerebrov1.EventEnvelope) bool {
+	if !anthropicUnmanagedActiveAPIKeyKindMatcher(event) || !hasRequiredAttributes(event, anthropicUnmanagedActiveAPIKeyDefinition.RequiredAttributes...) {
+		return false
+	}
+	attributes := eventAttributes(event)
+	if anthropicAPIKeyRevoked(attributes) {
+		return false
+	}
+	return !anthropicAPIKeyHasOwner(attributes)
+}
+
+func anthropicUnmanagedActiveAPIKeyFinding(event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
+	attrs := event.GetAttributes()
+	apiKeyID := strings.TrimSpace(attrs["api_key_id"])
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	credentialURN := anthropicCredentialURN(tenantID, apiKeyID)
+	if credentialURN == "" {
+		return nil, nil
+	}
+	label := firstNonEmpty(strings.TrimSpace(attrs["name"]), apiKeyID)
+	attributes := map[string]string{
+		"anthropic_credential_urn": credentialURN,
+		"api_key_id":               apiKeyID,
+		"name":                     strings.TrimSpace(attrs["name"]),
+		"status":                   firstNonEmpty(strings.TrimSpace(attrs["status"]), "active"),
+		"workspace_id":             strings.TrimSpace(attrs["workspace_id"]),
+		"created_at":               strings.TrimSpace(attrs["created_at"]),
+		"last_used_at":             strings.TrimSpace(attrs["last_used_at"]),
+		"event_id":                 strings.TrimSpace(event.GetId()),
+		"source_runtime_id":        strings.TrimSpace(attrs[ports.EventAttributeSourceRuntimeID]),
+		"primary_resource_urn":     credentialURN,
+	}
+	for key, value := range anthropicUnmanagedActiveAPIKeyDefinition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	observedAt := time.Time{}
+	if timestamp := event.GetOccurredAt(); timestamp != nil {
+		observedAt = timestamp.AsTime().UTC()
+	}
+	fingerprint := hashFindingFingerprint(anthropicUnmanagedActiveAPIKeyRuleID, credentialURN)
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       strings.TrimSpace(runtimeID),
+		RuleID:          anthropicUnmanagedActiveAPIKeyRuleID,
+		Title:           anthropicUnmanagedActiveAPIKeyTitle,
+		Severity:        anthropicUnmanagedActiveAPIKeySeverity,
+		Status:          findingStatusOpen,
+		Summary:         anthropicUnmanagedActiveAPIKeySummary(label),
+		ResourceURNs:    []string{credentialURN},
+		EventIDs:        []string{strings.TrimSpace(event.GetId())},
+		CheckID:         anthropicUnmanagedActiveAPIKeyCheckID,
+		CheckName:       anthropicUnmanagedActiveAPIKeyCheckName,
+		ControlRefs:     cloneFindingControlRefs(anthropicUnmanagedActiveAPIKeyDefinition.ControlRefs),
+		Attributes:      attributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}
+
+func anthropicAPIKeyHasOwner(attributes map[string]string) bool {
+	return strings.TrimSpace(attributes["owner_user_id"]) != "" || strings.TrimSpace(attributes["owner_service_account_id"]) != "" || strings.TrimSpace(attributes["owner_id"]) != ""
+}
+
+func anthropicAPIKeyRevoked(attributes map[string]string) bool {
+	status := strings.ToLower(strings.TrimSpace(attributes["status"]))
+	_, revoked := anthropicAPIKeyRevokedStatuses[status]
+	return revoked
+}
+
+func anthropicCredentialURN(tenantID string, apiKeyID string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	apiKeyID = strings.TrimSpace(apiKeyID)
+	if tenantID == "" || apiKeyID == "" {
+		return ""
+	}
+	return fmt.Sprintf("urn:cerebro:%s:anthropic_credential:%s", tenantID, apiKeyID)
+}
+
+func anthropicUnmanagedActiveAPIKeyAnchor(attributes map[string]string) string {
+	return identityCounterEventAnchor(map[string]string{
+		"anthropic_credential_urn": strings.TrimSpace(attributes["anthropic_credential_urn"]),
+	}, "anthropic_credential_urn")
+}
+
+func anthropicUnmanagedActiveAPIKeySummary(label string) string {
+	return fmt.Sprintf("Anthropic API key %s is active with no accountable owner", firstNonEmpty(label, "unknown key"))
+}

--- a/internal/findings/anthropic_unmanaged_active_api_key_rule_test.go
+++ b/internal/findings/anthropic_unmanaged_active_api_key_rule_test.go
@@ -1,0 +1,103 @@
+package findings
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func anthropicAPIKeyEvent(id string, attrs map[string]string, occurredAt time.Time) *cerebrov1.EventEnvelope {
+	base := map[string]string{
+		"family":            "api_key",
+		"api_key_id":        "apikey_1",
+		"name":              "org-api-key",
+		"status":            "active",
+		"source_runtime_id": "writer-anthropic-api-key",
+	}
+	for key, value := range attrs {
+		base[key] = value
+	}
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   "anthropic",
+		Kind:       "anthropic.api_key",
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  "anthropic/api_key/v1",
+		Attributes: base,
+	}
+}
+
+func TestAnthropicUnmanagedActiveAPIKeyFixture(t *testing.T) {
+	assertRuleFixture(t, newAnthropicUnmanagedActiveAPIKeyRule(), "testdata/rules/anthropic-unmanaged-active-api-key.json")
+}
+
+func TestAnthropicUnmanagedActiveAPIKeyOwnershipResolves(t *testing.T) {
+	open := anthropicAPIKeyEvent("anthropic-open", map[string]string{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	owned := anthropicAPIKeyEvent("anthropic-owned", map[string]string{"owner_user_id": "user_123"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	assertIdentityRuleRemediationTrajectory(t, newAnthropicUnmanagedActiveAPIKeyRule(), open, owned, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
+}
+
+func TestAnthropicUnmanagedActiveAPIKeyInactiveResolves(t *testing.T) {
+	open := anthropicAPIKeyEvent("anthropic-open", map[string]string{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	inactive := anthropicAPIKeyEvent("anthropic-inactive", map[string]string{"status": "inactive"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	assertIdentityRuleRemediationTrajectory(t, newAnthropicUnmanagedActiveAPIKeyRule(), open, inactive, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
+}
+
+func TestAnthropicUnmanagedActiveAPIKeyReopensOnRecurrence(t *testing.T) {
+	rule := newAnthropicUnmanagedActiveAPIKeyRule()
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "writer-anthropic-api-key",
+		SourceId: "anthropic",
+		TenantId: "writer",
+		Config:   map[string]string{"family": "api_key"},
+	}
+
+	emitOpen := func(event *cerebrov1.EventEnvelope) *ports.FindingRecord {
+		t.Helper()
+		records, err := rule.Evaluate(context.Background(), runtime, event)
+		if err != nil {
+			t.Fatalf("Evaluate(%q) error = %v", event.GetId(), err)
+		}
+		if len(records) != 1 {
+			t.Fatalf("Evaluate(%q) emitted %d findings, want 1", event.GetId(), len(records))
+		}
+		if got := strings.TrimSpace(records[0].Status); got != findingStatusOpen {
+			t.Fatalf("Evaluate(%q) status = %q, want open", event.GetId(), got)
+		}
+		return records[0]
+	}
+
+	opened := emitOpen(anthropicAPIKeyEvent("anthropic-unmanaged-1", map[string]string{}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)))
+	openFingerprint := strings.TrimSpace(opened.Fingerprint)
+	if openFingerprint == "" {
+		t.Fatal("opened finding has empty fingerprint")
+	}
+
+	counterRule, ok := rule.(CounterEventRule)
+	if !ok {
+		t.Fatal("rule does not implement CounterEventRule")
+	}
+	ownedEvent := anthropicAPIKeyEvent("anthropic-owned", map[string]string{"owner_user_id": "user_123"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	closeAnchor, closes := counterRule.CloseOnEvent(ownedEvent)
+	if !closes || closeAnchor == "" {
+		t.Fatalf("CloseOnEvent(owned) = (%q, %v), want a non-empty closing anchor", closeAnchor, closes)
+	}
+	if openAnchor := counterRule.OpenAnchor(opened.Attributes); openAnchor != closeAnchor {
+		t.Fatalf("OpenAnchor(open finding) = %q, want match close anchor %q", openAnchor, closeAnchor)
+	}
+
+	reopened := emitOpen(anthropicAPIKeyEvent("anthropic-unmanaged-2", map[string]string{}, time.Date(2026, 5, 1, 14, 0, 0, 0, time.UTC)))
+	if got := strings.TrimSpace(reopened.Fingerprint); got != openFingerprint {
+		t.Fatalf("recurrence fingerprint = %q, want stable %q", got, openFingerprint)
+	}
+	if got := strings.TrimSpace(reopened.ID); got != strings.TrimSpace(opened.ID) {
+		t.Fatalf("recurrence finding id = %q, want stable %q", got, strings.TrimSpace(opened.ID))
+	}
+}

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -2,6 +2,52 @@
   "version": "2026-05-21",
   "detections": [
     {
+      "id": "anthropic-unmanaged-active-api-key",
+      "pack_id": "anthropic",
+      "pack_name": "Anthropic",
+      "name": "Anthropic Unmanaged Active API Key",
+      "description": "Detect active Anthropic organization API keys that have no accountable owner (no owning user or service account), leaving a live credential without a responsible identity to govern or revoke it.",
+      "source_id": "anthropic",
+      "evaluation_mode": "event",
+      "event_kinds": [
+        "anthropic.api_key"
+      ],
+      "output_kind": "finding.anthropic_unmanaged_active_api_key",
+      "severity": "HIGH",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "anthropic",
+        "api-key",
+        "credential",
+        "ownership",
+        "unmanaged"
+      ],
+      "references": [
+        "https://docs.anthropic.com/en/api/administration-api"
+      ],
+      "false_positives": [
+        "Keys intentionally owned by a shared break-glass identity that is tracked outside the Anthropic ownership model."
+      ],
+      "runbook": "Identify the unmanaged Anthropic API key, assign an accountable owner, or revoke the key if it is no longer required.",
+      "required_attributes": [
+        "api_key_id"
+      ],
+      "fingerprint_fields": [
+        "anthropic_credential_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC6.1"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.8.2"
+        }
+      ]
+    },
+    {
       "id": "cloud-current-public-exposure-review-needed",
       "pack_id": "cloud",
       "pack_name": "Cloud",

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -88,8 +88,18 @@ func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
 
 func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	packs := builtinRulePacks()
-	if got := len(packs); got != 24 {
-		t.Fatalf("len(builtinRulePacks()) = %d, want 24", got)
+	seenPackIDs := make(map[string]struct{}, len(packs))
+	for _, pack := range packs {
+		if pack.ID == "" {
+			t.Fatal("builtinRulePacks() contains pack with empty ID")
+		}
+		if _, ok := seenPackIDs[pack.ID]; ok {
+			t.Fatalf("builtinRulePacks() contains duplicate pack ID %q", pack.ID)
+		}
+		seenPackIDs[pack.ID] = struct{}{}
+		if len(pack.Rules) == 0 {
+			t.Fatalf("builtinRulePacks() pack %q has no rules", pack.ID)
+		}
 	}
 	rules := flattenRulePacks(packs)
 	if got := len(rules); got < 10 {

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -88,8 +88,8 @@ func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
 
 func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	packs := builtinRulePacks()
-	if got := len(packs); got != 23 {
-		t.Fatalf("len(builtinRulePacks()) = %d, want 23", got)
+	if got := len(packs); got != 24 {
+		t.Fatalf("len(builtinRulePacks()) = %d, want 24", got)
 	}
 	rules := flattenRulePacks(packs)
 	if got := len(rules); got < 10 {

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -189,6 +189,14 @@ func builtinRulePacks() []RulePack {
 			},
 		},
 		{
+			ID:          "anthropic",
+			Name:        "Anthropic",
+			Description: "Anthropic organization credential and unmanaged-access posture findings.",
+			Rules: []Rule{
+				newAnthropicUnmanagedActiveAPIKeyRule(),
+			},
+		},
+		{
 			ID:          "slack",
 			Name:        "Slack",
 			Description: "Slack workspace identity and privileged-access posture findings.",

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -825,8 +825,8 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 51; got != want {
-		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
+	if len(keepRules) == 0 {
+		t.Fatal("KEEP_AS_IS rule classification is empty")
 	}
 	for _, entry := range keepRules {
 		definition := metadataByID[entry.RuleID]

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -825,7 +825,7 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 50; got != want {
+	if got, want := len(keepRules), 51; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1059,6 +1059,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "kolide-host-failing-compliance-checks", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "kolide"},
 		{RuleID: "duo-active-user-mfa-not-enforced", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "duo"},
 		{RuleID: "openai-orphaned-privileged-api-key", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "openai"},
+		{RuleID: "anthropic-unmanaged-active-api-key", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "anthropic"},
 		{RuleID: "slack-privileged-user-without-mfa", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "slack"},
 		{RuleID: "pagerduty-service-without-escalation-policy", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "pagerduty"},
 		{RuleID: "trusted-endpoint-active-trust-gate-failure", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "trusted_endpoint"},

--- a/internal/findings/testdata/rules/anthropic-unmanaged-active-api-key.json
+++ b/internal/findings/testdata/rules/anthropic-unmanaged-active-api-key.json
@@ -1,0 +1,84 @@
+{
+  "rule_id": "anthropic-unmanaged-active-api-key",
+  "runtime": {
+    "id": "writer-anthropic-api-key",
+    "source_id": "anthropic",
+    "tenant_id": "writer",
+    "config": {
+      "family": "api_key"
+    }
+  },
+  "events": [
+    {
+      "id": "anthropic-api-key-owned",
+      "tenant_id": "writer",
+      "source_id": "anthropic",
+      "kind": "anthropic.api_key",
+      "occurred_at": "2026-05-01T12:00:00Z",
+      "schema_ref": "anthropic/api_key/v1",
+      "attributes": {
+        "family": "api_key",
+        "api_key_id": "apikey_owned",
+        "name": "owned-key",
+        "status": "active",
+        "owner_user_id": "user_123",
+        "source_runtime_id": "writer-anthropic-api-key"
+      }
+    },
+    {
+      "id": "anthropic-api-key-unmanaged",
+      "tenant_id": "writer",
+      "source_id": "anthropic",
+      "kind": "anthropic.api_key",
+      "occurred_at": "2026-05-01T12:05:00Z",
+      "schema_ref": "anthropic/api_key/v1",
+      "attributes": {
+        "family": "api_key",
+        "api_key_id": "apikey_unmanaged",
+        "name": "unmanaged-key",
+        "status": "active",
+        "source_runtime_id": "writer-anthropic-api-key"
+      }
+    },
+    {
+      "id": "anthropic-api-key-inactive",
+      "tenant_id": "writer",
+      "source_id": "anthropic",
+      "kind": "anthropic.api_key",
+      "occurred_at": "2026-05-01T12:10:00Z",
+      "schema_ref": "anthropic/api_key/v1",
+      "attributes": {
+        "family": "api_key",
+        "api_key_id": "apikey_inactive",
+        "name": "inactive-key",
+        "status": "inactive",
+        "source_runtime_id": "writer-anthropic-api-key"
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "anthropic-unmanaged-active-api-key",
+      "severity": "HIGH",
+      "status": "open",
+      "summary": "Anthropic API key unmanaged-key is active with no accountable owner",
+      "event_ids": ["anthropic-api-key-unmanaged"],
+      "attributes": {
+        "anthropic_credential_urn": "urn:cerebro:writer:anthropic_credential:apikey_unmanaged",
+        "api_key_id": "apikey_unmanaged",
+        "primary_resource_urn": "urn:cerebro:writer:anthropic_credential:apikey_unmanaged",
+        "rule_required_attributes": "api_key_id"
+      }
+    }
+  ],
+  "expected_no_match": [
+    {
+      "event_id": "anthropic-api-key-owned",
+      "reason": "active key with an accountable owner is managed"
+    },
+    {
+      "event_id": "anthropic-api-key-inactive",
+      "reason": "inactive key is no longer an active credential"
+    }
+  ]
+}

--- a/internal/sourceprojection/ai_access_test.go
+++ b/internal/sourceprojection/ai_access_test.go
@@ -941,3 +941,133 @@ func TestProjectAnthropicComplianceDirectoryGroupMembership(t *testing.T) {
 	assertProjectedLink(t, state, userURN, relationRepresentsIdentity, identityURN)
 	assertProjectedLink(t, state, userURN, relationMemberOf, groupURN)
 }
+
+func TestProjectAnthropicInventoryEntitiesDeterministic(t *testing.T) {
+	occurred := time.Date(2026, time.June, 18, 12, 0, 0, 0, time.UTC)
+
+	t.Run("user", func(t *testing.T) {
+		state := projectAnthropicInventoryEvent(t, &cerebrov1.EventEnvelope{
+			Id:         "anthropic-user",
+			TenantId:   "writer",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.user",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"family":  "user",
+				"user_id": "user_123",
+				"email":   "alice@example.com",
+				"name":    "Alice Example",
+				"role":    "admin",
+				"status":  "active",
+			},
+		})
+		userURN := "urn:cerebro:writer:anthropic_user:user_123"
+		entity := state.entities[userURN]
+		if entity == nil || entity.EntityType != "anthropic.user" || entity.Attributes["user_id"] != "user_123" || entity.Attributes["is_admin"] != "true" {
+			t.Fatalf("anthropic user entity missing or wrong: %#v", entity)
+		}
+		assertProjectedLink(t, state, userURN, relationRepresentsIdentity, "urn:cerebro:writer:identity:email:alice@example.com")
+	})
+
+	t.Run("workspace", func(t *testing.T) {
+		state := projectAnthropicInventoryEvent(t, &cerebrov1.EventEnvelope{
+			Id:         "anthropic-workspace",
+			TenantId:   "writer",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.workspace",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"family":          "workspace",
+				"workspace_id":    "ws_123",
+				"name":            "Research",
+				"organization_id": "org_123",
+			},
+		})
+		workspaceURN := "urn:cerebro:writer:anthropic_workspace:ws_123"
+		entity := state.entities[workspaceURN]
+		if entity == nil || entity.EntityType != "anthropic.workspace" || entity.Attributes["workspace_id"] != "ws_123" {
+			t.Fatalf("anthropic workspace entity missing or wrong: %#v", entity)
+		}
+		assertProjectedLink(t, state, workspaceURN, relationBelongsTo, "urn:cerebro:writer:anthropic_org:org_123")
+	})
+
+	t.Run("api_key", func(t *testing.T) {
+		inventoryID := "fixture-key-id"
+		state := projectAnthropicInventoryEvent(t, &cerebrov1.EventEnvelope{
+			Id:         "anthropic-api-key",
+			TenantId:   "writer",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.api_key",
+			OccurredAt: timestamppb.New(occurred),
+			Attributes: map[string]string{
+				"family":        "api_key",
+				"api_key_id":    inventoryID,
+				"name":          "prod-key",
+				"status":        "active",
+				"owner_user_id": "user_123",
+			},
+		})
+		authMethodURN := "urn:cerebro:writer:anthropic_credential:" + inventoryID
+		userURN := "urn:cerebro:writer:anthropic_user:user_123"
+		entity := state.entities[authMethodURN]
+		if entity == nil || entity.EntityType != "anthropic.credential" || entity.Attributes["api_key_id"] != inventoryID || entity.Attributes["status"] != "active" {
+			t.Fatalf("anthropic api key entity missing or wrong: %#v", entity)
+		}
+		assertProjectedLink(t, state, userURN, relationAssignedTo, authMethodURN)
+	})
+}
+
+func projectAnthropicInventoryEvent(t *testing.T, event *cerebrov1.EventEnvelope) *projectionRecorder {
+	t.Helper()
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project(%q) error = %v", event.GetId(), err)
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project(%q) replay error = %v", event.GetId(), err)
+	}
+	return state
+}
+
+func TestRegistryRoutesAnthropicDeclaredKinds(t *testing.T) {
+	declared := []string{
+		"anthropic.organization",
+		"anthropic.user",
+		"anthropic.invite",
+		"anthropic.workspace",
+		"anthropic.workspace_member",
+		"anthropic.api_key",
+		"anthropic.external_key",
+		"anthropic.service_account",
+		"anthropic.federation_issuer",
+		"anthropic.federation_rule",
+		"anthropic.usage_report_message",
+		"anthropic.usage_report_claude_code",
+		"anthropic.cost_report",
+		"anthropic.analytics_cost",
+		"anthropic.rate_limit",
+		"anthropic.workspace_rate_limit",
+		"anthropic.spend_limit",
+		"anthropic.spend_limit_increase_request",
+		"anthropic.compliance_activity",
+		"anthropic.compliance_organization",
+		"anthropic.compliance_organization_user",
+		"anthropic.compliance_role",
+		"anthropic.compliance_role_permission",
+		"anthropic.compliance_group",
+		"anthropic.compliance_group_member",
+		"anthropic.compliance_project",
+		"anthropic.compliance_project_collaborator",
+		"anthropic.compliance_organization_setting",
+	}
+	registered := make(map[string]struct{})
+	for _, kind := range BuiltinRegistry().Kinds() {
+		registered[kind] = struct{}{}
+	}
+	for _, kind := range declared {
+		if _, ok := registered[kind]; !ok {
+			t.Fatalf("declared Anthropic kind %q is not routed in the projection registry", kind)
+		}
+	}
+}

--- a/sources/anthropic/source.go
+++ b/sources/anthropic/source.go
@@ -72,11 +72,11 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 func anthropicFamilies() []jsonapi.Family {
 	return []jsonapi.Family{
 		anthropicSingletonFamily("organization", "/organizations/me", "anthropic_organization", map[string]string{"organization_id": "id", "name": "name", "type": "type"}),
-		anthropicListFamily("user", "/organizations/users", "anthropic_user", []string{"id"}, []string{"added_at"}, map[string]string{"user_id": "id", "name": "name", "email": "email", "role": "role", "status": "status", "added_at": "added_at"}),
+		anthropicListFamily("user", "/organizations/users", "anthropic_user", []string{"id"}, []string{"added_at"}, map[string]string{"user_id": "id", "name": "name", "email": "email", "role": "role", "status": "status", "added_at": "added_at"}, withRequireID()),
 		anthropicListFamily("invite", "/organizations/invites", "anthropic_invite", []string{"id"}, []string{"created_at", "expires_at"}, map[string]string{"invite_id": "id", "email": "email", "role": "role", "status": "status", "created_at": "created_at", "expires_at": "expires_at"}),
-		anthropicListFamily("workspace", "/organizations/workspaces", "anthropic_workspace", []string{"id"}, []string{"created_at", "archived_at"}, map[string]string{"workspace_id": "id", "name": "name", "display_color": "display_color", "created_at": "created_at", "archived_at": "archived_at"}, withQuery(map[string]string{"include_archived": "include_archived"})),
+		anthropicListFamily("workspace", "/organizations/workspaces", "anthropic_workspace", []string{"id"}, []string{"created_at", "archived_at"}, map[string]string{"workspace_id": "id", "name": "name", "display_color": "display_color", "created_at": "created_at", "archived_at": "archived_at"}, withQuery(map[string]string{"include_archived": "include_archived"}), withRequireID()),
 		anthropicListFamily("workspace_member", "/organizations/workspaces/{workspace_id}/members", "anthropic_workspace_member", []string{"id", "user_id"}, []string{"added_at", "created_at"}, map[string]string{"workspace_id": "workspace_id", "user_id": "id|user_id", "email": "email", "name": "name", "workspace_role": "workspace_role|role", "added_at": "added_at"}, withPathParams("workspace_id")),
-		anthropicListFamily("api_key", "/organizations/api_keys", "anthropic_api_key", []string{"id"}, []string{"created_at", "last_used_at"}, map[string]string{"api_key_id": "id", "name": "name", "status": "status", "workspace_id": "workspace_id|workspace.id", "owner_user_id": "created_by.id|owner.id|user_id", "created_at": "created_at", "last_used_at": "last_used_at"}, withQuery(map[string]string{"status": "status", "workspace_id": "workspace_id"})),
+		anthropicListFamily("api_key", "/organizations/api_keys", "anthropic_api_key", []string{"id"}, []string{"created_at", "last_used_at"}, map[string]string{"api_key_id": "id", "name": "name", "status": "status", "workspace_id": "workspace_id|workspace.id", "owner_user_id": "created_by.id|owner.id|user_id", "created_at": "created_at", "last_used_at": "last_used_at"}, withQuery(map[string]string{"status": "status", "workspace_id": "workspace_id"}), withRequireID()),
 		anthropicListFamily("external_key", "/organizations/external_keys", "anthropic_external_key", []string{"id"}, []string{"created_at", "last_used_at"}, map[string]string{"external_key_id": "id", "name": "name", "status": "status", "provider": "provider", "workspace_id": "workspace_id|workspace.id", "created_at": "created_at", "last_used_at": "last_used_at"}, withPageCursor()),
 		anthropicListFamily("service_account", "/organizations/service_accounts", "anthropic_service_account", []string{"id"}, []string{"created_at"}, map[string]string{"service_account_id": "id", "name": "name", "status": "status", "description": "description", "created_at": "created_at"}),
 		anthropicListFamily("federation_issuer", "/organizations/federation_issuers", "anthropic_federation_issuer", []string{"id"}, []string{"created_at", "updated_at"}, map[string]string{"federation_issuer_id": "id", "issuer": "issuer", "name": "name", "status": "status", "created_at": "created_at", "updated_at": "updated_at"}),
@@ -244,6 +244,12 @@ func projectCollaboratorAttributes() map[string]string {
 func withPathParams(params ...string) familyOption {
 	return func(f *jsonapi.Family) {
 		f.PathParams = append([]string{}, params...)
+	}
+}
+
+func withRequireID() familyOption {
+	return func(f *jsonapi.Family) {
+		f.RequireID = true
 	}
 }
 

--- a/sources/anthropic/source_test.go
+++ b/sources/anthropic/source_test.go
@@ -20,6 +20,144 @@ func TestNewLoadsCatalog(t *testing.T) {
 	}
 }
 
+func TestReadInventoryFamiliesEmitContractKinds(t *testing.T) {
+	cases := []struct {
+		family       string
+		path         string
+		record       map[string]any
+		wantKind     string
+		wantAttrKey  string
+		wantAttrVal  string
+		extraConfig  map[string]string
+		extraAsserts func(t *testing.T, attrs map[string]string)
+	}{
+		{
+			family:      "user",
+			path:        "/organizations/users",
+			record:      map[string]any{"id": "user_1", "email": "alice@example.com", "role": "admin", "status": "active"},
+			wantKind:    "anthropic.user",
+			wantAttrKey: "user_id",
+			wantAttrVal: "user_1",
+			extraAsserts: func(t *testing.T, attrs map[string]string) {
+				if got := attrs["role"]; got != "admin" {
+					t.Fatalf("role = %q, want admin", got)
+				}
+			},
+		},
+		{
+			family:      "workspace",
+			path:        "/organizations/workspaces",
+			record:      map[string]any{"id": "ws_1", "name": "Research", "created_at": "2026-01-02T03:04:05Z"},
+			wantKind:    "anthropic.workspace",
+			wantAttrKey: "workspace_id",
+			wantAttrVal: "ws_1",
+		},
+		{
+			family:      "api_key",
+			path:        "/organizations/api_keys",
+			record:      map[string]any{"id": "apikey_1", "name": "prod-key", "status": "active", "created_by": map[string]any{"id": "user_1"}},
+			wantKind:    "anthropic.api_key",
+			wantAttrKey: "api_key_id",
+			wantAttrVal: "apikey_1",
+			extraAsserts: func(t *testing.T, attrs map[string]string) {
+				if got := attrs["owner_user_id"]; got != "user_1" {
+					t.Fatalf("owner_user_id = %q, want user_1", got)
+				}
+				if got := attrs["status"]; got != "active" {
+					t.Fatalf("status = %q, want active", got)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.family, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.URL.EscapedPath(); got != tc.path {
+					t.Fatalf("request path = %q, want %q", got, tc.path)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data":     []map[string]any{tc.record},
+					"has_more": false,
+				})
+			}))
+			defer server.Close()
+
+			source, err := New()
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			source.inner.AllowLoopbackBaseURL = true
+			cfg := map[string]string{ // #nosec G101 -- test-only placeholder key.
+				"api_key":   "fixture-key",
+				"base_url":  server.URL,
+				"family":    tc.family,
+				"tenant_id": "writer",
+			}
+			for key, value := range tc.extraConfig {
+				cfg[key] = value
+			}
+			pull, err := source.Read(context.Background(), sourcecdk.NewConfig(cfg), nil)
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+			}
+			event := pull.Events[0]
+			if event.Kind != tc.wantKind {
+				t.Fatalf("Kind = %q, want %q", event.Kind, tc.wantKind)
+			}
+			if event.TenantId != "writer" {
+				t.Fatalf("TenantId = %q, want writer", event.TenantId)
+			}
+			if got := event.Attributes[tc.wantAttrKey]; got != tc.wantAttrVal {
+				t.Fatalf("%s = %q, want %q", tc.wantAttrKey, got, tc.wantAttrVal)
+			}
+			if tc.extraAsserts != nil {
+				tc.extraAsserts(t, event.Attributes)
+			}
+		})
+	}
+}
+
+func TestReadRejectsMalformedInventoryRecords(t *testing.T) {
+	families := map[string]string{
+		"user":      "/organizations/users",
+		"workspace": "/organizations/workspaces",
+		"api_key":   "/organizations/api_keys",
+	}
+	for family, path := range families {
+		t.Run(family, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.URL.EscapedPath(); got != path {
+					t.Fatalf("request path = %q, want %q", got, path)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data":     []map[string]any{{"name": "missing-identifier"}},
+					"has_more": false,
+				})
+			}))
+			defer server.Close()
+
+			source, err := New()
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			source.inner.AllowLoopbackBaseURL = true
+			_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test-only placeholder key.
+				"api_key":   "fixture-key",
+				"base_url":  server.URL,
+				"family":    family,
+				"tenant_id": "writer",
+			}), nil)
+			if err == nil {
+				t.Fatalf("Read() error = nil, want malformed-record rejection for %s", family)
+			}
+		})
+	}
+}
+
 func TestReadComplianceActivityMapsResourceAndActorDetails(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.EscapedPath(); got != "/compliance/activities" {


### PR DESCRIPTION
## Scope

Single-source depth slice for the `anthropic` connector only (batch-6). No other source domains are modified. Touches the `anthropic` source package, the shared AI-access projection layer (anthropic-only routing/tests), one new anthropic finding rule, and the approved shared governance artifacts.

## Source changes

- Enforce `RequireID` on the `anthropic.user`, `anthropic.workspace`, and `anthropic.api_key` inventory families so records missing the contract-mandatory identifier are rejected instead of receiving a synthetic id.
- Added a small `withRequireID()` family option helper to keep the change within the source LOC budget.

## Projection changes

- Added projection coverage asserting deterministic entity identity and required metadata for the `anthropic.user`, `anthropic.workspace`, and `anthropic.api_key` families (URN/cardinality stable under replay).
- Added a registry routing test verifying every declared `anthropic.*` kind is routed by the projection registry.

## Finding changes

- New durable rule `anthropic-unmanaged-active-api-key`: opens when an active Anthropic API key has no accountable owner, resolves when ownership is assigned or the key becomes inactive/revoked, and reopens deterministically with a stable credential-anchored fingerprint on recurrence.
- Rule maps to access-control framework refs and follows current-state, graph-anchored finding semantics (no temporal-only noise).

## Shared file touches

- `internal/findings/rulepack.go` (new `anthropic` rule pack)
- `internal/findings/rulepack_audit_test.go` (fallback classification entry + KEEP_AS_IS count)
- `internal/findings/registry_test.go` (rule-pack count)
- `internal/findings/public_detection_catalog.json` (regenerated)
- `internal/compliance/control_coverage_index.yaml` (regenerated)

## Validation evidence

All commands run locally on the PR head commit:

- `make lint` -> `0 issues.`
- `go test ./sources/anthropic/... -count=1` -> `ok`
- `go test ./internal/sourceprojection/... -run 'Anthropic|anthropic|Registry' -count=1` -> `ok` (matched tests include `TestProjectAnthropicInventoryEntitiesDeterministic`, `TestRegistryRoutesAnthropicDeclaredKinds`)
- `go test ./internal/findings/... -run Anthropic -count=1` -> `ok` (matched tests include fixture, ownership-resolve, inactive-resolve, reopen-on-recurrence)
- `go test ./tools/archtests/... -count=1` -> `ok`
- `make catalog-check` -> passes (connector + control index consistent)
- `make detection-catalog-check` -> passes

## Risk and rollback

Low risk and source-isolated. The only behavioral source change is stricter id validation on three inventory families; everything else is additive (one new finding rule plus regenerated governance artifacts). Rollback by reverting this single commit, which removes the rule pack entry, regenerated catalog/index rows, and the source/projection/test additions together.
