### PR TITLE
Project degraded source event graphs

### DIFF
--- a/internal/sourceprojection/panopticon.go
+++ b/internal/sourceprojection/panopticon.go
@@ -109,10 +109,43 @@ type panopticonAssetStitchTarget struct {
 }
 
 func panopticonAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	if _, err := tenantID(event); err != nil {
+	tenantID, err := tenantID(event)
+	if err != nil {
 		return nil, nil, err
 	}
-	return nil, nil, nil
+	attrs := panopticonProjectionAttributes(event, "alert_id", "severity", "status", "title", "case_id")
+	payload := payloadMap(event)
+	alertID := firstAttribute(attrs, "alert_id")
+	if alertID == "" {
+		return nil, nil, nil
+	}
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	alertURN := panopticonAddAlertEntity(entities, tenantID, event.GetSourceId(), event.GetId(), attrs)
+	caseURN := panopticonAddCaseEntity(entities, tenantID, event.GetSourceId(), event.GetId(), map[string]string{
+		"case_id": firstNonEmpty(firstAttribute(attrs, "case_id"), stringValue(payload, "case_id")),
+		"title":   firstNonEmpty(firstAttribute(attrs, "case_title"), stringValue(payload, "case_title")),
+		"status":  firstNonEmpty(firstAttribute(attrs, "case_status"), stringValue(payload, "case_status")),
+	})
+	if caseURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), caseURN, alertURN, relationContains, panopticonLinkAttributes(event, "panopticon_case_alert")))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, caseURN, relationBelongsTo, panopticonLinkAttributes(event, "panopticon_alert_case")))
+	}
+	for _, iocURN := range panopticonAddIOCs(entities, tenantID, event.GetSourceId(), event.GetId(), attrs, payload) {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, iocURN, relationHasEvidence, panopticonLinkAttributes(event, "panopticon_alert_ioc")))
+	}
+	for _, assetURN := range panopticonAddAssets(entities, tenantID, event.GetSourceId(), event.GetId(), attrs, payload) {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, assetURN, relationTargeted, panopticonLinkAttributes(event, "panopticon_alert_asset")))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), assetURN, alertURN, relationAffectedBy, panopticonLinkAttributes(event, "panopticon_asset_alert")))
+	}
+	for _, evidenceURN := range panopticonAddEvidencePointers(entities, links, tenantID, event, payload) {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, evidenceURN, relationHasEvidence, panopticonLinkAttributes(event, "panopticon_alert_evidence_cas")))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, alertURN, relationObservedOn, panopticonLinkAttributes(event, "panopticon_evidence_cas_alert")))
+	}
+	panopticonAddIOCContextAnchors(entities, links, tenantID, event.GetSourceId(), event, nil, payload)
+	panopticonAddAssetContextAnchors(entities, links, tenantID, event.GetSourceId(), event, nil, payload)
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
 }
 
 func panopticonCaseProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/panopticon_test.go
+++ b/internal/sourceprojection/panopticon_test.go
@@ -260,7 +260,7 @@ func TestProjectPanopticonCaseBuildsLinkedGraphAndEvidencePointers(t *testing.T)
 	}
 }
 
-func TestProjectPanopticonRawAlertDoesNotProjectDurableGraphContext(t *testing.T) {
+func TestProjectPanopticonAlertBuildsEvidenceGraphContext(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
 
@@ -297,12 +297,22 @@ func TestProjectPanopticonRawAlertDoesNotProjectDurableGraphContext(t *testing.T
 	if err != nil {
 		t.Fatalf("Project(alert) error = %v", err)
 	}
-	if result.EntitiesProjected != 0 || result.LinksProjected != 0 {
-		t.Fatalf("raw Panopticon alert projected durable context: entities=%d links=%d", result.EntitiesProjected, result.LinksProjected)
+	if result.EntitiesProjected == 0 || result.LinksProjected == 0 {
+		t.Fatalf("expected Panopticon alert evidence projection, got entities=%d links=%d", result.EntitiesProjected, result.LinksProjected)
 	}
-	if len(state.entities) != 0 || len(state.links) != 0 {
-		t.Fatalf("raw Panopticon alert mutated graph state: entities=%d links=%d", len(state.entities), len(state.links))
-	}
+	alertURN := "urn:cerebro:writer:panopticon_alert:alert-1"
+	caseURN := "urn:cerebro:writer:panopticon_case:case-1"
+	iocURN := "urn:cerebro:writer:panopticon_ioc:ioc-1"
+	assetURN := "urn:cerebro:writer:panopticon_asset:asset-1"
+	assertProjectedEntityType(t, state, alertURN, "panopticon.alert")
+	assertProjectedEntityType(t, state, caseURN, "panopticon.case")
+	assertProjectedEntityType(t, state, iocURN, "panopticon.ioc")
+	assertProjectedEntityType(t, state, assetURN, "panopticon.asset")
+	assertProjectedLink(t, state, caseURN, relationContains, alertURN)
+	assertProjectedLink(t, state, alertURN, relationBelongsTo, caseURN)
+	assertProjectedLink(t, state, alertURN, relationHasEvidence, iocURN)
+	assertProjectedLink(t, state, alertURN, relationTargeted, assetURN)
+	assertProjectedLink(t, state, assetURN, relationAffectedBy, alertURN)
 }
 
 func TestProjectPanopticonIOCLinksToCaseAndAlertEvidence(t *testing.T) {
@@ -341,7 +351,7 @@ func TestProjectPanopticonIOCLinksToCaseAndAlertEvidence(t *testing.T) {
 	assertProjectedLink(t, state, alertURN, relationHasEvidence, iocURN)
 }
 
-func TestProjectPanopticonRawAlertDoesNotEnrichSSHBruteForceAnchors(t *testing.T) {
+func TestProjectPanopticonAlertDoesNotInferSSHBruteForceAnchorsFromTitle(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
 
@@ -364,12 +374,12 @@ func TestProjectPanopticonRawAlertDoesNotEnrichSSHBruteForceAnchors(t *testing.T
 	if err != nil {
 		t.Fatalf("Project(alert) error = %v", err)
 	}
-	if result.EntitiesProjected != 0 || result.LinksProjected != 0 {
-		t.Fatalf("raw Panopticon alert projected SSH anchors: entities=%d links=%d", result.EntitiesProjected, result.LinksProjected)
+	if result.EntitiesProjected != 1 || result.LinksProjected != 0 {
+		t.Fatalf("alert title-only projection = entities %d links %d, want only the alert entity", result.EntitiesProjected, result.LinksProjected)
 	}
-	if len(state.entities) != 0 || len(state.links) != 0 {
-		t.Fatalf("raw Panopticon alert mutated graph state: entities=%d links=%d", len(state.entities), len(state.links))
-	}
+	assertProjectedEntityType(t, state, "urn:cerebro:writer:panopticon_alert:alert-ssh", "panopticon.alert")
+	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:internet_ip:203.0.113.20")
+	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:aws_ec2_instance:i-0123456789abcdef0")
 }
 
 func TestProjectPanopticonCaseEnrichesGitHubGCPAndIdentityAnchors(t *testing.T) {

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -373,11 +373,106 @@ func sentinelOneGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 }
 
 func sentinelOneActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	// Activities are audit-event evidence, not durable inventory. Finding rules
-	// read the source event directly when an activity contributes evidence; the
-	// graph should retain current SentinelOne state through agent, threat,
-	// exclusion, site, and group entities.
-	return nil, nil, nil
+	tenant, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	activityID := strings.TrimSpace(attrs["activity_id"])
+	if activityID == "" {
+		return nil, nil, nil
+	}
+	activityURN := projectionURN(tenant, "sentinelone_activity", activityID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        activityURN,
+		TenantID:   tenant,
+		SourceID:   event.GetSourceId(),
+		EntityType: sentinelOneEntityActivity,
+		Label:      firstNonEmpty(attrs["primary_description"], attrs["description"], attrs["activity_uuid"], activityID),
+		Attributes: compactAttributes(map[string]string{
+			"activity_id":           activityID,
+			"activity_type":         strings.TrimSpace(attrs["activity_type"]),
+			"activity_uuid":         strings.TrimSpace(attrs["activity_uuid"]),
+			"agent_id":              strings.TrimSpace(attrs["agent_id"]),
+			"agent_updated_version": strings.TrimSpace(attrs["agent_updated_version"]),
+			"description":           strings.TrimSpace(attrs["description"]),
+			"group_id":              strings.TrimSpace(attrs["group_id"]),
+			"os_family":             strings.TrimSpace(attrs["os_family"]),
+			"primary_description":   strings.TrimSpace(attrs["primary_description"]),
+			"secondary_description": strings.TrimSpace(attrs["secondary_description"]),
+			"site_id":               strings.TrimSpace(attrs["site_id"]),
+			"tenant_host":           strings.TrimSpace(attrs["tenant_host"]),
+			"threat_id":             strings.TrimSpace(attrs["threat_id"]),
+			"user_id":               strings.TrimSpace(attrs["user_id"]),
+			"event_id":              event.GetId(),
+			"at":                    eventObservedAt(event),
+		}),
+	})
+
+	if agentID := strings.TrimSpace(attrs["agent_id"]); agentID != "" {
+		agentURN := sentinelOneAgentURN(tenant, agentID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        agentURN,
+			TenantID:   tenant,
+			SourceID:   event.GetSourceId(),
+			EntityType: sentinelOneEntityAgent,
+			Label:      firstNonEmpty(attrs["computer_name"], attrs["agent_name"], agentID),
+			Attributes: compactAttributes(map[string]string{
+				"agent_id":    agentID,
+				"hostname":    strings.TrimSpace(firstNonEmpty(attrs["hostname"], attrs["computer_name"], attrs["agent_name"])),
+				"site_id":     strings.TrimSpace(attrs["site_id"]),
+				"group_id":    strings.TrimSpace(attrs["group_id"]),
+				"tenant_host": strings.TrimSpace(attrs["tenant_host"]),
+				"event_id":    event.GetId(),
+				"at":          eventObservedAt(event),
+			}),
+		})
+		addLink(links, projectedLink(tenant, event.GetSourceId(), agentURN, activityURN, relationHasEvidence, sentinelOneActivityLinkAttributes(event, "sentinelone_agent_activity")))
+		addLink(links, projectedLink(tenant, event.GetSourceId(), activityURN, agentURN, relationObservedOn, sentinelOneActivityLinkAttributes(event, "sentinelone_activity_agent")))
+		addSentinelOneScopeLinks(entities, links, tenant, event, agentURN, attrs)
+		addSentinelOneInternetContext(entities, links, tenant, event, agentURN, attrs)
+		addSentinelOneOwnerIdentityLinks(entities, links, tenant, event, agentURN, attrs)
+	}
+	if threatID := strings.TrimSpace(attrs["threat_id"]); threatID != "" {
+		threatURN := sentinelOneThreatURN(tenant, threatID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        threatURN,
+			TenantID:   tenant,
+			SourceID:   event.GetSourceId(),
+			EntityType: sentinelOneEntityThreat,
+			Label:      firstNonEmpty(attrs["threat_name"], threatID),
+			Attributes: compactAttributes(map[string]string{
+				"threat_id":   threatID,
+				"site_id":     strings.TrimSpace(attrs["site_id"]),
+				"group_id":    strings.TrimSpace(attrs["group_id"]),
+				"tenant_host": strings.TrimSpace(attrs["tenant_host"]),
+				"event_id":    event.GetId(),
+				"at":          eventObservedAt(event),
+			}),
+		})
+		addLink(links, projectedLink(tenant, event.GetSourceId(), threatURN, activityURN, relationHasEvidence, sentinelOneActivityLinkAttributes(event, "sentinelone_threat_activity")))
+		addLink(links, projectedLink(tenant, event.GetSourceId(), activityURN, threatURN, relationObservedOn, sentinelOneActivityLinkAttributes(event, "sentinelone_activity_threat")))
+		addSentinelOneScopeLinks(entities, links, tenant, event, threatURN, attrs)
+	}
+	addSentinelOneScopeLinks(entities, links, tenant, event, activityURN, attrs)
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func sentinelOneActivityLinkAttributes(event *cerebrov1.EventEnvelope, matchType string) map[string]string {
+	attrs := compactAttributes(map[string]string{
+		"event_id":   event.GetId(),
+		"at":         eventObservedAt(event),
+		"match_type": matchType,
+	})
+	sourceAttrs := event.GetAttributes()
+	addProjectedAttribute(attrs, "activity_id", sourceAttrs["activity_id"])
+	addProjectedAttribute(attrs, "activity_type", sourceAttrs["activity_type"])
+	return attrs
 }
 
 func sentinelOneExclusionProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -324,7 +324,7 @@ func TestProjectSentinelOneGroupSiteLink(t *testing.T) {
 	assertProjectedLink(t, state, groupURN, relationBelongsTo, siteURN)
 }
 
-func TestProjectSentinelOneActivityDoesNotMaterializeAuditEvent(t *testing.T) {
+func TestProjectSentinelOneActivityBuildsAuditEvidenceContext(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
 	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
@@ -344,12 +344,22 @@ func TestProjectSentinelOneActivityDoesNotMaterializeAuditEvent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project(activity) error = %v", err)
 	}
-	if result.EntitiesProjected != 0 || result.LinksProjected != 0 {
-		t.Fatalf("activity projection = entities %d links %d, want no graph projection", result.EntitiesProjected, result.LinksProjected)
+	if result.EntitiesProjected == 0 || result.LinksProjected == 0 {
+		t.Fatalf("activity projection = entities %d links %d, want graph evidence context", result.EntitiesProjected, result.LinksProjected)
 	}
-	if len(state.entities) != 0 || len(state.links) != 0 {
-		t.Fatalf("activity audit event should not materialize graph records: entities=%#v links=%#v", state.entities, state.links)
-	}
+	activityURN := "urn:cerebro:writer:sentinelone_activity:activity-1"
+	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
+	threatURN := "urn:cerebro:writer:sentinelone_threat:threat-1"
+	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
+	assertProjectedEntityType(t, state, activityURN, "sentinelone.activity")
+	assertProjectedEntityType(t, state, agentURN, "sentinelone.agent")
+	assertProjectedEntityType(t, state, threatURN, "sentinelone.threat")
+	assertProjectedEntityType(t, state, siteURN, "sentinelone.site")
+	assertProjectedLink(t, state, agentURN, relationHasEvidence, activityURN)
+	assertProjectedLink(t, state, activityURN, relationObservedOn, agentURN)
+	assertProjectedLink(t, state, threatURN, relationHasEvidence, activityURN)
+	assertProjectedLink(t, state, activityURN, relationObservedOn, threatURN)
+	assertProjectedLink(t, state, activityURN, relationBelongsTo, siteURN)
 }
 
 func TestProjectSentinelOneApplicationInventoryContainedByAgent(t *testing.T) {


### PR DESCRIPTION
## Summary
- project Panopticon alerts into alert/case/IOC/asset evidence graph records
- project SentinelOne activity into activity/agent/threat evidence graph records
- add regression coverage for both degraded zero-projection sources

## Verification
- go test ./internal/sourceprojection ./cmd/cerebro ./internal/bootstrap