### PR TITLE
feat: add declarative catalog projection relationships

### DIFF
--- a/internal/connectorcatalog/catalog/identity-access-secrets.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets.yaml
@@ -663,6 +663,21 @@ entries:
             schema_ref: doppler/secrets/v1
           projection:
             template: secret
+            entity:
+              entity_type: secret
+              urn_kind: secret
+              id_attributes: [secret_id]
+              label_attribute: secret_name
+            fields:
+              project_id: project.id|project_id|project
+            relationships:
+              - relation: belongs_to
+                to:
+                  entity_type: doppler.project
+                  urn_kind: doppler_project
+                  id_attributes: [project_id]
+                required_attributes: [project_id]
+                match_type: secret_project
           coverage:
             - id: secrets
               type: entity_family
@@ -784,6 +799,21 @@ entries:
             schema_ref: hashicorp_vault/secrets/v1
           projection:
             template: secret
+            entity:
+              entity_type: secret
+              urn_kind: secret
+              id_attributes: [secret_id]
+              label_attribute: secret_name
+            fields:
+              owner_user_id: owner_id|created_by.id|created_by|user_id
+            relationships:
+              - relation: owned_by
+                to:
+                  entity_type: hashicorp_vault.user
+                  urn_kind: hashicorp_vault_user
+                  id_attributes: [owner_user_id]
+                required_attributes: [owner_user_id]
+                match_type: secret_owner
           coverage:
             - id: secrets
               type: entity_family

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 )
 
 const (
@@ -28,15 +29,41 @@ const (
 var (
 	ErrInvalidDefinition = errors.New("invalid connector definition")
 
-	idPattern         = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
-	definitionIDRun   = regexp.MustCompile(`[^a-z0-9_-]+`)
-	templateVar       = regexp.MustCompile(`\$\{([a-z]+)\.([a-z][a-z0-9_-]*)\}`)
-	statusIdentifier  = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
-	stageOrder        = []string{StageDraft, StageSandbox, StagePilot, StageApproved, StageCertified}
-	supportedMethods  = map[string]struct{}{"GET": {}, "POST": {}}
-	paginationTypes   = map[string]struct{}{"": {}, "none": {}, "cursor": {}, "page": {}, "offset": {}, "link": {}, "next_url": {}}
-	incrementalStates = map[string]struct{}{"": {}, "high_watermark": {}, "opaque_cursor": {}}
-	stageRank         = map[string]int{
+	idPattern           = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+	entityTypePattern   = regexp.MustCompile(`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$`)
+	definitionIDRun     = regexp.MustCompile(`[^a-z0-9_-]+`)
+	templateVar         = regexp.MustCompile(`\$\{([a-z]+)\.([a-z][a-z0-9_-]*)\}`)
+	statusIdentifier    = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	stageOrder          = []string{StageDraft, StageSandbox, StagePilot, StageApproved, StageCertified}
+	supportedMethods    = map[string]struct{}{"GET": {}, "POST": {}}
+	paginationTypes     = map[string]struct{}{"": {}, "none": {}, "cursor": {}, "page": {}, "offset": {}, "link": {}, "next_url": {}}
+	incrementalStates   = map[string]struct{}{"": {}, "high_watermark": {}, "opaque_cursor": {}}
+	projectionRelations = map[string]struct{}{
+		"attached_to": {},
+		"belongs_to":  {},
+		"contains":    {},
+		"member_of":   {},
+		"owned_by":    {},
+	}
+	unstableProjectionAttributes = map[string]struct{}{
+		"created_at":      {},
+		"cursor":          {},
+		"event_id":        {},
+		"idempotency_key": {},
+		"last_seen_at":    {},
+		"next_cursor":     {},
+		"observed_at":     {},
+		"page":            {},
+		"page_token":      {},
+		"pagination":      {},
+		"request_id":      {},
+		"run_id":          {},
+		"source_event_id": {},
+		"timestamp":       {},
+		"updated_at":      {},
+		"uuid":            {},
+	}
+	stageRank = map[string]int{
 		StageDraft:     0,
 		StageSandbox:   1,
 		StagePilot:     2,
@@ -175,8 +202,30 @@ type EventMappingSpec struct {
 
 // ProjectionSpec describes a generic projector template for emitted events.
 type ProjectionSpec struct {
-	Template string            `json:"template,omitempty"`
-	Fields   map[string]string `json:"fields,omitempty"`
+	Template      string                       `json:"template,omitempty"`
+	Fields        map[string]string            `json:"fields,omitempty"`
+	Entity        *ProjectionEntitySpec        `json:"entity,omitempty"`
+	Relationships []ProjectionRelationshipSpec `json:"relationships,omitempty"`
+}
+
+// ProjectionEntitySpec describes how a projected entity URN is built from
+// already-emitted event attributes.
+type ProjectionEntitySpec struct {
+	EntityType     string   `json:"entity_type,omitempty"`
+	URNKind        string   `json:"urn_kind,omitempty"`
+	IDAttributes   []string `json:"id_attributes,omitempty"`
+	LabelAttribute string   `json:"label_attribute,omitempty"`
+}
+
+// ProjectionRelationshipSpec describes one declarative graph edge emitted from
+// already-emitted event attributes.
+type ProjectionRelationshipSpec struct {
+	Relation           string                `json:"relation"`
+	From               *ProjectionEntitySpec `json:"from,omitempty"`
+	To                 ProjectionEntitySpec  `json:"to"`
+	RequiredAttributes []string              `json:"required_attributes,omitempty"`
+	LinkAttributes     []string              `json:"link_attributes,omitempty"`
+	MatchType          string                `json:"match_type,omitempty"`
 }
 
 // CoverageDimensionSpec mirrors sourcecdk coverage dimensions without coupling
@@ -604,11 +653,172 @@ func validateFamilyIntegrationFields(family ResourceFamily, add func(ValidationC
 	if family.Event.SchemaRef != "" && strings.ContainsAny(family.Event.SchemaRef, "\r\n\t ") {
 		add(blocking("schema_ref_"+family.ID, "Schema ref", "Schema refs must not contain whitespace."))
 	}
+	validateProjectionIntegrationFields(family, add)
 	for _, dimension := range family.Coverage {
 		if strings.TrimSpace(dimension.Type) == "" || strings.TrimSpace(dimension.Support) == "" {
 			add(blocking("coverage_"+family.ID, "Coverage", "Coverage dimensions need type and support."))
 		}
 	}
+}
+
+func validateProjectionIntegrationFields(family ResourceFamily, add func(ValidationCheck)) {
+	if family.Projection == nil {
+		return
+	}
+	projection := family.Projection
+	attributes := knownProjectionAttributes(family)
+	if projection.Entity != nil {
+		validateProjectionEntity(family.ID, "projection_entity", *projection.Entity, add)
+		validateProjectionAttributeRefs(family.ID, "projection_entity", projection.Entity.IDAttributes, attributes, add)
+		if projection.Entity.LabelAttribute != "" {
+			validateProjectionAttributeRefs(family.ID, "projection_entity_label", []string{projection.Entity.LabelAttribute}, attributes, add)
+		}
+	}
+	if len(projection.Relationships) == 0 {
+		return
+	}
+	if strings.ReplaceAll(projection.Template, "-", "_") == "audit_event" {
+		add(blocking("projection_relationships_"+family.ID, "Projection relationships", "Audit event families cannot emit durable graph relationships in v1."))
+	}
+	if len(projection.Relationships) > 8 {
+		add(blocking("projection_relationships_"+family.ID, "Projection relationships", "Projection relationships are capped at eight per family."))
+	}
+	for i, relationship := range projection.Relationships {
+		id := fmt.Sprintf("projection_relationship_%s_%d", family.ID, i)
+		if _, ok := projectionRelations[relationship.Relation]; !ok {
+			add(blocking(id+"_relation", "Projection relationship", "Use one of belongs_to, contains, owned_by, member_of, or attached_to."))
+		}
+		if strings.TrimSpace(relationship.MatchType) == "" {
+			add(blocking(id+"_match_type", "Projection relationship match type", "Add a stable match_type explaining the relationship source."))
+		}
+		if relationship.From != nil {
+			validateProjectionEntity(family.ID, id+"_from", *relationship.From, add)
+			validateProjectionAttributeRefs(family.ID, id+"_from", relationship.From.IDAttributes, attributes, add)
+			if relationship.From.LabelAttribute != "" {
+				validateProjectionAttributeRefs(family.ID, id+"_from_label", []string{relationship.From.LabelAttribute}, attributes, add)
+			}
+		}
+		validateProjectionEntity(family.ID, id+"_to", relationship.To, add)
+		validateProjectionAttributeRefs(family.ID, id+"_to", relationship.To.IDAttributes, attributes, add)
+		if relationship.To.LabelAttribute != "" {
+			validateProjectionAttributeRefs(family.ID, id+"_to_label", []string{relationship.To.LabelAttribute}, attributes, add)
+		}
+		validateProjectionAttributeRefs(family.ID, id+"_required", relationship.RequiredAttributes, attributes, add)
+		validateProjectionAttributeRefs(family.ID, id+"_link", relationship.LinkAttributes, attributes, add)
+	}
+}
+
+func validateProjectionEntity(familyID string, id string, entity ProjectionEntitySpec, add func(ValidationCheck)) {
+	if !entityTypePattern.MatchString(strings.TrimSpace(entity.EntityType)) {
+		add(blocking(id+"_"+familyID+"_entity_type", "Projection entity type", "Projection entity_type must use dotted lowercase identifier syntax."))
+	}
+	if !idPattern.MatchString(strings.TrimSpace(entity.URNKind)) {
+		add(blocking(id+"_"+familyID+"_urn_kind", "Projection URN kind", "Projection urn_kind must be a lowercase identifier."))
+	}
+	if len(entity.IDAttributes) == 0 {
+		add(blocking(id+"_"+familyID+"_id_attributes", "Projection entity identity", "Projection entities need at least one id_attribute."))
+	}
+}
+
+func validateProjectionAttributeRefs(familyID string, id string, refs []string, known map[string]struct{}, add func(ValidationCheck)) {
+	for _, ref := range refs {
+		attr := strings.TrimSpace(ref)
+		if attr == "" {
+			continue
+		}
+		if unstableProjectionAttribute(attr) {
+			add(blocking(id+"_"+familyID+"_unstable_"+normalizeDefinitionID(attr), "Projection attribute stability", "Projection relationships cannot use event IDs, timestamps, cursors, request IDs, run IDs, or other ephemeral anchors."))
+			continue
+		}
+		if _, ok := known[attr]; !ok {
+			add(blocking(id+"_"+familyID+"_attribute_"+normalizeDefinitionID(attr), "Projection attribute", "Projection relationship attributes must be emitted by projection.fields, event.required_attributes, or known template defaults."))
+		}
+	}
+}
+
+func unstableProjectionAttribute(attribute string) bool {
+	normalized := canonicalProjectionAttribute(attribute)
+	if _, ok := unstableProjectionAttributes[normalized]; ok {
+		return true
+	}
+	return strings.HasSuffix(normalized, "_timestamp") || strings.HasSuffix(normalized, "_cursor") || strings.HasSuffix(normalized, "_request_id") || strings.HasSuffix(normalized, "_run_id")
+}
+
+func canonicalProjectionAttribute(attribute string) string {
+	var b strings.Builder
+	lastUnderscore := true
+	lastUpper := false
+	for _, r := range strings.TrimSpace(attribute) {
+		switch {
+		case r == '.' || r == '-' || unicode.IsSpace(r):
+			if !lastUnderscore {
+				b.WriteByte('_')
+				lastUnderscore = true
+				lastUpper = false
+			}
+		case unicode.IsUpper(r):
+			if b.Len() > 0 && !lastUnderscore && !lastUpper {
+				b.WriteByte('_')
+			}
+			b.WriteRune(unicode.ToLower(r))
+			lastUnderscore = false
+			lastUpper = true
+		default:
+			b.WriteRune(unicode.ToLower(r))
+			lastUnderscore = r == '_'
+			lastUpper = false
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func knownProjectionAttributes(family ResourceFamily) map[string]struct{} {
+	known := map[string]struct{}{
+		"external_id":     {},
+		"family":          {},
+		"observed_at":     {},
+		"provider":        {},
+		"resource_id":     {},
+		"resource_name":   {},
+		"resource_type":   {},
+		"resource_urn":    {},
+		"source_provider": {},
+	}
+	addKnown := func(values ...string) {
+		for _, value := range values {
+			if value = strings.TrimSpace(value); value != "" {
+				known[value] = struct{}{}
+			}
+		}
+	}
+	addKnown(family.Event.RequiredAttributes...)
+	addKnown(family.IDField, family.NameField, family.UpdatedAtField)
+	switch strings.TrimSpace(family.Projection.Template) {
+	case "finding", "vulnerability":
+		addKnown("finding_id", "severity", "status", "title", "description")
+	case "identity_user":
+		addKnown("user_id", "email", "display_name", "status")
+	case "identity_group":
+		addKnown("group_id", "group_email", "group_name")
+	case "group_membership":
+		addKnown("group_id", "member_id", "member_email")
+	case "audit_event":
+		addKnown("event_type", "actor_id", "actor_email")
+	case "secret":
+		addKnown("secret_id", "secret_name", "secret_type", "secret_status", "secret_rotation_enabled", "secret_last_rotated_at")
+	case "policy":
+		addKnown("policy_id", "policy_name", "policy_type", "policy_status", "policy_severity")
+	case "deployment":
+		addKnown("deployment_id", "deployment_name", "deployment_environment", "deployment_status", "deployment_url", "deployment_commit_sha", "deployment_branch")
+	case "alert":
+		addKnown("alert_id", "alert_name", "alert_severity", "alert_status", "alert_type", "alert_source", "alert_fired_at", "alert_resolved_at")
+	}
+	if family.Projection != nil {
+		for key := range family.Projection.Fields {
+			addKnown(key)
+		}
+	}
+	return known
 }
 
 func normalizeIdentifier(value string) string {
@@ -772,7 +982,41 @@ func normalizeProjectionSpec(projection *ProjectionSpec) *ProjectionSpec {
 	next := *projection
 	next.Template = normalizeIdentifier(next.Template)
 	next.Fields = normalizeStringMap(next.Fields)
+	next.Entity = normalizeProjectionEntitySpec(next.Entity)
+	next.Relationships = normalizeProjectionRelationshipSpecs(next.Relationships)
 	return &next
+}
+
+func normalizeProjectionEntitySpec(entity *ProjectionEntitySpec) *ProjectionEntitySpec {
+	if entity == nil {
+		return nil
+	}
+	next := *entity
+	next.EntityType = strings.TrimSpace(next.EntityType)
+	next.URNKind = normalizeIdentifier(next.URNKind)
+	next.IDAttributes = normalizeOrderedStringList(next.IDAttributes)
+	next.LabelAttribute = strings.TrimSpace(next.LabelAttribute)
+	return &next
+}
+
+func normalizeProjectionRelationshipSpecs(relationships []ProjectionRelationshipSpec) []ProjectionRelationshipSpec {
+	if len(relationships) == 0 {
+		return nil
+	}
+	normalized := make([]ProjectionRelationshipSpec, 0, len(relationships))
+	for _, relationship := range relationships {
+		relationship.Relation = normalizeIdentifier(relationship.Relation)
+		relationship.From = normalizeProjectionEntitySpec(relationship.From)
+		to := normalizeProjectionEntitySpec(&relationship.To)
+		if to != nil {
+			relationship.To = *to
+		}
+		relationship.RequiredAttributes = normalizeOrderedStringList(relationship.RequiredAttributes)
+		relationship.LinkAttributes = normalizeOrderedStringList(relationship.LinkAttributes)
+		relationship.MatchType = normalizeIdentifier(relationship.MatchType)
+		normalized = append(normalized, relationship)
+	}
+	return normalized
 }
 
 func normalizeCoverageDimensionSpec(familyID string, dimension CoverageDimensionSpec) CoverageDimensionSpec {
@@ -844,6 +1088,23 @@ func normalizeStringList(values []string) []string {
 		normalized = append(normalized, trimmed)
 	}
 	sort.Strings(normalized)
+	return normalized
+}
+
+func normalizeOrderedStringList(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
 	return normalized
 }
 

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -148,6 +148,137 @@ func TestValidateBlocksUnsupportedResourceMethods(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsProjectionRelationships(t *testing.T) {
+	definition, err := Normalize(Definition{
+		TenantID: "tenant-a",
+		SourceID: "example",
+		Auth:     AuthSpec{Model: "none"},
+		ResourceFamilies: []ResourceFamily{{
+			ID:      "secrets",
+			Path:    "/v1/secrets",
+			IDField: "id",
+			Event: EventMappingSpec{
+				Kind:      "example.secrets",
+				SchemaRef: "example/secrets/v1",
+			},
+			Projection: &ProjectionSpec{
+				Template: "secret",
+				Fields: map[string]string{
+					"vault_id": "mount_accessor|mount_path",
+				},
+				Relationships: []ProjectionRelationshipSpec{{
+					Relation: "belongs_to",
+					To: ProjectionEntitySpec{
+						EntityType:   "example.vault",
+						URNKind:      "example_vault",
+						IDAttributes: []string{"vault_id"},
+					},
+					MatchType: "secret_vault",
+				}},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if definition.Validation.Status != ValidationReady {
+		t.Fatalf("validation status = %q, want ready: %#v", definition.Validation.Status, definition.Validation.Checks)
+	}
+	relationship := definition.ResourceFamilies[0].Projection.Relationships[0]
+	if relationship.Relation != "belongs_to" || relationship.MatchType != "secret_vault" {
+		t.Fatalf("relationship normalization = %#v", relationship)
+	}
+}
+
+func TestValidateBlocksUnsafeProjectionRelationships(t *testing.T) {
+	definition, err := Normalize(Definition{
+		TenantID: "tenant-a",
+		SourceID: "example",
+		Auth:     AuthSpec{Model: "none"},
+		ResourceFamilies: []ResourceFamily{
+			{
+				ID:      "assets",
+				Path:    "/v1/assets",
+				IDField: "id",
+				Event: EventMappingSpec{
+					Kind:      "example.assets",
+					SchemaRef: "example/assets/v1",
+				},
+				Projection: &ProjectionSpec{
+					Template: "asset",
+					Fields:   map[string]string{"eventID": "eventID"},
+					Relationships: []ProjectionRelationshipSpec{{
+						Relation: "depends_on",
+						To: ProjectionEntitySpec{
+							EntityType:   "example.run",
+							URNKind:      "example_run",
+							IDAttributes: []string{"eventID"},
+						},
+					}},
+				},
+			},
+			{
+				ID:      "audit_events",
+				Path:    "/v1/audit",
+				IDField: "id",
+				Event: EventMappingSpec{
+					Kind:      "example.audit_events",
+					SchemaRef: "example/audit_events/v1",
+				},
+				Projection: &ProjectionSpec{
+					Template: "audit-event",
+					Fields:   map[string]string{"actor_user_id": "actor.id"},
+					Relationships: []ProjectionRelationshipSpec{{
+						Relation: "owned_by",
+						To: ProjectionEntitySpec{
+							EntityType:   "example.user",
+							URNKind:      "example_user",
+							IDAttributes: []string{"actor_user_id"},
+						},
+						MatchType: "audit_owner",
+					}},
+				},
+			},
+			{
+				ID:      "policies",
+				Path:    "/v1/policies",
+				IDField: "id",
+				Event: EventMappingSpec{
+					Kind:      "example.policies",
+					SchemaRef: "example/policies/v1",
+					URNKind:   "policy_urn_kind",
+				},
+				Projection: &ProjectionSpec{
+					Template: "policy",
+					Relationships: []ProjectionRelationshipSpec{{
+						Relation: "owned_by",
+						To: ProjectionEntitySpec{
+							EntityType:   "example.owner",
+							URNKind:      "example_owner",
+							IDAttributes: []string{"policy_urn_kind"},
+						},
+						MatchType: "policy_owner",
+					}},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	for _, want := range []string{
+		"projection_relationship_assets_0_relation",
+		"projection_relationship_assets_0_match_type",
+		"projection_relationship_assets_0_to_assets_unstable_eventid",
+		"projection_relationships_audit_events",
+		"projection_relationship_policies_0_to_policies_attribute_policy_urn_kind",
+	} {
+		if !hasBlockingCheck(definition.Validation.Checks, want) {
+			t.Fatalf("validation checks = %#v, want blocker %q", definition.Validation.Checks, want)
+		}
+	}
+}
+
 func TestValidateBlocksProtocolRelativeResourcePaths(t *testing.T) {
 	for _, path := range []string{"//evil.example/v1/assets", `/\evil.example\v1\assets`} {
 		t.Run(path, func(t *testing.T) {

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -117,6 +117,7 @@ type familyData struct {
 	PageSizeParams        []string
 	RequiredAttributes    []string
 	RequiredPayloadFields []string
+	Projection            *connectordefinitions.ProjectionSpec
 }
 
 type oauthClientCredentialsData struct {
@@ -655,6 +656,7 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			PageSizeParams:        pageSizeParamsForResource(resource),
 			RequiredAttributes:    requiredAttributes,
 			RequiredPayloadFields: requiredPayloadFields,
+			Projection:            resource.Projection,
 		})
 	}
 	return families, nil
@@ -1181,6 +1183,13 @@ func attributePathsForFamily(family familyData) map[string]string {
 		base["alert_resolved_at"] = "resolved_at|closed_at|acknowledged_at"
 		base["alert_description"] = "description|summary|message|body"
 	}
+	if family.Projection != nil {
+		for key, value := range family.Projection.Fields {
+			if strings.TrimSpace(key) != "" && strings.TrimSpace(value) != "" {
+				base[strings.TrimSpace(key)] = strings.TrimSpace(value)
+			}
+		}
+	}
 	return base
 }
 
@@ -1336,35 +1345,84 @@ func renderProjectionGo(request normalizedRequest) string {
 	sourcePrefix := lowerCamelIdentifier(request.SourceID)
 	var b strings.Builder
 	fmt.Fprintf(&b, "package sourceprojection\n\n")
+	fmt.Fprintf(&b, "import (\n")
 	if projectionNeedsStrings(request.Families) {
-		fmt.Fprintf(&b, "import (\n\t\"strings\"\n\n\tcerebrov1 \"github.com/writer/cerebro/gen/cerebro/v1\"\n\t\"github.com/writer/cerebro/internal/ports\"\n)\n\n")
-	} else {
-		fmt.Fprintf(&b, "import (\n\tcerebrov1 \"github.com/writer/cerebro/gen/cerebro/v1\"\n\t\"github.com/writer/cerebro/internal/ports\"\n)\n\n")
+		fmt.Fprintf(&b, "\t\"strings\"\n\n")
+	}
+	fmt.Fprintf(&b, "\tcerebrov1 \"github.com/writer/cerebro/gen/cerebro/v1\"\n")
+	if projectionNeedsConnectordefinitions(request.Families) {
+		fmt.Fprintf(&b, "\t\"github.com/writer/cerebro/internal/connectordefinitions\"\n")
+	}
+	fmt.Fprintf(&b, "\t\"github.com/writer/cerebro/internal/ports\"\n)\n\n")
+	for _, family := range request.Families {
+		if projectionFamilyNeedsAugmentation(family) {
+			fmt.Fprintf(&b, "var %sProjectionResource = connectordefinitions.ResourceFamily{\n\tID: %s,\n\tProjection: &connectordefinitions.ProjectionSpec{\n", family.ProjectorName, strconv.Quote(family.Name))
+			renderProjectionSpecLiteral(&b, family.Projection, "\t\t")
+			fmt.Fprintf(&b, "\t},\n}\n\n")
+		}
 	}
 	for _, family := range request.Families {
 		switch family.Class {
 		case "asset":
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sAssetProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			renderProjectionDispatchReturn(&b, request.SourceID, family, sourcePrefix+"AssetProjections")
+			fmt.Fprintf(&b, "}\n\n")
 		case "finding":
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sFindingProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			renderProjectionDispatchReturn(&b, request.SourceID, family, sourcePrefix+"FindingProjections")
+			fmt.Fprintf(&b, "}\n\n")
 		case "secret":
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sSecretProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			renderProjectionDispatchReturn(&b, request.SourceID, family, sourcePrefix+"SecretProjections")
+			fmt.Fprintf(&b, "}\n\n")
 		case "policy":
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sPolicyProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			renderProjectionDispatchReturn(&b, request.SourceID, family, sourcePrefix+"PolicyProjections")
+			fmt.Fprintf(&b, "}\n\n")
 		case "deployment":
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sDeploymentProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			renderProjectionDispatchReturn(&b, request.SourceID, family, sourcePrefix+"DeploymentProjections")
+			fmt.Fprintf(&b, "}\n\n")
 		case "alert":
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn %sAlertProjections(event)\n}\n\n", family.ProjectorName, sourcePrefix)
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			renderProjectionDispatchReturn(&b, request.SourceID, family, sourcePrefix+"AlertProjections")
+			fmt.Fprintf(&b, "}\n\n")
 		case "identity_user":
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn identityUserProjections(event, identityProjectionProfile{Provider: %s})\n}\n\n", family.ProjectorName, strconv.Quote(request.SourceID))
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			if projectionFamilyNeedsAugmentation(family) {
+				fmt.Fprintf(&b, "\treturn projectCatalogRuntimeWithRelationships(%s, %sProjectionResource, func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\t\treturn identityUserProjections(event, identityProjectionProfile{Provider: %s})\n\t}, event)\n", strconv.Quote(request.SourceID), family.ProjectorName, strconv.Quote(request.SourceID))
+			} else {
+				fmt.Fprintf(&b, "\treturn identityUserProjections(event, identityProjectionProfile{Provider: %s})\n", strconv.Quote(request.SourceID))
+			}
+			fmt.Fprintf(&b, "}\n\n")
 		case "identity_group":
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn identityGroupProjections(event, identityProjectionProfile{Provider: %s})\n}\n\n", family.ProjectorName, strconv.Quote(request.SourceID))
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			if projectionFamilyNeedsAugmentation(family) {
+				fmt.Fprintf(&b, "\treturn projectCatalogRuntimeWithRelationships(%s, %sProjectionResource, func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\t\treturn identityGroupProjections(event, identityProjectionProfile{Provider: %s})\n\t}, event)\n", strconv.Quote(request.SourceID), family.ProjectorName, strconv.Quote(request.SourceID))
+			} else {
+				fmt.Fprintf(&b, "\treturn identityGroupProjections(event, identityProjectionProfile{Provider: %s})\n", strconv.Quote(request.SourceID))
+			}
+			fmt.Fprintf(&b, "}\n\n")
 		case "group_membership":
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn identityGroupMembershipProjections(event, identityProjectionProfile{Provider: %s})\n}\n\n", family.ProjectorName, strconv.Quote(request.SourceID))
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			if projectionFamilyNeedsAugmentation(family) {
+				fmt.Fprintf(&b, "\treturn projectCatalogRuntimeWithRelationships(%s, %sProjectionResource, func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\t\treturn identityGroupMembershipProjections(event, identityProjectionProfile{Provider: %s})\n\t}, event)\n", strconv.Quote(request.SourceID), family.ProjectorName, strconv.Quote(request.SourceID))
+			} else {
+				fmt.Fprintf(&b, "\treturn identityGroupMembershipProjections(event, identityProjectionProfile{Provider: %s})\n", strconv.Quote(request.SourceID))
+			}
+			fmt.Fprintf(&b, "}\n\n")
 		case "audit_event":
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn identityAuditProjections(event, identityProjectionProfile{Provider: %s})\n}\n\n", family.ProjectorName, strconv.Quote(request.SourceID))
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			if projectionFamilyNeedsAugmentation(family) {
+				fmt.Fprintf(&b, "\treturn projectCatalogRuntimeWithRelationships(%s, %sProjectionResource, func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\t\treturn identityAuditProjections(event, identityProjectionProfile{Provider: %s})\n\t}, event)\n", strconv.Quote(request.SourceID), family.ProjectorName, strconv.Quote(request.SourceID))
+			} else {
+				fmt.Fprintf(&b, "\treturn identityAuditProjections(event, identityProjectionProfile{Provider: %s})\n", strconv.Quote(request.SourceID))
+			}
+			fmt.Fprintf(&b, "}\n\n")
 		default:
-			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\treturn runtimeEvidenceProjections(event)\n}\n\n", family.ProjectorName)
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			renderProjectionDispatchReturn(&b, request.SourceID, family, "runtimeEvidenceProjections")
+			fmt.Fprintf(&b, "}\n\n")
 		}
 	}
 	if firstFamilyClass(request.Families, "asset").Name != "" {
@@ -1392,6 +1450,85 @@ func renderProjectionGo(request normalizedRequest) string {
 		fmt.Fprintf(&b, "\ttenantID, err := tenantID(event)\n\tif err != nil {\n\t\treturn nil, nil, err\n\t}\n\tattributes := event.GetAttributes()\n\talertID := firstNonEmpty(attributes[\"alert_id\"], event.GetId())\n\talertURN := projectionURN(tenantID, \"alert\", alertID)\n\tentities := map[string]*ports.ProjectedEntity{}\n\tlinks := map[string]*ports.ProjectedLink{}\n\taddEntity(entities, &ports.ProjectedEntity{URN: alertURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: \"alert\", Label: firstNonEmpty(attributes[\"alert_name\"], alertID), Attributes: map[string]string{\"alert_id\": alertID, \"alert_severity\": strings.TrimSpace(attributes[\"alert_severity\"]), \"alert_status\": strings.TrimSpace(attributes[\"alert_status\"]), \"alert_type\": strings.TrimSpace(attributes[\"alert_type\"]), \"alert_source\": strings.TrimSpace(attributes[\"alert_source\"]), \"alert_fired_at\": strings.TrimSpace(attributes[\"alert_fired_at\"]), \"alert_resolved_at\": strings.TrimSpace(attributes[\"alert_resolved_at\"]), \"source_runtime_id\": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})\n\tif evidenceID := strings.TrimSpace(attributes[\"evidence_id\"]); evidenceID != \"\" {\n\t\tevidenceURN := projectionURN(tenantID, \"runtime_evidence\", evidenceID)\n\t\taddEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: \"runtime_evidence\", Label: evidenceID, Attributes: map[string]string{\"evidence_id\": evidenceID, \"evidence_cas_uri\": strings.TrimSpace(attributes[\"evidence_cas_uri\"]), \"evidence_cas_digest\": strings.TrimSpace(attributes[\"evidence_cas_digest\"])}})\n\t\taddLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, evidenceURN, relationHasEvidence, map[string]string{\"event_id\": event.GetId()}))\n\t}\n\treturn identityProjectionResult(entities, links)\n}\n")
 	}
 	return b.String()
+}
+
+func projectionNeedsConnectordefinitions(families []familyData) bool {
+	for _, family := range families {
+		if projectionFamilyNeedsAugmentation(family) {
+			return true
+		}
+	}
+	return false
+}
+
+func projectionFamilyNeedsAugmentation(family familyData) bool {
+	return family.Projection != nil && (family.Projection.Entity != nil || len(family.Projection.Relationships) != 0)
+}
+
+func renderProjectionDispatchReturn(b *strings.Builder, sourceID string, family familyData, baseFunc string) {
+	if projectionFamilyNeedsAugmentation(family) {
+		fmt.Fprintf(b, "\treturn projectCatalogRuntimeWithRelationships(%s, %sProjectionResource, %s, event)\n", strconv.Quote(sourceID), family.ProjectorName, baseFunc)
+		return
+	}
+	fmt.Fprintf(b, "\treturn %s(event)\n", baseFunc)
+}
+
+func renderProjectionSpecLiteral(b *strings.Builder, projection *connectordefinitions.ProjectionSpec, indent string) {
+	if projection == nil {
+		return
+	}
+	if strings.TrimSpace(projection.Template) != "" {
+		fmt.Fprintf(b, "%sTemplate: %s,\n", indent, strconv.Quote(projection.Template))
+	}
+	if len(projection.Fields) != 0 {
+		fmt.Fprintf(b, "%sFields: map[string]string{%s},\n", indent, renderedAttributeMap(projection.Fields))
+	}
+	if projection.Entity != nil {
+		fmt.Fprintf(b, "%sEntity: &connectordefinitions.ProjectionEntitySpec{\n", indent)
+		renderProjectionEntitySpecLiteral(b, *projection.Entity, indent+"\t")
+		fmt.Fprintf(b, "%s},\n", indent)
+	}
+	if len(projection.Relationships) != 0 {
+		fmt.Fprintf(b, "%sRelationships: []connectordefinitions.ProjectionRelationshipSpec{\n", indent)
+		for _, relationship := range projection.Relationships {
+			fmt.Fprintf(b, "%s\t{\n", indent)
+			fmt.Fprintf(b, "%s\t\tRelation: %s,\n", indent, strconv.Quote(relationship.Relation))
+			if relationship.From != nil {
+				fmt.Fprintf(b, "%s\t\tFrom: &connectordefinitions.ProjectionEntitySpec{\n", indent)
+				renderProjectionEntitySpecLiteral(b, *relationship.From, indent+"\t\t\t")
+				fmt.Fprintf(b, "%s\t\t},\n", indent)
+			}
+			fmt.Fprintf(b, "%s\t\tTo: connectordefinitions.ProjectionEntitySpec{\n", indent)
+			renderProjectionEntitySpecLiteral(b, relationship.To, indent+"\t\t\t")
+			fmt.Fprintf(b, "%s\t\t},\n", indent)
+			if len(relationship.RequiredAttributes) != 0 {
+				fmt.Fprintf(b, "%s\t\tRequiredAttributes: []string{%s},\n", indent, quotedStrings(relationship.RequiredAttributes))
+			}
+			if len(relationship.LinkAttributes) != 0 {
+				fmt.Fprintf(b, "%s\t\tLinkAttributes: []string{%s},\n", indent, quotedStrings(relationship.LinkAttributes))
+			}
+			if strings.TrimSpace(relationship.MatchType) != "" {
+				fmt.Fprintf(b, "%s\t\tMatchType: %s,\n", indent, strconv.Quote(relationship.MatchType))
+			}
+			fmt.Fprintf(b, "%s\t},\n", indent)
+		}
+		fmt.Fprintf(b, "%s},\n", indent)
+	}
+}
+
+func renderProjectionEntitySpecLiteral(b *strings.Builder, entity connectordefinitions.ProjectionEntitySpec, indent string) {
+	if strings.TrimSpace(entity.EntityType) != "" {
+		fmt.Fprintf(b, "%sEntityType: %s,\n", indent, strconv.Quote(entity.EntityType))
+	}
+	if strings.TrimSpace(entity.URNKind) != "" {
+		fmt.Fprintf(b, "%sURNKind: %s,\n", indent, strconv.Quote(entity.URNKind))
+	}
+	if len(entity.IDAttributes) != 0 {
+		fmt.Fprintf(b, "%sIDAttributes: []string{%s},\n", indent, quotedStrings(entity.IDAttributes))
+	}
+	if strings.TrimSpace(entity.LabelAttribute) != "" {
+		fmt.Fprintf(b, "%sLabelAttribute: %s,\n", indent, strconv.Quote(entity.LabelAttribute))
+	}
 }
 
 func projectionNeedsStrings(families []familyData) bool {

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -186,6 +186,149 @@ func TestGenerateDefinitionWritesIdentitySource(t *testing.T) {
 	}
 }
 
+func TestGenerateDefinitionCarriesProjectionRelationships(t *testing.T) {
+	outputDir := t.TempDir()
+	_, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			SchemaVersion: connectordefinitions.SchemaVersionIntegrationV1,
+			ID:            "tenant-a-example_vault",
+			TenantID:      "tenant-a",
+			SourceID:      "example_vault",
+			DisplayName:   "Example Vault",
+			Auth: connectordefinitions.AuthSpec{
+				Model: "bearer_token",
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "token",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL: "https://api.example.test",
+				Verification: &connectordefinitions.VerificationSpec{
+					Path: "/v1/health",
+				},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:             "secrets",
+				Path:           "/v1/secrets",
+				RecordSelector: "$.data[*]",
+				IDField:        "id",
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "example_vault.secrets",
+					SchemaRef: "example_vault/secrets/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{
+					Template: "secret",
+					Fields: map[string]string{
+						"owner_user_id": "created_by.id",
+						"vault_id":      "mount_accessor",
+					},
+					Entity: &connectordefinitions.ProjectionEntitySpec{
+						EntityType:     "secret",
+						URNKind:        "secret",
+						IDAttributes:   []string{"secret_id"},
+						LabelAttribute: "secret_name",
+					},
+					Relationships: []connectordefinitions.ProjectionRelationshipSpec{{
+						Relation: "belongs_to",
+						To: connectordefinitions.ProjectionEntitySpec{
+							EntityType:   "example_vault.vault",
+							URNKind:      "example_vault_vault",
+							IDAttributes: []string{"vault_id"},
+						},
+						MatchType: "secret_vault",
+					}},
+				},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{Type: "entity_family", Support: "supported"}},
+			}},
+		},
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefinition() error = %v", err)
+	}
+	source := readGeneratedFile(t, outputDir, "sources/example_vault/source.go")
+	for _, want := range []string{`"owner_user_id": "created_by.id"`, `"vault_id": "mount_accessor"`} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("generated source missing relationship attribute path %q:\n%s", want, source)
+		}
+	}
+	projection := readGeneratedFile(t, outputDir, "internal/sourceprojection/example_vault.go")
+	for _, want := range []string{
+		`"github.com/writer/cerebro/internal/connectordefinitions"`,
+		"projectCatalogRuntimeWithRelationships",
+		"connectordefinitions.ProjectionRelationshipSpec",
+		`MatchType: "secret_vault"`,
+	} {
+		if !strings.Contains(projection, want) {
+			t.Fatalf("generated projection missing %q:\n%s", want, projection)
+		}
+	}
+}
+
+func TestGenerateDefinitionCarriesAuditEventProjectionEntity(t *testing.T) {
+	outputDir := t.TempDir()
+	_, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			SchemaVersion: connectordefinitions.SchemaVersionIntegrationV1,
+			ID:            "tenant-a-example_audit",
+			TenantID:      "tenant-a",
+			SourceID:      "example_audit",
+			DisplayName:   "Example Audit",
+			Auth: connectordefinitions.AuthSpec{
+				Model: "bearer_token",
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "token",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL: "https://api.example.test",
+				Verification: &connectordefinitions.VerificationSpec{
+					Path: "/v1/health",
+				},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:             "audit_events",
+				Path:           "/v1/audit",
+				RecordSelector: "$.data[*]",
+				IDField:        "id",
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "example_audit.audit_events",
+					SchemaRef: "example_audit/audit_events/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{
+					Template: "audit_event",
+					Fields:   map[string]string{"audit_id": "id"},
+					Entity: &connectordefinitions.ProjectionEntitySpec{
+						EntityType:   "example_audit.audit_event",
+						URNKind:      "example_audit_event",
+						IDAttributes: []string{"audit_id"},
+					},
+				},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{Type: "audit_event", Support: "supported"}},
+			}},
+		},
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefinition() error = %v", err)
+	}
+	projection := readGeneratedFile(t, outputDir, "internal/sourceprojection/example_audit.go")
+	for _, want := range []string{
+		"projectCatalogRuntimeWithRelationships",
+		"identityAuditProjections",
+		`EntityType:`,
+		`"example_audit.audit_event"`,
+	} {
+		if !strings.Contains(projection, want) {
+			t.Fatalf("generated audit projection missing %q:\n%s", want, projection)
+		}
+	}
+}
+
 func TestGenerateDefinitionHealthPathWithQueryUsesRequestURI(t *testing.T) {
 	outputDir := t.TempDir()
 	_, err := GenerateDefinition(DefinitionRequest{

--- a/internal/sourceprojection/catalogrelationships.go
+++ b/internal/sourceprojection/catalogrelationships.go
@@ -1,0 +1,205 @@
+package sourceprojection
+
+import (
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/connectordefinitions"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func augmentCatalogRuntimeProjector(sourceID string, resource connectordefinitions.ResourceFamily, base ProjectFunc) ProjectFunc {
+	if base == nil {
+		return nil
+	}
+	projection := resource.Projection
+	if projection == nil || (projection.Entity == nil && len(projection.Relationships) == 0) {
+		return base
+	}
+	return func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		return projectCatalogRuntimeWithRelationships(sourceID, resource, base, event)
+	}
+}
+
+func projectCatalogRuntimeWithRelationships(sourceID string, resource connectordefinitions.ResourceFamily, base ProjectFunc, event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	entities, links, err := base(event)
+	if err != nil || event == nil || resource.Projection == nil {
+		return entities, links, err
+	}
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	entityMap := projectedEntityMap(entities)
+	linkMap := projectedLinkMap(links)
+	attributes := event.GetAttributes()
+	primaryURN := catalogProjectionPrimaryURN(entities)
+	if resource.Projection.Entity != nil {
+		if entity := catalogProjectionEntityFromSpec(tenantID, sourceID, attributes, *resource.Projection.Entity); entity != nil {
+			previousPrimaryURN := primaryURN
+			primaryURN = entity.URN
+			mergePrimaryProjectionEntity(entityMap[previousPrimaryURN], entity)
+			addEntity(entityMap, entity)
+			if previousPrimaryURN != "" && previousPrimaryURN != primaryURN && shouldReplaceCatalogProjectionPrimary(entityMap[previousPrimaryURN]) {
+				rewireCatalogProjectionLinks(linkMap, previousPrimaryURN, primaryURN)
+				delete(entityMap, previousPrimaryURN)
+			}
+		}
+	}
+	for _, relationship := range resource.Projection.Relationships {
+		if !catalogProjectionRelationshipRequired(attributes, relationship) {
+			continue
+		}
+		fromURN := primaryURN
+		if relationship.From != nil {
+			fromEntity := catalogProjectionEntityFromSpec(tenantID, sourceID, attributes, *relationship.From)
+			if fromEntity == nil {
+				continue
+			}
+			addEntity(entityMap, fromEntity)
+			fromURN = fromEntity.URN
+		}
+		if strings.TrimSpace(fromURN) == "" {
+			continue
+		}
+		toEntity := catalogProjectionEntityFromSpec(tenantID, sourceID, attributes, relationship.To)
+		if toEntity == nil {
+			continue
+		}
+		addEntity(entityMap, toEntity)
+		addLink(linkMap, projectedLink(tenantID, sourceID, fromURN, toEntity.URN, relationship.Relation, catalogProjectionLinkAttributes(event, attributes, relationship)))
+	}
+	return identityProjectionResult(entityMap, linkMap)
+}
+
+func projectedEntityMap(entities []*ports.ProjectedEntity) map[string]*ports.ProjectedEntity {
+	out := map[string]*ports.ProjectedEntity{}
+	for _, entity := range entities {
+		addEntity(out, entity)
+	}
+	return out
+}
+
+func projectedLinkMap(links []*ports.ProjectedLink) map[string]*ports.ProjectedLink {
+	out := map[string]*ports.ProjectedLink{}
+	for _, link := range links {
+		addLink(out, link)
+	}
+	return out
+}
+
+func catalogProjectionPrimaryURN(entities []*ports.ProjectedEntity) string {
+	for _, entity := range entities {
+		if entity == nil {
+			continue
+		}
+		if strings.TrimSpace(entity.URN) == "" || strings.TrimSpace(entity.EntityType) == "runtime.evidence" {
+			continue
+		}
+		return entity.URN
+	}
+	return ""
+}
+
+func shouldReplaceCatalogProjectionPrimary(entity *ports.ProjectedEntity) bool {
+	if entity == nil {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(entity.EntityType), "runtime.")
+}
+
+func mergePrimaryProjectionEntity(previous *ports.ProjectedEntity, next *ports.ProjectedEntity) {
+	if previous == nil || next == nil {
+		return
+	}
+	if next.Attributes == nil {
+		next.Attributes = map[string]string{}
+	}
+	for key, value := range previous.Attributes {
+		if strings.TrimSpace(next.Attributes[key]) == "" && strings.TrimSpace(value) != "" {
+			next.Attributes[key] = value
+		}
+	}
+}
+
+func rewireCatalogProjectionLinks(links map[string]*ports.ProjectedLink, previousURN string, nextURN string) {
+	if strings.TrimSpace(previousURN) == "" || strings.TrimSpace(nextURN) == "" || previousURN == nextURN {
+		return
+	}
+	for key, link := range links {
+		if link == nil {
+			continue
+		}
+		changed := false
+		if link.FromURN == previousURN {
+			link.FromURN = nextURN
+			changed = true
+		}
+		if link.ToURN == previousURN {
+			link.ToURN = nextURN
+			changed = true
+		}
+		if changed {
+			delete(links, key)
+			addLink(links, link)
+		}
+	}
+}
+
+func catalogProjectionEntityFromSpec(tenantID string, sourceID string, attributes map[string]string, spec connectordefinitions.ProjectionEntitySpec) *ports.ProjectedEntity {
+	idParts := make([]string, 0, len(spec.IDAttributes))
+	entityAttrs := map[string]string{}
+	for _, attr := range spec.IDAttributes {
+		value := strings.TrimSpace(attributes[attr])
+		if value == "" {
+			return nil
+		}
+		idParts = append(idParts, value)
+		entityAttrs[attr] = value
+	}
+	urn := projectionURN(tenantID, spec.URNKind, idParts...)
+	if urn == "" {
+		return nil
+	}
+	label := strings.TrimSpace(attributes[spec.LabelAttribute])
+	if label == "" {
+		label = strings.Join(idParts, "/")
+	}
+	if spec.LabelAttribute != "" {
+		addProjectedAttribute(entityAttrs, spec.LabelAttribute, attributes[spec.LabelAttribute])
+	}
+	addProjectedAttribute(entityAttrs, ports.EventAttributeSourceRuntimeID, attributes[ports.EventAttributeSourceRuntimeID])
+	return &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: spec.EntityType,
+		Label:      label,
+		Attributes: entityAttrs,
+	}
+}
+
+func catalogProjectionRelationshipRequired(attributes map[string]string, relationship connectordefinitions.ProjectionRelationshipSpec) bool {
+	required := relationship.RequiredAttributes
+	if len(required) == 0 {
+		required = append(required, relationship.To.IDAttributes...)
+		if relationship.From != nil {
+			required = append(required, relationship.From.IDAttributes...)
+		}
+	}
+	for _, attr := range required {
+		if strings.TrimSpace(attributes[attr]) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func catalogProjectionLinkAttributes(event *cerebrov1.EventEnvelope, attributes map[string]string, relationship connectordefinitions.ProjectionRelationshipSpec) map[string]string {
+	out := map[string]string{"event_id": event.GetId()}
+	addProjectedAttribute(out, "match_type", relationship.MatchType)
+	for _, attr := range relationship.LinkAttributes {
+		addProjectedAttribute(out, attr, attributes[attr])
+	}
+	return out
+}

--- a/internal/sourceprojection/catalogruntime.go
+++ b/internal/sourceprojection/catalogruntime.go
@@ -62,30 +62,32 @@ func catalogRuntimeProjectorFor(sourceID string, resource connectordefinitions.R
 	if resource.Projection != nil {
 		template = strings.TrimSpace(resource.Projection.Template)
 	}
+	var base ProjectFunc
 	switch template {
 	case "identity_user":
-		return func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		base = func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 			return identityUserProjections(event, identityProjectionProfile{Provider: sourceID})
 		}
 	case "identity_group":
-		return func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		base = func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 			return identityGroupProjections(event, identityProjectionProfile{Provider: sourceID})
 		}
 	case "group_membership":
-		return func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		base = func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 			return identityGroupMembershipProjections(event, identityProjectionProfile{Provider: sourceID})
 		}
 	case "audit_event":
-		return func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		base = func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 			return identityAuditProjections(event, identityProjectionProfile{Provider: sourceID})
 		}
 	case "evidence_cas_reference":
-		return runtimeEvidenceProjections
+		base = runtimeEvidenceProjections
 	case "finding", "vulnerability":
-		return catalogRuntimeFindingProjections
+		base = catalogRuntimeFindingProjections
 	default:
-		return catalogRuntimeAssetProjections
+		base = catalogRuntimeAssetProjections
 	}
+	return augmentCatalogRuntimeProjector(sourceID, resource, base)
 }
 
 func catalogRuntimeAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/catalogruntime_test.go
+++ b/internal/sourceprojection/catalogruntime_test.go
@@ -161,6 +161,100 @@ func TestCatalogRuntimeAssetProjectionRequiresStableResourceIdentity(t *testing.
 	}
 }
 
+func TestCatalogRuntimeProjectionRelationships(t *testing.T) {
+	resource := connectordefinitions.ResourceFamily{
+		ID: "secrets",
+		Projection: &connectordefinitions.ProjectionSpec{
+			Template: "secret",
+			Fields: map[string]string{
+				"owner_user_id": "created_by.id",
+				"vault_id":      "mount_accessor",
+			},
+			Entity: &connectordefinitions.ProjectionEntitySpec{
+				EntityType:     "secret",
+				URNKind:        "secret",
+				IDAttributes:   []string{"secret_id"},
+				LabelAttribute: "secret_name",
+			},
+			Relationships: []connectordefinitions.ProjectionRelationshipSpec{
+				{
+					Relation: "belongs_to",
+					To: connectordefinitions.ProjectionEntitySpec{
+						EntityType:   "hashicorp_vault.vault",
+						URNKind:      "hashicorp_vault_vault",
+						IDAttributes: []string{"vault_id"},
+					},
+					MatchType: "secret_vault",
+				},
+				{
+					Relation:           "owned_by",
+					RequiredAttributes: []string{"owner_user_id"},
+					To: connectordefinitions.ProjectionEntitySpec{
+						EntityType:   "hashicorp_vault.user",
+						URNKind:      "hashicorp_vault_user",
+						IDAttributes: []string{"owner_user_id"},
+					},
+					MatchType: "secret_owner",
+				},
+			},
+		},
+	}
+	projector := catalogRuntimeProjectorFor("hashicorp_vault", resource)
+	entities, links, err := projector(&cerebrov1.EventEnvelope{
+		Id:       "event-1",
+		TenantId: "tenant",
+		SourceId: "hashicorp_vault",
+		Kind:     "hashicorp_vault.secrets",
+		Attributes: map[string]string{
+			"resource_id":    "secret-1",
+			"resource_type":  "secret",
+			"secret_id":      "secret-1",
+			"secret_name":    "database/password",
+			"vault_id":       "kv",
+			"owner_user_id":  "user-1",
+			"source_runtime": "runtime-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("projector error = %v", err)
+	}
+	if !hasProjectedEntityType(entities, "secret") || !hasProjectedEntityType(entities, "hashicorp_vault.vault") || !hasProjectedEntityType(entities, "hashicorp_vault.user") {
+		t.Fatalf("entities missing deep relationship endpoints: %#v", entities)
+	}
+	if hasProjectedEntityType(entities, "runtime.secret") {
+		t.Fatalf("projection.entity should replace flat runtime secret entity: %#v", entities)
+	}
+	if !projectedLinksContain(links, "urn:cerebro:tenant:secret:secret-1", relationBelongsTo, "urn:cerebro:tenant:hashicorp_vault_vault:kv") {
+		t.Fatalf("secret-vault link missing: %#v", links)
+	}
+	if !projectedLinksContain(links, "urn:cerebro:tenant:secret:secret-1", relationOwnedBy, "urn:cerebro:tenant:hashicorp_vault_user:user-1") {
+		t.Fatalf("secret-owner link missing: %#v", links)
+	}
+
+	entities, links, err = projector(&cerebrov1.EventEnvelope{
+		Id:       "event-2",
+		TenantId: "tenant",
+		SourceId: "hashicorp_vault",
+		Kind:     "hashicorp_vault.secrets",
+		Attributes: map[string]string{
+			"resource_id":   "secret-2",
+			"resource_type": "secret",
+			"secret_id":     "secret-2",
+			"secret_name":   "database/username",
+			"vault_id":      "kv",
+		},
+	})
+	if err != nil {
+		t.Fatalf("projector without owner error = %v", err)
+	}
+	if !hasProjectedEntityType(entities, "secret") || !projectedLinksContain(links, "urn:cerebro:tenant:secret:secret-2", relationBelongsTo, "urn:cerebro:tenant:hashicorp_vault_vault:kv") {
+		t.Fatalf("missing required owner should not suppress base entity or vault link: entities=%#v links=%#v", entities, links)
+	}
+	if projectedLinksContainRelationFrom(links, "urn:cerebro:tenant:secret:secret-2", relationOwnedBy) {
+		t.Fatalf("owner link emitted despite missing owner_user_id: %#v", links)
+	}
+}
+
 func TestCatalogRuntimeFindingProjectionRequiresStableFindingIdentity(t *testing.T) {
 	entities, links, err := catalogRuntimeFindingProjections(&cerebrov1.EventEnvelope{
 		Id:       "event-ephemeral",
@@ -183,6 +277,24 @@ func TestCatalogRuntimeFindingProjectionRequiresStableFindingIdentity(t *testing
 func hasProjectedEntityType(entities []*ports.ProjectedEntity, entityType string) bool {
 	for _, entity := range entities {
 		if entity.EntityType == entityType {
+			return true
+		}
+	}
+	return false
+}
+
+func projectedLinksContain(links []*ports.ProjectedLink, fromURN string, relation string, toURN string) bool {
+	for _, link := range links {
+		if link.FromURN == fromURN && link.Relation == relation && link.ToURN == toURN {
+			return true
+		}
+	}
+	return false
+}
+
+func projectedLinksContainRelationFrom(links []*ports.ProjectedLink, fromURN string, relation string) bool {
+	for _, link := range links {
+		if link.FromURN == fromURN && link.Relation == relation {
 			return true
 		}
 	}

--- a/sources/internal/catalogruntime/source.go
+++ b/sources/internal/catalogruntime/source.go
@@ -179,6 +179,14 @@ func projectionClass(resource connectordefinitions.ResourceFamily) string {
 	switch strings.TrimSpace(resource.Projection.Template) {
 	case "finding", "vulnerability":
 		return "finding"
+	case "secret":
+		return "secret"
+	case "policy":
+		return "policy"
+	case "deployment":
+		return "deployment"
+	case "alert":
+		return "alert"
 	case "identity_user", "identity_group", "group_membership", "audit_event", "evidence_cas_reference":
 		return strings.TrimSpace(resource.Projection.Template)
 	default:
@@ -199,6 +207,14 @@ func idKeys(resource connectordefinitions.ResourceFamily, class string) []string
 		keys = append(keys, "membership_id", "id", "group_id", "member_id", "user_id", "email")
 	case "audit_event":
 		keys = append(keys, "event_id", "id", "uuid", "request_id")
+	case "secret":
+		keys = append(keys, "secret_id", "id", "key", "sid", "name")
+	case "policy":
+		keys = append(keys, "policy_id", "id", "control_id", "key", "sid")
+	case "deployment":
+		keys = append(keys, "deployment_id", "id", "name", "uid")
+	case "alert":
+		keys = append(keys, "alert_id", "id", "sid", "incident_id", "uuid")
 	default:
 		keys = append(keys, "id", "urn", "resource_urn", "name")
 	}
@@ -246,6 +262,36 @@ func attributePaths(resource connectordefinitions.ResourceFamily, class string) 
 		attrs["event_type"] = "event_type|event_name|action|type"
 		attrs["actor_id"] = "actor_id|actor.id|actorId|user_id|user.id"
 		attrs["actor_email"] = "actor_email|actor.email|email|user.email"
+	case "secret":
+		attrs["secret_id"] = "secret_id|id|key|sid|name"
+		attrs["secret_name"] = "secret_name|name|display_name|label|title"
+		attrs["secret_type"] = "secret_type|type|kind"
+		attrs["secret_status"] = "secret_status|status|state"
+		attrs["secret_rotation_enabled"] = "secret_rotation_enabled|rotation_enabled|auto_rotate"
+		attrs["secret_last_rotated_at"] = "secret_last_rotated_at|last_rotated_at|last_rotated|rotated_at"
+	case "policy":
+		attrs["policy_id"] = "policy_id|id|control_id|key|sid"
+		attrs["policy_name"] = "policy_name|name|display_name|title|label"
+		attrs["policy_type"] = "policy_type|type|kind|category"
+		attrs["policy_status"] = "policy_status|status|state|enabled"
+		attrs["policy_severity"] = "severity|risk|priority"
+	case "deployment":
+		attrs["deployment_id"] = "deployment_id|id|name|uid"
+		attrs["deployment_name"] = "deployment_name|name|display_name|title|label"
+		attrs["deployment_environment"] = "environment|env|stage|target"
+		attrs["deployment_status"] = "status|state|ready"
+		attrs["deployment_url"] = "url|deployment_url|endpoint|domain"
+		attrs["deployment_commit_sha"] = "commit_sha|commit|sha|revision|git_sha"
+		attrs["deployment_branch"] = "branch|ref|git_branch|head_branch"
+	case "alert":
+		attrs["alert_id"] = "alert_id|id|sid|incident_id|uuid"
+		attrs["alert_name"] = "alert_name|name|title|summary|subject"
+		attrs["alert_severity"] = "severity|priority|level|risk"
+		attrs["alert_status"] = "status|state|resolved|acknowledged"
+		attrs["alert_type"] = "alert_type|type|category|kind"
+		attrs["alert_source"] = "source|alert_source|monitor|check"
+		attrs["alert_fired_at"] = "fired_at|triggered_at|created_at|occurred_at|timestamp"
+		attrs["alert_resolved_at"] = "resolved_at|closed_at|acknowledged_at"
 	}
 	if resource.Projection != nil {
 		for key, value := range resource.Projection.Fields {

--- a/sources/internal/catalogruntime/source_test.go
+++ b/sources/internal/catalogruntime/source_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/writer/cerebro/internal/connectordefinitions"
@@ -215,6 +216,30 @@ func TestProjectionFieldsOverrideClassDefaults(t *testing.T) {
 	}
 	if attrs["title"] == "" {
 		t.Fatal("title default missing")
+	}
+}
+
+func TestSecretProjectionTemplateDefaults(t *testing.T) {
+	resource := connectordefinitions.ResourceFamily{
+		ID: "secrets",
+		Projection: &connectordefinitions.ProjectionSpec{
+			Template: "secret",
+		},
+	}
+	if got := projectionClass(resource); got != "secret" {
+		t.Fatalf("projectionClass() = %q, want secret", got)
+	}
+	keys := idKeys(resource, "secret")
+	for _, want := range []string{"secret_id", "id"} {
+		if !slices.Contains(keys, want) {
+			t.Fatalf("idKeys() = %#v, want %q", keys, want)
+		}
+	}
+	attrs := attributePaths(resource, "secret")
+	for _, want := range []string{"secret_id", "secret_name"} {
+		if attrs[want] == "" {
+			t.Fatalf("attributePaths()[%q] missing in %#v", want, attrs)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements declarative deep graph relationships for catalog/sourcegen-backed sources so cheap sources can emit assets plus their resource relationships, not just flat runtime nodes.

### What changed

- Extends `connectordefinitions.ProjectionSpec` with:
  - `entity` to converge the primary entity to a stable spine URN.
  - `relationships` to declare durable graph edges from emitted event attributes.
- Adds validation guardrails:
  - v1 relation allowlist: `belongs_to`, `contains`, `owned_by`, `member_of`, `attached_to`.
  - endpoint `entity_type`, `urn_kind`, and `id_attributes` required.
  - rejects audit-event relationships, unstable anchors like event IDs/cursors/run IDs/timestamps, and non-emitted attributes.
  - caps relationships at 8 per family.
- Adds `catalogrelationships.go`, a shared projection augmenter used by catalog runtime and generated projectors.
- Updates sourcegen to:
  - carry projection specs into generated projection code.
  - merge `projection.fields` into generated JSON API attributes.
  - wrap generated projectors with the shared relationship augmenter.
- Adds validation, runtime projection, and sourcegen tests.
- Retrofits the first high-value secrets slice:
  - Doppler secrets `belongs_to` Doppler projects.
  - HashiCorp Vault secrets `owned_by` Vault users.

## Validation

- `go test ./...`
- `golangci-lint run --timeout 10m ./api/... ./cmd/... ./internal/... ./sources/...`

Both pass locally.
