### PR TITLE
fix: stretch JetStream publish retry budget

### DIFF
--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -32,14 +32,18 @@ const (
 	defaultReplayLimit         = 100
 	maxReplayLimit             = 1000
 	maxReplayCandidates        = 5000
-	publishRetryAttempts       = 4
-	publishRetryInitialBackoff = 50 * time.Millisecond
-	publishClientRetryAttempts = 2
-	publishClientRetryWait     = 250 * time.Millisecond
-	publishAttemptTimeout      = 15 * time.Second
+	publishRetryAttempts       = 10
+	publishRetryInitialBackoff = 250 * time.Millisecond
+	publishRetryMaxBackoff     = 5 * time.Second
+	publishClientRetryAttempts = 5
+	publishClientRetryWait     = 500 * time.Millisecond
+	publishAttemptTimeout      = 30 * time.Second
+	publishRetryMaxElapsed     = 90 * time.Second
 	jetstreamCanaryKind        = "cerebro.health.jetstream_canary"
 	jetstreamCanaryMinInterval = time.Minute
 )
+
+var waitBeforePublishRetryFunc = waitBeforePublishRetry
 
 type publisher interface {
 	AccountInfo(context.Context) (*jetstream.AccountInfo, error)
@@ -62,6 +66,11 @@ type publishTelemetry struct {
 	LastBackoff    time.Duration
 	LastRetryable  bool
 	Duration       time.Duration
+	RetryBudget    time.Duration
+	AttemptTimeout time.Duration
+	MaxBackoff     time.Duration
+	ClientRetries  int
+	ClientWait     time.Duration
 	AckStream      string
 	AckSequence    uint64
 	AckDuplicate   bool
@@ -287,13 +296,23 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 }
 
 func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, eventAttrs func() telemetry.Attributes) (publishTelemetry, error) {
-	result := publishTelemetry{Attempts: 0, MaxAttempts: publishRetryAttempts}
+	result := publishTelemetry{
+		Attempts:       0,
+		MaxAttempts:    publishRetryAttempts,
+		RetryBudget:    publishRetryMaxElapsed,
+		AttemptTimeout: publishAttemptTimeout,
+		MaxBackoff:     publishRetryMaxBackoff,
+		ClientRetries:  publishClientRetryAttempts,
+		ClientWait:     publishClientRetryWait,
+	}
 	backoff := publishRetryInitialBackoff
 	started := time.Now()
+	retryCtx, cancelRetry := context.WithTimeout(ctx, publishRetryMaxElapsed)
+	defer cancelRetry()
 	var err error
 	for attempt := 1; attempt <= result.MaxAttempts; attempt++ {
 		result.Attempts = attempt
-		attemptCtx, cancel := context.WithTimeout(ctx, publishAttemptTimeout)
+		attemptCtx, cancel := context.WithTimeout(retryCtx, publishAttemptTimeout)
 		ack, publishErr := l.js.PublishMsg(
 			attemptCtx,
 			msg,
@@ -308,7 +327,7 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, e
 		}
 		err = publishErr
 		result.LastRetryable = retryablePublishError(err)
-		if attempt == result.MaxAttempts || !result.LastRetryable || ctx.Err() != nil {
+		if attempt == result.MaxAttempts || !result.LastRetryable || retryCtx.Err() != nil {
 			result.Duration = time.Since(started)
 			if result.RetryCount > 0 {
 				telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, err)))
@@ -322,12 +341,12 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, e
 			telemetry.Field{Key: "messaging.jetstream.publish.next_attempt", Value: attempt + 1},
 			telemetry.Field{Key: "messaging.jetstream.publish.next_backoff_ms", Value: backoff.Milliseconds()},
 		)))
-		if waitErr := waitBeforePublishRetry(ctx, backoff); waitErr != nil {
+		if waitErr := waitBeforePublishRetryFunc(retryCtx, backoff); waitErr != nil {
 			result.Duration = time.Since(started)
 			telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, waitErr)))
 			return result, waitErr
 		}
-		backoff *= 2
+		backoff = minDuration(backoff*2, publishRetryMaxBackoff)
 	}
 	result.Duration = time.Since(started)
 	return result, err
@@ -361,6 +380,11 @@ func (r publishTelemetry) attrs() telemetry.Attributes {
 		telemetry.Field{Key: "messaging.jetstream.publish.retryable_last_error", Value: r.LastRetryable},
 		telemetry.Field{Key: "messaging.jetstream.publish.last_backoff_ms", Value: r.LastBackoff.Milliseconds()},
 		telemetry.Field{Key: "messaging.jetstream.publish.duration_ms", Value: r.Duration.Milliseconds()},
+		telemetry.Field{Key: "messaging.jetstream.publish.retry_budget_ms", Value: r.RetryBudget.Milliseconds()},
+		telemetry.Field{Key: "messaging.jetstream.publish.attempt_timeout_ms", Value: r.AttemptTimeout.Milliseconds()},
+		telemetry.Field{Key: "messaging.jetstream.publish.max_backoff_ms", Value: r.MaxBackoff.Milliseconds()},
+		telemetry.Field{Key: "messaging.jetstream.publish.client_retry_attempts", Value: r.ClientRetries},
+		telemetry.Field{Key: "messaging.jetstream.publish.client_retry_wait_ms", Value: r.ClientWait.Milliseconds()},
 	)
 	if r.AckUnavailable {
 		attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.ack.unavailable", Value: true})
@@ -412,6 +436,13 @@ func waitBeforePublishRetry(ctx context.Context, delay time.Duration) error {
 	case <-timer.C:
 		return nil
 	}
+}
+
+func minDuration(left, right time.Duration) time.Duration {
+	if left < right {
+		return left
+	}
+	return right
 }
 
 // Replay returns the newest matching stored envelopes in append order.

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -138,6 +138,22 @@ func jetstreamTelemetryPayloads(t *testing.T, stderr string, kind string, name s
 	return payloads
 }
 
+func skipPublishRetryWaits(t *testing.T) {
+	t.Helper()
+	original := waitBeforePublishRetryFunc
+	waitBeforePublishRetryFunc = func(ctx context.Context, _ time.Duration) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+	t.Cleanup(func() {
+		waitBeforePublishRetryFunc = original
+	})
+}
+
 func TestAppendPublishesEnvelope(t *testing.T) {
 	pub := &fakePublisher{}
 	log := &Log{js: pub, subjectPrefix: "events"}
@@ -170,6 +186,7 @@ func TestAppendPublishesEnvelope(t *testing.T) {
 }
 
 func TestAppendRetriesTransientPublishErrorWhenMessageIDIsSet(t *testing.T) {
+	skipPublishRetryWaits(t)
 	pub := &fakePublisher{
 		publishErrs: []error{
 			errors.New("nats: no response from stream"),
@@ -191,6 +208,7 @@ func TestAppendRetriesTransientPublishErrorWhenMessageIDIsSet(t *testing.T) {
 }
 
 func TestAppendEmitsPublishRetryTelemetry(t *testing.T) {
+	skipPublishRetryWaits(t)
 	pub := &fakePublisher{
 		publishErrs: []error{
 			errors.New("nats: no response from stream"),
@@ -226,6 +244,21 @@ func TestAppendEmitsPublishRetryTelemetry(t *testing.T) {
 	if retry["messaging.jetstream.publish.next_attempt"] != float64(2) {
 		t.Fatalf("next attempt = %v, want 2", retry["messaging.jetstream.publish.next_attempt"])
 	}
+	if retry["messaging.jetstream.publish.retry_budget_ms"] != float64(publishRetryMaxElapsed.Milliseconds()) {
+		t.Fatalf("retry budget = %v, want %d", retry["messaging.jetstream.publish.retry_budget_ms"], publishRetryMaxElapsed.Milliseconds())
+	}
+	if retry["messaging.jetstream.publish.attempt_timeout_ms"] != float64(publishAttemptTimeout.Milliseconds()) {
+		t.Fatalf("attempt timeout = %v, want %d", retry["messaging.jetstream.publish.attempt_timeout_ms"], publishAttemptTimeout.Milliseconds())
+	}
+	if retry["messaging.jetstream.publish.max_backoff_ms"] != float64(publishRetryMaxBackoff.Milliseconds()) {
+		t.Fatalf("max backoff = %v, want %d", retry["messaging.jetstream.publish.max_backoff_ms"], publishRetryMaxBackoff.Milliseconds())
+	}
+	if retry["messaging.jetstream.publish.client_retry_attempts"] != float64(publishClientRetryAttempts) {
+		t.Fatalf("client retry attempts = %v, want %d", retry["messaging.jetstream.publish.client_retry_attempts"], publishClientRetryAttempts)
+	}
+	if retry["messaging.jetstream.publish.client_retry_wait_ms"] != float64(publishClientRetryWait.Milliseconds()) {
+		t.Fatalf("client retry wait = %v, want %d", retry["messaging.jetstream.publish.client_retry_wait_ms"], publishClientRetryWait.Milliseconds())
+	}
 
 	recoveredEvents := jetstreamTelemetryPayloads(t, stderr, "event", "jetstream.publish.recovered")
 	if len(recoveredEvents) != 1 {
@@ -248,13 +281,13 @@ func TestAppendEmitsPublishRetryTelemetry(t *testing.T) {
 }
 
 func TestAppendEmitsPublishRetryExhaustedTelemetry(t *testing.T) {
+	skipPublishRetryWaits(t)
+	errs := make([]error, publishRetryAttempts)
+	for i := range errs {
+		errs[i] = errors.New("nats: no response from stream")
+	}
 	pub := &fakePublisher{
-		publishErrs: []error{
-			errors.New("nats: no response from stream"),
-			errors.New("nats: no response from stream"),
-			errors.New("nats: no response from stream"),
-			errors.New("nats: no response from stream"),
-		},
+		publishErrs: errs,
 	}
 	log := &Log{js: pub, subjectPrefix: "events"}
 
@@ -285,6 +318,12 @@ func TestAppendEmitsPublishRetryExhaustedTelemetry(t *testing.T) {
 	if exhausted["messaging.jetstream.publish.max_attempts"] != float64(publishRetryAttempts) {
 		t.Fatalf("exhausted max attempts = %v, want %d", exhausted["messaging.jetstream.publish.max_attempts"], publishRetryAttempts)
 	}
+	if exhausted["messaging.jetstream.publish.retry_budget_ms"] != float64(publishRetryMaxElapsed.Milliseconds()) {
+		t.Fatalf("retry budget = %v, want %d", exhausted["messaging.jetstream.publish.retry_budget_ms"], publishRetryMaxElapsed.Milliseconds())
+	}
+	if exhausted["messaging.jetstream.publish.last_backoff_ms"] != float64(publishRetryMaxBackoff.Milliseconds()) {
+		t.Fatalf("last backoff = %v, want capped %d", exhausted["messaging.jetstream.publish.last_backoff_ms"], publishRetryMaxBackoff.Milliseconds())
+	}
 	errorEvents := jetstreamTelemetryPayloads(t, stderr, "event", "jetstream.error")
 	if len(errorEvents) != 1 {
 		t.Fatalf("jetstream.error events = %d, want 1; stderr=%s", len(errorEvents), stderr)
@@ -295,6 +334,7 @@ func TestAppendEmitsPublishRetryExhaustedTelemetry(t *testing.T) {
 }
 
 func TestAppendRetriesTransientPublishErrorWithDerivedMessageID(t *testing.T) {
+	skipPublishRetryWaits(t)
 	pub := &fakePublisher{
 		publishErrs: []error{
 			errors.New("nats: no response from stream"),


### PR DESCRIPTION
## Summary
- expands JetStream publish resilience from a short 4-attempt ladder to a 90s bounded retry budget
- increases client-side JetStream request retry patience for stream stalls
- adds capped backoff and publishes the retry budget/client retry knobs into wide events
- keeps unit tests fast with a retry-wait test hook while asserting the new fields

## Live Evidence
- sec-dev v2.1.479 still emitted `jetstream.publish.retry_exhausted` for `sec.findings.v1.recorded` after only ~2.36s total publish duration
- NATS stream was live and lag was 0, but the file-backed stream had ~10.6M messages and recovered a corrupt state index at startup, so short app-side publish budgets were failing graph/finding runs during stream pressure

## Tests
- `go test ./internal/appendlog/jetstream`
- `go test ./internal/appendlog/... ./internal/config`
- `git diff --check`
- `go test ./...`