### PR TITLE
feat(backstage): deepen connector with ownership-accountability finding

### DIFF
--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -170,7 +170,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 1053 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 1054 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/internal/compliance/control_coverage_index.yaml
+++ b/internal/compliance/control_coverage_index.yaml
@@ -7,7 +7,7 @@ profiles:
         selected_controls: 31
         mapped_controls: 31
         unmapped_controls: 0
-        mapped_rules: 470
+        mapped_rules: 471
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 31
@@ -124,10 +124,11 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 5
+          rule_count: 6
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
+            - backstage-critical-component-missing-owner
             - identity-account-deprovision
             - identity-offboarding-sla
             - m365-terminated-users-active
@@ -468,10 +469,11 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 4
+          rule_count: 5
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
+            - backstage-critical-component-missing-owner
             - identity-account-deprovision
             - identity-offboarding-sla
         - framework_id: cjis-security-policy
@@ -1338,10 +1340,11 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 5
+          rule_count: 6
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
+            - backstage-critical-component-missing-owner
             - identity-account-deprovision
             - identity-offboarding-sla
             - m365-terminated-users-active
@@ -1909,10 +1912,11 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 4
+          rule_count: 5
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
+            - backstage-critical-component-missing-owner
             - identity-account-deprovision
             - identity-offboarding-sla
         - framework_id: cjis-security-policy
@@ -4682,6 +4686,16 @@ profiles:
               control_id: 5.10.1.2
             - framework_name: CJIS Security Policy
               control_id: PA-8
+        - rule_id: backstage-critical-component-missing-owner
+          controls:
+            - framework_name: CJIS Security Policy
+              control_id: 5.12.1
+            - framework_name: CJIS Security Policy
+              control_id: 5.2.1
+            - framework_name: CJIS Security Policy
+              control_id: PA-12
+            - framework_name: CJIS Security Policy
+              control_id: PA-2
         - rule_id: backup-encryption
           controls:
             - framework_name: CJIS Security Policy
@@ -11926,7 +11940,7 @@ profiles:
         selected_controls: 52
         mapped_controls: 52
         unmapped_controls: 0
-        mapped_rules: 458
+        mapped_rules: 459
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 52
@@ -13364,10 +13378,11 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 4
+          rule_count: 5
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
+            - backstage-critical-component-missing-owner
             - identity-account-deprovision
             - identity-offboarding-sla
         - framework_id: cmmc-2
@@ -19078,6 +19093,10 @@ profiles:
               control_id: MP.L2
             - framework_name: CMMC 2.0
               control_id: SC.L2
+        - rule_id: backstage-critical-component-missing-owner
+          controls:
+            - framework_name: CMMC 2.0
+              control_id: AT.L2
         - rule_id: backup-encryption
           controls:
             - framework_name: CMMC 2.0
@@ -42603,7 +42622,7 @@ profiles:
         selected_controls: 22
         mapped_controls: 22
         unmapped_controls: 0
-        mapped_rules: 463
+        mapped_rules: 464
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 22
@@ -43071,10 +43090,11 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 4
+          rule_count: 5
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
+            - backstage-critical-component-missing-owner
             - identity-account-deprovision
             - identity-offboarding-sla
         - framework_id: nis2
@@ -44211,10 +44231,11 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 4
+          rule_count: 5
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
+            - backstage-critical-component-missing-owner
             - identity-account-deprovision
             - identity-offboarding-sla
       rules:
@@ -45172,6 +45193,12 @@ profiles:
           controls:
             - framework_name: NIS2
               control_id: Art.21(2)(h)
+        - rule_id: backstage-critical-component-missing-owner
+          controls:
+            - framework_name: NIS2
+              control_id: Art.21(2)(g)
+            - framework_name: NIS2
+              control_id: CIR-2024-2690-8.2
         - rule_id: backup-encryption
           controls:
             - framework_name: NIS2
@@ -47345,7 +47372,7 @@ profiles:
         selected_controls: 53
         mapped_controls: 53
         unmapped_controls: 0
-        mapped_rules: 510
+        mapped_rules: 511
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 53
@@ -48104,7 +48131,7 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 86
+          rule_count: 87
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
@@ -48115,6 +48142,7 @@ profiles:
             - aws-rds-backup-enabled
             - aws-rds-deletion-protection
             - aws-s3-bucket-versioning-enabled
+            - backstage-critical-component-missing-owner
             - backup-encryption
             - backup-offsite
             - backup-retention
@@ -48212,7 +48240,7 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 86
+          rule_count: 87
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
@@ -48223,6 +48251,7 @@ profiles:
             - aws-rds-backup-enabled
             - aws-rds-deletion-protection
             - aws-s3-bucket-versioning-enabled
+            - backstage-critical-component-missing-owner
             - backup-encryption
             - backup-offsite
             - backup-retention
@@ -49575,10 +49604,11 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 4
+          rule_count: 5
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
+            - backstage-critical-component-missing-owner
             - identity-account-deprovision
             - identity-offboarding-sla
         - framework_id: nist-csf-2.0
@@ -49601,10 +49631,11 @@ profiles:
             - framework_name: SOC 2
               control_id: CC1.4
           coverage_status: mapped
-          rule_count: 4
+          rule_count: 5
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
+            - backstage-critical-component-missing-owner
             - identity-account-deprovision
             - identity-offboarding-sla
         - framework_id: nist-csf-2.0
@@ -52201,6 +52232,16 @@ profiles:
               control_id: PR.DS
             - framework_name: NIST CSF 2.0
               control_id: PR.DS-01
+        - rule_id: backstage-critical-component-missing-owner
+          controls:
+            - framework_name: NIST CSF 2.0
+              control_id: GV.RR
+            - framework_name: NIST CSF 2.0
+              control_id: GV.RR-02
+            - framework_name: NIST CSF 2.0
+              control_id: PR.AT
+            - framework_name: NIST CSF 2.0
+              control_id: PR.AT-01
         - rule_id: backup-encryption
           controls:
             - framework_name: NIST CSF 2.0
@@ -61095,7 +61136,7 @@ profiles:
         selected_controls: 36
         mapped_controls: 25
         unmapped_controls: 11
-        mapped_rules: 930
+        mapped_rules: 931
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 36
@@ -61223,10 +61264,11 @@ profiles:
             status: placeholder
             score: 0
           coverage_status: mapped
-          rule_count: 2
+          rule_count: 3
           mapped_rules:
             - ai-bias-testing
             - ai-explainability
+            - backstage-critical-component-missing-owner
         - framework_name: SOC 2
           family_id: CC1
           family_name: Control Environment
@@ -63132,6 +63174,10 @@ profiles:
           controls:
             - framework_name: SOC 2
               control_id: CC6.7
+        - rule_id: backstage-critical-component-missing-owner
+          controls:
+            - framework_name: SOC 2
+              control_id: CC1.4
         - rule_id: backup-encryption
           controls:
             - framework_name: SOC 2

--- a/internal/findings/backstage_critical_component_missing_owner_rule.go
+++ b/internal/findings/backstage_critical_component_missing_owner_rule.go
@@ -1,0 +1,264 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	backstageCriticalComponentMissingOwnerRuleID    = "backstage-critical-component-missing-owner"
+	backstageCriticalComponentMissingOwnerTitle     = "Backstage Critical Component Missing Accountable Owner"
+	backstageCriticalComponentMissingOwnerSeverity  = "HIGH"
+	backstageCriticalComponentMissingOwnerCheckID   = "backstage-critical-component-missing-owner-current"
+	backstageCriticalComponentMissingOwnerCheckName = "Backstage Critical Component Missing Accountable Owner (current state)"
+)
+
+var backstageCriticalComponentMissingOwnerControlRefs = []ports.FindingControlRef{
+	{FrameworkName: "SOC 2", ControlID: "CC1.4"},
+	{FrameworkName: "ISO 27001:2022", ControlID: "A.5.2"},
+}
+
+var backstageCriticalComponentTiers = map[string]struct{}{
+	"critical":    {},
+	"crown_jewel": {},
+	"crown-jewel": {},
+	"tier0":       {},
+	"tier-0":      {},
+	"tier_0":      {},
+	"p0":          {},
+	"high":        {},
+	"highest":     {},
+	"gold":        {},
+}
+
+var backstageUnaccountableOwners = map[string]struct{}{
+	"unknown":    {},
+	"unowned":    {},
+	"none":       {},
+	"n/a":        {},
+	"na":         {},
+	"tbd":        {},
+	"unassigned": {},
+	"nobody":     {},
+}
+
+var backstageDecommissionedLifecycles = map[string]struct{}{
+	"deprecated":     {},
+	"decommissioned": {},
+	"retired":        {},
+	"archived":       {},
+	"deleted":        {},
+	"removed":        {},
+	"end-of-life":    {},
+	"eol":            {},
+}
+
+type backstageCriticalComponentMissingOwnerRule struct {
+	Rule
+	definition RuleDefinition
+}
+
+var backstageCriticalComponentMissingOwnerDefinition = RuleDefinition{
+	ID:                 backstageCriticalComponentMissingOwnerRuleID,
+	Name:               backstageCriticalComponentMissingOwnerTitle,
+	Description:        "Detect business-critical Backstage components that have no accountable owner, leaving a high-importance service without a responsible team to govern its security posture, on-call response, or remediation.",
+	SourceID:           "backstage",
+	EventKinds:         []string{"backstage.component"},
+	OutputKind:         "finding.backstage_critical_component_missing_owner",
+	Severity:           backstageCriticalComponentMissingOwnerSeverity,
+	Status:             findingStatusOpen,
+	Maturity:           "test",
+	Tags:               []string{"backstage", "ownership", "accountability", "service-catalog", "crown-jewel"},
+	References:         []string{"https://backstage.io/docs/features/software-catalog/system-model"},
+	FalsePositives:     []string{"Critical components intentionally owned by a shared platform group that is tracked outside the Backstage ownership model."},
+	Runbook:            "Identify the unowned critical Backstage component and assign an accountable owning team in the catalog, or downgrade its criticality if it is no longer business-critical.",
+	RequiredAttributes: []string{"name"},
+	FingerprintFields:  []string{"backstage_component_urn"},
+	ControlRefs:        backstageCriticalComponentMissingOwnerControlRefs,
+	Lifecycle:          Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorSourceState},
+}
+
+var backstageCriticalComponentMissingOwnerKindMatcher = eventKindMatcher(backstageCriticalComponentMissingOwnerDefinition.EventKinds...)
+
+func newBackstageCriticalComponentMissingOwnerRule() Rule {
+	rule := newEventRule(eventRuleConfig{
+		definition: backstageCriticalComponentMissingOwnerDefinition,
+		match:      matchesBackstageCriticalComponentMissingOwner,
+		build: func(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+			return backstageCriticalComponentMissingOwnerFinding(event, runtime.GetId())
+		},
+	})
+	return &backstageCriticalComponentMissingOwnerRule{
+		Rule:       rule,
+		definition: backstageCriticalComponentMissingOwnerDefinition,
+	}
+}
+
+func (r *backstageCriticalComponentMissingOwnerRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
+func (r *backstageCriticalComponentMissingOwnerRule) OpenAnchor(attributes map[string]string) string {
+	return backstageCriticalComponentMissingOwnerAnchor(attributes)
+}
+
+// CloseOnEvent resolves an open finding when a later snapshot of the same
+// component shows an accountable owner (remediation), is no longer critical
+// (downgraded), or is decommissioned (no longer an active service), so resolved
+// components do not leave stale open findings.
+func (r *backstageCriticalComponentMissingOwnerRule) CloseOnEvent(event Event) (string, bool) {
+	if !backstageCriticalComponentMissingOwnerKindMatcher(event) || !hasRequiredAttributes(event, backstageCriticalComponentMissingOwnerDefinition.RequiredAttributes...) {
+		return "", false
+	}
+	attributes := eventAttributes(event)
+	if backstageComponentIsCritical(attributes["criticality"]) &&
+		!backstageComponentHasAccountableOwner(attributes) &&
+		!backstageComponentDecommissioned(attributes) {
+		return "", false
+	}
+	componentURN := backstageComponentResourceURN(event.GetTenantId(), attributes)
+	anchor := backstageCriticalComponentMissingOwnerAnchor(map[string]string{"backstage_component_urn": componentURN})
+	return anchor, anchor != ""
+}
+
+func matchesBackstageCriticalComponentMissingOwner(event *cerebrov1.EventEnvelope) bool {
+	if !backstageCriticalComponentMissingOwnerKindMatcher(event) || !hasRequiredAttributes(event, backstageCriticalComponentMissingOwnerDefinition.RequiredAttributes...) {
+		return false
+	}
+	attributes := eventAttributes(event)
+	if backstageComponentDecommissioned(attributes) {
+		return false
+	}
+	if !backstageComponentIsCritical(attributes["criticality"]) {
+		return false
+	}
+	return !backstageComponentHasAccountableOwner(attributes)
+}
+
+func backstageCriticalComponentMissingOwnerFinding(event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
+	attrs := event.GetAttributes()
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	componentURN := backstageComponentResourceURN(tenantID, attrs)
+	if componentURN == "" {
+		return nil, nil
+	}
+	name := strings.TrimSpace(attrs["name"])
+	label := firstNonEmpty(strings.TrimSpace(attrs["entity_ref"]), name)
+	attributes := map[string]string{
+		"backstage_component_urn": componentURN,
+		"name":                    name,
+		"namespace":               strings.TrimSpace(attrs["namespace"]),
+		"component_kind":          strings.TrimSpace(attrs["kind"]),
+		"type":                    strings.TrimSpace(attrs["type"]),
+		"lifecycle":               strings.TrimSpace(attrs["lifecycle"]),
+		"criticality":             strings.TrimSpace(attrs["criticality"]),
+		"system":                  strings.TrimSpace(attrs["system"]),
+		"entity_ref":              strings.TrimSpace(attrs["entity_ref"]),
+		"event_id":                strings.TrimSpace(event.GetId()),
+		"source_runtime_id":       strings.TrimSpace(attrs[ports.EventAttributeSourceRuntimeID]),
+		"primary_resource_urn":    componentURN,
+	}
+	for key, value := range backstageCriticalComponentMissingOwnerDefinition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	observedAt := time.Time{}
+	if timestamp := event.GetOccurredAt(); timestamp != nil {
+		observedAt = timestamp.AsTime().UTC()
+	}
+	fingerprint := hashFindingFingerprint(backstageCriticalComponentMissingOwnerRuleID, componentURN)
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       strings.TrimSpace(runtimeID),
+		RuleID:          backstageCriticalComponentMissingOwnerRuleID,
+		Title:           backstageCriticalComponentMissingOwnerTitle,
+		Severity:        backstageCriticalComponentMissingOwnerSeverity,
+		Status:          findingStatusOpen,
+		Summary:         backstageCriticalComponentMissingOwnerSummary(label),
+		ResourceURNs:    []string{componentURN},
+		EventIDs:        []string{strings.TrimSpace(event.GetId())},
+		CheckID:         backstageCriticalComponentMissingOwnerCheckID,
+		CheckName:       backstageCriticalComponentMissingOwnerCheckName,
+		ControlRefs:     cloneFindingControlRefs(backstageCriticalComponentMissingOwnerDefinition.ControlRefs),
+		Attributes:      attributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}
+
+func backstageComponentIsCritical(value string) bool {
+	for _, token := range strings.Split(value, ",") {
+		token = strings.ToLower(strings.TrimSpace(token))
+		if token == "" {
+			continue
+		}
+		if _, ok := backstageCriticalComponentTiers[token]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func backstageComponentHasAccountableOwner(attributes map[string]string) bool {
+	owner := strings.TrimSpace(attributes["owner"])
+	if owner == "" {
+		return false
+	}
+	normalized := normalizeBackstageOwnerValue(owner)
+	if normalized == "" {
+		return false
+	}
+	_, placeholder := backstageUnaccountableOwners[normalized]
+	return !placeholder
+}
+
+func backstageComponentDecommissioned(attributes map[string]string) bool {
+	lifecycle := strings.ToLower(strings.TrimSpace(attributes["lifecycle"]))
+	_, ok := backstageDecommissionedLifecycles[lifecycle]
+	return ok
+}
+
+func normalizeBackstageOwnerValue(owner string) string {
+	owner = strings.ToLower(strings.TrimSpace(owner))
+	owner = strings.TrimPrefix(owner, "group:")
+	owner = strings.TrimPrefix(owner, "user:")
+	return strings.TrimSpace(owner)
+}
+
+func backstageComponentResourceURN(tenantID string, attributes map[string]string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return ""
+	}
+	entityRef := strings.TrimSpace(attributes["entity_ref"])
+	if entityRef == "" {
+		name := strings.TrimSpace(attributes["name"])
+		if name == "" {
+			return ""
+		}
+		kind := firstNonEmpty(strings.TrimSpace(attributes["kind"]), "Component")
+		namespace := firstNonEmpty(strings.TrimSpace(attributes["namespace"]), "default")
+		entityRef = kind + "/" + namespace + "/" + name
+	}
+	return fmt.Sprintf("urn:cerebro:%s:service:%s", tenantID, strings.ToLower(entityRef))
+}
+
+func backstageCriticalComponentMissingOwnerAnchor(attributes map[string]string) string {
+	return identityCounterEventAnchor(map[string]string{
+		"backstage_component_urn": strings.TrimSpace(attributes["backstage_component_urn"]),
+	}, "backstage_component_urn")
+}
+
+func backstageCriticalComponentMissingOwnerSummary(label string) string {
+	return fmt.Sprintf("Backstage critical component %s has no accountable owner", firstNonEmpty(label, "unknown component"))
+}

--- a/internal/findings/backstage_critical_component_missing_owner_rule_test.go
+++ b/internal/findings/backstage_critical_component_missing_owner_rule_test.go
@@ -1,0 +1,116 @@
+package findings
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func backstageComponentEvent(id string, attrs map[string]string, occurredAt time.Time) *cerebrov1.EventEnvelope {
+	base := map[string]string{
+		"family":            "component",
+		"name":              "payments",
+		"namespace":         "default",
+		"kind":              "Component",
+		"type":              "service",
+		"lifecycle":         "production",
+		"criticality":       "tier0",
+		"source_runtime_id": "writer-backstage-component",
+	}
+	for key, value := range attrs {
+		if value == "" {
+			delete(base, key)
+			continue
+		}
+		base[key] = value
+	}
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   "backstage",
+		Kind:       "backstage.component",
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  "backstage/component/v1",
+		Attributes: base,
+	}
+}
+
+func TestBackstageCriticalComponentMissingOwnerFixture(t *testing.T) {
+	assertRuleFixture(t, newBackstageCriticalComponentMissingOwnerRule(), "testdata/rules/backstage-critical-component-missing-owner.json")
+}
+
+func TestBackstageCriticalComponentMissingOwnerOwnershipResolves(t *testing.T) {
+	open := backstageComponentEvent("backstage-open", map[string]string{"owner": ""}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	owned := backstageComponentEvent("backstage-owned", map[string]string{"owner": "group:platform/payments"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	assertIdentityRuleRemediationTrajectory(t, newBackstageCriticalComponentMissingOwnerRule(), open, owned, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
+}
+
+func TestBackstageCriticalComponentMissingOwnerDowngradeResolves(t *testing.T) {
+	open := backstageComponentEvent("backstage-open", map[string]string{"owner": ""}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	downgraded := backstageComponentEvent("backstage-downgraded", map[string]string{"owner": "", "criticality": "low"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	assertIdentityRuleRemediationTrajectory(t, newBackstageCriticalComponentMissingOwnerRule(), open, downgraded, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
+}
+
+func TestBackstageCriticalComponentMissingOwnerDecommissionResolves(t *testing.T) {
+	open := backstageComponentEvent("backstage-open", map[string]string{"owner": ""}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	retired := backstageComponentEvent("backstage-retired", map[string]string{"owner": "", "lifecycle": "deprecated"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	assertIdentityRuleRemediationTrajectory(t, newBackstageCriticalComponentMissingOwnerRule(), open, retired, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
+}
+
+func TestBackstageCriticalComponentMissingOwnerReopensOnRecurrence(t *testing.T) {
+	rule := newBackstageCriticalComponentMissingOwnerRule()
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "writer-backstage-component",
+		SourceId: "backstage",
+		TenantId: "writer",
+		Config:   map[string]string{"family": "component"},
+	}
+
+	emitOpen := func(event *cerebrov1.EventEnvelope) *ports.FindingRecord {
+		t.Helper()
+		records, err := rule.Evaluate(context.Background(), runtime, event)
+		if err != nil {
+			t.Fatalf("Evaluate(%q) error = %v", event.GetId(), err)
+		}
+		if len(records) != 1 {
+			t.Fatalf("Evaluate(%q) emitted %d findings, want 1", event.GetId(), len(records))
+		}
+		if got := strings.TrimSpace(records[0].Status); got != findingStatusOpen {
+			t.Fatalf("Evaluate(%q) status = %q, want open", event.GetId(), got)
+		}
+		return records[0]
+	}
+
+	opened := emitOpen(backstageComponentEvent("backstage-unowned-1", map[string]string{"owner": ""}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)))
+	openFingerprint := strings.TrimSpace(opened.Fingerprint)
+	if openFingerprint == "" {
+		t.Fatal("opened finding has empty fingerprint")
+	}
+
+	counterRule, ok := rule.(CounterEventRule)
+	if !ok {
+		t.Fatal("rule does not implement CounterEventRule")
+	}
+	ownedEvent := backstageComponentEvent("backstage-owned", map[string]string{"owner": "group:platform/payments"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	closeAnchor, closes := counterRule.CloseOnEvent(ownedEvent)
+	if !closes || closeAnchor == "" {
+		t.Fatalf("CloseOnEvent(owned) = (%q, %v), want a non-empty closing anchor", closeAnchor, closes)
+	}
+	if openAnchor := counterRule.OpenAnchor(opened.Attributes); openAnchor != closeAnchor {
+		t.Fatalf("OpenAnchor(open finding) = %q, want match close anchor %q", openAnchor, closeAnchor)
+	}
+
+	reopened := emitOpen(backstageComponentEvent("backstage-unowned-2", map[string]string{"owner": ""}, time.Date(2026, 5, 1, 14, 0, 0, 0, time.UTC)))
+	if got := strings.TrimSpace(reopened.Fingerprint); got != openFingerprint {
+		t.Fatalf("recurrence fingerprint = %q, want stable %q", got, openFingerprint)
+	}
+	if got := strings.TrimSpace(reopened.ID); got != strings.TrimSpace(opened.ID) {
+		t.Fatalf("recurrence finding id = %q, want stable %q", got, strings.TrimSpace(opened.ID))
+	}
+}

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -2,6 +2,52 @@
   "version": "2026-05-21",
   "detections": [
     {
+      "id": "backstage-critical-component-missing-owner",
+      "pack_id": "backstage",
+      "pack_name": "Backstage",
+      "name": "Backstage Critical Component Missing Accountable Owner",
+      "description": "Detect business-critical Backstage components that have no accountable owner, leaving a high-importance service without a responsible team to govern its security posture, on-call response, or remediation.",
+      "source_id": "backstage",
+      "evaluation_mode": "event",
+      "event_kinds": [
+        "backstage.component"
+      ],
+      "output_kind": "finding.backstage_critical_component_missing_owner",
+      "severity": "HIGH",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "accountability",
+        "backstage",
+        "crown-jewel",
+        "ownership",
+        "service-catalog"
+      ],
+      "references": [
+        "https://backstage.io/docs/features/software-catalog/system-model"
+      ],
+      "false_positives": [
+        "Critical components intentionally owned by a shared platform group that is tracked outside the Backstage ownership model."
+      ],
+      "runbook": "Identify the unowned critical Backstage component and assign an accountable owning team in the catalog, or downgrade its criticality if it is no longer business-critical.",
+      "required_attributes": [
+        "name"
+      ],
+      "fingerprint_fields": [
+        "backstage_component_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC1.4"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.5.2"
+        }
+      ]
+    },
+    {
       "id": "cloud-current-public-exposure-review-needed",
       "pack_id": "cloud",
       "pack_name": "Cloud",

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -88,8 +88,8 @@ func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
 
 func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	packs := builtinRulePacks()
-	if got := len(packs); got != 24 {
-		t.Fatalf("len(builtinRulePacks()) = %d, want 24", got)
+	if got := len(packs); got != 25 {
+		t.Fatalf("len(builtinRulePacks()) = %d, want 25", got)
 	}
 	rules := flattenRulePacks(packs)
 	if got := len(rules); got < 10 {

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -221,6 +221,14 @@ func builtinRulePacks() []RulePack {
 			},
 		},
 		{
+			ID:          "backstage",
+			Name:        "Backstage",
+			Description: "Backstage service-catalog ownership and accountability posture findings.",
+			Rules: []Rule{
+				newBackstageCriticalComponentMissingOwnerRule(),
+			},
+		},
+		{
 			ID:          "policy",
 			Name:        "Policy",
 			Description: "Generated compliance policy checks and evidence mappings.",

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -825,7 +825,7 @@ func assertRulepackGraphEvidence(t *testing.T, store *stubFindingStore, findingI
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 51; got != want {
+	if got, want := len(keepRules), 52; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1063,6 +1063,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "pagerduty-service-without-escalation-policy", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "pagerduty"},
 		{RuleID: "trusted-endpoint-active-trust-gate-failure", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "trusted_endpoint"},
 		{RuleID: "security-tooling-map-control-coverage-gap", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "security_tooling_map"},
+		{RuleID: "backstage-critical-component-missing-owner", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "backstage"},
 		{RuleID: "vulnview-actionable-external-finding", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "vulnview"},
 		{RuleID: "vulnview-external-asset-concentrated-signal", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "vulnview"},
 	}

--- a/internal/findings/testdata/rules/backstage-critical-component-missing-owner.json
+++ b/internal/findings/testdata/rules/backstage-critical-component-missing-owner.json
@@ -1,0 +1,116 @@
+{
+  "rule_id": "backstage-critical-component-missing-owner",
+  "runtime": {
+    "id": "writer-backstage-component",
+    "source_id": "backstage",
+    "tenant_id": "writer",
+    "config": {
+      "family": "component"
+    }
+  },
+  "events": [
+    {
+      "id": "backstage-component-owned",
+      "tenant_id": "writer",
+      "source_id": "backstage",
+      "kind": "backstage.component",
+      "occurred_at": "2026-05-01T12:00:00Z",
+      "schema_ref": "backstage/component/v1",
+      "attributes": {
+        "family": "component",
+        "name": "billing",
+        "namespace": "default",
+        "kind": "Component",
+        "type": "service",
+        "lifecycle": "production",
+        "criticality": "tier0",
+        "owner": "group:platform/billing",
+        "source_runtime_id": "writer-backstage-component"
+      }
+    },
+    {
+      "id": "backstage-component-unowned",
+      "tenant_id": "writer",
+      "source_id": "backstage",
+      "kind": "backstage.component",
+      "occurred_at": "2026-05-01T12:05:00Z",
+      "schema_ref": "backstage/component/v1",
+      "attributes": {
+        "family": "component",
+        "name": "payments",
+        "namespace": "default",
+        "kind": "Component",
+        "type": "service",
+        "lifecycle": "production",
+        "criticality": "tier0",
+        "source_runtime_id": "writer-backstage-component"
+      }
+    },
+    {
+      "id": "backstage-component-noncritical",
+      "tenant_id": "writer",
+      "source_id": "backstage",
+      "kind": "backstage.component",
+      "occurred_at": "2026-05-01T12:10:00Z",
+      "schema_ref": "backstage/component/v1",
+      "attributes": {
+        "family": "component",
+        "name": "docs-site",
+        "namespace": "default",
+        "kind": "Component",
+        "type": "website",
+        "lifecycle": "production",
+        "criticality": "low",
+        "source_runtime_id": "writer-backstage-component"
+      }
+    },
+    {
+      "id": "backstage-component-deprecated",
+      "tenant_id": "writer",
+      "source_id": "backstage",
+      "kind": "backstage.component",
+      "occurred_at": "2026-05-01T12:15:00Z",
+      "schema_ref": "backstage/component/v1",
+      "attributes": {
+        "family": "component",
+        "name": "legacy-gateway",
+        "namespace": "default",
+        "kind": "Component",
+        "type": "service",
+        "lifecycle": "deprecated",
+        "criticality": "tier0",
+        "source_runtime_id": "writer-backstage-component"
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "backstage-critical-component-missing-owner",
+      "severity": "HIGH",
+      "status": "open",
+      "summary": "Backstage critical component payments has no accountable owner",
+      "event_ids": ["backstage-component-unowned"],
+      "attributes": {
+        "backstage_component_urn": "urn:cerebro:writer:service:component/default/payments",
+        "name": "payments",
+        "criticality": "tier0",
+        "primary_resource_urn": "urn:cerebro:writer:service:component/default/payments",
+        "rule_required_attributes": "name"
+      }
+    }
+  ],
+  "expected_no_match": [
+    {
+      "event_id": "backstage-component-owned",
+      "reason": "critical component with an accountable owner is governed"
+    },
+    {
+      "event_id": "backstage-component-noncritical",
+      "reason": "non-critical component without owner is not durable risk"
+    },
+    {
+      "event_id": "backstage-component-deprecated",
+      "reason": "decommissioned component is no longer an active accountability gap"
+    }
+  ]
+}

--- a/internal/sourceprojection/security_spine_test.go
+++ b/internal/sourceprojection/security_spine_test.go
@@ -2,6 +2,7 @@ package sourceprojection
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -140,6 +141,54 @@ func TestProjectBackstageComponentLinksKubernetesRuntime(t *testing.T) {
 	assertProjectedLink(t, state, namespaceURN, relationBelongsTo, clusterURN)
 	assertProjectedLink(t, state, clusterURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:123456789012")
 	assertProjectedLink(t, state, workloadURN, relationRunsAs, serviceAccountURN)
+}
+
+func TestRegistryRoutesBackstageDeclaredKinds(t *testing.T) {
+	declared := []string{
+		"backstage.component",
+	}
+	registered := make(map[string]struct{})
+	for _, kind := range BuiltinRegistry().Kinds() {
+		registered[kind] = struct{}{}
+	}
+	for _, kind := range declared {
+		if _, ok := registered[kind]; !ok {
+			t.Fatalf("declared Backstage kind %q is not routed in the projection registry", kind)
+		}
+	}
+}
+
+func TestProjectBackstageComponentWithoutOwnerOmitsOwnerLink(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	event := &cerebrov1.EventEnvelope{
+		Id:         "evt-backstage-unowned",
+		TenantId:   "writer",
+		SourceId:   "backstage",
+		Kind:       "backstage.component",
+		OccurredAt: timestamppb.New(time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)),
+		Attributes: map[string]string{
+			"name":        "ledger",
+			"namespace":   "default",
+			"kind":        "Component",
+			"type":        "service",
+			"criticality": "tier0",
+		},
+	}
+
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	serviceURN := "urn:cerebro:writer:service:component/default/ledger"
+	if state.entities[serviceURN] == nil {
+		t.Fatalf("component entity %q was not projected", serviceURN)
+	}
+	for key := range state.links {
+		if strings.Contains(key, "|"+relationOwnedBy+"|") {
+			t.Fatalf("unexpected ownership link %q for component without an owner", key)
+		}
+	}
 }
 
 func TestProjectSecurityToolingMapTool(t *testing.T) {

--- a/sources/backstage/source.go
+++ b/sources/backstage/source.go
@@ -40,10 +40,11 @@ func New() (*Source, error) {
 		TokenScheme:     "Bearer",
 		Families: []jsonapi.Family{
 			{
-				Name:    familyComponent,
-				Path:    "/api/catalog/entities/by-query",
-				URNKind: "backstage_component",
-				IDKeys:  []string{"metadata.uid", "metadata.name", "name"},
+				Name:      familyComponent,
+				Path:      "/api/catalog/entities/by-query",
+				URNKind:   "backstage_component",
+				RequireID: true,
+				IDKeys:    []string{"metadata.uid", "metadata.name", "name"},
 				TimestampKeys: []string{
 					"updated_at", "created_at",
 				},

--- a/sources/backstage/source_test.go
+++ b/sources/backstage/source_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,6 +96,91 @@ func TestReadComponentFamily(t *testing.T) {
 	}
 	if event.Attributes["criticality"] != "high" || event.Attributes["data_class"] != "restricted" {
 		t.Fatalf("annotation attrs = %#v, want Backstage annotation attributes", event.Attributes)
+	}
+}
+
+func TestReadComponentFamilyEmitsOwnershipContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"kind": "Component",
+				"metadata": map[string]any{
+					"uid":       "component-9",
+					"name":      "payments",
+					"namespace": "default",
+					"annotations": map[string]any{
+						"cerebro.io/criticality": "tier0",
+					},
+				},
+				"spec": map[string]any{
+					"type":      "service",
+					"lifecycle": "production",
+					"owner":     "group:platform/payments",
+					"system":    "commerce",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"token":     "backstage-token",
+		"family":    "component",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+	event := pull.Events[0]
+	for _, required := range []string{"name", "kind"} {
+		if strings.TrimSpace(event.Attributes[required]) == "" {
+			t.Fatalf("required attribute %q missing, attrs = %#v", required, event.Attributes)
+		}
+	}
+	if event.Attributes["owner"] != "group:platform/payments" {
+		t.Fatalf("owner = %q, want group:platform/payments", event.Attributes["owner"])
+	}
+	if event.Attributes["criticality"] != "tier0" {
+		t.Fatalf("criticality = %q, want tier0", event.Attributes["criticality"])
+	}
+	if event.Attributes["system"] != "commerce" {
+		t.Fatalf("system = %q, want commerce", event.Attributes["system"])
+	}
+}
+
+func TestReadComponentFamilyRejectsRecordWithoutIdentity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"kind": "Component",
+				"spec": map[string]any{"type": "service"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"token":     "backstage-token",
+		"family":    "component",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want rejection of component record without stable identity")
 	}
 }
 


### PR DESCRIPTION
## Scope
Single-source full-depth slice for the `backstage` connector (batch-6). No other source domains are modified. Changes cover the source, projection, and finding layers plus required shared governance artifacts.

## Source changes
- Enforce stable-identity on the `backstage.component` family (`RequireID`) so records without a resolvable component identity are rejected instead of being emitted under a synthetic ID.
- Added source tests asserting component identity/ownership context emission and rejection of identity-less records.

## Projection changes
- Added explicit registry routing coverage for declared Backstage kinds and a negative-path test confirming components without an owner do not emit an ownership link (component/service entity and ownership/system/context relationships are exercised by existing projection tests).

## Finding changes
- New durable, graph-anchored rule `backstage-critical-component-missing-owner`: opens when a business-critical component has no accountable owner, resolves on ownership assignment, criticality downgrade, or decommission, and reopens deterministically on recurrence with a stable component-URN fingerprint.
- Added rule unit tests, lifecycle trajectory tests, and a JSON fixture (risky vs. control cases).

## Shared file touches
- `internal/findings/rulepack.go`: registered the new Backstage rule pack.
- `internal/findings/rulepack_audit_test.go`: added fallback classification entry and updated KEEP_AS_IS count.
- `internal/findings/registry_test.go`: updated rule-pack count assertion.
- `internal/findings/public_detection_catalog.json`: regenerated.
- `internal/compliance/control_coverage_index.yaml`: regenerated control mappings.

## Validation evidence
- `make lint` → `0 issues.`
- `go test ./sources/backstage/... -count=1` → ok
- `go test ./internal/sourceprojection/... -run 'Backstage|backstage|Registry' -count=1` → ok (Backstage-specific tests matched and passed)
- `go test ./internal/findings/... -run Backstage -count=1` → ok (5 matched tests: fixture, ownership/downgrade/decommission resolve, reopen-on-recurrence)
- `go test ./internal/findings/... -count=1` → ok (rulepack/registry/audit governance)
- `go test ./tools/archtests/... -count=1` → ok
- `make catalog-check` → ok (includes control-index --check)
- `make detection-catalog-check` → ok

## Risk and rollback
- Low blast radius: additive rule pack plus a single source hardening flag. Revert this branch's commit to fully roll back; generated catalog/index artifacts revert with it. No storage-shape, CDK-budget, or platform-boundary changes; no non-goal crossed.
