### PR TITLE
refactor(sources): extract shared JSON object scalar reads into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -27,7 +27,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `azure` | 2856 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 1104 | Move shared API pagination and response normalization into reusable source helpers. |
 | `gcp` | 2104 | Extract project traversal, service clients, and resource-family pagination helpers. |
-| `github` | 2102 | Split audit/event readers from repository/user normalization and shared pagination. |
+| `github` | 2028 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 827 | Extract API client setup and paginated directory readers. |
 | `grc` | 1378 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2361 | Extract client, pagination, and identity/group/application readers into smaller units. |

--- a/internal/sourcecdk/json_object.go
+++ b/internal/sourcecdk/json_object.go
@@ -1,0 +1,117 @@
+package sourcecdk
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// JSONObject is a decoded JSON object whose values are still untyped. It gives
+// sources typed scalar reads over provider payloads without leaking
+// map[string]any across an exported Source CDK boundary; callers convert a
+// decoded object with sourcecdk.JSONObject(raw) and read fields by key.
+type JSONObject map[string]any
+
+// String returns the trimmed string at key, or "" when the value is absent or
+// is not a JSON string.
+func (o JSONObject) String(key string) string {
+	value, ok := o[key]
+	if !ok {
+		return ""
+	}
+	stringValue, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(stringValue)
+}
+
+// ScalarString renders the scalar at key as a string: strings are trimmed,
+// booleans and JSON numbers are formatted, and nested objects/arrays are
+// re-encoded as JSON. Absent values and unsupported shapes return "".
+func (o JSONObject) ScalarString(key string) string {
+	value, ok := o[key]
+	if !ok {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case bool:
+		return strconv.FormatBool(typed)
+	case float64:
+		return strconv.FormatInt(int64(typed), 10)
+	case int:
+		return strconv.Itoa(typed)
+	case int64:
+		return strconv.FormatInt(typed, 10)
+	case map[string]any, []any:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return ""
+		}
+		return string(encoded)
+	default:
+		return ""
+	}
+}
+
+// Bool returns the boolean at key, or false when the value is absent or is not
+// a JSON boolean.
+func (o JSONObject) Bool(key string) bool {
+	value, ok := o[key]
+	if !ok {
+		return false
+	}
+	boolValue, ok := value.(bool)
+	if !ok {
+		return false
+	}
+	return boolValue
+}
+
+// BoolString renders the boolean at key as "true"/"false", or "" when the value
+// is absent or is not a JSON boolean.
+func (o JSONObject) BoolString(key string) string {
+	value, ok := o[key]
+	if !ok {
+		return ""
+	}
+	boolValue, ok := value.(bool)
+	if !ok {
+		return ""
+	}
+	return strconv.FormatBool(boolValue)
+}
+
+// Int64 reads a numeric field as int64. JSON numbers decode to float64 inside an
+// untyped object, so this coerces float64/int/int64/json.Number/string forms to
+// a stable int64 and returns 0 for absent, nil, or non-numeric values.
+func (o JSONObject) Int64(key string) int64 {
+	value, ok := o[key]
+	if !ok || value == nil {
+		return 0
+	}
+	switch typed := value.(type) {
+	case float64:
+		return int64(typed)
+	case int:
+		return int64(typed)
+	case int64:
+		return typed
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0
+		}
+		return parsed
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	default:
+		return 0
+	}
+}

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -561,100 +561,26 @@ func auditScope(entry *gogithub.AuditEntry, raw map[string]any, settings setting
 }
 
 func rawString(raw map[string]any, key string) string {
-	value, ok := raw[key]
-	if !ok {
-		return ""
-	}
-	stringValue, ok := value.(string)
-	if !ok {
-		return ""
-	}
-	return strings.TrimSpace(stringValue)
+	return sourcecdk.JSONObject(raw).String(key)
 }
 
 func rawScalarString(raw map[string]any, key string) string {
-	value, ok := raw[key]
-	if !ok {
-		return ""
-	}
-	switch typed := value.(type) {
-	case string:
-		return strings.TrimSpace(typed)
-	case bool:
-		return strconv.FormatBool(typed)
-	case float64:
-		return strconv.FormatInt(int64(typed), 10)
-	case int:
-		return strconv.Itoa(typed)
-	case int64:
-		return strconv.FormatInt(typed, 10)
-	case map[string]any, []any:
-		encoded, err := json.Marshal(typed)
-		if err != nil {
-			return ""
-		}
-		return string(encoded)
-	default:
-		return ""
-	}
+	return sourcecdk.JSONObject(raw).ScalarString(key)
 }
 
 func rawBool(raw map[string]any, key string) bool {
-	value, ok := raw[key]
-	if !ok {
-		return false
-	}
-	boolValue, ok := value.(bool)
-	if !ok {
-		return false
-	}
-	return boolValue
+	return sourcecdk.JSONObject(raw).Bool(key)
 }
 
 func boolString(raw map[string]any, key string) string {
-	value, ok := raw[key]
-	if !ok {
-		return ""
-	}
-	boolValue, ok := value.(bool)
-	if !ok {
-		return ""
-	}
-	return strconv.FormatBool(boolValue)
+	return sourcecdk.JSONObject(raw).BoolString(key)
 }
 
-// rawInt64 reads a numeric field from the raw audit log payload. The GitHub
-// audit log API returns IDs as JSON numbers, which json.Unmarshal turns into
-// float64 inside map[string]any; encoding/json never falls back to int64 for
-// untyped maps. We round to int64 here so the projector sees stable integer
-// IDs and the actor_id == org_id comparison in the rule is exact.
+// rawInt64 coerces a numeric raw audit field to a stable int64 so the projector
+// sees exact IDs (e.g. the actor_id == org_id comparison) even though JSON
+// numbers decode as float64 inside an untyped map.
 func rawInt64(raw map[string]any, key string) int64 {
-	value, ok := raw[key]
-	if !ok || value == nil {
-		return 0
-	}
-	switch typed := value.(type) {
-	case float64:
-		return int64(typed)
-	case int:
-		return int64(typed)
-	case int64:
-		return typed
-	case json.Number:
-		value, err := typed.Int64()
-		if err != nil {
-			return 0
-		}
-		return value
-	case string:
-		value, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
-		if err != nil {
-			return 0
-		}
-		return value
-	default:
-		return 0
-	}
+	return sourcecdk.JSONObject(raw).Int64(key)
 }
 
 // positiveInt64String returns the decimal form of a positive int64 or empty

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -19,7 +19,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"azure":           2856,
 	"cosmo":           1104,
 	"gcp":             2104,
-	"github":          2102,
+	"github":          2028,
 	"googleworkspace": 827,
 	"grc":             1378,
 	"okta":            2361,


### PR DESCRIPTION
## What
Extract the provider-agnostic untyped-JSON scalar coercion helpers out of the `sources/github` package into a new, typed `sourcecdk.JSONObject` in `internal/sourcecdk`. The source package keeps thin wrappers that delegate to the shared methods, so all call sites stay identical.

`JSONObject` is a named type exposing typed methods (`String`, `ScalarString`, `Bool`, `BoolString`, `Int64`) rather than passing untyped maps across an exported boundary.

## Why
Continues the Source CDK extraction effort (#956, #684): shared I/O and decoding behavior belongs in the Source CDK so per-source packages shrink toward the LOC budget instead of re-implementing common plumbing.

## Notes
- Pure refactor: no change to emitted events, attributes, schema refs, cursors, or runtime behavior.
- Method bodies are ported verbatim from the source helpers; the source retains thin wrappers.
- Lowers the github no-growth ratchet (archtest budget + extraction doc table) to the new exact LOC.
- Compliant with the `nountypedboundary` rule: only typed values cross the exported boundary; untyped values are boxed in the named type.

## Tests
- `go build ./...`
- `go test ./sources/github/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/... -count=1`
- `make check-structural` (no violations)
