### PR TITLE
Fix Backstage placeholder owner refs

### DIFF
--- a/internal/findings/backstage_critical_component_missing_owner_rule.go
+++ b/internal/findings/backstage_critical_component_missing_owner_rule.go
@@ -232,6 +232,9 @@ func normalizeBackstageOwnerValue(owner string) string {
 	owner = strings.ToLower(strings.TrimSpace(owner))
 	owner = strings.TrimPrefix(owner, "group:")
 	owner = strings.TrimPrefix(owner, "user:")
+	if slash := strings.LastIndex(owner, "/"); slash >= 0 {
+		owner = owner[slash+1:]
+	}
 	return strings.TrimSpace(owner)
 }
 

--- a/internal/findings/backstage_critical_component_missing_owner_rule.go
+++ b/internal/findings/backstage_critical_component_missing_owner_rule.go
@@ -253,7 +253,35 @@ func backstageComponentResourceURN(tenantID string, attributes map[string]string
 		namespace := firstNonEmpty(strings.TrimSpace(attributes["namespace"]), "default")
 		entityRef = kind + "/" + namespace + "/" + name
 	}
-	return fmt.Sprintf("urn:cerebro:%s:service:%s", tenantID, strings.ToLower(entityRef))
+	return fmt.Sprintf("urn:cerebro:%s:service:%s", tenantID, canonicalBackstageComponentEntityRef(
+		entityRef,
+		firstNonEmpty(strings.TrimSpace(attributes["kind"]), "Component"),
+		firstNonEmpty(strings.TrimSpace(attributes["namespace"]), "default"),
+		strings.TrimSpace(attributes["name"]),
+	))
+}
+
+func canonicalBackstageComponentEntityRef(entityRef string, kind string, namespace string, name string) string {
+	value := strings.ToLower(strings.TrimSpace(entityRef))
+	if value == "" {
+		return strings.ToLower(firstNonEmpty(kind, "Component")) + "/" + strings.ToLower(firstNonEmpty(namespace, "default")) + "/" + strings.ToLower(strings.TrimSpace(name))
+	}
+	if colon := strings.Index(value, ":"); colon > 0 {
+		refKind := strings.TrimSpace(value[:colon])
+		remainder := strings.TrimSpace(value[colon+1:])
+		if slash := strings.Index(remainder, "/"); slash > 0 {
+			return refKind + "/" + strings.TrimSpace(remainder[:slash]) + "/" + strings.TrimSpace(remainder[slash+1:])
+		}
+		return refKind + "/default/" + remainder
+	}
+	parts := strings.Split(value, "/")
+	if len(parts) == 3 {
+		return strings.TrimSpace(parts[0]) + "/" + strings.TrimSpace(parts[1]) + "/" + strings.TrimSpace(parts[2])
+	}
+	if len(parts) == 2 {
+		return strings.ToLower(firstNonEmpty(kind, "Component")) + "/" + strings.TrimSpace(parts[0]) + "/" + strings.TrimSpace(parts[1])
+	}
+	return value
 }
 
 func backstageCriticalComponentMissingOwnerAnchor(attributes map[string]string) string {

--- a/internal/findings/backstage_critical_component_missing_owner_rule_test.go
+++ b/internal/findings/backstage_critical_component_missing_owner_rule_test.go
@@ -51,6 +51,15 @@ func TestBackstageCriticalComponentMissingOwnerOwnershipResolves(t *testing.T) {
 	assertIdentityRuleRemediationTrajectory(t, newBackstageCriticalComponentMissingOwnerRule(), open, owned, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
 }
 
+func TestBackstageCriticalComponentMissingOwnerCanonicalEntityRefResolves(t *testing.T) {
+	open := backstageComponentEvent("backstage-open-fallback-ref", map[string]string{"owner": ""}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	owned := backstageComponentEvent("backstage-owned-canonical-ref", map[string]string{
+		"owner":      "group:platform/payments",
+		"entity_ref": "component:default/payments",
+	}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))
+	assertIdentityRuleRemediationTrajectory(t, newBackstageCriticalComponentMissingOwnerRule(), open, owned, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
+}
+
 func TestBackstageCriticalComponentMissingOwnerDowngradeResolves(t *testing.T) {
 	open := backstageComponentEvent("backstage-open", map[string]string{"owner": ""}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 	downgraded := backstageComponentEvent("backstage-downgraded", map[string]string{"owner": "", "criticality": "low"}, time.Date(2026, 5, 1, 13, 0, 0, 0, time.UTC))

--- a/internal/findings/backstage_critical_component_missing_owner_rule_test.go
+++ b/internal/findings/backstage_critical_component_missing_owner_rule_test.go
@@ -63,6 +63,28 @@ func TestBackstageCriticalComponentMissingOwnerDecommissionResolves(t *testing.T
 	assertIdentityRuleRemediationTrajectory(t, newBackstageCriticalComponentMissingOwnerRule(), open, retired, cerebrov1.FindingStatus_FINDING_STATUS_RESOLVED)
 }
 
+func TestBackstageCriticalComponentMissingOwnerNamespaceQualifiedPlaceholders(t *testing.T) {
+	cases := []struct {
+		name      string
+		owner     string
+		wantOwned bool
+	}{
+		{name: "missing owner", owner: "", wantOwned: false},
+		{name: "bare placeholder", owner: "unknown", wantOwned: false},
+		{name: "group placeholder entity ref", owner: "group:default/unknown", wantOwned: false},
+		{name: "user placeholder entity ref", owner: "user:default/unassigned", wantOwned: false},
+		{name: "qualified owning team", owner: "group:platform/payments", wantOwned: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			owned := backstageComponentHasAccountableOwner(map[string]string{"owner": tc.owner})
+			if owned != tc.wantOwned {
+				t.Fatalf("backstageComponentHasAccountableOwner(owner=%q) = %v, want %v", tc.owner, owned, tc.wantOwned)
+			}
+		})
+	}
+}
+
 func TestBackstageCriticalComponentMissingOwnerReopensOnRecurrence(t *testing.T) {
 	rule := newBackstageCriticalComponentMissingOwnerRule()
 	runtime := &cerebrov1.SourceRuntime{

--- a/internal/sourceprojection/security_spine.go
+++ b/internal/sourceprojection/security_spine.go
@@ -25,7 +25,7 @@ func backstageComponentProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 	}
 	kind := firstNonEmpty(attrs["kind"], nestedString(payload, "kind"), "Component")
 	namespace := firstNonEmpty(attrs["namespace"], nestedString(payload, "metadata.namespace"), "default")
-	entityRef := firstNonEmpty(attrs["entity_ref"], backstageEntityRef(kind, namespace, name))
+	entityRef := canonicalBackstageEntityRef(firstNonEmpty(attrs["entity_ref"], backstageEntityRef(kind, namespace, name)), kind, namespace, name)
 	componentURN := projectionURN(tenantID, "service", strings.ToLower(entityRef))
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
@@ -432,6 +432,29 @@ func backstageComponentEntityType(componentType string) string {
 
 func backstageEntityRef(kind string, namespace string, name string) string {
 	return strings.ToLower(firstNonEmpty(kind, "Component")) + "/" + strings.ToLower(firstNonEmpty(namespace, "default")) + "/" + strings.ToLower(strings.TrimSpace(name))
+}
+
+func canonicalBackstageEntityRef(entityRef string, kind string, namespace string, name string) string {
+	value := strings.ToLower(strings.TrimSpace(entityRef))
+	if value == "" {
+		return backstageEntityRef(kind, namespace, name)
+	}
+	if colon := strings.Index(value, ":"); colon > 0 {
+		refKind := strings.TrimSpace(value[:colon])
+		remainder := strings.TrimSpace(value[colon+1:])
+		if slash := strings.Index(remainder, "/"); slash > 0 {
+			return refKind + "/" + strings.TrimSpace(remainder[:slash]) + "/" + strings.TrimSpace(remainder[slash+1:])
+		}
+		return refKind + "/default/" + remainder
+	}
+	parts := strings.Split(value, "/")
+	if len(parts) == 3 {
+		return strings.TrimSpace(parts[0]) + "/" + strings.TrimSpace(parts[1]) + "/" + strings.TrimSpace(parts[2])
+	}
+	if len(parts) == 2 {
+		return strings.ToLower(firstNonEmpty(kind, "Component")) + "/" + strings.TrimSpace(parts[0]) + "/" + strings.TrimSpace(parts[1])
+	}
+	return value
 }
 
 func backstageAnnotation(payload map[string]any, key string) string {

--- a/internal/sourceprojection/security_spine_test.go
+++ b/internal/sourceprojection/security_spine_test.go
@@ -65,6 +65,36 @@ func TestProjectBackstageComponent(t *testing.T) {
 	assertProjectedLinkMissing(t, state, ownerURN, relationRepresentsIdentity, "urn:cerebro:writer:identity:login:security")
 }
 
+func TestProjectBackstageComponentCanonicalizesEntityRef(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	event := &cerebrov1.EventEnvelope{
+		Id:       "evt-backstage-canonical",
+		TenantId: "writer",
+		SourceId: "backstage",
+		Kind:     "backstage.component",
+		Attributes: map[string]string{
+			"name":       "payments",
+			"namespace":  "default",
+			"kind":       "Component",
+			"entity_ref": "component:default/payments",
+			"type":       "service",
+		},
+	}
+
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	serviceURN := "urn:cerebro:writer:service:component/default/payments"
+	entity := state.entities[serviceURN]
+	if entity == nil {
+		t.Fatalf("service entity %q missing from %#v", serviceURN, state.entities)
+	}
+	if got := entity.Attributes["backstage_entity_ref"]; got != "component/default/payments" {
+		t.Fatalf("backstage_entity_ref = %q, want canonical component/default/payments", got)
+	}
+}
+
 func TestProjectBackstageComponentLinksClassificationAndCriticality(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)


### PR DESCRIPTION
## Summary
- Normalize namespace-qualified Backstage owner refs before placeholder detection
- Treat canonical placeholder refs like group:default/unknown and user:default/unassigned as unaccountable
- Add regression coverage for placeholder and accountable owner refs

## Validation
- go test ./internal/findings -run BackstageCriticalComponentMissingOwner -count=1
- ./scripts/pre_commit_checks.sh
- make lint