### PR TITLE
refactor(sources): extract shared open-CIDR detection into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -26,7 +26,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `aws` | 19121 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
 | `azure` | 2856 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 1104 | Move shared API pagination and response normalization into reusable source helpers. |
-| `gcp` | 2104 | Extract project traversal, service clients, and resource-family pagination helpers. |
+| `gcp` | 2095 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2102 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 827 | Extract API client setup and paginated directory readers. |
 | `grc` | 1378 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |

--- a/internal/sourcecdk/cidr.go
+++ b/internal/sourcecdk/cidr.go
@@ -1,0 +1,22 @@
+package sourcecdk
+
+import "strings"
+
+const (
+	openIPv4AnyCIDR = "0.0.0.0/0"
+	openIPv6AnyCIDR = "::/0"
+)
+
+// FirstOpenCIDR returns the first value that opens access to the entire
+// internet ("0.0.0.0/0" or "::/0"), trimmed of surrounding whitespace, or ""
+// when none of the values are an unrestricted range. It lets sources detect
+// public network exposure without re-implementing the any-address check.
+func FirstOpenCIDR(values []string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == openIPv4AnyCIDR || trimmed == openIPv6AnyCIDR {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/sourcecdk/cidr_test.go
+++ b/internal/sourcecdk/cidr_test.go
@@ -1,0 +1,27 @@
+package sourcecdk
+
+import "testing"
+
+func TestFirstOpenCIDR(t *testing.T) {
+	cases := []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{name: "nil", values: nil, want: ""},
+		{name: "empty", values: []string{}, want: ""},
+		{name: "ipv4 any", values: []string{"10.0.0.0/8", "0.0.0.0/0"}, want: "0.0.0.0/0"},
+		{name: "ipv6 any", values: []string{"::/0"}, want: "::/0"},
+		{name: "trims whitespace", values: []string{"  0.0.0.0/0  "}, want: "0.0.0.0/0"},
+		{name: "first match wins", values: []string{"::/0", "0.0.0.0/0"}, want: "::/0"},
+		{name: "no open range", values: []string{"10.0.0.0/8", "192.168.0.0/16"}, want: ""},
+		{name: "host route is not open", values: []string{"0.0.0.0/32"}, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FirstOpenCIDR(tc.values); got != tc.want {
+				t.Fatalf("FirstOpenCIDR(%v) = %q, want %q", tc.values, got, tc.want)
+			}
+		})
+	}
+}

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -1924,7 +1924,7 @@ func artifactImageEvent(settings settings, record gcpcloud.ArtifactImageRecord) 
 
 func resourceExposureEvent(settings settings, record firewallRecord) (*primitives.Event, error) {
 	allowed := firewallPrimaryAllowed(record)
-	sourceCIDR := firstPublicCIDR(record.SourceRanges)
+	sourceCIDR := sourcecdk.FirstOpenCIDR(record.SourceRanges)
 	resourceID := firstNonEmpty(record.ID, record.Name)
 	attributes := map[string]string{
 		"action":            "allow",
@@ -2107,17 +2107,7 @@ func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, 
 }
 
 func firewallPublicIngress(record firewallRecord) bool {
-	return strings.EqualFold(record.Direction, "INGRESS") && !record.Disabled && firstPublicCIDR(record.SourceRanges) != "" && len(record.Allowed) != 0
-}
-
-func firstPublicCIDR(values []string) string {
-	for _, value := range values {
-		trimmed := strings.TrimSpace(value)
-		if trimmed == "0.0.0.0/0" || trimmed == "::/0" {
-			return trimmed
-		}
-	}
-	return ""
+	return strings.EqualFold(record.Direction, "INGRESS") && !record.Disabled && sourcecdk.FirstOpenCIDR(record.SourceRanges) != "" && len(record.Allowed) != 0
 }
 
 func firewallPrimaryAllowed(record firewallRecord) gcpcloud.ComputeFirewallAllowed {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -18,7 +18,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"aws":             19121,
 	"azure":           2856,
 	"cosmo":           1104,
-	"gcp":             2104,
+	"gcp":             2095,
 	"github":          2102,
 	"googleworkspace": 827,
 	"grc":             1378,


### PR DESCRIPTION
## What
Extract the provider-agnostic "open to the entire internet" network-range check out of the GCP source into a new typed Source CDK helper `sourcecdk.FirstOpenCIDR([]string) string` (`internal/sourcecdk/cidr.go`), with focused unit tests. The GCP source now calls the shared helper from its firewall ingress predicate and exposure mapping.

## Why
Continues the Source CDK extraction effort (#956, #684): shared, provider-agnostic behavior (here, network-exposure detection) belongs in the Source CDK rather than being re-implemented per source. This lets the legacy `gcp` package keep ratcheting down toward the 300 LOC budget.

## Notes
- Pure refactor: the extracted helper preserves identical logic, so there is no change to emitted events, attributes, URNs, schema refs, cursors, or runtime behavior.
- The no-growth ratchet for `gcp` is lowered accordingly (2104 -> 2095) in both the archtest budget and the extraction-plan doc.
- The exported helper signature is fully typed (`[]string` -> `string`) and imports no reserved packages.

## Tests
- `go build ./...`
- `go test ./sources/gcp/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/... -count=1`
- `make check-structural` (no violations)