### PR TITLE
[codex] Extend policy finding DSL authoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-check policy-rule-generate policy-rule-check detection-catalog-generate detection-catalog-check new-aws-collector docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check detection-catalog-generate detection-catalog-check new-aws-collector docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -278,7 +278,16 @@ graph-action-check: ## Verify generated graph action registry is current.
 finding-dsl-migrate: ## Convert legacy JSON policy files to PolicyFindingRule DSL YAML.
 	go run ./tools/findingdsl --migrate-policies --write
 
-finding-dsl-check: ## Validate PolicyFindingRule DSL authoring files.
+finding-dsl-test: ## Run PolicyFindingRule fixture suites.
+	go run ./tools/findingdsl test
+
+finding-dsl-schema-generate: ## Regenerate PolicyFindingRule JSON Schema.
+	go run ./tools/findingdsl schema --write
+
+finding-dsl-schema-check: ## Verify PolicyFindingRule JSON Schema is current.
+	go run ./tools/findingdsl schema --check
+
+finding-dsl-check: finding-dsl-schema-check finding-dsl-test ## Validate PolicyFindingRule DSL authoring files.
 	go run ./tools/findingdsl --check
 
 policy-rule-generate: ## Regenerate generated policy rule catalog.

--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -8,6 +8,8 @@ Policies are generated into Go rule definitions in `internal/findings/policy_rul
 
 Generated rule copy, evidence type, assessment methods, false-positive guidance, and auditor notes are enriched from `internal/compliance/policy_rule_extensions.yaml`; see `docs/POLICY_RULE_EXTENSIONS.md`. Control pack authoring, custom frameworks, and selected control coverage are documented in `docs/COMPLIANCE_CONTROLS.md`.
 
+Editor integrations can use the generated JSON Schema at `schemas/policy-finding-rule.schema.json`.
+
 ## Basic Policy
 
 ```yaml
@@ -64,11 +66,11 @@ spec:
 | `spec.mitreAttack` | No | MITRE tactic and technique mappings. |
 | `spec.enabled` | No | Set to `false` to keep a policy in the catalog while disabling generated rule support. |
 
-Every policy must have either `spec.match.conditions` or `spec.match.query`.
+Every policy must have exactly one match mode: either `spec.match.conditions` or `spec.match.query`.
 
 ## CEL Policies
 
-Use `spec.match.conditions` for resource-state or event-state checks. Conditions are stored as strings because the policy runtime owns CEL evaluation; the DSL validator checks the envelope and required metadata, not semantic CEL execution.
+Use `spec.match.conditions` for resource-state or event-state checks. Conditions are stored as strings because the policy runtime owns CEL evaluation. The DSL validator parse-checks the supported predicate envelope, including helpers such as `path`, `exists_path`, `cmp_eq`, `cmp_ne`, `cmp_gt`, `cmp_lt`, `cmp_ge`, `cmp_le`, `in_list`, `contains_value`, `matches_value`, `ends_with_value`, and `list_value(...).exists(...)`.
 
 ```yaml
 spec:
@@ -98,6 +100,90 @@ spec:
 
 The generated finding rule records `policy_query_present=true` and treats each failed evidence event as a policy finding candidate keyed by policy and resource identifiers.
 
+## Authoring Commands
+
+Create a policy scaffold:
+
+```bash
+go run ./tools/findingdsl new \
+  --write \
+  --domain aws \
+  --id aws-s3-bucket-no-public-access \
+  --name "S3 Bucket Public Access Block" \
+  --description "S3 buckets should have public access blocked." \
+  --severity critical \
+  --resource aws::s3::bucket \
+  --condition 'cmp_eq(path(resource, "block_public_acls"), false)' \
+  --framework "SOC 2:CC6" \
+  --tag aws \
+  --risk-category EXTERNAL_EXPOSURE \
+  --remediation "Enable S3 public access block settings."
+```
+
+Without `--write`, `new` prints the YAML to stdout. When `--out` is omitted, the file path is `policies/<domain>/<id>.yaml`.
+
+Format one file or the full catalog:
+
+```bash
+go run ./tools/findingdsl fmt --write policies/aws/aws-s3-public.yaml
+go run ./tools/findingdsl fmt --check
+```
+
+Generate or verify the editor schema:
+
+```bash
+make finding-dsl-schema-generate
+make finding-dsl-schema-check
+```
+
+The legacy flag interface remains available for automation:
+
+```bash
+go run ./tools/findingdsl --check
+go run ./tools/findingdsl --migrate-policies --write
+```
+
+## Fixture Tests
+
+Policy behavior can be covered with `PolicyFindingRuleTest` files next to the policy. A suite named `policies/aws/aws-s3-public.test.yaml` defaults to testing `policies/aws/aws-s3-public.yaml`.
+
+```yaml
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+  - name: bucket without public access block fails
+    resource:
+      block_public_acls: false
+    wantFinding: true
+  - name: bucket with public access block passes
+    resource:
+      block_public_acls: true
+    wantFinding: false
+```
+
+For query-backed policies, use `queryRows`; any returned row means the policy should produce a finding:
+
+```yaml
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+policy: policies/identity/example-query-policy.yaml
+cases:
+  - name: returned row fails
+    queryRows:
+      - id: user-1
+    wantFinding: true
+  - name: empty result passes
+    resource:
+      placeholder: true
+    wantFinding: false
+```
+
+Run suites with:
+
+```bash
+go run ./tools/findingdsl test
+```
+
 ## Validation And Generation
 
 Run focused checks after editing policy DSL files:
@@ -116,7 +202,7 @@ make policy-rule-check
 make detection-catalog-check
 ```
 
-`make policy-rule-check` depends on `finding-dsl-check`, so stale generated rule output and invalid DSL files fail together.
+`make finding-dsl-check` verifies the JSON Schema, runs policy fixture suites, rejects unknown YAML fields, rejects legacy JSON policy files, checks condition/query mode correctness, parse-checks condition expressions, and validates required DSL metadata. `make policy-rule-check` depends on `finding-dsl-check`, so stale generated rule output and invalid DSL files fail together.
 
 ## Migration
 

--- a/internal/findingdsl/expression.go
+++ b/internal/findingdsl/expression.go
@@ -15,6 +15,9 @@ type evalEnv struct {
 	vars map[string]any
 }
 
+// PolicyResource is the resource document evaluated by condition-backed rules.
+type PolicyResource map[string]any
+
 type literalExpression struct {
 	value any
 }
@@ -186,7 +189,7 @@ func ParsePolicyCondition(condition string) error {
 	return err
 }
 
-func EvaluatePolicyConditions(conditions []string, resource map[string]any) (bool, error) {
+func EvaluatePolicyConditions(conditions []string, resource PolicyResource) (bool, error) {
 	env := &evalEnv{vars: map[string]any{"resource": resource}}
 	for idx, condition := range conditions {
 		expr, err := parsePolicyExpression(condition)
@@ -716,6 +719,12 @@ func lookupPath(value any, path string) (any, bool) {
 			return nil, false
 		}
 		switch typed := current.(type) {
+		case PolicyResource:
+			next, ok := typed[part]
+			if !ok {
+				return nil, false
+			}
+			current = next
 		case map[string]any:
 			next, ok := typed[part]
 			if !ok {

--- a/internal/findingdsl/expression.go
+++ b/internal/findingdsl/expression.go
@@ -1,0 +1,828 @@
+package findingdsl
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type expression interface {
+	eval(*evalEnv) (any, error)
+}
+
+type evalEnv struct {
+	vars map[string]any
+}
+
+type literalExpression struct {
+	value any
+}
+
+func (e literalExpression) eval(_ *evalEnv) (any, error) {
+	return e.value, nil
+}
+
+type identExpression struct {
+	name string
+}
+
+func (e identExpression) eval(env *evalEnv) (any, error) {
+	value, ok := env.vars[e.name]
+	if !ok {
+		return nil, fmt.Errorf("unknown identifier %q", e.name)
+	}
+	return value, nil
+}
+
+type listExpression struct {
+	items []expression
+}
+
+func (e listExpression) eval(env *evalEnv) (any, error) {
+	out := make([]any, 0, len(e.items))
+	for _, item := range e.items {
+		value, err := item.eval(env)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, value)
+	}
+	return out, nil
+}
+
+type objectExpression struct {
+	values map[string]expression
+}
+
+func (e objectExpression) eval(env *evalEnv) (any, error) {
+	out := make(map[string]any, len(e.values))
+	for key, expr := range e.values {
+		value, err := expr.eval(env)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
+type unaryExpression struct {
+	op   string
+	expr expression
+}
+
+func (e unaryExpression) eval(env *evalEnv) (any, error) {
+	value, err := e.expr.eval(env)
+	if err != nil {
+		return nil, err
+	}
+	switch e.op {
+	case "!":
+		boolean, ok := value.(bool)
+		if !ok {
+			return nil, fmt.Errorf("operator ! requires bool, got %T", value)
+		}
+		return !boolean, nil
+	default:
+		return nil, fmt.Errorf("unsupported unary operator %q", e.op)
+	}
+}
+
+type binaryExpression struct {
+	op    string
+	left  expression
+	right expression
+}
+
+func (e binaryExpression) eval(env *evalEnv) (any, error) {
+	left, err := e.left.eval(env)
+	if err != nil {
+		return nil, err
+	}
+	leftBool, ok := left.(bool)
+	if !ok {
+		return nil, fmt.Errorf("operator %s requires bool left operand, got %T", e.op, left)
+	}
+	switch e.op {
+	case "&&":
+		if !leftBool {
+			return false, nil
+		}
+	case "||":
+		if leftBool {
+			return true, nil
+		}
+	default:
+		return nil, fmt.Errorf("unsupported binary operator %q", e.op)
+	}
+	right, err := e.right.eval(env)
+	if err != nil {
+		return nil, err
+	}
+	rightBool, ok := right.(bool)
+	if !ok {
+		return nil, fmt.Errorf("operator %s requires bool right operand, got %T", e.op, right)
+	}
+	if e.op == "&&" {
+		return leftBool && rightBool, nil
+	}
+	return leftBool || rightBool, nil
+}
+
+type callExpression struct {
+	name string
+	args []expression
+}
+
+func (e callExpression) eval(env *evalEnv) (any, error) {
+	args, err := evalArgs(env, e.args)
+	if err != nil {
+		return nil, err
+	}
+	switch e.name {
+	case "path":
+		return evalPath(args)
+	case "exists_path":
+		_, ok, err := pathLookupArgs(args)
+		if err != nil {
+			return nil, err
+		}
+		return ok, nil
+	case "cmp_eq", "cmp_ne", "cmp_gt", "cmp_lt", "cmp_ge", "cmp_le":
+		return evalCompare(e.name, args)
+	case "in_list":
+		return evalInList(args)
+	case "contains_value":
+		return evalContainsValue(args)
+	case "matches_value":
+		return evalMatchesValue(args)
+	case "ends_with_value":
+		return evalEndsWithValue(args)
+	case "list_value":
+		return evalListValue(args)
+	default:
+		return nil, fmt.Errorf("unsupported function %q", e.name)
+	}
+}
+
+type methodCallExpression struct {
+	receiver expression
+	name     string
+	args     []expression
+}
+
+func (e methodCallExpression) eval(env *evalEnv) (any, error) {
+	switch e.name {
+	case "exists":
+		return evalExistsMethod(env, e.receiver, e.args)
+	default:
+		return nil, fmt.Errorf("unsupported method %q", e.name)
+	}
+}
+
+func ParsePolicyCondition(condition string) error {
+	_, err := parsePolicyExpression(condition)
+	return err
+}
+
+func EvaluatePolicyConditions(conditions []string, resource map[string]any) (bool, error) {
+	env := &evalEnv{vars: map[string]any{"resource": resource}}
+	for idx, condition := range conditions {
+		expr, err := parsePolicyExpression(condition)
+		if err != nil {
+			return false, fmt.Errorf("condition[%d]: %w", idx, err)
+		}
+		value, err := expr.eval(env)
+		if err != nil {
+			return false, fmt.Errorf("condition[%d]: %w", idx, err)
+		}
+		boolean, ok := value.(bool)
+		if !ok {
+			return false, fmt.Errorf("condition[%d]: expression returned %T, want bool", idx, value)
+		}
+		if !boolean {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func parsePolicyExpression(input string) (expression, error) {
+	tokens, err := lexPolicyExpression(input)
+	if err != nil {
+		return nil, err
+	}
+	parser := expressionParser{tokens: tokens}
+	expr, err := parser.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	if token := parser.peek(); token.kind != tokenEOF {
+		return nil, fmt.Errorf("unexpected token %q", token.value)
+	}
+	return expr, nil
+}
+
+type tokenKind int
+
+const (
+	tokenEOF tokenKind = iota
+	tokenIdent
+	tokenString
+	tokenNumber
+	tokenSymbol
+)
+
+type expressionToken struct {
+	kind  tokenKind
+	value string
+}
+
+func lexPolicyExpression(input string) ([]expressionToken, error) {
+	var tokens []expressionToken
+	for idx := 0; idx < len(input); {
+		ch := input[idx]
+		if isSpace(ch) {
+			idx++
+			continue
+		}
+		if isIdentStart(ch) {
+			start := idx
+			idx++
+			for idx < len(input) && isIdentPart(input[idx]) {
+				idx++
+			}
+			tokens = append(tokens, expressionToken{kind: tokenIdent, value: input[start:idx]})
+			continue
+		}
+		if ch == '"' {
+			value, next, err := lexString(input, idx)
+			if err != nil {
+				return nil, err
+			}
+			tokens = append(tokens, expressionToken{kind: tokenString, value: value})
+			idx = next
+			continue
+		}
+		if isNumberStart(input, idx) {
+			start := idx
+			idx++
+			for idx < len(input) && (input[idx] == '.' || input[idx] >= '0' && input[idx] <= '9') {
+				idx++
+			}
+			tokens = append(tokens, expressionToken{kind: tokenNumber, value: input[start:idx]})
+			continue
+		}
+		if idx+1 < len(input) {
+			pair := input[idx : idx+2]
+			if pair == "&&" || pair == "||" {
+				tokens = append(tokens, expressionToken{kind: tokenSymbol, value: pair})
+				idx += 2
+				continue
+			}
+		}
+		if strings.ContainsRune("(),[].!{}:", rune(ch)) {
+			tokens = append(tokens, expressionToken{kind: tokenSymbol, value: string(ch)})
+			idx++
+			continue
+		}
+		return nil, fmt.Errorf("unexpected character %q", ch)
+	}
+	tokens = append(tokens, expressionToken{kind: tokenEOF})
+	return tokens, nil
+}
+
+func lexString(input string, start int) (string, int, error) {
+	var builder strings.Builder
+	for idx := start + 1; idx < len(input); idx++ {
+		ch := input[idx]
+		if ch == '"' {
+			return builder.String(), idx + 1, nil
+		}
+		if ch == '\\' {
+			if idx+1 >= len(input) {
+				return "", 0, fmt.Errorf("unterminated string escape")
+			}
+			idx++
+			switch escaped := input[idx]; escaped {
+			case '\\', '"':
+				builder.WriteByte(escaped)
+			case 'n':
+				builder.WriteByte('\n')
+			case 't':
+				builder.WriteByte('\t')
+			case 'u':
+				if idx+4 >= len(input) {
+					return "", 0, fmt.Errorf("short unicode string escape")
+				}
+				hex := input[idx+1 : idx+5]
+				value, err := strconv.ParseInt(hex, 16, 32)
+				if err != nil {
+					return "", 0, fmt.Errorf("invalid unicode string escape \\u%s", hex)
+				}
+				builder.WriteRune(rune(value))
+				idx += 4
+			default:
+				return "", 0, fmt.Errorf("unsupported string escape \\%c", escaped)
+			}
+			continue
+		}
+		builder.WriteByte(ch)
+	}
+	return "", 0, fmt.Errorf("unterminated string")
+}
+
+type expressionParser struct {
+	tokens []expressionToken
+	pos    int
+}
+
+func (p *expressionParser) parseOr() (expression, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.match("||") {
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = binaryExpression{op: "||", left: left, right: right}
+	}
+	return left, nil
+}
+
+func (p *expressionParser) parseAnd() (expression, error) {
+	left, err := p.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+	for p.match("&&") {
+		right, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		left = binaryExpression{op: "&&", left: left, right: right}
+	}
+	return left, nil
+}
+
+func (p *expressionParser) parseUnary() (expression, error) {
+	if p.match("!") {
+		expr, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return unaryExpression{op: "!", expr: expr}, nil
+	}
+	return p.parsePostfix()
+}
+
+func (p *expressionParser) parsePostfix() (expression, error) {
+	expr, err := p.parsePrimary()
+	if err != nil {
+		return nil, err
+	}
+	for p.match(".") {
+		name, err := p.consumeIdent("method name")
+		if err != nil {
+			return nil, err
+		}
+		args, err := p.parseCallArgs()
+		if err != nil {
+			return nil, err
+		}
+		expr = methodCallExpression{receiver: expr, name: name, args: args}
+	}
+	return expr, nil
+}
+
+func (p *expressionParser) parsePrimary() (expression, error) {
+	token := p.advance()
+	switch token.kind {
+	case tokenIdent:
+		switch token.value {
+		case "true":
+			return literalExpression{value: true}, nil
+		case "false":
+			return literalExpression{value: false}, nil
+		case "null":
+			return literalExpression{value: nil}, nil
+		}
+		if p.peek().value == "(" {
+			args, err := p.parseCallArgs()
+			if err != nil {
+				return nil, err
+			}
+			return callExpression{name: token.value, args: args}, nil
+		}
+		return identExpression{name: token.value}, nil
+	case tokenString:
+		return literalExpression{value: token.value}, nil
+	case tokenNumber:
+		number, err := strconv.ParseFloat(token.value, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid number %q", token.value)
+		}
+		return literalExpression{value: number}, nil
+	case tokenSymbol:
+		if token.value == "(" {
+			expr, err := p.parseOr()
+			if err != nil {
+				return nil, err
+			}
+			if !p.match(")") {
+				return nil, fmt.Errorf("expected )")
+			}
+			return expr, nil
+		}
+		if token.value == "[" {
+			return p.parseList()
+		}
+		if token.value == "{" {
+			return p.parseObject()
+		}
+	}
+	return nil, fmt.Errorf("unexpected token %q", token.value)
+}
+
+func (p *expressionParser) parseList() (expression, error) {
+	var items []expression
+	if p.match("]") {
+		return listExpression{items: items}, nil
+	}
+	for {
+		item, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+		if p.match("]") {
+			return listExpression{items: items}, nil
+		}
+		if !p.match(",") {
+			return nil, fmt.Errorf("expected , or ]")
+		}
+	}
+}
+
+func (p *expressionParser) parseObject() (expression, error) {
+	values := map[string]expression{}
+	if p.match("}") {
+		return objectExpression{values: values}, nil
+	}
+	for {
+		keyToken := p.advance()
+		if keyToken.kind != tokenString && keyToken.kind != tokenIdent {
+			return nil, fmt.Errorf("expected object key")
+		}
+		if !p.match(":") {
+			return nil, fmt.Errorf("expected colon")
+		}
+		value, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		values[keyToken.value] = value
+		if p.match("}") {
+			return objectExpression{values: values}, nil
+		}
+		if !p.match(",") {
+			return nil, fmt.Errorf("expected , or }")
+		}
+	}
+}
+
+func (p *expressionParser) parseCallArgs() ([]expression, error) {
+	if !p.match("(") {
+		return nil, fmt.Errorf("expected (")
+	}
+	var args []expression
+	if p.match(")") {
+		return args, nil
+	}
+	for {
+		arg, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, arg)
+		if p.match(")") {
+			return args, nil
+		}
+		if !p.match(",") {
+			return nil, fmt.Errorf("expected , or )")
+		}
+	}
+}
+
+func (p *expressionParser) consumeIdent(label string) (string, error) {
+	token := p.advance()
+	if token.kind != tokenIdent {
+		return "", fmt.Errorf("expected %s", label)
+	}
+	return token.value, nil
+}
+
+func (p *expressionParser) match(value string) bool {
+	if p.peek().value != value {
+		return false
+	}
+	p.pos++
+	return true
+}
+
+func (p *expressionParser) advance() expressionToken {
+	token := p.peek()
+	if token.kind != tokenEOF {
+		p.pos++
+	}
+	return token
+}
+
+func (p *expressionParser) peek() expressionToken {
+	if p.pos >= len(p.tokens) {
+		return expressionToken{kind: tokenEOF}
+	}
+	return p.tokens[p.pos]
+}
+
+func evalArgs(env *evalEnv, expressions []expression) ([]any, error) {
+	out := make([]any, 0, len(expressions))
+	for _, expr := range expressions {
+		value, err := expr.eval(env)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, value)
+	}
+	return out, nil
+}
+
+func evalPath(args []any) (any, error) {
+	value, _, err := pathLookupArgs(args)
+	return value, err
+}
+
+func pathLookupArgs(args []any) (any, bool, error) {
+	if len(args) != 2 {
+		return nil, false, fmt.Errorf("path requires 2 arguments")
+	}
+	path, ok := args[1].(string)
+	if !ok {
+		return nil, false, fmt.Errorf("path argument 2 must be string")
+	}
+	value, found := lookupPath(args[0], path)
+	return value, found, nil
+}
+
+func evalCompare(name string, args []any) (bool, error) {
+	if len(args) != 2 {
+		return false, fmt.Errorf("%s requires 2 arguments", name)
+	}
+	cmp := compareValues(args[0], args[1])
+	switch name {
+	case "cmp_eq":
+		return cmp == 0, nil
+	case "cmp_ne":
+		return cmp != 0, nil
+	case "cmp_gt":
+		return cmp > 0, nil
+	case "cmp_lt":
+		return cmp < 0, nil
+	case "cmp_ge":
+		return cmp >= 0, nil
+	case "cmp_le":
+		return cmp <= 0, nil
+	default:
+		return false, fmt.Errorf("unsupported comparison %q", name)
+	}
+}
+
+func evalInList(args []any) (bool, error) {
+	if len(args) != 2 {
+		return false, fmt.Errorf("in_list requires 2 arguments")
+	}
+	values, ok := toAnySlice(args[1])
+	if !ok {
+		return false, fmt.Errorf("in_list argument 2 must be a list")
+	}
+	for _, value := range values {
+		if compareValues(args[0], value) == 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func evalContainsValue(args []any) (bool, error) {
+	if len(args) != 2 {
+		return false, fmt.Errorf("contains_value requires 2 arguments")
+	}
+	needle := fmt.Sprint(args[1])
+	switch haystack := args[0].(type) {
+	case string:
+		return strings.Contains(haystack, needle), nil
+	case []any:
+		for _, item := range haystack {
+			if compareValues(item, args[1]) == 0 || strings.Contains(fmt.Sprint(item), needle) {
+				return true, nil
+			}
+		}
+		return false, nil
+	default:
+		return false, nil
+	}
+}
+
+func evalMatchesValue(args []any) (bool, error) {
+	if len(args) != 2 {
+		return false, fmt.Errorf("matches_value requires 2 arguments")
+	}
+	pattern, ok := args[1].(string)
+	if !ok {
+		return false, fmt.Errorf("matches_value argument 2 must be string")
+	}
+	return regexp.MatchString(pattern, fmt.Sprint(args[0]))
+}
+
+func evalEndsWithValue(args []any) (bool, error) {
+	if len(args) != 2 {
+		return false, fmt.Errorf("ends_with_value requires 2 arguments")
+	}
+	return strings.HasSuffix(fmt.Sprint(args[0]), fmt.Sprint(args[1])), nil
+}
+
+func evalListValue(args []any) ([]any, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("list_value requires 1 argument")
+	}
+	if args[0] == nil {
+		return nil, nil
+	}
+	values, ok := toAnySlice(args[0])
+	if !ok {
+		return nil, fmt.Errorf("list_value argument must be a list")
+	}
+	return values, nil
+}
+
+func evalExistsMethod(env *evalEnv, receiver expression, args []expression) (bool, error) {
+	if len(args) != 2 {
+		return false, fmt.Errorf("exists requires iterator name and predicate")
+	}
+	ident, ok := args[0].(identExpression)
+	if !ok {
+		return false, fmt.Errorf("exists first argument must be an identifier")
+	}
+	value, err := receiver.eval(env)
+	if err != nil {
+		return false, err
+	}
+	values, ok := toAnySlice(value)
+	if !ok {
+		return false, fmt.Errorf("exists receiver must be a list")
+	}
+	oldValue, hadOldValue := env.vars[ident.name]
+	defer func() {
+		if hadOldValue {
+			env.vars[ident.name] = oldValue
+			return
+		}
+		delete(env.vars, ident.name)
+	}()
+	for _, item := range values {
+		env.vars[ident.name] = item
+		result, err := args[1].eval(env)
+		if err != nil {
+			return false, err
+		}
+		boolean, ok := result.(bool)
+		if !ok {
+			return false, fmt.Errorf("exists predicate returned %T, want bool", result)
+		}
+		if boolean {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func lookupPath(value any, path string) (any, bool) {
+	current := value
+	for _, part := range strings.Split(path, ".") {
+		if part == "" {
+			return nil, false
+		}
+		switch typed := current.(type) {
+		case map[string]any:
+			next, ok := typed[part]
+			if !ok {
+				return nil, false
+			}
+			current = next
+		case map[any]any:
+			next, ok := typed[part]
+			if !ok {
+				return nil, false
+			}
+			current = next
+		case []any:
+			index, err := strconv.Atoi(part)
+			if err != nil || index < 0 || index >= len(typed) {
+				return nil, false
+			}
+			current = typed[index]
+		default:
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func compareValues(left any, right any) int {
+	if left == nil && right == nil {
+		return 0
+	}
+	if left == nil {
+		return -1
+	}
+	if right == nil {
+		return 1
+	}
+	if leftNumber, ok := toFloat(left); ok {
+		if rightNumber, ok := toFloat(right); ok {
+			if leftNumber < rightNumber {
+				return -1
+			}
+			if leftNumber > rightNumber {
+				return 1
+			}
+			return 0
+		}
+	}
+	leftString := fmt.Sprint(left)
+	rightString := fmt.Sprint(right)
+	if leftString < rightString {
+		return -1
+	}
+	if leftString > rightString {
+		return 1
+	}
+	return 0
+}
+
+func toFloat(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case uint64:
+		return float64(typed), true
+	case uint:
+		return float64(typed), true
+	default:
+		return 0, false
+	}
+}
+
+func toAnySlice(value any) ([]any, bool) {
+	switch typed := value.(type) {
+	case []any:
+		return typed, true
+	case []map[string]any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, item)
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+func isSpace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+}
+
+func isIdentStart(ch byte) bool {
+	return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch == '_'
+}
+
+func isIdentPart(ch byte) bool {
+	return isIdentStart(ch) || ch >= '0' && ch <= '9'
+}
+
+func isNumberStart(input string, idx int) bool {
+	ch := input[idx]
+	if ch >= '0' && ch <= '9' {
+		return true
+	}
+	return ch == '-' && idx+1 < len(input) && input[idx+1] >= '0' && input[idx+1] <= '9'
+}

--- a/internal/findingdsl/format.go
+++ b/internal/findingdsl/format.go
@@ -1,0 +1,141 @@
+package findingdsl
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type NewPolicyRuleInput struct {
+	ID              string
+	Domain          string
+	Name            string
+	Description     string
+	Severity        string
+	Effect          string
+	Resource        string
+	ResourceType    string
+	Conditions      []string
+	Query           string
+	Tags            []string
+	RiskCategories  []string
+	Frameworks      []PolicyFramework
+	Remediation     string
+	RemediationStep []string
+}
+
+func NewPolicyRule(input NewPolicyRuleInput) PolicyFindingRule {
+	severity := strings.TrimSpace(input.Severity)
+	if severity == "" {
+		severity = "medium"
+	}
+	effect := strings.TrimSpace(input.Effect)
+	if effect == "" && len(trimStrings(input.Conditions)) != 0 {
+		effect = "forbid"
+	}
+	rule := PolicyFindingRule{
+		APIVersion: APIVersion,
+		Kind:       KindPolicyFindingRule,
+		Metadata: PolicyRuleMetadata{
+			ID:          strings.TrimSpace(input.ID),
+			Name:        strings.TrimSpace(input.Name),
+			Description: strings.TrimSpace(input.Description),
+			Tags:        trimStrings(input.Tags),
+		},
+		Spec: PolicyFindingRuleSpec{
+			Severity:       severity,
+			Effect:         effect,
+			Resource:       strings.TrimSpace(input.Resource),
+			ResourceType:   strings.TrimSpace(input.ResourceType),
+			Match:          PolicyRuleMatch{Conditions: trimStrings(input.Conditions), Query: strings.TrimSpace(input.Query)},
+			Remediation:    PolicyRuleRemediation{Summary: strings.TrimSpace(input.Remediation), Steps: trimStrings(input.RemediationStep)},
+			RiskCategories: trimStrings(input.RiskCategories),
+			Frameworks:     normalizeFrameworks(input.Frameworks),
+		},
+	}
+	if len(rule.Spec.Match.Conditions) != 0 {
+		rule.Spec.Match.ConditionFormat = "cel"
+	}
+	if domain := strings.TrimSpace(input.Domain); domain != "" {
+		rule.RelPath = PolicyRuleRelPath(domain, rule.Metadata.ID)
+		rule.Domain = domain
+	}
+	return NormalizePolicyRule(rule)
+}
+
+func NormalizePolicyRule(rule PolicyFindingRule) PolicyFindingRule {
+	rule.APIVersion = firstNonEmpty(strings.TrimSpace(rule.APIVersion), APIVersion)
+	rule.Kind = firstNonEmpty(strings.TrimSpace(rule.Kind), KindPolicyFindingRule)
+	rule.Metadata.ID = strings.TrimSpace(rule.Metadata.ID)
+	rule.Metadata.Name = strings.TrimSpace(rule.Metadata.Name)
+	rule.Metadata.Description = strings.TrimSpace(rule.Metadata.Description)
+	rule.Metadata.LastModified = strings.TrimSpace(rule.Metadata.LastModified)
+	rule.Metadata.Tags = trimStrings(rule.Metadata.Tags)
+	rule.Spec.Severity = strings.TrimSpace(rule.Spec.Severity)
+	rule.Spec.Category = strings.TrimSpace(rule.Spec.Category)
+	rule.Spec.Effect = strings.TrimSpace(rule.Spec.Effect)
+	rule.Spec.Principal = strings.TrimSpace(rule.Spec.Principal)
+	rule.Spec.Action = strings.TrimSpace(rule.Spec.Action)
+	rule.Spec.Resource = strings.TrimSpace(rule.Spec.Resource)
+	rule.Spec.ResourceType = strings.TrimSpace(rule.Spec.ResourceType)
+	rule.Spec.Match.Conditions = trimStrings(rule.Spec.Match.Conditions)
+	rule.Spec.Match.ConditionFormat = strings.TrimSpace(rule.Spec.Match.ConditionFormat)
+	if strings.EqualFold(rule.Spec.Match.ConditionFormat, "cel") {
+		rule.Spec.Match.ConditionFormat = "cel"
+	}
+	rule.Spec.Match.Query = strings.TrimSpace(rule.Spec.Match.Query)
+	rule.Spec.Remediation.Summary = strings.TrimSpace(rule.Spec.Remediation.Summary)
+	rule.Spec.Remediation.Steps = trimStrings(rule.Spec.Remediation.Steps)
+	rule.Spec.RiskCategories = trimStrings(rule.Spec.RiskCategories)
+	rule.Spec.Frameworks = normalizeFrameworks(rule.Spec.Frameworks)
+	for idx := range rule.Spec.MITREAttack {
+		rule.Spec.MITREAttack[idx].Tactic = strings.TrimSpace(rule.Spec.MITREAttack[idx].Tactic)
+		rule.Spec.MITREAttack[idx].Technique = strings.TrimSpace(rule.Spec.MITREAttack[idx].Technique)
+	}
+	return rule
+}
+
+func FormatPolicyRuleYAML(rule PolicyFindingRule) ([]byte, error) {
+	return MarshalPolicyRuleYAML(NormalizePolicyRule(rule))
+}
+
+func PolicyRuleRelPath(domain string, id string) string {
+	return filepath.ToSlash(filepath.Join("policies", strings.TrimSpace(domain), strings.TrimSpace(id)+".yaml"))
+}
+
+func ParseFrameworkSpec(value string) (PolicyFramework, error) {
+	name, controls, ok := strings.Cut(value, ":")
+	if !ok {
+		return PolicyFramework{}, fmt.Errorf("framework %q must use name:control[,control] format", value)
+	}
+	framework := PolicyFramework{Name: strings.TrimSpace(name)}
+	for _, control := range strings.Split(controls, ",") {
+		if trimmed := strings.TrimSpace(control); trimmed != "" {
+			framework.Controls = append(framework.Controls, trimmed)
+		}
+	}
+	if framework.Name == "" || len(framework.Controls) == 0 {
+		return PolicyFramework{}, fmt.Errorf("framework %q must include name and at least one control", value)
+	}
+	return framework, nil
+}
+
+func normalizeFrameworks(frameworks []PolicyFramework) []PolicyFramework {
+	out := make([]PolicyFramework, 0, len(frameworks))
+	for _, framework := range frameworks {
+		normalized := PolicyFramework{Name: strings.TrimSpace(framework.Name), Controls: trimStrings(framework.Controls)}
+		if normalized.Name != "" || len(normalized.Controls) != 0 {
+			out = append(out, normalized)
+		}
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/findingdsl/policy_rule.go
+++ b/internal/findingdsl/policy_rule.go
@@ -1,6 +1,7 @@
 package findingdsl
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -246,6 +247,9 @@ func LoadPolicyRules(root string) ([]PolicyFindingRule, []Issue, error) {
 		if rel == ControlMappingRelPath {
 			return nil
 		}
+		if isPolicyTestRelPath(rel) {
+			return nil
+		}
 		ext := strings.ToLower(filepath.Ext(path))
 		if ext == ".json" {
 			issues = append(issues, Issue{Path: rel, Message: "legacy JSON policy files are not allowed; use PolicyFindingRule DSL YAML"})
@@ -306,7 +310,9 @@ func LoadPolicyRuleFile(root string, path string) (PolicyFindingRule, []Issue, e
 		return PolicyFindingRule{}, nil, fmt.Errorf("read %s: %w", rel, err)
 	}
 	var rule PolicyFindingRule
-	if parseErr := yaml.Unmarshal(content, &rule); parseErr != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	decoder.KnownFields(true)
+	if parseErr := decoder.Decode(&rule); parseErr != nil {
 		return policyRuleIssue(rel, "invalid PolicyFindingRule YAML: "+parseErr.Error())
 	}
 	rule.RelPath = rel
@@ -343,12 +349,18 @@ func ValidatePolicyRule(rule PolicyFindingRule) []Issue {
 			issues = append(issues, Issue{Path: path, Message: field.name + " is required"})
 		}
 	}
+	if policyID := strings.TrimSpace(rule.Metadata.ID); policyID != "" && !isPolicyID(policyID) {
+		issues = append(issues, Issue{Path: path, Message: "metadata.id must use dash-separated alphanumeric segments"})
+	}
 	if severity := strings.ToUpper(strings.TrimSpace(rule.Spec.Severity)); severity != "" && !stringSetContains([]string{"INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"}, severity) {
 		issues = append(issues, Issue{Path: path, Message: "spec.severity must be one of info, low, medium, high, critical"})
 	}
 	hasConditions := len(trimStrings(rule.Spec.Match.Conditions)) != 0
 	hasQuery := strings.TrimSpace(rule.Spec.Match.Query) != ""
 	hasAssert := policyAssertConfigured(rule.Spec.Assert)
+	if hasConditions && hasQuery {
+		issues = append(issues, Issue{Path: path, Message: "spec.match.conditions and spec.match.query are mutually exclusive"})
+	}
 	if !hasConditions && !hasQuery && !hasAssert {
 		issues = append(issues, Issue{Path: path, Message: "spec.match.conditions, spec.match.query, or spec.assert is required"})
 	}
@@ -359,9 +371,28 @@ func ValidatePolicyRule(rule PolicyFindingRule) []Issue {
 		if format := strings.TrimSpace(rule.Spec.Match.ConditionFormat); format != "" && !strings.EqualFold(format, "cel") {
 			issues = append(issues, Issue{Path: path, Message: "spec.match.conditionFormat must be cel when present"})
 		}
+		for idx, condition := range rule.Spec.Match.Conditions {
+			if strings.TrimSpace(condition) == "" {
+				issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("spec.match.conditions[%d] must be non-empty", idx)})
+				continue
+			}
+			if err := ParsePolicyCondition(condition); err != nil {
+				issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("spec.match.conditions[%d] is invalid: %v", idx, err)})
+			}
+		}
+	}
+	if hasQuery {
+		if strings.TrimSpace(rule.Spec.Match.ConditionFormat) != "" {
+			issues = append(issues, Issue{Path: path, Message: "spec.match.conditionFormat is only valid with spec.match.conditions"})
+		}
+		if !startsWithQueryKeyword(rule.Spec.Match.Query) {
+			issues = append(issues, Issue{Path: path, Message: "spec.match.query must start with SELECT or WITH"})
+		}
 	}
 	issues = append(issues, validateStringArray(path, "metadata.tags", rule.Metadata.Tags)...)
 	issues = append(issues, validateStringArray(path, "spec.riskCategories", rule.Spec.RiskCategories)...)
+	issues = append(issues, validateUniqueStringArray(path, "metadata.tags", rule.Metadata.Tags)...)
+	issues = append(issues, validateUniqueStringArray(path, "spec.riskCategories", rule.Spec.RiskCategories)...)
 	issues = append(issues, validateFrameworks(path, rule.Spec.Frameworks)...)
 	issues = append(issues, validatePolicyRuleContract(path, rule.Spec)...)
 	return issues
@@ -566,10 +597,18 @@ func validateFrameworks(path string, frameworks []PolicyFramework) []Issue {
 		if len(framework.Controls) == 0 {
 			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("spec.frameworks[%d].controls is required", idx)})
 		}
+		seenControls := map[string]int{}
 		for controlIdx, control := range framework.Controls {
-			if strings.TrimSpace(control) == "" {
+			controlID := strings.TrimSpace(control)
+			if controlID == "" {
 				issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("spec.frameworks[%d].controls[%d] is required", idx, controlIdx)})
+				continue
 			}
+			if previousIdx, ok := seenControls[controlID]; ok {
+				issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("spec.frameworks[%d].controls[%d] duplicates controls[%d]", idx, controlIdx, previousIdx)})
+				continue
+			}
+			seenControls[controlID] = controlIdx
 		}
 	}
 	return issues
@@ -652,6 +691,21 @@ func unstableFingerprintField(value string) bool {
 	}
 }
 
+func validateUniqueStringArray(path string, field string, values []string) []Issue {
+	seen := map[string]int{}
+	for idx, value := range values {
+		normalized := strings.TrimSpace(value)
+		if normalized == "" {
+			continue
+		}
+		if previousIdx, ok := seen[normalized]; ok {
+			return []Issue{{Path: path, Message: fmt.Sprintf("%s[%d] duplicates %s[%d]", field, idx, field, previousIdx)}}
+		}
+		seen[normalized] = idx
+	}
+	return nil
+}
+
 func trimStrings(values []string) []string {
 	out := make([]string, 0, len(values))
 	for _, value := range values {
@@ -669,6 +723,33 @@ func stringSetContains(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func startsWithQueryKeyword(query string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(query))
+	return strings.HasPrefix(upper, "SELECT ") || strings.HasPrefix(upper, "SELECT\n") || strings.HasPrefix(upper, "WITH ") || strings.HasPrefix(upper, "WITH\n")
+}
+
+func isPolicyID(value string) bool {
+	segmentHasAlnum := false
+	previousDash := false
+	for idx, ch := range value {
+		isAlnum := ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9'
+		switch {
+		case isAlnum:
+			segmentHasAlnum = true
+			previousDash = false
+		case ch == '-':
+			if idx == 0 || previousDash || !segmentHasAlnum {
+				return false
+			}
+			previousDash = true
+			segmentHasAlnum = false
+		default:
+			return false
+		}
+	}
+	return segmentHasAlnum && !previousDash
 }
 
 func slashRel(root string, path string) string {

--- a/internal/findingdsl/policy_rule_test.go
+++ b/internal/findingdsl/policy_rule_test.go
@@ -280,7 +280,7 @@ unexpected: true
 }
 
 func TestEvaluatePolicyConditions(t *testing.T) {
-	resource := map[string]any{
+	resource := PolicyResource{
 		"public": true,
 		"rules": []any{
 			map[string]any{"port": "443", "source": "10.0.0.0/8"},

--- a/internal/findingdsl/policy_rule_test.go
+++ b/internal/findingdsl/policy_rule_test.go
@@ -251,6 +251,108 @@ func TestLegacyPolicyRoundTrip(t *testing.T) {
 	}
 }
 
+func TestValidatePolicyRuleRejectsUnknownYAMLFields(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "policies/aws/example.yaml", `
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRule
+metadata:
+  id: aws-example
+  name: AWS Example
+  description: Example policy
+spec:
+  severity: high
+  match:
+    query: SELECT id FROM resources
+  frameworks:
+    - name: SOC 2
+      controls: [CC6]
+unexpected: true
+`)
+
+	_, issues, err := LoadPolicyRuleFile(root, filepath.Join(root, "policies/aws/example.yaml"))
+	if err != nil {
+		t.Fatalf("LoadPolicyRuleFile() error = %v", err)
+	}
+	if len(issues) != 1 || !strings.Contains(issues[0].Message, "field unexpected not found") {
+		t.Fatalf("issues = %#v, want unknown field rejection", issues)
+	}
+}
+
+func TestEvaluatePolicyConditions(t *testing.T) {
+	resource := map[string]any{
+		"public": true,
+		"rules": []any{
+			map[string]any{"port": "443", "source": "10.0.0.0/8"},
+			map[string]any{"port": "22", "source": "0.0.0.0/0"},
+		},
+	}
+	got, err := EvaluatePolicyConditions([]string{
+		`cmp_eq(path(resource, "public"), true)`,
+		`list_value(path(resource, "rules")).exists(item, (cmp_eq(path(item, "port"), "22")) && (cmp_eq(path(item, "source"), "0.0.0.0/0")))`,
+	}, resource)
+	if err != nil {
+		t.Fatalf("EvaluatePolicyConditions() error = %v", err)
+	}
+	if !got {
+		t.Fatal("EvaluatePolicyConditions() = false, want true")
+	}
+}
+
+func TestRunPolicyRuleTestSuite(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "policies/aws/example.yaml", `
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRule
+metadata:
+  id: aws-example
+  name: AWS Example
+  description: Example policy
+spec:
+  severity: high
+  effect: forbid
+  resource: aws::s3::bucket
+  match:
+    conditionFormat: cel
+    conditions:
+      - cmp_eq(path(resource, "public"), true)
+  frameworks:
+    - name: SOC 2
+      controls: [CC6]
+`)
+	writeTestFile(t, root, "policies/aws/example.test.yaml", `
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+  - name: public bucket fails
+    resource:
+      public: true
+    wantFinding: true
+  - name: private bucket passes
+    resource:
+      public: false
+    wantFinding: false
+`)
+
+	issues := RunPolicyRuleTestSuite(root, filepath.Join(root, "policies/aws/example.test.yaml"))
+	if len(issues) != 0 {
+		t.Fatalf("RunPolicyRuleTestSuite() issues = %#v, want none", issues)
+	}
+}
+
+func TestPolicyRuleJSONSchema(t *testing.T) {
+	schema, err := PolicyRuleJSONSchema()
+	if err != nil {
+		t.Fatalf("PolicyRuleJSONSchema() error = %v", err)
+	}
+	text := string(schema)
+	for _, want := range []string{`"apiVersion"`, APIVersion, KindPolicyFindingRule, `"additionalProperties": false`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("schema missing %q:\n%s", want, text)
+		}
+	}
+}
+
 func issuesContain(issues []Issue, want string) bool {
 	for _, issue := range issues {
 		if strings.Contains(issue.Message, want) {

--- a/internal/findingdsl/schema.go
+++ b/internal/findingdsl/schema.go
@@ -1,0 +1,153 @@
+package findingdsl
+
+import "encoding/json"
+
+const PolicyRuleSchemaRelPath = "schemas/policy-finding-rule.schema.json"
+
+func PolicyRuleJSONSchema() ([]byte, error) {
+	schema := map[string]any{
+		"$schema":              "https://json-schema.org/draft/2020-12/schema",
+		"$id":                  "https://cerebro.writer.com/schemas/policy-finding-rule.schema.json",
+		"title":                "Cerebro PolicyFindingRule",
+		"description":          "Authoring schema for generated Cerebro policy finding rules.",
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"apiVersion", "kind", "metadata", "spec"},
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"const": APIVersion},
+			"kind":       map[string]any{"const": KindPolicyFindingRule},
+			"metadata":   metadataSchema(),
+			"spec":       specSchema(),
+		},
+	}
+	return json.MarshalIndent(schema, "", "  ")
+}
+
+func metadataSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"id", "name", "description"},
+		"properties": map[string]any{
+			"id": map[string]any{
+				"type":        "string",
+				"pattern":     "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$",
+				"description": "Stable policy and generated rule identifier.",
+			},
+			"name":         stringSchema("Human-readable policy name."),
+			"description":  stringSchema("What the policy checks and why it matters."),
+			"lastModified": stringSchema("Source policy timestamp for imported catalogs."),
+			"tags":         stringArraySchema("Tags for categorization, routing, and catalog search."),
+		},
+	}
+}
+
+func specSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"severity", "match", "frameworks"},
+		"properties": map[string]any{
+			"severity": map[string]any{
+				"type": "string",
+				"enum": []string{"critical", "high", "medium", "low", "info", "CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"},
+			},
+			"category":       stringSchema("Optional generated policy category override."),
+			"effect":         stringSchema("Policy effect, usually forbid for CEL-backed policies."),
+			"principal":      stringSchema("Principal selector metadata for access-control-style policies."),
+			"action":         stringSchema("Action selector metadata for access-control-style policies."),
+			"resource":       stringSchema("Resource selector or resource family."),
+			"resourceType":   stringSchema("Human-readable resource type."),
+			"match":          matchSchema(),
+			"remediation":    remediationSchema(),
+			"riskCategories": stringArraySchema("Normalized risk category labels."),
+			"frameworks": map[string]any{
+				"type":     "array",
+				"minItems": 1,
+				"items":    frameworkSchema(),
+			},
+			"mitreAttack": map[string]any{
+				"type":  "array",
+				"items": mitreSchema(),
+			},
+			"enabled": map[string]any{"type": "boolean"},
+		},
+		"oneOf": []map[string]any{
+			{"required": []string{"match"}},
+		},
+	}
+}
+
+func matchSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"conditions": map[string]any{
+				"type":     "array",
+				"minItems": 1,
+				"items":    stringSchema("CEL-style policy condition expression."),
+			},
+			"conditionFormat": map[string]any{"type": "string", "enum": []string{"cel"}},
+			"query":           stringSchema("Query that returns failing rows for query-backed policies."),
+		},
+		"oneOf": []map[string]any{
+			{"required": []string{"conditions"}},
+			{"required": []string{"query"}},
+		},
+	}
+}
+
+func remediationSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"summary": stringSchema("Short remediation intent."),
+			"steps":   stringArraySchema("Ordered remediation steps."),
+		},
+	}
+}
+
+func frameworkSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"name", "controls"},
+		"properties": map[string]any{
+			"name": stringSchema("Compliance framework name."),
+			"controls": map[string]any{
+				"type":     "array",
+				"minItems": 1,
+				"items":    stringSchema("Framework control identifier."),
+			},
+		},
+	}
+}
+
+func mitreSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"tactic":    stringSchema("MITRE ATT&CK tactic."),
+			"technique": stringSchema("MITRE ATT&CK technique."),
+		},
+	}
+}
+
+func stringArraySchema(description string) map[string]any {
+	return map[string]any{
+		"type":        "array",
+		"description": description,
+		"items":       stringSchema(""),
+	}
+}
+
+func stringSchema(description string) map[string]any {
+	schema := map[string]any{"type": "string"}
+	if description != "" {
+		schema["description"] = description
+	}
+	return schema
+}

--- a/internal/findingdsl/test_suite.go
+++ b/internal/findingdsl/test_suite.go
@@ -1,0 +1,170 @@
+package findingdsl
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const KindPolicyFindingRuleTest = "PolicyFindingRuleTest"
+
+type PolicyRuleTestSuite struct {
+	APIVersion string               `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string               `json:"kind" yaml:"kind"`
+	Policy     string               `json:"policy,omitempty" yaml:"policy,omitempty"`
+	Cases      []PolicyRuleTestCase `json:"cases" yaml:"cases"`
+	RelPath    string               `json:"-" yaml:"-"`
+}
+
+type PolicyRuleTestCase struct {
+	Name        string           `json:"name" yaml:"name"`
+	Resource    map[string]any   `json:"resource,omitempty" yaml:"resource,omitempty"`
+	QueryRows   []map[string]any `json:"queryRows,omitempty" yaml:"queryRows,omitempty"`
+	WantFinding bool             `json:"wantFinding" yaml:"wantFinding"`
+}
+
+func DiscoverPolicyTestSuites(root string) ([]string, error) {
+	root = filepath.Clean(root)
+	var suites []string
+	err := filepath.WalkDir(filepath.Join(root, "policies"), func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if isPolicyTestRelPath(filepath.ToSlash(path)) {
+			rel, err := safeRel(root, path)
+			if err != nil {
+				return err
+			}
+			suites = append(suites, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return suites, nil
+}
+
+func LoadPolicyRuleTestSuite(root string, path string) (PolicyRuleTestSuite, []Issue, error) {
+	root = filepath.Clean(root)
+	rel, err := safeRel(root, path)
+	if err != nil {
+		return PolicyRuleTestSuite{}, nil, err
+	}
+	content, err := fs.ReadFile(os.DirFS(root), rel)
+	if err != nil {
+		return PolicyRuleTestSuite{}, nil, fmt.Errorf("read %s: %w", rel, err)
+	}
+	var suite PolicyRuleTestSuite
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	decoder.KnownFields(true)
+	if parseErr := decoder.Decode(&suite); parseErr != nil {
+		return policyRuleTestSuiteIssue(rel, "invalid PolicyFindingRuleTest YAML: "+parseErr.Error())
+	}
+	suite.RelPath = rel
+	return suite, ValidatePolicyRuleTestSuite(suite), nil
+}
+
+func policyRuleTestSuiteIssue(path string, message string) (PolicyRuleTestSuite, []Issue, error) {
+	return PolicyRuleTestSuite{}, []Issue{{Path: path, Message: message}}, nil
+}
+
+func ValidatePolicyRuleTestSuite(suite PolicyRuleTestSuite) []Issue {
+	path := suite.RelPath
+	if path == "" {
+		path = "<policy-test-suite>"
+	}
+	var issues []Issue
+	if strings.TrimSpace(suite.APIVersion) != APIVersion {
+		issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("apiVersion must be %q", APIVersion)})
+	}
+	if strings.TrimSpace(suite.Kind) != KindPolicyFindingRuleTest {
+		issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("kind must be %q", KindPolicyFindingRuleTest)})
+	}
+	if len(suite.Cases) == 0 {
+		issues = append(issues, Issue{Path: path, Message: "cases is required"})
+	}
+	for idx, testCase := range suite.Cases {
+		if strings.TrimSpace(testCase.Name) == "" {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d].name is required", idx)})
+		}
+		if len(testCase.Resource) == 0 && len(testCase.QueryRows) == 0 {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] must include resource or queryRows", idx)})
+		}
+	}
+	return issues
+}
+
+func RunPolicyRuleTestSuite(root string, suitePath string) []Issue {
+	suite, issues, err := LoadPolicyRuleTestSuite(root, suitePath)
+	if err != nil {
+		return []Issue{{Path: suitePath, Message: err.Error()}}
+	}
+	if len(issues) != 0 {
+		return issues
+	}
+	policyRel := strings.TrimSpace(suite.Policy)
+	if policyRel == "" {
+		policyRel = policyRelForSuite(suite.RelPath)
+	}
+	rule, ruleIssues, err := LoadPolicyRuleFile(root, filepath.Join(root, filepath.FromSlash(policyRel)))
+	if err != nil {
+		return []Issue{{Path: suite.RelPath, Message: err.Error()}}
+	}
+	if len(ruleIssues) != 0 {
+		out := make([]Issue, 0, len(ruleIssues))
+		for _, issue := range ruleIssues {
+			out = append(out, Issue{Path: suite.RelPath, Message: "policy " + issue.Path + ": " + issue.Message})
+		}
+		return out
+	}
+	var out []Issue
+	for idx, testCase := range suite.Cases {
+		got, err := EvaluatePolicyRuleTestCase(rule, testCase)
+		if err != nil {
+			out = append(out, Issue{Path: suite.RelPath, Message: fmt.Sprintf("cases[%d] %q: %v", idx, testCase.Name, err)})
+			continue
+		}
+		if got != testCase.WantFinding {
+			out = append(out, Issue{Path: suite.RelPath, Message: fmt.Sprintf("cases[%d] %q: finding = %t, want %t", idx, testCase.Name, got, testCase.WantFinding)})
+		}
+	}
+	return out
+}
+
+func EvaluatePolicyRuleTestCase(rule PolicyFindingRule, testCase PolicyRuleTestCase) (bool, error) {
+	if strings.TrimSpace(rule.Spec.Match.Query) != "" {
+		return len(testCase.QueryRows) != 0, nil
+	}
+	conditions := trimStrings(rule.Spec.Match.Conditions)
+	if len(conditions) == 0 {
+		return false, fmt.Errorf("policy has no conditions to evaluate")
+	}
+	return EvaluatePolicyConditions(conditions, testCase.Resource)
+}
+
+func isPolicyTestRelPath(path string) bool {
+	return strings.HasSuffix(path, ".test.yaml") || strings.HasSuffix(path, ".test.yml")
+}
+
+func policyRelForSuite(path string) string {
+	if strings.HasSuffix(path, ".test.yaml") {
+		return strings.TrimSuffix(path, ".test.yaml") + ".yaml"
+	}
+	return strings.TrimSuffix(path, ".test.yml") + ".yml"
+}

--- a/internal/findingdsl/test_suite.go
+++ b/internal/findingdsl/test_suite.go
@@ -155,7 +155,7 @@ func EvaluatePolicyRuleTestCase(rule PolicyFindingRule, testCase PolicyRuleTestC
 	if len(conditions) == 0 {
 		return false, fmt.Errorf("policy has no conditions to evaluate")
 	}
-	return EvaluatePolicyConditions(conditions, testCase.Resource)
+	return EvaluatePolicyConditions(conditions, PolicyResource(testCase.Resource))
 }
 
 func isPolicyTestRelPath(path string) bool {

--- a/policies/aws/aws-s3-public.test.yaml
+++ b/policies/aws/aws-s3-public.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: bucket without public access block fails
+      resource:
+          block_public_acls: false
+      wantFinding: true
+    - name: bucket with public access block passes
+      resource:
+          block_public_acls: true
+      wantFinding: false

--- a/policies/identity/identity-okta-privileged-no-mfa.yaml
+++ b/policies/identity/identity-okta-privileged-no-mfa.yaml
@@ -13,6 +13,20 @@ spec:
     severity: HIGH
     category: identity
     resourceType: okta_user
+    match:
+        query: SELECT u.id AS id, u.login AS account_name FROM okta_users u WHERE LOWER(COALESCE(u.status, '')) IN ('active','enabled','provisioned','onboarded') AND (COALESCE(u.is_admin, false) = true) AND COALESCE(u.mfa_enrolled, false) = false
+    remediation:
+        summary: Immediately enforce MFA on privileged identities and suspend privileged actions until compliant.
+    frameworks:
+        - name: SOC 2
+          controls:
+            - CC6.1
+        - name: NIST 800-53 r5
+          controls:
+            - IA-2
+        - name: ISO 27001:2022
+          controls:
+            - A.5.17
     input:
         sourceKinds:
             - okta.user
@@ -37,7 +51,9 @@ spec:
         all:
             - field: privilege_level
               op: in
-              value: [admin, super_admin]
+              value:
+                - admin
+                - super_admin
             - field: mfa_enrolled
               op: eq
               value: false
@@ -127,18 +143,4 @@ spec:
             estimateFrom: graph.neighborhood
         verification:
             rerunPolicy: true
-    match:
-        query: SELECT u.id AS id, u.login AS account_name FROM okta_users u WHERE LOWER(COALESCE(u.status, '')) IN ('active','enabled','provisioned','onboarded') AND (COALESCE(u.is_admin, false) = true) AND COALESCE(u.mfa_enrolled, false) = false
-    remediation:
-        summary: Immediately enforce MFA on privileged identities and suspend privileged actions until compliant.
-    frameworks:
-        - name: SOC 2
-          controls:
-            - CC6.1
-        - name: NIST 800-53 r5
-          controls:
-            - IA-2
-        - name: ISO 27001:2022
-          controls:
-            - A.5.17
     enabled: true

--- a/policies/vendor/vendor-auth-method.yaml
+++ b/policies/vendor/vendor-auth-method.yaml
@@ -14,7 +14,7 @@ spec:
     category: vendor
     resourceType: vendor
     match:
-        query: "SELECT id, name, risk_level FROM vendors WHERE authentication_method IS NULL OR authentication_method = ''"
+        query: SELECT id, name, risk_level FROM vendors WHERE authentication_method IS NULL OR authentication_method = ''
     remediation:
         summary: Document the authentication method for vendor access (SSO, MFA, API keys, etc.).
     frameworks:

--- a/policies/vendor/vendor-dpa-exists.yaml
+++ b/policies/vendor/vendor-dpa-exists.yaml
@@ -16,10 +16,10 @@ spec:
     effect: forbid
     resource: vendors
     match:
-        conditionFormat: cel
         conditions:
             - cmp_eq(path(resource, "processes_personal_data"), true)
             - cmp_ne(path(resource, "dpa_signed"), true)
+        conditionFormat: cel
     remediation:
         summary: Execute a Data Processing Agreement with the vendor that covers data protection requirements per GDPR, CCPA, and other applicable regulations
         steps:

--- a/policies/vendor/vendor-pci-compliance.yaml
+++ b/policies/vendor/vendor-pci-compliance.yaml
@@ -14,7 +14,7 @@ spec:
     category: vendor
     resourceType: vendor
     match:
-        query: "SELECT id, name, risk_level, processes_cardholder_data FROM vendors WHERE processes_cardholder_data = true AND risk_level = 'high' AND (pci_aoc_date IS NULL OR pci_aoc_date < NOW() - INTERVAL '365 days')"
+        query: SELECT id, name, risk_level, processes_cardholder_data FROM vendors WHERE processes_cardholder_data = true AND risk_level = 'high' AND (pci_aoc_date IS NULL OR pci_aoc_date < NOW() - INTERVAL '365 days')
     remediation:
         summary: Obtain current PCI DSS Attestation of Compliance (AOC) from all high-risk vendors that process cardholder data.
     frameworks:

--- a/policies/vendor/vendor-risk-assessed.yaml
+++ b/policies/vendor/vendor-risk-assessed.yaml
@@ -14,10 +14,10 @@ spec:
     effect: forbid
     resource: vendors
     match:
-        conditionFormat: cel
         conditions:
             - cmp_eq(path(resource, "risk_level"), null)
             - cmp_eq(path(resource, "vendor_status"), path(resource, "ACTIVE"))
+        conditionFormat: cel
     remediation:
         summary: Assess the vendor's risk level based on the type of data accessed, service criticality, and security posture
         steps:

--- a/policies/vendor/vendor-security-review.yaml
+++ b/policies/vendor/vendor-security-review.yaml
@@ -15,10 +15,10 @@ spec:
     effect: forbid
     resource: vendors
     match:
-        conditionFormat: cel
         conditions:
             - cmp_eq(path(resource, "risk_level"), path(resource, "HIGH"))
             - cmp_ne(path(resource, "security_review_complete"), true)
+        conditionFormat: cel
     remediation:
         summary: Complete a security review of the vendor including review of their SOC2 report, security questionnaire, or conduct a security assessment
         steps:

--- a/schemas/policy-finding-rule.schema.json
+++ b/schemas/policy-finding-rule.schema.json
@@ -1,0 +1,220 @@
+{
+  "$id": "https://cerebro.writer.com/schemas/policy-finding-rule.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Authoring schema for generated Cerebro policy finding rules.",
+  "properties": {
+    "apiVersion": {
+      "const": "cerebro.writer.com/v1alpha1"
+    },
+    "kind": {
+      "const": "PolicyFindingRule"
+    },
+    "metadata": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "description": "What the policy checks and why it matters.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Stable policy and generated rule identifier.",
+          "pattern": "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$",
+          "type": "string"
+        },
+        "lastModified": {
+          "description": "Source policy timestamp for imported catalogs.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Human-readable policy name.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Tags for categorization, routing, and catalog search.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "description"
+      ],
+      "type": "object"
+    },
+    "spec": {
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "required": [
+            "match"
+          ]
+        }
+      ],
+      "properties": {
+        "action": {
+          "description": "Action selector metadata for access-control-style policies.",
+          "type": "string"
+        },
+        "category": {
+          "description": "Optional generated policy category override.",
+          "type": "string"
+        },
+        "effect": {
+          "description": "Policy effect, usually forbid for CEL-backed policies.",
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "frameworks": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "controls": {
+                "items": {
+                  "description": "Framework control identifier.",
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "name": {
+                "description": "Compliance framework name.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "controls"
+            ],
+            "type": "object"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "match": {
+          "additionalProperties": false,
+          "oneOf": [
+            {
+              "required": [
+                "conditions"
+              ]
+            },
+            {
+              "required": [
+                "query"
+              ]
+            }
+          ],
+          "properties": {
+            "conditionFormat": {
+              "enum": [
+                "cel"
+              ],
+              "type": "string"
+            },
+            "conditions": {
+              "items": {
+                "description": "CEL-style policy condition expression.",
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "query": {
+              "description": "Query that returns failing rows for query-backed policies.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "mitreAttack": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "tactic": {
+                "description": "MITRE ATT\u0026CK tactic.",
+                "type": "string"
+              },
+              "technique": {
+                "description": "MITRE ATT\u0026CK technique.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "principal": {
+          "description": "Principal selector metadata for access-control-style policies.",
+          "type": "string"
+        },
+        "remediation": {
+          "additionalProperties": false,
+          "properties": {
+            "steps": {
+              "description": "Ordered remediation steps.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "summary": {
+              "description": "Short remediation intent.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "resource": {
+          "description": "Resource selector or resource family.",
+          "type": "string"
+        },
+        "resourceType": {
+          "description": "Human-readable resource type.",
+          "type": "string"
+        },
+        "riskCategories": {
+          "description": "Normalized risk category labels.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "severity": {
+          "enum": [
+            "critical",
+            "high",
+            "medium",
+            "low",
+            "info",
+            "CRITICAL",
+            "HIGH",
+            "MEDIUM",
+            "LOW",
+            "INFO"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "severity",
+        "match",
+        "frameworks"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "title": "Cerebro PolicyFindingRule",
+  "type": "object"
+}

--- a/scripts/changed_checks.py
+++ b/scripts/changed_checks.py
@@ -91,7 +91,7 @@ def select_commands(files: list[str], repo: Path) -> list[CommandPlan]:
     if any(path_matches(path, prefixes=("sources/", "policies/", "internal/compliance/", "internal/findings/", "tools/catalogcheck/", "internal/connectorcatalog/catalog/")) for path in files):
         add_command(commands, seen, "catalog-check", ["make", "catalog-check"], "Source, policy, finding, connector, or compliance catalog changed.")
 
-    if any(path_matches(path, prefixes=("policies/", "tools/findingdsl/", "internal/findingdsl/", "tools/policyrulegen/"), exact=("internal/compliance/policy_rule_extensions.yaml",)) for path in files):
+    if any(path_matches(path, prefixes=("policies/", "schemas/", "tools/findingdsl/", "internal/findingdsl/", "tools/policyrulegen/"), exact=("internal/compliance/policy_rule_extensions.yaml",)) for path in files):
         add_command(commands, seen, "finding-dsl-check", ["make", "finding-dsl-check"], "Policy DSL authoring changed.")
         add_command(commands, seen, "policy-rule-check", ["make", "policy-rule-check"], "Policy authoring or generated rule enrichment changed.")
         add_command(commands, seen, "detection-catalog-check", ["make", "detection-catalog-check"], "Policy rule changes affect the public detection catalog.")

--- a/scripts/tests/test_changed_checks.py
+++ b/scripts/tests/test_changed_checks.py
@@ -27,6 +27,10 @@ class ChangedChecksTests(unittest.TestCase):
         self.assertIn("policy-rule-check", names)
         self.assertIn("detection-catalog-check", names)
 
+    def test_policy_schema_paths_select_dsl_check(self):
+        names = self.command_names(["schemas/policy-finding-rule.schema.json"])
+        self.assertIn("finding-dsl-check", names)
+
     def test_script_paths_select_python_tests(self):
         names = self.command_names(["scripts/droid_review_context.py"])
         self.assertIn("python-script-tests", names)

--- a/tools/findingdsl/main.go
+++ b/tools/findingdsl/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
@@ -12,29 +13,292 @@ import (
 	"github.com/writer/cerebro/internal/findingdsl"
 )
 
-func main() {
-	root := flag.String("root", ".", "repository root")
-	check := flag.Bool("check", false, "validate checked-in finding DSL files")
-	migratePolicies := flag.Bool("migrate-policies", false, "convert legacy policy JSON files into PolicyFindingRule DSL YAML")
-	write := flag.Bool("write", false, "write migration output")
-	flag.Parse()
+type stringList []string
 
+func (s *stringList) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *stringList) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
+func main() {
+	if len(os.Args) > 1 && !strings.HasPrefix(os.Args[1], "-") {
+		if err := runCommand(os.Args[1], os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "findingdsl: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if err := runLegacy(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "findingdsl: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runCommand(command string, args []string) error {
+	switch command {
+	case "check":
+		return runCheck(args)
+	case "migrate", "migrate-policies":
+		return runMigrate(args)
+	case "new":
+		return runNew(args)
+	case "fmt":
+		return runFmt(args)
+	case "schema":
+		return runSchema(args)
+	case "test":
+		return runTest(args)
+	default:
+		return fmt.Errorf("unknown command %q", command)
+	}
+}
+
+func runLegacy(args []string) error {
+	flags := flag.NewFlagSet("findingdsl", flag.ContinueOnError)
+	root := flags.String("root", ".", "repository root")
+	check := flags.Bool("check", false, "validate checked-in finding DSL files")
+	migratePolicies := flags.Bool("migrate-policies", false, "convert legacy policy JSON files into PolicyFindingRule DSL YAML")
+	write := flags.Bool("write", false, "write migration output")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
 	if !*check && !*migratePolicies {
-		fmt.Fprintln(os.Stderr, "findingdsl: one of --check or --migrate-policies is required")
-		os.Exit(2)
+		return errors.New("one of --check or --migrate-policies is required")
 	}
 	if *migratePolicies {
 		if err := migratePolicyFiles(filepath.Clean(*root), *write); err != nil {
-			fmt.Fprintf(os.Stderr, "findingdsl: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 	}
 	if *check {
 		if err := checkPolicyRules(filepath.Clean(*root)); err != nil {
-			fmt.Fprintf(os.Stderr, "findingdsl: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 	}
+	return nil
+}
+
+func runCheck(args []string) error {
+	flags := flag.NewFlagSet("findingdsl check", flag.ContinueOnError)
+	root := flags.String("root", ".", "repository root")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	return checkPolicyRules(filepath.Clean(*root))
+}
+
+func runMigrate(args []string) error {
+	flags := flag.NewFlagSet("findingdsl migrate", flag.ContinueOnError)
+	root := flags.String("root", ".", "repository root")
+	write := flags.Bool("write", false, "write migration output")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	return migratePolicyFiles(filepath.Clean(*root), *write)
+}
+
+func runNew(args []string) error {
+	flags := flag.NewFlagSet("findingdsl new", flag.ContinueOnError)
+	root := flags.String("root", ".", "repository root")
+	id := flags.String("id", "", "policy id")
+	domain := flags.String("domain", "", "policy domain under policies/")
+	name := flags.String("name", "", "policy name")
+	description := flags.String("description", "", "policy description")
+	severity := flags.String("severity", "medium", "policy severity")
+	effect := flags.String("effect", "forbid", "policy effect for condition-backed policies")
+	resource := flags.String("resource", "", "policy resource selector")
+	resourceType := flags.String("resource-type", "", "human-readable resource type")
+	remediation := flags.String("remediation", "", "remediation summary")
+	query := flags.String("query", "", "query-backed policy expression")
+	output := flags.String("out", "", "output path; defaults to policies/<domain>/<id>.yaml")
+	write := flags.Bool("write", false, "write the policy file instead of printing YAML")
+	var conditions stringList
+	var tags stringList
+	var risks stringList
+	var frameworks stringList
+	var steps stringList
+	flags.Var(&conditions, "condition", "condition-backed policy expression; repeatable")
+	flags.Var(&tags, "tag", "metadata tag; repeatable")
+	flags.Var(&risks, "risk-category", "risk category; repeatable")
+	flags.Var(&frameworks, "framework", "framework mapping as name:control[,control]; repeatable")
+	flags.Var(&steps, "remediation-step", "remediation step; repeatable")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	parsedFrameworks, err := parseFrameworks(frameworks)
+	if err != nil {
+		return err
+	}
+	rule := findingdsl.NewPolicyRule(findingdsl.NewPolicyRuleInput{
+		ID:              *id,
+		Domain:          *domain,
+		Name:            *name,
+		Description:     *description,
+		Severity:        *severity,
+		Effect:          *effect,
+		Resource:        *resource,
+		ResourceType:    *resourceType,
+		Conditions:      conditions,
+		Query:           *query,
+		Tags:            tags,
+		RiskCategories:  risks,
+		Frameworks:      parsedFrameworks,
+		Remediation:     *remediation,
+		RemediationStep: steps,
+	})
+	if issues := findingdsl.ValidatePolicyRule(rule); len(issues) != 0 {
+		printIssues(issues)
+		return fmt.Errorf("new policy is invalid with %d issue(s)", len(issues))
+	}
+	content, err := findingdsl.FormatPolicyRuleYAML(rule)
+	if err != nil {
+		return err
+	}
+	if !*write {
+		_, err := os.Stdout.Write(content)
+		return err
+	}
+	targetRel := strings.TrimSpace(*output)
+	if targetRel == "" {
+		if strings.TrimSpace(*domain) == "" {
+			return errors.New("--domain is required when --out is omitted")
+		}
+		targetRel = findingdsl.PolicyRuleRelPath(*domain, rule.Metadata.ID)
+	}
+	if err := writeRepoFile(filepath.Clean(*root), targetRel, content, 0o600); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "findingdsl: wrote %s\n", filepath.ToSlash(targetRel))
+	return nil
+}
+
+func runFmt(args []string) error {
+	flags := flag.NewFlagSet("findingdsl fmt", flag.ContinueOnError)
+	root := flags.String("root", ".", "repository root")
+	write := flags.Bool("write", false, "rewrite policy files in place")
+	check := flags.Bool("check", false, "fail if any policy file is not formatted")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	cleanRoot := filepath.Clean(*root)
+	paths := flags.Args()
+	if len(paths) == 0 {
+		discovered, err := allPolicyRulePaths(cleanRoot)
+		if err != nil {
+			return err
+		}
+		paths = discovered
+	}
+	changed := 0
+	for _, path := range paths {
+		rel, err := policyRel(cleanRoot, resolvePath(cleanRoot, path))
+		if err != nil {
+			return err
+		}
+		rule, issues, err := findingdsl.LoadPolicyRuleFile(cleanRoot, filepath.Join(cleanRoot, filepath.FromSlash(rel)))
+		if err != nil {
+			return err
+		}
+		if len(issues) != 0 {
+			printIssues(issues)
+			return fmt.Errorf("%s is invalid", rel)
+		}
+		formatted, err := findingdsl.FormatPolicyRuleYAML(rule)
+		if err != nil {
+			return err
+		}
+		current, err := readRepoFile(cleanRoot, rel)
+		if err != nil {
+			return err
+		}
+		if bytes.Equal(current, formatted) {
+			continue
+		}
+		changed++
+		if *write {
+			if err := writeRepoFile(cleanRoot, rel, formatted, 0o600); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "formatted %s\n", rel)
+			continue
+		}
+		fmt.Fprintf(os.Stdout, "%s needs formatting\n", rel)
+	}
+	if changed != 0 && (*check || !*write) {
+		return fmt.Errorf("%d policy file(s) need formatting", changed)
+	}
+	return nil
+}
+
+func runSchema(args []string) error {
+	flags := flag.NewFlagSet("findingdsl schema", flag.ContinueOnError)
+	root := flags.String("root", ".", "repository root")
+	output := flags.String("out", findingdsl.PolicyRuleSchemaRelPath, "schema output path")
+	write := flags.Bool("write", false, "write schema output")
+	check := flags.Bool("check", false, "fail if schema output is stale")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	schema, err := findingdsl.PolicyRuleJSONSchema()
+	if err != nil {
+		return err
+	}
+	schema = append(schema, '\n')
+	if !*write && !*check {
+		_, err := os.Stdout.Write(schema)
+		return err
+	}
+	cleanRoot := filepath.Clean(*root)
+	if *write {
+		return writeRepoFile(cleanRoot, *output, schema, 0o600)
+	}
+	current, err := readRepoFile(cleanRoot, *output)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(current, schema) {
+		return fmt.Errorf("%s is stale; run go run ./tools/findingdsl schema --write", filepath.ToSlash(*output))
+	}
+	return nil
+}
+
+func runTest(args []string) error {
+	flags := flag.NewFlagSet("findingdsl test", flag.ContinueOnError)
+	root := flags.String("root", ".", "repository root")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	cleanRoot := filepath.Clean(*root)
+	paths := flags.Args()
+	if len(paths) == 0 {
+		discovered, err := findingdsl.DiscoverPolicyTestSuites(cleanRoot)
+		if err != nil {
+			return err
+		}
+		paths = discovered
+	}
+	if len(paths) == 0 {
+		fmt.Fprintln(os.Stdout, "findingdsl: no policy test suites found")
+		return nil
+	}
+	var issues []findingdsl.Issue
+	for _, path := range paths {
+		rel, err := policyRel(cleanRoot, resolvePath(cleanRoot, path))
+		if err != nil {
+			return err
+		}
+		issues = append(issues, findingdsl.RunPolicyRuleTestSuite(cleanRoot, filepath.Join(cleanRoot, filepath.FromSlash(rel)))...)
+	}
+	if len(issues) != 0 {
+		printIssues(issues)
+		return fmt.Errorf("policy DSL tests failed with %d issue(s)", len(issues))
+	}
+	fmt.Fprintf(os.Stdout, "findingdsl: %d policy test suite(s) passed\n", len(paths))
+	return nil
 }
 
 func checkPolicyRules(root string) error {
@@ -42,9 +306,7 @@ func checkPolicyRules(root string) error {
 	if err != nil {
 		return err
 	}
-	for _, issue := range issues {
-		fmt.Fprintf(os.Stderr, "%s: %s\n", issue.Path, issue.Message)
-	}
+	printIssues(issues)
 	if len(issues) != 0 {
 		return fmt.Errorf("policy DSL validation failed with %d issue(s)", len(issues))
 	}
@@ -150,6 +412,112 @@ func ensureMigrationTargetAvailable(root *os.Root, rel string) error {
 	return errors.New("destination already exists")
 }
 
+func allPolicyRulePaths(root string) ([]string, error) {
+	var paths []string
+	err := filepath.WalkDir(filepath.Join(root, "policies"), func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel := filepath.ToSlash(path)
+		if entry.Type()&os.ModeSymlink != 0 || findingdsl.ControlMappingRelPath == rel || strings.Contains(rel, ".test.") {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		policyPath, err := policyRel(root, path)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, policyPath)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return paths, nil
+}
+
+func parseFrameworks(values []string) ([]findingdsl.PolicyFramework, error) {
+	frameworks := make([]findingdsl.PolicyFramework, 0, len(values))
+	for _, value := range values {
+		framework, err := findingdsl.ParseFrameworkSpec(value)
+		if err != nil {
+			return nil, err
+		}
+		frameworks = append(frameworks, framework)
+	}
+	return frameworks, nil
+}
+
+func printIssues(issues []findingdsl.Issue) {
+	for _, issue := range issues {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", issue.Path, issue.Message)
+	}
+}
+
+func readRepoFile(root string, rel string) ([]byte, error) {
+	cleanRel, err := safeRepoRel(rel)
+	if err != nil {
+		return nil, err
+	}
+	content, err := fs.ReadFile(os.DirFS(root), cleanRel)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", cleanRel, err)
+	}
+	return content, nil
+}
+
+func writeRepoFile(root string, rel string, content []byte, perm fs.FileMode) error {
+	cleanRel, err := safeRepoRel(rel)
+	if err != nil {
+		return err
+	}
+	repoRoot, err := os.OpenRoot(root)
+	if err != nil {
+		return fmt.Errorf("open repository root: %w", err)
+	}
+	defer repoRoot.Close()
+	dir := filepath.ToSlash(filepath.Dir(cleanRel))
+	if dir != "." {
+		if err := repoRoot.MkdirAll(dir, 0o750); err != nil {
+			return fmt.Errorf("create %s: %w", dir, err)
+		}
+	}
+	if err := rejectSymlink(repoRoot, cleanRel); err != nil {
+		return fmt.Errorf("write %s: %w", cleanRel, err)
+	}
+	if err := repoRoot.WriteFile(cleanRel, content, perm); err != nil {
+		return fmt.Errorf("write %s: %w", cleanRel, err)
+	}
+	return nil
+}
+
+func rejectSymlink(root *os.Root, rel string) error {
+	info, err := root.Lstat(rel)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("symlinked generated files are not allowed")
+	}
+	return nil
+}
+
+func resolvePath(root string, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(root, filepath.FromSlash(path))
+}
+
 func policyRel(root string, path string) (string, error) {
 	rel, err := filepath.Rel(root, path)
 	if err != nil {
@@ -163,4 +531,12 @@ func policyRel(root string, path string) (string, error) {
 		return "", fmt.Errorf("policy path %q is outside policies/", rel)
 	}
 	return rel, nil
+}
+
+func safeRepoRel(rel string) (string, error) {
+	cleanRel := filepath.ToSlash(filepath.Clean(filepath.FromSlash(rel)))
+	if strings.HasPrefix(cleanRel, "../") || cleanRel == ".." || filepath.IsAbs(cleanRel) {
+		return "", fmt.Errorf("path %q escapes repository root", rel)
+	}
+	return cleanRel, nil
 }


### PR DESCRIPTION
## Summary
- add authoring commands for the policy finding DSL: `new`, `fmt`, `schema`, and `test`
- add deep rule validation, CEL-like condition parsing/evaluation, generated JSON Schema, and fixture-based policy tests
- wire the expanded checks into Makefile and changed-check selection, plus update policy docs

## Validation
- `go test ./internal/findingdsl ./tools/findingdsl`
- `make finding-dsl-check`
- `go run ./tools/findingdsl fmt --check`
- `go run ./tools/findingdsl schema --check`
- `go run ./tools/findingdsl test`
- `go test ./internal/findingdsl ./tools/findingdsl ./tools/policyrulegen ./tools/catalogcheck`
- `make finding-dsl-check policy-rule-check detection-catalog-check catalog-check graph-action-check docs-drift-check readme-check`
- `python3 -m unittest scripts.tests.test_changed_checks`
- `make lint`
- `make changed-check`
- `git diff --check`