### PR TITLE
fix: scope JetStream publish retry telemetry

### DIFF
--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -382,7 +382,7 @@ func jetstreamTelemetryAttrs(operation string) telemetry.Attributes {
 
 func jetstreamTelemetryError(ctx context.Context, span *telemetry.Span, operation string, err error) {
 	jetstreamAnnotateMain(ctx, operation, "failed")
-	attrs := jetstreamErrorTelemetryAttrs(err)
+	attrs := jetstreamErrorTelemetryAttrs(operation, err)
 	telemetry.CaptureError(ctx, "jetstream.error", err, telemetry.Attrs(
 		telemetry.Field{Key: "component", Value: "appendlog.jetstream"},
 		telemetry.Field{Key: "operation", Value: operation},
@@ -390,11 +390,11 @@ func jetstreamTelemetryError(ctx context.Context, span *telemetry.Span, operatio
 	telemetry.End(span, "failed", attrs)
 }
 
-func jetstreamErrorTelemetryAttrs(err error) telemetry.Attributes {
-	attrs := telemetry.Attrs(
-		telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)},
-		telemetry.Field{Key: "messaging.jetstream.publish.retryable", Value: retryablePublishError(err)},
-	)
+func jetstreamErrorTelemetryAttrs(operation string, err error) telemetry.Attributes {
+	attrs := telemetry.Attrs(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+	if strings.TrimSpace(operation) == "append" {
+		attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.publish.retryable", Value: retryablePublishError(err)})
+	}
 	var apiErr *jetstream.APIError
 	if errors.As(err, &apiErr) && apiErr != nil {
 		attrs = attrs.With(telemetry.Attrs(

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -144,7 +144,7 @@ func TestAppendDoesNotRetryWithoutMessageID(t *testing.T) {
 }
 
 func TestJetstreamErrorTelemetryAttrsIncludesAPIErrorDetails(t *testing.T) {
-	attrs := jetstreamErrorTelemetryAttrs(&natsjetstream.APIError{
+	attrs := jetstreamErrorTelemetryAttrs("append", &natsjetstream.APIError{
 		Code:        503,
 		ErrorCode:   natsjetstream.JSErrCodeStreamNotFound,
 		Description: "stream not found",
@@ -164,6 +164,15 @@ func TestJetstreamErrorTelemetryAttrsIncludesAPIErrorDetails(t *testing.T) {
 	}
 	if values["messaging.jetstream.publish.retryable"] != "false" {
 		t.Fatalf("messaging.jetstream.publish.retryable = %q, want false", values["messaging.jetstream.publish.retryable"])
+	}
+}
+
+func TestJetstreamErrorTelemetryAttrsScopesPublishRetryableToAppend(t *testing.T) {
+	attrs := jetstreamErrorTelemetryAttrs("ping", errors.New("nats: no response from stream"))
+	for _, attr := range attrs.OTELAttributes() {
+		if string(attr.Key) == "messaging.jetstream.publish.retryable" {
+			t.Fatalf("unexpected publish retryable attr on ping: %v", attr.Value.AsInterface())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary\n- scope publish retryable telemetry to append failures only\n- keep JetStream API error diagnostics on all operation failures\n- add coverage that ping failures do not emit the publish retryable attribute\n\n## Validation\n- go test ./internal/appendlog/jetstream\n- ./scripts/pre_commit_checks.sh\n- make lint