### PR TITLE
feat: add wide event telemetry rollups

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -716,12 +716,14 @@ func annotateOrchestratorRuntimeMain(ctx context.Context, result *orchestratorRu
 	}
 	healthRecord := normalizedOrchestratorRuntimeHealth(result)
 	healthState := sourcehealth.Evaluate(healthRecord)
+	healthGate := orchestratorRuntimeHealthGate(healthRecord, healthState, status)
 	if healthState.FreshnessState != "" {
 		telemetry.IncrementMain(ctx, "orchestrator.runtime.freshness."+orchestratorPhaseTelemetryKey(healthState.FreshnessState)+".count", 1)
 	}
 	if healthState.BackfillEligible {
 		telemetry.IncrementMain(ctx, "orchestrator.runtime.backfill_eligible.count", 1)
 	}
+	annotateOrchestratorHealthGateMain(ctx, healthRecord, healthState, healthGate)
 	mainAttrs := attrs.With(telemetry.Attrs(
 		telemetryField("orchestrator.runtime.last_status", status),
 		telemetryField("orchestrator.runtime.last_runtime_id", result.RuntimeID),
@@ -758,8 +760,66 @@ func annotateOrchestratorRuntimeMain(ctx context.Context, result *orchestratorRu
 		telemetryField("source_runtime.checkpoint_cursor_present", healthRecord.CheckpointCursorPresent),
 		telemetryField("source_runtime.contract_probe_state", healthRecord.ContractProbeState),
 		telemetryField("source_runtime.contract_probe_status", sourcehealth.ContractProbeStatus(healthRecord.ContractProbeState)),
+		telemetryField("orchestrator.runtime_health_gate.status", healthGate.Status),
+		telemetryField("orchestrator.runtime_health_gate.blocking_state", healthGate.BlockingState),
+		telemetryField("orchestrator.runtime_health_gate.needs_attention", healthGate.NeedsAttention),
 	))
 	telemetry.AnnotateMainPhase(ctx, "orchestrator.runtime", status, mainAttrs)
+}
+
+type orchestratorHealthGate struct {
+	Status         string
+	BlockingState  string
+	NeedsAttention bool
+}
+
+func orchestratorRuntimeHealthGate(record sourcehealth.Record, state sourcehealth.State, runtimeStatus string) orchestratorHealthGate {
+	if strings.EqualFold(strings.TrimSpace(runtimeStatus), "failed") {
+		return orchestratorHealthGate{Status: "blocked", BlockingState: "runtime_failed", NeedsAttention: true}
+	}
+	if state.FindingEvaluationState == "failed" {
+		return orchestratorHealthGate{Status: "blocked", BlockingState: "finding_failed", NeedsAttention: true}
+	}
+	switch strings.TrimSpace(state.FreshnessState) {
+	case "healthy":
+		return orchestratorHealthGate{Status: "pass", BlockingState: "none"}
+	case "source_failed", "graph_failed":
+		return orchestratorHealthGate{Status: "blocked", BlockingState: state.FreshnessState, NeedsAttention: true}
+	case "disabled":
+		return orchestratorHealthGate{Status: "degraded", BlockingState: "disabled", NeedsAttention: true}
+	case "source_stale", "graph_missing", "graph_behind":
+		return orchestratorHealthGate{Status: "degraded", BlockingState: state.FreshnessState, NeedsAttention: true}
+	}
+	if strings.EqualFold(strings.TrimSpace(record.Status), "healthy") {
+		return orchestratorHealthGate{Status: "degraded", BlockingState: "graph_missing", NeedsAttention: true}
+	}
+	return orchestratorHealthGate{Status: "degraded", BlockingState: "unknown", NeedsAttention: true}
+}
+
+func annotateOrchestratorHealthGateMain(ctx context.Context, record sourcehealth.Record, state sourcehealth.State, gate orchestratorHealthGate) {
+	telemetry.IncrementMain(ctx, "orchestrator.runtime_health_gate.total_count", 1)
+	telemetry.IncrementMain(ctx, "orchestrator.runtime_health_gate."+orchestratorPhaseTelemetryKey(gate.Status)+"_count", 1)
+	if !gate.NeedsAttention {
+		telemetry.IncrementMain(ctx, "orchestrator.runtime_health_gate.healthy_count", 1)
+	} else {
+		telemetry.IncrementMain(ctx, "orchestrator.runtime_health_gate.needs_attention_count", 1)
+	}
+	if state.BackfillEligible {
+		telemetry.IncrementMain(ctx, "orchestrator.runtime_health_gate.backfill_eligible_count", 1)
+	}
+	if gate.BlockingState != "" && gate.BlockingState != "none" {
+		telemetry.IncrementMain(ctx, "orchestrator.runtime_health_gate."+orchestratorPhaseTelemetryKey(gate.BlockingState)+".count", 1)
+	}
+	maxOptionalMain(ctx, "orchestrator.runtime_health_gate.max_sync_lag_seconds", record.SyncLagSeconds)
+	maxOptionalMain(ctx, "orchestrator.runtime_health_gate.max_watermark_lag_seconds", record.WatermarkLagSeconds)
+	maxOptionalMain(ctx, "orchestrator.runtime_health_gate.max_graph_lag_seconds", record.GraphLagSeconds)
+}
+
+func maxOptionalMain(ctx context.Context, key string, value *int64) {
+	if value == nil {
+		return
+	}
+	telemetry.MaxMain(ctx, key, *value)
 }
 
 func normalizedOrchestratorRuntimeHealth(result *orchestratorRuntimeResult) sourcehealth.Record {
@@ -881,7 +941,27 @@ func captureOrchestratorError(ctx context.Context, name string, iteration uint32
 			WithField(telemetryField("source_id", runtime.GetSourceId())).
 			WithField(telemetryField("tenant_id", runtime.GetTenantId()))
 	}
+	telemetry.AnnotateMainIfAbsent(ctx, orchestratorFirstFailureAttrs(name, attrs, iteration, runtime, stage, err))
 	telemetry.CaptureError(ctx, name, err, attrs)
+}
+
+func orchestratorFirstFailureAttrs(name string, attrs telemetry.Attributes, iteration uint32, runtime *cerebrov1.SourceRuntime, stage string, err error) telemetry.Attributes {
+	firstFailure := telemetry.Attrs(
+		telemetryField("orchestrator.first_failure.present", true),
+		telemetryField("orchestrator.first_failure.event_name", strings.TrimSpace(name)),
+		telemetryField("orchestrator.first_failure.stage", strings.TrimSpace(stage)),
+		telemetryField("orchestrator.first_failure.error_kind", telemetry.ErrorKind(err)),
+		telemetryField("orchestrator.first_failure.error_fingerprint", telemetry.ErrorFingerprint(name, err, attrs)),
+		telemetryField("orchestrator.first_failure.iteration", iteration),
+	)
+	if runtime != nil {
+		firstFailure = firstFailure.With(telemetry.Attrs(
+			telemetryField("orchestrator.first_failure.runtime_id", runtime.GetId()),
+			telemetryField("orchestrator.first_failure.source_id", runtime.GetSourceId()),
+			telemetryField("orchestrator.first_failure.tenant_id", runtime.GetTenantId()),
+		))
+	}
+	return firstFailure
 }
 
 func applyGraphIngestCounters(runtimeResult *orchestratorRuntimeResult, graphResult *graphingest.RunResult, attrs telemetry.Attributes) telemetry.Attributes {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -216,34 +216,70 @@ func TestAnnotateOrchestratorRuntimeMainAddsHealthFields(t *testing.T) {
 
 	payload := lastCommandTelemetryPayload(t, stderr)
 	for key, want := range map[string]any{
-		"source_runtime.family":                        "code",
-		"source_runtime.enabled_state":                 "enabled",
-		"source_runtime.freshness_state":               "healthy",
-		"source_runtime.source_sync_state":             "current",
-		"source_runtime.graph_ingest_state":            "current",
-		"source_runtime.finding_evaluation_state":      "current",
-		"source_runtime.next_action":                   "monitor",
-		"source_runtime.backfill_eligible":             false,
-		"source_runtime.contract_probe_state":          "passing",
-		"source_runtime.contract_probe_status":         "success",
-		"source_runtime.cursor_pending":                true,
-		"source_runtime.checkpoint_cursor_present":     true,
-		"orchestrator.runtime.freshness.healthy.count": float64(1),
+		"source_runtime.family":                           "code",
+		"source_runtime.enabled_state":                    "enabled",
+		"source_runtime.freshness_state":                  "healthy",
+		"source_runtime.source_sync_state":                "current",
+		"source_runtime.graph_ingest_state":               "current",
+		"source_runtime.finding_evaluation_state":         "current",
+		"source_runtime.next_action":                      "monitor",
+		"source_runtime.backfill_eligible":                false,
+		"source_runtime.contract_probe_state":             "passing",
+		"source_runtime.contract_probe_status":            "success",
+		"source_runtime.cursor_pending":                   true,
+		"source_runtime.checkpoint_cursor_present":        true,
+		"orchestrator.runtime.freshness.healthy.count":    float64(1),
+		"orchestrator.runtime_health_gate.status":         "pass",
+		"orchestrator.runtime_health_gate.blocking_state": "none",
+		"orchestrator.runtime_health_gate.pass_count":     float64(1),
+		"orchestrator.runtime_health_gate.healthy_count":  float64(1),
 	} {
 		if got := payload[key]; got != want {
 			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
 		}
 	}
 	for key, want := range map[string]float64{
-		"source_runtime.sync_lag_seconds":         30,
-		"source_runtime.watermark_lag_seconds":    45,
-		"source_runtime.graph_lag_seconds":        60,
-		"source_runtime.expected_cadence_seconds": 300,
-		"source_runtime.stale_after_seconds":      600,
+		"source_runtime.sync_lag_seconds":                            30,
+		"source_runtime.watermark_lag_seconds":                       45,
+		"source_runtime.graph_lag_seconds":                           60,
+		"source_runtime.expected_cadence_seconds":                    300,
+		"source_runtime.stale_after_seconds":                         600,
+		"orchestrator.runtime_health_gate.max_sync_lag_seconds":      30,
+		"orchestrator.runtime_health_gate.max_watermark_lag_seconds": 45,
+		"orchestrator.runtime_health_gate.max_graph_lag_seconds":     60,
 	} {
 		if got := payload[key]; got != want {
 			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
 		}
+	}
+}
+
+func TestCaptureOrchestratorErrorAnnotatesFirstFailureOnly(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "github", TenantId: "writer"}
+	stderr := captureCommandStderr(t, func() {
+		ctx, span := telemetry.StartMain(context.Background(), "orchestrator.run", telemetry.Attrs())
+		captureOrchestratorError(ctx, "orchestrator.runtime.error", 1, runtime, "sync", context.DeadlineExceeded)
+		captureOrchestratorError(ctx, "orchestrator.runtime.error", 1, runtime, "graph_ingest", errors.New("graph failed"))
+		telemetry.End(span, "failed", telemetry.Attrs())
+	})
+
+	payload := lastCommandTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"orchestrator.first_failure.present":    true,
+		"orchestrator.first_failure.event_name": "orchestrator.runtime.error",
+		"orchestrator.first_failure.stage":      "sync",
+		"orchestrator.first_failure.error_kind": "context_deadline_exceeded",
+		"orchestrator.first_failure.iteration":  float64(1),
+		"orchestrator.first_failure.runtime_id": "runtime-1",
+		"orchestrator.first_failure.source_id":  "github",
+		"orchestrator.first_failure.tenant_id":  "writer",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if got, ok := payload["orchestrator.first_failure.error_fingerprint"].(string); !ok || got == "" {
+		t.Fatalf("first failure fingerprint missing: %#v", payload)
 	}
 }
 

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -18,6 +18,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourcehealth"
 	"github.com/writer/cerebro/internal/sourceruntime"
+	"github.com/writer/cerebro/internal/telemetry"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -231,7 +232,9 @@ func (a *App) handleGetConnectorCoverage(w http.ResponseWriter, r *http.Request)
 		writeSourceRuntimeError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, sourcecoverage.BuildScopedReport(health.Coverage, r.URL.Query().Get("tenant_id"), r.URL.Query().Get("source_id"), health.GeneratedAt))
+	report := sourcecoverage.BuildScopedReport(health.Coverage, r.URL.Query().Get("tenant_id"), r.URL.Query().Get("source_id"), health.GeneratedAt)
+	emitSourceCoverageGateTelemetry(r.Context(), report)
+	writeJSON(w, http.StatusOK, report)
 }
 func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthResponse, error) {
 	limit, err := uint32QueryParam(r, "limit")
@@ -364,6 +367,40 @@ func (a *App) sourceCoverageRecords(runtimes []*cerebrov1.SourceRuntime, filter 
 		TenantID: strings.TrimSpace(filter.TenantID),
 		SourceID: strings.TrimSpace(filter.SourceID),
 	})
+}
+
+func emitSourceCoverageGateTelemetry(ctx context.Context, report sourcecoverage.Report) {
+	gate := report.Gate
+	if strings.TrimSpace(gate.Status) == "" {
+		gate = sourcecoverage.GateForTotals(report.Totals)
+		report.Gate = gate
+	}
+	attrs := sourceCoverageGateTelemetryAttributes(report)
+	telemetry.Event(ctx, "source_coverage.release_gate", attrs)
+	telemetry.IncrementMain(ctx, "source_coverage.release_gate.count", 1)
+	telemetry.IncrementMain(ctx, "source_coverage.release_gate."+gate.Status+".count", 1)
+	telemetry.AnnotateMain(ctx, attrs)
+}
+
+func sourceCoverageGateTelemetryAttributes(report sourcecoverage.Report) telemetry.Attributes {
+	gate := report.Gate
+	if strings.TrimSpace(gate.Status) == "" {
+		gate = sourcecoverage.GateForTotals(report.Totals)
+	}
+	return telemetry.Attrs(
+		telemetry.Field{Key: "source_coverage.gate.status", Value: gate.Status},
+		telemetry.Field{Key: "source_coverage.gate.blocking_reason", Value: gate.BlockingReason},
+		telemetry.Field{Key: "source_coverage.dimensions.total", Value: report.Totals.Dimensions},
+		telemetry.Field{Key: "source_coverage.high_value_dimensions.total", Value: report.Totals.HighValueDimensions},
+		telemetry.Field{Key: "source_coverage.healthy_count", Value: report.Totals.Healthy},
+		telemetry.Field{Key: "source_coverage.partial_count", Value: report.Totals.Partial},
+		telemetry.Field{Key: "source_coverage.unsupported_count", Value: report.Totals.Unsupported},
+		telemetry.Field{Key: "source_coverage.unconfigured_count", Value: report.Totals.Unconfigured},
+		telemetry.Field{Key: "source_coverage.stale_count", Value: report.Totals.Stale},
+		telemetry.Field{Key: "source_coverage.failed_count", Value: report.Totals.Failed},
+		telemetry.Field{Key: "source_coverage.unknown_count", Value: report.Totals.Unknown},
+		telemetry.Field{Key: "source_coverage.blind_spot_count", Value: report.Totals.BlindSpots},
+	)
 }
 
 func runtimeFreshnessRecordFromHealth(record sourceRuntimeHealthRecord) runtimeFreshnessRecord {

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -476,9 +476,46 @@ func TestConnectorCoverageReportUsesAuthenticatedTenantAndBlindSpotTotals(t *tes
 	if report.Totals.Dimensions != 3 || report.Totals.BlindSpots != 2 {
 		t.Fatalf("report totals = %#v", report.Totals)
 	}
+	if report.Gate.Status != "fail" || report.Gate.BlockingReason != "blind_spot" {
+		t.Fatalf("report gate = %#v, want blind_spot failure", report.Gate)
+	}
 	for _, record := range report.Records {
 		if record.TenantID == "other" || record.RuntimeID == "other-okta-application" {
 			t.Fatalf("report leaked other tenant record: %#v", record)
+		}
+	}
+}
+
+func TestEmitSourceCoverageGateTelemetry(t *testing.T) {
+	report := sourcecoverage.Report{
+		Totals: sourcecoverage.Totals{
+			Dimensions:          4,
+			HighValueDimensions: 3,
+			Healthy:             1,
+			Failed:              1,
+			Unconfigured:        1,
+			BlindSpots:          2,
+		},
+	}
+	report.Gate = sourcecoverage.GateForTotals(report.Totals)
+
+	stderr := captureBootstrapStderr(t, func() {
+		emitSourceCoverageGateTelemetry(context.Background(), report)
+	})
+	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"name":                                        "source_coverage.release_gate",
+		"source_coverage.gate.status":                 "fail",
+		"source_coverage.gate.blocking_reason":        "failed",
+		"source_coverage.dimensions.total":            float64(4),
+		"source_coverage.high_value_dimensions.total": float64(3),
+		"source_coverage.healthy_count":               float64(1),
+		"source_coverage.failed_count":                float64(1),
+		"source_coverage.unconfigured_count":          float64(1),
+		"source_coverage.blind_spot_count":            float64(2),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
 		}
 	}
 }

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -2012,7 +2012,7 @@ func (s *Service) finishCompletedRun(ctx context.Context, run *cerebrov1.Finding
 	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
 		return fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
 	}
-	emitFindingEvaluationRunTelemetry(ctx, run)
+	emitFindingEvaluationRunTelemetry(ctx, run, nil)
 	return nil
 }
 
@@ -2030,7 +2030,7 @@ func (s *Service) finishFailedRun(ctx context.Context, run *cerebrov1.FindingEva
 			fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err),
 		)
 	}
-	emitFindingEvaluationRunTelemetry(ctx, run)
+	emitFindingEvaluationRunTelemetry(ctx, run, evaluationErr)
 	return evaluationErr
 }
 
@@ -2049,7 +2049,7 @@ func (s *Service) finishCompletedGraphRun(ctx context.Context, run *cerebrov1.Fi
 	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
 		return fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
 	}
-	emitFindingEvaluationRunTelemetry(ctx, run)
+	emitFindingEvaluationRunTelemetry(ctx, run, nil)
 	return nil
 }
 
@@ -2071,7 +2071,7 @@ func (s *Service) finishFailedGraphRun(ctx context.Context, run *cerebrov1.Findi
 			fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err),
 		)
 	}
-	emitFindingEvaluationRunTelemetry(ctx, run)
+	emitFindingEvaluationRunTelemetry(ctx, run, evaluationErr)
 	return evaluationErr
 }
 
@@ -2090,7 +2090,7 @@ func (s *Service) markRuleEvaluationFailed(ctx context.Context, state *ruleEvalu
 			fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err),
 		)
 	}
-	emitFindingEvaluationRunTelemetry(ctx, run)
+	emitFindingEvaluationRunTelemetry(ctx, run, evaluationErr)
 	state.failed = true
 	return nil
 }
@@ -2122,15 +2122,24 @@ func setGraphFindingEvaluationRunMetrics(run *cerebrov1.FindingEvaluationRun, gr
 	run.FindingIds = append([]string(nil), findingIDs...)
 }
 
-func emitFindingEvaluationRunTelemetry(ctx context.Context, run *cerebrov1.FindingEvaluationRun) {
+func emitFindingEvaluationRunTelemetry(ctx context.Context, run *cerebrov1.FindingEvaluationRun, evaluationErr error) {
 	if run == nil {
 		return
 	}
+	stage := findingEvaluationTelemetryStage(evaluationErr)
+	failureStage := ""
+	if evaluationErr != nil {
+		failureStage = stage
+	}
+	ruleType := findingEvaluationRuleType(run)
 	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "run_id", Value: strings.TrimSpace(run.GetId())},
 		telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(run.GetRuntimeId())},
 		telemetry.Field{Key: "rule_id", Value: strings.TrimSpace(run.GetRuleId())},
 		telemetry.Field{Key: "status", Value: strings.TrimSpace(run.GetStatus())},
+		telemetry.Field{Key: "finding_evaluation.stage", Value: stage},
+		telemetry.Field{Key: "finding_evaluation.failure_stage", Value: failureStage},
+		telemetry.Field{Key: "finding_evaluation.rule_type", Value: ruleType},
 		telemetry.Field{Key: "event_limit", Value: run.GetEventLimit()},
 		telemetry.Field{Key: "events_processed", Value: run.GetEventsProcessed()},
 		telemetry.Field{Key: "events_matched", Value: run.GetEventsMatched()},
@@ -2138,15 +2147,34 @@ func emitFindingEvaluationRunTelemetry(ctx context.Context, run *cerebrov1.Findi
 		telemetry.Field{Key: "graph_rule", Value: run.GetGraphRule()},
 		telemetry.Field{Key: "graph_rows_read", Value: run.GetGraphRowsRead()},
 	)
+	if evaluationErr != nil {
+		attrs = attrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(evaluationErr)},
+			telemetry.Field{Key: "error_fingerprint", Value: telemetry.ErrorFingerprint("finding_evaluation.run", evaluationErr, attrs)},
+		))
+	}
 	telemetry.Event(ctx, "finding_evaluation.run", attrs)
 	telemetry.IncrementMain(ctx, "finding_evaluation.run.count", 1)
-	if !strings.EqualFold(strings.TrimSpace(run.GetStatus()), "completed") {
+	status := strings.TrimSpace(run.GetStatus())
+	if strings.EqualFold(status, "completed") {
+		telemetry.IncrementMain(ctx, "finding_evaluation."+ruleType+".completed.count", 1)
+	} else {
 		telemetry.IncrementMain(ctx, "finding_evaluation.run.non_completed.count", 1)
+		telemetry.IncrementMain(ctx, "finding_evaluation."+ruleType+".failed.count", 1)
+	}
+	if run.GetFindingsEmitted() > 0 {
+		telemetry.IncrementMain(ctx, "finding_evaluation.findings_emitted.count", int64(run.GetFindingsEmitted()))
+	}
+	if run.GetGraphRowsRead() > 0 {
+		telemetry.IncrementMain(ctx, "finding_evaluation.graph_rows_read.count", int64(run.GetGraphRowsRead()))
 	}
 	telemetry.AnnotateMain(ctx, telemetry.Attrs(
 		telemetry.Field{Key: "finding_evaluation.runtime_id", Value: strings.TrimSpace(run.GetRuntimeId())},
 		telemetry.Field{Key: "finding_evaluation.rule_id", Value: strings.TrimSpace(run.GetRuleId())},
-		telemetry.Field{Key: "finding_evaluation.status", Value: strings.TrimSpace(run.GetStatus())},
+		telemetry.Field{Key: "finding_evaluation.status", Value: status},
+		telemetry.Field{Key: "finding_evaluation.stage", Value: stage},
+		telemetry.Field{Key: "finding_evaluation.failure_stage", Value: failureStage},
+		telemetry.Field{Key: "finding_evaluation.rule_type", Value: ruleType},
 		telemetry.Field{Key: "finding_evaluation.event_limit", Value: run.GetEventLimit()},
 		telemetry.Field{Key: "finding_evaluation.events_processed", Value: run.GetEventsProcessed()},
 		telemetry.Field{Key: "finding_evaluation.events_matched", Value: run.GetEventsMatched()},
@@ -2154,6 +2182,52 @@ func emitFindingEvaluationRunTelemetry(ctx context.Context, run *cerebrov1.Findi
 		telemetry.Field{Key: "finding_evaluation.graph_rule", Value: run.GetGraphRule()},
 		telemetry.Field{Key: "finding_evaluation.graph_rows_read", Value: run.GetGraphRowsRead()},
 	))
+}
+
+func findingEvaluationRuleType(run *cerebrov1.FindingEvaluationRun) string {
+	if run != nil && run.GetGraphRule() {
+		return "graph_rule"
+	}
+	return "event_rule"
+}
+
+func findingEvaluationTelemetryStage(err error) string {
+	if err == nil {
+		return "finalize_run"
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error()))
+	switch {
+	case strings.Contains(message, "persist finding evaluation run"):
+		return "persist_run"
+	case strings.Contains(message, "replay runtime"):
+		return "replay"
+	case strings.Contains(message, "execute graph rule"):
+		return "graph_query"
+	case strings.Contains(message, "evaluate graph rule"):
+		return "graph_evaluate_rows"
+	case strings.Contains(message, "evaluate finding rule"):
+		return "evaluate_rule"
+	case strings.Contains(message, "reconcile finding identity"):
+		return "reconcile_identity"
+	case strings.Contains(message, "persist finding"):
+		return "upsert_finding"
+	case strings.Contains(message, "build evidence"):
+		return "build_evidence"
+	case strings.Contains(message, "persist evidence"):
+		return "persist_evidence"
+	case strings.Contains(message, "action recommendations"):
+		return "project_action_recommendations"
+	case strings.Contains(message, "graph anchor") || strings.Contains(message, " finding ") && strings.Contains(message, " anchor"):
+		return "project_anchor"
+	case strings.Contains(message, "external refs"):
+		return "project_external_refs"
+	case strings.Contains(message, "resolve stale") || strings.Contains(message, "resolve retired"):
+		return "resolve_stale"
+	case strings.Contains(message, "counter-event close evidence"):
+		return "persist_close_evidence"
+	default:
+		return "unknown"
+	}
 }
 
 func (s *Service) markRuleEvaluationsFailed(ctx context.Context, states []*ruleEvaluationState, evaluationErr error) error {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2130,16 +2130,19 @@ func TestFindingEvaluationRunFinalizersEmitTelemetry(t *testing.T) {
 	})
 	payload := decodeTelemetryPayload(t, stderr)
 	for key, want := range map[string]any{
-		"kind":             "event",
-		"name":             "finding_evaluation.run",
-		"run_id":           "run-1",
-		"runtime_id":       "runtime-okta",
-		"rule_id":          "rule-a",
-		"status":           "completed",
-		"event_limit":      float64(25),
-		"events_processed": float64(7),
-		"events_matched":   float64(3),
-		"findings_emitted": float64(2),
+		"kind":                             "event",
+		"name":                             "finding_evaluation.run",
+		"run_id":                           "run-1",
+		"runtime_id":                       "runtime-okta",
+		"rule_id":                          "rule-a",
+		"status":                           "completed",
+		"finding_evaluation.stage":         "finalize_run",
+		"finding_evaluation.failure_stage": "",
+		"finding_evaluation.rule_type":     "event_rule",
+		"event_limit":                      float64(25),
+		"events_processed":                 float64(7),
+		"events_matched":                   float64(3),
+		"findings_emitted":                 float64(2),
 	} {
 		if got := payload[key]; got != want {
 			t.Fatalf("telemetry[%s] = %#v, want %#v; payload=%#v", key, got, want, payload)
@@ -2173,6 +2176,19 @@ func TestFailedFindingEvaluationRunFinalizerEmitsTelemetry(t *testing.T) {
 	}
 	if got := payload["findings_emitted"]; got != float64(1) {
 		t.Fatalf("telemetry findings_emitted = %#v, want 1; payload=%#v", got, payload)
+	}
+	for key, want := range map[string]any{
+		"finding_evaluation.stage":         "unknown",
+		"finding_evaluation.failure_stage": "unknown",
+		"finding_evaluation.rule_type":     "event_rule",
+		"error_kind":                       "error",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if got, ok := payload["error_fingerprint"].(string); !ok || got == "" {
+		t.Fatalf("telemetry error_fingerprint missing: %#v", payload)
 	}
 }
 

--- a/internal/sourcecoverage/coverage.go
+++ b/internal/sourcecoverage/coverage.go
@@ -76,6 +76,7 @@ type Report struct {
 	TenantID           string    `json:"tenant_id,omitempty"`
 	SourceID           string    `json:"source_id,omitempty"`
 	Totals             Totals    `json:"totals"`
+	Gate               Gate      `json:"gate"`
 	Records            []Record  `json:"records"`
 	BlindSpots         []Record  `json:"blind_spots"`
 	Summaries          []Summary `json:"summaries"`
@@ -93,6 +94,11 @@ type Totals struct {
 	Failed              int `json:"failed"`
 	Unknown             int `json:"unknown"`
 	BlindSpots          int `json:"blind_spots"`
+}
+
+type Gate struct {
+	Status         string `json:"status"`
+	BlockingReason string `json:"blocking_reason"`
 }
 
 func ContractsFromRegistry(registry *sourcecdk.Registry) []sourcecdk.CoverageContract {
@@ -181,12 +187,14 @@ func BuildReport(records []Record, options Options, generatedAt time.Time) Repor
 	options.SourceID = strings.TrimSpace(options.SourceID)
 	clonedRecords := cloneRecords(records)
 	blindSpots := BlindSpots(clonedRecords)
+	totals := TotalsFor(clonedRecords)
 	return Report{
 		Version:            "source-coverage/v1",
 		GeneratedAt:        generatedAt.UTC().Format(time.RFC3339Nano),
 		TenantID:           options.TenantID,
 		SourceID:           options.SourceID,
-		Totals:             TotalsFor(clonedRecords),
+		Totals:             totals,
+		Gate:               GateForTotals(totals),
 		Records:            clonedRecords,
 		BlindSpots:         blindSpots,
 		Summaries:          Summaries(clonedRecords),
@@ -234,6 +242,27 @@ func TotalsFor(records []Record) Totals {
 		}
 	}
 	return totals
+}
+
+func GateForTotals(totals Totals) Gate {
+	switch {
+	case totals.Failed > 0:
+		return Gate{Status: "fail", BlockingReason: "failed"}
+	case totals.BlindSpots > 0:
+		return Gate{Status: "fail", BlockingReason: "blind_spot"}
+	case totals.Stale > 0:
+		return Gate{Status: "warn", BlockingReason: "stale"}
+	case totals.Unconfigured > 0:
+		return Gate{Status: "warn", BlockingReason: "unconfigured"}
+	case totals.Unsupported > 0:
+		return Gate{Status: "warn", BlockingReason: "unsupported"}
+	case totals.Partial > 0:
+		return Gate{Status: "warn", BlockingReason: "partial"}
+	case totals.Unknown > 0:
+		return Gate{Status: "warn", BlockingReason: "unknown"}
+	default:
+		return Gate{Status: "pass", BlockingReason: "none"}
+	}
 }
 
 func Summaries(records []Record) []Summary {

--- a/internal/sourcecoverage/coverage_test.go
+++ b/internal/sourcecoverage/coverage_test.go
@@ -73,11 +73,34 @@ func TestBuildReportSummarizesRecordsAndBlindSpots(t *testing.T) {
 	if report.Totals.Healthy != 1 || report.Totals.Unconfigured != 1 || report.Totals.Failed != 1 || report.Totals.Partial != 1 {
 		t.Fatalf("report state totals = %#v", report.Totals)
 	}
+	if report.Gate.Status != "fail" || report.Gate.BlockingReason != "failed" {
+		t.Fatalf("report gate = %#v, want failed release gate", report.Gate)
+	}
 	if len(report.BlindSpots) != 2 || len(report.BlindSpotSummaries) != 2 {
 		t.Fatalf("blind spot report = %#v", report)
 	}
 	if len(report.Summaries) != 2 {
 		t.Fatalf("summary count = %d, want 2", len(report.Summaries))
+	}
+}
+
+func TestGateForTotalsUsesBoundedReleaseGateReasons(t *testing.T) {
+	cases := []struct {
+		name   string
+		totals Totals
+		want   Gate
+	}{
+		{name: "pass", totals: Totals{Healthy: 2}, want: Gate{Status: "pass", BlockingReason: "none"}},
+		{name: "blind spot", totals: Totals{BlindSpots: 1, Unconfigured: 1}, want: Gate{Status: "fail", BlockingReason: "blind_spot"}},
+		{name: "stale", totals: Totals{Stale: 1}, want: Gate{Status: "warn", BlockingReason: "stale"}},
+		{name: "partial", totals: Totals{Partial: 1}, want: Gate{Status: "warn", BlockingReason: "partial"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GateForTotals(tc.totals); got != tc.want {
+				t.Fatalf("GateForTotals() = %#v, want %#v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -247,16 +247,18 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	status := "failed"
 	spanAttributes := telemetry.Attrs()
 	var (
-		runtime             *cerebrov1.SourceRuntime
-		eventContracts      []sourcecdk.EventContract
-		contractConfigured  bool
-		runtimeLoadedForRun bool
-		eventsAppended      uint32
-		pagesRead           uint32
-		recordsScanned      uint32
-		recordsRejected     uint32
-		entitiesProjected   uint32
-		linksProjected      uint32
+		runtime                *cerebrov1.SourceRuntime
+		eventContracts         []sourcecdk.EventContract
+		contractConfigured     bool
+		runtimeLoadedForRun    bool
+		eventsAppended         uint32
+		pagesRead              uint32
+		recordsScanned         uint32
+		recordsRejected        uint32
+		entitiesProjected      uint32
+		linksProjected         uint32
+		lastQuarantineCategory string
+		checkpointAdvanced     bool
 	)
 	defer func() {
 		if err != nil {
@@ -268,6 +270,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			}
 		}
 		telemetry.IncrementMain(ctx, "source_runtime.sync.count", 1)
+		spanAttributes = spanAttributes.With(sourceRuntimeSyncRollupAttributes(recordsScanned, eventsAppended, recordsRejected, lastQuarantineCategory, checkpointAdvanced))
 		spanAttributes = spanAttributes.
 			WithField(telemetry.Field{Key: "source_runtime.sync.contract_configured", Value: contractConfigured}).
 			WithField(telemetry.Field{Key: "source_runtime.sync.runtime_loaded", Value: runtimeLoadedForRun})
@@ -397,6 +400,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 				if quarantinableContractError(err) {
 					recordsRejected++
 					category := invalidEventFailureCategory(err)
+					lastQuarantineCategory = category
 					recordRuntimeInvalidEvent(runtime, syncedEvent, category, err, time.Now().UTC(), len(eventContracts) > 0)
 					telemetry.Event(ctx, "source_runtime.invalid_event", telemetry.Attrs(
 						telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
@@ -444,6 +448,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
 			return nil, err
 		}
+		checkpointAdvanced = runtimeCheckpointAdvanced(originalCheckpoint, runtime.GetCheckpoint())
 		pageCommittedAttrs := withFamilyFreshnessTelemetry(telemetry.Attrs(
 			telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
 			telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()},
@@ -452,10 +457,12 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "records_scanned", Value: recordsScanned},
 			telemetry.Field{Key: "records_accepted", Value: eventsAppended},
 			telemetry.Field{Key: "records_rejected", Value: recordsRejected},
+			telemetry.Field{Key: "records_quarantined", Value: recordsRejected},
 			telemetry.Field{Key: "events_appended", Value: eventsAppended},
 			telemetry.Field{Key: "entities_projected", Value: entitiesProjected},
 			telemetry.Field{Key: "links_projected", Value: linksProjected},
 			telemetry.Field{Key: "has_next_cursor", Value: pull.NextCursor != nil},
+			telemetry.Field{Key: "checkpoint_advanced", Value: checkpointAdvanced},
 			telemetry.Field{Key: "short_circuit_reason", Value: pageShortCircuitReason},
 			telemetry.Field{Key: "reconciliation_reason", Value: pageReconciliationReason},
 		), runtime.GetCheckpoint())
@@ -477,6 +484,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "records_scanned", Value: recordsScanned})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "records_accepted", Value: eventsAppended})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "records_rejected", Value: recordsRejected})
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "records_quarantined", Value: recordsRejected})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "events_appended", Value: eventsAppended})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "entities_projected", Value: entitiesProjected})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "links_projected", Value: linksProjected})
@@ -620,6 +628,52 @@ func updateRuntimeSyncStatus(runtime *cerebrov1.SourceRuntime, status runtimeSyn
 		return
 	}
 	setRuntimeConfig(runtime.Config, runtimeContractProbeStateConfigKey, contractProbeStateForRuntime(runtime, runtime.Config[runtimeLastFailureCategoryConfigKey], status.ContractConfigured))
+}
+
+func sourceRuntimeSyncRollupAttributes(recordsScanned uint32, recordsAccepted uint32, recordsQuarantined uint32, lastQuarantineCategory string, checkpointAdvanced bool) telemetry.Attributes {
+	lastQuarantineCategory = strings.TrimSpace(lastQuarantineCategory)
+	if lastQuarantineCategory == "" {
+		lastQuarantineCategory = "none"
+	}
+	return telemetry.Attrs(
+		telemetry.Field{Key: "source_runtime.sync.records_scanned", Value: recordsScanned},
+		telemetry.Field{Key: "source_runtime.sync.records_accepted", Value: recordsAccepted},
+		telemetry.Field{Key: "source_runtime.sync.records_quarantined", Value: recordsQuarantined},
+		telemetry.Field{Key: "source_runtime.sync.quarantine_present", Value: recordsQuarantined > 0},
+		telemetry.Field{Key: "source_runtime.sync.acceptance_bucket", Value: sourceRuntimeSyncAcceptanceBucket(recordsScanned, recordsAccepted, recordsQuarantined)},
+		telemetry.Field{Key: "source_runtime.sync.last_quarantine_category", Value: lastQuarantineCategory},
+		telemetry.Field{Key: "source_runtime.sync.checkpoint_advanced", Value: checkpointAdvanced},
+	)
+}
+
+func sourceRuntimeSyncAcceptanceBucket(recordsScanned uint32, recordsAccepted uint32, recordsQuarantined uint32) string {
+	switch {
+	case recordsScanned == 0:
+		return "none"
+	case recordsQuarantined == 0 && recordsAccepted == recordsScanned:
+		return "all"
+	case recordsAccepted == 0:
+		return "none"
+	default:
+		return "partial"
+	}
+}
+
+func runtimeCheckpointAdvanced(before *cerebrov1.SourceCheckpoint, after *cerebrov1.SourceCheckpoint) bool {
+	if sourceCheckpointEmpty(after) {
+		return false
+	}
+	if sourceCheckpointEmpty(before) {
+		return true
+	}
+	return !proto.Equal(before, after)
+}
+
+func sourceCheckpointEmpty(checkpoint *cerebrov1.SourceCheckpoint) bool {
+	if checkpoint == nil {
+		return true
+	}
+	return strings.TrimSpace(checkpoint.GetCursorOpaque()) == "" && timestampValue(checkpoint.GetWatermark()).IsZero()
 }
 
 func clearRuntimeInvalidEvent(config map[string]string) {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1909,6 +1909,19 @@ func TestSyncRuntimeRejectsEventsMissingCatalogContractFields(t *testing.T) {
 			t.Fatalf("contract probe telemetry %s = %#v, want %#v; payload=%#v", key, got, want, probePayload)
 		}
 	}
+	syncPayload := sourceRuntimeTelemetryPayload(t, stderr, "source_runtime.sync")
+	for key, want := range map[string]any{
+		"source_runtime.sync.records_scanned":          float64(1),
+		"source_runtime.sync.records_accepted":         float64(0),
+		"source_runtime.sync.records_quarantined":      float64(1),
+		"source_runtime.sync.quarantine_present":       true,
+		"source_runtime.sync.acceptance_bucket":        "none",
+		"source_runtime.sync.last_quarantine_category": "missing_required_attribute",
+	} {
+		if got := syncPayload[key]; got != want {
+			t.Fatalf("sync telemetry %s = %#v, want %#v; payload=%#v", key, got, want, syncPayload)
+		}
+	}
 }
 
 func TestEmitSourceRuntimeContractProbeMapsPassingState(t *testing.T) {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -71,7 +71,7 @@ type RuntimeMetadata struct {
 }
 
 const maxAttributeStringLength = 1024
-const wideEventSchemaVersion = "2026-06-18.1"
+const wideEventSchemaVersion = "2026-06-18.2"
 
 var (
 	runtimeMetadataMu sync.RWMutex
@@ -408,6 +408,12 @@ func AnnotateMain(ctx context.Context, attributes Attributes) {
 	}
 }
 
+func AnnotateMainIfAbsent(ctx context.Context, attributes Attributes) {
+	if span, ok := ctx.Value(mainSpanContextKey{}).(*Span); ok && span != nil {
+		span.annotateIfAbsent(attributes)
+	}
+}
+
 func IncrementMain(ctx context.Context, key string, delta int64) {
 	if strings.TrimSpace(key) == "" || delta == 0 {
 		return
@@ -597,6 +603,31 @@ func (s *Span) annotate(attributes Attributes) {
 	s.mu.Unlock()
 	if s.otelSpan != nil && s.otelSpan.SpanContext().IsValid() {
 		s.otelSpan.SetAttributes(attributes.OTELAttributes()...)
+	}
+}
+
+func (s *Span) annotateIfAbsent(attributes Attributes) {
+	if s == nil || len(attributes.values) == 0 {
+		return
+	}
+	inserted := Attrs()
+	s.mu.Lock()
+	if s.annotations == nil {
+		s.annotations = map[string]any{}
+	}
+	for key, value := range attributes.values {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		if _, exists := s.annotations[key]; exists {
+			continue
+		}
+		s.annotations[key] = value
+		inserted = inserted.with(key, value)
+	}
+	s.mu.Unlock()
+	if len(inserted.values) > 0 && s.otelSpan != nil && s.otelSpan.SpanContext().IsValid() {
+		s.otelSpan.SetAttributes(inserted.OTELAttributes()...)
 	}
 }
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -219,6 +219,11 @@ func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
 			Field{Key: "oversized", Value: strings.Repeat("x", maxAttributeStringLength+256)},
 		))
 		AnnotateMain(ctx, Attrs(Field{Key: "cache.redis.last_status", Value: "hit"}))
+		AnnotateMainIfAbsent(ctx, Attrs(Field{Key: "first.error_stage", Value: "sync"}))
+		AnnotateMainIfAbsent(ctx, Attrs(
+			Field{Key: "first.error_stage", Value: "graph_ingest"},
+			Field{Key: "first.error_kind", Value: "context_deadline_exceeded"},
+		))
 		IncrementMain(ctx, "cache.redis.hit.count", 1)
 		IncrementMain(ctx, "cache.redis.hit.count", 2)
 		MaxMain(ctx, "cache.redis.max_latency_ms", 5)
@@ -246,6 +251,12 @@ func TestStartMainAccumulatesWideEventAnnotations(t *testing.T) {
 	}
 	if got := payload["cache.redis.max_latency_ms"]; got != float64(5) {
 		t.Fatalf("max value = %#v, want 5; payload=%#v", got, payload)
+	}
+	if got := payload["first.error_stage"]; got != "sync" {
+		t.Fatalf("first-if-absent attr = %#v, want sync; payload=%#v", got, payload)
+	}
+	if got := payload["first.error_kind"]; got != "context_deadline_exceeded" {
+		t.Fatalf("first-if-absent new attr = %#v, want context_deadline_exceeded; payload=%#v", got, payload)
 	}
 	if got := payload["explicit_end_attr"]; got != "kept" {
 		t.Fatalf("explicit end attr missing: %#v", payload)


### PR DESCRIPTION
## Summary
- add runtime health gate and first-failure breadcrumbs to orchestrator wide events
- add source runtime sync/quarantine rollups and finding evaluation stage rollups
- add source coverage release-gate telemetry with schema version 2026-06-18.2

## Validation
- go test focused telemetry packages
- make verify