### PR TITLE
feat: enrich source runtime wide events

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehealth"
 	"github.com/writer/cerebro/internal/sourceregistry"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
@@ -61,23 +62,24 @@ type orchestratorIterationResult struct {
 }
 
 type orchestratorRuntimeResult struct {
-	RuntimeID            string `json:"runtime_id"`
-	SourceID             string `json:"source_id,omitempty"`
-	TenantID             string `json:"tenant_id,omitempty"`
-	Sync                 string `json:"sync"`
-	PagesRead            uint32 `json:"pages_read,omitempty"`
-	EventsAppended       uint32 `json:"events_appended,omitempty"`
-	FindingRules         string `json:"finding_rules"`
-	EventsEvaluated      uint32 `json:"events_evaluated,omitempty"`
-	FindingEvaluations   int    `json:"finding_evaluations,omitempty"`
-	GraphIngest          string `json:"graph_ingest"`
-	EntitiesProjected    uint32 `json:"entities_projected,omitempty"`
-	LinksProjected       uint32 `json:"links_projected,omitempty"`
-	GraphRules           string `json:"graph_rules"`
-	GraphRuleEvaluations int    `json:"graph_rule_evaluations,omitempty"`
-	GraphRuleFindings    int    `json:"graph_rule_findings,omitempty"`
-	GraphRuleRowsRead    uint32 `json:"graph_rule_rows_read,omitempty"`
-	Error                string `json:"error,omitempty"`
+	RuntimeID            string              `json:"runtime_id"`
+	SourceID             string              `json:"source_id,omitempty"`
+	TenantID             string              `json:"tenant_id,omitempty"`
+	Sync                 string              `json:"sync"`
+	PagesRead            uint32              `json:"pages_read,omitempty"`
+	EventsAppended       uint32              `json:"events_appended,omitempty"`
+	FindingRules         string              `json:"finding_rules"`
+	EventsEvaluated      uint32              `json:"events_evaluated,omitempty"`
+	FindingEvaluations   int                 `json:"finding_evaluations,omitempty"`
+	GraphIngest          string              `json:"graph_ingest"`
+	EntitiesProjected    uint32              `json:"entities_projected,omitempty"`
+	LinksProjected       uint32              `json:"links_projected,omitempty"`
+	GraphRules           string              `json:"graph_rules"`
+	GraphRuleEvaluations int                 `json:"graph_rule_evaluations,omitempty"`
+	GraphRuleFindings    int                 `json:"graph_rule_findings,omitempty"`
+	GraphRuleRowsRead    uint32              `json:"graph_rule_rows_read,omitempty"`
+	Error                string              `json:"error,omitempty"`
+	Health               sourcehealth.Record `json:"-"`
 }
 
 func runOrchestrator(args []string) error {
@@ -107,6 +109,16 @@ func shouldPrintOrchestratorResult(result *orchestratorResult) bool {
 
 func orchestratorShutdownSignals() []os.Signal {
 	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}
+
+func orchestratorScheduleName(options orchestratorOptions) string {
+	if options.RunForever {
+		return "forever"
+	}
+	if options.Iterations > 1 {
+		return "interval"
+	}
+	return "single_run"
 }
 
 func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
@@ -232,6 +244,10 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		telemetryField("page_limit", options.PageLimit),
 		telemetryField("event_limit", options.EventLimit),
 		telemetryField("graph_page_limit", options.GraphPageLimit),
+		telemetryField("effective_page_limit", options.PageLimit),
+		telemetryField("effective_event_limit", options.EventLimit),
+		telemetryField("effective_graph_page_limit", options.GraphPageLimit),
+		telemetryField("orchestrator.schedule.name", orchestratorScheduleName(options)),
 		telemetryField("phase_timeout_ms", options.PhaseTimeout.Milliseconds()),
 		telemetryField("graph_timeout_ms", options.GraphTimeout.Milliseconds()),
 		telemetryField("iterations", options.Iterations),
@@ -458,11 +474,14 @@ func runOrchestratorIteration(
 			telemetryField("runtime_id", runtime.GetId()),
 			telemetryField("source_id", runtime.GetSourceId()),
 			telemetryField("tenant_id", runtime.GetTenantId()),
+			telemetryField("effective_page_limit", options.PageLimit),
+			telemetryField("effective_event_limit", options.EventLimit),
 		)
 		runtimeResult := &orchestratorRuntimeResult{
 			RuntimeID: strings.TrimSpace(runtime.GetId()),
 			SourceID:  strings.TrimSpace(runtime.GetSourceId()),
 			TenantID:  strings.TrimSpace(runtime.GetTenantId()),
+			Health:    sourcehealth.RecordFromRuntime(runtime, time.Now().UTC()),
 		}
 		acquired, err := acquireOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner)
 		if err != nil {
@@ -519,6 +538,10 @@ func runOrchestratorIteration(
 			runtimeResult.Sync = "completed"
 			runtimeResult.PagesRead = syncResult.GetPagesRead()
 			runtimeResult.EventsAppended = syncResult.GetEventsAppended()
+			if syncResult.GetRuntime() != nil {
+				runtime = syncResult.GetRuntime()
+				runtimeResult.Health = sourcehealth.RecordFromRuntime(runtime, time.Now().UTC())
+			}
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "pages_read", runtimeResult.PagesRead)
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "events_appended", runtimeResult.EventsAppended)
 		}
@@ -546,6 +569,7 @@ func runOrchestratorIteration(
 		} else {
 			runtimeResult.GraphIngest = "completed"
 		}
+		runtimeResult.Health = withOrchestratorGraphHealth(runtimeResult.Health, graphResult, runtimeResult.GraphIngest, time.Now().UTC())
 		findingResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.finding_rules", iteration, runtime, options.PhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateRulesResult, error) {
 			return findingService.EvaluateSourceRuntimeRules(phaseCtx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit})
 		})
@@ -566,6 +590,7 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "events_evaluated", runtimeResult.EventsEvaluated)
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_evaluations", runtimeResult.FindingEvaluations)
 		}
+		runtimeResult.Health = withOrchestratorFindingHealth(runtimeResult.Health, runtimeResult.FindingRules)
 		// Run graph rules whenever the projection has caught up to the same cursor
 		// reached by source sync, even if a trailing PutIngestRun(completed) write
 		// failed. The graph is fresh enough for read-only rules at that point.
@@ -649,9 +674,16 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 		telemetryField("tenant_id", runtime.GetTenantId()),
 		telemetryField("timeout_ms", timeout.Milliseconds()),
 	))
+	started := time.Now()
 	result, err := fn(phaseCtx)
+	durationMs := time.Since(started).Milliseconds()
 	status := "completed"
-	endAttrs := telemetry.Attrs()
+	phaseKey := orchestratorPhaseTelemetryKey(name)
+	endAttrs := telemetry.Attrs(
+		telemetryField("duration_ms", durationMs),
+		telemetryField("phase."+phaseKey+".last_duration_ms", durationMs),
+	)
+	telemetry.MaxMain(phaseCtx, "phase."+phaseKey+".max_duration_ms", durationMs)
 	if err != nil {
 		status = "failed"
 		endAttrs = withTelemetryField(endAttrs, "error_kind", telemetry.ErrorKind(err))
@@ -682,6 +714,14 @@ func annotateOrchestratorRuntimeMain(ctx context.Context, result *orchestratorRu
 	case "failed":
 		telemetry.IncrementMain(ctx, "orchestrator.runtime.failed.count", 1)
 	}
+	healthRecord := normalizedOrchestratorRuntimeHealth(result)
+	healthState := sourcehealth.Evaluate(healthRecord)
+	if healthState.FreshnessState != "" {
+		telemetry.IncrementMain(ctx, "orchestrator.runtime.freshness."+orchestratorPhaseTelemetryKey(healthState.FreshnessState)+".count", 1)
+	}
+	if healthState.BackfillEligible {
+		telemetry.IncrementMain(ctx, "orchestrator.runtime.backfill_eligible.count", 1)
+	}
 	mainAttrs := attrs.With(telemetry.Attrs(
 		telemetryField("orchestrator.runtime.last_status", status),
 		telemetryField("orchestrator.runtime.last_runtime_id", result.RuntimeID),
@@ -700,8 +740,131 @@ func annotateOrchestratorRuntimeMain(ctx context.Context, result *orchestratorRu
 		telemetryField("orchestrator.runtime.last_graph_rule_evaluations", result.GraphRuleEvaluations),
 		telemetryField("orchestrator.runtime.last_graph_rule_findings", result.GraphRuleFindings),
 		telemetryField("orchestrator.runtime.last_graph_rule_rows_read", result.GraphRuleRowsRead),
+		telemetryField("source_runtime.family", healthRecord.Family),
+		telemetryField("source_runtime.enabled_state", healthRecord.EnabledState),
+		telemetryField("source_runtime.freshness_state", healthState.FreshnessState),
+		telemetryField("source_runtime.source_sync_state", healthState.SourceSyncState),
+		telemetryField("source_runtime.graph_ingest_state", healthState.GraphIngestState),
+		telemetryField("source_runtime.finding_evaluation_state", healthState.FindingEvaluationState),
+		telemetryField("source_runtime.failure_class", healthState.FailureClass),
+		telemetryField("source_runtime.next_action", healthState.NextAction),
+		telemetryField("source_runtime.backfill_eligible", healthState.BackfillEligible),
+		telemetryField("source_runtime.sync_lag_seconds", optionalInt64Value(healthRecord.SyncLagSeconds)),
+		telemetryField("source_runtime.watermark_lag_seconds", optionalInt64Value(healthRecord.WatermarkLagSeconds)),
+		telemetryField("source_runtime.graph_lag_seconds", optionalInt64Value(healthRecord.GraphLagSeconds)),
+		telemetryField("source_runtime.expected_cadence_seconds", optionalInt64Value(healthRecord.ExpectedCadenceSeconds)),
+		telemetryField("source_runtime.stale_after_seconds", optionalInt64Value(healthRecord.StaleAfterSeconds)),
+		telemetryField("source_runtime.cursor_pending", healthRecord.CursorPending),
+		telemetryField("source_runtime.checkpoint_cursor_present", healthRecord.CheckpointCursorPresent),
+		telemetryField("source_runtime.contract_probe_state", healthRecord.ContractProbeState),
+		telemetryField("source_runtime.contract_probe_status", sourcehealth.ContractProbeStatus(healthRecord.ContractProbeState)),
 	))
 	telemetry.AnnotateMainPhase(ctx, "orchestrator.runtime", status, mainAttrs)
+}
+
+func normalizedOrchestratorRuntimeHealth(result *orchestratorRuntimeResult) sourcehealth.Record {
+	record := result.Health
+	if strings.TrimSpace(record.RuntimeID) == "" {
+		record.RuntimeID = result.RuntimeID
+	}
+	if strings.TrimSpace(record.SourceID) == "" {
+		record.SourceID = result.SourceID
+	}
+	if strings.TrimSpace(record.TenantID) == "" {
+		record.TenantID = result.TenantID
+	}
+	if strings.TrimSpace(record.EnabledState) == "" {
+		record.EnabledState = "unknown"
+	}
+	if strings.TrimSpace(record.Status) == "" {
+		record.Status = "unknown"
+	}
+	if strings.TrimSpace(record.ContractProbeState) == "" {
+		record.ContractProbeState = "unknown"
+	}
+	if result.Sync == "failed" {
+		record.Status = "failing"
+		if strings.TrimSpace(record.LastFailureCategory) == "" {
+			record.LastFailureCategory = "source_sync_failed"
+		}
+	}
+	if record.LatestGraphRun == nil {
+		switch result.GraphIngest {
+		case "completed", "failed", "running", "pending":
+			record.LatestGraphRun = &sourcehealth.GraphRun{Status: result.GraphIngest}
+		}
+	}
+	if record.LatestFindingEvaluation == nil {
+		switch result.FindingRules {
+		case "completed", "failed", "running", "pending":
+			record.LatestFindingEvaluation = &sourcehealth.FindingEvaluation{Status: result.FindingRules}
+		}
+	}
+	return record
+}
+
+func withOrchestratorGraphHealth(record sourcehealth.Record, graphResult *graphingest.RunResult, graphStatus string, now time.Time) sourcehealth.Record {
+	if graphResult == nil {
+		if graphStatus != "" && graphStatus != "skipped" {
+			record.LatestGraphRun = &sourcehealth.GraphRun{Status: graphStatus}
+		}
+		return record
+	}
+	status := strings.TrimSpace(graphResult.Run.Status)
+	if status == "" {
+		status = graphStatus
+	}
+	if status == "" {
+		status = "unknown"
+	}
+	record.LatestGraphRun = &sourcehealth.GraphRun{Status: status}
+	record.GraphLagSeconds = orchestratorGraphRunLagSeconds(now, graphResult.Run.StartedAt, graphResult.Run.FinishedAt)
+	return record
+}
+
+func withOrchestratorFindingHealth(record sourcehealth.Record, findingStatus string) sourcehealth.Record {
+	switch findingStatus {
+	case "completed", "failed", "running", "pending":
+		record.LatestFindingEvaluation = &sourcehealth.FindingEvaluation{Status: findingStatus}
+	}
+	return record
+}
+
+func orchestratorGraphRunLagSeconds(now time.Time, startedAt string, finishedAt string) *int64 {
+	if finished, ok := parseOrchestratorRFC3339(finishedAt); ok {
+		return orchestratorSecondsSince(now, finished)
+	}
+	if started, ok := parseOrchestratorRFC3339(startedAt); ok {
+		return orchestratorSecondsSince(now, started)
+	}
+	return nil
+}
+
+func parseOrchestratorRFC3339(value string) (time.Time, bool) {
+	text := strings.TrimSpace(value)
+	if text == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, text)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed.UTC(), true
+}
+
+func orchestratorSecondsSince(now time.Time, then time.Time) *int64 {
+	seconds := int64(now.UTC().Sub(then.UTC()).Seconds())
+	if seconds < 0 {
+		seconds = 0
+	}
+	return &seconds
+}
+
+func optionalInt64Value(value *int64) any {
+	if value == nil {
+		return nil
+	}
+	return *value
 }
 
 func captureOrchestratorError(ctx context.Context, name string, iteration uint32, runtime *cerebrov1.SourceRuntime, stage string, err error) {
@@ -847,6 +1010,17 @@ func appendRuntimeError(existing string, stage string, err error) string {
 
 func telemetryField(key string, value any) telemetry.Field {
 	return telemetry.Field{Key: key, Value: value}
+}
+
+func orchestratorPhaseTelemetryKey(name string) string {
+	key := strings.TrimSpace(name)
+	key = strings.ReplaceAll(key, ".", "_")
+	key = strings.ReplaceAll(key, "-", "_")
+	key = strings.Trim(key, "_")
+	if key == "" {
+		return "unknown"
+	}
+	return key
 }
 
 func withTelemetryField(attributes telemetry.Attributes, key string, value any) telemetry.Attributes {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehealth"
 	"github.com/writer/cerebro/internal/sourceprojection"
 	"github.com/writer/cerebro/internal/sourceruntime"
+	"github.com/writer/cerebro/internal/telemetry"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -127,6 +129,28 @@ func TestRunOrchestratorPhasePassesThroughErrors(t *testing.T) {
 	}
 }
 
+func TestRunOrchestratorPhaseAnnotatesMainDuration(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "github", TenantId: "writer"}
+	stderr := captureCommandStderr(t, func() {
+		ctx, span := telemetry.StartMain(context.Background(), "orchestrator.run", telemetry.Attrs())
+		_, err := runOrchestratorPhase[int](ctx, "orchestrator.test_phase", 1, runtime, time.Second, func(context.Context) (int, error) {
+			return 1, nil
+		})
+		if err != nil {
+			t.Fatalf("runOrchestratorPhase() error = %v", err)
+		}
+		telemetry.End(span, "completed", telemetry.Attrs())
+	})
+
+	payload := lastCommandTelemetryPayload(t, stderr)
+	if _, ok := payload["phase.orchestrator_test_phase.last_duration_ms"].(float64); !ok {
+		t.Fatalf("last duration missing: %#v", payload)
+	}
+	if _, ok := payload["phase.orchestrator_test_phase.max_duration_ms"].(float64); !ok {
+		t.Fatalf("max duration missing: %#v", payload)
+	}
+}
+
 // runOrchestratorPhase must inherit cancellation from the parent runtime
 // context. The orchestrator's lease-renewal goroutine cancels the
 // runtime context when lease renewal fails, and that cancellation must
@@ -146,6 +170,80 @@ func TestRunOrchestratorPhaseInheritsParentCancellation(t *testing.T) {
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("runOrchestratorPhase() error = %v, want context.Canceled (inherited from parent)", err)
+	}
+}
+
+func TestAnnotateOrchestratorRuntimeMainAddsHealthFields(t *testing.T) {
+	syncLag := int64(30)
+	watermarkLag := int64(45)
+	graphLag := int64(60)
+	cadence := int64(300)
+	staleAfter := int64(600)
+	stderr := captureCommandStderr(t, func() {
+		ctx, span := telemetry.StartMain(context.Background(), "orchestrator.run", telemetry.Attrs())
+		annotateOrchestratorRuntimeMain(ctx, &orchestratorRuntimeResult{
+			RuntimeID:      "runtime-1",
+			SourceID:       "github",
+			TenantID:       "writer",
+			Sync:           "completed",
+			GraphIngest:    "completed",
+			FindingRules:   "completed",
+			GraphRules:     "completed",
+			PagesRead:      2,
+			EventsAppended: 3,
+			Health: sourcehealth.Record{
+				RuntimeID:                 "runtime-1",
+				SourceID:                  "github",
+				TenantID:                  "writer",
+				Family:                    "code",
+				EnabledState:              "enabled",
+				Status:                    "healthy",
+				ContractProbeState:        "passing",
+				CursorPending:             true,
+				CheckpointCursorPresent:   true,
+				SyncLagSeconds:            &syncLag,
+				WatermarkLagSeconds:       &watermarkLag,
+				GraphLagSeconds:           &graphLag,
+				ExpectedCadenceSeconds:    &cadence,
+				StaleAfterSeconds:         &staleAfter,
+				LatestGraphRun:            &sourcehealth.GraphRun{Status: "completed"},
+				LatestFindingEvaluation:   &sourcehealth.FindingEvaluation{Status: "completed"},
+				ScheduleContextConfigured: true,
+			},
+		}, "completed", telemetry.Attrs())
+		telemetry.End(span, "completed", telemetry.Attrs())
+	})
+
+	payload := lastCommandTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"source_runtime.family":                        "code",
+		"source_runtime.enabled_state":                 "enabled",
+		"source_runtime.freshness_state":               "healthy",
+		"source_runtime.source_sync_state":             "current",
+		"source_runtime.graph_ingest_state":            "current",
+		"source_runtime.finding_evaluation_state":      "current",
+		"source_runtime.next_action":                   "monitor",
+		"source_runtime.backfill_eligible":             false,
+		"source_runtime.contract_probe_state":          "passing",
+		"source_runtime.contract_probe_status":         "success",
+		"source_runtime.cursor_pending":                true,
+		"source_runtime.checkpoint_cursor_present":     true,
+		"orchestrator.runtime.freshness.healthy.count": float64(1),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	for key, want := range map[string]float64{
+		"source_runtime.sync_lag_seconds":         30,
+		"source_runtime.watermark_lag_seconds":    45,
+		"source_runtime.graph_lag_seconds":        60,
+		"source_runtime.expected_cadence_seconds": 300,
+		"source_runtime.stale_after_seconds":      600,
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
 	}
 }
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -13,7 +13,8 @@ For capacity SLOs, saturation dashboards, alert templates, autoscaling signals, 
 ## Wide Event Contract
 
 Cerebro follows a wide-event model for request and job debugging. Each top-level
-unit of work emits one canonical span/event with:
+unit of work emits one canonical span/event with schema version `2026-06-18.1`
+and:
 
 - `main=true`
 - `wide_event=true`
@@ -43,6 +44,16 @@ Main spans include two generic rollup families:
 
 - `dependency.*`: counts and last-seen status for Postgres, Neo4j, Redis, JetStream, outbound HTTP, and graph-agent LLM calls. Use this when you do not yet know which dependency is guilty.
 - `phase.*`: counts and last-seen status for orchestration phases, source sync, graph ingest, GRC dashboard subtasks, and source operations. Use this when one logical job has several internal steps.
+
+Orchestrator wide events also carry interpreted source runtime health fields so
+a single `orchestrator.run` span can explain whether work is blocked by source
+sync, graph ingest, finding evaluation, or a backfill need:
+
+- `source_runtime.family`, `source_runtime.enabled_state`, `source_runtime.freshness_state`, `source_runtime.source_sync_state`, `source_runtime.graph_ingest_state`, `source_runtime.finding_evaluation_state`
+- `source_runtime.failure_class`, `source_runtime.next_action`, `source_runtime.backfill_eligible`
+- `source_runtime.sync_lag_seconds`, `source_runtime.watermark_lag_seconds`, `source_runtime.graph_lag_seconds`, `source_runtime.expected_cadence_seconds`, `source_runtime.stale_after_seconds`
+- `source_runtime.cursor_pending`, `source_runtime.checkpoint_cursor_present`, `source_runtime.contract_probe_state`, `source_runtime.contract_probe_status`
+- `orchestrator.runtime.freshness.<state>.count`, `orchestrator.runtime.backfill_eligible.count`, and per-phase `phase.<phase>.last_duration_ms` / `phase.<phase>.max_duration_ms`
 
 Inbound HTTP requests create a main OTEL `http.server` span. The route label is
 normalized before emission. Unknown or dynamic paths are collapsed to route
@@ -84,6 +95,15 @@ Core runtime operations emit structured spans and diagnostic events:
 | `neo4j.read`, `neo4j.write` | Graph store transactions |
 | `redis.cache.*`, `redis.ping` | Query cache operations, hits/misses, version bumps |
 | `jetstream.ping`, `jetstream.append`, `jetstream.replay` | Append-log health, publish, and replay |
+
+Runtime contract diagnostics emit bounded events for deployment gates and
+alarms:
+
+| Event | Coverage |
+| --- | --- |
+| `source_runtime.contract_probe` | Contract-configured runtime probe status, with `contract_probe_status` in `success`, `failure`, `stale`, or `unknown` |
+| `source_runtime.validation` | Terminal source event validation rejects, with bounded `failure_category` and `missing_canonical_field_class` |
+| `runtime.evidence.link_status` | EvidenceCAS runtime evidence link rollup, with `link_status` in `linked`, `missing_resource`, `missing_case`, or `orphan` |
 
 Outbound HTTP uses W3C `traceparent`. The source transport and graph-agent HTTP doer inject child trace context, but they do not emit full URLs, query strings, request bodies, authorization headers, or API keys. Graph-agent LLM spans also do not emit prompt text, completion text, raw Cypher, raw tool arguments, rows, or headers.
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -3170,10 +3170,10 @@ func writeWorkflowReplayError(w http.ResponseWriter, err error) {
 }
 
 func timestampValue(value *timestamppb.Timestamp) time.Time {
-	if value == nil {
+	if value == nil || (value.GetSeconds() == 0 && value.GetNanos() == 0) {
 		return time.Time{}
 	}
-	return value.AsTime()
+	return value.AsTime().UTC()
 }
 func readProtoJSON(r *http.Request, message proto.Message) error {
 	if r.Body == nil {

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -16,6 +16,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecoverage"
+	"github.com/writer/cerebro/internal/sourcehealth"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -366,23 +367,7 @@ func (a *App) sourceCoverageRecords(runtimes []*cerebrov1.SourceRuntime, filter 
 }
 
 func runtimeFreshnessRecordFromHealth(record sourceRuntimeHealthRecord) runtimeFreshnessRecord {
-	lifecycleState := "active"
-	if strings.ToLower(strings.TrimSpace(record.EnabledState)) == "disabled" {
-		lifecycleState = "disabled"
-	}
-	sourceSyncState := runtimeFreshnessSourceSyncState(record)
-	graphIngestState := sourceRuntimeGraphState(record)
-	findingEvaluationState := runtimeFreshnessFindingEvaluationState(record)
-	scheduleState := "unknown"
-	if record.ScheduleContextConfigured {
-		scheduleState = "configured"
-	}
-	freshnessState, failureClass, failureReason, nextAction := runtimeFreshnessState(record, lifecycleState, sourceSyncState, graphIngestState)
-	backfillEligible, backfillReason := runtimeBackfillEligibility(lifecycleState, sourceSyncState, graphIngestState)
-	workflow := ""
-	if backfillEligible {
-		workflow = "source-runtime-backfill"
-	}
+	state := sourcehealth.Evaluate(sourceHealthRecord(record))
 	return runtimeFreshnessRecord{
 		runtimeFreshnessIdentity: runtimeFreshnessIdentity{
 			RuntimeID: record.RuntimeID,
@@ -391,16 +376,16 @@ func runtimeFreshnessRecordFromHealth(record sourceRuntimeHealthRecord) runtimeF
 			Family:    record.Family,
 		},
 		runtimeFreshnessStates: runtimeFreshnessStates{
-			LifecycleState:            lifecycleState,
-			ScheduleState:             scheduleState,
-			FreshnessState:            freshnessState,
-			SourceSyncState:           sourceSyncState,
-			GraphIngestState:          graphIngestState,
-			FindingEvaluationState:    findingEvaluationState,
-			FailureClass:              failureClass,
-			FailureReason:             failureReason,
-			BackfillEligible:          backfillEligible,
-			BackfillEligibilityReason: backfillReason,
+			LifecycleState:            state.LifecycleState,
+			ScheduleState:             state.ScheduleState,
+			FreshnessState:            state.FreshnessState,
+			SourceSyncState:           state.SourceSyncState,
+			GraphIngestState:          state.GraphIngestState,
+			FindingEvaluationState:    state.FindingEvaluationState,
+			FailureClass:              state.FailureClass,
+			FailureReason:             state.FailureReason,
+			BackfillEligible:          state.BackfillEligible,
+			BackfillEligibilityReason: state.BackfillEligibilityReason,
 		},
 		runtimeFreshnessObservations: runtimeFreshnessObservations{
 			LastSyncedAt:            record.LastSyncedAt,
@@ -415,8 +400,8 @@ func runtimeFreshnessRecordFromHealth(record sourceRuntimeHealthRecord) runtimeF
 			GeneratedAt:             record.GeneratedAt,
 		},
 		runtimeFreshnessActions: runtimeFreshnessActions{
-			NextAction:                nextAction,
-			RecommendedWorkflow:       workflow,
+			NextAction:                state.NextAction,
+			RecommendedWorkflow:       state.RecommendedWorkflow,
 			CursorPending:             record.CursorPending,
 			CheckpointCursorPresent:   record.CheckpointCursorPresent,
 			ScheduleContextConfigured: record.ScheduleContextConfigured,
@@ -424,76 +409,34 @@ func runtimeFreshnessRecordFromHealth(record sourceRuntimeHealthRecord) runtimeF
 	}
 }
 
-func runtimeFreshnessSourceSyncState(record sourceRuntimeHealthRecord) string {
-	if strings.TrimSpace(record.LastFailureCategory) != "" {
-		return "failed"
+func sourceHealthRecord(record sourceRuntimeHealthRecord) sourcehealth.Record {
+	var graphRun *sourcehealth.GraphRun
+	if record.LatestGraphRun != nil {
+		graphRun = &sourcehealth.GraphRun{Status: record.LatestGraphRun.Status}
 	}
-	switch strings.ToLower(strings.TrimSpace(record.Status)) {
-	case "failing":
-		return "failed"
-	case "stale":
-		return "stale"
-	case "healthy":
-		return "current"
-	default:
-		return "unknown"
+	var findingEvaluation *sourcehealth.FindingEvaluation
+	if record.LatestFindingEvaluation != nil {
+		findingEvaluation = &sourcehealth.FindingEvaluation{Status: record.LatestFindingEvaluation.Status}
 	}
-}
-
-func runtimeFreshnessFindingEvaluationState(record sourceRuntimeHealthRecord) string {
-	if record.LatestFindingEvaluation == nil {
-		return "not_observed"
-	}
-	status := strings.ToLower(strings.TrimSpace(record.LatestFindingEvaluation.Status))
-	if strings.Contains(status, "fail") || strings.Contains(status, "error") || strings.Contains(status, "cancel") {
-		return "failed"
-	}
-	if strings.Contains(status, "running") || strings.Contains(status, "pending") {
-		return "running"
-	}
-	return "current"
-}
-
-func runtimeFreshnessState(record sourceRuntimeHealthRecord, lifecycleState string, sourceSyncState string, graphIngestState string) (string, string, string, string) {
-	if lifecycleState != "active" {
-		return "disabled", "disabled", "runtime is disabled", "review_runtime_enablement"
-	}
-	if sourceSyncState == "failed" {
-		failureClass := strings.TrimSpace(record.LastFailureCategory)
-		if failureClass == "" {
-			failureClass = "source_sync_failed"
-		}
-		return "source_failed", failureClass, "source sync is failing", "fix_source_sync"
-	}
-	switch graphIngestState {
-	case "failed":
-		return "graph_failed", "graph_ingest_failed", "latest graph ingest failed", "inspect_graph_ingest"
-	case "not_observed":
-		return "graph_missing", "graph_ingest_missing", "no graph ingest run has been observed", "plan_backfill"
-	case "behind":
-		return "graph_behind", "graph_ingest_behind", "graph ingest is older than the configured freshness window", "plan_backfill"
-	}
-	if sourceSyncState == "stale" {
-		return "source_stale", "source_sync_stale", "source runtime is older than the configured freshness window", "run_source_sync"
-	}
-	if sourceSyncState == "current" && (graphIngestState == "current" || graphIngestState == "running") {
-		return "healthy", "", "", "monitor"
-	}
-	return "unknown", "insufficient_signal", "source or graph freshness signal is unavailable", "inspect_runtime"
-}
-
-func runtimeBackfillEligibility(lifecycleState string, sourceSyncState string, graphIngestState string) (bool, string) {
-	if lifecycleState != "active" {
-		return false, "runtime is disabled"
-	}
-	if sourceSyncState == "failed" {
-		return false, "source sync must succeed before graph backfill"
-	}
-	switch graphIngestState {
-	case "failed", "not_observed", "behind":
-		return true, "graph ingest is missing, failed, or behind"
-	default:
-		return false, "graph ingest backfill is not indicated"
+	return sourcehealth.Record{
+		RuntimeID:                 record.RuntimeID,
+		SourceID:                  record.SourceID,
+		TenantID:                  record.TenantID,
+		Family:                    record.Family,
+		EnabledState:              record.EnabledState,
+		Status:                    record.Status,
+		LastFailureCategory:       record.LastFailureCategory,
+		ContractProbeState:        record.ContractProbeState,
+		CursorPending:             record.CursorPending,
+		CheckpointCursorPresent:   record.CheckpointCursorPresent,
+		ScheduleContextConfigured: record.ScheduleContextConfigured,
+		SyncLagSeconds:            record.SyncLagSeconds,
+		WatermarkLagSeconds:       record.WatermarkLagSeconds,
+		GraphLagSeconds:           record.GraphLagSeconds,
+		ExpectedCadenceSeconds:    record.ExpectedCadenceSeconds,
+		StaleAfterSeconds:         record.StaleAfterSeconds,
+		LatestGraphRun:            graphRun,
+		LatestFindingEvaluation:   findingEvaluation,
 	}
 }
 
@@ -612,20 +555,7 @@ func sourceRuntimeHealthSummaries(records []sourceRuntimeHealthRecord) []sourceR
 }
 
 func sourceRuntimeGraphState(record sourceRuntimeHealthRecord) string {
-	if record.LatestGraphRun == nil {
-		return "not_observed"
-	}
-	status := strings.ToLower(strings.TrimSpace(record.LatestGraphRun.Status))
-	if strings.Contains(status, "fail") || strings.Contains(status, "error") || strings.Contains(status, "cancel") {
-		return "failed"
-	}
-	if strings.Contains(status, "running") || strings.Contains(status, "pending") {
-		return "running"
-	}
-	if record.GraphLagSeconds != nil && record.StaleAfterSeconds != nil && *record.GraphLagSeconds > *record.StaleAfterSeconds {
-		return "behind"
-	}
-	return "current"
+	return sourcehealth.GraphIngestState(sourceHealthRecord(record))
 }
 
 func (a *App) sourceRuntimeHealthRecord(ctx context.Context, runtime *cerebrov1.SourceRuntime, generatedAt time.Time) (sourceRuntimeHealthRecord, error) {

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -681,7 +681,7 @@ func runtimeContractProbeState(runtime *cerebrov1.SourceRuntime) string {
 	if strings.TrimSpace(runtime.GetSourceId()) != "evidence_cas" {
 		return "not_configured"
 	}
-	if runtime.GetLastSyncedAt() == nil {
+	if timestampValue(runtime.GetLastSyncedAt()).IsZero() {
 		return "unknown"
 	}
 	return "passing"

--- a/internal/sourcehealth/health.go
+++ b/internal/sourcehealth/health.go
@@ -1,0 +1,335 @@
+package sourcehealth
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	RuntimeLastFailureCategoryConfigKey = "__cerebro_runtime_last_failure_category"
+	RuntimeContractProbeStateConfigKey  = "__cerebro_runtime_contract_probe_state"
+	ExpectedCadenceSecondsConfigKey     = "expected_cadence_seconds"
+	StaleAfterSecondsConfigKey          = "stale_after_seconds"
+)
+
+type GraphRun struct {
+	Status string
+}
+
+type FindingEvaluation struct {
+	Status string
+}
+
+type Record struct {
+	RuntimeID                 string
+	SourceID                  string
+	TenantID                  string
+	Family                    string
+	EnabledState              string
+	Status                    string
+	LastFailureCategory       string
+	ContractProbeState        string
+	CursorPending             bool
+	CheckpointCursorPresent   bool
+	ScheduleContextConfigured bool
+	SyncLagSeconds            *int64
+	WatermarkLagSeconds       *int64
+	GraphLagSeconds           *int64
+	ExpectedCadenceSeconds    *int64
+	StaleAfterSeconds         *int64
+	LatestGraphRun            *GraphRun
+	LatestFindingEvaluation   *FindingEvaluation
+}
+
+type State struct {
+	LifecycleState            string
+	ScheduleState             string
+	FreshnessState            string
+	SourceSyncState           string
+	GraphIngestState          string
+	FindingEvaluationState    string
+	FailureClass              string
+	FailureReason             string
+	BackfillEligible          bool
+	BackfillEligibilityReason string
+	NextAction                string
+	RecommendedWorkflow       string
+}
+
+func RecordFromRuntime(runtime *cerebrov1.SourceRuntime, now time.Time) Record {
+	if runtime == nil {
+		return Record{EnabledState: "unknown", Status: "unknown", ContractProbeState: "unknown"}
+	}
+	record := Record{
+		RuntimeID:                 strings.TrimSpace(runtime.GetId()),
+		SourceID:                  strings.TrimSpace(runtime.GetSourceId()),
+		TenantID:                  strings.TrimSpace(runtime.GetTenantId()),
+		Family:                    strings.TrimSpace(runtime.GetConfig()["family"]),
+		EnabledState:              RuntimeEnabledState(runtime),
+		Status:                    RuntimeStatus(runtime, now),
+		LastFailureCategory:       strings.TrimSpace(runtime.GetConfig()[RuntimeLastFailureCategoryConfigKey]),
+		ContractProbeState:        RuntimeContractProbeState(runtime),
+		CursorPending:             strings.TrimSpace(runtime.GetNextCursor().GetOpaque()) != "",
+		CheckpointCursorPresent:   strings.TrimSpace(runtime.GetCheckpoint().GetCursorOpaque()) != "",
+		ScheduleContextConfigured: false,
+	}
+	if lastSynced := timestampValue(runtime.GetLastSyncedAt()); !lastSynced.IsZero() {
+		record.SyncLagSeconds = secondsSince(now, lastSynced.UTC())
+	}
+	if watermark := timestampValue(runtime.GetCheckpoint().GetWatermark()); !watermark.IsZero() {
+		record.WatermarkLagSeconds = secondsSince(now, watermark.UTC())
+	}
+	if expectedCadence := RuntimeConfigInt64(runtime, ExpectedCadenceSecondsConfigKey); expectedCadence > 0 {
+		record.ExpectedCadenceSeconds = &expectedCadence
+		record.ScheduleContextConfigured = true
+	}
+	if staleAfter := RuntimeConfigInt64(runtime, StaleAfterSecondsConfigKey); staleAfter > 0 {
+		record.StaleAfterSeconds = &staleAfter
+		record.ScheduleContextConfigured = true
+	}
+	return record
+}
+
+func RuntimeConfigInt64(runtime *cerebrov1.SourceRuntime, key string) int64 {
+	if runtime == nil {
+		return 0
+	}
+	value, err := strconv.ParseInt(strings.TrimSpace(runtime.GetConfig()[key]), 10, 64)
+	if err != nil || value <= 0 {
+		return 0
+	}
+	return value
+}
+
+func RuntimeEnabledState(runtime *cerebrov1.SourceRuntime) string {
+	if runtime == nil {
+		return "unknown"
+	}
+	switch strings.ToLower(strings.TrimSpace(runtime.GetConfig()["enabled"])) {
+	case "false", "0", "disabled":
+		return "disabled"
+	default:
+		return "enabled"
+	}
+}
+
+func RuntimeStatus(runtime *cerebrov1.SourceRuntime, now time.Time) string {
+	if runtime == nil {
+		return "unknown"
+	}
+	if strings.TrimSpace(runtime.GetConfig()[RuntimeLastFailureCategoryConfigKey]) != "" {
+		return "failing"
+	}
+	lastSynced := timestampValue(runtime.GetLastSyncedAt())
+	if lastSynced.IsZero() {
+		return "unknown"
+	}
+	if staleAfter := RuntimeConfigInt64(runtime, StaleAfterSecondsConfigKey); staleAfter > 0 && now.UTC().Sub(lastSynced.UTC()) > time.Duration(staleAfter)*time.Second {
+		return "stale"
+	}
+	return "healthy"
+}
+
+func RuntimeContractProbeState(runtime *cerebrov1.SourceRuntime) string {
+	if runtime == nil {
+		return "unknown"
+	}
+	if state := strings.TrimSpace(runtime.GetConfig()[RuntimeContractProbeStateConfigKey]); state != "" {
+		return state
+	}
+	if strings.TrimSpace(runtime.GetSourceId()) != "evidence_cas" {
+		return "not_configured"
+	}
+	if runtime.GetLastSyncedAt() == nil {
+		return "unknown"
+	}
+	return "passing"
+}
+
+func Evaluate(record Record) State {
+	lifecycleState := "active"
+	if strings.ToLower(strings.TrimSpace(record.EnabledState)) == "disabled" {
+		lifecycleState = "disabled"
+	}
+	scheduleState := "unknown"
+	if record.ScheduleContextConfigured {
+		scheduleState = "configured"
+	}
+	sourceSyncState := SourceSyncState(record)
+	graphIngestState := GraphIngestState(record)
+	findingEvaluationState := FindingEvaluationState(record)
+	freshnessState, failureClass, failureReason, nextAction := FreshnessState(record, lifecycleState, sourceSyncState, graphIngestState)
+	backfillEligible, backfillReason := BackfillEligibility(lifecycleState, sourceSyncState, graphIngestState)
+	workflow := ""
+	if backfillEligible {
+		workflow = "source-runtime-backfill"
+	}
+	return State{
+		LifecycleState:            lifecycleState,
+		ScheduleState:             scheduleState,
+		FreshnessState:            freshnessState,
+		SourceSyncState:           sourceSyncState,
+		GraphIngestState:          graphIngestState,
+		FindingEvaluationState:    findingEvaluationState,
+		FailureClass:              failureClass,
+		FailureReason:             failureReason,
+		BackfillEligible:          backfillEligible,
+		BackfillEligibilityReason: backfillReason,
+		NextAction:                nextAction,
+		RecommendedWorkflow:       workflow,
+	}
+}
+
+func timestampValue(value *timestamppb.Timestamp) time.Time {
+	if value == nil {
+		return time.Time{}
+	}
+	timestamp := value.AsTime()
+	if timestamp.IsZero() {
+		return time.Time{}
+	}
+	return timestamp.UTC()
+}
+
+func secondsSince(now time.Time, then time.Time) *int64 {
+	seconds := int64(now.UTC().Sub(then.UTC()).Seconds())
+	if seconds < 0 {
+		seconds = 0
+	}
+	return &seconds
+}
+
+func SourceSyncState(record Record) string {
+	if strings.TrimSpace(record.LastFailureCategory) != "" {
+		return "failed"
+	}
+	switch strings.ToLower(strings.TrimSpace(record.Status)) {
+	case "failing":
+		return "failed"
+	case "stale":
+		return "stale"
+	case "healthy":
+		return "current"
+	default:
+		return "unknown"
+	}
+}
+
+func FindingEvaluationState(record Record) string {
+	if record.LatestFindingEvaluation == nil {
+		return "not_observed"
+	}
+	status := strings.ToLower(strings.TrimSpace(record.LatestFindingEvaluation.Status))
+	if strings.Contains(status, "fail") || strings.Contains(status, "error") || strings.Contains(status, "cancel") {
+		return "failed"
+	}
+	if strings.Contains(status, "running") || strings.Contains(status, "pending") {
+		return "running"
+	}
+	return "current"
+}
+
+func FreshnessState(record Record, lifecycleState string, sourceSyncState string, graphIngestState string) (string, string, string, string) {
+	if lifecycleState != "active" {
+		return "disabled", "disabled", "runtime is disabled", "review_runtime_enablement"
+	}
+	if sourceSyncState == "failed" {
+		failureClass := strings.TrimSpace(record.LastFailureCategory)
+		if failureClass == "" {
+			failureClass = "source_sync_failed"
+		}
+		return "source_failed", failureClass, "source sync is failing", "fix_source_sync"
+	}
+	switch graphIngestState {
+	case "failed":
+		return "graph_failed", "graph_ingest_failed", "latest graph ingest failed", "inspect_graph_ingest"
+	case "not_observed":
+		return "graph_missing", "graph_ingest_missing", "no graph ingest run has been observed", "plan_backfill"
+	case "behind":
+		return "graph_behind", "graph_ingest_behind", "graph ingest is older than the configured freshness window", "plan_backfill"
+	}
+	if sourceSyncState == "stale" {
+		return "source_stale", "source_sync_stale", "source runtime is older than the configured freshness window", "run_source_sync"
+	}
+	if sourceSyncState == "current" && (graphIngestState == "current" || graphIngestState == "running") {
+		return "healthy", "", "", "monitor"
+	}
+	return "unknown", "insufficient_signal", "source or graph freshness signal is unavailable", "inspect_runtime"
+}
+
+func BackfillEligibility(lifecycleState string, sourceSyncState string, graphIngestState string) (bool, string) {
+	if lifecycleState != "active" {
+		return false, "runtime is disabled"
+	}
+	if sourceSyncState == "failed" {
+		return false, "source sync must succeed before graph backfill"
+	}
+	switch graphIngestState {
+	case "failed", "not_observed", "behind":
+		return true, "graph ingest is missing, failed, or behind"
+	default:
+		return false, "graph ingest backfill is not indicated"
+	}
+}
+
+func GraphIngestState(record Record) string {
+	if record.LatestGraphRun == nil {
+		return "not_observed"
+	}
+	status := strings.ToLower(strings.TrimSpace(record.LatestGraphRun.Status))
+	if strings.Contains(status, "fail") || strings.Contains(status, "error") || strings.Contains(status, "cancel") {
+		return "failed"
+	}
+	if strings.Contains(status, "running") || strings.Contains(status, "pending") {
+		return "running"
+	}
+	if record.GraphLagSeconds != nil && record.StaleAfterSeconds != nil && *record.GraphLagSeconds > *record.StaleAfterSeconds {
+		return "behind"
+	}
+	return "current"
+}
+
+func ContractProbeStatus(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "passing", "success":
+		return "success"
+	case "failure", "failed", "failing":
+		return "failure"
+	case "stale":
+		return "stale"
+	default:
+		return "unknown"
+	}
+}
+
+func LinkStatusRollup(resourceLinkStatus string, caseLinkStatus string) string {
+	resourceMissing := strings.EqualFold(strings.TrimSpace(resourceLinkStatus), "missing")
+	caseMissing := strings.EqualFold(strings.TrimSpace(caseLinkStatus), "missing")
+	switch {
+	case resourceMissing && caseMissing:
+		return "orphan"
+	case resourceMissing:
+		return "missing_resource"
+	case caseMissing:
+		return "missing_case"
+	default:
+		return "linked"
+	}
+}
+
+func ValidationFieldClass(category string) string {
+	switch strings.ToLower(strings.TrimSpace(category)) {
+	case "missing_required_attribute":
+		return "attribute"
+	case "missing_required_payload_field":
+		return "payload_field"
+	case "missing_canonical_field":
+		return "canonical_field"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/sourcehealth/health.go
+++ b/internal/sourcehealth/health.go
@@ -144,7 +144,7 @@ func RuntimeContractProbeState(runtime *cerebrov1.SourceRuntime) string {
 	if strings.TrimSpace(runtime.GetSourceId()) != "evidence_cas" {
 		return "not_configured"
 	}
-	if runtime.GetLastSyncedAt() == nil {
+	if timestampValue(runtime.GetLastSyncedAt()).IsZero() {
 		return "unknown"
 	}
 	return "passing"
@@ -186,6 +186,12 @@ func Evaluate(record Record) State {
 
 func timestampValue(value *timestamppb.Timestamp) time.Time {
 	if value == nil {
+		return time.Time{}
+	}
+	if value.GetSeconds() == 0 && value.GetNanos() == 0 {
+		return time.Time{}
+	}
+	if err := value.CheckValid(); err != nil {
 		return time.Time{}
 	}
 	timestamp := value.AsTime()

--- a/internal/sourcehealth/health_test.go
+++ b/internal/sourcehealth/health_test.go
@@ -1,0 +1,170 @@
+package sourcehealth
+
+import "testing"
+
+func TestEvaluateClassifiesRuntimeFreshness(t *testing.T) {
+	staleAfter := int64(3600)
+	graphLag := int64(7200)
+	tests := []struct {
+		name             string
+		record           Record
+		wantFreshness    string
+		wantFailureClass string
+		wantGraphState   string
+		wantSourceState  string
+		wantBackfill     bool
+		wantNextAction   string
+		wantRecommended  string
+	}{
+		{
+			name: "healthy",
+			record: Record{
+				EnabledState:      "enabled",
+				Status:            "healthy",
+				LatestGraphRun:    &GraphRun{Status: "completed"},
+				GraphLagSeconds:   int64Ptr(60),
+				StaleAfterSeconds: &staleAfter,
+			},
+			wantFreshness:   "healthy",
+			wantGraphState:  "current",
+			wantSourceState: "current",
+			wantNextAction:  "monitor",
+		},
+		{
+			name: "missing graph",
+			record: Record{
+				EnabledState:      "enabled",
+				Status:            "healthy",
+				GraphLagSeconds:   &graphLag,
+				StaleAfterSeconds: &staleAfter,
+			},
+			wantFreshness:    "graph_missing",
+			wantFailureClass: "graph_ingest_missing",
+			wantGraphState:   "not_observed",
+			wantSourceState:  "current",
+			wantBackfill:     true,
+			wantNextAction:   "plan_backfill",
+			wantRecommended:  "source-runtime-backfill",
+		},
+		{
+			name: "source failed",
+			record: Record{
+				EnabledState:        "enabled",
+				Status:              "failing",
+				LastFailureCategory: "auth_error",
+				LatestGraphRun:      &GraphRun{Status: "completed"},
+				StaleAfterSeconds:   &staleAfter,
+			},
+			wantFreshness:    "source_failed",
+			wantFailureClass: "auth_error",
+			wantGraphState:   "current",
+			wantSourceState:  "failed",
+			wantNextAction:   "fix_source_sync",
+		},
+		{
+			name: "disabled",
+			record: Record{
+				EnabledState: "disabled",
+				Status:       "unknown",
+			},
+			wantFreshness:    "disabled",
+			wantFailureClass: "disabled",
+			wantGraphState:   "not_observed",
+			wantSourceState:  "unknown",
+			wantNextAction:   "review_runtime_enablement",
+		},
+		{
+			name: "running graph remains healthy",
+			record: Record{
+				EnabledState:   "enabled",
+				Status:         "healthy",
+				LatestGraphRun: &GraphRun{Status: "running"},
+			},
+			wantFreshness:   "healthy",
+			wantGraphState:  "running",
+			wantSourceState: "current",
+			wantNextAction:  "monitor",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := Evaluate(test.record)
+			if got.FreshnessState != test.wantFreshness {
+				t.Fatalf("FreshnessState = %q, want %q; state=%+v", got.FreshnessState, test.wantFreshness, got)
+			}
+			if got.FailureClass != test.wantFailureClass {
+				t.Fatalf("FailureClass = %q, want %q; state=%+v", got.FailureClass, test.wantFailureClass, got)
+			}
+			if got.GraphIngestState != test.wantGraphState {
+				t.Fatalf("GraphIngestState = %q, want %q; state=%+v", got.GraphIngestState, test.wantGraphState, got)
+			}
+			if got.SourceSyncState != test.wantSourceState {
+				t.Fatalf("SourceSyncState = %q, want %q; state=%+v", got.SourceSyncState, test.wantSourceState, got)
+			}
+			if got.BackfillEligible != test.wantBackfill {
+				t.Fatalf("BackfillEligible = %v, want %v; state=%+v", got.BackfillEligible, test.wantBackfill, got)
+			}
+			if got.NextAction != test.wantNextAction {
+				t.Fatalf("NextAction = %q, want %q; state=%+v", got.NextAction, test.wantNextAction, got)
+			}
+			if got.RecommendedWorkflow != test.wantRecommended {
+				t.Fatalf("RecommendedWorkflow = %q, want %q; state=%+v", got.RecommendedWorkflow, test.wantRecommended, got)
+			}
+		})
+	}
+}
+
+func TestContractProbeStatus(t *testing.T) {
+	tests := map[string]string{
+		"passing":        "success",
+		" success ":      "success",
+		"failure":        "failure",
+		"failed":         "failure",
+		"stale":          "stale",
+		"not_configured": "unknown",
+		"":               "unknown",
+	}
+	for input, want := range tests {
+		if got := ContractProbeStatus(input); got != want {
+			t.Fatalf("ContractProbeStatus(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestLinkStatusRollup(t *testing.T) {
+	tests := []struct {
+		resource string
+		caseLink string
+		want     string
+	}{
+		{resource: "linked", caseLink: "linked", want: "linked"},
+		{resource: "missing", caseLink: "linked", want: "missing_resource"},
+		{resource: "linked", caseLink: "missing", want: "missing_case"},
+		{resource: "missing", caseLink: "missing", want: "orphan"},
+		{resource: "not_applicable", caseLink: "not_supplied", want: "linked"},
+	}
+	for _, test := range tests {
+		if got := LinkStatusRollup(test.resource, test.caseLink); got != test.want {
+			t.Fatalf("LinkStatusRollup(%q, %q) = %q, want %q", test.resource, test.caseLink, got, test.want)
+		}
+	}
+}
+
+func TestValidationFieldClass(t *testing.T) {
+	tests := map[string]string{
+		"missing_required_attribute":     "attribute",
+		"missing_required_payload_field": "payload_field",
+		"missing_canonical_field":        "canonical_field",
+		"invalid_event":                  "unknown",
+	}
+	for input, want := range tests {
+		if got := ValidationFieldClass(input); got != want {
+			t.Fatalf("ValidationFieldClass(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
+}

--- a/internal/sourcehealth/health_test.go
+++ b/internal/sourcehealth/health_test.go
@@ -1,6 +1,12 @@
 package sourcehealth
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
 
 func TestEvaluateClassifiesRuntimeFreshness(t *testing.T) {
 	staleAfter := int64(3600)
@@ -129,6 +135,29 @@ func TestContractProbeStatus(t *testing.T) {
 		if got := ContractProbeStatus(input); got != want {
 			t.Fatalf("ContractProbeStatus(%q) = %q, want %q", input, got, want)
 		}
+	}
+}
+
+func TestRecordFromRuntimeTreatsZeroProtoTimestampAsUnset(t *testing.T) {
+	now := time.Date(2026, 6, 18, 20, 0, 0, 0, time.UTC)
+	runtime := &cerebrov1.SourceRuntime{
+		Id:           "writer-evidence-cas",
+		SourceId:     "evidence_cas",
+		TenantId:     "writer",
+		LastSyncedAt: &timestamppb.Timestamp{},
+		Config:       map[string]string{StaleAfterSecondsConfigKey: "3600"},
+	}
+
+	record := RecordFromRuntime(runtime, now)
+
+	if record.Status != "unknown" {
+		t.Fatalf("Status = %q, want unknown for zero proto timestamp", record.Status)
+	}
+	if record.SyncLagSeconds != nil {
+		t.Fatalf("SyncLagSeconds = %v, want nil for zero proto timestamp", *record.SyncLagSeconds)
+	}
+	if got := RuntimeContractProbeState(runtime); got != "unknown" {
+		t.Fatalf("RuntimeContractProbeState = %q, want unknown for zero proto timestamp", got)
 	}
 }
 

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -15,6 +15,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcehealth"
 	"github.com/writer/cerebro/internal/telemetry"
 )
 
@@ -393,8 +394,11 @@ func emitRuntimeEvidenceTelemetry(ctx context.Context, event *cerebrov1.EventEnv
 	if evidenceCount == 0 && outcome != "conflict" {
 		return
 	}
+	runtimeID := strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID])
 	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "tenant_id", Value: event.GetTenantId()},
 		telemetry.Field{Key: "source_id", Value: boundedEvidenceSourceID(event.GetSourceId())},
+		telemetry.Field{Key: "runtime_id", Value: runtimeID},
 		telemetry.Field{Key: "event_kind", Value: boundedEvidenceEventKind(event.GetKind())},
 		telemetry.Field{Key: "outcome", Value: boundedEvidenceOutcome(outcome)},
 		telemetry.Field{Key: "conflict_category", Value: boundedConflictCategory(conflictCategory)},
@@ -412,6 +416,26 @@ func emitRuntimeEvidenceTelemetry(ctx context.Context, event *cerebrov1.EventEnv
 	}
 	telemetry.AnnotateMain(ctx, attrs.With(telemetry.Attrs(
 		telemetry.Field{Key: "source_projection.runtime_evidence.present", Value: true},
+	)))
+	linkStatus := sourcehealth.LinkStatusRollup(resourceLinkStatus, caseLinkStatus)
+	linkAttrs := telemetry.Attrs(
+		telemetry.Field{Key: "tenant_id", Value: event.GetTenantId()},
+		telemetry.Field{Key: "source_id", Value: boundedEvidenceSourceID(event.GetSourceId())},
+		telemetry.Field{Key: "runtime_id", Value: runtimeID},
+		telemetry.Field{Key: "event_kind", Value: boundedEvidenceEventKind(event.GetKind())},
+		telemetry.Field{Key: "link_status", Value: linkStatus},
+		telemetry.Field{Key: "resource_link_status", Value: resourceLinkStatus},
+		telemetry.Field{Key: "case_link_status", Value: caseLinkStatus},
+		telemetry.Field{Key: "orphan_count", Value: orphanCount},
+		telemetry.Field{Key: "missing_case_count", Value: missingCaseCount},
+	)
+	telemetry.Event(ctx, "runtime.evidence.link_status", linkAttrs)
+	telemetry.IncrementMain(ctx, "runtime.evidence.link_status.count", 1)
+	if linkStatus != "linked" {
+		telemetry.IncrementMain(ctx, "runtime.evidence.link_status.failure.count", 1)
+	}
+	telemetry.AnnotateMain(ctx, linkAttrs.With(telemetry.Attrs(
+		telemetry.Field{Key: "runtime.evidence.link_status.present", Value: true},
 	)))
 }
 

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -5108,6 +5108,20 @@ func TestProjectEvidenceCASMissingLinksAreObservableAndBounded(t *testing.T) {
 			t.Fatalf("telemetry %s = %#v, want %#v (payload %#v)", key, got, want, payload)
 		}
 	}
+	linkPayload := sourceProjectionTelemetryEventPayload(t, stderr, "runtime.evidence.link_status")
+	for key, want := range map[string]any{
+		"source_id":            "evidence_cas",
+		"runtime_id":           "iris-runtime",
+		"link_status":          "orphan",
+		"resource_link_status": "missing",
+		"case_link_status":     "missing",
+		"orphan_count":         float64(1),
+		"missing_case_count":   float64(1),
+	} {
+		if got := linkPayload[key]; got != want {
+			t.Fatalf("link telemetry %s = %#v, want %#v (payload %#v)", key, got, want, linkPayload)
+		}
+	}
 	for _, prohibited := range []string{"evidence-orphan", "iris-event-orphan", "sha256orphan", "evidencecas://", "case-missing"} {
 		if strings.Contains(stderr, prohibited) {
 			t.Fatalf("telemetry leaked high-cardinality value %q: %s", prohibited, stderr)

--- a/internal/sourceruntime/lease_test.go
+++ b/internal/sourceruntime/lease_test.go
@@ -375,3 +375,22 @@ func sourceRuntimeTelemetryPayload(t *testing.T, stderr string, name string) map
 	t.Fatalf("telemetry span_end %q not found in stderr: %s", name, stderr)
 	return nil
 }
+
+func sourceRuntimeTelemetryEventPayload(t *testing.T, stderr string, name string) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(stderr), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		payload := map[string]any{}
+		if err := json.Unmarshal([]byte(lines[i]), &payload); err != nil {
+			t.Fatalf("unmarshal telemetry payload %q: %v", lines[i], err)
+		}
+		if payload["kind"] == "event" && payload["name"] == name {
+			return payload
+		}
+	}
+	t.Fatalf("telemetry event %q not found in stderr: %s", name, stderr)
+	return nil
+}

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/sourcehealth"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/telemetry"
 )
@@ -409,6 +410,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 						telemetry.Field{Key: "source_runtime.invalid_event.last_failure_category", Value: category},
 						telemetry.Field{Key: "source_runtime.invalid_event.last_retryable", Value: false},
 					))
+					emitSourceRuntimeValidation(ctx, runtime, category)
 					continue
 				}
 				return nil, fmt.Errorf("validate source event %q: %w", syncedEvent.GetId(), err)
@@ -486,6 +488,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "checkpoint_watermark", Value: watermark.Format(time.RFC3339Nano)})
 		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "source_runtime_watermark_lag_seconds", Value: lagSeconds})
 	}
+	emitSourceRuntimeContractProbe(ctx, runtime)
 	return &cerebrov1.SyncSourceRuntimeResponse{
 		Runtime:           redactRuntime(runtime),
 		Source:            source.Spec(),
@@ -649,6 +652,55 @@ func invalidEventFailureCategory(err error) string {
 	default:
 		return "invalid_event"
 	}
+}
+
+func emitSourceRuntimeValidation(ctx context.Context, runtime *cerebrov1.SourceRuntime, category string) {
+	if runtime == nil {
+		return
+	}
+	missingClass := sourcehealth.ValidationFieldClass(category)
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
+		telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()},
+		telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()},
+		telemetry.Field{Key: "failure_category", Value: category},
+		telemetry.Field{Key: "missing_canonical_field_class", Value: missingClass},
+	)
+	telemetry.Event(ctx, "source_runtime.validation", attrs)
+	telemetry.IncrementMain(ctx, "source_runtime.validation.count", 1)
+	telemetry.AnnotateMain(ctx, attrs.With(telemetry.Attrs(
+		telemetry.Field{Key: "source_runtime.validation.last_missing_canonical_field_class", Value: missingClass},
+	)))
+}
+
+func emitSourceRuntimeContractProbe(ctx context.Context, runtime *cerebrov1.SourceRuntime) {
+	if runtime == nil {
+		return
+	}
+	state := strings.TrimSpace(runtime.GetConfig()[runtimeContractProbeStateConfigKey])
+	if state == "" {
+		state = sourcehealth.RuntimeContractProbeState(runtime)
+	}
+	if strings.EqualFold(state, "not_configured") {
+		return
+	}
+	status := sourcehealth.ContractProbeStatus(state)
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
+		telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()},
+		telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()},
+		telemetry.Field{Key: "contract_probe_state", Value: state},
+		telemetry.Field{Key: "contract_probe_status", Value: status},
+	)
+	telemetry.Event(ctx, "source_runtime.contract_probe", attrs)
+	telemetry.IncrementMain(ctx, "source_runtime.contract_probe.count", 1)
+	if status != "success" {
+		telemetry.IncrementMain(ctx, "source_runtime.contract_probe.failure.count", 1)
+	}
+	telemetry.AnnotateMain(ctx, attrs.With(telemetry.Attrs(
+		telemetry.Field{Key: "source_runtime.contract_probe.last_status", Value: status},
+		telemetry.Field{Key: "source_runtime.contract_probe.last_state", Value: state},
+	)))
 }
 
 func recordRuntimeInvalidEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope, category string, cause error, observedAt time.Time, contractConfigured bool) {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1853,10 +1853,14 @@ func TestSyncRuntimeRejectsEventsMissingCatalogContractFields(t *testing.T) {
 	log := &appendLog{}
 	service := New(registry, store, log, nil)
 
-	resp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "example-contract-event"})
-	if err != nil {
-		t.Fatalf("Sync() error = %v", err)
-	}
+	var resp *cerebrov1.SyncSourceRuntimeResponse
+	stderr := captureSourceRuntimeStderr(t, func() {
+		var syncErr error
+		resp, syncErr = service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "example-contract-event"})
+		if syncErr != nil {
+			t.Fatalf("Sync() error = %v", syncErr)
+		}
+	})
 	if len(log.events) != 0 {
 		t.Fatalf("len(appendLog.events) = %d, want 0", len(log.events))
 	}
@@ -1880,6 +1884,52 @@ func TestSyncRuntimeRejectsEventsMissingCatalogContractFields(t *testing.T) {
 	}
 	if stored.GetLastSyncedAt() == nil {
 		t.Fatal("LastSyncedAt is nil, want terminal rejection to commit sync status")
+	}
+	validationPayload := sourceRuntimeTelemetryEventPayload(t, stderr, "source_runtime.validation")
+	for key, want := range map[string]any{
+		"runtime_id":                    "example-contract-event",
+		"source_id":                     "contract_event",
+		"tenant_id":                     "example",
+		"failure_category":              "missing_required_attribute",
+		"missing_canonical_field_class": "attribute",
+	} {
+		if got := validationPayload[key]; got != want {
+			t.Fatalf("validation telemetry %s = %#v, want %#v; payload=%#v", key, got, want, validationPayload)
+		}
+	}
+	probePayload := sourceRuntimeTelemetryEventPayload(t, stderr, "source_runtime.contract_probe")
+	for key, want := range map[string]any{
+		"runtime_id":            "example-contract-event",
+		"source_id":             "contract_event",
+		"tenant_id":             "example",
+		"contract_probe_state":  "failure",
+		"contract_probe_status": "failure",
+	} {
+		if got := probePayload[key]; got != want {
+			t.Fatalf("contract probe telemetry %s = %#v, want %#v; payload=%#v", key, got, want, probePayload)
+		}
+	}
+}
+
+func TestEmitSourceRuntimeContractProbeMapsPassingState(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "example-contract-event",
+		SourceId: "contract_event",
+		TenantId: "example",
+		Config: map[string]string{
+			runtimeContractProbeStateConfigKey: "passing",
+		},
+	}
+	stderr := captureSourceRuntimeStderr(t, func() {
+		emitSourceRuntimeContractProbe(context.Background(), runtime)
+	})
+
+	payload := sourceRuntimeTelemetryEventPayload(t, stderr, "source_runtime.contract_probe")
+	if got := payload["contract_probe_status"]; got != "success" {
+		t.Fatalf("contract_probe_status = %#v, want success; payload=%#v", got, payload)
+	}
+	if got := payload["contract_probe_state"]; got != "passing" {
+		t.Fatalf("contract_probe_state = %#v, want passing; payload=%#v", got, payload)
 	}
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -70,7 +70,7 @@ type RuntimeMetadata struct {
 }
 
 const maxAttributeStringLength = 1024
-const wideEventSchemaVersion = "2026-06-18"
+const wideEventSchemaVersion = "2026-06-18.1"
 
 var (
 	runtimeMetadataMu sync.RWMutex
@@ -427,6 +427,17 @@ func IncrementMain(ctx context.Context, key string, delta int64) {
 	span.increment(key, delta)
 }
 
+func MaxMain(ctx context.Context, key string, value int64) {
+	if strings.TrimSpace(key) == "" {
+		return
+	}
+	span, ok := ctx.Value(mainSpanContextKey{}).(*Span)
+	if !ok || span == nil {
+		return
+	}
+	span.max(key, value)
+}
+
 func AnnotateMainDependency(ctx context.Context, system string, component string, operation string, status string, attributes Attributes) {
 	system = boundedKeyPart(system)
 	if system == "" {
@@ -605,19 +616,8 @@ func (s *Span) increment(key string, delta int64) {
 		s.annotations = map[string]any{}
 	}
 	current := int64(0)
-	switch value := s.annotations[key].(type) {
-	case int:
-		current = int64(value)
-	case int64:
+	if value, ok := numericInt64(s.annotations[key]); ok {
 		current = value
-	case uint32:
-		current = int64(value)
-	case uint64:
-		if value <= uint64(^uint(0)>>1) {
-			current = int64(value)
-		}
-	case float64:
-		current = int64(value)
 	}
 	next := current + delta
 	s.annotations[key] = next
@@ -625,6 +625,44 @@ func (s *Span) increment(key string, delta int64) {
 	if s.otelSpan != nil && s.otelSpan.SpanContext().IsValid() {
 		s.otelSpan.SetAttributes(attribute.Int64(key, next))
 	}
+}
+
+func (s *Span) max(key string, value int64) {
+	if s == nil {
+		return
+	}
+	updated := false
+	s.mu.Lock()
+	if s.annotations == nil {
+		s.annotations = map[string]any{}
+	}
+	current, ok := numericInt64(s.annotations[key])
+	if !ok || value > current {
+		s.annotations[key] = value
+		updated = true
+	}
+	s.mu.Unlock()
+	if updated && s.otelSpan != nil && s.otelSpan.SpanContext().IsValid() {
+		s.otelSpan.SetAttributes(attribute.Int64(key, value))
+	}
+}
+
+func numericInt64(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), true
+	case int64:
+		return v, true
+	case uint32:
+		return int64(v), true
+	case uint64:
+		if v <= uint64(^uint(0)>>1) {
+			return int64(v), true
+		}
+	case float64:
+		return int64(v), true
+	}
+	return 0, false
 }
 
 func (s *Span) snapshotAnnotations() map[string]any {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -220,6 +220,8 @@ func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
 		AnnotateMain(ctx, Attrs(Field{Key: "cache.redis.last_status", Value: "hit"}))
 		IncrementMain(ctx, "cache.redis.hit.count", 1)
 		IncrementMain(ctx, "cache.redis.hit.count", 2)
+		MaxMain(ctx, "cache.redis.max_latency_ms", 5)
+		MaxMain(ctx, "cache.redis.max_latency_ms", 3)
 		End(span, "completed", Attrs(Field{Key: "explicit_end_attr", Value: "kept"}))
 	})
 	payload := telemetrySpanEndPayloadByName(t, stderr, "test.main")
@@ -240,6 +242,9 @@ func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
 	}
 	if got := payload["cache.redis.hit.count"]; got != float64(3) {
 		t.Fatalf("incremented count = %#v, want 3; payload=%#v", got, payload)
+	}
+	if got := payload["cache.redis.max_latency_ms"]; got != float64(5) {
+		t.Fatalf("max value = %#v, want 5; payload=%#v", got, payload)
 	}
 	if got := payload["explicit_end_attr"]; got != "kept" {
 		t.Fatalf("explicit end attr missing: %#v", payload)


### PR DESCRIPTION
## Summary
- add shared source runtime health derivation for REST and wide-event telemetry
- annotate orchestrator wide events with bounded runtime health, lag, contract, schedule, and phase-duration fields
- emit contract probe, validation, and runtime evidence link-status events for operational gates

## Validation
- make check