### PR TITLE
fix: validate policy DSL assertion operands

### DIFF
--- a/docs/domains/policies.md
+++ b/docs/domains/policies.md
@@ -64,6 +64,13 @@ spec:
 | `spec.graph.rowLimit` | No | Optional row cap from 1 to 3000. Required when the query does not include `LIMIT`. |
 | `spec.graph.params` | No | Static scalar Cypher params merged with runtime `tenant_id` and `row_limit`. |
 | `spec.graph.requiredColumns` | No | Return aliases the validator must find in `spec.graph.query`. |
+| `spec.input` | No | Evidence input contract: source kinds, event kinds, required claims, required fields, and freshness SLA. |
+| `spec.assert` | Conditional | Structured evidence assertions for policies that evaluate normalized evidence records instead of CEL or SQL. |
+| `spec.context` | No | Graph anchors, graph enrichment, and severity adjustment metadata used to explain and prioritize findings. |
+| `spec.evidence` | No | Evidence type, audit requirement, accepted sources, required fields, fingerprint fields, and freshness metadata. |
+| `spec.audit` | No | Auditor-facing evidence, assessment, exception, risk, remediation, and false-positive guidance. |
+| `spec.verification` | No | Fixture expectations, mutation checks, and remediation rerun expectations for policy validation. |
+| `spec.actions` | No | Owner resolution, remediation steps, effort, blast-radius, and policy-rerun guidance. |
 | `spec.remediation.summary` | No | Remediation intent used in generated runbooks and finding attributes. |
 | `spec.remediation.steps` | No | Optional ordered remediation steps. |
 | `spec.riskCategories` | No | Normalized risk category labels. |
@@ -72,6 +79,38 @@ spec:
 | `spec.enabled` | No | Set to `false` to keep a policy in the catalog while disabling generated rule support. |
 
 Every policy must have exactly one match mode: `spec.match.conditions`, `spec.match.query`, `spec.assert`, or `spec.graph`.
+
+## Assertion Policies
+
+Use `spec.assert` for normalized evidence records where the policy can be stated as field-level expectations. Assertions are useful for auditor-facing controls because they pair cleanly with input, evidence, audit, verification, and action metadata.
+
+```yaml
+spec:
+  severity: high
+  frameworks:
+    - name: SOC 2
+      controls: [CC6]
+  input:
+    sourceKinds: [okta.user]
+    requiredFields: [tenant_id, resource_urn, privilege_level, mfa_enrolled, observed_at]
+    freshnessSLA: 24h
+  assert:
+    all:
+      - field: privilege_level
+        op: in
+        value: [admin, super_admin]
+      - field: mfa_enrolled
+        op: eq
+        value: false
+  evidence:
+    type: identity_configuration
+    assessmentMethods: [examine, test]
+    requiredForAudit: true
+  audit:
+    auditorStatement: Privileged users are required to have MFA before administrative SaaS access.
+    falsePositives:
+      - The account is disabled or outside the privileged population.
+```
 
 ## CEL Policies
 

--- a/docs/domains/policies.md
+++ b/docs/domains/policies.md
@@ -78,7 +78,7 @@ spec:
 | `spec.mitreAttack` | No | MITRE tactic and technique mappings. |
 | `spec.enabled` | No | Set to `false` to keep a policy in the catalog while disabling generated rule support. |
 
-Every policy must have exactly one match mode: `spec.match.conditions`, `spec.match.query`, `spec.assert`, or `spec.graph`.
+Every policy must define `spec.graph` or at least one non-graph evaluation mode: `spec.match.conditions`, `spec.match.query`, or `spec.assert`. `spec.graph` is mutually exclusive with `spec.match` and `spec.assert`; `spec.match.conditions` and `spec.match.query` are mutually exclusive.
 
 ## Assertion Policies
 

--- a/internal/findingdsl/policy_rule.go
+++ b/internal/findingdsl/policy_rule.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -512,9 +513,43 @@ func validateAssertions(path string, field string, assertions []PolicyRuleAssert
 		}
 		if !stringSetContains([]string{"eq", "ne", "in", "not_in", "gt", "gte", "lt", "lte", "exists", "is_true", "is_false"}, op) {
 			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s[%d].op must be one of eq, ne, in, not_in, gt, gte, lt, lte, exists, is_true, is_false", field, idx)})
+			continue
 		}
+		issues = append(issues, validateAssertionValue(path, field, idx, op, assertion.Value)...)
 	}
 	return issues
+}
+
+func validateAssertionValue(path string, field string, idx int, op string, value any) []Issue {
+	if !assertionOpRequiresValue(op) {
+		return nil
+	}
+	if value == nil {
+		return []Issue{{Path: path, Message: fmt.Sprintf("%s[%d].value is required for op %s", field, idx, op)}}
+	}
+	if !assertionOpRequiresListValue(op) {
+		return nil
+	}
+	if !assertionValueIsList(value) {
+		return []Issue{{Path: path, Message: fmt.Sprintf("%s[%d].value must be a list for op %s", field, idx, op)}}
+	}
+	if reflect.ValueOf(value).Len() == 0 {
+		return []Issue{{Path: path, Message: fmt.Sprintf("%s[%d].value must be a non-empty list for op %s", field, idx, op)}}
+	}
+	return nil
+}
+
+func assertionOpRequiresValue(op string) bool {
+	return stringSetContains([]string{"eq", "ne", "in", "not_in", "gt", "gte", "lt", "lte"}, op)
+}
+
+func assertionOpRequiresListValue(op string) bool {
+	return op == "in" || op == "not_in"
+}
+
+func assertionValueIsList(value any) bool {
+	kind := reflect.ValueOf(value).Kind()
+	return kind == reflect.Array || kind == reflect.Slice
 }
 
 func validateSeverityAdjustments(path string, adjustments []PolicyRuleSeverityAdjustment) []Issue {

--- a/internal/findingdsl/policy_rule.go
+++ b/internal/findingdsl/policy_rule.go
@@ -372,9 +372,6 @@ func ValidatePolicyRule(rule PolicyFindingRule) []Issue {
 	if hasConditions && hasQuery {
 		issues = append(issues, Issue{Path: path, Message: "spec.match.conditions and spec.match.query are mutually exclusive"})
 	}
-	if hasAssert && (hasConditions || hasQuery) {
-		issues = append(issues, Issue{Path: path, Message: "spec.assert is mutually exclusive with spec.match"})
-	}
 	if hasGraph && (hasConditions || hasQuery || hasAssert) {
 		issues = append(issues, Issue{Path: path, Message: "spec.graph is mutually exclusive with spec.match and spec.assert"})
 	}

--- a/internal/findingdsl/policy_rule.go
+++ b/internal/findingdsl/policy_rule.go
@@ -371,6 +371,9 @@ func ValidatePolicyRule(rule PolicyFindingRule) []Issue {
 	if hasConditions && hasQuery {
 		issues = append(issues, Issue{Path: path, Message: "spec.match.conditions and spec.match.query are mutually exclusive"})
 	}
+	if hasAssert && (hasConditions || hasQuery) {
+		issues = append(issues, Issue{Path: path, Message: "spec.assert is mutually exclusive with spec.match"})
+	}
 	if hasGraph && (hasConditions || hasQuery || hasAssert) {
 		issues = append(issues, Issue{Path: path, Message: "spec.graph is mutually exclusive with spec.match and spec.assert"})
 	}

--- a/internal/findingdsl/policy_rule_test.go
+++ b/internal/findingdsl/policy_rule_test.go
@@ -190,6 +190,53 @@ func TestValidatePolicyRuleRejectsUnsafeContractMetadata(t *testing.T) {
 	}
 }
 
+func TestValidatePolicyRuleRejectsAssertionOperands(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		assertions []PolicyRuleAssertion
+		wantIssue  string
+	}{
+		{
+			name:       "binary op missing value",
+			assertions: []PolicyRuleAssertion{{Field: "privilege_level", Op: "eq"}},
+			wantIssue:  "spec.assert.all[0].value is required for op eq",
+		},
+		{
+			name:       "membership op missing value",
+			assertions: []PolicyRuleAssertion{{Field: "privilege_level", Op: "in"}},
+			wantIssue:  "spec.assert.all[0].value is required for op in",
+		},
+		{
+			name:       "membership op scalar value",
+			assertions: []PolicyRuleAssertion{{Field: "privilege_level", Op: "in", Value: "admin"}},
+			wantIssue:  "spec.assert.all[0].value must be a list for op in",
+		},
+		{
+			name:       "membership op empty list",
+			assertions: []PolicyRuleAssertion{{Field: "privilege_level", Op: "in", Value: []string{}}},
+			wantIssue:  "spec.assert.all[0].value must be a non-empty list for op in",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			issues := ValidatePolicyRule(policyRuleWithAssertions(tc.assertions...))
+			if !issuesContain(issues, tc.wantIssue) {
+				t.Fatalf("issues = %#v, missing %q", issues, tc.wantIssue)
+			}
+		})
+	}
+}
+
+func TestValidatePolicyRuleAcceptsAssertionOperands(t *testing.T) {
+	rule := policyRuleWithAssertions(
+		PolicyRuleAssertion{Field: "mfa_enrolled", Op: "exists"},
+		PolicyRuleAssertion{Field: "mfa_enrolled", Op: "eq", Value: false},
+		PolicyRuleAssertion{Field: "privilege_level", Op: "in", Value: []string{"admin", "owner"}},
+	)
+	if issues := ValidatePolicyRule(rule); len(issues) != 0 {
+		t.Fatalf("ValidatePolicyRule() issues = %#v, want none", issues)
+	}
+}
+
 func TestValidatePolicyRuleAcceptsGraphPolicy(t *testing.T) {
 	rule := PolicyFindingRule{
 		APIVersion: APIVersion,
@@ -520,6 +567,25 @@ spec:
     - name: SOC 2
       controls: [CC6]
 `
+}
+
+func policyRuleWithAssertions(assertions ...PolicyRuleAssertion) PolicyFindingRule {
+	return PolicyFindingRule{
+		APIVersion: APIVersion,
+		Kind:       KindPolicyFindingRule,
+		Metadata: PolicyRuleMetadata{
+			ID:          "assertions",
+			Name:        "Assertions",
+			Description: "Assertion validation test",
+		},
+		Spec: PolicyFindingRuleSpec{
+			Severity: "high",
+			Assert:   PolicyRuleAssert{All: assertions},
+			Frameworks: []PolicyFramework{
+				{Name: "SOC 2", Controls: []string{"CC6.1"}},
+			},
+		},
+	}
 }
 
 func writeTestFile(t *testing.T, root string, rel string, content string) {

--- a/internal/findingdsl/policy_rule_test.go
+++ b/internal/findingdsl/policy_rule_test.go
@@ -304,17 +304,6 @@ func TestValidatePolicyRuleRejectsInvalidGraphPolicy(t *testing.T) {
 	}
 }
 
-func TestValidatePolicyRuleRejectsMixedMatchAndAssertModes(t *testing.T) {
-	rule := policyRuleWithAssertions(PolicyRuleAssertion{Field: "mfa_enrolled", Op: "is_false"})
-	rule.Spec.Match = PolicyRuleMatch{
-		Query: "SELECT id FROM resources WHERE mfa_enrolled = false",
-	}
-	issues := ValidatePolicyRule(rule)
-	if !issuesContain(issues, "spec.assert is mutually exclusive with spec.match") {
-		t.Fatalf("issues = %#v, want mixed match/assert mode rejection", issues)
-	}
-}
-
 func TestLoadPolicyRulesRejectsLegacyJSONPolicies(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, root, "policies/aws/example.json", `{"id":"aws-example"}`)

--- a/internal/findingdsl/policy_rule_test.go
+++ b/internal/findingdsl/policy_rule_test.go
@@ -257,6 +257,17 @@ func TestValidatePolicyRuleRejectsInvalidGraphPolicy(t *testing.T) {
 	}
 }
 
+func TestValidatePolicyRuleRejectsMixedMatchAndAssertModes(t *testing.T) {
+	rule := policyRuleWithAssertions(PolicyRuleAssertion{Field: "mfa_enrolled", Op: "is_false"})
+	rule.Spec.Match = PolicyRuleMatch{
+		Query: "SELECT id FROM resources WHERE mfa_enrolled = false",
+	}
+	issues := ValidatePolicyRule(rule)
+	if !issuesContain(issues, "spec.assert is mutually exclusive with spec.match") {
+		t.Fatalf("issues = %#v, want mixed match/assert mode rejection", issues)
+	}
+}
+
 func TestLoadPolicyRulesRejectsLegacyJSONPolicies(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, root, "policies/aws/example.json", `{"id":"aws-example"}`)
@@ -457,7 +468,22 @@ func TestPolicyRuleJSONSchema(t *testing.T) {
 		t.Fatalf("PolicyRuleJSONSchema() error = %v", err)
 	}
 	text := string(schema)
-	for _, want := range []string{`"apiVersion"`, APIVersion, KindPolicyFindingRule, `"additionalProperties": false`} {
+	for _, want := range []string{
+		`"apiVersion"`,
+		APIVersion,
+		KindPolicyFindingRule,
+		`"additionalProperties": false`,
+		`"input"`,
+		`"assert"`,
+		`"context"`,
+		`"evidence"`,
+		`"audit"`,
+		`"verification"`,
+		`"actions"`,
+		`"auditorStatement"`,
+		`"acceptableEvidence"`,
+		`"remediationCheck"`,
+	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("schema missing %q:\n%s", want, text)
 		}

--- a/internal/findingdsl/schema.go
+++ b/internal/findingdsl/schema.go
@@ -63,13 +63,6 @@ func specSchema() map[string]any {
 			"graph":          graphFindingSchema(),
 			"remediation":    remediationSchema(),
 			"riskCategories": stringArraySchema("Normalized risk category labels."),
-			"input":          openObjectSchema("Runtime, claim, and field requirements for evaluating the policy."),
-			"assert":         openObjectSchema("Structured assertions for evidence-backed policy checks."),
-			"context":        openObjectSchema("Graph and severity-adjustment context for policy evaluation."),
-			"evidence":       openObjectSchema("Evidence requirements and fingerprinting metadata."),
-			"audit":          openObjectSchema("Auditor-facing evidence, exception, and risk guidance."),
-			"verification":   openObjectSchema("Author-supplied verification fixtures and mutation checks."),
-			"actions":        openObjectSchema("Ownership, remediation, and verification action hints."),
 			"frameworks": map[string]any{
 				"type":     "array",
 				"minItems": 1,
@@ -79,7 +72,14 @@ func specSchema() map[string]any {
 				"type":  "array",
 				"items": mitreSchema(),
 			},
-			"enabled": map[string]any{"type": "boolean"},
+			"input":        inputSchema(),
+			"assert":       assertSchema(),
+			"context":      contextSchema(),
+			"evidence":     evidenceSchema(),
+			"audit":        auditSchema(),
+			"verification": verificationSchema(),
+			"actions":      actionsSchema(),
+			"enabled":      map[string]any{"type": "boolean"},
 		},
 		"oneOf": []map[string]any{
 			{"required": []string{"match"}},
@@ -143,6 +143,245 @@ func remediationSchema() map[string]any {
 	}
 }
 
+func inputSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"sourceKinds":    stringArraySchema("Source record kinds required to evaluate the policy."),
+			"eventKinds":     stringArraySchema("Evidence or result event kinds accepted by the policy."),
+			"requiredClaims": stringArraySchema("Normalized claims that must be present before evaluation."),
+			"requiredFields": stringArraySchema("Fields required on every evaluated evidence record."),
+			"requiredFieldsByKind": map[string]any{
+				"type":                 "object",
+				"additionalProperties": stringArraySchema("Fields required for this evidence kind."),
+			},
+			"freshnessSLA": stringSchema("Maximum acceptable evidence age, such as 24h or 14d."),
+		},
+	}
+}
+
+func assertSchema() map[string]any {
+	assertions := map[string]any{
+		"type":     "array",
+		"minItems": 1,
+		"items":    assertionSchema(),
+	}
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"all": assertions,
+			"any": assertions,
+		},
+		"anyOf": []map[string]any{
+			{"required": []string{"all"}},
+			{"required": []string{"any"}},
+		},
+	}
+}
+
+func assertionSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"field", "op"},
+		"properties": map[string]any{
+			"field": stringSchema("Evidence field or normalized context path to evaluate."),
+			"op": map[string]any{
+				"type": "string",
+				"enum": []string{"eq", "ne", "in", "not_in", "gt", "gte", "lt", "lte", "exists", "is_true", "is_false"},
+			},
+			"value": map[string]any{"description": "Expected comparison value for operators that need one."},
+		},
+	}
+}
+
+func contextSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"graph": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]any{
+					"anchors": stringArraySchema("Evidence fields that anchor graph lookup."),
+					"enrich":  stringArraySchema("Graph-derived context to attach to the finding."),
+				},
+			},
+			"severityAdjustments": map[string]any{
+				"type":  "array",
+				"items": severityAdjustmentSchema(),
+			},
+		},
+	}
+}
+
+func severityAdjustmentSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"when"},
+		"properties": map[string]any{
+			"when": stringSchema("Expression over policy context that triggers the adjustment."),
+			"set": map[string]any{
+				"type": "string",
+				"enum": []string{"critical", "high", "medium", "low", "info", "CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"},
+			},
+			"delta": stringSchema("Relative severity adjustment."),
+		},
+		"anyOf": []map[string]any{
+			{"required": []string{"set"}},
+			{"required": []string{"delta"}},
+		},
+	}
+}
+
+func evidenceSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"type":              stringSchema("Normalized evidence type used for audit and routing."),
+			"assessmentMethods": assessmentMethodsSchema(),
+			"requiredForAudit":  map[string]any{"type": "boolean"},
+			"freshnessSLA":      stringSchema("Maximum acceptable evidence age for this policy."),
+			"acceptableSources": stringArraySchema("Authoritative systems accepted as evidence sources."),
+			"requiredFields":    stringArraySchema("Fields required on collected evidence."),
+			"fingerprintFields": stringArraySchema("Stable fields used to fingerprint repeated findings."),
+		},
+	}
+}
+
+func auditSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"evidenceType":       stringSchema("Auditor-facing evidence type."),
+			"assessmentMethods":  assessmentMethodsSchema(),
+			"freshnessSLA":       stringSchema("Maximum acceptable age for auditor-facing evidence."),
+			"auditorStatement":   stringSchema("Plain-language control statement for auditors."),
+			"auditorGuidance":    stringSchema("Guidance for interpreting evidence and exceptions."),
+			"riskStatement":      stringSchema("Risk addressed by the policy."),
+			"remediationIntent":  stringSchema("Expected remediation outcome."),
+			"acceptableEvidence": acceptableEvidenceSchema(),
+			"exceptionPolicy":    exceptionPolicySchema(),
+			"exceptionGuidance":  stringArraySchema("Accepted exception scenarios."),
+			"falsePositives":     stringArraySchema("Common false-positive explanations."),
+		},
+	}
+}
+
+func acceptableEvidenceSchema() map[string]any {
+	return map[string]any{
+		"type": "array",
+		"items": map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"required":             []string{"source"},
+			"properties": map[string]any{
+				"source": stringSchema("Authoritative evidence source."),
+				"fields": stringArraySchema("Fields expected from this source."),
+			},
+		},
+	}
+}
+
+func exceptionPolicySchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"maxAge":           stringSchema("Maximum exception age, such as 14d."),
+			"requiresApproval": map[string]any{"type": "boolean"},
+		},
+	}
+}
+
+func verificationSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"fixtures": map[string]any{
+				"type":  "array",
+				"items": verificationFixtureSchema(),
+			},
+			"mutationChecks":   stringArraySchema("Negative checks used to harden the policy."),
+			"remediationCheck": remediationCheckSchema(),
+		},
+	}
+}
+
+func verificationFixtureSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"name", "expect"},
+		"properties": map[string]any{
+			"name":        stringSchema("Fixture identifier."),
+			"expect":      map[string]any{"type": "string", "enum": []string{"finding", "pass"}},
+			"description": stringSchema("What the fixture proves."),
+		},
+	}
+}
+
+func remediationCheckSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"rerunAfter": stringSchema("Trigger after which the policy should be rerun."),
+			"expectedStatus": map[string]any{
+				"type": "string",
+				"enum": []string{"pass", "finding", "closed", "open"},
+			},
+		},
+	}
+}
+
+func actionsSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"owner": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]any{
+					"from":     stringSchema("Primary owner lookup path."),
+					"fallback": stringSchema("Fallback owner lookup path."),
+				},
+			},
+			"remediation": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]any{
+					"type":  stringSchema("Remediation action type."),
+					"steps": stringArraySchema("Ordered action steps."),
+				},
+			},
+			"effort": map[string]any{"type": "string", "enum": []string{"low", "medium", "high"}},
+			"blastRadius": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]any{
+					"estimateFrom": stringSchema("Context path used to estimate blast radius."),
+				},
+			},
+			"verification": map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]any{
+					"rerunPolicy": map[string]any{"type": "boolean"},
+				},
+			},
+		},
+	}
+}
+
 func frameworkSchema() map[string]any {
 	return map[string]any{
 		"type":                 "object",
@@ -170,20 +409,23 @@ func mitreSchema() map[string]any {
 	}
 }
 
+func assessmentMethodsSchema() map[string]any {
+	return map[string]any{
+		"type":        "array",
+		"description": "Audit assessment methods.",
+		"items": map[string]any{
+			"type": "string",
+			"enum": []string{"examine", "interview", "observe", "test"},
+		},
+	}
+}
+
 func stringArraySchema(description string) map[string]any {
 	return map[string]any{
 		"type":        "array",
 		"description": description,
 		"items":       stringSchema(""),
 	}
-}
-
-func openObjectSchema(description string) map[string]any {
-	schema := map[string]any{"type": "object"}
-	if description != "" {
-		schema["description"] = description
-	}
-	return schema
 }
 
 func stringSchema(description string) map[string]any {

--- a/internal/findingdsl/schema.go
+++ b/internal/findingdsl/schema.go
@@ -82,9 +82,22 @@ func specSchema() map[string]any {
 			"enabled":      map[string]any{"type": "boolean"},
 		},
 		"oneOf": []map[string]any{
-			{"required": []string{"match"}},
-			{"required": []string{"assert"}},
-			{"required": []string{"graph"}},
+			{
+				"required": []string{"graph"},
+				"not": map[string]any{
+					"anyOf": []map[string]any{
+						{"required": []string{"match"}},
+						{"required": []string{"assert"}},
+					},
+				},
+			},
+			{
+				"anyOf": []map[string]any{
+					{"required": []string{"match"}},
+					{"required": []string{"assert"}},
+				},
+				"not": map[string]any{"required": []string{"graph"}},
+			},
 		},
 	}
 }

--- a/schemas/policy-finding-rule.schema.json
+++ b/schemas/policy-finding-rule.schema.json
@@ -56,19 +56,42 @@
       "additionalProperties": false,
       "oneOf": [
         {
-          "required": [
-            "match"
-          ]
-        },
-        {
-          "required": [
-            "assert"
-          ]
-        },
-        {
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "match"
+                ]
+              },
+              {
+                "required": [
+                  "assert"
+                ]
+              }
+            ]
+          },
           "required": [
             "graph"
           ]
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "match"
+              ]
+            },
+            {
+              "required": [
+                "assert"
+              ]
+            }
+          ],
+          "not": {
+            "required": [
+              "graph"
+            ]
+          }
         }
       ],
       "properties": {

--- a/schemas/policy-finding-rule.schema.json
+++ b/schemas/policy-finding-rule.schema.json
@@ -77,15 +77,252 @@
           "type": "string"
         },
         "actions": {
-          "description": "Ownership, remediation, and verification action hints.",
+          "additionalProperties": false,
+          "properties": {
+            "blastRadius": {
+              "additionalProperties": false,
+              "properties": {
+                "estimateFrom": {
+                  "description": "Context path used to estimate blast radius.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "effort": {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "type": "string"
+            },
+            "owner": {
+              "additionalProperties": false,
+              "properties": {
+                "fallback": {
+                  "description": "Fallback owner lookup path.",
+                  "type": "string"
+                },
+                "from": {
+                  "description": "Primary owner lookup path.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "remediation": {
+              "additionalProperties": false,
+              "properties": {
+                "steps": {
+                  "description": "Ordered action steps.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "description": "Remediation action type.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "verification": {
+              "additionalProperties": false,
+              "properties": {
+                "rerunPolicy": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            }
+          },
           "type": "object"
         },
         "assert": {
-          "description": "Structured assertions for evidence-backed policy checks.",
+          "additionalProperties": false,
+          "anyOf": [
+            {
+              "required": [
+                "all"
+              ]
+            },
+            {
+              "required": [
+                "any"
+              ]
+            }
+          ],
+          "properties": {
+            "all": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "field": {
+                    "description": "Evidence field or normalized context path to evaluate.",
+                    "type": "string"
+                  },
+                  "op": {
+                    "enum": [
+                      "eq",
+                      "ne",
+                      "in",
+                      "not_in",
+                      "gt",
+                      "gte",
+                      "lt",
+                      "lte",
+                      "exists",
+                      "is_true",
+                      "is_false"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Expected comparison value for operators that need one."
+                  }
+                },
+                "required": [
+                  "field",
+                  "op"
+                ],
+                "type": "object"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "any": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "field": {
+                    "description": "Evidence field or normalized context path to evaluate.",
+                    "type": "string"
+                  },
+                  "op": {
+                    "enum": [
+                      "eq",
+                      "ne",
+                      "in",
+                      "not_in",
+                      "gt",
+                      "gte",
+                      "lt",
+                      "lte",
+                      "exists",
+                      "is_true",
+                      "is_false"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Expected comparison value for operators that need one."
+                  }
+                },
+                "required": [
+                  "field",
+                  "op"
+                ],
+                "type": "object"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
           "type": "object"
         },
         "audit": {
-          "description": "Auditor-facing evidence, exception, and risk guidance.",
+          "additionalProperties": false,
+          "properties": {
+            "acceptableEvidence": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "fields": {
+                    "description": "Fields expected from this source.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "source": {
+                    "description": "Authoritative evidence source.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "assessmentMethods": {
+              "description": "Audit assessment methods.",
+              "items": {
+                "enum": [
+                  "examine",
+                  "interview",
+                  "observe",
+                  "test"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "auditorGuidance": {
+              "description": "Guidance for interpreting evidence and exceptions.",
+              "type": "string"
+            },
+            "auditorStatement": {
+              "description": "Plain-language control statement for auditors.",
+              "type": "string"
+            },
+            "evidenceType": {
+              "description": "Auditor-facing evidence type.",
+              "type": "string"
+            },
+            "exceptionGuidance": {
+              "description": "Accepted exception scenarios.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "exceptionPolicy": {
+              "additionalProperties": false,
+              "properties": {
+                "maxAge": {
+                  "description": "Maximum exception age, such as 14d.",
+                  "type": "string"
+                },
+                "requiresApproval": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "falsePositives": {
+              "description": "Common false-positive explanations.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "freshnessSLA": {
+              "description": "Maximum acceptable age for auditor-facing evidence.",
+              "type": "string"
+            },
+            "remediationIntent": {
+              "description": "Expected remediation outcome.",
+              "type": "string"
+            },
+            "riskStatement": {
+              "description": "Risk addressed by the policy.",
+              "type": "string"
+            }
+          },
           "type": "object"
         },
         "category": {
@@ -93,7 +330,76 @@
           "type": "string"
         },
         "context": {
-          "description": "Graph and severity-adjustment context for policy evaluation.",
+          "additionalProperties": false,
+          "properties": {
+            "graph": {
+              "additionalProperties": false,
+              "properties": {
+                "anchors": {
+                  "description": "Evidence fields that anchor graph lookup.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "enrich": {
+                  "description": "Graph-derived context to attach to the finding.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "severityAdjustments": {
+              "items": {
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "required": [
+                      "set"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "delta"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "delta": {
+                    "description": "Relative severity adjustment.",
+                    "type": "string"
+                  },
+                  "set": {
+                    "enum": [
+                      "critical",
+                      "high",
+                      "medium",
+                      "low",
+                      "info",
+                      "CRITICAL",
+                      "HIGH",
+                      "MEDIUM",
+                      "LOW",
+                      "INFO"
+                    ],
+                    "type": "string"
+                  },
+                  "when": {
+                    "description": "Expression over policy context that triggers the adjustment.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
           "type": "object"
         },
         "effect": {
@@ -104,7 +410,54 @@
           "type": "boolean"
         },
         "evidence": {
-          "description": "Evidence requirements and fingerprinting metadata.",
+          "additionalProperties": false,
+          "properties": {
+            "acceptableSources": {
+              "description": "Authoritative systems accepted as evidence sources.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "assessmentMethods": {
+              "description": "Audit assessment methods.",
+              "items": {
+                "enum": [
+                  "examine",
+                  "interview",
+                  "observe",
+                  "test"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "fingerprintFields": {
+              "description": "Stable fields used to fingerprint repeated findings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "freshnessSLA": {
+              "description": "Maximum acceptable evidence age for this policy.",
+              "type": "string"
+            },
+            "requiredFields": {
+              "description": "Fields required on collected evidence.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "requiredForAudit": {
+              "type": "boolean"
+            },
+            "type": {
+              "description": "Normalized evidence type used for audit and routing.",
+              "type": "string"
+            }
+          },
           "type": "object"
         },
         "frameworks": {
@@ -172,7 +525,51 @@
           "type": "object"
         },
         "input": {
-          "description": "Runtime, claim, and field requirements for evaluating the policy.",
+          "additionalProperties": false,
+          "properties": {
+            "eventKinds": {
+              "description": "Evidence or result event kinds accepted by the policy.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "freshnessSLA": {
+              "description": "Maximum acceptable evidence age, such as 24h or 14d.",
+              "type": "string"
+            },
+            "requiredClaims": {
+              "description": "Normalized claims that must be present before evaluation.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "requiredFields": {
+              "description": "Fields required on every evaluated evidence record.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "requiredFieldsByKind": {
+              "additionalProperties": {
+                "description": "Fields required for this evidence kind.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": "object"
+            },
+            "sourceKinds": {
+              "description": "Source record kinds required to evaluate the policy.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
           "type": "object"
         },
         "match": {
@@ -280,7 +677,63 @@
           "type": "string"
         },
         "verification": {
-          "description": "Author-supplied verification fixtures and mutation checks.",
+          "additionalProperties": false,
+          "properties": {
+            "fixtures": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "description": {
+                    "description": "What the fixture proves.",
+                    "type": "string"
+                  },
+                  "expect": {
+                    "enum": [
+                      "finding",
+                      "pass"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Fixture identifier.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "expect"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "mutationChecks": {
+              "description": "Negative checks used to harden the policy.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "remediationCheck": {
+              "additionalProperties": false,
+              "properties": {
+                "expectedStatus": {
+                  "enum": [
+                    "pass",
+                    "finding",
+                    "closed",
+                    "open"
+                  ],
+                  "type": "string"
+                },
+                "rerunAfter": {
+                  "description": "Trigger after which the policy should be rerun.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
           "type": "object"
         }
       },


### PR DESCRIPTION
## Summary
- require values for binary policy assertion ops
- require non-empty list values for in/not_in policy assertions
- add regression coverage for invalid and valid assertion operands

## Validation
- go test ./internal/findingdsl -count=1 -v
- make finding-dsl-check
- make verify