### PR TITLE
refactor(sources): extract shared host-safety guards into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -30,7 +30,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `github` | 2102 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 827 | Extract API client setup and paginated directory readers. |
 | `grc` | 1378 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
-| `okta` | 2361 | Extract client, pagination, and identity/group/application readers into smaller units. |
+| `okta` | 2269 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 820 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2181 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1064 | Split feed/client access from vulnerability record normalization. |

--- a/internal/sourcecdk/host_safety.go
+++ b/internal/sourcecdk/host_safety.go
@@ -1,0 +1,112 @@
+package sourcecdk
+
+import (
+	"math"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// IsUnsafeHost reports whether host targets a loopback, private,
+// link-local, unspecified, or multicast address, or an explicit
+// localhost name. It normalizes bracketed, zoned, and shorthand numeric
+// IPv4 forms before classifying so connectors cannot be coerced into
+// reaching internal endpoints.
+func IsUnsafeHost(host string) bool {
+	value := normalizedIPHost(host)
+	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(value)
+	if ip == nil {
+		ip = parseNumericIPv4Host(value)
+	}
+	if ip == nil {
+		return false
+	}
+	return isUnsafeIP(ip)
+}
+
+// IsLoopbackHost reports whether host refers to a loopback address or an
+// explicit localhost name, using the same normalization as IsUnsafeHost.
+func IsLoopbackHost(host string) bool {
+	value := normalizedIPHost(host)
+	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(value)
+	if ip == nil {
+		ip = parseNumericIPv4Host(value)
+	}
+	return ip != nil && ip.IsLoopback()
+}
+
+func isUnsafeIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast()
+}
+
+func normalizedIPHost(host string) string {
+	value := strings.TrimRight(strings.ToLower(strings.TrimSpace(host)), ".")
+	value = strings.Trim(value, "[]")
+	if address, _, ok := strings.Cut(value, "%"); ok {
+		value = address
+	}
+	return value
+}
+
+func parseNumericIPv4Host(host string) net.IP {
+	if strings.Contains(host, ":") {
+		return nil
+	}
+	parts := strings.Split(host, ".")
+	if len(parts) == 0 || len(parts) > 4 {
+		return nil
+	}
+	values := make([]uint64, len(parts))
+	for i, part := range parts {
+		if part == "" {
+			return nil
+		}
+		value, err := strconv.ParseUint(part, 0, 32)
+		if err != nil {
+			return nil
+		}
+		values[i] = value
+	}
+	var ipv4 uint32
+	switch len(values) {
+	case 1:
+		ipv4 = uint32FromUint64(values[0])
+	case 2:
+		if values[0] > 0xff || values[1] > 0xffffff {
+			return nil
+		}
+		ipv4 = uint32FromUint64(values[0]<<24 | values[1])
+	case 3:
+		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xffff {
+			return nil
+		}
+		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2])
+	case 4:
+		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xff || values[3] > 0xff {
+			return nil
+		}
+		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2]<<8 | values[3])
+	}
+	return net.IPv4(byte(ipv4>>24), byte(ipv4>>16), byte(ipv4>>8), byte(ipv4))
+}
+
+func uint32FromUint64(value uint64) uint32 {
+	if value > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(value)
+}

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -653,7 +652,7 @@ func normalizeDomain(raw string, allowLoopback bool) (string, error) {
 		return "", fmt.Errorf("okta domain must be a valid host")
 	}
 	host = strings.TrimRight(strings.ToLower(host), ".")
-	if isUnsafeHost(host) && (!allowLoopback || !isLoopbackHost(host)) {
+	if sourcecdk.IsUnsafeHost(host) && (!allowLoopback || !sourcecdk.IsLoopbackHost(host)) {
 		return "", fmt.Errorf("okta domain must not target loopback, private, or link-local hosts")
 	}
 	return host, nil
@@ -665,7 +664,7 @@ func normalizeBaseURL(raw string, domain string, allowLoopback bool) (string, er
 		return "", fmt.Errorf("parse okta base_url: %w", err)
 	}
 	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
-	allowInsecureLoopback := allowLoopback && parsed.Scheme == "http" && isLoopbackHost(host)
+	allowInsecureLoopback := allowLoopback && parsed.Scheme == "http" && sourcecdk.IsLoopbackHost(host)
 	if parsed.Scheme != "https" && !allowInsecureLoopback {
 		return "", fmt.Errorf("okta base_url must use https")
 	}
@@ -678,12 +677,12 @@ func normalizeBaseURL(raw string, domain string, allowLoopback bool) (string, er
 	if (parsed.Path != "" && parsed.Path != "/") || parsed.RawPath != "" {
 		return "", fmt.Errorf("okta base_url must be an origin URL")
 	}
-	allowCustomLoopbackPort := allowLoopback && isLoopbackHost(host)
+	allowCustomLoopbackPort := allowLoopback && sourcecdk.IsLoopbackHost(host)
 	if strings.TrimSpace(parsed.Port()) != "" && parsed.Port() != "443" && !allowCustomLoopbackPort {
 		return "", fmt.Errorf("okta base_url must not include a custom port")
 	}
-	allowLoopbackHost := allowLoopback && isLoopbackHost(host)
-	if isUnsafeHost(host) && !allowLoopbackHost {
+	allowLoopbackHost := allowLoopback && sourcecdk.IsLoopbackHost(host)
+	if sourcecdk.IsUnsafeHost(host) && !allowLoopbackHost {
 		return "", fmt.Errorf("okta base_url must not target loopback, private, or link-local hosts")
 	}
 	if host != strings.ToLower(strings.TrimSpace(domain)) && !allowLoopbackHost {
@@ -691,103 +690,6 @@ func normalizeBaseURL(raw string, domain string, allowLoopback bool) (string, er
 	}
 	parsed.Path = ""
 	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func isUnsafeHost(host string) bool {
-	value := normalizedIPHost(host)
-	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
-		return true
-	}
-	ip := net.ParseIP(value)
-	if ip == nil {
-		ip = parseNumericIPv4Host(value)
-	}
-	if ip == nil {
-		return false
-	}
-	return isUnsafeIP(ip)
-}
-
-func isUnsafeIP(ip net.IP) bool {
-	if ip == nil {
-		return false
-	}
-	return ip.IsLoopback() ||
-		ip.IsPrivate() ||
-		ip.IsLinkLocalUnicast() ||
-		ip.IsLinkLocalMulticast() ||
-		ip.IsUnspecified() ||
-		ip.IsMulticast()
-}
-
-func isLoopbackHost(host string) bool {
-	value := normalizedIPHost(host)
-	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
-		return true
-	}
-	ip := net.ParseIP(value)
-	if ip == nil {
-		ip = parseNumericIPv4Host(value)
-	}
-	return ip != nil && ip.IsLoopback()
-}
-
-func normalizedIPHost(host string) string {
-	value := strings.TrimRight(strings.ToLower(strings.TrimSpace(host)), ".")
-	value = strings.Trim(value, "[]")
-	if address, _, ok := strings.Cut(value, "%"); ok {
-		value = address
-	}
-	return value
-}
-
-func parseNumericIPv4Host(host string) net.IP {
-	if strings.Contains(host, ":") {
-		return nil
-	}
-	parts := strings.Split(host, ".")
-	if len(parts) == 0 || len(parts) > 4 {
-		return nil
-	}
-	values := make([]uint64, len(parts))
-	for i, part := range parts {
-		if part == "" {
-			return nil
-		}
-		value, err := strconv.ParseUint(part, 0, 32)
-		if err != nil {
-			return nil
-		}
-		values[i] = value
-	}
-	var ipv4 uint32
-	switch len(values) {
-	case 1:
-		ipv4 = uint32FromUint64(values[0])
-	case 2:
-		if values[0] > 0xff || values[1] > 0xffffff {
-			return nil
-		}
-		ipv4 = uint32FromUint64(values[0]<<24 | values[1])
-	case 3:
-		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xffff {
-			return nil
-		}
-		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2])
-	case 4:
-		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xff || values[3] > 0xff {
-			return nil
-		}
-		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2]<<8 | values[3])
-	}
-	return net.IPv4(byte(ipv4>>24), byte(ipv4>>16), byte(ipv4>>8), byte(ipv4))
-}
-
-func uint32FromUint64(value uint64) uint32 {
-	if value > math.MaxUint32 {
-		return math.MaxUint32
-	}
-	return uint32(value)
 }
 
 func normalizeAuditSortOrder(raw string) (string, error) {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -22,7 +22,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"github":          2102,
 	"googleworkspace": 827,
 	"grc":             1378,
-	"okta":            2361,
+	"okta":            2269,
 	"panopticon":      820,
 	"sentinelone":     2181,
 	"vulnview":        1064,


### PR DESCRIPTION
## What
Extracts the provider-agnostic host-safety classification helpers out of the `sources/okta` package into a new, typed `internal/sourcecdk/host_safety.go`. The Source CDK now exposes `IsUnsafeHost` and `IsLoopbackHost`, backed by unexported helpers for IP normalization and shorthand-IPv4 parsing. The okta source calls these shared helpers instead of carrying its own copies.

## Why
Advances the Source CDK extraction effort (#956, #684) by relocating genuinely shared, reusable behavior into the CDK and shrinking a grandfathered source package. Exported signatures stay fully typed (string / bool / `net.IP`), satisfying the untyped-boundary rule, and the helper avoids `net/http` so it stays within the Source CDK import boundary.

## Notes
- Pure refactor: no change to emitted events, attributes, URNs, schema refs, cursors, or validation behavior.
- Lowers the okta no-growth ratchet from 2361 to 2269 LOC (archtest budget + extraction doc table).

## Tests
- `go build ./...`
- `go test ./sources/okta/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/... -count=1`
- `make check-structural` (no violations)
