### PR TITLE
fix: make JetStream publish retry budget configurable

### DIFF
--- a/docs/operations/hosting.md
+++ b/docs/operations/hosting.md
@@ -211,6 +211,10 @@ Cerebro uses these values for proxy-aware URL reconstruction and DPoP `htu` vali
 | `CEREBRO_JETSTREAM_URL` | NATS URL. Setting this can infer the driver. Store credentials in the URL only if your secret manager handles it safely. |
 | `CEREBRO_JETSTREAM_SUBJECT_PREFIX` | Subject prefix. Use a stable, environment-specific prefix if multiple logical deployments share a NATS cluster. |
 | `CEREBRO_JETSTREAM_DRAIN_TIMEOUT` | Optional graceful drain timeout for shutdown. |
+| `CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT` | Optional per-process bulkhead for concurrent publishes. Use this when many source runtimes can publish at once. |
+| `CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED` | Optional total retry budget for retryable publishes. Keep it above observed stream restore time plus margin. |
+| `CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS`, `CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF`, `CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF`, `CEREBRO_JETSTREAM_PUBLISH_ATTEMPT_TIMEOUT` | Optional outer retry shape for NATS restarts, transient timeouts, and stream leader stalls. |
+| `CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_ATTEMPTS`, `CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_WAIT` | Optional inner NATS client retry shape used inside each outer publish attempt. |
 
 NATS JetStream should have durable storage, retention appropriate for replay needs, and monitoring for stream health, consumer lag, and disk pressure.
 

--- a/docs/reference/config-env-vars.md
+++ b/docs/reference/config-env-vars.md
@@ -24,6 +24,14 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_JETSTREAM_URL` | unset | NATS JetStream URL. Setting this infers `jetstream`. |
 | `CEREBRO_JETSTREAM_SUBJECT_PREFIX` | `events` | Subject prefix for append-log events. |
 | `CEREBRO_JETSTREAM_DRAIN_TIMEOUT` | NATS default | Optional timeout for graceful NATS connection drain during shutdown. |
+| `CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT` | unlimited | Optional per-process bulkhead for concurrent JetStream publishes. |
+| `CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS` | `10` | Optional maximum outer publish attempts for retryable JetStream publish errors. |
+| `CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF` | `250ms` | Optional first outer publish retry backoff. |
+| `CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF` | `5s` | Optional cap for outer publish retry backoff. |
+| `CEREBRO_JETSTREAM_PUBLISH_ATTEMPT_TIMEOUT` | `30s` | Optional timeout for each outer publish attempt. |
+| `CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED` | `90s` | Optional total outer publish retry budget. Set above expected NATS restore time in environments with large streams. |
+| `CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_ATTEMPTS` | `5` | Optional NATS client retry attempts inside each outer publish attempt. |
+| `CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_WAIT` | `500ms` | Optional NATS client retry wait inside each outer publish attempt. |
 | `CEREBRO_STATE_STORE_DRIVER` | inferred | State-store driver. Supported: `postgres`. |
 | `CEREBRO_POSTGRES_DSN` | unset | Postgres connection string. Setting this infers `postgres`. |
 | `CEREBRO_CONNECTOR_CREDENTIAL_KEY` | unset | High-entropy key used to seal Cerebro-managed connector credentials before storing them in Postgres. Supports `_FILE` via `CEREBRO_CONNECTOR_CREDENTIAL_KEY_FILE`. |

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -82,6 +82,16 @@ type publishTelemetry struct {
 	AckUnavailable bool
 }
 
+type publishRetryConfig struct {
+	MaxAttempts         int
+	InitialBackoff      time.Duration
+	MaxBackoff          time.Duration
+	ClientRetryAttempts int
+	ClientRetryWait     time.Duration
+	AttemptTimeout      time.Duration
+	MaxElapsed          time.Duration
+}
+
 type jetStreamReplayManager struct {
 	js jetstream.JetStream
 }
@@ -113,6 +123,7 @@ type Log struct {
 	replay        replayManager
 	subjectPrefix string
 	publishSlots  chan struct{}
+	publishRetry  publishRetryConfig
 	canaryMu      sync.Mutex
 	lastCanary    time.Time
 }
@@ -160,11 +171,85 @@ func Open(cfg config.AppendLogConfig) (*Log, error) {
 		js:            js,
 		replay:        &jetStreamReplayManager{js: js},
 		subjectPrefix: prefix,
+		publishRetry:  publishRetryConfigFromAppendLog(cfg),
 	}
 	if cfg.JetStreamPublishMaxInFlight > 0 {
 		log.publishSlots = make(chan struct{}, cfg.JetStreamPublishMaxInFlight)
 	}
 	return log, nil
+}
+
+func publishRetryConfigFromAppendLog(cfg config.AppendLogConfig) publishRetryConfig {
+	retry := defaultPublishRetryConfig()
+	if cfg.JetStreamPublishRetryAttempts > 0 {
+		retry.MaxAttempts = cfg.JetStreamPublishRetryAttempts
+	}
+	if cfg.JetStreamPublishRetryInitialBackoff > 0 {
+		retry.InitialBackoff = cfg.JetStreamPublishRetryInitialBackoff
+	}
+	if cfg.JetStreamPublishRetryMaxBackoff > 0 {
+		retry.MaxBackoff = cfg.JetStreamPublishRetryMaxBackoff
+	}
+	if cfg.JetStreamPublishClientRetryAttempts > 0 {
+		retry.ClientRetryAttempts = cfg.JetStreamPublishClientRetryAttempts
+	}
+	if cfg.JetStreamPublishClientRetryWait > 0 {
+		retry.ClientRetryWait = cfg.JetStreamPublishClientRetryWait
+	}
+	if cfg.JetStreamPublishAttemptTimeout > 0 {
+		retry.AttemptTimeout = cfg.JetStreamPublishAttemptTimeout
+	}
+	if cfg.JetStreamPublishRetryMaxElapsed > 0 {
+		retry.MaxElapsed = cfg.JetStreamPublishRetryMaxElapsed
+	}
+	if retry.InitialBackoff > retry.MaxBackoff {
+		retry.InitialBackoff = retry.MaxBackoff
+	}
+	if retry.AttemptTimeout > retry.MaxElapsed {
+		retry.AttemptTimeout = retry.MaxElapsed
+	}
+	return retry
+}
+
+func defaultPublishRetryConfig() publishRetryConfig {
+	return publishRetryConfig{
+		MaxAttempts:         publishRetryAttempts,
+		InitialBackoff:      publishRetryInitialBackoff,
+		MaxBackoff:          publishRetryMaxBackoff,
+		ClientRetryAttempts: publishClientRetryAttempts,
+		ClientRetryWait:     publishClientRetryWait,
+		AttemptTimeout:      publishAttemptTimeout,
+		MaxElapsed:          publishRetryMaxElapsed,
+	}
+}
+
+func (l *Log) effectivePublishRetryConfig() publishRetryConfig {
+	if l == nil {
+		return defaultPublishRetryConfig()
+	}
+	retry := l.publishRetry
+	if retry.MaxAttempts <= 0 {
+		retry.MaxAttempts = publishRetryAttempts
+	}
+	if retry.InitialBackoff <= 0 {
+		retry.InitialBackoff = publishRetryInitialBackoff
+	}
+	if retry.MaxBackoff <= 0 {
+		retry.MaxBackoff = publishRetryMaxBackoff
+	}
+	if retry.ClientRetryAttempts <= 0 {
+		retry.ClientRetryAttempts = publishClientRetryAttempts
+	}
+	if retry.ClientRetryWait <= 0 {
+		retry.ClientRetryWait = publishClientRetryWait
+	}
+	if retry.AttemptTimeout <= 0 {
+		retry.AttemptTimeout = publishAttemptTimeout
+	}
+	if retry.MaxElapsed <= 0 {
+		retry.MaxElapsed = publishRetryMaxElapsed
+	}
+	return retry
 }
 
 // Close closes the underlying NATS connection.
@@ -308,23 +393,24 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 }
 
 func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, eventAttrs func() telemetry.Attributes) (publishTelemetry, error) {
+	retry := l.effectivePublishRetryConfig()
 	result := publishTelemetry{
 		Attempts:       0,
-		MaxAttempts:    publishRetryAttempts,
-		RetryBudget:    publishRetryMaxElapsed,
-		AttemptTimeout: publishAttemptTimeout,
-		MaxBackoff:     publishRetryMaxBackoff,
-		ClientRetries:  publishClientRetryAttempts,
-		ClientWait:     publishClientRetryWait,
+		MaxAttempts:    retry.MaxAttempts,
+		RetryBudget:    retry.MaxElapsed,
+		AttemptTimeout: retry.AttemptTimeout,
+		MaxBackoff:     retry.MaxBackoff,
+		ClientRetries:  retry.ClientRetryAttempts,
+		ClientWait:     retry.ClientRetryWait,
 	}
-	backoff := publishRetryInitialBackoff
+	backoff := retry.InitialBackoff
 	started := time.Now()
-	retryCtx, cancelRetry := context.WithTimeout(ctx, publishRetryMaxElapsed)
+	retryCtx, cancelRetry := context.WithTimeout(ctx, retry.MaxElapsed)
 	defer cancelRetry()
 	var err error
 	for attempt := 1; attempt <= result.MaxAttempts; attempt++ {
 		result.Attempts = attempt
-		attemptCtx, cancel := context.WithTimeout(retryCtx, publishAttemptTimeout)
+		attemptCtx, cancel := context.WithTimeout(retryCtx, retry.AttemptTimeout)
 		wait, release, acquireErr := l.acquirePublishSlot(attemptCtx)
 		result.BulkheadWait += wait
 		result.BulkheadLimit = l.publishLimit()
@@ -356,14 +442,14 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, e
 				telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, waitErr)))
 				return result, waitErr
 			}
-			backoff = minDuration(backoff*2, publishRetryMaxBackoff)
+			backoff = minDuration(backoff*2, retry.MaxBackoff)
 			continue
 		}
 		ack, publishErr := l.js.PublishMsg(
 			attemptCtx,
 			msg,
-			jetstream.WithRetryAttempts(publishClientRetryAttempts),
-			jetstream.WithRetryWait(publishClientRetryWait),
+			jetstream.WithRetryAttempts(retry.ClientRetryAttempts),
+			jetstream.WithRetryWait(retry.ClientRetryWait),
 		)
 		release()
 		cancel()
@@ -398,7 +484,7 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, e
 			telemetry.Event(ctx, "jetstream.publish.retry_exhausted", eventAttrs().With(result.attrs()).With(jetstreamErrorTelemetryAttrs(operation, waitErr)))
 			return result, waitErr
 		}
-		backoff = minDuration(backoff*2, publishRetryMaxBackoff)
+		backoff = minDuration(backoff*2, retry.MaxBackoff)
 	}
 	result.Duration = time.Since(started)
 	return result, err

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/workflowevents"
@@ -154,6 +155,40 @@ func skipPublishRetryWaits(t *testing.T) {
 	})
 }
 
+func TestPublishRetryConfigUsesAppendLogOverrides(t *testing.T) {
+	retry := publishRetryConfigFromAppendLog(config.AppendLogConfig{
+		JetStreamPublishRetryAttempts:       22,
+		JetStreamPublishRetryInitialBackoff: 750 * time.Millisecond,
+		JetStreamPublishRetryMaxBackoff:     9 * time.Second,
+		JetStreamPublishClientRetryAttempts: 6,
+		JetStreamPublishClientRetryWait:     800 * time.Millisecond,
+		JetStreamPublishAttemptTimeout:      45 * time.Second,
+		JetStreamPublishRetryMaxElapsed:     5 * time.Minute,
+	})
+
+	if retry.MaxAttempts != 22 {
+		t.Fatalf("MaxAttempts = %d, want 22", retry.MaxAttempts)
+	}
+	if retry.InitialBackoff != 750*time.Millisecond {
+		t.Fatalf("InitialBackoff = %v, want 750ms", retry.InitialBackoff)
+	}
+	if retry.MaxBackoff != 9*time.Second {
+		t.Fatalf("MaxBackoff = %v, want 9s", retry.MaxBackoff)
+	}
+	if retry.ClientRetryAttempts != 6 {
+		t.Fatalf("ClientRetryAttempts = %d, want 6", retry.ClientRetryAttempts)
+	}
+	if retry.ClientRetryWait != 800*time.Millisecond {
+		t.Fatalf("ClientRetryWait = %v, want 800ms", retry.ClientRetryWait)
+	}
+	if retry.AttemptTimeout != 45*time.Second {
+		t.Fatalf("AttemptTimeout = %v, want 45s", retry.AttemptTimeout)
+	}
+	if retry.MaxElapsed != 5*time.Minute {
+		t.Fatalf("MaxElapsed = %v, want 5m", retry.MaxElapsed)
+	}
+}
+
 func TestAppendPublishesEnvelope(t *testing.T) {
 	pub := &fakePublisher{}
 	log := &Log{js: pub, subjectPrefix: "events"}
@@ -277,6 +312,66 @@ func TestAppendEmitsPublishRetryTelemetry(t *testing.T) {
 	}
 	if end["messaging.jetstream.publish.retry_count"] != float64(1) {
 		t.Fatalf("span retry count = %v, want 1", end["messaging.jetstream.publish.retry_count"])
+	}
+}
+
+func TestAppendRetryTelemetryUsesConfiguredPublishBudget(t *testing.T) {
+	skipPublishRetryWaits(t)
+	pub := &fakePublisher{
+		publishErrs: []error{
+			errors.New("nats: no response from stream"),
+			nil,
+		},
+	}
+	log := &Log{
+		js:            pub,
+		subjectPrefix: "events",
+		publishRetry: publishRetryConfig{
+			MaxAttempts:         7,
+			InitialBackoff:      750 * time.Millisecond,
+			MaxBackoff:          9 * time.Second,
+			ClientRetryAttempts: 6,
+			ClientRetryWait:     800 * time.Millisecond,
+			AttemptTimeout:      45 * time.Second,
+			MaxElapsed:          5 * time.Minute,
+		},
+	}
+
+	stderr := captureJetstreamTelemetry(t, func() {
+		err := log.Append(context.Background(), &cerebrov1.EventEnvelope{
+			Id:   "evt-configured-retry-telemetry",
+			Kind: "entity.upsert",
+		})
+		if err != nil {
+			t.Fatalf("Append() error = %v", err)
+		}
+	})
+
+	retryEvents := jetstreamTelemetryPayloads(t, stderr, "event", "jetstream.publish.retry")
+	if len(retryEvents) != 1 {
+		t.Fatalf("retry events = %d, want 1; stderr=%s", len(retryEvents), stderr)
+	}
+	retry := retryEvents[0]
+	if retry["messaging.jetstream.publish.max_attempts"] != float64(7) {
+		t.Fatalf("max attempts = %v, want 7", retry["messaging.jetstream.publish.max_attempts"])
+	}
+	if retry["messaging.jetstream.publish.retry_budget_ms"] != float64((5 * time.Minute).Milliseconds()) {
+		t.Fatalf("retry budget = %v, want 5m", retry["messaging.jetstream.publish.retry_budget_ms"])
+	}
+	if retry["messaging.jetstream.publish.attempt_timeout_ms"] != float64((45 * time.Second).Milliseconds()) {
+		t.Fatalf("attempt timeout = %v, want 45s", retry["messaging.jetstream.publish.attempt_timeout_ms"])
+	}
+	if retry["messaging.jetstream.publish.max_backoff_ms"] != float64((9 * time.Second).Milliseconds()) {
+		t.Fatalf("max backoff = %v, want 9s", retry["messaging.jetstream.publish.max_backoff_ms"])
+	}
+	if retry["messaging.jetstream.publish.client_retry_attempts"] != float64(6) {
+		t.Fatalf("client retry attempts = %v, want 6", retry["messaging.jetstream.publish.client_retry_attempts"])
+	}
+	if retry["messaging.jetstream.publish.client_retry_wait_ms"] != float64((800 * time.Millisecond).Milliseconds()) {
+		t.Fatalf("client retry wait = %v, want 800ms", retry["messaging.jetstream.publish.client_retry_wait_ms"])
+	}
+	if retry["messaging.jetstream.publish.next_backoff_ms"] != float64((750 * time.Millisecond).Milliseconds()) {
+		t.Fatalf("next backoff = %v, want 750ms", retry["messaging.jetstream.publish.next_backoff_ms"])
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,11 +73,18 @@ type RateLimitConfig struct {
 
 // AppendLogConfig selects and configures the append-log driver.
 type AppendLogConfig struct {
-	Driver                      string
-	JetStreamURL                string
-	JetStreamSubjectPrefix      string
-	JetStreamDrainTimeout       time.Duration
-	JetStreamPublishMaxInFlight int
+	Driver                              string
+	JetStreamURL                        string
+	JetStreamSubjectPrefix              string
+	JetStreamDrainTimeout               time.Duration
+	JetStreamPublishMaxInFlight         int
+	JetStreamPublishRetryAttempts       int
+	JetStreamPublishRetryInitialBackoff time.Duration
+	JetStreamPublishRetryMaxBackoff     time.Duration
+	JetStreamPublishAttemptTimeout      time.Duration
+	JetStreamPublishRetryMaxElapsed     time.Duration
+	JetStreamPublishClientRetryAttempts int
+	JetStreamPublishClientRetryWait     time.Duration
 }
 
 // StateStoreConfig selects and configures the current-state store driver.
@@ -551,6 +558,27 @@ func Load() (Config, error) {
 	if cfg.AppendLog.JetStreamPublishMaxInFlight, err = parseIntEnv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", 0); err != nil {
 		return Config{}, err
 	}
+	if cfg.AppendLog.JetStreamPublishRetryAttempts, err = parseIntEnv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.AppendLog.JetStreamPublishRetryInitialBackoff, err = parseDurationEnv("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.AppendLog.JetStreamPublishRetryMaxBackoff, err = parseDurationEnv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.AppendLog.JetStreamPublishAttemptTimeout, err = parseDurationEnv("CEREBRO_JETSTREAM_PUBLISH_ATTEMPT_TIMEOUT", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.AppendLog.JetStreamPublishRetryMaxElapsed, err = parseDurationEnv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.AppendLog.JetStreamPublishClientRetryAttempts, err = parseIntEnv("CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_ATTEMPTS", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.AppendLog.JetStreamPublishClientRetryWait, err = parseDurationEnv("CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_WAIT", 0); err != nil {
+		return Config{}, err
+	}
 	if cfg.StateStore.PostgresMaxOpenConns, err = parseIntEnv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", 0); err != nil {
 		return Config{}, err
 	}
@@ -634,6 +662,9 @@ func Load() (Config, error) {
 		}
 		if cfg.AppendLog.JetStreamPublishMaxInFlight < 0 {
 			return Config{}, errors.New("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT must be greater than or equal to 0")
+		}
+		if err := validateJetStreamPublishRetryConfig(cfg.AppendLog); err != nil {
+			return Config{}, err
 		}
 	default:
 		return Config{}, fmt.Errorf("unsupported CEREBRO_APPEND_LOG_DRIVER %q", cfg.AppendLog.Driver)
@@ -764,6 +795,24 @@ func validateRequestOriginConfig(cfg RequestOriginConfig) error {
 		if _, _, err := net.ParseCIDR(strings.TrimSpace(rawCIDR)); err != nil {
 			return fmt.Errorf("CEREBRO_TRUSTED_PROXY_CIDRS contains invalid CIDR %q: %w", rawCIDR, err)
 		}
+	}
+	return nil
+}
+
+func validateJetStreamPublishRetryConfig(cfg AppendLogConfig) error {
+	if cfg.JetStreamPublishRetryAttempts < 0 {
+		return errors.New("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS must be greater than or equal to 0")
+	}
+	if cfg.JetStreamPublishClientRetryAttempts < 0 {
+		return errors.New("CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_ATTEMPTS must be greater than or equal to 0")
+	}
+	if cfg.JetStreamPublishRetryInitialBackoff > 0 && cfg.JetStreamPublishRetryMaxBackoff > 0 &&
+		cfg.JetStreamPublishRetryInitialBackoff > cfg.JetStreamPublishRetryMaxBackoff {
+		return errors.New("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF must be less than or equal to CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF")
+	}
+	if cfg.JetStreamPublishAttemptTimeout > 0 && cfg.JetStreamPublishRetryMaxElapsed > 0 &&
+		cfg.JetStreamPublishAttemptTimeout > cfg.JetStreamPublishRetryMaxElapsed {
+		return errors.New("CEREBRO_JETSTREAM_PUBLISH_ATTEMPT_TIMEOUT must be less than or equal to CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,13 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_ATTEMPT_TIMEOUT", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_ATTEMPTS", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_WAIT", "")
 	t.Setenv("CEREBRO_STATE_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_POSTGRES_DSN", "")
 	t.Setenv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", "")
@@ -145,6 +152,13 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "cerebro.events")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "4s")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "12")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", "22")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF", "750ms")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF", "9s")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_ATTEMPT_TIMEOUT", "45s")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED", "5m")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_ATTEMPTS", "6")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_WAIT", "800ms")
 	t.Setenv("CEREBRO_STATE_STORE_DRIVER", StateStoreDriverPostgres)
 	t.Setenv("CEREBRO_POSTGRES_DSN", "postgres://127.0.0.1:5432/cerebro?sslmode=disable")
 	t.Setenv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", "20")
@@ -247,6 +261,27 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.AppendLog.JetStreamPublishMaxInFlight != 12 {
 		t.Fatalf("JetStreamPublishMaxInFlight = %d, want 12", cfg.AppendLog.JetStreamPublishMaxInFlight)
+	}
+	if cfg.AppendLog.JetStreamPublishRetryAttempts != 22 {
+		t.Fatalf("JetStreamPublishRetryAttempts = %d, want 22", cfg.AppendLog.JetStreamPublishRetryAttempts)
+	}
+	if cfg.AppendLog.JetStreamPublishRetryInitialBackoff != 750*time.Millisecond {
+		t.Fatalf("JetStreamPublishRetryInitialBackoff = %v, want 750ms", cfg.AppendLog.JetStreamPublishRetryInitialBackoff)
+	}
+	if cfg.AppendLog.JetStreamPublishRetryMaxBackoff != 9*time.Second {
+		t.Fatalf("JetStreamPublishRetryMaxBackoff = %v, want 9s", cfg.AppendLog.JetStreamPublishRetryMaxBackoff)
+	}
+	if cfg.AppendLog.JetStreamPublishAttemptTimeout != 45*time.Second {
+		t.Fatalf("JetStreamPublishAttemptTimeout = %v, want 45s", cfg.AppendLog.JetStreamPublishAttemptTimeout)
+	}
+	if cfg.AppendLog.JetStreamPublishRetryMaxElapsed != 5*time.Minute {
+		t.Fatalf("JetStreamPublishRetryMaxElapsed = %v, want 5m", cfg.AppendLog.JetStreamPublishRetryMaxElapsed)
+	}
+	if cfg.AppendLog.JetStreamPublishClientRetryAttempts != 6 {
+		t.Fatalf("JetStreamPublishClientRetryAttempts = %d, want 6", cfg.AppendLog.JetStreamPublishClientRetryAttempts)
+	}
+	if cfg.AppendLog.JetStreamPublishClientRetryWait != 800*time.Millisecond {
+		t.Fatalf("JetStreamPublishClientRetryWait = %v, want 800ms", cfg.AppendLog.JetStreamPublishClientRetryWait)
 	}
 	if cfg.StateStore.Driver != StateStoreDriverPostgres {
 		t.Fatalf("StateStore.Driver = %q, want %q", cfg.StateStore.Driver, StateStoreDriverPostgres)
@@ -518,6 +553,14 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_URL", "")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_ATTEMPT_TIMEOUT", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_ATTEMPTS", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_WAIT", "")
 	t.Setenv("CEREBRO_STATE_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_POSTGRES_DSN", "")
 	t.Setenv("CEREBRO_POSTGRES_MAX_OPEN_CONNS", "")
@@ -1176,6 +1219,42 @@ func TestLoadRejectsNegativeJetStreamPublishMaxInFlight(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "-1")
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadRejectsInvalidJetStreamPublishRetryBounds(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+	}{
+		{
+			name: "initial backoff exceeds max backoff",
+			env: map[string]string{
+				"CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF": "10s",
+				"CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF":     "1s",
+			},
+		},
+		{
+			name: "attempt timeout exceeds retry budget",
+			env: map[string]string{
+				"CEREBRO_JETSTREAM_PUBLISH_ATTEMPT_TIMEOUT":   "5m",
+				"CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED": "30s",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearDependencyEnv(t)
+			t.Setenv("CEREBRO_APPEND_LOG_DRIVER", AppendLogDriverJetStream)
+			t.Setenv("CEREBRO_JETSTREAM_URL", "nats://127.0.0.1:4222")
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+			if _, err := Load(); err == nil {
+				t.Fatal("Load() error = nil, want non-nil")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary\n- expose JetStream publish retry attempts/backoff/timeouts/client retries through append-log config\n- carry effective retry budgets into JetStream wide-event telemetry\n- document the operational knobs for large stream restore windows\n\n## Verification\n- go test ./internal/config ./internal/appendlog/jetstream