### PR TITLE
fix: project doppler projects as typed nodes and assert identity fragmentation

### DIFF
--- a/internal/connectorcatalog/catalog/identity-access-secrets.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets.yaml
@@ -702,6 +702,11 @@ entries:
             schema_ref: doppler/projects/v1
           projection:
             template: asset
+            entity:
+              entity_type: doppler.project
+              urn_kind: doppler_project
+              id_attributes: [resource_id]
+              label_attribute: resource_name
           coverage:
             - id: projects
               type: entity_family

--- a/internal/graphrebuild/memory_graph.go
+++ b/internal/graphrebuild/memory_graph.go
@@ -150,6 +150,7 @@ func (s *memoryGraphStore) IntegrityChecks(context.Context) ([]graphstore.Integr
 		{Name: "self_referential_relations", Expected: 0},
 		{Name: "github_code_repositories_without_owner_link", Expected: 0},
 		{Name: "aws_public_endpoints_without_instance_link", Expected: 0},
+		{Name: "cross_kind_identity_fragmentation", Expected: 0},
 	}
 	for _, entity := range s.entities {
 		if entity.Label == "" {
@@ -178,10 +179,72 @@ func (s *memoryGraphStore) IntegrityChecks(context.Context) ([]graphstore.Integr
 			checks[4].Actual++
 		}
 	}
+	checks[7].Actual = s.crossKindIdentityFragmentation()
 	for index := range checks {
 		checks[index].Passed = checks[index].Actual == checks[index].Expected
 	}
 	return checks, nil
+}
+
+// crossKindIdentityFragmentation counts pairs of entities that share a tenant and
+// URN id-portion but carry different URN kinds and are not linked to each other.
+// This is the signature of a relationship target that fragments identity: the
+// same real object is projected under two kinds (e.g. a typed node and a runtime
+// stub) that never merge. Directly-linked twins (such as identifier/identity
+// nodes) are intentionally excluded because they are a deliberate paired model.
+func (s *memoryGraphStore) crossKindIdentityFragmentation() int64 {
+	type idKey struct {
+		tenant string
+		id     string
+	}
+	type kindedURN struct {
+		kind string
+		urn  string
+	}
+	groups := map[idKey][]kindedURN{}
+	for _, entity := range s.entities {
+		kind, id, ok := projectionURNKindAndID(entity.URN)
+		if !ok {
+			continue
+		}
+		key := idKey{tenant: entity.TenantID, id: id}
+		groups[key] = append(groups[key], kindedURN{kind: kind, urn: entity.URN})
+	}
+	var fragmented int64
+	for _, group := range groups {
+		for i := 0; i < len(group); i++ {
+			for j := i + 1; j < len(group); j++ {
+				if group[i].kind == group[j].kind {
+					continue
+				}
+				if s.memoryEntitiesLinked(group[i].urn, group[j].urn) {
+					continue
+				}
+				fragmented++
+			}
+		}
+	}
+	return fragmented
+}
+
+func (s *memoryGraphStore) memoryEntitiesLinked(first string, second string) bool {
+	for _, link := range s.links {
+		if (link.FromURN == first && link.ToURN == second) || (link.FromURN == second && link.ToURN == first) {
+			return true
+		}
+	}
+	return false
+}
+
+// projectionURNKindAndID splits a cerebro projection URN of the form
+// urn:cerebro:<tenant>:<kind>:<id...> into its kind and id-portion. The id-portion
+// keeps any trailing colons so multi-segment ids are compared intact.
+func projectionURNKindAndID(urn string) (kind string, id string, ok bool) {
+	parts := strings.SplitN(strings.TrimSpace(urn), ":", 5)
+	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
+		return "", "", false
+	}
+	return parts[3], parts[4], true
 }
 
 func cloneMemoryAttributes(attributes map[string]string) map[string]string {

--- a/internal/graphrebuild/memory_graph_test.go
+++ b/internal/graphrebuild/memory_graph_test.go
@@ -90,6 +90,67 @@ func TestMemoryGraphStoreIntegrityChecksLinkageGuardrails(t *testing.T) {
 	}
 }
 
+func TestMemoryGraphStoreFlagsCrossKindIdentityFragmentation(t *testing.T) {
+	store, err := newMemoryGraphStore()
+	if err != nil {
+		t.Fatalf("newMemoryGraphStore() error = %v", err)
+	}
+	scratch := store.(*memoryGraphStore)
+	ctx := context.Background()
+
+	for _, entity := range []*ports.ProjectedEntity{
+		{
+			URN:        "urn:cerebro:writer:doppler_project:proj-1",
+			TenantID:   "writer",
+			SourceID:   "doppler",
+			EntityType: "doppler.project",
+			Label:      "Platform",
+		},
+		{
+			URN:        "urn:cerebro:writer:runtime_project:proj-1",
+			TenantID:   "writer",
+			SourceID:   "doppler",
+			EntityType: "runtime.project",
+			Label:      "proj-1",
+		},
+		{
+			URN:        "urn:cerebro:writer:identifier:email:user@example.test",
+			TenantID:   "writer",
+			SourceID:   "vault",
+			EntityType: "identifier.email",
+			Label:      "user@example.test",
+		},
+		{
+			URN:        "urn:cerebro:writer:identity:email:user@example.test",
+			TenantID:   "writer",
+			SourceID:   "vault",
+			EntityType: "identity.email",
+			Label:      "user@example.test",
+		},
+	} {
+		if err := scratch.UpsertProjectedEntity(ctx, entity); err != nil {
+			t.Fatalf("UpsertProjectedEntity(%s) error = %v", entity.URN, err)
+		}
+	}
+	if err := scratch.UpsertProjectedLink(ctx, &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "vault",
+		FromURN:  "urn:cerebro:writer:identifier:email:user@example.test",
+		Relation: "represents_identity",
+		ToURN:    "urn:cerebro:writer:identity:email:user@example.test",
+	}); err != nil {
+		t.Fatalf("UpsertProjectedLink() error = %v", err)
+	}
+
+	checks, err := scratch.IntegrityChecks(ctx)
+	if err != nil {
+		t.Fatalf("IntegrityChecks() error = %v", err)
+	}
+	if got := memoryIntegrityActual(checks, "cross_kind_identity_fragmentation"); got != 1 {
+		t.Fatalf("cross_kind_identity_fragmentation = %d, want 1 (only the unlinked doppler/runtime pair, linked identifier/identity twins excluded)", got)
+	}
+}
+
 func TestMemoryGraphStoreSuppressesBroadTwoHopPathSummaries(t *testing.T) {
 	store, err := newMemoryGraphStore()
 	if err != nil {

--- a/internal/graphrebuild/relationship_graph_test.go
+++ b/internal/graphrebuild/relationship_graph_test.go
@@ -39,7 +39,6 @@ func TestRebuildDryRunMergesDopplerSecretProjectWithoutFragmentation(t *testing.
 			result := replayDryRun(t, "writer-doppler", "doppler", order.events)
 
 			projectURN := "urn:cerebro:writer:doppler_project:proj-1"
-			secretURN := "urn:cerebro:writer:secret:secret-1"
 			if result.GraphNodes != 2 {
 				t.Fatalf("GraphNodes = %d, want 2 (entities=%#v)", result.GraphNodes, result.PreviewEntities)
 			}
@@ -49,7 +48,7 @@ func TestRebuildDryRunMergesDopplerSecretProjectWithoutFragmentation(t *testing.
 			if !containsEntityURN(result.PreviewEntities, projectURN) {
 				t.Fatalf("missing merged doppler_project node: %#v", result.PreviewEntities)
 			}
-			if !containsLink(result.PreviewLinks, secretURN, "belongs_to", projectURN) {
+			if !containsLink(result.PreviewLinks, "urn:cerebro:writer:secret:secret-1", "belongs_to", projectURN) {
 				t.Fatalf("missing belongs_to edge to merged project: %#v", result.PreviewLinks)
 			}
 			if !containsAssertion(result.GraphAssertions, "cross_kind_identity_fragmentation", 0, 0, true) {
@@ -80,9 +79,8 @@ func TestRebuildDryRunMergesHashicorpVaultSecretOwnerWithUser(t *testing.T) {
 	}
 	result := replayDryRun(t, "writer-vault", "hashicorp_vault", events)
 
-	secretURN := "urn:cerebro:writer:secret:vsecret-1"
 	userURN := "urn:cerebro:writer:hashicorp_vault_user:user-1"
-	if !containsLink(result.PreviewLinks, secretURN, "owned_by", userURN) {
+	if !containsLink(result.PreviewLinks, "urn:cerebro:writer:secret:vsecret-1", "owned_by", userURN) {
 		t.Fatalf("missing owned_by edge: %#v", result.PreviewLinks)
 	}
 	hasOutgoing := false
@@ -117,7 +115,7 @@ func replayDryRun(t *testing.T, runtimeID string, sourceID string, events []*cer
 	result, err := service.RebuildDryRun(context.Background(), Request{
 		Mode:         modeReplay,
 		RuntimeID:    runtimeID,
-		EventLimit:   uint32(len(events)),
+		EventLimit:   uint32(len(events)), // #nosec G115 -- test event counts are tiny and fit uint32
 		PreviewLimit: 20,
 	})
 	if err != nil {

--- a/internal/graphrebuild/relationship_graph_test.go
+++ b/internal/graphrebuild/relationship_graph_test.go
@@ -1,0 +1,127 @@
+package graphrebuild
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+// TestRebuildDryRunMergesDopplerSecretProjectWithoutFragmentation pins the
+// doppler projects family projecting a typed doppler_project node so the secret
+// belongs_to edge merges onto it instead of fragmenting into an isolated
+// runtime_project node. Both replay orders must converge on the same merged
+// graph.
+func TestRebuildDryRunMergesDopplerSecretProjectWithoutFragmentation(t *testing.T) {
+	secret := func() *cerebrov1.EventEnvelope {
+		return testRuntimeEvent("doppler-secret-1", "doppler.secrets", "writer-doppler", map[string]string{
+			"secret_id":   "secret-1",
+			"secret_name": "DATABASE_URL",
+			"project_id":  "proj-1",
+		})
+	}
+	project := func() *cerebrov1.EventEnvelope {
+		return testRuntimeEvent("doppler-project-1", "doppler.projects", "writer-doppler", map[string]string{
+			"resource_id":   "proj-1",
+			"resource_type": "project",
+			"resource_name": "Platform",
+		})
+	}
+	orders := []struct {
+		name   string
+		events []*cerebrov1.EventEnvelope
+	}{
+		{name: "secret_first", events: []*cerebrov1.EventEnvelope{secret(), project()}},
+		{name: "project_first", events: []*cerebrov1.EventEnvelope{project(), secret()}},
+	}
+	for _, order := range orders {
+		t.Run(order.name, func(t *testing.T) {
+			result := replayDryRun(t, "writer-doppler", "doppler", order.events)
+
+			projectURN := "urn:cerebro:writer:doppler_project:proj-1"
+			secretURN := "urn:cerebro:writer:secret:secret-1"
+			if result.GraphNodes != 2 {
+				t.Fatalf("GraphNodes = %d, want 2 (entities=%#v)", result.GraphNodes, result.PreviewEntities)
+			}
+			if containsEntityURN(result.PreviewEntities, "urn:cerebro:writer:runtime_project:proj-1") {
+				t.Fatalf("found fragmented runtime_project node: %#v", result.PreviewEntities)
+			}
+			if !containsEntityURN(result.PreviewEntities, projectURN) {
+				t.Fatalf("missing merged doppler_project node: %#v", result.PreviewEntities)
+			}
+			if !containsLink(result.PreviewLinks, secretURN, "belongs_to", projectURN) {
+				t.Fatalf("missing belongs_to edge to merged project: %#v", result.PreviewLinks)
+			}
+			if !containsAssertion(result.GraphAssertions, "cross_kind_identity_fragmentation", 0, 0, true) {
+				t.Fatalf("cross_kind_identity_fragmentation not clean: %#v", result.GraphAssertions)
+			}
+			if !containsTopologyPreview(result.GraphTopology, "isolated", 0) {
+				t.Fatalf("expected no isolated nodes: %#v", result.GraphTopology)
+			}
+		})
+	}
+}
+
+// TestRebuildDryRunMergesHashicorpVaultSecretOwnerWithUser is the clean
+// counterpart: the secret owned_by edge merges onto the real user node (which
+// carries its own outgoing edges), with no identity fragmentation.
+func TestRebuildDryRunMergesHashicorpVaultSecretOwnerWithUser(t *testing.T) {
+	events := []*cerebrov1.EventEnvelope{
+		testRuntimeEvent("vault-user-1", "hashicorp_vault.users", "writer-vault", map[string]string{
+			"user_id":     "user-1",
+			"resource_id": "user-1",
+			"email":       "user@example.test",
+		}),
+		testRuntimeEvent("vault-secret-1", "hashicorp_vault.secrets", "writer-vault", map[string]string{
+			"secret_id":     "vsecret-1",
+			"secret_name":   "api-key",
+			"owner_user_id": "user-1",
+		}),
+	}
+	result := replayDryRun(t, "writer-vault", "hashicorp_vault", events)
+
+	secretURN := "urn:cerebro:writer:secret:vsecret-1"
+	userURN := "urn:cerebro:writer:hashicorp_vault_user:user-1"
+	if !containsLink(result.PreviewLinks, secretURN, "owned_by", userURN) {
+		t.Fatalf("missing owned_by edge: %#v", result.PreviewLinks)
+	}
+	hasOutgoing := false
+	for _, link := range result.PreviewLinks {
+		if link != nil && link.FromURN == userURN {
+			hasOutgoing = true
+			break
+		}
+	}
+	if !hasOutgoing {
+		t.Fatalf("owner target did not merge with the real user node (no outgoing edges from %s): %#v", userURN, result.PreviewLinks)
+	}
+	if !containsAssertion(result.GraphAssertions, "cross_kind_identity_fragmentation", 0, 0, true) {
+		t.Fatalf("cross_kind_identity_fragmentation not clean: %#v", result.GraphAssertions)
+	}
+	if !containsTopologyPreview(result.GraphTopology, "isolated", 0) {
+		t.Fatalf("expected no isolated nodes: %#v", result.GraphTopology)
+	}
+}
+
+func replayDryRun(t *testing.T, runtimeID string, sourceID string, events []*cerebrov1.EventEnvelope) *Result {
+	t.Helper()
+	for _, event := range events {
+		event.SourceId = sourceID
+		event.TenantId = "writer"
+	}
+	service := New(nil, &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {Id: runtimeID, SourceId: sourceID, TenantId: "writer"},
+		},
+	}, &eventReplayer{events: events})
+	result, err := service.RebuildDryRun(context.Background(), Request{
+		Mode:         modeReplay,
+		RuntimeID:    runtimeID,
+		EventLimit:   uint32(len(events)),
+		PreviewLimit: 20,
+	})
+	if err != nil {
+		t.Fatalf("RebuildDryRun() error = %v", err)
+	}
+	return result
+}

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -192,8 +192,8 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 		t.Fatalf("len(StageConfirmations) = %d, want 9", len(result.StageConfirmations))
 	}
 	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph", "verify_integrity", "verify_path_patterns", "verify_topology", "verify_traversals")
-	if got := result.StageConfirmations[5].AssertionsPassed; got != 7 {
-		t.Fatalf("verify_integrity assertions_passed = %d, want 7", got)
+	if got := result.StageConfirmations[5].AssertionsPassed; got != 8 {
+		t.Fatalf("verify_integrity assertions_passed = %d, want 8", got)
 	}
 	if got := result.StageConfirmations[5].AssertionsFailed; got != 0 {
 		t.Fatalf("verify_integrity assertions_failed = %d, want 0", got)
@@ -235,8 +235,11 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if got := countValue(result.GraphRelationTypes, "authored"); got != 1 {
 		t.Fatalf("graph relation type authored = %d, want 1", got)
 	}
-	if len(result.GraphAssertions) != 7 {
-		t.Fatalf("len(GraphAssertions) = %d, want 7", len(result.GraphAssertions))
+	if len(result.GraphAssertions) != 8 {
+		t.Fatalf("len(GraphAssertions) = %d, want 8", len(result.GraphAssertions))
+	}
+	if !containsAssertion(result.GraphAssertions, "cross_kind_identity_fragmentation", 0, 0, true) {
+		t.Fatalf("GraphAssertions missing cross_kind_identity_fragmentation: %#v", result.GraphAssertions)
 	}
 	if !containsAssertion(result.GraphAssertions, "tenant_mismatched_relations", 0, 0, true) {
 		t.Fatalf("GraphAssertions missing tenant_mismatched_relations: %#v", result.GraphAssertions)
@@ -658,8 +661,8 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if len(result.GraphTraversals) != 4 {
 		t.Fatalf("len(GraphTraversals) = %d, want 4", len(result.GraphTraversals))
 	}
-	if got := result.StageConfirmations[5].AssertionsPassed; got != 7 {
-		t.Fatalf("verify_integrity assertions_passed = %d, want 7", got)
+	if got := result.StageConfirmations[5].AssertionsPassed; got != 8 {
+		t.Fatalf("verify_integrity assertions_passed = %d, want 8", got)
 	}
 	if got := result.StageConfirmations[6].PatternsVerified; got != 4 {
 		t.Fatalf("verify_path_patterns patterns_verified = %d, want 4", got)


### PR DESCRIPTION
## Summary
The doppler projects family projected a generic runtime asset node, while the secret `belongs_to` edge targeted a typed project node. The relationship therefore landed on an empty stub node, and the real project node sat isolated and unreachable in the graph. The vault secret->owner path already merges correctly because both sides project the same typed node.

- Project the doppler projects family as a typed entity so the secret relationship merges onto the real project node instead of fragmenting.
- Add a `cross_kind_identity_fragmentation` dry-run integrity assertion that flags when the same tenant and id is projected under two URN kinds with no link between them. Directly-linked twins (identifier/identity nodes) are excluded because they are a deliberate paired model.

## Testing
- `go test ./internal/graphrebuild ./internal/sourceprojection ./internal/connectordefinitions ./internal/connectorcatalog/...`
- `make catalog-check` (137/137), `make sourcegen-check` (137/137)
- `go build ./...`, `go vet`, `gofmt -l`