### PR TITLE
Guard graph agent query outputs

### DIFF
--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -27,6 +28,7 @@ var (
 const (
 	maxInternalAttributeValueBytes = 4096
 	maxInternalAttributesJSONBytes = 64 << 10
+	redactedGraphRowValue          = "[graph value omitted]"
 )
 
 var summaryURNPattern = regexp.MustCompile(`urn:cerebro:[A-Za-z0-9_:@./#%+-]+`)
@@ -374,7 +376,7 @@ func cypherRowsToMaps(rows []ports.CypherRow) []map[string]any {
 		}
 		sort.Strings(keys)
 		for _, key := range keys {
-			values[key] = row.Values[key]
+			values[key] = sanitizeCypherRowValue(row.Values[key])
 		}
 		result = append(result, values)
 	}
@@ -386,7 +388,109 @@ func sanitizeInternalRowFields(rows []map[string]any) {
 		mergeInternalAttributes(row, "finding_attributes_json_internal", []string{"summary", "status", "severity", "effective_severity", "risk_score"})
 		mergeInternalAttributes(row, "relation_attributes_json_internal", []string{"severity", "effective_severity", "risk_score"})
 		mergeInternalAttributes(row, "source_attributes_json_internal", []string{"status", "health", "last_sync_at", "last_sync_minutes", "last_success_at", "last_error"})
+		removeRawAttributeJSONFields(row)
 	}
+}
+
+func removeRawAttributeJSONFields(row map[string]any) {
+	for key, value := range row {
+		if rawAttributeJSONKey(key) {
+			delete(row, key)
+			continue
+		}
+		row[key] = sanitizeCypherRowValue(value)
+	}
+}
+
+func sanitizeCypherRowValue(value any) any {
+	switch typed := value.(type) {
+	case nil, string, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, json.Number:
+		return typed
+	case time.Time:
+		return typed.Format(time.RFC3339Nano)
+	case map[string]any:
+		return sanitizeStringMapValue(typed)
+	case map[string]string:
+		result := make(map[string]any, len(typed))
+		for key, value := range typed {
+			if rawAttributeJSONKey(key) {
+				continue
+			}
+			result[key] = value
+		}
+		return result
+	case []any:
+		result := make([]any, 0, len(typed))
+		for _, item := range typed {
+			result = append(result, sanitizeCypherRowValue(item))
+		}
+		return result
+	default:
+		return sanitizeReflectRowValue(reflect.ValueOf(value))
+	}
+}
+
+func sanitizeStringMapValue(values map[string]any) map[string]any {
+	result := make(map[string]any, len(values))
+	for key, value := range values {
+		if rawAttributeJSONKey(key) {
+			continue
+		}
+		result[key] = sanitizeCypherRowValue(value)
+	}
+	return result
+}
+
+func sanitizeReflectRowValue(value reflect.Value) any {
+	if !value.IsValid() {
+		return nil
+	}
+	for value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			return nil
+		}
+		value = value.Elem()
+	}
+	if !value.CanInterface() {
+		return redactedGraphRowValue
+	}
+	switch value.Kind() {
+	case reflect.String:
+		return value.String()
+	case reflect.Bool:
+		return value.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return value.Uint()
+	case reflect.Float32, reflect.Float64:
+		return value.Float()
+	case reflect.Slice, reflect.Array:
+		result := make([]any, 0, value.Len())
+		for i := 0; i < value.Len(); i++ {
+			result = append(result, sanitizeReflectRowValue(value.Index(i)))
+		}
+		return result
+	case reflect.Map:
+		if value.Type().Key().Kind() != reflect.String {
+			return redactedGraphRowValue
+		}
+		result := make(map[string]any, value.Len())
+		for _, key := range value.MapKeys() {
+			keyText := key.String()
+			if rawAttributeJSONKey(keyText) {
+				continue
+			}
+			result[keyText] = sanitizeReflectRowValue(value.MapIndex(key))
+		}
+		return result
+	default:
+		return redactedGraphRowValue
+	}
+}
+
+func rawAttributeJSONKey(key string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(key)), "attributes_json")
 }
 
 func postProcessAskRows(conversion conversionResult, rows []map[string]any) []map[string]any {

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -792,6 +792,41 @@ func TestSanitizeInternalAttributesKeepsOnlyBoundedScalars(t *testing.T) {
 	}
 }
 
+func TestSanitizeInternalAttributesDropsRawGraphAttributes(t *testing.T) {
+	type projectedNode struct {
+		Props map[string]any
+	}
+	rows := []map[string]any{{
+		"attributes_json":                  `{"secret":"raw"}`,
+		"finding_attributes_json":          `{"secret":"raw"}`,
+		"finding_attributes_json_internal": `{"severity":"HIGH"}`,
+		"node":                             projectedNode{Props: map[string]any{"urn": "urn:cerebro:writer:asset:alpha", "attributes_json": `{"secret":"raw"}`}},
+		"nested":                           map[string]any{"safe": "value", "attributes_json": `{"secret":"raw"}`},
+	}}
+
+	sanitizeInternalRowFields(rows)
+
+	row := rows[0]
+	for _, key := range []string{"attributes_json", "finding_attributes_json", "finding_attributes_json_internal"} {
+		if _, exists := row[key]; exists {
+			t.Fatalf("%s leaked in row: %#v", key, row)
+		}
+	}
+	if got := row["severity"]; got != "HIGH" {
+		t.Fatalf("severity = %q, want HIGH", got)
+	}
+	if got := row["node"]; got != redactedGraphRowValue {
+		t.Fatalf("node = %#v, want redacted graph value", got)
+	}
+	nested, ok := row["nested"].(map[string]any)
+	if !ok || nested["safe"] != "value" {
+		t.Fatalf("nested = %#v, want sanitized map", row["nested"])
+	}
+	if _, exists := nested["attributes_json"]; exists {
+		t.Fatalf("nested raw attributes leaked: %#v", nested)
+	}
+}
+
 func TestServiceRequiresTenantID(t *testing.T) {
 	service := NewService(&askStore{}, NewStubLLMClient(), ValidatorOptions{})
 	err := service.Stream(context.Background(), AskRequest{Question: "hello"}, func(Event) error { return nil })

--- a/internal/graphagent/summary.go
+++ b/internal/graphagent/summary.go
@@ -3,8 +3,14 @@ package graphagent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
+)
+
+var (
+	ErrSummaryRowTooLarge     = errors.New("graph row exceeds summary byte limit")
+	ErrSummaryPayloadTooLarge = errors.New("graph rows exceed summary byte limit")
 )
 
 func (s *Service) summarizeRows(ctx context.Context, request AskRequest, model string, cypher string, rows []map[string]any, history []HistoryMessage) (string, error) {
@@ -64,7 +70,7 @@ func validateSummaryRows(rows []map[string]any, byteThreshold int, mapReduce boo
 			return fmt.Errorf("marshal graph row %d for summary: %w", i+1, err)
 		}
 		if len(raw) > byteThreshold {
-			return fmt.Errorf("graph row %d exceeds summary byte limit %d", i+1, byteThreshold)
+			return fmt.Errorf("%w: row %d exceeds limit %d", ErrSummaryRowTooLarge, i+1, byteThreshold)
 		}
 	}
 	if mapReduce {
@@ -75,7 +81,7 @@ func validateSummaryRows(rows []map[string]any, byteThreshold int, mapReduce boo
 		return fmt.Errorf("marshal graph rows for summary: %w", err)
 	}
 	if len(raw) > byteThreshold {
-		return fmt.Errorf("graph rows exceed summary byte limit %d", byteThreshold)
+		return fmt.Errorf("%w: limit %d", ErrSummaryPayloadTooLarge, byteThreshold)
 	}
 	return nil
 }

--- a/internal/graphagent/summary.go
+++ b/internal/graphagent/summary.go
@@ -8,6 +8,9 @@ import (
 )
 
 func (s *Service) summarizeRows(ctx context.Context, request AskRequest, model string, cypher string, rows []map[string]any, history []HistoryMessage) (string, error) {
+	if err := validateSummaryRows(rows, s.options.MapReduceByteThreshold, s.options.EnableMapReduce); err != nil {
+		return "", err
+	}
 	if !s.options.EnableMapReduce || !shouldMapReduceRows(rows, s.options.MapReduceRowThreshold, s.options.MapReduceByteThreshold) {
 		return s.llm.Summarize(ctx, SummarizeRequest{
 			TenantID: strings.TrimSpace(request.TenantID),
@@ -49,6 +52,32 @@ func (s *Service) summarizeRows(ctx context.Context, request AskRequest, model s
 		Rows:     reduceRows,
 		History:  history,
 	})
+}
+
+func validateSummaryRows(rows []map[string]any, byteThreshold int, mapReduce bool) error {
+	if byteThreshold <= 0 {
+		byteThreshold = 64 << 10
+	}
+	for i, row := range rows {
+		raw, err := json.Marshal(row)
+		if err != nil {
+			return fmt.Errorf("marshal graph row %d for summary: %w", i+1, err)
+		}
+		if len(raw) > byteThreshold {
+			return fmt.Errorf("graph row %d exceeds summary byte limit %d", i+1, byteThreshold)
+		}
+	}
+	if mapReduce {
+		return nil
+	}
+	raw, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("marshal graph rows for summary: %w", err)
+	}
+	if len(raw) > byteThreshold {
+		return fmt.Errorf("graph rows exceed summary byte limit %d", byteThreshold)
+	}
+	return nil
 }
 
 func shouldMapReduceRows(rows []map[string]any, rowThreshold int, byteThreshold int) bool {

--- a/internal/graphagent/summary_test.go
+++ b/internal/graphagent/summary_test.go
@@ -1,0 +1,44 @@
+package graphagent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSummarizeRowsRejectsSingleOversizedRow(t *testing.T) {
+	llm := &StubLLMClient{}
+	service := NewServiceWithOptions(nil, llm, ValidatorOptions{}, ServiceOptions{
+		EnableMapReduce:        true,
+		MapReduceByteThreshold: 64,
+	})
+
+	_, err := service.summarizeRows(context.Background(), AskRequest{TenantID: "writer", Question: "summarize"}, "", "RETURN row", []map[string]any{{
+		"entity_urn": "urn:cerebro:writer:asset:alpha",
+		"blob":       strings.Repeat("a", 128),
+	}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "exceeds summary byte limit") {
+		t.Fatalf("summarizeRows() err = %v, want summary byte limit", err)
+	}
+	if len(llm.SummaryRequests) != 0 {
+		t.Fatalf("summary requests = %d, want none", len(llm.SummaryRequests))
+	}
+}
+
+func TestSummarizeRowsRejectsOversizedOneShotPayload(t *testing.T) {
+	llm := &StubLLMClient{}
+	service := NewServiceWithOptions(nil, llm, ValidatorOptions{}, ServiceOptions{
+		MapReduceByteThreshold: 96,
+	})
+
+	_, err := service.summarizeRows(context.Background(), AskRequest{TenantID: "writer", Question: "summarize"}, "", "RETURN row", []map[string]any{
+		{"entity_urn": "urn:cerebro:writer:asset:alpha", "label": strings.Repeat("a", 30)},
+		{"entity_urn": "urn:cerebro:writer:asset:beta", "label": strings.Repeat("b", 30)},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "graph rows exceed summary byte limit") {
+		t.Fatalf("summarizeRows() err = %v, want summary payload byte limit", err)
+	}
+	if len(llm.SummaryRequests) != 0 {
+		t.Fatalf("summary requests = %d, want none", len(llm.SummaryRequests))
+	}
+}

--- a/internal/graphagent/summary_test.go
+++ b/internal/graphagent/summary_test.go
@@ -2,6 +2,7 @@ package graphagent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -17,7 +18,7 @@ func TestSummarizeRowsRejectsSingleOversizedRow(t *testing.T) {
 		"entity_urn": "urn:cerebro:writer:asset:alpha",
 		"blob":       strings.Repeat("a", 128),
 	}}, nil)
-	if err == nil || !strings.Contains(err.Error(), "exceeds summary byte limit") {
+	if !errors.Is(err, ErrSummaryRowTooLarge) {
 		t.Fatalf("summarizeRows() err = %v, want summary byte limit", err)
 	}
 	if len(llm.SummaryRequests) != 0 {
@@ -35,7 +36,7 @@ func TestSummarizeRowsRejectsOversizedOneShotPayload(t *testing.T) {
 		{"entity_urn": "urn:cerebro:writer:asset:alpha", "label": strings.Repeat("a", 30)},
 		{"entity_urn": "urn:cerebro:writer:asset:beta", "label": strings.Repeat("b", 30)},
 	}, nil)
-	if err == nil || !strings.Contains(err.Error(), "graph rows exceed summary byte limit") {
+	if !errors.Is(err, ErrSummaryPayloadTooLarge) {
 		t.Fatalf("summarizeRows() err = %v, want summary payload byte limit", err)
 	}
 	if len(llm.SummaryRequests) != 0 {

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -99,6 +99,9 @@ func (v *Validator) validate(ctx context.Context, cypher string, params map[stri
 	if hasProcedureCall(tokens) {
 		return validatorRefusal("procedure_call_not_allowed", "procedure CALL clauses are forbidden"), 0, nil
 	}
+	if hasForbiddenExpansion(tokens) {
+		return validatorRefusal("expansion_not_allowed", "row-expanding Cypher expressions such as UNWIND, range(), and collect() are forbidden"), 0, nil
+	}
 	limit, ok := queryLimit(tokens)
 	if !ok {
 		return validatorRefusal("limit_required", "read Cypher must include a numeric LIMIT clause"), 0, nil
@@ -414,6 +417,22 @@ func allNodePatternsTenantScoped(query string) bool {
 func hasProcedureCall(tokens []cypherToken) bool {
 	for i, token := range tokens {
 		if keywordToken(token, "CALL") && !symbolTokenAt(tokens, i+1, "{") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasForbiddenExpansion(tokens []cypherToken) bool {
+	for i, token := range tokens {
+		if keywordToken(token, "UNWIND") {
+			return true
+		}
+		if token.kind != cypherTokenIdentifier || !symbolTokenAt(tokens, i+1, "(") {
+			continue
+		}
+		switch strings.ToLower(token.text) {
+		case "range", "collect":
 			return true
 		}
 	}

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -107,6 +107,16 @@ RETURN b.urn AS urn LIMIT 25`,
 			reason: "procedure CALL",
 		},
 		{
+			name:   "unwind expansion",
+			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) UNWIND range(1, 1000000) AS i RETURN e.urn, i LIMIT 1`,
+			reason: "row-expanding",
+		},
+		{
+			name:   "collect expansion before limit",
+			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN collect(e.attributes_json) AS attributes LIMIT 1`,
+			reason: "row-expanding",
+		},
+		{
 			name:   "call local binding cannot escape",
 			cypher: `MATCH (seed:Entity {tenant_id: $tenant_id}) CALL { WITH seed MATCH (seed)-[:RELATION]->(tmp:Entity {tenant_id: $tenant_id}) RETURN 1 AS keep LIMIT 1 } MATCH (tmp) RETURN tmp.urn LIMIT 25`,
 			reason: "inline tenant_id",


### PR DESCRIPTION
## Summary
- reject row-expanding Cypher constructs (`UNWIND`, `range()`, `collect()`) before execution
- normalize graph-agent row values so raw `attributes_json` projections and opaque graph node objects are not emitted or summarized
- cap graph summary payloads so oversized rows or non-map-reduced batches are refused before reaching LLM providers

## Security
Fixes CAND-DEEP-028, CAND-DEEP-029, and CAND-DEEP-031. These changes prevent bounded-looking Cypher from expanding before LIMIT, stop raw graph attributes from entering API/LLM rows, and block oversized row payload forwarding to summarization providers.

## Tests
- `gofmt -w internal/graphagent/validator.go internal/graphagent/validator_test.go internal/graphagent/ask.go internal/graphagent/ask_test.go internal/graphagent/summary.go internal/graphagent/summary_test.go`
- `go test ./internal/graphagent -run 'TestValidatorRejectsUnsafeCypher|TestSanitizeInternalAttributes|TestSummarizeRows|TestAskMapReduceSummarizesLargeRowSets|TestServiceDoesNotPostProcessLLMFallbackRows' -count=1 -v`\n- `go test ./internal/graphagent -count=1`