### PR TITLE
refactor(sources): extract shared offset page cursor into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -33,4 +33,4 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `okta` | 2361 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 820 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2181 | Extract API paging, agent/application readers, and shared response normalization. |
-| `vulnview` | 1064 | Split feed/client access from vulnerability record normalization. |
+| `vulnview` | 1042 | Split feed/client access from vulnerability record normalization. |

--- a/internal/sourcecdk/offset_cursor.go
+++ b/internal/sourcecdk/offset_cursor.go
@@ -1,0 +1,35 @@
+package sourcecdk
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PageByOffset returns the window of items addressed by a decimal offset cursor
+// together with the cursor for the following page. An empty cursor starts at
+// the beginning of items; the returned next cursor is empty once items are
+// exhausted. It lets sources that buffer a full result set page over it with a
+// stable, opaque integer cursor without reimplementing the bounds arithmetic.
+func PageByOffset[T any](items []T, cursor string, pageSize int) ([]T, string, error) {
+	offset := 0
+	if strings.TrimSpace(cursor) != "" {
+		parsed, err := strconv.Atoi(strings.TrimSpace(cursor))
+		if err != nil || parsed < 0 {
+			return nil, "", fmt.Errorf("invalid offset cursor %q", cursor)
+		}
+		offset = parsed
+	}
+	if offset >= len(items) {
+		return nil, "", nil
+	}
+	end := offset + pageSize
+	if end > len(items) {
+		end = len(items)
+	}
+	next := ""
+	if end < len(items) {
+		next = strconv.Itoa(end)
+	}
+	return items[offset:end], next, nil
+}

--- a/internal/sourcecdk/offset_cursor_test.go
+++ b/internal/sourcecdk/offset_cursor_test.go
@@ -1,0 +1,50 @@
+package sourcecdk
+
+import "testing"
+
+func TestPageByOffset(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+	cases := []struct {
+		name     string
+		cursor   string
+		pageSize int
+		want     []string
+		wantNext string
+		wantErr  bool
+	}{
+		{name: "first page", cursor: "", pageSize: 2, want: []string{"a", "b"}, wantNext: "2"},
+		{name: "middle page", cursor: "2", pageSize: 2, want: []string{"c", "d"}, wantNext: "4"},
+		{name: "final partial page", cursor: "4", pageSize: 2, want: []string{"e"}, wantNext: ""},
+		{name: "offset at end", cursor: "5", pageSize: 2, want: nil, wantNext: ""},
+		{name: "offset past end", cursor: "9", pageSize: 2, want: nil, wantNext: ""},
+		{name: "page larger than items", cursor: "", pageSize: 10, want: []string{"a", "b", "c", "d", "e"}, wantNext: ""},
+		{name: "whitespace cursor starts at zero", cursor: "  ", pageSize: 2, want: []string{"a", "b"}, wantNext: "2"},
+		{name: "non-numeric cursor", cursor: "abc", pageSize: 2, wantErr: true},
+		{name: "negative cursor", cursor: "-1", pageSize: 2, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			page, next, err := PageByOffset(items, tc.cursor, tc.pageSize)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("PageByOffset() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("PageByOffset() error = %v", err)
+			}
+			if next != tc.wantNext {
+				t.Fatalf("next cursor = %q, want %q", next, tc.wantNext)
+			}
+			if len(page) != len(tc.want) {
+				t.Fatalf("page = %v, want %v", page, tc.want)
+			}
+			for i := range page {
+				if page[i] != tc.want[i] {
+					t.Fatalf("page[%d] = %q, want %q", i, page[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -376,7 +376,7 @@ func (s *Source) list(ctx context.Context, settings settings, path string, curso
 	if serverPaged(cursor, pageSize, len(records), response.NextCursor) {
 		return records, strings.TrimSpace(response.NextCursor), nil
 	}
-	return pageRecords(records, cursor, pageSize)
+	return sourcecdk.PageByOffset(records, cursor, pageSize)
 }
 
 func (s *Source) listDNSAlerts(ctx context.Context, settings settings, cursor string, pageSize int) ([]record, string, error) {
@@ -424,7 +424,7 @@ func (s *Source) listDNSAlerts(ctx context.Context, settings settings, cursor st
 			})
 		}
 	}
-	page, nextAlertOffset, err := pageRecords(records, strconv.Itoa(alertOffset), pageSize)
+	page, nextAlertOffset, err := sourcecdk.PageByOffset(records, strconv.Itoa(alertOffset), pageSize)
 	if err != nil {
 		return nil, "", err
 	}
@@ -488,29 +488,6 @@ func encodeDNSAlertCursor(assetCursor string, alertOffset string) string {
 		return ""
 	}
 	return "dns:" + base64.RawURLEncoding.EncodeToString(payload)
-}
-
-func pageRecords(records []record, cursor string, pageSize int) ([]record, string, error) {
-	offset := 0
-	if strings.TrimSpace(cursor) != "" {
-		parsed, err := strconv.Atoi(strings.TrimSpace(cursor))
-		if err != nil || parsed < 0 {
-			return nil, "", fmt.Errorf("invalid VulnView cursor %q", cursor)
-		}
-		offset = parsed
-	}
-	if offset >= len(records) {
-		return nil, "", nil
-	}
-	end := offset + pageSize
-	if end > len(records) {
-		end = len(records)
-	}
-	next := ""
-	if end < len(records) {
-		next = strconv.Itoa(end)
-	}
-	return records[offset:end], next, nil
 }
 
 func (s *Source) getJSON(ctx context.Context, settings settings, requestPath string, query url.Values, target any) error {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -25,7 +25,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"okta":            2361,
 	"panopticon":      820,
 	"sentinelone":     2181,
-	"vulnview":        1064,
+	"vulnview":        1042,
 }
 
 func TestSourcePackagesHaveCatalogFixturesAndTests(t *testing.T) {


### PR DESCRIPTION
## What

Extracts the buffered offset-pagination helper out of the `vulnview` source into a generic, typed Source CDK primitive `sourcecdk.PageByOffset[T any]` (new `internal/sourcecdk/offset_cursor.go`). The source now calls the shared helper instead of its own copy. Adds a focused unit test for the helper.

## Why

Part of the Source CDK no-growth effort (#956, #684): shared I/O and pagination plumbing belongs in `internal/sourcecdk`, not duplicated per source. Offset paging over a buffered result set is provider-agnostic, so moving it shrinks the source package and makes the primitive reusable.

## Notes

- Pure refactor: no change to emitted events, attributes, URNs, schema refs, or cursor formats. The decimal-offset cursor semantics are identical (same bounds arithmetic and next-cursor encoding).
- The new helper uses generics, matching the existing `FamilyEngine[T]` style, and keeps a typed signature (no untyped boundary).
- Lowers the grandfathered no-growth LOC ratchet for the source `1064 -> 1042` in both `tools/archtests/source_packages_test.go` and `docs/engineering/source-cdk-extraction.md`.

## Tests

- `go build ./...`
- `go test ./sources/vulnview/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/... -count=1`
- `make check-structural` (no violations)
