### PR TITLE
docs: surface graph-action tooling in README capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker compose up --build
 
 - A Go bootstrap service built around `net/http`, Connect RPC, and `cmd/cerebro`.
 - Built-in source integrations for cloud, SaaS, identity, endpoint, vulnerability, compliance, and workflow signals.
-- Source runtime sync, append-log replay, claim/finding/report workflows, compliance control coverage, and optional graph projection/query tooling.
+- Source runtime sync, append-log replay, claim/finding/report workflows, compliance control coverage, and optional graph projection, query, and action tooling.
 - Optional MCP, graph-agent, and device-authenticated telemetry surfaces.
 - Policy and FindingRule YAML DSL catalogs, generated detection catalogs, SDK helpers, OpenAPI/Connect contracts, release artifacts, and local validation tooling.
 


### PR DESCRIPTION
## Summary
The README "What Is In This Repo" capabilities list omitted graph action execution, which is now a first-class capability (`internal/graphactions` / `internal/graphactionapi`, action catalog, dry-run approval gate). This adds it to the graph tooling bullet. `graph-agent` is intentionally retained, as it remains a valid current domain surface.

Companion metadata fix (already applied, no code change): the repo "About" description and topics were refreshed from the stale "Security Data Platform for Cloud and SaaS Posture Management" / `cspm` framing to the repo's standard "operations data platform" wording.

## Validation
- `make readme-check`: clean
- `make oss-audit`: clean
