### PR TITLE
feat: switch Droid review to GLM-5.2, add URN collision linter, harden scoped identities

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -12,6 +12,7 @@ jobs:
   droid-review-preflight:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       checks: read
@@ -263,6 +264,7 @@ jobs:
     # preflight context but skip the secret-dependent Droid execution job.
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && needs.droid-review-preflight.outputs.run_droid_review == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -280,8 +282,9 @@ jobs:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
           automatic_security_review: true
-          # Fast deterministic preflight runs first; use Sonnet for the actual
-          # bug-finding review so Droid does not fall back to stale depth presets.
-          review_model: ${{ needs.droid-review-preflight.outputs.review_model || 'claude-sonnet-4-6' }}
+          # Fast deterministic preflight runs first; use GLM-5.2 for the actual
+          # bug-finding review (faster than Sonnet while maintaining quality).
+          review_model: ${{ needs.droid-review-preflight.outputs.review_model || 'glm-5.2' }}
           security_model: gpt-5.4
+          reasoning_effort: medium
           allowed_bots: dependabot

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -66,12 +66,8 @@ jobs:
           !contains(github.event.pull_request.title || '', '@droid scaffold source'))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
     steps:
       - name: Verify trusted target
         id: target
@@ -138,6 +134,6 @@ jobs:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           # Keep manual @droid reviews as the escalation path after the fast
           # preflight-backed automatic pass has already run.
-          review_model: claude-sonnet-4-6
+          review_model: glm-5.2
           security_model: gpt-5.4
           reasoning_effort: high

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -68,6 +68,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
     steps:
       - name: Verify trusted target
         id: target

--- a/Makefile
+++ b/Makefile
@@ -424,6 +424,21 @@ land-pr: ## Wait for core/Droid gates, merge PR, then delete the PR branch.
 	@if [ -z "$(PR)" ]; then echo "PR is required, e.g. make land-pr PR=719" >&2; exit 2; fi
 	python3 scripts/land_pr.py "$(PR)" --repo "$(LAND_PR_REPO)" $(if $(filter true,$(LAND_PR_ADMIN)),--admin,) $(if $(filter true,$(LAND_PR_KEEP_BRANCH)),--keep-branch,) $(if $(filter true,$(LAND_PR_ALLOW_LARGE)),--allow-large-pr,)
 
+ci-poll: ## Poll PR checks until complete or timeout (PR required, optional INTERVAL and TIMEOUT).
+	@if [ -z "$(PR)" ]; then echo "PR is required, e.g. make ci-poll PR=719" >&2; exit 2; fi
+	@interval="$(INTERVAL)"; timeout_s="$(TIMEOUT)"; \
+	if [ -z "$$interval" ]; then interval=60; fi; \
+	if [ -z "$$timeout_s" ]; then timeout_s=1800; fi; \
+	elapsed=0; \
+	while [ $$elapsed -lt $$timeout_s ]; do \
+		status=$$(gh pr checks $(PR) --repo writer/cerebro 2>&1); \
+		echo "$$status"; \
+		if echo "$$status" | grep -qE '^(fail|error)'; then echo "CI failed"; exit 1; fi; \
+		if ! echo "$$status" | grep -qE 'pending|in_progress|queued|0\b'; then echo "All checks passed"; exit 0; fi; \
+		sleep $$interval; elapsed=$$((elapsed + interval)); \
+	done; \
+	echo "CI polling timed out after $$timeout_s seconds"; exit 1
+
 # ==== Project Hygiene ====
 ##@ Project Hygiene
 clean: ## Remove build artifacts.

--- a/Makefile
+++ b/Makefile
@@ -431,10 +431,9 @@ ci-poll: ## Poll PR checks until complete or timeout (PR required, optional INTE
 	if [ -z "$$timeout_s" ]; then timeout_s=1800; fi; \
 	elapsed=0; \
 	while [ $$elapsed -lt $$timeout_s ]; do \
-		status=$$(gh pr checks $(PR) --repo writer/cerebro 2>&1); \
-		echo "$$status"; \
-		if echo "$$status" | grep -qE '^(fail|error)'; then echo "CI failed"; exit 1; fi; \
-		if ! echo "$$status" | grep -qE 'pending|in_progress|queued|0\b'; then echo "All checks passed"; exit 0; fi; \
+		gh pr checks $(PR) --repo writer/cerebro 2>&1; rc=$$?; \
+		if [ $$rc -eq 1 ]; then echo "CI failed"; exit 1; fi; \
+		if [ $$rc -eq 0 ]; then echo "All checks passed"; exit 0; fi; \
 		sleep $$interval; elapsed=$$((elapsed + interval)); \
 	done; \
 	echo "CI polling timed out after $$timeout_s seconds"; exit 1

--- a/internal/sourceprojection/cloudflare_test.go
+++ b/internal/sourceprojection/cloudflare_test.go
@@ -2,6 +2,8 @@ package sourceprojection
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -161,14 +163,14 @@ func TestProjectCloudflareScopedInventoryLinks(t *testing.T) {
 
 	accountURN := "urn:cerebro:writer:cloudflare_account:acct-1"
 	zoneURN := "urn:cerebro:writer:cloudflare_zone:zone-1"
-	accessAppURN := "urn:cerebro:writer:cloudflare_access_application:app-1"
-	accountRulesetURN := "urn:cerebro:writer:cloudflare_account_ruleset:ruleset-1"
+	accessAppURN := "urn:cerebro:writer:cloudflare_access_application:acct-1%7Capp-1"
+	accountRulesetURN := "urn:cerebro:writer:cloudflare_account_ruleset:acct-1%7Cruleset-1"
 	workerScriptURN := "urn:cerebro:writer:cloudflare_worker_script:acct-1%7Capi"
 	poolURN := "urn:cerebro:writer:cloudflare_load_balancer_pool:pool-1"
 	defaultPoolURN := "urn:cerebro:writer:cloudflare_load_balancer_pool:pool-2"
-	zoneAccessGroupURN := "urn:cerebro:writer:cloudflare_zone_access_group:group-1"
-	zoneRulesetURN := "urn:cerebro:writer:cloudflare_zone_ruleset:zone-ruleset-1"
-	loadBalancerURN := "urn:cerebro:writer:cloudflare_load_balancer:lb-1"
+	zoneAccessGroupURN := "urn:cerebro:writer:cloudflare_zone_access_group:zone-1%7Cgroup-1"
+	zoneRulesetURN := "urn:cerebro:writer:cloudflare_zone_ruleset:zone-1%7Czone-ruleset-1"
+	loadBalancerURN := "urn:cerebro:writer:cloudflare_load_balancer:zone-1%7Clb-1"
 	auditURN := "urn:cerebro:writer:cloudflare_audit_log:audit-1"
 
 	for _, urn := range []string{accessAppURN, accountRulesetURN, workerScriptURN, poolURN, zoneAccessGroupURN, zoneRulesetURN, loadBalancerURN, auditURN} {
@@ -228,6 +230,136 @@ func TestProjectCloudflareLoadBalancerDoesNotUseZoneAsIdentity(t *testing.T) {
 	eventURN := "urn:cerebro:writer:cloudflare_load_balancer:cf-lb-missing-id"
 	if entity := state.entities[eventURN]; entity == nil || entity.EntityType != "cloudflare.load_balancer" {
 		t.Fatalf("load balancer fallback entity missing or wrong: %#v", entity)
+	}
+}
+
+func TestProjectCloudflareScopedResourcesRequireScopeKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		eventID  string
+		kind     string
+		attrs    map[string]string
+		entityID string
+	}{
+		{
+			name:     "access_application without account_id",
+			eventID:  "cf-app-no-account",
+			kind:     "cloudflare.access_application",
+			attrs:    map[string]string{"application_id": "app-1", "name": "Admin App"},
+			entityID: "app-1",
+		},
+		{
+			name:     "zone_access_group without zone_id",
+			eventID:  "cf-group-no-zone",
+			kind:     "cloudflare.zone_access_group",
+			attrs:    map[string]string{"group_id": "group-1", "name": "Employees"},
+			entityID: "group-1",
+		},
+		{
+			name:     "account_ruleset without account_id",
+			eventID:  "cf-ruleset-no-account",
+			kind:     "cloudflare.account_ruleset",
+			attrs:    map[string]string{"ruleset_id": "ruleset-1", "name": "WAF"},
+			entityID: "ruleset-1",
+		},
+		{
+			name:     "gateway_rule without account_id",
+			eventID:  "cf-gw-rule-no-account",
+			kind:     "cloudflare.gateway_rule",
+			attrs:    map[string]string{"rule_id": "rule-1", "name": "Block bad traffic"},
+			entityID: "rule-1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := &projectionRecorder{}
+			service := New(state, nil)
+
+			event := cloudflareTestEvent(tc.eventID, tc.kind, tc.attrs, `{"id":"`+tc.entityID+`"}`)
+			if _, err := service.Project(context.Background(), event); err != nil {
+				t.Fatalf("Project() error = %v", err)
+			}
+
+			family := strings.ReplaceAll(tc.kind, ".", "_")
+			unscopedURN := fmt.Sprintf("urn:cerebro:writer:%s:%s", family, tc.entityID)
+			if entity := state.entities[unscopedURN]; entity != nil {
+				t.Fatalf("unscoped entity %s must not exist: %#v", unscopedURN, entity)
+			}
+			eventURN := fmt.Sprintf("urn:cerebro:writer:%s:%s", family, tc.eventID)
+			if entity := state.entities[eventURN]; entity == nil || entity.EntityType != tc.kind {
+				t.Fatalf("fallback entity %s missing or wrong: %#v", eventURN, entity)
+			}
+		})
+	}
+}
+
+func TestProjectCloudflareScopedResourcesStayDistinctAcrossScopes(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     string
+		idKey    string
+		idValue  string
+		scopeKey string
+		scopeA   string
+		scopeB   string
+	}{
+		{
+			name:     "access_application across accounts",
+			kind:     "cloudflare.access_application",
+			idKey:    "application_id",
+			idValue:  "app-1",
+			scopeKey: "account_id",
+			scopeA:   "acct-1",
+			scopeB:   "acct-2",
+		},
+		{
+			name:     "zone_access_group across zones",
+			kind:     "cloudflare.zone_access_group",
+			idKey:    "group_id",
+			idValue:  "group-1",
+			scopeKey: "zone_id",
+			scopeA:   "zone-1",
+			scopeB:   "zone-2",
+		},
+		{
+			name:     "load_balancer across zones",
+			kind:     "cloudflare.load_balancer",
+			idKey:    "load_balancer_id",
+			idValue:  "lb-1",
+			scopeKey: "zone_id",
+			scopeA:   "zone-1",
+			scopeB:   "zone-2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := &projectionRecorder{}
+			service := New(state, nil)
+
+			for i, scope := range []string{tc.scopeA, tc.scopeB} {
+				event := cloudflareTestEvent(
+					fmt.Sprintf("cf-%s-%d", tc.idValue, i),
+					tc.kind,
+					map[string]string{tc.idKey: tc.idValue, tc.scopeKey: scope, "name": "test"},
+					`{"id":"`+tc.idValue+`"}`,
+				)
+				if _, err := service.Project(context.Background(), event); err != nil {
+					t.Fatalf("Project() error = %v", err)
+				}
+			}
+
+			family := strings.ReplaceAll(tc.kind, ".", "_")
+			urnA := fmt.Sprintf("urn:cerebro:writer:%s:%s%%7C%s", family, tc.scopeA, tc.idValue)
+			urnB := fmt.Sprintf("urn:cerebro:writer:%s:%s%%7C%s", family, tc.scopeB, tc.idValue)
+			if urnA == urnB {
+				t.Fatalf("URNs must differ across scopes: %s", urnA)
+			}
+			for _, urn := range []string{urnA, urnB} {
+				if entity := state.entities[urn]; entity == nil {
+					t.Fatalf("expected entity %s; entities=%#v", urn, state.entities)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/sourceprojection/inventory_projection.go
+++ b/internal/sourceprojection/inventory_projection.go
@@ -51,18 +51,24 @@ func inventoryEntityID(kind string, family string, attrs map[string]string) stri
 		return joinProjectionIdentity(attrs, "cluster_id", "namespace", "resource_id", "name")
 	case "kubernetes.container":
 		return joinProjectionIdentity(attrs, "cluster_id", "namespace", "resource_id", "container_name")
-	case "cloudflare.access_application", "cloudflare.zone_access_application":
-		return joinProjectionIdentity(attrs, "application_id", "id")
-	case "cloudflare.access_group", "cloudflare.zone_access_group":
-		return joinProjectionIdentity(attrs, "group_id", "id")
-	case "cloudflare.account_ruleset", "cloudflare.zone_ruleset":
-		return joinProjectionIdentity(attrs, "ruleset_id", "id")
+	case "cloudflare.access_application":
+		return joinRequiredScopedProjectionIdentity(attrs, "account_id", "application_id", "id")
+	case "cloudflare.zone_access_application":
+		return joinRequiredScopedProjectionIdentity(attrs, "zone_id", "application_id", "id")
+	case "cloudflare.access_group":
+		return joinRequiredScopedProjectionIdentity(attrs, "account_id", "group_id", "id")
+	case "cloudflare.zone_access_group":
+		return joinRequiredScopedProjectionIdentity(attrs, "zone_id", "group_id", "id")
+	case "cloudflare.account_ruleset":
+		return joinRequiredScopedProjectionIdentity(attrs, "account_id", "ruleset_id", "id")
+	case "cloudflare.zone_ruleset":
+		return joinRequiredScopedProjectionIdentity(attrs, "zone_id", "ruleset_id", "id")
 	case "cloudflare.audit_log":
 		return joinProjectionIdentity(attrs, "audit_id", "id")
 	case "cloudflare.gateway_rule":
-		return joinProjectionIdentity(attrs, "rule_id", "id")
+		return joinRequiredScopedProjectionIdentity(attrs, "account_id", "rule_id", "id")
 	case "cloudflare.load_balancer":
-		return joinProjectionIdentity(attrs, "load_balancer_id", "id")
+		return joinRequiredScopedProjectionIdentity(attrs, "zone_id", "load_balancer_id", "id")
 	case "cloudflare.load_balancer_pool":
 		return joinProjectionIdentity(attrs, "pool_id", "id")
 	case "cloudflare.worker_script":
@@ -107,9 +113,6 @@ func inventoryEntityID(kind string, family string, attrs map[string]string) stri
 		"resource_id",
 		"uid",
 		"id",
-		"name",
-		"email",
-		"username",
 		"vulnerability_id",
 		"package",
 		"external_id",

--- a/tools/droidreview/main.go
+++ b/tools/droidreview/main.go
@@ -17,9 +17,17 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/tools/droidreview/bodyread"
+	"github.com/writer/cerebro/tools/droidreview/urnlinter"
 )
 
-const sonnetBugReviewModel = "claude-sonnet-4-6"
+const bugReviewModel = "glm-5.2"
+
+func reviewModel() string {
+	if model := os.Getenv("DROID_REVIEW_MODEL"); model != "" {
+		return model
+	}
+	return bugReviewModel
+}
 
 type preflightResult struct {
 	ChangedFiles   []string          `json:"changed_files"`
@@ -86,7 +94,7 @@ func writeJSONFile(path string, result preflightResult) error {
 func run(base, head, repo string) (preflightResult, error) {
 	files, err := changedFiles(base, head, repo)
 	if err != nil {
-		return preflightResult{RunDroidReview: true, ReviewModel: sonnetBugReviewModel}, err
+		return preflightResult{RunDroidReview: true, ReviewModel: reviewModel()}, err
 	}
 	result := classifyReview(files)
 	result.Checks = []string{
@@ -95,6 +103,7 @@ func run(base, head, repo string) (preflightResult, error) {
 		"cypher-safety",
 		"ask-post-processing-boundary",
 		"candidate-lifecycle-atomicity",
+		"urn-identity-safety",
 	}
 	result.ProbePlan = reviewProbePlan(files)
 	for _, file := range files {
@@ -129,6 +138,18 @@ func run(base, head, repo string) (preflightResult, error) {
 		result.Findings = append(result.Findings, cypherFindings(file, body)...)
 		result.Findings = append(result.Findings, askPostProcessingFindings(file, body)...)
 		result.Findings = append(result.Findings, candidateLifecycleFindings(file, body)...)
+		urnFindings, err := urnlinter.FindDisplayNameInURN(file, body)
+		if err != nil {
+			return result, fmt.Errorf("scan %s for URN identity: %w", file, err)
+		}
+		for _, finding := range urnFindings {
+			result.Findings = append(result.Findings, checkFinding{
+				Rule:    "urn-identity-safety",
+				File:    finding.File,
+				Line:    finding.Line,
+				Message: fmt.Sprintf("%s uses display-name field %q in URN identity chain; prefer stable provider IDs (resource_id, uid) to avoid collisions", finding.Function, finding.DisplayName),
+			})
+		}
 	}
 	if len(result.Findings) > 0 {
 		var message strings.Builder
@@ -229,7 +250,7 @@ func classifyReview(files []string) preflightResult {
 	result := preflightResult{
 		ChangedFiles:   files,
 		RunDroidReview: false,
-		ReviewModel:    sonnetBugReviewModel,
+		ReviewModel:    reviewModel(),
 		ReviewReason:   "docs/templates only; fast preflight and CI are sufficient",
 	}
 	for _, file := range files {

--- a/tools/droidreview/main_test.go
+++ b/tools/droidreview/main_test.go
@@ -33,8 +33,8 @@ func TestClassifyReviewSkipsDocsOnly(t *testing.T) {
 	if result.RunDroidReview {
 		t.Fatalf("RunDroidReview = true, want false for docs-only changes")
 	}
-	if result.ReviewModel != sonnetBugReviewModel {
-		t.Fatalf("ReviewModel = %q, want %q", result.ReviewModel, sonnetBugReviewModel)
+	if result.ReviewModel != reviewModel() {
+		t.Fatalf("ReviewModel = %q, want %q", result.ReviewModel, reviewModel())
 	}
 }
 
@@ -63,7 +63,7 @@ func TestWriteJSONFilePersistsPreflightShape(t *testing.T) {
 	result := preflightResult{
 		ChangedFiles:   []string{"internal/graphagent/ask.go"},
 		RunDroidReview: true,
-		ReviewModel:    sonnetBugReviewModel,
+		ReviewModel:    reviewModel(),
 		ReviewReason:   "code changed",
 		Checks:         []string{"cypher-safety"},
 		Findings:       []checkFinding{{Rule: "cypher-safety", File: "internal/graphagent/ask.go", Line: 12, Message: "bad cypher"}},

--- a/tools/droidreview/testdata/preflight_sample.json
+++ b/tools/droidreview/testdata/preflight_sample.json
@@ -5,14 +5,15 @@
     "scripts/droid_ci_context.py"
   ],
   "run_droid_review": true,
-  "review_model": "claude-sonnet-4-6",
+  "review_model": "glm-5.2",
   "review_reason": "code, workflow, API, source, or security-sensitive paths changed",
   "checks": [
     "bounded-body-read",
     "source-http-safety",
     "cypher-safety",
     "ask-post-processing-boundary",
-    "candidate-lifecycle-atomicity"
+    "candidate-lifecycle-atomicity",
+    "urn-identity-safety"
   ],
   "findings": [],
   "probe_plan": [

--- a/tools/droidreview/testdata/review_context/preflight.json
+++ b/tools/droidreview/testdata/review_context/preflight.json
@@ -4,7 +4,7 @@
     ".github/workflows/droid-review.yml"
   ],
   "run_droid_review": true,
-  "review_model": "claude-sonnet-4-6",
+  "review_model": "glm-5.2",
   "review_reason": "code, workflow, API, source, or security-sensitive paths changed",
   "findings": [],
   "checks": ["cypher-safety"],

--- a/tools/droidreview/urnlinter/urnlinter.go
+++ b/tools/droidreview/urnlinter/urnlinter.go
@@ -1,0 +1,111 @@
+package urnlinter
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+)
+
+type Finding struct {
+	File        string
+	Line        int
+	Function    string
+	DisplayName string
+}
+
+var displayNameFields = map[string]bool{
+	"workload_name":  true,
+	"resource_name":  true,
+	"name":           true,
+	"label":          true,
+	"display_name":   true,
+	"email":          true,
+	"username":       true,
+	"login":          true,
+	"target_name":    true,
+	"principal":      true,
+	"setting_name":   true,
+	"service_name":   true,
+	"ingress_name":   true,
+	"node_name":      true,
+	"binding_name":   true,
+	"role_name":      true,
+	"container_name": true,
+	"vault_name":     true,
+}
+
+func FindDisplayNameInURN(filePath string, source []byte) ([]Finding, error) {
+	if !strings.HasSuffix(filePath, ".go") || strings.HasSuffix(filePath, "_test.go") {
+		return nil, nil
+	}
+	if !strings.Contains(string(source), "URN") && !strings.Contains(string(source), "firstNonEmpty") {
+		return nil, nil
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filePath, source, 0)
+	if err != nil {
+		return nil, err
+	}
+	var findings []Finding
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || fn.Name == nil {
+			continue
+		}
+		if !strings.HasSuffix(fn.Name.Name, "URN") {
+			continue
+		}
+		ast.Inspect(fn, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if !isCallTo(call, "firstNonEmpty") {
+				return true
+			}
+			for _, arg := range call.Args {
+				fieldName := extractMapKey(arg)
+				if fieldName == "" {
+					continue
+				}
+				if displayNameFields[fieldName] {
+					findings = append(findings, Finding{
+						File:        filepath.ToSlash(filePath),
+						Line:        fset.Position(call.Pos()).Line,
+						Function:    fn.Name.Name,
+						DisplayName: fieldName,
+					})
+				}
+			}
+			return true
+		})
+	}
+	return findings, nil
+}
+
+func isCallTo(call *ast.CallExpr, name string) bool {
+	ident, ok := call.Fun.(*ast.Ident)
+	return ok && ident.Name == name
+}
+
+func extractMapKey(expr ast.Expr) string {
+	index, ok := expr.(*ast.IndexExpr)
+	if !ok {
+		return ""
+	}
+	lit, ok := index.Index.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return ""
+	}
+	value, err := literalString(lit.Value)
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+func literalString(raw string) (string, error) {
+	return strings.Trim(raw, `"`), nil
+}

--- a/tools/droidreview/urnlinter/urnlinter_test.go
+++ b/tools/droidreview/urnlinter/urnlinter_test.go
@@ -1,0 +1,154 @@
+package urnlinter
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestFindDisplayNameInURNFlagsWorkloadName(t *testing.T) {
+	source := []byte(`package test
+
+func testURN(tenantID string, attrs map[string]string) string {
+	id := firstNonEmpty(attrs["resource_id"], attrs["uid"], attrs["workload_name"])
+	return id
+}
+`)
+	findings, err := FindDisplayNameInURN("test.go", source)
+	if err != nil {
+		t.Fatalf("FindDisplayNameInURN() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %#v", len(findings), findings)
+	}
+	if findings[0].DisplayName != "workload_name" {
+		t.Fatalf("expected workload_name, got %q", findings[0].DisplayName)
+	}
+	if findings[0].Function != "testURN" {
+		t.Fatalf("expected testURN, got %q", findings[0].Function)
+	}
+}
+
+func TestFindDisplayNameInURNFlagsName(t *testing.T) {
+	source := []byte(`package test
+
+func kubernetesServiceURN(tenantID string, attrs map[string]string) string {
+	name := firstNonEmpty(attrs["service_name"], attrs["resource_name"], attrs["name"])
+	return name
+}
+`)
+	findings, err := FindDisplayNameInURN("kubernetes.go", source)
+	if err != nil {
+		t.Fatalf("FindDisplayNameInURN() error = %v", err)
+	}
+	if len(findings) == 0 {
+		t.Fatal("expected findings for display-name fields in URN function")
+	}
+	displayNames := map[string]bool{}
+	for _, f := range findings {
+		displayNames[f.DisplayName] = true
+	}
+	for _, want := range []string{"service_name", "resource_name", "name"} {
+		if !displayNames[want] {
+			t.Fatalf("expected finding for %q, not found in %#v", want, findings)
+		}
+	}
+}
+
+func TestFindDisplayNameInURNSkipsSafeURN(t *testing.T) {
+	source := []byte(`package test
+
+func safeURN(tenantID string, attrs map[string]string) string {
+	id := firstNonEmpty(attrs["resource_id"], attrs["uid"])
+	return id
+}
+`)
+	findings, err := FindDisplayNameInURN("safe.go", source)
+	if err != nil {
+		t.Fatalf("FindDisplayNameInURN() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings for safe URN, got %d: %#v", len(findings), findings)
+	}
+}
+
+func TestFindDisplayNameInURNSkipsNonURNFunctions(t *testing.T) {
+	source := []byte(`package test
+
+func buildLabel(attrs map[string]string) string {
+	return firstNonEmpty(attrs["name"], attrs["display_name"])
+}
+`)
+	findings, err := FindDisplayNameInURN("label.go", source)
+	if err != nil {
+		t.Fatalf("FindDisplayNameInURN() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings for non-URN function, got %d: %#v", len(findings), findings)
+	}
+}
+
+func TestFindDisplayNameInURNSkipsTestFiles(t *testing.T) {
+	source := []byte(`package test
+
+func testURN(attrs map[string]string) string {
+	return firstNonEmpty(attrs["name"])
+}
+`)
+	findings, err := FindDisplayNameInURN("projector_test.go", source)
+	if err != nil {
+		t.Fatalf("FindDisplayNameInURN() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings for test file, got %d", len(findings))
+	}
+}
+
+func TestLiteralString(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`"resource_id"`, "resource_id"},
+		{`"uid"`, "uid"},
+	}
+	for _, tc := range cases {
+		got, err := literalString(tc.input)
+		if err != nil {
+			t.Fatalf("literalString(%q) error = %v", tc.input, err)
+		}
+		if got != tc.want {
+			t.Fatalf("literalString(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestExtractMapKey(t *testing.T) {
+	source := []byte(`package test
+func f() { _ = attrs["resource_id"] }
+`)
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", source, 0)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var found string
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		ast.Inspect(fn, func(node ast.Node) bool {
+			index, ok := node.(*ast.IndexExpr)
+			if !ok {
+				return true
+			}
+			found = extractMapKey(index)
+			return false
+		})
+	}
+	if found != "resource_id" {
+		t.Fatalf("extractMapKey = %q, want resource_id", found)
+	}
+}


### PR DESCRIPTION
## Summary

- Switch Droid auto review and manual @droid review model from claude-sonnet-4-6 to glm-5.2 with env var override (DROID_REVIEW_MODEL)
- Add reasoning_effort: medium to auto review and timeout-minutes to all Droid workflow jobs for faster, bounded runtime
- Add URN identity safety linter (tools/droidreview/urnlinter) that flags display-name fields in URN builder functions, wired into make droid-review-preflight
- Require account_id/zone_id scope for all Cloudflare scoped inventory kinds (access_application, access_group, ruleset, gateway_rule, load_balancer) via joinRequiredScopedProjectionIdentity
- Remove name/email/username from generic inventoryEntityID fallback chain to prevent display-name identity collisions
- Add make ci-poll target for non-blocking CI status polling

## Test Plan

- go test ./tools/droidreview/... -count=1
- go test ./internal/sourceprojection -count=1
- go test ./...
- make lint
- make droid-review-preflight

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.