### PR TITLE
refactor(sources): extract shared host-safety into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -32,5 +32,5 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `grc` | 1378 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2361 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 820 | Separate request plumbing from emitted record construction. |
-| `sentinelone` | 2181 | Extract API paging, agent/application readers, and shared response normalization. |
+| `sentinelone` | 2089 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1064 | Split feed/client access from vulnerability record normalization. |

--- a/internal/sourcecdk/host_safety.go
+++ b/internal/sourcecdk/host_safety.go
@@ -1,0 +1,112 @@
+package sourcecdk
+
+import (
+	"math"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// HostIsUnsafe reports whether a configured source host targets a loopback,
+// private, link-local, unspecified, or multicast address. It additionally
+// rejects obfuscated numeric IPv4 hosts (decimal, octal, or hexadecimal forms)
+// that net.ParseIP alone does not normalize, closing an SSRF bypass that bare
+// net.ParseIP-based checks leave open.
+func HostIsUnsafe(host string) bool {
+	value := normalizedIPHost(host)
+	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(value)
+	if ip == nil {
+		ip = parseNumericIPv4Host(value)
+	}
+	if ip == nil {
+		return false
+	}
+	return ipIsUnsafe(ip)
+}
+
+// HostIsLoopback reports whether a host refers to a loopback address, including
+// the localhost names and obfuscated numeric IPv4 loopback hosts.
+func HostIsLoopback(host string) bool {
+	value := normalizedIPHost(host)
+	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(value)
+	if ip == nil {
+		ip = parseNumericIPv4Host(value)
+	}
+	return ip != nil && ip.IsLoopback()
+}
+
+func ipIsUnsafe(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast()
+}
+
+func normalizedIPHost(host string) string {
+	value := strings.TrimRight(strings.ToLower(strings.TrimSpace(host)), ".")
+	value = strings.Trim(value, "[]")
+	if address, _, ok := strings.Cut(value, "%"); ok {
+		value = address
+	}
+	return value
+}
+
+func parseNumericIPv4Host(host string) net.IP {
+	if strings.Contains(host, ":") {
+		return nil
+	}
+	parts := strings.Split(host, ".")
+	if len(parts) == 0 || len(parts) > 4 {
+		return nil
+	}
+	values := make([]uint64, len(parts))
+	for i, part := range parts {
+		if part == "" {
+			return nil
+		}
+		value, err := strconv.ParseUint(part, 0, 32)
+		if err != nil {
+			return nil
+		}
+		values[i] = value
+	}
+	var ipv4 uint32
+	switch len(values) {
+	case 1:
+		ipv4 = uint32FromUint64(values[0])
+	case 2:
+		if values[0] > 0xff || values[1] > 0xffffff {
+			return nil
+		}
+		ipv4 = uint32FromUint64(values[0]<<24 | values[1])
+	case 3:
+		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xffff {
+			return nil
+		}
+		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2])
+	case 4:
+		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xff || values[3] > 0xff {
+			return nil
+		}
+		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2]<<8 | values[3])
+	}
+	return net.IPv4(byte(ipv4>>24), byte(ipv4>>16), byte(ipv4>>8), byte(ipv4))
+}
+
+func uint32FromUint64(value uint64) uint32 {
+	if value > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(value)
+}

--- a/sources/sentinelone/source.go
+++ b/sources/sentinelone/source.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -206,7 +205,7 @@ func normalizeBaseURL(raw string, allowLoopback bool) (string, string, error) {
 		return "", "", fmt.Errorf("parse sentinelone base_url: %w", err)
 	}
 	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
-	allowInsecureLoopback := allowLoopback && parsed.Scheme == "http" && isLoopbackHost(host)
+	allowInsecureLoopback := allowLoopback && parsed.Scheme == "http" && sourcecdk.HostIsLoopback(host)
 	if parsed.Scheme != "https" && !allowInsecureLoopback {
 		return "", "", fmt.Errorf("sentinelone base_url must use https")
 	}
@@ -219,113 +218,16 @@ func normalizeBaseURL(raw string, allowLoopback bool) (string, string, error) {
 	if (parsed.Path != "" && parsed.Path != "/") || parsed.RawPath != "" {
 		return "", "", fmt.Errorf("sentinelone base_url must be an origin URL")
 	}
-	allowCustomPort := allowLoopback && isLoopbackHost(host)
+	allowCustomPort := allowLoopback && sourcecdk.HostIsLoopback(host)
 	if strings.TrimSpace(parsed.Port()) != "" && parsed.Port() != "443" && !allowCustomPort {
 		return "", "", fmt.Errorf("sentinelone base_url must not include a custom port")
 	}
-	allowLoopbackHost := allowLoopback && isLoopbackHost(host)
-	if isUnsafeHost(host) && !allowLoopbackHost {
+	allowLoopbackHost := allowLoopback && sourcecdk.HostIsLoopback(host)
+	if sourcecdk.HostIsUnsafe(host) && !allowLoopbackHost {
 		return "", "", fmt.Errorf("sentinelone base_url must not target loopback, private, or link-local hosts")
 	}
 	parsed.Path = ""
 	return strings.TrimRight(parsed.String(), "/"), host, nil
-}
-
-func isUnsafeHost(host string) bool {
-	value := normalizedIPHost(host)
-	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
-		return true
-	}
-	ip := net.ParseIP(value)
-	if ip == nil {
-		ip = parseNumericIPv4Host(value)
-	}
-	if ip == nil {
-		return false
-	}
-	return isUnsafeIP(ip)
-}
-
-func isUnsafeIP(ip net.IP) bool {
-	if ip == nil {
-		return false
-	}
-	return ip.IsLoopback() ||
-		ip.IsPrivate() ||
-		ip.IsLinkLocalUnicast() ||
-		ip.IsLinkLocalMulticast() ||
-		ip.IsUnspecified() ||
-		ip.IsMulticast()
-}
-
-func isLoopbackHost(host string) bool {
-	value := normalizedIPHost(host)
-	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
-		return true
-	}
-	ip := net.ParseIP(value)
-	if ip == nil {
-		ip = parseNumericIPv4Host(value)
-	}
-	return ip != nil && ip.IsLoopback()
-}
-
-func normalizedIPHost(host string) string {
-	value := strings.TrimRight(strings.ToLower(strings.TrimSpace(host)), ".")
-	value = strings.Trim(value, "[]")
-	if address, _, ok := strings.Cut(value, "%"); ok {
-		value = address
-	}
-	return value
-}
-
-func parseNumericIPv4Host(host string) net.IP {
-	if strings.Contains(host, ":") {
-		return nil
-	}
-	parts := strings.Split(host, ".")
-	if len(parts) == 0 || len(parts) > 4 {
-		return nil
-	}
-	values := make([]uint64, len(parts))
-	for i, part := range parts {
-		if part == "" {
-			return nil
-		}
-		value, err := strconv.ParseUint(part, 0, 32)
-		if err != nil {
-			return nil
-		}
-		values[i] = value
-	}
-	var ipv4 uint32
-	switch len(values) {
-	case 1:
-		ipv4 = uint32FromUint64(values[0])
-	case 2:
-		if values[0] > 0xff || values[1] > 0xffffff {
-			return nil
-		}
-		ipv4 = uint32FromUint64(values[0]<<24 | values[1])
-	case 3:
-		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xffff {
-			return nil
-		}
-		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2])
-	case 4:
-		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xff || values[3] > 0xff {
-			return nil
-		}
-		ipv4 = uint32FromUint64(values[0]<<24 | values[1]<<16 | values[2]<<8 | values[3])
-	}
-	return net.IPv4(byte(ipv4>>24), byte(ipv4>>16), byte(ipv4>>8), byte(ipv4))
-}
-
-func uint32FromUint64(value uint64) uint32 {
-	if value > math.MaxUint32 {
-		return math.MaxUint32
-	}
-	return uint32(value)
 }
 
 type listFunc[T any] func(context.Context, settings, string, int) ([]T, string, error)

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -24,7 +24,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"grc":             1378,
 	"okta":            2361,
 	"panopticon":      820,
-	"sentinelone":     2181,
+	"sentinelone":     2089,
 	"vulnview":        1064,
 }
 


### PR DESCRIPTION
## What
Extracts the provider-agnostic host/IP safety classification out of the SentinelOne source connector into a new typed helper file in the Source CDK (`internal/sourcecdk/host_safety.go`), exposing `HostIsUnsafe` and `HostIsLoopback`. The connector now calls the shared helper instead of carrying its own copy.

The moved logic rejects loopback/private/link-local/unspecified/multicast targets and additionally normalizes obfuscated numeric IPv4 hosts (decimal/octal/hex forms) that `net.ParseIP` alone does not catch.

## Why
Part of the Source CDK extraction effort (#956, #684): shared request/safety plumbing should live in the CDK so legacy source packages shrink toward the LOC budget instead of duplicating common behavior across connectors.

## Notes
- Pure refactor: no change to emitted events, attributes, URNs, schema refs, cursors, or runtime validation behavior. The relocated code is identical logic, only moved and renamed at the two call sites.
- The helper uses typed signatures (string / net.IP / bool) to satisfy the CDK typed-boundary rule, and imports only `net` (not `net/http`), respecting the HTTP-client boundary.
- No-growth ratchet lowered for the affected source package (2181 to 2089) in both the archtest budget and the extraction-plan doc.

## Tests
- `go build ./...`
- `go test ./sources/sentinelone/... ./internal/sourcecdk/... -count=1`
- `go test ./tools/archtests/... -count=1`
- `make check-structural`

All green.
