### PR TITLE
Narrow finding replay by event kind

### DIFF
--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -44,6 +44,12 @@ const (
 	jetstreamCanaryMinInterval = time.Minute
 )
 
+const (
+	replayStrategyEmptyStream       = "empty_stream"
+	replayStrategyLegacyReverseScan = "legacy_reverse_scan"
+	replayStrategySubjectIndex      = "subject_index"
+)
+
 var waitBeforePublishRetryFunc = waitBeforePublishRetry
 
 type publisher interface {
@@ -57,7 +63,8 @@ type replayManager interface {
 }
 
 type replayStream interface {
-	GetMsg(context.Context, uint64, ...jetstream.GetMsgOpt) (*jetstream.RawStreamMsg, error)
+	GetMsg(context.Context, uint64) (*jetstream.RawStreamMsg, error)
+	GetNextMsgForSubject(context.Context, uint64, string) (*jetstream.RawStreamMsg, error)
 }
 
 type publishTelemetry struct {
@@ -113,7 +120,19 @@ func (m *jetStreamReplayManager) Stream(ctx context.Context, stream string) (rep
 	if err != nil {
 		return nil, err
 	}
-	return streamRef, nil
+	return &jetStreamReplayStream{stream: streamRef}, nil
+}
+
+type jetStreamReplayStream struct {
+	stream jetstream.Stream
+}
+
+func (s *jetStreamReplayStream) GetMsg(ctx context.Context, seq uint64) (*jetstream.RawStreamMsg, error) {
+	return s.stream.GetMsg(ctx, seq)
+}
+
+func (s *jetStreamReplayStream) GetNextMsgForSubject(ctx context.Context, seq uint64, subject string) (*jetstream.RawStreamMsg, error) {
+	return s.stream.GetMsg(ctx, seq, jetstream.WithGetMsgSubject(subject))
 }
 
 // Log is the JetStream-backed append-log implementation.
@@ -670,51 +689,33 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		return nil, err
 	}
 	started := time.Now()
-	var scanned, missing, subjectMatched, decoded, matched uint64
-	candidates := make([]replayCandidate, 0, limit)
+	var candidates []replayCandidate
+	var scan replayScanStats
+	subjectFilters, useSubjectIndex, err := exactReplaySubjectFilters(prefix, request)
+	if err != nil {
+		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, 0, 0, 0, 0, 0, 0, ctx)))
+		return nil, err
+	}
 	if stream.State.LastSeq == 0 || stream.State.LastSeq < stream.State.FirstSeq {
+		recordJetStreamReplayMetrics(ctx, replayScanStats{strategy: replayStrategyEmptyStream, subjectFilterCount: len(subjectFilters)}, "completed", "", time.Since(started), 0)
 		endAttrs := streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, 0, 0, 0, 0, 0, 0, ctx)).
+			With(jetstreamReplayStrategyAttrs(replayStrategyEmptyStream, len(subjectFilters))).
 			WithField(telemetry.Field{Key: "events_returned", Value: 0}).
 			WithField(telemetry.Field{Key: "messaging.jetstream.replay.duration_ms", Value: time.Since(started).Milliseconds()})
 		jetstreamAnnotateMain(ctx, "replay", "completed", endAttrs)
 		telemetry.End(span, "completed", endAttrs)
 		return nil, nil
 	}
-	for seq := stream.State.LastSeq; ; seq-- {
-		scanned++
-		raw, err := streamRef.GetMsg(ctx, seq)
-		if err != nil {
-			if errors.Is(err, jetstream.ErrMsgNotFound) {
-				missing++
-				if seq == stream.State.FirstSeq {
-					break
-				}
-				continue
-			}
-			err = fmt.Errorf("get replay message %s:%d: %w", stream.Config.Name, seq, err)
-			jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, scanned, missing, subjectMatched, decoded, matched, seq, ctx)))
-			return nil, err
-		}
-		if raw != nil && replaySubjectMatchesAnyPrefix(raw.Subject, subjectPrefixes) {
-			subjectMatched++
-			event, err := decodeReplayEvent(raw)
-			if err != nil {
-				err = fmt.Errorf("decode replay message %s:%d: %w", stream.Config.Name, seq, err)
-				jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, scanned, missing, subjectMatched, decoded, matched, seq, ctx)))
-				return nil, err
-			}
-			decoded++
-			if matchesReplayRequest(event, request) {
-				matched++
-				candidates = append(candidates, replayCandidate{event: event, seq: seq})
-				if countAtLeastUint32(len(candidates), candidateLimit) {
-					break
-				}
-			}
-		}
-		if seq == stream.State.FirstSeq {
-			break
-		}
+	if useSubjectIndex {
+		candidates, scan, err = replaySubjectIndexed(ctx, stream.Config.Name, stream.State, streamRef, subjectFilters, request, candidateLimit)
+	} else {
+		scan.strategy = replayStrategyLegacyReverseScan
+		candidates, scan, err = replayLegacyReverse(ctx, stream.Config.Name, stream.State, streamRef, subjectPrefixes, request, candidateLimit)
+	}
+	if err != nil {
+		recordJetStreamReplayMetrics(ctx, scan, "failed", jetstreamErrorCategory(err), time.Since(started), 0)
+		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(scan.attrs(limit, candidateLimit, ctx)))
+		return nil, err
 	}
 	sort.SliceStable(candidates, func(i, j int) bool {
 		return replayCandidateNewer(candidates[i], candidates[j])
@@ -729,12 +730,143 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	for _, candidate := range candidates {
 		events = append(events, candidate.event)
 	}
-	endAttrs := streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, scanned, missing, subjectMatched, decoded, matched, 0, ctx)).
+	recordJetStreamReplayMetrics(ctx, scan, "completed", "", time.Since(started), len(events))
+	endAttrs := streamAttrs.With(scan.attrs(limit, candidateLimit, ctx)).
 		WithField(telemetry.Field{Key: "events_returned", Value: len(events)}).
 		WithField(telemetry.Field{Key: "messaging.jetstream.replay.duration_ms", Value: time.Since(started).Milliseconds()})
 	jetstreamAnnotateMain(ctx, "replay", "completed", endAttrs)
 	telemetry.End(span, "completed", endAttrs)
 	return events, nil
+}
+
+type replayScanStats struct {
+	scanned            uint64
+	missing            uint64
+	subjectMatched     uint64
+	decoded            uint64
+	matched            uint64
+	sequence           uint64
+	strategy           string
+	subjectFilterCount int
+}
+
+func (s replayScanStats) attrs(limit uint32, candidateLimit uint32, ctx context.Context) telemetry.Attributes {
+	strategy := strings.TrimSpace(s.strategy)
+	if strategy == "" {
+		strategy = replayStrategyLegacyReverseScan
+	}
+	return jetstreamReplayScanAttrs(limit, candidateLimit, s.scanned, s.missing, s.subjectMatched, s.decoded, s.matched, s.sequence, ctx).
+		With(jetstreamReplayStrategyAttrs(strategy, s.subjectFilterCount))
+}
+
+func replayLegacyReverse(ctx context.Context, streamName string, state jetstream.StreamState, stream replayStream, subjectPrefixes []string, request ports.ReplayRequest, candidateLimit uint32) ([]replayCandidate, replayScanStats, error) {
+	stats := replayScanStats{strategy: replayStrategyLegacyReverseScan}
+	candidates := make([]replayCandidate, 0, candidateLimit)
+	for seq := state.LastSeq; ; seq-- {
+		stats.scanned++
+		raw, err := stream.GetMsg(ctx, seq)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrMsgNotFound) {
+				stats.missing++
+				if seq == state.FirstSeq {
+					break
+				}
+				continue
+			}
+			stats.sequence = seq
+			return nil, stats, fmt.Errorf("get replay message %s:%d: %w", streamName, seq, err)
+		}
+		if raw != nil && replaySubjectMatchesAnyPrefix(raw.Subject, subjectPrefixes) {
+			stats.subjectMatched++
+			event, err := decodeReplayEvent(raw)
+			if err != nil {
+				stats.sequence = seq
+				return nil, stats, fmt.Errorf("decode replay message %s:%d: %w", streamName, seq, err)
+			}
+			stats.decoded++
+			if matchesReplayRequest(event, request) {
+				stats.matched++
+				candidates = append(candidates, replayCandidate{event: event, seq: seq})
+				if countAtLeastUint32(len(candidates), candidateLimit) {
+					break
+				}
+			}
+		}
+		if seq == state.FirstSeq {
+			break
+		}
+	}
+	return candidates, stats, nil
+}
+
+func replaySubjectIndexed(ctx context.Context, streamName string, state jetstream.StreamState, stream replayStream, subjects []string, request ports.ReplayRequest, candidateLimit uint32) ([]replayCandidate, replayScanStats, error) {
+	stats := replayScanStats{strategy: replayStrategySubjectIndex, subjectFilterCount: len(subjects)}
+	candidates := make([]replayCandidate, 0, candidateLimit)
+	for _, subject := range subjects {
+		for seq := state.FirstSeq; seq <= state.LastSeq; {
+			raw, err := stream.GetNextMsgForSubject(ctx, seq, subject)
+			if err != nil {
+				if errors.Is(err, jetstream.ErrMsgNotFound) {
+					stats.missing++
+					break
+				}
+				stats.sequence = seq
+				return nil, stats, fmt.Errorf("get replay message %s:%d subject %q: %w", streamName, seq, subject, err)
+			}
+			if raw == nil || raw.Sequence == 0 || raw.Sequence > state.LastSeq {
+				stats.missing++
+				break
+			}
+			if raw.Sequence < seq {
+				stats.sequence = seq
+				return nil, stats, fmt.Errorf("get replay message %s:%d subject %q returned older sequence %d", streamName, seq, subject, raw.Sequence)
+			}
+			stats.scanned++
+			stats.subjectMatched++
+			event, err := decodeReplayEvent(raw)
+			if err != nil {
+				stats.sequence = raw.Sequence
+				return nil, stats, fmt.Errorf("decode replay message %s:%d: %w", streamName, raw.Sequence, err)
+			}
+			stats.decoded++
+			if matchesReplayRequest(event, request) {
+				stats.matched++
+				candidates = appendNewestReplayCandidate(candidates, replayCandidate{event: event, seq: raw.Sequence}, candidateLimit)
+			}
+			if raw.Sequence == ^uint64(0) {
+				break
+			}
+			seq = raw.Sequence + 1
+		}
+	}
+	return candidates, stats, nil
+}
+
+func appendNewestReplayCandidate(candidates []replayCandidate, candidate replayCandidate, candidateLimit uint32) []replayCandidate {
+	candidates = append(candidates, candidate)
+	if countGreaterThanUint32(len(candidates), candidateLimit) {
+		sort.SliceStable(candidates, func(i, j int) bool {
+			return replayCandidateNewer(candidates[i], candidates[j])
+		})
+		candidates = candidates[:candidateLimit]
+	}
+	return candidates
+}
+
+func recordJetStreamReplayMetrics(ctx context.Context, scan replayScanStats, status string, errorCategory string, duration time.Duration, returned int) {
+	observability.RecordJetStreamReplay(ctx, observability.JetStreamReplayMetrics{
+		Strategy:             scan.strategy,
+		Status:               status,
+		ErrorCategory:        errorCategory,
+		Duration:             duration,
+		Scanned:              scan.scanned,
+		Missing:              scan.missing,
+		SubjectMatched:       scan.subjectMatched,
+		Decoded:              scan.decoded,
+		Matched:              scan.matched,
+		Returned:             uint64(returned), // #nosec G115 -- returned is len(events), always non-negative.
+		SubjectFilterPresent: scan.subjectFilterCount > 0,
+	})
 }
 
 func (l *Log) shouldRunCanary(now time.Time) bool {
@@ -920,6 +1052,19 @@ func jetstreamReplayScanAttrs(limit uint32, candidateLimit uint32, scanned uint6
 	return attrs
 }
 
+func jetstreamReplayStrategyAttrs(strategy string, subjectFilterCount int) telemetry.Attributes {
+	strategy = strings.TrimSpace(strategy)
+	if strategy == "" {
+		strategy = replayStrategyLegacyReverseScan
+	}
+	return telemetry.Attrs(
+		telemetry.Field{Key: "messaging.jetstream.replay.strategy", Value: strategy},
+		telemetry.Field{Key: "messaging.jetstream.replay.subject_filter_count", Value: subjectFilterCount},
+		telemetry.Field{Key: "messaging.jetstream.replay.subject_indexed", Value: strategy == replayStrategySubjectIndex},
+		telemetry.Field{Key: "messaging.jetstream.replay.legacy_full_scan", Value: strategy == replayStrategyLegacyReverseScan},
+	)
+}
+
 func contextDeadlineBudgetMs(ctx context.Context) int64 {
 	deadline, ok := ctx.Deadline()
 	if !ok {
@@ -1066,6 +1211,31 @@ func replaySubjectPrefixes(prefix string, request ports.ReplayRequest) []string 
 		subjectPrefixes = append(subjectPrefixes, replaySubjectPrefix(prefix, kindPrefix))
 	}
 	return subjectPrefixes
+}
+
+func exactReplaySubjectFilters(prefix string, request ports.ReplayRequest) ([]string, bool, error) {
+	if !request.ExactKindFilters {
+		return nil, false, nil
+	}
+	kindPrefixes := replayKindPrefixes(request)
+	if len(kindPrefixes) == 0 {
+		return nil, false, nil
+	}
+	subjects := make([]string, 0, len(kindPrefixes))
+	seen := map[string]struct{}{}
+	for _, kindPrefix := range kindPrefixes {
+		subject, err := eventSubject(prefix, kindPrefix)
+		if err != nil {
+			return nil, false, err
+		}
+		if _, ok := seen[subject]; ok {
+			continue
+		}
+		seen[subject] = struct{}{}
+		subjects = append(subjects, subject)
+	}
+	sort.Strings(subjects)
+	return subjects, len(subjects) > 0, nil
 }
 
 func replaySubjectMatchesPrefix(subject string, prefix string) bool {
@@ -1237,12 +1407,13 @@ func normalizeReplayLimit(limit uint32) uint32 {
 
 func normalizeReplayRequest(req ports.ReplayRequest) ports.ReplayRequest {
 	normalized := ports.ReplayRequest{
-		RuntimeID:       strings.TrimSpace(req.RuntimeID),
-		KindPrefix:      strings.TrimSpace(req.KindPrefix),
-		KindPrefixes:    normalizeReplayKindPrefixes(req.KindPrefixes),
-		TenantID:        strings.TrimSpace(req.TenantID),
-		AttributeEquals: make(map[string]string, len(req.AttributeEquals)),
-		Limit:           req.Limit,
+		RuntimeID:        strings.TrimSpace(req.RuntimeID),
+		KindPrefix:       strings.TrimSpace(req.KindPrefix),
+		KindPrefixes:     normalizeReplayKindPrefixes(req.KindPrefixes),
+		ExactKindFilters: req.ExactKindFilters,
+		TenantID:         strings.TrimSpace(req.TenantID),
+		AttributeEquals:  make(map[string]string, len(req.AttributeEquals)),
+		Limit:            req.Limit,
 	}
 	for key, value := range req.AttributeEquals {
 		trimmedKey := strings.TrimSpace(key)

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -52,13 +54,14 @@ func (f *fakePublisher) PublishMsg(_ context.Context, msg *nats.Msg, _ ...natsje
 }
 
 type fakeReplayManager struct {
-	streams     []*natsjetstream.StreamInfo
-	msgs        map[string]map[uint64]*natsjetstream.RawStreamMsg
-	err         error
-	getMsgErr   error
-	msgFunc     func(stream string, seq uint64) *natsjetstream.RawStreamMsg
-	streamCalls int
-	getMsgCalls int
+	streams      []*natsjetstream.StreamInfo
+	msgs         map[string]map[uint64]*natsjetstream.RawStreamMsg
+	err          error
+	getMsgErr    error
+	msgFunc      func(stream string, seq uint64) *natsjetstream.RawStreamMsg
+	streamCalls  int
+	getMsgCalls  int
+	nextForCalls int
 }
 
 func (f *fakeReplayManager) Streams(context.Context) ([]*natsjetstream.StreamInfo, error) {
@@ -79,7 +82,7 @@ type fakeReplayStream struct {
 	msgs    map[uint64]*natsjetstream.RawStreamMsg
 }
 
-func (f *fakeReplayStream) GetMsg(_ context.Context, seq uint64, _ ...natsjetstream.GetMsgOpt) (*natsjetstream.RawStreamMsg, error) {
+func (f *fakeReplayStream) GetMsg(_ context.Context, seq uint64) (*natsjetstream.RawStreamMsg, error) {
 	if f.manager != nil {
 		f.manager.getMsgCalls++
 		if f.manager.getMsgErr != nil {
@@ -93,7 +96,40 @@ func (f *fakeReplayStream) GetMsg(_ context.Context, seq uint64, _ ...natsjetstr
 	if raw == nil {
 		return nil, natsjetstream.ErrMsgNotFound
 	}
-	return raw, nil
+	cloned := *raw
+	if cloned.Sequence == 0 {
+		cloned.Sequence = seq
+	}
+	return &cloned, nil
+}
+
+func (f *fakeReplayStream) GetNextMsgForSubject(_ context.Context, seq uint64, subject string) (*natsjetstream.RawStreamMsg, error) {
+	if f.manager != nil {
+		f.manager.nextForCalls++
+		if f.manager.getMsgErr != nil {
+			return nil, f.manager.getMsgErr
+		}
+	}
+	maxSeq := seq
+	for current := range f.msgs {
+		if current > maxSeq {
+			maxSeq = current
+		}
+	}
+	for current := seq; current <= maxSeq; current++ {
+		raw := f.msgs[current]
+		if raw == nil && f.manager != nil && f.manager.msgFunc != nil {
+			raw = f.manager.msgFunc(f.stream, current)
+		}
+		if raw != nil && raw.Subject == subject {
+			cloned := *raw
+			if cloned.Sequence == 0 {
+				cloned.Sequence = current
+			}
+			return &cloned, nil
+		}
+	}
+	return nil, natsjetstream.ErrMsgNotFound
 }
 
 func captureJetstreamTelemetry(t *testing.T, fn func()) string {
@@ -829,6 +865,89 @@ func TestReplayFiltersEventsByRuntime(t *testing.T) {
 	}
 }
 
+func TestReplayExactKindFiltersUseSubjectIndex(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{
+					Name:     "CEREBRO_EVENTS",
+					Subjects: []string{"events.>"},
+				},
+				State: natsjetstream.StreamState{FirstSeq: 1, LastSeq: 5, Msgs: 5},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				2: rawReplayMsg(t, "events.github.pull_request", replayEvent("evt-2", "github.pull_request", "writer-github")),
+				3: rawReplayMsg(t, "events.github.audit", replayEvent("evt-3", "github.audit", "other-runtime")),
+				4: rawReplayMsg(t, "events.github.audit", replayEvent("evt-4", "github.audit", "writer-github")),
+				5: rawReplayMsg(t, "events.ignored", replayEvent("evt-5", "ignored", "writer-github")),
+			},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	stderr := captureJetstreamTelemetry(t, func() {
+		events, err := log.Replay(context.Background(), ports.ReplayRequest{
+			RuntimeID:        "writer-github",
+			KindPrefixes:     []string{"github.audit"},
+			ExactKindFilters: true,
+			Limit:            2,
+		})
+		if err != nil {
+			t.Fatalf("Replay() error = %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("len(events) = %d, want 2", len(events))
+		}
+		if events[0].GetId() != "evt-1" || events[1].GetId() != "evt-4" {
+			t.Fatalf("replayed ids = [%q, %q], want [evt-1, evt-4]", events[0].GetId(), events[1].GetId())
+		}
+	})
+
+	if replay.getMsgCalls != 0 {
+		t.Fatalf("legacy GetMsg calls = %d, want 0", replay.getMsgCalls)
+	}
+	if replay.nextForCalls == 0 {
+		t.Fatal("NextFor subject calls = 0, want subject-index replay")
+	}
+	spanEnds := jetstreamTelemetryPayloads(t, stderr, "span_end", "jetstream.replay")
+	if len(spanEnds) != 1 {
+		t.Fatalf("jetstream.replay span_end events = %d, want 1; stderr=%s", len(spanEnds), stderr)
+	}
+	payload := spanEnds[0]
+	for key, want := range map[string]any{
+		"messaging.jetstream.replay.strategy":              replayStrategySubjectIndex,
+		"messaging.jetstream.replay.subject_indexed":       true,
+		"messaging.jetstream.replay.legacy_full_scan":      false,
+		"messaging.jetstream.replay.subject_filter_count":  float64(1),
+		"messaging.jetstream.replay.scanned_count":         float64(3),
+		"messaging.jetstream.replay.subject_matched_count": float64(3),
+		"messaging.jetstream.replay.decoded_count":         float64(3),
+		"messaging.jetstream.replay.matched_count":         float64(2),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+}
+
+func TestAppendNewestReplayCandidateKeepsNewestSequences(t *testing.T) {
+	var candidates []replayCandidate
+	for _, seq := range []uint64{100, 1, 2, 3, 101, 4} {
+		candidates = appendNewestReplayCandidate(candidates, replayCandidate{seq: seq}, 3)
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].seq < candidates[j].seq
+	})
+	got := []uint64{candidates[0].seq, candidates[1].seq, candidates[2].seq}
+	want := []uint64{4, 100, 101}
+	if !slices.Equal(got, want) {
+		t.Fatalf("kept sequences = %#v, want %#v", got, want)
+	}
+}
+
 func TestReplayEmitsScanTelemetry(t *testing.T) {
 	replay := &fakeReplayManager{
 		streams: []*natsjetstream.StreamInfo{
@@ -873,6 +992,9 @@ func TestReplayEmitsScanTelemetry(t *testing.T) {
 		"messaging.jetstream.replay.subject_matched_count": float64(2),
 		"messaging.jetstream.replay.decoded_count":         float64(2),
 		"messaging.jetstream.replay.matched_count":         float64(2),
+		"messaging.jetstream.replay.strategy":              replayStrategyLegacyReverseScan,
+		"messaging.jetstream.replay.subject_indexed":       false,
+		"messaging.jetstream.replay.legacy_full_scan":      true,
 		"events_returned":                                  float64(2),
 	} {
 		if got := payload[key]; got != want {

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -154,10 +154,7 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 	}
 	var events []*cerebrov1.EventEnvelope
 	if rulesNeedReplay(runtime, ruleEvaluationStatesFromCandidateStates(states)) {
-		events, err = s.replayer.Replay(ctx, ports.ReplayRequest{
-			RuntimeID: runtimeID,
-			Limit:     normalizedLimit,
-		})
+		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, rulesFromCandidateStates(states)))
 		if err != nil {
 			evaluationErr := fmt.Errorf("replay runtime %q events for candidates: %w", runtimeID, err)
 			return nil, s.markCandidateEvaluationsFailed(ctx, states, evaluationErr)
@@ -889,6 +886,17 @@ func ruleEvaluationStatesFromCandidateStates(states []*candidateRuleEvaluationSt
 			continue
 		}
 		out = append(out, &ruleEvaluationState{rule: state.rule})
+	}
+	return out
+}
+
+func rulesFromCandidateStates(states []*candidateRuleEvaluationState) []Rule {
+	out := make([]Rule, 0, len(states))
+	for _, state := range states {
+		if state == nil || state.rule == nil {
+			continue
+		}
+		out = append(out, state.rule)
 	}
 	return out
 }

--- a/internal/findings/security_reviewer_finding_rule_test.go
+++ b/internal/findings/security_reviewer_finding_rule_test.go
@@ -2,6 +2,7 @@ package findings
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -157,21 +158,22 @@ func TestSecurityReviewerFindingRuleEntersCandidateEvaluationPipeline(t *testing
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 	runtime := securityReviewerRuntime()
+	replayer := &stubReplayer{events: []*cerebrov1.EventEnvelope{
+		securityReviewerEvent("reviewer-finding-1", map[string]string{
+			"file":           "internal/bootstrap/app.go",
+			"line":           "42",
+			"message":        "handler accepts reviewer-controlled redirect target",
+			"repository":     "writer/cerebro",
+			"review_subject": "https://github.com/writer/cerebro/pull/1058",
+			"reviewer":       "security-reviewer",
+			"rule":           "open-redirect",
+			"severity":       "high",
+		}),
+	}}
 	store := &stubFindingStore{}
 	service := NewWithRegistry(
 		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{runtime.GetId(): runtime}},
-		&stubReplayer{events: []*cerebrov1.EventEnvelope{
-			securityReviewerEvent("reviewer-finding-1", map[string]string{
-				"file":           "internal/bootstrap/app.go",
-				"line":           "42",
-				"message":        "handler accepts reviewer-controlled redirect target",
-				"repository":     "writer/cerebro",
-				"review_subject": "https://github.com/writer/cerebro/pull/1058",
-				"reviewer":       "security-reviewer",
-				"rule":           "open-redirect",
-				"severity":       "high",
-			}),
-		}},
+		replayer,
 		store,
 		store,
 		store,
@@ -185,6 +187,12 @@ func TestSecurityReviewerFindingRuleEntersCandidateEvaluationPipeline(t *testing
 	})
 	if err != nil {
 		t.Fatalf("EvaluateSourceRuntimeCandidateRules() error = %v", err)
+	}
+	if !replayer.request.ExactKindFilters {
+		t.Fatal("Replay().ExactKindFilters = false, want true")
+	}
+	if got, want := replayer.request.KindPrefixes, []string{"security_reviewer.finding"}; !slices.Equal(got, want) {
+		t.Fatalf("Replay().KindPrefixes = %#v, want %#v", got, want)
 	}
 	if got := store.candidateState.upsertCount; got != 1 {
 		t.Fatalf("candidate upserts = %d, want 1", got)

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -311,10 +311,7 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	}
 	var events []*cerebrov1.EventEnvelope
 	if rule.SupportsRuntime(runtime) {
-		events, err = s.replayer.Replay(ctx, ports.ReplayRequest{
-			RuntimeID: runtimeID,
-			Limit:     normalizedLimit,
-		})
+		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, []Rule{rule}))
 		if err != nil {
 			evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
 			return nil, s.finishFailedRun(ctx, run, 0, 0, nil, evaluationErr)
@@ -448,10 +445,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 	}
 	var events []*cerebrov1.EventEnvelope
 	if rulesNeedReplay(runtime, states) {
-		events, err = s.replayer.Replay(ctx, ports.ReplayRequest{
-			RuntimeID: runtimeID,
-			Limit:     normalizedLimit,
-		})
+		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, rulesFromEvaluationStates(states)))
 		if err != nil {
 			evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
 			return nil, s.markRuleEvaluationsFailed(ctx, states, evaluationErr)
@@ -567,6 +561,74 @@ func rulesNeedReplay(runtime *cerebrov1.SourceRuntime, states []*ruleEvaluationS
 		}
 	}
 	return false
+}
+
+func replayRequestForRules(runtime *cerebrov1.SourceRuntime, runtimeID string, limit uint32, rules []Rule) ports.ReplayRequest {
+	request := ports.ReplayRequest{
+		RuntimeID: strings.TrimSpace(runtimeID),
+		Limit:     limit,
+	}
+	kindPrefixes := replayExactKindFiltersForRules(runtime, rules)
+	if len(kindPrefixes) > 0 {
+		request.KindPrefixes = kindPrefixes
+		request.ExactKindFilters = true
+	}
+	return request
+}
+
+func replayExactKindFiltersForRules(runtime *cerebrov1.SourceRuntime, rules []Rule) []string {
+	runtimeKind := strings.TrimSpace(runtimeConfiguredEventKind(runtime))
+	seen := map[string]struct{}{}
+	supportingRules := 0
+	for _, rule := range rules {
+		if rule == nil || !rule.SupportsRuntime(runtime) {
+			continue
+		}
+		supportingRules++
+		metadataRule, ok := rule.(MetadataRule)
+		if !ok {
+			return nil
+		}
+		definition := metadataRule.RuleMetadata()
+		if len(definition.EventKinds) == 0 {
+			return nil
+		}
+		matchedRuleKind := false
+		for _, rawKind := range definition.EventKinds {
+			kind := strings.TrimSpace(rawKind)
+			if kind == "" {
+				continue
+			}
+			if runtimeKind != "" && kind != runtimeKind {
+				continue
+			}
+			seen[kind] = struct{}{}
+			matchedRuleKind = true
+		}
+		if !matchedRuleKind {
+			return nil
+		}
+	}
+	if supportingRules == 0 {
+		return nil
+	}
+	kinds := make([]string, 0, len(seen))
+	for kind := range seen {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
+func rulesFromEvaluationStates(states []*ruleEvaluationState) []Rule {
+	rules := make([]Rule, 0, len(states))
+	for _, state := range states {
+		if state == nil || state.rule == nil {
+			continue
+		}
+		rules = append(rules, state.rule)
+	}
+	return rules
 }
 
 // ListFindings loads persisted findings for one runtime.

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -764,6 +764,96 @@ func (r *emittingRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
 	return ok
 }
 
+type metadataStubRule struct {
+	*stubRule
+	definition RuleDefinition
+}
+
+func (r *metadataStubRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
+func TestReplayExactKindFiltersForRulesIntersectRuntimeKind(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "writer-okta-policy-rule",
+		SourceId: "okta",
+		Config:   map[string]string{"family": "policy_rule"},
+	}
+	rules := []Rule{
+		&metadataStubRule{
+			stubRule: &stubRule{
+				spec:               &cerebrov1.RuleSpec{Id: "rule-a"},
+				supportedSourceIDs: map[string]struct{}{"okta": {}},
+			},
+			definition: RuleDefinition{EventKinds: []string{"okta.audit", "okta.policy_rule"}},
+		},
+		&metadataStubRule{
+			stubRule: &stubRule{
+				spec:               &cerebrov1.RuleSpec{Id: "rule-b"},
+				supportedSourceIDs: map[string]struct{}{"okta": {}},
+			},
+			definition: RuleDefinition{EventKinds: []string{"okta.policy_rule"}},
+		},
+		&metadataStubRule{
+			stubRule: &stubRule{
+				spec:               &cerebrov1.RuleSpec{Id: "rule-c"},
+				supportedSourceIDs: map[string]struct{}{"github": {}},
+			},
+			definition: RuleDefinition{EventKinds: []string{"github.audit"}},
+		},
+	}
+
+	request := replayRequestForRules(runtime, runtime.GetId(), 25, rules)
+	if !request.ExactKindFilters {
+		t.Fatal("ExactKindFilters = false, want true")
+	}
+	if got, want := request.KindPrefixes, []string{"okta.policy_rule"}; !slices.Equal(got, want) {
+		t.Fatalf("KindPrefixes = %#v, want %#v", got, want)
+	}
+	if got := request.RuntimeID; got != runtime.GetId() {
+		t.Fatalf("RuntimeID = %q, want %q", got, runtime.GetId())
+	}
+	if got := request.Limit; got != uint32(25) {
+		t.Fatalf("Limit = %d, want 25", got)
+	}
+}
+
+func TestReplayExactKindFiltersForRulesRequireSupportingRuleCoverage(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "writer-okta-policy-rule",
+		SourceId: "okta",
+		Config:   map[string]string{"family": "policy_rule"},
+	}
+	covered := &metadataStubRule{
+		stubRule: &stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "covered"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		definition: RuleDefinition{EventKinds: []string{"okta.policy_rule"}},
+	}
+	opaque := &stubRule{
+		spec:               &cerebrov1.RuleSpec{Id: "opaque"},
+		supportedSourceIDs: map[string]struct{}{"okta": {}},
+	}
+	if got := replayExactKindFiltersForRules(runtime, []Rule{covered, opaque}); len(got) != 0 {
+		t.Fatalf("replayExactKindFiltersForRules() with opaque supporting rule = %#v, want nil", got)
+	}
+
+	mismatched := &metadataStubRule{
+		stubRule: &stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "mismatched"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		definition: RuleDefinition{EventKinds: []string{"okta.audit"}},
+	}
+	if got := replayExactKindFiltersForRules(runtime, []Rule{covered, mismatched}); len(got) != 0 {
+		t.Fatalf("replayExactKindFiltersForRules() with uncovered metadata rule = %#v, want nil", got)
+	}
+}
+
 func (r *emittingRule) Evaluate(_ context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
 	if r == nil || runtime == nil || event == nil || strings.TrimSpace(event.GetId()) != strings.TrimSpace(r.triggerEventID) {
 		return nil, nil
@@ -1012,6 +1102,12 @@ func TestEvaluateSourceRuntimeFindingsReplaysOktaPolicyRuleLifecycleTampering(t 
 	}
 	if got := replayer.request.Limit; got != 25 {
 		t.Fatalf("Replay().Limit = %d, want 25", got)
+	}
+	if !replayer.request.ExactKindFilters {
+		t.Fatal("Replay().ExactKindFilters = false, want true")
+	}
+	if got, want := replayer.request.KindPrefixes, []string{"okta.policy_rule"}; !slices.Equal(got, want) {
+		t.Fatalf("Replay().KindPrefixes = %#v, want %#v", got, want)
 	}
 	if len(result.Findings) != 1 {
 		t.Fatalf("len(Findings) = %d, want 1", len(result.Findings))

--- a/internal/observability/domain_metrics.go
+++ b/internal/observability/domain_metrics.go
@@ -110,6 +110,31 @@ func otelJetStreamPublishMaxAttemptsExhausted() otelmetric.Int64Counter {
 	return instrument
 }
 
+func otelJetStreamReplayRequests() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.jetstream.replay.requests",
+		otelmetric.WithDescription("Total JetStream replay requests by strategy, status, and error category."),
+	)
+	return instrument
+}
+
+func otelJetStreamReplayDuration() otelmetric.Float64Histogram {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Float64Histogram(
+		"cerebro.jetstream.replay.duration",
+		otelmetric.WithDescription("JetStream replay duration by strategy, status, and error category."),
+		otelmetric.WithUnit("s"),
+	)
+	return instrument
+}
+
+func otelJetStreamReplayRecords() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.jetstream.replay.records",
+		otelmetric.WithDescription("JetStream replay records scanned, decoded, matched, missing, or returned."),
+	)
+	return instrument
+}
+
 // SourceRuntimeSyncMetrics is intentionally shaped for low-cardinality OTEL
 // metrics. Runtime IDs, tenant IDs, resource URNs, evidence IDs, request IDs,
 // and trace IDs belong in spans/wide events, not metric labels.
@@ -164,6 +189,23 @@ type JetStreamPublishMetrics struct {
 	Duration             time.Duration
 	RetryCount           int
 	MaxAttemptsExhausted bool
+}
+
+// JetStreamReplayMetrics is intentionally scoped to operational dimensions.
+// Runtime IDs, tenant IDs, event IDs, subjects, and request IDs belong in spans
+// and wide events rather than metric labels.
+type JetStreamReplayMetrics struct {
+	Strategy             string
+	Status               string
+	ErrorCategory        string
+	Duration             time.Duration
+	Scanned              uint64
+	Missing              uint64
+	SubjectMatched       uint64
+	Decoded              uint64
+	Matched              uint64
+	Returned             uint64
+	SubjectFilterPresent bool
 }
 
 func RecordSourceRuntimeSync(ctx context.Context, metrics SourceRuntimeSyncMetrics) {
@@ -237,6 +279,25 @@ func RecordJetStreamPublish(ctx context.Context, metrics JetStreamPublishMetrics
 	}
 }
 
+func RecordJetStreamReplay(ctx context.Context, metrics JetStreamReplayMetrics) {
+	attrs := []attribute.KeyValue{
+		attribute.String("strategy", boundedMetricValue(metrics.Strategy, "unknown")),
+		attribute.String("status", boundedMetricValue(metrics.Status, "unknown")),
+		attribute.String("error_category", boundedMetricValue(metrics.ErrorCategory, "none")),
+		attribute.Bool("subject_filter_present", metrics.SubjectFilterPresent),
+	}
+	otelJetStreamReplayRequests().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+	if metrics.Duration >= 0 {
+		otelJetStreamReplayDuration().Record(ctx, metrics.Duration.Seconds(), otelmetric.WithAttributes(attrs...))
+	}
+	recordJetStreamReplayRecordCount(ctx, attrs, "scanned", metrics.Scanned)
+	recordJetStreamReplayRecordCount(ctx, attrs, "missing", metrics.Missing)
+	recordJetStreamReplayRecordCount(ctx, attrs, "subject_matched", metrics.SubjectMatched)
+	recordJetStreamReplayRecordCount(ctx, attrs, "decoded", metrics.Decoded)
+	recordJetStreamReplayRecordCount(ctx, attrs, "matched", metrics.Matched)
+	recordJetStreamReplayRecordCount(ctx, attrs, "returned", metrics.Returned)
+}
+
 func recordSourceRuntimeRecordCount(ctx context.Context, base []attribute.KeyValue, kind string, count int64) {
 	if count <= 0 {
 		return
@@ -251,6 +312,14 @@ func recordSourceProjectionRecordCount(ctx context.Context, base []attribute.Key
 	}
 	attrs := append(cloneMetricAttributes(base), attribute.String("record.kind", kind))
 	otelSourceProjectionRecords().Add(ctx, count, otelmetric.WithAttributes(attrs...))
+}
+
+func recordJetStreamReplayRecordCount(ctx context.Context, base []attribute.KeyValue, kind string, count uint64) {
+	if count == 0 {
+		return
+	}
+	attrs := append(cloneMetricAttributes(base), attribute.String("record.kind", kind))
+	otelJetStreamReplayRecords().Add(ctx, boundedUint64ToInt64(count), otelmetric.WithAttributes(attrs...))
 }
 
 func cloneMetricAttributes(values []attribute.KeyValue) []attribute.KeyValue {
@@ -318,4 +387,12 @@ func maxInt64(value int64, minimum int64) int64 {
 		return minimum
 	}
 	return value
+}
+
+func boundedUint64ToInt64(value uint64) int64 {
+	const maxMetricInt64 = int64(1<<63 - 1)
+	if value > uint64(maxMetricInt64) {
+		return maxMetricInt64
+	}
+	return int64(value) // #nosec G115 -- value is capped above.
 }

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -16,12 +16,13 @@ type AppendLog interface {
 
 // ReplayRequest scopes a bounded event replay from the append log.
 type ReplayRequest struct {
-	RuntimeID       string
-	KindPrefix      string
-	KindPrefixes    []string
-	TenantID        string
-	AttributeEquals map[string]string
-	Limit           uint32
+	RuntimeID        string
+	KindPrefix       string
+	KindPrefixes     []string
+	ExactKindFilters bool
+	TenantID         string
+	AttributeEquals  map[string]string
+	Limit            uint32
 }
 
 // EventReplayer replays stored event envelopes from the append log.


### PR DESCRIPTION
## Summary
- Narrow finding-rule replay requests to exact event kinds from supporting rule metadata and runtime family, with safe fallback when any replayed rule is not fully covered.
- Use JetStream subject-index lookup for exact kind filters instead of reverse-scanning the full stream.
- Add replay strategy telemetry and low-cardinality OTEL replay metrics for scan volume, matches, returns, and failures.

## Validation
- `go test ./...`
- `make lint`
