### PR TITLE
fix: NOJIRA add JetStream append diagnostics

### DIFF
--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -382,12 +382,28 @@ func jetstreamTelemetryAttrs(operation string) telemetry.Attributes {
 
 func jetstreamTelemetryError(ctx context.Context, span *telemetry.Span, operation string, err error) {
 	jetstreamAnnotateMain(ctx, operation, "failed")
-	attrs := telemetry.Attrs(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+	attrs := jetstreamErrorTelemetryAttrs(err)
 	telemetry.CaptureError(ctx, "jetstream.error", err, telemetry.Attrs(
 		telemetry.Field{Key: "component", Value: "appendlog.jetstream"},
 		telemetry.Field{Key: "operation", Value: operation},
-	))
+	).With(attrs))
 	telemetry.End(span, "failed", attrs)
+}
+
+func jetstreamErrorTelemetryAttrs(err error) telemetry.Attributes {
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)},
+		telemetry.Field{Key: "messaging.jetstream.publish.retryable", Value: retryablePublishError(err)},
+	)
+	var apiErr *jetstream.APIError
+	if errors.As(err, &apiErr) && apiErr != nil {
+		attrs = attrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "nats.api.error.code", Value: apiErr.Code},
+			telemetry.Field{Key: "nats.jetstream.error_code", Value: uint16(apiErr.ErrorCode)},
+			telemetry.Field{Key: "nats.jetstream.error_description", Value: strings.TrimSpace(apiErr.Description)},
+		))
+	}
+	return attrs
 }
 
 func jetstreamAnnotateMain(ctx context.Context, operation string, status string) {

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -3,6 +3,7 @@ package jetstream
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -139,6 +140,30 @@ func TestAppendDoesNotRetryWithoutMessageID(t *testing.T) {
 	}
 	if pub.publishCalls != 1 {
 		t.Fatalf("publish calls = %d, want 1", pub.publishCalls)
+	}
+}
+
+func TestJetstreamErrorTelemetryAttrsIncludesAPIErrorDetails(t *testing.T) {
+	attrs := jetstreamErrorTelemetryAttrs(&natsjetstream.APIError{
+		Code:        503,
+		ErrorCode:   natsjetstream.JSErrCodeStreamNotFound,
+		Description: "stream not found",
+	})
+	values := map[string]string{}
+	for _, attr := range attrs.OTELAttributes() {
+		values[string(attr.Key)] = fmt.Sprint(attr.Value.AsInterface())
+	}
+	if values["nats.api.error.code"] != "503" {
+		t.Fatalf("nats.api.error.code = %q, want 503", values["nats.api.error.code"])
+	}
+	if values["nats.jetstream.error_code"] != strconv.Itoa(int(natsjetstream.JSErrCodeStreamNotFound)) {
+		t.Fatalf("nats.jetstream.error_code = %q, want %d", values["nats.jetstream.error_code"], natsjetstream.JSErrCodeStreamNotFound)
+	}
+	if values["nats.jetstream.error_description"] != "stream not found" {
+		t.Fatalf("nats.jetstream.error_description = %q, want stream not found", values["nats.jetstream.error_description"])
+	}
+	if values["messaging.jetstream.publish.retryable"] != "false" {
+		t.Fatalf("messaging.jetstream.publish.retryable = %q, want false", values["messaging.jetstream.publish.retryable"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- enrich JetStream append failures with safe, bounded NATS API diagnostics
- emit `nats.api.error.code`, `nats.jetstream.error_code`, `nats.jetstream.error_description`, and `messaging.jetstream.publish.retryable` on failed append spans/events
- cover API-error diagnostic extraction in append-log tests

## Verification
- go test ./internal/appendlog/jetstream ./cmd/cerebro ./internal/config ./sources/aws ./sources/internal/awssecurity

## Operational context
#1267 already landed the Security Hub checkpoint, GCP WIF allowlist, and GitHub org-source bootstrap fixes. This follow-up keeps the deeper stream observability from the original branch: sec-dev wide events showed `jetstream_js_error` during graph-rule/finding-rule append paths, but the previous event shape lacked enough NATS detail to tell timeout vs API/limit/state causes.