### PR TITLE
fix: Address merged review feedback

### DIFF
--- a/.github/workflows/load-smoke.yml
+++ b/.github/workflows/load-smoke.yml
@@ -66,7 +66,9 @@ jobs:
           echo "::add-mask::$target_url"
           echo "skip=false" >> "$GITHUB_OUTPUT"
           {
-            echo "CEREBRO_BASE_URL=$target_url"
+            echo "CEREBRO_BASE_URL<<LOAD_SMOKE_BASE_URL"
+            echo "$target_url"
+            echo "LOAD_SMOKE_BASE_URL"
             echo "LOAD_SMOKE_DURATION=${INPUT_DURATION_SECONDS:-60}"
             echo "LOAD_SMOKE_RPS=${INPUT_RPS:-3}"
             echo "LOAD_SMOKE_CONCURRENCY=${INPUT_CONCURRENCY:-6}"

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ GITHUB_FINDINGS_REPO ?=
 GITHUB_FINDINGS_GRAPH_PREVIEW ?= tmp/github-findings-graph-preview.json
 GITHUB_AUDIT_FINDINGS_GRAPH_PREVIEW ?= tmp/github-audit-findings-graph-preview.json
 CEREBRO_BASE_URL ?= http://127.0.0.1:8080
+export CEREBRO_BASE_URL
 WORKFLOW_REPLAY_KIND_PREFIX ?= workflow.v1.
 WORKFLOW_REPLAY_KIND ?= knowledge_decision
 WORKFLOW_REPLAY_TENANT ?= writer
@@ -339,7 +340,7 @@ release-smoke: ## Validate GoReleaser configuration.
 	$(GORELEASER) check
 
 load-smoke: ## Run bounded capacity/load smoke checks against CEREBRO_BASE_URL.
-	CEREBRO_BASE_URL="$(CEREBRO_BASE_URL)" $(PYTHON) scripts/load_smoke.py \
+	$(PYTHON) scripts/load_smoke.py \
 		$(foreach path,$(LOAD_SMOKE_PATHS),--path "$(path)") \
 		--duration "$(LOAD_SMOKE_DURATION)" \
 		--rps "$(LOAD_SMOKE_RPS)" \

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,6 @@ release-smoke: ## Validate GoReleaser configuration.
 
 load-smoke: ## Run bounded capacity/load smoke checks against CEREBRO_BASE_URL.
 	$(PYTHON) scripts/load_smoke.py \
-		--base-url "$(CEREBRO_BASE_URL)" \
 		$(foreach path,$(LOAD_SMOKE_PATHS),--path "$(path)") \
 		--duration "$(LOAD_SMOKE_DURATION)" \
 		--rps "$(LOAD_SMOKE_RPS)" \

--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ release-smoke: ## Validate GoReleaser configuration.
 	$(GORELEASER) check
 
 load-smoke: ## Run bounded capacity/load smoke checks against CEREBRO_BASE_URL.
-	$(PYTHON) scripts/load_smoke.py \
+	CEREBRO_BASE_URL="$(CEREBRO_BASE_URL)" $(PYTHON) scripts/load_smoke.py \
 		$(foreach path,$(LOAD_SMOKE_PATHS),--path "$(path)") \
 		--duration "$(LOAD_SMOKE_DURATION)" \
 		--rps "$(LOAD_SMOKE_RPS)" \

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -308,7 +308,7 @@ func startFindingRiskBackfill(ctx context.Context, backfiller findingRiskBackfil
 			telemetry.Field{Key: "job.name", Value: "finding.risk_backfill"},
 			telemetry.Field{Key: "backfiller_present", Value: false},
 		)
-		_, span := telemetry.StartMain(ctx, "finding.risk_backfill", attrs)
+		ctx, span := telemetry.StartMain(ctx, "finding.risk_backfill", attrs)
 		telemetry.AnnotateMainPhase(ctx, "finding.risk_backfill", "skipped", attrs)
 		telemetry.End(span, "skipped", attrs)
 		close(done)

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -142,7 +142,7 @@ Cerebro enables OTEL export when `CEREBRO_OTEL_ENABLED=true` or when an OTLP end
 | `CEREBRO_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Trace endpoint override |
 | `CEREBRO_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Metric endpoint override |
 | `CEREBRO_OTEL_EXPORTER_OTLP_HEADERS` | Comma-separated OTLP auth headers; mount from secrets only |
-| `CEREBRO_OTEL_EXPORTER_OTLP_INSECURE` | Allow insecure transport only for loopback collectors |
+| `CEREBRO_OTEL_EXPORTER_OTLP_INSECURE` | Allow insecure transport only for loopback HTTP collectors, and only when a loopback OTLP endpoint is set |
 | `CEREBRO_OTEL_TRACES_SAMPLE_RATE` | Float from `0` to `1` |
 | `CEREBRO_OTEL_METRICS_EXPORT_INTERVAL` | Duration such as `30s` or `1m` |
 | `OTEL_RESOURCE_ATTRIBUTES` | Standard resource attributes, for example `deployment.environment.name=sec-dev` |

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2957,11 +2957,13 @@ func sensitiveSourceConfigKey(key string) bool {
 	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(value)
 	if strings.Contains(compact, "apikey") ||
 		strings.Contains(compact, "accesskey") ||
+		strings.Contains(compact, "credential") ||
 		strings.Contains(compact, "privatekey") ||
+		strings.Contains(compact, "passphrase") ||
 		strings.Contains(compact, "signingkey") {
 		return true
 	}
-	return value == "key"
+	return value == "key" || compact == "sshkey"
 }
 
 type bootstrapErrorMapping struct {
@@ -3633,7 +3635,6 @@ func findingCandidateMessage(candidate *ports.FindingCandidateRecord) *cerebrov1
 		RuleId:             candidate.RuleID,
 		Fingerprint:        candidate.Fingerprint,
 		Status:             candidate.Status,
-		Finding:            findingMessage(candidate.Finding),
 		Evidence:           candidate.Evidence,
 		LastRunId:          candidate.LastRunID,
 		ObservationCount:   candidate.ObservationCount,

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -1048,7 +1048,7 @@ func (a *App) handleRevokeConnectorCredential(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if err := authorizeTenantID(r.Context(), record.TenantID); err != nil {
-		writeConnectorError(w, err)
+		writeConnectorError(w, normalizeIDLookupError(err, ports.ErrConnectorCredentialNotFound))
 		return
 	}
 	updated, err := broker.Revoke(r.Context(), connectorcredentials.RevokeRequest{

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -504,7 +504,8 @@ func writeDeviceAuthServiceError(w http.ResponseWriter, err error) {
 		errors.Is(err, attestation.ErrKeyIDMismatch),
 		errors.Is(err, attestation.ErrUnsupportedVendor):
 		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_attestation", err.Error())
-	case errors.Is(err, deviceauth.ErrDPoPMissing):
+	case errors.Is(err, deviceauth.ErrDPoPMissing),
+		errors.Is(err, deviceauth.ErrDPoPBindingMissing):
 		writeDeviceAuthError(w, http.StatusUnauthorized, "dpop_required", err.Error())
 	case errors.Is(err, deviceauth.ErrDPoPVerifierUnavailable):
 		writeDeviceAuthError(w, http.StatusServiceUnavailable, "dpop_unavailable", err.Error())

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -637,8 +637,9 @@ func TestDeviceAuthEnrollRejectsWrongHardware(t *testing.T) {
 		Token string `json:"token"`
 	}
 	_ = json.Unmarshal(resp.Body.Bytes(), &bootstrap)
+	deviceKey := newTestDeviceDPoPKey(t)
 
-	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewBufferString(`{"bootstrap_token":"`+bootstrap.Token+`","hardware_uuid":"hw-DIFFERENT"}`))
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewBufferString(`{"bootstrap_token":"`+bootstrap.Token+`","hardware_uuid":"hw-DIFFERENT","device_key":`+deviceKey.jwkJSON+`}`))
 	req.Header.Set("Content-Type", "application/json")
 	resp = httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -374,6 +374,7 @@ func TestWriteDeviceAuthServiceErrorMapsAttestationFailures(t *testing.T) {
 		{name: "invalid statement", err: attestation.ErrInvalidStatement, status: http.StatusBadRequest, code: "invalid_attestation"},
 		{name: "invalid chain", err: attestation.ErrChainInvalid, status: http.StatusBadRequest, code: "invalid_attestation"},
 		{name: "nonce mismatch", err: attestation.ErrNonceMismatch, status: http.StatusBadRequest, code: "invalid_attestation"},
+		{name: "dpop binding missing", err: deviceauth.ErrDPoPBindingMissing, status: http.StatusUnauthorized, code: "dpop_required"},
 		{name: "dpop verifier unavailable", err: deviceauth.ErrDPoPVerifierUnavailable, status: http.StatusServiceUnavailable, code: "dpop_unavailable"},
 	}
 	for _, tt := range tests {

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -333,7 +333,7 @@ func (e *askWideEvent) finish(r *http.Request, started time.Time, status int, er
 	if r != nil {
 		attrs = attrs.WithField(telemetry.Field{Key: "http.method", Value: r.Method})
 		attrs = attrs.WithField(telemetry.Field{Key: "http.route", Value: "POST /grc/ask"})
-		attrs = attrs.WithField(telemetry.Field{Key: "http.user_agent.present", Value: strings.TrimSpace(r.Header.Get("User-Agent")) != ""})
+		attrs = attrs.WithField(telemetry.Field{Key: "http.user_agent.present", Value: r.Header.Get("User-Agent") != ""})
 	}
 	telemetry.Event(r.Context(), "cerebro.grc.ask", attrs)
 	telemetry.IncrementMain(r.Context(), "grc.ask.count", 1)

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -490,85 +490,56 @@ func upsertGRCInventoryAccountability(ctx context.Context, store ports.GRCInvent
 	if err := validateGRCInventoryAssetURN(request.AssetURN); err != nil {
 		return nil, err
 	}
-	existing, err := loadGRCInventoryScopeRecord(ctx, store, tenantID, request.AssetURN)
-	if err != nil {
-		return nil, err
-	}
-	scopeState := grcinventory.ScopeStateInScope
-	scopeReason := ""
-	sourceID := request.SourceID
-	attributes := map[string]string{}
-	if existing != nil {
-		if strings.TrimSpace(existing.ScopeState) != "" {
-			scopeState = existing.ScopeState
-		}
-		scopeReason = existing.Reason
-		if sourceID == "" {
-			sourceID = existing.SourceID
-		}
-		for key, value := range existing.Attributes {
-			if strings.TrimSpace(key) != "" && strings.TrimSpace(value) != "" {
-				attributes[key] = value
-			}
-		}
-	}
+	setAttributes := map[string]string{}
+	clearAttributes := []string{}
 	switch request.State {
 	case grcinventory.AccountabilityKnown:
 		if request.Owner == "" {
 			return nil, fmt.Errorf("%w: owner is required when state is known", errInvalidHTTPRequest)
 		}
-		attributes[grcinventory.AttributeAccountabilityState] = grcinventory.AccountabilityKnown
-		attributes[grcinventory.AttributeAccountabilityPrincipal] = request.Owner
-		attributes["owner"] = request.Owner
-		attributes[grcinventory.AttributeOwnerSource] = grcinventory.AttributeOwnerSourceCerebro
-		attributes["accountability_required"] = "true"
-		delete(attributes, grcinventory.AttributeOwnerNotRequired)
+		setAttributes[grcinventory.AttributeAccountabilityState] = grcinventory.AccountabilityKnown
+		setAttributes[grcinventory.AttributeAccountabilityPrincipal] = request.Owner
+		setAttributes["owner"] = request.Owner
+		setAttributes[grcinventory.AttributeOwnerSource] = grcinventory.AttributeOwnerSourceCerebro
+		setAttributes["accountability_required"] = "true"
+		clearAttributes = append(clearAttributes, grcinventory.AttributeOwnerNotRequired)
 	case grcinventory.AccountabilityNone:
-		attributes[grcinventory.AttributeAccountabilityState] = grcinventory.AccountabilityNone
-		attributes[grcinventory.AttributeOwnerNotRequired] = "true"
-		delete(attributes, grcinventory.AttributeAccountabilityPrincipal)
-		delete(attributes, "owner")
-		delete(attributes, grcinventory.AttributeOwnerSource)
-		delete(attributes, "accountability_required")
+		setAttributes[grcinventory.AttributeAccountabilityState] = grcinventory.AccountabilityNone
+		setAttributes[grcinventory.AttributeOwnerNotRequired] = "true"
+		clearAttributes = append(clearAttributes,
+			grcinventory.AttributeAccountabilityPrincipal,
+			"owner",
+			grcinventory.AttributeOwnerSource,
+			"accountability_required",
+		)
 	case "clear":
-		delete(attributes, grcinventory.AttributeAccountabilityState)
-		delete(attributes, grcinventory.AttributeAccountabilityPrincipal)
-		delete(attributes, grcinventory.AttributeAccountabilityReason)
-		delete(attributes, grcinventory.AttributeOwnerNotRequired)
-		delete(attributes, grcinventory.AttributeOwnerSource)
-		delete(attributes, "owner")
-		delete(attributes, "accountability_required")
-		delete(attributes, "accountability_updated_by")
-		delete(attributes, "accountability_updated_at")
+		clearAttributes = append(clearAttributes,
+			grcinventory.AttributeAccountabilityState,
+			grcinventory.AttributeAccountabilityPrincipal,
+			grcinventory.AttributeAccountabilityReason,
+			grcinventory.AttributeOwnerNotRequired,
+			grcinventory.AttributeOwnerSource,
+			"owner",
+			"accountability_required",
+			"accountability_updated_by",
+			"accountability_updated_at",
+		)
 	default:
 		return nil, fmt.Errorf("%w: state must be known, not_required, or clear", errInvalidHTTPRequest)
 	}
 	if request.State != "clear" {
-		attributes[grcinventory.AttributeAccountabilityReason] = fallbackString(request.Reason, accountabilityDefaultReason(request.State))
-		attributes["accountability_updated_by"] = strings.TrimSpace(updatedBy)
-		attributes["accountability_updated_at"] = time.Now().UTC().Format(time.RFC3339)
+		setAttributes[grcinventory.AttributeAccountabilityReason] = fallbackString(request.Reason, accountabilityDefaultReason(request.State))
+		setAttributes["accountability_updated_by"] = strings.TrimSpace(updatedBy)
+		setAttributes["accountability_updated_at"] = time.Now().UTC().Format(time.RFC3339)
 	}
-	return store.UpsertGRCInventoryScope(ctx, ports.GRCInventoryScopeRecord{
-		TenantID:   tenantID,
-		AssetURN:   request.AssetURN,
-		SourceID:   sourceID,
-		ScopeState: scopeState,
-		Reason:     scopeReason,
-		UpdatedBy:  updatedBy,
-		Attributes: attributes,
+	return store.UpdateGRCInventoryAccountability(ctx, ports.GRCInventoryAccountabilityUpdate{
+		TenantID:        tenantID,
+		AssetURN:        request.AssetURN,
+		SourceID:        request.SourceID,
+		UpdatedBy:       updatedBy,
+		SetAttributes:   setAttributes,
+		ClearAttributes: clearAttributes,
 	})
-}
-
-func loadGRCInventoryScopeRecord(ctx context.Context, store ports.GRCInventoryScopeStore, tenantID string, assetURN string) (*ports.GRCInventoryScopeRecord, error) {
-	records, err := store.ListGRCInventoryScopes(ctx, ports.GRCInventoryScopeFilter{
-		TenantID:  tenantID,
-		AssetURNs: []string{assetURN},
-		Limit:     1,
-	})
-	if err != nil || len(records) == 0 {
-		return nil, err
-	}
-	return records[0], nil
 }
 
 func accountabilityDefaultReason(state string) string {

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -477,9 +477,13 @@ func upsertGRCInventoryAccountability(ctx context.Context, store ports.GRCInvent
 	}
 	request.AssetURN = strings.TrimSpace(request.AssetURN)
 	request.SourceID = strings.TrimSpace(request.SourceID)
+	request.RuntimeID = strings.TrimSpace(request.RuntimeID)
 	request.State = strings.TrimSpace(request.State)
 	request.Owner = strings.TrimSpace(request.Owner)
 	request.Reason = strings.TrimSpace(request.Reason)
+	if request.RuntimeID != "" {
+		return nil, fmt.Errorf("%w: runtime_id is not supported for accountability updates", errInvalidHTTPRequest)
+	}
 	if request.AssetURN == "" {
 		return nil, fmt.Errorf("%w: asset_urn is required", errInvalidHTTPRequest)
 	}
@@ -845,11 +849,11 @@ func (a *App) handleUpdateGRCInventoryAssetReportTriage(w http.ResponseWriter, r
 		return
 	}
 	if err := authorizeTenantID(r.Context(), record.TenantID); err != nil {
-		writeGRCError(w, err)
+		writeGRCError(w, normalizeIDLookupError(err, ports.ErrGRCInventoryAssetReportNotFound))
 		return
 	}
 	if err := authorizeCerebroURNTenant(r.Context(), record.AssetURN); err != nil {
-		writeGRCError(w, err)
+		writeGRCError(w, normalizeIDLookupError(err, ports.ErrGRCInventoryAssetReportNotFound))
 		return
 	}
 	triagedBy := strings.TrimSpace(request.TriagedBy)

--- a/internal/bootstrap/grc_inventory_test.go
+++ b/internal/bootstrap/grc_inventory_test.go
@@ -127,6 +127,9 @@ func TestGRCInventoryAccountabilityUpdatePreservesExistingScope(t *testing.T) {
 	if got := record.Attributes["existing"]; got != "kept" {
 		t.Fatalf("existing attribute = %q, want kept", got)
 	}
+	if store.listCalls != 0 {
+		t.Fatalf("ListGRCInventoryScopes calls = %d, want atomic accountability update without read-before-write", store.listCalls)
+	}
 }
 
 func TestGRCInventoryResourceScopeRejectsMalformedAssetURN(t *testing.T) {
@@ -230,7 +233,8 @@ func TestGRCInventoryScopePropagationUpdatesRuntimeResourcePolicy(t *testing.T) 
 }
 
 type stubInventoryScopeStore struct {
-	records map[string]*ports.GRCInventoryScopeRecord
+	records   map[string]*ports.GRCInventoryScopeRecord
+	listCalls int
 }
 
 func (s *stubInventoryScopeStore) Ping(context.Context) error { return nil }
@@ -244,7 +248,39 @@ func (s *stubInventoryScopeStore) UpsertGRCInventoryScope(_ context.Context, rec
 	return cloneInventoryScopeRecord(cloned), nil
 }
 
+func (s *stubInventoryScopeStore) UpdateGRCInventoryAccountability(_ context.Context, update ports.GRCInventoryAccountabilityUpdate) (*ports.GRCInventoryScopeRecord, error) {
+	if s.records == nil {
+		s.records = map[string]*ports.GRCInventoryScopeRecord{}
+	}
+	key := inventoryScopeRecordKey(update.TenantID, update.AssetURN)
+	record := cloneInventoryScopeRecord(s.records[key])
+	if record == nil {
+		record = &ports.GRCInventoryScopeRecord{
+			TenantID:   update.TenantID,
+			AssetURN:   update.AssetURN,
+			ScopeState: grcinventory.ScopeStateInScope,
+			Attributes: map[string]string{},
+		}
+	}
+	if record.Attributes == nil {
+		record.Attributes = map[string]string{}
+	}
+	if update.SourceID != "" {
+		record.SourceID = update.SourceID
+	}
+	record.UpdatedBy = update.UpdatedBy
+	for _, key := range update.ClearAttributes {
+		delete(record.Attributes, key)
+	}
+	for key, value := range update.SetAttributes {
+		record.Attributes[key] = value
+	}
+	s.records[key] = cloneInventoryScopeRecord(record)
+	return cloneInventoryScopeRecord(record), nil
+}
+
 func (s *stubInventoryScopeStore) ListGRCInventoryScopes(_ context.Context, filter ports.GRCInventoryScopeFilter) ([]*ports.GRCInventoryScopeRecord, error) {
+	s.listCalls++
 	if s.records == nil {
 		return nil, nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -740,6 +740,9 @@ func (cfg OpenTelemetryConfig) hasExporterConfig() bool {
 }
 
 func validateOpenTelemetryEndpoints(cfg OpenTelemetryConfig) error {
+	if cfg.Insecure && !cfg.hasExporterConfig() {
+		return fmt.Errorf("%w: CEREBRO_OTEL_EXPORTER_OTLP_INSECURE requires a loopback HTTP OTLP endpoint", errUnsafeOTLPTransportMode)
+	}
 	for _, endpoint := range []struct {
 		name  string
 		value string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -456,6 +456,17 @@ func TestLoadRejectsInsecureFlagForHTTPSOTELEndpoint(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsInsecureOTLPWithoutEndpoint(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_OTEL_ENABLED", "true")
+	t.Setenv("CEREBRO_OTEL_EXPORTER_OTLP_INSECURE", "true")
+
+	_, err := Load()
+	if !errors.Is(err, errUnsafeOTLPTransportMode) {
+		t.Fatalf("Load() error = %v, want insecure OTLP without endpoint rejection", err)
+	}
+}
+
 func TestLoadRejectsMalformedOTELEndpoint(t *testing.T) {
 	clearDependencyEnv(t)
 	t.Setenv("CEREBRO_OTEL_ENABLED", "true")

--- a/internal/deviceauth/dpop.go
+++ b/internal/deviceauth/dpop.go
@@ -316,6 +316,7 @@ var (
 	ErrDPoPMissingJTI          = errors.New("deviceauth: dpop missing jti")
 	ErrDPoPReplay              = errors.New("deviceauth: dpop jti replayed")
 	ErrDPoPMissing             = errors.New("deviceauth: dpop proof header missing")
+	ErrDPoPBindingMissing      = errors.New("deviceauth: dpop binding missing")
 	ErrDPoPJKTMismatch         = errors.New("deviceauth: dpop key thumbprint does not match cnf.jkt")
 	ErrDPoPVerifierUnavailable = errors.New("deviceauth: dpop verifier unavailable")
 )

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -344,6 +344,9 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	if agentJKT != "" && attestationJKT != "" && !constantTimeStringEqual(agentJKT, attestationJKT) {
 		return EnrollResponse{}, fmt.Errorf("%w: device_key thumbprint does not match attested key", ErrInvalidRequest)
 	}
+	if agentJKT == "" && attestationJKT == "" {
+		return EnrollResponse{}, fmt.Errorf("%w: device_key or attestation is required to bind refresh tokens", ErrInvalidRequest)
+	}
 	hash := HashToken(bootstrapToken)
 	consumed, err := s.store.ConsumeBootstrapToken(ctx, hash, hardwareUUID, now, "agent")
 	if err != nil {
@@ -580,7 +583,7 @@ func (s *Service) RefreshTokenRateLimitKey(ctx context.Context, refreshToken str
 func (s *Service) verifyDPoPForRefresh(device DeviceRecord, request TokenRequest) error {
 	jkt := strings.TrimSpace(device.Metadata["dpop_jkt"])
 	if jkt == "" {
-		return fmt.Errorf("%w: device has no DPoP binding", ErrDPoPMissing)
+		return fmt.Errorf("%w: device has no DPoP binding", ErrInvalidRequest)
 	}
 	if s.cfg.DPoP == nil {
 		return ErrDPoPVerifierUnavailable

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -395,7 +395,7 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	}
 	// Pin dpop_jkt in priority order: attestation-bound key (hardware
 	// proven), then an existing hardware-bound key, then agent-supplied
-	// key (software assurance), then prior non-hardware enrollment key.
+	// key (software assurance).
 	// Enrollment must produce a binding before any refresh token is minted.
 	switch {
 	case attestationJKT != "":
@@ -408,8 +408,6 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 		}
 	case agentJKT != "":
 		metadata["dpop_jkt"] = agentJKT
-	case priorJKT != "":
-		metadata["dpop_jkt"] = priorJKT
 	}
 	if strings.TrimSpace(metadata["dpop_jkt"]) == "" {
 		return EnrollResponse{}, fmt.Errorf("%w: device_key or attestation is required to bind refresh tokens", ErrInvalidRequest)

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -583,7 +583,7 @@ func (s *Service) RefreshTokenRateLimitKey(ctx context.Context, refreshToken str
 func (s *Service) verifyDPoPForRefresh(device DeviceRecord, request TokenRequest) error {
 	jkt := strings.TrimSpace(device.Metadata["dpop_jkt"])
 	if jkt == "" {
-		return fmt.Errorf("%w: device has no DPoP binding", ErrInvalidRequest)
+		return fmt.Errorf("%w: device has no DPoP binding", ErrDPoPBindingMissing)
 	}
 	if s.cfg.DPoP == nil {
 		return ErrDPoPVerifierUnavailable

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -161,18 +161,9 @@ func TestServiceEnrollRejectsUnboundRefreshTokenMinting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
-	boundBootstrap, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
-		HardwareUUID: "hw-unbound",
-		TenantID:     "writer",
-		TTL:          time.Hour,
-		IssuedBy:     "operator",
-	})
-	if err != nil {
-		t.Fatalf("IssueBootstrapToken(bound): %v", err)
-	}
 	deviceJWK, _ := makeEd25519JWK(t, pub)
 	enroll, err := service.Enroll(ctx, EnrollRequest{
-		BootstrapToken: boundBootstrap.Token,
+		BootstrapToken: bootstrap.Token,
 		HardwareUUID:   "hw-unbound",
 		OSType:         "darwin",
 		DeviceJWK:      deviceJWK,
@@ -211,8 +202,8 @@ func TestServiceIssueTokenRejectsLegacyUnboundDeviceRefresh(t *testing.T) {
 		RefreshToken: refresh,
 		HTTPMethod:   "POST",
 		HTTPURL:      "https://cerebro.test/platform/devices/token",
-	}); !errors.Is(err, ErrDPoPMissing) {
-		t.Fatalf("IssueToken legacy unbound err = %v, want ErrDPoPMissing", err)
+	}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("IssueToken legacy unbound err = %v, want ErrInvalidRequest", err)
 	}
 	row, err := store.LookupRefreshToken(ctx, HashToken(refresh), now)
 	if err != nil {
@@ -227,7 +218,12 @@ func TestServiceEnrollRequiresMatchingHardware(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)
 	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
-	if _, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-DIFFERENT"}); !errors.Is(err, ErrBootstrapTokenMismatch) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	deviceJWK, _ := makeEd25519JWK(t, pub)
+	if _, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-DIFFERENT", DeviceJWK: deviceJWK}); !errors.Is(err, ErrBootstrapTokenMismatch) {
 		t.Fatalf("Enroll with wrong hw err = %v, want ErrBootstrapTokenMismatch", err)
 	}
 }

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -176,6 +176,50 @@ func TestServiceEnrollRejectsUnboundRefreshTokenMinting(t *testing.T) {
 	}
 }
 
+func TestServiceReenrollRequiresPresentedBindingForSoftwareDevice(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	deviceJWK, _ := makeEd25519JWK(t, pub)
+	firstBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-software", TenantID: "writer"})
+	first, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: firstBootstrap.Token,
+		HardwareUUID:   "hw-software",
+		OSType:         "darwin",
+		DeviceJWK:      deviceJWK,
+	})
+	if err != nil {
+		t.Fatalf("first Enroll: %v", err)
+	}
+	device, err := service.LookupDevice(ctx, first.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice: %v", err)
+	}
+	priorJKT := strings.TrimSpace(device.Metadata["dpop_jkt"])
+	if priorJKT == "" {
+		t.Fatal("first enrollment did not bind DPoP JKT")
+	}
+
+	secondBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-software", TenantID: "writer"})
+	if _, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: secondBootstrap.Token,
+		HardwareUUID:   "hw-software",
+		OSType:         "darwin",
+	}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("second Enroll without presented binding err = %v, want ErrInvalidRequest", err)
+	}
+	device, err = service.LookupDevice(ctx, first.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice after rejected reenroll: %v", err)
+	}
+	if got := strings.TrimSpace(device.Metadata["dpop_jkt"]); got != priorJKT {
+		t.Fatalf("dpop_jkt after rejected reenroll = %q, want preserved %q", got, priorJKT)
+	}
+}
+
 func TestServiceIssueTokenRejectsLegacyUnboundDeviceRefresh(t *testing.T) {
 	ctx := context.Background()
 	service, store, now := newServiceForTest(t)

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -202,8 +202,8 @@ func TestServiceIssueTokenRejectsLegacyUnboundDeviceRefresh(t *testing.T) {
 		RefreshToken: refresh,
 		HTTPMethod:   "POST",
 		HTTPURL:      "https://cerebro.test/platform/devices/token",
-	}); !errors.Is(err, ErrInvalidRequest) {
-		t.Fatalf("IssueToken legacy unbound err = %v, want ErrInvalidRequest", err)
+	}); !errors.Is(err, ErrDPoPBindingMissing) {
+		t.Fatalf("IssueToken legacy unbound err = %v, want ErrDPoPBindingMissing", err)
 	}
 	row, err := store.LookupRefreshToken(ctx, HashToken(refresh), now)
 	if err != nil {

--- a/internal/findings/kolide_host_failing_compliance_checks_rule.go
+++ b/internal/findings/kolide_host_failing_compliance_checks_rule.go
@@ -304,9 +304,6 @@ func kolideHostDeprovisioned(attributes map[string]string) bool {
 	if registered, ok := parseOptionalBoolAttribute(attributes, "registered"); ok && !registered {
 		return true
 	}
-	if managed, ok := parseOptionalBoolAttribute(attributes, "mdm_enabled"); ok && !managed {
-		return true
-	}
 	status := strings.ToLower(strings.TrimSpace(attributes["status"]))
 	_, deprovisioned := kolideHostDeprovisionedStatuses[status]
 	return deprovisioned

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -297,7 +297,7 @@ func hasForbiddenAPOCCall(tokens []cypherToken) bool {
 
 func hasAPOCInvocation(tokens []cypherToken) bool {
 	for i, token := range tokens {
-		if token.kind == cypherTokenIdentifier && strings.HasPrefix(strings.ToLower(token.text), "apoc.") && symbolTokenAt(tokens, i+1, "(") {
+		if functionNameToken(token) && strings.HasPrefix(strings.ToLower(token.text), "apoc.") && symbolTokenAt(tokens, i+1, "(") {
 			return true
 		}
 	}

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -40,6 +40,7 @@ type cypherTokenKind int
 
 const (
 	cypherTokenIdentifier cypherTokenKind = iota
+	cypherTokenEscapedIdentifier
 	cypherTokenNumber
 	cypherTokenSymbol
 	cypherTokenParameter
@@ -200,7 +201,9 @@ func lexCypher(query string) []cypherToken {
 		case ch == '\'' || ch == '"':
 			i = skipQuotedLiteral(query, i, ch)
 		case ch == '`':
-			i = skipEscapedIdentifier(query, i)
+			text, end := escapedIdentifierToken(query, i)
+			tokens = append(tokens, cypherToken{kind: cypherTokenEscapedIdentifier, text: text, pos: i})
+			i = end
 		case ch == '/' && i+1 < len(query) && query[i+1] == '/':
 			for i+1 < len(query) && query[i+1] != '\n' && query[i+1] != '\r' {
 				i++
@@ -242,17 +245,20 @@ func lexCypher(query string) []cypherToken {
 	return tokens
 }
 
-func skipEscapedIdentifier(query string, start int) int {
+func escapedIdentifierToken(query string, start int) (string, int) {
+	var builder strings.Builder
 	for i := start + 1; i < len(query); i++ {
 		if query[i] == '`' {
 			if i+1 < len(query) && query[i+1] == '`' {
+				builder.WriteByte('`')
 				i++
 				continue
 			}
-			return i
+			return builder.String(), i
 		}
+		builder.WriteByte(query[i])
 	}
-	return len(query) - 1
+	return builder.String(), len(query) - 1
 }
 
 func hasForbiddenWriteOrBulkLoad(tokens []cypherToken) bool {
@@ -428,7 +434,7 @@ func hasForbiddenExpansion(tokens []cypherToken) bool {
 		if keywordToken(token, "UNWIND") {
 			return true
 		}
-		if token.kind != cypherTokenIdentifier || !symbolTokenAt(tokens, i+1, "(") {
+		if !functionNameToken(token) || !symbolTokenAt(tokens, i+1, "(") {
 			continue
 		}
 		switch strings.ToLower(token.text) {
@@ -697,6 +703,10 @@ func keywordTokenAt(tokens []cypherToken, index int, keyword string) bool {
 
 func keywordToken(token cypherToken, keyword string) bool {
 	return token.kind == cypherTokenIdentifier && strings.EqualFold(token.text, keyword)
+}
+
+func functionNameToken(token cypherToken) bool {
+	return token.kind == cypherTokenIdentifier || token.kind == cypherTokenEscapedIdentifier
 }
 
 func upperToken(token cypherToken) string {

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -117,6 +117,16 @@ RETURN b.urn AS urn LIMIT 25`,
 			reason: "row-expanding",
 		},
 		{
+			name:   "escaped collect expansion before limit",
+			cypher: "MATCH (e:Entity {tenant_id: $tenant_id}) RETURN `collect`(e.attributes_json) AS attributes LIMIT 1",
+			reason: "row-expanding",
+		},
+		{
+			name:   "escaped range expansion before limit",
+			cypher: "MATCH (e:Entity {tenant_id: $tenant_id}) RETURN `range`(1, 1000000) AS ids LIMIT 1",
+			reason: "row-expanding",
+		},
+		{
 			name:   "call local binding cannot escape",
 			cypher: `MATCH (seed:Entity {tenant_id: $tenant_id}) CALL { WITH seed MATCH (seed)-[:RELATION]->(tmp:Entity {tenant_id: $tenant_id}) RETURN 1 AS keep LIMIT 1 } MATCH (tmp) RETURN tmp.urn LIMIT 25`,
 			reason: "inline tenant_id",

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -35,6 +35,11 @@ func TestValidatorRejectsUnsafeCypher(t *testing.T) {
 			reason: "APOC",
 		},
 		{
+			name:   "escaped apoc function",
+			cypher: "MATCH (e:Entity {tenant_id: $tenant_id}) RETURN `apoc.convert.fromJsonMap`(e.attributes_json).source_family AS source_family LIMIT 25",
+			reason: "APOC",
+		},
+		{
 			name:   "missing limit",
 			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn`,
 			reason: "LIMIT",

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -40,6 +40,11 @@ func TestValidatorRejectsUnsafeCypher(t *testing.T) {
 			reason: "APOC",
 		},
 		{
+			name:   "escaped apoc sleep function",
+			cypher: "MATCH (e:Entity {tenant_id: $tenant_id}) RETURN `apoc.util.sleep`(5000) AS x LIMIT 1",
+			reason: "APOC",
+		},
+		{
 			name:   "missing limit",
 			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn`,
 			reason: "LIMIT",

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1301,7 +1301,7 @@ func (s *Store) read(ctx context.Context, work func(context.Context, neo4jdriver
 		return work(ctx, tx)
 	})
 	if err != nil {
-		neo4jTelemetryError(ctx, span, "read", err)
+		neo4jTelemetryError(ctx, span, s.database, "read", err)
 		return nil, err
 	}
 	neo4jAnnotateMain(ctx, s.database, "read", "completed")
@@ -1315,7 +1315,7 @@ func (s *Store) write(ctx context.Context, work neo4jdriver.ManagedTransactionWo
 	defer func() { _ = session.Close(ctx) }()
 	result, err := session.ExecuteWrite(ctx, work)
 	if err != nil {
-		neo4jTelemetryError(ctx, span, "write", err)
+		neo4jTelemetryError(ctx, span, s.database, "write", err)
 		return nil, err
 	}
 	neo4jAnnotateMain(ctx, s.database, "write", "completed")
@@ -1336,12 +1336,13 @@ func neo4jTelemetryAttrs(operation string, database string, timeout time.Duratio
 	return attrs
 }
 
-func neo4jTelemetryError(ctx context.Context, span *telemetry.Span, operation string, err error) {
-	neo4jAnnotateMain(ctx, "", operation, "failed")
+func neo4jTelemetryError(ctx context.Context, span *telemetry.Span, database string, operation string, err error) {
+	neo4jAnnotateMain(ctx, database, operation, "failed")
 	attrs := telemetry.Attrs(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 	telemetry.CaptureError(ctx, "neo4j.error", err, telemetry.Attrs(
 		telemetry.Field{Key: "component", Value: "graphstore.neo4j"},
 		telemetry.Field{Key: "operation", Value: operation},
+		telemetry.Field{Key: "db.namespace", Value: strings.TrimSpace(database)},
 	))
 	telemetry.End(span, "failed", attrs)
 }

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"net/http"
 	"sort"
 	"strconv"
@@ -101,6 +102,28 @@ func Middleware(next http.Handler) http.Handler {
 		}
 		started := time.Now()
 		recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				durationSeconds := time.Since(started).Seconds()
+				labels := map[string]string{
+					"method":      method,
+					"route":       route,
+					"status_code": strconv.Itoa(http.StatusInternalServerError),
+				}
+				Default.Inc("cerebro_http_requests_total", labels)
+				Default.Add("cerebro_http_request_duration_seconds_sum", labels, durationSeconds)
+				Default.Inc("cerebro_http_request_duration_seconds_count", labels)
+				recordOTELHTTPServerRequest(ctx, labels, http.StatusInternalServerError, durationSeconds)
+				telemetry.Event(ctx, "http.server.error", telemetry.Attrs(
+					telemetry.Field{Key: "http.request.method", Value: method},
+					telemetry.Field{Key: "http.route", Value: route},
+					telemetry.Field{Key: "http.response.status_code", Value: http.StatusInternalServerError},
+					telemetry.Field{Key: "error_kind", Value: "panic"},
+				))
+				telemetry.End(span, "failed", httpResponseWideAttributes(recorder).WithField(telemetry.Field{Key: "error_kind", Value: "panic"}))
+				panic(recovered)
+			}
+		}()
 		next.ServeHTTP(recorder, r)
 		durationSeconds := time.Since(started).Seconds()
 		labels := map[string]string{
@@ -313,12 +336,10 @@ func requestHost(r *http.Request) string {
 	if host == "" && r.URL != nil {
 		host = r.URL.Host
 	}
-	if strings.Contains(host, ":") {
-		if hostname, _, ok := strings.Cut(host, ":"); ok {
-			return hostname
-		}
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		return strings.Trim(hostname, "[]")
 	}
-	return host
+	return strings.Trim(host, "[]")
 }
 
 func requestPort(r *http.Request) int {
@@ -329,7 +350,7 @@ func requestPort(r *http.Request) int {
 	if host == "" && r.URL != nil {
 		host = r.URL.Host
 	}
-	if _, port, ok := strings.Cut(host, ":"); ok {
+	if _, port, err := net.SplitHostPort(host); err == nil {
 		parsed, err := strconv.Atoi(port)
 		if err == nil && parsed > 0 {
 			return parsed
@@ -366,12 +387,10 @@ func remoteAddressHash(r *http.Request) string {
 		return ""
 	}
 	host := r.RemoteAddr
-	if strings.Contains(host, ":") {
-		if parsedHost, _, ok := strings.Cut(host, ":"); ok {
-			host = parsedHost
-		}
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
 	}
-	sum := sha256.Sum256([]byte(strings.TrimSpace(host)))
+	sum := sha256.Sum256([]byte("cerebro-http-client:" + strings.Trim(strings.TrimSpace(host), "[]")))
 	return hex.EncodeToString(sum[:8])
 }
 

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -121,7 +121,9 @@ func Middleware(next http.Handler) http.Handler {
 					telemetry.Field{Key: "error_kind", Value: "panic"},
 				))
 				telemetry.End(span, "failed", httpResponseWideAttributes(recorder).WithField(telemetry.Field{Key: "error_kind", Value: "panic"}))
-				panic(recovered)
+				if !recorder.wroteHeader {
+					http.Error(recorder, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				}
 			}
 		}()
 		next.ServeHTTP(recorder, r)

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -105,6 +106,7 @@ func Middleware(next http.Handler) http.Handler {
 		defer func() {
 			if recovered := recover(); recovered != nil {
 				durationSeconds := time.Since(started).Seconds()
+				panicAttrs := panicTelemetryAttributes(recovered)
 				labels := map[string]string{
 					"method":      method,
 					"route":       route,
@@ -119,8 +121,10 @@ func Middleware(next http.Handler) http.Handler {
 					telemetry.Field{Key: "http.route", Value: route},
 					telemetry.Field{Key: "http.response.status_code", Value: http.StatusInternalServerError},
 					telemetry.Field{Key: "error_kind", Value: "panic"},
-				))
-				telemetry.End(span, "failed", httpResponseWideAttributes(recorder).WithField(telemetry.Field{Key: "error_kind", Value: "panic"}))
+				).With(panicAttrs))
+				telemetry.End(span, "failed", httpResponseWideAttributes(recorder).With(telemetry.Attrs(
+					telemetry.Field{Key: "error_kind", Value: "panic"},
+				)).With(panicAttrs))
 				if !recorder.wroteHeader {
 					http.Error(recorder, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				}
@@ -150,6 +154,14 @@ func Middleware(next http.Handler) http.Handler {
 		}
 		telemetry.End(span, status, httpResponseWideAttributes(recorder))
 	})
+}
+
+func panicTelemetryAttributes(recovered any) telemetry.Attributes {
+	return telemetry.Attrs(
+		telemetry.Field{Key: "exception.type", Value: fmt.Sprintf("%T", recovered)},
+		telemetry.Field{Key: "exception.message", Value: fmt.Sprint(recovered)},
+		telemetry.Field{Key: "exception.stacktrace", Value: string(debug.Stack())},
+	)
 }
 
 func recordOTELHTTPServerRequest(ctx context.Context, labels map[string]string, statusCode int, durationSeconds float64) {

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -104,6 +105,7 @@ func Middleware(next http.Handler) http.Handler {
 		recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		defer func() {
 			if recovered := recover(); recovered != nil {
+				panicAttrs := panicTelemetryAttributes(recovered)
 				durationSeconds := time.Since(started).Seconds()
 				labels := map[string]string{
 					"method":      method,
@@ -114,16 +116,15 @@ func Middleware(next http.Handler) http.Handler {
 				Default.Add("cerebro_http_request_duration_seconds_sum", labels, durationSeconds)
 				Default.Inc("cerebro_http_request_duration_seconds_count", labels)
 				recordOTELHTTPServerRequest(ctx, labels, http.StatusInternalServerError, durationSeconds)
+				if !recorder.wroteHeader {
+					http.Error(recorder, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				}
 				telemetry.Event(ctx, "http.server.error", telemetry.Attrs(
 					telemetry.Field{Key: "http.request.method", Value: method},
 					telemetry.Field{Key: "http.route", Value: route},
 					telemetry.Field{Key: "http.response.status_code", Value: http.StatusInternalServerError},
-					telemetry.Field{Key: "error_kind", Value: "panic"},
-				))
-				telemetry.End(span, "failed", httpResponseWideAttributes(recorder).WithField(telemetry.Field{Key: "error_kind", Value: "panic"}))
-				if !recorder.wroteHeader {
-					http.Error(recorder, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-				}
+				).With(panicAttrs))
+				telemetry.End(span, "failed", httpResponseWideAttributes(recorder).With(panicAttrs))
 			}
 		}()
 		next.ServeHTTP(recorder, r)
@@ -150,6 +151,15 @@ func Middleware(next http.Handler) http.Handler {
 		}
 		telemetry.End(span, status, httpResponseWideAttributes(recorder))
 	})
+}
+
+func panicTelemetryAttributes(recovered any) telemetry.Attributes {
+	return telemetry.Attrs(
+		telemetry.Field{Key: "error_kind", Value: "panic"},
+		telemetry.Field{Key: "exception.type", Value: fmt.Sprintf("%T", recovered)},
+		telemetry.Field{Key: "exception.message", Value: fmt.Sprint(recovered)},
+		telemetry.Field{Key: "exception.stacktrace", Value: string(debug.Stack())},
+	)
 }
 
 func recordOTELHTTPServerRequest(ctx context.Context, labels map[string]string, statusCode int, durationSeconds float64) {

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -78,7 +78,7 @@ func TestMiddlewareReturnsTraceIDHeader(t *testing.T) {
 }
 
 func TestMiddlewareEmitsHTTPWideEventFields(t *testing.T) {
-	_, stderr := captureObservabilityOutput(t, func() {
+	stderr := captureObservabilityOutput(t, func() {
 		handler := Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			telemetry.AnnotateMain(r.Context(), telemetry.Attrs(
 				telemetry.Field{Key: "tenant_id", Value: "tenant-a"},
@@ -178,6 +178,36 @@ func TestMiddlewareMarksServerErrorsOnOpenTelemetrySpan(t *testing.T) {
 	}
 }
 
+func TestMiddlewareRecordsPanicPayloadAndStack(t *testing.T) {
+	stderr := captureObservabilityOutput(t, func() {
+		handler := Middleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			panic("boom")
+		}))
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+		if recorder.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+		}
+	})
+
+	payload := observabilityTelemetryPayload(t, stderr, "span_end", "http.server")
+	if got := payload["error_kind"]; got != "panic" {
+		t.Fatalf("error_kind = %#v, want panic; payload=%#v", got, payload)
+	}
+	if got := payload["exception.message"]; got != "boom" {
+		t.Fatalf("exception.message = %#v, want boom; payload=%#v", got, payload)
+	}
+	if got := payload["exception.type"]; got != "string" {
+		t.Fatalf("exception.type = %#v, want string; payload=%#v", got, payload)
+	}
+	stack, ok := payload["exception.stacktrace"].(string)
+	if !ok || !strings.Contains(stack, "internal/observability/metrics.go") {
+		t.Fatalf("exception.stacktrace = %#v, want middleware stack; payload=%#v", payload["exception.stacktrace"], payload)
+	}
+}
+
 func TestStatusRecorderPreservesFlushAndUnwrap(t *testing.T) {
 	inner := &flushResponseWriter{headers: http.Header{}}
 	recorder := &statusRecorder{ResponseWriter: inner, status: http.StatusOK}
@@ -223,7 +253,7 @@ func (w *flushResponseWriter) Flush() {
 	w.flushed = true
 }
 
-func captureObservabilityOutput(t *testing.T, fn func()) (string, string) {
+func captureObservabilityOutput(t *testing.T, fn func()) string {
 	t.Helper()
 	oldStdout := os.Stdout
 	oldStderr := os.Stderr
@@ -249,15 +279,14 @@ func captureObservabilityOutput(t *testing.T, fn func()) (string, string) {
 	if err := stderrWriter.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}
-	stdout, err := io.ReadAll(stdoutReader)
-	if err != nil {
+	if _, err := io.ReadAll(stdoutReader); err != nil {
 		t.Fatalf("read stdout: %v", err)
 	}
 	stderr, err := io.ReadAll(stderrReader)
 	if err != nil {
 		t.Fatalf("read stderr: %v", err)
 	}
-	return string(stdout), string(stderr)
+	return string(stderr)
 }
 
 func observabilityTelemetryPayload(t *testing.T, stderr string, kind string, name string) map[string]any {

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -178,6 +178,41 @@ func TestMiddlewareMarksServerErrorsOnOpenTelemetrySpan(t *testing.T) {
 	}
 }
 
+func TestMiddlewarePanicTelemetryIncludesPayloadAndStack(t *testing.T) {
+	_, stderr := captureObservabilityOutput(t, func() {
+		handler := Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			panic("boom-panic")
+		}))
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+		if recorder.Code != http.StatusInternalServerError {
+			t.Fatalf("panic response status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+		}
+	})
+
+	event := observabilityTelemetryPayload(t, stderr, "event", "http.server.error")
+	if got := event["exception.message"]; got != "boom-panic" {
+		t.Fatalf("event exception.message = %#v, want boom-panic; event=%#v", got, event)
+	}
+	if got := event["exception.type"]; got != "string" {
+		t.Fatalf("event exception.type = %#v, want string; event=%#v", got, event)
+	}
+	stack, ok := event["exception.stacktrace"].(string)
+	if !ok || !strings.Contains(stack, "TestMiddlewarePanicTelemetryIncludesPayloadAndStack") {
+		t.Fatalf("event exception.stacktrace = %#v, want test stack frame", event["exception.stacktrace"])
+	}
+
+	spanEnd := observabilityTelemetryPayload(t, stderr, "span_end", "http.server")
+	if got := spanEnd["exception.message"]; got != "boom-panic" {
+		t.Fatalf("span exception.message = %#v, want boom-panic; span=%#v", got, spanEnd)
+	}
+	if got := spanEnd["error_kind"]; got != "panic" {
+		t.Fatalf("span error_kind = %#v, want panic; span=%#v", got, spanEnd)
+	}
+}
+
 func TestStatusRecorderPreservesFlushAndUnwrap(t *testing.T) {
 	inner := &flushResponseWriter{headers: http.Header{}}
 	recorder := &statusRecorder{ResponseWriter: inner, status: http.StatusOK}

--- a/internal/ports/grc_inventory.go
+++ b/internal/ports/grc_inventory.go
@@ -40,9 +40,19 @@ type GRCInventoryScopeFilter struct {
 	Limit      uint32
 }
 
+type GRCInventoryAccountabilityUpdate struct {
+	TenantID        string
+	AssetURN        string
+	SourceID        string
+	UpdatedBy       string
+	SetAttributes   map[string]string
+	ClearAttributes []string
+}
+
 type GRCInventoryScopeStore interface {
 	StateStore
 	UpsertGRCInventoryScope(context.Context, GRCInventoryScopeRecord) (*GRCInventoryScopeRecord, error)
+	UpdateGRCInventoryAccountability(context.Context, GRCInventoryAccountabilityUpdate) (*GRCInventoryScopeRecord, error)
 	ListGRCInventoryScopes(context.Context, GRCInventoryScopeFilter) ([]*GRCInventoryScopeRecord, error)
 }
 

--- a/internal/sourceprojection/ai_access.go
+++ b/internal/sourceprojection/ai_access.go
@@ -453,6 +453,9 @@ func aiCredentialProjections(event *cerebrov1.EventEnvelope, profile aiAccessPro
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 	credentialID := firstNonEmpty(attrs["api_key_id"], attrs["external_key_id"], attrs["credential_id"], attrs["id"])
+	if strings.TrimSpace(credentialID) == "" {
+		return identityProjectionResult(entities, links)
+	}
 	credentialURN := projectionURN(tenantID, profile.Provider+"_credential", credentialID)
 	if credentialURN == "" {
 		return identityProjectionResult(entities, links)
@@ -877,7 +880,8 @@ func aiFederationRuleProjections(event *cerebrov1.EventEnvelope, profile aiAcces
 	ruleID := firstNonEmpty(attrs["federation_rule_id"], attrs["id"])
 	ruleURN := projectionURN(tenantID, profile.Provider+"_federation_rule", ruleID)
 	issuerURN := projectionURN(tenantID, profile.Provider+"_federation_issuer", firstNonEmpty(attrs["issuer_id"], attrs["federation_issuer_id"]))
-	serviceAccountURN := identityPrincipalURN(tenantID, profile.Provider, "service_account", attrs["service_account_id"], "")
+	serviceAccountID := strings.TrimSpace(attrs["service_account_id"])
+	serviceAccountURN := identityPrincipalURN(tenantID, profile.Provider, "service_account", serviceAccountID, "")
 	if ruleURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        ruleURN,
@@ -906,14 +910,14 @@ func aiFederationRuleProjections(event *cerebrov1.EventEnvelope, profile aiAcces
 		})
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), issuerURN, ruleURN, relationGrantsEntitlement, aiEventLinkAttributes(event, "issuer_rule")))
 	}
-	if serviceAccountURN != "" {
+	if serviceAccountID != "" && serviceAccountURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        serviceAccountURN,
 			TenantID:   tenantID,
 			SourceID:   event.GetSourceId(),
 			EntityType: profile.Provider + ".service_account",
-			Label:      attrs["service_account_id"],
-			Attributes: map[string]string{"service_account_id": attrs["service_account_id"], "principal_type": "service_account"},
+			Label:      serviceAccountID,
+			Attributes: map[string]string{"service_account_id": serviceAccountID, "principal_type": "service_account"},
 		})
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), ruleURN, serviceAccountURN, relationCanAssume, aiEventLinkAttributes(event, "federation_rule_service_account")))
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), ruleURN, serviceAccountURN, relationCanImpersonate, aiEventLinkAttributes(event, "federation_rule_service_account")))

--- a/internal/sourceprojection/cerebro.go
+++ b/internal/sourceprojection/cerebro.go
@@ -151,7 +151,7 @@ func addCerebroCredentialEntities(entities map[string]*ports.ProjectedEntity, li
 }
 
 func addCerebroScopeEntities(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, attrs map[string]string, principalURN string, credentialURN string, routeURN string) {
-	for _, scope := range splitCerebroList(firstNonEmpty(attrs["required_scopes"], attrs["matched_scope"], attrs["scopes"])) {
+	for _, scope := range splitCerebroList(firstNonEmpty(attrs["matched_scope"], attrs["scopes"], attrs["required_scopes"])) {
 		scopeURN := cerebroScopeURN(tenantID, scope)
 		addCerebroScopeEntity(entities, tenantID, event.GetSourceId(), scopeURN, scope)
 		if routeURN != "" {
@@ -255,6 +255,9 @@ func cerebroAccessAllowed(attrs map[string]string) bool {
 	outcome := normalizeIdentifier(firstNonEmpty(attrs["outcome_result"], attrs["status"]))
 	if outcome == "allowed" || outcome == "allow" || outcome == "success" || outcome == "succeeded" || outcome == "ok" {
 		return true
+	}
+	if outcome != "" {
+		return false
 	}
 	status := strings.TrimSpace(firstNonEmpty(attrs["effective_status_code"], attrs["status_code"]))
 	return strings.HasPrefix(status, "2")

--- a/internal/sourceprojection/cloudflare.go
+++ b/internal/sourceprojection/cloudflare.go
@@ -236,9 +236,6 @@ func cloudflareDNSRecordRetractions(event *cerebrov1.EventEnvelope) ([]*ports.Pr
 	}
 	recordURN := cloudflareDNSRecordURN(tenantID, recordID)
 	previousZoneURN := cloudflareZoneURN(tenantID, previousZoneID)
-	if recordURN == "" || previousZoneURN == "" {
-		return nil, nil
-	}
 	links := map[string]*ports.ProjectedLink{}
 	retractionAttrs := map[string]string{
 		"event_id":   event.GetId(),

--- a/internal/sourceprojection/duo.go
+++ b/internal/sourceprojection/duo.go
@@ -132,22 +132,25 @@ func duoEndpointProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 
 func duoPhoneProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return duoFactorProjections(event, "phone_id", duoPhoneURN, "duo.phone", map[string]string{
-		"name":       "name",
-		"number":     "number",
-		"platform":   "platform",
-		"model":      "model",
-		"activated":  "activated",
-		"encrypted":  "encrypted",
-		"screenlock": "screenlock",
-		"tampered":   "tampered",
+		"name":         "name",
+		"number":       "number",
+		"platform":     "platform",
+		"model":        "model",
+		"activated":    "activated",
+		"encrypted":    "encrypted",
+		"screenlock":   "screenlock",
+		"tampered":     "tampered",
+		"capabilities": "capabilities",
+		"last_seen_at": "last_seen_at",
 	})
 }
 
 func duoTokenProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return duoFactorProjections(event, "token_id", duoTokenURN, "duo.token", map[string]string{
-		"serial":    "serial",
-		"type":      "type",
-		"totp_step": "totp_step",
+		"serial":       "serial",
+		"type":         "type",
+		"totp_step":    "totp_step",
+		"last_seen_at": "last_seen_at",
 	})
 }
 

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -446,6 +446,7 @@ func sentinelOneActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pr
 			Label:      firstNonEmpty(attrs["threat_name"], threatID),
 			Attributes: compactAttributes(map[string]string{
 				"threat_id":   threatID,
+				"threat_name": strings.TrimSpace(attrs["threat_name"]),
 				"site_id":     strings.TrimSpace(attrs["site_id"]),
 				"group_id":    strings.TrimSpace(attrs["group_id"]),
 				"tenant_host": strings.TrimSpace(attrs["tenant_host"]),

--- a/internal/sourceprojection/tailscale.go
+++ b/internal/sourceprojection/tailscale.go
@@ -15,6 +15,10 @@ func tailscaleUserURN(tenantID string, userID string) string {
 	return projectionURN(tenantID, "tailscale_user", strings.TrimSpace(userID))
 }
 
+func tailscaleUserKey(attrs map[string]string) string {
+	return firstNonEmpty(attrs["login_name"], attrs["email"], attrs["owner_email"], attrs["user_id"])
+}
+
 func tailscaleDeviceURN(tenantID string, deviceID string) string {
 	return projectionURN(tenantID, "tailscale_device", strings.TrimSpace(deviceID))
 }
@@ -133,8 +137,9 @@ func tailscaleUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projecte
 	if userID == "" {
 		return nil, nil, nil
 	}
+	userKey := firstNonEmpty(tailscaleUserKey(attrs), userID)
 	entities := map[string]*ports.ProjectedEntity{}
-	addEntity(entities, tailscaleEntity(event, tailscaleUserURN(tenantID, userID), "tailscale.user", firstNonEmpty(attrs["login_name"], attrs["email"], userID), tailscaleAttributes(map[string]string{
+	addEntity(entities, tailscaleEntity(event, tailscaleUserURN(tenantID, userKey), "tailscale.user", firstNonEmpty(attrs["login_name"], attrs["email"], userID), tailscaleAttributes(map[string]string{
 		"user_id":      userID,
 		"login_name":   attrs["login_name"],
 		"email":        attrs["email"],
@@ -175,7 +180,7 @@ func tailscaleDeviceProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 		"blocks_incoming_connections": attrs["blocks_incoming_connections"],
 		"tags":                        attrs["tags"],
 	})))
-	if ownerID := firstNonEmpty(attrs["user_id"], attrs["owner_email"]); strings.TrimSpace(ownerID) != "" {
+	if ownerID := tailscaleUserKey(attrs); strings.TrimSpace(ownerID) != "" {
 		ownerURN := tailscaleUserURN(tenantID, ownerID)
 		addEntity(entities, tailscaleEntity(event, ownerURN, "tailscale.user", "", map[string]string{"user_id": strings.TrimSpace(ownerID)}))
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), deviceURN, ownerURN, relationOwnedBy, map[string]string{
@@ -375,7 +380,7 @@ func tailscaleDeviceAccessRetractions(event *cerebrov1.EventEnvelope) ([]*ports.
 		return nil, err
 	}
 	deviceID := strings.TrimSpace(attrs["device_id"])
-	ownerID := firstNonEmpty(attrs["user_id"], attrs["owner_email"])
+	ownerID := tailscaleUserKey(attrs)
 	if deviceID == "" || strings.TrimSpace(ownerID) == "" {
 		return nil, nil
 	}

--- a/internal/sourceprojection/tailscale.go
+++ b/internal/sourceprojection/tailscale.go
@@ -182,7 +182,12 @@ func tailscaleDeviceProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 	})))
 	if ownerID := tailscaleUserKey(attrs); strings.TrimSpace(ownerID) != "" {
 		ownerURN := tailscaleUserURN(tenantID, ownerID)
-		addEntity(entities, tailscaleEntity(event, ownerURN, "tailscale.user", "", map[string]string{"user_id": strings.TrimSpace(ownerID)}))
+		ownerAttrs := map[string]string{
+			"user_id":    attrs["user_id"],
+			"login_name": attrs["login_name"],
+			"email":      firstNonEmpty(attrs["email"], attrs["owner_email"]),
+		}
+		addEntity(entities, tailscaleEntity(event, ownerURN, "tailscale.user", "", tailscaleAttributes(ownerAttrs)))
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), deviceURN, ownerURN, relationOwnedBy, map[string]string{
 			"event_id":   event.GetId(),
 			"at":         eventObservedAt(event),

--- a/internal/sourceprojection/tailscale.go
+++ b/internal/sourceprojection/tailscale.go
@@ -16,7 +16,7 @@ func tailscaleUserURN(tenantID string, userID string) string {
 }
 
 func tailscaleUserKey(attrs map[string]string) string {
-	return firstNonEmpty(attrs["login_name"], attrs["email"], attrs["owner_email"], attrs["user_id"])
+	return firstNonEmpty(attrs["user_id"], attrs["login_name"], attrs["email"], attrs["owner_email"])
 }
 
 func tailscaleDeviceURN(tenantID string, deviceID string) string {

--- a/internal/sourceprojection/tailscale.go
+++ b/internal/sourceprojection/tailscale.go
@@ -16,7 +16,7 @@ func tailscaleUserURN(tenantID string, userID string) string {
 }
 
 func tailscaleUserKey(attrs map[string]string) string {
-	return firstNonEmpty(attrs["login_name"], attrs["email"], attrs["owner_email"], attrs["user_id"])
+	return firstNonEmpty(attrs["user_id"], attrs["login_name"], attrs["email"], attrs["owner_email"])
 }
 
 func tailscaleDeviceURN(tenantID string, deviceID string) string {
@@ -137,9 +137,8 @@ func tailscaleUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projecte
 	if userID == "" {
 		return nil, nil, nil
 	}
-	userKey := firstNonEmpty(tailscaleUserKey(attrs), userID)
 	entities := map[string]*ports.ProjectedEntity{}
-	addEntity(entities, tailscaleEntity(event, tailscaleUserURN(tenantID, userKey), "tailscale.user", firstNonEmpty(attrs["login_name"], attrs["email"], userID), tailscaleAttributes(map[string]string{
+	addEntity(entities, tailscaleEntity(event, tailscaleUserURN(tenantID, userID), "tailscale.user", firstNonEmpty(attrs["login_name"], attrs["email"], userID), tailscaleAttributes(map[string]string{
 		"user_id":      userID,
 		"login_name":   attrs["login_name"],
 		"email":        attrs["email"],

--- a/internal/sourceprojection/tailscale_test.go
+++ b/internal/sourceprojection/tailscale_test.go
@@ -145,6 +145,31 @@ func TestProjectTailscaleDeviceOwnerStubKeepsUserIDTyped(t *testing.T) {
 	}
 }
 
+func TestProjectTailscaleUserAndDeviceShareUserIDURN(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	for _, event := range []*cerebrov1.EventEnvelope{
+		tailscaleTestEvent("ts-user-canonical", "tailscale.user", map[string]string{
+			"user_id": "user-1", "login_name": "alice@writer.com", "email": "alice@writer.com", "role": "admin",
+		}),
+		tailscaleTestEvent("ts-device-canonical-owner", "tailscale.device", map[string]string{
+			"device_id": "device-1", "user_id": "user-1", "owner_email": "alice@writer.com", "authorized": "true",
+		}),
+	} {
+		if _, err := service.Project(context.Background(), event); err != nil {
+			t.Fatalf("Project(%s) error = %v", event.GetId(), err)
+		}
+	}
+	userURN := "urn:cerebro:writer:tailscale_user:user-1"
+	if entity := state.entities[userURN]; entity == nil || entity.Attributes["email"] != "alice@writer.com" || entity.Attributes["user_id"] != "user-1" {
+		t.Fatalf("canonical user entity missing attrs: %#v", entity)
+	}
+	if split := state.entities["urn:cerebro:writer:tailscale_user:alice@writer.com"]; split != nil {
+		t.Fatalf("device owner created split user entity: %#v", split)
+	}
+}
+
 func TestProjectTailscaleDeviceDeauthorizationRetraction(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/tailscale_test.go
+++ b/internal/sourceprojection/tailscale_test.go
@@ -122,6 +122,29 @@ func TestRegistryRoutesTailscaleCoreKinds(t *testing.T) {
 	}
 }
 
+func TestProjectTailscaleDeviceOwnerStubKeepsUserIDTyped(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	event := tailscaleTestEvent("ts-device-owner-email", "tailscale.device", map[string]string{
+		"device_id": "device-1", "owner_email": "alice@writer.com", "authorized": "true",
+	})
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	userURN := "urn:cerebro:writer:tailscale_user:alice@writer.com"
+	entity := state.entities[userURN]
+	if entity == nil {
+		t.Fatalf("tailscale owner stub missing: %#v", state.entities)
+	}
+	if got := entity.Attributes["user_id"]; got != "" {
+		t.Fatalf("owner stub user_id = %q, want empty when event has no user_id", got)
+	}
+	if got := entity.Attributes["email"]; got != "alice@writer.com" {
+		t.Fatalf("owner stub email = %q, want alice@writer.com", got)
+	}
+}
+
 func TestProjectTailscaleDeviceDeauthorizationRetraction(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/tailscale_test.go
+++ b/internal/sourceprojection/tailscale_test.go
@@ -145,6 +145,31 @@ func TestProjectTailscaleDeviceOwnerStubKeepsUserIDTyped(t *testing.T) {
 	}
 }
 
+func TestProjectTailscaleUserURNPrefersStableUserID(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	event := tailscaleTestEvent("ts-user-canonical", "tailscale.user", map[string]string{
+		"user_id":    "user-1",
+		"login_name": "alice@writer.com",
+		"email":      "alice@writer.com",
+	})
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	userURN := "urn:cerebro:writer:tailscale_user:user-1"
+	entity := state.entities[userURN]
+	if entity == nil {
+		t.Fatalf("tailscale user entity missing at stable user_id URN: %#v", state.entities)
+	}
+	if got := entity.Attributes["login_name"]; got != "alice@writer.com" {
+		t.Fatalf("login_name = %q, want alice@writer.com", got)
+	}
+	if splitURN := "urn:cerebro:writer:tailscale_user:alice@writer.com"; state.entities[splitURN] != nil {
+		t.Fatalf("tailscale user projected split login_name URN %q: %#v", splitURN, state.entities[splitURN])
+	}
+}
+
 func TestProjectTailscaleDeviceDeauthorizationRetraction(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/trivy.go
+++ b/internal/sourceprojection/trivy.go
@@ -156,7 +156,7 @@ func trivyFixProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnti
 	vulnerabilityID := strings.TrimSpace(attrs["vulnerability_id"])
 	pkg := strings.TrimSpace(attrs["package"])
 	fixedVersion := strings.TrimSpace(attrs["fixed_version"])
-	if vulnerabilityID == "" || pkg == "" || fixedVersion == "" {
+	if imageDigest == "" || vulnerabilityID == "" || pkg == "" || fixedVersion == "" {
 		return nil, nil, nil
 	}
 	entities := map[string]*ports.ProjectedEntity{}

--- a/internal/statestore/postgres/grc_inventory.go
+++ b/internal/statestore/postgres/grc_inventory.go
@@ -85,6 +85,54 @@ RETURNING tenant_id, asset_urn, source_id, scope_state, reason, updated_by, attr
 	return scanGRCInventoryScope(row)
 }
 
+func (s *Store) UpdateGRCInventoryAccountability(ctx context.Context, update ports.GRCInventoryAccountabilityUpdate) (*ports.GRCInventoryScopeRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCInventoryScopeTables(ctx); err != nil {
+		return nil, err
+	}
+	update.TenantID = strings.TrimSpace(update.TenantID)
+	update.AssetURN = strings.TrimSpace(update.AssetURN)
+	update.SourceID = strings.TrimSpace(update.SourceID)
+	update.UpdatedBy = strings.TrimSpace(update.UpdatedBy)
+	if update.TenantID == "" || update.AssetURN == "" {
+		return nil, errors.New("tenant_id and asset_urn are required")
+	}
+	setAttrs := sanitizedStringMap(update.SetAttributes)
+	clearAttrs := sanitizedStringSlice(update.ClearAttributes)
+	attrs, err := json.Marshal(setAttrs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal inventory accountability attributes: %w", err)
+	}
+	clearKeys, err := json.Marshal(clearAttrs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal inventory accountability clear keys: %w", err)
+	}
+	row := s.db.QueryRowContext(ctx, `
+INSERT INTO grc_inventory_scopes (tenant_id, asset_urn, source_id, scope_state, reason, updated_by, attributes_json)
+VALUES ($1, $2, $3, 'in_scope', '', $4, $5::jsonb)
+ON CONFLICT (tenant_id, asset_urn)
+DO UPDATE SET source_id = CASE
+                  WHEN EXCLUDED.source_id <> '' THEN EXCLUDED.source_id
+                  ELSE grc_inventory_scopes.source_id
+              END,
+              updated_by = EXCLUDED.updated_by,
+              attributes_json = (
+                  SELECT COALESCE(jsonb_object_agg(existing.key, existing.value), '{}'::jsonb)
+                  FROM jsonb_each(grc_inventory_scopes.attributes_json) AS existing(key, value)
+                  WHERE NOT EXISTS (
+                      SELECT 1
+                      FROM jsonb_array_elements_text($6::jsonb) AS cleared(key)
+                      WHERE cleared.key = existing.key
+                  )
+              ) || $5::jsonb,
+              updated_at = NOW()
+RETURNING tenant_id, asset_urn, source_id, scope_state, reason, updated_by, attributes_json::text, created_at, updated_at`,
+		update.TenantID, update.AssetURN, update.SourceID, update.UpdatedBy, string(attrs), string(clearKeys))
+	return scanGRCInventoryScope(row)
+}
+
 func (s *Store) ListGRCInventoryScopes(ctx context.Context, filter ports.GRCInventoryScopeFilter) ([]*ports.GRCInventoryScopeRecord, error) {
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
@@ -354,6 +402,36 @@ func scanGRCInventoryAssetReportSummary(row scanner) (*ports.GRCInventoryAssetRe
 		return nil, err
 	}
 	return summary, nil
+}
+
+func sanitizedStringMap(values map[string]string) map[string]string {
+	sanitized := map[string]string{}
+	for key, value := range values {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		sanitized[key] = value
+	}
+	return sanitized
+}
+
+func sanitizedStringSlice(values []string) []string {
+	sanitized := []string{}
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		sanitized = append(sanitized, value)
+	}
+	return sanitized
 }
 
 func emptyStringMap(values map[string]string) map[string]string {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -128,8 +129,6 @@ func RuntimeAttributes() Attributes {
 
 func RuntimeAttributesFor(metadata RuntimeMetadata) Attributes {
 	hostname, _ := os.Hostname()
-	var memory runtime.MemStats
-	runtime.ReadMemStats(&memory)
 	resourceAttributes := parseResourceAttributes(metadata.ResourceAttributes)
 	serviceName := firstNonEmpty(
 		metadata.ServiceName,
@@ -176,13 +175,6 @@ func RuntimeAttributesFor(metadata RuntimeMetadata) Attributes {
 		Field{Key: "process.cpu.count", Value: runtime.NumCPU()},
 		Field{Key: "process.gomaxprocs", Value: runtime.GOMAXPROCS(0)},
 		Field{Key: "go.goroutine.count", Value: runtime.NumGoroutine()},
-		Field{Key: "go.gc.count", Value: memory.NumGC},
-		Field{Key: "go.memory.heap_alloc_bytes", Value: memory.HeapAlloc},
-		Field{Key: "go.memory.heap_sys_bytes", Value: memory.HeapSys},
-		Field{Key: "go.memory.heap_idle_bytes", Value: memory.HeapIdle},
-		Field{Key: "go.memory.heap_inuse_bytes", Value: memory.HeapInuse},
-		Field{Key: "go.memory.stack_inuse_bytes", Value: memory.StackInuse},
-		Field{Key: "go.memory.next_gc_bytes", Value: memory.NextGC},
 		Field{Key: "cloud.provider", Value: cloudProvider},
 		Field{Key: "cloud.region", Value: cloudRegion},
 		Field{Key: "cloud.platform", Value: cloudPlatform(metadata, cloudProvider)},
@@ -428,10 +420,11 @@ func IncrementMain(ctx context.Context, key string, delta int64) {
 }
 
 func AnnotateMainDependency(ctx context.Context, system string, component string, operation string, status string, attributes Attributes) {
-	system = boundedKeyPart(system)
+	system = strings.TrimSpace(system)
 	if system == "" {
 		system = "unknown"
 	}
+	system = boundedKeyPart(system)
 	component = strings.TrimSpace(component)
 	operation = strings.TrimSpace(operation)
 	status = strings.TrimSpace(status)
@@ -623,7 +616,7 @@ func (s *Span) increment(key string, delta int64) {
 	s.annotations[key] = next
 	s.mu.Unlock()
 	if s.otelSpan != nil && s.otelSpan.SpanContext().IsValid() {
-		s.otelSpan.SetAttributes(attribute.Int64(key, next))
+		s.otelSpan.SetAttributes(otelAttribute(key, safeAttributeValue(key, next)))
 	}
 }
 
@@ -945,6 +938,9 @@ func boundString(value string, limit int) string {
 	value = strings.TrimSpace(value)
 	if limit <= 0 || len(value) <= limit {
 		return value
+	}
+	for limit > 0 && !utf8.ValidString(value[:limit]) {
+		limit--
 	}
 	return value[:limit] + "..."
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -266,10 +267,6 @@ func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
 		"duration.bucket",
 		"process.uptime_ms",
 		"go.goroutine.count",
-		"go.memory.heap_alloc_bytes",
-		"go.memory.heap_sys_bytes",
-		"go.memory.heap_inuse_bytes",
-		"go.memory.next_gc_bytes",
 	} {
 		if _, ok := payload[key]; !ok {
 			t.Fatalf("%s missing from wide event payload=%#v", key, payload)
@@ -281,6 +278,16 @@ func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
 	}
 	if got := payload["service.name"]; got != "cerebro" {
 		t.Fatalf("runtime service attr = %#v, want cerebro; payload=%#v", got, payload)
+	}
+}
+
+func TestBoundStringPreservesUTF8(t *testing.T) {
+	got := boundString("aaébb", 3)
+	if !utf8.ValidString(got) {
+		t.Fatalf("boundString returned invalid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("boundString(%q) = %q, want ellipsis suffix", "aaébb", got)
 	}
 }
 

--- a/scripts/droid_post_merge_health.py
+++ b/scripts/droid_post_merge_health.py
@@ -257,7 +257,7 @@ def classify_droid_review(pr: dict[str, object], comments: list[dict[str, object
     elif active_progress:
         status = "in_progress"
         reason = "Droid has an unsuperseded in-progress comment."
-    elif has_active_droid_check(pr):
+    elif has_active_droid_check(pr) and not finished:
         status = "in_progress"
         reason = "Droid review check is still in progress."
     elif post_merge_checkout_errors and finished:

--- a/scripts/load_smoke.py
+++ b/scripts/load_smoke.py
@@ -164,6 +164,8 @@ def fetch_once(base_url: str, path: str, headers: dict[str, str], timeout_second
         status_code = exc.code
         try:
             response_bytes = len(exc.read(max_read_bytes))
+        except OSError as read_exc:
+            error_kind = read_exc.__class__.__name__
         finally:
             exc.close()
     except TimeoutError:

--- a/sources/anthropic/catalog.yaml
+++ b/sources/anthropic/catalog.yaml
@@ -205,7 +205,7 @@ event_contracts:
   - kind: anthropic.compliance_group_member
     schema_ref: anthropic/compliance_group_member/v1
     required_attributes: [group_id, user_id]
-    required_payload_fields: [user_id]
+    required_payload_fields: [id]
   - kind: anthropic.compliance_project
     schema_ref: anthropic/compliance_project/v1
     required_attributes: [project_id]

--- a/sources/internal/oktaasset/asset.go
+++ b/sources/internal/oktaasset/asset.go
@@ -293,6 +293,7 @@ func apiTokenAttributes(settings Settings, record Record) map[string]string {
 func authorizationServerAttributes(settings Settings, record Record) map[string]string {
 	signing := nestedMap(record.mapValue("credentials"), "signing")
 	metadataLink := nestedMap(record.mapValue("_links"), "metadata")
+	jwksLink := nestedMap(record.mapValue("_links"), "jwks")
 	audiences := nonEmptyAnyStrings(record.anySlice("audiences"))
 	attrs := map[string]string{
 		"audience_count":          strconv.Itoa(len(audiences)),
@@ -305,7 +306,7 @@ func authorizationServerAttributes(settings Settings, record Record) map[string]
 		"issuer":                  record.String("issuer"),
 		"issuer_host":             urlHost(record.String("issuer")),
 		"issuer_mode":             record.String("issuerMode"),
-		"jwks_uri_host":           urlHost(firstNonEmpty(record.String("jwks_uri"), stringMap(metadataLink, "href"))),
+		"jwks_uri_host":           urlHost(firstNonEmpty(record.String("jwks_uri"), stringMap(jwksLink, "href"), stringMap(metadataLink, "href"))),
 		"kid":                     stringMap(signing, "kid"),
 		"last_updated_at":         record.String("lastUpdated"),
 		"name":                    record.String("name"),

--- a/sources/kandji/source.go
+++ b/sources/kandji/source.go
@@ -71,7 +71,7 @@ func New() (*Source, error) {
 					"filevault_enabled":  "filevault_enabled|filevault.filevault_enabled",
 					"is_missing":         "is_missing",
 					"agent_installed":    "agent_installed|kandji_agent.agent_installed",
-					"status":             "mdm_status|status|state",
+					"status":             "status|state|mdm_status",
 					"last_check_in_at":   "last_check_in|mdm.last_check_in|kandji_agent.last_check_in",
 					"compliance_status":  "compliance_status",
 					"agent_installed_at": "agent_installed_at|kandji_agent.install_date",

--- a/tools/archtests/deepsec_config_guardrails_test.go
+++ b/tools/archtests/deepsec_config_guardrails_test.go
@@ -34,7 +34,7 @@ func TestDeepSecConfigKeepsSecurityCriticalSurfacesInScope(t *testing.T) {
 			"sources/",
 			"tools/",
 		} {
-			if strings.HasPrefix(normalized, forbidden) {
+			if ignorePathCoversDeepSecSurface(normalized, forbidden) {
 				t.Fatalf("deepsec ignorePaths excludes security-critical surface %q via %q", forbidden, normalized)
 			}
 		}
@@ -64,5 +64,35 @@ func TestDeepSecConfigKeepsSecurityCriticalSurfacesInScope(t *testing.T) {
 		if !strings.Contains(text, required) {
 			t.Fatalf("deepsec priorityPaths missing %s", required)
 		}
+	}
+}
+
+func ignorePathCoversDeepSecSurface(pattern string, surface string) bool {
+	normalized := strings.TrimPrefix(filepath.ToSlash(strings.TrimSpace(pattern)), "./")
+	surface = filepath.ToSlash(strings.TrimSpace(surface))
+	if normalized == "" || surface == "" {
+		return false
+	}
+	if strings.HasPrefix(normalized, surface) {
+		return true
+	}
+	for strings.HasPrefix(normalized, "**/") {
+		normalized = strings.TrimPrefix(normalized, "**/")
+		if strings.HasPrefix(normalized, surface) {
+			return true
+		}
+	}
+	return strings.Contains(normalized, "/"+surface)
+}
+
+func TestIgnorePathCoversDeepSecSurfaceDetectsGlobBypass(t *testing.T) {
+	if !ignorePathCoversDeepSecSurface("**/internal/**", "internal/") {
+		t.Fatal("glob-prefixed internal ignore path was not detected")
+	}
+	if !ignorePathCoversDeepSecSurface("foo/tools/**", "tools/") {
+		t.Fatal("nested tools ignore path was not detected")
+	}
+	if ignorePathCoversDeepSecSurface("tmp/internal-not-surface/**", "internal/") {
+		t.Fatal("non-surface segment was treated as ignored internal surface")
 	}
 }


### PR DESCRIPTION
## Summary

- Addresses active merged Droid review feedback across auth, graph validation, telemetry, observability, source projections, source catalogs, load-smoke, config guardrails, and GRC accountability updates.
- Hardens cross-tenant lookup behavior, DPoP/device auth edge cases, unsafe finding candidate payloads, security-critical DeepSec ignore-path checks, and observability panic handling.
- Adds a store-level atomic GRC accountability update path to avoid read-before-write races while preserving existing scope attributes.

## Test Plan

- `make test`
- `make lint`
- `make catalog-check detection-catalog-check docs-drift-check`
- `python3 -m unittest scripts.tests.test_load_smoke scripts.tests.test_droid_post_merge_health`
- Targeted touched-package Go tests for graphagent, deviceauth/bootstrap, sourceprojection, findings, and control index tooling.
- GitHub CI: build, catalog, coverage, docker-smoke, docs-drift, gitleaks, govulncheck, lint, mcp, openapi, oss-audit, proto, race, readme, release-smoke, script-test, sdk, sdk-dependency-audit, semgrep, structural, test, tenant-data leak check, and verify.

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
