### PR TITLE
feat: sourcegen hardening, new auth models, projection templates, and tooling

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -264,7 +264,7 @@ jobs:
     # preflight context but skip the secret-dependent Droid execution job.
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && needs.droid-review-preflight.outputs.run_droid_review == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write
@@ -277,6 +277,8 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Auto Review
+        id: droid-review-first
+        continue-on-error: true
         uses: Factory-AI/droid-action@150e8c231191631016a9563bf5d8388e36382de9 # main
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
@@ -284,6 +286,18 @@ jobs:
           automatic_security_review: true
           # Fast deterministic preflight runs first; use GLM-5.2 for the actual
           # bug-finding review (faster than Sonnet while maintaining quality).
+          review_model: ${{ needs.droid-review-preflight.outputs.review_model || 'glm-5.2' }}
+          security_model: gpt-5.4
+          reasoning_effort: medium
+          allowed_bots: dependabot
+      - name: Retry Droid Auto Review on failure
+        if: steps.droid-review-first.outcome == 'failure'
+        continue-on-error: true
+        uses: Factory-AI/droid-action@150e8c231191631016a9563bf5d8388e36382de9 # main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          automatic_review: true
+          automatic_security_review: true
           review_model: ${{ needs.droid-review-preflight.outputs.review_model || 'glm-5.2' }}
           security_model: gpt-5.4
           reasoning_effort: medium

--- a/cmd/cerebro/source_runtime_sdk.go
+++ b/cmd/cerebro/source_runtime_sdk.go
@@ -11,7 +11,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcegen"
 )
 
-const sourceRuntimeSDKNewUsage = "usage: %s source-runtime sdk [new <source-id> [catalog=true] [definition=<definition.json>] [source_type=json_api] [auth_model=bearer_token|api_token|api_key] [asset_schemas=<schema[,schema]>] [finding_schemas=<schema[,schema]>] [freshness_expectation=<duration>] [failure_modes=<mode[,mode]>] [name=<name>] [description=<description>] [health_path=<path>] [output_dir=<dir>] [dry_run=true] [force=true] | classify <definition.json>]"
+const sourceRuntimeSDKNewUsage = "usage: %s source-runtime sdk [new <source-id> [catalog=true] [definition=<definition.json>] [source_type=json_api] [auth_model=bearer_token|api_token|api_key] [asset_schemas=<schema[,schema]>] [finding_schemas=<schema[,schema]>] [freshness_expectation=<duration>] [failure_modes=<mode[,mode]>] [name=<name>] [description=<description>] [health_path=<path>] [output_dir=<dir>] [dry_run=true] [force=true] | classify <definition.json> | wire <source-id> [output_dir=<dir>] [dry_run=true] | validate <source-id> [output_dir=<dir>]]"
 
 type sourceRuntimeSDKNewRequest struct {
 	sourcegen.Request
@@ -35,6 +35,10 @@ func runSourceRuntimeSDK(args []string) error {
 		return printJSON(result)
 	case "classify":
 		return runSourceRuntimeSDKClassify(args[1:])
+	case "wire":
+		return runSourceRuntimeSDKWire(args[1:])
+	case "validate":
+		return runSourceRuntimeSDKValidate(args[1:])
 	default:
 		return usageError(fmt.Sprintf(sourceRuntimeSDKNewUsage, os.Args[0]))
 	}
@@ -211,4 +215,55 @@ func parseSourceRuntimeSDKNewArgs(args []string) (sourceRuntimeSDKNewRequest, er
 		},
 		CatalogDefinition: catalogDefinition,
 	}, nil
+}
+
+func runSourceRuntimeSDKWire(args []string) error {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return usageError(fmt.Sprintf(sourceRuntimeSDKNewUsage, os.Args[0]))
+	}
+	sourceID := strings.TrimSpace(args[0])
+	values := map[string]string{}
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return fmt.Errorf("invalid wire argument %q; want key=value", arg)
+		}
+		values[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	dryRun, err := parseBoolValue(values["dry_run"])
+	if err != nil {
+		return fmt.Errorf("parse dry_run: %w", err)
+	}
+	result, err := sourcegen.Wire(sourcegen.WireRequest{
+		SourceID:  sourceID,
+		OutputDir: firstNonEmptyCLI(values["output_dir"], "."),
+		DryRun:    dryRun,
+	})
+	if err != nil {
+		return err
+	}
+	return printJSON(result)
+}
+
+func runSourceRuntimeSDKValidate(args []string) error {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return usageError(fmt.Sprintf(sourceRuntimeSDKNewUsage, os.Args[0]))
+	}
+	sourceID := strings.TrimSpace(args[0])
+	values := map[string]string{}
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return fmt.Errorf("invalid validate argument %q; want key=value", arg)
+		}
+		values[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	result, err := sourcegen.Validate(sourcegen.ValidateRequest{
+		SourceID:  sourceID,
+		OutputDir: firstNonEmptyCLI(values["output_dir"], "."),
+	})
+	if err != nil {
+		return err
+	}
+	return printJSON(result)
 }

--- a/internal/connectordefinitions/classifier.go
+++ b/internal/connectordefinitions/classifier.go
@@ -99,11 +99,13 @@ func DefaultGrammar() Grammar {
 			"opaque_cursor",
 		},
 		ProjectionTemplates: []string{
+			"alert",
 			"app_entitlement",
 			"asset",
 			"audit_event",
 			"cloud_resource",
 			"compliance_control",
+			"deployment",
 			"endpoint_device",
 			"finding",
 			"group_membership",

--- a/internal/connectordefinitions/openapigen/generator.go
+++ b/internal/connectordefinitions/openapigen/generator.go
@@ -144,14 +144,14 @@ func collectCandidates(doc *openapi3.T, sourceID string) []candidate {
 		operations := pair.item.Operations()
 		methods := sortedOperationMethods(operations)
 		for _, method := range methods {
-			if method != "GET" {
-				continue
-			}
 			operation := operations[method]
 			if operation == nil || operation.Deprecated {
 				continue
 			}
 			schema := responseSchema(operation)
+			if method != "GET" && (method != "POST" || !isPostListing(operation, schema)) {
+				continue
+			}
 			selector, listKey, itemSchema, ok := recordShape(pair.path, schema)
 			if !ok {
 				continue
@@ -171,7 +171,7 @@ func collectCandidates(doc *openapi3.T, sourceID string) []candidate {
 				ID:             familyID,
 				Label:          titleFromID(familyID),
 				Path:           renderedPath,
-				Method:         "GET",
+				Method:         method,
 				RecordSelector: selector,
 				ListKey:        listKey,
 				IDField:        idField,
@@ -420,6 +420,28 @@ func normalizeServerURL(value string) string {
 	return strings.TrimRight(parsed.String(), "/")
 }
 
+// isPostListing determines whether a POST operation is a listing endpoint
+// (returns an array of records) rather than a creation/action endpoint.
+// A POST is considered a listing endpoint if its response schema is an array
+// or an object with an array field (same shape as GET listing endpoints).
+func isPostListing(_ *openapi3.Operation, schema *openapi3.SchemaRef) bool {
+	value := schemaValue(schema)
+	if value == nil {
+		return false
+	}
+	if isSchemaType(value, "array") {
+		return true
+	}
+	if isSchemaType(value, "object") && value.Properties != nil {
+		for _, prop := range value.Properties {
+			if isArraySchema(prop) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func responseSchema(operation *openapi3.Operation) *openapi3.SchemaRef {
 	if operation == nil || operation.Responses == nil {
 		return nil
@@ -642,10 +664,14 @@ func projectionTemplate(familyID, path string, operation *openapi3.Operation, pr
 		return "identity_user"
 	case containsAny(resourceText, "group", "team", "role", "organization", "workspace"):
 		return "identity_group"
-	case containsAny(text, "finding", "alert", "vulnerability", "vuln", "issue", "incident", "risk", "detection", "threat"):
+	case containsAny(text, "alert", "alarm", "notification", "incident", "pager", "siren"):
+		return "alert"
+	case containsAny(text, "finding", "vulnerability", "vuln", "issue", "risk", "detection", "threat"):
 		return "finding"
 	case containsAny(resourceText, "secret", "credential", "token", "password", "api_key", "apikey", "vault"):
 		return "secret"
+	case containsAny(text, "deployment", "deploy", "release", "build"):
+		return "deployment"
 	case containsAny(text, "policy", "compliance", "control", "rule", "standard", "framework", "baseline", "posture"):
 		return "policy"
 	case containsAny(text, "evidence", "case", "artifact"):
@@ -687,6 +713,16 @@ func projectionSpec(template, familyID, idField, nameField string, properties ma
 		fields["policy_id"] = firstNonEmpty(idField, "id")
 		fields["policy_name"] = firstNonEmpty(nameField, idField)
 		fields["policy_type"] = familyID
+	case "deployment":
+		fields["deployment_id"] = firstNonEmpty(idField, "id")
+		fields["deployment_name"] = firstNonEmpty(nameField, idField)
+		fields["deployment_environment"] = chooseField(properties, []string{"environment", "env", "stage", "target"})
+		fields["deployment_status"] = chooseField(properties, []string{"status", "state", "ready"})
+	case "alert":
+		fields["alert_id"] = firstNonEmpty(idField, "id")
+		fields["alert_name"] = firstNonEmpty(nameField, chooseField(properties, []string{"title", "summary", "subject"}), idField)
+		fields["alert_severity"] = chooseField(properties, []string{"severity", "priority", "level", "risk"})
+		fields["alert_status"] = chooseField(properties, []string{"status", "state", "resolved"})
 	case "evidence_cas_reference":
 		fields["evidence_id"] = firstNonEmpty(idField, "id")
 		fields["evidence_type"] = familyID
@@ -931,6 +967,10 @@ func coverageID(template, familyID string) string {
 		return "secrets"
 	case "policy":
 		return "policies"
+	case "deployment":
+		return "deployments"
+	case "alert":
+		return "alerts"
 	default:
 		return familyID
 	}
@@ -946,6 +986,10 @@ func coverageType(template string) string {
 		return "entity_family"
 	case "policy":
 		return "lifecycle_state"
+	case "deployment":
+		return "deployment_state"
+	case "alert":
+		return "alert_state"
 	default:
 		return "entity_family"
 	}
@@ -966,6 +1010,10 @@ func highValueBonus(template, familyID, path string) int {
 	case "secret":
 		return 25
 	case "policy":
+		return 20
+	case "deployment":
+		return 15
+	case "alert":
 		return 20
 	}
 	text := strings.ToLower(strings.Join([]string{familyID, path}, " "))

--- a/internal/connectordefinitions/openapigen/generator_test.go
+++ b/internal/connectordefinitions/openapigen/generator_test.go
@@ -44,8 +44,8 @@ func TestGenerateBuildsSourcegenReadyDefinition(t *testing.T) {
 		t.Fatalf("user pagination = %#v", users.Pagination)
 	}
 	alert := familyByID(t, definition.ResourceFamilies, "alert")
-	if alert.Projection == nil || alert.Projection.Template != "finding" {
-		t.Fatalf("alert projection = %#v, want finding", alert.Projection)
+	if alert.Projection == nil || alert.Projection.Template != "alert" {
+		t.Fatalf("alert projection = %#v, want alert", alert.Projection)
 	}
 	if report.EndpointCount != 4 || len(report.Selected) != 4 {
 		t.Fatalf("report = %#v", report)

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -28,6 +28,8 @@ const (
 	AuthModelOAuthClientCredentials = "oauth_client_credentials" // #nosec G101 -- auth model identifier, not credential material.
 	AuthModelJWT                    = "jwt"
 	AuthModelSignature              = "signature"
+	AuthModelAWSSigV4               = "aws_sigv4"
+	AuthModelTwoStep                = "two_step"
 
 	defaultFreshnessExpectation = 24 * time.Hour
 	defaultHealthPath           = "/healthz"
@@ -410,6 +412,10 @@ func authModelConfig(authModel string) (string, string, error) {
 		return "Bearer", "token", nil
 	case AuthModelSignature:
 		return "Signature", "token", nil
+	case AuthModelAWSSigV4:
+		return "AWS4-HMAC-SHA256", "access_key", nil
+	case AuthModelTwoStep:
+		return "Bearer", "api_key", nil
 	default:
 		return "", "", fmt.Errorf("auth_model %q must be executable by a JSON API runtime", authModel)
 	}
@@ -431,6 +437,10 @@ func executableAuthModel(authModel string) (string, error) {
 		return AuthModelSignature, nil
 	case AuthModelOAuthClientCredentials:
 		return AuthModelOAuthClientCredentials, nil
+	case AuthModelAWSSigV4:
+		return AuthModelAWSSigV4, nil
+	case AuthModelTwoStep:
+		return AuthModelTwoStep, nil
 	default:
 		return "", fmt.Errorf("%w: auth model %q needs provider auth runtime support before sourcegen can emit executable code", errUnsupportedDefinition, authModel)
 	}
@@ -729,6 +739,10 @@ func executableProjectionClass(resource connectordefinitions.ResourceFamily) (st
 		return "secret", nil
 	case "policy", "compliance_control":
 		return "policy", nil
+	case "deployment":
+		return "deployment", nil
+	case "alert":
+		return "alert", nil
 	case "identity_user", "identity_group", "group_membership", "audit_event", "evidence_cas_reference":
 		return template, nil
 	default:
@@ -754,6 +768,10 @@ func requiredAttributesForClass(class string) []string {
 		return []string{"tenant_id", "source_event_id", "secret_id", "secret_name"}
 	case "policy":
 		return []string{"tenant_id", "source_event_id", "policy_id", "policy_name"}
+	case "deployment":
+		return []string{"tenant_id", "source_event_id", "deployment_id", "deployment_name"}
+	case "alert":
+		return []string{"tenant_id", "source_event_id", "alert_id", "alert_severity"}
 	default:
 		return []string{"tenant_id", "source_event_id", "resource_urn", "resource_type", "resource_id"}
 	}
@@ -1037,6 +1055,10 @@ func idKeysForFamily(family familyData) []string {
 		base = append(base, "secret_id", "id", "name", "key", "sid")
 	case "policy":
 		base = append(base, "policy_id", "id", "name", "key", "control_id")
+	case "deployment":
+		base = append(base, "deployment_id", "id", "name", "url", "uid")
+	case "alert":
+		base = append(base, "alert_id", "id", "sid", "incident_id", "uuid")
 	default:
 		base = append(base, "id", "urn", "resource_urn", "name")
 	}
@@ -1125,6 +1147,26 @@ func attributePathsForFamily(family familyData) map[string]string {
 		base["policy_description"] = "description|summary|body"
 		base["policy_severity"] = "severity|risk|priority"
 		base["policy_created_at"] = "created_at|created|date_created"
+	case "deployment":
+		base["deployment_id"] = "deployment_id|id|name|uid"
+		base["deployment_name"] = "deployment_name|name|display_name|title|label"
+		base["deployment_environment"] = "environment|env|stage|target"
+		base["deployment_status"] = "status|state|ready"
+		base["deployment_url"] = "url|deployment_url|endpoint|domain"
+		base["deployment_commit_sha"] = "commit_sha|commit|sha|revision|git_sha"
+		base["deployment_branch"] = "branch|ref|git_branch|head_branch"
+		base["deployment_created_at"] = "created_at|created|date_created"
+		base["deployment_updated_at"] = "updated_at|updated|last_modified"
+	case "alert":
+		base["alert_id"] = "alert_id|id|sid|incident_id|uuid"
+		base["alert_name"] = "alert_name|name|title|summary|subject"
+		base["alert_severity"] = "severity|priority|level|risk"
+		base["alert_status"] = "status|state|resolved|acknowledged"
+		base["alert_type"] = "alert_type|type|category|kind"
+		base["alert_source"] = "source|alert_source|monitor|check"
+		base["alert_fired_at"] = "fired_at|triggered_at|created_at|occurred_at|timestamp"
+		base["alert_resolved_at"] = "resolved_at|closed_at|acknowledged_at"
+		base["alert_description"] = "description|summary|message|body"
 	}
 	return base
 }
@@ -1163,6 +1205,14 @@ func renderSourceTestGo(request normalizedRequest) string {
 	fmt.Fprintf(&b, "\t\t_ = json.NewEncoder(w).Encode(map[string]any{\"items\": []map[string]string{{\"id\": \"record-1\", \"resource_urn\": \"urn:cerebro:tenant:runtime_asset:record-1\", \"resource_type\": \"asset\", \"resource_id\": \"record-1\", \"name\": \"Record One\", \"updated_at\": \"2026-06-01T00:00:00Z\"}}})\n")
 	fmt.Fprintf(&b, "\t}))\n\tdefer server.Close()\n")
 	fmt.Fprintf(&b, "\tcfgValues := map[string]string{\"tenant_id\": \"tenant\", \"base_url\": server.URL, \"family\": defaultFamily")
+	// Also set template variables so runtimeConfig template resolution is exercised
+	// even if base_url is removed from the config.
+	for _, key := range extractTemplateKeys(request.BaseURLTemplate) {
+		if key == "base_url" || key == "family" || key == request.TokenConfigKey {
+			continue
+		}
+		fmt.Fprintf(&b, ", %s: %s", strconv.Quote(key), strconv.Quote(testConfigValue(key)))
+	}
 	if request.OAuth != nil {
 		fmt.Fprintf(&b, ", \"token_url\": server.URL + \"/oauth/token\", \"client_id\": \"client-id\", \"client_secret\": \"client-secret\"")
 		for _, key := range request.ConfigKeys {
@@ -1316,6 +1366,14 @@ func renderProjectionGo(request normalizedRequest) string {
 		fmt.Fprintf(&b, "func %sPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", sourcePrefix)
 		fmt.Fprintf(&b, "\ttenantID, err := tenantID(event)\n\tif err != nil {\n\t\treturn nil, nil, err\n\t}\n\tattributes := event.GetAttributes()\n\tpolicyID := firstNonEmpty(attributes[\"policy_id\"], event.GetId())\n\tpolicyURN := projectionURN(tenantID, \"policy\", policyID)\n\tentities := map[string]*ports.ProjectedEntity{}\n\tlinks := map[string]*ports.ProjectedLink{}\n\taddEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: \"policy\", Label: firstNonEmpty(attributes[\"policy_name\"], policyID), Attributes: map[string]string{\"policy_id\": policyID, \"policy_type\": strings.TrimSpace(attributes[\"policy_type\"]), \"policy_status\": strings.TrimSpace(attributes[\"policy_status\"]), \"policy_severity\": strings.TrimSpace(attributes[\"policy_severity\"]), \"source_runtime_id\": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})\n\tif evidenceID := strings.TrimSpace(attributes[\"evidence_id\"]); evidenceID != \"\" {\n\t\tevidenceURN := projectionURN(tenantID, \"runtime_evidence\", evidenceID)\n\t\taddEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: \"runtime_evidence\", Label: evidenceID, Attributes: map[string]string{\"evidence_id\": evidenceID, \"evidence_cas_uri\": strings.TrimSpace(attributes[\"evidence_cas_uri\"]), \"evidence_cas_digest\": strings.TrimSpace(attributes[\"evidence_cas_digest\"])}})\n\t\taddLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{\"event_id\": event.GetId()}))\n\t}\n\treturn identityProjectionResult(entities, links)\n}\n")
 	}
+	if firstFamilyClass(request.Families, "deployment").Name != "" {
+		fmt.Fprintf(&b, "func %sDeploymentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", sourcePrefix)
+		fmt.Fprintf(&b, "\ttenantID, err := tenantID(event)\n\tif err != nil {\n\t\treturn nil, nil, err\n\t}\n\tattributes := event.GetAttributes()\n\tdeploymentID := firstNonEmpty(attributes[\"deployment_id\"], event.GetId())\n\tdeploymentURN := projectionURN(tenantID, \"deployment\", deploymentID)\n\tentities := map[string]*ports.ProjectedEntity{}\n\tlinks := map[string]*ports.ProjectedLink{}\n\taddEntity(entities, &ports.ProjectedEntity{URN: deploymentURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: \"deployment\", Label: firstNonEmpty(attributes[\"deployment_name\"], deploymentID), Attributes: map[string]string{\"deployment_id\": deploymentID, \"deployment_environment\": strings.TrimSpace(attributes[\"deployment_environment\"]), \"deployment_status\": strings.TrimSpace(attributes[\"deployment_status\"]), \"deployment_url\": strings.TrimSpace(attributes[\"deployment_url\"]), \"deployment_commit_sha\": strings.TrimSpace(attributes[\"deployment_commit_sha\"]), \"deployment_branch\": strings.TrimSpace(attributes[\"deployment_branch\"]), \"source_runtime_id\": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})\n\tif evidenceID := strings.TrimSpace(attributes[\"evidence_id\"]); evidenceID != \"\" {\n\t\tevidenceURN := projectionURN(tenantID, \"runtime_evidence\", evidenceID)\n\t\taddEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: \"runtime_evidence\", Label: evidenceID, Attributes: map[string]string{\"evidence_id\": evidenceID, \"evidence_cas_uri\": strings.TrimSpace(attributes[\"evidence_cas_uri\"]), \"evidence_cas_digest\": strings.TrimSpace(attributes[\"evidence_cas_digest\"])}})\n\t\taddLink(links, projectedLink(tenantID, event.GetSourceId(), deploymentURN, evidenceURN, relationHasEvidence, map[string]string{\"event_id\": event.GetId()}))\n\t}\n\treturn identityProjectionResult(entities, links)\n}\n")
+	}
+	if firstFamilyClass(request.Families, "alert").Name != "" {
+		fmt.Fprintf(&b, "func %sAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", sourcePrefix)
+		fmt.Fprintf(&b, "\ttenantID, err := tenantID(event)\n\tif err != nil {\n\t\treturn nil, nil, err\n\t}\n\tattributes := event.GetAttributes()\n\talertID := firstNonEmpty(attributes[\"alert_id\"], event.GetId())\n\talertURN := projectionURN(tenantID, \"alert\", alertID)\n\tentities := map[string]*ports.ProjectedEntity{}\n\tlinks := map[string]*ports.ProjectedLink{}\n\taddEntity(entities, &ports.ProjectedEntity{URN: alertURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: \"alert\", Label: firstNonEmpty(attributes[\"alert_name\"], alertID), Attributes: map[string]string{\"alert_id\": alertID, \"alert_severity\": strings.TrimSpace(attributes[\"alert_severity\"]), \"alert_status\": strings.TrimSpace(attributes[\"alert_status\"]), \"alert_type\": strings.TrimSpace(attributes[\"alert_type\"]), \"alert_source\": strings.TrimSpace(attributes[\"alert_source\"]), \"alert_fired_at\": strings.TrimSpace(attributes[\"alert_fired_at\"]), \"alert_resolved_at\": strings.TrimSpace(attributes[\"alert_resolved_at\"]), \"source_runtime_id\": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})\n\tif evidenceID := strings.TrimSpace(attributes[\"evidence_id\"]); evidenceID != \"\" {\n\t\tevidenceURN := projectionURN(tenantID, \"runtime_evidence\", evidenceID)\n\t\taddEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: \"runtime_evidence\", Label: evidenceID, Attributes: map[string]string{\"evidence_id\": evidenceID, \"evidence_cas_uri\": strings.TrimSpace(attributes[\"evidence_cas_uri\"]), \"evidence_cas_digest\": strings.TrimSpace(attributes[\"evidence_cas_digest\"])}})\n\t\taddLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, evidenceURN, relationHasEvidence, map[string]string{\"event_id\": event.GetId()}))\n\t}\n\treturn identityProjectionResult(entities, links)\n}\n")
+	}
 	return b.String()
 }
 
@@ -1323,7 +1381,9 @@ func projectionNeedsStrings(families []familyData) bool {
 	return firstFamilyClass(families, "asset").Name != "" ||
 		firstFamilyClass(families, "finding").Name != "" ||
 		firstFamilyClass(families, "secret").Name != "" ||
-		firstFamilyClass(families, "policy").Name != ""
+		firstFamilyClass(families, "policy").Name != "" ||
+		firstFamilyClass(families, "deployment").Name != "" ||
+		firstFamilyClass(families, "alert").Name != ""
 }
 
 func renderProjectionTestGo(request normalizedRequest) string {
@@ -1331,6 +1391,8 @@ func renderProjectionTestGo(request normalizedRequest) string {
 	findingFamily := firstFamilyClass(request.Families, "finding")
 	secretFamily := firstFamilyClass(request.Families, "secret")
 	policyFamily := firstFamilyClass(request.Families, "policy")
+	deploymentFamily := firstFamilyClass(request.Families, "deployment")
+	alertFamily := firstFamilyClass(request.Families, "alert")
 	userFamily := firstFamilyClass(request.Families, "identity_user")
 	groupFamily := firstFamilyClass(request.Families, "identity_group")
 	membershipFamily := firstFamilyClass(request.Families, "group_membership")
@@ -1358,6 +1420,16 @@ func renderProjectionTestGo(request normalizedRequest) string {
 		fmt.Fprintf(&b, "func Test%sPolicyProjection(t *testing.T) {\n", pascalIdentifier(request.SourceID))
 		fmt.Fprintf(&b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"policy_id\": \"policy-1\", \"policy_name\": \"Require MFA\", \"policy_type\": \"access\", \"policy_status\": \"enabled\", \"evidence_id\": \"evidence-1\"}}\n", strconv.Quote(request.SourceID), strconv.Quote(policyFamily.EventKind))
 		fmt.Fprintf(&b, "\tentities, links, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tif len(entities) == 0 {\n\t\tt.Fatal(\"expected projected policy\")\n\t}\n\tif len(links) == 0 {\n\t\tt.Fatal(\"expected projected evidence links\")\n\t}\n}\n\n", policyFamily.ProjectorName)
+	}
+	if deploymentFamily.Class == "deployment" {
+		fmt.Fprintf(&b, "func Test%sDeploymentProjection(t *testing.T) {\n", pascalIdentifier(request.SourceID))
+		fmt.Fprintf(&b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"deployment_id\": \"dep-1\", \"deployment_name\": \"Production\", \"deployment_environment\": \"production\", \"deployment_status\": \"ready\", \"evidence_id\": \"evidence-1\"}}\n", strconv.Quote(request.SourceID), strconv.Quote(deploymentFamily.EventKind))
+		fmt.Fprintf(&b, "\tentities, links, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tif len(entities) == 0 {\n\t\tt.Fatal(\"expected projected deployment\")\n\t}\n\tif len(links) == 0 {\n\t\tt.Fatal(\"expected projected evidence links\")\n\t}\n}\n\n", deploymentFamily.ProjectorName)
+	}
+	if alertFamily.Class == "alert" {
+		fmt.Fprintf(&b, "func Test%sAlertProjection(t *testing.T) {\n", pascalIdentifier(request.SourceID))
+		fmt.Fprintf(&b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"alert_id\": \"alert-1\", \"alert_name\": \"High Error Rate\", \"alert_severity\": \"critical\", \"alert_status\": \"open\", \"evidence_id\": \"evidence-1\"}}\n", strconv.Quote(request.SourceID), strconv.Quote(alertFamily.EventKind))
+		fmt.Fprintf(&b, "\tentities, links, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tif len(entities) == 0 {\n\t\tt.Fatal(\"expected projected alert\")\n\t}\n\tif len(links) == 0 {\n\t\tt.Fatal(\"expected projected evidence links\")\n\t}\n}\n\n", alertFamily.ProjectorName)
 	}
 	if userFamily.Class == "identity_user" {
 		fmt.Fprintf(&b, "func Test%sIdentityUserProjection(t *testing.T) {\n", pascalIdentifier(request.SourceID))

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -413,7 +413,7 @@ func authModelConfig(authModel string) (string, string, error) {
 	case AuthModelSignature:
 		return "Signature", "token", nil
 	case AuthModelAWSSigV4:
-		return "AWS4-HMAC-SHA256", "access_key", nil
+		return "AWS4-HMAC-SHA256", "client_id", nil
 	case AuthModelTwoStep:
 		return "Bearer", "api_key", nil
 	default:

--- a/internal/sourcegen/validate.go
+++ b/internal/sourcegen/validate.go
@@ -1,0 +1,247 @@
+package sourcegen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ValidateRequest configures the sourcegen validate command.
+type ValidateRequest struct {
+	SourceID  string
+	OutputDir string
+}
+
+// ValidateResult reports validation findings for a generated source.
+type ValidateResult struct {
+	SourceID string          `json:"source_id"`
+	Valid    bool            `json:"valid"`
+	Issues   []ValidateIssue `json:"issues"`
+}
+
+// ValidateIssue describes one validation finding.
+type ValidateIssue struct {
+	Severity string `json:"severity"`
+	File     string `json:"file"`
+	Message  string `json:"message"`
+}
+
+// Validate cross-checks a generated source's catalog.yaml, deploy.yaml,
+// and source.go for consistency. It catches the class of bugs that the
+// Droid review found (missing templateKeys, dangling evidence links,
+// undeclared secretKeys) at generation time rather than at CI time.
+func Validate(request ValidateRequest) (*ValidateResult, error) {
+	sourceID := strings.TrimSpace(request.SourceID)
+	if sourceID == "" {
+		return nil, fmt.Errorf("source_id is required")
+	}
+	outputDir := strings.TrimSpace(request.OutputDir)
+	if outputDir == "" {
+		outputDir = "."
+	}
+
+	sourceDir := filepath.Join(outputDir, "sources", sourceID)
+	result := &ValidateResult{SourceID: sourceID, Valid: true}
+
+	// 1. Check catalog.yaml exists and has emitted_kinds.
+	catalogPath := filepath.Join(sourceDir, "catalog.yaml")
+	catalogBytes, err := os.ReadFile(catalogPath) // #nosec G304 -- known path.
+	if err != nil {
+		result.Valid = false
+		result.Issues = append(result.Issues, ValidateIssue{
+			Severity: "error",
+			File:     catalogPath,
+			Message:  fmt.Sprintf("catalog.yaml not found: %v", err),
+		})
+		return result, nil
+	}
+
+	// 2. Check source.go exists and verify templateKeys.
+	sourcePath := filepath.Join(sourceDir, "source.go")
+	sourceBytes, err := os.ReadFile(sourcePath) // #nosec G304 -- known path.
+	if err != nil {
+		result.Valid = false
+		result.Issues = append(result.Issues, ValidateIssue{
+			Severity: "error",
+			File:     sourcePath,
+			Message:  fmt.Sprintf("source.go not found: %v", err),
+		})
+		return result, nil
+	}
+	sourceText := string(sourceBytes)
+
+	// 3. Verify templateKeys include all template variables from defaultBaseURLTemplate.
+	templateKeys := extractTemplateKeysFromSource(sourceText)
+	baseURLTemplate := extractBaseURLTemplateFromSource(sourceText)
+	if baseURLTemplate != "" {
+		templateVars := extractTemplateKeys(baseURLTemplate)
+		for _, varKey := range templateVars {
+			found := false
+			for _, tk := range templateKeys {
+				if tk == varKey {
+					found = true
+					break
+				}
+			}
+			if !found {
+				result.Valid = false
+				result.Issues = append(result.Issues, ValidateIssue{
+					Severity: "error",
+					File:     sourcePath,
+					Message:  fmt.Sprintf("templateKey %q is referenced in defaultBaseURLTemplate %q but not in templateKeys", varKey, baseURLTemplate),
+				})
+			}
+		}
+	}
+
+	// 4. Check deploy.yaml exists and verify secretKeys.
+	deployPath := filepath.Join(sourceDir, "deploy.yaml")
+	deployBytes, err := os.ReadFile(deployPath) // #nosec G304 -- known path.
+	if err != nil {
+		result.Valid = false
+		result.Issues = append(result.Issues, ValidateIssue{
+			Severity: "warning",
+			File:     deployPath,
+			Message:  fmt.Sprintf("deploy.yaml not found: %v", err),
+		})
+	} else {
+		deployText := string(deployBytes)
+		secretKeys := extractSecretKeysFromDeploy(deployText)
+		envRefs := extractEnvRefsFromDeploy(deployText)
+		for _, ref := range envRefs {
+			found := false
+			for _, sk := range secretKeys {
+				if sk == ref {
+					found = true
+					break
+				}
+			}
+			if !found {
+				result.Valid = false
+				result.Issues = append(result.Issues, ValidateIssue{
+					Severity: "error",
+					File:     deployPath,
+					Message:  fmt.Sprintf("env reference %q is used in deploy.yaml but not declared in secretKeys", ref),
+				})
+			}
+		}
+	}
+
+	// 5. Verify the source is wired into the source registry.
+	registryPath := filepath.Join(outputDir, "internal/sourceregistry/registry.go")
+	registryBytes, err := os.ReadFile(registryPath) // #nosec G304 -- known path.
+	if err == nil {
+		registryText := string(registryBytes)
+		if !strings.Contains(registryText, fmt.Sprintf(`name: %q`, sourceID)) {
+			result.Issues = append(result.Issues, ValidateIssue{
+				Severity: "warning",
+				File:     registryPath,
+				Message:  fmt.Sprintf("source %q is not wired into the source registry", sourceID),
+			})
+		}
+	}
+
+	// 6. Verify the source is wired into the projection registry.
+	projRegistryPath := filepath.Join(outputDir, "internal/sourceprojection/registry.go")
+	projRegistryBytes, err := os.ReadFile(projRegistryPath) // #nosec G304 -- known path.
+	if err == nil {
+		projRegistryText := string(projRegistryBytes)
+		kinds := parseEmittedKindsFromCatalog(catalogBytes)
+		for _, kind := range kinds {
+			if !strings.Contains(projRegistryText, fmt.Sprintf("%q:", kind)) {
+				result.Issues = append(result.Issues, ValidateIssue{
+					Severity: "warning",
+					File:     projRegistryPath,
+					Message:  fmt.Sprintf("kind %q is not wired into the projection registry", kind),
+				})
+			}
+		}
+	}
+
+	// 7. Verify docs reference includes the source.
+	docsPath := filepath.Join(outputDir, "docs/reference/sources.md")
+	docsBytes, err := os.ReadFile(docsPath) // #nosec G304 -- known path.
+	if err == nil {
+		docsText := string(docsBytes)
+		if !strings.Contains(docsText, fmt.Sprintf("| `%s` |", sourceID)) {
+			result.Issues = append(result.Issues, ValidateIssue{
+				Severity: "warning",
+				File:     docsPath,
+				Message:  fmt.Sprintf("source %q is not listed in docs/reference/sources.md", sourceID),
+			})
+		}
+	}
+
+	if len(result.Issues) > 0 {
+		for _, issue := range result.Issues {
+			if issue.Severity == "error" {
+				result.Valid = false
+				break
+			}
+		}
+	}
+
+	return result, nil
+}
+
+var templateKeysPattern = regexp.MustCompile(`var templateKeys = \[\]string\{([^}]+)\}`)
+var baseURLTemplatePattern = regexp.MustCompile(`defaultBaseURLTemplate = "([^"]+)"`)
+var envRefPattern = regexp.MustCompile(`env:(\w+)`)
+
+func extractTemplateKeysFromSource(sourceText string) []string {
+	matches := templateKeysPattern.FindStringSubmatch(sourceText)
+	if len(matches) < 2 {
+		return nil
+	}
+	raw := matches[1]
+	var keys []string
+	for _, part := range strings.Split(raw, ",") {
+		key := strings.Trim(strings.TrimSpace(part), `"`)
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+func extractBaseURLTemplateFromSource(sourceText string) string {
+	matches := baseURLTemplatePattern.FindStringSubmatch(sourceText)
+	if len(matches) < 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+func extractSecretKeysFromDeploy(deployText string) []string {
+	// Find the secretKeys section.
+	lines := strings.Split(deployText, "\n")
+	var keys []string
+	inSecretKeys := false
+	for _, line := range lines {
+		if strings.HasPrefix(line, "secretKeys:") {
+			inSecretKeys = true
+			continue
+		}
+		if inSecretKeys {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "- ") {
+				key := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
+				keys = append(keys, key)
+			} else if !strings.HasPrefix(line, " ") && trimmed != "" {
+				inSecretKeys = false
+			}
+		}
+	}
+	return keys
+}
+
+func extractEnvRefsFromDeploy(deployText string) []string {
+	matches := envRefPattern.FindAllStringSubmatch(deployText, -1)
+	var refs []string
+	for _, m := range matches {
+		refs = append(refs, m[1])
+	}
+	return refs
+}

--- a/internal/sourcegen/wire.go
+++ b/internal/sourcegen/wire.go
@@ -156,6 +156,14 @@ func wireSourceRegistry(path, importAlias, importPath, sourceID, loaderEntry str
 			entry := strings.TrimSuffix(loaderEntry, "\n")
 			lines = append(lines[:insertIdx], append([]string{entry}, lines[insertIdx:]...)...)
 			text = strings.Join(lines, "\n")
+		} else {
+			// Source ID sorts after all existing entries; append before the closing brace.
+			marker := "}"
+			idx := strings.LastIndex(text, marker)
+			if idx >= 0 {
+				entry := strings.TrimSuffix(loaderEntry, "\n")
+				text = text[:idx] + entry + "\n" + text[idx:]
+			}
 		}
 	}
 
@@ -225,6 +233,9 @@ func wireDocsReference(path, entry, sourceID string) error {
 	if insertIdx >= 0 {
 		lines = append(lines[:insertIdx], append([]string{entry}, lines[insertIdx:]...)...)
 		text = strings.Join(lines, "\n")
+	} else {
+		// Source ID sorts after all existing entries; append at end of file.
+		text = strings.TrimRight(text, "\n") + "\n" + entry + "\n"
 	}
 
 	return os.WriteFile(path, []byte(text), 0o600) // #nosec G703 -- operator-provided CLI path.

--- a/internal/sourcegen/wire.go
+++ b/internal/sourcegen/wire.go
@@ -1,0 +1,276 @@
+package sourcegen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// WireRequest configures the sourcegen wire command.
+type WireRequest struct {
+	SourceID  string
+	OutputDir string
+	DryRun    bool
+}
+
+// WireResult reports the changes made by the wire command.
+type WireResult struct {
+	SourceID           string   `json:"source_id"`
+	RegistryImport     string   `json:"registry_import"`
+	RegistryLoader     string   `json:"registry_loader"`
+	ProjectionMappings []string `json:"projection_mappings"`
+	DocsEntry          string   `json:"docs_entry"`
+	FilesModified      []string `json:"files_modified"`
+}
+
+// Wire auto-wires a generated source into the source registry, projection
+// registry, and docs reference. It reads the source's catalog.yaml to
+// determine the source ID and emitted kinds, then inserts the appropriate
+// imports, loader entries, and projector mappings.
+func Wire(request WireRequest) (*WireResult, error) {
+	sourceID := strings.TrimSpace(request.SourceID)
+	if sourceID == "" {
+		return nil, fmt.Errorf("source_id is required")
+	}
+	outputDir := strings.TrimSpace(request.OutputDir)
+	if outputDir == "" {
+		outputDir = "."
+	}
+
+	// Read the generated source's catalog.yaml to get emitted kinds.
+	catalogPath := filepath.Join(outputDir, "sources", sourceID, "catalog.yaml")
+	catalogBytes, err := os.ReadFile(catalogPath) // #nosec G304 -- operator-provided path.
+	if err != nil {
+		return nil, fmt.Errorf("read catalog.yaml for %s: %w", sourceID, err)
+	}
+	kinds := parseEmittedKindsFromCatalog(catalogBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse catalog kinds for %s: %w", sourceID, err)
+	}
+	if len(kinds) == 0 {
+		return nil, fmt.Errorf("no emitted kinds found in catalog.yaml for %s", sourceID)
+	}
+
+	// Generate the import alias (e.g., "hashicorpvaultsource" for "hashicorp_vault").
+	importAlias := sourceIDToImportAlias(sourceID)
+	importPath := fmt.Sprintf("github.com/writer/cerebro/sources/%s", sourceID)
+
+	// Generate the loader entry.
+	loaderEntry := fmt.Sprintf("\t{\n\t\tname: %q,\n\t\tload: func() (sourcecdk.Source, error) {\n\t\t\treturn %s.New()\n\t\t},\n\t},\n", sourceID, importAlias)
+
+	// Generate the projection mappings.
+	prefix := sourceIDToPascal(sourceID)
+	var projectionMappings []string
+	for _, kind := range kinds {
+		familyPart := strings.TrimPrefix(kind, sourceID+".")
+		funcName := fmt.Sprintf("%s%sProjections", prefix, pascalIdentifier(familyPart))
+		mapping := fmt.Sprintf("\t%q: %s,", kind, funcName)
+		projectionMappings = append(projectionMappings, mapping)
+	}
+
+	// Generate the docs entry.
+	docsEntry := fmt.Sprintf("| `%s` | %s source | %s |", sourceID, sourceIDToTitle(sourceID), strings.Join(kinds, ", "))
+
+	result := &WireResult{
+		SourceID:           sourceID,
+		RegistryImport:     fmt.Sprintf(`%s "%s"`, importAlias, importPath),
+		RegistryLoader:     loaderEntry,
+		ProjectionMappings: projectionMappings,
+		DocsEntry:          docsEntry,
+	}
+
+	if request.DryRun {
+		return result, nil
+	}
+
+	// Apply changes to the registry files.
+	registryPath := filepath.Join(outputDir, "internal/sourceregistry/registry.go")
+	if err := wireSourceRegistry(registryPath, importAlias, importPath, sourceID, loaderEntry); err != nil {
+		return nil, fmt.Errorf("wire source registry: %w", err)
+	}
+	result.FilesModified = append(result.FilesModified, registryPath)
+
+	projectionRegistryPath := filepath.Join(outputDir, "internal/sourceprojection/registry.go")
+	if err := wireProjectionRegistry(projectionRegistryPath, sourceID, projectionMappings); err != nil {
+		return nil, fmt.Errorf("wire projection registry: %w", err)
+	}
+	result.FilesModified = append(result.FilesModified, projectionRegistryPath)
+
+	docsPath := filepath.Join(outputDir, "docs/reference/sources.md")
+	if err := wireDocsReference(docsPath, docsEntry, sourceID); err != nil {
+		return nil, fmt.Errorf("wire docs reference: %w", err)
+	}
+	result.FilesModified = append(result.FilesModified, docsPath)
+
+	return result, nil
+}
+
+func wireSourceRegistry(path, importAlias, importPath, sourceID, loaderEntry string) error {
+	content, err := os.ReadFile(path) // #nosec G304 -- known path.
+	if err != nil {
+		return err
+	}
+	text := string(content)
+
+	// Add import in the right position (after the last source import, before non-source imports).
+	importLine := fmt.Sprintf("\t%s %q\n", importAlias, importPath)
+	if !strings.Contains(text, importLine) {
+		// Find the last source import line and insert after it.
+		lines := strings.Split(text, "\n")
+		insertIdx := -1
+		for i, line := range lines {
+			if strings.Contains(line, `github.com/writer/cerebro/sources/`) {
+				insertIdx = i + 1
+			}
+		}
+		if insertIdx >= 0 {
+			lines = append(lines[:insertIdx], append([]string{strings.TrimRight(importLine, "\n")}, lines[insertIdx:]...)...)
+			text = strings.Join(lines, "\n")
+		}
+	}
+
+	// Add loader entry in the right position (alphabetical by name).
+	if !strings.Contains(text, fmt.Sprintf(`name: %q`, sourceID)) {
+		// Find the right position based on source ID alphabetical order.
+		lines := strings.Split(text, "\n")
+		insertIdx := -1
+		for i, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "name: \"") {
+				existingName := strings.Trim(strings.TrimPrefix(trimmed, "name: "), "\"")
+				if existingName > sourceID {
+					// Find the start of this entry block (the opening brace).
+					for j := i - 1; j >= 0; j-- {
+						if strings.TrimSpace(lines[j]) == "{" {
+							insertIdx = j
+							break
+						}
+					}
+					break
+				}
+			}
+		}
+		if insertIdx >= 0 {
+			entry := strings.TrimSuffix(loaderEntry, "\n")
+			lines = append(lines[:insertIdx], append([]string{entry}, lines[insertIdx:]...)...)
+			text = strings.Join(lines, "\n")
+		}
+	}
+
+	return os.WriteFile(path, []byte(text), 0o600) // #nosec G703 -- operator-provided CLI path.
+}
+
+func wireProjectionRegistry(path, sourceID string, mappings []string) error {
+	content, err := os.ReadFile(path) // #nosec G304 -- known path.
+	if err != nil {
+		return err
+	}
+	text := string(content)
+
+	// Check if already wired.
+	firstKind := sourceID + "."
+	if strings.Contains(text, firstKind) {
+		// Already wired for this source, skip.
+		return nil
+	}
+
+	// Insert before the awscollectorgen marker.
+	marker := "// awscollectorgen:projector"
+	idx := strings.Index(text, marker)
+	if idx < 0 {
+		return fmt.Errorf("marker %q not found in projection registry", marker)
+	}
+
+	// Build the block to insert.
+	var block strings.Builder
+	fmt.Fprintf(&block, "\t// %s generated projectors (sourcegen promotion)\n", sourceID)
+	for _, m := range mappings {
+		block.WriteString(m)
+		block.WriteString("\n")
+	}
+	block.WriteString("\n")
+
+	// Find the line start before the marker.
+	lineStart := strings.LastIndex(text[:idx], "\n") + 1
+	text = text[:lineStart] + block.String() + text[lineStart:]
+
+	return os.WriteFile(path, []byte(text), 0o600) // #nosec G703 -- operator-provided CLI path.
+}
+
+func wireDocsReference(path, entry, sourceID string) error {
+	content, err := os.ReadFile(path) // #nosec G304 -- known path.
+	if err != nil {
+		return err
+	}
+	text := string(content)
+
+	if strings.Contains(text, fmt.Sprintf("| `%s` |", sourceID)) {
+		return nil // Already present.
+	}
+
+	// Find the right alphabetical position in the table.
+	lines := strings.Split(text, "\n")
+	insertIdx := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "| `") {
+			existingID := strings.Trim(strings.TrimPrefix(strings.Split(line, "|")[1], " `"), "` ")
+			if existingID > sourceID {
+				insertIdx = i
+				break
+			}
+		}
+	}
+	if insertIdx >= 0 {
+		lines = append(lines[:insertIdx], append([]string{entry}, lines[insertIdx:]...)...)
+		text = strings.Join(lines, "\n")
+	}
+
+	return os.WriteFile(path, []byte(text), 0o600) // #nosec G703 -- operator-provided CLI path.
+}
+
+func sourceIDToImportAlias(sourceID string) string {
+	return strings.Join(strings.Split(sourceID, "_"), "") + "source"
+}
+
+func sourceIDToPascal(sourceID string) string {
+	return pascalIdentifier(sourceID)
+}
+
+func sourceIDToTitle(sourceID string) string {
+	parts := strings.Split(sourceID, "_")
+	for i, p := range parts {
+		if len(p) > 0 {
+			r := []rune(p)
+			r[0] = []rune(strings.ToUpper(string(r[0])))[0]
+			parts[i] = string(r)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// parseEmittedKindsFromCatalog reads a catalog.yaml file and extracts the emitted_kinds list.
+func parseEmittedKindsFromCatalog(data []byte) []string {
+	text := string(data)
+	var kinds []string
+	lines := strings.Split(text, "\n")
+	inKinds := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(line, "emitted_kinds:") {
+			inKinds = true
+			continue
+		}
+		if inKinds {
+			if strings.HasPrefix(trimmed, "- ") {
+				kind := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
+				kinds = append(kinds, kind)
+			} else if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") && trimmed != "" {
+				inKinds = false
+			}
+		}
+	}
+	sort.Strings(kinds)
+	return kinds
+}

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -108,6 +108,7 @@ type settings struct {
 	clientSecret             string
 	refreshToken             string
 	tokenURL                 string
+	apiKey                   string
 	oauthScopes              []string
 	oauthTokenParams         map[string]string
 	oauthTokenRequestMethod  string
@@ -244,8 +245,8 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 		token:                   firstNonEmpty(configValue(cfg, "token"), configValue(cfg, "api_token"), configValue(cfg, "api_key"), configValue(cfg, "access_token"), configValue(cfg, "jwt"), configValue(cfg, "signature")),
 		username:                configValue(cfg, "username"),
 		password:                configValue(cfg, "password"),
-		clientID:                configValue(cfg, "client_id"),
-		clientSecret:            configValue(cfg, "client_secret"),
+		clientID:                firstNonEmpty(configValue(cfg, "client_id"), configValue(cfg, "access_key")),
+		clientSecret:            firstNonEmpty(configValue(cfg, "client_secret"), configValue(cfg, "secret_key")),
 		refreshToken:            configValue(cfg, "refresh_token"),
 		tokenURL:                firstNonEmpty(configuredTokenURL, s.options.OAuthTokenURL),
 		oauthScopes:             cloneStrings(s.options.OAuthScopes),
@@ -254,6 +255,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 		perPage:                 defaultPageSize,
 		region:                  configValue(cfg, "region"),
 		service:                 configValue(cfg, "service"),
+		apiKey:                  configValue(cfg, "api_key"),
 	}
 	if resolved.family == "" {
 		resolved.family = strings.TrimSpace(s.options.DefaultFamily)
@@ -613,13 +615,9 @@ func (s *Source) authorizeRequest(ctx context.Context, settings settings, req *h
 	case "aws_sigv4":
 		return s.setAWSSigV4Auth(ctx, req, settings)
 	case "two_step":
-		token := settings.token
-		if token == "" {
-			var err error
-			token, err = s.twoStepAccessToken(ctx, settings)
-			if err != nil {
-				return err
-			}
+		token, err := s.twoStepAccessToken(ctx, settings)
+		if err != nil {
+			return err
 		}
 		return setTokenHeader(req, "Authorization", "Bearer", token, s.options.SourceID)
 	default:
@@ -675,7 +673,7 @@ func (s *Source) setAWSSigV4Auth(_ context.Context, req *http.Request, settings 
 	sortedQuery := make([]string, 0, len(req.URL.Query()))
 	for k, vs := range req.URL.Query() {
 		for _, v := range vs {
-			sortedQuery = append(sortedQuery, url.QueryEscape(k)+"="+url.QueryEscape(v))
+			sortedQuery = append(sortedQuery, rfc3986Escape(k)+"="+rfc3986Escape(v))
 		}
 	}
 	sort.Strings(sortedQuery)
@@ -724,7 +722,7 @@ func (s *Source) setAWSSigV4Auth(_ context.Context, req *http.Request, settings 
 // twoStepAccessToken exchanges an API key for a session token via a two-step
 // flow. It POSTs the api_key to the token_url and caches the result.
 func (s *Source) twoStepAccessToken(ctx context.Context, settings settings) (string, error) {
-	apiKey := settings.token
+	apiKey := settings.apiKey
 	if apiKey == "" {
 		return "", fmt.Errorf("%s api_key is required for two_step auth", s.options.SourceID)
 	}
@@ -750,7 +748,14 @@ func (s *Source) twoStepAccessToken(ctx context.Context, settings settings) (str
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := s.client.Do(req)
+	client := s.client
+	if client == nil {
+		client = sourcehttp.NewClient(sourcehttp.ClientOptions{
+			SourceID:      s.options.SourceID,
+			AllowLoopback: s.AllowLoopbackBaseURL,
+		})
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("%s two_step token exchange: %w", s.options.SourceID, err)
 	}
@@ -789,6 +794,16 @@ func hmacSHA256(key []byte, data string) []byte {
 	mac := hmac.New(sha256.New, key)
 	_, _ = mac.Write([]byte(data))
 	return mac.Sum(nil)
+}
+
+// rfc3986Escape encodes a string per RFC 3986, which AWS SigV4 requires.
+// Unlike url.QueryEscape, it encodes spaces as %20 (not +) and does not
+// encode tilde (~).
+func rfc3986Escape(s string) string {
+	escaped := url.QueryEscape(s)
+	escaped = strings.ReplaceAll(escaped, "+", "%20")
+	escaped = strings.ReplaceAll(escaped, "%7E", "~")
+	return escaped
 }
 
 func setTokenHeader(req *http.Request, header string, scheme string, token string, sourceID string) error {

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -116,6 +116,8 @@ type settings struct {
 	query                    url.Values
 	perPage                  int
 	privateEndpointAllowlist []string
+	region                   string
+	service                  string
 }
 
 type cachedOAuthToken struct {
@@ -250,6 +252,8 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 		oauthTokenParams:        cloneStringMap(s.options.OAuthTokenParams),
 		oauthTokenRequestMethod: firstNonEmpty(configValue(cfg, "token_request_auth_method"), s.options.OAuthTokenRequestAuthMethod),
 		perPage:                 defaultPageSize,
+		region:                  configValue(cfg, "region"),
+		service:                 configValue(cfg, "service"),
 	}
 	if resolved.family == "" {
 		resolved.family = strings.TrimSpace(s.options.DefaultFamily)
@@ -606,6 +610,18 @@ func (s *Source) authorizeRequest(ctx context.Context, settings settings, req *h
 		return setTokenHeader(req, "Authorization", "Bearer", settings.token, s.options.SourceID)
 	case "signature":
 		return setTokenHeader(req, "Authorization", firstNonEmpty(s.options.TokenScheme, "Signature"), settings.token, s.options.SourceID)
+	case "aws_sigv4":
+		return s.setAWSSigV4Auth(ctx, req, settings)
+	case "two_step":
+		token := settings.token
+		if token == "" {
+			var err error
+			token, err = s.twoStepAccessToken(ctx, settings)
+			if err != nil {
+				return err
+			}
+		}
+		return setTokenHeader(req, "Authorization", "Bearer", token, s.options.SourceID)
 	default:
 		return fmt.Errorf("%s auth model %q is not supported by jsonapi", s.options.SourceID, authModel)
 	}
@@ -631,6 +647,148 @@ func setDuoHMACAuth(req *http.Request, settings settings, sourceID string) error
 	signature := hex.EncodeToString(mac.Sum(nil))
 	req.SetBasicAuth(integrationKey, signature)
 	return nil
+}
+
+// setAWSSigV4Auth signs the request with AWS Signature Version 4.
+// It uses access_key/secret_key from config (mapped to clientID/clientSecret)
+// and derives region and service from the request URL host or config values.
+func (s *Source) setAWSSigV4Auth(_ context.Context, req *http.Request, settings settings) error {
+	accessKey := firstNonEmpty(settings.clientID, settings.username)
+	secretKey := firstNonEmpty(settings.clientSecret, settings.password)
+	if accessKey == "" || secretKey == "" {
+		return fmt.Errorf("%s access_key and secret_key are required for aws_sigv4 auth", s.options.SourceID)
+	}
+	region := firstNonEmpty(settings.region, "us-east-1")
+	service := firstNonEmpty(settings.service, "execute-api")
+
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+
+	req.Header.Set("X-Amz-Date", amzDate)
+
+	// Build canonical request.
+	canonicalURI := req.URL.EscapedPath()
+	if canonicalURI == "" {
+		canonicalURI = "/"
+	}
+	sortedQuery := make([]string, 0, len(req.URL.Query()))
+	for k, vs := range req.URL.Query() {
+		for _, v := range vs {
+			sortedQuery = append(sortedQuery, url.QueryEscape(k)+"="+url.QueryEscape(v))
+		}
+	}
+	sort.Strings(sortedQuery)
+	canonicalQuery := strings.Join(sortedQuery, "&")
+
+	payloadHash := "UNSIGNED-PAYLOAD"
+	if req.Body == nil {
+		payloadHash = sha256Hex([]byte(""))
+	}
+
+	canonicalHeaders := "host:" + req.URL.Host + "\n" + "x-amz-date:" + amzDate + "\n"
+	signedHeaders := "host;x-amz-date"
+
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		canonicalURI,
+		canonicalQuery,
+		canonicalHeaders + "\n",
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	// Build string to sign.
+	credentialScope := dateStamp + "/" + region + "/" + service + "/aws4_request"
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	// Calculate signing key.
+	kDate := hmacSHA256([]byte("AWS4"+secretKey), dateStamp)
+	kRegion := hmacSHA256(kDate, region)
+	kService := hmacSHA256(kRegion, service)
+	kSigning := hmacSHA256(kService, "aws4_request")
+
+	signature := hex.EncodeToString(hmacSHA256(kSigning, stringToSign))
+
+	authHeader := fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		accessKey, credentialScope, signedHeaders, signature)
+	req.Header.Set("Authorization", authHeader)
+	return nil
+}
+
+// twoStepAccessToken exchanges an API key for a session token via a two-step
+// flow. It POSTs the api_key to the token_url and caches the result.
+func (s *Source) twoStepAccessToken(ctx context.Context, settings settings) (string, error) {
+	apiKey := settings.token
+	if apiKey == "" {
+		return "", fmt.Errorf("%s api_key is required for two_step auth", s.options.SourceID)
+	}
+	tokenURL := settings.tokenURL
+	if tokenURL == "" {
+		return "", fmt.Errorf("%s token_url is required for two_step auth", s.options.SourceID)
+	}
+
+	cacheKey := "two_step:" + tokenURL
+	s.oauthTokenMu.Lock()
+	defer s.oauthTokenMu.Unlock()
+
+	now := time.Now()
+	if cached, ok := s.oauthTokens[cacheKey]; ok && cached.accessToken != "" && cached.expiresAt.After(now.Add(time.Minute)) {
+		return cached.accessToken, nil
+	}
+
+	body := url.Values{"api_key": {apiKey}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(body.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("%s two_step token request: %w", s.options.SourceID, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%s two_step token exchange: %w", s.options.SourceID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%s two_step token exchange returned status %d", s.options.SourceID, resp.StatusCode)
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		Token       string `json:"token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&tokenResp); err != nil {
+		return "", fmt.Errorf("%s two_step token decode: %w", s.options.SourceID, err)
+	}
+	token := firstNonEmpty(tokenResp.AccessToken, tokenResp.Token)
+	if token == "" {
+		return "", fmt.Errorf("%s two_step token exchange returned empty token", s.options.SourceID)
+	}
+
+	expiresAt := now.Add(time.Hour)
+	if tokenResp.ExpiresIn > 0 {
+		expiresAt = now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	}
+	s.oauthTokens[cacheKey] = cachedOAuthToken{accessToken: token, expiresAt: expiresAt}
+	return token, nil
+}
+
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(data))
+	return mac.Sum(nil)
 }
 
 func setTokenHeader(req *http.Request, header string, scheme string, token string, sourceID string) error {
@@ -1290,7 +1448,7 @@ func normalizedAuthModel(value string) string {
 		return "bearer_token"
 	case "api_key", "api_token":
 		return "api_key"
-	case "basic", "duo_hmac", "oauth_client_credentials", "oauth_authorization_code", "jwt", "signature", "none":
+	case "basic", "duo_hmac", "oauth_client_credentials", "oauth_authorization_code", "jwt", "signature", "none", "aws_sigv4", "two_step":
 		return value
 	default:
 		return value


### PR DESCRIPTION
## Summary

8 improvements to the source codegen pipeline that address bottlenecks identified after PR #1314.

## Changes

### 1. sourcegen wire (new CLI subcommand)
Auto-wires a generated source into the source registry, projection registry, and docs reference. Eliminates the manual hand-editing step that was the #1 bottleneck for promoting catalog entries to hardened built-in sources.

```bash
cerebro source-runtime sdk wire hashicorp_vault
```

### 2. sourcegen validate (new CLI subcommand)
Cross-checks a generated source's catalog.yaml, deploy.yaml, and source.go for consistency. Catches the class of bugs the Droid review found (missing templateKeys, undeclared secretKeys, unwired registries) at generation time rather than CI time.

```bash
cerebro source-runtime sdk validate hashicorp_vault
```

### 3. Fix test masking
Generated tests now include template variables in the test config (e.g. `vault_addr`) alongside `base_url`, so runtimeConfig template resolution is exercised even when base_url is pre-set. This would have caught the P1 templateKeys bug from PR #1314.

### 4. aws_sigv4 auth model
Full AWS Signature Version 4 signing in the jsonapi runtime with HMAC-SHA256, canonical request construction, string-to-sign, and signing key derivation. Unlocks AWS-adjacent APIs that use SigV4 signing.

### 5. two_step auth model
Token exchange flow in the jsonapi runtime. Exchanges an API key for a session token via a POST to token_url, caches the result, and uses it as a Bearer token. Unlocks APIs that require a token exchange step.

### 6. deployment + alert projection templates
Two new projection templates (grammar 14 -> 16):
- `deployment`: environment, status, commit_sha, branch, URL
- `alert`: severity, status, type, source, fired_at, resolved_at

Each follows the same pattern: grammar entry, sourcegen class mapper, id keys, attribute paths, projection rendering, test rendering, and openapigen keyword detection.

### 7. POST-body listing in openapigen
POST operations with array responses are now classified as listing endpoints. The `isPostListing` function checks if the response schema is an array or contains an array field. Unlocks POST-only APIs (e.g. Plaid, GraphQL gateways).

### 8. Droid review retry
The Droid review workflow now retries automatically on failure with a second attempt. Timeout increased from 15 to 20 minutes to reduce timeout-induced failures.

## Tests

All packages pass including arch tests and lint (0 issues).