### PR TITLE
Fix singleton graph projection joins

### DIFF
--- a/internal/sourceprojection/cosmo.go
+++ b/internal/sourceprojection/cosmo.go
@@ -200,7 +200,7 @@ func addCosmoCategoryLink(entities map[string]*ports.ProjectedEntity, links map[
 	if category == "" {
 		return
 	}
-	categoryURN := projectionURN(tenantID, "cosmo_fact_category", normalizeIdentifier(category))
+	categoryURN := projectionURN(tenantID, "cosmo_fact_category", cosmoExternalIDKey(category))
 	addEntity(entities, cosmoEntity(event, categoryURN, "cosmo.fact.category", category, map[string]string{"category": category}))
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), fromURN, categoryURN, relationTaggedAs, map[string]string{"event_id": event.GetId(), "source_attribute": "category"}))
 }

--- a/internal/sourceprojection/cosmo.go
+++ b/internal/sourceprojection/cosmo.go
@@ -35,7 +35,7 @@ func cosmoSessionProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projected
 	if user := firstNonEmpty(attrs["user"], stringValue(payload, "user")); user != "" {
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), sessionURN, user, event.GetOccurredAt())
 	}
-	addCosmoThreadLink(entities, links, event, tenantID, sessionURN, firstNonEmpty(attrs["thread_key"], stringValue(payload, "thread_key"), attrs["ticket_id"], stringValue(payload, "ticket_id")))
+	addCosmoThreadLink(entities, links, event, tenantID, sessionURN, firstNonEmpty(attrs["thread_key"], stringValue(payload, "thread_key")))
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }

--- a/internal/sourceprojection/cosmo.go
+++ b/internal/sourceprojection/cosmo.go
@@ -35,6 +35,7 @@ func cosmoSessionProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projected
 	if user := firstNonEmpty(attrs["user"], stringValue(payload, "user")); user != "" {
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), sessionURN, user, event.GetOccurredAt())
 	}
+	addCosmoThreadLink(entities, links, event, tenantID, sessionURN, firstNonEmpty(attrs["thread_key"], stringValue(payload, "thread_key"), attrs["ticket_id"], stringValue(payload, "ticket_id")))
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
@@ -69,6 +70,9 @@ func cosmoFactProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 	addEntity(entities, cosmoEntity(event, factURN, "cosmo.fact", factID, cosmoAttributes(attrs, factAttributes)))
 	if sessionID := cosmoFactSessionID(source); sessionID != "" {
 		addCosmoSessionLink(entities, links, event, tenantID, factURN, sessionID)
+	}
+	if category := firstNonEmpty(attrs["category"], stringValue(payload, "category")); category != "" {
+		addCosmoCategoryLink(entities, links, event, tenantID, factURN, category)
 	}
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
@@ -179,6 +183,26 @@ func addCosmoSessionLink(entities map[string]*ports.ProjectedEntity, links map[s
 	}
 	addEntity(entities, cosmoEntity(event, sessionURN, "cosmo.session", sessionID, map[string]string{"ticket_id": strings.TrimSpace(sessionID)}))
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), fromURN, sessionURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+}
+
+func addCosmoThreadLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, event *cerebrov1.EventEnvelope, tenantID string, fromURN string, threadID string) {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return
+	}
+	threadURN := projectionURN(tenantID, "cosmo_thread", cosmoExternalIDKey(threadID))
+	addEntity(entities, cosmoEntity(event, threadURN, "cosmo.thread", threadID, map[string]string{"thread_key": threadID}))
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), fromURN, threadURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+}
+
+func addCosmoCategoryLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, event *cerebrov1.EventEnvelope, tenantID string, fromURN string, category string) {
+	category = strings.TrimSpace(category)
+	if category == "" {
+		return
+	}
+	categoryURN := projectionURN(tenantID, "cosmo_fact_category", normalizeIdentifier(category))
+	addEntity(entities, cosmoEntity(event, categoryURN, "cosmo.fact.category", category, map[string]string{"category": category}))
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), fromURN, categoryURN, relationTaggedAs, map[string]string{"event_id": event.GetId(), "source_attribute": "category"}))
 }
 
 func addCosmoMessageUserLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, event *cerebrov1.EventEnvelope, tenantID string, messageURN string, attrs map[string]string, payload map[string]any) {

--- a/internal/sourceprojection/cosmo_test.go
+++ b/internal/sourceprojection/cosmo_test.go
@@ -53,7 +53,7 @@ func TestProjectCosmoFact(t *testing.T) {
 	if got := fact.Attributes["key"]; got != "risk:key" {
 		t.Fatalf("fact key attribute = %q, want raw key", got)
 	}
-	categoryURN := "urn:cerebro:writer:cosmo_fact_category:risk"
+	categoryURN := cosmoTestURN("cosmo_fact_category", "risk")
 	assertCosmoProjectedEntity(t, entities, categoryURN, "cosmo.fact.category")
 	assertCosmoProjectedLink(t, links, fact.URN, relationTaggedAs, categoryURN)
 }
@@ -108,6 +108,29 @@ func TestProjectCosmoFactLinksPayloadSourceSession(t *testing.T) {
 		t.Fatalf("session ticket_id attribute = %q, want raw payload session id", got)
 	}
 	assertCosmoProjectedLink(t, links, factURN, relationBelongsTo, sessionURN)
+}
+
+func TestProjectCosmoFactLinksHashedCategory(t *testing.T) {
+	entities, links, err := BuiltinRegistry().Project(&cerebrov1.EventEnvelope{
+		Id:       "cosmo-writer-fact-risk-category",
+		TenantId: "writer",
+		SourceId: "cosmo",
+		Kind:     "cosmo.fact",
+		Attributes: map[string]string{
+			"key":      "risk:key",
+			"category": "security:risk/high",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	factURN := cosmoTestURN("cosmo_fact", "risk:key")
+	categoryURN := cosmoTestURN("cosmo_fact_category", "security:risk/high")
+	category := cosmoProjectedEntity(t, entities, categoryURN, "cosmo.fact.category")
+	if got := category.Attributes["category"]; got != "security:risk/high" {
+		t.Fatalf("category attribute = %q, want raw category", got)
+	}
+	assertCosmoProjectedLink(t, links, factURN, relationTaggedAs, categoryURN)
 }
 
 func TestProjectCosmoFactCarriesCoordinationRiskState(t *testing.T) {

--- a/internal/sourceprojection/cosmo_test.go
+++ b/internal/sourceprojection/cosmo_test.go
@@ -25,9 +25,12 @@ func TestProjectCosmoSession(t *testing.T) {
 		t.Fatalf("Project() error = %v", err)
 	}
 	sessionURN := cosmoTestURN("cosmo_session", "ticket-1")
+	threadURN := cosmoTestURN("cosmo_thread", "thread-1")
 	assertCosmoProjectedEntity(t, entities, sessionURN, "cosmo.session")
+	assertCosmoProjectedEntity(t, entities, threadURN, "cosmo.thread")
 	assertCosmoProjectedEntity(t, entities, "urn:cerebro:writer:identity:email:alice@example.com", "identity.email")
 	assertCosmoProjectedLink(t, links, sessionURN, relationRepresentsIdentity, "urn:cerebro:writer:identity:email:alice@example.com")
+	assertCosmoProjectedLink(t, links, sessionURN, relationBelongsTo, threadURN)
 }
 
 func TestProjectCosmoFact(t *testing.T) {
@@ -50,9 +53,9 @@ func TestProjectCosmoFact(t *testing.T) {
 	if got := fact.Attributes["key"]; got != "risk:key" {
 		t.Fatalf("fact key attribute = %q, want raw key", got)
 	}
-	if len(links) != 0 {
-		t.Fatalf("len(links) = %d, want 0", len(links))
-	}
+	categoryURN := "urn:cerebro:writer:cosmo_fact_category:risk"
+	assertCosmoProjectedEntity(t, entities, categoryURN, "cosmo.fact.category")
+	assertCosmoProjectedLink(t, links, fact.URN, relationTaggedAs, categoryURN)
 }
 
 func TestProjectCosmoFactLinksSourceSession(t *testing.T) {

--- a/internal/sourceprojection/cosmo_test.go
+++ b/internal/sourceprojection/cosmo_test.go
@@ -33,6 +33,28 @@ func TestProjectCosmoSession(t *testing.T) {
 	assertCosmoProjectedLink(t, links, sessionURN, relationBelongsTo, threadURN)
 }
 
+func TestProjectCosmoSessionDoesNotLinkTicketIDAsThread(t *testing.T) {
+	entities, links, err := BuiltinRegistry().Project(&cerebrov1.EventEnvelope{
+		Id:       "cosmo-writer-session-ticket-only",
+		TenantId: "writer",
+		SourceId: "cosmo",
+		Kind:     "cosmo.session",
+		Attributes: map[string]string{
+			"record_id": "ticket-1",
+			"ticket_id": "ticket-1",
+			"status":    "open",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	sessionURN := cosmoTestURN("cosmo_session", "ticket-1")
+	threadURN := cosmoTestURN("cosmo_thread", "ticket-1")
+	assertCosmoProjectedEntity(t, entities, sessionURN, "cosmo.session")
+	assertCosmoProjectedEntityMissing(t, entities, threadURN)
+	assertCosmoProjectedLinkMissing(t, links, sessionURN, relationBelongsTo, threadURN)
+}
+
 func TestProjectCosmoFact(t *testing.T) {
 	entities, links, err := BuiltinRegistry().Project(&cerebrov1.EventEnvelope{
 		Id:       "cosmo-writer-fact-risk",
@@ -431,6 +453,15 @@ func assertCosmoProjectedEntity(t *testing.T, entities []*ports.ProjectedEntity,
 	_ = cosmoProjectedEntity(t, entities, urn, entityType)
 }
 
+func assertCosmoProjectedEntityMissing(t *testing.T, entities []*ports.ProjectedEntity, urn string) {
+	t.Helper()
+	for _, entity := range entities {
+		if entity.URN == urn {
+			t.Fatalf("projected entity %q unexpectedly present: %#v", urn, entity)
+		}
+	}
+}
+
 func cosmoTestURN(kind string, id string) string {
 	return projectionURN("writer", kind, cosmoExternalIDKey(id))
 }
@@ -454,4 +485,13 @@ func assertCosmoProjectedLink(t *testing.T, links []*ports.ProjectedLink, from s
 		}
 	}
 	t.Fatalf("projected link %q %q %q missing from %#v", from, relation, to, links)
+}
+
+func assertCosmoProjectedLinkMissing(t *testing.T, links []*ports.ProjectedLink, from string, relation string, to string) {
+	t.Helper()
+	for _, link := range links {
+		if link.FromURN == from && link.Relation == relation && link.ToURN == to {
+			t.Fatalf("projected link %q %q %q unexpectedly present in %#v", from, relation, to, links)
+		}
+	}
 }

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -946,6 +946,7 @@ func identityAuditProjections(event *cerebrov1.EventEnvelope, profile identityPr
 		if resourceIdentifier := firstNonEmpty(resourceEmail, resourceID); extractEmailIdentifier(resourceIdentifier) != "" {
 			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), resourceURN, resourceIdentifier, event.GetOccurredAt())
 		}
+		addIdentityAuditResourceContext(entities, links, tenantID, event, profile, resourceURN, attributes, resourceType, resourceID)
 	}
 	if actorURN != "" && resourceURN != "" {
 		actedAttrs := map[string]string{
@@ -957,6 +958,57 @@ func identityAuditProjections(event *cerebrov1.EventEnvelope, profile identityPr
 	}
 	addAzureResourceGroupLinks(entities, links, tenantID, event.GetSourceId(), event, profile, attributes, resourceURN)
 	return identityProjectionResult(entities, links)
+}
+
+func addIdentityAuditResourceContext(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, profile identityProjectionProfile, resourceURN string, attributes map[string]string, resourceType string, resourceID string) {
+	switch profile.Provider {
+	case "aws":
+		if accountID := firstNonEmpty(awsAccountID(attributes["domain"]), awsAccountID(attributes["aws_account_id"]), awsAccountIDFromARN(resourceID)); accountID != "" {
+			addCloudAccountLink(entities, links, tenantID, event.GetSourceId(), event, resourceURN, accountID, profile.Provider)
+		}
+		if !strings.Contains(strings.TrimSpace(resourceID), ":role/") {
+			return
+		}
+		roleURN := identityPrincipalURN(tenantID, profile.Provider, "role", resourceID, "")
+		if roleURN == "" {
+			return
+		}
+		roleName := awsRoleNameFromARN(resourceID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        roleURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: profile.entityType("role"),
+			Label:      firstNonEmpty(roleName, resourceID),
+			Attributes: map[string]string{
+				"role_arn":  strings.TrimSpace(resourceID),
+				"role_name": roleName,
+			},
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, roleURN, relationRepresents, map[string]string{
+			"event_id":       event.GetId(),
+			"match_type":     "aws_audit_resource_role_arn",
+			"resource_id":    strings.TrimSpace(resourceID),
+			"resource_type":  strings.TrimSpace(resourceType),
+			"canonical_type": "aws.role",
+		}))
+	case "gcp":
+		if projectID := firstNonEmpty(attributes["gcp_project_id"], attributes["project_id"], gcpProjectIDFromResource(resourceID), attributes["domain"]); projectID != "" {
+			addCloudAccountLink(entities, links, tenantID, event.GetSourceId(), event, resourceURN, projectID, profile.Provider)
+		}
+	case "azure":
+		if subscriptionID := firstNonEmpty(attributes["subscription_id"], azureSubscriptionIDFromScope(resourceID), azureSubscriptionIDFromScope(attributes["target_id"])); subscriptionID != "" {
+			addCloudAccountLink(entities, links, tenantID, event.GetSourceId(), event, resourceURN, subscriptionID, profile.Provider)
+		}
+	}
+}
+
+func awsRoleNameFromARN(value string) string {
+	_, roleName, ok := strings.Cut(strings.TrimSpace(value), ":role/")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(roleName)
 }
 
 func isAWSAssumedRoleActor(profile identityProjectionProfile, actorType string, actorID string) bool {

--- a/internal/sourceprojection/panopticon.go
+++ b/internal/sourceprojection/panopticon.go
@@ -2,6 +2,7 @@ package sourceprojection
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -1861,6 +1862,18 @@ func panopticonCollectAlertIDs(value any, add func(string)) {
 			if trimmed := strings.TrimSpace(part); trimmed != "" {
 				add(trimmed)
 			}
+		}
+	case float64:
+		if alertID := strings.TrimSpace(strconv.FormatFloat(typed, 'f', -1, 64)); alertID != "" {
+			add(alertID)
+		}
+	case int:
+		if alertID := strings.TrimSpace(strconv.Itoa(typed)); alertID != "" {
+			add(alertID)
+		}
+	case int64:
+		if alertID := strings.TrimSpace(strconv.FormatInt(typed, 10)); alertID != "" {
+			add(alertID)
 		}
 	case []string:
 		for _, item := range typed {

--- a/internal/sourceprojection/panopticon.go
+++ b/internal/sourceprojection/panopticon.go
@@ -153,7 +153,7 @@ func panopticonCaseProjections(event *cerebrov1.EventEnvelope) ([]*ports.Project
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := panopticonProjectionAttributes(event, "case_id", "status", "title")
+	attrs := panopticonProjectionAttributes(event, "case_id", "status", "title", "upstream_alert_ids", "alert_ids", "source_alert_ids", "related_alert_ids")
 	payload := payloadMap(event)
 	caseID := firstAttribute(attrs, "case_id")
 	if caseID == "" {
@@ -162,8 +162,8 @@ func panopticonCaseProjections(event *cerebrov1.EventEnvelope) ([]*ports.Project
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 	caseURN := panopticonAddCaseEntity(entities, tenantID, event.GetSourceId(), event.GetId(), attrs)
-	for _, alert := range panopticonObjects(payload, "alerts", "linked_alerts") {
-		alertURN := panopticonAddAlertEntity(entities, tenantID, event.GetSourceId(), event.GetId(), panopticonAttributesFromObject(alert, "alert_id", "id", "severity", "status", "title"))
+	for _, alertAttrs := range panopticonCaseAlertAttributes(attrs, payload) {
+		alertURN := panopticonAddAlertEntity(entities, tenantID, event.GetSourceId(), event.GetId(), alertAttrs)
 		if alertURN == "" {
 			continue
 		}
@@ -1820,6 +1820,63 @@ func panopticonObjects(payload map[string]any, keys ...string) []map[string]any 
 		}
 	}
 	return objects
+}
+
+func panopticonCaseAlertAttributes(attrs map[string]string, payload map[string]any) []map[string]string {
+	seen := map[string]struct{}{}
+	var results []map[string]string
+	add := func(values map[string]string) {
+		alertID := strings.TrimSpace(values["alert_id"])
+		if alertID == "" {
+			return
+		}
+		if _, ok := seen[alertID]; ok {
+			return
+		}
+		seen[alertID] = struct{}{}
+		results = append(results, values)
+	}
+	for _, alert := range panopticonObjects(payload, "alerts", "linked_alerts", "source_alerts", "upstream_alerts", "related_alerts") {
+		add(panopticonAttributesFromObject(alert, "alert_id", "id", "severity", "status", "title"))
+	}
+	for _, key := range []string{"upstream_alert_ids", "alert_ids", "source_alert_ids", "related_alert_ids"} {
+		panopticonCollectAlertIDs(attrs[key], func(alertID string) {
+			add(map[string]string{"alert_id": alertID})
+		})
+		panopticonCollectAlertIDs(payload[key], func(alertID string) {
+			add(map[string]string{"alert_id": alertID})
+		})
+	}
+	return results
+}
+
+func panopticonCollectAlertIDs(value any, add func(string)) {
+	switch typed := value.(type) {
+	case nil:
+		return
+	case string:
+		for _, part := range strings.FieldsFunc(typed, func(r rune) bool {
+			return r == ',' || r == ';' || r == '\n' || r == '\t'
+		}) {
+			if trimmed := strings.TrimSpace(part); trimmed != "" {
+				add(trimmed)
+			}
+		}
+	case []string:
+		for _, item := range typed {
+			if trimmed := strings.TrimSpace(item); trimmed != "" {
+				add(trimmed)
+			}
+		}
+	case []any:
+		for _, item := range typed {
+			panopticonCollectAlertIDs(item, add)
+		}
+	case map[string]any:
+		if alertID := panopticonString(typed, "alert_id", "id"); alertID != "" {
+			add(alertID)
+		}
+	}
 }
 
 func panopticonAttributesFromObject(object map[string]any, keys ...string) map[string]string {

--- a/internal/sourceprojection/panopticon_test.go
+++ b/internal/sourceprojection/panopticon_test.go
@@ -278,7 +278,7 @@ func TestProjectPanopticonCaseLinksScalarAlertIDs(t *testing.T) {
 		},
 		Payload: mustJSON(t, map[string]any{
 			"case_id":            "case-1",
-			"upstream_alert_ids": []any{"alert-1", "alert-2"},
+			"upstream_alert_ids": []any{"alert-1", "alert-2", 12345},
 			"related_alert_ids":  "alert-2, alert-3",
 		}),
 	})
@@ -287,7 +287,7 @@ func TestProjectPanopticonCaseLinksScalarAlertIDs(t *testing.T) {
 	}
 
 	caseURN := "urn:cerebro:writer:panopticon_case:case-1"
-	for _, alertID := range []string{"alert-1", "alert-2", "alert-3", "alert-4"} {
+	for _, alertID := range []string{"alert-1", "alert-2", "alert-3", "alert-4", "12345"} {
 		alertURN := "urn:cerebro:writer:panopticon_alert:" + alertID
 		assertProjectedEntityType(t, state, alertURN, "panopticon.alert")
 		assertProjectedLink(t, state, caseURN, relationContains, alertURN)

--- a/internal/sourceprojection/panopticon_test.go
+++ b/internal/sourceprojection/panopticon_test.go
@@ -163,9 +163,10 @@ func TestProjectPanopticonCaseBuildsLinkedGraphAndEvidencePointers(t *testing.T)
 		Kind:       "panopticon.case",
 		OccurredAt: timestamppb.New(occurred),
 		Attributes: map[string]string{
-			"case_id": "case-1",
-			"status":  "investigating",
-			"title":   "Credential exposure investigation",
+			"case_id":   "case-1",
+			"status":    "investigating",
+			"title":     "Credential exposure investigation",
+			"alert_ids": "alert-4",
 		},
 		Payload: mustJSON(t, map[string]any{
 			"case_id": "case-1",
@@ -257,6 +258,40 @@ func TestProjectPanopticonCaseBuildsLinkedGraphAndEvidencePointers(t *testing.T)
 		if strings.Contains(strings.ToLower(entity.EntityType), "finding") || strings.Contains(strings.ToLower(urn), ":finding") || strings.Contains(strings.ToLower(urn), "timeline") {
 			t.Fatalf("raw Panopticon temporal data should not be promoted into findings/timeline entities: %s %#v", urn, entity)
 		}
+	}
+}
+
+func TestProjectPanopticonCaseLinksScalarAlertIDs(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "panopticon-case-event-scalar-alerts",
+		TenantId: "writer",
+		SourceId: "panopticon",
+		Kind:     "panopticon.case",
+		Attributes: map[string]string{
+			"case_id":   "case-1",
+			"status":    "investigating",
+			"title":     "Credential exposure investigation",
+			"alert_ids": "alert-4",
+		},
+		Payload: mustJSON(t, map[string]any{
+			"case_id":            "case-1",
+			"upstream_alert_ids": []any{"alert-1", "alert-2"},
+			"related_alert_ids":  "alert-2, alert-3",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	caseURN := "urn:cerebro:writer:panopticon_case:case-1"
+	for _, alertID := range []string{"alert-1", "alert-2", "alert-3", "alert-4"} {
+		alertURN := "urn:cerebro:writer:panopticon_alert:" + alertID
+		assertProjectedEntityType(t, state, alertURN, "panopticon.alert")
+		assertProjectedLink(t, state, caseURN, relationContains, alertURN)
+		assertProjectedLink(t, state, alertURN, relationBelongsTo, caseURN)
 	}
 }
 

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -3165,6 +3165,60 @@ func TestProjectAWSCloudTrailActorEmailPreservesAlternateIdentifier(t *testing.T
 	}
 }
 
+func TestProjectAWSCloudTrailRoleResourceLinksCanonicalRole(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	roleARN := "arn:aws:iam::123456789012:role/AdminRole"
+	event := &cerebrov1.EventEnvelope{
+		Id:       "aws-cloudtrail-role-resource",
+		TenantId: "writer",
+		SourceId: "aws",
+		Kind:     "aws.cloudtrail",
+		Attributes: map[string]string{
+			"domain":        "123456789012",
+			"event_type":    "ListRolePolicies",
+			"resource_id":   roleARN,
+			"resource_type": "resource",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	resourceURN := "urn:cerebro:writer:aws_resource:" + roleARN
+	roleURN := "urn:cerebro:writer:aws_role:" + roleARN
+	assertProjectedEntityType(t, state, resourceURN, "aws.resource")
+	assertProjectedEntityType(t, state, roleURN, "aws.role")
+	assertProjectedLink(t, state, resourceURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:123456789012")
+	assertProjectedLink(t, state, resourceURN, relationRepresents, roleURN)
+}
+
+func TestProjectGCPAuditResourceLinksProject(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	resourceID := "projects/writer-prod/locations/us-central1/keyRings/ring-1/cryptoKeys/key-1"
+	event := &cerebrov1.EventEnvelope{
+		Id:       "gcp-audit-resource",
+		TenantId: "writer",
+		SourceId: "gcp",
+		Kind:     "gcp.audit",
+		Attributes: map[string]string{
+			"event_type":    "GetCryptoKey",
+			"resource_id":   resourceID,
+			"resource_type": "audited_resource",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	resourceURN := "urn:cerebro:writer:gcp_audited_resource:" + resourceID
+	assertProjectedEntityType(t, state, resourceURN, "gcp.audited.resource")
+	assertProjectedLink(t, state, resourceURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
+}
+
 func TestProjectGoogleWorkspaceAuditTargetEmailLinksIdentity(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -570,6 +570,20 @@ func sentinelOneApplicationInventoryProjections(event *cerebrov1.EventEnvelope) 
 		},
 	})
 	agentURN := sentinelOneAgentURN(tenant, agentID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        agentURN,
+		TenantID:   tenant,
+		SourceID:   event.GetSourceId(),
+		EntityType: sentinelOneEntityAgent,
+		Label:      firstNonEmpty(attrs["computer_name"], attrs["agent_name"], agentID),
+		Attributes: compactAttributes(map[string]string{
+			"agent_id":    agentID,
+			"hostname":    strings.TrimSpace(firstNonEmpty(attrs["hostname"], attrs["computer_name"], attrs["agent_name"])),
+			"tenant_host": strings.TrimSpace(attrs["tenant_host"]),
+			"event_id":    event.GetId(),
+			"at":          eventObservedAt(event),
+		}),
+	})
 	addLink(links, projectedLink(tenant, event.GetSourceId(), agentURN, appURN, relationContains, map[string]string{"event_id": event.GetId()}))
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -1,6 +1,7 @@
 package sourceprojection
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -520,6 +521,7 @@ func sentinelOneExclusionProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 			"tenant_host":         strings.TrimSpace(attrs["tenant_host"]),
 		},
 	})
+	addSentinelOneExclusionScopeLinks(entities, links, tenant, event, exclusionURN, attrs)
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
@@ -615,6 +617,86 @@ func addSentinelOneScopeLinks(entities map[string]*ports.ProjectedEntity, links 
 		})
 		addLink(links, projectedLink(tenant, event.GetSourceId(), fromURN, groupURN, relationMemberOf, map[string]string{"event_id": event.GetId()}))
 	}
+}
+
+func addSentinelOneExclusionScopeLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenant string, event *cerebrov1.EventEnvelope, exclusionURN string, attrs map[string]string) {
+	for _, siteID := range sentinelOneScopeIDs(attrs["scope"], "siteIds", "site_ids", "siteId", "site_id") {
+		siteURN := sentinelOneSiteURN(tenant, siteID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        siteURN,
+			TenantID:   tenant,
+			SourceID:   event.GetSourceId(),
+			EntityType: sentinelOneEntitySite,
+			Label:      firstNonEmpty(attrs["scope_name"], siteID),
+			Attributes: map[string]string{"site_id": siteID, "site_name": strings.TrimSpace(attrs["scope_name"])},
+		})
+		addLink(links, projectedLink(tenant, event.GetSourceId(), exclusionURN, siteURN, relationTargeted, map[string]string{"event_id": event.GetId(), "match_type": "sentinelone_exclusion_site_scope"}))
+	}
+	for _, groupID := range sentinelOneScopeIDs(attrs["scope"], "groupIds", "group_ids", "groupId", "group_id") {
+		groupURN := sentinelOneGroupURN(tenant, groupID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        groupURN,
+			TenantID:   tenant,
+			SourceID:   event.GetSourceId(),
+			EntityType: sentinelOneEntityGroup,
+			Label:      firstNonEmpty(attrs["scope_name"], groupID),
+			Attributes: map[string]string{"group_id": groupID, "group_name": strings.TrimSpace(attrs["scope_name"])},
+		})
+		addLink(links, projectedLink(tenant, event.GetSourceId(), exclusionURN, groupURN, relationTargeted, map[string]string{"event_id": event.GetId(), "match_type": "sentinelone_exclusion_group_scope"}))
+	}
+	for _, accountID := range sentinelOneScopeIDs(attrs["scope"], "accountIds", "account_ids", "accountId", "account_id") {
+		accountURN := sentinelOneAccountURN(tenant, accountID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        accountURN,
+			TenantID:   tenant,
+			SourceID:   event.GetSourceId(),
+			EntityType: sentinelOneEntityAccount,
+			Label:      firstNonEmpty(attrs["scope_name"], accountID),
+			Attributes: map[string]string{"account_id": accountID, "account_name": strings.TrimSpace(attrs["scope_name"])},
+		})
+		addLink(links, projectedLink(tenant, event.GetSourceId(), exclusionURN, accountURN, relationTargeted, map[string]string{"event_id": event.GetId(), "match_type": "sentinelone_exclusion_account_scope"}))
+	}
+}
+
+func sentinelOneScopeIDs(raw string, keys ...string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var ids []string
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		ids = append(ids, value)
+	}
+	for _, key := range keys {
+		switch value := decoded[key].(type) {
+		case string:
+			add(value)
+		case []any:
+			for _, item := range value {
+				if itemString, ok := item.(string); ok {
+					add(itemString)
+				}
+			}
+		case []string:
+			for _, item := range value {
+				add(item)
+			}
+		}
+	}
+	return ids
 }
 
 func addSentinelOneThreatClassificationLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenant string, event *cerebrov1.EventEnvelope, threatURN string, attrs map[string]string) {

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -2,6 +2,7 @@ package sourceprojection
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 
@@ -680,16 +681,26 @@ func sentinelOneScopeIDs(raw string, keys ...string) []string {
 		seen[value] = struct{}{}
 		ids = append(ids, value)
 	}
+	addValue := func(value any) {
+		switch typed := value.(type) {
+		case string:
+			add(typed)
+		case float64:
+			add(strconv.FormatFloat(typed, 'f', -1, 64))
+		case int:
+			add(strconv.Itoa(typed))
+		case int64:
+			add(strconv.FormatInt(typed, 10))
+		}
+	}
 	for _, key := range keys {
 		switch value := decoded[key].(type) {
-		case string:
-			add(value)
 		case []any:
 			for _, item := range value {
-				if itemString, ok := item.(string); ok {
-					add(itemString)
-				}
+				addValue(item)
 			}
+		default:
+			addValue(value)
 		}
 	}
 	return ids

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -2,7 +2,6 @@ package sourceprojection
 
 import (
 	"encoding/json"
-	"strconv"
 	"strings"
 	"time"
 
@@ -665,7 +664,9 @@ func sentinelOneScopeIDs(raw string, keys ...string) []string {
 		return nil
 	}
 	var decoded map[string]any
-	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
 		return nil
 	}
 	seen := map[string]struct{}{}
@@ -681,27 +682,21 @@ func sentinelOneScopeIDs(raw string, keys ...string) []string {
 		seen[value] = struct{}{}
 		ids = append(ids, value)
 	}
-	addValue := func(value any) {
-		switch typed := value.(type) {
+	var addValue func(any)
+	addValue = func(value any) {
+		switch value := value.(type) {
 		case string:
-			add(typed)
-		case float64:
-			add(strconv.FormatFloat(typed, 'f', -1, 64))
-		case int:
-			add(strconv.Itoa(typed))
-		case int64:
-			add(strconv.FormatInt(typed, 10))
-		}
-	}
-	for _, key := range keys {
-		switch value := decoded[key].(type) {
+			add(value)
+		case json.Number:
+			add(value.String())
 		case []any:
 			for _, item := range value {
 				addValue(item)
 			}
-		default:
-			addValue(value)
 		}
+	}
+	for _, key := range keys {
+		addValue(decoded[key])
 	}
 	return ids
 }

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -690,10 +690,6 @@ func sentinelOneScopeIDs(raw string, keys ...string) []string {
 					add(itemString)
 				}
 			}
-		case []string:
-			for _, item := range value {
-				add(item)
-			}
 		}
 	}
 	return ids

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -407,7 +407,7 @@ func TestProjectSentinelOneExclusion(t *testing.T) {
 			"exclusion_type": "path",
 			"mode":           "suppress_alerts",
 			"os_type":        "macos",
-			"scope":          `{"siteIds":["site-1",12345]}`,
+			"scope":          `{"siteIds":["site-1",2104712254931195613]}`,
 			"scope_name":     "Production",
 			"value":          "/Applications/Approved.app",
 		},
@@ -418,14 +418,14 @@ func TestProjectSentinelOneExclusion(t *testing.T) {
 	if state.entities[exclusionURN] == nil {
 		t.Fatal("exclusion entity missing")
 	}
-	if got := state.entities[exclusionURN].Attributes["scope"]; got != `{"siteIds":["site-1",12345]}` {
+	if got := state.entities[exclusionURN].Attributes["scope"]; got != `{"siteIds":["site-1",2104712254931195613]}` {
 		t.Fatalf("exclusion scope = %q, want site JSON", got)
 	}
 	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
 	if entity := state.entities[siteURN]; entity == nil || entity.EntityType != "sentinelone.site" {
 		t.Fatalf("site entity missing or wrong type: %#v", entity)
 	}
-	numericSiteURN := "urn:cerebro:writer:sentinelone_site:12345"
+	numericSiteURN := "urn:cerebro:writer:sentinelone_site:2104712254931195613"
 	if entity := state.entities[numericSiteURN]; entity == nil || entity.EntityType != "sentinelone.site" {
 		t.Fatalf("numeric site entity missing or wrong type: %#v", entity)
 	}

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -407,7 +407,8 @@ func TestProjectSentinelOneExclusion(t *testing.T) {
 			"exclusion_type": "path",
 			"mode":           "suppress_alerts",
 			"os_type":        "macos",
-			"scope":          "site",
+			"scope":          `{"siteIds":["site-1"]}`,
+			"scope_name":     "Production",
 			"value":          "/Applications/Approved.app",
 		},
 	}); err != nil {
@@ -417,7 +418,12 @@ func TestProjectSentinelOneExclusion(t *testing.T) {
 	if state.entities[exclusionURN] == nil {
 		t.Fatal("exclusion entity missing")
 	}
-	if got := state.entities[exclusionURN].Attributes["scope"]; got != "site" {
-		t.Fatalf("exclusion scope = %q, want site", got)
+	if got := state.entities[exclusionURN].Attributes["scope"]; got != `{"siteIds":["site-1"]}` {
+		t.Fatalf("exclusion scope = %q, want site JSON", got)
 	}
+	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
+	if entity := state.entities[siteURN]; entity == nil || entity.EntityType != "sentinelone.site" {
+		t.Fatalf("site entity missing or wrong type: %#v", entity)
+	}
+	assertProjectedLink(t, state, exclusionURN, relationTargeted, siteURN)
 }

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -388,6 +388,9 @@ func TestProjectSentinelOneApplicationInventoryContainedByAgent(t *testing.T) {
 	if state.entities[appURN] == nil {
 		t.Fatalf("application entity missing; got entities=%v", state.entities)
 	}
+	if entity := state.entities[agentURN]; entity == nil || entity.EntityType != "sentinelone.agent" {
+		t.Fatalf("agent entity missing or wrong type: %#v", entity)
+	}
 	assertProjectedLink(t, state, agentURN, relationContains, appURN)
 }
 

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -407,7 +407,7 @@ func TestProjectSentinelOneExclusion(t *testing.T) {
 			"exclusion_type": "path",
 			"mode":           "suppress_alerts",
 			"os_type":        "macos",
-			"scope":          `{"siteIds":["site-1"]}`,
+			"scope":          `{"siteIds":["site-1",12345]}`,
 			"scope_name":     "Production",
 			"value":          "/Applications/Approved.app",
 		},
@@ -418,12 +418,17 @@ func TestProjectSentinelOneExclusion(t *testing.T) {
 	if state.entities[exclusionURN] == nil {
 		t.Fatal("exclusion entity missing")
 	}
-	if got := state.entities[exclusionURN].Attributes["scope"]; got != `{"siteIds":["site-1"]}` {
+	if got := state.entities[exclusionURN].Attributes["scope"]; got != `{"siteIds":["site-1",12345]}` {
 		t.Fatalf("exclusion scope = %q, want site JSON", got)
 	}
 	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
 	if entity := state.entities[siteURN]; entity == nil || entity.EntityType != "sentinelone.site" {
 		t.Fatalf("site entity missing or wrong type: %#v", entity)
 	}
+	numericSiteURN := "urn:cerebro:writer:sentinelone_site:12345"
+	if entity := state.entities[numericSiteURN]; entity == nil || entity.EntityType != "sentinelone.site" {
+		t.Fatalf("numeric site entity missing or wrong type: %#v", entity)
+	}
 	assertProjectedLink(t, state, exclusionURN, relationTargeted, siteURN)
+	assertProjectedLink(t, state, exclusionURN, relationTargeted, numericSiteURN)
 }


### PR DESCRIPTION
## Summary
- materialize SentinelOne agent stubs with application inventory so agent->installed app links can ingest in the same projection batch
- link Panopticon cases to scalar and alternate alert ID collections
- add Cosmo thread and fact-category context links for sessions and facts

## Validation
- go test ./internal/sourceprojection -run 'SentinelOneApplication|Panopticon.*Case|Cosmo' -count=1 -v
- go test ./internal/sourceprojection -count=1
- go test ./...
- make lint
- git diff --check