### PR TITLE
Restrict server-local source preview config

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1946,6 +1946,65 @@ func TestBootstrapSourcePreviewEndpointsDoNotResolveEnvReferences(t *testing.T) 
 	}
 }
 
+func TestBootstrapSourcePreviewRejectsServerLocalSourceConfig(t *testing.T) {
+	kubernetes := &bootstrapTokenSource{id: "kubernetes"}
+	trivy := &bootstrapTokenSource{id: "trivy"}
+	registry, err := sourcecdk.NewRegistry(kubernetes, trivy)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	for _, tt := range []struct {
+		name   string
+		path   string
+		config map[string]string
+	}{
+		{
+			name:   "http kubernetes in cluster",
+			path:   "/sources/kubernetes/check",
+			config: map[string]string{"tenant_id": "writer", "in_cluster": "true"},
+		},
+		{
+			name:   "http kubernetes kubeconfig path",
+			path:   "/sources/kubernetes/discover",
+			config: map[string]string{"tenant_id": "writer", "kubeconfig_path": "/var/run/cerebro/kubeconfig"},
+		},
+		{
+			name:   "http trivy report path",
+			path:   "/sources/trivy/read",
+			config: map[string]string{"tenant_id": "writer", "report_path": "/var/lib/cerebro/report.json"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := sourceGet(t, server, tt.path, tt.config)
+			if err != nil {
+				t.Fatalf("GET %s error = %v", tt.path, err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("GET %s status = %d, want %d", tt.path, resp.StatusCode, http.StatusBadRequest)
+			}
+		})
+	}
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	if _, err := client.CheckSource(context.Background(), connect.NewRequest(&cerebrov1.CheckSourceRequest{
+		SourceId: "kubernetes",
+		Config:   map[string]string{"tenant_id": "writer", "in_cluster": "true"},
+	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("CheckSource(kubernetes) error = %v, want InvalidArgument", err)
+	}
+	if _, err := client.ReadSource(context.Background(), connect.NewRequest(&cerebrov1.ReadSourceRequest{
+		SourceId: "trivy",
+		Config:   map[string]string{"tenant_id": "writer", "path": "/var/lib/cerebro/report.json"},
+	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("ReadSource(trivy) error = %v, want InvalidArgument", err)
+	}
+}
+
 func TestAuthMiddlewareProtectsNonPublicRoutes(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -66,7 +66,7 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 	if err != nil {
 		return nil, err
 	}
-	config, err := s.previewConfig(req.GetConfig())
+	config, err := s.previewConfig(req.GetSourceId(), req.GetConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 	if err != nil {
 		return nil, err
 	}
-	config, err := s.previewConfig(req.GetConfig())
+	config, err := s.previewConfig(req.GetSourceId(), req.GetConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (_
 	if err != nil {
 		return nil, err
 	}
-	config, err := s.previewConfig(req.GetConfig())
+	config, err := s.previewConfig(req.GetSourceId(), req.GetConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -164,15 +164,38 @@ func sourceOperationError(err error) error {
 	return err
 }
 
-func (s *Service) previewConfig(values map[string]string) (map[string]string, error) {
+func (s *Service) previewConfig(sourceID string, values map[string]string) (map[string]string, error) {
 	config := make(map[string]string, len(values))
 	for key, value := range values {
-		if !s.allowInternalConfig && sourceconfig.InternalKey(key) {
-			return nil, fmt.Errorf("%w: source config %q is reserved", ErrInvalidRequest, strings.TrimSpace(key))
+		if !s.allowInternalConfig {
+			if sourceconfig.InternalKey(key) {
+				return nil, fmt.Errorf("%w: source config %q is reserved", ErrInvalidRequest, strings.TrimSpace(key))
+			}
+			if serverLocalPreviewConfigKey(sourceID, key) {
+				return nil, fmt.Errorf("%w: source config %q is not allowed for %s preview", ErrInvalidRequest, strings.TrimSpace(key), strings.TrimSpace(sourceID))
+			}
 		}
 		config[key] = value
 	}
 	return config, nil
+}
+
+func serverLocalPreviewConfigKey(sourceID string, key string) bool {
+	normalizedSourceID := strings.ToLower(strings.TrimSpace(sourceID))
+	normalizedKey := strings.ToLower(strings.TrimSpace(key))
+	switch normalizedSourceID {
+	case "kubernetes":
+		switch normalizedKey {
+		case "in_cluster", "kubeconfig", "kubeconfig_path":
+			return true
+		}
+	case "trivy":
+		switch normalizedKey {
+		case "path", "report_path":
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Service) lookup(sourceID string) (sourcecdk.Source, error) {

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -166,6 +166,86 @@ func TestCheckRejectsInternalRuntimeConfigKeys(t *testing.T) {
 	}
 }
 
+func TestPreviewRejectsServerLocalSourceConfig(t *testing.T) {
+	kubernetes := &recordingSource{id: "kubernetes"}
+	trivy := &recordingSource{id: "trivy"}
+	registry, err := sourcecdk.NewRegistry(kubernetes, trivy)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := New(registry)
+
+	for _, tt := range []struct {
+		name     string
+		sourceID string
+		config   map[string]string
+	}{
+		{
+			name:     "kubernetes in cluster",
+			sourceID: "kubernetes",
+			config:   map[string]string{"tenant_id": "writer", "in_cluster": "true"},
+		},
+		{
+			name:     "kubernetes kubeconfig path",
+			sourceID: "kubernetes",
+			config:   map[string]string{"tenant_id": "writer", "kubeconfig_path": "/var/run/cerebro/kubeconfig"},
+		},
+		{
+			name:     "kubernetes kubeconfig alias",
+			sourceID: "kubernetes",
+			config:   map[string]string{"tenant_id": "writer", "kubeconfig": "/var/run/cerebro/kubeconfig"},
+		},
+		{
+			name:     "trivy path",
+			sourceID: "trivy",
+			config:   map[string]string{"tenant_id": "writer", "path": "/var/lib/cerebro/report.json"},
+		},
+		{
+			name:     "trivy report path",
+			sourceID: "trivy",
+			config:   map[string]string{"tenant_id": "writer", "report_path": "/var/lib/cerebro/report.json"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			beforeCalls := kubernetes.calls + trivy.calls
+			if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: tt.sourceID, Config: tt.config}); !errors.Is(err, ErrInvalidRequest) {
+				t.Fatalf("Check() error = %v, want ErrInvalidRequest", err)
+			}
+			if _, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{SourceId: tt.sourceID, Config: tt.config}); !errors.Is(err, ErrInvalidRequest) {
+				t.Fatalf("Discover() error = %v, want ErrInvalidRequest", err)
+			}
+			if _, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: tt.sourceID, Config: tt.config}); !errors.Is(err, ErrInvalidRequest) {
+				t.Fatalf("Read() error = %v, want ErrInvalidRequest", err)
+			}
+			if got := kubernetes.calls + trivy.calls; got != beforeCalls {
+				t.Fatalf("source calls = %d, want %d", got, beforeCalls)
+			}
+		})
+	}
+}
+
+func TestPreviewAllowsServerLocalSourceConfigForInternalRuntime(t *testing.T) {
+	trivy := &recordingSource{id: "trivy"}
+	registry, err := sourcecdk.NewRegistry(trivy)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := New(registry).WithInternalConfigAllowed()
+
+	if _, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
+		SourceId: "trivy",
+		Config: map[string]string{
+			"tenant_id":   "writer",
+			"report_path": "/var/lib/cerebro/report.json",
+		},
+	}); err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if trivy.calls != 1 {
+		t.Fatalf("trivy calls = %d, want 1", trivy.calls)
+	}
+}
+
 func TestCheckDiscoverAndReadOkta(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
@@ -338,6 +418,30 @@ func (s *errorSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.U
 
 func (s *errorSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	return sourcecdk.Pull{}, s.err
+}
+
+type recordingSource struct {
+	id    string
+	calls int
+}
+
+func (s *recordingSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: s.id, Name: "Recording " + s.id}
+}
+
+func (s *recordingSource) Check(context.Context, sourcecdk.Config) error {
+	s.calls++
+	return nil
+}
+
+func (s *recordingSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	s.calls++
+	return nil, nil
+}
+
+func (s *recordingSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	s.calls++
+	return sourcecdk.Pull{}, nil
 }
 
 func newFixtureRegistry() (*sourcecdk.Registry, error) {


### PR DESCRIPTION
## Summary
- reject server-local Kubernetes and Trivy preview config before source execution
- keep internal runtime source execution behavior unchanged
- add sourceops and HTTP/Connect regression coverage

## Tests
- go test ./internal/sourceops ./internal/bootstrap -run 'Test(PreviewRejectsServerLocalSourceConfig|PreviewAllowsServerLocalSourceConfigForInternalRuntime|BootstrapSourcePreviewRejectsServerLocalSourceConfig)$' -count=1\n- go test ./internal/sourceops ./internal/bootstrap -count=1\n- golangci-lint run --timeout 10m --new-from-rev=origin/main ./internal/sourceops ./internal/bootstrap\n- go test ./...\n- make cover\n- make check-structural check-structural-test check-arch\n- scripts/leak_check.sh staged\n- git diff --check