### PR TITLE
refactor(sources): extract shared HTTP retry/status handling into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -29,7 +29,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `gcp` | 2104 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2102 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 827 | Extract API client setup and paginated directory readers. |
-| `grc` | 1378 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
+| `grc` | 1343 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2361 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 820 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2181 | Extract API paging, agent/application readers, and shared response normalization. |

--- a/internal/sourcecdk/http_retry.go
+++ b/internal/sourcecdk/http_retry.go
@@ -1,0 +1,66 @@
+package sourcecdk
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Retryable HTTP status codes are defined as literals so the Source CDK keeps no
+// net/http dependency, which the bootstrap HTTP-boundary guardrail reserves for
+// internal/sourcehttp.
+const (
+	statusTooManyRequests  = 429
+	statusServerErrorFloor = 500
+)
+
+// HTTPStatusError carries an HTTP status code alongside a provider message so
+// sources can classify unauthorized and retryable responses without re-parsing
+// the raw response body.
+type HTTPStatusError struct {
+	Code    int
+	Message string
+}
+
+// Error returns the provider-supplied (or status-derived) message.
+func (e *HTTPStatusError) Error() string {
+	return e.Message
+}
+
+// StatusCode returns the HTTP status code carried by the error.
+func (e *HTTPStatusError) StatusCode() int {
+	return e.Code
+}
+
+// IsHTTPStatus reports whether err is (or wraps) an *HTTPStatusError carrying the
+// given status code.
+func IsHTTPStatus(err error, code int) bool {
+	var statusErr *HTTPStatusError
+	return errors.As(err, &statusErr) && statusErr.Code == code
+}
+
+// IsRetryableHTTPStatus reports whether err carries a 429 Too Many Requests or any
+// 5xx status code, the responses a source should retry with backoff.
+func IsRetryableHTTPStatus(err error) bool {
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	return statusErr.Code == statusTooManyRequests || statusErr.Code >= statusServerErrorFloor
+}
+
+// SleepContext blocks for delay or until ctx is cancelled, returning ctx.Err() if
+// the wait is interrupted. A non-positive delay returns immediately.
+func SleepContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -7,7 +7,6 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -104,19 +103,6 @@ type tokenResponse struct {
 	AccessToken string `json:"access_token"`
 	ExpiresIn   int    `json:"expires_in"`
 	TokenType   string `json:"token_type"`
-}
-
-type responseError struct {
-	statusCode int
-	message    string
-}
-
-func (e *responseError) Error() string {
-	return e.message
-}
-
-func (e *responseError) StatusCode() int {
-	return e.statusCode
 }
 
 // New constructs the GRC source.
@@ -296,7 +282,7 @@ func (s *Source) list(ctx context.Context, settings settings, path string, curso
 		return nil, "", err
 	}
 	response, err := s.listPage(ctx, settings, path, cursor, pageSize, token)
-	if err != nil && isUnauthorizedResponse(err) {
+	if err != nil && sourcecdk.IsHTTPStatus(err, http.StatusUnauthorized) {
 		s.invalidateToken(settings)
 		token, tokenErr := s.token(ctx, settings)
 		if tokenErr != nil {
@@ -373,10 +359,10 @@ func (s *Source) token(ctx context.Context, settings settings) (string, error) {
 		if err == nil {
 			break
 		}
-		if !isRetryableTokenResponse(err) || attempt >= len(backoffs) {
+		if !sourcecdk.IsRetryableHTTPStatus(err) || attempt >= len(backoffs) {
 			return "", fmt.Errorf("request grc token: %w", err)
 		}
-		if sleepErr := sleepContext(ctx, backoffs[attempt]); sleepErr != nil {
+		if sleepErr := sourcecdk.SleepContext(ctx, backoffs[attempt]); sleepErr != nil {
 			return "", fmt.Errorf("request grc token retry: %w", sleepErr)
 		}
 	}
@@ -430,33 +416,6 @@ func (s *Source) invalidateToken(settings settings) {
 	}
 	s.accessToken = ""
 	s.tokenExpiresAt = time.Time{}
-}
-
-func isUnauthorizedResponse(err error) bool {
-	var responseErr *responseError
-	return errors.As(err, &responseErr) && responseErr.statusCode == http.StatusUnauthorized
-}
-
-func isRetryableTokenResponse(err error) bool {
-	var responseErr *responseError
-	if !errors.As(err, &responseErr) {
-		return false
-	}
-	return responseErr.statusCode == http.StatusTooManyRequests || responseErr.statusCode >= http.StatusInternalServerError
-}
-
-func sleepContext(ctx context.Context, delay time.Duration) error {
-	if delay <= 0 {
-		return nil
-	}
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
 }
 
 func (s *Source) doJSON(req *http.Request, target any) error {
@@ -1459,7 +1418,7 @@ func decodeResponseError(statusCode int, body []byte) error {
 	if message == "" {
 		message = http.StatusText(statusCode)
 	}
-	return &responseError{statusCode: statusCode, message: message}
+	return &sourcecdk.HTTPStatusError{Code: statusCode, Message: message}
 }
 
 func configValue(cfg sourcecdk.Config, key string) string {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -21,7 +21,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"gcp":             2104,
 	"github":          2102,
 	"googleworkspace": 827,
-	"grc":             1378,
+	"grc":             1343,
 	"okta":            2361,
 	"panopticon":      820,
 	"sentinelone":     2181,


### PR DESCRIPTION
## What
Extract the shared, provider-agnostic HTTP status/retry primitives used by REST-style source connectors into the Source CDK as a new `internal/sourcecdk/http_retry.go`: a typed `HTTPStatusError`, plus `IsHTTPStatus`, `IsRetryableHTTPStatus`, and `SleepContext`. The `grc` source now consumes these shared helpers instead of its own local copies.

## Why
Continues the Source CDK extraction effort (#956, #684): keep legacy source packages shrinking toward the shared budget by moving common request-plumbing (status classification, retry/backoff) out of individual sources. This lowers the `grc` no-growth ratchet from 1378 to 1343 LOC.

## Notes
- Pure refactor: no change to emitted events, attributes, cursors, schema refs, or runtime behavior.
- Extracted symbols use only typed signatures (nountypedboundary-compliant) and keep the CDK free of a `net/http` dependency.
- No-growth ratchet lowered (1378 -> 1343) in both the archtest budget and the extraction-plan doc.

## Tests
- `go build ./...`
- `go test ./sources/grc/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/... -count=1`
- `make check-structural` (no violations)
