### PR TITLE
Normalize device revoke lookup errors

### DIFF
--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -377,7 +377,7 @@ func (h *deviceAuthHTTPHandler) handleRevoke(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if err := authorizeTenantScopeRequired(r.Context(), device.TenantID); err != nil {
-		writeDeviceAuthError(w, http.StatusForbidden, "tenant_forbidden", err.Error())
+		writeDeviceAuthServiceError(w, deviceauth.ErrDeviceNotFound)
 		return
 	}
 	if err := h.service.Revoke(r.Context(), deviceID, body.Reason); err != nil {

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -223,7 +223,7 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 	}
 }
 
-func TestDeviceAuthRevokeAuthorizesTargetDeviceTenant(t *testing.T) {
+func TestDeviceAuthRevokeNormalizesForeignDeviceLookup(t *testing.T) {
 	app := newAppForDeviceTest(t)
 	handler := app.Handler()
 	ctx := context.Background()
@@ -250,11 +250,11 @@ func TestDeviceAuthRevokeAuthorizesTargetDeviceTenant(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
-	if resp.Code != http.StatusForbidden {
+	if resp.Code != http.StatusNotFound {
 		t.Fatalf("revoke status = %d, body=%s", resp.Code, resp.Body.String())
 	}
-	if !strings.Contains(resp.Body.String(), "tenant_forbidden") {
-		t.Fatalf("revoke body = %s, want tenant_forbidden", resp.Body.String())
+	if !strings.Contains(resp.Body.String(), "device_not_found") {
+		t.Fatalf("revoke body = %s, want device_not_found", resp.Body.String())
 	}
 	device, err := app.deviceService.LookupDevice(ctx, enroll.DeviceID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- normalize cross-tenant device revoke lookups to the same not-found response as absent devices
- keep the existing guard that prevents cross-tenant device revocation
- update the device revoke regression to assert the oracle is closed

## Security
Fixes CAND-DEEP-030 from the Codex Security deep scan. The revoke path previously looked up the target device before tenant authorization and returned `tenant_forbidden` for existing foreign devices but `device_not_found` for absent IDs.

## Tests
- `go test ./internal/bootstrap -run 'TestDeviceAuthRevokeNormalizesForeignDeviceLookup' -count=1 -v`\n- `go test ./internal/bootstrap ./internal/deviceauth -count=1`