### PR TITLE
refactor(sources): extract shared payload overlay into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -28,7 +28,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `cosmo` | 1104 | Move shared API pagination and response normalization into reusable source helpers. |
 | `gcp` | 2104 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2102 | Split audit/event readers from repository/user normalization and shared pagination. |
-| `googleworkspace` | 827 | Extract API client setup and paginated directory readers. |
+| `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
 | `grc` | 1378 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2361 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 820 | Separate request plumbing from emitted record construction. |

--- a/internal/sourcecdk/payload_overlay.go
+++ b/internal/sourcecdk/payload_overlay.go
@@ -1,0 +1,40 @@
+package sourcecdk
+
+import "encoding/json"
+
+// PayloadOverlay accumulates provider-agnostic context fields that are merged
+// onto a raw provider record before it is stored as an event payload. Sources
+// decode the raw record into a JSON object and overlay a small number of
+// caller-supplied scalar fields (such as tenant or scope identifiers); the
+// merge-and-re-encode mechanism is identical across sources, so it lives here
+// rather than in each source package.
+type PayloadOverlay struct {
+	fields map[string]string
+}
+
+// NewPayloadOverlay returns an empty overlay ready to accept fields via Set.
+func NewPayloadOverlay() *PayloadOverlay {
+	return &PayloadOverlay{fields: map[string]string{}}
+}
+
+// Set records a top-level field to overlay onto the raw payload and returns the
+// overlay so calls can be chained.
+func (o *PayloadOverlay) Set(key string, value string) *PayloadOverlay {
+	o.fields[key] = value
+	return o
+}
+
+// MergeRawJSON decodes raw (a JSON object, or empty for no base fields), overlays
+// the accumulated fields, and returns the re-marshaled payload bytes.
+func (o *PayloadOverlay) MergeRawJSON(raw json.RawMessage) ([]byte, error) {
+	payload := map[string]any{}
+	if len(raw) != 0 {
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return nil, err
+		}
+	}
+	for key, value := range o.fields {
+		payload[key] = value
+	}
+	return json.Marshal(payload)
+}

--- a/internal/sourcecdk/payload_overlay_test.go
+++ b/internal/sourcecdk/payload_overlay_test.go
@@ -1,0 +1,46 @@
+package sourcecdk
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPayloadOverlayMergesFieldsWithoutBase(t *testing.T) {
+	got, err := NewPayloadOverlay().Set("domain", "writer.com").MergeRawJSON(nil)
+	if err != nil {
+		t.Fatalf("MergeRawJSON() error = %v", err)
+	}
+	if string(got) != `{"domain":"writer.com"}` {
+		t.Fatalf("MergeRawJSON() = %s, want {\"domain\":\"writer.com\"}", got)
+	}
+}
+
+func TestPayloadOverlayOverlaysAndOverwritesRawFields(t *testing.T) {
+	raw := json.RawMessage(`{"id":"1001","domain":"stale"}`)
+	got, err := NewPayloadOverlay().
+		Set("domain", "writer.com").
+		Set("group_key", "security@writer.com").
+		MergeRawJSON(raw)
+	if err != nil {
+		t.Fatalf("MergeRawJSON() error = %v", err)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(got, &decoded); err != nil {
+		t.Fatalf("Unmarshal(%s) error = %v", got, err)
+	}
+	for key, want := range map[string]string{
+		"id":        "1001",
+		"domain":    "writer.com",
+		"group_key": "security@writer.com",
+	} {
+		if decoded[key] != want {
+			t.Fatalf("payload[%q] = %q, want %q", key, decoded[key], want)
+		}
+	}
+}
+
+func TestPayloadOverlayReturnsErrorForInvalidRaw(t *testing.T) {
+	if _, err := NewPayloadOverlay().MergeRawJSON(json.RawMessage(`not-json`)); err == nil {
+		t.Fatal("MergeRawJSON() error = nil, want decode error")
+	}
+}

--- a/sources/googleworkspace/source.go
+++ b/sources/googleworkspace/source.go
@@ -521,7 +521,7 @@ func sourceEvent(settings settings, raw json.RawMessage) (*primitives.Event, err
 
 func userEvent(settings settings, record userRecord) (*primitives.Event, error) {
 	occurredAt := firstParsedTime(record.LastLoginTime, record.CreationTime)
-	payload, err := payloadWithRaw(record.raw, map[string]any{"domain": settings.domain})
+	payload, err := sourcecdk.NewPayloadOverlay().Set("domain", settings.domain).MergeRawJSON(record.raw)
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +538,7 @@ func userEvent(settings settings, record userRecord) (*primitives.Event, error) 
 }
 
 func groupEvent(settings settings, record groupRecord) (*primitives.Event, error) {
-	payload, err := payloadWithRaw(record.raw, map[string]any{"domain": settings.domain})
+	payload, err := sourcecdk.NewPayloadOverlay().Set("domain", settings.domain).MergeRawJSON(record.raw)
 	if err != nil {
 		return nil, err
 	}
@@ -555,7 +555,7 @@ func groupEvent(settings settings, record groupRecord) (*primitives.Event, error
 }
 
 func groupMemberEvent(settings settings, record memberRecord) (*primitives.Event, error) {
-	payload, err := payloadWithRaw(record.raw, map[string]any{"domain": settings.domain, "group_key": settings.groupKey})
+	payload, err := sourcecdk.NewPayloadOverlay().Set("domain", settings.domain).Set("group_key", settings.groupKey).MergeRawJSON(record.raw)
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +572,7 @@ func groupMemberEvent(settings settings, record memberRecord) (*primitives.Event
 }
 
 func roleAssignmentEvent(settings settings, record roleAssignmentRecord) (*primitives.Event, error) {
-	payload, err := payloadWithRaw(record.raw, map[string]any{"domain": settings.domain})
+	payload, err := sourcecdk.NewPayloadOverlay().Set("domain", settings.domain).MergeRawJSON(record.raw)
 	if err != nil {
 		return nil, err
 	}
@@ -596,7 +596,7 @@ func auditSourceEvent(settings settings, record auditRecord) (*primitives.Event,
 		eventName = record.Events[0].Name
 		eventType = record.Events[0].Type
 	}
-	payload, err := payloadWithRaw(record.raw, map[string]any{"domain": settings.domain})
+	payload, err := sourcecdk.NewPayloadOverlay().Set("domain", settings.domain).MergeRawJSON(record.raw)
 	if err != nil {
 		return nil, err
 	}
@@ -727,19 +727,6 @@ func discoverURN(settings settings, raw json.RawMessage) (sourcecdk.URN, error) 
 	kind := strings.TrimPrefix(strings.ReplaceAll(event.Kind, ".", "_"), "google_workspace_")
 	id := firstNonEmpty(event.Attributes["user_id"], event.Attributes["group_id"], event.Attributes["role_assignment_id"], event.Attributes["event_type"])
 	return sourcecdk.ParseURN("urn:cerebro:" + settings.domain + ":google_workspace_" + kind + ":" + id)
-}
-
-func payloadWithRaw(raw json.RawMessage, extra map[string]any) ([]byte, error) {
-	payload := map[string]any{}
-	if len(raw) != 0 {
-		if err := json.Unmarshal(raw, &payload); err != nil {
-			return nil, err
-		}
-	}
-	for key, value := range extra {
-		payload[key] = value
-	}
-	return json.Marshal(payload)
 }
 
 func firstParsedTime(values ...string) time.Time {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -20,7 +20,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"cosmo":           1104,
 	"gcp":             2104,
 	"github":          2102,
-	"googleworkspace": 827,
+	"googleworkspace": 815,
 	"grc":             1378,
 	"okta":            2361,
 	"panopticon":      820,


### PR DESCRIPTION
## What
Extract the duplicated "merge a raw provider record with a few context fields, then re-encode the event payload" mechanism out of the `googleworkspace` source and into a typed `PayloadOverlay` helper in `internal/sourcecdk`. The source now builds payloads via `sourcecdk.NewPayloadOverlay().Set(...).MergeRawJSON(raw)`.

## Why
Per the Source CDK extraction effort (#956, #684), shared provider-agnostic plumbing should live in `internal/sourcecdk` rather than being copied into each source package. This payload-assembly pattern is identical across multiple sources, so it belongs in the CDK. Extracting it also lowers the legacy `googleworkspace` LOC ceiling.

## Notes
- Pure refactor: no change to emitted events, attributes, schema refs, payload bytes, or cursors. The merge performs the same decode/overlay/marshal operations as before.
- The helper uses a typed boxed builder (`Set(key, value string)`), so no untyped `any`/`map[string]any` appears in any exported signature (structural lint compliant).
- No-growth ratchet for `googleworkspace` lowered 827 -> 815 in both `tools/archtests/source_packages_test.go` and `docs/engineering/source-cdk-extraction.md`.

## Tests
- `go build ./...`
- `go test ./sources/googleworkspace/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/... -count=1`
- `make check-structural` (no violations)
