### PR TITLE
[codex] add multi-cloud deployment templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The compose stack starts Cerebro with NATS JetStream, Postgres, Neo4j, and a loc
 | --- | --- | --- |
 | Run the lightweight server | `make serve-dev` | Starts the API without external stores using an acknowledged local-only auth/rate-limit opt-out; useful for health, source catalog, and OpenAPI checks. |
 | Run the durable local stack | `docker compose up --build` | Starts Cerebro with NATS JetStream, Postgres, Neo4j, and the local bearer key `local-dev-key`. |
-| Host Cerebro | `docs/HOSTING.md`, `docs/DEPLOYMENT_EXAMPLES.md`, and `docs/OPERATIONS_RUNBOOK.md` | Deployment guidance, example platform shapes, health checks, operations, and rollout. |
+| Host Cerebro | `docs/HOSTING.md`, `docs/CLOUD_DEPLOYMENT.md`, `docs/DEPLOYMENT_EXAMPLES.md`, and `docs/OPERATIONS_RUNBOOK.md` | Deployment guidance, AWS/GCP/Azure Pulumi templates, example platform shapes, health checks, operations, and rollout. |
 | Preserve production headroom | `docs/HEADROOM.md`, `docs/OBSERVABILITY.md`, and `make load-smoke` | Capacity SLOs, saturation alerts, autoscaling signals, wide-event incident queries, and bounded live load smoke checks. |
 | Try a local end-to-end path | `docs/GETTING_STARTED.md` | Creates an SDK source runtime, writes a synthetic claim, and reads it back. |
 | Explore the API | `GET /openapi.yaml` or `api/openapi.yaml` | JSON HTTP routes are generated and checked against the OpenAPI contract. |
@@ -436,6 +436,7 @@ Some files in `docs/` describe broader or historical architecture and may be ahe
 | [API reference](docs/API_REFERENCE.md) | OpenAPI-oriented route reference |
 | [Configuration](docs/CONFIGURATION.md) | configuration and deployment notes |
 | [Hosting](docs/HOSTING.md) | hosting guide for containers, backing stores, proxy/TLS, operations, and rollout |
+| [Cloud deployment](docs/CLOUD_DEPLOYMENT.md) | AWS, GCP, Azure, and Pulumi template guidance |
 | [Deployment examples](docs/DEPLOYMENT_EXAMPLES.md) | portable examples for Docker Compose, Kubernetes, ECS-style tasks, systemd, and scheduled jobs |
 | [Operations runbook](docs/OPERATIONS_RUNBOOK.md) | startup, health, dependency, rollout, rollback, and incident triage guidance |
 | [Observability](docs/OBSERVABILITY.md) | OTEL, structured span logs, trace propagation, error capture, and verification |

--- a/deploy/pulumi/.gitignore
+++ b/deploy/pulumi/.gitignore
@@ -1,0 +1,5 @@
+.pulumi-state/
+.venv/
+__pycache__/
+*.pyc
+uv.lock

--- a/deploy/pulumi/Pulumi.aws.yaml
+++ b/deploy/pulumi/Pulumi.aws.yaml
@@ -1,0 +1,11 @@
+config:
+  cerebro:cloud: aws
+  cerebro:name: cerebro-aws-example
+  cerebro:image: ghcr.io/writer/cerebro:latest
+  cerebro:apiAuthEnabled: "false"
+  cerebro:publicOrigin: https://cerebro.example.com
+  cerebro:awsRegion: us-east-1
+  cerebro:awsAvailabilityZones:
+    - us-east-1a
+    - us-east-1b
+encryptionsalt: v1:3bEOV/VxFZI=:v1:HadDLAMOXnVa1xEm:nT2XfUC42lkUoyRLrgX6dZj6zzYG4A==

--- a/deploy/pulumi/Pulumi.azure.yaml
+++ b/deploy/pulumi/Pulumi.azure.yaml
@@ -1,0 +1,8 @@
+config:
+  cerebro:cloud: azure
+  cerebro:name: cerebro-azure-example
+  cerebro:image: ghcr.io/writer/cerebro:latest
+  cerebro:apiAuthEnabled: "false"
+  cerebro:publicOrigin: https://cerebro.example.com
+  cerebro:azureLocation: eastus
+encryptionsalt: v1:Oi5k9s+pCKo=:v1:LjQpnfOxABX2GXHJ:h7cjI4cj2VOS4CVqUJtd+zXPZmeZDg==

--- a/deploy/pulumi/Pulumi.gcp.yaml
+++ b/deploy/pulumi/Pulumi.gcp.yaml
@@ -1,0 +1,9 @@
+config:
+  cerebro:cloud: gcp
+  cerebro:name: cerebro-gcp-example
+  cerebro:image: ghcr.io/writer/cerebro:latest
+  cerebro:apiAuthEnabled: "false"
+  cerebro:publicOrigin: https://cerebro.example.com
+  cerebro:gcpProject: example-project
+  cerebro:gcpRegion: us-central1
+encryptionsalt: v1:Ub8wb+km/ko=:v1:gllA9zVlSEqpeOFk:M1pniv5iw93gORvAoitE6WON7TiH6Q==

--- a/deploy/pulumi/Pulumi.yaml
+++ b/deploy/pulumi/Pulumi.yaml
@@ -1,0 +1,58 @@
+name: cerebro
+runtime:
+  name: python
+  options:
+    toolchain: uv
+description: Multi-cloud Pulumi templates for hosting the Cerebro runtime
+
+config:
+  cerebro:cloud:
+    type: string
+    description: Cloud target. Supported values are aws, gcp, and azure.
+  cerebro:name:
+    type: string
+    default: cerebro
+    description: Resource name prefix.
+  cerebro:image:
+    type: string
+    description: Cerebro runtime image to deploy.
+  cerebro:containerPort:
+    type: integer
+    default: 8080
+    description: Cerebro container port.
+  cerebro:minReplicas:
+    type: integer
+    default: 1
+    description: Minimum number of API replicas.
+  cerebro:maxReplicas:
+    type: integer
+    default: 1
+    description: Maximum number of API replicas.
+  cerebro:cpu:
+    type: integer
+    default: 1
+    description: API container vCPU count. AWS converts this to ECS CPU units.
+  cerebro:memoryMiB:
+    type: integer
+    default: 2048
+    description: API container memory in MiB.
+  cerebro:publicOrigin:
+    type: string
+    default: ""
+    description: Public HTTPS origin for Cerebro.
+  cerebro:trustedProxyCIDRs:
+    type: string
+    default: ""
+    description: Comma-separated CIDRs whose forwarded headers may be trusted.
+  cerebro:trustedProxyCount:
+    type: integer
+    default: 1
+    description: Number of trusted trailing X-Forwarded-For hops.
+  cerebro:apiAuthEnabled:
+    type: boolean
+    default: true
+    description: Require bearer/API-key auth for protected routes.
+  cerebro:allowedTenants:
+    type: string
+    default: ""
+    description: Optional comma-separated tenant allowlist.

--- a/deploy/pulumi/README.md
+++ b/deploy/pulumi/README.md
@@ -1,0 +1,113 @@
+# Cerebro Pulumi Templates
+
+These Pulumi templates deploy the public Cerebro runtime on AWS, Google Cloud, or Azure using environment-agnostic defaults. They intentionally use placeholder names and caller-owned configuration only. Do not put live account IDs, hostnames, tenant names, source schedules, provider tokens, or secret values in this directory.
+
+The templates deploy the Cerebro API container and wire any backing services you provide through cloud-native secret mechanisms:
+
+- AWS: ECS Fargate service behind an Application Load Balancer.
+- GCP: Cloud Run v2 service.
+- Azure: Azure Container Apps service.
+
+Postgres, NATS JetStream, and Neo4j/Aura are configured by passing DSNs and URLs as Pulumi secrets. You can use managed services, self-hosted services, or third-party services as long as the Cerebro container can reach them.
+
+## Runtime Profiles
+
+| Profile | Required template config | Cerebro features |
+| --- | --- | --- |
+| Lightweight API | image, cloud, region/location | `/livez`, `/health`, `/openapi.yaml`, `/sources`, and provider-free source previews |
+| Durable API | `cerebro:postgresDsn` | persisted runtimes, claims, findings, reports, OAuth, and device-auth state |
+| Durable sync | `cerebro:postgresDsn`, `cerebro:jetstreamUrl` | source runtime sync and append-log-backed replay |
+| Graph-enabled | `cerebro:postgresDsn`, `cerebro:jetstreamUrl`, `cerebro:neo4jUri`, `cerebro:neo4jUsername`, `cerebro:neo4jPassword` | graph ingest, graph queries, graph health, and graph-agent workflows |
+
+## Install
+
+```bash
+cd deploy/pulumi
+uv sync
+```
+
+Use a local Pulumi backend for previews when you do not want to touch Pulumi Cloud:
+
+```bash
+export PULUMI_BACKEND_URL="file://$PWD/.pulumi-state"
+export PULUMI_CONFIG_PASSPHRASE="local-preview-only"
+```
+
+## Preview Without Deploying
+
+Each checked-in example stack is intentionally lightweight and unauthenticated so it can be previewed without live secrets. Do not deploy these exact stack files to a shared environment.
+
+```bash
+pulumi preview --stack aws --refresh=false
+pulumi preview --stack gcp --refresh=false
+pulumi preview --stack azure --refresh=false
+```
+
+For real deployments, set a release image, enable API auth, and provide secrets first:
+
+```bash
+pulumi config set cerebro:image ghcr.io/writer/cerebro:vX.Y.Z
+pulumi config set cerebro:apiAuthEnabled true
+pulumi config set --secret cerebro:apiKeys '<random-key>:<principal>:<tenant-id>'
+pulumi config set --secret cerebro:postgresDsn '<postgres-dsn-with-tls>'
+pulumi config set --secret cerebro:jetstreamUrl '<nats-url>'
+pulumi config set --secret cerebro:neo4jUri '<neo4j-or-aura-uri>'
+pulumi config set --secret cerebro:neo4jUsername '<neo4j-user>'
+pulumi config set --secret cerebro:neo4jPassword '<neo4j-password>'
+```
+
+## Cloud Selection
+
+Set `cerebro:cloud` to one of:
+
+- `aws`
+- `gcp`
+- `azure`
+
+The shared config keys are the same across clouds:
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `cerebro:name` | `cerebro` | Resource name prefix. Use lowercase letters, numbers, and hyphens. |
+| `cerebro:image` | required | Runtime image, usually `ghcr.io/writer/cerebro:<release-tag>` or a cloud-registry mirror. |
+| `cerebro:containerPort` | `8080` | Container port. |
+| `cerebro:minReplicas` | `1` | Minimum running replicas where supported. |
+| `cerebro:maxReplicas` | `1` | Maximum replicas where supported. Raise carefully because backing stores and source cursors need matching capacity. |
+| `cerebro:cpu` | `1` | vCPU count for GCP/Azure; AWS converts this to ECS CPU units. |
+| `cerebro:memoryMiB` | `2048` | Container memory. |
+| `cerebro:publicOrigin` | unset | Set to the external HTTPS origin for shared deployments. |
+| `cerebro:trustedProxyCIDRs` | unset | Comma-separated trusted proxy CIDRs. |
+| `cerebro:trustedProxyCount` | `1` | Trusted trailing `X-Forwarded-For` hops. |
+| `cerebro:apiAuthEnabled` | `true` | Keep true outside local or validation-only stacks. |
+| `cerebro:apiKeys` | unset | Secret API key entries. Required when API auth is enabled unless using structured credentials. |
+| `cerebro:apiCredentialsJson` | unset | Secret structured credential JSON. Alternative to simple API keys. |
+| `cerebro:allowedTenants` | unset | Optional tenant allowlist. |
+| `cerebro:postgresDsn` | unset | Secret Postgres DSN. Enables the Postgres state store. |
+| `cerebro:jetstreamUrl` | unset | Secret NATS URL. Enables JetStream append log. |
+| `cerebro:neo4jUri` | unset | Secret Neo4j/Aura URI. Enables Neo4j graph store when username/password are also set. |
+| `cerebro:neo4jUsername` | unset | Secret graph username. |
+| `cerebro:neo4jPassword` | unset | Secret graph password. |
+| `cerebro:connectorCredentialKey` | unset | Secret key for Cerebro-managed connector credentials. |
+| `cerebro:connectorTransitPrivateKey` | unset | Secret shared RSA private key for browser-submitted connector credentials. |
+| `cerebro:capabilityTokenSecrets` | unset | Secret HMAC material for capability-token auth. |
+| `cerebro:extraEnv` | `{}` | Non-secret environment variable map. |
+| `cerebro:extraSecrets` | `{}` | Secret environment variable map. |
+
+Cloud-specific keys:
+
+| Cloud | Keys |
+| --- | --- |
+| AWS | `cerebro:awsRegion`, `cerebro:awsAvailabilityZones`, `cerebro:awsVpcCidr`, `cerebro:awsPublicSubnetCidrs`, `cerebro:awsAssignPublicIp`, `cerebro:awsSkipCredentialsValidation` |
+| GCP | `cerebro:gcpProject`, `cerebro:gcpRegion`, `cerebro:gcpIngress`, `cerebro:gcpAllowUnauthenticated` |
+| Azure | `cerebro:azureLocation`, `cerebro:azureResourceGroupName`, `cerebro:azureExternalIngress` |
+
+## Production Notes
+
+These templates are a portable starting point, not a replacement for your organization's deployment controls.
+
+- Put the service behind TLS and set `cerebro:publicOrigin` to the HTTPS origin clients use.
+- Strip untrusted inbound forwarded headers at the edge and set `cerebro:trustedProxyCIDRs` to your real proxy or load-balancer network.
+- Keep API auth enabled and store credentials as Pulumi secrets or in your cloud secret manager.
+- Use private networking for Postgres, NATS JetStream, Neo4j/Aura, Redis/Valkey, and source-provider egress where available.
+- Run scheduled source sync and graph ingest jobs separately from the API service so retries, concurrency, and capacity can be tuned independently.
+- Preview every stack with `--refresh=false` before review, then run a normal preview with real credentials before `pulumi up`.

--- a/deploy/pulumi/__main__.py
+++ b/deploy/pulumi/__main__.py
@@ -1,0 +1,19 @@
+from runtime import CerebroRuntimeConfig
+
+
+def main() -> None:
+    config = CerebroRuntimeConfig.from_pulumi()
+
+    if config.cloud == "aws":
+        from aws_stack import deploy
+    elif config.cloud == "gcp":
+        from gcp_stack import deploy
+    elif config.cloud == "azure":
+        from azure_stack import deploy
+    else:
+        raise ValueError("cerebro:cloud must be one of aws, gcp, or azure")
+
+    deploy(config)
+
+
+main()

--- a/deploy/pulumi/aws_stack.py
+++ b/deploy/pulumi/aws_stack.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import json
+
+import pulumi
+import pulumi_aws as aws
+
+from runtime import CerebroRuntimeConfig, SecretEnv, aws_cpu_units
+
+
+def deploy(config: CerebroRuntimeConfig) -> None:
+    provider = aws.Provider(
+        "aws-provider",
+        region=config.aws_region,
+        skip_credentials_validation=config.aws_skip_credentials_validation,
+        skip_metadata_api_check=config.aws_skip_credentials_validation,
+        skip_requesting_account_id=config.aws_skip_credentials_validation,
+    )
+    opts = pulumi.ResourceOptions(provider=provider)
+
+    subnet_cidrs = config.aws_public_subnet_cidrs
+    if len(subnet_cidrs) < 2:
+        raise ValueError("cerebro:awsPublicSubnetCidrs must contain at least two subnet CIDRs")
+    availability_zones = config.aws_availability_zones or [
+        f"{config.aws_region}a",
+        f"{config.aws_region}b",
+    ]
+    if len(availability_zones) < len(subnet_cidrs):
+        raise ValueError("cerebro:awsAvailabilityZones must cover every public subnet CIDR")
+
+    vpc = aws.ec2.Vpc(
+        f"{config.name}-vpc",
+        cidr_block=config.aws_vpc_cidr,
+        enable_dns_hostnames=True,
+        enable_dns_support=True,
+        tags={"Name": f"{config.name}-vpc"},
+        opts=opts,
+    )
+    internet_gateway = aws.ec2.InternetGateway(
+        f"{config.name}-igw",
+        vpc_id=vpc.id,
+        tags={"Name": f"{config.name}-igw"},
+        opts=opts,
+    )
+    route_table = aws.ec2.RouteTable(
+        f"{config.name}-public-rt",
+        vpc_id=vpc.id,
+        routes=[aws.ec2.RouteTableRouteArgs(cidr_block="0.0.0.0/0", gateway_id=internet_gateway.id)],
+        tags={"Name": f"{config.name}-public-rt"},
+        opts=opts,
+    )
+    subnets = []
+    for index, cidr in enumerate(subnet_cidrs):
+        subnet = aws.ec2.Subnet(
+            f"{config.name}-public-{index + 1}",
+            vpc_id=vpc.id,
+            cidr_block=cidr,
+            availability_zone=availability_zones[index],
+            map_public_ip_on_launch=True,
+            tags={"Name": f"{config.name}-public-{index + 1}"},
+            opts=opts,
+        )
+        aws.ec2.RouteTableAssociation(
+            f"{config.name}-public-{index + 1}-rt",
+            subnet_id=subnet.id,
+            route_table_id=route_table.id,
+            opts=opts,
+        )
+        subnets.append(subnet)
+
+    alb_sg = aws.ec2.SecurityGroup(
+        f"{config.name}-alb-sg",
+        vpc_id=vpc.id,
+        description="Cerebro ALB ingress",
+        ingress=[
+            aws.ec2.SecurityGroupIngressArgs(
+                protocol="tcp",
+                from_port=80,
+                to_port=80,
+                cidr_blocks=["0.0.0.0/0"],
+            )
+        ],
+        egress=[
+            aws.ec2.SecurityGroupEgressArgs(
+                protocol="-1",
+                from_port=0,
+                to_port=0,
+                cidr_blocks=["0.0.0.0/0"],
+            )
+        ],
+        tags={"Name": f"{config.name}-alb-sg"},
+        opts=opts,
+    )
+    app_sg = aws.ec2.SecurityGroup(
+        f"{config.name}-app-sg",
+        vpc_id=vpc.id,
+        description="Cerebro ECS task ingress",
+        ingress=[
+            aws.ec2.SecurityGroupIngressArgs(
+                protocol="tcp",
+                from_port=config.container_port,
+                to_port=config.container_port,
+                security_groups=[alb_sg.id],
+            )
+        ],
+        egress=[
+            aws.ec2.SecurityGroupEgressArgs(
+                protocol="-1",
+                from_port=0,
+                to_port=0,
+                cidr_blocks=["0.0.0.0/0"],
+            )
+        ],
+        tags={"Name": f"{config.name}-app-sg"},
+        opts=opts,
+    )
+
+    cluster = aws.ecs.Cluster(
+        f"{config.name}-cluster",
+        name=_aws_name(config.name, "cluster", 255),
+        settings=[aws.ecs.ClusterSettingArgs(name="containerInsights", value="enabled")],
+        tags={"Name": f"{config.name}-cluster"},
+        opts=opts,
+    )
+    log_group = aws.cloudwatch.LogGroup(
+        f"{config.name}-logs",
+        name=f"/ecs/{config.name}",
+        retention_in_days=30,
+        opts=opts,
+    )
+    execution_role = aws.iam.Role(
+        f"{config.name}-execution-role",
+        name=_aws_name(config.name, "execution-role", 64),
+        assume_role_policy=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    }
+                ],
+            }
+        ),
+        opts=opts,
+    )
+    execution_policy_attachment = aws.iam.RolePolicyAttachment(
+        f"{config.name}-execution-policy",
+        role=execution_role.name,
+        policy_arn="arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+        opts=opts,
+    )
+    task_role = aws.iam.Role(
+        f"{config.name}-task-role",
+        name=_aws_name(config.name, "task-role", 64),
+        assume_role_policy=execution_role.assume_role_policy,
+        opts=opts,
+    )
+
+    secret_refs = _create_secrets(config.name, config.secret_env(), opts)
+    if secret_refs:
+        aws.iam.RolePolicy(
+            f"{config.name}-execution-secrets",
+            role=execution_role.id,
+            policy=pulumi.Output.json_dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": ["secretsmanager:GetSecretValue"],
+                            "Resource": [secret["arn"] for secret in secret_refs],
+                        }
+                    ],
+                }
+            ),
+            opts=opts,
+        )
+
+    container_definition = _container_definition(config, log_group.name, secret_refs)
+    task_definition = aws.ecs.TaskDefinition(
+        f"{config.name}-task",
+        family=config.name,
+        cpu=aws_cpu_units(config.cpu),
+        memory=str(config.memory_mib),
+        network_mode="awsvpc",
+        requires_compatibilities=["FARGATE"],
+        execution_role_arn=execution_role.arn,
+        task_role_arn=task_role.arn,
+        container_definitions=pulumi.Output.json_dumps([container_definition]),
+        opts=pulumi.ResourceOptions(provider=provider, depends_on=[execution_policy_attachment]),
+    )
+
+    load_balancer = aws.lb.LoadBalancer(
+        f"{config.name}-alb",
+        name=_aws_name(config.name, "alb", 32),
+        load_balancer_type="application",
+        security_groups=[alb_sg.id],
+        subnets=[subnet.id for subnet in subnets],
+        tags={"Name": f"{config.name}-alb"},
+        opts=opts,
+    )
+    target_group = aws.lb.TargetGroup(
+        f"{config.name}-tg",
+        name=_aws_name(config.name, "tg", 32),
+        port=config.container_port,
+        protocol="HTTP",
+        target_type="ip",
+        vpc_id=vpc.id,
+        health_check=aws.lb.TargetGroupHealthCheckArgs(
+            path="/health",
+            matcher="200-399",
+            interval=30,
+            timeout=5,
+            healthy_threshold=2,
+            unhealthy_threshold=3,
+        ),
+        tags={"Name": f"{config.name}-tg"},
+        opts=opts,
+    )
+    listener = aws.lb.Listener(
+        f"{config.name}-http",
+        load_balancer_arn=load_balancer.arn,
+        port=80,
+        protocol="HTTP",
+        default_actions=[
+            aws.lb.ListenerDefaultActionArgs(
+                type="forward",
+                target_group_arn=target_group.arn,
+            )
+        ],
+        opts=opts,
+    )
+    service = aws.ecs.Service(
+        f"{config.name}-api",
+        name=_aws_name(config.name, "api", 255),
+        cluster=cluster.id,
+        desired_count=max(config.min_replicas, 1),
+        launch_type="FARGATE",
+        task_definition=task_definition.arn,
+        network_configuration=aws.ecs.ServiceNetworkConfigurationArgs(
+            subnets=[subnet.id for subnet in subnets],
+            security_groups=[app_sg.id],
+            assign_public_ip=config.aws_assign_public_ip,
+        ),
+        load_balancers=[
+            aws.ecs.ServiceLoadBalancerArgs(
+                target_group_arn=target_group.arn,
+                container_name="cerebro",
+                container_port=config.container_port,
+            )
+        ],
+        deployment_circuit_breaker=aws.ecs.ServiceDeploymentCircuitBreakerArgs(enable=True, rollback=True),
+        opts=pulumi.ResourceOptions(provider=provider, depends_on=[listener]),
+    )
+
+    pulumi.export("cloud", "aws")
+    pulumi.export("service_name", service.name)
+    pulumi.export("cluster_name", cluster.name)
+    pulumi.export("url", pulumi.Output.concat("http://", load_balancer.dns_name))
+
+
+def _create_secrets(name: str, secrets: list[SecretEnv], opts: pulumi.ResourceOptions) -> list[dict[str, pulumi.Input[str]]]:
+    refs = []
+    for secret in secrets:
+        resource_name = f"{name}-{secret.name.lower().replace('_', '-')}"
+        secret_resource = aws.secretsmanager.Secret(
+            resource_name,
+            name=f"{name}/{secret.name}",
+            opts=opts,
+        )
+        aws.secretsmanager.SecretVersion(
+            f"{resource_name}-version",
+            secret_id=secret_resource.id,
+            secret_string=secret.value,
+            opts=opts,
+        )
+        refs.append({"name": secret.name, "arn": secret_resource.arn})
+    return refs
+
+
+def _aws_name(prefix: str, suffix: str, max_length: int) -> str:
+    value = f"{prefix}-{suffix}"
+    if len(value) <= max_length:
+        return value
+    suffix_part = f"-{suffix}"
+    keep = max_length - len(suffix_part)
+    if keep <= 0:
+        return suffix[:max_length]
+    return f"{prefix[:keep].rstrip('-')}{suffix_part}"
+
+
+def _container_definition(
+    config: CerebroRuntimeConfig,
+    log_group_name: pulumi.Input[str],
+    secret_refs: list[dict[str, pulumi.Input[str]]],
+) -> dict:
+    return {
+        "name": "cerebro",
+        "image": config.image,
+        "essential": True,
+        "command": ["serve"],
+        "portMappings": [
+            {
+                "containerPort": config.container_port,
+                "hostPort": config.container_port,
+                "protocol": "tcp",
+            }
+        ],
+        "environment": [{"name": key, "value": value} for key, value in sorted(config.plain_env().items())],
+        "secrets": [{"name": ref["name"], "valueFrom": ref["arn"]} for ref in secret_refs],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": log_group_name,
+                "awslogs-region": config.aws_region,
+                "awslogs-stream-prefix": "cerebro",
+            },
+        },
+        "healthCheck": {
+            "command": ["CMD-SHELL", f"curl -fsS http://127.0.0.1:{config.container_port}/livez >/dev/null || exit 1"],
+            "interval": 30,
+            "timeout": 5,
+            "retries": 3,
+            "startPeriod": 20,
+        },
+    }

--- a/deploy/pulumi/azure_stack.py
+++ b/deploy/pulumi/azure_stack.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pulumi
+import pulumi_azure_native as azure
+
+from runtime import CerebroRuntimeConfig, SecretEnv, normalized_secret_name
+
+
+def deploy(config: CerebroRuntimeConfig) -> None:
+    provider = azure.Provider("azure-provider")
+    opts = pulumi.ResourceOptions(provider=provider)
+
+    resource_group = azure.resources.ResourceGroup(
+        f"{config.name}-rg",
+        resource_group_name=config.azure_resource_group_name,
+        location=config.azure_location,
+        opts=opts,
+    )
+    environment = azure.app.ManagedEnvironment(
+        f"{config.name}-env",
+        environment_name=f"{config.name}-env",
+        resource_group_name=resource_group.name,
+        location=resource_group.location,
+        opts=opts,
+    )
+
+    secrets = _container_app_secrets(config.secret_env())
+    container_app = azure.app.ContainerApp(
+        f"{config.name}-app",
+        container_app_name=config.name,
+        resource_group_name=resource_group.name,
+        location=resource_group.location,
+        managed_environment_id=environment.id,
+        configuration=azure.app.ConfigurationArgs(
+            ingress=azure.app.IngressArgs(
+                external=config.azure_external_ingress,
+                target_port=config.container_port,
+                transport="auto",
+            ),
+            secrets=secrets,
+        ),
+        template=azure.app.TemplateArgs(
+            containers=[
+                azure.app.ContainerArgs(
+                    name="cerebro",
+                    image=config.image,
+                    args=["serve"],
+                    env=_plain_env(config) + _secret_env(config.secret_env()),
+                    resources=azure.app.ContainerResourcesArgs(
+                        cpu=config.cpu,
+                        memory=f"{config.memory_mib / 1024:g}Gi",
+                    ),
+                    probes=[
+                        azure.app.ContainerAppProbeArgs(
+                            type="Liveness",
+                            http_get=azure.app.ContainerAppProbeHttpGetArgs(
+                                path="/livez",
+                                port=config.container_port,
+                            ),
+                            period_seconds=30,
+                            timeout_seconds=5,
+                            failure_threshold=3,
+                        )
+                    ],
+                )
+            ],
+            scale=azure.app.ScaleArgs(
+                min_replicas=config.min_replicas,
+                max_replicas=config.max_replicas,
+            ),
+        ),
+        opts=opts,
+    )
+
+    pulumi.export("cloud", "azure")
+    pulumi.export("resource_group_name", resource_group.name)
+    pulumi.export("service_name", container_app.name)
+    pulumi.export("url", container_app.configuration.apply(lambda cfg: f"https://{cfg.ingress.fqdn}" if cfg and cfg.ingress and cfg.ingress.fqdn else ""))
+
+
+def _container_app_secrets(secrets: list[SecretEnv]) -> list[azure.app.SecretArgs]:
+    return [
+        azure.app.SecretArgs(
+            name=normalized_secret_name(secret.name),
+            value=secret.value,
+        )
+        for secret in secrets
+    ]
+
+def _plain_env(config: CerebroRuntimeConfig) -> list[azure.app.EnvironmentVarArgs]:
+    return [
+        azure.app.EnvironmentVarArgs(name=key, value=value)
+        for key, value in sorted(config.plain_env().items())
+    ]
+
+
+def _secret_env(secrets: list[SecretEnv]) -> list[azure.app.EnvironmentVarArgs]:
+    return [
+        azure.app.EnvironmentVarArgs(
+            name=secret.name,
+            secret_ref=normalized_secret_name(secret.name),
+        )
+        for secret in secrets
+    ]

--- a/deploy/pulumi/gcp_stack.py
+++ b/deploy/pulumi/gcp_stack.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import pulumi
+import pulumi_gcp as gcp
+
+from runtime import CerebroRuntimeConfig, SecretEnv, normalized_secret_name
+
+
+def deploy(config: CerebroRuntimeConfig) -> None:
+    if not config.gcp_project:
+        raise ValueError("cerebro:gcpProject is required for GCP deployments")
+
+    provider = gcp.Provider(
+        "gcp-provider",
+        project=config.gcp_project,
+        region=config.gcp_region,
+    )
+    opts = pulumi.ResourceOptions(provider=provider)
+
+    secret_refs = _create_secrets(config.name, config.secret_env(), opts)
+    service = gcp.cloudrunv2.Service(
+        f"{config.name}-service",
+        name=config.name,
+        location=config.gcp_region,
+        ingress=config.gcp_ingress,
+        template=gcp.cloudrunv2.ServiceTemplateArgs(
+            scaling=gcp.cloudrunv2.ServiceTemplateScalingArgs(
+                min_instance_count=config.min_replicas,
+                max_instance_count=config.max_replicas,
+            ),
+            containers=[
+                gcp.cloudrunv2.ServiceTemplateContainerArgs(
+                    image=config.image,
+                    commands=["/usr/local/bin/cerebro"],
+                    args=["serve"],
+                    ports=gcp.cloudrunv2.ServiceTemplateContainerPortsArgs(
+                        container_port=config.container_port,
+                    ),
+                    envs=_plain_env(config) + _secret_env(secret_refs),
+                    resources=gcp.cloudrunv2.ServiceTemplateContainerResourcesArgs(
+                        limits={
+                            "cpu": str(config.cpu),
+                            "memory": f"{config.memory_mib}Mi",
+                        },
+                    ),
+                    startup_probe=gcp.cloudrunv2.ServiceTemplateContainerStartupProbeArgs(
+                        http_get=gcp.cloudrunv2.ServiceTemplateContainerStartupProbeHttpGetArgs(
+                            path="/livez",
+                            port=config.container_port,
+                        ),
+                        initial_delay_seconds=10,
+                        timeout_seconds=5,
+                        period_seconds=10,
+                        failure_threshold=12,
+                    ),
+                    liveness_probe=gcp.cloudrunv2.ServiceTemplateContainerLivenessProbeArgs(
+                        http_get=gcp.cloudrunv2.ServiceTemplateContainerLivenessProbeHttpGetArgs(
+                            path="/livez",
+                            port=config.container_port,
+                        ),
+                        timeout_seconds=5,
+                        period_seconds=30,
+                        failure_threshold=3,
+                    ),
+                )
+            ],
+        ),
+        opts=opts,
+    )
+
+    if config.gcp_allow_unauthenticated:
+        gcp.cloudrunv2.ServiceIamMember(
+            f"{config.name}-invoker",
+            name=service.name,
+            location=service.location,
+            role="roles/run.invoker",
+            member="allUsers",
+            opts=opts,
+        )
+
+    pulumi.export("cloud", "gcp")
+    pulumi.export("service_name", service.name)
+    pulumi.export("url", service.uri)
+
+
+def _create_secrets(name: str, secrets: list[SecretEnv], opts: pulumi.ResourceOptions) -> list[dict[str, pulumi.Input[str]]]:
+    refs = []
+    for secret in secrets:
+        secret_id = normalized_secret_name(f"{name}-{secret.name}")
+        secret_resource = gcp.secretmanager.Secret(
+            secret_id,
+            secret_id=secret_id,
+            replication=gcp.secretmanager.SecretReplicationArgs(
+                auto=gcp.secretmanager.SecretReplicationAutoArgs(),
+            ),
+            opts=opts,
+        )
+        version = gcp.secretmanager.SecretVersion(
+            f"{secret_id}-version",
+            secret=secret_resource.id,
+            secret_data=secret.value,
+            opts=opts,
+        )
+        refs.append({"name": secret.name, "secret": secret_resource.secret_id, "version": version.version})
+    return refs
+
+
+def _plain_env(config: CerebroRuntimeConfig) -> list[gcp.cloudrunv2.ServiceTemplateContainerEnvArgs]:
+    return [
+        gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(name=key, value=value)
+        for key, value in sorted(config.plain_env().items())
+    ]
+
+
+def _secret_env(secret_refs: list[dict[str, pulumi.Input[str]]]) -> list[gcp.cloudrunv2.ServiceTemplateContainerEnvArgs]:
+    return [
+        gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
+            name=ref["name"],
+            value_source=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceArgs(
+                secret_key_ref=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceSecretKeyRefArgs(
+                    secret=ref["secret"],
+                    version=ref["version"],
+                )
+            ),
+        )
+        for ref in secret_refs
+    ]

--- a/deploy/pulumi/pyproject.toml
+++ b/deploy/pulumi/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "cerebro-cloud-pulumi"
+version = "0.1.0"
+description = "Multi-cloud Pulumi templates for Cerebro"
+requires-python = ">=3.11"
+dependencies = [
+    "pulumi>=3.150.0,<4.0.0",
+    "pulumi-aws>=7.0.0,<8.0.0",
+    "pulumi-azure-native>=3.0.0,<4.0.0",
+    "pulumi-gcp>=9.0.0,<10.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0,<9.0.0",
+]

--- a/deploy/pulumi/runtime.py
+++ b/deploy/pulumi/runtime.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Mapping
+
+import pulumi
+
+
+_NAME_RE = re.compile(r"[^a-z0-9-]+")
+
+
+@dataclass(frozen=True)
+class SecretEnv:
+    name: str
+    value: pulumi.Output[str]
+
+
+@dataclass(frozen=True)
+class CerebroRuntimeConfig:
+    cloud: str
+    name: str
+    image: str
+    container_port: int
+    min_replicas: int
+    max_replicas: int
+    cpu: float
+    memory_mib: int
+    shutdown_timeout: str
+    public_origin: str
+    trusted_proxy_cidrs: str
+    trusted_proxy_count: int
+    api_auth_enabled: bool
+    allowed_tenants: str
+    extra_env: Mapping[str, str]
+    extra_secrets: Mapping[str, pulumi.Output[str]]
+    api_keys: pulumi.Output[str] | None
+    api_credentials_json: pulumi.Output[str] | None
+    postgres_dsn: pulumi.Output[str] | None
+    jetstream_url: pulumi.Output[str] | None
+    neo4j_uri: pulumi.Output[str] | None
+    neo4j_username: pulumi.Output[str] | None
+    neo4j_password: pulumi.Output[str] | None
+    connector_credential_key: pulumi.Output[str] | None
+    connector_transit_private_key: pulumi.Output[str] | None
+    capability_token_secrets: pulumi.Output[str] | None
+    aws_region: str
+    aws_availability_zones: list[str]
+    aws_vpc_cidr: str
+    aws_public_subnet_cidrs: list[str]
+    aws_assign_public_ip: bool
+    aws_skip_credentials_validation: bool
+    gcp_project: str
+    gcp_region: str
+    gcp_ingress: str
+    gcp_allow_unauthenticated: bool
+    azure_location: str
+    azure_resource_group_name: str
+    azure_external_ingress: bool
+
+    @classmethod
+    def from_pulumi(cls) -> "CerebroRuntimeConfig":
+        cfg = pulumi.Config("cerebro")
+        name = _slug(cfg.get("name") or "cerebro")
+        cloud = (cfg.require("cloud")).strip().lower()
+        container_port = _positive_int(cfg.get_int("containerPort"), 8080, "containerPort")
+        min_replicas = _positive_int(cfg.get_int("minReplicas"), 1, "minReplicas", allow_zero=True)
+        max_replicas = _positive_int(cfg.get_int("maxReplicas"), 1, "maxReplicas")
+        if max_replicas < min_replicas:
+            raise ValueError("cerebro:maxReplicas must be greater than or equal to cerebro:minReplicas")
+
+        cpu = cfg.get_float("cpu") or 1
+        if cpu <= 0:
+            raise ValueError("cerebro:cpu must be positive")
+        memory_mib = _positive_int(cfg.get_int("memoryMiB"), 2048, "memoryMiB")
+
+        extra_env = cfg.get_object("extraEnv") or {}
+        if not isinstance(extra_env, dict) or not all(isinstance(k, str) and isinstance(v, str) for k, v in extra_env.items()):
+            raise ValueError("cerebro:extraEnv must be an object with string keys and string values")
+
+        extra_secret_values = cfg.get_secret_object("extraSecrets")
+        extra_secrets: dict[str, pulumi.Output[str]] = {}
+        if extra_secret_values is not None:
+            if not isinstance(extra_secret_values, dict):
+                raise ValueError("cerebro:extraSecrets must be an object with string keys and values")
+            for key, value in extra_secret_values.items():
+                if not isinstance(key, str):
+                    raise ValueError("cerebro:extraSecrets keys must be strings")
+                extra_secrets[key] = pulumi.Output.secret(value)
+
+        return cls(
+            cloud=cloud,
+            name=name,
+            image=cfg.require("image"),
+            container_port=container_port,
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+            cpu=cpu,
+            memory_mib=memory_mib,
+            shutdown_timeout=cfg.get("shutdownTimeout") or "10s",
+            public_origin=cfg.get("publicOrigin") or "",
+            trusted_proxy_cidrs=cfg.get("trustedProxyCIDRs") or "",
+            trusted_proxy_count=_positive_int(cfg.get_int("trustedProxyCount"), 1, "trustedProxyCount", allow_zero=True),
+            api_auth_enabled=_config_bool(cfg, "apiAuthEnabled", True),
+            allowed_tenants=cfg.get("allowedTenants") or "",
+            extra_env=extra_env,
+            extra_secrets=extra_secrets,
+            api_keys=cfg.get_secret("apiKeys"),
+            api_credentials_json=cfg.get_secret("apiCredentialsJson"),
+            postgres_dsn=cfg.get_secret("postgresDsn"),
+            jetstream_url=cfg.get_secret("jetstreamUrl"),
+            neo4j_uri=cfg.get_secret("neo4jUri"),
+            neo4j_username=cfg.get_secret("neo4jUsername"),
+            neo4j_password=cfg.get_secret("neo4jPassword"),
+            connector_credential_key=cfg.get_secret("connectorCredentialKey"),
+            connector_transit_private_key=cfg.get_secret("connectorTransitPrivateKey"),
+            capability_token_secrets=cfg.get_secret("capabilityTokenSecrets"),
+            aws_region=cfg.get("awsRegion") or "us-east-1",
+            aws_availability_zones=list(cfg.get_object("awsAvailabilityZones") or []),
+            aws_vpc_cidr=cfg.get("awsVpcCidr") or "10.42.0.0/16",
+            aws_public_subnet_cidrs=list(cfg.get_object("awsPublicSubnetCidrs") or ["10.42.0.0/24", "10.42.1.0/24"]),
+            aws_assign_public_ip=_config_bool(cfg, "awsAssignPublicIp", True),
+            aws_skip_credentials_validation=_config_bool(cfg, "awsSkipCredentialsValidation", True),
+            gcp_project=cfg.get("gcpProject") or "",
+            gcp_region=cfg.get("gcpRegion") or "us-central1",
+            gcp_ingress=cfg.get("gcpIngress") or "INGRESS_TRAFFIC_ALL",
+            gcp_allow_unauthenticated=_config_bool(cfg, "gcpAllowUnauthenticated", True),
+            azure_location=cfg.get("azureLocation") or "eastus",
+            azure_resource_group_name=cfg.get("azureResourceGroupName") or f"{name}-rg",
+            azure_external_ingress=_config_bool(cfg, "azureExternalIngress", True),
+        )
+
+    def plain_env(self) -> dict[str, pulumi.Input[str]]:
+        env: dict[str, pulumi.Input[str]] = {
+            "CEREBRO_HTTP_ADDR": f":{self.container_port}",
+            "CEREBRO_SHUTDOWN_TIMEOUT": self.shutdown_timeout,
+            "CEREBRO_API_AUTH_ENABLED": _bool_env(self.api_auth_enabled),
+            "CEREBRO_TRUSTED_PROXY_COUNT": str(self.trusted_proxy_count),
+        }
+        if self.public_origin:
+            env["CEREBRO_PUBLIC_ORIGIN"] = self.public_origin
+        if self.trusted_proxy_cidrs:
+            env["CEREBRO_TRUSTED_PROXY_CIDRS"] = self.trusted_proxy_cidrs
+        if self.allowed_tenants:
+            env["CEREBRO_ALLOWED_TENANTS"] = self.allowed_tenants
+        if self.postgres_dsn:
+            env["CEREBRO_STATE_STORE_DRIVER"] = "postgres"
+        if self.jetstream_url:
+            env["CEREBRO_APPEND_LOG_DRIVER"] = "jetstream"
+            env["CEREBRO_JETSTREAM_SUBJECT_PREFIX"] = "events"
+        if self.neo4j_uri:
+            env["CEREBRO_GRAPH_STORE_DRIVER"] = "neo4j"
+        env.update(self.extra_env)
+        return env
+
+    def secret_env(self) -> list[SecretEnv]:
+        pairs = [
+            ("CEREBRO_API_KEYS", self.api_keys),
+            ("CEREBRO_API_CREDENTIALS_JSON", self.api_credentials_json),
+            ("CEREBRO_POSTGRES_DSN", self.postgres_dsn),
+            ("CEREBRO_JETSTREAM_URL", self.jetstream_url),
+            ("CEREBRO_NEO4J_URI", self.neo4j_uri),
+            ("CEREBRO_NEO4J_USERNAME", self.neo4j_username),
+            ("CEREBRO_NEO4J_PASSWORD", self.neo4j_password),
+            ("CEREBRO_CONNECTOR_CREDENTIAL_KEY", self.connector_credential_key),
+            ("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY", self.connector_transit_private_key),
+            ("CEREBRO_CAPABILITY_TOKEN_SECRETS", self.capability_token_secrets),
+        ]
+        secrets = [SecretEnv(name, value) for name, value in pairs if value is not None]
+        secrets.extend(SecretEnv(name, value) for name, value in self.extra_secrets.items())
+        return secrets
+
+
+def normalized_secret_name(name: str) -> str:
+    return _slug(name.lower().replace("_", "-"))
+
+
+def aws_cpu_units(vcpu: float) -> str:
+    return str(int(vcpu * 1024))
+
+
+def _config_bool(config: pulumi.Config, key: str, default: bool) -> bool:
+    value = config.get_bool(key)
+    return default if value is None else value
+
+
+def _positive_int(value: int | None, default: int, key: str, *, allow_zero: bool = False) -> int:
+    resolved = default if value is None else value
+    if resolved < 0 or (resolved == 0 and not allow_zero):
+        raise ValueError(f"cerebro:{key} must be {'non-negative' if allow_zero else 'positive'}")
+    return resolved
+
+
+def _slug(value: str) -> str:
+    slug = _NAME_RE.sub("-", value.strip().lower()).strip("-")
+    if not slug:
+        raise ValueError("resource name must contain at least one lowercase letter or number")
+    return slug
+
+
+def _bool_env(value: bool) -> str:
+    return "true" if value else "false"

--- a/docs/CLOUD_DEPLOYMENT.md
+++ b/docs/CLOUD_DEPLOYMENT.md
@@ -1,0 +1,293 @@
+# Cloud Deployment
+
+This guide explains how to deploy Cerebro on AWS, Google Cloud, or Azure without depending on any private deployment topology. All names, regions, projects, subscriptions, hostnames, tenant IDs, schedules, secrets, and sizing values are examples. Replace them with values owned by your environment.
+
+Use it with:
+
+- [`docs/HOSTING.md`](./HOSTING.md) for the runtime hosting contract.
+- [`docs/CONFIG_ENV_VARS.md`](./CONFIG_ENV_VARS.md) for all supported environment variables.
+- [`docs/OPERATIONS_RUNBOOK.md`](./OPERATIONS_RUNBOOK.md) for health checks, rollout, rollback, and incident handling.
+- [`deploy/pulumi`](../deploy/pulumi) for validated Pulumi templates.
+
+## Deployment Contract
+
+Cerebro is one HTTP container plus optional backing services:
+
+```text
+TLS edge or load balancer
+  |
+  v
+Cerebro API container
+  |
+  +--> Postgres, when durable state is enabled
+  +--> NATS JetStream, when append-log sync or replay is enabled
+  +--> Neo4j or Aura, when graph projection and graph queries are enabled
+  +--> source provider APIs, when source runtimes sync external systems
+```
+
+The container runs:
+
+```text
+/usr/local/bin/cerebro serve
+```
+
+It listens on `:8080` by default. Use `/livez` for process liveness and `/health` for dependency-aware readiness.
+
+## Pulumi Templates
+
+The templates in [`deploy/pulumi`](../deploy/pulumi) use one shared configuration model and choose a cloud backend with `cerebro:cloud`:
+
+| Cloud | Template target | What it creates |
+| --- | --- | --- |
+| AWS | ECS Fargate plus Application Load Balancer | VPC, public subnets, ALB, ECS cluster, task definition, service, logs, IAM, and optional Secrets Manager entries |
+| GCP | Cloud Run v2 | Cloud Run service, optional public invoker binding, and optional Secret Manager entries |
+| Azure | Azure Container Apps | Resource group, Container Apps managed environment, Container App, ingress, and Container App secrets |
+
+The templates do not create a private organization-specific control plane, source runtime schedules, DNS zones, certificates, Postgres clusters, NATS clusters, or Neo4j/Aura instances. They wire the API service to those dependencies when you provide their DSNs or URLs as Pulumi secrets.
+
+Install:
+
+```bash
+cd deploy/pulumi
+uv sync
+```
+
+Preview locally without deploying:
+
+```bash
+export PULUMI_BACKEND_URL="file://$PWD/.pulumi-state"
+export PULUMI_CONFIG_PASSPHRASE="local-preview-only"
+
+pulumi stack init aws || true
+pulumi stack init gcp || true
+pulumi stack init azure || true
+
+pulumi preview --stack aws --refresh=false
+pulumi preview --stack gcp --refresh=false
+pulumi preview --stack azure --refresh=false
+```
+
+The checked-in stacks are preview-only examples with `cerebro:apiAuthEnabled=false`. Do not deploy them to a shared environment as-is.
+
+## Common Production Config
+
+Set a real image and enable auth before any shared deployment:
+
+```bash
+pulumi config set cerebro:image ghcr.io/writer/cerebro:vX.Y.Z
+pulumi config set cerebro:apiAuthEnabled true
+pulumi config set cerebro:publicOrigin https://cerebro.example.com
+pulumi config set cerebro:trustedProxyCIDRs 10.0.0.0/8
+pulumi config set cerebro:trustedProxyCount 1
+pulumi config set --secret cerebro:apiKeys '<random-key>:<principal>:<tenant-id>'
+```
+
+Enable durable state:
+
+```bash
+pulumi config set --secret cerebro:postgresDsn '<postgres-dsn-with-tls>'
+```
+
+Enable append-log-backed source sync and replay:
+
+```bash
+pulumi config set --secret cerebro:jetstreamUrl '<nats-jetstream-url>'
+```
+
+Enable graph projection and graph queries:
+
+```bash
+pulumi config set --secret cerebro:neo4jUri '<neo4j-or-aura-uri>'
+pulumi config set --secret cerebro:neo4jUsername '<neo4j-user>'
+pulumi config set --secret cerebro:neo4jPassword '<neo4j-password>'
+```
+
+Optional connector-credential and capability-token secrets:
+
+```bash
+pulumi config set --secret cerebro:connectorCredentialKey '<high-entropy-key>'
+pulumi config set --secret cerebro:connectorTransitPrivateKey '<rsa-private-key-pem>'
+pulumi config set --secret cerebro:capabilityTokenSecrets '<hmac-secret-1>,<hmac-secret-2>'
+```
+
+For any additional non-secret runtime variable, use:
+
+```bash
+pulumi config set --path 'cerebro:extraEnv.CEREBRO_CACHE_MODE' redis
+```
+
+For any additional secret runtime variable, use:
+
+```bash
+pulumi config set --secret --path 'cerebro:extraSecrets.CEREBRO_CACHE_URL' '<redis-or-valkey-url>'
+```
+
+## AWS
+
+The AWS template deploys the Cerebro API on ECS Fargate behind an Application Load Balancer.
+
+Example setup:
+
+```bash
+cd deploy/pulumi
+export PULUMI_BACKEND_URL="file://$PWD/.pulumi-state"
+export PULUMI_CONFIG_PASSPHRASE="local-preview-only"
+
+pulumi stack select aws --create
+pulumi config set cerebro:cloud aws
+pulumi config set cerebro:name cerebro-prod
+pulumi config set cerebro:awsRegion us-east-1
+pulumi config set --path 'cerebro:awsAvailabilityZones[0]' us-east-1a
+pulumi config set --path 'cerebro:awsAvailabilityZones[1]' us-east-1b
+pulumi config set cerebro:image '<account>.dkr.ecr.us-east-1.amazonaws.com/cerebro:vX.Y.Z'
+```
+
+Recommended AWS hardening before `pulumi up`:
+
+- Mirror the public image to ECR or an approved registry.
+- Put tasks in private subnets with controlled egress for shared environments.
+- Terminate TLS with ACM on the load balancer or an upstream edge.
+- Use RDS or Aurora PostgreSQL with TLS, backups, and least-privilege credentials.
+- Use managed or self-hosted NATS JetStream with persistent storage.
+- Use Neo4j Aura or an operated Neo4j deployment with encrypted connections.
+- Restrict ALB ingress CIDRs or place the service behind a private edge when appropriate.
+- Store runtime secrets in Secrets Manager through Pulumi secrets or your secret-import pipeline.
+
+Preview:
+
+```bash
+AWS_PROFILE=<profile> pulumi preview --stack aws --refresh=false
+```
+
+Deploy only after reviewing the preview:
+
+```bash
+AWS_PROFILE=<profile> pulumi up --stack aws
+```
+
+## Google Cloud
+
+The GCP template deploys the Cerebro API on Cloud Run v2.
+
+Example setup:
+
+```bash
+cd deploy/pulumi
+export PULUMI_BACKEND_URL="file://$PWD/.pulumi-state"
+export PULUMI_CONFIG_PASSPHRASE="local-preview-only"
+
+pulumi stack select gcp --create
+pulumi config set cerebro:cloud gcp
+pulumi config set cerebro:name cerebro-prod
+pulumi config set cerebro:gcpProject example-project
+pulumi config set cerebro:gcpRegion us-central1
+pulumi config set cerebro:image 'us-central1-docker.pkg.dev/example-project/cerebro/cerebro:vX.Y.Z'
+```
+
+Recommended GCP hardening before `pulumi up`:
+
+- Mirror the public image to Artifact Registry.
+- Use Cloud SQL for PostgreSQL or another operated Postgres endpoint with TLS.
+- Use managed NATS or run NATS JetStream on GKE or another persistent platform.
+- Use Neo4j Aura or an operated Neo4j deployment with encrypted connections.
+- Set `cerebro:gcpAllowUnauthenticated=false` when an authenticated edge or IAM invoker policy owns access.
+- Use Serverless VPC Access or equivalent private connectivity for private dependencies.
+- Store runtime secrets in Secret Manager through Pulumi secrets or your secret-import pipeline.
+
+Preview:
+
+```bash
+gcloud auth application-default login
+pulumi preview --stack gcp --refresh=false
+```
+
+Deploy only after reviewing the preview:
+
+```bash
+pulumi up --stack gcp
+```
+
+## Azure
+
+The Azure template deploys the Cerebro API on Azure Container Apps.
+
+Example setup:
+
+```bash
+cd deploy/pulumi
+export PULUMI_BACKEND_URL="file://$PWD/.pulumi-state"
+export PULUMI_CONFIG_PASSPHRASE="local-preview-only"
+
+pulumi stack select azure --create
+pulumi config set cerebro:cloud azure
+pulumi config set cerebro:name cerebro-prod
+pulumi config set cerebro:azureLocation eastus
+pulumi config set cerebro:azureResourceGroupName cerebro-prod-rg
+pulumi config set cerebro:image 'example.azurecr.io/cerebro:vX.Y.Z'
+```
+
+Recommended Azure hardening before `pulumi up`:
+
+- Mirror the public image to Azure Container Registry.
+- Use Azure Database for PostgreSQL Flexible Server or another operated Postgres endpoint with TLS.
+- Use managed NATS or run NATS JetStream on AKS or another persistent platform.
+- Use Neo4j Aura or an operated Neo4j deployment with encrypted connections.
+- Put Container Apps in a network-integrated environment when dependencies are private.
+- Put Azure Front Door, Application Gateway, or another TLS edge in front of the app for shared deployments.
+- Store runtime secrets as Container App secrets through Pulumi secrets or your secret-import pipeline.
+
+Preview:
+
+```bash
+az login
+pulumi preview --stack azure --refresh=false
+```
+
+Deploy only after reviewing the preview:
+
+```bash
+pulumi up --stack azure
+```
+
+## Background Jobs
+
+The API service should stay separate from scheduled source sync and graph ingest jobs. Use the same Cerebro image and secret set, but schedule commands independently:
+
+```bash
+cerebro source-runtime sync <runtime-id> page_limit=100
+cerebro graph ingest-runtime <runtime-id> page_limit=100
+```
+
+Common scheduler mappings:
+
+| Cloud | Scheduler shape |
+| --- | --- |
+| AWS | EventBridge Scheduler or EventBridge rule launching an ECS Fargate task |
+| GCP | Cloud Scheduler triggering a Cloud Run Job or Workflows step |
+| Azure | Container Apps Job with a schedule trigger |
+
+Keep runtime IDs, tenant assignments, provider credentials, and cadence in your deployment repository or scheduler config. Do not publish live schedules in generic docs.
+
+## Validation
+
+Before opening a deployment PR:
+
+```bash
+cd deploy/pulumi
+uv sync
+uv run python -m py_compile __main__.py runtime.py aws_stack.py gcp_stack.py azure_stack.py
+pulumi preview --stack <aws|gcp|azure> --refresh=false
+```
+
+The templates were validated locally with `pulumi preview --refresh=false` for all three example stacks and with placeholder secret config for durable/graph-enabled previews. No `pulumi up` was run.
+
+After deploying to a real environment, verify:
+
+```bash
+curl -fsS https://cerebro.example.com/livez
+curl -fsS https://cerebro.example.com/health
+curl -fsS -H "Authorization: Bearer ${CEREBRO_API_KEY}" \
+  https://cerebro.example.com/sources
+```
+
+For durable or graph-enabled deployments, also run the checks in [`docs/OPERATIONS_RUNBOOK.md`](./OPERATIONS_RUNBOOK.md).

--- a/docs/DEPLOYMENT_EXAMPLES.md
+++ b/docs/DEPLOYMENT_EXAMPLES.md
@@ -5,6 +5,7 @@ This guide gives portable deployment patterns for OSS users. All names, hosts, i
 Use it with:
 
 - [`docs/HOSTING.md`](./HOSTING.md) for the hosting contract.
+- [`docs/CLOUD_DEPLOYMENT.md`](./CLOUD_DEPLOYMENT.md) for AWS, GCP, Azure, and Pulumi templates.
 - [`docs/OPERATIONS_RUNBOOK.md`](./OPERATIONS_RUNBOOK.md) for rollout and operations.
 - [`docs/AUTH_TENANCY.md`](./AUTH_TENANCY.md) for auth and proxy-aware origin settings.
 - [`.env.example`](../.env.example) for a local environment template.
@@ -55,6 +56,22 @@ It starts:
 - Docker volumes for local persistence.
 
 Do not copy local compose credentials into a shared deployment.
+
+## Multi-cloud Pulumi templates
+
+Use [`deploy/pulumi`](../deploy/pulumi) when you want a validated starting point for AWS, GCP, or Azure. The templates share one Cerebro config model and deploy the API container to ECS Fargate, Cloud Run, or Azure Container Apps. Postgres, NATS JetStream, Neo4j/Aura, and optional cache endpoints are passed as Pulumi secrets so each deployment can choose its own managed or self-hosted backing services.
+
+Start with [`docs/CLOUD_DEPLOYMENT.md`](./CLOUD_DEPLOYMENT.md), then preview before deploying:
+
+```bash
+cd deploy/pulumi
+uv sync
+pulumi preview --stack aws --refresh=false
+pulumi preview --stack gcp --refresh=false
+pulumi preview --stack azure --refresh=false
+```
+
+The checked-in example stacks are validation examples, not production stack files.
 
 ## Production-like environment variables
 

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -5,6 +5,7 @@ This guide describes how to host the Cerebro bootstrap service using public, env
 Use it with:
 
 - [`README.md`](../README.md) for the current runtime overview and quick start.
+- [`docs/CLOUD_DEPLOYMENT.md`](./CLOUD_DEPLOYMENT.md) for AWS, GCP, Azure, and Pulumi templates.
 - [`docs/CONFIGURATION.md`](./CONFIGURATION.md) for a short configuration baseline.
 - [`docs/CONFIG_ENV_VARS.md`](./CONFIG_ENV_VARS.md) for the current environment variable reference.
 - [`api/openapi.yaml`](../api/openapi.yaml) for the JSON HTTP route contract.
@@ -82,6 +83,10 @@ For a hosted environment, publish the Cerebro image to your registry and run one
 - persistent managed backing services.
 
 The runtime image should run as a non-root user and expose only the HTTP port needed by the service. The checked-in Dockerfiles already set the entrypoint and health check. Your platform only needs to pass the required environment variables and route traffic to the configured HTTP address.
+
+### Pulumi cloud templates
+
+For AWS, GCP, or Azure, start from [`docs/CLOUD_DEPLOYMENT.md`](./CLOUD_DEPLOYMENT.md) and the templates in [`deploy/pulumi`](../deploy/pulumi). They provide a shared multi-cloud config surface for the Cerebro API container and cloud-native secret injection while keeping account-specific networking, DNS, backing-service choices, source schedules, and rollout policy in your deployment environment.
 
 ### Generic orchestrator example
 


### PR DESCRIPTION
## Summary

Adds public, environment-agnostic deployment guidance and Pulumi templates for hosting Cerebro on AWS, Google Cloud, and Azure.

## What changed

- Added `docs/CLOUD_DEPLOYMENT.md` covering the portable runtime contract, provider setup, hardening guidance, background jobs, and validation flow.
- Added `deploy/pulumi` with a shared config model and provider-specific templates for AWS ECS Fargate, GCP Cloud Run v2, and Azure Container Apps.
- Added template README, example stacks, dependency metadata, and cloud-native secret wiring for optional Postgres, NATS JetStream, Neo4j/Aura, and auth secrets.
- Linked the new cloud deployment guide from the README, hosting guide, and deployment examples.

## Why

Cerebro already documents the runtime hosting contract, but operators need a validated public starting point for deploying the same container contract on common cloud platforms without depending on private environment details.

## Validation

- `git diff --cached --check`
- `uv sync`
- `uv run python -m py_compile __main__.py runtime.py aws_stack.py gcp_stack.py azure_stack.py`
- `make readme-check docs-drift-check`
- `./scripts/leak_check.sh range origin/main...HEAD`
- `pulumi preview --stack aws --refresh=false`
- `pulumi preview --stack gcp --refresh=false`
- `pulumi preview --stack azure --refresh=false`
- Placeholder durable/graph-enabled Pulumi previews for AWS, GCP, and Azure

No `pulumi up` was run.
