### PR TITLE
Fix graph health runtime contract

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -135,9 +135,10 @@ type graphIngestRuntimeRunnerResult struct {
 }
 
 type graphIngestRunsOptions struct {
-	RuntimeID string
-	Status    string
-	Limit     int
+	RuntimeID  string
+	RuntimeIDs []string
+	Status     string
+	Limit      int
 }
 
 type graphHealthOptions struct {
@@ -824,9 +825,10 @@ func runGraphIngestRuns(args []string) error {
 	}
 	defer logClose(closeDeps)
 	result, err := graphingest.New(nil, nil, nil, deps.GraphStore).ListRuns(ctx, graphstore.IngestRunFilter{
-		RuntimeID: options.RuntimeID,
-		Status:    options.Status,
-		Limit:     options.Limit,
+		RuntimeID:  options.RuntimeID,
+		RuntimeIDs: options.RuntimeIDs,
+		Status:     options.Status,
+		Limit:      options.Limit,
 	})
 	if err != nil {
 		return err
@@ -1357,6 +1359,8 @@ func parseGraphIngestRunsArgs(args []string) (graphIngestRunsOptions, error) {
 		switch strings.TrimSpace(key) {
 		case "runtime_id":
 			options.RuntimeID = strings.TrimSpace(value)
+		case "runtime_ids":
+			options.RuntimeIDs = appendUniqueGraphHealthValues(options.RuntimeIDs, splitCleanupValues(value))
 		case "status":
 			options.Status = strings.TrimSpace(value)
 			if !validGraphIngestRunStatus(options.Status) {

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -153,6 +153,7 @@ func TestPrepareGraphRuntimeSourceConfigDoesNotHydrateGitHubFromLocalCLI(t *test
 func TestParseGraphIngestRunsArgs(t *testing.T) {
 	options, err := parseGraphIngestRunsArgs([]string{
 		"runtime_id=writer-github",
+		"runtime_ids=writer-github,writer-kolide",
 		"status=failed",
 		"limit=7",
 	})
@@ -161,6 +162,9 @@ func TestParseGraphIngestRunsArgs(t *testing.T) {
 	}
 	if options.RuntimeID != "writer-github" || options.Status != "failed" || options.Limit != 7 {
 		t.Fatalf("options = %#v, want runtime/status/limit", options)
+	}
+	if got, want := strings.Join(options.RuntimeIDs, ","), "writer-github,writer-kolide"; got != want {
+		t.Fatalf("RuntimeIDs = %q, want %q", got, want)
 	}
 }
 

--- a/docs/SOURCE_CDK_EXTRACTION.md
+++ b/docs/SOURCE_CDK_EXTRACTION.md
@@ -26,7 +26,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `aws` | 19121 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
 | `azure` | 2856 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 1112 | Move shared API pagination and response normalization into reusable source helpers. |
-| `gcp` | 2116 | Extract project traversal, service clients, and resource-family pagination helpers. |
+| `gcp` | 2104 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2110 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 827 | Extract API client setup and paginated directory readers. |
 | `grc` | 1378 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -363,9 +363,10 @@ func (s *Service) ListRuns(ctx context.Context, filter graphstore.IngestRunFilte
 		return nil, err
 	}
 	failed, err := runStore.ListIngestRuns(ctx, graphstore.IngestRunFilter{
-		RuntimeID: normalized.RuntimeID,
-		Status:    graphstore.IngestRunStatusFailed,
-		Limit:     MaxStatusLimit,
+		RuntimeID:  normalized.RuntimeID,
+		RuntimeIDs: normalized.RuntimeIDs,
+		Status:     graphstore.IngestRunStatusFailed,
+		Limit:      MaxStatusLimit,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -1173,6 +1173,30 @@ func TestHealthEmitsTelemetry(t *testing.T) {
 	}
 }
 
+func TestListRunsFailedCountHonorsRuntimeIDsFilter(t *testing.T) {
+	store := &stubRunStore{
+		runs: []graphstore.IngestRun{
+			{ID: "runtime-a-failed", RuntimeID: "runtime-a", Status: graphstore.IngestRunStatusFailed},
+			{ID: "runtime-b-failed", RuntimeID: "runtime-b", Status: graphstore.IngestRunStatusFailed},
+			{ID: "runtime-c-failed", RuntimeID: "runtime-c", Status: graphstore.IngestRunStatusFailed},
+			{ID: "runtime-a-completed", RuntimeID: "runtime-a", Status: graphstore.IngestRunStatusCompleted},
+		},
+	}
+	result, err := New(nil, nil, nil, store).ListRuns(context.Background(), graphstore.IngestRunFilter{
+		RuntimeIDs: []string{"runtime-a", "runtime-b"},
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("ListRuns() error = %v", err)
+	}
+	if result.FailedCount != 2 {
+		t.Fatalf("ListRuns().FailedCount = %d, want 2 scoped to runtime_ids", result.FailedCount)
+	}
+	if len(result.Runs) != 3 {
+		t.Fatalf("len(ListRuns().Runs) = %d, want 3 scoped runs", len(result.Runs))
+	}
+}
+
 func TestListRunsTelemetryRecordsInvalidRequest(t *testing.T) {
 	stderr := captureGraphIngestStderr(t, func() {
 		_, err := New(nil, nil, nil, &stubRunStore{}).ListRuns(context.Background(), graphstore.IngestRunFilter{Status: "bogus"})

--- a/internal/sourcecdk/cursor_test.go
+++ b/internal/sourcecdk/cursor_test.go
@@ -169,6 +169,22 @@ func TestIncrementalCheckpointForCursorAllowsEmptyCursor(t *testing.T) {
 	}
 }
 
+func TestIncrementalCursorTokenIgnoresLegacyTokenWhenCheckpointed(t *testing.T) {
+	checkpoint := &cerebrov1.SourceCheckpoint{
+		Watermark: timestamppb.New(time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)),
+	}
+	if got := IncrementalCursorToken("gcp", "audit", &cerebrov1.SourceCursor{Opaque: "legacy-page-token"}, checkpoint); got != "" {
+		t.Fatalf("IncrementalCursorToken(legacy) = %q, want empty", got)
+	}
+	if got := IncrementalCursorToken("gcp", "audit", &cerebrov1.SourceCursor{Opaque: "legacy-page-token"}, nil); got != "legacy-page-token" {
+		t.Fatalf("IncrementalCursorToken(no checkpoint) = %q, want legacy token", got)
+	}
+	cursor := &cerebrov1.SourceCursor{Opaque: IncrementalCursor("gcp", "audit", "fresh-page-token", checkpoint)}
+	if got := IncrementalCursorToken("gcp", "audit", cursor, checkpoint); got != "fresh-page-token" {
+		t.Fatalf("IncrementalCursorToken(incremental) = %q, want fresh-page-token", got)
+	}
+}
+
 func watermarkTestEvent(id string, occurredAt time.Time) *primitives.Event {
 	return &primitives.Event{
 		Id:         id,

--- a/internal/sourcecdk/watermark.go
+++ b/internal/sourcecdk/watermark.go
@@ -262,6 +262,30 @@ func IncrementalCheckpointForCursor(source string, family string, cursor *cerebr
 	return readCheckpoint
 }
 
+// IncrementalCursorToken returns a provider continuation token for an
+// incremental scan. Legacy bare provider tokens are ignored once a durable
+// watermark exists because provider-side watermark filters usually change the
+// token contract for the remote API.
+func IncrementalCursorToken(source string, family string, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) string {
+	if cursor == nil {
+		return ""
+	}
+	opaque := strings.TrimSpace(cursor.GetOpaque())
+	if opaque == "" {
+		return ""
+	}
+	if envelope, ok := DecodeCursorEnvelope(opaque); ok {
+		if !incrementalCursorMatches(envelope, source, family) {
+			return ""
+		}
+		return strings.TrimSpace(envelope.Token)
+	}
+	if checkpointHasWatermark(checkpoint) {
+		return ""
+	}
+	return opaque
+}
+
 // IncrementalCursor wraps a provider token with the comparison watermark and
 // boundary IDs used for this incremental scan.
 func IncrementalCursor(source string, family string, token string, checkpoint *cerebrov1.SourceCheckpoint) string {
@@ -288,6 +312,10 @@ func IncrementalCursor(source string, family string, token string, checkpoint *c
 		return token
 	}
 	return opaque
+}
+
+func checkpointHasWatermark(checkpoint *cerebrov1.SourceCheckpoint) bool {
+	return checkpoint != nil && checkpoint.GetWatermark() != nil && !checkpoint.GetWatermark().AsTime().IsZero()
 }
 
 func incrementalCursorMatches(envelope CursorEnvelope, source string, family string) bool {

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -3,6 +3,7 @@ package sourcehttp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -56,6 +57,8 @@ type ResponseBody struct {
 	Header     http.Header
 	Body       []byte
 }
+
+type JSONBody interface{}
 
 func NewClient(options ClientOptions) *http.Client {
 	return HardenClient(nil, options)
@@ -176,6 +179,26 @@ func NewRequest(ctx context.Context, sourceID string, baseURL string, allowLoopb
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("build request %s: %w", requestPath, err)
+	}
+	return req, nil
+}
+
+func NewJSONRequest(ctx context.Context, sourceID string, baseURL string, allowLoopback bool, method string, requestPath string, query url.Values, body JSONBody) (*http.Request, error) {
+	var payload []byte
+	if body != nil {
+		var err error
+		payload, err = json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal %s request: %w", requestPath, err)
+		}
+	}
+	req, err := NewRequest(ctx, sourceID, baseURL, allowLoopback, method, requestPath, query, payload)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
 	return req, nil
 }

--- a/internal/sourcehttp/safe_test.go
+++ b/internal/sourcehttp/safe_test.go
@@ -121,6 +121,26 @@ func TestNewRequestNormalizesOriginPathQueryAndBody(t *testing.T) {
 	}
 }
 
+func TestNewJSONRequestSetsJSONHeadersAndBody(t *testing.T) {
+	req, err := NewJSONRequest(context.Background(), "test_source", "https://api.example.com", false, http.MethodPost, "/v1/items", nil, map[string]string{"id": "123"})
+	if err != nil {
+		t.Fatalf("NewJSONRequest() error = %v", err)
+	}
+	if got := req.Header.Get("Accept"); got != "application/json" {
+		t.Fatalf("Accept = %q, want application/json", got)
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("ReadAll(request body) error = %v", err)
+	}
+	if string(body) != `{"id":"123"}` {
+		t.Fatalf("body = %q, want JSON payload", string(body))
+	}
+}
+
 func TestSafeRoundTripperPropagatesTraceWithoutLeakingURLQuery(t *testing.T) {
 	var propagated string
 	ctx, parent := telemetry.StartMain(context.Background(), "test.parent", telemetry.Attrs())

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -385,12 +385,12 @@ func sentinelOneActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pr
 	if activityID == "" {
 		return nil, nil, nil
 	}
-	activityURN := projectionURN(tenant, "sentinelone_activity", activityID)
+	activityURN := projectionURN(tenant, "runtime_evidence", activityID)
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        activityURN,
 		TenantID:   tenant,
 		SourceID:   event.GetSourceId(),
-		EntityType: sentinelOneEntityActivity,
+		EntityType: "runtime.evidence",
 		Label:      firstNonEmpty(attrs["primary_description"], attrs["description"], attrs["activity_uuid"], activityID),
 		Attributes: compactAttributes(map[string]string{
 			"activity_id":           activityID,
@@ -407,7 +407,12 @@ func sentinelOneActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pr
 			"tenant_host":           strings.TrimSpace(attrs["tenant_host"]),
 			"threat_id":             strings.TrimSpace(attrs["threat_id"]),
 			"user_id":               strings.TrimSpace(attrs["user_id"]),
+			"evidence_id":           activityID,
+			"evidence_type":         sentinelOneEntityActivity,
 			"event_id":              event.GetId(),
+			"source_event_id":       event.GetId(),
+			"source_runtime_id":     strings.TrimSpace(attrs["source_runtime_id"]),
+			"source_system":         "sentinelone",
 			"at":                    eventObservedAt(event),
 		}),
 	})

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -347,11 +347,14 @@ func TestProjectSentinelOneActivityBuildsAuditEvidenceContext(t *testing.T) {
 	if result.EntitiesProjected == 0 || result.LinksProjected == 0 {
 		t.Fatalf("activity projection = entities %d links %d, want graph evidence context", result.EntitiesProjected, result.LinksProjected)
 	}
-	activityURN := "urn:cerebro:writer:sentinelone_activity:activity-1"
+	activityURN := "urn:cerebro:writer:runtime_evidence:activity-1"
 	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
 	threatURN := "urn:cerebro:writer:sentinelone_threat:threat-1"
 	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
-	assertProjectedEntityType(t, state, activityURN, "sentinelone.activity")
+	assertProjectedEntityType(t, state, activityURN, "runtime.evidence")
+	if got := state.entities[activityURN].Attributes["evidence_type"]; got != "sentinelone.activity" {
+		t.Fatalf("activity evidence_type = %q, want sentinelone.activity", got)
+	}
 	assertProjectedEntityType(t, state, agentURN, "sentinelone.agent")
 	assertProjectedEntityType(t, state, threatURN, "sentinelone.threat")
 	assertProjectedEntityType(t, state, siteURN, "sentinelone.site")

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -1992,19 +1992,10 @@ func getBytes(ctx context.Context, source *Source, settings settings, defaultBas
 	if baseURL == "" {
 		baseURL = defaultBaseURL()
 	}
-	var payload []byte
-	if body != nil {
-		var err error
-		payload, err = json.Marshal(body)
-		if err != nil {
-			return nil, false, fmt.Errorf("marshal %s request: %w", requestPath, err)
-		}
-	}
-	req, err := sourcehttp.NewRequest(ctx, "gcp", baseURL, source != nil && source.allowLoopbackBaseURL, method, requestPath, query, payload)
+	req, err := sourcehttp.NewJSONRequest(ctx, "gcp", baseURL, source != nil && source.allowLoopbackBaseURL, method, requestPath, query, body)
 	if err != nil {
 		return nil, false, err
 	}
-	req.Header.Set("Accept", "application/json")
 	if maxBytes > 0 {
 		req.Header.Set("Accept", "*/*")
 		req.Header.Set("Range", fmt.Sprintf("bytes=0-%d", maxBytes-1))
@@ -2014,9 +2005,6 @@ func getBytes(ctx context.Context, source *Source, settings settings, defaultBas
 		return nil, false, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
 	client := sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: "gcp"})
 	if source != nil && source.client != nil {
 		client = source.client

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -34,6 +34,7 @@ var catalogFS embed.FS
 const (
 	defaultFamily                                                                                                                                                                                        = familyAudit
 	defaultPageSize                                                                                                                                                                                      = 10
+	gcpComputeInventoryMaxBodyBytes                                                                                                                                                                      = 64 << 20
 	gcsObjectContentSampleBytes                                                                                                                                                                          = 64 << 10
 	maxPageSize                                                                                                                                                                                          = 200
 	familyAssetMetadata                                                                                                                                                                                  = "asset_metadata"
@@ -677,7 +678,7 @@ func gcpFamily[T any](source *Source, options gcpFamilyOptions[T]) sourcecdk.Fam
 	if options.ListWithCheckpoint != nil {
 		family.ReadWithCheckpoint = func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
 			readCheckpoint := sourcecdk.IncrementalCheckpointForCursor("gcp", options.Name, cursor, checkpoint)
-			token := sourcecdk.CursorToken(cursor)
+			token := sourcecdk.IncrementalCursorToken("gcp", options.Name, cursor, checkpoint)
 			records, next, err := options.ListWithCheckpoint(ctx, source, settings, token, settings.perPage, readCheckpoint)
 			if err != nil {
 				return sourcecdk.Pull{}, fmt.Errorf("lookup %s for %s: %w", options.Label, tenantID(settings), err)
@@ -1130,7 +1131,7 @@ func listComputeInstances(ctx context.Context, source *Source, settings settings
 	gcpcloud.AddPageToken(query, pageToken)
 	var response computeAggregatedListResponse
 	path := "/compute/v1/projects/" + url.PathEscape(settings.projectID) + "/aggregated/instances"
-	if err := getJSON(ctx, source, settings, computeBaseURL, http.MethodGet, path, query, nil, &response); err != nil {
+	if err := getComputeJSON(ctx, source, settings, path, query, nil, &response); err != nil {
 		return nil, "", err
 	}
 	rawRecords := make([]json.RawMessage, 0)
@@ -1170,7 +1171,7 @@ func computeGlobalLister[T any](collection, label string, extraQuery url.Values)
 		gcpcloud.AddPageToken(query, pageToken)
 		var response pageResponse
 		path := "/compute/v1/projects/" + url.PathEscape(settings.projectID) + "/global/" + collection
-		if err := getJSON(ctx, source, settings, computeBaseURL, http.MethodGet, path, query, nil, &response); err != nil {
+		if err := getComputeJSON(ctx, source, settings, path, query, nil, &response); err != nil {
 			return nil, "", err
 		}
 		records, err := gcpcloud.DecodeRecords(response.Items, label, gcpcloud.SaveRawField[T])
@@ -1202,7 +1203,7 @@ func listComputeAggregatedRecords[T any](ctx context.Context, source *Source, se
 	gcpcloud.AddPageToken(query, pageToken)
 	var response computeAggregatedListResponse
 	path := "/compute/v1/projects/" + url.PathEscape(settings.projectID) + "/aggregated/" + collection
-	if err := getJSON(ctx, source, settings, computeBaseURL, http.MethodGet, path, query, nil, &response); err != nil {
+	if err := getComputeJSON(ctx, source, settings, path, query, nil, &response); err != nil {
 		return nil, "", err
 	}
 	records, err := gcpcloud.DecodeRecords(gcpcloud.ComputeAggregatedRawRecords(response.Items, selectRecords, scopeField), label, gcpcloud.SaveRawField[T])
@@ -1797,7 +1798,7 @@ func listResourceExposures(ctx context.Context, source *Source, settings setting
 	gcpcloud.AddPageToken(query, pageToken)
 	var response pageResponse
 	path := "/compute/v1/projects/" + url.PathEscape(settings.projectID) + "/global/firewalls"
-	if err := getJSON(ctx, source, settings, computeBaseURL, http.MethodGet, path, query, nil, &response); err != nil {
+	if err := getComputeJSON(ctx, source, settings, path, query, nil, &response); err != nil {
 		return nil, "", err
 	}
 	firewalls, err := gcpcloud.DecodeRecords(response.Items, "gcp firewall", func(record *firewallRecord, raw json.RawMessage) { record.Raw = append(json.RawMessage(nil), raw...) })
@@ -1975,7 +1976,15 @@ func sourceEvent(settings settings, id string, kind string, schemaRef string, pa
 }
 
 func getJSON(ctx context.Context, source *Source, settings settings, defaultBaseURL func() string, method string, requestPath string, query url.Values, body any, target any) error {
-	content, _, err := getBytes(ctx, source, settings, defaultBaseURL, method, requestPath, query, body, 0)
+	return getJSONWithMaxBytes(ctx, source, settings, defaultBaseURL, method, requestPath, query, body, target, 0)
+}
+
+func getComputeJSON(ctx context.Context, source *Source, settings settings, requestPath string, query url.Values, body any, target any) error {
+	return getJSONWithMaxBytes(ctx, source, settings, computeBaseURL, http.MethodGet, requestPath, query, body, target, gcpComputeInventoryMaxBodyBytes)
+}
+
+func getJSONWithMaxBytes(ctx context.Context, source *Source, settings settings, defaultBaseURL func() string, method string, requestPath string, query url.Values, body any, target any, maxBytes int) error {
+	content, _, err := getBytes(ctx, source, settings, defaultBaseURL, method, requestPath, query, body, maxBytes)
 	if err != nil {
 		return err
 	}

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -1124,7 +1124,7 @@ func listComputeInstances(ctx context.Context, source *Source, settings settings
 	gcpcloud.AddPageToken(query, pageToken)
 	var response computeAggregatedListResponse
 	path := "/compute/v1/projects/" + url.PathEscape(settings.projectID) + "/aggregated/instances"
-	if err := getComputeJSON(ctx, source, settings, path, query, nil, &response); err != nil {
+	if err := getComputeJSON(ctx, source, settings, path, query, &response); err != nil {
 		return nil, "", err
 	}
 	rawRecords := make([]json.RawMessage, 0)
@@ -1164,7 +1164,7 @@ func computeGlobalLister[T any](collection, label string, extraQuery url.Values)
 		gcpcloud.AddPageToken(query, pageToken)
 		var response pageResponse
 		path := "/compute/v1/projects/" + url.PathEscape(settings.projectID) + "/global/" + collection
-		if err := getComputeJSON(ctx, source, settings, path, query, nil, &response); err != nil {
+		if err := getComputeJSON(ctx, source, settings, path, query, &response); err != nil {
 			return nil, "", err
 		}
 		records, err := gcpcloud.DecodeRecords(response.Items, label, gcpcloud.SaveRawField[T])
@@ -1196,7 +1196,7 @@ func listComputeAggregatedRecords[T any](ctx context.Context, source *Source, se
 	gcpcloud.AddPageToken(query, pageToken)
 	var response computeAggregatedListResponse
 	path := "/compute/v1/projects/" + url.PathEscape(settings.projectID) + "/aggregated/" + collection
-	if err := getComputeJSON(ctx, source, settings, path, query, nil, &response); err != nil {
+	if err := getComputeJSON(ctx, source, settings, path, query, &response); err != nil {
 		return nil, "", err
 	}
 	records, err := gcpcloud.DecodeRecords(gcpcloud.ComputeAggregatedRawRecords(response.Items, selectRecords, scopeField), label, gcpcloud.SaveRawField[T])
@@ -1791,7 +1791,7 @@ func listResourceExposures(ctx context.Context, source *Source, settings setting
 	gcpcloud.AddPageToken(query, pageToken)
 	var response pageResponse
 	path := "/compute/v1/projects/" + url.PathEscape(settings.projectID) + "/global/firewalls"
-	if err := getComputeJSON(ctx, source, settings, path, query, nil, &response); err != nil {
+	if err := getComputeJSON(ctx, source, settings, path, query, &response); err != nil {
 		return nil, "", err
 	}
 	firewalls, err := gcpcloud.DecodeRecords(response.Items, "gcp firewall", func(record *firewallRecord, raw json.RawMessage) { record.Raw = append(json.RawMessage(nil), raw...) })
@@ -1972,8 +1972,8 @@ func getJSON(ctx context.Context, source *Source, settings settings, defaultBase
 	return getJSONWithMaxBytes(ctx, source, settings, defaultBaseURL, method, requestPath, query, body, target, 0)
 }
 
-func getComputeJSON(ctx context.Context, source *Source, settings settings, requestPath string, query url.Values, body any, target any) error {
-	return getJSONWithMaxBytes(ctx, source, settings, computeBaseURL, http.MethodGet, requestPath, query, body, target, gcpComputeInventoryMaxBodyBytes)
+func getComputeJSON(ctx context.Context, source *Source, settings settings, requestPath string, query url.Values, target any) error {
+	return getJSONWithMaxBytes(ctx, source, settings, computeBaseURL, http.MethodGet, requestPath, query, nil, target, gcpComputeInventoryMaxBodyBytes)
 }
 
 func getJSONWithMaxBytes(ctx context.Context, source *Source, settings settings, defaultBaseURL func() string, method string, requestPath string, query url.Values, body any, target any, maxBytes int) error {

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -104,19 +104,12 @@ type Source struct {
 }
 
 type settings struct {
-	family                                              string
-	projectID                                           string
-	customerID                                          string
-	groupKey                                            string
-	serviceAccountEmail                                 string
-	location                                            string
-	keyRing                                             string
-	artifactRepository                                  string
-	token, wifAudience, wifServiceAccount, wifAWSRegion string
-	tenantID, wifBindings                               string
-	baseURL                                             string
-	filter                                              string
-	perPage                                             int
+	family, projectID, customerID, groupKey                    string
+	serviceAccountEmail, location, keyRing, artifactRepository string
+	token, wifAudience, wifServiceAccount, wifAWSRegion        string
+	tenantID, wifBindings                                      string
+	baseURL, filter                                            string
+	perPage                                                    int
 }
 
 type pageResponse = gcpcloud.GenericPageResponse

--- a/sources/gcp/source_test.go
+++ b/sources/gcp/source_test.go
@@ -15,6 +15,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/sourcehttp"
 	"github.com/writer/cerebro/sources/internal/gcpcloud"
 )
 
@@ -1014,6 +1015,73 @@ func TestReadLiveGCPAuditLogsWithCheckpoint(t *testing.T) {
 	wantFilter := `timestamp >= "` + watermark.Add(-gcpcloud.FindingCheckpointLookback).Format(time.RFC3339Nano) + `"`
 	if got := gotBody["filter"]; got != wantFilter {
 		t.Fatalf("filter = %v, want %s", got, wantFilter)
+	}
+}
+
+func TestReadLiveGCPAuditLogsWithCheckpointIgnoresLegacyPageToken(t *testing.T) {
+	watermark := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v2/entries:list" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if _, ok := gotBody["pageToken"]; ok {
+			t.Fatalf("checkpointed audit read sent stale pageToken in body: %#v", gotBody)
+		}
+		writeJSON(t, w, map[string]any{"entries": []map[string]any{
+			{"insertId": "new-audit", "timestamp": watermark.Add(time.Hour).Format(time.RFC3339Nano), "protoPayload": map[string]any{"methodName": "storage.buckets.update"}},
+		}})
+	}))
+	defer server.Close()
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url":   server.URL,
+		"family":     familyAudit,
+		"project_id": "writer-prod",
+		"token":      "test-token",
+	}), &cerebrov1.SourceCursor{Opaque: "stale-provider-page-token"}, &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(watermark)})
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(%s) error = %v", familyAudit, err)
+	}
+	if got := gotBody["orderBy"]; got != "timestamp desc" {
+		t.Fatalf("orderBy = %v, want timestamp desc", got)
+	}
+}
+
+func TestReadLiveGCPComputeInstancesAllowsLargeAggregatedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/compute/v1/projects/writer-prod/aggregated/instances" {
+			http.NotFound(w, r)
+			return
+		}
+		padding := strings.Repeat("x", sourcehttp.MaxBodyBytes+1024)
+		writeJSON(t, w, map[string]any{"padding": padding, "items": map[string]any{}})
+	}))
+	defer server.Close()
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url":   server.URL,
+		"family":     familyComputeInstance,
+		"project_id": "writer-prod",
+		"token":      "test-token",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read(%s) error = %v", familyComputeInstance, err)
+	}
+	if len(pull.Events) != 0 {
+		t.Fatalf("len(events) = %d, want 0", len(pull.Events))
 	}
 }
 

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -18,7 +18,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"aws":             19121,
 	"azure":           2856,
 	"cosmo":           1112,
-	"gcp":             2116,
+	"gcp":             2104,
 	"github":          2110,
 	"googleworkspace": 827,
 	"grc":             1378,


### PR DESCRIPTION
## Summary
- add comma-separated runtime_ids support to graph ingest-runs so deploy verification can batch scoped ingest-history checks
- remodel SentinelOne activity projections as runtime.evidence instead of sentinelone.activity inventory nodes
- preserve agent/threat/site evidence context while keeping graph integrity invariants clean

## Evidence
- live sec-dev verifier reported unsupported graph ingest-runs argument runtime_ids and fell back to many single-runtime ECS tasks
- live graph integrity reported sentinelone_activity_events_projected_as_assets after the v2.1.459 activity projection release

## Tests
- go test ./cmd/cerebro ./internal/sourceprojection ./internal/graphstore/neo4j