### PR TITLE
NOJIRA: Enrich JetStream publish telemetry

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -13,7 +13,7 @@ For capacity SLOs, saturation dashboards, alert templates, autoscaling signals, 
 ## Wide Event Contract
 
 Cerebro follows a wide-event model for request and job debugging. Each top-level
-unit of work emits one canonical span/event with schema version `2026-06-18.1`
+unit of work emits one canonical span/event with schema version `2026-06-18.2`
 and:
 
 - `main=true`
@@ -106,7 +106,7 @@ Core runtime operations emit structured spans and diagnostic events:
 | `postgres.ping`, `postgres.ensure_statements` | Postgres readiness and schema setup |
 | `neo4j.read`, `neo4j.write` | Graph store transactions |
 | `redis.cache.*`, `redis.ping` | Query cache operations, hits/misses, version bumps |
-| `jetstream.ping`, `jetstream.append`, `jetstream.replay` | Append-log health, publish, and replay |
+| `jetstream.ping`, `jetstream.append`, `jetstream.replay` | Append-log health, publish attempts/retries/acks, and replay |
 
 Runtime contract diagnostics emit bounded events for deployment gates and
 alarms:

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -2,6 +2,8 @@ package jetstream
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
@@ -44,6 +46,19 @@ type replayManager interface {
 
 type replayStream interface {
 	GetMsg(context.Context, uint64, ...jetstream.GetMsgOpt) (*jetstream.RawStreamMsg, error)
+}
+
+type publishTelemetry struct {
+	Attempts       int
+	MaxAttempts    int
+	RetryCount     int
+	LastBackoff    time.Duration
+	LastRetryable  bool
+	Duration       time.Duration
+	AckStream      string
+	AckSequence    uint64
+	AckDuplicate   bool
+	AckUnavailable bool
 }
 
 type jetStreamReplayManager struct {
@@ -217,36 +232,100 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 	if event.Id != "" {
 		msg.Header.Set(nats.MsgIdHdr, event.Id)
 	}
-	if err := l.publishMsg(ctx, msg); err != nil {
+	publishAttrs := func() telemetry.Attributes {
+		return jetstreamPublishMessageAttrs(subject, l.subjectPrefix, len(payload), msg.Header.Get(nats.MsgIdHdr))
+	}
+	publishResult, err := l.publishMsg(ctx, msg, publishAttrs)
+	endAttrs := publishAttrs().With(publishResult.attrs())
+	if err != nil {
 		err = fmt.Errorf("publish event: %w", err)
-		jetstreamTelemetryError(ctx, span, "append", err)
+		jetstreamTelemetryError(ctx, span, "append", err, endAttrs)
 		return err
 	}
-	jetstreamAnnotateMain(ctx, "append", "completed")
-	telemetry.End(span, "completed", telemetry.Attrs(telemetry.Field{Key: "payload_bytes", Value: len(payload)}))
+	if publishResult.RetryCount > 0 {
+		telemetry.IncrementMain(ctx, "messaging.jetstream.publish.recovered.count", 1)
+		telemetry.Event(ctx, "jetstream.publish.recovered", endAttrs)
+	}
+	jetstreamAnnotateMain(ctx, "append", "completed", endAttrs)
+	telemetry.End(span, "completed", endAttrs)
 	return nil
 }
 
-func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg) error {
-	attempts := 1
+func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, eventAttrs func() telemetry.Attributes) (publishTelemetry, error) {
+	result := publishTelemetry{Attempts: 0, MaxAttempts: 1}
 	if msg.Header.Get(nats.MsgIdHdr) != "" {
-		attempts = publishRetryAttempts
+		result.MaxAttempts = publishRetryAttempts
 	}
 	backoff := publishRetryInitialBackoff
+	started := time.Now()
 	var err error
-	for attempt := 1; attempt <= attempts; attempt++ {
-		if _, err = l.js.PublishMsg(ctx, msg); err == nil {
-			return nil
+	for attempt := 1; attempt <= result.MaxAttempts; attempt++ {
+		result.Attempts = attempt
+		ack, publishErr := l.js.PublishMsg(ctx, msg)
+		if publishErr == nil {
+			result.Duration = time.Since(started)
+			result.applyAck(ack)
+			return result, nil
 		}
-		if attempt == attempts || !retryablePublishError(err) || ctx.Err() != nil {
-			return err
+		err = publishErr
+		result.LastRetryable = retryablePublishError(err)
+		if attempt == result.MaxAttempts || !result.LastRetryable || ctx.Err() != nil {
+			result.Duration = time.Since(started)
+			if result.RetryCount > 0 {
+				telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs("append", err)))
+			}
+			return result, err
 		}
+		result.RetryCount++
+		result.LastBackoff = backoff
+		telemetry.IncrementMain(ctx, "messaging.jetstream.publish.retry.count", 1)
+		telemetry.Event(ctx, "jetstream.publish.retry", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs("append", err)).With(telemetry.Attrs(
+			telemetry.Field{Key: "messaging.jetstream.publish.next_attempt", Value: attempt + 1},
+			telemetry.Field{Key: "messaging.jetstream.publish.next_backoff_ms", Value: backoff.Milliseconds()},
+		)))
 		if waitErr := waitBeforePublishRetry(ctx, backoff); waitErr != nil {
-			return waitErr
+			result.Duration = time.Since(started)
+			telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs("append", waitErr)))
+			return result, waitErr
 		}
 		backoff *= 2
 	}
-	return err
+	result.Duration = time.Since(started)
+	return result, err
+}
+
+func (r *publishTelemetry) applyAck(ack *jetstream.PubAck) {
+	if ack == nil {
+		r.AckUnavailable = true
+		return
+	}
+	r.AckStream = strings.TrimSpace(ack.Stream)
+	r.AckSequence = ack.Sequence
+	r.AckDuplicate = ack.Duplicate
+}
+
+func (r publishTelemetry) attrs() telemetry.Attributes {
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "messaging.jetstream.publish.attempts", Value: r.Attempts},
+		telemetry.Field{Key: "messaging.jetstream.publish.max_attempts", Value: r.MaxAttempts},
+		telemetry.Field{Key: "messaging.jetstream.publish.retry_count", Value: r.RetryCount},
+		telemetry.Field{Key: "messaging.jetstream.publish.retryable_last_error", Value: r.LastRetryable},
+		telemetry.Field{Key: "messaging.jetstream.publish.last_backoff_ms", Value: r.LastBackoff.Milliseconds()},
+		telemetry.Field{Key: "messaging.jetstream.publish.duration_ms", Value: r.Duration.Milliseconds()},
+	)
+	if r.AckUnavailable {
+		attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.ack.unavailable", Value: true})
+	}
+	if r.AckStream != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.ack.stream", Value: r.AckStream})
+	}
+	if r.AckSequence > 0 {
+		attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.ack.sequence", Value: r.AckSequence})
+	}
+	if r.AckStream != "" || r.AckSequence > 0 || r.AckDuplicate {
+		attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.ack.duplicate", Value: r.AckDuplicate})
+	}
+	return attrs
 }
 
 func retryablePublishError(err error) bool {
@@ -380,9 +459,34 @@ func jetstreamTelemetryAttrs(operation string) telemetry.Attributes {
 	)
 }
 
-func jetstreamTelemetryError(ctx context.Context, span *telemetry.Span, operation string, err error) {
-	jetstreamAnnotateMain(ctx, operation, "failed")
+func jetstreamPublishMessageAttrs(subject string, subjectPrefix string, payloadBytes int, messageID string) telemetry.Attributes {
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "messaging.system", Value: "nats"},
+		telemetry.Field{Key: "messaging.operation", Value: "publish"},
+		telemetry.Field{Key: "messaging.destination.name", Value: strings.TrimSpace(subject)},
+		telemetry.Field{Key: "messaging.destination.kind", Value: "topic"},
+		telemetry.Field{Key: "messaging.jetstream.subject", Value: strings.TrimSpace(subject)},
+		telemetry.Field{Key: "messaging.jetstream.subject_prefix", Value: strings.Trim(strings.TrimSpace(subjectPrefix), ".")},
+		telemetry.Field{Key: "messaging.message.id.present", Value: strings.TrimSpace(messageID) != ""},
+		telemetry.Field{Key: "payload_bytes", Value: payloadBytes},
+	)
+	if strings.TrimSpace(messageID) != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "messaging.message.id_hash", Value: shortHash(messageID)})
+	}
+	return attrs
+}
+
+func shortHash(value string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(value)))
+	return hex.EncodeToString(sum[:8])
+}
+
+func jetstreamTelemetryError(ctx context.Context, span *telemetry.Span, operation string, err error, extra ...telemetry.Attributes) {
 	attrs := jetstreamErrorTelemetryAttrs(operation, err)
+	for _, item := range extra {
+		attrs = attrs.With(item)
+	}
+	jetstreamAnnotateMain(ctx, operation, "failed", attrs)
 	telemetry.CaptureError(ctx, "jetstream.error", err, telemetry.Attrs(
 		telemetry.Field{Key: "component", Value: "appendlog.jetstream"},
 		telemetry.Field{Key: "operation", Value: operation},
@@ -406,16 +510,27 @@ func jetstreamErrorTelemetryAttrs(operation string, err error) telemetry.Attribu
 	return attrs
 }
 
-func jetstreamAnnotateMain(ctx context.Context, operation string, status string) {
+func jetstreamAnnotateMain(ctx context.Context, operation string, status string, extra ...telemetry.Attributes) {
+	operation = strings.TrimSpace(operation)
+	status = strings.TrimSpace(status)
 	telemetry.IncrementMain(ctx, "messaging.jetstream.operation.count", 1)
+	if operation != "" {
+		telemetry.IncrementMain(ctx, "messaging.jetstream."+operation+".count", 1)
+	}
 	if status == "failed" {
 		telemetry.IncrementMain(ctx, "messaging.jetstream.error.count", 1)
+		if operation != "" {
+			telemetry.IncrementMain(ctx, "messaging.jetstream."+operation+".error.count", 1)
+		}
 	}
 	attrs := telemetry.Attrs(
-		telemetry.Field{Key: "messaging.jetstream.last_operation", Value: strings.TrimSpace(operation)},
-		telemetry.Field{Key: "messaging.jetstream.last_status", Value: strings.TrimSpace(status)},
+		telemetry.Field{Key: "messaging.jetstream.last_operation", Value: operation},
+		telemetry.Field{Key: "messaging.jetstream.last_status", Value: status},
 		telemetry.Field{Key: "messaging.system", Value: "nats"},
 	)
+	for _, item := range extra {
+		attrs = attrs.With(item)
+	}
 	telemetry.AnnotateMain(ctx, attrs)
 	telemetry.AnnotateMainDependency(ctx, "messaging.jetstream", "appendlog.jetstream", operation, status, attrs)
 }

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -2,9 +2,13 @@ package jetstream
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,6 +82,49 @@ func (f *fakeReplayStream) GetMsg(_ context.Context, seq uint64, _ ...natsjetstr
 	return raw, nil
 }
 
+func captureJetstreamTelemetry(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = oldStderr
+		_ = writer.Close()
+		_ = reader.Close()
+	}()
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr pipe: %v", err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr pipe: %v", err)
+	}
+	return string(output)
+}
+
+func jetstreamTelemetryPayloads(t *testing.T, stderr string, kind string, name string) []map[string]any {
+	t.Helper()
+	var payloads []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			t.Fatalf("telemetry line is not JSON: %v\nline=%s\nstderr=%s", err, line, stderr)
+		}
+		if payload["kind"] == kind && payload["name"] == name {
+			payloads = append(payloads, payload)
+		}
+	}
+	return payloads
+}
+
 func TestAppendPublishesEnvelope(t *testing.T) {
 	pub := &fakePublisher{}
 	log := &Log{js: pub, subjectPrefix: "events"}
@@ -127,6 +174,110 @@ func TestAppendRetriesTransientPublishErrorWhenMessageIDIsSet(t *testing.T) {
 	}
 	if pub.publishCalls != 2 {
 		t.Fatalf("publish calls = %d, want 2", pub.publishCalls)
+	}
+}
+
+func TestAppendEmitsPublishRetryTelemetry(t *testing.T) {
+	pub := &fakePublisher{
+		publishErrs: []error{
+			errors.New("nats: no response from stream"),
+			nil,
+		},
+	}
+	log := &Log{js: pub, subjectPrefix: "events"}
+
+	stderr := captureJetstreamTelemetry(t, func() {
+		err := log.Append(context.Background(), &cerebrov1.EventEnvelope{
+			Id:   "evt-retry-telemetry",
+			Kind: "entity.upsert",
+		})
+		if err != nil {
+			t.Fatalf("Append() error = %v", err)
+		}
+	})
+
+	if strings.Contains(stderr, "evt-retry-telemetry") {
+		t.Fatalf("raw message id leaked into telemetry: %s", stderr)
+	}
+	retryEvents := jetstreamTelemetryPayloads(t, stderr, "event", "jetstream.publish.retry")
+	if len(retryEvents) != 1 {
+		t.Fatalf("retry events = %d, want 1; stderr=%s", len(retryEvents), stderr)
+	}
+	retry := retryEvents[0]
+	if retry["messaging.jetstream.subject"] != "events.entity.upsert" {
+		t.Fatalf("retry subject = %v, want events.entity.upsert", retry["messaging.jetstream.subject"])
+	}
+	if retry["messaging.jetstream.publish.retry_count"] != float64(1) {
+		t.Fatalf("retry count = %v, want 1", retry["messaging.jetstream.publish.retry_count"])
+	}
+	if retry["messaging.jetstream.publish.next_attempt"] != float64(2) {
+		t.Fatalf("next attempt = %v, want 2", retry["messaging.jetstream.publish.next_attempt"])
+	}
+
+	recoveredEvents := jetstreamTelemetryPayloads(t, stderr, "event", "jetstream.publish.recovered")
+	if len(recoveredEvents) != 1 {
+		t.Fatalf("recovered events = %d, want 1; stderr=%s", len(recoveredEvents), stderr)
+	}
+	spanEnds := jetstreamTelemetryPayloads(t, stderr, "span_end", "jetstream.append")
+	if len(spanEnds) != 1 {
+		t.Fatalf("jetstream.append span_end events = %d, want 1; stderr=%s", len(spanEnds), stderr)
+	}
+	end := spanEnds[0]
+	if end["messaging.message.id.present"] != true {
+		t.Fatalf("message id present = %v, want true", end["messaging.message.id.present"])
+	}
+	if hash, ok := end["messaging.message.id_hash"].(string); !ok || hash == "" {
+		t.Fatalf("message id hash = %v, want non-empty string", end["messaging.message.id_hash"])
+	}
+	if end["messaging.jetstream.publish.retry_count"] != float64(1) {
+		t.Fatalf("span retry count = %v, want 1", end["messaging.jetstream.publish.retry_count"])
+	}
+}
+
+func TestAppendEmitsPublishRetryExhaustedTelemetry(t *testing.T) {
+	pub := &fakePublisher{
+		publishErrs: []error{
+			errors.New("nats: no response from stream"),
+			errors.New("nats: no response from stream"),
+			errors.New("nats: no response from stream"),
+			errors.New("nats: no response from stream"),
+		},
+	}
+	log := &Log{js: pub, subjectPrefix: "events"}
+
+	stderr := captureJetstreamTelemetry(t, func() {
+		err := log.Append(context.Background(), &cerebrov1.EventEnvelope{
+			Id:   "evt-exhausted-telemetry",
+			Kind: "entity.upsert",
+		})
+		if err == nil {
+			t.Fatal("Append() error = nil, want non-nil")
+		}
+	})
+
+	if pub.publishCalls != publishRetryAttempts {
+		t.Fatalf("publish calls = %d, want %d", pub.publishCalls, publishRetryAttempts)
+	}
+	if strings.Contains(stderr, "evt-exhausted-telemetry") {
+		t.Fatalf("raw message id leaked into telemetry: %s", stderr)
+	}
+	exhaustedEvents := jetstreamTelemetryPayloads(t, stderr, "event", "jetstream.publish.retry_exhausted")
+	if len(exhaustedEvents) != 1 {
+		t.Fatalf("retry_exhausted events = %d, want 1; stderr=%s", len(exhaustedEvents), stderr)
+	}
+	exhausted := exhaustedEvents[0]
+	if exhausted["messaging.jetstream.publish.retry_count"] != float64(publishRetryAttempts-1) {
+		t.Fatalf("exhausted retry count = %v, want %d", exhausted["messaging.jetstream.publish.retry_count"], publishRetryAttempts-1)
+	}
+	if exhausted["messaging.jetstream.publish.max_attempts"] != float64(publishRetryAttempts) {
+		t.Fatalf("exhausted max attempts = %v, want %d", exhausted["messaging.jetstream.publish.max_attempts"], publishRetryAttempts)
+	}
+	errorEvents := jetstreamTelemetryPayloads(t, stderr, "event", "jetstream.error")
+	if len(errorEvents) != 1 {
+		t.Fatalf("jetstream.error events = %d, want 1; stderr=%s", len(errorEvents), stderr)
+	}
+	if errorEvents[0]["messaging.jetstream.publish.retry_count"] != float64(publishRetryAttempts-1) {
+		t.Fatalf("jetstream.error retry count = %v, want %d", errorEvents[0]["messaging.jetstream.publish.retry_count"], publishRetryAttempts-1)
 	}
 }
 


### PR DESCRIPTION
## Summary
- enrich JetStream publish telemetry with attempt, retry, backoff, duration, and ack stream/sequence/duplicate fields
- emit `jetstream.publish.retry`, `jetstream.publish.recovered`, and `jetstream.publish.retry_exhausted` events for CloudWatch and log drill-down
- keep message IDs safe by emitting presence plus a short SHA-256 hash, never the raw ID

Companion internal CloudWatch/Pulumi PR: https://github.com/WriterInternal/cerebro/pull/1499

## Context
- Wide-event rollups from the original stack landed on `main` in `0e7b94d1`, so this PR now carries only the JetStream publish telemetry gap closure.

## Tests
- `go test ./...`
