### PR TITLE
refactor(sources): extract NDJSON archive reader into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -22,7 +22,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 
 | Source | Current LOC Budget | Extraction Pressure |
 | --- | ---: | --- |
-| `aurelius` | 653 | Split source orchestration from record mapping and shared request plumbing. |
+| `aurelius` | 623 | Split source orchestration from record mapping and shared request plumbing. |
 | `aws` | 19121 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
 | `azure` | 2856 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 1104 | Move shared API pagination and response normalization into reusable source helpers. |

--- a/internal/sourcecdk/ndjson_archive.go
+++ b/internal/sourcecdk/ndjson_archive.go
@@ -1,0 +1,63 @@
+package sourcecdk
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrNDJSONDecompressedTooLarge is returned by ReadNDJSONArchive when the
+// decompressed stream exceeds the configured byte ceiling.
+var ErrNDJSONDecompressedTooLarge = errors.New("decompressed ndjson archive exceeds limit")
+
+type countingReader struct {
+	reader    io.Reader
+	bytesRead int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.bytesRead += int64(n)
+	return n, err
+}
+
+// ReadNDJSONArchive reads newline-delimited JSON from r, transparently
+// decompressing gzip when gzipped is true. It enforces a decompressed byte
+// ceiling and a maximum line length, returning each non-empty line's raw bytes.
+// Returned slices are copies safe to retain after the call.
+func ReadNDJSONArchive(r io.Reader, gzipped bool, decompressedLimitBytes int64, maxLineBytes int) ([][]byte, error) {
+	if gzipped {
+		gz, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, fmt.Errorf("gunzip: %w", err)
+		}
+		defer func() { _ = gz.Close() }()
+		r = gz
+	}
+	counter := &countingReader{reader: io.LimitReader(r, decompressedLimitBytes+1)}
+	scanner := bufio.NewScanner(counter)
+	scanner.Buffer(make([]byte, 0, 64<<10), maxLineBytes)
+	lines := make([][]byte, 0, 64)
+	for scanner.Scan() {
+		if counter.bytesRead > decompressedLimitBytes {
+			return nil, fmt.Errorf("%w: %d bytes", ErrNDJSONDecompressedTooLarge, decompressedLimitBytes)
+		}
+		text := bytes.TrimSpace(scanner.Bytes())
+		if len(text) == 0 {
+			continue
+		}
+		line := make([]byte, len(text))
+		copy(line, text)
+		lines = append(lines, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan archive: %w", err)
+	}
+	if counter.bytesRead > decompressedLimitBytes {
+		return nil, fmt.Errorf("%w: %d bytes", ErrNDJSONDecompressedTooLarge, decompressedLimitBytes)
+	}
+	return lines, nil
+}

--- a/internal/sourcecdk/ndjson_archive_test.go
+++ b/internal/sourcecdk/ndjson_archive_test.go
@@ -1,0 +1,59 @@
+package sourcecdk
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestReadNDJSONArchivePlainSkipsBlankLines(t *testing.T) {
+	input := strings.NewReader("{\"a\":1}\n\n  \n{\"b\":2}\n")
+	lines, err := ReadNDJSONArchive(input, false, 1<<20, 1<<20)
+	if err != nil {
+		t.Fatalf("ReadNDJSONArchive() error = %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("len(lines) = %d, want 2", len(lines))
+	}
+	if string(lines[0]) != "{\"a\":1}" || string(lines[1]) != "{\"b\":2}" {
+		t.Fatalf("lines = %q, want trimmed json records", lines)
+	}
+}
+
+func TestReadNDJSONArchiveGzip(t *testing.T) {
+	compressed := &bytes.Buffer{}
+	gz := gzip.NewWriter(compressed)
+	if _, err := gz.Write([]byte("{\"a\":1}\n{\"b\":2}\n")); err != nil {
+		t.Fatalf("gzip.Write() error = %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip.Close() error = %v", err)
+	}
+	lines, err := ReadNDJSONArchive(bytes.NewReader(compressed.Bytes()), true, 1<<20, 1<<20)
+	if err != nil {
+		t.Fatalf("ReadNDJSONArchive() error = %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("len(lines) = %d, want 2", len(lines))
+	}
+}
+
+func TestReadNDJSONArchiveEnforcesDecompressedLimit(t *testing.T) {
+	record := []byte("{\"value\":\"aaaaaaaaaaaaaaaaaaaa\"}\n")
+	compressed := &bytes.Buffer{}
+	gz := gzip.NewWriter(compressed)
+	for i := 0; i < 3; i++ {
+		if _, err := gz.Write(record); err != nil {
+			t.Fatalf("gzip.Write() error = %v", err)
+		}
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip.Close() error = %v", err)
+	}
+	_, err := ReadNDJSONArchive(bytes.NewReader(compressed.Bytes()), true, int64(len(record))*2, 1<<20)
+	if !errors.Is(err, ErrNDJSONDecompressedTooLarge) {
+		t.Fatalf("ReadNDJSONArchive() error = %v, want ErrNDJSONDecompressedTooLarge", err)
+	}
+}

--- a/sources/aurelius/source.go
+++ b/sources/aurelius/source.go
@@ -5,9 +5,7 @@
 package aurelius
 
 import (
-	"bufio"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"embed"
 	"encoding/json"
@@ -569,52 +567,22 @@ func (s *Source) readArchive(ctx context.Context, client s3API, bucket, key stri
 }
 
 func readArchiveRecords(reader io.Reader, key string, decompressedLimitBytes int64) ([]aureliusRecord, error) {
-	if strings.HasSuffix(key, ".gz") {
-		gz, err := gzip.NewReader(reader)
-		if err != nil {
-			return nil, fmt.Errorf("gunzip: %w", err)
-		}
-		defer func() { _ = gz.Close() }()
-		reader = gz
-	}
-	counter := &countingReader{reader: io.LimitReader(reader, decompressedLimitBytes+1)}
-	scanner := bufio.NewScanner(counter)
-	scanner.Buffer(make([]byte, 0, 64<<10), maxLineBytes)
-	records := make([]aureliusRecord, 0, 64)
-	line := 0
-	for scanner.Scan() {
-		if counter.bytesRead > decompressedLimitBytes {
+	lines, err := sourcecdk.ReadNDJSONArchive(reader, strings.HasSuffix(key, ".gz"), decompressedLimitBytes, maxLineBytes)
+	if err != nil {
+		if errors.Is(err, sourcecdk.ErrNDJSONDecompressedTooLarge) {
 			return nil, fmt.Errorf("%w: %d bytes", ErrDecompressedObjectTooLarge, decompressedLimitBytes)
 		}
-		line++
-		text := bytes.TrimSpace(scanner.Bytes())
-		if len(text) == 0 {
-			continue
-		}
+		return nil, err
+	}
+	records := make([]aureliusRecord, 0, len(lines))
+	for index, line := range lines {
 		var rec aureliusRecord
-		if err := json.Unmarshal(text, &rec); err != nil {
-			return nil, fmt.Errorf("decode line %d: %w", line, err)
+		if err := json.Unmarshal(line, &rec); err != nil {
+			return nil, fmt.Errorf("decode line %d: %w", index+1, err)
 		}
 		records = append(records, rec)
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan archive: %w", err)
-	}
-	if counter.bytesRead > decompressedLimitBytes {
-		return nil, fmt.Errorf("%w: %d bytes", ErrDecompressedObjectTooLarge, decompressedLimitBytes)
-	}
 	return records, nil
-}
-
-type countingReader struct {
-	reader    io.Reader
-	bytesRead int64
-}
-
-func (r *countingReader) Read(p []byte) (int, error) {
-	n, err := r.reader.Read(p)
-	r.bytesRead += int64(n)
-	return n, err
 }
 
 func buildEvent(st settings, rec aureliusRecord, kind, schemaRef string) (*primitives.Event, error) {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -14,7 +14,7 @@ const newSourcePackageLOCBudget = 300
 // sources. If a source shrinks, lower its ceiling in the same change; if a
 // source grows, move shared behavior into the Source CDK instead of raising it.
 var grandfatheredSourcePackageLOCBudgets = map[string]int{
-	"aurelius":        653,
+	"aurelius":        623,
 	"aws":             19121,
 	"azure":           2856,
 	"cosmo":           1104,


### PR DESCRIPTION
## What
Extract the gzip/NDJSON archive reader (line scanning, max-line and decompressed-size limits) out of the `aurelius` source into a reusable `internal/sourcecdk.ReadNDJSONArchive` helper.

## Why
Part of the Source CDK extraction effort (#956, #684). `aurelius` is a grandfathered source over the 300-LOC Source CDK budget. This moves self-contained, provider-agnostic archive-reading behavior into the shared CDK so other NDJSON-archive sources can reuse it, and ratchets the aurelius ceiling down 653 -> 623.

## Notes
- No change to emitted events. `readArchiveRecords` remains a thin wrapper that maps the shared limit error back to the source's `ErrDecompressedObjectTooLarge`.
- Lowered `grandfatheredSourcePackageLOCBudgets["aurelius"]` and the extraction-plan doc row to the new exact LOC, per the no-growth ratchet.

## Tests
- `go build ./...`
- `go test ./sources/aurelius/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/ -run Grandfathered -count=1`
- Added `internal/sourcecdk/ndjson_archive_test.go` (plain, gzip, blank-line, decompressed-limit).