### PR TITLE
refactor(sources): extract shared time-window selector into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -23,7 +23,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | Source | Current LOC Budget | Extraction Pressure |
 | --- | ---: | --- |
 | `aurelius` | 653 | Split source orchestration from record mapping and shared request plumbing. |
-| `aws` | 19121 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
+| `aws` | 19070 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
 | `azure` | 2856 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 1104 | Move shared API pagination and response normalization into reusable source helpers. |
 | `gcp` | 2104 | Extract project traversal, service clients, and resource-family pagination helpers. |

--- a/internal/sourcecdk/time_selector.go
+++ b/internal/sourcecdk/time_selector.go
@@ -1,0 +1,65 @@
+package sourcecdk
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ParseTimeSelector resolves a time-window selector that is either a relative
+// simplified ISO-8601 duration (interpreted as that span before now) or an
+// absolute RFC3339 timestamp. Values beginning with "P" (case-insensitive) are
+// treated as durations; all other values are parsed as RFC3339 timestamps.
+func ParseTimeSelector(value string, now time.Time) (time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(strings.ToUpper(trimmed), "P") {
+		duration, err := parseSimpleISODuration(trimmed)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return now.Add(-duration), nil
+	}
+	return time.Parse(time.RFC3339, trimmed)
+}
+
+func parseSimpleISODuration(value string) (time.Duration, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(value))
+	if normalized == "" || normalized[0] != 'P' {
+		return 0, fmt.Errorf("duration must start with P")
+	}
+	remaining := strings.TrimPrefix(normalized, "P")
+	days := 0
+	if index := strings.Index(remaining, "D"); index >= 0 {
+		parsed, err := strconv.Atoi(remaining[:index])
+		if err != nil {
+			return 0, err
+		}
+		days = parsed
+		remaining = remaining[index+1:]
+	}
+	hours := 0
+	minutes := 0
+	if strings.HasPrefix(remaining, "T") {
+		remaining = strings.TrimPrefix(remaining, "T")
+		if index := strings.Index(remaining, "H"); index >= 0 {
+			parsed, err := strconv.Atoi(remaining[:index])
+			if err != nil {
+				return 0, err
+			}
+			hours = parsed
+			remaining = remaining[index+1:]
+		}
+		if index := strings.Index(remaining, "M"); index >= 0 {
+			parsed, err := strconv.Atoi(remaining[:index])
+			if err != nil {
+				return 0, err
+			}
+			minutes = parsed
+		}
+	}
+	if days == 0 && hours == 0 && minutes == 0 {
+		return 0, fmt.Errorf("duration must include days, hours, or minutes")
+	}
+	return time.Duration(days)*24*time.Hour + time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute, nil
+}

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -4023,7 +4023,7 @@ func listCloudTrailEvents(ctx context.Context, clients awsClients, settings sett
 		input.LookupAttributes = []cloudtrailtypes.LookupAttribute{{AttributeKey: cloudtrailtypes.LookupAttributeKey(settings.cloudTrail.lookupKey), AttributeValue: awssdk.String(settings.cloudTrail.lookupValue)}}
 	}
 	if !resume && firstNonEmpty(settings.cloudTrail.startTime, settings.cloudTrail.since) != "" {
-		parsed, err := parseAWSTimeSelector(firstNonEmpty(settings.cloudTrail.startTime, settings.cloudTrail.since), now)
+		parsed, err := sourcecdk.ParseTimeSelector(firstNonEmpty(settings.cloudTrail.startTime, settings.cloudTrail.since), now)
 		if err != nil {
 			return nil, "", fmt.Errorf("parse aws start_time: %w", err)
 		}
@@ -4735,59 +4735,6 @@ func awsDNSSuffix(region string) string {
 		return "amazonaws.com.cn"
 	}
 	return "amazonaws.com"
-}
-
-func parseAWSTimeSelector(value string, now time.Time) (time.Time, error) {
-	trimmed := strings.TrimSpace(value)
-	if strings.HasPrefix(strings.ToUpper(trimmed), "P") {
-		duration, err := parseSimpleISODuration(trimmed)
-		if err != nil {
-			return time.Time{}, err
-		}
-		return now.Add(-duration), nil
-	}
-	return time.Parse(time.RFC3339, trimmed)
-}
-
-func parseSimpleISODuration(value string) (time.Duration, error) {
-	normalized := strings.ToUpper(strings.TrimSpace(value))
-	if normalized == "" || normalized[0] != 'P' {
-		return 0, fmt.Errorf("duration must start with P")
-	}
-	remaining := strings.TrimPrefix(normalized, "P")
-	days := 0
-	if index := strings.Index(remaining, "D"); index >= 0 {
-		parsed, err := strconv.Atoi(remaining[:index])
-		if err != nil {
-			return 0, err
-		}
-		days = parsed
-		remaining = remaining[index+1:]
-	}
-	hours := 0
-	minutes := 0
-	if strings.HasPrefix(remaining, "T") {
-		remaining = strings.TrimPrefix(remaining, "T")
-		if index := strings.Index(remaining, "H"); index >= 0 {
-			parsed, err := strconv.Atoi(remaining[:index])
-			if err != nil {
-				return 0, err
-			}
-			hours = parsed
-			remaining = remaining[index+1:]
-		}
-		if index := strings.Index(remaining, "M"); index >= 0 {
-			parsed, err := strconv.Atoi(remaining[:index])
-			if err != nil {
-				return 0, err
-			}
-			minutes = parsed
-		}
-	}
-	if days == 0 && hours == 0 && minutes == 0 {
-		return 0, fmt.Errorf("duration must include days, hours, or minutes")
-	}
-	return time.Duration(days)*24*time.Hour + time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute, nil
 }
 
 func cloudTrailActor(event cloudtrailtypes.Event, detail cloudTrailDetail) cloudTrailUserIdentity {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -15,7 +15,7 @@ const newSourcePackageLOCBudget = 300
 // source grows, move shared behavior into the Source CDK instead of raising it.
 var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"aurelius":        653,
-	"aws":             19121,
+	"aws":             19070,
 	"azure":           2856,
 	"cosmo":           1104,
 	"gcp":             2104,


### PR DESCRIPTION
## What
Extract the shared time-window selector parser (a relative simplified ISO-8601 duration or an absolute RFC3339 timestamp) out of the `aws` source into a typed `ParseTimeSelector` helper in `internal/sourcecdk`.

## Why
Continues the Source CDK extraction effort (#956, #684) by moving genuinely provider-agnostic time parsing into shared, typed code. This is a first partial step for the largest grandfathered source; `aws` still needs a dedicated multi-PR extraction.

## Notes
- Pure refactor: no change to emitted events, attributes, schema refs, URNs, cursors, or runtime behavior.
- The extracted helper uses fully typed signatures (`string`, `time.Time`, `time.Duration`, `error`) and introduces no untyped boundaries.
- The `aws` no-growth ratchet (archtest budget + extraction doc table) is lowered accordingly.

## Tests
- `go build ./...`
- `go test ./sources/aws/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/... -count=1`
- `make check-structural`
