### PR TITLE
[codex] Add graph action contract metadata

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6771,14 +6771,14 @@ components:
       properties:
         action:
           type: string
-          enum: [identity.okta.suspend_user, identity.okta.unsuspend_user]
+          enum: [identity.okta.suspend_user, identity.okta.unsuspend_user, endpoint.cerebro.revoke_device]
         finding_id:
           type: string
           minLength: 1
           description: Required finding id. Cerebro authorizes the finding tenant, derives the default target, and links the provider action back to the finding.
         target:
           type: string
-          description: Optional explicit graph action target within the authorized finding context. For Okta identity actions this is an Okta user id, login, or email.
+          description: Optional explicit graph action target within the authorized finding context. For Okta identity actions this is an Okta user id, login, or email; for Cerebro device actions this is the finding-scoped device id.
         reason:
           type: string
           maxLength: 2048
@@ -6824,13 +6824,13 @@ components:
           type: string
         action:
           type: string
-          enum: [identity.okta.suspend_user, identity.okta.unsuspend_user]
+          enum: [identity.okta.suspend_user, identity.okta.unsuspend_user, endpoint.cerebro.revoke_device]
         provider:
           type: string
-          enum: [access-approvals]
+          enum: [access-approvals, cerebro-device-auth]
         status:
           type: string
-          enum: [pending, running, succeeded, failed]
+          enum: [pending, queued, running, succeeded, failed, cancelled, needs_attention]
         target:
           type: string
         external_id:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,11 +154,16 @@ target selection, provider request shaping, idempotency, provider dispatch, and
 external reference mapping stay behind `internal/graphactions` and
 `internal/graphactionapi`. Supported actions are cataloged in
 `internal/graphactions/action_catalog.yaml` and generated into the registry with
-`make graph-action-generate`; new providers add an `ActionProvider` adapter
-rather than branching in bootstrap or handler code. First-party providers, such
-as Cerebro device-auth revocation, use the same adapter boundary as external
-providers so target derivation, tenant checks, workflow events, and
-reconciliation remain shared.
+`make graph-action-generate`. The generated registry also exposes serializable
+action metadata plus action id, provider id, and target-kind lists so API
+schemas, agent tools, and future codegen can consume the same provider-neutral
+contract without reaching into resolver hooks. Action lifecycle strings are
+defined in `internal/graphactions` and cover queued/running, terminal, and
+needs-attention states across external and first-party providers. New providers
+add an `ActionProvider` adapter rather than branching in bootstrap or handler
+code. First-party providers, such as Cerebro device-auth revocation, use the
+same adapter boundary as external providers so target derivation, tenant checks,
+workflow events, and reconciliation remain shared.
 
 A2A discovery, outbound event subscription metadata, and public idempotency
 semantics also live in `internal/agentplatform`. The bootstrap budget includes

--- a/internal/graphactions/cerebro_device_provider.go
+++ b/internal/graphactions/cerebro_device_provider.go
@@ -45,7 +45,7 @@ func (p CerebroDeviceProvider) ExecuteGraphAction(ctx context.Context, spec Acti
 	}
 	device.Status = "revoked"
 	device.RevokedAt = p.now()
-	return GraphActionFromCerebroDevice(spec.ID, device, request, "succeeded", "revoked", ""), nil
+	return GraphActionFromCerebroDevice(spec.ID, device, request, ActionStatusSucceeded, "revoked", ""), nil
 }
 
 func (p CerebroDeviceProvider) GetGraphAction(ctx context.Context, externalID string) (*GraphAction, error) {
@@ -63,10 +63,10 @@ func (p CerebroDeviceProvider) GetGraphAction(ctx context.Context, externalID st
 		}
 		return nil, fmt.Errorf("%w: lookup device: %w", ErrRemote, err)
 	}
-	status := "needs_attention"
+	status := ActionStatusNeedsAttention
 	reason := "device is not revoked"
 	if strings.EqualFold(strings.TrimSpace(device.Status), "revoked") {
-		status = "succeeded"
+		status = ActionStatusSucceeded
 		reason = ""
 	}
 	return GraphActionFromCerebroDevice(ActionEndpointCerebroRevokeDevice, device, ProviderActionRequest{}, status, device.Status, reason), nil

--- a/internal/graphactions/contract.go
+++ b/internal/graphactions/contract.go
@@ -1,0 +1,75 @@
+package graphactions
+
+import "strings"
+
+const (
+	ActionStatusPending        = "pending"
+	ActionStatusQueued         = "queued"
+	ActionStatusRunning        = "running"
+	ActionStatusSucceeded      = "succeeded"
+	ActionStatusFailed         = "failed"
+	ActionStatusCancelled      = "cancelled"
+	ActionStatusNeedsAttention = "needs_attention"
+)
+
+type ActionMetadata struct {
+	ID             string `json:"id"`
+	Provider       string `json:"provider"`
+	ProviderAction string `json:"provider_action"`
+	TargetKind     string `json:"target_kind"`
+	Effect         string `json:"effect"`
+	Destructive    bool   `json:"destructive"`
+	ReversibleBy   string `json:"reversible_by,omitempty"`
+}
+
+func (s ActionSpec) Metadata() ActionMetadata {
+	return ActionMetadata{
+		ID:             strings.TrimSpace(s.ID),
+		Provider:       strings.TrimSpace(s.Provider),
+		ProviderAction: strings.TrimSpace(s.ProviderAction),
+		TargetKind:     strings.TrimSpace(s.TargetKind),
+		Effect:         strings.TrimSpace(s.Effect),
+		Destructive:    s.Destructive,
+		ReversibleBy:   strings.TrimSpace(s.ReversibleBy),
+	}
+}
+
+func NormalizeActionStatus(status string) string {
+	return strings.ToLower(strings.TrimSpace(status))
+}
+
+func KnownActionStatuses() []string {
+	return []string{
+		ActionStatusPending,
+		ActionStatusQueued,
+		ActionStatusRunning,
+		ActionStatusSucceeded,
+		ActionStatusFailed,
+		ActionStatusCancelled,
+		ActionStatusNeedsAttention,
+	}
+}
+
+func ActionStatusKnown(status string) bool {
+	switch NormalizeActionStatus(status) {
+	case ActionStatusPending,
+		ActionStatusQueued,
+		ActionStatusRunning,
+		ActionStatusSucceeded,
+		ActionStatusFailed,
+		ActionStatusCancelled,
+		ActionStatusNeedsAttention:
+		return true
+	default:
+		return false
+	}
+}
+
+func ActionStatusTerminal(status string) bool {
+	switch NormalizeActionStatus(status) {
+	case ActionStatusSucceeded, ActionStatusFailed, ActionStatusCancelled, ActionStatusNeedsAttention:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/graphactions/registry_gen.go
+++ b/internal/graphactions/registry_gen.go
@@ -15,6 +15,22 @@ const (
 	TargetKindOktaUser      = "identity.okta.user"
 )
 
+var generatedActionIDs = []string{
+	ActionIdentityOktaSuspendUser,
+	ActionIdentityOktaUnsuspendUser,
+	ActionEndpointCerebroRevokeDevice,
+}
+
+var generatedProviderIDs = []string{
+	ProviderAccessApprovals,
+	ProviderCerebroDeviceAuth,
+}
+
+var generatedTargetKinds = []string{
+	TargetKindCerebroDevice,
+	TargetKindOktaUser,
+}
+
 func DefaultRegistry() Registry {
 	actions := make(map[string]ActionSpec, len(generatedActionSpecs))
 	for _, spec := range generatedActionSpecs {
@@ -26,6 +42,32 @@ func DefaultRegistry() Registry {
 func KnownActionSpecs() []ActionSpec {
 	out := make([]ActionSpec, len(generatedActionSpecs))
 	copy(out, generatedActionSpecs)
+	return out
+}
+
+func KnownActionMetadata() []ActionMetadata {
+	out := make([]ActionMetadata, 0, len(generatedActionSpecs))
+	for _, spec := range generatedActionSpecs {
+		out = append(out, spec.Metadata())
+	}
+	return out
+}
+
+func KnownActionIDs() []string {
+	out := make([]string, len(generatedActionIDs))
+	copy(out, generatedActionIDs)
+	return out
+}
+
+func KnownProviderIDs() []string {
+	out := make([]string, len(generatedProviderIDs))
+	copy(out, generatedProviderIDs)
+	return out
+}
+
+func KnownTargetKinds() []string {
+	out := make([]string, len(generatedTargetKinds))
+	copy(out, generatedTargetKinds)
 	return out
 }
 

--- a/internal/graphactions/registry_test.go
+++ b/internal/graphactions/registry_test.go
@@ -1,0 +1,130 @@
+package graphactions
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestKnownActionContractHelpersExposeCatalogMetadata(t *testing.T) {
+	if got, want := KnownActionIDs(), []string{
+		ActionIdentityOktaSuspendUser,
+		ActionIdentityOktaUnsuspendUser,
+		ActionEndpointCerebroRevokeDevice,
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("KnownActionIDs() = %#v, want %#v", got, want)
+	}
+	if got, want := KnownProviderIDs(), []string{
+		ProviderAccessApprovals,
+		ProviderCerebroDeviceAuth,
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("KnownProviderIDs() = %#v, want %#v", got, want)
+	}
+	if got, want := KnownTargetKinds(), []string{
+		TargetKindCerebroDevice,
+		TargetKindOktaUser,
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("KnownTargetKinds() = %#v, want %#v", got, want)
+	}
+
+	metadata := KnownActionMetadata()
+	if len(metadata) != len(KnownActionSpecs()) {
+		t.Fatalf("KnownActionMetadata() len = %d, want %d", len(metadata), len(KnownActionSpecs()))
+	}
+	byID := map[string]ActionMetadata{}
+	for _, action := range metadata {
+		byID[action.ID] = action
+	}
+	for _, spec := range KnownActionSpecs() {
+		if got, want := byID[spec.ID], spec.Metadata(); got != want {
+			t.Fatalf("metadata for %q = %#v, want %#v", spec.ID, got, want)
+		}
+	}
+	device := byID[ActionEndpointCerebroRevokeDevice]
+	if device.Provider != ProviderCerebroDeviceAuth || device.TargetKind != TargetKindCerebroDevice || !device.Destructive {
+		t.Fatalf("device action metadata = %#v, want first-party destructive device action", device)
+	}
+}
+
+func TestKnownActionContractHelpersReturnCopies(t *testing.T) {
+	ids := KnownActionIDs()
+	ids[0] = "mutated"
+	if got := KnownActionIDs()[0]; got == "mutated" {
+		t.Fatalf("KnownActionIDs() returned mutable backing storage")
+	}
+	providers := KnownProviderIDs()
+	providers[0] = "mutated"
+	if got := KnownProviderIDs()[0]; got == "mutated" {
+		t.Fatalf("KnownProviderIDs() returned mutable backing storage")
+	}
+	targetKinds := KnownTargetKinds()
+	targetKinds[0] = "mutated"
+	if got := KnownTargetKinds()[0]; got == "mutated" {
+		t.Fatalf("KnownTargetKinds() returned mutable backing storage")
+	}
+	metadata := KnownActionMetadata()
+	metadata[0].ID = "mutated"
+	if got := KnownActionMetadata()[0].ID; got == "mutated" {
+		t.Fatalf("KnownActionMetadata() returned mutable backing storage")
+	}
+}
+
+func TestActionMetadataContractDoesNotExposeExecutableHooks(t *testing.T) {
+	typ := reflect.TypeOf(ActionMetadata{})
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Type.Kind() == reflect.Func {
+			t.Fatalf("ActionMetadata field %s exposes a function", field.Name)
+		}
+	}
+}
+
+func TestActionStatusContract(t *testing.T) {
+	if got, want := KnownActionStatuses(), []string{
+		ActionStatusPending,
+		ActionStatusQueued,
+		ActionStatusRunning,
+		ActionStatusSucceeded,
+		ActionStatusFailed,
+		ActionStatusCancelled,
+		ActionStatusNeedsAttention,
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("KnownActionStatuses() = %#v, want %#v", got, want)
+	}
+	statuses := KnownActionStatuses()
+	statuses[0] = "mutated"
+	if got := KnownActionStatuses()[0]; got == "mutated" {
+		t.Fatalf("KnownActionStatuses() returned mutable backing storage")
+	}
+
+	for _, status := range []string{
+		" " + ActionStatusPending + " ",
+		ActionStatusQueued,
+		"RUNNING",
+		ActionStatusSucceeded,
+		ActionStatusFailed,
+		ActionStatusCancelled,
+		ActionStatusNeedsAttention,
+	} {
+		if !ActionStatusKnown(status) {
+			t.Fatalf("ActionStatusKnown(%q) = false, want true", status)
+		}
+	}
+	for _, status := range []string{
+		ActionStatusSucceeded,
+		ActionStatusFailed,
+		ActionStatusCancelled,
+		ActionStatusNeedsAttention,
+	} {
+		if !ActionStatusTerminal(status) {
+			t.Fatalf("ActionStatusTerminal(%q) = false, want true", status)
+		}
+	}
+	for _, status := range []string{ActionStatusPending, ActionStatusQueued, ActionStatusRunning} {
+		if ActionStatusTerminal(status) {
+			t.Fatalf("ActionStatusTerminal(%q) = true, want false", status)
+		}
+	}
+	if ActionStatusKnown("unknown") {
+		t.Fatalf("ActionStatusKnown(unknown) = true, want false")
+	}
+}

--- a/tools/graphactiongen/main.go
+++ b/tools/graphactiongen/main.go
@@ -262,6 +262,9 @@ func renderCatalog(catalog actionCatalog) ([]byte, error) {
 	buf.WriteString("\npackage graphactions\n\n")
 	writeStringConstants(&buf, "Action IDs", actionConstants(catalog.Actions))
 	writeStringConstants(&buf, "Target kinds", targetKindConstants(catalog.Actions))
+	writeStringSlice(&buf, "generatedActionIDs", actionConstants(catalog.Actions))
+	writeStringSlice(&buf, "generatedProviderIDs", providerConstants(catalog.Actions))
+	writeStringSlice(&buf, "generatedTargetKinds", targetKindConstants(catalog.Actions))
 	buf.WriteString("func DefaultRegistry() Registry {\n")
 	buf.WriteString("\tactions := make(map[string]ActionSpec, len(generatedActionSpecs))\n")
 	buf.WriteString("\tfor _, spec := range generatedActionSpecs {\n")
@@ -272,6 +275,28 @@ func renderCatalog(catalog actionCatalog) ([]byte, error) {
 	buf.WriteString("func KnownActionSpecs() []ActionSpec {\n")
 	buf.WriteString("\tout := make([]ActionSpec, len(generatedActionSpecs))\n")
 	buf.WriteString("\tcopy(out, generatedActionSpecs)\n")
+	buf.WriteString("\treturn out\n")
+	buf.WriteString("}\n\n")
+	buf.WriteString("func KnownActionMetadata() []ActionMetadata {\n")
+	buf.WriteString("\tout := make([]ActionMetadata, 0, len(generatedActionSpecs))\n")
+	buf.WriteString("\tfor _, spec := range generatedActionSpecs {\n")
+	buf.WriteString("\t\tout = append(out, spec.Metadata())\n")
+	buf.WriteString("\t}\n")
+	buf.WriteString("\treturn out\n")
+	buf.WriteString("}\n\n")
+	buf.WriteString("func KnownActionIDs() []string {\n")
+	buf.WriteString("\tout := make([]string, len(generatedActionIDs))\n")
+	buf.WriteString("\tcopy(out, generatedActionIDs)\n")
+	buf.WriteString("\treturn out\n")
+	buf.WriteString("}\n\n")
+	buf.WriteString("func KnownProviderIDs() []string {\n")
+	buf.WriteString("\tout := make([]string, len(generatedProviderIDs))\n")
+	buf.WriteString("\tcopy(out, generatedProviderIDs)\n")
+	buf.WriteString("\treturn out\n")
+	buf.WriteString("}\n\n")
+	buf.WriteString("func KnownTargetKinds() []string {\n")
+	buf.WriteString("\tout := make([]string, len(generatedTargetKinds))\n")
+	buf.WriteString("\tcopy(out, generatedTargetKinds)\n")
 	buf.WriteString("\treturn out\n")
 	buf.WriteString("}\n\n")
 	buf.WriteString("var generatedActionSpecs = []ActionSpec{\n")
@@ -309,6 +334,23 @@ func actionConstants(actions []actionCatalogEntry) []stringConstant {
 	return out
 }
 
+func providerConstants(actions []actionCatalogEntry) []stringConstant {
+	seen := map[string]string{}
+	for _, action := range actions {
+		seen[action.ProviderConst] = action.Provider
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]stringConstant, 0, len(names))
+	for _, name := range names {
+		out = append(out, stringConstant{Name: name, Value: seen[name]})
+	}
+	return out
+}
+
 func targetKindConstants(actions []actionCatalogEntry) []stringConstant {
 	seen := map[string]string{}
 	for _, action := range actions {
@@ -336,4 +378,15 @@ func writeStringConstants(buf *bytes.Buffer, title string, constants []stringCon
 		fmt.Fprintf(buf, "\t%s = %q\n", constant.Name, constant.Value)
 	}
 	buf.WriteString(")\n\n")
+}
+
+func writeStringSlice(buf *bytes.Buffer, name string, constants []stringConstant) {
+	if len(constants) == 0 {
+		return
+	}
+	fmt.Fprintf(buf, "var %s = []string{\n", name)
+	for _, constant := range constants {
+		fmt.Fprintf(buf, "\t%s,\n", constant.Name)
+	}
+	buf.WriteString("}\n\n")
 }

--- a/tools/graphactiongen/main_test.go
+++ b/tools/graphactiongen/main_test.go
@@ -52,6 +52,12 @@ actions:
 		"ResolveTarget:    OktaUserTargetForFinding",
 		"CheckEligibility: FindingAllowsAction",
 		"ReversibleBy:     \"identity.okta.unsuspend_user\"",
+		"func KnownActionMetadata() []ActionMetadata",
+		"func KnownActionIDs() []string",
+		"func KnownProviderIDs() []string",
+		"func KnownTargetKinds() []string",
+		"generatedProviderIDs = []string",
+		"ProviderAccessApprovals",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("generated registry missing %q:\n%s", want, text)


### PR DESCRIPTION
## Summary
- add provider-neutral graph action metadata and lifecycle status helpers
- generate action id, provider id, target kind, and metadata helpers from the action catalog
- update OpenAPI/docs so the public contract includes first-party device revocation and the current lifecycle vocabulary

## Validation
- GOFLAGS=-mod=readonly go test ./internal/graphactions ./tools/graphactiongen -count=1
- GOFLAGS=-mod=readonly make graph-action-check
- GOFLAGS=-mod=readonly go test ./internal/graphactionapi ./internal/sourcehttp/graphactionhandler ./internal/graphactionworkflow ./internal/findingapi ./internal/bootstrap -count=1
- GOFLAGS=-mod=readonly make openapi-check
- GOFLAGS=-mod=readonly make openapi-lint
- GOFLAGS=-mod=readonly make docs-drift-check