### PR TITLE
fix: NOJIRA bound Security Hub checkpoint filter

### DIFF
--- a/cmd/cerebro/github_local.go
+++ b/cmd/cerebro/github_local.go
@@ -175,7 +175,12 @@ func githubReadRequiresRepo(command string, config map[string]string) bool {
 }
 
 func githubRuntimeRequiresRepo(config map[string]string) bool {
-	return strings.TrimSpace(config["family"]) != "audit"
+	switch strings.TrimSpace(config["family"]) {
+	case "", "pull_request", "dependabot_alert":
+		return true
+	default:
+		return false
+	}
 }
 
 func githubRequiresToken(config map[string]string) bool {

--- a/cmd/cerebro/github_local_test.go
+++ b/cmd/cerebro/github_local_test.go
@@ -266,6 +266,43 @@ func TestPrepareSourceRuntimeWithCLIAuditAppAuthSkipsTokenHydration(t *testing.T
 	}
 }
 
+func TestPrepareSourceRuntimeWithCLIOrgGitHubFamiliesSkipRepoHydration(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_GITHUB_APP_ID", "42")
+	t.Setenv("CEREBRO_SOURCE_GITHUB_INSTALLATION_ID", "123")
+	t.Setenv("CEREBRO_SOURCE_GITHUB_PRIVATE_KEY_BASE64", "key")
+	for _, family := range []string{"org_inventory", "repository", "secret_scanning_alert"} {
+		t.Run(family, func(t *testing.T) {
+			cli := &fakeGitHubLocalCLI{}
+			runtime, err := prepareSourceRuntimeWithCLI(context.Background(), &cerebrov1.SourceRuntime{
+				Id:       "example-github-" + family,
+				SourceId: githubSourceID,
+				Config: map[string]string{
+					"app_id":             "env:CEREBRO_SOURCE_GITHUB_APP_ID",
+					"family":             family,
+					"installation_id":    "env:CEREBRO_SOURCE_GITHUB_INSTALLATION_ID",
+					"owner":              "example-org",
+					"private_key_base64": "env:CEREBRO_SOURCE_GITHUB_PRIVATE_KEY_BASE64",
+				},
+			}, cli)
+			if err != nil {
+				t.Fatalf("prepareSourceRuntimeWithCLI() error = %v", err)
+			}
+			if _, ok := runtime.GetConfig()["repo"]; ok {
+				t.Fatalf("runtime.Config[repo] = %q, want omitted", runtime.GetConfig()["repo"])
+			}
+			if _, ok := runtime.GetConfig()["token"]; ok {
+				t.Fatalf("runtime.Config[token] = %q, want omitted", runtime.GetConfig()["token"])
+			}
+			if cli.repoCalls != 0 {
+				t.Fatalf("repoCalls = %d, want 0", cli.repoCalls)
+			}
+			if cli.authTokenCalls != 0 {
+				t.Fatalf("authTokenCalls = %d, want 0", cli.authTokenCalls)
+			}
+		})
+	}
+}
+
 func TestPrepareSourceConfigWithCLIResolvesEnvOwnerBeforeHydration(t *testing.T) {
 	t.Setenv("CEREBRO_SOURCE_GITHUB_OWNER", "writer")
 	cli := &fakeGitHubLocalCLI{

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -12,6 +12,7 @@ import (
 const (
 	sourceConfigEnvAllowlistEnv = "CEREBRO_SOURCE_CONFIG_ENV_ALLOWLIST"
 	awsAssumeRoleARNsEnv        = "CEREBRO_AWS_ASSUME_ROLE_ARNS"
+	gcpWIFBindingsEnv           = "CEREBRO_GCP_WIF_BINDINGS" // #nosec G101 -- env var name, not credential material.
 )
 
 func ResolveSourceConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
@@ -51,6 +52,9 @@ func resolveSourceConfigSecretReferences(ctx context.Context, sourceID string, v
 	}
 	if injectRuntimeAllowlist && (strings.EqualFold(strings.TrimSpace(sourceID), "aws") || strings.TrimSpace(values["role_arn"]) != "") {
 		resolved[sourceconfig.AWSAssumeRoleAllowlistKey] = strings.TrimSpace(os.Getenv(awsAssumeRoleARNsEnv))
+	}
+	if injectRuntimeAllowlist && (strings.EqualFold(strings.TrimSpace(sourceID), "gcp") || strings.TrimSpace(values["wif_audience"]) != "" || strings.TrimSpace(values["wif_service_account_email"]) != "") {
+		resolved[sourceconfig.GCPWIFAllowlistKey] = strings.TrimSpace(os.Getenv(gcpWIFBindingsEnv))
 	}
 	return resolved, nil
 }

--- a/internal/config/source_config_test.go
+++ b/internal/config/source_config_test.go
@@ -143,8 +143,44 @@ func TestResolveSourceRuntimeConfigInjectsAssumeRoleAllowlistForRoleARN(t *testi
 	}
 }
 
+func TestResolveSourceRuntimeConfigInjectsGCPWIFAllowlist(t *testing.T) {
+	binding := "writer=//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws|scanner@writer-iam.iam.gserviceaccount.com"
+	t.Setenv(gcpWIFBindingsEnv, binding)
+	resolved, err := ResolveSourceRuntimeConfigSecretReferences(context.Background(), "gcp", map[string]string{
+		"wif_audience":                  "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
+		"wif_service_account_email":     "scanner@writer-iam.iam.gserviceaccount.com",
+		sourceconfig.GCPWIFAllowlistKey: "caller-controlled",
+		sourceconfig.RuntimeTenantIDKey: "writer",
+	})
+	if err != nil {
+		t.Fatalf("ResolveSourceRuntimeConfigSecretReferences() error = %v", err)
+	}
+	if got := resolved[sourceconfig.GCPWIFAllowlistKey]; got != binding {
+		t.Fatalf("resolved gcp wif allowlist = %q, want deployment env value", got)
+	}
+	if got := resolved[sourceconfig.RuntimeTenantIDKey]; got != "writer" {
+		t.Fatalf("resolved runtime tenant = %q, want writer", got)
+	}
+}
+
+func TestResolveSourceRuntimeConfigInjectsGCPWIFAllowlistForWIFConfig(t *testing.T) {
+	binding := "writer=//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws|scanner@writer-iam.iam.gserviceaccount.com"
+	t.Setenv(gcpWIFBindingsEnv, binding)
+	resolved, err := ResolveSourceRuntimeConfigSecretReferences(context.Background(), "custom-gcp-wrapper", map[string]string{
+		"wif_audience":              "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
+		"wif_service_account_email": "scanner@writer-iam.iam.gserviceaccount.com",
+	})
+	if err != nil {
+		t.Fatalf("ResolveSourceRuntimeConfigSecretReferences() error = %v", err)
+	}
+	if got := resolved[sourceconfig.GCPWIFAllowlistKey]; got != binding {
+		t.Fatalf("resolved gcp wif allowlist = %q", got)
+	}
+}
+
 func TestResolveSourceConfigDoesNotInjectRuntimeAWSAllowlist(t *testing.T) {
 	t.Setenv(awsAssumeRoleARNsEnv, "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role")
+	t.Setenv(gcpWIFBindingsEnv, "writer=//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws|scanner@writer-iam.iam.gserviceaccount.com")
 	resolved, err := ResolveSourceConfigSecretReferences(context.Background(), "aws", map[string]string{
 		"account_id": "123456789012",
 	})
@@ -153,5 +189,8 @@ func TestResolveSourceConfigDoesNotInjectRuntimeAWSAllowlist(t *testing.T) {
 	}
 	if _, ok := resolved[sourceconfig.AWSAssumeRoleAllowlistKey]; ok {
 		t.Fatal("direct source config injected runtime AWS assume-role allowlist")
+	}
+	if _, ok := resolved[sourceconfig.GCPWIFAllowlistKey]; ok {
+		t.Fatal("direct source config injected runtime GCP WIF allowlist")
 	}
 }

--- a/sources/aws/security_services_test.go
+++ b/sources/aws/security_services_test.go
@@ -336,9 +336,10 @@ func TestReadAWSFindingFamiliesWithCheckpointUseUpdatedTimeRequests(t *testing.T
 			t.Fatalf("Security Hub sort = %#v, want UpdatedAt desc", input.SortCriteria)
 		}
 		if input.Filters == nil || len(input.Filters.UpdatedAt) != 1 {
-			t.Fatalf("Security Hub UpdatedAt filter = %#v, want one start filter", input.Filters)
+			t.Fatalf("Security Hub UpdatedAt filter = %#v, want one start/end filter", input.Filters)
 		}
 		assertAWSFindingFilterStart(t, awssdk.ToString(input.Filters.UpdatedAt[0].Start), watermark)
+		assertAWSFindingFilterEnd(t, awssdk.ToString(input.Filters.UpdatedAt[0].End), watermark)
 	})
 
 	t.Run("guardduty", func(t *testing.T) {
@@ -479,6 +480,7 @@ func TestReadAWSSecurityHubCheckpointCursorKeepsOriginalWatermark(t *testing.T) 
 		t.Fatalf("second NextToken = %q, want token-2", got)
 	}
 	assertAWSFindingFilterStart(t, awssdk.ToString(fake.securityHubInputs[1].Filters.UpdatedAt[0].Start), watermark)
+	assertAWSFindingFilterEnd(t, awssdk.ToString(fake.securityHubInputs[1].Filters.UpdatedAt[0].End), watermark)
 }
 
 func awsSecurityTestCheckpoint(watermark time.Time) *cerebrov1.SourceCheckpoint {
@@ -494,6 +496,18 @@ func assertAWSFindingFilterStart(t *testing.T, raw string, watermark time.Time) 
 	want := watermark.Add(-awsFindingCheckpointLookback)
 	if !got.Equal(want) {
 		t.Fatalf("filter start = %s, want %s", got, want)
+	}
+}
+
+func assertAWSFindingFilterEnd(t *testing.T, raw string, watermark time.Time) {
+	t.Helper()
+	got, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		t.Fatalf("parse filter end %q: %v", raw, err)
+	}
+	wantAfter := watermark.Add(-awsFindingCheckpointLookback)
+	if got.Before(wantAfter) {
+		t.Fatalf("filter end = %s, want >= %s", got, wantAfter)
 	}
 }
 

--- a/sources/internal/awssecurity/findings.go
+++ b/sources/internal/awssecurity/findings.go
@@ -42,8 +42,15 @@ func SecurityHubGetFindingsInput(maxResults int32, token string, checkpoint *cer
 		}},
 	}
 	if start, ok := checkpointStart(checkpoint, lookback); ok {
+		end := time.Now().UTC()
+		if end.Before(start) {
+			end = start
+		}
 		input.Filters = &securityhubtypes.AwsSecurityFindingFilters{
-			UpdatedAt: []securityhubtypes.DateFilter{{Start: awssdk.String(start.Format(time.RFC3339Nano))}},
+			UpdatedAt: []securityhubtypes.DateFilter{{
+				Start: awssdk.String(start.Format(time.RFC3339Nano)),
+				End:   awssdk.String(end.Format(time.RFC3339Nano)),
+			}},
 		}
 	}
 	return input


### PR DESCRIPTION
## Summary
- bound Security Hub checkpoint filters with both `UpdatedAt.Start` and `UpdatedAt.End` so incremental scans produce valid AWS requests
- inject `CEREBRO_GCP_WIF_BINDINGS` into source-runtime config resolution for GCP/WIF runtimes while keeping direct source config callers from spoofing it
- stop GitHub source-runtime bootstrap from shelling out to local `gh repo view` for org-scoped families (`org_inventory`, `repository`, `secret_scanning_alert`)
- enrich JetStream append failures with safe, bounded NATS API diagnostics (`nats.api.error.code`, `nats.jetstream.error_code`, description, retryable flag)

## Verification
- go test ./internal/config ./sources/aws ./sources/internal/awssecurity
- go test ./cmd/cerebro ./internal/config ./sources/aws ./sources/internal/awssecurity
- go test ./internal/appendlog/jetstream ./cmd/cerebro ./internal/config ./sources/aws ./sources/internal/awssecurity

## Operational context
This addresses the degraded sec-dev verifier blockers observed on June 18, 2026:
- Security Hub rejected checkpoint-only `UpdatedAt.Start` filters with `InvalidInputException`
- GCP bootstraps rejected WIF audience/service-account pairs without a runtime allowlist
- GitHub org-source bootstraps attempted to resolve repo context with `gh`, which is not present in ECS tasks
- wide events showed `jetstream_js_error` without enough NATS detail to tell whether stream failures were timeout, API/limit, or state related