### PR TITLE
feat: add flag-gated per-runtime append-log replay index

### DIFF
--- a/docs/operations/hosting.md
+++ b/docs/operations/hosting.md
@@ -215,6 +215,7 @@ Cerebro uses these values for proxy-aware URL reconstruction and DPoP `htu` vali
 | `CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED` | Optional total retry budget for retryable publishes. Keep it above observed stream restore time plus margin. |
 | `CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS`, `CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF`, `CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF`, `CEREBRO_JETSTREAM_PUBLISH_ATTEMPT_TIMEOUT` | Optional outer retry shape for NATS restarts, transient timeouts, and stream leader stalls. |
 | `CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_ATTEMPTS`, `CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_WAIT` | Optional inner NATS client retry shape used inside each outer publish attempt. |
+| `CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED` | Optional flag enabling the per-runtime append-log replay index for faster runtime-scoped replays. Default off; additive and backward compatible. |
 
 NATS JetStream should have durable storage, retention appropriate for replay needs, and monitoring for stream health, consumer lag, and disk pressure.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -172,6 +172,12 @@ the JSON-RPC contract, event subscription contract, and idempotency contract.
 Outbound webhook delivery remains a governed event contract until backed by a
 source/runtime adapter and durable delivery store.
 
+The append-log runtime replay index is populated by a global maintenance job
+whose scan-and-persist loop lives in `internal/appendlogindex`. The bootstrap
+budget includes only the job registration, admin authorization, payload
+adaptation, and dependency wiring that binds the append log's index source and
+the state store's index writer into that domain entry point.
+
 ## Postgres migrations
 
 State-store schema preparation runs at service startup and before store operations. Most migrations use additive `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, or `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` patterns.

--- a/docs/reference/config-env-vars.md
+++ b/docs/reference/config-env-vars.md
@@ -32,6 +32,7 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED` | `90s` | Optional total outer publish retry budget. Set above expected NATS restore time in environments with large streams. |
 | `CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_ATTEMPTS` | `5` | Optional NATS client retry attempts inside each outer publish attempt. |
 | `CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_WAIT` | `500ms` | Optional NATS client retry wait inside each outer publish attempt. |
+| `CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED` | unset | Optional flag enabling the per-runtime append-log replay index (schema, population job, and read path). Default off; additive and backward compatible. |
 | `CEREBRO_STATE_STORE_DRIVER` | inferred | State-store driver. Supported: `postgres`. |
 | `CEREBRO_POSTGRES_DSN` | unset | Postgres connection string. Setting this infers `postgres`. |
 | `CEREBRO_CONNECTOR_CREDENTIAL_KEY` | unset | High-entropy key used to seal Cerebro-managed connector credentials before storing them in Postgres. Supports `_FILE` via `CEREBRO_CONNECTOR_CREDENTIAL_KEY_FILE`. |

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -29,25 +29,28 @@ import (
 )
 
 const (
-	connectTimeout             = 5 * time.Second
-	defaultReplayLimit         = 100
-	maxReplayLimit             = 1000
-	maxReplayCandidates        = 5000
-	publishRetryAttempts       = 10
-	publishRetryInitialBackoff = 250 * time.Millisecond
-	publishRetryMaxBackoff     = 5 * time.Second
-	publishClientRetryAttempts = 5
-	publishClientRetryWait     = 500 * time.Millisecond
-	publishAttemptTimeout      = 30 * time.Second
-	publishRetryMaxElapsed     = 90 * time.Second
-	jetstreamCanaryKind        = "cerebro.health.jetstream_canary"
-	jetstreamCanaryMinInterval = time.Minute
+	connectTimeout               = 5 * time.Second
+	defaultReplayLimit           = 100
+	maxReplayLimit               = 1000
+	maxReplayCandidates          = 5000
+	publishRetryAttempts         = 10
+	publishRetryInitialBackoff   = 250 * time.Millisecond
+	publishRetryMaxBackoff       = 5 * time.Second
+	publishClientRetryAttempts   = 5
+	publishClientRetryWait       = 500 * time.Millisecond
+	publishAttemptTimeout        = 30 * time.Second
+	publishRetryMaxElapsed       = 90 * time.Second
+	jetstreamCanaryKind          = "cerebro.health.jetstream_canary"
+	jetstreamCanaryMinInterval   = time.Minute
+	defaultRuntimeIndexScanBatch = 1000
+	maxRuntimeIndexScanBatch     = 5000
 )
 
 const (
 	replayStrategyEmptyStream       = "empty_stream"
 	replayStrategyLegacyReverseScan = "legacy_reverse_scan"
 	replayStrategySubjectIndex      = "subject_index"
+	replayStrategyRuntimeIndex      = "runtime_index"
 )
 
 var waitBeforePublishRetryFunc = waitBeforePublishRetry
@@ -145,6 +148,18 @@ type Log struct {
 	publishRetry  publishRetryConfig
 	canaryMu      sync.Mutex
 	lastCanary    time.Time
+	runtimeIndex  ports.RuntimeReplayIndex
+}
+
+// SetRuntimeReplayIndex enables runtime-scoped replay acceleration backed by the
+// per-runtime append-log index. A nil index leaves replay on the subject/legacy
+// strategies. Replay stays correct regardless: the index only contributes
+// candidate sequences, and the un-indexed tail is always merged directly.
+func (l *Log) SetRuntimeReplayIndex(index ports.RuntimeReplayIndex) {
+	if l == nil {
+		return
+	}
+	l.runtimeIndex = index
 }
 
 // Open dials JetStream and returns an append-log implementation.
@@ -706,11 +721,20 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		telemetry.End(span, "completed", endAttrs)
 		return nil, nil
 	}
-	if useSubjectIndex {
-		candidates, scan, err = replaySubjectIndexed(ctx, stream.Config.Name, stream.State, streamRef, subjectFilters, request, candidateLimit)
-	} else {
-		scan.strategy = replayStrategyLegacyReverseScan
-		candidates, scan, err = replayLegacyReverse(ctx, stream.Config.Name, stream.State, streamRef, subjectPrefixes, request, candidateLimit)
+	resolved := false
+	if l.runtimeIndex != nil && request.RuntimeID != "" {
+		indexed, indexScan, ok, indexErr := replayRuntimeIndexed(ctx, l.runtimeIndex, stream.Config.Name, stream.State, streamRef, subjectFilters, useSubjectIndex, subjectPrefixes, request, candidateLimit)
+		if indexErr == nil && ok {
+			candidates, scan, resolved = indexed, indexScan, true
+		}
+	}
+	if !resolved {
+		if useSubjectIndex {
+			candidates, scan, err = replaySubjectIndexed(ctx, stream.Config.Name, stream.State, streamRef, subjectFilters, request, candidateLimit)
+		} else {
+			scan.strategy = replayStrategyLegacyReverseScan
+			candidates, scan, err = replayLegacyReverse(ctx, stream.Config.Name, stream.State, streamRef, subjectPrefixes, request, candidateLimit)
+		}
 	}
 	if err != nil {
 		recordJetStreamReplayMetrics(ctx, scan, "failed", jetstreamErrorCategory(err), time.Since(started), 0)
@@ -851,6 +875,187 @@ func appendNewestReplayCandidate(candidates []replayCandidate, candidate replayC
 		candidates = candidates[:candidateLimit]
 	}
 	return candidates
+}
+
+// replayRuntimeIndexed resolves a runtime-scoped replay from the per-runtime
+// index for the bulk of history, then always merges the un-indexed tail
+// (watermark, LastSeq] directly from the stream so events appended after the
+// asynchronous indexer's watermark are never missed (the sync-then-evaluate
+// orchestration relies on this). It returns ok=false without error when the
+// index is unpopulated so the caller falls back to the subject/legacy strategies.
+func replayRuntimeIndexed(ctx context.Context, index ports.RuntimeReplayIndex, streamName string, state jetstream.StreamState, stream replayStream, subjectFilters []string, useSubjectIndex bool, subjectPrefixes []string, request ports.ReplayRequest, candidateLimit uint32) ([]replayCandidate, replayScanStats, bool, error) {
+	stats := replayScanStats{strategy: replayStrategyRuntimeIndex, subjectFilterCount: len(subjectFilters)}
+	var kinds []string
+	if request.ExactKindFilters {
+		kinds = replayKindPrefixes(request)
+	}
+	lookup, err := index.LookupRuntimeReplay(ctx, ports.RuntimeIndexQuery{
+		RuntimeID: request.RuntimeID,
+		Kinds:     kinds,
+		Limit:     candidateLimit,
+	})
+	if err != nil {
+		return nil, stats, false, err
+	}
+	if !lookup.Available {
+		return nil, stats, false, nil
+	}
+	candidates := make([]replayCandidate, 0, candidateLimit)
+	seen := make(map[uint64]struct{}, candidateLimit)
+	for _, seq := range lookup.Sequences {
+		raw, err := stream.GetMsg(ctx, seq)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrMsgNotFound) {
+				stats.missing++
+				continue
+			}
+			stats.sequence = seq
+			return nil, stats, false, fmt.Errorf("get indexed replay message %s:%d: %w", streamName, seq, err)
+		}
+		if raw == nil {
+			stats.missing++
+			continue
+		}
+		stats.scanned++
+		stats.subjectMatched++
+		event, err := decodeReplayEvent(raw)
+		if err != nil {
+			stats.sequence = seq
+			return nil, stats, false, fmt.Errorf("decode indexed replay message %s:%d: %w", streamName, seq, err)
+		}
+		stats.decoded++
+		if !matchesReplayRequest(event, request) {
+			continue
+		}
+		stats.matched++
+		if _, ok := seen[seq]; ok {
+			continue
+		}
+		seen[seq] = struct{}{}
+		candidates = appendNewestReplayCandidate(candidates, replayCandidate{event: event, seq: seq}, candidateLimit)
+	}
+	if lookup.Watermark < state.LastSeq {
+		tailState := jetstream.StreamState{FirstSeq: lookup.Watermark + 1, LastSeq: state.LastSeq}
+		var (
+			tail     []replayCandidate
+			tailScan replayScanStats
+			tailErr  error
+		)
+		if useSubjectIndex {
+			tail, tailScan, tailErr = replaySubjectIndexed(ctx, streamName, tailState, stream, subjectFilters, request, candidateLimit)
+		} else {
+			tail, tailScan, tailErr = replayLegacyReverse(ctx, streamName, tailState, stream, subjectPrefixes, request, candidateLimit)
+		}
+		if tailErr != nil {
+			return nil, stats, false, tailErr
+		}
+		stats.scanned += tailScan.scanned
+		stats.missing += tailScan.missing
+		stats.subjectMatched += tailScan.subjectMatched
+		stats.decoded += tailScan.decoded
+		stats.matched += tailScan.matched
+		for _, candidate := range tail {
+			if _, ok := seen[candidate.seq]; ok {
+				continue
+			}
+			seen[candidate.seq] = struct{}{}
+			candidates = appendNewestReplayCandidate(candidates, candidate, candidateLimit)
+		}
+	}
+	return candidates, stats, true, nil
+}
+
+// ScanRuntimeIndex walks the stream forward from fromSeq, decoding up to batch
+// messages into per-runtime index entries. It skips the purged prefix via the
+// stream's FirstSeq and returns the new watermark (highest sequence examined),
+// letting the population job advance incrementally and idempotently.
+func (l *Log) ScanRuntimeIndex(ctx context.Context, fromSeq uint64, batch uint32) (ports.RuntimeIndexScan, error) {
+	ctx, span := telemetry.Start(ctx, "jetstream.runtime_index_scan", jetstreamTelemetryAttrs("runtime_index_scan"))
+	if l == nil || l.replay == nil {
+		err := errors.New("jetstream is not configured")
+		jetstreamTelemetryError(ctx, span, "runtime_index_scan", err)
+		return ports.RuntimeIndexScan{}, err
+	}
+	if batch == 0 {
+		batch = defaultRuntimeIndexScanBatch
+	}
+	if batch > maxRuntimeIndexScanBatch {
+		batch = maxRuntimeIndexScanBatch
+	}
+	stream, err := l.replayStream(ctx)
+	if err != nil {
+		jetstreamTelemetryError(ctx, span, "runtime_index_scan", err)
+		return ports.RuntimeIndexScan{}, err
+	}
+	lower := fromSeq
+	if first := stream.State.FirstSeq; first > 0 && lower+1 < first {
+		lower = first - 1
+	}
+	last := stream.State.LastSeq
+	if last == 0 || lower >= last {
+		watermark := lower
+		if watermark < fromSeq {
+			watermark = fromSeq
+		}
+		telemetry.End(span, "completed", telemetry.Attrs())
+		return ports.RuntimeIndexScan{Watermark: watermark, CaughtUp: true}, nil
+	}
+	streamRef, err := l.replay.Stream(ctx, stream.Config.Name)
+	if err != nil {
+		err = fmt.Errorf("open index scan stream %q: %w", stream.Config.Name, err)
+		jetstreamTelemetryError(ctx, span, "runtime_index_scan", err)
+		return ports.RuntimeIndexScan{}, err
+	}
+	end := lower + uint64(batch)
+	if end > last {
+		end = last
+	}
+	entries := make([]ports.RuntimeIndexEntry, 0, batch)
+	for seq := lower + 1; seq <= end; seq++ {
+		raw, err := streamRef.GetMsg(ctx, seq)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrMsgNotFound) {
+				continue
+			}
+			err = fmt.Errorf("get index scan message %s:%d: %w", stream.Config.Name, seq, err)
+			jetstreamTelemetryError(ctx, span, "runtime_index_scan", err)
+			return ports.RuntimeIndexScan{}, err
+		}
+		if raw == nil {
+			continue
+		}
+		event, err := decodeReplayEvent(raw)
+		if err != nil {
+			err = fmt.Errorf("decode index scan message %s:%d: %w", stream.Config.Name, seq, err)
+			jetstreamTelemetryError(ctx, span, "runtime_index_scan", err)
+			return ports.RuntimeIndexScan{}, err
+		}
+		if entry, ok := runtimeIndexEntry(event, raw.Sequence); ok {
+			entries = append(entries, entry)
+		}
+	}
+	telemetry.End(span, "completed", telemetry.Attrs())
+	return ports.RuntimeIndexScan{Entries: entries, Watermark: end, CaughtUp: end >= last}, nil
+}
+
+func runtimeIndexEntry(event *cerebrov1.EventEnvelope, seq uint64) (ports.RuntimeIndexEntry, bool) {
+	if event == nil {
+		return ports.RuntimeIndexEntry{}, false
+	}
+	runtimeID := strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID])
+	if runtimeID == "" {
+		return ports.RuntimeIndexEntry{}, false
+	}
+	entry := ports.RuntimeIndexEntry{
+		RuntimeID: runtimeID,
+		Seq:       seq,
+		TenantID:  strings.TrimSpace(event.GetTenantId()),
+		Kind:      strings.TrimSpace(event.GetKind()),
+	}
+	if occurredAt, ok := replayEventTime(event); ok {
+		entry.OccurredAt = occurredAt
+	}
+	return entry, true
 }
 
 func recordJetStreamReplayMetrics(ctx context.Context, scan replayScanStats, status string, errorCategory string, duration time.Duration, returned int) {

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -722,7 +722,7 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		return nil, nil
 	}
 	resolved := false
-	if l.runtimeIndex != nil && request.RuntimeID != "" {
+	if l.runtimeIndex != nil && runtimeIndexReplayEligible(request) {
 		indexed, indexScan, ok, indexErr := replayRuntimeIndexed(ctx, l.runtimeIndex, stream.Config.Name, stream.State, streamRef, subjectFilters, useSubjectIndex, subjectPrefixes, request, candidateLimit)
 		if indexErr == nil && ok {
 			candidates, scan, resolved = indexed, indexScan, true
@@ -875,6 +875,24 @@ func appendNewestReplayCandidate(candidates []replayCandidate, candidate replayC
 		candidates = candidates[:candidateLimit]
 	}
 	return candidates
+}
+
+// runtimeIndexReplayEligible reports whether a replay can be served from the
+// per-runtime index without risking dropped matches. The index narrows only by
+// runtime id and, in exact-kind mode, exact kinds. Any post-filter the index
+// does not apply (non-exact kind prefixes, attribute-equals, or a tenant
+// filter) could leave fewer than the requested limit of matches among the
+// newest indexed sequences while older matches sit below the watermark, so such
+// requests fall back to the subject/legacy strategies, which collect matched
+// candidates directly.
+func runtimeIndexReplayEligible(request ports.ReplayRequest) bool {
+	if request.RuntimeID == "" {
+		return false
+	}
+	if request.TenantID != "" || len(request.AttributeEquals) > 0 {
+		return false
+	}
+	return request.ExactKindFilters || len(replayKindPrefixes(request)) == 0
 }
 
 // replayRuntimeIndexed resolves a runtime-scoped replay from the per-runtime

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -1520,3 +1520,223 @@ func rawReplayMsg(t *testing.T, subject string, event *cerebrov1.EventEnvelope) 
 	}
 	return &natsjetstream.RawStreamMsg{Subject: subject, Data: payload}
 }
+
+type fakeRuntimeReplayIndex struct {
+	result ports.RuntimeIndexResult
+	err    error
+	query  ports.RuntimeIndexQuery
+	calls  int
+}
+
+func (f *fakeRuntimeReplayIndex) LookupRuntimeReplay(_ context.Context, query ports.RuntimeIndexQuery) (ports.RuntimeIndexResult, error) {
+	f.calls++
+	f.query = query
+	return f.result, f.err
+}
+
+func replayedEventIDs(events []*cerebrov1.EventEnvelope) []string {
+	ids := make([]string, 0, len(events))
+	for _, event := range events {
+		ids = append(ids, event.GetId())
+	}
+	return ids
+}
+
+func TestReplayRuntimeIndexedMergesUnindexedTail(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+				State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 5, Msgs: 5},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				2: rawReplayMsg(t, "events.github.audit", replayEvent("evt-2", "github.audit", "other-runtime")),
+				3: rawReplayMsg(t, "events.github.audit", replayEvent("evt-3", "github.audit", "writer-github")),
+				4: rawReplayMsg(t, "events.github.audit", replayEvent("evt-4", "github.audit", "other-runtime")),
+				5: rawReplayMsg(t, "events.github.audit", replayEvent("evt-5", "github.audit", "writer-github")),
+			},
+		},
+	}
+	index := &fakeRuntimeReplayIndex{result: ports.RuntimeIndexResult{Sequences: []uint64{3, 1}, Watermark: 3, Available: true}}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events", runtimeIndex: index}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 10})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if got, want := replayedEventIDs(events), []string{"evt-1", "evt-3", "evt-5"}; !slices.Equal(got, want) {
+		t.Fatalf("replayed ids = %#v, want %#v (index seqs plus tail-merged evt-5)", got, want)
+	}
+	if index.calls != 1 {
+		t.Fatalf("index lookup calls = %d, want 1", index.calls)
+	}
+	if index.query.RuntimeID != "writer-github" {
+		t.Fatalf("index query runtime = %q, want writer-github", index.query.RuntimeID)
+	}
+}
+
+func TestReplayRuntimeIndexedFallsBackWhenUnavailable(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+				State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 2, Msgs: 2},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				2: rawReplayMsg(t, "events.github.audit", replayEvent("evt-2", "github.audit", "other-runtime")),
+			},
+		},
+	}
+	index := &fakeRuntimeReplayIndex{result: ports.RuntimeIndexResult{Available: false}}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events", runtimeIndex: index}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 10})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if got, want := replayedEventIDs(events), []string{"evt-1"}; !slices.Equal(got, want) {
+		t.Fatalf("replayed ids = %#v, want %#v via fallback", got, want)
+	}
+	if index.calls != 1 {
+		t.Fatalf("index lookup calls = %d, want 1", index.calls)
+	}
+}
+
+func TestReplayRuntimeIndexedSkipsPurgedSequences(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+				State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 3, Msgs: 2},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				3: rawReplayMsg(t, "events.github.audit", replayEvent("evt-3", "github.audit", "writer-github")),
+			},
+		},
+	}
+	index := &fakeRuntimeReplayIndex{result: ports.RuntimeIndexResult{Sequences: []uint64{3, 2}, Watermark: 3, Available: true}}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events", runtimeIndex: index}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 10})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if got, want := replayedEventIDs(events), []string{"evt-3"}; !slices.Equal(got, want) {
+		t.Fatalf("replayed ids = %#v, want %#v (seq 2 purged by retention)", got, want)
+	}
+}
+
+func TestReplayRuntimeIndexedExactKindsUseSubjectTail(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+				State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 4, Msgs: 4},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				2: rawReplayMsg(t, "events.github.pull_request", replayEvent("evt-2", "github.pull_request", "writer-github")),
+				3: rawReplayMsg(t, "events.github.audit", replayEvent("evt-3", "github.audit", "writer-github")),
+				4: rawReplayMsg(t, "events.github.audit", replayEvent("evt-4", "github.audit", "writer-github")),
+			},
+		},
+	}
+	index := &fakeRuntimeReplayIndex{result: ports.RuntimeIndexResult{Sequences: []uint64{1}, Watermark: 2, Available: true}}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events", runtimeIndex: index}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{
+		RuntimeID:        "writer-github",
+		KindPrefixes:     []string{"github.audit"},
+		ExactKindFilters: true,
+		Limit:            10,
+	})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if got, want := replayedEventIDs(events), []string{"evt-1", "evt-3", "evt-4"}; !slices.Equal(got, want) {
+		t.Fatalf("replayed ids = %#v, want %#v", got, want)
+	}
+	if got, want := index.query.Kinds, []string{"github.audit"}; !slices.Equal(got, want) {
+		t.Fatalf("index query kinds = %#v, want %#v", got, want)
+	}
+	if replay.nextForCalls == 0 {
+		t.Fatal("subject-index tail expected to use GetNextMsgForSubject")
+	}
+}
+
+func TestScanRuntimeIndexCollectsRuntimeEntries(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+				State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 4, Msgs: 4},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				2: rawReplayMsg(t, "events.github.audit", replayEvent("evt-2", "github.audit", "other-runtime")),
+				3: rawReplayMsg(t, "events.github.audit", replayEvent("evt-3", "github.audit", "writer-github")),
+				4: rawReplayMsg(t, "events.ignored", replayEvent("evt-4", "ignored", "")),
+			},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	scan, err := log.ScanRuntimeIndex(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatalf("ScanRuntimeIndex() error = %v", err)
+	}
+	if scan.Watermark != 4 || !scan.CaughtUp {
+		t.Fatalf("scan watermark/caughtUp = %d/%v, want 4/true", scan.Watermark, scan.CaughtUp)
+	}
+	if len(scan.Entries) != 3 {
+		t.Fatalf("scan entries = %d, want 3 (empty-runtime message skipped)", len(scan.Entries))
+	}
+	first := scan.Entries[0]
+	if first.RuntimeID != "writer-github" || first.Seq != 1 || first.Kind != "github.audit" {
+		t.Fatalf("first entry = %#v, want writer-github seq 1 github.audit", first)
+	}
+}
+
+func TestScanRuntimeIndexSkipsPurgedPrefix(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+				State:  natsjetstream.StreamState{FirstSeq: 3, LastSeq: 4, Msgs: 2},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				3: rawReplayMsg(t, "events.github.audit", replayEvent("evt-3", "github.audit", "writer-github")),
+				4: rawReplayMsg(t, "events.github.audit", replayEvent("evt-4", "github.audit", "writer-github")),
+			},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	scan, err := log.ScanRuntimeIndex(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatalf("ScanRuntimeIndex() error = %v", err)
+	}
+	if scan.Watermark != 4 || !scan.CaughtUp {
+		t.Fatalf("scan watermark/caughtUp = %d/%v, want 4/true", scan.Watermark, scan.CaughtUp)
+	}
+	if len(scan.Entries) != 2 {
+		t.Fatalf("scan entries = %d, want 2", len(scan.Entries))
+	}
+	if replay.getMsgCalls != 2 {
+		t.Fatalf("getMsgCalls = %d, want 2 (purged prefix 1..2 skipped)", replay.getMsgCalls)
+	}
+}

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -1674,6 +1674,82 @@ func TestReplayRuntimeIndexedExactKindsUseSubjectTail(t *testing.T) {
 	}
 }
 
+func TestReplayRuntimeIndexedSkipsNonExactKindPrefix(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+				State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 3, Msgs: 3},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				2: rawReplayMsg(t, "events.github.pull_request", replayEvent("evt-2", "github.pull_request", "writer-github")),
+				3: rawReplayMsg(t, "events.github.pull_request", replayEvent("evt-3", "github.pull_request", "writer-github")),
+			},
+		},
+	}
+	// In non-exact prefix mode the index query is not kind-narrowed, so if it
+	// were consulted it would return the newest all-kind sequences (3, 2), which
+	// post-filter to zero github.audit matches with an empty tail, dropping
+	// evt-1 that the legacy reverse scan finds. The replay must skip the index.
+	index := &fakeRuntimeReplayIndex{result: ports.RuntimeIndexResult{Sequences: []uint64{3, 2}, Watermark: 3, Available: true}}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events", runtimeIndex: index}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{
+		RuntimeID:    "writer-github",
+		KindPrefixes: []string{"github.audit"},
+		Limit:        10,
+	})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if got, want := replayedEventIDs(events), []string{"evt-1"}; !slices.Equal(got, want) {
+		t.Fatalf("replayed ids = %#v, want %#v (legacy match; index must be skipped)", got, want)
+	}
+	if index.calls != 0 {
+		t.Fatalf("index lookup calls = %d, want 0 for non-exact kind prefix replay", index.calls)
+	}
+}
+
+func TestReplayRuntimeIndexedSkipsUnnarrowedFilters(t *testing.T) {
+	newLog := func(index *fakeRuntimeReplayIndex) *Log {
+		replay := &fakeReplayManager{
+			streams: []*natsjetstream.StreamInfo{
+				{
+					Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+					State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 1, Msgs: 1},
+				},
+			},
+			msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+				"CEREBRO_EVENTS": {
+					1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				},
+			},
+		}
+		return &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events", runtimeIndex: index}
+	}
+	for _, tt := range []struct {
+		name    string
+		request ports.ReplayRequest
+	}{
+		{name: "attribute filter", request: ports.ReplayRequest{RuntimeID: "writer-github", AttributeEquals: map[string]string{"team": "security"}, Limit: 10}},
+		{name: "tenant filter", request: ports.ReplayRequest{RuntimeID: "writer-github", TenantID: "writer", Limit: 10}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			index := &fakeRuntimeReplayIndex{result: ports.RuntimeIndexResult{Available: true, Watermark: 1}}
+			log := newLog(index)
+			if _, err := log.Replay(context.Background(), tt.request); err != nil {
+				t.Fatalf("Replay() error = %v", err)
+			}
+			if index.calls != 0 {
+				t.Fatalf("index lookup calls = %d, want 0 when filters are not index-narrowed", index.calls)
+			}
+		})
+	}
+}
+
 func TestScanRuntimeIndexCollectsRuntimeEntries(t *testing.T) {
 	replay := &fakeReplayManager{
 		streams: []*natsjetstream.StreamInfo{

--- a/internal/appendlogindex/indexer.go
+++ b/internal/appendlogindex/indexer.go
@@ -1,0 +1,61 @@
+// Package appendlogindex contains the domain logic that populates the
+// per-runtime append-log replay index from the append log into the state store.
+package appendlogindex
+
+import (
+	"context"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+// DefaultMaxBatches bounds how many scan windows a single population run
+// advances before yielding, keeping each job invocation bounded.
+const DefaultMaxBatches = 20
+
+// Result summarizes one population run.
+type Result struct {
+	IndexedEntries int
+	Batches        uint32
+	Watermark      uint64
+	CaughtUp       bool
+}
+
+// Populate advances the per-runtime append-log replay index from its persisted
+// watermark, scanning up to maxBatches windows from source and persisting each
+// window (entries plus the new watermark) idempotently via writer. Persisting
+// the watermark even when a window yields no runtime-bearing entries keeps the
+// indexer moving past canary/system events.
+func Populate(ctx context.Context, source ports.RuntimeIndexSource, writer ports.RuntimeIndexWriter, batch uint32, maxBatches uint32) (Result, error) {
+	if maxBatches == 0 {
+		maxBatches = DefaultMaxBatches
+	}
+	watermark, err := writer.RuntimeIndexWatermark(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	result := Result{Watermark: watermark}
+	for result.Batches < maxBatches {
+		scan, err := source.ScanRuntimeIndex(ctx, watermark, batch)
+		if err != nil {
+			return Result{}, err
+		}
+		result.Batches++
+		if len(scan.Entries) > 0 || scan.Watermark > watermark {
+			if err := writer.PutRuntimeIndexEntries(ctx, scan.Entries, scan.Watermark); err != nil {
+				return Result{}, err
+			}
+		}
+		result.IndexedEntries += len(scan.Entries)
+		if scan.Watermark <= watermark && len(scan.Entries) == 0 {
+			result.CaughtUp = true
+			break
+		}
+		watermark = scan.Watermark
+		result.Watermark = watermark
+		if scan.CaughtUp {
+			result.CaughtUp = true
+			break
+		}
+	}
+	return result, nil
+}

--- a/internal/appendlogindex/indexer_test.go
+++ b/internal/appendlogindex/indexer_test.go
@@ -1,0 +1,127 @@
+package appendlogindex
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type fakeIndexSource struct {
+	scans []ports.RuntimeIndexScan
+	calls []uint64
+}
+
+func (f *fakeIndexSource) ScanRuntimeIndex(_ context.Context, fromSeq uint64, _ uint32) (ports.RuntimeIndexScan, error) {
+	f.calls = append(f.calls, fromSeq)
+	idx := len(f.calls) - 1
+	if idx < len(f.scans) {
+		return f.scans[idx], nil
+	}
+	return ports.RuntimeIndexScan{Watermark: fromSeq, CaughtUp: true}, nil
+}
+
+type fakeIndexWriter struct {
+	watermark     uint64
+	watermarkErr  error
+	putErr        error
+	putWatermarks []uint64
+	putEntries    []int
+}
+
+func (f *fakeIndexWriter) RuntimeIndexWatermark(context.Context) (uint64, error) {
+	return f.watermark, f.watermarkErr
+}
+
+func (f *fakeIndexWriter) PutRuntimeIndexEntries(_ context.Context, entries []ports.RuntimeIndexEntry, watermark uint64) error {
+	if f.putErr != nil {
+		return f.putErr
+	}
+	f.putWatermarks = append(f.putWatermarks, watermark)
+	f.putEntries = append(f.putEntries, len(entries))
+	return nil
+}
+
+func entry(seq uint64) ports.RuntimeIndexEntry {
+	return ports.RuntimeIndexEntry{RuntimeID: "writer-github", Seq: seq, Kind: "github.audit"}
+}
+
+func TestPopulateAdvancesUntilCaughtUp(t *testing.T) {
+	source := &fakeIndexSource{scans: []ports.RuntimeIndexScan{
+		{Entries: []ports.RuntimeIndexEntry{entry(1), entry(2)}, Watermark: 1000},
+		{Entries: []ports.RuntimeIndexEntry{entry(3)}, Watermark: 2000, CaughtUp: true},
+	}}
+	writer := &fakeIndexWriter{}
+
+	result, err := Populate(context.Background(), source, writer, 0, 0)
+	if err != nil {
+		t.Fatalf("Populate() error = %v", err)
+	}
+	if result.IndexedEntries != 3 || result.Batches != 2 || result.Watermark != 2000 || !result.CaughtUp {
+		t.Fatalf("result = %#v, want 3 entries / 2 batches / watermark 2000 / caughtUp", result)
+	}
+	if len(source.calls) != 2 || source.calls[0] != 0 || source.calls[1] != 1000 {
+		t.Fatalf("scan offsets = %#v, want [0 1000]", source.calls)
+	}
+	if len(writer.putWatermarks) != 2 || writer.putWatermarks[0] != 1000 || writer.putWatermarks[1] != 2000 {
+		t.Fatalf("put watermarks = %#v, want [1000 2000]", writer.putWatermarks)
+	}
+}
+
+func TestPopulateStopsWhenNoProgress(t *testing.T) {
+	source := &fakeIndexSource{scans: []ports.RuntimeIndexScan{
+		{Watermark: 500},
+	}}
+	writer := &fakeIndexWriter{watermark: 500}
+
+	result, err := Populate(context.Background(), source, writer, 0, 0)
+	if err != nil {
+		t.Fatalf("Populate() error = %v", err)
+	}
+	if result.Batches != 1 || result.IndexedEntries != 0 || result.Watermark != 500 || !result.CaughtUp {
+		t.Fatalf("result = %#v, want 1 batch / 0 entries / watermark 500 / caughtUp", result)
+	}
+	if len(writer.putWatermarks) != 0 {
+		t.Fatalf("put watermarks = %#v, want none for no-progress scan", writer.putWatermarks)
+	}
+}
+
+func TestPopulateRespectsMaxBatches(t *testing.T) {
+	source := &fakeIndexSource{scans: []ports.RuntimeIndexScan{
+		{Entries: []ports.RuntimeIndexEntry{entry(1)}, Watermark: 100},
+		{Entries: []ports.RuntimeIndexEntry{entry(2)}, Watermark: 200},
+		{Entries: []ports.RuntimeIndexEntry{entry(3)}, Watermark: 300},
+	}}
+	writer := &fakeIndexWriter{}
+
+	result, err := Populate(context.Background(), source, writer, 0, 3)
+	if err != nil {
+		t.Fatalf("Populate() error = %v", err)
+	}
+	if result.Batches != 3 || result.CaughtUp {
+		t.Fatalf("result = %#v, want exactly 3 batches and not caughtUp", result)
+	}
+	if result.Watermark != 300 {
+		t.Fatalf("result watermark = %d, want 300", result.Watermark)
+	}
+}
+
+func TestPopulatePropagatesWatermarkReadError(t *testing.T) {
+	boom := errors.New("watermark boom")
+	writer := &fakeIndexWriter{watermarkErr: boom}
+	if _, err := Populate(context.Background(), &fakeIndexSource{}, writer, 0, 0); !errors.Is(err, boom) {
+		t.Fatalf("Populate() error = %v, want watermark boom", err)
+	}
+}
+
+func TestPopulatePropagatesPutError(t *testing.T) {
+	boom := errors.New("put boom")
+	source := &fakeIndexSource{scans: []ports.RuntimeIndexScan{
+		{Entries: []ports.RuntimeIndexEntry{entry(1)}, Watermark: 100},
+	}}
+	writer := &fakeIndexWriter{putErr: boom}
+	if _, err := Populate(context.Background(), source, writer, 0, 0); !errors.Is(err, boom) {
+		t.Fatalf("Populate() error = %v, want put boom", err)
+	}
+}

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -585,6 +585,20 @@ func authorizeTenantID(ctx context.Context, tenantID string) error {
 	return nil
 }
 
+// authorizeJobAdmin gates global (no-tenant) maintenance jobs on the admin role.
+// When no auth context is present (e.g. auth disabled) it allows the request,
+// consistent with authorizeTenantID.
+func authorizeJobAdmin(ctx context.Context) error {
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	if !ok {
+		return nil
+	}
+	if !principalHasAdminRole(auth.principal) {
+		return errScopeForbidden
+	}
+	return nil
+}
+
 func authorizeFindingCandidatePromotion(ctx context.Context) error {
 	auth, ok := ctx.Value(authContextKey{}).(authContext)
 	if !ok {

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -10,6 +10,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphagent"
 	graphstoreneo4j "github.com/writer/cerebro/internal/graphstore/neo4j"
+	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/querycache"
 	statestorepostgres "github.com/writer/cerebro/internal/statestore/postgres"
 )
@@ -59,6 +60,13 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 		closers = append(closers, func(context.Context) error {
 			return stateStore.Close()
 		})
+	}
+	if cfg.AppendLog.JetStreamRuntimeIndexEnabled {
+		if index, ok := deps.StateStore.(ports.RuntimeReplayIndex); ok && !isNilInterface(index) {
+			if appendLog, ok := deps.AppendLog.(*appendlogjetstream.Log); ok && appendLog != nil {
+				appendLog.SetRuntimeReplayIndex(index)
+			}
+		}
 	}
 	switch cfg.GraphStore.Driver {
 	case "":

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/appendlogindex"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphingest"
 	platformjobs "github.com/writer/cerebro/internal/jobs"
@@ -56,6 +57,9 @@ func (a *App) newJobService() *platformjobs.Service {
 	service.WithRunner(platformjobs.KindFindingRulesEvaluate, a.runFindingRulesEvaluateJob)
 	service.WithRunner(platformjobs.KindFindingsEvaluate, a.runFindingsEvaluateJob)
 	service.WithRunner(platformjobs.KindReportRun, a.runReportJob)
+	if a.cfg.AppendLog.JetStreamRuntimeIndexEnabled {
+		service.WithRunner(platformjobs.KindAppendLogRuntimeIndex, a.runAppendLogRuntimeIndexJob)
+	}
 	return service
 }
 
@@ -320,6 +324,33 @@ func (a *App) runFindingsEvaluateJob(ctx context.Context, job *ports.Job, _ *pla
 	return protoToMap(findingResponse(result)), nil, nil
 }
 
+// runAppendLogRuntimeIndexJob is the global (no runtime scope) maintenance job
+// that advances the per-runtime append-log replay index. Bootstrap only adapts
+// dependencies and payload; the population logic lives in appendlogindex.
+func (a *App) runAppendLogRuntimeIndexJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+	if !a.cfg.AppendLog.JetStreamRuntimeIndexEnabled {
+		return nil, nil, fmt.Errorf("%w: append log runtime index is disabled", platformjobs.ErrInvalidRequest)
+	}
+	source, ok := a.deps.AppendLog.(ports.RuntimeIndexSource)
+	if !ok || isNilInterface(source) {
+		return nil, nil, fmt.Errorf("%w: append log does not support runtime indexing", platformjobs.ErrRuntimeUnavailable)
+	}
+	writer, ok := a.deps.StateStore.(ports.RuntimeIndexWriter)
+	if !ok || isNilInterface(writer) {
+		return nil, nil, fmt.Errorf("%w: state store does not support runtime indexing", platformjobs.ErrRuntimeUnavailable)
+	}
+	result, err := appendlogindex.Populate(ctx, source, writer, uint32Payload(job.Payload, "batch"), uint32Payload(job.Payload, "max_batches"))
+	if err != nil {
+		return nil, nil, err
+	}
+	return map[string]any{
+		"indexed_entries": result.IndexedEntries,
+		"batches":         result.Batches,
+		"watermark":       result.Watermark,
+		"caught_up":       result.CaughtUp,
+	}, nil, nil
+}
+
 func (a *App) runReportJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
 	reportID := stringPayload(job.Payload, "report_id", job.SubjectID)
 	if reportID == "" {
@@ -368,6 +399,11 @@ func authorizeJobCreate(ctx context.Context, store ports.StateStore, request cre
 			return "", err
 		}
 		return firstNonEmpty(request.TenantID, reportTenantID), nil
+	case platformjobs.KindAppendLogRuntimeIndex:
+		if err := authorizeJobAdmin(ctx); err != nil {
+			return "", err
+		}
+		return "", nil
 	default:
 		return "", fmt.Errorf("%w: unsupported job kind %q", platformjobs.ErrInvalidRequest, strings.TrimSpace(request.Kind))
 	}

--- a/internal/bootstrap/jobs_test.go
+++ b/internal/bootstrap/jobs_test.go
@@ -109,3 +109,35 @@ func TestWriteJobErrorKeepsClientErrorsActionable(t *testing.T) {
 		t.Fatalf("error body = %q, want actionable client error", body["error"])
 	}
 }
+
+func TestAuthorizeJobCreateAppendLogRuntimeIndexRequiresAdmin(t *testing.T) {
+	store := &stubRuntimeStore{}
+	adminCtx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		principal: authPrincipal{Roles: []string{roleCerebroAdmin}},
+	})
+	if _, err := authorizeJobCreate(adminCtx, store, createJobHTTPRequest{Kind: platformjobs.KindAppendLogRuntimeIndex}); err != nil {
+		t.Fatalf("authorizeJobCreate() admin error = %v, want nil", err)
+	}
+	nonAdminCtx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		principal: authPrincipal{},
+	})
+	if _, err := authorizeJobCreate(nonAdminCtx, store, createJobHTTPRequest{Kind: platformjobs.KindAppendLogRuntimeIndex}); !errors.Is(err, errScopeForbidden) {
+		t.Fatalf("authorizeJobCreate() non-admin error = %v, want errScopeForbidden", err)
+	}
+}
+
+func TestRunAppendLogRuntimeIndexJobRejectsWhenDisabled(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0"}, Dependencies{StateStore: &stubRuntimeStore{}}, nil)
+	if _, _, err := app.runAppendLogRuntimeIndexJob(context.Background(), &ports.Job{}, nil); !errors.Is(err, platformjobs.ErrInvalidRequest) {
+		t.Fatalf("runAppendLogRuntimeIndexJob() disabled error = %v, want ErrInvalidRequest", err)
+	}
+}
+
+func TestRunAppendLogRuntimeIndexJobRequiresIndexCapableDeps(t *testing.T) {
+	cfg := config.Config{HTTPAddr: "127.0.0.1:0"}
+	cfg.AppendLog.JetStreamRuntimeIndexEnabled = true
+	app := New(cfg, Dependencies{StateStore: &stubRuntimeStore{}}, nil)
+	if _, _, err := app.runAppendLogRuntimeIndexJob(context.Background(), &ports.Job{}, nil); !errors.Is(err, platformjobs.ErrRuntimeUnavailable) {
+		t.Fatalf("runAppendLogRuntimeIndexJob() error = %v, want ErrRuntimeUnavailable", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,7 @@ type AppendLogConfig struct {
 	JetStreamPublishRetryMaxElapsed     time.Duration
 	JetStreamPublishClientRetryAttempts int
 	JetStreamPublishClientRetryWait     time.Duration
+	JetStreamRuntimeIndexEnabled        bool
 }
 
 // StateStoreConfig selects and configures the current-state store driver.
@@ -556,6 +557,9 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	if cfg.AppendLog.JetStreamPublishMaxInFlight, err = parseIntEnv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.AppendLog.JetStreamRuntimeIndexEnabled, err = parseBoolEnv("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED"); err != nil {
 		return Config{}, err
 	}
 	if cfg.AppendLog.JetStreamPublishRetryAttempts, err = parseIntEnv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", 0); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "")
+	t.Setenv("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF", "")
@@ -152,6 +153,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "cerebro.events")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "4s")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "12")
+	t.Setenv("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED", "true")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", "22")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF", "750ms")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF", "9s")
@@ -261,6 +263,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.AppendLog.JetStreamPublishMaxInFlight != 12 {
 		t.Fatalf("JetStreamPublishMaxInFlight = %d, want 12", cfg.AppendLog.JetStreamPublishMaxInFlight)
+	}
+	if !cfg.AppendLog.JetStreamRuntimeIndexEnabled {
+		t.Fatalf("JetStreamRuntimeIndexEnabled = %v, want true", cfg.AppendLog.JetStreamRuntimeIndexEnabled)
 	}
 	if cfg.AppendLog.JetStreamPublishRetryAttempts != 22 {
 		t.Fatalf("JetStreamPublishRetryAttempts = %d, want 22", cfg.AppendLog.JetStreamPublishRetryAttempts)
@@ -554,6 +559,7 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "")
+	t.Setenv("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF", "")

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -32,6 +32,7 @@ const (
 	KindReportRun                 = "report_run"
 	KindVulnDBSyncJobRun          = "vulndb_sync_job_run"
 	KindGraphRebuildDryRun        = "graph_rebuild_dry_run"
+	KindAppendLogRuntimeIndex     = "append_log_runtime_index"
 )
 
 type Runner func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error)

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -2,6 +2,7 @@ package ports
 
 import (
 	"context"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
@@ -28,4 +29,50 @@ type ReplayRequest struct {
 // EventReplayer replays stored event envelopes from the append log.
 type EventReplayer interface {
 	Replay(context.Context, ReplayRequest) ([]*cerebrov1.EventEnvelope, error)
+}
+
+// RuntimeIndexEntry is one append-log message indexed by source runtime and stream sequence.
+type RuntimeIndexEntry struct {
+	RuntimeID  string
+	Seq        uint64
+	TenantID   string
+	Kind       string
+	OccurredAt time.Time
+}
+
+// RuntimeIndexScan is one bounded forward scan of the append log for index population.
+type RuntimeIndexScan struct {
+	Entries   []RuntimeIndexEntry
+	Watermark uint64 // highest stream sequence examined; everything at or below it is processed.
+	CaughtUp  bool   // true when the scan reached the current stream tail.
+}
+
+// RuntimeIndexSource scans the append log forward to populate the per-runtime replay index.
+type RuntimeIndexSource interface {
+	ScanRuntimeIndex(ctx context.Context, fromSeq uint64, batch uint32) (RuntimeIndexScan, error)
+}
+
+// RuntimeIndexQuery scopes a per-runtime replay index lookup.
+type RuntimeIndexQuery struct {
+	RuntimeID string
+	Kinds     []string // exact event kinds; empty matches all kinds for the runtime.
+	Limit     uint32
+}
+
+// RuntimeIndexResult carries newest-first stream sequences for one runtime replay lookup.
+type RuntimeIndexResult struct {
+	Sequences []uint64
+	Watermark uint64
+	Available bool // true once the index has been populated (watermark > 0).
+}
+
+// RuntimeReplayIndex is the read side of the per-runtime append-log replay index.
+type RuntimeReplayIndex interface {
+	LookupRuntimeReplay(ctx context.Context, query RuntimeIndexQuery) (RuntimeIndexResult, error)
+}
+
+// RuntimeIndexWriter persists per-runtime replay index entries and advances the watermark.
+type RuntimeIndexWriter interface {
+	PutRuntimeIndexEntries(ctx context.Context, entries []RuntimeIndexEntry, watermark uint64) error
+	RuntimeIndexWatermark(ctx context.Context) (uint64, error)
 }

--- a/internal/statestore/postgres/append_log_runtime_index.go
+++ b/internal/statestore/postgres/append_log_runtime_index.go
@@ -1,0 +1,182 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+// appendLogRuntimeIndexer names the single watermark row tracking how far the
+// per-runtime append-log replay index has been populated.
+const appendLogRuntimeIndexer = "append_log_runtime_index"
+
+var ensureAppendLogRuntimeIndexStatements = []string{
+	`CREATE TABLE IF NOT EXISTS append_log_runtime_index (
+  runtime_id TEXT NOT NULL,
+  seq BIGINT NOT NULL,
+  tenant_id TEXT NOT NULL DEFAULT '',
+  kind TEXT NOT NULL DEFAULT '',
+  occurred_at TIMESTAMPTZ,
+  PRIMARY KEY (runtime_id, seq)
+)`,
+	`CREATE INDEX IF NOT EXISTS append_log_runtime_index_runtime_kind_seq_idx ON append_log_runtime_index (runtime_id, kind, seq DESC)`,
+	`CREATE TABLE IF NOT EXISTS append_log_index_state (
+  indexer TEXT PRIMARY KEY,
+  last_seq BIGINT NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+}
+
+// PutRuntimeIndexEntries upserts per-runtime replay index entries and advances
+// the population watermark to at least the supplied value, atomically.
+func (s *Store) PutRuntimeIndexEntries(ctx context.Context, entries []ports.RuntimeIndexEntry, watermark uint64) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogRuntimeIndexTable(ctx); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin append log runtime index batch: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	for _, entry := range entries {
+		runtimeID := strings.TrimSpace(entry.RuntimeID)
+		if runtimeID == "" {
+			continue
+		}
+		var occurredAt any
+		if !entry.OccurredAt.IsZero() {
+			occurredAt = entry.OccurredAt.UTC()
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO append_log_runtime_index (runtime_id, seq, tenant_id, kind, occurred_at)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (runtime_id, seq)
+DO UPDATE SET tenant_id = EXCLUDED.tenant_id, kind = EXCLUDED.kind, occurred_at = EXCLUDED.occurred_at`,
+			runtimeID, boundedInt64(entry.Seq), strings.TrimSpace(entry.TenantID), strings.TrimSpace(entry.Kind), occurredAt); err != nil {
+			return fmt.Errorf("upsert append log runtime index entry %q:%d: %w", runtimeID, entry.Seq, err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO append_log_index_state (indexer, last_seq, updated_at)
+VALUES ($1, $2, NOW())
+ON CONFLICT (indexer)
+DO UPDATE SET last_seq = GREATEST(append_log_index_state.last_seq, EXCLUDED.last_seq), updated_at = NOW()`,
+		appendLogRuntimeIndexer, boundedInt64(watermark)); err != nil {
+		return fmt.Errorf("advance append log runtime index watermark: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit append log runtime index batch: %w", err)
+	}
+	return nil
+}
+
+// RuntimeIndexWatermark reports the highest stream sequence indexed so far.
+func (s *Store) RuntimeIndexWatermark(ctx context.Context) (uint64, error) {
+	if s == nil || s.db == nil {
+		return 0, errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogRuntimeIndexTable(ctx); err != nil {
+		return 0, err
+	}
+	var lastSeq int64
+	err := s.db.QueryRowContext(ctx, `SELECT last_seq FROM append_log_index_state WHERE indexer = $1`, appendLogRuntimeIndexer).Scan(&lastSeq)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("query append log runtime index watermark: %w", err)
+	}
+	if lastSeq < 0 {
+		return 0, nil
+	}
+	return uint64(lastSeq), nil
+}
+
+// LookupRuntimeReplay returns the newest indexed stream sequences for one
+// runtime, optionally narrowed to exact event kinds, along with the watermark.
+func (s *Store) LookupRuntimeReplay(ctx context.Context, query ports.RuntimeIndexQuery) (ports.RuntimeIndexResult, error) {
+	runtimeID := strings.TrimSpace(query.RuntimeID)
+	if runtimeID == "" {
+		return ports.RuntimeIndexResult{}, errors.New("runtime id is required")
+	}
+	if s == nil || s.db == nil {
+		return ports.RuntimeIndexResult{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogRuntimeIndexTable(ctx); err != nil {
+		return ports.RuntimeIndexResult{}, err
+	}
+	watermark, err := s.RuntimeIndexWatermark(ctx)
+	if err != nil {
+		return ports.RuntimeIndexResult{}, err
+	}
+	result := ports.RuntimeIndexResult{Watermark: watermark, Available: watermark > 0}
+	if !result.Available || query.Limit == 0 {
+		return result, nil
+	}
+	statement, args := runtimeReplayIndexQuery(runtimeID, query.Kinds, watermark, query.Limit)
+	rows, err := s.db.QueryContext(ctx, statement, args...)
+	if err != nil {
+		return ports.RuntimeIndexResult{}, fmt.Errorf("query append log runtime index %q: %w", runtimeID, err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+	for rows.Next() {
+		var seq int64
+		if err := rows.Scan(&seq); err != nil {
+			return ports.RuntimeIndexResult{}, fmt.Errorf("scan append log runtime index sequence: %w", err)
+		}
+		if seq > 0 {
+			result.Sequences = append(result.Sequences, uint64(seq))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return ports.RuntimeIndexResult{}, fmt.Errorf("iterate append log runtime index %q: %w", runtimeID, err)
+	}
+	return result, nil
+}
+
+// runtimeReplayIndexQuery builds the newest-first sequence lookup, bounding by
+// the watermark and (optionally) exact event kinds. Values stay parameterized.
+func runtimeReplayIndexQuery(runtimeID string, kinds []string, watermark uint64, limit uint32) (string, []any) {
+	args := []any{runtimeID, boundedInt64(watermark)}
+	var builder strings.Builder
+	builder.WriteString("SELECT seq FROM append_log_runtime_index WHERE runtime_id = $1 AND seq <= $2")
+	normalizedKinds := normalizedNonEmptyStrings(kinds)
+	if len(normalizedKinds) > 0 {
+		placeholders := make([]string, 0, len(normalizedKinds))
+		for _, kind := range normalizedKinds {
+			args = append(args, kind)
+			placeholders = append(placeholders, "$"+strconv.Itoa(len(args)))
+		}
+		builder.WriteString(" AND kind IN (")
+		builder.WriteString(strings.Join(placeholders, ", "))
+		builder.WriteString(")")
+	}
+	args = append(args, boundedInt64(uint64(limit)))
+	builder.WriteString(" ORDER BY seq DESC LIMIT $")
+	builder.WriteString(strconv.Itoa(len(args)))
+	return builder.String(), args
+}
+
+func boundedInt64(value uint64) int64 {
+	if value > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(value) // #nosec G115 -- bounded above by the MaxInt64 check.
+}
+
+func (s *Store) ensureAppendLogRuntimeIndexTable(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.appendLogRuntimeIndexReady, "append log runtime index", ensureAppendLogRuntimeIndexStatements)
+}

--- a/internal/statestore/postgres/append_log_runtime_index_test.go
+++ b/internal/statestore/postgres/append_log_runtime_index_test.go
@@ -1,0 +1,101 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestPutRuntimeIndexEntriesRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	if err := store.PutRuntimeIndexEntries(context.Background(), nil, 0); err == nil {
+		t.Fatal("PutRuntimeIndexEntries() error = nil, want non-nil")
+	}
+}
+
+func TestRuntimeIndexWatermarkRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	if _, err := store.RuntimeIndexWatermark(context.Background()); err == nil {
+		t.Fatal("RuntimeIndexWatermark() error = nil, want non-nil")
+	}
+}
+
+func TestLookupRuntimeReplayRejectsMissingRuntimeID(t *testing.T) {
+	store := &Store{}
+	if _, err := store.LookupRuntimeReplay(context.Background(), ports.RuntimeIndexQuery{RuntimeID: "  "}); err == nil {
+		t.Fatal("LookupRuntimeReplay() error = nil, want non-nil for missing runtime id")
+	}
+}
+
+func TestAppendLogRuntimeIndexSchemaShape(t *testing.T) {
+	joined := strings.Join(ensureAppendLogRuntimeIndexStatements, "\n")
+	for _, fragment := range []string{
+		"CREATE TABLE IF NOT EXISTS append_log_runtime_index",
+		"PRIMARY KEY (runtime_id, seq)",
+		"append_log_runtime_index_runtime_kind_seq_idx",
+		"(runtime_id, kind, seq DESC)",
+		"CREATE TABLE IF NOT EXISTS append_log_index_state",
+		"indexer TEXT PRIMARY KEY",
+	} {
+		if !strings.Contains(joined, fragment) {
+			t.Fatalf("append log runtime index schema missing %q:\n%s", fragment, joined)
+		}
+	}
+}
+
+func TestRuntimeReplayIndexQueryWithoutKinds(t *testing.T) {
+	statement, args := runtimeReplayIndexQuery("writer-okta", nil, 42, 100)
+	for _, fragment := range []string{
+		"WHERE runtime_id = $1 AND seq <= $2",
+		"ORDER BY seq DESC LIMIT $3",
+	} {
+		if !strings.Contains(statement, fragment) {
+			t.Fatalf("runtimeReplayIndexQuery() = %q, missing %q", statement, fragment)
+		}
+	}
+	if strings.Contains(statement, "kind IN") {
+		t.Fatalf("runtimeReplayIndexQuery() unexpectedly filtered by kind: %q", statement)
+	}
+	if len(args) != 3 {
+		t.Fatalf("runtimeReplayIndexQuery() args = %#v, want runtime, watermark, limit", args)
+	}
+	if got, ok := args[0].(string); !ok || got != "writer-okta" {
+		t.Fatalf("runtimeReplayIndexQuery() args[0] = %#v, want runtime id", args[0])
+	}
+	if got, ok := args[1].(int64); !ok || got != 42 {
+		t.Fatalf("runtimeReplayIndexQuery() args[1] = %#v, want watermark 42", args[1])
+	}
+	if got, ok := args[2].(int64); !ok || got != 100 {
+		t.Fatalf("runtimeReplayIndexQuery() args[2] = %#v, want limit 100", args[2])
+	}
+}
+
+func TestRuntimeReplayIndexQueryWithKinds(t *testing.T) {
+	statement, args := runtimeReplayIndexQuery("writer-okta", []string{"okta.policy_rule", " ", "okta.policy_rule", "duo.user"}, 7, 25)
+	if !strings.Contains(statement, "AND kind IN ($3, $4)") {
+		t.Fatalf("runtimeReplayIndexQuery() = %q, want deduplicated kind IN ($3, $4)", statement)
+	}
+	if !strings.Contains(statement, "ORDER BY seq DESC LIMIT $5") {
+		t.Fatalf("runtimeReplayIndexQuery() = %q, want LIMIT placeholder after kinds", statement)
+	}
+	if len(args) != 5 {
+		t.Fatalf("runtimeReplayIndexQuery() args = %#v, want runtime, watermark, 2 kinds, limit", args)
+	}
+	if got, ok := args[2].(string); !ok || got != "okta.policy_rule" {
+		t.Fatalf("runtimeReplayIndexQuery() args[2] = %#v, want first kind", args[2])
+	}
+	if got, ok := args[4].(int64); !ok || got != 25 {
+		t.Fatalf("runtimeReplayIndexQuery() args[4] = %#v, want limit 25", args[4])
+	}
+}
+
+func TestBoundedInt64Caps(t *testing.T) {
+	if got := boundedInt64(123); got != 123 {
+		t.Fatalf("boundedInt64(123) = %d, want 123", got)
+	}
+	if got := boundedInt64(^uint64(0)); got <= 0 {
+		t.Fatalf("boundedInt64(maxuint64) = %d, want positive cap", got)
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -40,6 +40,7 @@ type Store struct {
 	grcInventoryAssetReportReady bool
 	connectorCredentialReady     bool
 	connectorDefinitionReady     bool
+	appendLogRuntimeIndexReady   bool
 }
 
 // Open opens a Postgres-backed current-state store.

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const bootstrapProductionGoLineBudget = 23362
+const bootstrapProductionGoLineBudget = 23367
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary

Adds an optional secondary index that accelerates runtime-scoped append-log replays.

- When enabled, replay resolves the bulk of a runtime's history from the index and **always merges the un-indexed tail** directly from the stream, so results stay correct and complete regardless of index freshness.
- When the flag is off or the index is unpopulated, replay **falls back** to the existing subject/legacy strategies with no behavior change.

## Changes

- **ports**: index entry/scan/query/result types and source/reader/writer interfaces.
- **state store**: additive Postgres tables for the index and its watermark, with parameterized newest-first lookups and optional exact-kind narrowing.
- **append log**: index-first replay strategy with mandatory tail-merge, plus a forward scan that emits per-runtime index entries.
- **population**: an incremental, idempotent maintenance job whose scan-and-persist loop lives in a dedicated domain package (`internal/appendlogindex`); bootstrap only wires dependencies, authorizes (admin), and adapts payloads.
- **config**: a single boolean flag, default off.

Disabled by default and gated end to end (schema, population, and read path) behind the flag.

## Tests

- New unit tests for the read strategy (index hit + tail-merge, fallback when unavailable, retention-purge skip, exact-kind tail), the forward scan, the Postgres store guards/schema/query builder, the population loop, the config flag, and job authorization.
- go build, go vet, gofmt, full go test, golangci-lint, and the architecture ratchet tests all pass.

## Compatibility

Additive and backward compatible. No schema or behavior changes occur unless the flag is explicitly enabled.
