### PR TITLE
fix(sentinelone): accept wrapped list responses

### DIFF
--- a/internal/sourcecdk/list_response.go
+++ b/internal/sourcecdk/list_response.go
@@ -1,0 +1,60 @@
+package sourcecdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type ListResponsePagination struct {
+	NextCursor string
+	TotalItems int
+}
+
+func DecodeListResponseData(raw json.RawMessage, label string, arrayKeys ...string) ([]json.RawMessage, ListResponsePagination, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return nil, ListResponsePagination{}, nil
+	}
+	if strings.HasPrefix(trimmed, "[") {
+		var records []json.RawMessage
+		if err := json.Unmarshal(raw, &records); err != nil {
+			return nil, ListResponsePagination{}, fmt.Errorf("decode %s data array: %w", label, err)
+		}
+		return records, ListResponsePagination{}, nil
+	}
+	if !strings.HasPrefix(trimmed, "{") {
+		return nil, ListResponsePagination{}, fmt.Errorf("decode %s data: expected array or object", label)
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil, ListResponsePagination{}, fmt.Errorf("decode %s data object: %w", label, err)
+	}
+	pagination := listPaginationFromObject(object)
+	for _, key := range append(arrayKeys, "items", "records", "data") {
+		value := object[key]
+		if len(value) == 0 || strings.TrimSpace(string(value)) == "null" || !strings.HasPrefix(strings.TrimSpace(string(value)), "[") {
+			continue
+		}
+		var records []json.RawMessage
+		if err := json.Unmarshal(value, &records); err != nil {
+			return nil, ListResponsePagination{}, fmt.Errorf("decode %s data.%s array: %w", label, key, err)
+		}
+		return records, pagination, nil
+	}
+	return nil, ListResponsePagination{}, fmt.Errorf("decode %s data object: missing records array", label)
+}
+
+func listPaginationFromObject(object map[string]json.RawMessage) ListResponsePagination {
+	var pagination ListResponsePagination
+	if raw := object["pagination"]; len(raw) > 0 && strings.TrimSpace(string(raw)) != "null" {
+		_ = json.Unmarshal(raw, &pagination)
+	}
+	if pagination.NextCursor == "" {
+		_ = json.Unmarshal(object["nextCursor"], &pagination.NextCursor)
+	}
+	if pagination.TotalItems == 0 {
+		_ = json.Unmarshal(object["totalItems"], &pagination.TotalItems)
+	}
+	return pagination
+}

--- a/internal/sourcecdk/list_response_test.go
+++ b/internal/sourcecdk/list_response_test.go
@@ -1,0 +1,46 @@
+package sourcecdk
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDecodeListResponseDataAcceptsArray(t *testing.T) {
+	records, pagination, err := DecodeListResponseData(json.RawMessage(`[{"id":"S-1"}]`), "sentinelone sites", "sites")
+	if err != nil {
+		t.Fatalf("DecodeListResponseData() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(records))
+	}
+	if pagination.NextCursor != "" {
+		t.Fatalf("NextCursor = %q, want empty", pagination.NextCursor)
+	}
+}
+
+func TestDecodeListResponseDataAcceptsWrappedObject(t *testing.T) {
+	records, pagination, err := DecodeListResponseData(
+		json.RawMessage(`{"sites":[{"id":"S-1"}],"pagination":{"nextCursor":"cursor-2","totalItems":2}}`),
+		"sentinelone sites",
+		"sites",
+	)
+	if err != nil {
+		t.Fatalf("DecodeListResponseData() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(records))
+	}
+	if pagination.NextCursor != "cursor-2" {
+		t.Fatalf("NextCursor = %q, want cursor-2", pagination.NextCursor)
+	}
+	if pagination.TotalItems != 2 {
+		t.Fatalf("TotalItems = %d, want 2", pagination.TotalItems)
+	}
+}
+
+func TestDecodeListResponseDataRejectsUnknownWrappedObject(t *testing.T) {
+	_, _, err := DecodeListResponseData(json.RawMessage(`{"unexpected":[{"id":"S-1"}]}`), "sentinelone sites", "sites")
+	if err == nil {
+		t.Fatal("DecodeListResponseData() error = nil, want non-nil")
+	}
+}

--- a/sources/sentinelone/source.go
+++ b/sources/sentinelone/source.go
@@ -66,8 +66,8 @@ type settings struct {
 }
 
 type listResponse struct {
-	Data       []json.RawMessage `json:"data"`
-	Pagination paginationInfo    `json:"pagination"`
+	Data       json.RawMessage `json:"data"`
+	Pagination paginationInfo  `json:"pagination"`
 }
 
 type paginationInfo struct {
@@ -98,7 +98,6 @@ func (e *responseError) StatusCode() int {
 	return e.statusCode
 }
 
-// New constructs the live SentinelOne source.
 func New() (*Source, error) {
 	spec, err := loadSpec()
 	if err != nil {
@@ -115,17 +114,14 @@ func New() (*Source, error) {
 	return source, nil
 }
 
-// Spec returns the static metadata for the SentinelOne source.
 func (s *Source) Spec() *cerebrov1.SourceSpec {
 	return s.spec
 }
 
-// Check validates that the configured SentinelOne family is reachable.
 func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 	return s.families.Check(ctx, cfg)
 }
 
-// Discover returns SentinelOne URNs for the configured family.
 func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
 	return s.families.Discover(ctx, cfg)
 }
@@ -631,8 +627,12 @@ func listJSONRecords[T any, P interface {
 	if err := source.getJSON(ctx, settings, requestPath, query, &resp); err != nil {
 		return nil, "", err
 	}
-	records := make([]T, 0, len(resp.Data))
-	for _, item := range resp.Data {
+	items, pagination, err := sourcecdk.DecodeListResponseData(resp.Data, requestPath, "activities", "agents", "applications", "exclusions", "groups", "sites", "threats")
+	if err != nil {
+		return nil, "", err
+	}
+	records := make([]T, 0, len(items))
+	for _, item := range items {
 		var record T
 		if err := json.Unmarshal(item, &record); err != nil {
 			return nil, "", fmt.Errorf("decode %s record: %w", requestPath, err)
@@ -640,7 +640,7 @@ func listJSONRecords[T any, P interface {
 		P(&record).setRaw(cloneRaw(item))
 		records = append(records, record)
 	}
-	return records, strings.TrimSpace(resp.Pagination.NextCursor), nil
+	return records, strings.TrimSpace(firstNonEmpty(pagination.NextCursor, resp.Pagination.NextCursor)), nil
 }
 
 func (s *Source) listThreats(ctx context.Context, settings settings, cursor string, limit int) ([]threatRecord, string, error) {


### PR DESCRIPTION
## Summary
- accept SentinelOne list responses where data is a wrapped object keyed by the collection name, e.g. data.sites
- preserve top-level pagination and nested pagination/nextCursor support
- fail closed when wrapped data does not contain a recognized records array

## Tests
- go test ./sources/sentinelone
- go test ./cmd/cerebro -run 'TestPrepareSource.*GitHub|TestPrepareSourceRuntimeWithCLIOrgGitHubFamiliesSkipRepoHydration|TestPrepareSourceRuntimeWithCLIAuditAppAuthSkipsTokenHydration'
- go test ./sources/... ./cmd/cerebro
- git diff --check