### PR TITLE
Redact sensitive finding response attributes

### DIFF
--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -105,6 +105,7 @@ const (
 	maxProtoJSONBodyBytes              = 1 << 20
 	healthCheckTimeout                 = 2 * time.Second
 	sourceRuntimeProgressConfigHashKey = "__cerebro_resolved_progress_config_hash"
+	redactedAttributeValue             = "[redacted]"
 )
 
 var (
@@ -412,7 +413,7 @@ func (a *App) handleGetFinding(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.GetFindingResponse{
-		Finding: findingMessage(finding),
+		Finding: safeFindingMessage(finding),
 	})
 }
 
@@ -442,7 +443,7 @@ func (a *App) handleResolveFinding(w http.ResponseWriter, r *http.Request) {
 	}
 	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.ResolveFindingResponse{
-		Finding: findingMessage(finding),
+		Finding: safeFindingMessage(finding),
 	})
 }
 
@@ -472,7 +473,7 @@ func (a *App) handleSuppressFinding(w http.ResponseWriter, r *http.Request) {
 	}
 	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.SuppressFindingResponse{
-		Finding: findingMessage(finding),
+		Finding: safeFindingMessage(finding),
 	})
 }
 
@@ -497,7 +498,7 @@ func (a *App) handleAssignFinding(w http.ResponseWriter, r *http.Request) {
 	}
 	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.AssignFindingResponse{
-		Finding: findingMessage(finding),
+		Finding: safeFindingMessage(finding),
 	})
 }
 
@@ -523,7 +524,7 @@ func (a *App) handleSetFindingDueDate(w http.ResponseWriter, r *http.Request) {
 	}
 	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.SetFindingDueDateResponse{
-		Finding: findingMessage(finding),
+		Finding: safeFindingMessage(finding),
 	})
 }
 
@@ -545,7 +546,7 @@ func (a *App) handleAddFindingNote(w http.ResponseWriter, r *http.Request) {
 	}
 	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.AddFindingNoteResponse{
-		Finding: findingMessage(finding),
+		Finding: safeFindingMessage(finding),
 	})
 }
 
@@ -573,7 +574,7 @@ func (a *App) handleLinkFindingTicket(w http.ResponseWriter, r *http.Request) {
 	}
 	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.LinkFindingTicketResponse{
-		Finding: findingMessage(finding),
+		Finding: safeFindingMessage(finding),
 	})
 }
 
@@ -595,7 +596,7 @@ func (a *App) handleLinkFindingExternalRef(w http.ResponseWriter, r *http.Reques
 	}
 	a.bumpGRCCacheForFinding(r.Context(), finding)
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.LinkFindingExternalRefResponse{
-		Finding: findingMessage(finding),
+		Finding: safeFindingMessage(finding),
 	})
 }
 
@@ -672,7 +673,7 @@ func (a *App) handleGetFindingEvidence(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, &cerebrov1.GetFindingEvidenceResponse{
-		Evidence: response,
+		Evidence: safeFindingEvidence(response),
 	})
 }
 
@@ -1724,7 +1725,7 @@ func (a *App) handleGetFindingCandidate(w http.ResponseWriter, r *http.Request) 
 		writeFindingError(w, normalizeIDLookupError(err, ports.ErrFindingCandidateNotFound))
 		return
 	}
-	writeProtoJSON(w, http.StatusOK, &cerebrov1.GetFindingCandidateResponse{Candidate: findingCandidateMessage(candidate)})
+	writeProtoJSON(w, http.StatusOK, &cerebrov1.GetFindingCandidateResponse{Candidate: safeFindingCandidateMessage(candidate)})
 }
 
 func (a *App) handlePromoteFindingCandidate(w http.ResponseWriter, r *http.Request) {
@@ -1840,9 +1841,7 @@ func (a *App) handleListFindingEvidence(w http.ResponseWriter, r *http.Request) 
 		writeFindingError(w, err)
 		return
 	}
-	writeProtoJSON(w, http.StatusOK, &cerebrov1.ListFindingEvidenceResponse{
-		Evidence: response.Evidence,
-	})
+	writeProtoJSON(w, http.StatusOK, listFindingEvidenceResponse(response))
 }
 
 func (a *App) handleListFindingEvaluationRuns(w http.ResponseWriter, r *http.Request) {
@@ -2088,7 +2087,7 @@ func (s *bootstrapService) GetFinding(ctx context.Context, req *connect.Request[
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
-	return connect.NewResponse(&cerebrov1.GetFindingResponse{Finding: findingMessage(finding)}), nil
+	return connect.NewResponse(&cerebrov1.GetFindingResponse{Finding: safeFindingMessage(finding)}), nil
 }
 
 func (s *bootstrapService) ListFindingCandidates(ctx context.Context, req *connect.Request[cerebrov1.ListFindingCandidatesRequest]) (*connect.Response[cerebrov1.ListFindingCandidatesResponse], error) {
@@ -2118,7 +2117,7 @@ func (s *bootstrapService) GetFindingCandidate(ctx context.Context, req *connect
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), candidate.RuntimeID); err != nil {
 		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingCandidateNotFound))
 	}
-	return connect.NewResponse(&cerebrov1.GetFindingCandidateResponse{Candidate: findingCandidateMessage(candidate)}), nil
+	return connect.NewResponse(&cerebrov1.GetFindingCandidateResponse{Candidate: safeFindingCandidateMessage(candidate)}), nil
 }
 
 func (s *bootstrapService) EvaluateSourceRuntimeFindingCandidates(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingCandidatesRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingCandidatesResponse], error) {
@@ -2199,7 +2198,7 @@ func (s *bootstrapService) ResolveFinding(ctx context.Context, req *connect.Requ
 		return nil, findingConnectError(err)
 	}
 	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
-	return connect.NewResponse(&cerebrov1.ResolveFindingResponse{Finding: findingMessage(finding)}), nil
+	return connect.NewResponse(&cerebrov1.ResolveFindingResponse{Finding: safeFindingMessage(finding)}), nil
 }
 
 func (s *bootstrapService) SuppressFinding(ctx context.Context, req *connect.Request[cerebrov1.SuppressFindingRequest]) (*connect.Response[cerebrov1.SuppressFindingResponse], error) {
@@ -2215,7 +2214,7 @@ func (s *bootstrapService) SuppressFinding(ctx context.Context, req *connect.Req
 		return nil, findingConnectError(err)
 	}
 	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
-	return connect.NewResponse(&cerebrov1.SuppressFindingResponse{Finding: findingMessage(finding)}), nil
+	return connect.NewResponse(&cerebrov1.SuppressFindingResponse{Finding: safeFindingMessage(finding)}), nil
 }
 
 func (s *bootstrapService) AssignFinding(ctx context.Context, req *connect.Request[cerebrov1.AssignFindingRequest]) (*connect.Response[cerebrov1.AssignFindingResponse], error) {
@@ -2227,7 +2226,7 @@ func (s *bootstrapService) AssignFinding(ctx context.Context, req *connect.Reque
 		return nil, findingConnectError(err)
 	}
 	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
-	return connect.NewResponse(&cerebrov1.AssignFindingResponse{Finding: findingMessage(finding)}), nil
+	return connect.NewResponse(&cerebrov1.AssignFindingResponse{Finding: safeFindingMessage(finding)}), nil
 }
 
 func (s *bootstrapService) SetFindingDueDate(ctx context.Context, req *connect.Request[cerebrov1.SetFindingDueDateRequest]) (*connect.Response[cerebrov1.SetFindingDueDateResponse], error) {
@@ -2243,7 +2242,7 @@ func (s *bootstrapService) SetFindingDueDate(ctx context.Context, req *connect.R
 		return nil, findingConnectError(err)
 	}
 	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
-	return connect.NewResponse(&cerebrov1.SetFindingDueDateResponse{Finding: findingMessage(finding)}), nil
+	return connect.NewResponse(&cerebrov1.SetFindingDueDateResponse{Finding: safeFindingMessage(finding)}), nil
 }
 
 func (s *bootstrapService) AddFindingNote(ctx context.Context, req *connect.Request[cerebrov1.AddFindingNoteRequest]) (*connect.Response[cerebrov1.AddFindingNoteResponse], error) {
@@ -2255,7 +2254,7 @@ func (s *bootstrapService) AddFindingNote(ctx context.Context, req *connect.Requ
 		return nil, findingConnectError(err)
 	}
 	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
-	return connect.NewResponse(&cerebrov1.AddFindingNoteResponse{Finding: findingMessage(finding)}), nil
+	return connect.NewResponse(&cerebrov1.AddFindingNoteResponse{Finding: safeFindingMessage(finding)}), nil
 }
 
 func (s *bootstrapService) LinkFindingTicket(ctx context.Context, req *connect.Request[cerebrov1.LinkFindingTicketRequest]) (*connect.Response[cerebrov1.LinkFindingTicketResponse], error) {
@@ -2273,7 +2272,7 @@ func (s *bootstrapService) LinkFindingTicket(ctx context.Context, req *connect.R
 		return nil, findingConnectError(err)
 	}
 	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
-	return connect.NewResponse(&cerebrov1.LinkFindingTicketResponse{Finding: findingMessage(finding)}), nil
+	return connect.NewResponse(&cerebrov1.LinkFindingTicketResponse{Finding: safeFindingMessage(finding)}), nil
 }
 
 func (s *bootstrapService) LinkFindingExternalRef(ctx context.Context, req *connect.Request[cerebrov1.LinkFindingExternalRefRequest]) (*connect.Response[cerebrov1.LinkFindingExternalRefResponse], error) {
@@ -2285,7 +2284,7 @@ func (s *bootstrapService) LinkFindingExternalRef(ctx context.Context, req *conn
 		return nil, findingConnectError(err)
 	}
 	bumpGRCCacheForFinding(ctx, s.deps.QueryCache, finding)
-	return connect.NewResponse(&cerebrov1.LinkFindingExternalRefResponse{Finding: findingMessage(finding)}), nil
+	return connect.NewResponse(&cerebrov1.LinkFindingExternalRefResponse{Finding: safeFindingMessage(finding)}), nil
 }
 
 func (s *bootstrapService) ListFindingEvidence(ctx context.Context, req *connect.Request[cerebrov1.ListFindingEvidenceRequest]) (*connect.Response[cerebrov1.ListFindingEvidenceResponse], error) {
@@ -2306,9 +2305,7 @@ func (s *bootstrapService) ListFindingEvidence(ctx context.Context, req *connect
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
-	return connect.NewResponse(&cerebrov1.ListFindingEvidenceResponse{
-		Evidence: response.Evidence,
-	}), nil
+	return connect.NewResponse(listFindingEvidenceResponse(response)), nil
 }
 
 func (s *bootstrapService) ListFindingEvaluationRuns(ctx context.Context, req *connect.Request[cerebrov1.ListFindingEvaluationRunsRequest]) (*connect.Response[cerebrov1.ListFindingEvaluationRunsResponse], error) {
@@ -2348,7 +2345,7 @@ func (s *bootstrapService) GetFindingEvidence(ctx context.Context, req *connect.
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), evidence.GetRuntimeId()); err != nil {
 		return nil, findingConnectError(normalizeIDLookupError(err, ports.ErrFindingEvidenceNotFound))
 	}
-	return connect.NewResponse(&cerebrov1.GetFindingEvidenceResponse{Evidence: evidence}), nil
+	return connect.NewResponse(&cerebrov1.GetFindingEvidenceResponse{Evidence: safeFindingEvidence(evidence)}), nil
 }
 
 func (s *bootstrapService) EvaluateSourceRuntimeFindingRules(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingRulesRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingRulesResponse], error) {
@@ -3435,9 +3432,9 @@ func findingResponse(result *findings.EvaluateResult) *cerebrov1.EvaluateSourceR
 		Rule:             result.Rule,
 		EventsEvaluated:  result.EventsEvaluated,
 		FindingsUpserted: boundedUint32(len(result.Findings)),
-		Findings:         findingMessages(result.Findings),
+		Findings:         safeFindingMessages(result.Findings),
 		Run:              result.Run,
-		Evidence:         result.Evidence,
+		Evidence:         safeFindingEvidenceMessages(result.Evidence),
 	}
 	return response
 }
@@ -3503,7 +3500,7 @@ func redactSourceRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRunt
 			continue
 		}
 		if sensitiveSourceConfigKey(key) {
-			config[key] = "[redacted]"
+			config[key] = redactedAttributeValue
 			continue
 		}
 		config[key] = value
@@ -3518,9 +3515,9 @@ func findingRuleEvaluationMessage(result *findings.RuleEvaluationResult) *cerebr
 	}
 	return &cerebrov1.FindingRuleEvaluation{
 		Rule:     result.Rule,
-		Findings: findingMessages(result.Findings),
+		Findings: safeFindingMessages(result.Findings),
 		Run:      result.Run,
-		Evidence: result.Evidence,
+		Evidence: safeFindingEvidenceMessages(result.Evidence),
 	}
 }
 
@@ -3531,7 +3528,7 @@ func findingCandidateRuleEvaluationMessage(result *findings.FindingCandidateEval
 	return &cerebrov1.FindingCandidateRuleEvaluation{
 		Rule:       result.Rule,
 		Run:        findingCandidateRunMessage(result.Run),
-		Candidates: findingCandidateMessages(result.Candidates),
+		Candidates: safeFindingCandidateMessages(result.Candidates),
 	}
 }
 
@@ -3540,7 +3537,7 @@ func listFindingsResponse(result *findings.ListResult) *cerebrov1.ListFindingsRe
 		return &cerebrov1.ListFindingsResponse{}
 	}
 	return &cerebrov1.ListFindingsResponse{
-		Findings: findingMessages(result.Findings),
+		Findings: safeFindingMessages(result.Findings),
 	}
 }
 
@@ -3549,7 +3546,16 @@ func listFindingCandidatesResponse(result *findings.ListCandidatesResult) *cereb
 		return &cerebrov1.ListFindingCandidatesResponse{}
 	}
 	return &cerebrov1.ListFindingCandidatesResponse{
-		Candidates: findingCandidateMessages(result.Candidates),
+		Candidates: safeFindingCandidateMessages(result.Candidates),
+	}
+}
+
+func listFindingEvidenceResponse(result *findings.ListEvidenceResult) *cerebrov1.ListFindingEvidenceResponse {
+	if result == nil {
+		return &cerebrov1.ListFindingEvidenceResponse{}
+	}
+	return &cerebrov1.ListFindingEvidenceResponse{
+		Evidence: safeFindingEvidenceMessages(result.Evidence),
 	}
 }
 
@@ -3558,8 +3564,8 @@ func promoteFindingCandidateResponse(result *findings.PromoteCandidateResult) *c
 		return &cerebrov1.PromoteFindingCandidateResponse{}
 	}
 	return &cerebrov1.PromoteFindingCandidateResponse{
-		Finding:    findingMessage(result.Finding),
-		Candidate:  findingCandidateMessage(result.Candidate),
+		Finding:    safeFindingMessage(result.Finding),
+		Candidate:  safeFindingCandidateMessage(result.Candidate),
 		DecisionId: result.DecisionID,
 	}
 }
@@ -3569,23 +3575,23 @@ func rejectFindingCandidateResponse(result *findings.RejectCandidateResult) *cer
 		return &cerebrov1.RejectFindingCandidateResponse{}
 	}
 	return &cerebrov1.RejectFindingCandidateResponse{
-		Candidate:  findingCandidateMessage(result.Candidate),
+		Candidate:  safeFindingCandidateMessage(result.Candidate),
 		DecisionId: result.DecisionID,
 	}
 }
 
-func findingMessages(findings []*ports.FindingRecord) []*cerebrov1.Finding {
+func safeFindingMessages(findings []*ports.FindingRecord) []*cerebrov1.Finding {
 	messages := make([]*cerebrov1.Finding, 0, len(findings))
 	for _, finding := range findings {
-		messages = append(messages, findingMessage(finding))
+		messages = append(messages, safeFindingMessage(finding))
 	}
 	return messages
 }
 
-func findingCandidateMessages(candidates []*ports.FindingCandidateRecord) []*cerebrov1.FindingCandidate {
+func safeFindingCandidateMessages(candidates []*ports.FindingCandidateRecord) []*cerebrov1.FindingCandidate {
 	messages := make([]*cerebrov1.FindingCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
-		messages = append(messages, findingCandidateMessage(candidate))
+		messages = append(messages, safeFindingCandidateMessage(candidate))
 	}
 	return messages
 }
@@ -3659,6 +3665,16 @@ func findingCandidateMessage(candidate *ports.FindingCandidateRecord) *cerebrov1
 	return message
 }
 
+func safeFindingCandidateMessage(candidate *ports.FindingCandidateRecord) *cerebrov1.FindingCandidate {
+	message := findingCandidateMessage(candidate)
+	if message == nil {
+		return nil
+	}
+	message.Finding = safeFindingMessage(candidate.Finding)
+	message.Evidence = safeFindingEvidenceMessages(candidate.Evidence)
+	return message
+}
+
 func findingMessage(finding *ports.FindingRecord) *cerebrov1.Finding {
 	if finding == nil {
 		return nil
@@ -3713,6 +3729,76 @@ func findingMessage(finding *ports.FindingRecord) *cerebrov1.Finding {
 		message.LastObservedAt = timestamppb.New(finding.LastObservedAt)
 	}
 	return message
+}
+
+func safeFindingMessage(finding *ports.FindingRecord) *cerebrov1.Finding {
+	message := findingMessage(finding)
+	if message == nil {
+		return nil
+	}
+	message.Attributes = redactSensitiveAttributes(message.GetAttributes())
+	return message
+}
+
+func safeFindingEvidenceMessages(evidence []*cerebrov1.FindingEvidence) []*cerebrov1.FindingEvidence {
+	messages := make([]*cerebrov1.FindingEvidence, 0, len(evidence))
+	for _, record := range evidence {
+		messages = append(messages, safeFindingEvidence(record))
+	}
+	return messages
+}
+
+func safeFindingEvidence(evidence *cerebrov1.FindingEvidence) *cerebrov1.FindingEvidence {
+	if evidence == nil {
+		return nil
+	}
+	cloned := proto.Clone(evidence).(*cerebrov1.FindingEvidence)
+	cloned.Attributes = redactSensitiveAttributes(cloned.GetAttributes())
+	cloned.GraphRows = safeGraphEvidenceRows(cloned.GetGraphRows())
+	for _, observation := range cloned.GetObservations() {
+		if observation == nil {
+			continue
+		}
+		observation.GraphRows = safeGraphEvidenceRows(observation.GetGraphRows())
+	}
+	return cloned
+}
+
+func safeGraphEvidenceRows(rows []*cerebrov1.GraphEvidenceRow) []*cerebrov1.GraphEvidenceRow {
+	if len(rows) == 0 {
+		return rows
+	}
+	safeRows := make([]*cerebrov1.GraphEvidenceRow, 0, len(rows))
+	for _, row := range rows {
+		if row == nil {
+			continue
+		}
+		cloned := proto.Clone(row).(*cerebrov1.GraphEvidenceRow)
+		cloned.Attributes = redactSensitiveAttributes(cloned.GetAttributes())
+		for _, path := range cloned.GetPaths() {
+			if path == nil {
+				continue
+			}
+			path.Attributes = redactSensitiveAttributes(path.GetAttributes())
+		}
+		safeRows = append(safeRows, cloned)
+	}
+	return safeRows
+}
+
+func redactSensitiveAttributes(attributes map[string]string) map[string]string {
+	if len(attributes) == 0 {
+		return attributes
+	}
+	redacted := make(map[string]string, len(attributes))
+	for key, value := range attributes {
+		if sensitiveSourceConfigKey(key) {
+			redacted[key] = redactedAttributeValue
+			continue
+		}
+		redacted[key] = value
+	}
+	return redacted
 }
 
 func findingRiskFactorMessages(factors []ports.FindingRiskFactor) []*cerebrov1.FindingRiskFactor {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -5647,6 +5647,41 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := evaluateFindingsResp.Msg.GetEvidence()[0].GetClaimIds(); len(got) != 1 || got[0] != "claim-1" {
 		t.Fatalf("EvaluateSourceRuntimeFindings evidence claim ids = %#v, want [claim-1]", got)
 	}
+	evaluatedFindingID := evaluateFindingsResp.Msg.GetFindings()[0].GetId()
+	storedFinding, ok := runtimeStore.findings[evaluatedFindingID]
+	if !ok {
+		t.Fatalf("stored finding %q missing", evaluatedFindingID)
+	}
+	if storedFinding.Attributes == nil {
+		storedFinding.Attributes = map[string]string{}
+	}
+	storedFinding.Attributes["api_key"] = "finding-secret"
+	storedFinding.Attributes["environment"] = "prod"
+	evaluatedEvidenceID := evaluateFindingsResp.Msg.GetEvidence()[0].GetId()
+	storedEvidence, ok := runtimeStore.findingEvidence[evaluatedEvidenceID]
+	if !ok {
+		t.Fatalf("stored evidence %q missing", evaluatedEvidenceID)
+	}
+	seedFindingEvidenceSecrets := func() {
+		for _, evidence := range runtimeStore.findingEvidence {
+			if evidence.Attributes == nil {
+				evidence.Attributes = map[string]string{}
+			}
+			evidence.Attributes["token"] = "evidence-secret"
+			evidence.Attributes["policy_rule_status"] = "inactive"
+			evidence.GraphRows = []*cerebrov1.GraphEvidenceRow{{
+				Label:      "policy-rule",
+				Attributes: map[string]string{"private_key": "row-secret", "resource_id": "rul-1"},
+				Paths: []*cerebrov1.GraphEvidencePath{{
+					Attributes: map[string]string{"password": "path-secret", "relation": "member"},
+				}},
+			}}
+		}
+	}
+	seedFindingEvidenceSecrets()
+	if got := storedEvidence.GetAttributes()["token"]; got != "evidence-secret" {
+		t.Fatalf("stored evaluated evidence token = %q, want original value", got)
+	}
 	listFindingsResp, err := client.ListFindings(context.Background(), connect.NewRequest(&cerebrov1.ListFindingsRequest{
 		RuntimeId:   "writer-okta-policy-rule",
 		RuleId:      "identity-okta-policy-rule-lifecycle-tampering",
@@ -5674,6 +5709,15 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := len(listFindingsResp.Msg.GetFindings()[0].GetControlRefs()); got != 2 {
 		t.Fatalf("len(ListFindings().Findings[0].ControlRefs) = %d, want 2", got)
+	}
+	if got := listFindingsResp.Msg.GetFindings()[0].GetAttributes()["api_key"]; got != "[redacted]" {
+		t.Fatalf("ListFindings().Findings[0].Attributes[api_key] = %q, want [redacted]", got)
+	}
+	if got := listFindingsResp.Msg.GetFindings()[0].GetAttributes()["environment"]; got != "prod" {
+		t.Fatalf("ListFindings().Findings[0].Attributes[environment] = %q, want prod", got)
+	}
+	if got := runtimeStore.findings[evaluatedFindingID].Attributes["api_key"]; got != "finding-secret" {
+		t.Fatalf("stored finding api_key = %q, want original value", got)
 	}
 	if got := runtimeStore.findingListRequest.TenantID; got != "writer" {
 		t.Fatalf("runtimeStore.findingListRequest.TenantID = %q, want writer", got)
@@ -5728,6 +5772,7 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := len(lifecycleEvaluation.GetEvidence()); got != 1 {
 		t.Fatalf("len(EvaluateSourceRuntimeFindingRules().Evaluations[0].Evidence) = %d, want 1", got)
 	}
+	seedFindingEvidenceSecrets()
 	listEvidenceResp, err := client.ListFindingEvidence(context.Background(), connect.NewRequest(&cerebrov1.ListFindingEvidenceRequest{
 		RuntimeId:    "writer-okta-policy-rule",
 		FindingId:    evaluateFindingsResp.Msg.GetFindings()[0].GetId(),
@@ -5744,6 +5789,22 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := len(listEvidenceResp.Msg.GetEvidence()); got != 1 {
 		t.Fatalf("len(ListFindingEvidence().Evidence) = %d, want 1", got)
 	}
+	listedConnectEvidence := listEvidenceResp.Msg.GetEvidence()[0]
+	if got := listedConnectEvidence.GetAttributes()["token"]; got != "[redacted]" {
+		t.Fatalf("ListFindingEvidence().Evidence[0].Attributes[token] = %q, want [redacted]", got)
+	}
+	if got := listedConnectEvidence.GetAttributes()["policy_rule_status"]; got != "inactive" {
+		t.Fatalf("ListFindingEvidence().Evidence[0].Attributes[policy_rule_status] = %q, want inactive", got)
+	}
+	if got := listedConnectEvidence.GetGraphRows()[0].GetAttributes()["private_key"]; got != "[redacted]" {
+		t.Fatalf("ListFindingEvidence().Evidence[0].GraphRows[0].Attributes[private_key] = %q, want [redacted]", got)
+	}
+	if got := listedConnectEvidence.GetGraphRows()[0].GetPaths()[0].GetAttributes()["password"]; got != "[redacted]" {
+		t.Fatalf("ListFindingEvidence().Evidence[0].GraphRows[0].Paths[0].Attributes[password] = %q, want [redacted]", got)
+	}
+	if got := runtimeStore.findingEvidence[listedConnectEvidence.GetId()].GetAttributes()["token"]; got != "evidence-secret" {
+		t.Fatalf("stored evidence token = %q, want original value", got)
+	}
 	getFindingEvidenceResp, err := client.GetFindingEvidence(context.Background(), connect.NewRequest(&cerebrov1.GetFindingEvidenceRequest{
 		Id: listEvidenceResp.Msg.GetEvidence()[0].GetId(),
 	}))
@@ -5752,6 +5813,9 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := getFindingEvidenceResp.Msg.GetEvidence().GetId(); got != listEvidenceResp.Msg.GetEvidence()[0].GetId() {
 		t.Fatalf("GetFindingEvidence().Evidence.Id = %q, want %q", got, listEvidenceResp.Msg.GetEvidence()[0].GetId())
+	}
+	if got := getFindingEvidenceResp.Msg.GetEvidence().GetAttributes()["token"]; got != "[redacted]" {
+		t.Fatalf("GetFindingEvidence().Evidence.Attributes[token] = %q, want [redacted]", got)
 	}
 	getEvaluationRunResp, err := client.GetFindingEvaluationRun(context.Background(), connect.NewRequest(&cerebrov1.GetFindingEvaluationRunRequest{
 		Id: evaluateFindingsResp.Msg.GetRun().GetId(),
@@ -5790,6 +5854,13 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := assignFinding["assignee"]; got != "secops" {
 		t.Fatalf("assign finding assignee = %#v, want secops", got)
+	}
+	assignAttributes, ok := assignFinding["attributes"].(map[string]any)
+	if !ok {
+		t.Fatalf("assign finding attributes = %#v, want object", assignFinding["attributes"])
+	}
+	if got := assignAttributes["api_key"]; got != "[redacted]" {
+		t.Fatalf("assign finding api_key = %#v, want [redacted]", got)
 	}
 	httpDueAt := "2026-05-01T12:00:00Z"
 	dueBody, err := protojson.Marshal(&cerebrov1.SetFindingDueDateRequest{DueAt: timestamppb.New(time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))})
@@ -5860,6 +5931,9 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := len(addNoteResp.Msg.GetFinding().GetNotes()); got != 2 {
 		t.Fatalf("len(AddFindingNote().Finding.Notes) = %d, want 2", got)
+	}
+	if got := addNoteResp.Msg.GetFinding().GetAttributes()["api_key"]; got != "[redacted]" {
+		t.Fatalf("AddFindingNote().Finding.Attributes[api_key] = %q, want [redacted]", got)
 	}
 	ticketBody, err := protojson.Marshal(&cerebrov1.LinkFindingTicketRequest{
 		Url:        "https://jira.writer.com/browse/ENG-123",
@@ -5956,6 +6030,16 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := getFindingBody["due_at"]; got != "2026-05-02T12:00:00Z" {
 		t.Fatalf("get finding due_at = %#v, want 2026-05-02T12:00:00Z", got)
+	}
+	getFindingAttributes, ok := getFindingBody["attributes"].(map[string]any)
+	if !ok {
+		t.Fatalf("get finding attributes = %#v, want object", getFindingBody["attributes"])
+	}
+	if got := getFindingAttributes["api_key"]; got != "[redacted]" {
+		t.Fatalf("get finding api_key = %#v, want [redacted]", got)
+	}
+	if got := getFindingAttributes["environment"]; got != "prod" {
+		t.Fatalf("get finding environment = %#v, want prod", got)
 	}
 	getFindingNotes, ok := getFindingBody["notes"].([]any)
 	if !ok || len(getFindingNotes) != 2 {
@@ -6094,6 +6178,33 @@ func TestFindingCandidateEndpointsEvaluateListGetAndPromote(t *testing.T) {
 	if candidateID == "" {
 		t.Fatal("candidate id is empty")
 	}
+	storedCandidate, ok := runtimeStore.findingCandidates[candidateID]
+	if !ok {
+		t.Fatalf("stored candidate %q missing", candidateID)
+	}
+	if storedCandidate.Finding == nil {
+		t.Fatal("stored candidate finding is nil")
+	}
+	if storedCandidate.Finding.Attributes == nil {
+		storedCandidate.Finding.Attributes = map[string]string{}
+	}
+	storedCandidate.Finding.Attributes["api_key"] = "candidate-finding-secret"
+	storedCandidate.Finding.Attributes["environment"] = "prod"
+	if len(storedCandidate.Evidence) != 1 {
+		t.Fatalf("len(stored candidate evidence) = %d, want 1", len(storedCandidate.Evidence))
+	}
+	if storedCandidate.Evidence[0].Attributes == nil {
+		storedCandidate.Evidence[0].Attributes = map[string]string{}
+	}
+	storedCandidate.Evidence[0].Attributes["token"] = "candidate-evidence-secret"
+	storedCandidate.Evidence[0].Attributes["resource_id"] = "rul-1"
+	storedCandidate.Evidence[0].GraphRows = []*cerebrov1.GraphEvidenceRow{{
+		Label:      "candidate-policy-rule",
+		Attributes: map[string]string{"private_key": "candidate-row-secret", "resource_id": "rul-1"},
+		Paths: []*cerebrov1.GraphEvidencePath{{
+			Attributes: map[string]string{"password": "candidate-path-secret", "relation": "member"},
+		}},
+	}}
 	if got := len(runtimeStore.findings); got != 0 {
 		t.Fatalf("production findings after candidate evaluate = %d, want 0", got)
 	}
@@ -6115,6 +6226,30 @@ func TestFindingCandidateEndpointsEvaluateListGetAndPromote(t *testing.T) {
 	if got := len(listCandidates); got != 1 {
 		t.Fatalf("listed candidates = %d, want 1", got)
 	}
+	listedCandidate, ok := listCandidates[0].(map[string]any)
+	if !ok {
+		t.Fatalf("listed candidate = %#v, want object", listCandidates[0])
+	}
+	listedCandidateFinding, ok := listedCandidate["finding"].(map[string]any)
+	if !ok {
+		t.Fatalf("listed candidate finding = %#v, want object", listedCandidate["finding"])
+	}
+	listedCandidateAttributes, ok := listedCandidateFinding["attributes"].(map[string]any)
+	if !ok {
+		t.Fatalf("listed candidate finding attributes = %#v, want object", listedCandidateFinding["attributes"])
+	}
+	if got := listedCandidateAttributes["api_key"]; got != "[redacted]" {
+		t.Fatalf("listed candidate finding api_key = %#v, want [redacted]", got)
+	}
+	listedCandidateEvidence := listedCandidate["evidence"].([]any)[0].(map[string]any)
+	listedEvidenceAttributes := listedCandidateEvidence["attributes"].(map[string]any)
+	if got := listedEvidenceAttributes["token"]; got != "[redacted]" {
+		t.Fatalf("listed candidate evidence token = %#v, want [redacted]", got)
+	}
+	listedGraphRow := listedCandidateEvidence["graph_rows"].([]any)[0].(map[string]any)
+	if got := listedGraphRow["attributes"].(map[string]any)["private_key"]; got != "[redacted]" {
+		t.Fatalf("listed candidate graph row private_key = %#v, want [redacted]", got)
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	getResp, err := client.GetFindingCandidate(context.Background(), connect.NewRequest(&cerebrov1.GetFindingCandidateRequest{Id: candidateID}))
@@ -6123,6 +6258,12 @@ func TestFindingCandidateEndpointsEvaluateListGetAndPromote(t *testing.T) {
 	}
 	if got := getResp.Msg.GetCandidate().GetId(); got != candidateID {
 		t.Fatalf("GetFindingCandidate().Candidate.Id = %q, want %q", got, candidateID)
+	}
+	if got := getResp.Msg.GetCandidate().GetFinding().GetAttributes()["api_key"]; got != "[redacted]" {
+		t.Fatalf("GetFindingCandidate().Candidate.Finding.Attributes[api_key] = %q, want [redacted]", got)
+	}
+	if got := getResp.Msg.GetCandidate().GetEvidence()[0].GetAttributes()["token"]; got != "[redacted]" {
+		t.Fatalf("GetFindingCandidate().Candidate.Evidence[0].Attributes[token] = %q, want [redacted]", got)
 	}
 
 	promoteBody, err := protojson.Marshal(&cerebrov1.PromoteFindingCandidateRequest{
@@ -6156,6 +6297,17 @@ func TestFindingCandidateEndpointsEvaluateListGetAndPromote(t *testing.T) {
 	if got := promotedCandidate["status"]; got != "promoted" {
 		t.Fatalf("promoted candidate status = %#v, want promoted", got)
 	}
+	promotedFinding := promotePayload["finding"].(map[string]any)
+	if got := promotedFinding["attributes"].(map[string]any)["api_key"]; got != "[redacted]" {
+		t.Fatalf("promoted finding api_key = %#v, want [redacted]", got)
+	}
+	promotedCandidateEvidence := promotedCandidate["evidence"].([]any)[0].(map[string]any)
+	if got := promotedCandidateEvidence["attributes"].(map[string]any)["token"]; got != "[redacted]" {
+		t.Fatalf("promoted candidate evidence token = %#v, want [redacted]", got)
+	}
+	if got := promotedCandidateEvidence["graph_rows"].([]any)[0].(map[string]any)["paths"].([]any)[0].(map[string]any)["attributes"].(map[string]any)["password"]; got != "[redacted]" {
+		t.Fatalf("promoted candidate graph path password = %#v, want [redacted]", got)
+	}
 	if got := len(runtimeStore.findings); got != 1 {
 		t.Fatalf("production findings after promote = %d, want 1", got)
 	}
@@ -6187,6 +6339,12 @@ func TestFindingCandidateEndpointsEvaluateListGetAndPromote(t *testing.T) {
 	}
 	if got := rejectResp.Msg.GetCandidate().GetStatus(); got != "rejected" {
 		t.Fatalf("RejectFindingCandidate().Candidate.Status = %q, want rejected", got)
+	}
+	if got := rejectResp.Msg.GetCandidate().GetFinding().GetAttributes()["api_key"]; got != "[redacted]" {
+		t.Fatalf("RejectFindingCandidate().Candidate.Finding.Attributes[api_key] = %q, want [redacted]", got)
+	}
+	if got := rejectResp.Msg.GetCandidate().GetEvidence()[0].GetGraphRows()[0].GetAttributes()["private_key"]; got != "[redacted]" {
+		t.Fatalf("RejectFindingCandidate().Candidate.Evidence[0].GraphRows[0].Attributes[private_key] = %q, want [redacted]", got)
 	}
 	if rejectResp.Msg.GetDecisionId() == "" {
 		t.Fatal("RejectFindingCandidate().DecisionId is empty")
@@ -7293,6 +7451,125 @@ func TestFindingMessageIncludesRiskFactors(t *testing.T) {
 	}
 	if factor.GetObservedAt().AsTime() != observedAt {
 		t.Fatalf("ObservedAt = %v, want %v", factor.GetObservedAt().AsTime(), observedAt)
+	}
+}
+
+func TestSafeFindingMessageRedactsSensitiveAttributes(t *testing.T) {
+	record := &ports.FindingRecord{
+		ID:         "finding-redaction",
+		Attributes: map[string]string{"api_key": "finding-secret", "environment": "prod"},
+	}
+
+	message := safeFindingMessage(record)
+	if got := message.GetAttributes()["api_key"]; got != "[redacted]" {
+		t.Fatalf("safe finding api_key = %q, want [redacted]", got)
+	}
+	if got := message.GetAttributes()["environment"]; got != "prod" {
+		t.Fatalf("safe finding environment = %q, want prod", got)
+	}
+	if got := record.Attributes["api_key"]; got != "finding-secret" {
+		t.Fatalf("source finding api_key = %q, want original value", got)
+	}
+}
+
+func TestSafeFindingEvidenceRedactsSensitiveAttributes(t *testing.T) {
+	evidence := &cerebrov1.FindingEvidence{
+		Id:         "evidence-redaction",
+		Attributes: map[string]string{"token": "evidence-secret", "resource_id": "asset-1"},
+		GraphRows: []*cerebrov1.GraphEvidenceRow{{
+			Label:      "root",
+			Attributes: map[string]string{"private_key": "row-secret", "asset_type": "service"},
+			Paths: []*cerebrov1.GraphEvidencePath{{
+				Attributes: map[string]string{"password": "path-secret", "relation": "owns"},
+			}},
+		}},
+		Observations: []*cerebrov1.FindingEvidenceObservation{{
+			GraphRows: []*cerebrov1.GraphEvidenceRow{{
+				Label:      "observation",
+				Attributes: map[string]string{"signing_key": "observation-secret", "asset_type": "user"},
+				Paths: []*cerebrov1.GraphEvidencePath{{
+					Attributes: map[string]string{"secret_access_key": "observation-path-secret", "relation": "member"},
+				}},
+			}},
+		}},
+	}
+
+	safe := safeFindingEvidence(evidence)
+	if got := safe.GetAttributes()["token"]; got != "[redacted]" {
+		t.Fatalf("safe evidence token = %q, want [redacted]", got)
+	}
+	if got := safe.GetAttributes()["resource_id"]; got != "asset-1" {
+		t.Fatalf("safe evidence resource_id = %q, want asset-1", got)
+	}
+	if got := safe.GetGraphRows()[0].GetAttributes()["private_key"]; got != "[redacted]" {
+		t.Fatalf("safe graph row private_key = %q, want [redacted]", got)
+	}
+	if got := safe.GetGraphRows()[0].GetPaths()[0].GetAttributes()["password"]; got != "[redacted]" {
+		t.Fatalf("safe graph path password = %q, want [redacted]", got)
+	}
+	if got := safe.GetObservations()[0].GetGraphRows()[0].GetAttributes()["signing_key"]; got != "[redacted]" {
+		t.Fatalf("safe observation graph row signing_key = %q, want [redacted]", got)
+	}
+	if got := safe.GetObservations()[0].GetGraphRows()[0].GetPaths()[0].GetAttributes()["secret_access_key"]; got != "[redacted]" {
+		t.Fatalf("safe observation graph path secret_access_key = %q, want [redacted]", got)
+	}
+	if got := evidence.GetAttributes()["token"]; got != "evidence-secret" {
+		t.Fatalf("source evidence token = %q, want original value", got)
+	}
+	if got := evidence.GetGraphRows()[0].GetAttributes()["private_key"]; got != "row-secret" {
+		t.Fatalf("source graph row private_key = %q, want original value", got)
+	}
+}
+
+func TestFindingCandidateResponsesRedactNestedAttributes(t *testing.T) {
+	candidate := &ports.FindingCandidateRecord{
+		ID:        "candidate-redaction",
+		TenantID:  "writer",
+		RuntimeID: "runtime-1",
+		Finding: &ports.FindingRecord{
+			ID:         "candidate-finding",
+			Attributes: map[string]string{"api_key": "candidate-finding-secret", "environment": "prod"},
+		},
+		Evidence: []*cerebrov1.FindingEvidence{{
+			Id:         "candidate-evidence",
+			Attributes: map[string]string{"token": "candidate-evidence-secret", "resource_id": "asset-1"},
+			GraphRows: []*cerebrov1.GraphEvidenceRow{{
+				Attributes: map[string]string{"private_key": "candidate-row-secret", "asset_type": "service"},
+				Paths: []*cerebrov1.GraphEvidencePath{{
+					Attributes: map[string]string{"password": "candidate-path-secret", "relation": "owns"},
+				}},
+			}},
+		}},
+	}
+
+	listResponse := listFindingCandidatesResponse(&findings.ListCandidatesResult{Candidates: []*ports.FindingCandidateRecord{candidate}})
+	listCandidate := listResponse.GetCandidates()[0]
+	if got := listCandidate.GetFinding().GetAttributes()["api_key"]; got != "[redacted]" {
+		t.Fatalf("list candidate finding api_key = %q, want [redacted]", got)
+	}
+	if got := listCandidate.GetEvidence()[0].GetAttributes()["token"]; got != "[redacted]" {
+		t.Fatalf("list candidate evidence token = %q, want [redacted]", got)
+	}
+	if got := listCandidate.GetEvidence()[0].GetGraphRows()[0].GetAttributes()["private_key"]; got != "[redacted]" {
+		t.Fatalf("list candidate graph row private_key = %q, want [redacted]", got)
+	}
+
+	promoteResponse := promoteFindingCandidateResponse(&findings.PromoteCandidateResult{
+		Candidate:  candidate,
+		Finding:    candidate.Finding,
+		DecisionID: "decision-1",
+	})
+	if got := promoteResponse.GetFinding().GetAttributes()["api_key"]; got != "[redacted]" {
+		t.Fatalf("promote finding api_key = %q, want [redacted]", got)
+	}
+	if got := promoteResponse.GetCandidate().GetEvidence()[0].GetGraphRows()[0].GetPaths()[0].GetAttributes()["password"]; got != "[redacted]" {
+		t.Fatalf("promote candidate graph path password = %q, want [redacted]", got)
+	}
+	if got := candidate.Finding.Attributes["api_key"]; got != "candidate-finding-secret" {
+		t.Fatalf("source candidate finding api_key = %q, want original value", got)
+	}
+	if got := candidate.Evidence[0].GetAttributes()["token"]; got != "candidate-evidence-secret" {
+		t.Fatalf("source candidate evidence token = %q, want original value", got)
 	}
 }
 

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -34,7 +34,6 @@ import (
 const (
 	mcpProtocolVersion          = "2025-11-25"
 	mcpEndpointPath             = "/api/v1/mcp"
-	mcpRedactedValue            = "[redacted]"
 	defaultMCPListLimit         = 25
 	maxMCPListLimit             = 100
 	defaultMCPAssetLimit        = 10
@@ -3097,18 +3096,7 @@ func mcpStringMapFromJSON(raw string) (map[string]string, error) {
 }
 
 func mcpRedactSensitiveAttributes(attributes map[string]string) map[string]string {
-	if len(attributes) == 0 {
-		return attributes
-	}
-	redacted := make(map[string]string, len(attributes))
-	for key, value := range attributes {
-		if sensitiveSourceConfigKey(key) {
-			redacted[key] = mcpRedactedValue
-			continue
-		}
-		redacted[key] = value
-	}
-	return redacted
+	return redactSensitiveAttributes(attributes)
 }
 
 func mcpSafeFindingValue(finding *ports.FindingRecord) (any, error) {
@@ -3128,12 +3116,7 @@ func mcpSafeFindingValues(findings []*ports.FindingRecord) ([]any, error) {
 }
 
 func mcpSafeFindingMessage(finding *ports.FindingRecord) *cerebrov1.Finding {
-	message := findingMessage(finding)
-	if message == nil {
-		return nil
-	}
-	message.Attributes = mcpRedactSensitiveAttributes(message.GetAttributes())
-	return message
+	return safeFindingMessage(finding)
 }
 
 func mcpSafeFindingEvidenceValue(evidence *cerebrov1.FindingEvidence) (any, error) {
@@ -3153,41 +3136,7 @@ func mcpSafeFindingEvidenceValues(evidence []*cerebrov1.FindingEvidence) ([]any,
 }
 
 func mcpSafeFindingEvidence(evidence *cerebrov1.FindingEvidence) *cerebrov1.FindingEvidence {
-	if evidence == nil {
-		return nil
-	}
-	cloned := proto.Clone(evidence).(*cerebrov1.FindingEvidence)
-	cloned.Attributes = mcpRedactSensitiveAttributes(cloned.GetAttributes())
-	cloned.GraphRows = mcpSafeGraphEvidenceRows(cloned.GetGraphRows())
-	for _, observation := range cloned.GetObservations() {
-		if observation == nil {
-			continue
-		}
-		observation.GraphRows = mcpSafeGraphEvidenceRows(observation.GetGraphRows())
-	}
-	return cloned
-}
-
-func mcpSafeGraphEvidenceRows(rows []*cerebrov1.GraphEvidenceRow) []*cerebrov1.GraphEvidenceRow {
-	if len(rows) == 0 {
-		return rows
-	}
-	safeRows := make([]*cerebrov1.GraphEvidenceRow, 0, len(rows))
-	for _, row := range rows {
-		if row == nil {
-			continue
-		}
-		cloned := proto.Clone(row).(*cerebrov1.GraphEvidenceRow)
-		cloned.Attributes = mcpRedactSensitiveAttributes(cloned.GetAttributes())
-		for _, path := range cloned.GetPaths() {
-			if path == nil {
-				continue
-			}
-			path.Attributes = mcpRedactSensitiveAttributes(path.GetAttributes())
-		}
-		safeRows = append(safeRows, cloned)
-	}
-	return safeRows
+	return safeFindingEvidence(evidence)
 }
 
 func mcpImpactKindIsAsset(kind string) bool {


### PR DESCRIPTION
## Summary
- Apply the shared response redaction policy to platform and Connect finding, evidence, and candidate serializers.
- Clone evidence graphs before redacting nested attributes so persisted records are not mutated.
- Reuse the shared sanitizer from MCP helpers to keep response surfaces consistent.

## Validation
- `go test ./internal/bootstrap -run 'Test(FindingEndpoints|FindingCandidateEndpointsEvaluateListGetAndPromote|SafeFindingMessageRedactsSensitiveAttributes|SafeFindingEvidenceRedactsSensitiveAttributes|FindingCandidateResponsesRedactNestedAttributes|MCPFindingSearchRuntimeStatusEvidenceAndInvestigation)$' -count=1`
- `go test ./internal/bootstrap -count=1`
- `go test ./...`
- `golangci-lint run --timeout 10m --new-from-rev=origin/main ./internal/bootstrap`
- `make cover`
- `make check-structural check-structural-test check-arch`
- `scripts/leak_check.sh staged`
