### PR TITLE
fix: address DSL review diagnostics

### DIFF
--- a/internal/findingdsl/policy_rule.go
+++ b/internal/findingdsl/policy_rule.go
@@ -512,6 +512,7 @@ func validatePolicyRuleGraph(path string, graph PolicyRuleGraphFinding) []Issue 
 		}
 		if isReservedGraphParam(key) {
 			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("spec.graph.params.%s must not override runtime parameter $%s", key, key)})
+			continue
 		}
 		if query != "" {
 			if _, ok := queryParams[key]; !ok {
@@ -928,7 +929,7 @@ func cypherQueryParams(query string) map[string]struct{} {
 }
 
 func cypherReturnAliases(query string) map[string]struct{} {
-	cleaned := stripCypherLiteralsAndComments(query)
+	cleaned := stripCypherLiteralsAndCommentsPreserveBacktickIdentifiers(query)
 	aliases := map[string]struct{}{}
 	for _, field := range splitCypherReturnFields(cypherReturnClause(cleaned)) {
 		if alias := cypherFieldAlias(field); alias != "" {
@@ -1082,6 +1083,14 @@ func isCypherKeywordSpace(ch byte) bool {
 }
 
 func stripCypherLiteralsAndComments(query string) string {
+	return stripCypherLiteralsAndCommentsMode(query, false)
+}
+
+func stripCypherLiteralsAndCommentsPreserveBacktickIdentifiers(query string) string {
+	return stripCypherLiteralsAndCommentsMode(query, true)
+}
+
+func stripCypherLiteralsAndCommentsMode(query string, preserveBacktickIdentifiers bool) string {
 	var out strings.Builder
 	out.Grow(len(query))
 	for idx := 0; idx < len(query); {
@@ -1111,7 +1120,36 @@ func stripCypherLiteralsAndComments(query string) string {
 			}
 			continue
 		}
-		if query[idx] == '\'' || query[idx] == '"' || query[idx] == '`' {
+		if query[idx] == '`' {
+			out.WriteByte(' ')
+			idx++
+			for idx < len(query) {
+				ch := query[idx]
+				idx++
+				if ch == '`' {
+					if idx < len(query) && query[idx] == '`' {
+						if preserveBacktickIdentifiers {
+							out.WriteByte('`')
+						} else {
+							out.WriteByte(' ')
+						}
+						idx++
+						continue
+					}
+					out.WriteByte(' ')
+					break
+				}
+				if preserveBacktickIdentifiers {
+					out.WriteByte(ch)
+				} else if ch == '\n' {
+					out.WriteByte('\n')
+				} else {
+					out.WriteByte(' ')
+				}
+			}
+			continue
+		}
+		if query[idx] == '\'' || query[idx] == '"' {
 			quote := query[idx]
 			out.WriteByte(' ')
 			idx++
@@ -1123,7 +1161,7 @@ func stripCypherLiteralsAndComments(query string) string {
 					out.WriteByte(' ')
 				}
 				idx++
-				if ch == '\\' && quote != '`' && idx < len(query) {
+				if ch == '\\' && idx < len(query) {
 					if query[idx] == '\n' {
 						out.WriteByte('\n')
 					} else {

--- a/internal/findingdsl/policy_rule_test.go
+++ b/internal/findingdsl/policy_rule_test.go
@@ -282,9 +282,9 @@ func TestValidatePolicyRuleAcceptsEscapedCypherLiteralsAndBacktickIdentifiers(t 
 				Query: `MATCH (entity:Entity {tenant_id: $tenant_id})
 WHERE entity.note = "escaped \" DELETE still literal"
   AND entity.` + "`MERGE status`" + ` = 'healthy'
-RETURN entity.urn AS primary_urn,
-       entity.urn AS fingerprint_key,
-       entity.label AS summary
+RETURN entity.urn AS ` + "`primary_urn`" + `,
+       entity.urn AS ` + "`fingerprint_key`" + `,
+       entity.label AS ` + "`summary`" + `
 LIMIT $row_limit`,
 				RequiredColumns: []string{"primary_urn", "fingerprint_key", "summary"},
 			},
@@ -293,6 +293,37 @@ LIMIT $row_limit`,
 	}
 	if issues := ValidatePolicyRule(rule); len(issues) != 0 {
 		t.Fatalf("ValidatePolicyRule() issues = %#v, want none", issues)
+	}
+}
+
+func TestValidatePolicyRuleReservedGraphParamDoesNotRequestQueryReference(t *testing.T) {
+	rule := PolicyFindingRule{
+		APIVersion: APIVersion,
+		Kind:       KindPolicyFindingRule,
+		Metadata: PolicyRuleMetadata{
+			ID:          "graph-reserved-param",
+			Name:        "Graph Reserved Param",
+			Description: "Graph policy with a reserved static param",
+		},
+		Spec: PolicyFindingRuleSpec{
+			Severity: "low",
+			Graph: PolicyRuleGraphFinding{
+				Query: `MATCH (entity:Entity)
+RETURN entity.urn AS primary_urn,
+       entity.urn AS fingerprint_key,
+       'Graph finding' AS summary
+LIMIT $row_limit`,
+				Params: map[string]any{"tenant_id": "writer"},
+			},
+			Frameworks: []PolicyFramework{{Name: "SOC 2", Controls: []string{"CC7.1"}}},
+		},
+	}
+	issues := ValidatePolicyRule(rule)
+	if !issuesContain(issues, "spec.graph.params.tenant_id must not override runtime parameter $tenant_id") {
+		t.Fatalf("ValidatePolicyRule() issues = %#v, want reserved param issue", issues)
+	}
+	if issuesContain(issues, "spec.graph.params.tenant_id must be referenced") {
+		t.Fatalf("ValidatePolicyRule() issues = %#v, want no misleading query reference issue", issues)
 	}
 }
 
@@ -615,8 +646,11 @@ cases:
 `)
 
 	issues := RunPolicyRuleTestSuite(root, filepath.Join(root, "policies/graph/example.test.yaml"))
-	if !issuesContain(issues, "queryRows[0].fingerprint_key is required") {
+	if !issuesContain(issues, "queryRows[0].fingerprint_key is a required graph return alias") {
 		t.Fatalf("RunPolicyRuleTestSuite() issues = %#v, want missing fingerprint", issues)
+	}
+	if issuesContain(issues, "queryRows[0].fingerprint_key is required by spec.graph.requiredColumns") {
+		t.Fatalf("RunPolicyRuleTestSuite() issues = %#v, want system requirement message", issues)
 	}
 }
 

--- a/internal/findingdsl/test_suite.go
+++ b/internal/findingdsl/test_suite.go
@@ -190,7 +190,11 @@ func validatePolicyRuleTestCaseAgainstRule(path string, rule PolicyFindingRule, 
 		for _, column := range requiredColumns {
 			value, ok := row[column]
 			if !ok {
-				issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] %q queryRows[%d].%s is required by spec.graph.requiredColumns", idx, testCase.Name, rowIdx, column)})
+				if graphFixtureSystemRequiredColumn(column) {
+					issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] %q queryRows[%d].%s is a required graph return alias", idx, testCase.Name, rowIdx, column)})
+				} else {
+					issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] %q queryRows[%d].%s is required by spec.graph.requiredColumns", idx, testCase.Name, rowIdx, column)})
+				}
 				continue
 			}
 			if graphFixtureColumnRequiresValue(column) && !testFixtureValuePresent(value) {
@@ -242,6 +246,15 @@ func graphFixtureColumnRequiresValue(column string) bool {
 	default:
 		return false
 	}
+}
+
+func graphFixtureSystemRequiredColumn(column string) bool {
+	for _, required := range requiredGraphReturnAliases() {
+		if column == required {
+			return true
+		}
+	}
+	return false
 }
 
 func testFixtureValuePresent(value any) bool {


### PR DESCRIPTION
## Summary
- suppress misleading reserved graph-param follow-up diagnostics
- preserve backtick-quoted aliases for graph return alias parsing without reintroducing unsafe keyword false positives
- clarify graph fixture messages for system-required return aliases

## Validation
- go test ./internal/findingdsl -count=1
- go test ./internal/findingdsl ./tools/findingdsl ./tools/policyrulegen -count=1
- make finding-dsl-check policy-rule-check detection-catalog-check catalog-check docs-drift-check