### PR TITLE
feat: deepen JetStream and job telemetry

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphingest"
+	"github.com/writer/cerebro/internal/jobs"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcehealth"
@@ -80,6 +81,16 @@ type orchestratorRuntimeResult struct {
 	GraphRuleRowsRead    uint32              `json:"graph_rule_rows_read,omitempty"`
 	Error                string              `json:"error,omitempty"`
 	Health               sourcehealth.Record `json:"-"`
+}
+
+type orchestratorJobMetadataContextKey struct{}
+
+type orchestratorJobMetadata struct {
+	ID        string
+	Kind      string
+	Name      string
+	Schedule  string
+	StartedAt time.Time
 }
 
 func runOrchestrator(args []string) error {
@@ -233,10 +244,24 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		return nil, fmt.Errorf("configure telemetry: %w", err)
 	}
 	defer shutdownTelemetry(orchestratorShutdownContext(options, ctx), closeTelemetry, cfg.ShutdownTimeout)
+	jobStartedAt := time.Now().UTC()
+	jobMeta := orchestratorJobMetadata{
+		ID:        orchestratorRunID(orchestratorScheduleName(options), jobStartedAt),
+		Kind:      jobs.KindSourceRuntimeOrchestrate,
+		Name:      "orchestrator.run",
+		Schedule:  orchestratorScheduleName(options),
+		StartedAt: jobStartedAt,
+	}
+	ctx = withOrchestratorJobMetadata(ctx, jobMeta)
 	ctx, span := telemetry.StartMain(ctx, "orchestrator.run", telemetry.Attrs(
 		telemetryField("operation.type", "background_job"),
 		telemetryField("workload.kind", "orchestrator"),
-		telemetryField("job.name", "orchestrator.run"),
+		telemetryField("job.id", jobMeta.ID),
+		telemetryField("job.kind", jobMeta.Kind),
+		telemetryField("job.name", jobMeta.Name),
+		telemetryField("job.schedule", jobMeta.Schedule),
+		telemetryField("job.status", "running"),
+		telemetryField("job.started_at_unix_ms", jobMeta.StartedAt.UnixMilli()),
 		telemetryField("runtime_id", options.Filter.RuntimeID),
 		telemetryField("tenant_id", options.Filter.TenantID),
 		telemetryField("source_id", options.Filter.SourceID),
@@ -253,6 +278,10 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		telemetryField("iterations", options.Iterations),
 		telemetryField("run_forever", options.RunForever),
 	))
+	telemetry.Event(ctx, "platform.job.started", orchestratorJobAttrs(ctx).With(telemetry.Attrs(
+		telemetryField("job.status", "running"),
+		telemetryField("job.runner.available", true),
+	)))
 	status := "failed"
 	spanAttributes := telemetry.Attrs()
 	defer func() {
@@ -260,8 +289,23 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 			status = "failed"
 			spanAttributes = withTelemetryField(spanAttributes, "error_kind", telemetry.ErrorKind(err))
 		}
-		telemetry.AnnotateMain(ctx, spanAttributes.WithField(telemetry.Field{Key: "orchestrator.status", Value: status}))
-		telemetry.End(span, status, spanAttributes)
+		terminalAttrs := spanAttributes.With(orchestratorJobAttrs(ctx)).With(telemetry.Attrs(
+			telemetryField("job.status", status),
+			telemetryField("job.status.final", status),
+			telemetryField("job.run_duration_ms", time.Since(jobMeta.StartedAt).Milliseconds()),
+			telemetryField("orchestrator.status", status),
+		))
+		if status == "completed" {
+			telemetry.Event(ctx, "platform.job.completed", terminalAttrs)
+		} else {
+			if err != nil {
+				telemetry.CaptureError(ctx, "platform.job.failed", err, terminalAttrs)
+			} else {
+				telemetry.Event(ctx, "platform.job.failed", terminalAttrs)
+			}
+		}
+		telemetry.AnnotateMain(ctx, terminalAttrs)
+		telemetry.End(span, status, terminalAttrs)
 	}()
 	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
 	if err != nil {
@@ -325,10 +369,19 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 	}
 	for {
 		iteration++
+		emitOrchestratorJobHeartbeat(ctx, iteration, "iteration_started", telemetry.Attrs(telemetryField("iteration", iteration)))
 		iterationResult, err := runOrchestratorIteration(ctx, lister, leaser, leaseOwner, runtimeService, findingService, graphService, options, iteration)
 		if err != nil {
 			runErr = err
 		}
+		iterationStatus := "completed"
+		if err != nil {
+			iterationStatus = "failed"
+		}
+		emitOrchestratorJobHeartbeat(ctx, iteration, "iteration_"+iterationStatus, telemetry.Attrs(
+			telemetryField("iteration", iteration),
+			telemetryField("orchestrator.iteration.status", iterationStatus),
+		))
 		result.Runs = appendOrchestratorRun(result.Runs, iterationResult, options.RunForever)
 		if !options.RunForever && iteration >= options.Iterations {
 			break
@@ -339,6 +392,10 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		select {
 		case <-ctx.Done():
 			spanAttributes = withTelemetryField(spanAttributes, "error_kind", telemetry.ErrorKind(ctx.Err()))
+			emitOrchestratorJobHeartbeat(ctx, iteration, "shutdown_requested", telemetry.Attrs(
+				telemetryField("iteration", iteration),
+				telemetryField("error_kind", telemetry.ErrorKind(ctx.Err())),
+			))
 			return result, ctx.Err()
 		case <-ticker.C:
 		}
@@ -483,6 +540,7 @@ func runOrchestratorIteration(
 			TenantID:  strings.TrimSpace(runtime.GetTenantId()),
 			Health:    sourcehealth.RecordFromRuntime(runtime, time.Now().UTC()),
 		}
+		emitOrchestratorJobRuntimeEvent(runtimeCtx, "platform.job.runtime.started", "running", iteration, runtime, runtimeResult, runtimeSpanAttrs)
 		acquired, err := acquireOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner)
 		if err != nil {
 			runtimeResult.Sync = "failed"
@@ -493,6 +551,7 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_kind", telemetry.ErrorKind(err))
 			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "lease", err)
 			annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
+			emitOrchestratorJobRuntimeEvent(runtimeCtx, "platform.job.runtime.failed", runtimeStatus, iteration, runtime, runtimeResult, runtimeSpanAttrs)
 			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		}
@@ -502,6 +561,7 @@ func runOrchestratorIteration(
 			runtimeStatus = "skipped"
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reason", "lease_not_acquired")
 			annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
+			emitOrchestratorJobRuntimeEvent(runtimeCtx, "platform.job.runtime.skipped", runtimeStatus, iteration, runtime, runtimeResult, runtimeSpanAttrs)
 			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		}
@@ -509,6 +569,8 @@ func runOrchestratorIteration(
 		runtimeCtx, cancelRuntime := context.WithCancel(runtimeCtx)
 		stopLeaseRenewal := startOrchestratorRuntimeLeaseRenewal(ctx, leaser, runtime, leaseOwner, cancelRuntime)
 		syncStartCursorOpaque := orchestratorRuntimeStartCursorOpaque(runtime)
+		syncStarted := time.Now()
+		emitOrchestratorJobPhaseStarted(runtimeCtx, "source_runtime.sync", iteration, runtime, 0)
 		syncResult, err := runtimeService.Sync(runtimeCtx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit})
 		if err != nil {
 			runtimeResult.Sync = "failed"
@@ -516,6 +578,9 @@ func runOrchestratorIteration(
 			runErr = err
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_stage", "sync")
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_kind", telemetry.ErrorKind(err))
+			emitOrchestratorJobPhaseEnded(runtimeCtx, "source_runtime.sync", "failed", iteration, runtime, time.Since(syncStarted), 0, telemetry.Attrs(
+				telemetryField("error_kind", telemetry.ErrorKind(err)),
+			))
 			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "sync", err)
 			cancelRuntime()
 			if renewalErr := stopLeaseRenewal(); renewalErr != nil {
@@ -532,6 +597,7 @@ func runOrchestratorIteration(
 			}
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
+			emitOrchestratorJobRuntimeEvent(runtimeCtx, "platform.job.runtime.failed", runtimeStatus, iteration, runtime, runtimeResult, runtimeSpanAttrs)
 			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		} else {
@@ -544,6 +610,10 @@ func runOrchestratorIteration(
 			}
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "pages_read", runtimeResult.PagesRead)
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "events_appended", runtimeResult.EventsAppended)
+			emitOrchestratorJobPhaseEnded(runtimeCtx, "source_runtime.sync", "completed", iteration, runtime, time.Since(syncStarted), 0, telemetry.Attrs(
+				telemetryField("pages_read", runtimeResult.PagesRead),
+				telemetryField("events_appended", runtimeResult.EventsAppended),
+			))
 		}
 		graphPageLimit := orchestratorGraphPageLimit(options.GraphPageLimit, runtimeResult.PagesRead)
 		resetGraphCheckpoint := runtimeResult.EventsAppended > 0 && syncStartCursorOpaque == ""
@@ -637,6 +707,11 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "runtime_error_present", true)
 		}
 		annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
+		runtimeEventName := "platform.job.runtime.completed"
+		if runtimeStatus == "failed" {
+			runtimeEventName = "platform.job.runtime.failed"
+		}
+		emitOrchestratorJobRuntimeEvent(runtimeCtx, runtimeEventName, runtimeStatus, iteration, runtime, runtimeResult, runtimeSpanAttrs)
 		telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 	}
 	status = "completed"
@@ -675,6 +750,7 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 		telemetryField("timeout_ms", timeout.Milliseconds()),
 	))
 	started := time.Now()
+	emitOrchestratorJobPhaseStarted(phaseCtx, name, iteration, runtime, timeout)
 	result, err := fn(phaseCtx)
 	durationMs := time.Since(started).Milliseconds()
 	status := "completed"
@@ -692,6 +768,7 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 		}
 		captureOrchestratorError(phaseCtx, name+".error", iteration, runtime, name, err)
 	}
+	emitOrchestratorJobPhaseEnded(phaseCtx, name, status, iteration, runtime, time.Since(started), timeout, endAttrs)
 	telemetry.AnnotateMainPhase(phaseCtx, name, status, endAttrs.
 		WithField(telemetryField("phase.iteration", iteration)).
 		WithField(telemetryField("phase.runtime_id", runtime.GetId())).
@@ -1086,6 +1163,162 @@ func appendRuntimeError(existing string, stage string, err error) string {
 		return message
 	}
 	return existing + "; " + message
+}
+
+func orchestratorRunID(schedule string, startedAt time.Time) string {
+	schedule = orchestratorPhaseTelemetryKey(schedule)
+	if schedule == "" {
+		schedule = "run"
+	}
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+	return fmt.Sprintf("orchestrator-%s-%d", schedule, startedAt.UTC().UnixNano())
+}
+
+func withOrchestratorJobMetadata(ctx context.Context, metadata orchestratorJobMetadata) context.Context {
+	return context.WithValue(ctx, orchestratorJobMetadataContextKey{}, metadata)
+}
+
+func orchestratorJobMetadataFromContext(ctx context.Context) orchestratorJobMetadata {
+	metadata, _ := ctx.Value(orchestratorJobMetadataContextKey{}).(orchestratorJobMetadata)
+	if strings.TrimSpace(metadata.Kind) == "" {
+		metadata.Kind = jobs.KindSourceRuntimeOrchestrate
+	}
+	if strings.TrimSpace(metadata.Name) == "" {
+		metadata.Name = "orchestrator.run"
+	}
+	return metadata
+}
+
+func orchestratorJobAttrs(ctx context.Context) telemetry.Attributes {
+	metadata := orchestratorJobMetadataFromContext(ctx)
+	attrs := telemetry.Attrs(
+		telemetryField("operation.type", "background_job"),
+		telemetryField("workload.kind", "orchestrator"),
+		telemetryField("job.id", metadata.ID),
+		telemetryField("job.kind", metadata.Kind),
+		telemetryField("job.name", metadata.Name),
+		telemetryField("job.schedule", metadata.Schedule),
+		telemetryField("job_id", metadata.ID),
+		telemetryField("job_kind", metadata.Kind),
+		telemetryField("job_name", metadata.Name),
+		telemetryField("job_schedule", metadata.Schedule),
+	)
+	if !metadata.StartedAt.IsZero() {
+		attrs = attrs.With(telemetry.Attrs(
+			telemetryField("job.started_at_unix_ms", metadata.StartedAt.UTC().UnixMilli()),
+			telemetryField("job.run_duration_ms", time.Since(metadata.StartedAt).Milliseconds()),
+		))
+	}
+	return attrs
+}
+
+func emitOrchestratorJobHeartbeat(ctx context.Context, sequence uint32, stage string, extra telemetry.Attributes) {
+	telemetry.IncrementMain(ctx, "job.heartbeat.count", 1)
+	telemetry.Event(ctx, "platform.job.heartbeat", orchestratorJobAttrs(ctx).With(extra).With(telemetry.Attrs(
+		telemetryField("job.status", "running"),
+		telemetryField("job.heartbeat.sequence", sequence),
+		telemetryField("job.heartbeat.stage", strings.TrimSpace(stage)),
+		telemetryField("job.heartbeat.at_unix_ms", time.Now().UTC().UnixMilli()),
+		telemetryField("job_heartbeat_sequence", sequence),
+		telemetryField("job_heartbeat_stage", strings.TrimSpace(stage)),
+	)))
+}
+
+func emitOrchestratorJobPhaseStarted(ctx context.Context, phase string, iteration uint32, runtime *cerebrov1.SourceRuntime, timeout time.Duration) {
+	telemetry.IncrementMain(ctx, "job.phase.started.count", 1)
+	telemetry.Event(ctx, "platform.job.phase.started", orchestratorJobAttrs(ctx).With(orchestratorPhaseEventAttrs(phase, "running", iteration, runtime, timeout, 0)).With(telemetry.Attrs(
+		telemetryField("job.phase.started_at_unix_ms", time.Now().UTC().UnixMilli()),
+	)))
+}
+
+func emitOrchestratorJobPhaseEnded(ctx context.Context, phase string, status string, iteration uint32, runtime *cerebrov1.SourceRuntime, duration time.Duration, timeout time.Duration, extra telemetry.Attributes) {
+	phaseKey := orchestratorPhaseTelemetryKey(phase)
+	telemetry.IncrementMain(ctx, "job.phase.finished.count", 1)
+	telemetry.IncrementMain(ctx, "job.phase."+phaseKey+".finished.count", 1)
+	if status == "failed" {
+		telemetry.IncrementMain(ctx, "job.phase.failed.count", 1)
+		telemetry.IncrementMain(ctx, "job.phase."+phaseKey+".failed.count", 1)
+	}
+	eventName := "platform.job.phase.completed"
+	if status == "failed" {
+		eventName = "platform.job.phase.failed"
+	}
+	telemetry.Event(ctx, eventName, orchestratorJobAttrs(ctx).With(orchestratorPhaseEventAttrs(phase, status, iteration, runtime, timeout, duration)).With(extra))
+}
+
+func orchestratorPhaseEventAttrs(phase string, status string, iteration uint32, runtime *cerebrov1.SourceRuntime, timeout time.Duration, duration time.Duration) telemetry.Attributes {
+	attrs := telemetry.Attrs(
+		telemetryField("iteration", iteration),
+		telemetryField("job.phase", strings.TrimSpace(phase)),
+		telemetryField("job.phase_key", orchestratorPhaseTelemetryKey(phase)),
+		telemetryField("job.phase.status", strings.TrimSpace(status)),
+		telemetryField("job.phase.timeout_ms", timeout.Milliseconds()),
+		telemetryField("job.phase.duration_ms", duration.Milliseconds()),
+		telemetryField("job_phase", strings.TrimSpace(phase)),
+		telemetryField("job_phase_key", orchestratorPhaseTelemetryKey(phase)),
+		telemetryField("job_phase_status", strings.TrimSpace(status)),
+		telemetryField("job_phase_timeout_ms", timeout.Milliseconds()),
+		telemetryField("job_phase_duration_ms", duration.Milliseconds()),
+		telemetryField("duration_ms", duration.Milliseconds()),
+	)
+	if runtime != nil {
+		attrs = attrs.With(telemetry.Attrs(
+			telemetryField("runtime_id", runtime.GetId()),
+			telemetryField("source_runtime_id", runtime.GetId()),
+			telemetryField("source_id", runtime.GetSourceId()),
+			telemetryField("tenant_id", runtime.GetTenantId()),
+		))
+	}
+	return attrs
+}
+
+func emitOrchestratorJobRuntimeEvent(ctx context.Context, name string, status string, iteration uint32, runtime *cerebrov1.SourceRuntime, result *orchestratorRuntimeResult, extra telemetry.Attributes) {
+	telemetry.IncrementMain(ctx, "job.runtime.event.count", 1)
+	if status != "" {
+		telemetry.IncrementMain(ctx, "job.runtime."+orchestratorPhaseTelemetryKey(status)+".count", 1)
+	}
+	telemetry.Event(ctx, name, orchestratorJobAttrs(ctx).With(orchestratorRuntimeEventAttrs(status, iteration, runtime, result)).With(extra))
+}
+
+func orchestratorRuntimeEventAttrs(status string, iteration uint32, runtime *cerebrov1.SourceRuntime, result *orchestratorRuntimeResult) telemetry.Attributes {
+	attrs := telemetry.Attrs(
+		telemetryField("iteration", iteration),
+		telemetryField("job.runtime.status", strings.TrimSpace(status)),
+		telemetryField("job_runtime_status", strings.TrimSpace(status)),
+	)
+	if runtime != nil {
+		attrs = attrs.With(telemetry.Attrs(
+			telemetryField("runtime_id", runtime.GetId()),
+			telemetryField("source_runtime_id", runtime.GetId()),
+			telemetryField("source_id", runtime.GetSourceId()),
+			telemetryField("tenant_id", runtime.GetTenantId()),
+		))
+	}
+	if result != nil {
+		attrs = attrs.With(telemetry.Attrs(
+			telemetryField("runtime_id", result.RuntimeID),
+			telemetryField("source_runtime_id", result.RuntimeID),
+			telemetryField("source_id", result.SourceID),
+			telemetryField("tenant_id", result.TenantID),
+			telemetryField("sync.status", result.Sync),
+			telemetryField("graph_ingest.status", result.GraphIngest),
+			telemetryField("finding_rules.status", result.FindingRules),
+			telemetryField("graph_rules.status", result.GraphRules),
+			telemetryField("pages_read", result.PagesRead),
+			telemetryField("events_appended", result.EventsAppended),
+			telemetryField("events_evaluated", result.EventsEvaluated),
+			telemetryField("entities_projected", result.EntitiesProjected),
+			telemetryField("links_projected", result.LinksProjected),
+			telemetryField("finding_evaluations", result.FindingEvaluations),
+			telemetryField("graph_rule_evaluations", result.GraphRuleEvaluations),
+			telemetryField("graph_rule_findings", result.GraphRuleFindings),
+			telemetryField("graph_rule_rows_read", result.GraphRuleRowsRead),
+			telemetryField("runtime_error_present", strings.TrimSpace(result.Error) != ""),
+		))
+	}
+	return attrs
 }
 
 func telemetryField(key string, value any) telemetry.Field {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/jobs"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcehealth"
@@ -151,6 +153,56 @@ func TestRunOrchestratorPhaseAnnotatesMainDuration(t *testing.T) {
 	}
 }
 
+func TestRunOrchestratorPhaseEmitsPlatformJobPhaseEvents(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "github", TenantId: "writer"}
+	stderr := captureCommandStderr(t, func() {
+		ctx, span := telemetry.StartMain(context.Background(), "orchestrator.run", telemetry.Attrs())
+		ctx = withOrchestratorJobMetadata(ctx, orchestratorJobMetadata{
+			ID:        "orchestrator-test-job",
+			Kind:      jobs.KindSourceRuntimeOrchestrate,
+			Name:      "orchestrator.run",
+			Schedule:  "single_run",
+			StartedAt: time.Now().Add(-time.Second),
+		})
+		_, err := runOrchestratorPhase[int](ctx, "orchestrator.test_phase", 3, runtime, time.Second, func(context.Context) (int, error) {
+			return 1, nil
+		})
+		if err != nil {
+			t.Fatalf("runOrchestratorPhase() error = %v", err)
+		}
+		telemetry.End(span, "completed", telemetry.Attrs())
+	})
+
+	started := commandTelemetryPayloads(t, stderr, "event", "platform.job.phase.started")
+	if len(started) != 1 {
+		t.Fatalf("platform.job.phase.started events = %d, want 1; stderr=%s", len(started), stderr)
+	}
+	completed := commandTelemetryPayloads(t, stderr, "event", "platform.job.phase.completed")
+	if len(completed) != 1 {
+		t.Fatalf("platform.job.phase.completed events = %d, want 1; stderr=%s", len(completed), stderr)
+	}
+	payload := completed[0]
+	for key, want := range map[string]any{
+		"job.id":           "orchestrator-test-job",
+		"job.kind":         jobs.KindSourceRuntimeOrchestrate,
+		"job.name":         "orchestrator.run",
+		"job.phase":        "orchestrator.test_phase",
+		"job.phase_key":    "orchestrator_test_phase",
+		"job.phase.status": "completed",
+		"iteration":        float64(3),
+		"runtime_id":       "runtime-1",
+		"source_id":        "github",
+		"tenant_id":        "writer",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if got, ok := payload["job.phase.duration_ms"].(float64); !ok || got < 0 {
+		t.Fatalf("job.phase.duration_ms = %#v, want non-negative number; payload=%#v", payload["job.phase.duration_ms"], payload)
+	}
+}
+
 // runOrchestratorPhase must inherit cancellation from the parent runtime
 // context. The orchestrator's lease-renewal goroutine cancels the
 // runtime context when lease renewal fails, and that cancellation must
@@ -281,6 +333,25 @@ func TestCaptureOrchestratorErrorAnnotatesFirstFailureOnly(t *testing.T) {
 	if got, ok := payload["orchestrator.first_failure.error_fingerprint"].(string); !ok || got == "" {
 		t.Fatalf("first failure fingerprint missing: %#v", payload)
 	}
+}
+
+func commandTelemetryPayloads(t *testing.T, stderr string, kind string, name string) []map[string]any {
+	t.Helper()
+	var payloads []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			t.Fatalf("telemetry line is not JSON: %v\nline=%s\nstderr=%s", err, line, stderr)
+		}
+		if payload["kind"] == kind && payload["name"] == name {
+			payloads = append(payloads, payload)
+		}
+	}
+	return payloads
 }
 
 func TestNewOrchestratorRuntimeServiceProjectsSourceSyncToStateOnly(t *testing.T) {

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -10,12 +10,14 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
@@ -32,6 +34,8 @@ const (
 	maxReplayCandidates        = 5000
 	publishRetryAttempts       = 4
 	publishRetryInitialBackoff = 50 * time.Millisecond
+	jetstreamCanaryKind        = "cerebro.health.jetstream_canary"
+	jetstreamCanaryMinInterval = time.Minute
 )
 
 type publisher interface {
@@ -91,6 +95,8 @@ type Log struct {
 	js            publisher
 	replay        replayManager
 	subjectPrefix string
+	canaryMu      sync.Mutex
+	lastCanary    time.Time
 }
 
 // Open dials JetStream and returns an append-log implementation.
@@ -172,21 +178,43 @@ func (l *Log) Ping(ctx context.Context) error {
 		jetstreamTelemetryError(ctx, span, "ping", err)
 		return err
 	}
+	pingAttrs := telemetry.Attrs()
+	accountStarted := time.Now()
 	_, err := l.js.AccountInfo(ctx)
+	pingAttrs = pingAttrs.WithField(telemetry.Field{Key: "messaging.jetstream.account_info.duration_ms", Value: time.Since(accountStarted).Milliseconds()})
 	if err != nil {
 		err = fmt.Errorf("jetstream account info: %w", err)
-		jetstreamTelemetryError(ctx, span, "ping", err)
+		jetstreamTelemetryError(ctx, span, "ping", err, pingAttrs)
 		return err
 	}
 	if l.replay != nil {
-		if _, err := l.replayStream(ctx); err != nil {
+		stream, err := l.replayStream(ctx)
+		if err != nil {
 			err = fmt.Errorf("jetstream stream readiness: %w", err)
-			jetstreamTelemetryError(ctx, span, "ping", err)
+			jetstreamTelemetryError(ctx, span, "ping", err, pingAttrs)
 			return err
 		}
+		pingAttrs = pingAttrs.With(jetstreamStreamTelemetryAttrs(stream))
+		if l.shouldRunCanary(time.Now().UTC()) {
+			canaryAttrs, err := l.runCanary(ctx, stream)
+			pingAttrs = pingAttrs.With(canaryAttrs)
+			if err != nil {
+				telemetry.Event(ctx, "jetstream.canary.failed", canaryAttrs.With(jetstreamErrorTelemetryAttrs("canary", err)))
+				err = fmt.Errorf("jetstream canary: %w", err)
+				jetstreamTelemetryError(ctx, span, "canary", err, pingAttrs)
+				return err
+			}
+			l.markCanarySucceeded(time.Now().UTC())
+			telemetry.Event(ctx, "jetstream.canary.completed", canaryAttrs)
+		} else {
+			pingAttrs = pingAttrs.With(telemetry.Attrs(
+				telemetry.Field{Key: "messaging.jetstream.canary.throttled", Value: true},
+				telemetry.Field{Key: "messaging.jetstream.canary.interval_ms", Value: jetstreamCanaryMinInterval.Milliseconds()},
+			))
+		}
 	}
-	jetstreamAnnotateMain(ctx, "ping", "completed")
-	telemetry.End(span, "completed", telemetry.Attrs())
+	jetstreamAnnotateMain(ctx, "ping", "completed", pingAttrs)
+	telemetry.End(span, "completed", pingAttrs)
 	return nil
 }
 
@@ -235,7 +263,7 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 	publishAttrs := func() telemetry.Attributes {
 		return jetstreamPublishMessageAttrs(subject, l.subjectPrefix, len(payload), msg.Header.Get(nats.MsgIdHdr))
 	}
-	publishResult, err := l.publishMsg(ctx, msg, publishAttrs)
+	publishResult, err := l.publishMsg(ctx, msg, "append", publishAttrs)
 	endAttrs := publishAttrs().With(publishResult.attrs())
 	if err != nil {
 		err = fmt.Errorf("publish event: %w", err)
@@ -251,7 +279,7 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 	return nil
 }
 
-func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, eventAttrs func() telemetry.Attributes) (publishTelemetry, error) {
+func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, eventAttrs func() telemetry.Attributes) (publishTelemetry, error) {
 	result := publishTelemetry{Attempts: 0, MaxAttempts: 1}
 	if msg.Header.Get(nats.MsgIdHdr) != "" {
 		result.MaxAttempts = publishRetryAttempts
@@ -272,20 +300,20 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, eventAttrs func() t
 		if attempt == result.MaxAttempts || !result.LastRetryable || ctx.Err() != nil {
 			result.Duration = time.Since(started)
 			if result.RetryCount > 0 {
-				telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs("append", err)))
+				telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, err)))
 			}
 			return result, err
 		}
 		result.RetryCount++
 		result.LastBackoff = backoff
 		telemetry.IncrementMain(ctx, "messaging.jetstream.publish.retry.count", 1)
-		telemetry.Event(ctx, "jetstream.publish.retry", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs("append", err)).With(telemetry.Attrs(
+		telemetry.Event(ctx, "jetstream.publish.retry", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, err)).With(telemetry.Attrs(
 			telemetry.Field{Key: "messaging.jetstream.publish.next_attempt", Value: attempt + 1},
 			telemetry.Field{Key: "messaging.jetstream.publish.next_backoff_ms", Value: backoff.Milliseconds()},
 		)))
 		if waitErr := waitBeforePublishRetry(ctx, backoff); waitErr != nil {
 			result.Duration = time.Since(started)
-			telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs("append", waitErr)))
+			telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, waitErr)))
 			return result, waitErr
 		}
 		backoff *= 2
@@ -332,6 +360,10 @@ func retryablePublishError(err error) bool {
 	if err == nil {
 		return false
 	}
+	var apiErr *jetstream.APIError
+	if errors.As(err, &apiErr) && apiErr != nil {
+		return apiErr.Code == 408 || apiErr.Code == 429 || apiErr.Code >= 500
+	}
 	text := strings.ToLower(err.Error())
 	for _, fragment := range []string{
 		"no response",
@@ -366,7 +398,8 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	ctx, span := telemetry.Start(ctx, "jetstream.replay", jetstreamTelemetryAttrs("replay").
 		WithField(telemetry.Field{Key: "replay.limit", Value: normalizeReplayLimit(request.Limit)}).
 		WithField(telemetry.Field{Key: "replay.kind_prefix_count", Value: len(replayKindPrefixes(request))}).
-		WithField(telemetry.Field{Key: "replay.attribute_filter_count", Value: len(request.AttributeEquals)}))
+		WithField(telemetry.Field{Key: "replay.attribute_filter_count", Value: len(request.AttributeEquals)}).
+		With(jetstreamReplayRequestAttrs(request)))
 	if l == nil || l.replay == nil {
 		err := errors.New("jetstream is not configured")
 		jetstreamTelemetryError(ctx, span, "replay", err)
@@ -382,9 +415,10 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		jetstreamTelemetryError(ctx, span, "replay", err)
 		return nil, err
 	}
+	streamAttrs := jetstreamStreamTelemetryAttrs(stream)
 	prefix, err := normalizeSubjectPrefix(l.subjectPrefix)
 	if err != nil {
-		jetstreamTelemetryError(ctx, span, "replay", err)
+		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs)
 		return nil, err
 	}
 	subjectPrefixes := replaySubjectPrefixes(prefix, request)
@@ -393,36 +427,46 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	streamRef, err := l.replay.Stream(ctx, stream.Config.Name)
 	if err != nil {
 		err = fmt.Errorf("open replay stream %q: %w", stream.Config.Name, err)
-		jetstreamTelemetryError(ctx, span, "replay", err)
+		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, 0, 0, 0, 0, 0, 0, ctx)))
 		return nil, err
 	}
+	started := time.Now()
+	var scanned, missing, subjectMatched, decoded, matched uint64
 	candidates := make([]replayCandidate, 0, limit)
 	if stream.State.LastSeq == 0 || stream.State.LastSeq < stream.State.FirstSeq {
-		jetstreamAnnotateMain(ctx, "replay", "completed")
-		telemetry.End(span, "completed", telemetry.Attrs(telemetry.Field{Key: "events_returned", Value: 0}))
+		endAttrs := streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, 0, 0, 0, 0, 0, 0, ctx)).
+			WithField(telemetry.Field{Key: "events_returned", Value: 0}).
+			WithField(telemetry.Field{Key: "messaging.jetstream.replay.duration_ms", Value: time.Since(started).Milliseconds()})
+		jetstreamAnnotateMain(ctx, "replay", "completed", endAttrs)
+		telemetry.End(span, "completed", endAttrs)
 		return nil, nil
 	}
 	for seq := stream.State.LastSeq; ; seq-- {
+		scanned++
 		raw, err := streamRef.GetMsg(ctx, seq)
 		if err != nil {
 			if errors.Is(err, jetstream.ErrMsgNotFound) {
+				missing++
 				if seq == stream.State.FirstSeq {
 					break
 				}
 				continue
 			}
 			err = fmt.Errorf("get replay message %s:%d: %w", stream.Config.Name, seq, err)
-			jetstreamTelemetryError(ctx, span, "replay", err)
+			jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, scanned, missing, subjectMatched, decoded, matched, seq, ctx)))
 			return nil, err
 		}
 		if raw != nil && replaySubjectMatchesAnyPrefix(raw.Subject, subjectPrefixes) {
+			subjectMatched++
 			event, err := decodeReplayEvent(raw)
 			if err != nil {
 				err = fmt.Errorf("decode replay message %s:%d: %w", stream.Config.Name, seq, err)
-				jetstreamTelemetryError(ctx, span, "replay", err)
+				jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, scanned, missing, subjectMatched, decoded, matched, seq, ctx)))
 				return nil, err
 			}
+			decoded++
 			if matchesReplayRequest(event, request) {
+				matched++
 				candidates = append(candidates, replayCandidate{event: event, seq: seq})
 				if countAtLeastUint32(len(candidates), candidateLimit) {
 					break
@@ -446,9 +490,107 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	for _, candidate := range candidates {
 		events = append(events, candidate.event)
 	}
-	jetstreamAnnotateMain(ctx, "replay", "completed")
-	telemetry.End(span, "completed", telemetry.Attrs(telemetry.Field{Key: "events_returned", Value: len(events)}))
+	endAttrs := streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, scanned, missing, subjectMatched, decoded, matched, 0, ctx)).
+		WithField(telemetry.Field{Key: "events_returned", Value: len(events)}).
+		WithField(telemetry.Field{Key: "messaging.jetstream.replay.duration_ms", Value: time.Since(started).Milliseconds()})
+	jetstreamAnnotateMain(ctx, "replay", "completed", endAttrs)
+	telemetry.End(span, "completed", endAttrs)
 	return events, nil
+}
+
+func (l *Log) shouldRunCanary(now time.Time) bool {
+	l.canaryMu.Lock()
+	defer l.canaryMu.Unlock()
+	if l.lastCanary.IsZero() {
+		return true
+	}
+	return now.Sub(l.lastCanary) >= jetstreamCanaryMinInterval
+}
+
+func (l *Log) markCanarySucceeded(now time.Time) {
+	l.canaryMu.Lock()
+	defer l.canaryMu.Unlock()
+	if now.After(l.lastCanary) {
+		l.lastCanary = now
+	}
+}
+
+func (l *Log) runCanary(ctx context.Context, stream *jetstream.StreamInfo) (telemetry.Attributes, error) {
+	started := time.Now()
+	attrs := jetstreamStreamTelemetryAttrs(stream).With(telemetry.Attrs(
+		telemetry.Field{Key: "messaging.jetstream.canary.enabled", Value: true},
+		telemetry.Field{Key: "messaging.jetstream.canary.kind", Value: "publish_replay"},
+		telemetry.Field{Key: "event.kind", Value: jetstreamCanaryKind},
+	))
+	finish := func(extra telemetry.Attributes) telemetry.Attributes {
+		durationMs := time.Since(started).Milliseconds()
+		return attrs.With(extra).With(telemetry.Attrs(
+			telemetry.Field{Key: "messaging.jetstream.canary.duration_ms", Value: durationMs},
+			telemetry.Field{Key: "canary_duration_ms", Value: durationMs},
+		))
+	}
+	subject, err := eventSubject(l.subjectPrefix, jetstreamCanaryKind)
+	if err != nil {
+		return finish(telemetry.Attrs()), err
+	}
+	now := time.Now().UTC()
+	event := &cerebrov1.EventEnvelope{
+		Id:         fmt.Sprintf("jetstream-canary-%d", now.UnixNano()),
+		Kind:       jetstreamCanaryKind,
+		OccurredAt: timestamppb.New(now),
+		Attributes: map[string]string{
+			"canary":    "true",
+			"component": "appendlog.jetstream",
+		},
+	}
+	payload, err := publishPayload(event)
+	if err != nil {
+		return finish(telemetry.Attrs()), fmt.Errorf("marshal canary event: %w", err)
+	}
+	msg := nats.NewMsg(subject)
+	msg.Data = payload
+	msg.Header.Set(nats.MsgIdHdr, event.Id)
+	publishAttrs := func() telemetry.Attributes {
+		return jetstreamPublishMessageAttrs(subject, l.subjectPrefix, len(payload), event.Id).With(attrs)
+	}
+	publishResult, err := l.publishMsg(ctx, msg, "canary", publishAttrs)
+	canaryAttrs := publishAttrs().With(publishResult.attrs()).With(telemetry.Attrs(
+		telemetry.Field{Key: "messaging.jetstream.canary.publish.duration_ms", Value: publishResult.Duration.Milliseconds()},
+	))
+	if err != nil {
+		return finish(canaryAttrs), fmt.Errorf("publish canary event: %w", err)
+	}
+	if publishResult.AckSequence == 0 {
+		return finish(canaryAttrs), errors.New("publish canary event: ack sequence unavailable")
+	}
+	streamName := strings.TrimSpace(publishResult.AckStream)
+	if streamName == "" && stream != nil {
+		streamName = strings.TrimSpace(stream.Config.Name)
+	}
+	if streamName == "" {
+		return finish(canaryAttrs), errors.New("publish canary event: ack stream unavailable")
+	}
+	replayStarted := time.Now()
+	streamRef, err := l.replay.Stream(ctx, streamName)
+	if err != nil {
+		return finish(canaryAttrs), fmt.Errorf("open canary replay stream %q: %w", streamName, err)
+	}
+	raw, err := streamRef.GetMsg(ctx, publishResult.AckSequence)
+	if err != nil {
+		return finish(canaryAttrs.WithField(telemetry.Field{Key: "messaging.jetstream.canary.replay.sequence", Value: publishResult.AckSequence})), fmt.Errorf("read canary message %s:%d: %w", streamName, publishResult.AckSequence, err)
+	}
+	replayed, err := decodeReplayEvent(raw)
+	if err != nil {
+		return finish(canaryAttrs.WithField(telemetry.Field{Key: "messaging.jetstream.canary.replay.sequence", Value: publishResult.AckSequence})), fmt.Errorf("decode canary message %s:%d: %w", streamName, publishResult.AckSequence, err)
+	}
+	if strings.TrimSpace(replayed.GetId()) != event.Id || strings.TrimSpace(replayed.GetKind()) != jetstreamCanaryKind {
+		return finish(canaryAttrs.WithField(telemetry.Field{Key: "messaging.jetstream.canary.replay.sequence", Value: publishResult.AckSequence})), errors.New("canary replayed unexpected event")
+	}
+	return finish(canaryAttrs.With(telemetry.Attrs(
+		telemetry.Field{Key: "messaging.jetstream.canary.replayed", Value: true},
+		telemetry.Field{Key: "messaging.jetstream.canary.replay.duration_ms", Value: time.Since(replayStarted).Milliseconds()},
+		telemetry.Field{Key: "messaging.jetstream.canary.replay.sequence", Value: publishResult.AckSequence},
+	))), nil
 }
 
 func jetstreamTelemetryAttrs(operation string) telemetry.Attributes {
@@ -476,6 +618,79 @@ func jetstreamPublishMessageAttrs(subject string, subjectPrefix string, payloadB
 	return attrs
 }
 
+func jetstreamStreamTelemetryAttrs(stream *jetstream.StreamInfo) telemetry.Attributes {
+	attrs := telemetry.Attrs()
+	if stream == nil {
+		return attrs
+	}
+	attrs = attrs.With(telemetry.Attrs(
+		telemetry.Field{Key: "messaging.jetstream.stream", Value: strings.TrimSpace(stream.Config.Name)},
+		telemetry.Field{Key: "messaging.jetstream.stream.subject_count", Value: len(stream.Config.Subjects)},
+		telemetry.Field{Key: "messaging.jetstream.stream.state.messages", Value: stream.State.Msgs},
+		telemetry.Field{Key: "messaging.jetstream.stream.state.bytes", Value: stream.State.Bytes},
+		telemetry.Field{Key: "messaging.jetstream.stream.state.first_sequence", Value: stream.State.FirstSeq},
+		telemetry.Field{Key: "messaging.jetstream.stream.state.last_sequence", Value: stream.State.LastSeq},
+		telemetry.Field{Key: "messaging.jetstream.stream.state.consumer_count", Value: stream.State.Consumers},
+		telemetry.Field{Key: "messaging.jetstream.stream.state.deleted_count", Value: stream.State.NumDeleted},
+		telemetry.Field{Key: "messaging.jetstream.stream.state.unique_subject_count", Value: stream.State.NumSubjects},
+	))
+	if stream.Cluster != nil {
+		attrs = attrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "messaging.jetstream.cluster.name", Value: strings.TrimSpace(stream.Cluster.Name)},
+			telemetry.Field{Key: "messaging.jetstream.cluster.leader", Value: strings.TrimSpace(stream.Cluster.Leader)},
+			telemetry.Field{Key: "messaging.jetstream.cluster.replica_count", Value: len(stream.Cluster.Replicas)},
+		))
+	}
+	return attrs
+}
+
+func jetstreamReplayRequestAttrs(request ports.ReplayRequest) telemetry.Attributes {
+	kindPrefixes := replayKindPrefixes(request)
+	filterKeys := make([]string, 0, len(request.AttributeEquals))
+	for key := range request.AttributeEquals {
+		filterKeys = append(filterKeys, strings.TrimSpace(key))
+	}
+	sort.Strings(filterKeys)
+	return telemetry.Attrs(
+		telemetry.Field{Key: "runtime_id", Value: request.RuntimeID},
+		telemetry.Field{Key: "tenant_id", Value: request.TenantID},
+		telemetry.Field{Key: "replay.kind_prefix", Value: request.KindPrefix},
+		telemetry.Field{Key: "replay.kind_prefixes", Value: strings.Join(kindPrefixes, ",")},
+		telemetry.Field{Key: "replay.attribute_filter_keys", Value: strings.Join(filterKeys, ",")},
+	)
+}
+
+func jetstreamReplayScanAttrs(limit uint32, candidateLimit uint32, scanned uint64, missing uint64, subjectMatched uint64, decoded uint64, matched uint64, sequence uint64, ctx context.Context) telemetry.Attributes {
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "messaging.jetstream.replay.limit", Value: limit},
+		telemetry.Field{Key: "messaging.jetstream.replay.candidate_limit", Value: candidateLimit},
+		telemetry.Field{Key: "messaging.jetstream.replay.scanned_count", Value: scanned},
+		telemetry.Field{Key: "messaging.jetstream.replay.missing_count", Value: missing},
+		telemetry.Field{Key: "messaging.jetstream.replay.subject_matched_count", Value: subjectMatched},
+		telemetry.Field{Key: "messaging.jetstream.replay.decoded_count", Value: decoded},
+		telemetry.Field{Key: "messaging.jetstream.replay.matched_count", Value: matched},
+		telemetry.Field{Key: "messaging.jetstream.replay.deadline_budget_ms", Value: contextDeadlineBudgetMs(ctx)},
+		telemetry.Field{Key: "replay_scanned_count", Value: scanned},
+		telemetry.Field{Key: "replay_matched_count", Value: matched},
+	)
+	if sequence > 0 {
+		attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.replay.sequence", Value: sequence})
+	}
+	return attrs
+}
+
+func contextDeadlineBudgetMs(ctx context.Context) int64 {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return 0
+	}
+	remaining := time.Until(deadline).Milliseconds()
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
 func shortHash(value string) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(value)))
 	return hex.EncodeToString(sum[:8])
@@ -496,7 +711,8 @@ func jetstreamTelemetryError(ctx context.Context, span *telemetry.Span, operatio
 
 func jetstreamErrorTelemetryAttrs(operation string, err error) telemetry.Attributes {
 	attrs := telemetry.Attrs(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
-	if strings.TrimSpace(operation) == "append" {
+	attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.error.category", Value: jetstreamErrorCategory(err)})
+	if strings.TrimSpace(operation) == "append" || strings.TrimSpace(operation) == "canary" {
 		attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.publish.retryable", Value: retryablePublishError(err)})
 	}
 	var apiErr *jetstream.APIError
@@ -508,6 +724,50 @@ func jetstreamErrorTelemetryAttrs(operation string, err error) telemetry.Attribu
 		))
 	}
 	return attrs
+}
+
+func jetstreamErrorCategory(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	}
+	var apiErr *jetstream.APIError
+	if errors.As(err, &apiErr) && apiErr != nil {
+		switch {
+		case apiErr.Code == 401 || apiErr.Code == 403:
+			return "permission"
+		case apiErr.Code == 404:
+			return "not_found"
+		case apiErr.Code == 408:
+			return "timeout"
+		case apiErr.Code == 429:
+			return "rate_limited"
+		case apiErr.Code >= 500:
+			return "server"
+		default:
+			return "api"
+		}
+	}
+	text := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(text, "timeout") || strings.Contains(text, "deadline"):
+		return "timeout"
+	case strings.Contains(text, "no response"):
+		return "no_response"
+	case strings.Contains(text, "connection") || strings.Contains(text, "reconnect") || strings.Contains(text, "broken pipe") || strings.Contains(text, "reset by peer") || strings.Contains(text, "closed"):
+		return "connection"
+	case strings.Contains(text, "permission") || strings.Contains(text, "authorization") || strings.Contains(text, "authentication"):
+		return "permission"
+	case strings.Contains(text, "not found") || strings.Contains(text, "no replay stream"):
+		return "not_found"
+	default:
+		return "unknown"
+	}
 }
 
 func jetstreamAnnotateMain(ctx context.Context, operation string, status string, extra ...telemetry.Attributes) {

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -27,6 +27,7 @@ type fakePublisher struct {
 	accountErr   error
 	publishErr   error
 	publishErrs  []error
+	ack          *natsjetstream.PubAck
 	published    *nats.Msg
 	publishCalls int
 }
@@ -43,6 +44,9 @@ func (f *fakePublisher) PublishMsg(_ context.Context, msg *nats.Msg, _ ...natsje
 		f.publishErrs = f.publishErrs[1:]
 		return &natsjetstream.PubAck{}, err
 	}
+	if f.ack != nil {
+		return f.ack, f.publishErr
+	}
 	return &natsjetstream.PubAck{}, f.publishErr
 }
 
@@ -50,6 +54,8 @@ type fakeReplayManager struct {
 	streams     []*natsjetstream.StreamInfo
 	msgs        map[string]map[uint64]*natsjetstream.RawStreamMsg
 	err         error
+	getMsgErr   error
+	msgFunc     func(stream string, seq uint64) *natsjetstream.RawStreamMsg
 	streamCalls int
 	getMsgCalls int
 }
@@ -63,19 +69,26 @@ func (f *fakeReplayManager) Stream(_ context.Context, stream string) (replayStre
 		return nil, f.err
 	}
 	f.streamCalls++
-	return &fakeReplayStream{manager: f, msgs: f.msgs[stream]}, nil
+	return &fakeReplayStream{manager: f, stream: stream, msgs: f.msgs[stream]}, nil
 }
 
 type fakeReplayStream struct {
 	manager *fakeReplayManager
+	stream  string
 	msgs    map[uint64]*natsjetstream.RawStreamMsg
 }
 
 func (f *fakeReplayStream) GetMsg(_ context.Context, seq uint64, _ ...natsjetstream.GetMsgOpt) (*natsjetstream.RawStreamMsg, error) {
 	if f.manager != nil {
 		f.manager.getMsgCalls++
+		if f.manager.getMsgErr != nil {
+			return nil, f.manager.getMsgErr
+		}
 	}
 	raw := f.msgs[seq]
+	if raw == nil && f.manager != nil && f.manager.msgFunc != nil {
+		raw = f.manager.msgFunc(f.stream, seq)
+	}
 	if raw == nil {
 		return nil, natsjetstream.ErrMsgNotFound
 	}
@@ -313,8 +326,8 @@ func TestJetstreamErrorTelemetryAttrsIncludesAPIErrorDetails(t *testing.T) {
 	if values["nats.jetstream.error_description"] != "stream not found" {
 		t.Fatalf("nats.jetstream.error_description = %q, want stream not found", values["nats.jetstream.error_description"])
 	}
-	if values["messaging.jetstream.publish.retryable"] != "false" {
-		t.Fatalf("messaging.jetstream.publish.retryable = %q, want false", values["messaging.jetstream.publish.retryable"])
+	if values["messaging.jetstream.publish.retryable"] != "true" {
+		t.Fatalf("messaging.jetstream.publish.retryable = %q, want true", values["messaging.jetstream.publish.retryable"])
 	}
 }
 
@@ -510,9 +523,65 @@ func TestPingAcceptsMatchingStream(t *testing.T) {
 			{Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}}},
 		},
 	}
-	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events", lastCanary: time.Now()}
 	if err := log.Ping(context.Background()); err != nil {
 		t.Fatalf("Ping() error = %v", err)
+	}
+}
+
+func TestPingRunsPublishReplayCanary(t *testing.T) {
+	pub := &fakePublisher{ack: &natsjetstream.PubAck{Stream: "CEREBRO_EVENTS", Sequence: 7}}
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+				State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 7, Msgs: 7, Bytes: 512, Consumers: 2, NumSubjects: 3},
+			},
+		},
+		msgFunc: func(_ string, seq uint64) *natsjetstream.RawStreamMsg {
+			if seq != 7 || pub.published == nil {
+				return nil
+			}
+			return &natsjetstream.RawStreamMsg{
+				Subject: pub.published.Subject,
+				Header:  pub.published.Header,
+				Data:    pub.published.Data,
+			}
+		},
+	}
+	log := &Log{js: pub, replay: replay, subjectPrefix: "events"}
+
+	stderr := captureJetstreamTelemetry(t, func() {
+		if err := log.Ping(context.Background()); err != nil {
+			t.Fatalf("Ping() error = %v", err)
+		}
+	})
+
+	if pub.publishCalls != 1 {
+		t.Fatalf("publish calls = %d, want 1", pub.publishCalls)
+	}
+	if pub.published == nil || pub.published.Subject != "events."+jetstreamCanaryKind {
+		t.Fatalf("canary subject = %#v, want events.%s", pub.published, jetstreamCanaryKind)
+	}
+	if got := pub.published.Header.Get(nats.MsgIdHdr); !strings.HasPrefix(got, "jetstream-canary-") {
+		t.Fatalf("canary msg id = %q, want generated canary id", got)
+	}
+	events := jetstreamTelemetryPayloads(t, stderr, "event", "jetstream.canary.completed")
+	if len(events) != 1 {
+		t.Fatalf("canary completed events = %d, want 1; stderr=%s", len(events), stderr)
+	}
+	payload := events[0]
+	for key, want := range map[string]any{
+		"messaging.jetstream.canary.replayed":                   true,
+		"messaging.jetstream.ack.stream":                        "CEREBRO_EVENTS",
+		"messaging.jetstream.ack.sequence":                      float64(7),
+		"messaging.jetstream.stream.state.messages":             float64(7),
+		"messaging.jetstream.stream.state.consumer_count":       float64(2),
+		"messaging.jetstream.stream.state.unique_subject_count": float64(3),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
 	}
 }
 
@@ -553,6 +622,61 @@ func TestReplayFiltersEventsByRuntime(t *testing.T) {
 	}
 	if replay.streamCalls != 1 {
 		t.Fatalf("streamCalls = %d, want 1", replay.streamCalls)
+	}
+}
+
+func TestReplayEmitsScanTelemetry(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{
+					Name:     "CEREBRO_EVENTS",
+					Subjects: []string{"events.>"},
+				},
+				State: natsjetstream.StreamState{FirstSeq: 1, LastSeq: 3, Msgs: 3, Bytes: 256, Consumers: 1, NumSubjects: 2},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				3: rawReplayMsg(t, "events.github.audit", replayEvent("evt-3", "github.audit", "writer-github")),
+			},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	stderr := captureJetstreamTelemetry(t, func() {
+		events, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 2})
+		if err != nil {
+			t.Fatalf("Replay() error = %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("len(events) = %d, want 2", len(events))
+		}
+	})
+
+	spanEnds := jetstreamTelemetryPayloads(t, stderr, "span_end", "jetstream.replay")
+	if len(spanEnds) != 1 {
+		t.Fatalf("jetstream.replay span_end events = %d, want 1; stderr=%s", len(spanEnds), stderr)
+	}
+	payload := spanEnds[0]
+	for key, want := range map[string]any{
+		"messaging.jetstream.stream":                       "CEREBRO_EVENTS",
+		"messaging.jetstream.stream.state.messages":        float64(3),
+		"messaging.jetstream.stream.state.bytes":           float64(256),
+		"messaging.jetstream.replay.scanned_count":         float64(3),
+		"messaging.jetstream.replay.missing_count":         float64(1),
+		"messaging.jetstream.replay.subject_matched_count": float64(2),
+		"messaging.jetstream.replay.decoded_count":         float64(2),
+		"messaging.jetstream.replay.matched_count":         float64(2),
+		"events_returned":                                  float64(2),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if _, ok := payload["messaging.jetstream.replay.duration_ms"].(float64); !ok {
+		t.Fatalf("replay duration missing: %#v", payload)
 	}
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -71,7 +71,7 @@ type RuntimeMetadata struct {
 }
 
 const maxAttributeStringLength = 1024
-const wideEventSchemaVersion = "2026-06-18.2"
+const wideEventSchemaVersion = "2026-06-19.1"
 
 var (
 	runtimeMetadataMu sync.RWMutex


### PR DESCRIPTION
## Summary
- add a throttled JetStream publish+replay canary from app health, with canary completion/failure events and stream-state fields
- enrich replay telemetry with scan counters, stream state, deadline budget, latency aliases, and operation-specific NATS error categorization
- emit orchestrator platform.job started/heartbeat/runtime/phase/terminal events and bump the wide-event schema version

## Tests
- go test ./...
