### PR TITLE
Add platform job wide event telemetry

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -45,6 +45,17 @@ Main spans include two generic rollup families:
 - `dependency.*`: counts and last-seen status for Postgres, Neo4j, Redis, JetStream, outbound HTTP, and graph-agent LLM calls. Use this when you do not yet know which dependency is guilty.
 - `phase.*`: counts and last-seen status for orchestration phases, source sync, graph ingest, GRC dashboard subtasks, and source operations. Use this when one logical job has several internal steps.
 
+Platform jobs created through `/platform/jobs` emit a `platform.job.run` main
+wide event. Treat it as the canonical envelope for async API-triggered work:
+source sync, source orchestration, graph ingest, finding evaluation, reports,
+and future durable job kinds. It carries the job id/kind/status, tenant,
+subject, runtime/report pivots when present, queue latency, run duration,
+cancel state, payload/result/ref key counts, sorted payload/result/ref key names,
+bounded error kind/fingerprint, and lifecycle events such as
+`platform.job.created`, `platform.job.started`, `platform.job.completed`,
+`platform.job.failed`, and `platform.job.cancel_requested`. It intentionally
+does not emit raw payload, result, idempotency key, or error strings.
+
 Orchestrator wide events also carry interpreted source runtime health fields so
 a single `orchestrator.run` span can explain whether work is blocked by source
 sync, graph ingest, finding evaluation, or a backfill need:
@@ -86,6 +97,7 @@ Core runtime operations emit structured spans and diagnostic events:
 | --- | --- |
 | `source.http.request` | Hardened source HTTP transport, DNS safety checks, host pinning, retries, upstream status |
 | `source.check`, `source.discover`, `source.read` | Source CDK operations |
+| `platform.job.run` | Durable `/platform/jobs` execution envelope and lifecycle |
 | `source_runtime.sync`, `source_runtime.sync_with_lease` | Runtime sync and lease lifecycle |
 | `source_projection.project` | Per-event projection attempt, status, projected/deleted counts, and tenant/source/runtime drill-down fields |
 | `graph.ingest_runtime` | Graph ingestion runs |

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -428,7 +428,11 @@ func jobTelemetryAttrs(job *ports.Job) telemetry.Attributes {
 		attrs = attrs.WithField(telemetry.Field{Key: "runtime_id", Value: runtimeID})
 		attrs = attrs.WithField(telemetry.Field{Key: "source_runtime_id", Value: runtimeID})
 	}
-	if reportID := firstStringPayload(job.Payload, "report_id", job.SubjectID); reportID != "" && (job.Kind == KindReportRun || job.SubjectType == "report") {
+	reportID := firstStringPayload(job.Payload, "report_id")
+	if reportID == "" {
+		reportID = strings.TrimSpace(job.SubjectID)
+	}
+	if reportID != "" && (job.Kind == KindReportRun || job.SubjectType == "report") {
 		attrs = attrs.WithField(telemetry.Field{Key: "report_id", Value: reportID})
 	}
 	if !job.CreatedAt.IsZero() && !job.StartedAt.IsZero() {

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -128,7 +128,7 @@ func (s *Service) StartAsync(ctx context.Context, job *ports.Job) { //nolint:con
 			s.mu.Unlock()
 			s.wg.Done()
 		}()
-		telemetry.Event(runCtx, "platform.job.async_started", jobTelemetryAttrs(job).WithField(telemetry.Field{Key: "job.async_id", Value: int64(asyncID)}))
+		telemetry.Event(runCtx, "platform.job.async_started", jobTelemetryAttrs(job).WithField(telemetry.Field{Key: "job.async_id", Value: asyncID}))
 		_ = s.Run(runCtx, job.ID)
 	}()
 }

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -3,14 +3,17 @@ package jobs
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 var (
@@ -84,6 +87,15 @@ func (s *Service) Create(ctx context.Context, request ports.CreateJobRequest) (*
 	if created {
 		_, _ = s.store.AppendJobEvent(ctx, ports.JobEvent{JobID: job.ID, Type: "created", Status: job.Status, Message: "job created"})
 	}
+	eventName := "platform.job.reused"
+	if created {
+		eventName = "platform.job.created"
+	}
+	telemetry.Event(ctx, eventName, jobTelemetryAttrs(job).With(telemetry.Attrs(
+		telemetry.Field{Key: "job.created", Value: created},
+		telemetry.Field{Key: "job.idempotency_key.present", Value: request.IdempotencyKey != ""},
+		telemetry.Field{Key: "job.idempotency_key.hash", Value: hashText(request.IdempotencyKey)},
+	)))
 	return job, created, nil
 }
 
@@ -116,6 +128,7 @@ func (s *Service) StartAsync(ctx context.Context, job *ports.Job) { //nolint:con
 			s.mu.Unlock()
 			s.wg.Done()
 		}()
+		telemetry.Event(runCtx, "platform.job.async_started", jobTelemetryAttrs(job).WithField(telemetry.Field{Key: "job.async_id", Value: int64(asyncID)}))
 		_ = s.Run(runCtx, job.ID)
 	}()
 }
@@ -154,57 +167,143 @@ func (s *Service) Run(ctx context.Context, jobID string) (err error) {
 	if s == nil || s.store == nil {
 		return ErrRuntimeUnavailable
 	}
+	var (
+		job       *ports.Job
+		span      *telemetry.Span
+		status    = "failed"
+		spanAttrs = telemetry.Attrs()
+		startedAt time.Time
+	)
 	defer func() {
 		recovered := recover()
-		if recovered == nil {
-			return
+		if recovered != nil {
+			status = ports.JobStatusFailed
+			panicErr := fmt.Errorf("%w: %v", ErrJobPanic, recovered)
+			spanAttrs = spanAttrs.With(telemetry.Attrs(
+				telemetry.Field{Key: "job.panic", Value: true},
+				telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(panicErr)},
+				telemetry.Field{Key: "error_fingerprint", Value: telemetry.ErrorFingerprint("platform.job.run", panicErr, jobTelemetryAttrs(job))},
+			))
+			err = s.failPanickedJob(context.WithoutCancel(ctx), jobID, recovered)
 		}
-		err = s.failPanickedJob(context.WithoutCancel(ctx), jobID, recovered)
+		if span != nil {
+			if job != nil {
+				spanAttrs = spanAttrs.With(jobTelemetryAttrs(job))
+			}
+			if !startedAt.IsZero() {
+				spanAttrs = spanAttrs.WithField(telemetry.Field{Key: "job.run_duration_ms", Value: s.now().Sub(startedAt).Milliseconds()})
+			}
+			telemetry.End(span, status, spanAttrs.WithField(telemetry.Field{Key: "job.status.final", Value: status}))
+		}
 	}()
-	job, err := s.store.GetJob(ctx, jobID)
+	job, err = s.store.GetJob(ctx, jobID)
 	if err != nil {
 		return err
 	}
+	ctx, span = telemetry.StartMain(ctx, "platform.job.run", jobTelemetryAttrs(job).With(telemetry.Attrs(
+		telemetry.Field{Key: "operation.type", Value: "platform_job"},
+		telemetry.Field{Key: "workload.kind", Value: "platform_job"},
+		telemetry.Field{Key: "job.name", Value: job.Kind},
+		telemetry.Field{Key: "job.status.initial", Value: job.Status},
+	)))
 	if job.Status != ports.JobStatusQueued {
+		status = "skipped"
+		spanAttrs = spanAttrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "job.run.skipped", Value: true},
+			telemetry.Field{Key: "job.run.skipped_reason", Value: "not_queued"},
+			telemetry.Field{Key: "job.status.current", Value: job.Status},
+		))
+		skippedAttrs := jobTelemetryAttrs(job).WithField(telemetry.Field{Key: "job.run.skipped_reason", Value: "not_queued"})
+		telemetry.Event(ctx, "platform.job.run_skipped", skippedAttrs)
 		return nil
 	}
 	runner := s.runners[job.Kind]
 	if runner == nil {
 		finished := s.now()
-		if _, err := s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusFailed, Message: "job runner unavailable", Error: "job runner unavailable", FinishedAt: &finished, AllowedStatuses: []string{ports.JobStatusQueued}}); err == nil {
+		if updated, err := s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusFailed, Message: "job runner unavailable", Error: "job runner unavailable", FinishedAt: &finished, AllowedStatuses: []string{ports.JobStatusQueued}}); err == nil {
+			job = updated
 			_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "failed", Status: ports.JobStatusFailed, Message: "job runner unavailable"})
 		}
+		status = ports.JobStatusFailed
+		runErr := fmt.Errorf("%w: runner missing for %s", ErrRuntimeUnavailable, job.Kind)
+		spanAttrs = spanAttrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "job.runner.available", Value: false},
+			telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(runErr)},
+			telemetry.Field{Key: "error_fingerprint", Value: telemetry.ErrorFingerprint("platform.job.run", runErr, jobTelemetryAttrs(job))},
+		))
+		telemetry.CaptureError(ctx, "platform.job.runner_unavailable", runErr, jobTelemetryAttrs(job))
 		return nil
 	}
 	now := s.now()
+	startedAt = now
 	job, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusRunning, Message: "job running", StartedAt: &now, AllowedStatuses: []string{ports.JobStatusQueued}})
 	if err != nil {
 		if errors.Is(err, ports.ErrJobUpdateConflict) {
+			status = "skipped"
+			spanAttrs = spanAttrs.With(telemetry.Attrs(
+				telemetry.Field{Key: "job.run.skipped", Value: true},
+				telemetry.Field{Key: "job.run.skipped_reason", Value: "state_conflict"},
+				telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)},
+			))
 			return nil
 		}
+		spanAttrs = spanAttrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 		return err
 	}
 	_, _ = s.store.AppendJobEvent(ctx, ports.JobEvent{JobID: job.ID, Type: "started", Status: ports.JobStatusRunning, Message: "job started"})
+	telemetry.Event(ctx, "platform.job.started", jobTelemetryAttrs(job).With(telemetry.Attrs(
+		telemetry.Field{Key: "job.queue_latency_ms", Value: jobQueueLatencyMs(job)},
+		telemetry.Field{Key: "job.runner.available", Value: true},
+	)))
 	result, refs, runErr := runner(ctx, job, s)
 	finished := s.now()
 	if runErr != nil {
-		_, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusFailed, Error: runErr.Error(), Message: "job failed", FinishedAt: &finished, AllowedStatuses: []string{ports.JobStatusRunning}})
+		job, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusFailed, Error: runErr.Error(), Message: "job failed", FinishedAt: &finished, AllowedStatuses: []string{ports.JobStatusRunning}})
 		if err != nil {
 			if errors.Is(err, ports.ErrJobUpdateConflict) {
+				status = ports.JobStatusFailed
+				spanAttrs = spanAttrs.With(telemetry.Attrs(
+					telemetry.Field{Key: "job.update_conflict", Value: true},
+					telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(runErr)},
+				))
 				return runErr
 			}
+			spanAttrs = spanAttrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 			return err
 		}
 		_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "failed", Status: ports.JobStatusFailed, Message: runErr.Error()})
+		status = ports.JobStatusFailed
+		spanAttrs = spanAttrs.With(jobResultTelemetryAttrs(result, refs)).With(telemetry.Attrs(
+			telemetry.Field{Key: "job.queue_latency_ms", Value: jobQueueLatencyMs(job)},
+			telemetry.Field{Key: "job.finished_at_unix_ms", Value: finished.UnixMilli()},
+			telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(runErr)},
+			telemetry.Field{Key: "error_fingerprint", Value: telemetry.ErrorFingerprint("platform.job.run", runErr, jobTelemetryAttrs(job))},
+		))
+		telemetry.CaptureError(ctx, "platform.job.failed", runErr, jobTelemetryAttrs(job))
+		telemetry.Event(ctx, "platform.job.failed", jobTelemetryAttrs(job).With(spanAttrs))
 		return runErr
 	}
 	progress := uint32(100)
-	_, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusCompleted, Progress: &progress, Message: "job completed", Result: result, ResultRefs: refs, FinishedAt: &finished, AllowedStatuses: []string{ports.JobStatusRunning}})
+	job, err = s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{Status: ports.JobStatusCompleted, Progress: &progress, Message: "job completed", Result: result, ResultRefs: refs, FinishedAt: &finished, AllowedStatuses: []string{ports.JobStatusRunning}})
 	if errors.Is(err, ports.ErrJobUpdateConflict) {
+		status = "skipped"
+		spanAttrs = spanAttrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "job.update_conflict", Value: true},
+			telemetry.Field{Key: "job.run.skipped_reason", Value: "completion_conflict"},
+		))
 		return nil
 	}
 	if err == nil {
 		_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{JobID: job.ID, Type: "completed", Status: ports.JobStatusCompleted, Message: "job completed"})
+		status = ports.JobStatusCompleted
+		spanAttrs = spanAttrs.With(jobResultTelemetryAttrs(result, refs)).With(telemetry.Attrs(
+			telemetry.Field{Key: "job.queue_latency_ms", Value: jobQueueLatencyMs(job)},
+			telemetry.Field{Key: "job.finished_at_unix_ms", Value: finished.UnixMilli()},
+			telemetry.Field{Key: "job.progress_percent", Value: progress},
+		))
+		telemetry.Event(ctx, "platform.job.completed", jobTelemetryAttrs(job).With(spanAttrs))
+	} else {
+		spanAttrs = spanAttrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 	}
 	return err
 }
@@ -284,6 +383,10 @@ func (s *Service) Cancel(ctx context.Context, jobID string) (*ports.Job, error) 
 		return nil, err
 	}
 	_, _ = s.store.AppendJobEvent(ctx, event)
+	telemetry.Event(ctx, "platform.job.cancel_requested", jobTelemetryAttrs(job).With(telemetry.Attrs(
+		telemetry.Field{Key: "job.cancel_requested", Value: true},
+		telemetry.Field{Key: "job.cancel.transitioned_terminal", Value: event.Type == "cancelled"},
+	)))
 	return job, nil
 }
 
@@ -293,4 +396,128 @@ func NewID() string {
 		return fmt.Sprintf("job-%d", time.Now().UnixNano())
 	}
 	return "job-" + hex.EncodeToString(b[:])
+}
+
+func jobTelemetryAttrs(job *ports.Job) telemetry.Attributes {
+	if job == nil {
+		return telemetry.Attrs()
+	}
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "job.id", Value: job.ID},
+		telemetry.Field{Key: "job.kind", Value: job.Kind},
+		telemetry.Field{Key: "job.status", Value: job.Status},
+		telemetry.Field{Key: "tenant_id", Value: job.TenantID},
+		telemetry.Field{Key: "job.tenant_id", Value: job.TenantID},
+		telemetry.Field{Key: "job.subject_type", Value: job.SubjectType},
+		telemetry.Field{Key: "job.subject_id", Value: job.SubjectID},
+		telemetry.Field{Key: "job.progress_percent", Value: job.Progress},
+		telemetry.Field{Key: "job.cancel_requested", Value: job.CancelRequested},
+		telemetry.Field{Key: "job.created_at_unix_ms", Value: unixMilliOrZero(job.CreatedAt)},
+		telemetry.Field{Key: "job.started_at_unix_ms", Value: unixMilliOrZero(job.StartedAt)},
+		telemetry.Field{Key: "job.finished_at_unix_ms", Value: unixMilliOrZero(job.FinishedAt)},
+		telemetry.Field{Key: "job.updated_at_unix_ms", Value: unixMilliOrZero(job.UpdatedAt)},
+		telemetry.Field{Key: "job.payload.key_count", Value: len(job.Payload)},
+		telemetry.Field{Key: "job.payload.keys", Value: strings.Join(sortedAnyMapKeys(job.Payload), ",")},
+		telemetry.Field{Key: "job.result.key_count", Value: len(job.Result)},
+		telemetry.Field{Key: "job.result.keys", Value: strings.Join(sortedAnyMapKeys(job.Result), ",")},
+		telemetry.Field{Key: "job.result_ref.key_count", Value: len(job.ResultRefs)},
+		telemetry.Field{Key: "job.result_ref.keys", Value: strings.Join(sortedStringMapKeys(job.ResultRefs), ",")},
+		telemetry.Field{Key: "job.idempotency_key.present", Value: job.IdempotencyKey != ""},
+		telemetry.Field{Key: "job.idempotency_key.hash", Value: hashText(job.IdempotencyKey)},
+	)
+	if runtimeID := jobRuntimeID(job); runtimeID != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "runtime_id", Value: runtimeID})
+		attrs = attrs.WithField(telemetry.Field{Key: "source_runtime_id", Value: runtimeID})
+	}
+	if reportID := firstStringPayload(job.Payload, "report_id", job.SubjectID); reportID != "" && (job.Kind == KindReportRun || job.SubjectType == "report") {
+		attrs = attrs.WithField(telemetry.Field{Key: "report_id", Value: reportID})
+	}
+	if !job.CreatedAt.IsZero() && !job.StartedAt.IsZero() {
+		attrs = attrs.WithField(telemetry.Field{Key: "job.queue_latency_ms", Value: job.StartedAt.Sub(job.CreatedAt).Milliseconds()})
+	}
+	if !job.StartedAt.IsZero() && !job.FinishedAt.IsZero() {
+		attrs = attrs.WithField(telemetry.Field{Key: "job.run_duration_ms", Value: job.FinishedAt.Sub(job.StartedAt).Milliseconds()})
+	}
+	return attrs
+}
+
+func jobResultTelemetryAttrs(result map[string]any, refs map[string]string) telemetry.Attributes {
+	return telemetry.Attrs(
+		telemetry.Field{Key: "job.result.key_count", Value: len(result)},
+		telemetry.Field{Key: "job.result.keys", Value: strings.Join(sortedAnyMapKeys(result), ",")},
+		telemetry.Field{Key: "job.result_ref.key_count", Value: len(refs)},
+		telemetry.Field{Key: "job.result_ref.keys", Value: strings.Join(sortedStringMapKeys(refs), ",")},
+	)
+}
+
+func jobRuntimeID(job *ports.Job) string {
+	if job == nil {
+		return ""
+	}
+	if runtimeID := firstStringPayload(job.Payload, "runtime_id", "source_runtime_id"); runtimeID != "" {
+		return runtimeID
+	}
+	if strings.Contains(job.Kind, "source_runtime") || strings.Contains(job.Kind, "graph_ingest") || strings.Contains(job.Kind, "finding") || job.SubjectType == "source_runtime" {
+		return strings.TrimSpace(job.SubjectID)
+	}
+	return ""
+}
+
+func firstStringPayload(values map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := values[key]
+		if !ok {
+			continue
+		}
+		text, ok := value.(string)
+		if !ok {
+			continue
+		}
+		text = strings.TrimSpace(text)
+		if text != "" && text != "<nil>" {
+			return text
+		}
+	}
+	return ""
+}
+
+func jobQueueLatencyMs(job *ports.Job) int64 {
+	if job == nil || job.CreatedAt.IsZero() || job.StartedAt.IsZero() {
+		return 0
+	}
+	return job.StartedAt.Sub(job.CreatedAt).Milliseconds()
+}
+
+func unixMilliOrZero(value time.Time) int64 {
+	if value.IsZero() {
+		return 0
+	}
+	return value.UnixMilli()
+}
+
+func sortedAnyMapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedStringMapKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func hashText(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:8])
 }

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -279,8 +279,7 @@ func (s *Service) Run(ctx context.Context, jobID string) (err error) {
 			telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(runErr)},
 			telemetry.Field{Key: "error_fingerprint", Value: telemetry.ErrorFingerprint("platform.job.run", runErr, jobTelemetryAttrs(job))},
 		))
-		telemetry.CaptureError(ctx, "platform.job.failed", runErr, jobTelemetryAttrs(job))
-		telemetry.Event(ctx, "platform.job.failed", jobTelemetryAttrs(job).With(spanAttrs))
+		telemetry.CaptureError(ctx, "platform.job.failed", runErr, jobTelemetryAttrs(job).With(spanAttrs))
 		return runErr
 	}
 	progress := uint32(100)

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -163,6 +163,61 @@ func TestRunEmitsPlatformJobWideEventWithoutPayloadValues(t *testing.T) {
 	}
 }
 
+func TestRunEmitsSinglePlatformJobFailedEvent(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-failed-telemetry"] = &ports.Job{
+		ID:     "job-failed-telemetry",
+		Kind:   KindReportRun,
+		Status: ports.JobStatusQueued,
+	}
+	service := New(store)
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		return nil, nil, errors.New("runner failed")
+	})
+
+	stderr := captureJobServiceStderr(t, func() {
+		if err := service.Run(context.Background(), "job-failed-telemetry"); err == nil {
+			t.Fatal("Run() error = nil, want runner failure")
+		}
+	})
+
+	failedEvents := jobTelemetryPayloads(t, stderr, "event", "platform.job.failed")
+	if len(failedEvents) != 1 {
+		t.Fatalf("platform.job.failed events = %d, want 1; stderr=%s", len(failedEvents), stderr)
+	}
+	runPayload := jobTelemetrySpanEndPayload(t, stderr, "platform.job.run")
+	if got := runPayload["job.status.final"]; got != ports.JobStatusFailed {
+		t.Fatalf("job.status.final = %#v, want %q; payload=%#v", got, ports.JobStatusFailed, runPayload)
+	}
+}
+
+func TestRunReportTelemetryFallsBackToSubjectID(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-report-telemetry"] = &ports.Job{
+		ID:          "job-report-telemetry",
+		Kind:        KindReportRun,
+		Status:      ports.JobStatusQueued,
+		SubjectType: "report",
+		SubjectID:   "report-subject-id",
+		Payload:     map[string]any{"report_id": "   "},
+	}
+	service := New(store)
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		return nil, nil, nil
+	})
+
+	stderr := captureJobServiceStderr(t, func() {
+		if err := service.Run(context.Background(), "job-report-telemetry"); err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	payload := jobTelemetrySpanEndPayload(t, stderr, "platform.job.run")
+	if got := payload["report_id"]; got != "report-subject-id" {
+		t.Fatalf("report_id = %#v, want SubjectID fallback; payload=%#v", got, payload)
+	}
+}
+
 func TestStartAsyncDetachesFromRequestAndWaitCancelsJob(t *testing.T) {
 	store := newMemoryJobStore()
 	service := New(store)
@@ -374,6 +429,17 @@ func captureJobServiceStderr(t *testing.T, fn func()) string {
 
 func jobTelemetrySpanEndPayload(t *testing.T, stderr string, name string) map[string]any {
 	t.Helper()
+	payloads := jobTelemetryPayloads(t, stderr, "span_end", name)
+	if len(payloads) > 0 {
+		return payloads[0]
+	}
+	t.Fatalf("telemetry span_end %q not found in stderr: %s", name, stderr)
+	return nil
+}
+
+func jobTelemetryPayloads(t *testing.T, stderr string, kind string, name string) []map[string]any {
+	t.Helper()
+	payloads := []map[string]any{}
 	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
@@ -382,10 +448,9 @@ func jobTelemetrySpanEndPayload(t *testing.T, stderr string, name string) map[st
 		if err := json.Unmarshal([]byte(line), &payload); err != nil {
 			t.Fatalf("unmarshal telemetry payload %q: %v", line, err)
 		}
-		if payload["kind"] == "span_end" && payload["name"] == name {
-			return payload
+		if payload["kind"] == kind && payload["name"] == name {
+			payloads = append(payloads, payload)
 		}
 	}
-	t.Fatalf("telemetry span_end %q not found in stderr: %s", name, stderr)
-	return nil
+	return payloads
 }

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -118,7 +118,7 @@ func TestRunEmitsPlatformJobWideEventWithoutPayloadValues(t *testing.T) {
 	service.WithRunner(KindSourceRuntimeOrchestrate, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
 		return map[string]any{
 			"events_appended": 25,
-			"secret_result":   "raw-result-secret-value",
+			"private_result":  "raw-result-private-value",
 		}, map[string]string{"graph_ingest_run_id": "graph-run-1"}, nil
 	})
 
@@ -142,7 +142,7 @@ func TestRunEmitsPlatformJobWideEventWithoutPayloadValues(t *testing.T) {
 		"job.payload.key_count": float64(2),
 		"job.payload.keys":      "api_token,runtime_id",
 		"job.result.key_count":  float64(2),
-		"job.result.keys":       "events_appended,secret_result",
+		"job.result.keys":       "events_appended,private_result",
 		"job.result_ref.keys":   "graph_ingest_run_id",
 	} {
 		if got := payload[key]; got != want {
@@ -155,7 +155,7 @@ func TestRunEmitsPlatformJobWideEventWithoutPayloadValues(t *testing.T) {
 	if got, ok := payload["job.run_duration_ms"].(float64); !ok || got <= 0 {
 		t.Fatalf("job.run_duration_ms = %#v, want positive number; payload=%#v", payload["job.run_duration_ms"], payload)
 	}
-	if strings.Contains(stderr, "raw-secret-token-value") || strings.Contains(stderr, "raw-result-secret-value") || strings.Contains(stderr, "idem-secret-value") {
+	if strings.Contains(stderr, "raw-secret-token-value") || strings.Contains(stderr, "raw-result-private-value") || strings.Contains(stderr, "idem-secret-value") {
 		t.Fatalf("platform job telemetry leaked raw payload/result/idempotency values: %s", stderr)
 	}
 	if !strings.Contains(stderr, `"name":"platform.job.started"`) || !strings.Contains(stderr, `"name":"platform.job.completed"`) {

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -2,8 +2,12 @@ package jobs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -84,6 +88,78 @@ func TestRunRecoversRunnerPanicAndMarksJobFailed(t *testing.T) {
 	}
 	if len(store.events) < 2 || store.events[len(store.events)-1].Type != "failed" {
 		t.Fatalf("events = %#v, want final failed event", store.events)
+	}
+}
+
+func TestRunEmitsPlatformJobWideEventWithoutPayloadValues(t *testing.T) {
+	createdAt := time.Date(2026, 6, 18, 21, 0, 0, 0, time.UTC)
+	store := newMemoryJobStore()
+	store.jobs["job-telemetry"] = &ports.Job{
+		ID:             "job-telemetry",
+		Kind:           KindSourceRuntimeOrchestrate,
+		Status:         ports.JobStatusQueued,
+		TenantID:       "writer",
+		SubjectType:    "source_runtime",
+		SubjectID:      "writer-okta-audit",
+		IdempotencyKey: "idem-secret-value",
+		Payload: map[string]any{
+			"runtime_id": "writer-okta-audit",
+			"api_token":  "raw-secret-token-value",
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
+	}
+	service := New(store)
+	now := createdAt
+	service.now = func() time.Time {
+		now = now.Add(2 * time.Second)
+		return now
+	}
+	service.WithRunner(KindSourceRuntimeOrchestrate, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		return map[string]any{
+			"events_appended": 25,
+			"secret_result":   "raw-result-secret-value",
+		}, map[string]string{"graph_ingest_run_id": "graph-run-1"}, nil
+	})
+
+	stderr := captureJobServiceStderr(t, func() {
+		if err := service.Run(context.Background(), "job-telemetry"); err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	payload := jobTelemetrySpanEndPayload(t, stderr, "platform.job.run")
+	for key, want := range map[string]any{
+		"main":                  true,
+		"wide_event":            true,
+		"event.dataset":         "cerebro.wide_events",
+		"job.id":                "job-telemetry",
+		"job.kind":              KindSourceRuntimeOrchestrate,
+		"job.status.final":      ports.JobStatusCompleted,
+		"tenant_id":             "writer",
+		"runtime_id":            "writer-okta-audit",
+		"source_runtime_id":     "writer-okta-audit",
+		"job.payload.key_count": float64(2),
+		"job.payload.keys":      "api_token,runtime_id",
+		"job.result.key_count":  float64(2),
+		"job.result.keys":       "events_appended,secret_result",
+		"job.result_ref.keys":   "graph_ingest_run_id",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if got, ok := payload["job.queue_latency_ms"].(float64); !ok || got <= 0 {
+		t.Fatalf("job.queue_latency_ms = %#v, want positive number; payload=%#v", payload["job.queue_latency_ms"], payload)
+	}
+	if got, ok := payload["job.run_duration_ms"].(float64); !ok || got <= 0 {
+		t.Fatalf("job.run_duration_ms = %#v, want positive number; payload=%#v", payload["job.run_duration_ms"], payload)
+	}
+	if strings.Contains(stderr, "raw-secret-token-value") || strings.Contains(stderr, "raw-result-secret-value") || strings.Contains(stderr, "idem-secret-value") {
+		t.Fatalf("platform job telemetry leaked raw payload/result/idempotency values: %s", stderr)
+	}
+	if !strings.Contains(stderr, `"name":"platform.job.started"`) || !strings.Contains(stderr, `"name":"platform.job.completed"`) {
+		t.Fatalf("platform job lifecycle events missing from stderr: %s", stderr)
 	}
 }
 
@@ -272,4 +348,44 @@ func cloneStringMap(values map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
+}
+
+func captureJobServiceStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stderr: %v", err)
+	}
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	payload, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	return string(payload)
+}
+
+func jobTelemetrySpanEndPayload(t *testing.T, stderr string, name string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		payload := map[string]any{}
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			t.Fatalf("unmarshal telemetry payload %q: %v", line, err)
+		}
+		if payload["kind"] == "span_end" && payload["name"] == name {
+			return payload
+		}
+	}
+	t.Fatalf("telemetry span_end %q not found in stderr: %s", name, stderr)
+	return nil
 }


### PR DESCRIPTION
## Summary
- emit a platform.job.run main wide event for durable /platform/jobs execution
- add lifecycle events for created/reused/started/completed/failed/cancel_requested and runner-unavailable paths
- include safe job pivots, queue latency, run duration, result/ref key shapes, and runtime/report IDs without raw payload/result/error/idempotency values
- document platform.job.run in the observability guide

## Validation
- go test ./...
- go test ./internal/jobs ./internal/telemetry ./internal/bootstrap
- git diff --check