### PR TITLE
refactor(sources): extract shared typed record decoding into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -24,7 +24,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | --- | ---: | --- |
 | `aurelius` | 653 | Split source orchestration from record mapping and shared request plumbing. |
 | `aws` | 19121 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
-| `azure` | 2856 | Extract subscription traversal, client factories, and paginated resource readers. |
+| `azure` | 2842 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 1104 | Move shared API pagination and response normalization into reusable source helpers. |
 | `gcp` | 2104 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2102 | Split audit/event readers from repository/user normalization and shared pagination. |

--- a/internal/sourcecdk/record_decode.go
+++ b/internal/sourcecdk/record_decode.go
@@ -1,0 +1,25 @@
+package sourcecdk
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeRecords unmarshals raw JSON list items into typed records. The optional
+// setRaw hook receives the verbatim bytes for each item so callers can retain
+// the original payload alongside the decoded value. The label is used only for
+// error context.
+func DecodeRecords[T any](rawRecords []json.RawMessage, label string, setRaw func(*T, json.RawMessage)) ([]T, error) {
+	records := make([]T, 0, len(rawRecords))
+	for _, raw := range rawRecords {
+		var record T
+		if err := json.Unmarshal(raw, &record); err != nil {
+			return nil, fmt.Errorf("decode %s: %w", label, err)
+		}
+		if setRaw != nil {
+			setRaw(&record, raw)
+		}
+		records = append(records, record)
+	}
+	return records, nil
+}

--- a/internal/sourcecdk/record_decode_test.go
+++ b/internal/sourcecdk/record_decode_test.go
@@ -1,0 +1,50 @@
+package sourcecdk
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type decodeRecordSample struct {
+	ID  string `json:"id"`
+	raw json.RawMessage
+}
+
+func TestDecodeRecordsDecodesAndCapturesRaw(t *testing.T) {
+	raw := []json.RawMessage{
+		json.RawMessage(`{"id":"a"}`),
+		json.RawMessage(`{"id":"b"}`),
+	}
+	records, err := DecodeRecords(raw, "sample", func(record *decodeRecordSample, bytes json.RawMessage) {
+		record.raw = append(json.RawMessage(nil), bytes...)
+	})
+	if err != nil {
+		t.Fatalf("DecodeRecords() error = %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("len(records) = %d, want 2", len(records))
+	}
+	if records[0].ID != "a" || records[1].ID != "b" {
+		t.Fatalf("decoded ids = %q,%q, want a,b", records[0].ID, records[1].ID)
+	}
+	if string(records[0].raw) != `{"id":"a"}` {
+		t.Fatalf("captured raw = %q, want {\"id\":\"a\"}", string(records[0].raw))
+	}
+}
+
+func TestDecodeRecordsNilHookAndEmptyInput(t *testing.T) {
+	records, err := DecodeRecords[decodeRecordSample](nil, "sample", nil)
+	if err != nil {
+		t.Fatalf("DecodeRecords() error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(records) = %d, want 0", len(records))
+	}
+}
+
+func TestDecodeRecordsReturnsErrorOnInvalidJSON(t *testing.T) {
+	_, err := DecodeRecords[decodeRecordSample]([]json.RawMessage{json.RawMessage(`{`)}, "sample", nil)
+	if err == nil {
+		t.Fatal("DecodeRecords() error = nil, want non-nil")
+	}
+}

--- a/sources/azure/source.go
+++ b/sources/azure/source.go
@@ -959,7 +959,7 @@ func listUsers(ctx context.Context, source *Source, settings settings, pageToken
 	if err := getGraphJSON(ctx, source, settings, firstNonEmpty(pageToken, "/v1.0/users"), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure user", func(record *userRecord, raw json.RawMessage) { record.raw = append(json.RawMessage(nil), raw...) })
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure user", func(record *userRecord, raw json.RawMessage) { record.raw = append(json.RawMessage(nil), raw...) })
 	return records, graphNext(response), err
 }
 
@@ -969,7 +969,7 @@ func listGroups(ctx context.Context, source *Source, settings settings, pageToke
 	if err := getGraphJSON(ctx, source, settings, firstNonEmpty(pageToken, "/v1.0/groups"), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure group", func(record *groupRecord, raw json.RawMessage) { record.raw = append(json.RawMessage(nil), raw...) })
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure group", func(record *groupRecord, raw json.RawMessage) { record.raw = append(json.RawMessage(nil), raw...) })
 	return records, graphNext(response), err
 }
 
@@ -980,7 +980,7 @@ func listGroupMemberships(ctx context.Context, source *Source, settings settings
 	if err := getGraphJSON(ctx, source, settings, firstNonEmpty(pageToken, path), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure group member", func(record *graphPrincipalRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure group member", func(record *graphPrincipalRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	return records, graphNext(response), err
@@ -993,7 +993,7 @@ func listAppRoleAssignments(ctx context.Context, source *Source, settings settin
 	if err := getGraphJSON(ctx, source, settings, firstNonEmpty(pageToken, path), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure app role assignment", func(record *appRoleAssignmentRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure app role assignment", func(record *appRoleAssignmentRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	return records, graphNext(response), err
@@ -1005,7 +1005,7 @@ func listApplications(ctx context.Context, source *Source, settings settings, pa
 	if err := getGraphJSON(ctx, source, settings, firstNonEmpty(pageToken, "/v1.0/applications"), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure application", func(record *applicationRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure application", func(record *applicationRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	return records, graphNext(response), err
@@ -1033,7 +1033,7 @@ func listServicePrincipals(ctx context.Context, source *Source, settings setting
 	if err := getGraphJSON(ctx, source, settings, firstNonEmpty(pageToken, "/v1.0/servicePrincipals"), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure service principal", func(record *servicePrincipalRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure service principal", func(record *servicePrincipalRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	return records, graphNext(response), err
@@ -1071,7 +1071,7 @@ func listDirectoryRoleAssignments(ctx context.Context, source *Source, settings 
 	if err := getGraphJSON(ctx, source, settings, firstNonEmpty(pageToken, "/v1.0/roleManagement/directory/roleAssignments"), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure directory role assignment", func(record *directoryRoleAssignmentRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure directory role assignment", func(record *directoryRoleAssignmentRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	return records, graphNext(response), err
@@ -1091,7 +1091,7 @@ func listDirectoryAuditsWithCheckpoint(ctx context.Context, source *Source, sett
 	if err := getGraphJSON(ctx, source, settings, firstNonEmpty(pageToken, "/v1.0/auditLogs/directoryAudits"), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure directory audit", func(record *directoryAuditRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure directory audit", func(record *directoryAuditRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	return records, graphNext(response), err
@@ -1104,7 +1104,7 @@ func listIAMRoleAssignmentsBase(ctx context.Context, source *Source, settings se
 	if err := getARMJSON(ctx, source, settings, firstNonEmpty(pageToken, path), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure rbac role assignment", func(record *armRoleAssignmentRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure rbac role assignment", func(record *armRoleAssignmentRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	if err != nil {
@@ -1156,7 +1156,7 @@ func listAssetMetadata(ctx context.Context, source *Source, settings settings, p
 	if err := getARMJSON(ctx, source, settings, firstNonEmpty(pageToken, path), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure resource metadata", func(record *armResourceRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure resource metadata", func(record *armResourceRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	return records, response.Next, err
@@ -1169,7 +1169,7 @@ func listARMTypedResources(ctx context.Context, source *Source, settings setting
 	if err := getARMJSON(ctx, source, settings, firstNonEmpty(pageToken, path), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, label, func(record *armTypedResourceRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(response.Value, label, func(record *armTypedResourceRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	return records, response.Next, err
@@ -1237,7 +1237,7 @@ func listSubnets(ctx context.Context, source *Source, settings settings, pageTok
 	if err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(rawRecords, "azure subnet", func(record *armTypedResourceRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(rawRecords, "azure subnet", func(record *armTypedResourceRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	return records, next, err
@@ -1345,7 +1345,7 @@ func listSQLDatabasesForServer(ctx context.Context, source *Source, settings set
 	if err := getARMJSON(ctx, source, settings, firstNonEmpty(pageToken, path), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	databases, err := decodeAzureRecords(response.Value, "azure sql database", func(record *armTypedResourceRecord, raw json.RawMessage) {
+	databases, err := sourcecdk.DecodeRecords(response.Value, "azure sql database", func(record *armTypedResourceRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	if err != nil {
@@ -1417,7 +1417,7 @@ func listKeyVaultChildrenForVault(ctx context.Context, source *Source, settings 
 	if err := getARMJSON(ctx, source, settings, firstNonEmpty(pageToken, path), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	children, err := decodeAzureRecords(response.Value, label, func(record *armTypedResourceRecord, raw json.RawMessage) {
+	children, err := sourcecdk.DecodeRecords(response.Value, label, func(record *armTypedResourceRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	if err != nil {
@@ -1497,7 +1497,7 @@ func listAzureARMChildrenForParent(ctx context.Context, source *Source, settings
 		}
 		return nil, "", err
 	}
-	children, err := decodeAzureRecords(response.Value, definition.Label, func(record *armTypedResourceRecord, raw json.RawMessage) {
+	children, err := sourcecdk.DecodeRecords(response.Value, definition.Label, func(record *armTypedResourceRecord, raw json.RawMessage) {
 		*record = inheritAzureResourceContext(*record, parent)
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
@@ -1538,7 +1538,7 @@ func listResourceExposures(ctx context.Context, source *Source, settings setting
 	if err := getARMJSON(ctx, source, settings, firstNonEmpty(pageToken, path), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	nsgs, err := decodeAzureRecords(response.Value, "azure network security group", func(record *nsgRecord, raw json.RawMessage) { record.raw = append(json.RawMessage(nil), raw...) })
+	nsgs, err := sourcecdk.DecodeRecords(response.Value, "azure network security group", func(record *nsgRecord, raw json.RawMessage) { record.raw = append(json.RawMessage(nil), raw...) })
 	if err != nil {
 		return nil, "", err
 	}
@@ -1570,7 +1570,7 @@ func listActivityLogsWithCheckpoint(ctx context.Context, source *Source, setting
 	if err := getARMJSON(ctx, source, settings, firstNonEmpty(pageToken, path), queryForPageToken(pageToken, query), &response); err != nil {
 		return nil, "", err
 	}
-	records, err := decodeAzureRecords(response.Value, "azure activity log", func(record *activityLogRecord, raw json.RawMessage) {
+	records, err := sourcecdk.DecodeRecords(response.Value, "azure activity log", func(record *activityLogRecord, raw json.RawMessage) {
 		record.raw = append(json.RawMessage(nil), raw...)
 	})
 	return records, response.Next, err
@@ -2636,21 +2636,6 @@ func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, 
 		return source.lookupIPAddrs
 	}
 	return net.DefaultResolver.LookupIPAddr
-}
-
-func decodeAzureRecords[T any](rawRecords []json.RawMessage, label string, setRaw func(*T, json.RawMessage)) ([]T, error) {
-	records := make([]T, 0, len(rawRecords))
-	for _, raw := range rawRecords {
-		var record T
-		if err := json.Unmarshal(raw, &record); err != nil {
-			return nil, fmt.Errorf("decode %s: %w", label, err)
-		}
-		if setRaw != nil {
-			setRaw(&record, raw)
-		}
-		records = append(records, record)
-	}
-	return records, nil
 }
 
 func azurePullFromRecords[T any](records []T, next string, build func(T) (*primitives.Event, error)) (sourcecdk.Pull, error) {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -16,7 +16,7 @@ const newSourcePackageLOCBudget = 300
 var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"aurelius":        653,
 	"aws":             19121,
-	"azure":           2856,
+	"azure":           2842,
 	"cosmo":           1104,
 	"gcp":             2104,
 	"github":          2102,


### PR DESCRIPTION
## What
Extracts the generic JSON list-item decoder out of the `azure` source into a new, reusable `internal/sourcecdk` helper `DecodeRecords[T]`, and updates every azure call site to use it. The source-local copy is removed.

## Why
Source packages should keep shared, provider-agnostic I/O and decoding plumbing in the Source CDK rather than re-implementing it per source (#956, #684). `DecodeRecords[T]` is the typed middle step between the CDK's existing `DecodeListResponseData` (raw page to `[]json.RawMessage`) and `PullFromRecords` (typed records to `Pull`).

## Notes
- Pure refactor: no change to emitted events, attributes, URNs, schema refs, cursors, or runtime behavior. The moved logic is identical; only its location changed.
- The helper uses fully typed parameters (`[]json.RawMessage`, a typed `setRaw` hook, named return) and does not import `net/http`, consistent with the CDK structural rules.
- Lowered the azure no-growth LOC ratchet `2856 -> 2842` in the arch test and the extraction docs table.

## Tests
- `go build ./...`
- `go test ./sources/azure/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/... -count=1`
- `make check-structural` (no violations)
