### PR TITLE
fix: dedupe catalog validation issues

### DIFF
--- a/tools/catalogcheck/catalogcheck.go
+++ b/tools/catalogcheck/catalogcheck.go
@@ -93,6 +93,7 @@ func checkRepositoryWithOptions(root string, options repositoryCheckOptions) ([]
 	issues = append(issues, checkFindingRuleMetadata(findingControlCatalog)...)
 	issues = append(issues, checkCorrelationCatalog()...)
 	issues = append(issues, checkComplianceEvidencePacketContract(controlCatalog)...)
+	issues = dedupeIssues(issues)
 	sort.Slice(issues, func(i int, j int) bool {
 		if issues[i].path != issues[j].path {
 			return issues[i].path < issues[j].path
@@ -100,6 +101,19 @@ func checkRepositoryWithOptions(root string, options repositoryCheckOptions) ([]
 		return issues[i].message < issues[j].message
 	})
 	return issues, nil
+}
+
+func dedupeIssues(issues []issue) []issue {
+	seen := map[issue]struct{}{}
+	deduped := make([]issue, 0, len(issues))
+	for _, issue := range issues {
+		if _, ok := seen[issue]; ok {
+			continue
+		}
+		seen[issue] = struct{}{}
+		deduped = append(deduped, issue)
+	}
+	return deduped
 }
 
 func loadComplianceControlCatalog(root string) (*compliance.CatalogIndex, []issue, error) {

--- a/tools/catalogcheck/catalogcheck_test.go
+++ b/tools/catalogcheck/catalogcheck_test.go
@@ -76,6 +76,9 @@ emitted_kinds: []
 	if len(issues) == 0 {
 		t.Fatal("issues = 0, want policy metadata issue")
 	}
+	if got := countIssueMessages(issues, "metadata.name is required"); got != 1 {
+		t.Fatalf("metadata.name issue count = %d, want 1; issues = %#v", got, issues)
+	}
 }
 
 func TestCheckConnectorDefinitionCatalogRejectsProofGateIssues(t *testing.T) {
@@ -701,4 +704,14 @@ func issueMessagesContain(issues []issue, substring string) bool {
 		}
 	}
 	return false
+}
+
+func countIssueMessages(issues []issue, substring string) int {
+	count := 0
+	for _, issue := range issues {
+		if strings.Contains(issue.message, substring) {
+			count++
+		}
+	}
+	return count
 }


### PR DESCRIPTION
## Summary

- Dedupe catalog validation issues after aggregating checks.
- Add regression coverage to ensure policy DSL metadata issues appear once in repository validation output.

## Test Plan

- go test ./tools/catalogcheck -count=1 -v
- make catalog-check

## Known Invariants

- Source connectors use internal/sourcehttp for outbound HTTP safety.
- Production body reads are bounded with io.LimitReader or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP htu, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: make droid-review-preflight.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with make land-pr PR=<number> so Droid finishes before branch deletion.