### PR TITLE
[codex] Add JetStream publish reliability metrics

### DIFF
--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -21,6 +21,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/telemetry"
@@ -71,6 +72,10 @@ type publishTelemetry struct {
 	MaxBackoff     time.Duration
 	ClientRetries  int
 	ClientWait     time.Duration
+	RetryExhausted bool
+	MaxExhausted   bool
+	BulkheadWait   time.Duration
+	BulkheadLimit  int
 	AckStream      string
 	AckSequence    uint64
 	AckDuplicate   bool
@@ -107,6 +112,7 @@ type Log struct {
 	js            publisher
 	replay        replayManager
 	subjectPrefix string
+	publishSlots  chan struct{}
 	canaryMu      sync.Mutex
 	lastCanary    time.Time
 }
@@ -149,12 +155,16 @@ func Open(cfg config.AppendLogConfig) (*Log, error) {
 		nc.Close()
 		return nil, fmt.Errorf("new jetstream client: %w", err)
 	}
-	return &Log{
+	log := &Log{
 		conn:          nc,
 		js:            js,
 		replay:        &jetStreamReplayManager{js: js},
 		subjectPrefix: prefix,
-	}, nil
+	}
+	if cfg.JetStreamPublishMaxInFlight > 0 {
+		log.publishSlots = make(chan struct{}, cfg.JetStreamPublishMaxInFlight)
+	}
+	return log, nil
 }
 
 // Close closes the underlying NATS connection.
@@ -283,9 +293,11 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 	endAttrs := publishAttrs().With(publishResult.attrs())
 	if err != nil {
 		err = fmt.Errorf("publish event: %w", err)
+		recordJetStreamPublish(ctx, "append", subject, "failed", err, publishResult)
 		jetstreamTelemetryError(ctx, span, "append", err, endAttrs)
 		return err
 	}
+	recordJetStreamPublish(ctx, "append", subject, "completed", nil, publishResult)
 	if publishResult.RetryCount > 0 {
 		telemetry.IncrementMain(ctx, "messaging.jetstream.publish.recovered.count", 1)
 		telemetry.Event(ctx, "jetstream.publish.recovered", endAttrs)
@@ -313,12 +325,47 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, e
 	for attempt := 1; attempt <= result.MaxAttempts; attempt++ {
 		result.Attempts = attempt
 		attemptCtx, cancel := context.WithTimeout(retryCtx, publishAttemptTimeout)
+		wait, release, acquireErr := l.acquirePublishSlot(attemptCtx)
+		result.BulkheadWait += wait
+		result.BulkheadLimit = l.publishLimit()
+		if acquireErr != nil {
+			cancel()
+			err = acquireErr
+			result.LastRetryable = retryablePublishError(err)
+			if attempt == result.MaxAttempts || !result.LastRetryable || retryCtx.Err() != nil {
+				result.Duration = time.Since(started)
+				result.RetryExhausted = result.RetryCount > 0
+				result.MaxExhausted = attempt == result.MaxAttempts
+				if result.RetryExhausted {
+					telemetry.IncrementMain(ctx, "messaging.jetstream.publish.retry_exhausted.count", 1)
+					telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, err)))
+				}
+				return result, err
+			}
+			result.RetryCount++
+			result.LastBackoff = backoff
+			telemetry.IncrementMain(ctx, "messaging.jetstream.publish.retry.count", 1)
+			telemetry.Event(ctx, "jetstream.publish.retry", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, err)).With(telemetry.Attrs(
+				telemetry.Field{Key: "messaging.jetstream.publish.next_attempt", Value: attempt + 1},
+				telemetry.Field{Key: "messaging.jetstream.publish.next_backoff_ms", Value: backoff.Milliseconds()},
+			)))
+			if waitErr := waitBeforePublishRetryFunc(retryCtx, backoff); waitErr != nil {
+				result.Duration = time.Since(started)
+				result.RetryExhausted = result.RetryCount > 0
+				telemetry.IncrementMain(ctx, "messaging.jetstream.publish.retry_exhausted.count", 1)
+				telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, waitErr)))
+				return result, waitErr
+			}
+			backoff = minDuration(backoff*2, publishRetryMaxBackoff)
+			continue
+		}
 		ack, publishErr := l.js.PublishMsg(
 			attemptCtx,
 			msg,
 			jetstream.WithRetryAttempts(publishClientRetryAttempts),
 			jetstream.WithRetryWait(publishClientRetryWait),
 		)
+		release()
 		cancel()
 		if publishErr == nil {
 			result.Duration = time.Since(started)
@@ -329,7 +376,10 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, e
 		result.LastRetryable = retryablePublishError(err)
 		if attempt == result.MaxAttempts || !result.LastRetryable || retryCtx.Err() != nil {
 			result.Duration = time.Since(started)
+			result.RetryExhausted = result.RetryCount > 0
+			result.MaxExhausted = attempt == result.MaxAttempts
 			if result.RetryCount > 0 {
+				telemetry.IncrementMain(ctx, "messaging.jetstream.publish.retry_exhausted.count", 1)
 				telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, err)))
 			}
 			return result, err
@@ -343,6 +393,8 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, e
 		)))
 		if waitErr := waitBeforePublishRetryFunc(retryCtx, backoff); waitErr != nil {
 			result.Duration = time.Since(started)
+			result.RetryExhausted = result.RetryCount > 0
+			telemetry.IncrementMain(ctx, "messaging.jetstream.publish.retry_exhausted.count", 1)
 			telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, waitErr)))
 			return result, waitErr
 		}
@@ -350,6 +402,29 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, e
 	}
 	result.Duration = time.Since(started)
 	return result, err
+}
+
+func (l *Log) acquirePublishSlot(ctx context.Context) (time.Duration, func(), error) {
+	limit := l.publishLimit()
+	if limit <= 0 || l.publishSlots == nil {
+		return 0, func() {}, nil
+	}
+	started := time.Now()
+	select {
+	case l.publishSlots <- struct{}{}:
+		return time.Since(started), func() {
+			<-l.publishSlots
+		}, nil
+	case <-ctx.Done():
+		return time.Since(started), func() {}, ctx.Err()
+	}
+}
+
+func (l *Log) publishLimit() int {
+	if l == nil || l.publishSlots == nil {
+		return 0
+	}
+	return cap(l.publishSlots)
 }
 
 func publishMessageID(event *cerebrov1.EventEnvelope, payload []byte) string {
@@ -378,6 +453,8 @@ func (r publishTelemetry) attrs() telemetry.Attributes {
 		telemetry.Field{Key: "messaging.jetstream.publish.max_attempts", Value: r.MaxAttempts},
 		telemetry.Field{Key: "messaging.jetstream.publish.retry_count", Value: r.RetryCount},
 		telemetry.Field{Key: "messaging.jetstream.publish.retryable_last_error", Value: r.LastRetryable},
+		telemetry.Field{Key: "messaging.jetstream.publish.retry_exhausted", Value: r.RetryExhausted},
+		telemetry.Field{Key: "messaging.jetstream.publish.max_attempts_exhausted", Value: r.MaxExhausted},
 		telemetry.Field{Key: "messaging.jetstream.publish.last_backoff_ms", Value: r.LastBackoff.Milliseconds()},
 		telemetry.Field{Key: "messaging.jetstream.publish.duration_ms", Value: r.Duration.Milliseconds()},
 		telemetry.Field{Key: "messaging.jetstream.publish.retry_budget_ms", Value: r.RetryBudget.Milliseconds()},
@@ -386,6 +463,13 @@ func (r publishTelemetry) attrs() telemetry.Attributes {
 		telemetry.Field{Key: "messaging.jetstream.publish.client_retry_attempts", Value: r.ClientRetries},
 		telemetry.Field{Key: "messaging.jetstream.publish.client_retry_wait_ms", Value: r.ClientWait.Milliseconds()},
 	)
+	if r.BulkheadLimit > 0 {
+		attrs = attrs.With(telemetry.Attrs(
+			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.enabled", Value: true},
+			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.max_in_flight", Value: r.BulkheadLimit},
+			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.wait_ms", Value: r.BulkheadWait.Milliseconds()},
+		))
+	}
 	if r.AckUnavailable {
 		attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.ack.unavailable", Value: true})
 	}
@@ -425,6 +509,22 @@ func retryablePublishError(err error) bool {
 		}
 	}
 	return false
+}
+
+func recordJetStreamPublish(ctx context.Context, operation string, subject string, status string, err error, result publishTelemetry) {
+	errorCategory := "none"
+	if err != nil {
+		errorCategory = jetstreamErrorCategory(err)
+	}
+	observability.RecordJetStreamPublish(ctx, observability.JetStreamPublishMetrics{
+		Subject:              subject,
+		Operation:            operation,
+		Status:               status,
+		ErrorCategory:        errorCategory,
+		Duration:             result.Duration,
+		RetryCount:           result.RetryCount,
+		MaxAttemptsExhausted: result.MaxExhausted,
+	})
 }
 
 func waitBeforePublishRetry(ctx context.Context, delay time.Duration) error {
@@ -611,8 +711,10 @@ func (l *Log) runCanary(ctx context.Context, stream *jetstream.StreamInfo) (tele
 		telemetry.Field{Key: "messaging.jetstream.canary.publish.duration_ms", Value: publishResult.Duration.Milliseconds()},
 	))
 	if err != nil {
+		recordJetStreamPublish(ctx, "canary", subject, "failed", err, publishResult)
 		return finish(canaryAttrs), fmt.Errorf("publish canary event: %w", err)
 	}
+	recordJetStreamPublish(ctx, "canary", subject, "completed", nil, publishResult)
 	if publishResult.AckSequence == 0 {
 		return finish(canaryAttrs), errors.New("publish canary event: ack sequence unavailable")
 	}

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -714,10 +714,10 @@ func (l *Log) runCanary(ctx context.Context, stream *jetstream.StreamInfo) (tele
 		recordJetStreamPublish(ctx, "canary", subject, "failed", err, publishResult)
 		return finish(canaryAttrs), fmt.Errorf("publish canary event: %w", err)
 	}
-	recordJetStreamPublish(ctx, "canary", subject, "completed", nil, publishResult)
 	if publishResult.AckSequence == 0 {
 		return finish(canaryAttrs), errors.New("publish canary event: ack sequence unavailable")
 	}
+	recordJetStreamPublish(ctx, "canary", subject, "completed", nil, publishResult)
 	streamName := strings.TrimSpace(publishResult.AckStream)
 	if streamName == "" && stream != nil {
 		streamName = strings.TrimSpace(stream.Config.Name)

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -324,12 +324,24 @@ func TestAppendEmitsPublishRetryExhaustedTelemetry(t *testing.T) {
 	if exhausted["messaging.jetstream.publish.last_backoff_ms"] != float64(publishRetryMaxBackoff.Milliseconds()) {
 		t.Fatalf("last backoff = %v, want capped %d", exhausted["messaging.jetstream.publish.last_backoff_ms"], publishRetryMaxBackoff.Milliseconds())
 	}
+	if exhausted["messaging.jetstream.publish.retry_exhausted"] != true {
+		t.Fatalf("exhausted retry flag = %v, want true", exhausted["messaging.jetstream.publish.retry_exhausted"])
+	}
+	if exhausted["messaging.jetstream.publish.max_attempts_exhausted"] != true {
+		t.Fatalf("max attempts exhausted = %v, want true", exhausted["messaging.jetstream.publish.max_attempts_exhausted"])
+	}
+	if exhausted["messaging.jetstream.error.category"] != "no_response" {
+		t.Fatalf("exhausted error category = %v, want no_response", exhausted["messaging.jetstream.error.category"])
+	}
 	errorEvents := jetstreamTelemetryPayloads(t, stderr, "event", "jetstream.error")
 	if len(errorEvents) != 1 {
 		t.Fatalf("jetstream.error events = %d, want 1; stderr=%s", len(errorEvents), stderr)
 	}
 	if errorEvents[0]["messaging.jetstream.publish.retry_count"] != float64(publishRetryAttempts-1) {
 		t.Fatalf("jetstream.error retry count = %v, want %d", errorEvents[0]["messaging.jetstream.publish.retry_count"], publishRetryAttempts-1)
+	}
+	if errorEvents[0]["messaging.jetstream.publish.max_attempts_exhausted"] != true {
+		t.Fatalf("jetstream.error max attempts exhausted = %v, want true", errorEvents[0]["messaging.jetstream.publish.max_attempts_exhausted"])
 	}
 }
 
@@ -355,6 +367,52 @@ func TestAppendRetriesTransientPublishErrorWithDerivedMessageID(t *testing.T) {
 	}
 	if got := pub.published.Header.Get(nats.MsgIdHdr); !strings.HasPrefix(got, "sha256:") {
 		t.Fatalf("derived msg id = %q, want sha256 fallback", got)
+	}
+}
+
+func TestAppendEmitsPublishBulkheadTelemetry(t *testing.T) {
+	pub := &fakePublisher{}
+	log := &Log{js: pub, subjectPrefix: "events", publishSlots: make(chan struct{}, 1)}
+
+	stderr := captureJetstreamTelemetry(t, func() {
+		err := log.Append(context.Background(), &cerebrov1.EventEnvelope{
+			Id:   "evt-bulkhead-telemetry",
+			Kind: "entity.upsert",
+		})
+		if err != nil {
+			t.Fatalf("Append() error = %v", err)
+		}
+	})
+
+	spanEnds := jetstreamTelemetryPayloads(t, stderr, "span_end", "jetstream.append")
+	if len(spanEnds) != 1 {
+		t.Fatalf("jetstream.append span_end events = %d, want 1; stderr=%s", len(spanEnds), stderr)
+	}
+	end := spanEnds[0]
+	if end["messaging.jetstream.publish.bulkhead.enabled"] != true {
+		t.Fatalf("bulkhead enabled = %v, want true", end["messaging.jetstream.publish.bulkhead.enabled"])
+	}
+	if end["messaging.jetstream.publish.bulkhead.max_in_flight"] != float64(1) {
+		t.Fatalf("bulkhead max in flight = %v, want 1", end["messaging.jetstream.publish.bulkhead.max_in_flight"])
+	}
+}
+
+func TestAcquirePublishSlotRespectsContextDeadline(t *testing.T) {
+	log := &Log{publishSlots: make(chan struct{}, 1)}
+	log.publishSlots <- struct{}{}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+
+	_, release, err := log.acquirePublishSlot(ctx)
+	if err == nil {
+		release()
+		t.Fatal("acquirePublishSlot() error = nil, want deadline error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("acquirePublishSlot() error = %v, want deadline exceeded", err)
+	}
+	if len(log.publishSlots) != 1 {
+		t.Fatalf("publishSlots len = %d, want 1", len(log.publishSlots))
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,10 +73,11 @@ type RateLimitConfig struct {
 
 // AppendLogConfig selects and configures the append-log driver.
 type AppendLogConfig struct {
-	Driver                 string
-	JetStreamURL           string
-	JetStreamSubjectPrefix string
-	JetStreamDrainTimeout  time.Duration
+	Driver                      string
+	JetStreamURL                string
+	JetStreamSubjectPrefix      string
+	JetStreamDrainTimeout       time.Duration
+	JetStreamPublishMaxInFlight int
 }
 
 // StateStoreConfig selects and configures the current-state store driver.
@@ -547,6 +548,9 @@ func Load() (Config, error) {
 	if cfg.AppendLog.JetStreamDrainTimeout, err = parseDurationEnv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", 0); err != nil {
 		return Config{}, err
 	}
+	if cfg.AppendLog.JetStreamPublishMaxInFlight, err = parseIntEnv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", 0); err != nil {
+		return Config{}, err
+	}
 	if cfg.StateStore.PostgresMaxOpenConns, err = parseIntEnv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", 0); err != nil {
 		return Config{}, err
 	}
@@ -627,6 +631,9 @@ func Load() (Config, error) {
 		}
 		if cfg.AppendLog.JetStreamSubjectPrefix == "" {
 			cfg.AppendLog.JetStreamSubjectPrefix = defaultJetStreamSubjectPrefix
+		}
+		if cfg.AppendLog.JetStreamPublishMaxInFlight < 0 {
+			return Config{}, errors.New("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT must be greater than or equal to 0")
 		}
 	default:
 		return Config{}, fmt.Errorf("unsupported CEREBRO_APPEND_LOG_DRIVER %q", cfg.AppendLog.Driver)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_URL", "")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "")
 	t.Setenv("CEREBRO_STATE_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_POSTGRES_DSN", "")
 	t.Setenv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", "")
@@ -143,6 +144,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_URL", "nats://127.0.0.1:4222")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "cerebro.events")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "4s")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "12")
 	t.Setenv("CEREBRO_STATE_STORE_DRIVER", StateStoreDriverPostgres)
 	t.Setenv("CEREBRO_POSTGRES_DSN", "postgres://127.0.0.1:5432/cerebro?sslmode=disable")
 	t.Setenv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", "20")
@@ -242,6 +244,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.AppendLog.JetStreamDrainTimeout != 4*time.Second {
 		t.Fatalf("JetStreamDrainTimeout = %v, want 4s", cfg.AppendLog.JetStreamDrainTimeout)
+	}
+	if cfg.AppendLog.JetStreamPublishMaxInFlight != 12 {
+		t.Fatalf("JetStreamPublishMaxInFlight = %d, want 12", cfg.AppendLog.JetStreamPublishMaxInFlight)
 	}
 	if cfg.StateStore.Driver != StateStoreDriverPostgres {
 		t.Fatalf("StateStore.Driver = %q, want %q", cfg.StateStore.Driver, StateStoreDriverPostgres)
@@ -1159,6 +1164,16 @@ func TestLoadRejectsMissingNeo4jPassword(t *testing.T) {
 
 func TestLoadRejectsInvalidDuration(t *testing.T) {
 	t.Setenv("CEREBRO_SHUTDOWN_TIMEOUT", "not-a-duration")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadRejectsNegativeJetStreamPublishMaxInFlight(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", AppendLogDriverJetStream)
+	t.Setenv("CEREBRO_JETSTREAM_URL", "nats://127.0.0.1:4222")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "-1")
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want non-nil")
 	}

--- a/internal/observability/domain_metrics.go
+++ b/internal/observability/domain_metrics.go
@@ -77,6 +77,39 @@ func otelGraphActionRecorded() otelmetric.Int64Counter {
 	return instrument
 }
 
+func otelJetStreamPublishRequests() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.jetstream.publish.requests",
+		otelmetric.WithDescription("Total JetStream publish requests by bounded subject, operation, status, and error category."),
+	)
+	return instrument
+}
+
+func otelJetStreamPublishRetries() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.jetstream.publish.retries",
+		otelmetric.WithDescription("Total JetStream publish retry attempts by bounded subject, operation, status, and error category."),
+	)
+	return instrument
+}
+
+func otelJetStreamPublishDuration() otelmetric.Float64Histogram {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Float64Histogram(
+		"cerebro.jetstream.publish.duration",
+		otelmetric.WithDescription("JetStream publish duration by bounded subject, operation, status, and error category."),
+		otelmetric.WithUnit("s"),
+	)
+	return instrument
+}
+
+func otelJetStreamPublishMaxAttemptsExhausted() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.jetstream.publish.max_attempts_exhausted",
+		otelmetric.WithDescription("Total JetStream publish requests that exhausted all configured attempts."),
+	)
+	return instrument
+}
+
 // SourceRuntimeSyncMetrics is intentionally shaped for low-cardinality OTEL
 // metrics. Runtime IDs, tenant IDs, resource URNs, evidence IDs, request IDs,
 // and trace IDs belong in spans/wide events, not metric labels.
@@ -118,6 +151,19 @@ type GraphActionMetrics struct {
 	Status         string
 	ExternalStatus string
 	DryRun         bool
+}
+
+// JetStreamPublishMetrics is intentionally scoped to bounded operational
+// dimensions. Message IDs, tenant IDs, runtime IDs, and resource identifiers
+// belong in spans/wide events rather than metric labels.
+type JetStreamPublishMetrics struct {
+	Subject              string
+	Operation            string
+	Status               string
+	ErrorCategory        string
+	Duration             time.Duration
+	RetryCount           int
+	MaxAttemptsExhausted bool
 }
 
 func RecordSourceRuntimeSync(ctx context.Context, metrics SourceRuntimeSyncMetrics) {
@@ -171,6 +217,26 @@ func RecordGraphAction(ctx context.Context, metrics GraphActionMetrics) {
 	otelGraphActionRecorded().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
 }
 
+func RecordJetStreamPublish(ctx context.Context, metrics JetStreamPublishMetrics) {
+	attrs := []attribute.KeyValue{
+		attribute.String("subject", boundedJetStreamMetricSubject(metrics.Subject)),
+		attribute.String("operation", boundedMetricValue(metrics.Operation, "unknown")),
+		attribute.String("status", boundedMetricValue(metrics.Status, "unknown")),
+		attribute.String("error_category", boundedMetricValue(metrics.ErrorCategory, "none")),
+		attribute.Bool("max_attempts_exhausted", metrics.MaxAttemptsExhausted),
+	}
+	otelJetStreamPublishRequests().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+	if metrics.Duration >= 0 {
+		otelJetStreamPublishDuration().Record(ctx, metrics.Duration.Seconds(), otelmetric.WithAttributes(attrs...))
+	}
+	if metrics.RetryCount > 0 {
+		otelJetStreamPublishRetries().Add(ctx, int64(metrics.RetryCount), otelmetric.WithAttributes(attrs...))
+	}
+	if metrics.MaxAttemptsExhausted {
+		otelJetStreamPublishMaxAttemptsExhausted().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+	}
+}
+
 func recordSourceRuntimeRecordCount(ctx context.Context, base []attribute.KeyValue, kind string, count int64) {
 	if count <= 0 {
 		return
@@ -219,6 +285,32 @@ func boundedMetricValue(value string, fallback string) string {
 		return fallback
 	}
 	return out.String()
+}
+
+func boundedJetStreamMetricSubject(subject string) string {
+	subject = boundedMetricValue(subject, "unknown")
+	switch {
+	case subject == "sec.findings.v1.recorded":
+		return subject
+	case strings.HasPrefix(subject, "sec.findings.v1."):
+		return "sec.findings.v1._other"
+	case strings.HasPrefix(subject, "sec."):
+		return boundedMetricSubjectPrefix(subject, 4)
+	case strings.HasPrefix(subject, "events.workflow.v1."):
+		return boundedMetricSubjectPrefix(subject, 5)
+	case strings.HasPrefix(subject, "events."):
+		return boundedMetricSubjectPrefix(subject, 3)
+	default:
+		return subject
+	}
+}
+
+func boundedMetricSubjectPrefix(subject string, maxTokens int) string {
+	tokens := strings.Split(subject, ".")
+	if len(tokens) <= maxTokens || maxTokens <= 0 {
+		return subject
+	}
+	return strings.Join(tokens[:maxTokens], ".") + "._other"
 }
 
 func maxInt64(value int64, minimum int64) int64 {

--- a/internal/observability/domain_metrics_test.go
+++ b/internal/observability/domain_metrics_test.go
@@ -99,6 +99,39 @@ func TestRecordGraphActionMetricsAreLowCardinality(t *testing.T) {
 	assertMetricHasBoolAttribute(t, metric, "dry_run", false)
 }
 
+func TestRecordJetStreamPublishMetricsAreLowCardinality(t *testing.T) {
+	reader, shutdown := installManualMetricReader(t)
+	RecordJetStreamPublish(context.Background(), JetStreamPublishMetrics{
+		Subject:              "sec.findings.v1.recorded",
+		Operation:            "append",
+		Status:               "failed",
+		ErrorCategory:        "no_response",
+		Duration:             250 * time.Millisecond,
+		RetryCount:           3,
+		MaxAttemptsExhausted: true,
+	})
+	t.Cleanup(shutdown)
+
+	metrics := collectMetrics(t, reader)
+	for _, name := range []string{
+		"cerebro.jetstream.publish.requests",
+		"cerebro.jetstream.publish.retries",
+		"cerebro.jetstream.publish.duration",
+		"cerebro.jetstream.publish.max_attempts_exhausted",
+	} {
+		if _, ok := metrics[name]; !ok {
+			t.Fatalf("metric %q missing from %#v", name, metricNames(metrics))
+		}
+	}
+	metric := metrics["cerebro.jetstream.publish.requests"]
+	assertNoForbiddenMetricAttributes(t, metric)
+	assertMetricHasAttribute(t, metric, "subject", "sec.findings.v1.recorded")
+	assertMetricHasAttribute(t, metric, "operation", "append")
+	assertMetricHasAttribute(t, metric, "status", "failed")
+	assertMetricHasAttribute(t, metric, "error_category", "no_response")
+	assertMetricHasBoolAttribute(t, metric, "max_attempts_exhausted", true)
+}
+
 func TestBoundedMetricValueNormalizesAndBoundsLabels(t *testing.T) {
 	got := boundedMetricValue("Runtime ID With Spaces And / Weird # Chars", "unknown")
 	if got != "runtime_id_with_spaces_and___weird___chars" {
@@ -109,6 +142,18 @@ func TestBoundedMetricValueNormalizesAndBoundsLabels(t *testing.T) {
 	}
 	if got := boundedMetricValue("source-"+strings.Repeat("x", 200), "unknown"); len(got) > 96 {
 		t.Fatalf("bounded metric value length = %d, want <= 96", len(got))
+	}
+}
+
+func TestBoundedJetStreamMetricSubjectCollapsesUnknownFindingsSubjects(t *testing.T) {
+	if got := boundedJetStreamMetricSubject("sec.findings.v1.recorded"); got != "sec.findings.v1.recorded" {
+		t.Fatalf("recorded subject = %q, want exact finding subject", got)
+	}
+	if got := boundedJetStreamMetricSubject("sec.findings.v1.some_new_subject"); got != "sec.findings.v1._other" {
+		t.Fatalf("other finding subject = %q, want collapsed finding family", got)
+	}
+	if got := boundedJetStreamMetricSubject("events.some.dynamic.identifier.value"); got != "events.some.dynamic._other" {
+		t.Fatalf("dynamic event subject = %q, want bounded event family", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add bounded OTEL metrics for JetStream publish requests, retries, duration, and max-attempt exhaustion
- preserve `sec.findings.v1.recorded` as an exact metric subject while collapsing broader subject families to avoid label explosion
- add `CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT` as an optional publish bulkhead and surface wait/limit telemetry on wide events
- enrich retry-exhausted telemetry with explicit `retry_exhausted` and `max_attempts_exhausted` fields

## Issue links
- Starts #1301
- Starts #1302
- Starts #1305
- Related: #1300, #1303, #1304

## Validation
- `go test ./internal/appendlog/jetstream`
- `go test ./internal/observability`
- `go test ./internal/config`
- `go test ./internal/appendlog/jetstream ./internal/observability ./internal/config ./internal/bootstrap`
- `go test ./...`
