### PR TITLE
fix: apply declarative catalog projection relationships to promoted sources

### DIFF
--- a/internal/sourceprojection/catalogrelationships.go
+++ b/internal/sourceprojection/catalogrelationships.go
@@ -1,6 +1,7 @@
 package sourceprojection
 
 import (
+	"sort"
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -89,16 +90,35 @@ func projectedLinkMap(links []*ports.ProjectedLink) map[string]*ports.ProjectedL
 }
 
 func catalogProjectionPrimaryURN(entities []*ports.ProjectedEntity) string {
+	candidates := make([]*ports.ProjectedEntity, 0, len(entities))
 	for _, entity := range entities {
-		if entity == nil {
+		if entity == nil || strings.TrimSpace(entity.URN) == "" || isProjectionEvidenceEntity(entity) {
 			continue
 		}
-		if strings.TrimSpace(entity.URN) == "" || strings.TrimSpace(entity.EntityType) == "runtime.evidence" {
-			continue
-		}
-		return entity.URN
+		candidates = append(candidates, entity)
 	}
-	return ""
+	if len(candidates) == 0 {
+		return ""
+	}
+	sort.SliceStable(candidates, func(i int, j int) bool {
+		leftRuntime := strings.HasPrefix(strings.TrimSpace(candidates[i].EntityType), "runtime.")
+		rightRuntime := strings.HasPrefix(strings.TrimSpace(candidates[j].EntityType), "runtime.")
+		if leftRuntime != rightRuntime {
+			return !leftRuntime
+		}
+		return candidates[i].URN < candidates[j].URN
+	})
+	return candidates[0].URN
+}
+
+// isProjectionEvidenceEntity reports whether an entity is an evidence node. The
+// generated bases disagree on spelling: asset/finding bases label evidence
+// "runtime.evidence" while the secret bases label it "runtime_evidence". Both
+// must be excluded from primary-anchor selection, otherwise a relationship edge
+// can anchor on (and then rewire/delete) the evidence node.
+func isProjectionEvidenceEntity(entity *ports.ProjectedEntity) bool {
+	entityType := strings.TrimSpace(entity.EntityType)
+	return entityType == "runtime.evidence" || entityType == "runtime_evidence"
 }
 
 func shouldReplaceCatalogProjectionPrimary(entity *ports.ProjectedEntity) bool {

--- a/internal/sourceprojection/catalogruntime.go
+++ b/internal/sourceprojection/catalogruntime.go
@@ -36,7 +36,14 @@ func registerCatalogRuntimeProjectorsForEntries(projectors map[string]ProjectFun
 			if kind == "" {
 				continue
 			}
-			if _, exists := projectors[kind]; exists {
+			if existing, exists := projectors[kind]; exists {
+				// A statically promoted projector already owns this kind. Still
+				// apply any declarative entity/relationship spec on top of it so
+				// catalog-declared edges take effect without regenerating the
+				// promoted Go (augment is a no-op when nothing is declared).
+				if existing != nil {
+					projectors[kind] = augmentCatalogRuntimeProjector(sourceID, resource, existing)
+				}
 				continue
 			}
 			projectors[kind] = catalogRuntimeProjectorFor(sourceID, resource)

--- a/internal/sourceprojection/catalogruntime_test.go
+++ b/internal/sourceprojection/catalogruntime_test.go
@@ -300,3 +300,84 @@ func projectedLinksContainRelationFrom(links []*ports.ProjectedLink, fromURN str
 	}
 	return false
 }
+
+func TestBuiltinRegistryAppliesDeclaredCatalogRelationships(t *testing.T) {
+	registry := BuiltinRegistry()
+
+	t.Run("doppler secrets belongs_to project", func(t *testing.T) {
+		projector := registry.projectors["doppler.secrets"]
+		if projector == nil {
+			t.Fatal("missing registered projector for doppler.secrets")
+		}
+		entities, links, err := projector(&cerebrov1.EventEnvelope{
+			Id:       "event-1",
+			TenantId: "tenant",
+			SourceId: "doppler",
+			Kind:     "doppler.secrets",
+			Attributes: map[string]string{
+				"secret_id":   "secret-1",
+				"secret_name": "DATABASE_URL",
+				"project_id":  "proj-1",
+				"evidence_id": "evidence-1",
+			},
+		})
+		if err != nil {
+			t.Fatalf("doppler.secrets projector error = %v", err)
+		}
+		if !projectedLinksContain(links, "urn:cerebro:tenant:secret:secret-1", relationBelongsTo, "urn:cerebro:tenant:doppler_project:proj-1") {
+			t.Fatalf("declared belongs_to edge not emitted by registered projector: %#v", links)
+		}
+		if !hasProjectedEntityType(entities, "runtime_evidence") {
+			t.Fatalf("evidence node dropped by relationship augmentation: %#v", entities)
+		}
+		if !projectedLinksContain(links, "urn:cerebro:tenant:secret:secret-1", relationHasEvidence, "urn:cerebro:tenant:runtime_evidence:evidence-1") {
+			t.Fatalf("has_evidence edge corrupted or dropped by relationship augmentation: %#v", links)
+		}
+	})
+
+	t.Run("hashicorp_vault secrets owned_by user", func(t *testing.T) {
+		projector := registry.projectors["hashicorp_vault.secrets"]
+		if projector == nil {
+			t.Fatal("missing registered projector for hashicorp_vault.secrets")
+		}
+		_, links, err := projector(&cerebrov1.EventEnvelope{
+			Id:       "event-1",
+			TenantId: "tenant",
+			SourceId: "hashicorp_vault",
+			Kind:     "hashicorp_vault.secrets",
+			Attributes: map[string]string{
+				"secret_id":     "secret-1",
+				"secret_name":   "kv/db",
+				"owner_user_id": "user-1",
+			},
+		})
+		if err != nil {
+			t.Fatalf("hashicorp_vault.secrets projector error = %v", err)
+		}
+		if !projectedLinksContain(links, "urn:cerebro:tenant:secret:secret-1", relationOwnedBy, "urn:cerebro:tenant:hashicorp_vault_user:user-1") {
+			t.Fatalf("declared owned_by edge not emitted by registered projector: %#v", links)
+		}
+	})
+}
+
+func TestCatalogProjectionPrimaryURNSkipsEvidenceAndIsDeterministic(t *testing.T) {
+	evidenceDotted := &ports.ProjectedEntity{URN: "urn:cerebro:tenant:runtime_evidence:e1", EntityType: "runtime.evidence"}
+	evidenceUnderscore := &ports.ProjectedEntity{URN: "urn:cerebro:tenant:runtime_evidence:e2", EntityType: "runtime_evidence"}
+	secret := &ports.ProjectedEntity{URN: "urn:cerebro:tenant:secret:s1", EntityType: "secret"}
+	runtimeNode := &ports.ProjectedEntity{URN: "urn:cerebro:tenant:runtime_host:h1", EntityType: "runtime.host"}
+
+	orders := [][]*ports.ProjectedEntity{
+		{evidenceUnderscore, runtimeNode, secret},
+		{secret, runtimeNode, evidenceDotted},
+		{runtimeNode, evidenceUnderscore, secret, evidenceDotted},
+	}
+	for _, order := range orders {
+		if got := catalogProjectionPrimaryURN(order); got != secret.URN {
+			t.Fatalf("primary URN = %q, want %q (typed entity preferred, evidence skipped) for order %#v", got, secret.URN, order)
+		}
+	}
+
+	if got := catalogProjectionPrimaryURN([]*ports.ProjectedEntity{evidenceDotted, evidenceUnderscore}); got != "" {
+		t.Fatalf("primary URN = %q, want empty when only evidence entities present", got)
+	}
+}


### PR DESCRIPTION
## Summary
Follow-up to #1318. The declarative projection `entity`/`relationships` added in #1318 were inert for already-promoted sources: the dynamic catalog registrar skipped any kind already owned by a statically registered projector, so the shipped secret-ownership edges never fired at runtime (CI stayed green because the catalog check only asserts a projector exists, not that it matches the declared spec).

This change:
- Augments statically promoted catalog projectors with their declared projection entity/relationships instead of skipping them, so catalog-declared edges take effect without regenerating Go. Augmentation is a no-op when nothing is declared, so only sources that declare relationships are affected.
- Makes primary-anchor selection deterministic and evidence-aware: it now skips evidence nodes in both spellings emitted by the generated bases and selects a stable anchor (typed entity preferred, then sorted), so augmenting an evidence-bearing base can no longer anchor on or delete the evidence node.

## Tests
- New regression tests assert the registered projectors emit the declared edges while preserving the evidence node and its edge; they fail without this change.
- Focused package tests, `go build ./...`, `go vet`, and `make catalog-check sourcegen-check` (137/137 generateable) all pass.

## Notes / follow-ups
- Cross-family URN agreement (ensuring a relationship target resolves to a node another family actually projects) is a separate hardening follow-up.
