### PR TITLE
fix: retry JetStream publishes with derived message IDs

### DIFF
--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -34,6 +34,9 @@ const (
 	maxReplayCandidates        = 5000
 	publishRetryAttempts       = 4
 	publishRetryInitialBackoff = 50 * time.Millisecond
+	publishClientRetryAttempts = 2
+	publishClientRetryWait     = 250 * time.Millisecond
+	publishAttemptTimeout      = 15 * time.Second
 	jetstreamCanaryKind        = "cerebro.health.jetstream_canary"
 	jetstreamCanaryMinInterval = time.Minute
 )
@@ -257,8 +260,12 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 	if workflowevents.IsSharedEnvelopeEvent(envelope) {
 		msg.Header = eventAttributesHeader(envelope.GetAttributes())
 	}
-	if event.Id != "" {
-		msg.Header.Set(nats.MsgIdHdr, event.Id)
+	messageID := publishMessageID(envelope, payload)
+	if messageID != "" {
+		if msg.Header == nil {
+			msg.Header = nats.Header{}
+		}
+		msg.Header.Set(nats.MsgIdHdr, messageID)
 	}
 	publishAttrs := func() telemetry.Attributes {
 		return jetstreamPublishMessageAttrs(subject, l.subjectPrefix, len(payload), msg.Header.Get(nats.MsgIdHdr))
@@ -280,16 +287,20 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 }
 
 func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, eventAttrs func() telemetry.Attributes) (publishTelemetry, error) {
-	result := publishTelemetry{Attempts: 0, MaxAttempts: 1}
-	if msg.Header.Get(nats.MsgIdHdr) != "" {
-		result.MaxAttempts = publishRetryAttempts
-	}
+	result := publishTelemetry{Attempts: 0, MaxAttempts: publishRetryAttempts}
 	backoff := publishRetryInitialBackoff
 	started := time.Now()
 	var err error
 	for attempt := 1; attempt <= result.MaxAttempts; attempt++ {
 		result.Attempts = attempt
-		ack, publishErr := l.js.PublishMsg(ctx, msg)
+		attemptCtx, cancel := context.WithTimeout(ctx, publishAttemptTimeout)
+		ack, publishErr := l.js.PublishMsg(
+			attemptCtx,
+			msg,
+			jetstream.WithRetryAttempts(publishClientRetryAttempts),
+			jetstream.WithRetryWait(publishClientRetryWait),
+		)
+		cancel()
 		if publishErr == nil {
 			result.Duration = time.Since(started)
 			result.applyAck(ack)
@@ -320,6 +331,16 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, e
 	}
 	result.Duration = time.Since(started)
 	return result, err
+}
+
+func publishMessageID(event *cerebrov1.EventEnvelope, payload []byte) string {
+	if event != nil {
+		if id := strings.TrimSpace(event.Id); id != "" {
+			return id
+		}
+	}
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func (r *publishTelemetry) applyAck(ack *jetstream.PubAck) {
@@ -368,6 +389,7 @@ func retryablePublishError(err error) bool {
 	for _, fragment := range []string{
 		"no response",
 		"timeout",
+		"deadline exceeded",
 		"temporarily unavailable",
 		"connection",
 		"reconnect",

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -294,16 +294,27 @@ func TestAppendEmitsPublishRetryExhaustedTelemetry(t *testing.T) {
 	}
 }
 
-func TestAppendDoesNotRetryWithoutMessageID(t *testing.T) {
-	pub := &fakePublisher{publishErr: errors.New("nats: no response from stream")}
+func TestAppendRetriesTransientPublishErrorWithDerivedMessageID(t *testing.T) {
+	pub := &fakePublisher{
+		publishErrs: []error{
+			errors.New("nats: no response from stream"),
+			nil,
+		},
+	}
 	log := &Log{js: pub, subjectPrefix: "events"}
 
-	err := log.Append(context.Background(), &cerebrov1.EventEnvelope{Kind: "entity.upsert"})
-	if err == nil {
-		t.Fatal("Append() error = nil, want non-nil")
+	event := &cerebrov1.EventEnvelope{Kind: "entity.upsert", TenantId: "tenant-1", SourceId: "source-1"}
+	if err := log.Append(context.Background(), event); err != nil {
+		t.Fatalf("Append() error = %v", err)
 	}
-	if pub.publishCalls != 1 {
-		t.Fatalf("publish calls = %d, want 1", pub.publishCalls)
+	if pub.publishCalls != 2 {
+		t.Fatalf("publish calls = %d, want 2", pub.publishCalls)
+	}
+	if event.Id != "" {
+		t.Fatalf("event id mutated = %q, want empty", event.Id)
+	}
+	if got := pub.published.Header.Get(nats.MsgIdHdr); !strings.HasPrefix(got, "sha256:") {
+		t.Fatalf("derived msg id = %q, want sha256 fallback", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive a deterministic NATS message ID for append-log events that arrive without one
- retry all retryable JetStream publish failures with explicit per-attempt timeout and NATS retry options
- keep retry telemetry on recovered/exhausted publish attempts so wide events show stream pressure clearly

## Live evidence
- sec-dev wide event at 2026-06-19T01:32:45Z failed `orchestrator.graph_rules` for `writer-okta-group` with `jetstream_js_error` / `nats: no response from stream`
- `JetStreamPublishRetries` stayed at 0 because missing-message-ID events were not retried

## Validation
- `go test ./internal/appendlog/jetstream`
- `go test ./internal/bootstrap -count=1`
- `go test ./internal/appendlog/... ./internal/bootstrap ./internal/findings ./cmd/cerebro`
- `make check-structural check-structural-test check-arch`
- `git diff --check`
