### PR TITLE
Render release contracts per environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,6 +315,7 @@ jobs:
           SOURCE_REPOSITORY: ${{ github.repository }}
           TARGET_ENVIRONMENT: ${{ matrix.target_environment }}
           APPLY_MODE: ${{ matrix.apply_mode }}
+          RUNTIME_CONTRACT_BASE: cerebro-runtime-contract-${{ matrix.target_environment }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN}" ]; then
@@ -359,6 +360,9 @@ jobs:
               --arg request_id "${request_id}" \
               --arg target_environment "${TARGET_ENVIRONMENT}" \
               --arg apply_mode "${APPLY_MODE}" \
+              --arg runtime_contract "${RUNTIME_CONTRACT_BASE}.json" \
+              --arg runtime_contract_signature "${RUNTIME_CONTRACT_BASE}.json.sig" \
+              --arg runtime_contract_certificate "${RUNTIME_CONTRACT_BASE}.json.pem" \
               '{
                 event_type: "cerebro-release-published",
                 client_payload: {
@@ -369,7 +373,10 @@ jobs:
                   source_ref: $source_ref,
                   request_id: $request_id,
                   target_environment: $target_environment,
-                  apply_mode: $apply_mode
+                  apply_mode: $apply_mode,
+                  runtime_contract: $runtime_contract,
+                  runtime_contract_signature: $runtime_contract_signature,
+                  runtime_contract_certificate: $runtime_contract_certificate
                 }
               }' | gh api --method POST "repos/${INFRA_REPOSITORY}/dispatches" --input -
 
@@ -412,8 +419,13 @@ jobs:
   runtime-contract:
     runs-on: ubuntu-latest
     needs: [resolve-tag, release-verify]
+    strategy:
+      fail-fast: false
+      matrix:
+        target_environment: [sec-dev, go-prod]
     env:
       RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
+      TARGET_ENVIRONMENT: ${{ matrix.target_environment }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -430,11 +442,11 @@ jobs:
           set -euo pipefail
           mkdir -p .dist
           go run ./cmd/sourcedeploy \
-            -env sec-dev \
+            -env "${TARGET_ENVIRONMENT}" \
             -tenant writer \
             -format contract-json \
             -image-tag "${RELEASE_TAG}" \
-            -out .dist/cerebro-runtime-contract.json
+            -out ".dist/cerebro-runtime-contract-${TARGET_ENVIRONMENT}.json"
 
       - name: Set up cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -448,18 +460,18 @@ jobs:
         run: |
           set -euo pipefail
           cosign sign-blob --yes \
-            --output-signature .dist/cerebro-runtime-contract.json.sig \
-            --output-certificate .dist/cerebro-runtime-contract.json.pem \
-            .dist/cerebro-runtime-contract.json
+            --output-signature ".dist/cerebro-runtime-contract-${TARGET_ENVIRONMENT}.json.sig" \
+            --output-certificate ".dist/cerebro-runtime-contract-${TARGET_ENVIRONMENT}.json.pem" \
+            ".dist/cerebro-runtime-contract-${TARGET_ENVIRONMENT}.json"
 
       - name: Upload runtime deploy contract
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: cerebro-runtime-contract
+          name: cerebro-runtime-contract-${{ matrix.target_environment }}
           path: |
-            .dist/cerebro-runtime-contract.json
-            .dist/cerebro-runtime-contract.json.sig
-            .dist/cerebro-runtime-contract.json.pem
+            .dist/cerebro-runtime-contract-${{ matrix.target_environment }}.json
+            .dist/cerebro-runtime-contract-${{ matrix.target_environment }}.json.sig
+            .dist/cerebro-runtime-contract-${{ matrix.target_environment }}.json.pem
           if-no-files-found: error
 
   runtime-contract-upload:
@@ -468,10 +480,16 @@ jobs:
     env:
       RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
     steps:
-      - name: Download runtime deploy contract
+      - name: Download sec-dev runtime deploy contract
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: cerebro-runtime-contract
+          name: cerebro-runtime-contract-sec-dev
+          path: .dist
+
+      - name: Download go-prod runtime deploy contract
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cerebro-runtime-contract-go-prod
           path: .dist
 
       - name: Upload runtime deploy contract to release
@@ -481,7 +499,10 @@ jobs:
         run: |
           set -euo pipefail
           gh release upload "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" \
-            .dist/cerebro-runtime-contract.json \
-            .dist/cerebro-runtime-contract.json.sig \
-            .dist/cerebro-runtime-contract.json.pem \
+            .dist/cerebro-runtime-contract-sec-dev.json \
+            .dist/cerebro-runtime-contract-sec-dev.json.sig \
+            .dist/cerebro-runtime-contract-sec-dev.json.pem \
+            .dist/cerebro-runtime-contract-go-prod.json \
+            .dist/cerebro-runtime-contract-go-prod.json.sig \
+            .dist/cerebro-runtime-contract-go-prod.json.pem \
             --clobber

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -496,7 +496,7 @@ The public handoff is:
 
 - the container image,
 - the binary behavior,
-- `cerebro-runtime-contract.json` when produced by release tooling,
+- the environment-specific `cerebro-runtime-contract-<environment>.json` when produced by release tooling,
 - API and proto contracts,
 - the documented environment variable surface.
 

--- a/docs/RELEASE_CONTRACT.md
+++ b/docs/RELEASE_CONTRACT.md
@@ -34,9 +34,9 @@ A release can include:
 - Linux runtime binaries,
 - multi-arch runtime image,
 - image provenance and signatures,
-- `cerebro-runtime-contract.json`,
-- `cerebro-runtime-contract.json.sig`,
-- `cerebro-runtime-contract.json.pem`.
+- environment-specific runtime contracts, such as `cerebro-runtime-contract-sec-dev.json` and `cerebro-runtime-contract-go-prod.json`,
+- matching runtime contract signatures,
+- matching runtime contract certificates.
 
 Runtime image:
 

--- a/docs/RELEASE_CONTRACT.md
+++ b/docs/RELEASE_CONTRACT.md
@@ -214,12 +214,15 @@ Keep those in your deployment system.
 
 ## Signature artifacts
 
-Releases upload:
+Releases upload one signed contract per deployment target:
 
 ```text
-cerebro-runtime-contract.json
-cerebro-runtime-contract.json.sig
-cerebro-runtime-contract.json.pem
+cerebro-runtime-contract-sec-dev.json
+cerebro-runtime-contract-sec-dev.json.sig
+cerebro-runtime-contract-sec-dev.json.pem
+cerebro-runtime-contract-go-prod.json
+cerebro-runtime-contract-go-prod.json.sig
+cerebro-runtime-contract-go-prod.json.pem
 ```
 
 Use the signature and certificate with your preferred Sigstore verification workflow. Verification policy is environment-specific, but the contract content is public and should not contain live secrets.
@@ -230,7 +233,7 @@ Suggested flow:
 
 1. Select an immutable release tag.
 2. Pull or pin `ghcr.io/writer/cerebro:<tag>`.
-3. Download `cerebro-runtime-contract.json`.
+3. Download the contract whose suffix matches your deployment target, such as `cerebro-runtime-contract-go-prod.json`.
 4. Verify the contract signature if your deployment process requires it.
 5. Check `required_secrets` against your secret manager.
 6. Check source runtimes against your intended tenants and schedules.

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -91,10 +91,18 @@ func TestReleaseWorkflowKeepsCIParityAndStableLatestGuard(t *testing.T) {
 		"target_environment: go-prod",
 		"apply_mode: pull_request",
 		"TARGET_ENVIRONMENT: ${{ matrix.target_environment }}",
+		"RUNTIME_CONTRACT_BASE: cerebro-runtime-contract-${{ matrix.target_environment }}",
+		`target_environment: [sec-dev, go-prod]`,
+		`-env "${TARGET_ENVIRONMENT}"`,
+		"cerebro-runtime-contract-sec-dev.json",
+		"cerebro-runtime-contract-go-prod.json",
 	} {
 		if !strings.Contains(release, marker) {
 			t.Fatalf("release workflow missing required marker %q", marker)
 		}
+	}
+	if strings.Contains(release, "-env sec-dev") {
+		t.Fatal("runtime deploy contract must not be pinned to sec-dev when release dispatches multiple environments")
 	}
 	latestIndex := strings.Index(release, `docker buildx imagetools create -t "${IMAGE_BASE}:latest"`)
 	stableGuardIndex := strings.Index(release, `if [ "${{ needs.resolve-tag.outputs.is_stable_release }}" = "true" ]; then`)


### PR DESCRIPTION
## Summary
- render and sign runtime deploy contracts for both sec-dev and go-prod
- upload environment-specific contract artifacts to releases
- include matching contract artifact names in infra dispatch payloads
- document the environment-specific contract names and guard against reintroducing a pinned sec-dev contract

## Security
Fixes CAND-DEEP-032 from the Codex Security deep scan. The release workflow previously uploaded one sec-dev-labeled runtime contract while dispatching both sec-dev and go-prod promotions.

## Tests
- `go test ./tools/archtests -run 'TestReleaseWorkflowKeepsCIParityAndStableLatestGuard' -count=1 -v`\n- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release yaml parses"'`