### PR TITLE
Add detailed orchestration observability

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -659,6 +659,9 @@ func runOrchestratorIteration(
 			emitOrchestratorJobPhaseEnded(syncCtx, "source_runtime.sync", "completed", iteration, runtime, time.Since(syncStarted), 0, telemetry.Attrs(
 				telemetryField("pages_read", runtimeResult.PagesRead),
 				telemetryField("events_appended", runtimeResult.EventsAppended),
+				telemetryField("runtime_returned", syncResult.GetRuntime() != nil),
+				telemetryField("next_cursor", syncResult.GetRuntime().GetNextCursor() != nil),
+				telemetryField("checkpoint_cursor", syncResult.GetRuntime().GetCheckpoint().GetCursorOpaque() != ""),
 			))
 		}
 		if !releaseSyncLease("sync_completed") {
@@ -738,6 +741,7 @@ func runOrchestratorIteration(
 		} else {
 			runtimeResult.GraphRules = "skipped"
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_skip_reason", "graph_ingest_not_caught_up")
+			emitOrchestratorJobPhaseSkipped(runtimeCtx, "orchestrator.graph_rules", iteration, runtime, options.PhaseTimeout, "graph_ingest_not_caught_up")
 		}
 		result.Runtimes = append(result.Runtimes, runtimeResult)
 		if runtimeResult.Error == "" {
@@ -797,7 +801,7 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 	endAttrs := telemetry.Attrs(
 		telemetryField("duration_ms", durationMs),
 		telemetryField("phase."+phaseKey+".last_duration_ms", durationMs),
-	)
+	).With(orchestratorPhaseDetailAttrs(result))
 	telemetry.MaxMain(phaseCtx, "phase."+phaseKey+".max_duration_ms", durationMs)
 	if err != nil {
 		status = "failed"
@@ -1119,6 +1123,91 @@ func applyGraphRuleCounters(runtimeResult *orchestratorRuntimeResult, graphRules
 	return attrs
 }
 
+func orchestratorPhaseDetailAttrs(result any) telemetry.Attributes {
+	switch value := result.(type) {
+	case *graphingest.RunResult:
+		return orchestratorGraphIngestDetailAttrs(value)
+	case *findings.EvaluateRulesResult:
+		return orchestratorFindingRulesDetailAttrs(value)
+	case *findings.EvaluateGraphRulesResult:
+		return orchestratorGraphRulesDetailAttrs(value)
+	default:
+		return telemetry.Attrs()
+	}
+}
+
+func orchestratorGraphIngestDetailAttrs(result *graphingest.RunResult) telemetry.Attributes {
+	if result == nil || result.Ingest == nil {
+		return telemetry.Attrs()
+	}
+	return telemetry.Attrs(
+		telemetryField("pages_read", result.Ingest.PagesRead),
+		telemetryField("events_read", result.Ingest.EventsRead),
+		telemetryField("entities_projected", result.Ingest.EntitiesProjected),
+		telemetryField("links_projected", result.Ingest.LinksProjected),
+		telemetryField("checkpoint_persisted", result.Ingest.CheckpointPersisted),
+		telemetryField("checkpoint_complete", result.Ingest.CheckpointComplete),
+		telemetryField("checkpoint_already_fresh", result.Ingest.CheckpointAlreadyFresh),
+		telemetryField("checkpoint_resumed", result.Ingest.CheckpointResumed),
+	)
+}
+
+func orchestratorFindingRulesDetailAttrs(result *findings.EvaluateRulesResult) telemetry.Attributes {
+	if result == nil {
+		return telemetry.Attrs()
+	}
+	var findingsEmitted int
+	for _, evaluation := range result.Evaluations {
+		if evaluation != nil {
+			findingsEmitted += len(evaluation.Findings)
+		}
+	}
+	return telemetry.Attrs(
+		telemetryField("events_evaluated", result.EventsEvaluated),
+		telemetryField("evaluations", len(result.Evaluations)),
+		telemetryField("findings_emitted", findingsEmitted),
+		telemetryField("runtime_returned", result.Runtime != nil),
+		telemetryField("events_per_evaluate", averageOrchestratorUint32Int(result.EventsEvaluated, len(result.Evaluations))),
+	)
+}
+
+func orchestratorGraphRulesDetailAttrs(result *findings.EvaluateGraphRulesResult) telemetry.Attributes {
+	if result == nil {
+		return telemetry.Attrs()
+	}
+	var findingsEmitted int
+	var evidenceWritten int
+	var rowsRead uint32
+	var truncated int
+	for _, evaluation := range result.Evaluations {
+		if evaluation == nil {
+			continue
+		}
+		findingsEmitted += len(evaluation.Findings)
+		evidenceWritten += len(evaluation.Evidence)
+		rowsRead += evaluation.RowsRead
+		if evaluation.Truncated {
+			truncated++
+		}
+	}
+	return telemetry.Attrs(
+		telemetryField("evaluations", len(result.Evaluations)),
+		telemetryField("findings_emitted", findingsEmitted),
+		telemetryField("evidence_written", evidenceWritten),
+		telemetryField("rows_read", rowsRead),
+		telemetryField("truncated_rules", truncated),
+		telemetryField("runtime_returned", result.Runtime != nil),
+		telemetryField("rows_per_evaluate", averageOrchestratorUint32Int(rowsRead, len(result.Evaluations))),
+	)
+}
+
+func averageOrchestratorUint32Int(total uint32, count int) float64 {
+	if count <= 0 {
+		return 0
+	}
+	return float64(total) / float64(count)
+}
+
 func orchestratorListFilter(filter ports.SourceRuntimeFilter) ports.SourceRuntimeFilter {
 	if filter.Limit == 0 {
 		filter.Limit = ^uint32(0)
@@ -1286,11 +1375,32 @@ func emitOrchestratorJobPhaseEnded(ctx context.Context, phase string, status str
 		telemetry.IncrementMain(ctx, "job.phase.failed.count", 1)
 		telemetry.IncrementMain(ctx, "job.phase."+phaseKey+".failed.count", 1)
 	}
+	if status == "skipped" {
+		telemetry.IncrementMain(ctx, "job.phase.skipped.count", 1)
+		telemetry.IncrementMain(ctx, "job.phase."+phaseKey+".skipped.count", 1)
+	}
 	eventName := "platform.job.phase.completed"
 	if status == "failed" {
 		eventName = "platform.job.phase.failed"
 	}
+	if status == "skipped" {
+		eventName = "platform.job.phase.skipped"
+	}
 	telemetry.Event(ctx, eventName, orchestratorJobAttrs(ctx).With(orchestratorPhaseEventAttrs(phase, status, iteration, runtime, timeout, duration)).With(extra))
+}
+
+func emitOrchestratorJobPhaseSkipped(ctx context.Context, phase string, iteration uint32, runtime *cerebrov1.SourceRuntime, timeout time.Duration, reason string) {
+	emitOrchestratorJobPhaseEnded(ctx, phase, "skipped", iteration, runtime, 0, timeout, telemetry.Attrs(
+		telemetryField("skip_reason", strings.TrimSpace(reason)),
+		telemetryField("job.phase.skip_reason", strings.TrimSpace(reason)),
+	))
+	telemetry.AnnotateMainPhase(ctx, phase, "skipped", telemetry.Attrs(
+		telemetryField("phase.iteration", iteration),
+		telemetryField("phase.runtime_id", runtime.GetId()),
+		telemetryField("phase.source_id", runtime.GetSourceId()),
+		telemetryField("phase.tenant_id", runtime.GetTenantId()),
+		telemetryField("phase.skip_reason", strings.TrimSpace(reason)),
+	))
 }
 
 func orchestratorPhaseEventAttrs(phase string, status string, iteration uint32, runtime *cerebrov1.SourceRuntime, timeout time.Duration, duration time.Duration) telemetry.Attributes {

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -15,6 +14,8 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphingest"
+	"github.com/writer/cerebro/internal/jobobservability"
+	"github.com/writer/cerebro/internal/jobpayload"
 	platformjobs "github.com/writer/cerebro/internal/jobs"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourceruntime"
@@ -186,15 +187,17 @@ func (a *App) handleCancelJob(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, jobResponse{Job: job})
 }
 
-func (a *App) runSourceRuntimeSyncJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
-	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+func (a *App) runSourceRuntimeSyncJob(ctx context.Context, job *ports.Job, service *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := jobpayload.String(job.Payload, "runtime_id", job.SubjectID)
 	if runtimeID == "" {
 		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
 	}
-	response, err := a.runtimeService().SyncWithLease(ctx, &cerebrov1.SyncSourceRuntimeRequest{
-		Id:        runtimeID,
-		PageLimit: uint32Payload(job.Payload, "page_limit"),
-	}, sourceruntime.SyncWithLeaseOptions{LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore)})
+	response, err := jobobservability.RunPhase(ctx, service, job, "source_runtime.sync", "source runtime sync", jobobservability.SourceRuntimeSyncPayload, func() (*cerebrov1.SyncSourceRuntimeResponse, error) {
+		return a.runtimeService().SyncWithLease(ctx, &cerebrov1.SyncSourceRuntimeRequest{
+			Id:        runtimeID,
+			PageLimit: jobpayload.Uint32(job.Payload, "page_limit"),
+		}, sourceruntime.SyncWithLeaseOptions{LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore)})
+	})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -202,37 +205,45 @@ func (a *App) runSourceRuntimeSyncJob(ctx context.Context, job *ports.Job, _ *pl
 	return protoToMap(response), nil, nil
 }
 
-func (a *App) runSourceRuntimeOrchestrateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
-	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+func (a *App) runSourceRuntimeOrchestrateJob(ctx context.Context, job *ports.Job, service *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := jobpayload.String(job.Payload, "runtime_id", job.SubjectID)
 	if runtimeID == "" {
 		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
 	}
-	syncResponse, err := a.runtimeService().SyncWithLease(ctx, &cerebrov1.SyncSourceRuntimeRequest{
-		Id:        runtimeID,
-		PageLimit: uint32Payload(job.Payload, "page_limit"),
-	}, sourceruntime.SyncWithLeaseOptions{LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore)})
-	if err != nil {
-		return nil, nil, err
-	}
-	graphResult, err := a.graphIngestService().RunRuntime(ctx, graphingest.RuntimeRequest{
-		RuntimeID: runtimeID,
-		PageLimit: uint32Payload(job.Payload, "graph_page_limit"),
-		Trigger:   "platform_orchestration_job",
+	syncResponse, err := jobobservability.RunPhase(ctx, service, job, "source_runtime.sync", "source runtime sync", jobobservability.SourceRuntimeSyncPayload, func() (*cerebrov1.SyncSourceRuntimeResponse, error) {
+		return a.runtimeService().SyncWithLease(ctx, &cerebrov1.SyncSourceRuntimeRequest{
+			Id:        runtimeID,
+			PageLimit: jobpayload.Uint32(job.Payload, "page_limit"),
+		}, sourceruntime.SyncWithLeaseOptions{LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore)})
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	ruleResult, err := a.findingService().EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
-		RuntimeID:  runtimeID,
-		RuleIDs:    stringSlicePayload(job.Payload, "rule_ids"),
-		EventLimit: uint32Payload(job.Payload, "event_limit"),
+	graphResult, err := jobobservability.RunPhase(ctx, service, job, "orchestrator.graph_ingest", "graph ingest", jobobservability.GraphIngestPayload, func() (*graphingest.RunResult, error) {
+		return a.graphIngestService().RunRuntime(ctx, graphingest.RuntimeRequest{
+			RuntimeID: runtimeID,
+			PageLimit: jobpayload.Uint32(job.Payload, "graph_page_limit"),
+			Trigger:   "platform_orchestration_job",
+		})
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	graphRulesResult, err := a.findingService().EvaluateSourceRuntimeGraphRules(ctx, findings.EvaluateGraphRulesRequest{
-		RuntimeID: runtimeID,
-		RuleIDs:   stringSlicePayload(job.Payload, "graph_rule_ids"),
+	ruleResult, err := jobobservability.RunPhase(ctx, service, job, "orchestrator.finding_rules", "finding rules", jobobservability.FindingRulesPayload, func() (*findings.EvaluateRulesResult, error) {
+		return a.findingService().EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
+			RuntimeID:  runtimeID,
+			RuleIDs:    jobpayload.StringSlice(job.Payload, "rule_ids"),
+			EventLimit: jobpayload.Uint32(job.Payload, "event_limit"),
+		})
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	graphRulesResult, err := jobobservability.RunPhase(ctx, service, job, "orchestrator.graph_rules", "graph rules", jobobservability.GraphRulesPayload, func() (*findings.EvaluateGraphRulesResult, error) {
+		return a.findingService().EvaluateSourceRuntimeGraphRules(ctx, findings.EvaluateGraphRulesRequest{
+			RuntimeID: runtimeID,
+			RuleIDs:   jobpayload.StringSlice(job.Payload, "graph_rule_ids"),
+		})
 	})
 	if err != nil {
 		return nil, nil, err
@@ -263,15 +274,17 @@ func (a *App) runSourceRuntimeOrchestrateJob(ctx context.Context, job *ports.Job
 	return result, refs, nil
 }
 
-func (a *App) runGraphIngestRuntimeJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
-	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+func (a *App) runGraphIngestRuntimeJob(ctx context.Context, job *ports.Job, service *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := jobpayload.String(job.Payload, "runtime_id", job.SubjectID)
 	if runtimeID == "" {
 		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
 	}
-	result, err := a.graphIngestService().RunRuntime(ctx, graphingest.RuntimeRequest{
-		RuntimeID: runtimeID,
-		PageLimit: uint32Payload(job.Payload, "page_limit"),
-		Trigger:   "platform_job",
+	result, err := jobobservability.RunPhase(ctx, service, job, "graph_ingest_runtime", "graph ingest", jobobservability.GraphIngestPayload, func() (*graphingest.RunResult, error) {
+		return a.graphIngestService().RunRuntime(ctx, graphingest.RuntimeRequest{
+			RuntimeID: runtimeID,
+			PageLimit: jobpayload.Uint32(job.Payload, "page_limit"),
+			Trigger:   "platform_job",
+		})
 	})
 	if err != nil {
 		return nil, nil, err
@@ -285,14 +298,16 @@ func (a *App) runGraphIngestRuntimeJob(ctx context.Context, job *ports.Job, _ *p
 	return out, refs, err
 }
 
-func (a *App) runGraphRulesEvaluateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
-	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+func (a *App) runGraphRulesEvaluateJob(ctx context.Context, job *ports.Job, service *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := jobpayload.String(job.Payload, "runtime_id", job.SubjectID)
 	if runtimeID == "" {
 		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
 	}
-	result, err := a.findingService().EvaluateSourceRuntimeGraphRules(ctx, findings.EvaluateGraphRulesRequest{
-		RuntimeID: runtimeID,
-		RuleIDs:   stringSlicePayload(job.Payload, "rule_ids"),
+	result, err := jobobservability.RunPhase(ctx, service, job, "graph_rules_evaluate", "graph rules", jobobservability.GraphRulesPayload, func() (*findings.EvaluateGraphRulesResult, error) {
+		return a.findingService().EvaluateSourceRuntimeGraphRules(ctx, findings.EvaluateGraphRulesRequest{
+			RuntimeID: runtimeID,
+			RuleIDs:   jobpayload.StringSlice(job.Payload, "rule_ids"),
+		})
 	})
 	if err != nil {
 		return nil, nil, err
@@ -302,15 +317,17 @@ func (a *App) runGraphRulesEvaluateJob(ctx context.Context, job *ports.Job, _ *p
 	return out, nil, err
 }
 
-func (a *App) runFindingRulesEvaluateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
-	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+func (a *App) runFindingRulesEvaluateJob(ctx context.Context, job *ports.Job, service *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := jobpayload.String(job.Payload, "runtime_id", job.SubjectID)
 	if runtimeID == "" {
 		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
 	}
-	result, err := a.findingService().EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
-		RuntimeID:  runtimeID,
-		RuleIDs:    stringSlicePayload(job.Payload, "rule_ids"),
-		EventLimit: uint32Payload(job.Payload, "event_limit"),
+	result, err := jobobservability.RunPhase(ctx, service, job, "finding_rules_evaluate", "finding rules", jobobservability.FindingRulesPayload, func() (*findings.EvaluateRulesResult, error) {
+		return a.findingService().EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
+			RuntimeID:  runtimeID,
+			RuleIDs:    jobpayload.StringSlice(job.Payload, "rule_ids"),
+			EventLimit: jobpayload.Uint32(job.Payload, "event_limit"),
+		})
 	})
 	if err != nil {
 		return nil, nil, err
@@ -320,15 +337,17 @@ func (a *App) runFindingRulesEvaluateJob(ctx context.Context, job *ports.Job, _ 
 	return out, nil, err
 }
 
-func (a *App) runFindingCandidatesEvaluateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
-	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+func (a *App) runFindingCandidatesEvaluateJob(ctx context.Context, job *ports.Job, service *platformjobs.Service) (map[string]any, map[string]string, error) {
+	runtimeID := jobpayload.String(job.Payload, "runtime_id", job.SubjectID)
 	if runtimeID == "" {
 		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
 	}
-	result, err := a.findingService().EvaluateSourceRuntimeCandidateRules(ctx, findings.EvaluateCandidateRulesRequest{
-		RuntimeID:  runtimeID,
-		RuleIDs:    stringSlicePayload(job.Payload, "rule_ids"),
-		EventLimit: uint32Payload(job.Payload, "event_limit"),
+	result, err := jobobservability.RunPhase(ctx, service, job, "finding_candidates_evaluate", "candidate rules", jobobservability.CandidateRulesPayload, func() (*findings.EvaluateCandidateRulesResult, error) {
+		return a.findingService().EvaluateSourceRuntimeCandidateRules(ctx, findings.EvaluateCandidateRulesRequest{
+			RuntimeID:  runtimeID,
+			RuleIDs:    jobpayload.StringSlice(job.Payload, "rule_ids"),
+			EventLimit: jobpayload.Uint32(job.Payload, "event_limit"),
+		})
 	})
 	if err != nil {
 		return nil, nil, err
@@ -339,14 +358,14 @@ func (a *App) runFindingCandidatesEvaluateJob(ctx context.Context, job *ports.Jo
 }
 
 func (a *App) runFindingsEvaluateJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
-	runtimeID := stringPayload(job.Payload, "runtime_id", job.SubjectID)
+	runtimeID := jobpayload.String(job.Payload, "runtime_id", job.SubjectID)
 	if runtimeID == "" {
 		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
 	}
 	result, err := a.findingService().EvaluateSourceRuntime(ctx, findings.EvaluateRequest{
 		RuntimeID:  runtimeID,
-		RuleID:     stringPayload(job.Payload, "rule_id", ""),
-		EventLimit: uint32Payload(job.Payload, "event_limit"),
+		RuleID:     jobpayload.String(job.Payload, "rule_id", ""),
+		EventLimit: jobpayload.Uint32(job.Payload, "event_limit"),
 	})
 	if err != nil {
 		return nil, nil, err
@@ -356,11 +375,11 @@ func (a *App) runFindingsEvaluateJob(ctx context.Context, job *ports.Job, _ *pla
 }
 
 func (a *App) runReportJob(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
-	reportID := stringPayload(job.Payload, "report_id", job.SubjectID)
+	reportID := jobpayload.String(job.Payload, "report_id", job.SubjectID)
 	if reportID == "" {
 		return nil, nil, fmt.Errorf("%w: report_id is required", platformjobs.ErrInvalidRequest)
 	}
-	parameters := stringMapPayload(job.Payload, "parameters")
+	parameters := jobpayload.StringMap(job.Payload, "parameters")
 	if job.TenantID != "" && parameters["tenant_id"] == "" {
 		parameters["tenant_id"] = job.TenantID
 	}
@@ -381,7 +400,7 @@ func authorizeJobCreate(ctx context.Context, store ports.StateStore, request cre
 	}
 	switch strings.TrimSpace(request.Kind) {
 	case platformjobs.KindSourceRuntimeSync, platformjobs.KindSourceRuntimeOrchestrate, platformjobs.KindGraphIngestRuntime, platformjobs.KindGraphRulesEvaluate, platformjobs.KindFindingRulesEvaluate, platformjobs.KindFindingCandidatesEvaluate, platformjobs.KindFindingsEvaluate:
-		runtimeID := stringPayload(request.Payload, "runtime_id", request.SubjectID)
+		runtimeID := jobpayload.String(request.Payload, "runtime_id", request.SubjectID)
 		runtimeTenantID, err := sourceRuntimeTenantID(ctx, sourceRuntimeStore(store), runtimeID, false)
 		if err != nil {
 			return "", err
@@ -391,7 +410,7 @@ func authorizeJobCreate(ctx context.Context, store ports.StateStore, request cre
 		}
 		return firstNonEmpty(request.TenantID, runtimeTenantID), nil
 	case platformjobs.KindReportRun:
-		parameters := stringMapPayload(request.Payload, "parameters")
+		parameters := jobpayload.StringMap(request.Payload, "parameters")
 		if request.TenantID != "" && parameters["tenant_id"] == "" {
 			parameters["tenant_id"] = request.TenantID
 		}
@@ -450,83 +469,4 @@ func jsonResultMap(value any) (map[string]any, error) {
 	out := map[string]any{}
 	_ = json.Unmarshal(payload, &out)
 	return out, nil
-}
-
-func stringPayload(payload map[string]any, key string, fallback string) string {
-	if value, ok := payload[key]; ok {
-		switch typed := value.(type) {
-		case string:
-			if strings.TrimSpace(typed) != "" {
-				return strings.TrimSpace(typed)
-			}
-		}
-	}
-	return strings.TrimSpace(fallback)
-}
-
-func uint32Payload(payload map[string]any, key string) uint32 {
-	value, ok := payload[key]
-	if !ok {
-		return 0
-	}
-	switch typed := value.(type) {
-	case float64:
-		if typed > 0 {
-			return uint32(typed)
-		}
-	case json.Number:
-		parsed, _ := strconv.ParseUint(string(typed), 10, 32)
-		return uint32(parsed)
-	case string:
-		parsed, _ := strconv.ParseUint(strings.TrimSpace(typed), 10, 32)
-		return uint32(parsed)
-	}
-	return 0
-}
-
-func stringSlicePayload(payload map[string]any, key string) []string {
-	value, ok := payload[key]
-	if !ok {
-		return nil
-	}
-	switch typed := value.(type) {
-	case []string:
-		return typed
-	case []any:
-		values := make([]string, 0, len(typed))
-		for _, item := range typed {
-			if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
-				values = append(values, strings.TrimSpace(text))
-			}
-		}
-		return values
-	case string:
-		if strings.TrimSpace(typed) == "" {
-			return nil
-		}
-		return []string{strings.TrimSpace(typed)}
-	default:
-		return nil
-	}
-}
-
-func stringMapPayload(payload map[string]any, key string) map[string]string {
-	result := map[string]string{}
-	value, ok := payload[key]
-	if !ok {
-		return result
-	}
-	switch typed := value.(type) {
-	case map[string]string:
-		for k, v := range typed {
-			result[k] = v
-		}
-	case map[string]any:
-		for k, v := range typed {
-			if text, ok := v.(string); ok {
-				result[k] = text
-			}
-		}
-	}
-	return result
 }

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -8,6 +8,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 // EvaluateGraphRulesRequest scopes one graph-rule evaluation pass over one runtime.
@@ -77,15 +78,20 @@ func (s *Service) EvaluateSourceRuntimeGraphRules(ctx context.Context, request E
 	return result, firstErr
 }
 
-func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule GraphRule, startedAt time.Time) (*GraphRuleEvaluationResult, error) {
+func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule GraphRule, startedAt time.Time) (result *GraphRuleEvaluationResult, err error) {
 	spec := rule.Spec()
 	run := newGraphFindingEvaluationRun(strings.TrimSpace(runtime.GetId()), spec.GetId(), startedAt)
-	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
-		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
-	}
-	result := &GraphRuleEvaluationResult{
+	result = &GraphRuleEvaluationResult{
 		Rule: spec,
 		Run:  run,
+	}
+	queryPresent := false
+	ruleStarted := time.Now()
+	defer func() {
+		emitGraphRuleEvaluationDetail(ctx, runtime, spec, result, queryPresent, time.Since(ruleStarted), err)
+	}()
+	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
+		return result, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
 	}
 	queryRequest := rule.QueryFor(runtime)
 	if strings.TrimSpace(queryRequest.Query) == "" {
@@ -100,6 +106,7 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		}
 		return result, nil
 	}
+	queryPresent = true
 	rows, err := s.graphQuery.ExecuteReadCypher(ctx, queryRequest)
 	if err != nil {
 		evaluationErr := fmt.Errorf("execute graph rule %q cypher: %w", spec.GetId(), err)
@@ -169,6 +176,59 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		return result, err
 	}
 	return result, nil
+}
+
+func emitGraphRuleEvaluationDetail(ctx context.Context, runtime *cerebrov1.SourceRuntime, spec *cerebrov1.RuleSpec, result *GraphRuleEvaluationResult, queryPresent bool, duration time.Duration, err error) {
+	status := "completed"
+	if err != nil {
+		status = "failed"
+	}
+	ruleID := ""
+	if spec != nil {
+		ruleID = strings.TrimSpace(spec.GetId())
+	}
+	var runID string
+	var rowsRead uint32
+	var findingsEmitted int
+	var evidenceWritten int
+	var truncated bool
+	if result != nil {
+		if result.Run != nil {
+			runID = strings.TrimSpace(result.Run.GetId())
+		}
+		rowsRead = result.RowsRead
+		findingsEmitted = len(result.Findings)
+		evidenceWritten = len(result.Evidence)
+		truncated = result.Truncated
+	}
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "component", Value: "findings.graph_rules"},
+		telemetry.Field{Key: "status", Value: status},
+		telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
+		telemetry.Field{Key: "source_runtime_id", Value: runtime.GetId()},
+		telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()},
+		telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()},
+		telemetry.Field{Key: "rule_id", Value: ruleID},
+		telemetry.Field{Key: "run_id", Value: runID},
+		telemetry.Field{Key: "query_present", Value: queryPresent},
+		telemetry.Field{Key: "rows_read", Value: rowsRead},
+		telemetry.Field{Key: "rows_truncated", Value: truncated},
+		telemetry.Field{Key: "findings_emitted", Value: findingsEmitted},
+		telemetry.Field{Key: "evidence_written", Value: evidenceWritten},
+		telemetry.Field{Key: "stale_resolution_skipped", Value: truncated},
+		telemetry.Field{Key: "duration_ms", Value: duration.Milliseconds()},
+	)
+	if err != nil {
+		attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+	}
+	telemetry.IncrementMain(ctx, "finding.graph_rule.evaluation.count", 1)
+	if status == "failed" {
+		telemetry.IncrementMain(ctx, "finding.graph_rule.evaluation.failed.count", 1)
+	}
+	if truncated {
+		telemetry.IncrementMain(ctx, "finding.graph_rule.evaluation.truncated.count", 1)
+	}
+	telemetry.Event(ctx, "finding.graph_rule.evaluation", attrs)
 }
 
 func retiredGraphRule(rule GraphRule) bool {

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -2,7 +2,9 @@ package findings
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -222,6 +224,76 @@ func TestEvaluateSourceRuntimeGraphRulesTruncatedSkipsStaleResolution(t *testing
 	if got := persisted.Status; got != findingStatusOpen {
 		t.Fatalf("stale finding status = %q, want still %q (truncated cypher view must not auto-resolve)", got, findingStatusOpen)
 	}
+}
+
+func TestEvaluateSourceRuntimeGraphRulesEmitsTelemetryDetail(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphStore := &stubGraphStore{
+		cypherRows: []ports.CypherRow{
+			{Values: map[string]any{"label": "row-1"}},
+			{Values: map[string]any{"label": "row-2"}},
+		},
+	}
+	rule := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "telemetry-rule"},
+		sourceID: "okta",
+		query: ports.CypherQueryRequest{
+			Query:    "MATCH (n {token: 'raw-secret-token-value'}) RETURN n",
+			Params:   map[string]any{"token": "raw-secret-token-value"},
+			RowLimit: 2,
+		},
+	}
+	registry, err := NewRegistry(rule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	stderr := captureFindingStderr(t, func() {
+		if _, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"}); err != nil {
+			t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+		}
+	})
+	if strings.Contains(stderr, "raw-secret-token-value") || strings.Contains(stderr, "MATCH") {
+		t.Fatalf("graph rule telemetry leaked query or params: %s", stderr)
+	}
+	payload := graphRuleEvaluationTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"name":                     "finding.graph_rule.evaluation",
+		"status":                   "completed",
+		"runtime_id":               "runtime-okta",
+		"source_id":                "okta",
+		"tenant_id":                "writer",
+		"rule_id":                  "telemetry-rule",
+		"query_present":            true,
+		"rows_read":                float64(2),
+		"rows_truncated":           true,
+		"findings_emitted":         float64(0),
+		"evidence_written":         float64(0),
+		"stale_resolution_skipped": true,
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+}
+
+func graphRuleEvaluationTelemetryPayload(t *testing.T, stderr string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		payload := map[string]any{}
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			t.Fatalf("decode telemetry JSON %q: %v", line, err)
+		}
+		if payload["name"] == "finding.graph_rule.evaluation" {
+			return payload
+		}
+	}
+	t.Fatalf("finding.graph_rule.evaluation telemetry not found: %s", stderr)
+	return nil
 }
 
 func TestEvaluateSourceRuntimeGraphRulesRequiresGraphQuery(t *testing.T) {

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -2,6 +2,8 @@ package neo4j
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -891,8 +893,11 @@ func (s *Store) ExecuteReadCypher(ctx context.Context, request ports.CypherQuery
 		rowLimit = ports.MaxCypherQueryRows
 	}
 	var rows []ports.CypherRow
+	var truncated bool
+	started := time.Now()
 	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
 		rows = nil
+		truncated = false
 		result, err := tx.Run(ctx, query, request.Params)
 		if err != nil {
 			return nil, err
@@ -903,6 +908,7 @@ func (s *Store) ExecuteReadCypher(ctx context.Context, request ports.CypherQuery
 		}
 		for result.Next(ctx) {
 			if len(rows) >= rowLimit {
+				truncated = true
 				break
 			}
 			record := result.Record()
@@ -917,8 +923,10 @@ func (s *Store) ExecuteReadCypher(ctx context.Context, request ports.CypherQuery
 		}
 		return nil, result.Err()
 	}); err != nil {
+		emitNeo4jReadCypherDetail(ctx, s.database, query, request.Params, rowLimit, len(rows), truncated, time.Since(started), "failed", err)
 		return nil, fmt.Errorf("execute read cypher: %w", err)
 	}
+	emitNeo4jReadCypherDetail(ctx, s.database, query, request.Params, rowLimit, len(rows), truncated, time.Since(started), "completed", nil)
 	return rows, nil
 }
 
@@ -1384,6 +1392,32 @@ func emitNeo4jReadGuardrail(ctx context.Context, database string, status string,
 		attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
 	}
 	telemetry.Event(ctx, "neo4j.read.guardrail", attrs)
+}
+
+func emitNeo4jReadCypherDetail(ctx context.Context, database string, query string, params map[string]any, rowLimit int, rowsReturned int, truncated bool, duration time.Duration, status string, err error) {
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "component", Value: "graphstore.neo4j"},
+		telemetry.Field{Key: "operation", Value: "read_cypher"},
+		telemetry.Field{Key: "db.system.name", Value: "neo4j"},
+		telemetry.Field{Key: "db.namespace", Value: strings.TrimSpace(database)},
+		telemetry.Field{Key: "cypher.query_hash", Value: safeCypherQueryHash(query)},
+		telemetry.Field{Key: "cypher.query_length", Value: len(query)},
+		telemetry.Field{Key: "cypher.param_count", Value: len(params)},
+		telemetry.Field{Key: "cypher.row_limit", Value: rowLimit},
+		telemetry.Field{Key: "cypher.rows_returned", Value: rowsReturned},
+		telemetry.Field{Key: "cypher.rows_truncated", Value: truncated},
+		telemetry.Field{Key: "duration_ms", Value: duration.Milliseconds()},
+		telemetry.Field{Key: "status", Value: strings.TrimSpace(status)},
+	)
+	if err != nil {
+		attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+	}
+	telemetry.Event(ctx, "neo4j.read.cypher", attrs)
+}
+
+func safeCypherQueryHash(query string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(query)))
+	return hex.EncodeToString(sum[:8])
 }
 
 func neo4jAnnotateMain(ctx context.Context, database string, operation string, status string) {

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -2,8 +2,10 @@ package neo4j
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -141,6 +143,40 @@ func TestValidateReadOnlyCypherRejectsMutatingClauses(t *testing.T) {
 		if err := validateReadOnlyCypher(query); err != nil {
 			t.Fatalf("validateReadOnlyCypher(%q) error = %v, want nil", query, err)
 		}
+	}
+}
+
+func TestEmitNeo4jReadCypherDetailDoesNotLeakQueryOrParams(t *testing.T) {
+	stderr := captureNeo4jStderr(t, func() {
+		emitNeo4jReadCypherDetail(context.Background(), "neo4j", "MATCH (n {token: 'raw-secret-token-value'}) RETURN n", map[string]any{
+			"token": "raw-secret-token-value",
+		}, 100, 100, true, 125*time.Millisecond, "completed", nil)
+	})
+	if strings.Contains(stderr, "MATCH") || strings.Contains(stderr, "raw-secret-token-value") || strings.Contains(stderr, "token") {
+		t.Fatalf("neo4j read cypher detail leaked query or params: %s", stderr)
+	}
+	payloads := neo4jTelemetryPayloads(t, stderr, "event", "neo4j.read.cypher")
+	if len(payloads) != 1 {
+		t.Fatalf("neo4j.read.cypher events = %d, want 1; stderr=%s", len(payloads), stderr)
+	}
+	payload := payloads[0]
+	for key, want := range map[string]any{
+		"operation":             "read_cypher",
+		"cypher.query_length":   float64(len("MATCH (n {token: 'raw-secret-token-value'}) RETURN n")),
+		"cypher.param_count":    float64(1),
+		"cypher.row_limit":      float64(100),
+		"cypher.rows_returned":  float64(100),
+		"cypher.rows_truncated": true,
+		"duration_ms":           float64(125),
+		"status":                "completed",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	hash, ok := payload["cypher.query_hash"].(string)
+	if !ok || len(hash) != 16 {
+		t.Fatalf("cypher.query_hash = %#v, want 16-char hash; payload=%#v", payload["cypher.query_hash"], payload)
 	}
 }
 
@@ -786,4 +822,44 @@ func waitForStore(t *testing.T, ctx context.Context, cfg config.GraphStoreConfig
 	}
 	t.Fatalf("neo4j did not become ready: %v", lastErr)
 	return nil
+}
+
+func captureNeo4jStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stderr: %v", err)
+	}
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	payload, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	return string(payload)
+}
+
+func neo4jTelemetryPayloads(t *testing.T, stderr string, kind string, name string) []map[string]any {
+	t.Helper()
+	payloads := []map[string]any{}
+	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		payload := map[string]any{}
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			t.Fatalf("unmarshal telemetry payload %q: %v", line, err)
+		}
+		if payload["kind"] == kind && payload["name"] == name {
+			payloads = append(payloads, payload)
+		}
+	}
+	return payloads
 }

--- a/internal/jobobservability/phases.go
+++ b/internal/jobobservability/phases.go
@@ -1,0 +1,151 @@
+package jobobservability
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphingest"
+	platformjobs "github.com/writer/cerebro/internal/jobs"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type Payload map[string]any
+
+func RunPhase[T any](ctx context.Context, service *platformjobs.Service, job *ports.Job, phase string, label string, payload func(T) Payload, run func() (T, error)) (T, error) {
+	if strings.TrimSpace(label) == "" {
+		label = strings.TrimSpace(phase)
+	}
+	started := time.Now()
+	RecordPhase(ctx, service, job, phase, ports.JobStatusRunning, label+" started", nil, 0, nil)
+	result, err := run()
+	if err != nil {
+		RecordPhase(ctx, service, job, phase, ports.JobStatusFailed, label+" failed", phasePayload(payload, result), time.Since(started), err)
+		return result, err
+	}
+	RecordPhase(ctx, service, job, phase, ports.JobStatusCompleted, label+" completed", phasePayload(payload, result), time.Since(started), nil)
+	return result, nil
+}
+
+func RecordPhase(ctx context.Context, service *platformjobs.Service, job *ports.Job, phase string, status string, message string, payload Payload, duration time.Duration, err error) {
+	service.RecordPhase(ctx, job, platformjobs.PhaseRecord{
+		Phase:    phase,
+		Status:   status,
+		Message:  message,
+		Payload:  payload,
+		Duration: duration,
+		Err:      err,
+	})
+}
+
+func phasePayload[T any](payload func(T) Payload, result T) Payload {
+	if payload == nil {
+		return nil
+	}
+	return payload(result)
+}
+
+func SourceRuntimeSyncPayload(result *cerebrov1.SyncSourceRuntimeResponse) Payload {
+	if result == nil {
+		return nil
+	}
+	return Payload{
+		"pages_read":        result.GetPagesRead(),
+		"events_appended":   result.GetEventsAppended(),
+		"next_cursor":       result.GetRuntime().GetNextCursor() != nil,
+		"runtime_returned":  result.GetRuntime() != nil,
+		"checkpoint_cursor": result.GetRuntime().GetCheckpoint().GetCursorOpaque() != "",
+	}
+}
+
+func GraphIngestPayload(result *graphingest.RunResult) Payload {
+	if result == nil || result.Ingest == nil {
+		return nil
+	}
+	return Payload{
+		"pages_read":               result.Ingest.PagesRead,
+		"events_read":              result.Ingest.EventsRead,
+		"entities_projected":       result.Ingest.EntitiesProjected,
+		"links_projected":          result.Ingest.LinksProjected,
+		"checkpoint_persisted":     result.Ingest.CheckpointPersisted,
+		"checkpoint_complete":      result.Ingest.CheckpointComplete,
+		"checkpoint_already_fresh": result.Ingest.CheckpointAlreadyFresh,
+		"checkpoint_resumed":       result.Ingest.CheckpointResumed,
+	}
+}
+
+func FindingRulesPayload(result *findings.EvaluateRulesResult) Payload {
+	if result == nil {
+		return nil
+	}
+	var findingsEmitted int
+	for _, evaluation := range result.Evaluations {
+		if evaluation != nil {
+			findingsEmitted += len(evaluation.Findings)
+		}
+	}
+	return Payload{
+		"events_evaluated":    result.EventsEvaluated,
+		"evaluations":         len(result.Evaluations),
+		"findings_emitted":    findingsEmitted,
+		"runtime_returned":    result.Runtime != nil,
+		"events_per_evaluate": averageUint32Int(result.EventsEvaluated, len(result.Evaluations)),
+	}
+}
+
+func GraphRulesPayload(result *findings.EvaluateGraphRulesResult) Payload {
+	if result == nil {
+		return nil
+	}
+	var findingsEmitted int
+	var evidenceWritten int
+	var rowsRead uint32
+	var truncated int
+	for _, evaluation := range result.Evaluations {
+		if evaluation == nil {
+			continue
+		}
+		findingsEmitted += len(evaluation.Findings)
+		evidenceWritten += len(evaluation.Evidence)
+		rowsRead += evaluation.RowsRead
+		if evaluation.Truncated {
+			truncated++
+		}
+	}
+	return Payload{
+		"evaluations":       len(result.Evaluations),
+		"findings_emitted":  findingsEmitted,
+		"evidence_written":  evidenceWritten,
+		"rows_read":         rowsRead,
+		"truncated_rules":   truncated,
+		"runtime_returned":  result.Runtime != nil,
+		"rows_per_evaluate": averageUint32Int(rowsRead, len(result.Evaluations)),
+	}
+}
+
+func CandidateRulesPayload(result *findings.EvaluateCandidateRulesResult) Payload {
+	if result == nil {
+		return nil
+	}
+	var candidatesEmitted int
+	for _, evaluation := range result.Evaluations {
+		if evaluation != nil {
+			candidatesEmitted += len(evaluation.Candidates)
+		}
+	}
+	return Payload{
+		"events_evaluated":   result.EventsEvaluated,
+		"evaluations":        len(result.Evaluations),
+		"candidates_emitted": candidatesEmitted,
+		"runtime_returned":   result.Runtime != nil,
+	}
+}
+
+func averageUint32Int(total uint32, count int) float64 {
+	if count <= 0 {
+		return 0
+	}
+	return float64(total) / float64(count)
+}

--- a/internal/jobpayload/payload.go
+++ b/internal/jobpayload/payload.go
@@ -1,0 +1,85 @@
+package jobpayload
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+type Payload map[string]any
+
+func String(payload Payload, key string, fallback string) string {
+	if value, ok := payload[key]; ok {
+		if typed, ok := value.(string); ok && strings.TrimSpace(typed) != "" {
+			return strings.TrimSpace(typed)
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func Uint32(payload Payload, key string) uint32 {
+	value, ok := payload[key]
+	if !ok {
+		return 0
+	}
+	switch typed := value.(type) {
+	case float64:
+		if typed > 0 {
+			return uint32(typed)
+		}
+	case json.Number:
+		parsed, _ := strconv.ParseUint(string(typed), 10, 32)
+		return uint32(parsed)
+	case string:
+		parsed, _ := strconv.ParseUint(strings.TrimSpace(typed), 10, 32)
+		return uint32(parsed)
+	}
+	return 0
+}
+
+func StringSlice(payload Payload, key string) []string {
+	value, ok := payload[key]
+	if !ok {
+		return nil
+	}
+	switch typed := value.(type) {
+	case []string:
+		return typed
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
+				values = append(values, strings.TrimSpace(text))
+			}
+		}
+		return values
+	case string:
+		if strings.TrimSpace(typed) == "" {
+			return nil
+		}
+		return []string{strings.TrimSpace(typed)}
+	default:
+		return nil
+	}
+}
+
+func StringMap(payload Payload, key string) map[string]string {
+	result := map[string]string{}
+	value, ok := payload[key]
+	if !ok {
+		return result
+	}
+	switch typed := value.(type) {
+	case map[string]string:
+		for k, v := range typed {
+			result[k] = v
+		}
+	case map[string]any:
+		for k, v := range typed {
+			if text, ok := v.(string); ok {
+				result[k] = text
+			}
+		}
+	}
+	return result
+}

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -50,6 +50,15 @@ type Service struct {
 	mu           sync.Mutex
 }
 
+type PhaseRecord struct {
+	Phase    string
+	Status   string
+	Message  string
+	Payload  map[string]any
+	Duration time.Duration
+	Err      error
+}
+
 func New(store ports.JobStore) *Service {
 	return &Service{store: store, runners: map[string]Runner{}, now: func() time.Time { return time.Now().UTC() }, asyncCancels: map[uint64]context.CancelFunc{}, asyncJobs: map[string]uint64{}}
 }
@@ -232,6 +241,187 @@ func (s *Service) startHeartbeat(ctx context.Context, job *ports.Job) func() {
 		cancel()
 		<-done
 	}
+}
+
+func (s *Service) RecordPhase(ctx context.Context, job *ports.Job, record PhaseRecord) {
+	if s == nil || s.store == nil || job == nil {
+		return
+	}
+	phase := strings.TrimSpace(record.Phase)
+	if phase == "" {
+		phase = "unknown"
+	}
+	status := normalizeJobPhaseStatus(record.Status)
+	message := strings.TrimSpace(record.Message)
+	if message == "" {
+		message = "job phase " + status
+	}
+	safePayload := sanitizeJobPhasePayload(record.Payload)
+	if record.Duration > 0 {
+		safePayload["duration_ms"] = record.Duration.Milliseconds()
+	}
+	if record.Err != nil {
+		safePayload["error_kind"] = telemetry.ErrorKind(record.Err)
+	}
+	safePayload["phase"] = phase
+	_, _ = s.store.AppendJobEvent(context.WithoutCancel(ctx), ports.JobEvent{
+		JobID:   job.ID,
+		Type:    jobPhaseEventType(status),
+		Status:  status,
+		Message: strings.TrimSpace(message),
+		Payload: safePayload,
+	})
+	telemetry.Event(ctx, jobPhaseTelemetryEventName(status), jobTelemetryAttrs(job).With(jobPhaseTelemetryAttrs(phase, status, safePayload, record.Duration)))
+}
+
+func normalizeJobPhaseStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "running", "started", "start":
+		return ports.JobStatusRunning
+	case "completed", "complete", "success", "succeeded":
+		return ports.JobStatusCompleted
+	case "failed", "failure", "error":
+		return ports.JobStatusFailed
+	case "skipped", "skip":
+		return "skipped"
+	case "cancelled", "canceled":
+		return ports.JobStatusCancelled
+	default:
+		return "unknown"
+	}
+}
+
+func jobPhaseEventType(status string) string {
+	switch normalizeJobPhaseStatus(status) {
+	case ports.JobStatusRunning:
+		return "phase_started"
+	case ports.JobStatusCompleted:
+		return "phase_completed"
+	case ports.JobStatusFailed:
+		return "phase_failed"
+	case ports.JobStatusCancelled:
+		return "phase_cancelled"
+	case "skipped":
+		return "phase_skipped"
+	default:
+		return "phase_event"
+	}
+}
+
+func jobPhaseTelemetryEventName(status string) string {
+	switch normalizeJobPhaseStatus(status) {
+	case ports.JobStatusRunning:
+		return "platform.job.phase.started"
+	case ports.JobStatusFailed:
+		return "platform.job.phase.failed"
+	case ports.JobStatusCancelled:
+		return "platform.job.phase.cancelled"
+	case "skipped":
+		return "platform.job.phase.skipped"
+	default:
+		return "platform.job.phase.completed"
+	}
+}
+
+func jobPhaseTelemetryAttrs(phase string, status string, payload map[string]any, duration time.Duration) telemetry.Attributes {
+	phaseKey := compactJobPhaseKey(phase)
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "job.phase", Value: strings.TrimSpace(phase)},
+		telemetry.Field{Key: "job.phase_key", Value: phaseKey},
+		telemetry.Field{Key: "job.phase.status", Value: normalizeJobPhaseStatus(status)},
+		telemetry.Field{Key: "job_phase", Value: strings.TrimSpace(phase)},
+		telemetry.Field{Key: "job_phase_key", Value: phaseKey},
+		telemetry.Field{Key: "job_phase_status", Value: normalizeJobPhaseStatus(status)},
+		telemetry.Field{Key: "job.phase.detail.key_count", Value: len(payload)},
+		telemetry.Field{Key: "job.phase.detail.keys", Value: strings.Join(sortedAnyMapKeys(payload), ",")},
+	)
+	if duration > 0 {
+		attrs = attrs.WithField(telemetry.Field{Key: "job.phase.duration_ms", Value: duration.Milliseconds()})
+	}
+	for _, key := range sortedAnyMapKeys(payload) {
+		if key == "phase" || sensitiveJobPhaseKey(key) {
+			continue
+		}
+		attrs = attrs.WithField(telemetry.Field{Key: "job.phase.detail." + compactJobPhaseKey(key), Value: payload[key]})
+	}
+	return attrs
+}
+
+func sanitizeJobPhasePayload(payload map[string]any) map[string]any {
+	if len(payload) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(payload))
+	for key, value := range payload {
+		key = strings.TrimSpace(key)
+		if key == "" || sensitiveJobPhaseKey(key) {
+			continue
+		}
+		out[key] = safeJobPhaseValue(value)
+	}
+	return out
+}
+
+func safeJobPhaseValue(value any) any {
+	switch v := value.(type) {
+	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return v
+	case string:
+		return boundJobPhaseString(v)
+	case map[string]any:
+		return fmt.Sprintf("map[%d]", len(v))
+	case []any:
+		return fmt.Sprintf("list[%d]", len(v))
+	case []string:
+		return fmt.Sprintf("list[%d]", len(v))
+	default:
+		return fmt.Sprintf("%T", value)
+	}
+}
+
+func boundJobPhaseString(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) > 256 {
+		return value[:256]
+	}
+	return value
+}
+
+func sensitiveJobPhaseKey(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	for _, part := range []string{"secret", "token", "password", "credential", "private_key", "api_key", "apikey", "dsn", "bearer"} {
+		if strings.Contains(key, part) {
+			return true
+		}
+	}
+	return false
+}
+
+func compactJobPhaseKey(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	var out strings.Builder
+	out.Grow(len(value))
+	lastUnderscore := false
+	for _, ch := range value {
+		ok := (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')
+		if ok {
+			out.WriteRune(ch)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			out.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	key := strings.Trim(out.String(), "_")
+	if key == "" {
+		return "unknown"
+	}
+	if len(key) > 64 {
+		return key[:64]
+	}
+	return key
 }
 
 func (s *Service) Run(ctx context.Context, jobID string) (err error) {

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -227,6 +227,75 @@ func TestRunAppendsHeartbeatEvent(t *testing.T) {
 	}
 }
 
+func TestRecordPhaseAppendsSanitizedEventAndTelemetry(t *testing.T) {
+	store := newMemoryJobStore()
+	service := New(store)
+	job := &ports.Job{
+		ID:        "job-phase",
+		Kind:      KindSourceRuntimeOrchestrate,
+		Status:    ports.JobStatusRunning,
+		TenantID:  "writer",
+		SubjectID: "runtime-okta",
+	}
+
+	stderr := captureJobServiceStderr(t, func() {
+		service.RecordPhase(context.Background(), job, PhaseRecord{
+			Phase:   "orchestrator.graph_ingest",
+			Status:  ports.JobStatusCompleted,
+			Message: "graph ingest completed",
+			Payload: map[string]any{
+				"entities_projected": 7,
+				"api_token":          "raw-secret-token-value",
+				"headers":            map[string]any{"authorization": "bearer raw-secret-token-value"},
+			},
+			Duration: 1500 * time.Millisecond,
+		})
+	})
+
+	if len(store.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(store.events))
+	}
+	event := store.events[0]
+	if event.Type != "phase_completed" || event.Status != ports.JobStatusCompleted {
+		t.Fatalf("event type/status = %q/%q, want phase_completed/completed", event.Type, event.Status)
+	}
+	if event.Payload["api_token"] != nil {
+		t.Fatalf("sensitive payload key persisted: %#v", event.Payload)
+	}
+	if event.Payload["headers"] != "map[1]" {
+		t.Fatalf("headers payload = %#v, want structural summary", event.Payload["headers"])
+	}
+	if strings.Contains(stderr, "raw-secret-token-value") {
+		t.Fatalf("phase telemetry leaked secret value: %s", stderr)
+	}
+	payloads := jobTelemetryPayloads(t, stderr, "event", "platform.job.phase.completed")
+	if len(payloads) != 1 {
+		t.Fatalf("platform.job.phase.completed events = %d, want 1; stderr=%s", len(payloads), stderr)
+	}
+	payload := payloads[0]
+	for key, want := range map[string]any{
+		"job.id":                              "job-phase",
+		"job.phase":                           "orchestrator.graph_ingest",
+		"job.phase.status":                    ports.JobStatusCompleted,
+		"job.phase.detail.entities_projected": float64(7),
+		"job.phase.detail.headers":            "map[1]",
+		"job.phase.detail.duration_ms":        float64(1500),
+		"job.phase.detail.keys":               "duration_ms,entities_projected,headers,phase",
+		"job.phase.duration_ms":               float64(1500),
+		"job.phase_key":                       "orchestrator_graph_ingest",
+		"job_phase_key":                       "orchestrator_graph_ingest",
+		"job_phase_status":                    ports.JobStatusCompleted,
+		"job.phase.detail.key_count":          float64(4),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if _, ok := payload["job.phase.detail.api_token"]; ok {
+		t.Fatalf("sensitive telemetry detail key emitted: %#v", payload)
+	}
+}
+
 func TestRunReportTelemetryFallsBackToSubjectID(t *testing.T) {
 	store := newMemoryJobStore()
 	store.jobs["job-report-telemetry"] = &ports.Job{


### PR DESCRIPTION
## Summary
- add durable platform job phase events and telemetry with safe detail payload summaries
- add CLI orchestrator phase detail/skipped telemetry
- add safe Neo4j read-Cypher query-shape telemetry and graph-rule per-rule result events
- move job phase/payload helpers out of bootstrap to stay within architecture surface limits

## Validation
- make check-structural
- go test ./...
- make lint