### PR TITLE
[codex] harden multi-cloud deployment templates

### DIFF
--- a/deploy/pulumi/Pulumi.aws.yaml
+++ b/deploy/pulumi/Pulumi.aws.yaml
@@ -1,5 +1,6 @@
 config:
   cerebro:cloud: aws
+  cerebro:deploymentProfile: preview
   cerebro:name: cerebro-aws-example
   cerebro:image: ghcr.io/writer/cerebro:latest
   cerebro:apiAuthEnabled: "false"

--- a/deploy/pulumi/Pulumi.azure.yaml
+++ b/deploy/pulumi/Pulumi.azure.yaml
@@ -1,5 +1,6 @@
 config:
   cerebro:cloud: azure
+  cerebro:deploymentProfile: preview
   cerebro:name: cerebro-azure-example
   cerebro:image: ghcr.io/writer/cerebro:latest
   cerebro:apiAuthEnabled: "false"

--- a/deploy/pulumi/Pulumi.gcp.yaml
+++ b/deploy/pulumi/Pulumi.gcp.yaml
@@ -1,5 +1,6 @@
 config:
   cerebro:cloud: gcp
+  cerebro:deploymentProfile: preview
   cerebro:name: cerebro-gcp-example
   cerebro:image: ghcr.io/writer/cerebro:latest
   cerebro:apiAuthEnabled: "false"

--- a/deploy/pulumi/Pulumi.yaml
+++ b/deploy/pulumi/Pulumi.yaml
@@ -16,6 +16,18 @@ config:
   cerebro:image:
     type: string
     description: Cerebro runtime image to deploy.
+  cerebro:deploymentProfile:
+    type: string
+    default: preview
+    description: Deployment profile. Use production for shared environments to enable guardrails.
+  cerebro:allowUnsafeProduction:
+    type: boolean
+    default: false
+    description: Explicitly allow production guardrail exceptions when paired with a justification.
+  cerebro:unsafeProductionJustification:
+    type: string
+    default: ""
+    description: Required when allowUnsafeProduction is true.
   cerebro:containerPort:
     type: integer
     default: 8080
@@ -48,6 +60,17 @@ config:
     type: integer
     default: 1
     description: Number of trusted trailing X-Forwarded-For hops.
+  cerebro:ingressCidrs:
+    type: array
+    items:
+      type: string
+    default:
+      - 0.0.0.0/0
+    description: CIDR allowlist for AWS ALB ingress.
+  cerebro:edgeAuthManaged:
+    type: boolean
+    default: false
+    description: Set true when an upstream edge owns authentication and forwarded-header hygiene.
   cerebro:apiAuthEnabled:
     type: boolean
     default: true
@@ -56,3 +79,41 @@ config:
     type: string
     default: ""
     description: Optional comma-separated tenant allowlist.
+  cerebro:existingSecretRefs:
+    type: object
+    default: {}
+    description: Existing cloud secret references keyed by Cerebro environment variable name.
+  cerebro:scheduledJobs:
+    type: array
+    items:
+      type: object
+    default: []
+    description: Optional scheduled job definitions that run the Cerebro image with command overrides.
+  cerebro:awsCertificateArn:
+    type: string
+    default: ""
+    description: Optional ACM certificate ARN for HTTPS on the AWS load balancer.
+  cerebro:awsEnablePrivateSubnets:
+    type: boolean
+    default: false
+    description: Run AWS ECS tasks in private subnets created by the template.
+  cerebro:awsEnableNatGateway:
+    type: boolean
+    default: false
+    description: Create a NAT gateway for AWS private subnet egress.
+  cerebro:gcpServiceAccountEmail:
+    type: string
+    default: ""
+    description: Optional Cloud Run service account email.
+  cerebro:gcpSchedulerServiceAccountEmail:
+    type: string
+    default: ""
+    description: Optional service account used by Cloud Scheduler to run Cloud Run Jobs.
+  cerebro:gcpVpcConnector:
+    type: string
+    default: ""
+    description: Optional Serverless VPC Access connector for Cloud Run.
+  cerebro:azureEnableSystemIdentity:
+    type: boolean
+    default: false
+    description: Enable a system-assigned identity on Azure Container Apps resources.

--- a/deploy/pulumi/README.md
+++ b/deploy/pulumi/README.md
@@ -2,22 +2,22 @@
 
 These Pulumi templates deploy the public Cerebro runtime on AWS, Google Cloud, or Azure using environment-agnostic defaults. They intentionally use placeholder names and caller-owned configuration only. Do not put live account IDs, hostnames, tenant names, source schedules, provider tokens, or secret values in this directory.
 
-The templates deploy the Cerebro API container and wire any backing services you provide through cloud-native secret mechanisms:
+The stack entrypoint creates one reusable `CerebroService` component. That component chooses a provider-specific child component from the shared `cerebro:cloud` config:
 
-- AWS: ECS Fargate service behind an Application Load Balancer.
-- GCP: Cloud Run v2 service.
-- Azure: Azure Container Apps service.
+- AWS: ECS Fargate service behind an Application Load Balancer, with optional ACM HTTPS, private subnets, NAT, and EventBridge Scheduler jobs.
+- GCP: Cloud Run v2 service, with optional service account, VPC connector, Cloud Run Jobs, and Cloud Scheduler triggers.
+- Azure: Azure Container Apps service, with optional system identity, Key Vault-backed secrets, and scheduled Container Apps Jobs.
 
-Postgres, NATS JetStream, and Neo4j/Aura are configured by passing DSNs and URLs as Pulumi secrets. You can use managed services, self-hosted services, or third-party services as long as the Cerebro container can reach them.
+Postgres, NATS JetStream, Neo4j/Aura, and Redis/Valkey are wired by DSN/URL secrets. You can provide those secrets through Pulumi-created cloud secrets or by referencing existing cloud secret manager entries.
 
 ## Runtime Profiles
 
 | Profile | Required template config | Cerebro features |
 | --- | --- | --- |
 | Lightweight API | image, cloud, region/location | `/livez`, `/health`, `/openapi.yaml`, `/sources`, and provider-free source previews |
-| Durable API | `cerebro:postgresDsn` | persisted runtimes, claims, findings, reports, OAuth, and device-auth state |
-| Durable sync | `cerebro:postgresDsn`, `cerebro:jetstreamUrl` | source runtime sync and append-log-backed replay |
-| Graph-enabled | `cerebro:postgresDsn`, `cerebro:jetstreamUrl`, `cerebro:neo4jUri`, `cerebro:neo4jUsername`, `cerebro:neo4jPassword` | graph ingest, graph queries, graph health, and graph-agent workflows |
+| Durable API | `CEREBRO_POSTGRES_DSN` via `cerebro:postgresDsn` or `cerebro:existingSecretRefs` | persisted runtimes, claims, findings, reports, OAuth, and device-auth state |
+| Durable sync | Postgres plus `CEREBRO_JETSTREAM_URL` | source runtime sync and append-log-backed replay |
+| Graph-enabled | Postgres, JetStream, `CEREBRO_NEO4J_URI`, `CEREBRO_NEO4J_USERNAME`, `CEREBRO_NEO4J_PASSWORD` | graph ingest, graph queries, graph health, and graph-agent workflows |
 
 ## Install
 
@@ -35,7 +35,7 @@ export PULUMI_CONFIG_PASSPHRASE="local-preview-only"
 
 ## Preview Without Deploying
 
-Each checked-in example stack is intentionally lightweight and unauthenticated so it can be previewed without live secrets. Do not deploy these exact stack files to a shared environment.
+Each checked-in example stack is explicitly marked `cerebro:deploymentProfile=preview` and intentionally keeps auth disabled so the resource graph can be previewed without live secrets. Do not deploy these exact stack files to a shared environment.
 
 ```bash
 pulumi preview --stack aws --refresh=false
@@ -43,17 +43,38 @@ pulumi preview --stack gcp --refresh=false
 pulumi preview --stack azure --refresh=false
 ```
 
-For real deployments, set a release image, enable API auth, and provide secrets first:
+If your workstation has no active provider auth, use dummy provider environment variables for preview-only validation with `--refresh=false`; do not use those values for deployment.
+
+For real deployments, set a release image, enable production guardrails, enable auth or an authenticated edge, and provide secrets first:
 
 ```bash
+pulumi config set cerebro:deploymentProfile production
 pulumi config set cerebro:image ghcr.io/writer/cerebro:vX.Y.Z
 pulumi config set cerebro:apiAuthEnabled true
+pulumi config set cerebro:publicOrigin https://cerebro.example.com
 pulumi config set --secret cerebro:apiKeys '<random-key>:<principal>:<tenant-id>'
 pulumi config set --secret cerebro:postgresDsn '<postgres-dsn-with-tls>'
 pulumi config set --secret cerebro:jetstreamUrl '<nats-url>'
 pulumi config set --secret cerebro:neo4jUri '<neo4j-or-aura-uri>'
 pulumi config set --secret cerebro:neo4jUsername '<neo4j-user>'
 pulumi config set --secret cerebro:neo4jPassword '<neo4j-password>'
+```
+
+## Guardrails
+
+Production stacks fail preview/update unless unsafe settings are fixed or explicitly overridden with a justification. The guardrails cover:
+
+- API authentication disabled without `cerebro:edgeAuthManaged=true`.
+- mutable `:latest` or untagged container images.
+- non-HTTPS `cerebro:publicOrigin`.
+- public ingress without API auth, edge auth, restricted ingress CIDRs, or IAM-only access.
+- AWS public load balancers without `cerebro:awsCertificateArn` or an upstream edge declaration.
+
+Temporary exceptions require both:
+
+```bash
+pulumi config set cerebro:allowUnsafeProduction true
+pulumi config set cerebro:unsafeProductionJustification '<why this is acceptable and time-bounded>'
 ```
 
 ## Cloud Selection
@@ -68,6 +89,7 @@ The shared config keys are the same across clouds:
 
 | Key | Default | Notes |
 | --- | --- | --- |
+| `cerebro:deploymentProfile` | `preview` | Set `production` for shared environments. |
 | `cerebro:name` | `cerebro` | Resource name prefix. Use lowercase letters, numbers, and hyphens. |
 | `cerebro:image` | required | Runtime image, usually `ghcr.io/writer/cerebro:<release-tag>` or a cloud-registry mirror. |
 | `cerebro:containerPort` | `8080` | Container port. |
@@ -78,7 +100,9 @@ The shared config keys are the same across clouds:
 | `cerebro:publicOrigin` | unset | Set to the external HTTPS origin for shared deployments. |
 | `cerebro:trustedProxyCIDRs` | unset | Comma-separated trusted proxy CIDRs. |
 | `cerebro:trustedProxyCount` | `1` | Trusted trailing `X-Forwarded-For` hops. |
-| `cerebro:apiAuthEnabled` | `true` | Keep true outside local or validation-only stacks. |
+| `cerebro:ingressCidrs` | `["0.0.0.0/0"]` | Applied to AWS ALB ingress; use cloud edge controls for GCP/Azure CIDR filtering. |
+| `cerebro:edgeAuthManaged` | `false` | Set true when an upstream edge owns authentication and forwarded-header hygiene. |
+| `cerebro:apiAuthEnabled` | `true` | Keep true outside local or validation-only stacks unless an authenticated edge owns access. |
 | `cerebro:apiKeys` | unset | Secret API key entries. Required when API auth is enabled unless using structured credentials. |
 | `cerebro:apiCredentialsJson` | unset | Secret structured credential JSON. Alternative to simple API keys. |
 | `cerebro:allowedTenants` | unset | Optional tenant allowlist. |
@@ -91,15 +115,81 @@ The shared config keys are the same across clouds:
 | `cerebro:connectorTransitPrivateKey` | unset | Secret shared RSA private key for browser-submitted connector credentials. |
 | `cerebro:capabilityTokenSecrets` | unset | Secret HMAC material for capability-token auth. |
 | `cerebro:extraEnv` | `{}` | Non-secret environment variable map. |
-| `cerebro:extraSecrets` | `{}` | Secret environment variable map. |
+| `cerebro:extraSecrets` | `{}` | Secret environment variable map created by the template. |
+| `cerebro:existingSecretRefs` | `{}` | Existing provider-native secret refs keyed by environment variable name. |
+| `cerebro:scheduledJobs` | `[]` | Optional scheduled jobs that run the same image with a command override. |
 
 Cloud-specific keys:
 
 | Cloud | Keys |
 | --- | --- |
-| AWS | `cerebro:awsRegion`, `cerebro:awsAvailabilityZones`, `cerebro:awsVpcCidr`, `cerebro:awsPublicSubnetCidrs`, `cerebro:awsAssignPublicIp`, `cerebro:awsSkipCredentialsValidation` |
-| GCP | `cerebro:gcpProject`, `cerebro:gcpRegion`, `cerebro:gcpIngress`, `cerebro:gcpAllowUnauthenticated` |
-| Azure | `cerebro:azureLocation`, `cerebro:azureResourceGroupName`, `cerebro:azureExternalIngress` |
+| AWS | `cerebro:awsRegion`, `cerebro:awsAvailabilityZones`, `cerebro:awsVpcCidr`, `cerebro:awsPublicSubnetCidrs`, `cerebro:awsPrivateSubnetCidrs`, `cerebro:awsEnablePrivateSubnets`, `cerebro:awsEnableNatGateway`, `cerebro:awsAssignPublicIp`, `cerebro:awsCertificateArn`, `cerebro:awsRedirectHttpToHttps`, `cerebro:awsLogRetentionDays`, `cerebro:awsSkipCredentialsValidation` |
+| GCP | `cerebro:gcpProject`, `cerebro:gcpRegion`, `cerebro:gcpIngress`, `cerebro:gcpAllowUnauthenticated`, `cerebro:gcpServiceAccountEmail`, `cerebro:gcpSchedulerServiceAccountEmail`, `cerebro:gcpVpcConnector` |
+| Azure | `cerebro:azureLocation`, `cerebro:azureResourceGroupName`, `cerebro:azureExternalIngress`, `cerebro:azureEnableSystemIdentity` |
+
+## Existing Secrets
+
+Use `existingSecretRefs` when your environment already manages secret material. The keys are Cerebro environment variables; each value is cloud-specific metadata.
+
+AWS Secrets Manager:
+
+```bash
+pulumi config set --path 'cerebro:existingSecretRefs.CEREBRO_POSTGRES_DSN.awsArn' \
+  'arn:aws:secretsmanager:us-east-1:111122223333:secret:cerebro/postgres'
+```
+
+GCP Secret Manager:
+
+```bash
+pulumi config set --path 'cerebro:existingSecretRefs.CEREBRO_POSTGRES_DSN.gcpSecret' \
+  'projects/example-project/secrets/cerebro-postgres-dsn'
+pulumi config set --path 'cerebro:existingSecretRefs.CEREBRO_POSTGRES_DSN.gcpVersion' latest
+```
+
+Azure Key Vault:
+
+```bash
+pulumi config set --path 'cerebro:existingSecretRefs.CEREBRO_POSTGRES_DSN.azureSecretName' \
+  cerebro-postgres-dsn
+pulumi config set --path 'cerebro:existingSecretRefs.CEREBRO_POSTGRES_DSN.azureKeyVaultUrl' \
+  'https://example-vault.vault.azure.net/secrets/cerebro-postgres-dsn'
+```
+
+For Azure Key Vault refs, grant the Container App system identity access to the referenced secrets.
+
+## Scheduled Jobs
+
+Scheduled jobs run the same image with a command override. Keep runtime IDs, tenant assignments, provider credentials, and cadence in your private deployment config, not in generic docs.
+
+```bash
+pulumi config set --path 'cerebro:scheduledJobs[0].name' sync-example
+pulumi config set --path 'cerebro:scheduledJobs[0].schedule' 'rate(15 minutes)'
+pulumi config set --path 'cerebro:scheduledJobs[0].command[0]' source-runtime
+pulumi config set --path 'cerebro:scheduledJobs[0].command[1]' sync
+pulumi config set --path 'cerebro:scheduledJobs[0].command[2]' '<runtime-id>'
+pulumi config set --path 'cerebro:scheduledJobs[0].command[3]' page_limit=100
+```
+
+Scheduler shapes:
+
+| Cloud | Template shape |
+| --- | --- |
+| AWS | EventBridge Scheduler launching the ECS task definition with container command overrides |
+| GCP | Cloud Run Job plus optional Cloud Scheduler HTTP trigger when `cerebro:gcpSchedulerServiceAccountEmail` is set |
+| Azure | Container Apps Job with a schedule trigger |
+
+AWS schedules use EventBridge Scheduler expressions such as `rate(15 minutes)` or `cron(...)`. GCP and Azure schedules use cron expressions.
+
+## Optional Dependency Modules
+
+The base component intentionally deploys the API service and job runners only. Dependency modules remain opt-in through provider-managed services or third-party services:
+
+- Postgres: provide `CEREBRO_POSTGRES_DSN` via `cerebro:postgresDsn` or `existingSecretRefs`.
+- NATS JetStream: provide `CEREBRO_JETSTREAM_URL`.
+- Neo4j/Aura: provide `CEREBRO_NEO4J_URI`, username, and password.
+- Redis/Valkey: set `cerebro:extraEnv.CEREBRO_CACHE_MODE=redis` and provide `CEREBRO_CACHE_URL` through `extraSecrets` or `existingSecretRefs`.
+- Private connectivity: use `awsEnablePrivateSubnets`, `awsEnableNatGateway`, `gcpVpcConnector`, or a network-integrated Azure Container Apps environment adapted in your deployment repo.
+- Identity/logging: use `gcpServiceAccountEmail`, Azure system identity, AWS task roles, and your cloud logging controls.
 
 ## Production Notes
 
@@ -107,7 +197,7 @@ These templates are a portable starting point, not a replacement for your organi
 
 - Put the service behind TLS and set `cerebro:publicOrigin` to the HTTPS origin clients use.
 - Strip untrusted inbound forwarded headers at the edge and set `cerebro:trustedProxyCIDRs` to your real proxy or load-balancer network.
-- Keep API auth enabled and store credentials as Pulumi secrets or in your cloud secret manager.
+- Keep API auth enabled or document the authenticated edge that owns access.
 - Use private networking for Postgres, NATS JetStream, Neo4j/Aura, Redis/Valkey, and source-provider egress where available.
 - Run scheduled source sync and graph ingest jobs separately from the API service so retries, concurrency, and capacity can be tuned independently.
 - Preview every stack with `--refresh=false` before review, then run a normal preview with real credentials before `pulumi up`.

--- a/deploy/pulumi/__main__.py
+++ b/deploy/pulumi/__main__.py
@@ -1,19 +1,14 @@
+import pulumi
+
+from components import CerebroService
 from runtime import CerebroRuntimeConfig
 
 
 def main() -> None:
     config = CerebroRuntimeConfig.from_pulumi()
-
-    if config.cloud == "aws":
-        from aws_stack import deploy
-    elif config.cloud == "gcp":
-        from gcp_stack import deploy
-    elif config.cloud == "azure":
-        from azure_stack import deploy
-    else:
-        raise ValueError("cerebro:cloud must be one of aws, gcp, or azure")
-
-    deploy(config)
+    service = CerebroService(config.name, config)
+    for key, value in service.outputs.items():
+        pulumi.export(key, value)
 
 
 main()

--- a/deploy/pulumi/aws_stack.py
+++ b/deploy/pulumi/aws_stack.py
@@ -5,28 +5,188 @@ import json
 import pulumi
 import pulumi_aws as aws
 
-from runtime import CerebroRuntimeConfig, SecretEnv, aws_cpu_units
+from runtime import CerebroRuntimeConfig, ExistingSecretRef, SecretEnv, ScheduledJob, aws_cpu_units, normalized_secret_name
 
 
-def deploy(config: CerebroRuntimeConfig) -> None:
-    provider = aws.Provider(
-        "aws-provider",
-        region=config.aws_region,
-        skip_credentials_validation=config.aws_skip_credentials_validation,
-        skip_metadata_api_check=config.aws_skip_credentials_validation,
-        skip_requesting_account_id=config.aws_skip_credentials_validation,
-    )
-    opts = pulumi.ResourceOptions(provider=provider)
+class AwsCerebroService(pulumi.ComponentResource):
+    def __init__(
+        self,
+        name: str,
+        config: CerebroRuntimeConfig,
+        opts: pulumi.ResourceOptions | None = None,
+    ) -> None:
+        super().__init__("cerebro:cloud:AwsService", name, None, opts)
+        provider = aws.Provider(
+            f"{name}-aws-provider",
+            region=config.aws_region,
+            skip_credentials_validation=config.aws_skip_credentials_validation,
+            skip_metadata_api_check=config.aws_skip_credentials_validation,
+            skip_requesting_account_id=config.aws_skip_credentials_validation,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+        child_opts = pulumi.ResourceOptions(provider=provider, parent=self)
 
-    subnet_cidrs = config.aws_public_subnet_cidrs
-    if len(subnet_cidrs) < 2:
+        network = _create_network(config, child_opts)
+        alb_sg, app_sg = _create_security_groups(config, network["vpc_id"], child_opts)
+
+        cluster = aws.ecs.Cluster(
+            f"{config.name}-cluster",
+            name=_aws_name(config.name, "cluster", 255),
+            settings=[aws.ecs.ClusterSettingArgs(name="containerInsights", value="enabled")],
+            tags={"Name": f"{config.name}-cluster"},
+            opts=child_opts,
+        )
+        log_group = aws.cloudwatch.LogGroup(
+            f"{config.name}-logs",
+            name=f"/ecs/{config.name}",
+            retention_in_days=config.aws_log_retention_days,
+            opts=child_opts,
+        )
+        execution_role = aws.iam.Role(
+            f"{config.name}-execution-role",
+            name=_aws_name(config.name, "execution-role", 64),
+            assume_role_policy=_assume_role_policy("ecs-tasks.amazonaws.com"),
+            opts=child_opts,
+        )
+        execution_policy_attachment = aws.iam.RolePolicyAttachment(
+            f"{config.name}-execution-policy",
+            role=execution_role.name,
+            policy_arn="arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+            opts=child_opts,
+        )
+        task_role = aws.iam.Role(
+            f"{config.name}-task-role",
+            name=_aws_name(config.name, "task-role", 64),
+            assume_role_policy=execution_role.assume_role_policy,
+            opts=child_opts,
+        )
+
+        created_secret_refs = _create_secrets(config.name, config.created_secret_env(), child_opts)
+        existing_secret_refs = _existing_aws_secret_refs(config.existing_secret_refs)
+        secret_refs = created_secret_refs + existing_secret_refs
+        if secret_refs:
+            aws.iam.RolePolicy(
+                f"{config.name}-execution-secrets",
+                role=execution_role.id,
+                policy=pulumi.Output.json_dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": ["secretsmanager:GetSecretValue"],
+                                "Resource": [secret["arn"] for secret in secret_refs],
+                            }
+                        ],
+                    }
+                ),
+                opts=child_opts,
+            )
+
+        container_definition = _container_definition(config, log_group.name, secret_refs)
+        task_definition = aws.ecs.TaskDefinition(
+            f"{config.name}-task",
+            family=config.name,
+            cpu=aws_cpu_units(config.cpu),
+            memory=str(config.memory_mib),
+            network_mode="awsvpc",
+            requires_compatibilities=["FARGATE"],
+            execution_role_arn=execution_role.arn,
+            task_role_arn=task_role.arn,
+            container_definitions=pulumi.Output.json_dumps([container_definition]),
+            opts=pulumi.ResourceOptions(provider=provider, parent=self, depends_on=[execution_policy_attachment]),
+        )
+
+        load_balancer = aws.lb.LoadBalancer(
+            f"{config.name}-alb",
+            name=_aws_name(config.name, "alb", 32),
+            load_balancer_type="application",
+            security_groups=[alb_sg.id],
+            subnets=network["public_subnet_ids"],
+            tags={"Name": f"{config.name}-alb"},
+            opts=child_opts,
+        )
+        target_group = aws.lb.TargetGroup(
+            f"{config.name}-tg",
+            name=_aws_name(config.name, "tg", 32),
+            port=config.container_port,
+            protocol="HTTP",
+            target_type="ip",
+            vpc_id=network["vpc_id"],
+            health_check=aws.lb.TargetGroupHealthCheckArgs(
+                path="/health",
+                matcher="200-399",
+                interval=30,
+                timeout=5,
+                healthy_threshold=2,
+                unhealthy_threshold=3,
+            ),
+            tags={"Name": f"{config.name}-tg"},
+            opts=child_opts,
+        )
+        listeners = _create_listeners(config, load_balancer.arn, target_group.arn, child_opts)
+        service = aws.ecs.Service(
+            f"{config.name}-api",
+            name=_aws_name(config.name, "api", 255),
+            cluster=cluster.id,
+            desired_count=max(config.min_replicas, 1),
+            launch_type="FARGATE",
+            task_definition=task_definition.arn,
+            network_configuration=aws.ecs.ServiceNetworkConfigurationArgs(
+                subnets=network["service_subnet_ids"],
+                security_groups=[app_sg.id],
+                assign_public_ip=config.aws_assign_public_ip if not config.aws_enable_private_subnets else False,
+            ),
+            load_balancers=[
+                aws.ecs.ServiceLoadBalancerArgs(
+                    target_group_arn=target_group.arn,
+                    container_name="cerebro",
+                    container_port=config.container_port,
+                )
+            ],
+            deployment_circuit_breaker=aws.ecs.ServiceDeploymentCircuitBreakerArgs(enable=True, rollback=True),
+            opts=pulumi.ResourceOptions(provider=provider, parent=self, depends_on=listeners),
+        )
+
+        schedule_names = _create_schedules(
+            config,
+            cluster.arn,
+            task_definition.arn,
+            execution_role.arn,
+            task_role.arn,
+            network["service_subnet_ids"],
+            [app_sg.id],
+            child_opts,
+        )
+
+        url_scheme = "https" if config.aws_certificate_arn else "http"
+        self.outputs = {
+            "cloud": "aws",
+            "service_name": service.name,
+            "cluster_name": cluster.name,
+            "cluster_arn": cluster.arn,
+            "task_definition_arn": task_definition.arn,
+            "url": pulumi.Output.concat(url_scheme, "://", load_balancer.dns_name),
+            "schedule_names": schedule_names,
+        }
+        self.register_outputs(self.outputs)
+
+
+def deploy(config: CerebroRuntimeConfig) -> AwsCerebroService:
+    service = AwsCerebroService(config.name, config)
+    for key, value in service.outputs.items():
+        pulumi.export(key, value)
+    return service
+
+
+def _create_network(config: CerebroRuntimeConfig, opts: pulumi.ResourceOptions) -> dict[str, list[pulumi.Input[str]] | pulumi.Input[str]]:
+    public_subnet_cidrs = config.aws_public_subnet_cidrs
+    if len(public_subnet_cidrs) < 2:
         raise ValueError("cerebro:awsPublicSubnetCidrs must contain at least two subnet CIDRs")
-    availability_zones = config.aws_availability_zones or [
-        f"{config.aws_region}a",
-        f"{config.aws_region}b",
-    ]
-    if len(availability_zones) < len(subnet_cidrs):
-        raise ValueError("cerebro:awsAvailabilityZones must cover every public subnet CIDR")
+    private_subnet_cidrs = config.aws_private_subnet_cidrs if config.aws_enable_private_subnets else []
+    availability_zones = config.aws_availability_zones or [f"{config.aws_region}a", f"{config.aws_region}b"]
+    if len(availability_zones) < max(len(public_subnet_cidrs), len(private_subnet_cidrs)):
+        raise ValueError("cerebro:awsAvailabilityZones must cover every configured subnet CIDR")
 
     vpc = aws.ec2.Vpc(
         f"{config.name}-vpc",
@@ -42,15 +202,16 @@ def deploy(config: CerebroRuntimeConfig) -> None:
         tags={"Name": f"{config.name}-igw"},
         opts=opts,
     )
-    route_table = aws.ec2.RouteTable(
+    public_route_table = aws.ec2.RouteTable(
         f"{config.name}-public-rt",
         vpc_id=vpc.id,
         routes=[aws.ec2.RouteTableRouteArgs(cidr_block="0.0.0.0/0", gateway_id=internet_gateway.id)],
         tags={"Name": f"{config.name}-public-rt"},
         opts=opts,
     )
-    subnets = []
-    for index, cidr in enumerate(subnet_cidrs):
+
+    public_subnets = []
+    for index, cidr in enumerate(public_subnet_cidrs):
         subnet = aws.ec2.Subnet(
             f"{config.name}-public-{index + 1}",
             vpc_id=vpc.id,
@@ -63,23 +224,94 @@ def deploy(config: CerebroRuntimeConfig) -> None:
         aws.ec2.RouteTableAssociation(
             f"{config.name}-public-{index + 1}-rt",
             subnet_id=subnet.id,
-            route_table_id=route_table.id,
+            route_table_id=public_route_table.id,
             opts=opts,
         )
-        subnets.append(subnet)
+        public_subnets.append(subnet)
 
-    alb_sg = aws.ec2.SecurityGroup(
-        f"{config.name}-alb-sg",
-        vpc_id=vpc.id,
-        description="Cerebro ALB ingress",
-        ingress=[
+    service_subnets = public_subnets
+    if private_subnet_cidrs:
+        private_route_table_routes = []
+        if config.aws_enable_nat_gateway:
+            eip = aws.ec2.Eip(
+                f"{config.name}-nat-eip",
+                domain="vpc",
+                tags={"Name": f"{config.name}-nat-eip"},
+                opts=opts,
+            )
+            nat_gateway = aws.ec2.NatGateway(
+                f"{config.name}-nat",
+                allocation_id=eip.id,
+                subnet_id=public_subnets[0].id,
+                tags={"Name": f"{config.name}-nat"},
+                opts=opts,
+            )
+            private_route_table_routes.append(aws.ec2.RouteTableRouteArgs(cidr_block="0.0.0.0/0", nat_gateway_id=nat_gateway.id))
+
+        private_route_table = aws.ec2.RouteTable(
+            f"{config.name}-private-rt",
+            vpc_id=vpc.id,
+            routes=private_route_table_routes,
+            tags={"Name": f"{config.name}-private-rt"},
+            opts=opts,
+        )
+        private_subnets = []
+        for index, cidr in enumerate(private_subnet_cidrs):
+            subnet = aws.ec2.Subnet(
+                f"{config.name}-private-{index + 1}",
+                vpc_id=vpc.id,
+                cidr_block=cidr,
+                availability_zone=availability_zones[index],
+                map_public_ip_on_launch=False,
+                tags={"Name": f"{config.name}-private-{index + 1}"},
+                opts=opts,
+            )
+            aws.ec2.RouteTableAssociation(
+                f"{config.name}-private-{index + 1}-rt",
+                subnet_id=subnet.id,
+                route_table_id=private_route_table.id,
+                opts=opts,
+            )
+            private_subnets.append(subnet)
+        service_subnets = private_subnets
+
+    return {
+        "vpc_id": vpc.id,
+        "public_subnet_ids": [subnet.id for subnet in public_subnets],
+        "service_subnet_ids": [subnet.id for subnet in service_subnets],
+    }
+
+
+def _create_security_groups(
+    config: CerebroRuntimeConfig,
+    vpc_id: pulumi.Input[str],
+    opts: pulumi.ResourceOptions,
+) -> tuple[aws.ec2.SecurityGroup, aws.ec2.SecurityGroup]:
+    alb_ingress = []
+    if config.aws_certificate_arn:
+        alb_ingress.append(
+            aws.ec2.SecurityGroupIngressArgs(
+                protocol="tcp",
+                from_port=443,
+                to_port=443,
+                cidr_blocks=config.ingress_cidrs,
+            )
+        )
+    if not config.aws_certificate_arn or config.aws_redirect_http_to_https:
+        alb_ingress.append(
             aws.ec2.SecurityGroupIngressArgs(
                 protocol="tcp",
                 from_port=80,
                 to_port=80,
-                cidr_blocks=["0.0.0.0/0"],
+                cidr_blocks=config.ingress_cidrs,
             )
-        ],
+        )
+
+    alb_sg = aws.ec2.SecurityGroup(
+        f"{config.name}-alb-sg",
+        vpc_id=vpc_id,
+        description="Cerebro ALB ingress",
+        ingress=alb_ingress,
         egress=[
             aws.ec2.SecurityGroupEgressArgs(
                 protocol="-1",
@@ -93,7 +325,7 @@ def deploy(config: CerebroRuntimeConfig) -> None:
     )
     app_sg = aws.ec2.SecurityGroup(
         f"{config.name}-app-sg",
-        vpc_id=vpc.id,
+        vpc_id=vpc_id,
         description="Cerebro ECS task ingress",
         ingress=[
             aws.ec2.SecurityGroupIngressArgs(
@@ -114,157 +346,77 @@ def deploy(config: CerebroRuntimeConfig) -> None:
         tags={"Name": f"{config.name}-app-sg"},
         opts=opts,
     )
+    return alb_sg, app_sg
 
-    cluster = aws.ecs.Cluster(
-        f"{config.name}-cluster",
-        name=_aws_name(config.name, "cluster", 255),
-        settings=[aws.ecs.ClusterSettingArgs(name="containerInsights", value="enabled")],
-        tags={"Name": f"{config.name}-cluster"},
-        opts=opts,
-    )
-    log_group = aws.cloudwatch.LogGroup(
-        f"{config.name}-logs",
-        name=f"/ecs/{config.name}",
-        retention_in_days=30,
-        opts=opts,
-    )
-    execution_role = aws.iam.Role(
-        f"{config.name}-execution-role",
-        name=_aws_name(config.name, "execution-role", 64),
-        assume_role_policy=json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-                        "Action": "sts:AssumeRole",
-                    }
-                ],
-            }
-        ),
-        opts=opts,
-    )
-    execution_policy_attachment = aws.iam.RolePolicyAttachment(
-        f"{config.name}-execution-policy",
-        role=execution_role.name,
-        policy_arn="arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
-        opts=opts,
-    )
-    task_role = aws.iam.Role(
-        f"{config.name}-task-role",
-        name=_aws_name(config.name, "task-role", 64),
-        assume_role_policy=execution_role.assume_role_policy,
-        opts=opts,
-    )
 
-    secret_refs = _create_secrets(config.name, config.secret_env(), opts)
-    if secret_refs:
-        aws.iam.RolePolicy(
-            f"{config.name}-execution-secrets",
-            role=execution_role.id,
-            policy=pulumi.Output.json_dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Action": ["secretsmanager:GetSecretValue"],
-                            "Resource": [secret["arn"] for secret in secret_refs],
-                        }
-                    ],
-                }
-            ),
+def _create_listeners(
+    config: CerebroRuntimeConfig,
+    load_balancer_arn: pulumi.Input[str],
+    target_group_arn: pulumi.Input[str],
+    opts: pulumi.ResourceOptions,
+) -> list[pulumi.Resource]:
+    listeners: list[pulumi.Resource] = []
+    if config.aws_certificate_arn:
+        https_listener = aws.lb.Listener(
+            f"{config.name}-https",
+            load_balancer_arn=load_balancer_arn,
+            port=443,
+            protocol="HTTPS",
+            certificate_arn=config.aws_certificate_arn,
+            ssl_policy="ELBSecurityPolicy-TLS13-1-2-2021-06",
+            default_actions=[
+                aws.lb.ListenerDefaultActionArgs(
+                    type="forward",
+                    target_group_arn=target_group_arn,
+                )
+            ],
             opts=opts,
         )
-
-    container_definition = _container_definition(config, log_group.name, secret_refs)
-    task_definition = aws.ecs.TaskDefinition(
-        f"{config.name}-task",
-        family=config.name,
-        cpu=aws_cpu_units(config.cpu),
-        memory=str(config.memory_mib),
-        network_mode="awsvpc",
-        requires_compatibilities=["FARGATE"],
-        execution_role_arn=execution_role.arn,
-        task_role_arn=task_role.arn,
-        container_definitions=pulumi.Output.json_dumps([container_definition]),
-        opts=pulumi.ResourceOptions(provider=provider, depends_on=[execution_policy_attachment]),
-    )
-
-    load_balancer = aws.lb.LoadBalancer(
-        f"{config.name}-alb",
-        name=_aws_name(config.name, "alb", 32),
-        load_balancer_type="application",
-        security_groups=[alb_sg.id],
-        subnets=[subnet.id for subnet in subnets],
-        tags={"Name": f"{config.name}-alb"},
-        opts=opts,
-    )
-    target_group = aws.lb.TargetGroup(
-        f"{config.name}-tg",
-        name=_aws_name(config.name, "tg", 32),
-        port=config.container_port,
-        protocol="HTTP",
-        target_type="ip",
-        vpc_id=vpc.id,
-        health_check=aws.lb.TargetGroupHealthCheckArgs(
-            path="/health",
-            matcher="200-399",
-            interval=30,
-            timeout=5,
-            healthy_threshold=2,
-            unhealthy_threshold=3,
-        ),
-        tags={"Name": f"{config.name}-tg"},
-        opts=opts,
-    )
-    listener = aws.lb.Listener(
-        f"{config.name}-http",
-        load_balancer_arn=load_balancer.arn,
-        port=80,
-        protocol="HTTP",
-        default_actions=[
-            aws.lb.ListenerDefaultActionArgs(
-                type="forward",
-                target_group_arn=target_group.arn,
+        listeners.append(https_listener)
+        if config.aws_redirect_http_to_https:
+            listeners.append(
+                aws.lb.Listener(
+                    f"{config.name}-http-redirect",
+                    load_balancer_arn=load_balancer_arn,
+                    port=80,
+                    protocol="HTTP",
+                    default_actions=[
+                        aws.lb.ListenerDefaultActionArgs(
+                            type="redirect",
+                            redirect=aws.lb.ListenerDefaultActionRedirectArgs(
+                                port="443",
+                                protocol="HTTPS",
+                                status_code="HTTP_301",
+                            ),
+                        )
+                    ],
+                    opts=opts,
+                )
             )
-        ],
-        opts=opts,
-    )
-    service = aws.ecs.Service(
-        f"{config.name}-api",
-        name=_aws_name(config.name, "api", 255),
-        cluster=cluster.id,
-        desired_count=max(config.min_replicas, 1),
-        launch_type="FARGATE",
-        task_definition=task_definition.arn,
-        network_configuration=aws.ecs.ServiceNetworkConfigurationArgs(
-            subnets=[subnet.id for subnet in subnets],
-            security_groups=[app_sg.id],
-            assign_public_ip=config.aws_assign_public_ip,
-        ),
-        load_balancers=[
-            aws.ecs.ServiceLoadBalancerArgs(
-                target_group_arn=target_group.arn,
-                container_name="cerebro",
-                container_port=config.container_port,
-            )
-        ],
-        deployment_circuit_breaker=aws.ecs.ServiceDeploymentCircuitBreakerArgs(enable=True, rollback=True),
-        opts=pulumi.ResourceOptions(provider=provider, depends_on=[listener]),
-    )
+        return listeners
 
-    pulumi.export("cloud", "aws")
-    pulumi.export("service_name", service.name)
-    pulumi.export("cluster_name", cluster.name)
-    pulumi.export("url", pulumi.Output.concat("http://", load_balancer.dns_name))
+    listeners.append(
+        aws.lb.Listener(
+            f"{config.name}-http",
+            load_balancer_arn=load_balancer_arn,
+            port=80,
+            protocol="HTTP",
+            default_actions=[
+                aws.lb.ListenerDefaultActionArgs(
+                    type="forward",
+                    target_group_arn=target_group_arn,
+                )
+            ],
+            opts=opts,
+        )
+    )
+    return listeners
 
 
 def _create_secrets(name: str, secrets: list[SecretEnv], opts: pulumi.ResourceOptions) -> list[dict[str, pulumi.Input[str]]]:
     refs = []
     for secret in secrets:
-        resource_name = f"{name}-{secret.name.lower().replace('_', '-')}"
+        resource_name = f"{name}-{normalized_secret_name(secret.name)}"
         secret_resource = aws.secretsmanager.Secret(
             resource_name,
             name=f"{name}/{secret.name}",
@@ -278,6 +430,108 @@ def _create_secrets(name: str, secrets: list[SecretEnv], opts: pulumi.ResourceOp
         )
         refs.append({"name": secret.name, "arn": secret_resource.arn})
     return refs
+
+
+def _existing_aws_secret_refs(secrets: list[ExistingSecretRef]) -> list[dict[str, pulumi.Input[str]]]:
+    refs = []
+    for secret in secrets:
+        if not secret.aws_arn:
+            raise ValueError(f"cerebro:existingSecretRefs.{secret.name}.awsArn is required for AWS")
+        refs.append({"name": secret.name, "arn": secret.aws_arn})
+    return refs
+
+
+def _create_schedules(
+    config: CerebroRuntimeConfig,
+    cluster_arn: pulumi.Input[str],
+    task_definition_arn: pulumi.Input[str],
+    execution_role_arn: pulumi.Input[str],
+    task_role_arn: pulumi.Input[str],
+    subnet_ids: list[pulumi.Input[str]],
+    security_group_ids: list[pulumi.Input[str]],
+    opts: pulumi.ResourceOptions,
+) -> list[pulumi.Input[str]]:
+    if not config.scheduled_jobs:
+        return []
+
+    schedule_role = aws.iam.Role(
+        f"{config.name}-scheduler-role",
+        name=_aws_name(config.name, "scheduler-role", 64),
+        assume_role_policy=_assume_role_policy("scheduler.amazonaws.com"),
+        opts=opts,
+    )
+    run_task_policy = aws.iam.RolePolicy(
+        f"{config.name}-scheduler-run-task",
+        role=schedule_role.id,
+        policy=pulumi.Output.json_dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["ecs:RunTask"],
+                        "Resource": task_definition_arn,
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": ["iam:PassRole"],
+                        "Resource": [execution_role_arn, task_role_arn],
+                    },
+                ],
+            }
+        ),
+        opts=opts,
+    )
+    schedule_opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(depends_on=[run_task_policy]))
+
+    schedules = []
+    for job in config.scheduled_jobs:
+        schedule = aws.scheduler.Schedule(
+            f"{config.name}-{job.name}-schedule",
+            name=_aws_name(config.name, f"{job.name}-schedule", 64),
+            description=job.description or f"Cerebro scheduled job {job.name}",
+            schedule_expression=job.schedule,
+            schedule_expression_timezone=job.time_zone,
+            state="ENABLED" if job.enabled else "DISABLED",
+            flexible_time_window=aws.scheduler.ScheduleFlexibleTimeWindowArgs(mode="OFF"),
+            target=aws.scheduler.ScheduleTargetArgs(
+                arn=cluster_arn,
+                role_arn=schedule_role.arn,
+                input=_ecs_schedule_input(job),
+                ecs_parameters=aws.scheduler.ScheduleTargetEcsParametersArgs(
+                    task_definition_arn=task_definition_arn,
+                    launch_type="FARGATE",
+                    task_count=1,
+                    network_configuration=aws.scheduler.ScheduleTargetEcsParametersNetworkConfigurationArgs(
+                        subnets=subnet_ids,
+                        security_groups=security_group_ids,
+                        assign_public_ip=config.aws_assign_public_ip if not config.aws_enable_private_subnets else False,
+                    ),
+                ),
+            ),
+            opts=schedule_opts,
+        )
+        schedules.append(schedule.name)
+    return schedules
+
+
+def _ecs_schedule_input(job: ScheduledJob) -> pulumi.Output[str]:
+    return pulumi.Output.json_dumps({"containerOverrides": [{"name": "cerebro", "command": job.command}]})
+
+
+def _assume_role_policy(service_principal: str) -> str:
+    return json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": service_principal},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    )
 
 
 def _aws_name(prefix: str, suffix: str, max_length: int) -> str:

--- a/deploy/pulumi/azure_stack.py
+++ b/deploy/pulumi/azure_stack.py
@@ -3,89 +3,193 @@ from __future__ import annotations
 import pulumi
 import pulumi_azure_native as azure
 
-from runtime import CerebroRuntimeConfig, SecretEnv, normalized_secret_name
+from runtime import CerebroRuntimeConfig, ExistingSecretRef, SecretEnv, ScheduledJob, normalized_secret_name
 
 
-def deploy(config: CerebroRuntimeConfig) -> None:
-    provider = azure.Provider("azure-provider")
-    opts = pulumi.ResourceOptions(provider=provider)
+class AzureCerebroService(pulumi.ComponentResource):
+    def __init__(
+        self,
+        name: str,
+        config: CerebroRuntimeConfig,
+        opts: pulumi.ResourceOptions | None = None,
+    ) -> None:
+        super().__init__("cerebro:cloud:AzureService", name, None, opts)
+        provider = azure.Provider(f"{name}-azure-provider", opts=pulumi.ResourceOptions(parent=self))
+        child_opts = pulumi.ResourceOptions(provider=provider, parent=self)
 
-    resource_group = azure.resources.ResourceGroup(
-        f"{config.name}-rg",
-        resource_group_name=config.azure_resource_group_name,
-        location=config.azure_location,
-        opts=opts,
-    )
-    environment = azure.app.ManagedEnvironment(
-        f"{config.name}-env",
-        environment_name=f"{config.name}-env",
-        resource_group_name=resource_group.name,
-        location=resource_group.location,
-        opts=opts,
-    )
+        resource_group = azure.resources.ResourceGroup(
+            f"{config.name}-rg",
+            resource_group_name=config.azure_resource_group_name,
+            location=config.azure_location,
+            opts=child_opts,
+        )
+        environment = azure.app.ManagedEnvironment(
+            f"{config.name}-env",
+            environment_name=f"{config.name}-env",
+            resource_group_name=resource_group.name,
+            location=resource_group.location,
+            opts=child_opts,
+        )
 
-    secrets = _container_app_secrets(config.secret_env())
-    container_app = azure.app.ContainerApp(
-        f"{config.name}-app",
-        container_app_name=config.name,
-        resource_group_name=resource_group.name,
-        location=resource_group.location,
-        managed_environment_id=environment.id,
-        configuration=azure.app.ConfigurationArgs(
-            ingress=azure.app.IngressArgs(
-                external=config.azure_external_ingress,
-                target_port=config.container_port,
-                transport="auto",
+        secret_refs = _container_app_secret_refs(config)
+        identity = _managed_identity(config)
+        container_app = azure.app.ContainerApp(
+            f"{config.name}-app",
+            container_app_name=config.name,
+            resource_group_name=resource_group.name,
+            location=resource_group.location,
+            managed_environment_id=environment.id,
+            identity=identity,
+            configuration=azure.app.ConfigurationArgs(
+                ingress=azure.app.IngressArgs(
+                    external=config.azure_external_ingress,
+                    target_port=config.container_port,
+                    transport="auto",
+                ),
+                secrets=_container_app_secrets(config),
             ),
-            secrets=secrets,
-        ),
-        template=azure.app.TemplateArgs(
-            containers=[
-                azure.app.ContainerArgs(
-                    name="cerebro",
-                    image=config.image,
-                    args=["serve"],
-                    env=_plain_env(config) + _secret_env(config.secret_env()),
-                    resources=azure.app.ContainerResourcesArgs(
-                        cpu=config.cpu,
-                        memory=f"{config.memory_mib / 1024:g}Gi",
-                    ),
-                    probes=[
-                        azure.app.ContainerAppProbeArgs(
-                            type="Liveness",
-                            http_get=azure.app.ContainerAppProbeHttpGetArgs(
-                                path="/livez",
-                                port=config.container_port,
-                            ),
-                            period_seconds=30,
-                            timeout_seconds=5,
-                            failure_threshold=3,
-                        )
-                    ],
-                )
-            ],
-            scale=azure.app.ScaleArgs(
-                min_replicas=config.min_replicas,
-                max_replicas=config.max_replicas,
+            template=azure.app.TemplateArgs(
+                containers=[
+                    azure.app.ContainerArgs(
+                        name="cerebro",
+                        image=config.image,
+                        args=["serve"],
+                        env=_plain_env(config) + _secret_env(secret_refs),
+                        resources=azure.app.ContainerResourcesArgs(
+                            cpu=config.cpu,
+                            memory=f"{config.memory_mib / 1024:g}Gi",
+                        ),
+                        probes=[
+                            azure.app.ContainerAppProbeArgs(
+                                type="Liveness",
+                                http_get=azure.app.ContainerAppProbeHttpGetArgs(
+                                    path="/livez",
+                                    port=config.container_port,
+                                ),
+                                period_seconds=30,
+                                timeout_seconds=5,
+                                failure_threshold=3,
+                            )
+                        ],
+                    )
+                ],
+                scale=azure.app.ScaleArgs(
+                    min_replicas=config.min_replicas,
+                    max_replicas=config.max_replicas,
+                ),
             ),
-        ),
-        opts=opts,
-    )
+            opts=child_opts,
+        )
 
-    pulumi.export("cloud", "azure")
-    pulumi.export("resource_group_name", resource_group.name)
-    pulumi.export("service_name", container_app.name)
-    pulumi.export("url", container_app.configuration.apply(lambda cfg: f"https://{cfg.ingress.fqdn}" if cfg and cfg.ingress and cfg.ingress.fqdn else ""))
+        job_names = _create_jobs(config, environment.id, resource_group, identity, secret_refs, child_opts)
+
+        self.outputs = {
+            "cloud": "azure",
+            "resource_group_name": resource_group.name,
+            "service_name": container_app.name,
+            "url": container_app.configuration.apply(
+                lambda cfg: f"https://{cfg.ingress.fqdn}" if cfg and cfg.ingress and cfg.ingress.fqdn else ""
+            ),
+            "job_names": job_names,
+        }
+        self.register_outputs(self.outputs)
 
 
-def _container_app_secrets(secrets: list[SecretEnv]) -> list[azure.app.SecretArgs]:
-    return [
+def deploy(config: CerebroRuntimeConfig) -> AzureCerebroService:
+    service = AzureCerebroService(config.name, config)
+    for key, value in service.outputs.items():
+        pulumi.export(key, value)
+    return service
+
+
+def _container_app_secret_refs(config: CerebroRuntimeConfig) -> list[dict[str, str]]:
+    refs = []
+    refs.extend({"env": secret.name, "secret": normalized_secret_name(secret.name)} for secret in config.created_secret_env())
+    for secret in config.existing_secret_refs:
+        if secret.azure_key_vault_url:
+            refs.append({"env": secret.name, "secret": secret.azure_secret_name or normalized_secret_name(secret.name)})
+        elif secret.azure_secret_name:
+            refs.append({"env": secret.name, "secret": secret.azure_secret_name})
+        else:
+            raise ValueError(
+                f"cerebro:existingSecretRefs.{secret.name}.azureKeyVaultUrl or azureSecretName is required for Azure"
+            )
+    return refs
+
+
+def _container_app_secrets(config: CerebroRuntimeConfig) -> list[azure.app.SecretArgs]:
+    secrets = [
         azure.app.SecretArgs(
             name=normalized_secret_name(secret.name),
             value=secret.value,
         )
-        for secret in secrets
+        for secret in config.created_secret_env()
     ]
+    for secret in config.existing_secret_refs:
+        if secret.azure_key_vault_url:
+            secrets.append(
+                azure.app.SecretArgs(
+                    name=secret.azure_secret_name or normalized_secret_name(secret.name),
+                    key_vault_url=secret.azure_key_vault_url,
+                    identity="system",
+                )
+            )
+    return secrets
+
+
+def _create_jobs(
+    config: CerebroRuntimeConfig,
+    environment_id: pulumi.Input[str],
+    resource_group: azure.resources.ResourceGroup,
+    identity: azure.app.ManagedServiceIdentityArgs | None,
+    secret_refs: list[dict[str, str]],
+    opts: pulumi.ResourceOptions,
+) -> list[pulumi.Input[str]]:
+    job_names: list[pulumi.Input[str]] = []
+    for job in config.scheduled_jobs:
+        container_job = azure.app.Job(
+            f"{config.name}-{job.name}-job",
+            job_name=f"{config.name}-{job.name}",
+            resource_group_name=resource_group.name,
+            location=resource_group.location,
+            environment_id=environment_id,
+            identity=identity,
+            configuration=azure.app.JobConfigurationArgs(
+                trigger_type="Schedule",
+                replica_timeout=job.timeout_seconds,
+                replica_retry_limit=job.retry_limit,
+                schedule_trigger_config=azure.app.JobConfigurationScheduleTriggerConfigArgs(
+                    cron_expression=job.schedule,
+                    parallelism=1,
+                    replica_completion_count=1,
+                ),
+                secrets=_container_app_secrets(config),
+            ),
+            template=azure.app.JobTemplateArgs(
+                containers=[
+                    azure.app.ContainerArgs(
+                        name="cerebro",
+                        image=config.image,
+                        args=job.command,
+                        env=_plain_env(config) + _secret_env(secret_refs),
+                        resources=azure.app.ContainerResourcesArgs(
+                            cpu=job.cpu or config.cpu,
+                            memory=f"{(job.memory_mib or config.memory_mib) / 1024:g}Gi",
+                        ),
+                    )
+                ],
+            ),
+            opts=opts,
+        )
+        job_names.append(container_job.name)
+    return job_names
+
+
+def _managed_identity(config: CerebroRuntimeConfig) -> azure.app.ManagedServiceIdentityArgs | None:
+    if not (config.azure_enable_system_identity or config.uses_azure_key_vault_refs()):
+        return None
+    return azure.app.ManagedServiceIdentityArgs(type="SystemAssigned")
+
 
 def _plain_env(config: CerebroRuntimeConfig) -> list[azure.app.EnvironmentVarArgs]:
     return [
@@ -94,11 +198,11 @@ def _plain_env(config: CerebroRuntimeConfig) -> list[azure.app.EnvironmentVarArg
     ]
 
 
-def _secret_env(secrets: list[SecretEnv]) -> list[azure.app.EnvironmentVarArgs]:
+def _secret_env(secrets: list[dict[str, str]]) -> list[azure.app.EnvironmentVarArgs]:
     return [
         azure.app.EnvironmentVarArgs(
-            name=secret.name,
-            secret_ref=normalized_secret_name(secret.name),
+            name=secret["env"],
+            secret_ref=secret["secret"],
         )
         for secret in secrets
     ]

--- a/deploy/pulumi/components.py
+++ b/deploy/pulumi/components.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pulumi
+
+from runtime import CerebroRuntimeConfig
+
+
+class CerebroService(pulumi.ComponentResource):
+    def __init__(
+        self,
+        name: str,
+        config: CerebroRuntimeConfig,
+        opts: pulumi.ResourceOptions | None = None,
+    ) -> None:
+        super().__init__("cerebro:cloud:CerebroService", name, None, opts)
+        config.validate_guardrails()
+
+        child_opts = pulumi.ResourceOptions(parent=self)
+        if config.cloud == "aws":
+            from aws_stack import AwsCerebroService
+
+            backend = AwsCerebroService(name, config, opts=child_opts)
+        elif config.cloud == "gcp":
+            from gcp_stack import GcpCerebroService
+
+            backend = GcpCerebroService(name, config, opts=child_opts)
+        elif config.cloud == "azure":
+            from azure_stack import AzureCerebroService
+
+            backend = AzureCerebroService(name, config, opts=child_opts)
+        else:
+            raise ValueError("cerebro:cloud must be one of aws, gcp, or azure")
+
+        self.outputs = backend.outputs
+        self.register_outputs(dict(self.outputs))

--- a/deploy/pulumi/gcp_stack.py
+++ b/deploy/pulumi/gcp_stack.py
@@ -3,84 +3,109 @@ from __future__ import annotations
 import pulumi
 import pulumi_gcp as gcp
 
-from runtime import CerebroRuntimeConfig, SecretEnv, normalized_secret_name
+from runtime import CerebroRuntimeConfig, ExistingSecretRef, SecretEnv, ScheduledJob, normalized_secret_name
 
 
-def deploy(config: CerebroRuntimeConfig) -> None:
-    if not config.gcp_project:
-        raise ValueError("cerebro:gcpProject is required for GCP deployments")
+class GcpCerebroService(pulumi.ComponentResource):
+    def __init__(
+        self,
+        name: str,
+        config: CerebroRuntimeConfig,
+        opts: pulumi.ResourceOptions | None = None,
+    ) -> None:
+        super().__init__("cerebro:cloud:GcpService", name, None, opts)
+        if not config.gcp_project:
+            raise ValueError("cerebro:gcpProject is required for GCP deployments")
 
-    provider = gcp.Provider(
-        "gcp-provider",
-        project=config.gcp_project,
-        region=config.gcp_region,
-    )
-    opts = pulumi.ResourceOptions(provider=provider)
+        provider = gcp.Provider(
+            f"{name}-gcp-provider",
+            project=config.gcp_project,
+            region=config.gcp_region,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+        child_opts = pulumi.ResourceOptions(provider=provider, parent=self)
 
-    secret_refs = _create_secrets(config.name, config.secret_env(), opts)
-    service = gcp.cloudrunv2.Service(
-        f"{config.name}-service",
-        name=config.name,
-        location=config.gcp_region,
-        ingress=config.gcp_ingress,
-        template=gcp.cloudrunv2.ServiceTemplateArgs(
-            scaling=gcp.cloudrunv2.ServiceTemplateScalingArgs(
-                min_instance_count=config.min_replicas,
-                max_instance_count=config.max_replicas,
+        created_secret_refs = _create_secrets(config.name, config.created_secret_env(), child_opts)
+        secret_refs = created_secret_refs + _existing_gcp_secret_refs(config.existing_secret_refs)
+        service = gcp.cloudrunv2.Service(
+            f"{config.name}-service",
+            name=config.name,
+            location=config.gcp_region,
+            ingress=config.gcp_ingress,
+            template=gcp.cloudrunv2.ServiceTemplateArgs(
+                scaling=gcp.cloudrunv2.ServiceTemplateScalingArgs(
+                    min_instance_count=config.min_replicas,
+                    max_instance_count=config.max_replicas,
+                ),
+                service_account=config.gcp_service_account_email or None,
+                vpc_access=_service_vpc_access(config),
+                containers=[
+                    gcp.cloudrunv2.ServiceTemplateContainerArgs(
+                        image=config.image,
+                        commands=["/usr/local/bin/cerebro"],
+                        args=["serve"],
+                        ports=gcp.cloudrunv2.ServiceTemplateContainerPortsArgs(
+                            container_port=config.container_port,
+                        ),
+                        envs=_service_plain_env(config) + _service_secret_env(secret_refs),
+                        resources=gcp.cloudrunv2.ServiceTemplateContainerResourcesArgs(
+                            limits={
+                                "cpu": str(config.cpu),
+                                "memory": f"{config.memory_mib}Mi",
+                            },
+                        ),
+                        startup_probe=gcp.cloudrunv2.ServiceTemplateContainerStartupProbeArgs(
+                            http_get=gcp.cloudrunv2.ServiceTemplateContainerStartupProbeHttpGetArgs(
+                                path="/livez",
+                                port=config.container_port,
+                            ),
+                            initial_delay_seconds=10,
+                            timeout_seconds=5,
+                            period_seconds=10,
+                            failure_threshold=12,
+                        ),
+                        liveness_probe=gcp.cloudrunv2.ServiceTemplateContainerLivenessProbeArgs(
+                            http_get=gcp.cloudrunv2.ServiceTemplateContainerLivenessProbeHttpGetArgs(
+                                path="/livez",
+                                port=config.container_port,
+                            ),
+                            timeout_seconds=5,
+                            period_seconds=30,
+                            failure_threshold=3,
+                        ),
+                    )
+                ],
             ),
-            containers=[
-                gcp.cloudrunv2.ServiceTemplateContainerArgs(
-                    image=config.image,
-                    commands=["/usr/local/bin/cerebro"],
-                    args=["serve"],
-                    ports=gcp.cloudrunv2.ServiceTemplateContainerPortsArgs(
-                        container_port=config.container_port,
-                    ),
-                    envs=_plain_env(config) + _secret_env(secret_refs),
-                    resources=gcp.cloudrunv2.ServiceTemplateContainerResourcesArgs(
-                        limits={
-                            "cpu": str(config.cpu),
-                            "memory": f"{config.memory_mib}Mi",
-                        },
-                    ),
-                    startup_probe=gcp.cloudrunv2.ServiceTemplateContainerStartupProbeArgs(
-                        http_get=gcp.cloudrunv2.ServiceTemplateContainerStartupProbeHttpGetArgs(
-                            path="/livez",
-                            port=config.container_port,
-                        ),
-                        initial_delay_seconds=10,
-                        timeout_seconds=5,
-                        period_seconds=10,
-                        failure_threshold=12,
-                    ),
-                    liveness_probe=gcp.cloudrunv2.ServiceTemplateContainerLivenessProbeArgs(
-                        http_get=gcp.cloudrunv2.ServiceTemplateContainerLivenessProbeHttpGetArgs(
-                            path="/livez",
-                            port=config.container_port,
-                        ),
-                        timeout_seconds=5,
-                        period_seconds=30,
-                        failure_threshold=3,
-                    ),
-                )
-            ],
-        ),
-        opts=opts,
-    )
-
-    if config.gcp_allow_unauthenticated:
-        gcp.cloudrunv2.ServiceIamMember(
-            f"{config.name}-invoker",
-            name=service.name,
-            location=service.location,
-            role="roles/run.invoker",
-            member="allUsers",
-            opts=opts,
+            opts=child_opts,
         )
 
-    pulumi.export("cloud", "gcp")
-    pulumi.export("service_name", service.name)
-    pulumi.export("url", service.uri)
+        if config.gcp_allow_unauthenticated:
+            gcp.cloudrunv2.ServiceIamMember(
+                f"{config.name}-invoker",
+                name=service.name,
+                location=service.location,
+                role="roles/run.invoker",
+                member="allUsers",
+                opts=child_opts,
+            )
+
+        job_names, scheduler_names = _create_jobs(config, secret_refs, child_opts)
+
+        self.outputs = {
+            "cloud": "gcp",
+            "service_name": service.name,
+            "url": service.uri,
+            "job_names": job_names,
+            "scheduler_names": scheduler_names,
+        }
+        self.register_outputs(self.outputs)
+
+
+def deploy(config: CerebroRuntimeConfig) -> GcpCerebroService:
+    service = GcpCerebroService(config.name, config)
+    for key, value in service.outputs.items():
+        pulumi.export(key, value)
+    return service
 
 
 def _create_secrets(name: str, secrets: list[SecretEnv], opts: pulumi.ResourceOptions) -> list[dict[str, pulumi.Input[str]]]:
@@ -105,14 +130,88 @@ def _create_secrets(name: str, secrets: list[SecretEnv], opts: pulumi.ResourceOp
     return refs
 
 
-def _plain_env(config: CerebroRuntimeConfig) -> list[gcp.cloudrunv2.ServiceTemplateContainerEnvArgs]:
+def _existing_gcp_secret_refs(secrets: list[ExistingSecretRef]) -> list[dict[str, pulumi.Input[str]]]:
+    refs = []
+    for secret in secrets:
+        if not secret.gcp_secret:
+            raise ValueError(f"cerebro:existingSecretRefs.{secret.name}.gcpSecret is required for GCP")
+        refs.append({"name": secret.name, "secret": secret.gcp_secret, "version": secret.gcp_version})
+    return refs
+
+
+def _create_jobs(
+    config: CerebroRuntimeConfig,
+    secret_refs: list[dict[str, pulumi.Input[str]]],
+    opts: pulumi.ResourceOptions,
+) -> tuple[list[pulumi.Input[str]], list[pulumi.Input[str]]]:
+    job_names: list[pulumi.Input[str]] = []
+    scheduler_names: list[pulumi.Input[str]] = []
+    for job in config.scheduled_jobs:
+        job_name = _gcp_job_name(config, job)
+        job_resource = gcp.cloudrunv2.Job(
+            f"{config.name}-{job.name}-job",
+            name=job_name,
+            location=config.gcp_region,
+            project=config.gcp_project,
+            template=gcp.cloudrunv2.JobTemplateArgs(
+                task_count=1,
+                parallelism=1,
+                template=gcp.cloudrunv2.JobTemplateTemplateArgs(
+                    service_account=config.gcp_service_account_email or None,
+                    timeout=f"{job.timeout_seconds}s",
+                    max_retries=job.retry_limit,
+                    vpc_access=_job_vpc_access(config),
+                    containers=[
+                        gcp.cloudrunv2.JobTemplateTemplateContainerArgs(
+                            image=config.image,
+                            commands=["/usr/local/bin/cerebro"],
+                            args=job.command,
+                            envs=_job_plain_env(config) + _job_secret_env(secret_refs),
+                            resources=gcp.cloudrunv2.JobTemplateTemplateContainerResourcesArgs(
+                                limits={
+                                    "cpu": str(job.cpu or config.cpu),
+                                    "memory": f"{job.memory_mib or config.memory_mib}Mi",
+                                },
+                            ),
+                        )
+                    ],
+                ),
+            ),
+            opts=opts,
+        )
+        job_names.append(job_resource.name)
+        if config.gcp_scheduler_service_account_email:
+            scheduler = gcp.cloudscheduler.Job(
+                f"{config.name}-{job.name}-scheduler",
+                name=f"projects/{config.gcp_project}/locations/{config.gcp_region}/jobs/{job_name}",
+                project=config.gcp_project,
+                region=config.gcp_region,
+                schedule=job.schedule,
+                time_zone=job.time_zone,
+                paused=not job.enabled,
+                description=job.description or f"Cerebro scheduled job {job.name}",
+                http_target=gcp.cloudscheduler.JobHttpTargetArgs(
+                    uri=_cloud_run_job_run_uri(config, job_name),
+                    http_method="POST",
+                    oauth_token=gcp.cloudscheduler.JobHttpTargetOauthTokenArgs(
+                        service_account_email=config.gcp_scheduler_service_account_email,
+                        scope="https://www.googleapis.com/auth/cloud-platform",
+                    ),
+                ),
+                opts=opts,
+            )
+            scheduler_names.append(scheduler.name)
+    return job_names, scheduler_names
+
+
+def _service_plain_env(config: CerebroRuntimeConfig) -> list[gcp.cloudrunv2.ServiceTemplateContainerEnvArgs]:
     return [
         gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(name=key, value=value)
         for key, value in sorted(config.plain_env().items())
     ]
 
 
-def _secret_env(secret_refs: list[dict[str, pulumi.Input[str]]]) -> list[gcp.cloudrunv2.ServiceTemplateContainerEnvArgs]:
+def _service_secret_env(secret_refs: list[dict[str, pulumi.Input[str]]]) -> list[gcp.cloudrunv2.ServiceTemplateContainerEnvArgs]:
     return [
         gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
             name=ref["name"],
@@ -125,3 +224,54 @@ def _secret_env(secret_refs: list[dict[str, pulumi.Input[str]]]) -> list[gcp.clo
         )
         for ref in secret_refs
     ]
+
+
+def _job_plain_env(config: CerebroRuntimeConfig) -> list[gcp.cloudrunv2.JobTemplateTemplateContainerEnvArgs]:
+    return [
+        gcp.cloudrunv2.JobTemplateTemplateContainerEnvArgs(name=key, value=value)
+        for key, value in sorted(config.plain_env().items())
+    ]
+
+
+def _job_secret_env(secret_refs: list[dict[str, pulumi.Input[str]]]) -> list[gcp.cloudrunv2.JobTemplateTemplateContainerEnvArgs]:
+    return [
+        gcp.cloudrunv2.JobTemplateTemplateContainerEnvArgs(
+            name=ref["name"],
+            value_source=gcp.cloudrunv2.JobTemplateTemplateContainerEnvValueSourceArgs(
+                secret_key_ref=gcp.cloudrunv2.JobTemplateTemplateContainerEnvValueSourceSecretKeyRefArgs(
+                    secret=ref["secret"],
+                    version=ref["version"],
+                )
+            ),
+        )
+        for ref in secret_refs
+    ]
+
+
+def _service_vpc_access(config: CerebroRuntimeConfig) -> gcp.cloudrunv2.ServiceTemplateVpcAccessArgs | None:
+    if not config.gcp_vpc_connector:
+        return None
+    return gcp.cloudrunv2.ServiceTemplateVpcAccessArgs(
+        connector=config.gcp_vpc_connector,
+        egress="PRIVATE_RANGES_ONLY",
+    )
+
+
+def _job_vpc_access(config: CerebroRuntimeConfig) -> gcp.cloudrunv2.JobTemplateTemplateVpcAccessArgs | None:
+    if not config.gcp_vpc_connector:
+        return None
+    return gcp.cloudrunv2.JobTemplateTemplateVpcAccessArgs(
+        connector=config.gcp_vpc_connector,
+        egress="PRIVATE_RANGES_ONLY",
+    )
+
+
+def _gcp_job_name(config: CerebroRuntimeConfig, job: ScheduledJob) -> str:
+    return f"{config.name}-{job.name}"
+
+
+def _cloud_run_job_run_uri(config: CerebroRuntimeConfig, job_name: str) -> str:
+    return (
+        f"https://{config.gcp_region}-run.googleapis.com/apis/run.googleapis.com/v1/"
+        f"namespaces/{config.gcp_project}/jobs/{job_name}:run"
+    )

--- a/deploy/pulumi/runtime.py
+++ b/deploy/pulumi/runtime.py
@@ -2,18 +2,43 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import re
-from typing import Mapping
+from typing import Any, Mapping
 
 import pulumi
 
 
 _NAME_RE = re.compile(r"[^a-z0-9-]+")
+_OPEN_CIDRS = {"0.0.0.0/0", "::/0"}
 
 
 @dataclass(frozen=True)
 class SecretEnv:
     name: str
     value: pulumi.Output[str]
+
+
+@dataclass(frozen=True)
+class ExistingSecretRef:
+    name: str
+    aws_arn: str = ""
+    gcp_secret: str = ""
+    gcp_version: str = "latest"
+    azure_key_vault_url: str = ""
+    azure_secret_name: str = ""
+
+
+@dataclass(frozen=True)
+class ScheduledJob:
+    name: str
+    schedule: str
+    command: list[str]
+    time_zone: str = "UTC"
+    enabled: bool = True
+    description: str = ""
+    timeout_seconds: int = 900
+    retry_limit: int = 1
+    cpu: float | None = None
+    memory_mib: int | None = None
 
 
 @dataclass(frozen=True)
@@ -27,13 +52,20 @@ class CerebroRuntimeConfig:
     cpu: float
     memory_mib: int
     shutdown_timeout: str
+    deployment_profile: str
+    allow_unsafe_production: bool
+    unsafe_production_justification: str
+    edge_auth_managed: bool
     public_origin: str
     trusted_proxy_cidrs: str
     trusted_proxy_count: int
+    ingress_cidrs: list[str]
     api_auth_enabled: bool
     allowed_tenants: str
     extra_env: Mapping[str, str]
     extra_secrets: Mapping[str, pulumi.Output[str]]
+    existing_secret_refs: list[ExistingSecretRef]
+    scheduled_jobs: list[ScheduledJob]
     api_keys: pulumi.Output[str] | None
     api_credentials_json: pulumi.Output[str] | None
     postgres_dsn: pulumi.Output[str] | None
@@ -48,15 +80,25 @@ class CerebroRuntimeConfig:
     aws_availability_zones: list[str]
     aws_vpc_cidr: str
     aws_public_subnet_cidrs: list[str]
+    aws_private_subnet_cidrs: list[str]
     aws_assign_public_ip: bool
+    aws_enable_private_subnets: bool
+    aws_enable_nat_gateway: bool
+    aws_certificate_arn: str
+    aws_redirect_http_to_https: bool
+    aws_log_retention_days: int
     aws_skip_credentials_validation: bool
     gcp_project: str
     gcp_region: str
     gcp_ingress: str
     gcp_allow_unauthenticated: bool
+    gcp_service_account_email: str
+    gcp_scheduler_service_account_email: str
+    gcp_vpc_connector: str
     azure_location: str
     azure_resource_group_name: str
     azure_external_ingress: bool
+    azure_enable_system_identity: bool
 
     @classmethod
     def from_pulumi(cls) -> "CerebroRuntimeConfig":
@@ -88,6 +130,12 @@ class CerebroRuntimeConfig:
                     raise ValueError("cerebro:extraSecrets keys must be strings")
                 extra_secrets[key] = pulumi.Output.secret(value)
 
+        deployment_profile = (cfg.get("deploymentProfile") or "preview").strip().lower()
+        if deployment_profile not in {"preview", "production"}:
+            raise ValueError("cerebro:deploymentProfile must be preview or production")
+
+        ingress_cidrs = _string_list(cfg.get_object("ingressCidrs"), ["0.0.0.0/0"], "ingressCidrs")
+
         return cls(
             cloud=cloud,
             name=name,
@@ -98,13 +146,20 @@ class CerebroRuntimeConfig:
             cpu=cpu,
             memory_mib=memory_mib,
             shutdown_timeout=cfg.get("shutdownTimeout") or "10s",
+            deployment_profile=deployment_profile,
+            allow_unsafe_production=_config_bool(cfg, "allowUnsafeProduction", False),
+            unsafe_production_justification=cfg.get("unsafeProductionJustification") or "",
+            edge_auth_managed=_config_bool(cfg, "edgeAuthManaged", False),
             public_origin=cfg.get("publicOrigin") or "",
             trusted_proxy_cidrs=cfg.get("trustedProxyCIDRs") or "",
             trusted_proxy_count=_positive_int(cfg.get_int("trustedProxyCount"), 1, "trustedProxyCount", allow_zero=True),
+            ingress_cidrs=ingress_cidrs,
             api_auth_enabled=_config_bool(cfg, "apiAuthEnabled", True),
             allowed_tenants=cfg.get("allowedTenants") or "",
             extra_env=extra_env,
             extra_secrets=extra_secrets,
+            existing_secret_refs=_existing_secret_refs(cfg.get_object("existingSecretRefs")),
+            scheduled_jobs=_scheduled_jobs(cfg.get_object("scheduledJobs")),
             api_keys=cfg.get_secret("apiKeys"),
             api_credentials_json=cfg.get_secret("apiCredentialsJson"),
             postgres_dsn=cfg.get_secret("postgresDsn"),
@@ -116,18 +171,36 @@ class CerebroRuntimeConfig:
             connector_transit_private_key=cfg.get_secret("connectorTransitPrivateKey"),
             capability_token_secrets=cfg.get_secret("capabilityTokenSecrets"),
             aws_region=cfg.get("awsRegion") or "us-east-1",
-            aws_availability_zones=list(cfg.get_object("awsAvailabilityZones") or []),
+            aws_availability_zones=_string_list(cfg.get_object("awsAvailabilityZones"), [], "awsAvailabilityZones"),
             aws_vpc_cidr=cfg.get("awsVpcCidr") or "10.42.0.0/16",
-            aws_public_subnet_cidrs=list(cfg.get_object("awsPublicSubnetCidrs") or ["10.42.0.0/24", "10.42.1.0/24"]),
+            aws_public_subnet_cidrs=_string_list(
+                cfg.get_object("awsPublicSubnetCidrs"),
+                ["10.42.0.0/24", "10.42.1.0/24"],
+                "awsPublicSubnetCidrs",
+            ),
+            aws_private_subnet_cidrs=_string_list(
+                cfg.get_object("awsPrivateSubnetCidrs"),
+                ["10.42.100.0/24", "10.42.101.0/24"],
+                "awsPrivateSubnetCidrs",
+            ),
             aws_assign_public_ip=_config_bool(cfg, "awsAssignPublicIp", True),
+            aws_enable_private_subnets=_config_bool(cfg, "awsEnablePrivateSubnets", False),
+            aws_enable_nat_gateway=_config_bool(cfg, "awsEnableNatGateway", False),
+            aws_certificate_arn=cfg.get("awsCertificateArn") or "",
+            aws_redirect_http_to_https=_config_bool(cfg, "awsRedirectHttpToHttps", True),
+            aws_log_retention_days=_positive_int(cfg.get_int("awsLogRetentionDays"), 30, "awsLogRetentionDays"),
             aws_skip_credentials_validation=_config_bool(cfg, "awsSkipCredentialsValidation", True),
             gcp_project=cfg.get("gcpProject") or "",
             gcp_region=cfg.get("gcpRegion") or "us-central1",
             gcp_ingress=cfg.get("gcpIngress") or "INGRESS_TRAFFIC_ALL",
             gcp_allow_unauthenticated=_config_bool(cfg, "gcpAllowUnauthenticated", True),
+            gcp_service_account_email=cfg.get("gcpServiceAccountEmail") or "",
+            gcp_scheduler_service_account_email=cfg.get("gcpSchedulerServiceAccountEmail") or "",
+            gcp_vpc_connector=cfg.get("gcpVpcConnector") or "",
             azure_location=cfg.get("azureLocation") or "eastus",
             azure_resource_group_name=cfg.get("azureResourceGroupName") or f"{name}-rg",
             azure_external_ingress=_config_bool(cfg, "azureExternalIngress", True),
+            azure_enable_system_identity=_config_bool(cfg, "azureEnableSystemIdentity", False),
         )
 
     def plain_env(self) -> dict[str, pulumi.Input[str]]:
@@ -143,17 +216,17 @@ class CerebroRuntimeConfig:
             env["CEREBRO_TRUSTED_PROXY_CIDRS"] = self.trusted_proxy_cidrs
         if self.allowed_tenants:
             env["CEREBRO_ALLOWED_TENANTS"] = self.allowed_tenants
-        if self.postgres_dsn:
+        if self.has_secret("CEREBRO_POSTGRES_DSN"):
             env["CEREBRO_STATE_STORE_DRIVER"] = "postgres"
-        if self.jetstream_url:
+        if self.has_secret("CEREBRO_JETSTREAM_URL"):
             env["CEREBRO_APPEND_LOG_DRIVER"] = "jetstream"
             env["CEREBRO_JETSTREAM_SUBJECT_PREFIX"] = "events"
-        if self.neo4j_uri:
+        if self.has_secret("CEREBRO_NEO4J_URI"):
             env["CEREBRO_GRAPH_STORE_DRIVER"] = "neo4j"
         env.update(self.extra_env)
         return env
 
-    def secret_env(self) -> list[SecretEnv]:
+    def created_secret_env(self) -> list[SecretEnv]:
         pairs = [
             ("CEREBRO_API_KEYS", self.api_keys),
             ("CEREBRO_API_CREDENTIALS_JSON", self.api_credentials_json),
@@ -169,6 +242,73 @@ class CerebroRuntimeConfig:
         secrets = [SecretEnv(name, value) for name, value in pairs if value is not None]
         secrets.extend(SecretEnv(name, value) for name, value in self.extra_secrets.items())
         return secrets
+
+    def secret_env(self) -> list[SecretEnv]:
+        return self.created_secret_env()
+
+    def all_secret_names(self) -> set[str]:
+        return {secret.name for secret in self.created_secret_env()} | {ref.name for ref in self.existing_secret_refs}
+
+    def has_secret(self, name: str) -> bool:
+        return name in self.all_secret_names()
+
+    def validate_guardrails(self) -> None:
+        risks = self.production_risks()
+        if not risks:
+            return
+        if self.deployment_profile == "production":
+            if not self.allow_unsafe_production:
+                joined = "\n- ".join(risks)
+                raise ValueError(
+                    "unsafe production deployment config; either fix these settings or set "
+                    "cerebro:allowUnsafeProduction=true with cerebro:unsafeProductionJustification:\n- "
+                    f"{joined}"
+                )
+            if not self.unsafe_production_justification.strip():
+                raise ValueError(
+                    "cerebro:unsafeProductionJustification is required when "
+                    "cerebro:allowUnsafeProduction=true"
+                )
+            for risk in risks:
+                pulumi.log.warn(f"unsafe production override accepted: {risk}")
+            return
+        for risk in risks:
+            pulumi.log.warn(f"preview-only deployment risk: {risk}")
+
+    def production_risks(self) -> list[str]:
+        risks: list[str] = []
+        if not self.api_auth_enabled and not self.edge_auth_managed:
+            risks.append("API authentication is disabled and no authenticated edge is declared")
+        if _image_uses_latest(self.image):
+            risks.append("container image uses the mutable latest tag")
+        if self.public_origin and not self.public_origin.startswith("https://"):
+            risks.append("public origin is not HTTPS")
+        if self.public_ingress_enabled() and not self._public_ingress_has_access_decision():
+            risks.append("public ingress is enabled without API auth, edge auth, restricted CIDRs, or IAM-only access")
+        if self.cloud == "aws" and self.public_ingress_enabled() and not self.aws_certificate_arn and not self.edge_auth_managed:
+            risks.append("AWS public load balancer is HTTP-only without an ACM certificate or upstream edge declaration")
+        return risks
+
+    def public_ingress_enabled(self) -> bool:
+        if self.cloud == "aws":
+            return True
+        if self.cloud == "gcp":
+            return self.gcp_ingress == "INGRESS_TRAFFIC_ALL"
+        if self.cloud == "azure":
+            return self.azure_external_ingress
+        return False
+
+    def uses_azure_key_vault_refs(self) -> bool:
+        return any(ref.azure_key_vault_url for ref in self.existing_secret_refs)
+
+    def _public_ingress_has_access_decision(self) -> bool:
+        if self.api_auth_enabled or self.edge_auth_managed:
+            return True
+        if self.cloud == "gcp" and not self.gcp_allow_unauthenticated:
+            return True
+        if self.cloud == "aws" and self.ingress_cidrs and not set(self.ingress_cidrs).intersection(_OPEN_CIDRS):
+            return True
+        return False
 
 
 def normalized_secret_name(name: str) -> str:
@@ -200,3 +340,106 @@ def _slug(value: str) -> str:
 
 def _bool_env(value: bool) -> str:
     return "true" if value else "false"
+
+
+def _string_list(value: Any, default: list[str], key: str) -> list[str]:
+    if value is None:
+        return list(default)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"cerebro:{key} must be a list of strings")
+    return list(value)
+
+
+def _existing_secret_refs(value: Any) -> list[ExistingSecretRef]:
+    if value is None:
+        return []
+    if not isinstance(value, dict):
+        raise ValueError("cerebro:existingSecretRefs must be an object keyed by environment variable name")
+    refs: list[ExistingSecretRef] = []
+    for name, raw in value.items():
+        if not isinstance(name, str):
+            raise ValueError("cerebro:existingSecretRefs keys must be strings")
+        if not isinstance(raw, dict):
+            raise ValueError(f"cerebro:existingSecretRefs.{name} must be an object")
+        refs.append(
+            ExistingSecretRef(
+                name=name,
+                aws_arn=_optional_string(raw, "awsArn"),
+                gcp_secret=_optional_string(raw, "gcpSecret"),
+                gcp_version=_optional_string(raw, "gcpVersion") or "latest",
+                azure_key_vault_url=_optional_string(raw, "azureKeyVaultUrl"),
+                azure_secret_name=_optional_string(raw, "azureSecretName"),
+            )
+        )
+    return refs
+
+
+def _scheduled_jobs(value: Any) -> list[ScheduledJob]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("cerebro:scheduledJobs must be a list")
+    jobs: list[ScheduledJob] = []
+    for index, raw in enumerate(value):
+        if not isinstance(raw, dict):
+            raise ValueError(f"cerebro:scheduledJobs[{index}] must be an object")
+        name = _required_string(raw, "name", f"scheduledJobs[{index}]")
+        schedule = _required_string(raw, "schedule", f"scheduledJobs[{index}]")
+        command = raw.get("command")
+        if not isinstance(command, list) or not command or not all(isinstance(part, str) for part in command):
+            raise ValueError(f"cerebro:scheduledJobs[{index}].command must be a non-empty list of strings")
+        cpu = raw.get("cpu")
+        if cpu is not None and not isinstance(cpu, int | float):
+            raise ValueError(f"cerebro:scheduledJobs[{index}].cpu must be a number")
+        memory_mib = raw.get("memoryMiB")
+        if memory_mib is not None and not isinstance(memory_mib, int):
+            raise ValueError(f"cerebro:scheduledJobs[{index}].memoryMiB must be an integer")
+        jobs.append(
+            ScheduledJob(
+                name=_slug(name),
+                schedule=schedule,
+                command=list(command),
+                time_zone=_optional_string(raw, "timeZone") or "UTC",
+                enabled=bool(raw.get("enabled", True)),
+                description=_optional_string(raw, "description"),
+                timeout_seconds=_positive_int(_optional_int(raw, "timeoutSeconds"), 900, f"scheduledJobs[{index}].timeoutSeconds"),
+                retry_limit=_positive_int(_optional_int(raw, "retryLimit"), 1, f"scheduledJobs[{index}].retryLimit", allow_zero=True),
+                cpu=float(cpu) if cpu is not None else None,
+                memory_mib=memory_mib,
+            )
+        )
+    return jobs
+
+
+def _required_string(raw: Mapping[str, Any], key: str, path: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"cerebro:{path}.{key} must be a non-empty string")
+    return value
+
+
+def _optional_string(raw: Mapping[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string")
+    return value
+
+
+def _optional_int(raw: Mapping[str, Any], key: str) -> int | None:
+    value = raw.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def _image_uses_latest(image: str) -> bool:
+    last_path_part = image.rsplit("/", 1)[-1]
+    if "@" in last_path_part:
+        return False
+    if ":" not in last_path_part:
+        return True
+    return last_path_part.rsplit(":", 1)[-1] == "latest"

--- a/deploy/pulumi/tests/test_components.py
+++ b/deploy/pulumi/tests/test_components.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+import pulumi
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from aws_stack import _container_definition, _existing_aws_secret_refs
+from azure_stack import _container_app_secret_refs, _container_app_secrets, _managed_identity
+from gcp_stack import _cloud_run_job_run_uri, _existing_gcp_secret_refs
+from runtime import CerebroRuntimeConfig, ExistingSecretRef, ScheduledJob
+
+
+class RecordingMocks(pulumi.runtime.Mocks):
+    def __init__(self) -> None:
+        self.resources: list[pulumi.runtime.MockResourceArgs] = []
+
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs) -> tuple[str, dict[str, Any]]:
+        self.resources.append(args)
+        return f"{args.name}_id", dict(args.inputs)
+
+    def call(self, args: pulumi.runtime.MockCallArgs) -> tuple[dict[str, Any], None]:
+        return dict(args.args), None
+
+
+MOCKS = RecordingMocks()
+pulumi.runtime.set_mocks(MOCKS, project="cerebro-cloud-pulumi", stack="unit", preview=True)
+
+
+@pytest.fixture(autouse=True)
+def clear_mocks() -> None:
+    MOCKS.resources.clear()
+
+
+def test_production_guardrails_block_unsafe_public_config() -> None:
+    config = _config(
+        "aws",
+        deployment_profile="production",
+        image="ghcr.io/writer/cerebro:latest",
+        api_auth_enabled=False,
+        public_origin="http://cerebro.example.com",
+    )
+
+    with pytest.raises(ValueError, match="unsafe production deployment config"):
+        config.validate_guardrails()
+
+
+def test_production_guardrails_allow_documented_override() -> None:
+    config = _config(
+        "aws",
+        deployment_profile="production",
+        allow_unsafe_production=True,
+        unsafe_production_justification="temporary private preview behind a controlled edge",
+        image="ghcr.io/writer/cerebro:latest",
+        api_auth_enabled=False,
+        edge_auth_managed=True,
+    )
+
+    config.validate_guardrails()
+
+
+def test_aws_secret_refs_drive_state_store_env_without_copying_secret_values() -> None:
+    config = _config(
+        "aws",
+        existing_secret_refs=[
+            ExistingSecretRef(
+                name="CEREBRO_POSTGRES_DSN",
+                aws_arn="arn:aws:secretsmanager:us-east-1:111122223333:secret:cerebro/postgres",
+            )
+        ],
+        scheduled_jobs=[_scheduled_job()],
+    )
+
+    secret_refs = _existing_aws_secret_refs(config.existing_secret_refs)
+    container = _container_definition(config, "/ecs/unit-aws", secret_refs)
+
+    assert secret_refs == [
+        {
+            "name": "CEREBRO_POSTGRES_DSN",
+            "arn": "arn:aws:secretsmanager:us-east-1:111122223333:secret:cerebro/postgres",
+        }
+    ]
+    assert {"name": "CEREBRO_STATE_STORE_DRIVER", "value": "postgres"} in container["environment"]
+    assert container["secrets"] == [{"name": "CEREBRO_POSTGRES_DSN", "valueFrom": secret_refs[0]["arn"]}]
+
+
+def test_gcp_existing_secret_ref_and_scheduler_target_uri_are_stable() -> None:
+    config = _config(
+        "gcp",
+        existing_secret_refs=[
+            ExistingSecretRef(
+                name="CEREBRO_POSTGRES_DSN",
+                gcp_secret="projects/example-project/secrets/cerebro-postgres-dsn",
+                gcp_version="latest",
+            )
+        ],
+        scheduled_jobs=[_scheduled_job(schedule="*/15 * * * *")],
+    )
+
+    secret_refs = _existing_gcp_secret_refs(config.existing_secret_refs)
+    uri = _cloud_run_job_run_uri(config, "unit-gcp-sync-example")
+
+    assert secret_refs == [
+        {
+            "name": "CEREBRO_POSTGRES_DSN",
+            "secret": "projects/example-project/secrets/cerebro-postgres-dsn",
+            "version": "latest",
+        }
+    ]
+    assert uri == (
+        "https://us-central1-run.googleapis.com/apis/run.googleapis.com/v1/"
+        "namespaces/example-project/jobs/unit-gcp-sync-example:run"
+    )
+
+
+def test_azure_key_vault_secret_ref_enables_system_identity() -> None:
+    config = _config(
+        "azure",
+        existing_secret_refs=[
+            ExistingSecretRef(
+                name="CEREBRO_POSTGRES_DSN",
+                azure_secret_name="cerebro-postgres-dsn",
+                azure_key_vault_url="https://example-vault.vault.azure.net/secrets/cerebro-postgres-dsn",
+            )
+        ],
+        scheduled_jobs=[_scheduled_job(schedule="*/15 * * * *")],
+    )
+
+    secret_refs = _container_app_secret_refs(config)
+    secrets = _container_app_secrets(config)
+
+    assert secret_refs == [{"env": "CEREBRO_POSTGRES_DSN", "secret": "cerebro-postgres-dsn"}]
+    assert _managed_identity(config) is not None
+    assert len(secrets) == 1
+
+
+def _scheduled_job(schedule: str = "rate(15 minutes)") -> ScheduledJob:
+    return ScheduledJob(
+        name="sync-example",
+        schedule=schedule,
+        command=["source-runtime", "sync", "example-runtime", "page_limit=100"],
+    )
+
+
+def _config(cloud: str, **overrides: Any) -> CerebroRuntimeConfig:
+    values: dict[str, Any] = {
+        "cloud": cloud,
+        "name": f"unit-{cloud}",
+        "image": "ghcr.io/writer/cerebro:v2.1.475",
+        "container_port": 8080,
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "cpu": 1.0,
+        "memory_mib": 2048,
+        "shutdown_timeout": "10s",
+        "deployment_profile": "preview",
+        "allow_unsafe_production": False,
+        "unsafe_production_justification": "",
+        "edge_auth_managed": False,
+        "public_origin": "https://cerebro.example.com",
+        "trusted_proxy_cidrs": "",
+        "trusted_proxy_count": 1,
+        "ingress_cidrs": ["0.0.0.0/0"],
+        "api_auth_enabled": True,
+        "allowed_tenants": "",
+        "extra_env": {},
+        "extra_secrets": {},
+        "existing_secret_refs": [],
+        "scheduled_jobs": [],
+        "api_keys": None,
+        "api_credentials_json": None,
+        "postgres_dsn": None,
+        "jetstream_url": None,
+        "neo4j_uri": None,
+        "neo4j_username": None,
+        "neo4j_password": None,
+        "connector_credential_key": None,
+        "connector_transit_private_key": None,
+        "capability_token_secrets": None,
+        "aws_region": "us-east-1",
+        "aws_availability_zones": ["us-east-1a", "us-east-1b"],
+        "aws_vpc_cidr": "10.42.0.0/16",
+        "aws_public_subnet_cidrs": ["10.42.0.0/24", "10.42.1.0/24"],
+        "aws_private_subnet_cidrs": ["10.42.100.0/24", "10.42.101.0/24"],
+        "aws_assign_public_ip": True,
+        "aws_enable_private_subnets": False,
+        "aws_enable_nat_gateway": False,
+        "aws_certificate_arn": "",
+        "aws_redirect_http_to_https": True,
+        "aws_log_retention_days": 30,
+        "aws_skip_credentials_validation": True,
+        "gcp_project": "example-project",
+        "gcp_region": "us-central1",
+        "gcp_ingress": "INGRESS_TRAFFIC_ALL",
+        "gcp_allow_unauthenticated": False,
+        "gcp_service_account_email": "cerebro-runtime@example-project.iam.gserviceaccount.com",
+        "gcp_scheduler_service_account_email": "cerebro-scheduler@example-project.iam.gserviceaccount.com",
+        "gcp_vpc_connector": "",
+        "azure_location": "eastus",
+        "azure_resource_group_name": f"unit-{cloud}-rg",
+        "azure_external_ingress": True,
+        "azure_enable_system_identity": False,
+    }
+    values.update(overrides)
+    return CerebroRuntimeConfig(**values)

--- a/docs/CLOUD_DEPLOYMENT.md
+++ b/docs/CLOUD_DEPLOYMENT.md
@@ -33,17 +33,17 @@ The container runs:
 
 It listens on `:8080` by default. Use `/livez` for process liveness and `/health` for dependency-aware readiness.
 
-## Pulumi Templates
+## Pulumi Component Model
 
-The templates in [`deploy/pulumi`](../deploy/pulumi) use one shared configuration model and choose a cloud backend with `cerebro:cloud`:
+The templates in [`deploy/pulumi`](../deploy/pulumi) use one shared `CerebroService` component and choose a cloud backend with `cerebro:cloud`:
 
-| Cloud | Template target | What it creates |
+| Cloud | Component target | What it creates |
 | --- | --- | --- |
-| AWS | ECS Fargate plus Application Load Balancer | VPC, public subnets, ALB, ECS cluster, task definition, service, logs, IAM, and optional Secrets Manager entries |
-| GCP | Cloud Run v2 | Cloud Run service, optional public invoker binding, and optional Secret Manager entries |
-| Azure | Azure Container Apps | Resource group, Container Apps managed environment, Container App, ingress, and Container App secrets |
+| AWS | ECS Fargate plus Application Load Balancer | VPC, public subnets, optional private subnets/NAT, ALB, optional ACM HTTPS, ECS cluster, task definition, service, logs, IAM, optional Secrets Manager entries, and optional EventBridge Scheduler jobs |
+| GCP | Cloud Run v2 | Cloud Run service, optional service account, optional VPC connector, optional Secret Manager entries, optional Cloud Run Jobs, and optional Cloud Scheduler triggers |
+| Azure | Azure Container Apps | Resource group, Container Apps managed environment, Container App, optional system identity, Container App secrets, Key Vault-backed secret refs, and optional scheduled Container Apps Jobs |
 
-The templates do not create a private organization-specific control plane, source runtime schedules, DNS zones, certificates, Postgres clusters, NATS clusters, or Neo4j/Aura instances. They wire the API service to those dependencies when you provide their DSNs or URLs as Pulumi secrets.
+The templates do not create a private organization-specific control plane, source runtime rollout catalog, DNS zones, managed Postgres clusters, NATS clusters, or Neo4j/Aura instances. They wire the API service and job runners to those dependencies when you provide DSNs, URLs, or existing secret references.
 
 Install:
 
@@ -67,11 +67,36 @@ pulumi preview --stack gcp --refresh=false
 pulumi preview --stack azure --refresh=false
 ```
 
-The checked-in stacks are preview-only examples with `cerebro:apiAuthEnabled=false`. Do not deploy them to a shared environment as-is.
+If your workstation has no active provider auth, use dummy provider environment variables only for preview-only validation with `--refresh=false`; never use dummy credentials for deployment.
+
+The checked-in stacks are preview-only examples with `cerebro:deploymentProfile=preview` and `cerebro:apiAuthEnabled=false`. Do not deploy them to a shared environment as-is.
+
+## Production Guardrails
+
+Set production mode before any shared deployment:
+
+```bash
+pulumi config set cerebro:deploymentProfile production
+```
+
+Production mode fails preview/update when the stack has common unsafe settings:
+
+- API auth disabled without `cerebro:edgeAuthManaged=true`.
+- mutable `:latest` or untagged images.
+- non-HTTPS public origin.
+- public ingress without API auth, edge auth, restricted ingress CIDRs, or IAM-only access.
+- AWS public ALB without `cerebro:awsCertificateArn` or an upstream edge declaration.
+
+Temporary exceptions must be explicit and justified:
+
+```bash
+pulumi config set cerebro:allowUnsafeProduction true
+pulumi config set cerebro:unsafeProductionJustification '<why this is acceptable and time-bounded>'
+```
 
 ## Common Production Config
 
-Set a real image and enable auth before any shared deployment:
+Set a real image, enable auth or declare an authenticated edge, and set the public origin:
 
 ```bash
 pulumi config set cerebro:image ghcr.io/writer/cerebro:vX.Y.Z
@@ -82,10 +107,25 @@ pulumi config set cerebro:trustedProxyCount 1
 pulumi config set --secret cerebro:apiKeys '<random-key>:<principal>:<tenant-id>'
 ```
 
-Enable durable state:
+Enable durable state with a Pulumi-created cloud secret:
 
 ```bash
 pulumi config set --secret cerebro:postgresDsn '<postgres-dsn-with-tls>'
+```
+
+Or reference an existing provider-native secret instead:
+
+```bash
+pulumi config set --path 'cerebro:existingSecretRefs.CEREBRO_POSTGRES_DSN.awsArn' \
+  'arn:aws:secretsmanager:us-east-1:111122223333:secret:cerebro/postgres'
+
+pulumi config set --path 'cerebro:existingSecretRefs.CEREBRO_POSTGRES_DSN.gcpSecret' \
+  'projects/example-project/secrets/cerebro-postgres-dsn'
+
+pulumi config set --path 'cerebro:existingSecretRefs.CEREBRO_POSTGRES_DSN.azureSecretName' \
+  cerebro-postgres-dsn
+pulumi config set --path 'cerebro:existingSecretRefs.CEREBRO_POSTGRES_DSN.azureKeyVaultUrl' \
+  'https://example-vault.vault.azure.net/secrets/cerebro-postgres-dsn'
 ```
 
 Enable append-log-backed source sync and replay:
@@ -110,21 +150,16 @@ pulumi config set --secret cerebro:connectorTransitPrivateKey '<rsa-private-key-
 pulumi config set --secret cerebro:capabilityTokenSecrets '<hmac-secret-1>,<hmac-secret-2>'
 ```
 
-For any additional non-secret runtime variable, use:
+For Redis/Valkey or other optional dependency URLs:
 
 ```bash
 pulumi config set --path 'cerebro:extraEnv.CEREBRO_CACHE_MODE' redis
-```
-
-For any additional secret runtime variable, use:
-
-```bash
 pulumi config set --secret --path 'cerebro:extraSecrets.CEREBRO_CACHE_URL' '<redis-or-valkey-url>'
 ```
 
 ## AWS
 
-The AWS template deploys the Cerebro API on ECS Fargate behind an Application Load Balancer.
+The AWS component deploys the Cerebro API on ECS Fargate behind an Application Load Balancer.
 
 Example setup:
 
@@ -135,23 +170,25 @@ export PULUMI_CONFIG_PASSPHRASE="local-preview-only"
 
 pulumi stack select aws --create
 pulumi config set cerebro:cloud aws
+pulumi config set cerebro:deploymentProfile production
 pulumi config set cerebro:name cerebro-prod
 pulumi config set cerebro:awsRegion us-east-1
 pulumi config set --path 'cerebro:awsAvailabilityZones[0]' us-east-1a
 pulumi config set --path 'cerebro:awsAvailabilityZones[1]' us-east-1b
 pulumi config set cerebro:image '<account>.dkr.ecr.us-east-1.amazonaws.com/cerebro:vX.Y.Z'
+pulumi config set cerebro:awsCertificateArn '<acm-certificate-arn>'
 ```
 
 Recommended AWS hardening before `pulumi up`:
 
 - Mirror the public image to ECR or an approved registry.
-- Put tasks in private subnets with controlled egress for shared environments.
-- Terminate TLS with ACM on the load balancer or an upstream edge.
+- Set `cerebro:awsCertificateArn` so the ALB serves HTTPS; HTTP redirects to HTTPS by default.
+- Restrict ALB ingress with `cerebro:ingressCidrs` or place the service behind a private edge.
+- Set `cerebro:awsEnablePrivateSubnets=true` and `cerebro:awsEnableNatGateway=true` when tasks should run in private subnets with outbound internet access.
 - Use RDS or Aurora PostgreSQL with TLS, backups, and least-privilege credentials.
 - Use managed or self-hosted NATS JetStream with persistent storage.
 - Use Neo4j Aura or an operated Neo4j deployment with encrypted connections.
-- Restrict ALB ingress CIDRs or place the service behind a private edge when appropriate.
-- Store runtime secrets in Secrets Manager through Pulumi secrets or your secret-import pipeline.
+- Store runtime secrets in Secrets Manager through Pulumi secrets, `existingSecretRefs`, or your secret-import pipeline.
 
 Preview:
 
@@ -167,7 +204,7 @@ AWS_PROFILE=<profile> pulumi up --stack aws
 
 ## Google Cloud
 
-The GCP template deploys the Cerebro API on Cloud Run v2.
+The GCP component deploys the Cerebro API on Cloud Run v2.
 
 Example setup:
 
@@ -178,10 +215,12 @@ export PULUMI_CONFIG_PASSPHRASE="local-preview-only"
 
 pulumi stack select gcp --create
 pulumi config set cerebro:cloud gcp
+pulumi config set cerebro:deploymentProfile production
 pulumi config set cerebro:name cerebro-prod
 pulumi config set cerebro:gcpProject example-project
 pulumi config set cerebro:gcpRegion us-central1
 pulumi config set cerebro:image 'us-central1-docker.pkg.dev/example-project/cerebro/cerebro:vX.Y.Z'
+pulumi config set cerebro:gcpAllowUnauthenticated false
 ```
 
 Recommended GCP hardening before `pulumi up`:
@@ -191,8 +230,9 @@ Recommended GCP hardening before `pulumi up`:
 - Use managed NATS or run NATS JetStream on GKE or another persistent platform.
 - Use Neo4j Aura or an operated Neo4j deployment with encrypted connections.
 - Set `cerebro:gcpAllowUnauthenticated=false` when an authenticated edge or IAM invoker policy owns access.
-- Use Serverless VPC Access or equivalent private connectivity for private dependencies.
-- Store runtime secrets in Secret Manager through Pulumi secrets or your secret-import pipeline.
+- Set `cerebro:gcpServiceAccountEmail` to a least-privilege Cloud Run service account.
+- Set `cerebro:gcpVpcConnector` when private dependencies require Serverless VPC Access.
+- Store runtime secrets in Secret Manager through Pulumi secrets, `existingSecretRefs`, or your secret-import pipeline.
 
 Preview:
 
@@ -209,7 +249,7 @@ pulumi up --stack gcp
 
 ## Azure
 
-The Azure template deploys the Cerebro API on Azure Container Apps.
+The Azure component deploys the Cerebro API on Azure Container Apps.
 
 Example setup:
 
@@ -220,6 +260,7 @@ export PULUMI_CONFIG_PASSPHRASE="local-preview-only"
 
 pulumi stack select azure --create
 pulumi config set cerebro:cloud azure
+pulumi config set cerebro:deploymentProfile production
 pulumi config set cerebro:name cerebro-prod
 pulumi config set cerebro:azureLocation eastus
 pulumi config set cerebro:azureResourceGroupName cerebro-prod-rg
@@ -234,7 +275,8 @@ Recommended Azure hardening before `pulumi up`:
 - Use Neo4j Aura or an operated Neo4j deployment with encrypted connections.
 - Put Container Apps in a network-integrated environment when dependencies are private.
 - Put Azure Front Door, Application Gateway, or another TLS edge in front of the app for shared deployments.
-- Store runtime secrets as Container App secrets through Pulumi secrets or your secret-import pipeline.
+- Use `cerebro:azureEnableSystemIdentity=true` or Key Vault-backed `existingSecretRefs` when the app needs managed identity.
+- Store runtime secrets as Container App secrets, Key Vault references, or your secret-import pipeline.
 
 Preview:
 
@@ -258,12 +300,23 @@ cerebro source-runtime sync <runtime-id> page_limit=100
 cerebro graph ingest-runtime <runtime-id> page_limit=100
 ```
 
+Configure jobs with `cerebro:scheduledJobs`:
+
+```bash
+pulumi config set --path 'cerebro:scheduledJobs[0].name' sync-example
+pulumi config set --path 'cerebro:scheduledJobs[0].schedule' 'rate(15 minutes)'
+pulumi config set --path 'cerebro:scheduledJobs[0].command[0]' source-runtime
+pulumi config set --path 'cerebro:scheduledJobs[0].command[1]' sync
+pulumi config set --path 'cerebro:scheduledJobs[0].command[2]' '<runtime-id>'
+pulumi config set --path 'cerebro:scheduledJobs[0].command[3]' page_limit=100
+```
+
 Common scheduler mappings:
 
 | Cloud | Scheduler shape |
 | --- | --- |
-| AWS | EventBridge Scheduler or EventBridge rule launching an ECS Fargate task |
-| GCP | Cloud Scheduler triggering a Cloud Run Job or Workflows step |
+| AWS | EventBridge Scheduler launching the ECS task definition with container command overrides |
+| GCP | Cloud Run Job plus optional Cloud Scheduler trigger when `cerebro:gcpSchedulerServiceAccountEmail` is set |
 | Azure | Container Apps Job with a schedule trigger |
 
 Keep runtime IDs, tenant assignments, provider credentials, and cadence in your deployment repository or scheduler config. Do not publish live schedules in generic docs.
@@ -275,11 +328,12 @@ Before opening a deployment PR:
 ```bash
 cd deploy/pulumi
 uv sync
-uv run python -m py_compile __main__.py runtime.py aws_stack.py gcp_stack.py azure_stack.py
+uv run python -m py_compile __main__.py components.py runtime.py aws_stack.py gcp_stack.py azure_stack.py
+uv run pytest -q
 pulumi preview --stack <aws|gcp|azure> --refresh=false
 ```
 
-The templates were validated locally with `pulumi preview --refresh=false` for all three example stacks and with placeholder secret config for durable/graph-enabled previews. No `pulumi up` was run.
+The templates should be validated with `pulumi preview --refresh=false` for all three example stacks and with placeholder secret config for durable/graph-enabled previews. Do not run `pulumi up` during template validation.
 
 After deploying to a real environment, verify:
 


### PR DESCRIPTION
## Summary

- Refactor the multi-cloud Pulumi templates behind a reusable `CerebroService` component.
- Add production guardrails for auth, HTTPS origins, mutable images, public ingress, and AWS HTTP-only ALBs.
- Add cloud-specific hardening and portability: AWS HTTPS/private subnet/scheduler support, GCP Cloud Run Jobs/Scheduler support, Azure Container Apps Jobs/Key Vault refs, and existing secret-reference support across clouds.
- Expand deployment docs with production profiles, guardrails, existing secrets, scheduled jobs, and optional dependency guidance.

## Validation

- `cd deploy/pulumi && uv run python -m py_compile __main__.py components.py runtime.py aws_stack.py gcp_stack.py azure_stack.py tests/test_components.py`
- `cd deploy/pulumi && uv run pytest -q`
- `make readme-check docs-drift-check`
- `git diff --cached --check`
- `./scripts/leak_check.sh staged`
- `./scripts/leak_check.sh range origin/main...HEAD`
- `pulumi preview --stack aws --refresh=false` with local backend and dummy AWS preview credentials
- `pulumi preview --stack gcp --refresh=false` with local backend; provider emitted a local auth warning but preview completed
- `pulumi preview --stack azure --refresh=false` with local backend and dummy ARM preview credentials
- Production-like placeholder previews for AWS/GCP/Azure optional paths, including existing secrets and scheduled jobs

No `pulumi up` was run.