### PR TITLE
Fix release dispatch payload limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,7 +315,6 @@ jobs:
           SOURCE_REPOSITORY: ${{ github.repository }}
           TARGET_ENVIRONMENT: ${{ matrix.target_environment }}
           APPLY_MODE: ${{ matrix.apply_mode }}
-          RUNTIME_CONTRACT_BASE: cerebro-runtime-contract-${{ matrix.target_environment }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN}" ]; then
@@ -351,7 +350,8 @@ jobs:
             requested_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             request_id="cerebro-${TARGET_ENVIRONMENT}-${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
-            jq -n \
+            payload="$(
+              jq -n \
               --arg tag "${RELEASE_TAG}" \
               --arg digest "${IMAGE_DIGEST}" \
               --arg release_url "https://github.com/${SOURCE_REPOSITORY}/releases/tag/${RELEASE_TAG}" \
@@ -360,9 +360,6 @@ jobs:
               --arg request_id "${request_id}" \
               --arg target_environment "${TARGET_ENVIRONMENT}" \
               --arg apply_mode "${APPLY_MODE}" \
-              --arg runtime_contract "${RUNTIME_CONTRACT_BASE}.json" \
-              --arg runtime_contract_signature "${RUNTIME_CONTRACT_BASE}.json.sig" \
-              --arg runtime_contract_certificate "${RUNTIME_CONTRACT_BASE}.json.pem" \
               '{
                 event_type: "cerebro-release-published",
                 client_payload: {
@@ -373,12 +370,16 @@ jobs:
                   source_ref: $source_ref,
                   request_id: $request_id,
                   target_environment: $target_environment,
-                  apply_mode: $apply_mode,
-                  runtime_contract: $runtime_contract,
-                  runtime_contract_signature: $runtime_contract_signature,
-                  runtime_contract_certificate: $runtime_contract_certificate
+                  apply_mode: $apply_mode
                 }
-              }' | gh api --method POST "repos/${INFRA_REPOSITORY}/dispatches" --input -
+              }'
+            )"
+            payload_keys="$(jq '.client_payload | length' <<<"${payload}")"
+            if [ "${payload_keys}" -gt 10 ]; then
+              echo "ERROR: repository_dispatch client_payload has ${payload_keys} keys; GitHub allows at most 10" >&2
+              exit 1
+            fi
+            gh api --method POST "repos/${INFRA_REPOSITORY}/dispatches" --input - <<<"${payload}"
 
             deadline=$((SECONDS + 120))
             while [ "${SECONDS}" -lt "${deadline}" ]; do

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -91,7 +91,9 @@ func TestReleaseWorkflowKeepsCIParityAndStableLatestGuard(t *testing.T) {
 		"target_environment: go-prod",
 		"apply_mode: pull_request",
 		"TARGET_ENVIRONMENT: ${{ matrix.target_environment }}",
-		"RUNTIME_CONTRACT_BASE: cerebro-runtime-contract-${{ matrix.target_environment }}",
+		`payload_keys="$(jq '.client_payload | length' <<<"${payload}")"`,
+		"GitHub allows at most 10",
+		`gh api --method POST "repos/${INFRA_REPOSITORY}/dispatches" --input - <<<"${payload}"`,
 		`target_environment: [sec-dev, go-prod]`,
 		`-env "${TARGET_ENVIRONMENT}"`,
 		"cerebro-runtime-contract-sec-dev.json",
@@ -99,6 +101,18 @@ func TestReleaseWorkflowKeepsCIParityAndStableLatestGuard(t *testing.T) {
 	} {
 		if !strings.Contains(release, marker) {
 			t.Fatalf("release workflow missing required marker %q", marker)
+		}
+	}
+	for _, stale := range []string{
+		`--arg runtime_contract `,
+		`--arg runtime_contract_signature `,
+		`--arg runtime_contract_certificate `,
+		`runtime_contract: $runtime_contract`,
+		`runtime_contract_signature: $runtime_contract_signature`,
+		`runtime_contract_certificate: $runtime_contract_certificate`,
+	} {
+		if strings.Contains(release, stale) {
+			t.Fatalf("release dispatch payload contains stale contract marker %q", stale)
 		}
 	}
 	if strings.Contains(release, "-env sec-dev") {


### PR DESCRIPTION
## Summary
- remove unused runtime contract asset names from the infra repository_dispatch payload
- add a release-job guard that fails before dispatch if client_payload exceeds GitHub's 10-key limit
- update the release packaging archtest to require the new guard and forbid stale dispatch contract keys

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- actionlint .github/workflows/release.yml
- go test ./tools/archtests