### PR TITLE
fix: address missed PR #1315 review feedback (POST listing, projection dispatch, wire, two_step)

### DIFF
--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -107,6 +107,7 @@ type familyData struct {
 	ConstName             string
 	ProjectorName         string
 	Path                  string
+	Method                string
 	URNKind               string
 	EventKind             string
 	SchemaRef             string
@@ -644,6 +645,7 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			ConstName:             "family" + pascalIdentifier(name),
 			ProjectorName:         lowerCamelIdentifier(request.SourceID + "_" + name + "_projections"),
 			Path:                  resource.Path,
+			Method:                methodForResource(resource),
 			URNKind:               urnKind,
 			EventKind:             eventKind,
 			SchemaRef:             schemaRef,
@@ -656,6 +658,14 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 		})
 	}
 	return families, nil
+}
+
+func methodForResource(resource connectordefinitions.ResourceFamily) string {
+	method := strings.ToUpper(strings.TrimSpace(resource.Method))
+	if method == "" || method == "GET" {
+		return ""
+	}
+	return method
 }
 
 func idKeysForResource(resource connectordefinitions.ResourceFamily) []string {
@@ -996,6 +1006,9 @@ func renderSourceGo(request normalizedRequest) string {
 		fmt.Fprintf(&b, "\t\t\t{\n")
 		fmt.Fprintf(&b, "\t\t\t\tName: %s,\n", family.ConstName)
 		fmt.Fprintf(&b, "\t\t\t\tPath: %s,\n", strconv.Quote(family.Path))
+		if strings.TrimSpace(family.Method) != "" {
+			fmt.Fprintf(&b, "\t\t\t\tMethod: %s,\n", strconv.Quote(family.Method))
+		}
 		fmt.Fprintf(&b, "\t\t\t\tURNKind: %s,\n", strconv.Quote(family.URNKind))
 		fmt.Fprintf(&b, "\t\t\t\tIDKeys: []string{%s},\n", quotedStrings(idKeysForFamily(family)))
 		if strings.TrimSpace(family.CursorParam) != "" {
@@ -1338,6 +1351,10 @@ func renderProjectionGo(request normalizedRequest) string {
 			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sSecretProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
 		case "policy":
 			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sPolicyProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
+		case "deployment":
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sDeploymentProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
+		case "alert":
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sAlertProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
 		case "identity_user":
 			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn identityUserProjections(event, identityProjectionProfile{Provider: %s})\n}\n\n", family.ProjectorName, strconv.Quote(request.SourceID))
 		case "identity_group":

--- a/internal/sourcegen/wire.go
+++ b/internal/sourcegen/wire.go
@@ -157,12 +157,18 @@ func wireSourceRegistry(path, importAlias, importPath, sourceID, loaderEntry str
 			lines = append(lines[:insertIdx], append([]string{entry}, lines[insertIdx:]...)...)
 			text = strings.Join(lines, "\n")
 		} else {
-			// Source ID sorts after all existing entries; append before the closing brace.
-			marker := "}"
-			idx := strings.LastIndex(text, marker)
-			if idx >= 0 {
+			// Source ID sorts after all existing entries; append at end of the loaders slice.
+			// Find the slice's closing brace by looking for }\n\n followed by a comment or func.
+			sliceEnd := strings.Index(text, "\n}\n\n// Builtin")
+			if sliceEnd < 0 {
+				sliceEnd = strings.Index(text, "\n}\n\nfunc ")
+			}
+			if sliceEnd < 0 {
+				sliceEnd = strings.Index(text, "\n}\n")
+			}
+			if sliceEnd >= 0 {
 				entry := strings.TrimSuffix(loaderEntry, "\n")
-				text = text[:idx] + entry + "\n" + text[idx:]
+				text = text[:sliceEnd+1] + "\t" + entry + "\n" + text[sliceEnd+1:]
 			}
 		}
 	}

--- a/internal/sourcegen/wire.go
+++ b/internal/sourcegen/wire.go
@@ -168,7 +168,7 @@ func wireSourceRegistry(path, importAlias, importPath, sourceID, loaderEntry str
 			}
 			if sliceEnd >= 0 {
 				entry := strings.TrimSuffix(loaderEntry, "\n")
-				text = text[:sliceEnd+1] + "\t" + entry + "\n" + text[sliceEnd+1:]
+				text = text[:sliceEnd+1] + entry + "\n" + text[sliceEnd+1:]
 			}
 		}
 	}

--- a/internal/sourcegen/wire_test.go
+++ b/internal/sourcegen/wire_test.go
@@ -1,0 +1,104 @@
+package sourcegen
+
+import (
+	"fmt"
+	"go/format"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const wireRegistryFixture = `package sourceregistry
+
+import (
+	sourcecdk "github.com/writer/cerebro/sources/internal/cdk"
+
+	alphasource "github.com/writer/cerebro/sources/alpha"
+	vulnviewsource "github.com/writer/cerebro/sources/vulnview"
+)
+
+var builtinSourceLoaders = []builtinSourceLoader{
+	{
+		name: "alpha",
+		load: func() (sourcecdk.Source, error) {
+			return alphasource.New()
+		},
+	},
+	{
+		name: "vulnview",
+		load: func() (sourcecdk.Source, error) {
+			return vulnviewsource.New()
+		},
+	},
+}
+
+// Builtin constructs the in-process source registry.
+func Builtin() (*sourcecdk.Registry, error) {
+	return nil, nil
+}
+`
+
+func wireRegistryForSource(t *testing.T, sourceID string) string {
+	t.Helper()
+	canonical, err := format.Source([]byte(wireRegistryFixture))
+	if err != nil {
+		t.Fatalf("fixture is not valid Go: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "registry.go")
+	if err := os.WriteFile(path, canonical, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	importAlias := sourceIDToImportAlias(sourceID)
+	importPath := "github.com/writer/cerebro/sources/" + sourceID
+	loaderEntry := fmt.Sprintf("\t{\n\t\tname: %q,\n\t\tload: func() (sourcecdk.Source, error) {\n\t\t\treturn %s.New()\n\t\t},\n\t},\n", sourceID, importAlias)
+	if err := wireSourceRegistry(path, importAlias, importPath, sourceID, loaderEntry); err != nil {
+		t.Fatalf("wireSourceRegistry() error = %v", err)
+	}
+	out, err := os.ReadFile(path) // #nosec G304 -- test temp path.
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+func expectedLoaderEntry(sourceID string) string {
+	return fmt.Sprintf("\t{\n\t\tname: %q,\n\t\tload: func() (sourcecdk.Source, error) {\n\t\t\treturn %s.New()\n\t\t},\n\t},", sourceID, sourceIDToImportAlias(sourceID))
+}
+
+// TestWireSourceRegistryAppendsWhenAlphabeticallyLast covers the end-fallback
+// path: a sourceID that sorts after every existing entry must land at the
+// builtinSourceLoaders slice close (not the file's last brace, which would put
+// it inside func Builtin and break compilation) with single-tab indentation.
+func TestWireSourceRegistryAppendsWhenAlphabeticallyLast(t *testing.T) {
+	out := wireRegistryForSource(t, "zscaler")
+	if _, err := format.Source([]byte(out)); err != nil {
+		t.Fatalf("generated registry is not valid Go (entry placed wrong?): %v\n%s", err, out)
+	}
+	if entry := expectedLoaderEntry("zscaler"); !strings.Contains(out, entry) {
+		t.Fatalf("zscaler loader entry missing or mis-indented; want:\n%s\ngot:\n%s", entry, out)
+	}
+	// The entry must sit inside the slice, before the slice's closing brace and
+	// the Builtin function, not after the function's return.
+	if idx := strings.Index(out, `name: "zscaler"`); idx < 0 || idx > strings.Index(out, "func Builtin(") {
+		t.Fatalf("zscaler entry not inside builtinSourceLoaders slice:\n%s", out)
+	}
+}
+
+// TestWireSourceRegistryInsertsAlphabetically covers the in-order path so both
+// insertion branches stay consistent and correctly indented.
+func TestWireSourceRegistryInsertsAlphabetically(t *testing.T) {
+	out := wireRegistryForSource(t, "beta")
+	if _, err := format.Source([]byte(out)); err != nil {
+		t.Fatalf("generated registry is not valid Go: %v\n%s", err, out)
+	}
+	if entry := expectedLoaderEntry("beta"); !strings.Contains(out, entry) {
+		t.Fatalf("beta loader entry missing or mis-indented; want:\n%s\ngot:\n%s", entry, out)
+	}
+	alphaIdx := strings.Index(out, `name: "alpha"`)
+	betaIdx := strings.Index(out, `name: "beta"`)
+	vulnIdx := strings.Index(out, `name: "vulnview"`)
+	if alphaIdx < 0 || betaIdx <= alphaIdx || vulnIdx <= betaIdx {
+		t.Fatalf("beta not inserted in alphabetical order (alpha=%d beta=%d vulnview=%d):\n%s", alphaIdx, betaIdx, vulnIdx, out)
+	}
+}

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -60,6 +60,7 @@ type Family struct {
 	Singleton             bool
 	RequireID             bool
 	IncrementalWatermark  bool
+	Method                string
 }
 
 // Options configures a JSON API-backed source adapter.
@@ -119,6 +120,7 @@ type settings struct {
 	privateEndpointAllowlist []string
 	region                   string
 	service                  string
+	familyMethod             string
 }
 
 type cachedOAuthToken struct {
@@ -271,6 +273,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if !ok {
 		return resolved, fmt.Errorf("%s family must be one of %s", s.options.SourceID, strings.Join(familyNames(s.options), ", "))
 	}
+	resolved.familyMethod = strings.TrimSpace(family.Method)
 	if s.options.RequireTenantID && resolved.tenantID == "" {
 		return resolved, fmt.Errorf("%s tenant_id is required", s.options.SourceID)
 	}
@@ -517,7 +520,11 @@ func (s *Source) doRequest(ctx context.Context, settings settings, path string, 
 	if encoded := query.Encode(); encoded != "" {
 		endpoint += "?" + encoded
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	method := http.MethodGet
+	if familyMethod := strings.TrimSpace(settings.familyMethod); familyMethod != "" {
+		method = familyMethod
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("build %s request: %w", s.options.SourceID, err)
 	}
@@ -751,15 +758,16 @@ func (s *Source) twoStepAccessToken(ctx context.Context, settings settings) (str
 	client := s.client
 	if client == nil {
 		client = sourcehttp.NewClient(sourcehttp.ClientOptions{
-			SourceID:      s.options.SourceID,
-			AllowLoopback: s.AllowLoopbackBaseURL,
+			SourceID:                 s.options.SourceID,
+			AllowLoopback:            s.AllowLoopbackBaseURL,
+			PrivateEndpointAllowlist: settings.privateEndpointAllowlist,
+			LookupIPAddrs:            lookupIPAddrs(s),
 		})
 	}
-	resp, err := client.Do(req)
+	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})
 	if err != nil {
 		return "", fmt.Errorf("%s two_step token exchange: %w", s.options.SourceID, err)
 	}
-	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("%s two_step token exchange returned status %d", s.options.SourceID, resp.StatusCode)
 	}
@@ -769,7 +777,7 @@ func (s *Source) twoStepAccessToken(ctx context.Context, settings settings) (str
 		Token       string `json:"token"`
 		ExpiresIn   int    `json:"expires_in"`
 	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&tokenResp); err != nil {
+	if err := json.Unmarshal(resp.Body, &tokenResp); err != nil {
 		return "", fmt.Errorf("%s two_step token decode: %w", s.options.SourceID, err)
 	}
 	token := firstNonEmpty(tokenResp.AccessToken, tokenResp.Token)

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -166,6 +166,39 @@ func TestReadMergesBareDetailObjectWhenAllowed(t *testing.T) {
 	}
 }
 
+func TestReadUsesFamilyMethod(t *testing.T) {
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		if r.URL.Path != "/devices/search" {
+			t.Fatalf("request path = %q, want /devices/search", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "device-1", "name": "macbook-1"}})
+	}))
+	defer server.Close()
+
+	source := newCustomTestSource(t, server.URL, Family{
+		Name:    "device",
+		Path:    "/devices/search",
+		Method:  http.MethodPost,
+		URNKind: "test_device",
+		IDKeys:  []string{"id"},
+	})
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"token":     "token-1",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("request method = %q, want POST", gotMethod)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+}
+
 func TestReadUsesBasicAuth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("alice:secret"))


### PR DESCRIPTION
## Summary

Follow-up to #1315. Four Droid review comments on that PR were not addressed before it merged. This PR resolves all four.

### Fixes

- **[P1] wire: loader inserted before wrong closing brace for alphabetically-last sources** (`internal/sourcegen/wire.go`)
  The else-branch used `strings.LastIndex(text, "}")`, which targets the closing brace of `func Builtin()` rather than the `builtinSourceLoaders` slice. Now locates the slice close via the `}` + `// Builtin` / `}` + `func ` markers so newly-added IDs sorting after `vulnview` produce valid Go.

- **[P1] renderProjectionGo missing `deployment` and `alert` cases** (`internal/sourcegen/generator.go`)
  Those classes fell through to `default` (`runtimeEvidenceProjections`) and, when the family name matched the class, collided with the dedicated helper name, producing duplicate function definitions. Added explicit `case "deployment"` / `case "alert"` dispatch.

- **[P1] POST listing produced non-functional generated code** (`sources/internal/jsonapi/source.go`, `internal/sourcegen/generator.go`)
  `isPostListing` admitted POST array responses and set `Method: "POST"` on the `ResourceFamily`, but the Method was never propagated. Plumbed a per-family `Method` through `ResourceFamily` -> `familyData` -> generated `jsonapi.Family` -> `settings.familyMethod`, and `doRequest` now issues the family's method instead of hardcoded GET. Added `TestReadUsesFamilyMethod`.

- **[P2] twoStepAccessToken fallback client dropped allowlist + retry** (`sources/internal/jsonapi/source.go`)
  Now builds the fallback client with `PrivateEndpointAllowlist` + `LookupIPAddrs` and routes through `sourcehttp.DoWithRetry`, matching `exchangeOAuthToken`/`doRequest`.

## Testing

- `go build` + `go test` green for sourcegen, jsonapi, connectordefinitions(/openapigen)
- arch tests, sourceregistry, sourceprojection, cmd/cerebro tests pass
- `golangci-lint` clean on affected packages
