### PR TITLE
Harden orchestration phase execution

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -299,6 +299,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 			telemetryField("job.run_duration_ms", time.Since(jobMeta.StartedAt).Milliseconds()),
 			telemetryField("orchestrator.status", status),
 		))
+		emitOrchestratorRunTerminalWideEvent(ctx, status, terminalAttrs)
 		if status == "completed" {
 			telemetry.Event(ctx, "platform.job.completed", terminalAttrs)
 		} else {
@@ -473,6 +474,37 @@ func orchestratorShutdownContext(options orchestratorOptions, fallback context.C
 	return fallback
 }
 
+func emitOrchestratorRunTerminalWideEvent(ctx context.Context, status string, attrs telemetry.Attributes) {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		status = "unknown"
+	}
+	telemetry.Event(ctx, "orchestrator.run.finished", telemetry.RuntimeAttributes().With(attrs).With(telemetry.Attrs(
+		telemetryField("event.dataset", "cerebro.wide_events"),
+		telemetryField("event.category", "operation"),
+		telemetryField("event.type", "end"),
+		telemetryField("event.outcome", orchestratorOutcomeForStatus(status)),
+		telemetryField("wide_event", true),
+		telemetryField("wide_event.contract", "orchestrator-run-terminal"),
+		telemetryField("operation.name", "orchestrator.run"),
+		telemetryField("operation.status", status),
+		telemetryField("status", status),
+	)))
+}
+
+func orchestratorOutcomeForStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "success", "succeeded":
+		return "success"
+	case "failed", "error":
+		return "failure"
+	case "skipped", "cancelled", "canceled":
+		return "neutral"
+	default:
+		return "unknown"
+	}
+}
+
 func runOrchestratorIteration(
 	ctx context.Context,
 	lister ports.SourceRuntimeListStore,
@@ -570,35 +602,45 @@ func runOrchestratorIteration(
 			continue
 		}
 		acquiredCount++
-		runtimeCtx, cancelRuntime := context.WithCancel(runtimeCtx)
-		stopLeaseRenewal := startOrchestratorRuntimeLeaseRenewal(ctx, leaser, runtime, leaseOwner, cancelRuntime)
+		syncCtx, cancelSync := context.WithCancel(runtimeCtx)
+		stopLeaseRenewal := startOrchestratorRuntimeLeaseRenewal(syncCtx, leaser, runtime, leaseOwner, cancelSync)
+		releaseSyncLease := func(stage string) bool {
+			cancelSync()
+			released := true
+			if err := stopLeaseRenewal(); err != nil {
+				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", err)
+				runErr = err
+				released = false
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error_kind", telemetry.ErrorKind(err))
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "source_runtime.lease_release_stage", stage)
+				captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "renew_lease", err)
+			}
+			if err := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); err != nil {
+				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", err)
+				runErr = err
+				released = false
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error_kind", telemetry.ErrorKind(err))
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "source_runtime.lease_release_stage", stage)
+				captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "release_lease", err)
+			}
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "source_runtime.lease_released_before_downstream", released)
+			return released
+		}
 		syncStartCursorOpaque := orchestratorRuntimeStartCursorOpaque(runtime)
 		syncStarted := time.Now()
-		emitOrchestratorJobPhaseStarted(runtimeCtx, "source_runtime.sync", iteration, runtime, 0)
-		syncResult, err := runtimeService.Sync(runtimeCtx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit})
+		emitOrchestratorJobPhaseStarted(syncCtx, "source_runtime.sync", iteration, runtime, 0)
+		syncResult, err := runtimeService.Sync(syncCtx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit})
 		if err != nil {
 			runtimeResult.Sync = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "sync", err)
 			runErr = err
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_stage", "sync")
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_kind", telemetry.ErrorKind(err))
-			emitOrchestratorJobPhaseEnded(runtimeCtx, "source_runtime.sync", "failed", iteration, runtime, time.Since(syncStarted), 0, telemetry.Attrs(
+			emitOrchestratorJobPhaseEnded(syncCtx, "source_runtime.sync", "failed", iteration, runtime, time.Since(syncStarted), 0, telemetry.Attrs(
 				telemetryField("error_kind", telemetry.ErrorKind(err)),
 			))
 			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "sync", err)
-			cancelRuntime()
-			if renewalErr := stopLeaseRenewal(); renewalErr != nil {
-				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", renewalErr)
-				runErr = renewalErr
-				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error_kind", telemetry.ErrorKind(renewalErr))
-				captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "renew_lease", renewalErr)
-			}
-			if releaseErr := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); releaseErr != nil {
-				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", releaseErr)
-				runErr = releaseErr
-				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error_kind", telemetry.ErrorKind(releaseErr))
-				captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "release_lease", releaseErr)
-			}
+			releaseSyncLease("sync_failed")
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
 			emitOrchestratorJobRuntimeEvent(runtimeCtx, "platform.job.runtime.failed", runtimeStatus, iteration, runtime, runtimeResult, runtimeSpanAttrs)
@@ -614,10 +656,17 @@ func runOrchestratorIteration(
 			}
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "pages_read", runtimeResult.PagesRead)
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "events_appended", runtimeResult.EventsAppended)
-			emitOrchestratorJobPhaseEnded(runtimeCtx, "source_runtime.sync", "completed", iteration, runtime, time.Since(syncStarted), 0, telemetry.Attrs(
+			emitOrchestratorJobPhaseEnded(syncCtx, "source_runtime.sync", "completed", iteration, runtime, time.Since(syncStarted), 0, telemetry.Attrs(
 				telemetryField("pages_read", runtimeResult.PagesRead),
 				telemetryField("events_appended", runtimeResult.EventsAppended),
 			))
+		}
+		if !releaseSyncLease("sync_completed") {
+			result.Runtimes = append(result.Runtimes, runtimeResult)
+			annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
+			emitOrchestratorJobRuntimeEvent(runtimeCtx, "platform.job.runtime.failed", runtimeStatus, iteration, runtime, runtimeResult, runtimeSpanAttrs)
+			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
+			continue
 		}
 		graphPageLimit := orchestratorGraphPageLimit(options.GraphPageLimit, runtimeResult.PagesRead)
 		resetGraphCheckpoint := runtimeResult.EventsAppended > 0 && syncStartCursorOpaque == ""
@@ -690,19 +739,6 @@ func runOrchestratorIteration(
 			runtimeResult.GraphRules = "skipped"
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_skip_reason", "graph_ingest_not_caught_up")
 		}
-		cancelRuntime()
-		if err := stopLeaseRenewal(); err != nil {
-			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", err)
-			runErr = err
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error_kind", telemetry.ErrorKind(err))
-			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "renew_lease", err)
-		}
-		if err := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); err != nil {
-			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", err)
-			runErr = err
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error_kind", telemetry.ErrorKind(err))
-			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "release_lease", err)
-		}
 		result.Runtimes = append(result.Runtimes, runtimeResult)
 		if runtimeResult.Error == "" {
 			runtimeStatus = "completed"
@@ -731,18 +767,17 @@ func runOrchestratorIteration(
 // runOrchestratorPhase wraps a single post-sync orchestrator step
 // (`finding_rules`, `graph_ingest`, `graph_rules`) with a named telemetry
 // span and a dedicated context timeout. The span surfaces a span_end
-// event per phase — without it, a stall between source_runtime.sync and
+// event per phase. Without it, a stall between source_runtime.sync and
 // orchestrator.runtime is opaque: there's no way to tell which step is
 // blocked from logs alone. The timeout decouples per-phase liveness from
-// the runtime-level lease TTL, so a single Neo4j tx waiting on a row
+// the source-sync lease TTL, so a single Neo4j tx waiting on a row
 // lock or a source.Read() retry storm can't park the iteration
 // indefinitely. On context deadline the phase returns
-// context.DeadlineExceeded, which the caller treats like any other
-// failure (lease releases, next iteration retries).
+// context.DeadlineExceeded, which the caller treats like any other failure.
 //
-// The phase context is derived from runtimeCtx so it still receives
-// lease-renewal cancellation. The generic R parameter lets each phase
-// return its own result type without an interface boxing dance.
+// The phase context is derived from runtimeCtx so it still receives parent
+// cancellation. The generic R parameter lets each phase return its own result
+// type without an interface boxing dance.
 func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iteration uint32, runtime *cerebrov1.SourceRuntime, timeout time.Duration, fn func(context.Context) (R, error)) (R, error) {
 	phaseCtx, cancel := context.WithTimeout(runtimeCtx, timeout)
 	defer cancel()

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -203,11 +203,39 @@ func TestRunOrchestratorPhaseEmitsPlatformJobPhaseEvents(t *testing.T) {
 	}
 }
 
+func TestEmitOrchestratorRunTerminalWideEvent(t *testing.T) {
+	stderr := captureCommandStderr(t, func() {
+		ctx, span := telemetry.StartMain(context.Background(), "orchestrator.run", telemetry.Attrs())
+		emitOrchestratorRunTerminalWideEvent(ctx, "completed", telemetry.Attrs(
+			telemetryField("job.id", "orchestrator-test-job"),
+		))
+		telemetry.End(span, "completed", telemetry.Attrs())
+	})
+
+	events := commandTelemetryPayloads(t, stderr, "event", "orchestrator.run.finished")
+	if len(events) != 1 {
+		t.Fatalf("orchestrator.run.finished events = %d, want 1; stderr=%s", len(events), stderr)
+	}
+	payload := events[0]
+	for key, want := range map[string]any{
+		"event.dataset":       "cerebro.wide_events",
+		"event.type":          "end",
+		"event.outcome":       "success",
+		"wide_event":          true,
+		"wide_event.contract": "orchestrator-run-terminal",
+		"operation.name":      "orchestrator.run",
+		"operation.status":    "completed",
+		"status":              "completed",
+		"job.id":              "orchestrator-test-job",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+}
+
 // runOrchestratorPhase must inherit cancellation from the parent runtime
-// context. The orchestrator's lease-renewal goroutine cancels the
-// runtime context when lease renewal fails, and that cancellation must
-// reach the phase function so it doesn't keep working with a stale
-// lease.
+// context so shutdown and caller cancellation reach phase work promptly.
 func TestRunOrchestratorPhaseInheritsParentCancellation(t *testing.T) {
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "github", TenantId: "writer"}
 	parent, cancel := context.WithCancel(context.Background())
@@ -656,6 +684,55 @@ func TestRunOrchestratorIterationRunsFindingRulesAfterGraphIngest(t *testing.T) 
 	linkKey := resourceURN + "|has_finding|urn:cerebro:writer:finding:finding-resource-aware"
 	if _, ok := graphStore.links[linkKey]; !ok {
 		t.Fatalf("finding resource link %q missing", linkKey)
+	}
+}
+
+func TestRunOrchestratorIterationReleasesLeaseBeforeGraphIngest(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	ruleRegistry, err := findings.NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() finding rule error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{
+			Id:       "runtime-1",
+			SourceId: "github",
+			TenantId: "writer",
+		},
+		acquired: true,
+	}
+	eventLog := &orchestratorEventLog{}
+	findingStore := &orchestratorFindingStore{}
+	graphStore := &releaseCheckingGraphStore{graphTestStore: newGraphTestStore(), store: store}
+
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(registry, store, eventLog, nil),
+		findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry),
+		graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore),
+		orchestratorOptions{},
+		1,
+	)
+	if err != nil {
+		t.Fatalf("runOrchestratorIteration() error = %v, want nil", err)
+	}
+	if got := len(result.Runtimes); got != 1 {
+		t.Fatalf("runtime result count = %d, want 1", got)
+	}
+	if !graphStore.checked {
+		t.Fatal("graph ingest did not project any entities")
+	}
+	if store.releaseID != "runtime-1" {
+		t.Fatalf("releaseID = %q, want runtime-1 before graph ingest", store.releaseID)
+	}
+	if result.Runtimes[0].GraphIngest != "completed" {
+		t.Fatalf("graph ingest status = %q, want completed", result.Runtimes[0].GraphIngest)
 	}
 }
 
@@ -1465,4 +1542,18 @@ type failingProjectionGraphStore struct {
 
 func (s *failingProjectionGraphStore) UpsertProjectedEntity(context.Context, *ports.ProjectedEntity) error {
 	return s.err
+}
+
+type releaseCheckingGraphStore struct {
+	*graphTestStore
+	store   *orchestratorRuntimeStore
+	checked bool
+}
+
+func (s *releaseCheckingGraphStore) UpsertProjectedEntity(ctx context.Context, entity *ports.ProjectedEntity) error {
+	s.checked = true
+	if s.store.releaseID == "" {
+		return errors.New("graph ingest started before runtime lease release")
+	}
+	return s.graphTestStore.UpsertProjectedEntity(ctx, entity)
 }

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -42,6 +42,7 @@ const (
 	publishRetryMaxElapsed     = 90 * time.Second
 	jetstreamCanaryKind        = "cerebro.health.jetstream_canary"
 	jetstreamCanaryMinInterval = time.Minute
+	replayScanWarningThreshold = 500_000
 )
 
 const (
@@ -714,6 +715,7 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	}
 	if err != nil {
 		recordJetStreamReplayMetrics(ctx, scan, "failed", jetstreamErrorCategory(err), time.Since(started), 0)
+		emitJetStreamReplayGuardrail(ctx, scan, time.Since(started), "failed", 0)
 		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(scan.attrs(limit, candidateLimit, ctx)))
 		return nil, err
 	}
@@ -731,6 +733,7 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		events = append(events, candidate.event)
 	}
 	recordJetStreamReplayMetrics(ctx, scan, "completed", "", time.Since(started), len(events))
+	emitJetStreamReplayGuardrail(ctx, scan, time.Since(started), "completed", len(events))
 	endAttrs := streamAttrs.With(scan.attrs(limit, candidateLimit, ctx)).
 		WithField(telemetry.Field{Key: "events_returned", Value: len(events)}).
 		WithField(telemetry.Field{Key: "messaging.jetstream.replay.duration_ms", Value: time.Since(started).Milliseconds()})
@@ -757,6 +760,31 @@ func (s replayScanStats) attrs(limit uint32, candidateLimit uint32, ctx context.
 	}
 	return jetstreamReplayScanAttrs(limit, candidateLimit, s.scanned, s.missing, s.subjectMatched, s.decoded, s.matched, s.sequence, ctx).
 		With(jetstreamReplayStrategyAttrs(strategy, s.subjectFilterCount))
+}
+
+func emitJetStreamReplayGuardrail(ctx context.Context, scan replayScanStats, duration time.Duration, status string, returned int) {
+	strategy := strings.TrimSpace(scan.strategy)
+	if strategy == "" {
+		strategy = replayStrategyLegacyReverseScan
+	}
+	legacyScan := strategy == replayStrategyLegacyReverseScan
+	highScan := scan.scanned >= replayScanWarningThreshold
+	if !legacyScan && !highScan {
+		return
+	}
+	telemetry.Event(ctx, "jetstream.replay.guardrail", telemetry.Attrs(
+		telemetry.Field{Key: "messaging.system", Value: "nats"},
+		telemetry.Field{Key: "messaging.operation", Value: "replay"},
+		telemetry.Field{Key: "messaging.jetstream.replay.strategy", Value: strategy},
+		telemetry.Field{Key: "messaging.jetstream.replay.legacy_full_scan", Value: legacyScan},
+		telemetry.Field{Key: "messaging.jetstream.replay.scanned_count", Value: scan.scanned},
+		telemetry.Field{Key: "messaging.jetstream.replay.scan_warning_threshold", Value: replayScanWarningThreshold},
+		telemetry.Field{Key: "messaging.jetstream.replay.high_scan", Value: highScan},
+		telemetry.Field{Key: "messaging.jetstream.replay.duration_ms", Value: duration.Milliseconds()},
+		telemetry.Field{Key: "events_returned", Value: returned},
+		telemetry.Field{Key: "status", Value: strings.TrimSpace(status)},
+		telemetry.Field{Key: "alert.recommended", Value: true},
+	))
 }
 
 func replayLegacyReverse(ctx context.Context, streamName string, state jetstream.StreamState, stream replayStream, subjectPrefixes []string, request ports.ReplayRequest, candidateLimit uint32) ([]replayCandidate, replayScanStats, error) {

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -1004,6 +1004,23 @@ func TestReplayEmitsScanTelemetry(t *testing.T) {
 	if _, ok := payload["messaging.jetstream.replay.duration_ms"].(float64); !ok {
 		t.Fatalf("replay duration missing: %#v", payload)
 	}
+	guardrails := jetstreamTelemetryPayloads(t, stderr, "event", "jetstream.replay.guardrail")
+	if len(guardrails) != 1 {
+		t.Fatalf("jetstream.replay.guardrail events = %d, want 1; stderr=%s", len(guardrails), stderr)
+	}
+	guardrail := guardrails[0]
+	for key, want := range map[string]any{
+		"messaging.jetstream.replay.strategy":         replayStrategyLegacyReverseScan,
+		"messaging.jetstream.replay.legacy_full_scan": true,
+		"messaging.jetstream.replay.scanned_count":    float64(3),
+		"messaging.jetstream.replay.high_scan":        false,
+		"alert.recommended":                           true,
+		"status":                                      "completed",
+	} {
+		if got := guardrail[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, guardrail)
+		}
+	}
 }
 
 func TestReplayAppliesDefaultLimit(t *testing.T) {

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -53,7 +53,9 @@ func (a *App) newJobService() *platformjobs.Service {
 	service.WithRunner(platformjobs.KindSourceRuntimeSync, a.runSourceRuntimeSyncJob)
 	service.WithRunner(platformjobs.KindSourceRuntimeOrchestrate, a.runSourceRuntimeOrchestrateJob)
 	service.WithRunner(platformjobs.KindGraphIngestRuntime, a.runGraphIngestRuntimeJob)
+	service.WithRunner(platformjobs.KindGraphRulesEvaluate, a.runGraphRulesEvaluateJob)
 	service.WithRunner(platformjobs.KindFindingRulesEvaluate, a.runFindingRulesEvaluateJob)
+	service.WithRunner(platformjobs.KindFindingCandidatesEvaluate, a.runFindingCandidatesEvaluateJob)
 	service.WithRunner(platformjobs.KindFindingsEvaluate, a.runFindingsEvaluateJob)
 	service.WithRunner(platformjobs.KindReportRun, a.runReportJob)
 	return service
@@ -228,22 +230,30 @@ func (a *App) runSourceRuntimeOrchestrateJob(ctx context.Context, job *ports.Job
 	if err != nil {
 		return nil, nil, err
 	}
-	graphPayload, err := json.Marshal(graphResult)
+	graphRulesResult, err := a.findingService().EvaluateSourceRuntimeGraphRules(ctx, findings.EvaluateGraphRulesRequest{
+		RuntimeID: runtimeID,
+		RuleIDs:   stringSlicePayload(job.Payload, "graph_rule_ids"),
+	})
 	if err != nil {
 		return nil, nil, err
 	}
-	graphOut := map[string]any{}
-	_ = json.Unmarshal(graphPayload, &graphOut)
-	rulePayload, err := json.Marshal(ruleResult)
+	graphOut, err := jsonResultMap(graphResult)
 	if err != nil {
 		return nil, nil, err
 	}
-	ruleOut := map[string]any{}
-	_ = json.Unmarshal(rulePayload, &ruleOut)
+	ruleOut, err := jsonResultMap(ruleResult)
+	if err != nil {
+		return nil, nil, err
+	}
+	graphRulesOut, err := jsonResultMap(graphRulesResult)
+	if err != nil {
+		return nil, nil, err
+	}
 	result := map[string]any{
 		"sync":          protoToMap(syncResponse),
 		"graph_ingest":  graphOut,
 		"finding_rules": ruleOut,
+		"graph_rules":   graphRulesOut,
 	}
 	refs := map[string]string{}
 	if graphResult.Run.ID != "" {
@@ -271,13 +281,25 @@ func (a *App) runGraphIngestRuntimeJob(ctx context.Context, job *ports.Job, _ *p
 	if result.Run.ID != "" {
 		refs["graph_ingest_run_id"] = result.Run.ID
 	}
-	payload, err := json.Marshal(result)
+	out, err := jsonResultMap(result)
+	return out, refs, err
+}
+
+func (a *App) runGraphRulesEvaluateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+	if runtimeID == "" {
+		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
+	}
+	result, err := a.findingService().EvaluateSourceRuntimeGraphRules(ctx, findings.EvaluateGraphRulesRequest{
+		RuntimeID: runtimeID,
+		RuleIDs:   stringSlicePayload(job.Payload, "rule_ids"),
+	})
 	if err != nil {
 		return nil, nil, err
 	}
-	out := map[string]any{}
-	_ = json.Unmarshal(payload, &out)
-	return out, refs, nil
+	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeGraph, grcCacheScopeInventory)
+	out, err := jsonResultMap(result)
+	return out, nil, err
 }
 
 func (a *App) runFindingRulesEvaluateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
@@ -294,13 +316,26 @@ func (a *App) runFindingRulesEvaluateJob(ctx context.Context, job *ports.Job, _ 
 		return nil, nil, err
 	}
 	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
-	payload, err := json.Marshal(result)
+	out, err := jsonResultMap(result)
+	return out, nil, err
+}
+
+func (a *App) runFindingCandidatesEvaluateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+	if runtimeID == "" {
+		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
+	}
+	result, err := a.findingService().EvaluateSourceRuntimeCandidateRules(ctx, findings.EvaluateCandidateRulesRequest{
+		RuntimeID:  runtimeID,
+		RuleIDs:    stringSlicePayload(job.Payload, "rule_ids"),
+		EventLimit: uint32Payload(job.Payload, "event_limit"),
+	})
 	if err != nil {
 		return nil, nil, err
 	}
-	out := map[string]any{}
-	_ = json.Unmarshal(payload, &out)
-	return out, nil, nil
+	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
+	out, err := jsonResultMap(result)
+	return out, nil, err
 }
 
 func (a *App) runFindingsEvaluateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
@@ -345,7 +380,7 @@ func authorizeJobCreate(ctx context.Context, store ports.StateStore, request cre
 		return "", err
 	}
 	switch strings.TrimSpace(request.Kind) {
-	case platformjobs.KindSourceRuntimeSync, platformjobs.KindSourceRuntimeOrchestrate, platformjobs.KindGraphIngestRuntime, platformjobs.KindFindingRulesEvaluate, platformjobs.KindFindingsEvaluate:
+	case platformjobs.KindSourceRuntimeSync, platformjobs.KindSourceRuntimeOrchestrate, platformjobs.KindGraphIngestRuntime, platformjobs.KindGraphRulesEvaluate, platformjobs.KindFindingRulesEvaluate, platformjobs.KindFindingCandidatesEvaluate, platformjobs.KindFindingsEvaluate:
 		runtimeID := stringPayload(request.Payload, "runtime_id", request.SubjectID)
 		runtimeTenantID, err := sourceRuntimeTenantID(ctx, sourceRuntimeStore(store), runtimeID, false)
 		if err != nil {
@@ -405,6 +440,16 @@ func protoToMap(message proto.Message) map[string]any {
 	out := map[string]any{}
 	_ = json.Unmarshal(payload, &out)
 	return out
+}
+
+func jsonResultMap(value any) (map[string]any, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]any{}
+	_ = json.Unmarshal(payload, &out)
+	return out, nil
 }
 
 func stringPayload(payload map[string]any, key string, fallback string) string {

--- a/internal/bootstrap/jobs_test.go
+++ b/internal/bootstrap/jobs_test.go
@@ -15,20 +15,48 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func TestAuthorizeJobCreateAllowsSourceRuntimeOrchestrate(t *testing.T) {
+func TestAuthorizeJobCreateAllowsRuntimePhaseJobs(t *testing.T) {
 	store := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
 		"runtime-1": {Id: "runtime-1", SourceId: "github", TenantId: "writer"},
 	}}
-	tenantID, err := authorizeJobCreate(context.Background(), store, createJobHTTPRequest{
-		Kind:     platformjobs.KindSourceRuntimeOrchestrate,
-		TenantID: "writer",
-		Payload:  map[string]any{"runtime_id": "runtime-1"},
-	})
-	if err != nil {
-		t.Fatalf("authorizeJobCreate() error = %v", err)
+	for _, kind := range []string{
+		platformjobs.KindSourceRuntimeOrchestrate,
+		platformjobs.KindGraphRulesEvaluate,
+		platformjobs.KindFindingCandidatesEvaluate,
+	} {
+		t.Run(kind, func(t *testing.T) {
+			tenantID, err := authorizeJobCreate(context.Background(), store, createJobHTTPRequest{
+				Kind:     kind,
+				TenantID: "writer",
+				Payload:  map[string]any{"runtime_id": "runtime-1"},
+			})
+			if err != nil {
+				t.Fatalf("authorizeJobCreate() error = %v", err)
+			}
+			if tenantID != "writer" {
+				t.Fatalf("authorizeJobCreate() tenantID = %q, want writer", tenantID)
+			}
+		})
 	}
-	if tenantID != "writer" {
-		t.Fatalf("authorizeJobCreate() tenantID = %q, want writer", tenantID)
+}
+
+func TestNewJobServiceRegistersRuntimePhaseJobs(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0"}, Dependencies{StateStore: newA2ATestJobStore()}, nil)
+	for _, kind := range []string{
+		platformjobs.KindGraphRulesEvaluate,
+		platformjobs.KindFindingCandidatesEvaluate,
+	} {
+		t.Run(kind, func(t *testing.T) {
+			_, _, err := app.jobService().Create(context.Background(), ports.CreateJobRequest{
+				Kind:      kind,
+				TenantID:  "writer",
+				SubjectID: "runtime-1",
+				Payload:   map[string]any{"runtime_id": "runtime-1"},
+			})
+			if err != nil {
+				t.Fatalf("Create(%s) error = %v", kind, err)
+			}
+		})
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,11 @@ const (
 )
 
 const (
+	DefaultNeo4jQueryTimeout = 2 * time.Minute
+	MaxNeo4jQueryTimeout     = 10 * time.Minute
+)
+
+const (
 	AppendLogDriverJetStream = "jetstream"
 	StateStoreDriverPostgres = "postgres"
 	GraphStoreDriverNeo4j    = "neo4j"
@@ -39,6 +44,7 @@ var (
 	errConfigValueConflict     = errors.New("config value and file are both set")
 	errInvalidOTLPEndpoint     = errors.New("invalid otlp endpoint")
 	errLegacyKuzuPath          = errors.New("CEREBRO_KUZU_PATH is no longer supported")
+	errNeo4jQueryTimeoutHigh   = errors.New("neo4j query timeout too high")
 	errUnsafeOTLPTransportMode = errors.New("unsafe otlp transport mode")
 )
 
@@ -592,7 +598,10 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	cfg.StateStore = ApplyPostgresPoolDefaults(cfg.StateStore)
-	if cfg.GraphStore.Neo4jQueryTimeout, err = parseDurationEnv("CEREBRO_NEO4J_QUERY_TIMEOUT", 0); err != nil {
+	if cfg.GraphStore.Neo4jQueryTimeout, err = parseDurationEnv("CEREBRO_NEO4J_QUERY_TIMEOUT", DefaultNeo4jQueryTimeout); err != nil {
+		return Config{}, err
+	}
+	if cfg.GraphStore.Neo4jQueryTimeout, err = EffectiveNeo4jQueryTimeout(cfg.GraphStore.Neo4jQueryTimeout); err != nil {
 		return Config{}, err
 	}
 	if cfg.GraphActions.AccessApprovals.Timeout, err = parseDurationEnv("CEREBRO_GRAPH_ACTIONS_ACCESS_APPROVALS_TIMEOUT", 10*time.Second); err != nil {
@@ -752,6 +761,16 @@ func ApplyPostgresPoolDefaults(cfg StateStoreConfig) StateStoreConfig {
 		cfg.PostgresConnMaxIdleTime = defaultPostgresConnMaxIdleTime
 	}
 	return cfg
+}
+
+func EffectiveNeo4jQueryTimeout(timeout time.Duration) (time.Duration, error) {
+	if timeout <= 0 {
+		timeout = DefaultNeo4jQueryTimeout
+	}
+	if timeout > MaxNeo4jQueryTimeout {
+		return 0, fmt.Errorf("%w: CEREBRO_NEO4J_QUERY_TIMEOUT must be at most %s", errNeo4jQueryTimeoutHigh, MaxNeo4jQueryTimeout)
+	}
+	return timeout, nil
 }
 
 func (cfg AuthConfig) HasCredentialMaterial() bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -105,6 +105,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.GraphStore.Driver != "" {
 		t.Fatalf("GraphStore.Driver = %q, want empty", cfg.GraphStore.Driver)
 	}
+	if cfg.GraphStore.Neo4jQueryTimeout != DefaultNeo4jQueryTimeout {
+		t.Fatalf("Neo4jQueryTimeout = %v, want %v", cfg.GraphStore.Neo4jQueryTimeout, DefaultNeo4jQueryTimeout)
+	}
 	if cfg.GraphAgentLLM.Provider != "" || cfg.GraphAgentLLM.MaxTokens != 0 {
 		t.Fatalf("GraphAgentLLM = %#v, want empty/default", cfg.GraphAgentLLM)
 	}
@@ -409,6 +412,19 @@ func TestLoadParsesMountedAPISecretFiles(t *testing.T) {
 	}
 	if got := cfg.Auth.CapabilityTokenSecrets; len(got) != 2 || got[0] != "secret-1" || got[1] != "secret-2" {
 		t.Fatalf("CapabilityTokenSecrets = %#v, want sorted mounted secrets", got)
+	}
+}
+
+func TestLoadRejectsExcessiveNeo4jQueryTimeout(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_NEO4J_QUERY_TIMEOUT", (MaxNeo4jQueryTimeout + time.Second).String())
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() error = nil, want excessive Neo4j query timeout error")
+	}
+	if !errors.Is(err, errNeo4jQueryTimeoutHigh) {
+		t.Fatalf("Load() error = %v, want %v", err, errNeo4jQueryTimeoutHigh)
 	}
 }
 

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -24,6 +24,7 @@ import (
 const defaultIngestRunListLimit = 25
 const maxAttributeMergeRetries = 5
 const defaultProjectionCleanupLimit = 1000
+const neo4jReadWarningThreshold = time.Minute
 const mergeEntityAndLoadAttributesQuery = `MERGE (e:Entity {urn: $urn})
 ON CREATE SET e.attributes_json = '{}', e.attributes_version = 0
 SET e.tenant_id = $tenant_id,
@@ -77,11 +78,15 @@ func Open(cfg config.GraphStoreConfig) (*Store, error) {
 		return nil, errors.New("neo4j password is required")
 	}
 	database := strings.TrimSpace(cfg.Neo4jDatabase)
+	queryTimeout, err := config.EffectiveNeo4jQueryTimeout(cfg.Neo4jQueryTimeout)
+	if err != nil {
+		return nil, err
+	}
 	driver, err := neo4jdriver.NewDriverWithContext(uri, neo4jdriver.BasicAuth(username, cfg.Neo4jPassword, ""))
 	if err != nil {
 		return nil, fmt.Errorf("open neo4j: %w", err)
 	}
-	return &Store{driver: driver, database: database, queryTimeout: cfg.Neo4jQueryTimeout}, nil
+	return &Store{driver: driver, database: database, queryTimeout: queryTimeout}, nil
 }
 
 // CloseContext closes the underlying driver.
@@ -1297,13 +1302,17 @@ func (s *Store) read(ctx context.Context, work func(context.Context, neo4jdriver
 	ctx, span := telemetry.Start(ctx, "neo4j.read", attrs)
 	session := s.driver.NewSession(ctx, neo4jdriver.SessionConfig{DatabaseName: s.database})
 	defer func() { _ = session.Close(ctx) }()
+	started := time.Now()
 	result, err := session.ExecuteRead(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
 		return work(ctx, tx)
 	})
+	duration := time.Since(started)
 	if err != nil {
+		emitNeo4jReadGuardrail(ctx, s.database, "failed", duration, s.queryTimeout, err)
 		neo4jTelemetryError(ctx, span, s.database, "read", err)
 		return nil, err
 	}
+	emitNeo4jReadGuardrail(ctx, s.database, "completed", duration, s.queryTimeout, nil)
 	neo4jAnnotateMain(ctx, s.database, "read", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return result, nil
@@ -1345,6 +1354,36 @@ func neo4jTelemetryError(ctx context.Context, span *telemetry.Span, database str
 		telemetry.Field{Key: "db.namespace", Value: strings.TrimSpace(database)},
 	))
 	telemetry.End(span, "failed", attrs)
+}
+
+func emitNeo4jReadGuardrail(ctx context.Context, database string, status string, duration time.Duration, timeout time.Duration, err error) {
+	slow := duration >= neo4jReadWarningThreshold
+	timedOut := errors.Is(err, context.DeadlineExceeded)
+	if timeout > 0 && duration >= timeout {
+		timedOut = true
+	}
+	if !slow && !timedOut {
+		return
+	}
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "component", Value: "graphstore.neo4j"},
+		telemetry.Field{Key: "operation", Value: "read"},
+		telemetry.Field{Key: "db.system.name", Value: "neo4j"},
+		telemetry.Field{Key: "db.namespace", Value: strings.TrimSpace(database)},
+		telemetry.Field{Key: "db.neo4j.read.duration_ms", Value: duration.Milliseconds()},
+		telemetry.Field{Key: "db.neo4j.read.warning_threshold_ms", Value: neo4jReadWarningThreshold.Milliseconds()},
+		telemetry.Field{Key: "db.neo4j.read.slow", Value: slow},
+		telemetry.Field{Key: "db.neo4j.read.timeout", Value: timedOut},
+		telemetry.Field{Key: "status", Value: strings.TrimSpace(status)},
+		telemetry.Field{Key: "alert.recommended", Value: true},
+	)
+	if timeout > 0 {
+		attrs = attrs.WithField(telemetry.Field{Key: "timeout_ms", Value: timeout.Milliseconds()})
+	}
+	if err != nil {
+		attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+	}
+	telemetry.Event(ctx, "neo4j.read.guardrail", attrs)
 }
 
 func neo4jAnnotateMain(ctx context.Context, database string, operation string, status string) {

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -30,6 +30,32 @@ func TestOpenRejectsIncompleteConfig(t *testing.T) {
 	}
 }
 
+func TestOpenAppliesEffectiveNeo4jQueryTimeout(t *testing.T) {
+	store, err := Open(config.GraphStoreConfig{
+		Neo4jURI:      "bolt://127.0.0.1:7687",
+		Neo4jUsername: "neo4j",
+		Neo4jPassword: "password",
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.CloseContext(context.Background())
+	})
+	if store.queryTimeout != config.DefaultNeo4jQueryTimeout {
+		t.Fatalf("query timeout = %v, want %v", store.queryTimeout, config.DefaultNeo4jQueryTimeout)
+	}
+
+	if _, err := Open(config.GraphStoreConfig{
+		Neo4jURI:          "bolt://127.0.0.1:7687",
+		Neo4jUsername:     "neo4j",
+		Neo4jPassword:     "password",
+		Neo4jQueryTimeout: config.MaxNeo4jQueryTimeout + time.Second,
+	}); err == nil {
+		t.Fatal("Open() error = nil, want excessive timeout error")
+	}
+}
+
 func TestProjectedEntityMergePreservesExistingLabelsForFallbackLabels(t *testing.T) {
 	if !strings.Contains(mergeEntityAndLoadAttributesQuery, "e.label = CASE WHEN $label <> $urn THEN $label ELSE coalesce(e.label, $label) END") {
 		t.Fatalf("entity merge does not preserve existing labels for fallback labels:\n%s", mergeEntityAndLoadAttributesQuery)

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -26,6 +26,7 @@ const (
 	KindSourceRuntimeSync         = "source_runtime_sync"
 	KindSourceRuntimeOrchestrate  = "source_runtime_orchestrate"
 	KindGraphIngestRuntime        = "graph_ingest_runtime"
+	KindGraphRulesEvaluate        = "graph_rules_evaluate"
 	KindFindingRulesEvaluate      = "finding_rules_evaluate"
 	KindFindingCandidatesEvaluate = "finding_candidates_evaluate"
 	KindFindingsEvaluate          = "findings_evaluate"
@@ -33,6 +34,8 @@ const (
 	KindVulnDBSyncJobRun          = "vulndb_sync_job_run"
 	KindGraphRebuildDryRun        = "graph_rebuild_dry_run"
 )
+
+const defaultJobHeartbeatInterval = 30 * time.Second
 
 type Runner func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error)
 
@@ -42,12 +45,13 @@ type Service struct {
 	now          func() time.Time
 	nextAsyncID  uint64
 	asyncCancels map[uint64]context.CancelFunc
+	asyncJobs    map[string]uint64
 	wg           sync.WaitGroup
 	mu           sync.Mutex
 }
 
 func New(store ports.JobStore) *Service {
-	return &Service{store: store, runners: map[string]Runner{}, now: func() time.Time { return time.Now().UTC() }, asyncCancels: map[uint64]context.CancelFunc{}}
+	return &Service{store: store, runners: map[string]Runner{}, now: func() time.Time { return time.Now().UTC() }, asyncCancels: map[uint64]context.CancelFunc{}, asyncJobs: map[string]uint64{}}
 }
 
 func (s *Service) WithRunner(kind string, runner Runner) *Service {
@@ -117,7 +121,13 @@ func (s *Service) StartAsync(ctx context.Context, job *ports.Job) { //nolint:con
 	if s.asyncCancels == nil {
 		s.asyncCancels = map[uint64]context.CancelFunc{}
 	}
+	if s.asyncJobs == nil {
+		s.asyncJobs = map[string]uint64{}
+	}
 	s.asyncCancels[asyncID] = cancel
+	if job.ID != "" {
+		s.asyncJobs[job.ID] = asyncID
+	}
 	s.wg.Add(1)
 	s.mu.Unlock()
 	go func() {
@@ -125,12 +135,30 @@ func (s *Service) StartAsync(ctx context.Context, job *ports.Job) { //nolint:con
 			cancel()
 			s.mu.Lock()
 			delete(s.asyncCancels, asyncID)
+			if job.ID != "" && s.asyncJobs[job.ID] == asyncID {
+				delete(s.asyncJobs, job.ID)
+			}
 			s.mu.Unlock()
 			s.wg.Done()
 		}()
 		telemetry.Event(runCtx, "platform.job.async_started", jobTelemetryAttrs(job).WithField(telemetry.Field{Key: "job.async_id", Value: asyncID}))
 		_ = s.Run(runCtx, job.ID)
 	}()
+}
+
+func (s *Service) cancelAsyncJob(jobID string) bool {
+	if s == nil || strings.TrimSpace(jobID) == "" {
+		return false
+	}
+	s.mu.Lock()
+	asyncID := s.asyncJobs[strings.TrimSpace(jobID)]
+	cancel := s.asyncCancels[asyncID]
+	s.mu.Unlock()
+	if cancel == nil {
+		return false
+	}
+	cancel()
+	return true
 }
 
 func (s *Service) Wait(ctx context.Context) error {
@@ -160,6 +188,49 @@ func (s *Service) Wait(ctx context.Context) error {
 		return nil
 	case <-ctxDone:
 		return ctx.Err()
+	}
+}
+
+func (s *Service) startHeartbeat(ctx context.Context, job *ports.Job) func() {
+	if s == nil || s.store == nil || job == nil {
+		return func() {}
+	}
+	heartbeatCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	var sequence uint64
+	emit := func() {
+		sequence++
+		payload := map[string]any{"sequence": sequence}
+		_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{
+			JobID:   job.ID,
+			Type:    "heartbeat",
+			Status:  ports.JobStatusRunning,
+			Message: "job heartbeat",
+			Payload: payload,
+		})
+		telemetry.Event(ctx, "platform.job.heartbeat", jobTelemetryAttrs(job).With(telemetry.Attrs(
+			telemetry.Field{Key: "job.status", Value: ports.JobStatusRunning},
+			telemetry.Field{Key: "job.heartbeat.sequence", Value: sequence},
+			telemetry.Field{Key: "job.heartbeat.at_unix_ms", Value: s.now().UnixMilli()},
+		)))
+	}
+	emit()
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(defaultJobHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-ticker.C:
+				emit()
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-done
 	}
 }
 
@@ -255,6 +326,8 @@ func (s *Service) Run(ctx context.Context, jobID string) (err error) {
 		telemetry.Field{Key: "job.queue_latency_ms", Value: jobQueueLatencyMs(job)},
 		telemetry.Field{Key: "job.runner.available", Value: true},
 	)))
+	stopHeartbeat := s.startHeartbeat(ctx, job)
+	defer stopHeartbeat()
 	result, refs, runErr := runner(ctx, job, s)
 	finished := s.now()
 	if runErr != nil {
@@ -382,9 +455,14 @@ func (s *Service) Cancel(ctx context.Context, jobID string) (*ports.Job, error) 
 		return nil, err
 	}
 	_, _ = s.store.AppendJobEvent(ctx, event)
+	cancelledAsync := false
+	if existing.Status == ports.JobStatusRunning {
+		cancelledAsync = s.cancelAsyncJob(existing.ID)
+	}
 	telemetry.Event(ctx, "platform.job.cancel_requested", jobTelemetryAttrs(job).With(telemetry.Attrs(
 		telemetry.Field{Key: "job.cancel_requested", Value: true},
 		telemetry.Field{Key: "job.cancel.transitioned_terminal", Value: event.Type == "cancelled"},
+		telemetry.Field{Key: "job.cancel.async_context_cancelled", Value: cancelledAsync},
 	)))
 	return job, nil
 }

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -194,6 +194,39 @@ func TestRunEmitsSinglePlatformJobFailedEvent(t *testing.T) {
 	}
 }
 
+func TestRunAppendsHeartbeatEvent(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-heartbeat"] = &ports.Job{
+		ID:     "job-heartbeat",
+		Kind:   KindReportRun,
+		Status: ports.JobStatusQueued,
+	}
+	service := New(store)
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		return nil, nil, nil
+	})
+
+	if err := service.Run(context.Background(), "job-heartbeat"); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	var heartbeat *ports.JobEvent
+	for _, event := range store.events {
+		if event.Type == "heartbeat" {
+			heartbeat = event
+			break
+		}
+	}
+	if heartbeat == nil {
+		t.Fatalf("heartbeat event missing: %#v", store.events)
+	}
+	if heartbeat.Status != ports.JobStatusRunning {
+		t.Fatalf("heartbeat status = %q, want running", heartbeat.Status)
+	}
+	if heartbeat.Payload["sequence"] != uint64(1) {
+		t.Fatalf("heartbeat sequence = %#v, want 1", heartbeat.Payload["sequence"])
+	}
+}
+
 func TestRunReportTelemetryFallsBackToSubjectID(t *testing.T) {
 	store := newMemoryJobStore()
 	store.jobs["job-report-telemetry"] = &ports.Job{
@@ -256,6 +289,49 @@ func TestStartAsyncDetachesFromRequestAndWaitCancelsJob(t *testing.T) {
 	case <-cancelled:
 	default:
 		t.Fatal("runner did not observe service cancellation")
+	}
+}
+
+func TestCancelRunningAsyncJobCancelsRunnerContext(t *testing.T) {
+	store := newMemoryJobStore()
+	service := New(store)
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	service.WithRunner(KindReportRun, func(ctx context.Context, _ *ports.Job, _ *Service) (map[string]any, map[string]string, error) {
+		close(started)
+		<-ctx.Done()
+		close(cancelled)
+		return nil, nil, ctx.Err()
+	})
+	job, created, err := service.Create(context.Background(), ports.CreateJobRequest{Kind: KindReportRun})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if !created {
+		t.Fatal("created = false, want true")
+	}
+	service.StartAsync(context.Background(), job)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("async job did not start")
+	}
+	cancelledJob, err := service.Cancel(context.Background(), job.ID)
+	if err != nil {
+		t.Fatalf("Cancel() error = %v", err)
+	}
+	if !cancelledJob.CancelRequested {
+		t.Fatal("CancelRequested = false, want true")
+	}
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not observe job cancellation")
+	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+	defer waitCancel()
+	if err := service.Wait(waitCtx); err != nil {
+		t.Fatalf("Wait() error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- scope CLI source-runtime leases to sync and release before graph/finding phases
- add compact terminal wide event plus alertable replay and Neo4j guardrail telemetry
- add Neo4j query timeout defaults/caps
- register graph-rules and candidate-evaluation platform job phases
- add durable job heartbeat events and propagate cancel to async runners

## Validation
- go test ./cmd/cerebro ./internal/config ./internal/graphstore/neo4j ./internal/appendlog/jetstream ./internal/jobs ./internal/bootstrap
- go test ./...
- make lint