### PR TITLE
Require explicit cloud source credentials

### DIFF
--- a/docs/SOURCE_CDK_EXTRACTION.md
+++ b/docs/SOURCE_CDK_EXTRACTION.md
@@ -23,10 +23,10 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | Source | Current LOC Budget | Extraction Pressure |
 | --- | ---: | --- |
 | `aurelius` | 653 | Split source orchestration from record mapping and shared request plumbing. |
-| `aws` | 19155 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
+| `aws` | 19121 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
 | `azure` | 2856 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 1112 | Move shared API pagination and response normalization into reusable source helpers. |
-| `gcp` | 2120 | Extract project traversal, service clients, and resource-family pagination helpers. |
+| `gcp` | 2116 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2110 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 827 | Extract API client setup and paginated directory readers. |
 | `grc` | 1378 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |

--- a/internal/sourceconfig/secrets.go
+++ b/internal/sourceconfig/secrets.go
@@ -9,6 +9,7 @@ const (
 	envPrefix                 = "env:"
 	credentialPrefix          = "credential:" // #nosec G101 -- runtime reference prefix, not secret material.
 	AWSAssumeRoleAllowlistKey = "__cerebro_aws_assume_role_arns"
+	GCPWIFAllowlistKey        = "__cerebro_gcp_wif_bindings"
 	RuntimeIDKey              = "__cerebro_runtime_id"
 	RuntimeTenantIDKey        = "__cerebro_runtime_tenant_id"
 )

--- a/internal/sourceconfig/secrets.go
+++ b/internal/sourceconfig/secrets.go
@@ -2,6 +2,7 @@ package sourceconfig
 
 import (
 	"context"
+	"regexp"
 	"strings"
 )
 
@@ -9,12 +10,14 @@ const (
 	envPrefix                 = "env:"
 	credentialPrefix          = "credential:" // #nosec G101 -- runtime reference prefix, not secret material.
 	AWSAssumeRoleAllowlistKey = "__cerebro_aws_assume_role_arns"
-	GCPWIFAllowlistKey        = "__cerebro_gcp_wif_bindings"
+	GCPWIFAllowlistKey        = "__cerebro_gcp_wif_bindings" // #nosec G101 -- internal allowlist key, not secret material.
 	RuntimeIDKey              = "__cerebro_runtime_id"
 	RuntimeTenantIDKey        = "__cerebro_runtime_tenant_id"
 )
 
 type Resolver func(context.Context, string, map[string]string) (map[string]string, error)
+
+var awsRoleARNPattern = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):iam::([0-9]{12}):role/[A-Za-z0-9+=,.@_/-]+$`)
 
 func IsSecretReference(value string) bool {
 	_, ok := SecretReferenceName(value)
@@ -81,6 +84,128 @@ func WithRuntimeContext(values map[string]string, tenantID string, runtimeID str
 		cloned[RuntimeTenantIDKey] = tenantID
 	}
 	return cloned
+}
+
+func ValidateAWSCredentialSource(profile string, accessKeyID string, secretAccessKey string, sessionToken string, roleARN string) error {
+	if strings.TrimSpace(profile) != "" {
+		return sourceConfigError("aws profile is not supported for source runtimes")
+	}
+	hasRuntimeCredential := strings.TrimSpace(accessKeyID) != "" || strings.TrimSpace(secretAccessKey) != "" || strings.TrimSpace(sessionToken) != ""
+	if hasRuntimeCredential {
+		if strings.TrimSpace(accessKeyID) == "" || strings.TrimSpace(secretAccessKey) == "" {
+			return sourceConfigError("aws access_key_id and secret_access_key must be provided together")
+		}
+		return nil
+	}
+	if strings.TrimSpace(roleARN) != "" {
+		return nil
+	}
+	return sourceConfigError("aws access_key_id and secret_access_key or allowlisted role_arn is required")
+}
+
+func ValidateAWSAssumeRoleBinding(accountID string, tenantID string, roleARN string, allowlist string) error {
+	matches := awsRoleARNPattern.FindStringSubmatch(strings.TrimSpace(roleARN))
+	if len(matches) != 3 {
+		return sourceConfigError("aws role_arn must be an IAM role ARN")
+	}
+	if strings.TrimSpace(accountID) != matches[2] {
+		return sourceConfigError("aws role_arn account must match account_id")
+	}
+	if strings.TrimSpace(tenantID) == "" {
+		return sourceConfigError("aws role_arn requires runtime tenant_id")
+	}
+	if !AWSAssumeRoleARNAllowed(tenantID, roleARN, allowlist) {
+		return sourceConfigError("aws role_arn is not allowed")
+	}
+	return nil
+}
+
+func AWSAssumeRoleARNAllowed(tenantID string, roleARN string, allowlist string) bool {
+	tenantID = strings.TrimSpace(tenantID)
+	roleARN = strings.TrimSpace(roleARN)
+	if tenantID == "" || roleARN == "" {
+		return false
+	}
+	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
+	}) {
+		value = strings.TrimSpace(value)
+		tenant, arn, ok := strings.Cut(value, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(tenant) == tenantID && strings.TrimSpace(arn) == roleARN {
+			return true
+		}
+	}
+	return false
+}
+
+func ValidateGCPTokenOrWIF(token string, audience string, serviceAccount string, tenantID string, allowlist string) error {
+	if strings.TrimSpace(token) != "" {
+		return nil
+	}
+	if strings.TrimSpace(audience) == "" && strings.TrimSpace(serviceAccount) == "" {
+		return sourceConfigError("gcp token or wif_audience and wif_service_account_email are required")
+	}
+	if strings.TrimSpace(audience) == "" {
+		return sourceConfigError("gcp wif_audience is required when token is not provided")
+	}
+	if strings.TrimSpace(serviceAccount) == "" {
+		return sourceConfigError("gcp wif_service_account_email is required when token is not provided")
+	}
+	return ValidateGCPWIFBinding(tenantID, audience, serviceAccount, allowlist)
+}
+
+func ValidateGCPWIFBinding(tenantID string, audience string, serviceAccount string, allowlist string) error {
+	if strings.TrimSpace(tenantID) == "" {
+		return sourceConfigError("gcp wif auth requires runtime tenant_id")
+	}
+	if !GCPWIFBindingAllowed(tenantID, audience, serviceAccount, allowlist) {
+		return sourceConfigError("gcp wif audience and service account are not allowed")
+	}
+	return nil
+}
+
+func GCPWIFBindingAllowed(tenantID string, audience string, serviceAccount string, allowlist string) bool {
+	tenantID = strings.TrimSpace(tenantID)
+	audience = strings.TrimSpace(audience)
+	serviceAccount = strings.TrimSpace(serviceAccount)
+	if tenantID == "" || audience == "" || serviceAccount == "" {
+		return false
+	}
+	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t'
+	}) {
+		value = strings.TrimSpace(value)
+		tenant, binding, ok := strings.Cut(value, "=")
+		if !ok || strings.TrimSpace(tenant) != tenantID {
+			continue
+		}
+		allowedAudience, allowedServiceAccount, ok := strings.Cut(strings.TrimSpace(binding), "|")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(allowedAudience) == audience && strings.TrimSpace(allowedServiceAccount) == serviceAccount {
+			return true
+		}
+	}
+	return false
+}
+
+func sourceConfigError(message string) error {
+	return &SourceConfigError{Message: strings.TrimSpace(message)}
+}
+
+type SourceConfigError struct {
+	Message string
+}
+
+func (e *SourceConfigError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
 }
 
 func SensitiveKey(key string) bool {

--- a/internal/sourceconfig/secrets_test.go
+++ b/internal/sourceconfig/secrets_test.go
@@ -23,3 +23,111 @@ func TestLiteralEnvPrefixKeyDetectsQueryLikeKeys(t *testing.T) {
 		t.Fatal("LiteralEnvPrefixKey(token) = true, want false")
 	}
 }
+
+func TestValidateAWSCredentialSourceRejectsHostFallback(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		profile         string
+		accessKeyID     string
+		secretAccessKey string
+		sessionToken    string
+		roleARN         string
+	}{
+		{name: "empty"},
+		{name: "shared profile", profile: "prod"},
+		{name: "partial static credentials", accessKeyID: "AKIA_TEST"},
+		{name: "session token only", sessionToken: "token"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateAWSCredentialSource(tt.profile, tt.accessKeyID, tt.secretAccessKey, tt.sessionToken, tt.roleARN); err == nil {
+				t.Fatal("ValidateAWSCredentialSource() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestValidateAWSCredentialSourceAllowsExplicitCredentialsOrDelegation(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		accessKeyID     string
+		secretAccessKey string
+		roleARN         string
+	}{
+		{name: "static credentials", accessKeyID: "AKIA_TEST", secretAccessKey: "secret"},
+		{name: "allowlisted role", roleARN: "arn:aws:iam::123456789012:role/cerebro-org-scan-role"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateAWSCredentialSource("", tt.accessKeyID, tt.secretAccessKey, "", tt.roleARN); err != nil {
+				t.Fatalf("ValidateAWSCredentialSource() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAWSAssumeRoleBindingRejectsUnsafeBindings(t *testing.T) {
+	allowed := "arn:aws:iam::123456789012:role/cerebro-org-scan-role"
+	for _, tt := range []struct {
+		name      string
+		accountID string
+		tenantID  string
+		roleARN   string
+		allowlist string
+	}{
+		{name: "unallowlisted role", accountID: "123456789012", tenantID: "writer", roleARN: "arn:aws:iam::123456789012:role/OtherRole", allowlist: "writer=" + allowed},
+		{name: "account mismatch", accountID: "123456789012", tenantID: "writer", roleARN: "arn:aws:iam::210987654321:role/cerebro-org-scan-role", allowlist: "writer=" + allowed},
+		{name: "invalid role arn", accountID: "123456789012", tenantID: "writer", roleARN: "legacy", allowlist: "writer=" + allowed},
+		{name: "tenant mismatch", accountID: "123456789012", tenantID: "writer", roleARN: allowed, allowlist: "other=" + allowed},
+		{name: "bare allowlist entry", accountID: "123456789012", tenantID: "writer", roleARN: allowed, allowlist: allowed},
+		{name: "missing runtime tenant", accountID: "123456789012", roleARN: allowed, allowlist: "writer=" + allowed},
+		{name: "empty tenant allowlist entry", accountID: "123456789012", tenantID: "writer", roleARN: allowed, allowlist: "=" + allowed},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateAWSAssumeRoleBinding(tt.accountID, tt.tenantID, tt.roleARN, tt.allowlist); err == nil {
+				t.Fatal("ValidateAWSAssumeRoleBinding() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestValidateAWSAssumeRoleBindingAllowsTrustedRuntime(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/cerebro-org-scan-role"
+	if err := ValidateAWSAssumeRoleBinding("123456789012", "writer", roleARN, "writer="+roleARN); err != nil {
+		t.Fatalf("ValidateAWSAssumeRoleBinding() error = %v", err)
+	}
+}
+
+func TestValidateGCPTokenOrWIFAllowsStaticToken(t *testing.T) {
+	if err := ValidateGCPTokenOrWIF("static-token", "", "", "", ""); err != nil {
+		t.Fatalf("ValidateGCPTokenOrWIF() error = %v", err)
+	}
+}
+
+func TestValidateGCPWIFBindingRejectsUntrustedRuntime(t *testing.T) {
+	audience := "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws"
+	serviceAccount := "scanner@writer-iam.iam.gserviceaccount.com"
+	for _, tt := range []struct {
+		name           string
+		tenantID       string
+		audience       string
+		serviceAccount string
+		allowlist      string
+	}{
+		{name: "missing runtime tenant", audience: audience, serviceAccount: serviceAccount, allowlist: "writer=" + audience + "|" + serviceAccount},
+		{name: "missing trusted binding", tenantID: "writer", audience: audience, serviceAccount: serviceAccount},
+		{name: "service account mismatch", tenantID: "writer", audience: audience, serviceAccount: serviceAccount, allowlist: "writer=" + audience + "|other@writer-iam.iam.gserviceaccount.com"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateGCPWIFBinding(tt.tenantID, tt.audience, tt.serviceAccount, tt.allowlist); err == nil {
+				t.Fatal("ValidateGCPWIFBinding() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestValidateGCPWIFBindingAllowsTrustedRuntime(t *testing.T) {
+	audience := "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws"
+	serviceAccount := "scanner@writer-iam.iam.gserviceaccount.com"
+	if err := ValidateGCPWIFBinding("writer", audience, serviceAccount, "writer="+audience+"|"+serviceAccount); err != nil {
+		t.Fatalf("ValidateGCPWIFBinding() error = %v", err)
+	}
+}

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -715,6 +715,7 @@ func TestProgressConfigHashIgnoresInternalRuntimeMetadata(t *testing.T) {
 		sourceconfig.RuntimeIDKey:              "writer-inventory",
 		sourceconfig.RuntimeTenantIDKey:        "writer",
 		sourceconfig.AWSAssumeRoleAllowlistKey: "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role",
+		sourceconfig.GCPWIFAllowlistKey:        "writer=//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws|scanner@writer-iam.iam.gserviceaccount.com",
 		runtimeProgressConfigHashKey:           "old-hash",
 	})
 	if base != withInternal {
@@ -727,6 +728,7 @@ func TestUserConfigStripsInternalAssumeRoleAllowlist(t *testing.T) {
 		"family":                               "public_endpoint",
 		runtimeProgressConfigHashKey:           "hash",
 		sourceconfig.AWSAssumeRoleAllowlistKey: "caller-controlled",
+		sourceconfig.GCPWIFAllowlistKey:        "caller-controlled",
 		sourceconfig.RuntimeIDKey:              "writer-endpoint",
 		sourceconfig.RuntimeTenantIDKey:        "writer",
 	})
@@ -735,6 +737,9 @@ func TestUserConfigStripsInternalAssumeRoleAllowlist(t *testing.T) {
 	}
 	if _, ok := config[sourceconfig.AWSAssumeRoleAllowlistKey]; ok {
 		t.Fatal("userConfig preserved internal assume-role allowlist key")
+	}
+	if _, ok := config[sourceconfig.GCPWIFAllowlistKey]; ok {
+		t.Fatal("userConfig preserved internal gcp wif allowlist key")
 	}
 	if _, ok := config[runtimeProgressConfigHashKey]; ok {
 		t.Fatal("userConfig preserved progress config hash key")
@@ -752,6 +757,9 @@ func TestResolveConfigPreservesTrustedInternalRuntimeConfig(t *testing.T) {
 		if _, ok := values[sourceconfig.AWSAssumeRoleAllowlistKey]; ok {
 			t.Fatal("resolver input preserved caller-controlled allowlist")
 		}
+		if _, ok := values[sourceconfig.GCPWIFAllowlistKey]; ok {
+			t.Fatal("resolver input preserved caller-controlled gcp wif allowlist")
+		}
 		if got := values[sourceconfig.RuntimeIDKey]; got != "writer-endpoint" {
 			t.Fatalf("resolver runtime id = %q, want writer-endpoint", got)
 		}
@@ -762,17 +770,22 @@ func TestResolveConfigPreservesTrustedInternalRuntimeConfig(t *testing.T) {
 			"family":                               "public_endpoint",
 			runtimeProgressConfigHashKey:           "hash",
 			sourceconfig.AWSAssumeRoleAllowlistKey: "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role",
+			sourceconfig.GCPWIFAllowlistKey:        "writer=//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws|scanner@writer-iam.iam.gserviceaccount.com",
 		}, nil
 	})
 
 	resolved, err := service.resolveConfig(context.Background(), "aws", "writer", "writer-endpoint", map[string]string{
 		sourceconfig.AWSAssumeRoleAllowlistKey: "caller-controlled",
+		sourceconfig.GCPWIFAllowlistKey:        "caller-controlled",
 	})
 	if err != nil {
 		t.Fatalf("resolveConfig() error = %v", err)
 	}
 	if got := resolved[sourceconfig.AWSAssumeRoleAllowlistKey]; got != "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role" {
 		t.Fatalf("assume-role allowlist = %q, want trusted resolver value", got)
+	}
+	if got := resolved[sourceconfig.GCPWIFAllowlistKey]; got != "writer=//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws|scanner@writer-iam.iam.gserviceaccount.com" {
+		t.Fatalf("gcp wif allowlist = %q, want trusted resolver value", got)
 	}
 	if got := resolved[sourceconfig.RuntimeTenantIDKey]; got != "writer" {
 		t.Fatalf("runtime tenant = %q, want writer", got)

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -2706,6 +2706,9 @@ func awsFamily[T any](clientFactory awsClientFactory, options awsFamilyOptions[T
 }
 
 func newAWSClients(ctx context.Context, settings settings) (awsClients, error) {
+	if err := validateAWSCredentialSource(settings); err != nil {
+		return awsClients{}, err
+	}
 	options := []func(*awsconfig.LoadOptions) error{awsconfig.WithRegion(settings.region)}
 	if settings.profile != "" {
 		options = append(options, awsconfig.WithSharedConfigProfile(settings.profile))
@@ -2814,6 +2817,23 @@ func newAWSClients(ctx context.Context, settings settings) (awsClients, error) {
 			openSearchServerless: opensearchserverless.NewFromConfig(cfg),
 		},
 	}, nil
+}
+
+func validateAWSCredentialSource(settings settings) error {
+	if strings.TrimSpace(settings.profile) != "" {
+		return fmt.Errorf("aws profile is not supported for source runtimes")
+	}
+	hasRuntimeCredential := strings.TrimSpace(settings.accessKeyID) != "" || strings.TrimSpace(settings.secretAccessKey) != "" || strings.TrimSpace(settings.sessionToken) != ""
+	if hasRuntimeCredential {
+		if strings.TrimSpace(settings.accessKeyID) == "" || strings.TrimSpace(settings.secretAccessKey) == "" {
+			return fmt.Errorf("aws access_key_id and secret_access_key must be provided together")
+		}
+		return nil
+	}
+	if strings.TrimSpace(settings.roleARN) != "" {
+		return nil
+	}
+	return fmt.Errorf("aws access_key_id and secret_access_key or allowlisted role_arn is required")
 }
 
 func parseSettings(cfg sourcecdk.Config) (settings, error) {

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -110,7 +110,6 @@ import (
 var catalogFS embed.FS
 
 var emailPattern = regexp.MustCompile(`(?i)[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}`)
-var awsRoleARNPattern = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):iam::([0-9]{12}):role/[A-Za-z0-9+=,.@_/-]+$`)
 
 const (
 	defaultFamily                            = familyCloudTrail
@@ -2706,7 +2705,7 @@ func awsFamily[T any](clientFactory awsClientFactory, options awsFamilyOptions[T
 }
 
 func newAWSClients(ctx context.Context, settings settings) (awsClients, error) {
-	if err := validateAWSCredentialSource(settings); err != nil {
+	if err := sourceconfig.ValidateAWSCredentialSource(settings.profile, settings.accessKeyID, settings.secretAccessKey, settings.sessionToken, settings.roleARN); err != nil {
 		return awsClients{}, err
 	}
 	options := []func(*awsconfig.LoadOptions) error{awsconfig.WithRegion(settings.region)}
@@ -2819,23 +2818,6 @@ func newAWSClients(ctx context.Context, settings settings) (awsClients, error) {
 	}, nil
 }
 
-func validateAWSCredentialSource(settings settings) error {
-	if strings.TrimSpace(settings.profile) != "" {
-		return fmt.Errorf("aws profile is not supported for source runtimes")
-	}
-	hasRuntimeCredential := strings.TrimSpace(settings.accessKeyID) != "" || strings.TrimSpace(settings.secretAccessKey) != "" || strings.TrimSpace(settings.sessionToken) != ""
-	if hasRuntimeCredential {
-		if strings.TrimSpace(settings.accessKeyID) == "" || strings.TrimSpace(settings.secretAccessKey) == "" {
-			return fmt.Errorf("aws access_key_id and secret_access_key must be provided together")
-		}
-		return nil
-	}
-	if strings.TrimSpace(settings.roleARN) != "" {
-		return nil
-	}
-	return fmt.Errorf("aws access_key_id and secret_access_key or allowlisted role_arn is required")
-}
-
 func parseSettings(cfg sourcecdk.Config) (settings, error) {
 	settings := settings{
 		family:          configValue(cfg, "family"),
@@ -2878,7 +2860,7 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		return settings, fmt.Errorf("aws account_id is required")
 	}
 	if settings.roleARN != "" {
-		if err := validateAssumeRoleConfig(settings); err != nil {
+		if err := sourceconfig.ValidateAWSAssumeRoleBinding(settings.accountID, settings.tenantID, settings.roleARN, settings.assumeRoleARNs); err != nil {
 			return settings, err
 		}
 	} else if settings.externalID != "" {
@@ -2916,44 +2898,6 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		return settings, fmt.Errorf("unsupported aws family %q", settings.family)
 	}
 	return settings, nil
-}
-
-func validateAssumeRoleConfig(settings settings) error {
-	matches := awsRoleARNPattern.FindStringSubmatch(settings.roleARN)
-	if len(matches) != 3 {
-		return fmt.Errorf("aws role_arn must be an IAM role ARN")
-	}
-	if matches[2] != settings.accountID {
-		return fmt.Errorf("aws role_arn account must match account_id")
-	}
-	if settings.tenantID == "" {
-		return fmt.Errorf("aws role_arn requires runtime tenant_id")
-	}
-	if !assumeRoleARNAllowed(settings.tenantID, settings.roleARN, settings.assumeRoleARNs) {
-		return fmt.Errorf("aws role_arn is not allowed")
-	}
-	return nil
-}
-
-func assumeRoleARNAllowed(tenantID string, roleARN string, allowlist string) bool {
-	tenantID = strings.TrimSpace(tenantID)
-	roleARN = strings.TrimSpace(roleARN)
-	if tenantID == "" || roleARN == "" {
-		return false
-	}
-	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
-		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
-	}) {
-		value = strings.TrimSpace(value)
-		tenant, arn, ok := strings.Cut(value, "=")
-		if !ok {
-			continue
-		}
-		if strings.TrimSpace(tenant) == tenantID && strings.TrimSpace(arn) == roleARN {
-			return true
-		}
-	}
-	return false
 }
 
 func listAccessKeys(ctx context.Context, clients awsClients, settings settings, cursor string, limit int) ([]iamtypes.AccessKeyMetadata, string, error) {

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -220,40 +220,6 @@ func TestParseSettingsRejectsUnsafeAssumeRoleConfig(t *testing.T) {
 	}
 }
 
-func TestValidateAWSCredentialSourceRejectsHostFallback(t *testing.T) {
-	for _, tt := range []struct {
-		name     string
-		settings settings
-	}{
-		{name: "empty", settings: settings{accountID: "123456789012", region: defaultRegion}},
-		{name: "shared profile", settings: settings{accountID: "123456789012", region: defaultRegion, profile: "prod"}},
-		{name: "partial static credentials", settings: settings{accountID: "123456789012", region: defaultRegion, accessKeyID: "AKIA_TEST"}},
-		{name: "session token only", settings: settings{accountID: "123456789012", region: defaultRegion, sessionToken: "token"}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := validateAWSCredentialSource(tt.settings); err == nil {
-				t.Fatal("validateAWSCredentialSource() error = nil, want non-nil")
-			}
-		})
-	}
-}
-
-func TestValidateAWSCredentialSourceAllowsExplicitCredentialsOrDelegation(t *testing.T) {
-	for _, tt := range []struct {
-		name     string
-		settings settings
-	}{
-		{name: "static credentials", settings: settings{accountID: "123456789012", region: defaultRegion, accessKeyID: "AKIA_TEST", secretAccessKey: "secret"}},
-		{name: "allowlisted role", settings: settings{accountID: "123456789012", region: defaultRegion, roleARN: "arn:aws:iam::123456789012:role/cerebro-org-scan-role"}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := validateAWSCredentialSource(tt.settings); err != nil {
-				t.Fatalf("validateAWSCredentialSource() error = %v", err)
-			}
-		})
-	}
-}
-
 func TestAWSPullFromRecordsPreservesNextCursorWithoutEvents(t *testing.T) {
 	pull, err := sourcecdk.PullFromRecords[string](nil, "next-page", nil, nil)
 	if err != nil {

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -220,6 +220,40 @@ func TestParseSettingsRejectsUnsafeAssumeRoleConfig(t *testing.T) {
 	}
 }
 
+func TestValidateAWSCredentialSourceRejectsHostFallback(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		settings settings
+	}{
+		{name: "empty", settings: settings{accountID: "123456789012", region: defaultRegion}},
+		{name: "shared profile", settings: settings{accountID: "123456789012", region: defaultRegion, profile: "prod"}},
+		{name: "partial static credentials", settings: settings{accountID: "123456789012", region: defaultRegion, accessKeyID: "AKIA_TEST"}},
+		{name: "session token only", settings: settings{accountID: "123456789012", region: defaultRegion, sessionToken: "token"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateAWSCredentialSource(tt.settings); err == nil {
+				t.Fatal("validateAWSCredentialSource() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestValidateAWSCredentialSourceAllowsExplicitCredentialsOrDelegation(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		settings settings
+	}{
+		{name: "static credentials", settings: settings{accountID: "123456789012", region: defaultRegion, accessKeyID: "AKIA_TEST", secretAccessKey: "secret"}},
+		{name: "allowlisted role", settings: settings{accountID: "123456789012", region: defaultRegion, roleARN: "arn:aws:iam::123456789012:role/cerebro-org-scan-role"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateAWSCredentialSource(tt.settings); err != nil {
+				t.Fatalf("validateAWSCredentialSource() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestAWSPullFromRecordsPreservesNextCursorWithoutEvents(t *testing.T) {
 	pull, err := sourcecdk.PullFromRecords[string](nil, "next-page", nil, nil)
 	if err != nil {

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -722,19 +722,8 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		}
 		settings.perPage = perPage
 	}
-	if settings.token == "" {
-		if settings.wifAudience == "" && settings.wifServiceAccount == "" {
-			return settings, fmt.Errorf("gcp token or wif_audience and wif_service_account_email are required")
-		}
-		if settings.wifAudience == "" {
-			return settings, fmt.Errorf("gcp wif_audience is required when token is not provided")
-		}
-		if settings.wifServiceAccount == "" {
-			return settings, fmt.Errorf("gcp wif_service_account_email is required when token is not provided")
-		}
-		if err := validateGCPWIFConfig(settings); err != nil {
-			return settings, err
-		}
+	if err := sourceconfig.ValidateGCPTokenOrWIF(settings.token, settings.wifAudience, settings.wifServiceAccount, settings.tenantID, settings.wifBindings); err != nil {
+		return settings, err
 	}
 	switch settings.family {
 	case familyAssetMetadata, familyAIDataset, familyAIEndpoint, familyArtifactRepo, familyAudit, familyBinaryAuthorizationPolicy, familyBinaryAuthorizationAttestor, familyBigQueryDataset, familyBigQueryTable, familyBigtableInstance, familyBigtableTable, familyCertificateManagerCertificate, familyCertificateManagerCertificateMap, familyCertificateManagerCertificateMapEntry, familyCertificateManagerDNSAuthorization, familyCloudFunction, familyCloudIDSEndpoint, familyCloudSchedulerJob, familyCloudRunRevision, familyCloudRunService, familyCloudSQLDatabase, familyCloudSQLInstance, familyCloudSQLUser, familyContainerRegistry, familyContainerVuln, familyComputeAddress, familyComputeBackendBucket, familyComputeBackendService, familyComputeDisk, familyComputeExternalVPNGateway, familyComputeFirewall, familyComputeForwardingRule, familyComputeHealthCheck, familyComputeInstance, familyComputeInstanceGroup, familyComputeInstanceGroupMgr, familyComputeInstanceTemplate, familyComputeInterconnect, familyComputeInterconnectAttachment, familyComputeNetworkEndpointGroup, familyComputeNetworkFirewallPolicy, familyComputeNetwork, familyComputePacketMirroring, familyComputeRoute, familyComputeRouter, familyComputeSecurityPolicy, familyComputeSSLCertificate, familyComputeSSLPolicy, familyComputeSubnetwork, familyComputeTargetGRPCProxy, familyComputeTargetHTTPProxy, familyComputeTargetHTTPSProxy, familyComputeTargetSSLProxy, familyComputeTargetTCPProxy, familyComputeTargetVPNGateway, familyComputeURLMap, familyComputeVPNGateway, familyComputeVPNTunnel, familyDNSManagedZone, familyDNSRecordSet, familyEffectivePermission, familyGCSBucket, familyGCSObject, familyGKECluster, familyGKENodePool, familyLoggingMetric, familyLoggingSink, familyMonitoringAlertPolicy, familyMonitoringNotificationChannel, familyOrgPolicy, familyPubSubSubscription, familyPubSubTopic, familyResourceExposure, familyResourceProject, familyRoleAssign, familySecret, familySecretVersion, familySecurityCenterFinding, familyServiceAcct, familyServiceUsageService, familySpannerDatabase, familySpannerInstance, familyVPCAccessConnector, familyWorkloadIdentityPool, familyWorkloadIdentityProvider:
@@ -777,45 +766,6 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		return settings, fmt.Errorf("gcp family must be one of asset_metadata, aiplatform_dataset, aiplatform_endpoint, artifact_registry_image, artifact_registry_repository, audit, binary_authorization_policy, binary_authorization_attestor, bigquery_dataset, bigquery_table, bigtable_instance, bigtable_table, certificate_manager_certificate, certificate_manager_certificate_map, certificate_manager_certificate_map_entry, certificate_manager_dns_authorization, cloud_function, cloud_ids_endpoint, cloud_scheduler_job, cloud_run_revision, cloud_run_service, cloud_sql_database, cloud_sql_instance, cloud_sql_user, compute_address, compute_backend_bucket, compute_backend_service, compute_disk, compute_external_vpn_gateway, compute_firewall, compute_forwarding_rule, compute_health_check, compute_instance, compute_instance_group, compute_instance_group_manager, compute_instance_template, compute_interconnect, compute_interconnect_attachment, compute_network_endpoint_group, compute_network_firewall_policy, compute_network, compute_packet_mirroring, compute_route, compute_router, compute_security_policy, compute_ssl_certificate, compute_ssl_policy, compute_subnetwork, compute_target_grpc_proxy, compute_target_http_proxy, compute_target_https_proxy, compute_target_ssl_proxy, compute_target_tcp_proxy, compute_target_vpn_gateway, compute_url_map, compute_vpn_gateway, compute_vpn_tunnel, container_registry, container_vulnerability, dns_managed_zone, dns_record_set, effective_permission, gcs_bucket, gcs_object, gke_cluster, gke_node_pool, group, group_membership, iam_role_assignment, kms_key, logging_metric, logging_project_sink, monitoring_alert_policy, monitoring_notification_channel, org_policy, pubsub_subscription, pubsub_topic, resource_exposure, resourcemanager_project, secret_manager_secret, secret_manager_version, security_center_finding, service_account, service_account_impersonation, service_usage_service, spanner_database, spanner_instance, vpc_access_connector, workload_identity_pool, workload_identity_provider, or service_account_key")
 	}
 	return settings, nil
-}
-
-func validateGCPWIFConfig(settings settings) error {
-	if strings.TrimSpace(settings.token) != "" {
-		return nil
-	}
-	if strings.TrimSpace(settings.tenantID) == "" {
-		return fmt.Errorf("gcp wif auth requires runtime tenant_id")
-	}
-	if !gcpWIFBindingAllowed(settings.tenantID, settings.wifAudience, settings.wifServiceAccount, settings.wifBindings) {
-		return fmt.Errorf("gcp wif audience and service account are not allowed")
-	}
-	return nil
-}
-
-func gcpWIFBindingAllowed(tenantID string, audience string, serviceAccount string, allowlist string) bool {
-	tenantID = strings.TrimSpace(tenantID)
-	audience = strings.TrimSpace(audience)
-	serviceAccount = strings.TrimSpace(serviceAccount)
-	if tenantID == "" || audience == "" || serviceAccount == "" {
-		return false
-	}
-	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
-		return r == ',' || r == ';' || r == '\n' || r == '\t'
-	}) {
-		value = strings.TrimSpace(value)
-		tenant, binding, ok := strings.Cut(value, "=")
-		if !ok || strings.TrimSpace(tenant) != tenantID {
-			continue
-		}
-		allowedAudience, allowedServiceAccount, ok := strings.Cut(strings.TrimSpace(binding), "|")
-		if !ok {
-			continue
-		}
-		if strings.TrimSpace(allowedAudience) == audience && strings.TrimSpace(allowedServiceAccount) == serviceAccount {
-			return true
-		}
-	}
-	return false
 }
 
 func listServiceAccounts(ctx context.Context, source *Source, settings settings, pageToken string, limit int) ([]serviceAccountRecord, string, error) {

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -23,6 +23,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourcehttp"
 	"github.com/writer/cerebro/sources/internal/gcpcloud"
 )
@@ -111,6 +112,7 @@ type settings struct {
 	keyRing                                             string
 	artifactRepository                                  string
 	token, wifAudience, wifServiceAccount, wifAWSRegion string
+	tenantID, wifBindings                               string
 	baseURL                                             string
 	filter                                              string
 	perPage                                             int
@@ -701,6 +703,8 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		wifAudience:         configValue(cfg, "wif_audience"),
 		wifServiceAccount:   configValue(cfg, "wif_service_account_email"),
 		wifAWSRegion:        configValue(cfg, "wif_aws_region"),
+		tenantID:            configValue(cfg, sourceconfig.RuntimeTenantIDKey),
+		wifBindings:         configValue(cfg, sourceconfig.GCPWIFAllowlistKey),
 		baseURL:             strings.TrimRight(configValue(cfg, "base_url"), "/"),
 		filter:              configValue(cfg, "filter"),
 		perPage:             defaultPageSize,
@@ -727,6 +731,9 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		}
 		if settings.wifServiceAccount == "" {
 			return settings, fmt.Errorf("gcp wif_service_account_email is required when token is not provided")
+		}
+		if err := validateGCPWIFConfig(settings); err != nil {
+			return settings, err
 		}
 	}
 	switch settings.family {
@@ -770,6 +777,45 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		return settings, fmt.Errorf("gcp family must be one of asset_metadata, aiplatform_dataset, aiplatform_endpoint, artifact_registry_image, artifact_registry_repository, audit, binary_authorization_policy, binary_authorization_attestor, bigquery_dataset, bigquery_table, bigtable_instance, bigtable_table, certificate_manager_certificate, certificate_manager_certificate_map, certificate_manager_certificate_map_entry, certificate_manager_dns_authorization, cloud_function, cloud_ids_endpoint, cloud_scheduler_job, cloud_run_revision, cloud_run_service, cloud_sql_database, cloud_sql_instance, cloud_sql_user, compute_address, compute_backend_bucket, compute_backend_service, compute_disk, compute_external_vpn_gateway, compute_firewall, compute_forwarding_rule, compute_health_check, compute_instance, compute_instance_group, compute_instance_group_manager, compute_instance_template, compute_interconnect, compute_interconnect_attachment, compute_network_endpoint_group, compute_network_firewall_policy, compute_network, compute_packet_mirroring, compute_route, compute_router, compute_security_policy, compute_ssl_certificate, compute_ssl_policy, compute_subnetwork, compute_target_grpc_proxy, compute_target_http_proxy, compute_target_https_proxy, compute_target_ssl_proxy, compute_target_tcp_proxy, compute_target_vpn_gateway, compute_url_map, compute_vpn_gateway, compute_vpn_tunnel, container_registry, container_vulnerability, dns_managed_zone, dns_record_set, effective_permission, gcs_bucket, gcs_object, gke_cluster, gke_node_pool, group, group_membership, iam_role_assignment, kms_key, logging_metric, logging_project_sink, monitoring_alert_policy, monitoring_notification_channel, org_policy, pubsub_subscription, pubsub_topic, resource_exposure, resourcemanager_project, secret_manager_secret, secret_manager_version, security_center_finding, service_account, service_account_impersonation, service_usage_service, spanner_database, spanner_instance, vpc_access_connector, workload_identity_pool, workload_identity_provider, or service_account_key")
 	}
 	return settings, nil
+}
+
+func validateGCPWIFConfig(settings settings) error {
+	if strings.TrimSpace(settings.token) != "" {
+		return nil
+	}
+	if strings.TrimSpace(settings.tenantID) == "" {
+		return fmt.Errorf("gcp wif auth requires runtime tenant_id")
+	}
+	if !gcpWIFBindingAllowed(settings.tenantID, settings.wifAudience, settings.wifServiceAccount, settings.wifBindings) {
+		return fmt.Errorf("gcp wif audience and service account are not allowed")
+	}
+	return nil
+}
+
+func gcpWIFBindingAllowed(tenantID string, audience string, serviceAccount string, allowlist string) bool {
+	tenantID = strings.TrimSpace(tenantID)
+	audience = strings.TrimSpace(audience)
+	serviceAccount = strings.TrimSpace(serviceAccount)
+	if tenantID == "" || audience == "" || serviceAccount == "" {
+		return false
+	}
+	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t'
+	}) {
+		value = strings.TrimSpace(value)
+		tenant, binding, ok := strings.Cut(value, "=")
+		if !ok || strings.TrimSpace(tenant) != tenantID {
+			continue
+		}
+		allowedAudience, allowedServiceAccount, ok := strings.Cut(strings.TrimSpace(binding), "|")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(allowedAudience) == audience && strings.TrimSpace(allowedServiceAccount) == serviceAccount {
+			return true
+		}
+	}
+	return false
 }
 
 func listServiceAccounts(ctx context.Context, source *Source, settings settings, pageToken string, limit int) ([]serviceAccountRecord, string, error) {

--- a/sources/gcp/source_test.go
+++ b/sources/gcp/source_test.go
@@ -14,6 +14,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/sources/internal/gcpcloud"
 )
 
@@ -43,6 +44,68 @@ func TestCheckRequiresProjectAndAuth(t *testing.T) {
 	}
 	if err := source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{"project_id": "writer-prod", "wif_service_account_email": "scanner@writer-iam.iam.gserviceaccount.com"})); err == nil {
 		t.Fatal("Check() error = nil, want missing WIF audience error")
+	}
+}
+
+func TestParseSettingsRejectsUntrustedWIFRuntime(t *testing.T) {
+	audience := "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws"
+	serviceAccount := "scanner@writer-iam.iam.gserviceaccount.com"
+	for _, tt := range []struct {
+		name   string
+		config map[string]string
+	}{
+		{
+			name: "missing runtime tenant",
+			config: map[string]string{
+				"project_id":                    "writer-prod",
+				"wif_audience":                  audience,
+				"wif_service_account_email":     serviceAccount,
+				sourceconfig.GCPWIFAllowlistKey: "writer=" + audience + "|" + serviceAccount,
+			},
+		},
+		{
+			name: "missing trusted binding",
+			config: map[string]string{
+				"project_id":                    "writer-prod",
+				"wif_audience":                  audience,
+				"wif_service_account_email":     serviceAccount,
+				sourceconfig.RuntimeTenantIDKey: "writer",
+			},
+		},
+		{
+			name: "service account mismatch",
+			config: map[string]string{
+				"project_id":                    "writer-prod",
+				"wif_audience":                  audience,
+				"wif_service_account_email":     serviceAccount,
+				sourceconfig.RuntimeTenantIDKey: "writer",
+				sourceconfig.GCPWIFAllowlistKey: "writer=" + audience + "|other@writer-iam.iam.gserviceaccount.com",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseSettings(sourcecdk.NewConfig(tt.config)); err == nil {
+				t.Fatal("parseSettings() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestParseSettingsAllowsTrustedWIFRuntime(t *testing.T) {
+	audience := "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws"
+	serviceAccount := "scanner@writer-iam.iam.gserviceaccount.com"
+	settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"project_id":                    "writer-prod",
+		"wif_audience":                  audience,
+		"wif_service_account_email":     serviceAccount,
+		sourceconfig.RuntimeTenantIDKey: "writer",
+		sourceconfig.GCPWIFAllowlistKey: "writer=" + audience + "|" + serviceAccount,
+	}))
+	if err != nil {
+		t.Fatalf("parseSettings() error = %v", err)
+	}
+	if settings.wifAudience != audience || settings.wifServiceAccount != serviceAccount {
+		t.Fatalf("wif settings = %q, %q", settings.wifAudience, settings.wifServiceAccount)
 	}
 }
 
@@ -232,12 +295,14 @@ func TestReadLiveGCPUsesWIFTokenSource(t *testing.T) {
 		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), nil
 	}
 	cfg := sourcecdk.NewConfig(map[string]string{
-		"base_url":                  server.URL,
-		"family":                    familyServiceAcct,
-		"project_id":                "writer-prod",
-		"wif_audience":              "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
-		"wif_service_account_email": "scanner@writer-iam.iam.gserviceaccount.com",
-		"wif_aws_region":            "us-east-1",
+		"base_url":                      server.URL,
+		"family":                        familyServiceAcct,
+		"project_id":                    "writer-prod",
+		"wif_audience":                  "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
+		"wif_service_account_email":     "scanner@writer-iam.iam.gserviceaccount.com",
+		"wif_aws_region":                "us-east-1",
+		sourceconfig.RuntimeTenantIDKey: "writer",
+		sourceconfig.GCPWIFAllowlistKey: "writer=//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws|scanner@writer-iam.iam.gserviceaccount.com",
 	})
 	pull, err := source.Read(context.Background(), cfg, nil)
 	if err != nil {

--- a/sources/gcp/source_test.go
+++ b/sources/gcp/source_test.go
@@ -47,68 +47,6 @@ func TestCheckRequiresProjectAndAuth(t *testing.T) {
 	}
 }
 
-func TestParseSettingsRejectsUntrustedWIFRuntime(t *testing.T) {
-	audience := "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws"
-	serviceAccount := "scanner@writer-iam.iam.gserviceaccount.com"
-	for _, tt := range []struct {
-		name   string
-		config map[string]string
-	}{
-		{
-			name: "missing runtime tenant",
-			config: map[string]string{
-				"project_id":                    "writer-prod",
-				"wif_audience":                  audience,
-				"wif_service_account_email":     serviceAccount,
-				sourceconfig.GCPWIFAllowlistKey: "writer=" + audience + "|" + serviceAccount,
-			},
-		},
-		{
-			name: "missing trusted binding",
-			config: map[string]string{
-				"project_id":                    "writer-prod",
-				"wif_audience":                  audience,
-				"wif_service_account_email":     serviceAccount,
-				sourceconfig.RuntimeTenantIDKey: "writer",
-			},
-		},
-		{
-			name: "service account mismatch",
-			config: map[string]string{
-				"project_id":                    "writer-prod",
-				"wif_audience":                  audience,
-				"wif_service_account_email":     serviceAccount,
-				sourceconfig.RuntimeTenantIDKey: "writer",
-				sourceconfig.GCPWIFAllowlistKey: "writer=" + audience + "|other@writer-iam.iam.gserviceaccount.com",
-			},
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			if _, err := parseSettings(sourcecdk.NewConfig(tt.config)); err == nil {
-				t.Fatal("parseSettings() error = nil, want non-nil")
-			}
-		})
-	}
-}
-
-func TestParseSettingsAllowsTrustedWIFRuntime(t *testing.T) {
-	audience := "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws"
-	serviceAccount := "scanner@writer-iam.iam.gserviceaccount.com"
-	settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
-		"project_id":                    "writer-prod",
-		"wif_audience":                  audience,
-		"wif_service_account_email":     serviceAccount,
-		sourceconfig.RuntimeTenantIDKey: "writer",
-		sourceconfig.GCPWIFAllowlistKey: "writer=" + audience + "|" + serviceAccount,
-	}))
-	if err != nil {
-		t.Fatalf("parseSettings() error = %v", err)
-	}
-	if settings.wifAudience != audience || settings.wifServiceAccount != serviceAccount {
-		t.Fatalf("wif settings = %q, %q", settings.wifAudience, settings.wifServiceAccount)
-	}
-}
-
 func TestGCPPullFromRecordsPreservesNextCursorWithoutEvents(t *testing.T) {
 	pull, err := gcpcloud.PullFromRecords[string](nil, "next-page", nil)
 	if err != nil {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -15,10 +15,10 @@ const newSourcePackageLOCBudget = 300
 // source grows, move shared behavior into the Source CDK instead of raising it.
 var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"aurelius":        653,
-	"aws":             19155,
+	"aws":             19121,
 	"azure":           2856,
 	"cosmo":           1112,
-	"gcp":             2120,
+	"gcp":             2116,
 	"github":          2110,
 	"googleworkspace": 827,
 	"grc":             1378,


### PR DESCRIPTION
## Summary
- reject AWS source runtime configs that would fall back to shared profiles or host default credentials
- keep AWS runtime auth limited to explicit static credentials or already-validated allowlisted role delegation
- require GCP AWS-backed WIF runtimes to match a trusted resolver-supplied tenant/audience/service-account binding before creating an AWS-backed subject token source

## Security
Fixes CAND-DEEP-033 and CAND-DEEP-034. The vulnerable paths now fail before the AWS SDK default provider chain can use the Cerebro host identity for caller-controlled source runtime configs.

## Tests
- `gofmt -w internal/sourceconfig/secrets.go sources/aws/source.go sources/aws/source_test.go sources/gcp/source.go sources/gcp/source_test.go internal/sourceruntime/service_test.go`
- `go test ./sources/aws ./sources/gcp ./internal/sourceruntime ./internal/sourceconfig -run 'Test(ParseSettings|ValidateAWSCredentialSource|CheckRequiresProjectAndAuth|ReadLiveGCPUsesWIFTokenSource|UserConfigStripsInternalAssumeRoleAllowlist|ResolveConfigPreservesTrustedInternalRuntimeConfig|ProgressConfigHashIgnoresInternalRuntimeMetadata)' -count=1 -v`\n- `go test ./sources/aws ./sources/gcp ./internal/sourceruntime ./internal/sourceconfig -count=1`