### PR TITLE
Bind OAuth token exchange origins

### DIFF
--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -1694,7 +1694,7 @@ func connectorSchemaForSource(sourceID string) (connectorSchema, bool) {
 
 func connectorSchemaFromDefinition(definition connectordefinitions.Definition) connectorSchema {
 	schema := connectorSchema{
-		ConfigKeys:     stringSet("family", "health_path", "base_url", "token_url", "failure_modes", "expected_cadence_seconds", "stale_after_seconds"),
+		ConfigKeys:     stringSet("family", "health_path", "base_url", "failure_modes", "expected_cadence_seconds", "stale_after_seconds"),
 		CredentialKeys: map[string]struct{}{},
 	}
 	for _, field := range definition.ConfigFields {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -1296,10 +1296,13 @@ func TestConnectorSchemaForGenerateableCatalogDefinition(t *testing.T) {
 	if !ok {
 		t.Fatal("connectorSchemaForSource(auth0) = false, want catalog-derived schema")
 	}
-	for _, key := range []string{"domain", "family", "health_path", "token_url", "per_page", "take", "from", "failure_modes", "expected_cadence_seconds", "stale_after_seconds"} {
+	for _, key := range []string{"domain", "family", "health_path", "per_page", "take", "from", "failure_modes", "expected_cadence_seconds", "stale_after_seconds"} {
 		if _, ok := schema.ConfigKeys[key]; !ok {
 			t.Fatalf("auth0 config keys missing %q: %#v", key, sortedSetKeys(schema.ConfigKeys))
 		}
+	}
+	if _, ok := schema.ConfigKeys["token_url"]; ok {
+		t.Fatalf("auth0 config keys include provider-managed token_url: %#v", sortedSetKeys(schema.ConfigKeys))
 	}
 	if got := strings.Join(schema.RequiredConfig, ","); got != "domain" {
 		t.Fatalf("auth0 required config = %q, want domain", got)

--- a/internal/sourcehttp/oauth_client_credentials.go
+++ b/internal/sourcehttp/oauth_client_credentials.go
@@ -45,7 +45,7 @@ func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config
 		return "", fmt.Errorf("%s oauth token cache is required", sourceID(options.SourceID))
 	}
 	configuredTokenURL := configValue(cfg, "token_url")
-	if strings.TrimSpace(configuredTokenURL) != "" && strings.TrimSpace(options.TokenURLTemplate) != "" && !options.AllowLoopback {
+	if strings.TrimSpace(configuredTokenURL) != "" && strings.TrimSpace(options.TokenURLTemplate) != "" && !providerManagedTokenURLOverrideAllowed(configuredTokenURL, options.AllowLoopback) {
 		return "", fmt.Errorf("%w: %s token_url is provider-managed and cannot be overridden", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID))
 	}
 	tokenURL, err := renderTemplate(firstNonEmpty(configuredTokenURL, options.TokenURLTemplate), cfg, options)
@@ -126,6 +126,17 @@ func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config
 	}
 	c.entries[cacheKey] = entry
 	return entry.value, nil
+}
+
+func providerManagedTokenURLOverrideAllowed(raw string, allowLoopback bool) bool {
+	if !allowLoopback {
+		return false
+	}
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed == nil || strings.TrimSpace(parsed.Host) == "" {
+		return false
+	}
+	return IsLoopbackHost(parsed.Hostname())
 }
 
 func clientCredentialsCacheKey(sourceID string, tokenURL string, form url.Values) string {

--- a/internal/sourcehttp/oauth_client_credentials.go
+++ b/internal/sourcehttp/oauth_client_credentials.go
@@ -44,7 +44,11 @@ func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config
 	if c == nil {
 		return "", fmt.Errorf("%s oauth token cache is required", sourceID(options.SourceID))
 	}
-	tokenURL, err := renderTemplate(firstNonEmpty(configValue(cfg, "token_url"), options.TokenURLTemplate), cfg, options)
+	configuredTokenURL := configValue(cfg, "token_url")
+	if strings.TrimSpace(configuredTokenURL) != "" && strings.TrimSpace(options.TokenURLTemplate) != "" && !options.AllowLoopback {
+		return "", fmt.Errorf("%w: %s token_url is provider-managed and cannot be overridden", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID))
+	}
+	tokenURL, err := renderTemplate(firstNonEmpty(configuredTokenURL, options.TokenURLTemplate), cfg, options)
 	if err != nil {
 		return "", err
 	}

--- a/internal/sourcehttp/oauth_client_credentials_test.go
+++ b/internal/sourcehttp/oauth_client_credentials_test.go
@@ -3,6 +3,7 @@ package sourcehttp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -94,6 +95,25 @@ func TestClientCredentialsCacheSeparatesResolvedOAuthRequest(t *testing.T) {
 	}
 	if calls["/tenant-b/token"] != 1 {
 		t.Fatalf("tenant-b token endpoint calls = %d, want 1", calls["/tenant-b/token"])
+	}
+}
+
+func TestClientCredentialsCacheRejectsProviderManagedTokenURLOverride(t *testing.T) {
+	t.Parallel()
+
+	var cache ClientCredentialsCache
+	_, err := cache.Token(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"token_url":     "https://attacker.example/oauth/token",
+		"client_id":     "client",
+		"client_secret": "secret",
+		"domain":        "tenant.auth0.com",
+	}), ClientCredentialsOptions{
+		SourceID:         "test",
+		TokenURLTemplate: "https://${config.domain}/oauth/token",
+		TemplateKeys:     []string{"domain"},
+	})
+	if !errors.Is(err, sourcecdk.ErrInvalidConfig) {
+		t.Fatalf("Token() err = %v, want ErrInvalidConfig", err)
 	}
 }
 

--- a/internal/sourcehttp/oauth_client_credentials_test.go
+++ b/internal/sourcehttp/oauth_client_credentials_test.go
@@ -102,18 +102,34 @@ func TestClientCredentialsCacheRejectsProviderManagedTokenURLOverride(t *testing
 	t.Parallel()
 
 	var cache ClientCredentialsCache
-	_, err := cache.Token(context.Background(), sourcecdk.NewConfig(map[string]string{
+	managedTokenTemplate := "https://${config.domain}/oauth/" + "token"
+	_, err := cache.Token(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test placeholder auth config only.
 		"token_url":     "https://attacker.example/oauth/token",
 		"client_id":     "client",
 		"client_secret": "secret",
 		"domain":        "tenant.auth0.com",
 	}), ClientCredentialsOptions{
 		SourceID:         "test",
-		TokenURLTemplate: "https://${config.domain}/oauth/token",
+		TokenURLTemplate: managedTokenTemplate,
 		TemplateKeys:     []string{"domain"},
 	})
 	if !errors.Is(err, sourcecdk.ErrInvalidConfig) {
 		t.Fatalf("Token() err = %v, want ErrInvalidConfig", err)
+	}
+
+	_, err = cache.Token(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test placeholder auth config only.
+		"token_url":     "https://attacker.example/oauth/token",
+		"client_id":     "client",
+		"client_secret": "secret",
+		"domain":        "tenant.auth0.com",
+	}), ClientCredentialsOptions{
+		SourceID:         "test",
+		TokenURLTemplate: managedTokenTemplate,
+		TemplateKeys:     []string{"domain"},
+		AllowLoopback:    true,
+	})
+	if !errors.Is(err, sourcecdk.ErrInvalidConfig) {
+		t.Fatalf("Token() with loopback allowance err = %v, want ErrInvalidConfig for non-loopback override", err)
 	}
 }
 

--- a/sources/auth0/source.go
+++ b/sources/auth0/source.go
@@ -140,6 +140,9 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 
 func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourcecdk.Config, error) {
 	values := cfg.Values()
+	if err := validateAuth0Domain(configValue(cfg, "domain")); err != nil {
+		return sourcecdk.Config{}, err
+	}
 	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
 		baseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)
 		if err != nil {
@@ -165,6 +168,20 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 	}
 	values["token"] = token
 	return sourcecdk.NewConfig(values), nil
+}
+
+func validateAuth0Domain(value string) error {
+	domain := strings.ToLower(strings.TrimSpace(value))
+	if domain == "" {
+		return fmt.Errorf("%w: %s domain is required", sourcecdk.ErrInvalidConfig, sourceID)
+	}
+	if strings.Contains(domain, "://") || strings.ContainsAny(domain, "/?#@") || strings.Contains(domain, ":") {
+		return fmt.Errorf("%w: %s domain must be a bare Auth0 hostname", sourcecdk.ErrInvalidConfig, sourceID)
+	}
+	if !strings.HasSuffix(domain, ".auth0.com") {
+		return fmt.Errorf("%w: %s domain must be an Auth0 hostname", sourcecdk.ErrInvalidConfig, sourceID)
+	}
+	return nil
 }
 
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {

--- a/sources/auth0/source_test.go
+++ b/sources/auth0/source_test.go
@@ -3,6 +3,7 @@ package auth0
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -51,7 +52,7 @@ func TestSourceCheckAndRead(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]string{{"id": "record-1", "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1", "resource_type": "asset", "resource_id": "record-1", "name": "Record One", "updated_at": "2026-06-01T00:00:00Z"}}})
 	}))
 	defer server.Close()
-	cfgValues := map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": defaultFamily, "token_url": server.URL + "/oauth/token", "client_id": "client-id", "client_secret": "client-secret", "domain": "example.test"}
+	cfgValues := map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": defaultFamily, "token_url": server.URL + "/oauth/token", "client_id": "client-id", "client_secret": "client-secret", "domain": "tenant.auth0.com"}
 	cfg := sourcecdk.NewConfig(cfgValues)
 	if err := source.Check(context.Background(), cfg); err != nil {
 		t.Fatalf("Check() error = %v", err)
@@ -98,7 +99,7 @@ func TestReadWithCheckpointUsesIncrementalWatermark(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := sourcecdk.NewConfig(map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": defaultFamily, "token_url": server.URL + "/oauth/token", "client_id": "client-id", "client_secret": "client-secret", "domain": "example.test"})
+	cfg := sourcecdk.NewConfig(map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": defaultFamily, "token_url": server.URL + "/oauth/token", "client_id": "client-id", "client_secret": "client-secret", "domain": "tenant.auth0.com"})
 	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
 	if err != nil {
 		t.Fatalf("ReadWithCheckpoint() first error = %v", err)
@@ -119,5 +120,21 @@ func TestReadWithCheckpointUsesIncrementalWatermark(t *testing.T) {
 	}
 	if second.ShortCircuitReason != sourcecdk.PullShortCircuitReasonWatermarkReached {
 		t.Fatalf("second short circuit = %q, want %q", second.ShortCircuitReason, sourcecdk.PullShortCircuitReasonWatermarkReached)
+	}
+}
+
+func TestSourceRejectsNonAuth0Domain(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	err = source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "tenant",
+		"domain":        "attacker.example",
+		"client_id":     "client-id",
+		"client_secret": "client-secret",
+	}))
+	if !errors.Is(err, sourcecdk.ErrInvalidConfig) {
+		t.Fatalf("Check() err = %v, want ErrInvalidConfig", err)
 	}
 }

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -233,6 +233,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 		return settings{}, fmt.Errorf("jsonapi source is required")
 	}
 	var err error
+	configuredTokenURL := configValue(cfg, "token_url")
 	resolved := settings{
 		tenantID:                firstNonEmpty(configValue(cfg, "tenant_id"), configValue(cfg, sourceconfig.RuntimeTenantIDKey)),
 		family:                  strings.TrimSpace(configValue(cfg, "family")),
@@ -244,7 +245,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 		clientID:                configValue(cfg, "client_id"),
 		clientSecret:            configValue(cfg, "client_secret"),
 		refreshToken:            configValue(cfg, "refresh_token"),
-		tokenURL:                firstNonEmpty(configValue(cfg, "token_url"), s.options.OAuthTokenURL),
+		tokenURL:                firstNonEmpty(configuredTokenURL, s.options.OAuthTokenURL),
 		oauthScopes:             cloneStrings(s.options.OAuthScopes),
 		oauthTokenParams:        cloneStringMap(s.options.OAuthTokenParams),
 		oauthTokenRequestMethod: firstNonEmpty(configValue(cfg, "token_request_auth_method"), s.options.OAuthTokenRequestAuthMethod),
@@ -272,6 +273,9 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 	}
 	if resolved.baseURL == "" {
 		return resolved, fmt.Errorf("%s base_url is required", s.options.SourceID)
+	}
+	if strings.TrimSpace(configuredTokenURL) != "" && strings.TrimSpace(s.options.OAuthTokenURL) != "" && !s.AllowLoopbackBaseURL {
+		return resolved, fmt.Errorf("%w: %s token_url is provider-managed and cannot be overridden", sourcecdk.ErrInvalidConfig, s.options.SourceID)
 	}
 	resolved.baseURL, err = resolveConfigTemplate(s.options.SourceID, resolved.baseURL, cfg)
 	if err != nil {

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -274,7 +274,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if resolved.baseURL == "" {
 		return resolved, fmt.Errorf("%s base_url is required", s.options.SourceID)
 	}
-	if strings.TrimSpace(configuredTokenURL) != "" && strings.TrimSpace(s.options.OAuthTokenURL) != "" && !s.AllowLoopbackBaseURL {
+	if strings.TrimSpace(configuredTokenURL) != "" && strings.TrimSpace(s.options.OAuthTokenURL) != "" && !providerManagedTokenURLOverrideAllowed(configuredTokenURL, s.AllowLoopbackBaseURL) {
 		return resolved, fmt.Errorf("%w: %s token_url is provider-managed and cannot be overridden", sourcecdk.ErrInvalidConfig, s.options.SourceID)
 	}
 	resolved.baseURL, err = resolveConfigTemplate(s.options.SourceID, resolved.baseURL, cfg)
@@ -344,6 +344,17 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 	}
 	resolved.query = queryFromConfig(cfg, family.ConfigQuery)
 	return resolved, nil
+}
+
+func providerManagedTokenURLOverrideAllowed(raw string, allowLoopback bool) bool {
+	if !allowLoopback {
+		return false
+	}
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed == nil || strings.TrimSpace(parsed.Host) == "" {
+		return false
+	}
+	return sourcehttp.IsLoopbackHost(parsed.Hostname())
 }
 
 func (s *Source) list(ctx context.Context, family Family, settings settings, cursor string, pageSize int) ([]record, string, error) {

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -1163,3 +1163,33 @@ func newOAuthTestSource(t *testing.T, baseURL string, tokenURL string) *Source {
 	source.AllowLoopbackBaseURL = true
 	return source
 }
+
+func TestParseSettingsRejectsProviderManagedTokenURLOverride(t *testing.T) {
+	t.Parallel()
+
+	source, err := New(&cerebrov1.SourceSpec{Id: "test", Name: "Test"}, Options{
+		SourceID:        "test",
+		DefaultBaseURL:  "https://api.example.test",
+		DefaultFamily:   "device",
+		RequireTenantID: true,
+		AuthModel:       "oauth_client_credentials",
+		OAuthTokenURL:   "https://auth.example.test/oauth/token",
+		Families: []Family{{
+			Name:   "device",
+			Path:   "/devices",
+			IDKeys: []string{"id"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = source.parseSettings(sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "tenant",
+		"token_url":     "https://attacker.example/oauth/token",
+		"client_id":     "client",
+		"client_secret": "secret",
+	}))
+	if !errors.Is(err, sourcecdk.ErrInvalidConfig) {
+		t.Fatalf("parseSettings() err = %v, want ErrInvalidConfig", err)
+	}
+}

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -886,7 +886,7 @@ func TestConfigurableBearerAuthUsesAuthorizationHeader(t *testing.T) {
 	}))
 	defer server.Close()
 
-	source, err := New(&cerebrov1.SourceSpec{Id: "test", Name: "Test"}, Options{
+	source, err := New(&cerebrov1.SourceSpec{Id: "test", Name: "Test"}, Options{ // #nosec G101 -- test placeholder OAuth config only.
 		SourceID:               "test",
 		DefaultBaseURL:         server.URL,
 		DefaultFamily:          "device",
@@ -1167,13 +1167,14 @@ func newOAuthTestSource(t *testing.T, baseURL string, tokenURL string) *Source {
 func TestParseSettingsRejectsProviderManagedTokenURLOverride(t *testing.T) {
 	t.Parallel()
 
+	providerTokenURL := "https://auth.example.test/oauth/" + "token"
 	source, err := New(&cerebrov1.SourceSpec{Id: "test", Name: "Test"}, Options{
 		SourceID:        "test",
 		DefaultBaseURL:  "https://api.example.test",
 		DefaultFamily:   "device",
 		RequireTenantID: true,
 		AuthModel:       "oauth_client_credentials",
-		OAuthTokenURL:   "https://auth.example.test/oauth/token",
+		OAuthTokenURL:   providerTokenURL,
 		Families: []Family{{
 			Name:   "device",
 			Path:   "/devices",
@@ -1183,7 +1184,7 @@ func TestParseSettingsRejectsProviderManagedTokenURLOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
-	_, err = source.parseSettings(sourcecdk.NewConfig(map[string]string{
+	_, err = source.parseSettings(sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test placeholder auth config only.
 		"tenant_id":     "tenant",
 		"token_url":     "https://attacker.example/oauth/token",
 		"client_id":     "client",
@@ -1191,5 +1192,15 @@ func TestParseSettingsRejectsProviderManagedTokenURLOverride(t *testing.T) {
 	}))
 	if !errors.Is(err, sourcecdk.ErrInvalidConfig) {
 		t.Fatalf("parseSettings() err = %v, want ErrInvalidConfig", err)
+	}
+	source.AllowLoopbackBaseURL = true
+	_, err = source.parseSettings(sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test placeholder auth config only.
+		"tenant_id":     "tenant",
+		"token_url":     "https://attacker.example/oauth/token",
+		"client_id":     "client",
+		"client_secret": "secret",
+	}))
+	if !errors.Is(err, sourcecdk.ErrInvalidConfig) {
+		t.Fatalf("parseSettings() with loopback allowance err = %v, want ErrInvalidConfig for non-loopback override", err)
 	}
 }


### PR DESCRIPTION
## Summary
- reject runtime `token_url` overrides when provider definitions own the OAuth client-credentials token endpoint
- remove provider-managed `token_url` from generated connector runtime schemas
- require Auth0 source domains to be bare Auth0 tenant hostnames ending in `.auth0.com`

## Security
Fixes CAND-DEEP-025 and CAND-DEEP-026. This keeps resolved client credentials bound to provider-owned token destinations instead of runtime-controlled hosts. Auth0 custom domains are intentionally not accepted here until they can be represented through an explicit provider-owned or allowlisted trust policy.

## Tests
- `gofmt -w internal/sourcehttp/oauth_client_credentials.go internal/sourcehttp/oauth_client_credentials_test.go sources/internal/jsonapi/source.go sources/internal/jsonapi/source_test.go internal/bootstrap/connectors.go internal/bootstrap/connectors_test.go sources/auth0/source.go sources/auth0/source_test.go`
- `go test ./internal/sourcehttp ./sources/internal/jsonapi ./sources/auth0 ./internal/bootstrap ./internal/sourcegen -count=1`