### PR TITLE
feat: add GRC finding trends endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1765,6 +1765,34 @@ paths:
       responses:
         '200':
           description: GRC dashboard summary, priority findings, controls, evidence, and connector health.
+  /grc/trends:
+    get:
+      summary: GRC finding trends
+      tags:
+        - GRC
+      parameters:
+        - $ref: '#/components/parameters/tenantIDQuery'
+        - $ref: '#/components/parameters/runtimeIDQuery'
+        - $ref: '#/components/parameters/sourceIDQuery'
+        - name: interval
+          in: query
+          schema:
+            type: string
+            enum:
+              - day
+              - week
+              - month
+            default: day
+        - name: days
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 366
+            default: 90
+      responses:
+        '200':
+          description: Time-bucketed finding flow series with opened, closed, severity splits, and a reconstructed open backlog per bucket.
   /grc/ask:
     post:
       summary: Ask natural-language questions over the GRC graph

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -109,6 +109,13 @@ rule coverage, evidence freshness, control status behavior, custom profile
 resolution, report metadata construction, and export rendering stay behind that
 domain package.
 
+The GRC finding-trends route adds a small HTTP adapter that resolves request
+scope, parses the interval and window parameters, fans out per-tenant runtime
+queries to the `GRCFindingTrendsStore` port, merges the returned buckets across
+tenants, and reconstructs the running open backlog before JSON response mapping.
+The time-bucketed aggregation, severity classification, and open-at-window-start
+baseline stay behind `internal/statestore/postgres`.
+
 The agent platform graph preflight contract lives in `internal/agentplatform`.
 The bootstrap budget includes the HTTP and MCP request/response mapping needed
 to force authenticated tenant context, expose preflight to agents, and attach

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -317,6 +317,160 @@ func joinGRCErrors(errs <-chan error) error {
 	return joined
 }
 
+const (
+	grcTrendsDefaultDays = uint32(90)
+	grcTrendsMaxDays     = uint32(366)
+)
+
+type grcTrendPoint struct {
+	Date           string `json:"date"`
+	Opened         int    `json:"opened"`
+	OpenedCritical int    `json:"opened_critical"`
+	OpenedHigh     int    `json:"opened_high"`
+	Closed         int    `json:"closed"`
+	OpenTotal      int    `json:"open_total"`
+}
+
+type grcTrendsResponse struct {
+	Interval    string          `json:"interval"`
+	Start       time.Time       `json:"start"`
+	End         time.Time       `json:"end"`
+	Points      []grcTrendPoint `json:"points"`
+	GeneratedAt time.Time       `json:"generated_at"`
+}
+
+func (a *App) handleGRCTrends(w http.ResponseWriter, r *http.Request) {
+	scope, err := grcScopeFromRequest(r)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	interval, days, err := grcTrendsParamsFromRequest(r)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	end := time.Now().UTC()
+	start := end.AddDate(0, 0, -int(days))
+	runtimes, err := a.grcListRuntimes(r, scope)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	trends, err := a.grcFindingTrends(r, runtimes, start, end, interval)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, grcTrendsResponse{
+		Interval:    interval,
+		Start:       start,
+		End:         end,
+		Points:      grcBuildTrendPoints(trends),
+		GeneratedAt: time.Now().UTC(),
+	})
+}
+
+func grcTrendsParamsFromRequest(r *http.Request) (string, uint32, error) {
+	interval := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("interval")))
+	if interval == "" {
+		interval = "day"
+	}
+	switch interval {
+	case "day", "week", "month":
+	default:
+		return "", 0, fmt.Errorf("%w: interval must be day, week, or month", errInvalidHTTPRequest)
+	}
+	days, err := uint32QueryParam(r, "days")
+	if err != nil {
+		return "", 0, err
+	}
+	if days == 0 {
+		days = grcTrendsDefaultDays
+	}
+	if days > grcTrendsMaxDays {
+		days = grcTrendsMaxDays
+	}
+	return interval, days, nil
+}
+
+func (a *App) grcFindingTrends(r *http.Request, runtimes []*cerebrov1.SourceRuntime, start, end time.Time, interval string) (*ports.GRCFindingTrends, error) {
+	store := findingStore(a.deps.StateStore)
+	provider, ok := store.(grcFindingTrendsProvider)
+	if !ok {
+		return nil, findings.ErrRuntimeUnavailable
+	}
+	runtimeIDsByTenant := map[string][]string{}
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		tenantID := strings.TrimSpace(runtime.GetTenantId())
+		runtimeID := strings.TrimSpace(runtime.GetId())
+		if tenantID == "" || runtimeID == "" {
+			continue
+		}
+		runtimeIDsByTenant[tenantID] = append(runtimeIDsByTenant[tenantID], runtimeID)
+	}
+	merged := map[time.Time]*ports.GRCFindingTrendPoint{}
+	openAtStart := 0
+	for tenantID, runtimeIDs := range runtimeIDsByTenant {
+		trends, err := provider.SummarizeGRCFindingTrends(r.Context(), ports.GRCFindingTrendsRequest{
+			FindingRequest: ports.ListFindingsRequest{TenantID: tenantID, RuntimeIDs: runtimeIDs},
+			Start:          start,
+			End:            end,
+			Interval:       interval,
+		})
+		if err != nil {
+			return nil, err
+		}
+		openAtStart += trends.OpenAtStart
+		for _, point := range trends.Points {
+			key := point.BucketStart.UTC()
+			agg := merged[key]
+			if agg == nil {
+				agg = &ports.GRCFindingTrendPoint{BucketStart: key}
+				merged[key] = agg
+			}
+			agg.Opened += point.Opened
+			agg.OpenedCritical += point.OpenedCritical
+			agg.OpenedHigh += point.OpenedHigh
+			agg.Closed += point.Closed
+		}
+	}
+	points := make([]ports.GRCFindingTrendPoint, 0, len(merged))
+	for _, point := range merged {
+		points = append(points, *point)
+	}
+	sort.Slice(points, func(i, j int) bool {
+		return points[i].BucketStart.Before(points[j].BucketStart)
+	})
+	return &ports.GRCFindingTrends{Points: points, OpenAtStart: openAtStart}, nil
+}
+
+func grcBuildTrendPoints(trends *ports.GRCFindingTrends) []grcTrendPoint {
+	if trends == nil {
+		return []grcTrendPoint{}
+	}
+	running := trends.OpenAtStart
+	points := make([]grcTrendPoint, 0, len(trends.Points))
+	for _, point := range trends.Points {
+		running += point.Opened - point.Closed
+		if running < 0 {
+			running = 0
+		}
+		points = append(points, grcTrendPoint{
+			Date:           point.BucketStart.UTC().Format("2006-01-02"),
+			Opened:         point.Opened,
+			OpenedCritical: point.OpenedCritical,
+			OpenedHigh:     point.OpenedHigh,
+			Closed:         point.Closed,
+			OpenTotal:      running,
+		})
+	}
+	return points
+}
+
 func (a *App) handleGRCFindings(w http.ResponseWriter, r *http.Request) {
 	scope, err := grcScopeFromRequest(r)
 	if err != nil {
@@ -654,6 +808,10 @@ type grcFindingEvidenceHeaderLister interface {
 
 type grcFindingHeaderLister interface {
 	ListGRCFindings(context.Context, ports.ListFindingsRequest) ([]*ports.FindingRecord, error)
+}
+
+type grcFindingTrendsProvider interface {
+	SummarizeGRCFindingTrends(context.Context, ports.GRCFindingTrendsRequest) (ports.GRCFindingTrends, error)
 }
 
 func grcDashboardTelemetryAttrs() telemetry.Attributes {

--- a/internal/bootstrap/grc_trends_test.go
+++ b/internal/bootstrap/grc_trends_test.go
@@ -1,0 +1,148 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestGRCBuildTrendPointsReconstructsRunningBacklog(t *testing.T) {
+	base := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	trends := &ports.GRCFindingTrends{
+		OpenAtStart: 10,
+		Points: []ports.GRCFindingTrendPoint{
+			{BucketStart: base, Opened: 3, OpenedCritical: 1, OpenedHigh: 1, Closed: 1},
+			{BucketStart: base.AddDate(0, 0, 1), Opened: 0, Closed: 4},
+			{BucketStart: base.AddDate(0, 0, 2), Opened: 2, Closed: 0},
+		},
+	}
+
+	points := grcBuildTrendPoints(trends)
+	if len(points) != 3 {
+		t.Fatalf("points = %d, want 3", len(points))
+	}
+	if points[0].Date != "2026-03-01" {
+		t.Fatalf("points[0].Date = %q, want 2026-03-01", points[0].Date)
+	}
+	for i, want := range []int{12, 8, 10} { // 10+3-1; 12+0-4; 8+2-0
+		if points[i].OpenTotal != want {
+			t.Fatalf("points[%d].OpenTotal = %d, want %d", i, points[i].OpenTotal, want)
+		}
+	}
+}
+
+func TestGRCBuildTrendPointsClampsBacklogAtZero(t *testing.T) {
+	trends := &ports.GRCFindingTrends{
+		OpenAtStart: 1,
+		Points: []ports.GRCFindingTrendPoint{
+			{BucketStart: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), Closed: 5},
+		},
+	}
+	if got := grcBuildTrendPoints(trends)[0].OpenTotal; got != 0 {
+		t.Fatalf("OpenTotal = %d, want 0 (clamped)", got)
+	}
+}
+
+func TestGRCBuildTrendPointsNilReturnsEmptySlice(t *testing.T) {
+	points := grcBuildTrendPoints(nil)
+	if points == nil || len(points) != 0 {
+		t.Fatalf("points = %#v, want empty non-nil slice", points)
+	}
+}
+
+func TestGRCTrendsParamsFromRequestDefaults(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/grc/trends", nil)
+	interval, days, err := grcTrendsParamsFromRequest(r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if interval != "day" || days != grcTrendsDefaultDays {
+		t.Fatalf("interval=%q days=%d, want day/%d", interval, days, grcTrendsDefaultDays)
+	}
+}
+
+func TestGRCTrendsParamsFromRequestClampsDays(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/grc/trends?days=100000&interval=week", nil)
+	interval, days, err := grcTrendsParamsFromRequest(r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if interval != "week" || days != grcTrendsMaxDays {
+		t.Fatalf("interval=%q days=%d, want week/%d", interval, days, grcTrendsMaxDays)
+	}
+}
+
+func TestGRCTrendsParamsFromRequestRejectsInterval(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/grc/trends?interval=hour", nil)
+	if _, _, err := grcTrendsParamsFromRequest(r); err == nil {
+		t.Fatalf("expected error for unsupported interval")
+	}
+}
+
+type stubGRCTrendsStore struct {
+	*stubRuntimeStore
+	calls int
+	last  ports.GRCFindingTrendsRequest
+}
+
+func (s *stubGRCTrendsStore) SummarizeGRCFindingTrends(_ context.Context, request ports.GRCFindingTrendsRequest) (ports.GRCFindingTrends, error) {
+	s.calls++
+	s.last = request
+	base := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	return ports.GRCFindingTrends{
+		OpenAtStart: 5,
+		Points: []ports.GRCFindingTrendPoint{
+			{BucketStart: base, Opened: 2, OpenedCritical: 1, Closed: 0},
+			{BucketStart: base.AddDate(0, 0, 1), Opened: 0, Closed: 3},
+		},
+	}, nil
+}
+
+func TestHandleGRCTrendsReturnsSeries(t *testing.T) {
+	store := &stubGRCTrendsStore{stubRuntimeStore: &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta": {Id: "writer-okta", SourceId: "okta", TenantId: "writer"},
+		},
+	}}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/trends?tenant_id=writer&days=30")
+	if err != nil {
+		t.Fatalf("GET /grc/trends error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/trends status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload grcTrendsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /grc/trends: %v", err)
+	}
+	if payload.Interval != "day" {
+		t.Fatalf("interval = %q, want day", payload.Interval)
+	}
+	if len(payload.Points) != 2 {
+		t.Fatalf("points = %d, want 2", len(payload.Points))
+	}
+	if payload.Points[0].OpenTotal != 7 || payload.Points[1].OpenTotal != 4 { // 5+2-0; 7+0-3
+		t.Fatalf("open totals = %d,%d want 7,4", payload.Points[0].OpenTotal, payload.Points[1].OpenTotal)
+	}
+	if payload.Points[0].OpenedCritical != 1 {
+		t.Fatalf("opened_critical = %d, want 1", payload.Points[0].OpenedCritical)
+	}
+	if store.calls != 1 {
+		t.Fatalf("trends store calls = %d, want 1", store.calls)
+	}
+	if store.last.Interval != "day" {
+		t.Fatalf("store interval = %q, want day", store.last.Interval)
+	}
+}

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -86,6 +86,7 @@ func (app *App) registerReportRoutes(mux *http.ServeMux) {
 
 func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /grc/dashboard", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("dashboard", 30*time.Second, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCDashboard))
+	registerHTTPRoute(mux, "GET /grc/trends", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("trends", time.Minute, grcCacheScopeFindings, grcCacheScopeRuntime), app.handleGRCTrends))
 	registerHTTPRoute(mux, "POST /grc/ask", routeSurfacePlatformHTTP, app.handleGRCAsk)
 	registerHTTPRoute(mux, "GET /grc/findings", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("findings", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCFindings))
 	registerHTTPRoute(mux, "GET /grc/controls", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("controls", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCControls))

--- a/internal/ports/grc.go
+++ b/internal/ports/grc.go
@@ -1,6 +1,9 @@
 package ports
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // GRCDashboardAggregateRequest scopes aggregate counts needed by the GRC dashboard.
 type GRCDashboardAggregateRequest struct {
@@ -19,4 +22,37 @@ type GRCDashboardAggregate struct {
 type GRCDashboardAggregateStore interface {
 	StateStore
 	SummarizeGRCDashboard(context.Context, GRCDashboardAggregateRequest) (GRCDashboardAggregate, error)
+}
+
+// GRCFindingTrendsRequest scopes the time-bucketed finding trend aggregation.
+// Trends are derived from current-state finding timestamps: findings are
+// bucketed as opened by first_observed_at and as closed by status_updated_at
+// for non-open rows. Interval must be one of "day", "week", or "month".
+type GRCFindingTrendsRequest struct {
+	FindingRequest ListFindingsRequest
+	Start          time.Time
+	End            time.Time
+	Interval       string
+}
+
+// GRCFindingTrendPoint holds one bucket of finding flow counts.
+type GRCFindingTrendPoint struct {
+	BucketStart    time.Time
+	Opened         int
+	OpenedCritical int
+	OpenedHigh     int
+	Closed         int
+}
+
+// GRCFindingTrends is the bucketed trend series plus the open backlog at the
+// window start, which lets callers reconstruct a running open total.
+type GRCFindingTrends struct {
+	Points      []GRCFindingTrendPoint
+	OpenAtStart int
+}
+
+// GRCFindingTrendsStore provides a purpose-built time-bucketed trend aggregation.
+type GRCFindingTrendsStore interface {
+	StateStore
+	SummarizeGRCFindingTrends(context.Context, GRCFindingTrendsRequest) (GRCFindingTrends, error)
 }

--- a/internal/statestore/postgres/grc_trends.go
+++ b/internal/statestore/postgres/grc_trends.go
@@ -1,0 +1,149 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var grcTrendIntervals = map[string]struct{}{
+	"day":   {},
+	"week":  {},
+	"month": {},
+}
+
+// SummarizeGRCFindingTrends derives a time-bucketed finding flow series from the
+// findings table. Findings are bucketed as opened by first_observed_at and as
+// closed by status_updated_at for non-open rows; the baseline counts findings
+// that were open at the window start so callers can reconstruct a running open
+// total. Counts share the dashboard's current-state fidelity: only the latest
+// status transition is retained, so historical reopen cycles are approximate.
+func (s *Store) SummarizeGRCFindingTrends(ctx context.Context, request ports.GRCFindingTrendsRequest) (ports.GRCFindingTrends, error) {
+	if s == nil || s.db == nil {
+		return ports.GRCFindingTrends{}, errors.New("postgres is not configured")
+	}
+	interval := strings.ToLower(strings.TrimSpace(request.Interval))
+	if interval == "" {
+		interval = "day"
+	}
+	if _, ok := grcTrendIntervals[interval]; !ok {
+		return ports.GRCFindingTrends{}, fmt.Errorf("unsupported grc trends interval %q", request.Interval)
+	}
+	if request.Start.IsZero() || request.End.IsZero() || !request.End.After(request.Start) {
+		return ports.GRCFindingTrends{}, errors.New("grc trends window requires start before end")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return ports.GRCFindingTrends{}, err
+	}
+	clauses, findingArgs, err := findingFilterClauses(request.FindingRequest)
+	if err != nil {
+		return ports.GRCFindingTrends{}, err
+	}
+	whereFindings := strings.Join(clauses, " AND ")
+
+	seriesQuery, seriesArgs := grcFindingTrendsSeriesQuery(whereFindings, findingArgs, interval, request.Start, request.End)
+	rows, err := s.db.QueryContext(ctx, seriesQuery, seriesArgs...)
+	if err != nil {
+		return ports.GRCFindingTrends{}, fmt.Errorf("summarize grc finding trends: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var points []ports.GRCFindingTrendPoint
+	for rows.Next() {
+		var point ports.GRCFindingTrendPoint
+		if err := rows.Scan(&point.BucketStart, &point.Opened, &point.OpenedCritical, &point.OpenedHigh, &point.Closed); err != nil {
+			return ports.GRCFindingTrends{}, fmt.Errorf("scan grc finding trend point: %w", err)
+		}
+		point.BucketStart = point.BucketStart.UTC()
+		points = append(points, point)
+	}
+	if err := rows.Err(); err != nil {
+		return ports.GRCFindingTrends{}, fmt.Errorf("iterate grc finding trends: %w", err)
+	}
+
+	baselineQuery, baselineArgs := grcFindingTrendsBaselineQuery(whereFindings, findingArgs, interval, request.Start)
+	var openAtStart int
+	if err := s.db.QueryRowContext(ctx, baselineQuery, baselineArgs...).Scan(&openAtStart); err != nil {
+		return ports.GRCFindingTrends{}, fmt.Errorf("summarize grc finding trends baseline: %w", err)
+	}
+
+	return ports.GRCFindingTrends{Points: points, OpenAtStart: openAtStart}, nil
+}
+
+func grcFindingTrendsSeriesQuery(whereFindings string, findingArgs []any, interval string, start, end time.Time) (string, []any) {
+	args := append([]any{}, findingArgs...)
+	intervalArg := fmt.Sprintf("$%d", len(args)+1)
+	args = append(args, interval)
+	startArg := fmt.Sprintf("$%d", len(args)+1)
+	args = append(args, start.UTC())
+	endArg := fmt.Sprintf("$%d", len(args)+1)
+	args = append(args, end.UTC())
+	effectiveSeverity := findingEffectiveSeveritySQL()
+	query := `
+WITH scope AS (
+  SELECT status, ` + effectiveSeverity + ` AS effective_severity, first_observed_at, status_updated_at
+  FROM findings
+  WHERE ` + whereFindings + `
+),
+bounds AS (
+  SELECT
+    date_trunc(` + intervalArg + `, ` + startArg + `::timestamptz) AS start_bucket,
+    date_trunc(` + intervalArg + `, ` + endArg + `::timestamptz) AS end_bucket,
+    ('1 ' || ` + intervalArg + `)::interval AS step
+),
+buckets AS (
+  SELECT generate_series(b.start_bucket, b.end_bucket, b.step) AS bucket_start FROM bounds b
+),
+opened AS (
+  SELECT
+    date_trunc(` + intervalArg + `, scope.first_observed_at) AS bucket_start,
+    COUNT(*) AS opened,
+    COUNT(*) FILTER (WHERE scope.effective_severity = 'CRITICAL') AS opened_critical,
+    COUNT(*) FILTER (WHERE scope.effective_severity = 'HIGH') AS opened_high
+  FROM scope, bounds b
+  WHERE scope.first_observed_at >= b.start_bucket AND scope.first_observed_at < b.end_bucket + b.step
+  GROUP BY 1
+),
+closed AS (
+  SELECT
+    date_trunc(` + intervalArg + `, scope.status_updated_at) AS bucket_start,
+    COUNT(*) AS closed
+  FROM scope, bounds b
+  WHERE LOWER(scope.status) <> 'open'
+    AND scope.status_updated_at IS NOT NULL
+    AND scope.status_updated_at >= b.start_bucket AND scope.status_updated_at < b.end_bucket + b.step
+  GROUP BY 1
+)
+SELECT
+  buckets.bucket_start,
+  COALESCE(opened.opened, 0),
+  COALESCE(opened.opened_critical, 0),
+  COALESCE(opened.opened_high, 0),
+  COALESCE(closed.closed, 0)
+FROM buckets
+LEFT JOIN opened ON opened.bucket_start = buckets.bucket_start
+LEFT JOIN closed ON closed.bucket_start = buckets.bucket_start
+ORDER BY buckets.bucket_start`
+	return query, args
+}
+
+func grcFindingTrendsBaselineQuery(whereFindings string, findingArgs []any, interval string, start time.Time) (string, []any) {
+	args := append([]any{}, findingArgs...)
+	intervalArg := fmt.Sprintf("$%d", len(args)+1)
+	args = append(args, interval)
+	startArg := fmt.Sprintf("$%d", len(args)+1)
+	args = append(args, start.UTC())
+	query := `
+SELECT COUNT(*)
+FROM findings
+WHERE ` + whereFindings + `
+  AND first_observed_at < date_trunc(` + intervalArg + `, ` + startArg + `::timestamptz)
+  AND (
+    LOWER(status) = 'open'
+    OR (status_updated_at IS NOT NULL AND status_updated_at >= date_trunc(` + intervalArg + `, ` + startArg + `::timestamptz))
+  )`
+	return query, args
+}

--- a/internal/statestore/postgres/grc_trends_test.go
+++ b/internal/statestore/postgres/grc_trends_test.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestGRCFindingTrendsSeriesQueryStructure(t *testing.T) {
+	clauses, args, err := findingFilterClauses(ports.ListFindingsRequest{TenantID: "writer", RuntimeIDs: []string{"writer-okta"}})
+	if err != nil {
+		t.Fatalf("findingFilterClauses error = %v", err)
+	}
+	where := strings.Join(clauses, " AND ")
+	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	query, queryArgs := grcFindingTrendsSeriesQuery(where, args, "day", start, end)
+
+	for _, fragment := range []string{
+		"WHERE tenant_id = $1",
+		"generate_series",
+		"date_trunc(",
+		"FILTER (WHERE scope.effective_severity = 'CRITICAL')",
+		"FILTER (WHERE scope.effective_severity = 'HIGH')",
+		"LOWER(scope.status) <> 'open'",
+		"scope.status_updated_at IS NOT NULL",
+		"LEFT JOIN opened",
+		"LEFT JOIN closed",
+		"ORDER BY buckets.bucket_start",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("series query missing %q:\n%s", fragment, query)
+		}
+	}
+
+	if len(queryArgs) != len(args)+3 {
+		t.Fatalf("series args = %d, want %d", len(queryArgs), len(args)+3)
+	}
+	if queryArgs[len(args)] != "day" {
+		t.Fatalf("interval arg = %v, want day", queryArgs[len(args)])
+	}
+	if got, ok := queryArgs[len(args)+1].(time.Time); !ok || !got.Equal(start.UTC()) {
+		t.Fatalf("start arg = %v, want %v", queryArgs[len(args)+1], start.UTC())
+	}
+	if got, ok := queryArgs[len(args)+2].(time.Time); !ok || !got.Equal(end.UTC()) {
+		t.Fatalf("end arg = %v, want %v", queryArgs[len(args)+2], end.UTC())
+	}
+}
+
+func TestGRCFindingTrendsBaselineQueryStructure(t *testing.T) {
+	clauses, args, err := findingFilterClauses(ports.ListFindingsRequest{TenantID: "writer", RuntimeIDs: []string{"writer-okta"}})
+	if err != nil {
+		t.Fatalf("findingFilterClauses error = %v", err)
+	}
+	where := strings.Join(clauses, " AND ")
+	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	query, queryArgs := grcFindingTrendsBaselineQuery(where, args, "week", start)
+
+	for _, fragment := range []string{
+		"SELECT COUNT(*)",
+		"WHERE tenant_id = $1",
+		"first_observed_at < date_trunc(",
+		"LOWER(status) = 'open'",
+		"status_updated_at >= date_trunc(",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("baseline query missing %q:\n%s", fragment, query)
+		}
+	}
+
+	if len(queryArgs) != len(args)+2 {
+		t.Fatalf("baseline args = %d, want %d", len(queryArgs), len(args)+2)
+	}
+	if queryArgs[len(args)] != "week" {
+		t.Fatalf("interval arg = %v, want week", queryArgs[len(args)])
+	}
+	if got, ok := queryArgs[len(args)+1].(time.Time); !ok || !got.Equal(start.UTC()) {
+		t.Fatalf("start arg = %v, want %v", queryArgs[len(args)+1], start.UTC())
+	}
+}

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const bootstrapProductionGoLineBudget = 23367
+const bootstrapProductionGoLineBudget = 23526
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
Adds `GET /grc/trends`, a time-bucketed finding-flow series for the GRC dashboard, derived from the current-state findings table. No new store or snapshot table is introduced; this is a read view over existing data, consistent with the GRC analytics non-goals.

## What it returns
For a tenant/runtime scope and a bounded time window, a per-bucket series:
- `opened` (bucketed by `first_observed_at`), with `opened_critical` / `opened_high` splits
- `closed` (bucketed by `status_updated_at` for non-open rows)
- `open_total`: a running open backlog reconstructed from an open-at-window-start baseline plus cumulative opened minus closed

Query params: `interval=day|week|month` (default `day`), `days` (default 90, bounded), plus the standard `tenant_id` / `runtime_id` / `source_id` scope.

## Implementation
- `internal/ports/grc.go`: request/result types and an optional `GRCFindingTrendsStore` capability.
- `internal/statestore/postgres/grc_trends.go`: a scoped CTE aggregate (`generate_series` buckets, `date_trunc`, `FILTER` severity splits) plus a baseline backlog query, reusing the existing finding filter clauses and effective-severity SQL.
- `internal/bootstrap/grc.go`: lean handler, per-tenant merge, and running-backlog reconstruction.
- `internal/bootstrap/routes.go`: route registration mirroring the dashboard cache policy.
- `api/openapi.yaml`: contract entry (route parity checked).

## Fidelity
Shares the same current-state fidelity as the rest of `/grc/*`: only the latest status transition is retained, so reopen cycles are approximate. An event-log-accurate variant is a noted follow-on.

## Testing
- Postgres query-builder unit tests (structure and argument ordering).
- Handler/logic tests: param parsing and defaults, running-backlog reconstruction, and an end-to-end JSON check via an in-memory store stub.
- `go build`, `go vet`, the full `internal/bootstrap` suite, `golangci-lint` on the touched packages, and OpenAPI route parity all pass.
- Validated the live SQL against a Postgres instance with seeded data across day/week/month intervals.