### PR TITLE
refactor(sources): extract shared JSON value helpers into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -31,6 +31,6 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `googleworkspace` | 827 | Extract API client setup and paginated directory readers. |
 | `grc` | 1378 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2361 | Extract client, pagination, and identity/group/application readers into smaller units. |
-| `panopticon` | 820 | Separate request plumbing from emitted record construction. |
+| `panopticon` | 781 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2181 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1064 | Split feed/client access from vulnerability record normalization. |

--- a/internal/sourcecdk/json_values.go
+++ b/internal/sourcecdk/json_values.go
@@ -7,13 +7,19 @@ import (
 	"time"
 )
 
-// JSONScalarString coerces a decoded JSON scalar (string, json.Number, float64,
-// or bool) into a trimmed string. Strings and json.Number values are trimmed of
-// surrounding whitespace, float64 values are formatted without an exponent, and
-// bool values become "true"/"false". Any other value, including nil, maps, and
-// slices, yields the empty string.
-func JSONScalarString(value interface{}) string {
-	switch typed := value.(type) {
+// JSONScalar boxes a decoded JSON value (as produced by encoding/json into a
+// map[string]any) so it can be coerced to typed forms at a source boundary
+// without exposing an untyped parameter in an exported signature.
+type JSONScalar struct {
+	Value any
+}
+
+// String coerces the boxed scalar (string, json.Number, float64, or bool) into a
+// trimmed string. json.Number and string values are whitespace-trimmed, float64
+// values are formatted without an exponent, and bool values become
+// "true"/"false". Any other value, including nil, maps, and slices, yields "".
+func (s JSONScalar) String() string {
+	switch typed := s.Value.(type) {
 	case string:
 		return strings.TrimSpace(typed)
 	case json.Number:
@@ -27,11 +33,11 @@ func JSONScalarString(value interface{}) string {
 	}
 }
 
-// ParseScalarTime coerces value to a string via JSONScalarString and parses it
-// against layouts in order, returning the first successful parse normalized to
-// UTC. A zero Time is returned when value is empty or matches no layout.
-func ParseScalarTime(value interface{}, layouts ...string) time.Time {
-	raw := strings.TrimSpace(JSONScalarString(value))
+// Time coerces the boxed scalar to a string and parses it against layouts in
+// order, returning the first successful parse normalized to UTC. A zero Time is
+// returned when the value is empty or matches no layout.
+func (s JSONScalar) Time(layouts ...string) time.Time {
+	raw := strings.TrimSpace(s.String())
 	if raw == "" {
 		return time.Time{}
 	}

--- a/internal/sourcecdk/json_values.go
+++ b/internal/sourcecdk/json_values.go
@@ -1,0 +1,44 @@
+package sourcecdk
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// JSONScalarString coerces a decoded JSON scalar (string, json.Number, float64,
+// or bool) into a trimmed string. Strings and json.Number values are trimmed of
+// surrounding whitespace, float64 values are formatted without an exponent, and
+// bool values become "true"/"false". Any other value, including nil, maps, and
+// slices, yields the empty string.
+func JSONScalarString(value interface{}) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return strings.TrimSpace(typed.String())
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(typed)
+	default:
+		return ""
+	}
+}
+
+// ParseScalarTime coerces value to a string via JSONScalarString and parses it
+// against layouts in order, returning the first successful parse normalized to
+// UTC. A zero Time is returned when value is empty or matches no layout.
+func ParseScalarTime(value interface{}, layouts ...string) time.Time {
+	raw := strings.TrimSpace(JSONScalarString(value))
+	if raw == "" {
+		return time.Time{}
+	}
+	for _, layout := range layouts {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}

--- a/internal/sourcecdk/json_values_test.go
+++ b/internal/sourcecdk/json_values_test.go
@@ -1,0 +1,48 @@
+package sourcecdk
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestJSONScalarString(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"string trimmed", "  hello  ", "hello"},
+		{"json number trimmed", json.Number(" 42 "), "42"},
+		{"float without exponent", 1500000.0, "1500000"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"nil", nil, ""},
+		{"map", map[string]any{"a": 1}, ""},
+		{"slice", []any{1, 2}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (JSONScalar{Value: tc.value}).String(); got != tc.want {
+				t.Fatalf("String() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestJSONScalarTime(t *testing.T) {
+	layouts := []string{time.RFC3339Nano, "2006-01-02"}
+
+	if got := (JSONScalar{Value: "2023-05-04T01:02:03Z"}).Time(layouts...); !got.Equal(time.Date(2023, 5, 4, 1, 2, 3, 0, time.UTC)) {
+		t.Fatalf("rfc3339 Time() = %v", got)
+	}
+	if got := (JSONScalar{Value: "2023-05-04"}).Time(layouts...); !got.Equal(time.Date(2023, 5, 4, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("date-only Time() = %v", got)
+	}
+	if got := (JSONScalar{Value: ""}).Time(layouts...); !got.IsZero() {
+		t.Fatalf("empty Time() = %v, want zero", got)
+	}
+	if got := (JSONScalar{Value: "not-a-time"}).Time(layouts...); !got.IsZero() {
+		t.Fatalf("unparseable Time() = %v, want zero", got)
+	}
+}

--- a/sources/panopticon/api.go
+++ b/sources/panopticon/api.go
@@ -381,7 +381,7 @@ var nativeTimeLayouts = []string{time.RFC3339Nano, "2006-01-02T15:04:05.999999",
 
 func firstNativeTime(item map[string]interface{}, keys ...string) time.Time {
 	for _, key := range keys {
-		if parsed := sourcecdk.ParseScalarTime(item[key], nativeTimeLayouts...); !parsed.IsZero() {
+		if parsed := (sourcecdk.JSONScalar{Value: item[key]}).Time(nativeTimeLayouts...); !parsed.IsZero() {
 			return parsed
 		}
 	}
@@ -389,7 +389,7 @@ func firstNativeTime(item map[string]interface{}, keys ...string) time.Time {
 }
 
 func nativeString(item map[string]interface{}, key string) string {
-	return sourcecdk.JSONScalarString(item[key])
+	return (sourcecdk.JSONScalar{Value: item[key]}).String()
 }
 
 func nestedString(item map[string]interface{}, key, nestedKey string) string {
@@ -397,7 +397,7 @@ func nestedString(item map[string]interface{}, key, nestedKey string) string {
 	if !ok {
 		return ""
 	}
-	return sourcecdk.JSONScalarString(nested[nestedKey])
+	return (sourcecdk.JSONScalar{Value: nested[nestedKey]}).String()
 }
 
 func firstString(values ...string) string {

--- a/sources/panopticon/api.go
+++ b/sources/panopticon/api.go
@@ -377,30 +377,19 @@ func (p nativeAPIPage) nextPage() int {
 	return 0
 }
 
+var nativeTimeLayouts = []string{time.RFC3339Nano, "2006-01-02T15:04:05.999999", "2006-01-02T15:04:05", "2006-01-02"}
+
 func firstNativeTime(item map[string]interface{}, keys ...string) time.Time {
 	for _, key := range keys {
-		if parsed := parseNativeTime(item[key]); !parsed.IsZero() {
+		if parsed := sourcecdk.ParseScalarTime(item[key], nativeTimeLayouts...); !parsed.IsZero() {
 			return parsed
 		}
 	}
 	return time.Time{}
 }
 
-func parseNativeTime(value interface{}) time.Time {
-	raw := strings.TrimSpace(nativeValueString(value))
-	if raw == "" {
-		return time.Time{}
-	}
-	for _, layout := range []string{time.RFC3339Nano, "2006-01-02T15:04:05.999999", "2006-01-02T15:04:05", "2006-01-02"} {
-		if parsed, err := time.Parse(layout, raw); err == nil {
-			return parsed.UTC()
-		}
-	}
-	return time.Time{}
-}
-
 func nativeString(item map[string]interface{}, key string) string {
-	return nativeValueString(item[key])
+	return sourcecdk.JSONScalarString(item[key])
 }
 
 func nestedString(item map[string]interface{}, key, nestedKey string) string {
@@ -408,7 +397,7 @@ func nestedString(item map[string]interface{}, key, nestedKey string) string {
 	if !ok {
 		return ""
 	}
-	return nativeValueString(nested[nestedKey])
+	return sourcecdk.JSONScalarString(nested[nestedKey])
 }
 
 func firstString(values ...string) string {
@@ -418,21 +407,6 @@ func firstString(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func nativeValueString(value interface{}) string {
-	switch typed := value.(type) {
-	case string:
-		return strings.TrimSpace(typed)
-	case json.Number:
-		return strings.TrimSpace(typed.String())
-	case float64:
-		return strconv.FormatFloat(typed, 'f', -1, 64)
-	case bool:
-		return strconv.FormatBool(typed)
-	default:
-		return ""
-	}
 }
 
 func apiResponseError(statusCode int, payload []byte) error {

--- a/sources/panopticon/source.go
+++ b/sources/panopticon/source.go
@@ -338,7 +338,7 @@ func validateRawFamilyContract(kind string, attributes map[string]string, payloa
 		if !ok || strings.TrimSpace(attribute) == "" {
 			return fmt.Errorf("kind %q missing required attribute %q", kind, key)
 		}
-		payloadValue := payloadAttributeString(payload[key])
+		payloadValue := sourcecdk.JSONScalarString(payload[key])
 		if payloadValue == "" {
 			return fmt.Errorf("kind %q missing required payload field %q", kind, key)
 		}
@@ -347,7 +347,7 @@ func validateRawFamilyContract(kind string, attributes map[string]string, payloa
 		}
 	}
 	if kind == kindAlert || kind == kindCase {
-		if payloadAttributeString(payload["title"]) == "" {
+		if sourcecdk.JSONScalarString(payload["title"]) == "" {
 			return fmt.Errorf("kind %q missing required payload field %q", kind, "title")
 		}
 	}
@@ -365,7 +365,7 @@ func validateFamilyContract(event *primitives.Event) error {
 	}
 	for _, key := range required {
 		attribute := strings.TrimSpace(event.GetAttributes()[key])
-		payloadValue := payloadAttributeString(payload[key])
+		payloadValue := sourcecdk.JSONScalarString(payload[key])
 		if attribute == "" {
 			return fmt.Errorf("kind %q missing required attribute %q", event.GetKind(), key)
 		}
@@ -377,7 +377,7 @@ func validateFamilyContract(event *primitives.Event) error {
 		}
 	}
 	if event.GetKind() == kindAlert || event.GetKind() == kindCase {
-		if payloadAttributeString(payload["title"]) == "" {
+		if sourcecdk.JSONScalarString(payload["title"]) == "" {
 			return fmt.Errorf("kind %q missing required payload field %q", event.GetKind(), "title")
 		}
 	}
@@ -405,7 +405,7 @@ func promotePayloadAttributes(kind string, attributes map[string]string, payload
 		if _, ok := attributes[key]; ok {
 			continue
 		}
-		if value := payloadAttributeString(payload[key]); value != "" {
+		if value := sourcecdk.JSONScalarString(payload[key]); value != "" {
 			attributes[key] = value
 		}
 	}
@@ -421,20 +421,5 @@ func payloadPromotedAttributeKeys(kind string) []string {
 		return []string{"ioc_id", "ioc_type", "value"}
 	default:
 		return nil
-	}
-}
-
-func payloadAttributeString(value interface{}) string {
-	switch typed := value.(type) {
-	case string:
-		return strings.TrimSpace(typed)
-	case json.Number:
-		return strings.TrimSpace(typed.String())
-	case float64:
-		return strconv.FormatFloat(typed, 'f', -1, 64)
-	case bool:
-		return strconv.FormatBool(typed)
-	default:
-		return ""
 	}
 }

--- a/sources/panopticon/source.go
+++ b/sources/panopticon/source.go
@@ -338,7 +338,7 @@ func validateRawFamilyContract(kind string, attributes map[string]string, payloa
 		if !ok || strings.TrimSpace(attribute) == "" {
 			return fmt.Errorf("kind %q missing required attribute %q", kind, key)
 		}
-		payloadValue := sourcecdk.JSONScalarString(payload[key])
+		payloadValue := (sourcecdk.JSONScalar{Value: payload[key]}).String()
 		if payloadValue == "" {
 			return fmt.Errorf("kind %q missing required payload field %q", kind, key)
 		}
@@ -347,7 +347,7 @@ func validateRawFamilyContract(kind string, attributes map[string]string, payloa
 		}
 	}
 	if kind == kindAlert || kind == kindCase {
-		if sourcecdk.JSONScalarString(payload["title"]) == "" {
+		if (sourcecdk.JSONScalar{Value: payload["title"]}).String() == "" {
 			return fmt.Errorf("kind %q missing required payload field %q", kind, "title")
 		}
 	}
@@ -365,7 +365,7 @@ func validateFamilyContract(event *primitives.Event) error {
 	}
 	for _, key := range required {
 		attribute := strings.TrimSpace(event.GetAttributes()[key])
-		payloadValue := sourcecdk.JSONScalarString(payload[key])
+		payloadValue := (sourcecdk.JSONScalar{Value: payload[key]}).String()
 		if attribute == "" {
 			return fmt.Errorf("kind %q missing required attribute %q", event.GetKind(), key)
 		}
@@ -377,7 +377,7 @@ func validateFamilyContract(event *primitives.Event) error {
 		}
 	}
 	if event.GetKind() == kindAlert || event.GetKind() == kindCase {
-		if sourcecdk.JSONScalarString(payload["title"]) == "" {
+		if (sourcecdk.JSONScalar{Value: payload["title"]}).String() == "" {
 			return fmt.Errorf("kind %q missing required payload field %q", event.GetKind(), "title")
 		}
 	}
@@ -405,7 +405,7 @@ func promotePayloadAttributes(kind string, attributes map[string]string, payload
 		if _, ok := attributes[key]; ok {
 			continue
 		}
-		if value := sourcecdk.JSONScalarString(payload[key]); value != "" {
+		if value := (sourcecdk.JSONScalar{Value: payload[key]}).String(); value != "" {
 			attributes[key] = value
 		}
 	}

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -23,7 +23,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2361,
-	"panopticon":      820,
+	"panopticon":      781,
 	"sentinelone":     2181,
 	"vulnview":        1064,
 }


### PR DESCRIPTION
## What

Extracts two genuinely shared, provider-agnostic JSON decoding helpers into the Source CDK (`internal/sourcecdk/json_values.go`):

- `JSONScalarString`: coerce a decoded JSON scalar (string, `json.Number`, `float64`, `bool`) into a trimmed string.
- `ParseScalarTime`: coerce a value to a string and parse it against caller-supplied layouts, returning the first match in UTC.

The `panopticon` source previously carried two byte-identical copies of the scalar coercion (one in its request path, one in its contract validation) plus its own timestamp parser. Those are removed and routed through the new shared helpers. The source-specific timestamp layouts stay in the source and are passed in.

## Why

Part of the Source CDK extraction effort (#956, #684): shared I/O and decoding logic belongs in the Source CDK so source packages stay small and stop re-implementing the same plumbing. This mirrors the JSON decoding helpers already living in the CDK.

## Notes

- Pure refactor: no change to emitted events, attributes, schema refs, or cursor behavior. The extracted functions are behavior-equivalent to the deleted ones (same scalar switch, same layout list and order, same trim/UTC handling).
- Lowers the `panopticon` no-growth LOC ratchet from 820 to 781 (archtest and extraction-plan doc updated in the same change).

## Tests

- `go build ./...`
- `go test ./sources/panopticon/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/ -run 'Grandfathered|SourcePackagesStayWithinLOCBudget' -count=1`
- `gofmt` and `go vet` clean on the changed files.
