### PR TITLE
refactor(sources): deepen Source CDK contracts (#956)

### DIFF
--- a/internal/sourcecdk/catalog.go
+++ b/internal/sourcecdk/catalog.go
@@ -12,32 +12,28 @@ import (
 )
 
 var (
-	catalogEventContracts    sync.Map
-	catalogCoverageContracts sync.Map
+	catalogEventContracts     sync.Map
+	catalogCoverageContracts  sync.Map
+	catalogLifecycleContracts sync.Map
 )
 
 type catalogFile struct {
-	ID             string                 `yaml:"id"`
-	Name           string                 `yaml:"name"`
-	Description    string                 `yaml:"description"`
-	EmittedKinds   []string               `yaml:"emitted_kinds"`
-	KindLifecycle  []catalogKindLifecycle `yaml:"kind_lifecycle"`
-	Families       []CatalogFamily        `yaml:"families"`
-	EventContracts []EventContract        `yaml:"event_contracts"`
-	Coverage       CoverageContract       `yaml:"coverage_contract"`
-}
-
-type catalogKindLifecycle struct {
-	Kind        string `yaml:"kind"`
-	Status      string `yaml:"status"`
-	Replacement string `yaml:"replacement"`
+	ID             string           `yaml:"id"`
+	Name           string           `yaml:"name"`
+	Description    string           `yaml:"description"`
+	EmittedKinds   []string         `yaml:"emitted_kinds"`
+	KindLifecycle  []KindLifecycle  `yaml:"kind_lifecycle"`
+	Families       []CatalogFamily  `yaml:"families"`
+	EventContracts []EventContract  `yaml:"event_contracts"`
+	Coverage       CoverageContract `yaml:"coverage_contract"`
 }
 
 type SourceCatalog struct {
-	Spec             *cerebrov1.SourceSpec
-	Families         []CatalogFamily
-	EventContracts   []EventContract
-	CoverageContract *CoverageContract
+	Spec              *cerebrov1.SourceSpec
+	Families          []CatalogFamily
+	EventContracts    []EventContract
+	CoverageContract  *CoverageContract
+	LifecycleContract *LifecycleContract
 }
 
 // CatalogFamily declares optional per-family source catalog capabilities.
@@ -86,7 +82,8 @@ func LoadSourceCatalog(data []byte) (*SourceCatalog, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := validateCatalogLifecycle(catalog.KindLifecycle); err != nil {
+	lifecycleContract, err := normalizeLifecycleContract(catalog.ID, emittedKinds, catalog.KindLifecycle)
+	if err != nil {
 		return nil, err
 	}
 	families, err := normalizeCatalogFamilies(catalog.Families)
@@ -103,17 +100,23 @@ func LoadSourceCatalog(data []byte) (*SourceCatalog, error) {
 	}
 	registerCatalogEventContracts(catalog.ID, eventContracts)
 	registerCatalogCoverageContract(catalog.ID, coverageContract)
+	registerCatalogLifecycleContract(catalog.ID, lifecycleContract)
 	var coverage *CoverageContract
 	if len(coverageContract.Dimensions) > 0 {
 		cloned := cloneCoverageContract(coverageContract)
 		coverage = &cloned
+	}
+	var lifecycle *LifecycleContract
+	if len(lifecycleContract.Kinds) > 0 {
+		cloned := cloneLifecycleContract(lifecycleContract)
+		lifecycle = &cloned
 	}
 	return &SourceCatalog{Spec: &cerebrov1.SourceSpec{
 		Id:           catalog.ID,
 		Name:         catalog.Name,
 		Description:  catalog.Description,
 		EmittedKinds: emittedKinds,
-	}, Families: families, EventContracts: eventContracts, CoverageContract: coverage}, nil
+	}, Families: families, EventContracts: eventContracts, CoverageContract: coverage, LifecycleContract: lifecycle}, nil
 }
 
 func registerCatalogEventContracts(sourceID string, contracts []EventContract) {
@@ -165,6 +168,31 @@ func catalogCoverageContractForSource(sourceID string) *CoverageContract {
 	return &cloned
 }
 
+func registerCatalogLifecycleContract(sourceID string, contract LifecycleContract) {
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return
+	}
+	if len(contract.Kinds) == 0 {
+		catalogLifecycleContracts.Delete(sourceID)
+		return
+	}
+	catalogLifecycleContracts.Store(sourceID, cloneLifecycleContract(contract))
+}
+
+func catalogLifecycleContractForSource(sourceID string) *LifecycleContract {
+	value, ok := catalogLifecycleContracts.Load(strings.TrimSpace(sourceID))
+	if !ok {
+		return nil
+	}
+	contract, ok := value.(LifecycleContract)
+	if !ok {
+		return nil
+	}
+	cloned := cloneLifecycleContract(contract)
+	return &cloned
+}
+
 func normalizeCatalogKinds(values []string) ([]string, error) {
 	kinds := make([]string, 0, len(values))
 	seen := map[string]struct{}{}
@@ -183,34 +211,6 @@ func normalizeCatalogKinds(values []string) ([]string, error) {
 		kinds = append(kinds, kind)
 	}
 	return kinds, nil
-}
-
-func validateCatalogLifecycle(entries []catalogKindLifecycle) error {
-	seen := map[string]struct{}{}
-	for _, entry := range entries {
-		kind := strings.TrimSpace(entry.Kind)
-		status := strings.ToLower(strings.TrimSpace(entry.Status))
-		if kind == "" {
-			return fmt.Errorf("kind_lifecycle kind is required")
-		}
-		if !validEventKind(kind) {
-			return fmt.Errorf("kind_lifecycle kind %q must use dot-separated lowercase identifiers", kind)
-		}
-		if _, ok := seen[kind]; ok {
-			return fmt.Errorf("duplicate kind_lifecycle kind %q", kind)
-		}
-		seen[kind] = struct{}{}
-		switch status {
-		case "active", "planned", "deprecated", "retired":
-		default:
-			return fmt.Errorf("kind_lifecycle kind %q has invalid status %q", kind, entry.Status)
-		}
-		replacement := strings.TrimSpace(entry.Replacement)
-		if replacement != "" && !validEventKind(replacement) {
-			return fmt.Errorf("kind_lifecycle kind %q has invalid replacement %q", kind, replacement)
-		}
-	}
-	return nil
 }
 
 func normalizeCatalogFamilies(families []CatalogFamily) ([]CatalogFamily, error) {

--- a/internal/sourcecdk/catalog_test.go
+++ b/internal/sourcecdk/catalog_test.go
@@ -46,21 +46,27 @@ emitted_kinds:
 }
 
 func TestLoadCatalogValidatesKindLifecycle(t *testing.T) {
-	spec, err := LoadCatalog([]byte(`
+	catalog, err := LoadSourceCatalog([]byte(`
 id: github
 name: GitHub
 description: GitHub source
 emitted_kinds:
   - github.audit
 kind_lifecycle:
+  - kind: github.audit
+    status: active
   - kind: github.secret_scanning
     status: planned
 `))
 	if err != nil {
-		t.Fatalf("LoadCatalog() error = %v", err)
+		t.Fatalf("LoadSourceCatalog() error = %v", err)
 	}
+	spec := catalog.Spec
 	if len(spec.EmittedKinds) != 1 || spec.EmittedKinds[0] != "github.audit" {
 		t.Fatalf("EmittedKinds = %#v, want active emitted kind only", spec.EmittedKinds)
+	}
+	if catalog.LifecycleContract == nil || len(catalog.LifecycleContract.Kinds) != 2 {
+		t.Fatalf("LifecycleContract = %#v, want two lifecycle entries", catalog.LifecycleContract)
 	}
 }
 
@@ -293,6 +299,44 @@ coverage_contract:
 	}
 }
 
+func TestNewRegistryPreservesCatalogLifecycleContracts(t *testing.T) {
+	_, err := LoadSourceCatalog([]byte(`
+id: lifecycle_source
+name: Lifecycle Source
+emitted_kinds:
+  - lifecycle_source.event
+kind_lifecycle:
+  - kind: lifecycle_source.event
+    status: active
+  - kind: lifecycle_source.old_event
+    status: deprecated
+    replacement: lifecycle_source.event
+`))
+	if err != nil {
+		t.Fatalf("LoadSourceCatalog() error = %v", err)
+	}
+	registry, err := NewRegistry(catalogTestSource{id: "lifecycle_source"})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	registered, ok := registry.Get("lifecycle_source")
+	if !ok {
+		t.Fatal("registry missing lifecycle_source")
+	}
+	provider, ok := registered.(LifecycleContractProvider)
+	if !ok {
+		t.Fatalf("registered source does not implement LifecycleContractProvider")
+	}
+	contract := provider.LifecycleContract()
+	if contract.SourceID != "lifecycle_source" || len(contract.Kinds) != 2 {
+		t.Fatalf("LifecycleContract() = %#v, want lifecycle_source contract", contract)
+	}
+	contracts := registry.LifecycleContracts()
+	if len(contracts) != 1 || contracts[0].SourceID != "lifecycle_source" {
+		t.Fatalf("LifecycleContracts() = %#v, want lifecycle_source", contracts)
+	}
+}
+
 func TestNewRegistryPreservesCatalogCheckpointAwareSources(t *testing.T) {
 	_, err := LoadSourceCatalog([]byte(`
 id: checkpoint_catalog_source
@@ -390,6 +434,35 @@ kind_lifecycle:
     status: maybe
 `)); err == nil {
 		t.Fatal("LoadCatalog() error = nil, want invalid lifecycle status error")
+	}
+}
+
+func TestLoadCatalogRejectsActiveLifecycleKindNotEmitted(t *testing.T) {
+	if _, err := LoadCatalog([]byte(`
+id: github
+name: GitHub
+emitted_kinds:
+  - github.audit
+kind_lifecycle:
+  - kind: github.secret_scanning
+    status: active
+`)); err == nil {
+		t.Fatal("LoadCatalog() error = nil, want active not emitted lifecycle error")
+	}
+}
+
+func TestLoadCatalogRejectsDanglingLifecycleReplacement(t *testing.T) {
+	if _, err := LoadCatalog([]byte(`
+id: github
+name: GitHub
+emitted_kinds:
+  - github.audit
+kind_lifecycle:
+  - kind: github.audit
+    status: deprecated
+    replacement: github.next
+`)); err == nil {
+		t.Fatal("LoadCatalog() error = nil, want dangling replacement error")
 	}
 }
 

--- a/internal/sourcecdk/config_template.go
+++ b/internal/sourcecdk/config_template.go
@@ -1,0 +1,49 @@
+package sourcecdk
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConfigValue returns a source config value or an empty string.
+func ConfigValue(cfg Config, key string) string {
+	value, _ := cfg.Lookup(key)
+	return value
+}
+
+// RequiredConfigValue returns a trimmed required config value.
+func RequiredConfigValue(sourceID string, cfg Config, key string) (string, error) {
+	key = strings.TrimSpace(key)
+	value := strings.TrimSpace(ConfigValue(cfg, key))
+	if value == "" {
+		return "", fmt.Errorf("%w: %s %s is required", ErrInvalidConfig, strings.TrimSpace(sourceID), key)
+	}
+	return value, nil
+}
+
+// RenderConfigTemplate resolves ${config.key}, ${credential.key}, and
+// ${connection.key} placeholders from source configuration.
+func RenderConfigTemplate(sourceID string, template string, cfg Config, keys []string) (string, error) {
+	rendered := strings.TrimSpace(template)
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		for _, prefix := range []string{"config", "credential", "connection"} {
+			placeholder := "${" + prefix + "." + key + "}"
+			if !strings.Contains(rendered, placeholder) {
+				continue
+			}
+			value, err := RequiredConfigValue(sourceID, cfg, key)
+			if err != nil {
+				return "", err
+			}
+			rendered = strings.ReplaceAll(rendered, placeholder, value)
+		}
+	}
+	if strings.Contains(rendered, "${") {
+		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", ErrInvalidConfig, strings.TrimSpace(sourceID), template)
+	}
+	return rendered, nil
+}

--- a/internal/sourcecdk/deep_contracts_test.go
+++ b/internal/sourcecdk/deep_contracts_test.go
@@ -1,0 +1,138 @@
+package sourcecdk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestIdentityHelpersBuildStableURNsAndEventIDs(t *testing.T) {
+	urn, err := URNForEscaped("tenant", "github.repo", "owner/name", "repo:1")
+	if err != nil {
+		t.Fatalf("URNForEscaped() error = %v", err)
+	}
+	if _, err := ParseURN(urn.String()); err != nil {
+		t.Fatalf("ParseURN(%q) error = %v", urn, err)
+	}
+	if got, want := EventID("source", "family", "record"), EventID("source", "family", "record"); got != want {
+		t.Fatalf("EventID not stable: %q != %q", got, want)
+	}
+	if StableExternalID("", "fallback") != "fallback" {
+		t.Fatalf("StableExternalID empty fallback mismatch")
+	}
+}
+
+func TestRenderConfigTemplate(t *testing.T) {
+	cfg := NewConfig(map[string]string{"domain": "example.com", "region": "us"})
+	got, err := RenderConfigTemplate("test", "https://${config.domain}/${credential.region}", cfg, []string{"domain", "region"})
+	if err != nil {
+		t.Fatalf("RenderConfigTemplate() error = %v", err)
+	}
+	if got != "https://example.com/us" {
+		t.Fatalf("RenderConfigTemplate() = %q", got)
+	}
+	if _, err := RenderConfigTemplate("test", "https://${config.missing}", cfg, []string{"missing"}); !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("RenderConfigTemplate missing error = %v, want ErrInvalidConfig", err)
+	}
+}
+
+func TestSourceErrorKind(t *testing.T) {
+	err := WrapSourceError(ErrorKindRateLimited, "github", "audit", errors.New("provider said slow down"))
+	if got := SourceErrorKind(err); got != ErrorKindRateLimited {
+		t.Fatalf("SourceErrorKind() = %q, want %q", got, ErrorKindRateLimited)
+	}
+	if got := SourceErrorKind(&HTTPStatusError{Code: 503, Message: "try later"}); got != ErrorKindTransient {
+		t.Fatalf("SourceErrorKind(503) = %q, want transient", got)
+	}
+}
+
+func TestFamilyFromPageReaderReadsAndDiscovers(t *testing.T) {
+	type settings struct{ tenant string }
+	type client struct{}
+	type record struct{ id string }
+	reader := PageReader[settings, client, record]{
+		SourceID: "test",
+		Family:   "resource",
+		Clients: func(context.Context, settings) (client, error) {
+			return client{}, nil
+		},
+		List: func(_ context.Context, _ client, _ settings, token string, _ int) ([]record, string, error) {
+			if token == "" {
+				return []record{{id: "one"}}, "next", nil
+			}
+			return []record{{id: "two"}}, "", nil
+		},
+		URN: func(s settings, r record) (URN, error) {
+			return URNFor(s.tenant, "resource", r.id)
+		},
+		Event: func(s settings, r record) (*primitives.Event, error) {
+			return &primitives.Event{
+				Id:         EventID("test", r.id),
+				TenantId:   s.tenant,
+				SourceId:   "test",
+				Kind:       "test.resource",
+				OccurredAt: timestamppb.New(time.Unix(0, 0).UTC()),
+				SchemaRef:  "test/resource/v1",
+				Payload:    []byte(`{"id":"` + r.id + `"}`),
+			}, nil
+		},
+	}
+	family := FamilyFromPageReader(reader)
+	urns, err := family.Discover(context.Background(), settings{tenant: "tenant"})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(urns) != 1 || urns[0] != "urn:cerebro:tenant:resource:one" {
+		t.Fatalf("Discover() = %#v", urns)
+	}
+	pull, err := family.Read(context.Background(), settings{tenant: "tenant"}, nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 || pull.NextCursor.GetOpaque() != "next" {
+		t.Fatalf("Read() = %#v", pull)
+	}
+}
+
+func TestValidateFixtureSuite(t *testing.T) {
+	source, err := NewFixtureSource(FixtureSourceOptions{
+		Spec: &cerebrov1.SourceSpec{Id: "fixture", Name: "Fixture", EmittedKinds: []string{"fixture.event"}},
+		Contracts: []EventContract{{
+			Kind:                  "fixture.event",
+			SchemaRef:             "fixture/event/v1",
+			RequiredPayloadFields: []string{"id"},
+		}},
+		DefaultFamily: "default",
+		Families: []FixtureFamily{{
+			Name: "default",
+			URNs: []URN{"urn:cerebro:tenant:fixture:one"},
+			Events: []*primitives.Event{{
+				Id:         "event-1",
+				TenantId:   "tenant",
+				SourceId:   "fixture",
+				Kind:       "fixture.event",
+				OccurredAt: timestamppb.New(time.Unix(0, 0).UTC()),
+				SchemaRef:  "fixture/event/v1",
+				Payload:    []byte(`{"id":"one"}`),
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewFixtureSource() error = %v", err)
+	}
+	if err := ValidateFixtureSuite(context.Background(), FixtureSuiteOptions{Source: source, RequireDiscover: true}); err != nil {
+		t.Fatalf("ValidateFixtureSuite() error = %v", err)
+	}
+}
+
+func TestPullStatistics(t *testing.T) {
+	stats := PullStatistics(Pull{Events: []*primitives.Event{{}}, NextCursor: &cerebrov1.SourceCursor{Opaque: "next"}})
+	if stats.Events != 1 || !stats.HasNextCursor {
+		t.Fatalf("PullStatistics() = %#v", stats)
+	}
+}

--- a/internal/sourcecdk/errors.go
+++ b/internal/sourcecdk/errors.go
@@ -1,0 +1,79 @@
+package sourcecdk
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrorKind classifies source failures without relying on provider-specific text.
+type ErrorKind string
+
+const (
+	ErrorKindInvalidConfig ErrorKind = "invalid_source_config"
+	ErrorKindAuth          ErrorKind = "auth"
+	ErrorKindPermission    ErrorKind = "permission"
+	ErrorKindRateLimited   ErrorKind = "rate_limited"
+	ErrorKindProvider      ErrorKind = "provider"
+	ErrorKindTransient     ErrorKind = "transient"
+	ErrorKindDecode        ErrorKind = "decode"
+	ErrorKindInvalidEvent  ErrorKind = "invalid_event"
+)
+
+// SourceError carries a stable source failure classification plus bounded labels.
+type SourceError struct {
+	Kind     ErrorKind
+	SourceID string
+	Family   string
+	Err      error
+}
+
+func (e *SourceError) Error() string {
+	if e == nil {
+		return ""
+	}
+	parts := []string{string(e.Kind)}
+	if sourceID := strings.TrimSpace(e.SourceID); sourceID != "" {
+		parts = append(parts, "source="+sourceID)
+	}
+	if family := strings.TrimSpace(e.Family); family != "" {
+		parts = append(parts, "family="+family)
+	}
+	message := strings.Join(parts, " ")
+	if e.Err == nil {
+		return message
+	}
+	return message + ": " + e.Err.Error()
+}
+
+func (e *SourceError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// WrapSourceError annotates err with a stable source error kind.
+func WrapSourceError(kind ErrorKind, sourceID string, family string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &SourceError{Kind: kind, SourceID: strings.TrimSpace(sourceID), Family: strings.TrimSpace(family), Err: err}
+}
+
+// SourceErrorKind returns the stable classification for err.
+func SourceErrorKind(err error) ErrorKind {
+	if err == nil {
+		return ""
+	}
+	var sourceErr *SourceError
+	if errors.As(err, &sourceErr) && sourceErr != nil && sourceErr.Kind != "" {
+		return sourceErr.Kind
+	}
+	if errors.Is(err, ErrInvalidConfig) {
+		return ErrorKindInvalidConfig
+	}
+	if IsRetryableHTTPStatus(err) {
+		return ErrorKindTransient
+	}
+	return ErrorKindProvider
+}

--- a/internal/sourcecdk/fixture_suite.go
+++ b/internal/sourcecdk/fixture_suite.go
@@ -1,0 +1,103 @@
+package sourcecdk
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+// FixtureSuiteT is the subset of testing.TB used by RunFixtureSuite.
+type FixtureSuiteT interface {
+	Helper()
+	Fatalf(string, ...any)
+}
+
+// FixtureSuiteOptions configures a reusable source contract test.
+type FixtureSuiteOptions struct {
+	Source          Source
+	Config          Config
+	FamilyConfigs   map[string]Config
+	MaxPages        int
+	RequireDiscover bool
+}
+
+// RunFixtureSuite exercises Check, Discover, Read pagination, and event
+// contracts for deterministic source fixtures.
+func RunFixtureSuite(t FixtureSuiteT, ctx context.Context, options FixtureSuiteOptions) {
+	t.Helper()
+	if err := ValidateFixtureSuite(ctx, options); err != nil {
+		t.Fatalf("source fixture suite failed: %v", err)
+	}
+}
+
+// ValidateFixtureSuite is the non-testing implementation behind RunFixtureSuite.
+func ValidateFixtureSuite(ctx context.Context, options FixtureSuiteOptions) error {
+	if sourceIsNil(options.Source) {
+		return fmt.Errorf("source is required")
+	}
+	configs := []Config{options.Config}
+	if len(options.FamilyConfigs) > 0 {
+		configs = configs[:0]
+		families := make([]string, 0, len(options.FamilyConfigs))
+		for family := range options.FamilyConfigs {
+			families = append(families, family)
+		}
+		sort.Strings(families)
+		for _, family := range families {
+			configs = append(configs, options.FamilyConfigs[family])
+		}
+	}
+	maxPages := options.MaxPages
+	if maxPages <= 0 {
+		maxPages = 100
+	}
+	for _, cfg := range configs {
+		if err := options.Source.Check(ctx, cfg); err != nil {
+			return fmt.Errorf("check: %w", err)
+		}
+		if options.RequireDiscover {
+			urns, err := options.Source.Discover(ctx, cfg)
+			if err != nil {
+				return fmt.Errorf("discover: %w", err)
+			}
+			for _, urn := range urns {
+				if _, err := ParseURN(urn.String()); err != nil {
+					return fmt.Errorf("discover urn %q: %w", urn, err)
+				}
+			}
+		}
+		var cursor *cerebrov1.SourceCursor
+		for page := 0; page < maxPages; page++ {
+			pull, err := options.Source.Read(ctx, cfg, cursor)
+			if err != nil {
+				return fmt.Errorf("read page %d: %w", page+1, err)
+			}
+			for _, event := range pull.Events {
+				if err := ValidateEventEnvelopeWithContracts(event, fixtureSuiteContracts(options.Source)); err != nil {
+					return fmt.Errorf("validate event %q: %w", event.GetId(), err)
+				}
+			}
+			if pull.NextCursor == nil {
+				break
+			}
+			if cursor != nil && cursor.GetOpaque() == pull.NextCursor.GetOpaque() {
+				return fmt.Errorf("read page %d returned same next cursor %q", page+1, pull.NextCursor.GetOpaque())
+			}
+			cursor = pull.NextCursor
+			if page == maxPages-1 {
+				return fmt.Errorf("read exceeded max pages %d", maxPages)
+			}
+		}
+	}
+	return nil
+}
+
+func fixtureSuiteContracts(source Source) []EventContract {
+	provider, ok := source.(EventContractProvider)
+	if !ok {
+		return nil
+	}
+	return provider.EventContracts()
+}

--- a/internal/sourcecdk/identity.go
+++ b/internal/sourcecdk/identity.go
@@ -1,0 +1,65 @@
+package sourcecdk
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// StableExternalID returns a deterministic, delimiter-safe key for provider IDs.
+func StableExternalID(value string, emptyFallback string) string {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return emptyFallback
+	}
+	sum := sha256.Sum256([]byte(normalized))
+	return "id-" + hex.EncodeToString(sum[:16])
+}
+
+// URNFor builds and validates a tenant-scoped source entity URN.
+func URNFor(tenant, kind, providerID string) (URN, error) {
+	tenant = strings.TrimSpace(tenant)
+	kind = strings.TrimSpace(kind)
+	providerID = strings.TrimSpace(providerID)
+	if tenant == "" {
+		return "", fmt.Errorf("tenant is required")
+	}
+	if kind == "" {
+		return "", fmt.Errorf("urn kind is required")
+	}
+	if providerID == "" {
+		return "", fmt.Errorf("provider id is required")
+	}
+	return ParseURN("urn:cerebro:" + tenant + ":" + kind + ":" + providerID)
+}
+
+// URNForEscaped builds a URN after hashing provider-controlled parts that may
+// contain delimiters, display names, slashes, or other collision-prone text.
+func URNForEscaped(tenant, kind string, parts ...string) (URN, error) {
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		normalized = append(normalized, part)
+	}
+	if len(normalized) == 0 {
+		return "", fmt.Errorf("provider id parts are required")
+	}
+	return URNFor(tenant, kind, StableExternalID(strings.Join(normalized, "\x00"), "missing"))
+}
+
+// EventID returns a deterministic event ID key from stable source/provider parts.
+func EventID(parts ...string) string {
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		normalized = append(normalized, part)
+	}
+	return StableExternalID(strings.Join(normalized, "\x00"), "id-missing")
+}

--- a/internal/sourcecdk/lifecycle_contract.go
+++ b/internal/sourcecdk/lifecycle_contract.go
@@ -1,0 +1,108 @@
+package sourcecdk
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// LifecycleStatus describes the rollout state for one source-emitted event kind.
+type LifecycleStatus string
+
+const (
+	LifecycleStatusActive     LifecycleStatus = "active"
+	LifecycleStatusPlanned    LifecycleStatus = "planned"
+	LifecycleStatusDeprecated LifecycleStatus = "deprecated"
+	LifecycleStatusRetired    LifecycleStatus = "retired"
+)
+
+// KindLifecycle describes whether a source event kind is actively emitted or
+// intentionally planned/deprecated/retired.
+type KindLifecycle struct {
+	Kind        string          `json:"kind" yaml:"kind"`
+	Status      LifecycleStatus `json:"status" yaml:"status"`
+	Replacement string          `json:"replacement,omitempty" yaml:"replacement,omitempty"`
+}
+
+// LifecycleContract is the catalog-backed lifecycle contract for a source.
+type LifecycleContract struct {
+	SourceID string          `json:"source_id" yaml:"source_id"`
+	Kinds    []KindLifecycle `json:"kinds" yaml:"kinds"`
+}
+
+// LifecycleContractProvider exposes catalog-level source kind lifecycle data.
+type LifecycleContractProvider interface {
+	LifecycleContract() LifecycleContract
+}
+
+func normalizeLifecycleContract(sourceID string, emittedKinds []string, entries []KindLifecycle) (LifecycleContract, error) {
+	sourceID = strings.TrimSpace(sourceID)
+	emitted := map[string]struct{}{}
+	for _, kind := range emittedKinds {
+		kind = strings.TrimSpace(kind)
+		if kind != "" {
+			emitted[kind] = struct{}{}
+		}
+	}
+	known := map[string]struct{}{}
+	normalized := make([]KindLifecycle, 0, len(entries)+len(emittedKinds))
+	for _, entry := range entries {
+		kind := strings.TrimSpace(entry.Kind)
+		status := LifecycleStatus(strings.ToLower(strings.TrimSpace(string(entry.Status))))
+		replacement := strings.TrimSpace(entry.Replacement)
+		if kind == "" {
+			return LifecycleContract{}, fmt.Errorf("kind_lifecycle kind is required")
+		}
+		if !validEventKind(kind) {
+			return LifecycleContract{}, fmt.Errorf("kind_lifecycle kind %q must use dot-separated lowercase identifiers", kind)
+		}
+		if _, ok := known[kind]; ok {
+			return LifecycleContract{}, fmt.Errorf("duplicate kind_lifecycle kind %q", kind)
+		}
+		known[kind] = struct{}{}
+		switch status {
+		case LifecycleStatusActive, LifecycleStatusPlanned, LifecycleStatusDeprecated, LifecycleStatusRetired:
+		default:
+			return LifecycleContract{}, fmt.Errorf("kind_lifecycle kind %q has invalid status %q", kind, entry.Status)
+		}
+		if replacement != "" && !validEventKind(replacement) {
+			return LifecycleContract{}, fmt.Errorf("kind_lifecycle kind %q has invalid replacement %q", kind, replacement)
+		}
+		if _, emittedKind := emitted[kind]; !emittedKind && status == LifecycleStatusActive {
+			return LifecycleContract{}, fmt.Errorf("kind_lifecycle kind %q is active but not listed in emitted_kinds", kind)
+		}
+		normalized = append(normalized, KindLifecycle{Kind: kind, Status: status, Replacement: replacement})
+	}
+	for kind := range emitted {
+		if _, ok := known[kind]; ok {
+			continue
+		}
+		normalized = append(normalized, KindLifecycle{Kind: kind, Status: LifecycleStatusActive})
+		known[kind] = struct{}{}
+	}
+	for _, entry := range normalized {
+		if entry.Replacement == "" {
+			continue
+		}
+		if _, ok := known[entry.Replacement]; !ok {
+			return LifecycleContract{}, fmt.Errorf("kind_lifecycle kind %q replacement %q is not declared", entry.Kind, entry.Replacement)
+		}
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		return normalized[i].Kind < normalized[j].Kind
+	})
+	if len(normalized) == 0 {
+		return LifecycleContract{}, nil
+	}
+	return LifecycleContract{SourceID: sourceID, Kinds: normalized}, nil
+}
+
+func cloneLifecycleContract(contract LifecycleContract) LifecycleContract {
+	contract.SourceID = strings.TrimSpace(contract.SourceID)
+	if len(contract.Kinds) == 0 {
+		contract.Kinds = nil
+		return contract
+	}
+	contract.Kinds = append([]KindLifecycle(nil), contract.Kinds...)
+	return contract
+}

--- a/internal/sourcecdk/observability.go
+++ b/internal/sourcecdk/observability.go
@@ -1,0 +1,54 @@
+package sourcecdk
+
+import (
+	"context"
+	"strings"
+)
+
+type operationContextKey struct{}
+
+// OperationContext carries bounded source operation labels.
+type OperationContext struct {
+	SourceID  string
+	Family    string
+	Operation string
+}
+
+// AnnotateOperation returns a context carrying bounded source operation labels.
+func AnnotateOperation(ctx context.Context, op OperationContext) context.Context {
+	return context.WithValue(ctx, operationContextKey{}, normalizeOperationContext(op))
+}
+
+// OperationFromContext returns bounded source operation labels from ctx.
+func OperationFromContext(ctx context.Context) (OperationContext, bool) {
+	op, ok := ctx.Value(operationContextKey{}).(OperationContext)
+	return op, ok
+}
+
+// PullStats summarizes a source pull without exposing provider identifiers.
+type PullStats struct {
+	Events               int
+	HasCheckpoint        bool
+	HasNextCursor        bool
+	ShortCircuitReason   PullShortCircuitReason
+	ReconciliationReason PullReconciliationReason
+}
+
+// PullStatistics returns bounded counts and flags for source observability.
+func PullStatistics(pull Pull) PullStats {
+	return PullStats{
+		Events:               len(pull.Events),
+		HasCheckpoint:        pull.Checkpoint != nil,
+		HasNextCursor:        pull.NextCursor != nil,
+		ShortCircuitReason:   pull.ShortCircuitReason,
+		ReconciliationReason: pull.ReconciliationReason,
+	}
+}
+
+func normalizeOperationContext(op OperationContext) OperationContext {
+	return OperationContext{
+		SourceID:  strings.TrimSpace(op.SourceID),
+		Family:    strings.TrimSpace(op.Family),
+		Operation: strings.TrimSpace(op.Operation),
+	}
+}

--- a/internal/sourcecdk/provider.go
+++ b/internal/sourcecdk/provider.go
@@ -1,0 +1,109 @@
+package sourcecdk
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+)
+
+// ProviderClientFactory constructs a provider client from parsed source settings.
+type ProviderClientFactory[S any, C any] func(context.Context, S) (C, error)
+
+// PageReader captures the common source shape: make a client, list one provider
+// page, normalize records into events, and carry a next cursor token.
+type PageReader[S any, C any, R any] struct {
+	SourceID string
+	Family   string
+	Label    string
+	Clients  ProviderClientFactory[S, C]
+	List     func(context.Context, C, S, string, int) ([]R, string, error)
+	Event    func(S, R) (*primitives.Event, error)
+	URN      func(S, R) (URN, error)
+	PageSize func(S) int
+}
+
+// FamilyFromPageReader converts a PageReader into a Family entry.
+func FamilyFromPageReader[S any, C any, R any](reader PageReader[S, C, R]) Family[S] {
+	return Family[S]{
+		Name: strings.TrimSpace(reader.Family),
+		Discover: func(ctx context.Context, settings S) ([]URN, error) {
+			records, _, err := readProviderPage(ctx, settings, nil, reader, "")
+			if err != nil {
+				return nil, err
+			}
+			urns := make([]URN, 0, len(records))
+			for _, record := range records {
+				if reader.URN == nil {
+					continue
+				}
+				urn, err := reader.URN(settings, record)
+				if err != nil {
+					return nil, err
+				}
+				urns = append(urns, urn)
+			}
+			return urns, nil
+		},
+		Read: func(ctx context.Context, settings S, cursor *cerebrov1.SourceCursor) (Pull, error) {
+			records, next, err := readProviderPage(ctx, settings, cursor, reader, CursorToken(cursor))
+			if err != nil {
+				return Pull{}, err
+			}
+			events := make([]*primitives.Event, 0, len(records))
+			for _, record := range records {
+				if reader.Event == nil {
+					return Pull{}, fmt.Errorf("page reader %q event mapper is required", readerLabel(reader))
+				}
+				event, err := reader.Event(settings, record)
+				if err != nil {
+					return Pull{}, err
+				}
+				if event != nil {
+					events = append(events, event)
+				}
+			}
+			pull := Pull{Events: events}
+			if strings.TrimSpace(next) != "" {
+				pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strings.TrimSpace(next)}
+			}
+			return pull, nil
+		},
+	}
+}
+
+func readProviderPage[S any, C any, R any](ctx context.Context, settings S, _ *cerebrov1.SourceCursor, reader PageReader[S, C, R], token string) ([]R, string, error) {
+	if reader.Clients == nil {
+		return nil, "", fmt.Errorf("page reader %q client factory is required", readerLabel(reader))
+	}
+	if reader.List == nil {
+		return nil, "", fmt.Errorf("page reader %q list function is required", readerLabel(reader))
+	}
+	client, err := reader.Clients(ctx, settings)
+	if err != nil {
+		return nil, "", err
+	}
+	records, next, err := reader.List(ctx, client, settings, strings.TrimSpace(token), providerPageSize(reader, settings))
+	if err != nil {
+		return nil, "", err
+	}
+	return records, strings.TrimSpace(next), nil
+}
+
+func providerPageSize[S any, C any, R any](reader PageReader[S, C, R], settings S) int {
+	if reader.PageSize == nil {
+		return 0
+	}
+	return reader.PageSize(settings)
+}
+
+func readerLabel[S any, C any, R any](reader PageReader[S, C, R]) string {
+	for _, value := range []string{reader.Label, reader.Family, reader.SourceID} {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return "source"
+}

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -173,6 +173,7 @@ func NewRegistry(sources ...Source) (*Registry, error) {
 		}
 		source = sourceWithCatalogEventContracts(source, id)
 		source = sourceWithCatalogCoverageContract(source, id)
+		source = sourceWithCatalogLifecycleContract(source, id)
 		indexed[id] = source
 	}
 	return &Registry{sources: indexed}, nil
@@ -270,6 +271,61 @@ func sourceWithCatalogCoverageContract(source Source, sourceID string) Source {
 	return &catalogCoverageSource{Source: source, coverage: cloneCoverageContract(*contract)}
 }
 
+type catalogLifecycleSource struct {
+	Source
+	lifecycle LifecycleContract
+}
+
+func (s *catalogLifecycleSource) LifecycleContract() LifecycleContract {
+	if s == nil {
+		return LifecycleContract{}
+	}
+	return cloneLifecycleContract(s.lifecycle)
+}
+
+func (s *catalogLifecycleSource) EventContracts() []EventContract {
+	if s == nil {
+		return nil
+	}
+	provider, ok := s.Source.(EventContractProvider)
+	if !ok {
+		return nil
+	}
+	return cloneEventContracts(provider.EventContracts())
+}
+
+func (s *catalogLifecycleSource) CoverageContract() CoverageContract {
+	if s == nil {
+		return CoverageContract{}
+	}
+	provider, ok := s.Source.(CoverageContractProvider)
+	if !ok {
+		return CoverageContract{}
+	}
+	return cloneCoverageContract(provider.CoverageContract())
+}
+
+func (s *catalogLifecycleSource) ReadWithCheckpoint(ctx context.Context, cfg Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (Pull, error) {
+	if s == nil || sourceIsNil(s.Source) {
+		return Pull{}, fmt.Errorf("source is required")
+	}
+	if reader, ok := s.Source.(CheckpointAwareSource); ok {
+		return reader.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
+	}
+	return s.Read(ctx, cfg, cursor)
+}
+
+func sourceWithCatalogLifecycleContract(source Source, sourceID string) Source {
+	if _, ok := source.(LifecycleContractProvider); ok {
+		return source
+	}
+	contract := catalogLifecycleContractForSource(sourceID)
+	if contract == nil {
+		return source
+	}
+	return &catalogLifecycleSource{Source: source, lifecycle: cloneLifecycleContract(*contract)}
+}
+
 func sourceIsNil(source Source) bool {
 	if source == nil {
 		return true
@@ -330,6 +386,31 @@ func (r *Registry) CoverageContracts() []CoverageContract {
 			continue
 		}
 		contracts = append(contracts, cloneCoverageContract(contract))
+	}
+	return contracts
+}
+
+// LifecycleContracts returns source lifecycle contracts sorted by source ID.
+func (r *Registry) LifecycleContracts() []LifecycleContract {
+	if r == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(r.sources))
+	for id := range r.sources {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	contracts := make([]LifecycleContract, 0, len(ids))
+	for _, id := range ids {
+		provider, ok := r.sources[id].(LifecycleContractProvider)
+		if !ok {
+			continue
+		}
+		contract := provider.LifecycleContract()
+		if len(contract.Kinds) == 0 {
+			continue
+		}
+		contracts = append(contracts, cloneLifecycleContract(contract))
 	}
 	return contracts
 }

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -851,6 +851,11 @@ func renderCatalog(request normalizedRequest) string {
 	for _, family := range request.Families {
 		fmt.Fprintf(&b, "  - %s\n", family.EventKind)
 	}
+	fmt.Fprintf(&b, "kind_lifecycle:\n")
+	for _, family := range request.Families {
+		fmt.Fprintf(&b, "  - kind: %s\n", family.EventKind)
+		fmt.Fprintf(&b, "    status: active\n")
+	}
 	fmt.Fprintf(&b, "coverage_contract:\n")
 	fmt.Fprintf(&b, "  owner_domain: source_runtime\n")
 	fmt.Fprintf(&b, "  authority_domain: %s\n", request.SourceID)
@@ -1034,18 +1039,15 @@ func renderSourceGo(request normalizedRequest) string {
 	fmt.Fprintf(&b, "func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {\n\truntimeCfg, err := s.runtimeConfig(ctx, cfg)\n\tif err != nil {\n\t\treturn err\n\t}\n\tif err := s.checkHealth(ctx, runtimeCfg); err != nil {\n\t\treturn err\n\t}\n\treturn s.inner.Check(ctx, runtimeCfg)\n}\n\n")
 	fmt.Fprintf(&b, "func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {\n\truntimeCfg, err := s.runtimeConfig(ctx, cfg)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\treturn s.inner.Discover(ctx, runtimeCfg)\n}\n\n")
 	fmt.Fprintf(&b, "func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {\n\truntimeCfg, err := s.runtimeConfig(ctx, cfg)\n\tif err != nil {\n\t\treturn sourcecdk.Pull{}, err\n\t}\n\treturn s.inner.Read(ctx, runtimeCfg, cursor)\n}\n\n")
-	fmt.Fprintf(&b, "func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourcecdk.Config, error) {\n\tvalues := cfg.Values()\n\tif strings.TrimSpace(values[\"base_url\"]) == \"\" && strings.TrimSpace(defaultBaseURLTemplate) != \"\" {\n\t\tbaseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)\n\t\tif err != nil {\n\t\t\treturn sourcecdk.Config{}, err\n\t\t}\n\t\tvalues[\"base_url\"] = baseURL\n\t}\n")
+	fmt.Fprintf(&b, "func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourcecdk.Config, error) {\n\tvalues := cfg.Values()\n\tif strings.TrimSpace(values[\"base_url\"]) == \"\" && strings.TrimSpace(defaultBaseURLTemplate) != \"\" {\n\t\tbaseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)\n\t\tif err != nil {\n\t\t\treturn sourcecdk.Config{}, err\n\t\t}\n\t\tvalues[\"base_url\"] = baseURL\n\t}\n")
 	if request.OAuth != nil {
 		fmt.Fprintf(&b, "\tif s == nil {\n\t\treturn sourcecdk.Config{}, fmt.Errorf(\"%%s source is required\", sourceID)\n\t}\n\ttoken, err := s.tokenCache.Token(ctx, cfg, sourcehttp.ClientCredentialsOptions{\n\t\tSourceID: sourceID,\n\t\tTokenURLTemplate: oauthTokenURLTemplate,\n\t\tTemplateKeys: templateKeys,\n\t\tScopes: oauthScopes,\n\t\tScopeSeparator: oauthScopeSeparator,\n\t\tTokenParams: oauthTokenParams,\n\t\tExpirationBuffer: oauthTokenExpirationBuffer,\n\t\tAllowLoopback: s.allowLoopback,\n\t})\n\tif err != nil {\n\t\treturn sourcecdk.Config{}, err\n\t}\n\tvalues[\"token\"] = token\n")
 	} else {
 		fmt.Fprintf(&b, "\t_ = ctx\n")
 	}
 	fmt.Fprintf(&b, "\treturn sourcecdk.NewConfig(values), nil\n}\n\n")
-	fmt.Fprintf(&b, "func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {\n\tpath := firstNonEmpty(configValue(cfg, \"health_path\"), defaultHealthPath)\n\treturn s.inner.CheckPath(ctx, cfg, path, nil)\n}\n\n")
-	b.WriteString("func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {\n\trendered := strings.TrimSpace(template)\n\tfor _, key := range templateKeys {\n\t\tfor _, prefix := range []string{\"config\", \"credential\", \"connection\"} {\n\t\t\tplaceholder := \"${\" + prefix + \".\" + key + \"}\"\n\t\t\tif !strings.Contains(rendered, placeholder) {\n\t\t\t\tcontinue\n\t\t\t}\n\t\t\tvalue, err := requiredConfigValue(cfg, key)\n\t\t\tif err != nil {\n\t\t\t\treturn \"\", err\n\t\t\t}\n\t\t\trendered = strings.ReplaceAll(rendered, placeholder, value)\n\t\t}\n\t}\n\tif strings.Contains(rendered, \"${\") {\n\t\treturn \"\", fmt.Errorf(\"%w: %s template %q contains unresolved variable\", sourcecdk.ErrInvalidConfig, sourceID, template)\n\t}\n\treturn rendered, nil\n}\n\n")
-	b.WriteString("func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {\n\tvalue := strings.TrimSpace(configValue(cfg, key))\n\tif value == \"\" {\n\t\treturn \"\", fmt.Errorf(\"%w: %s %s is required\", sourcecdk.ErrInvalidConfig, sourceID, key)\n\t}\n\treturn value, nil\n}\n\n")
+	fmt.Fprintf(&b, "func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {\n\tpath := firstNonEmpty(sourcecdk.ConfigValue(cfg, \"health_path\"), defaultHealthPath)\n\treturn s.inner.CheckPath(ctx, cfg, path, nil)\n}\n\n")
 	fmt.Fprintf(&b, "func loadSpec() (*cerebrov1.SourceSpec, error) {\n\tspecBytes, err := catalogFS.ReadFile(\"catalog.yaml\")\n\tif err != nil {\n\t\treturn nil, fmt.Errorf(\"read catalog: %%w\", err)\n\t}\n\tspec, err := sourcecdk.LoadCatalog(specBytes)\n\tif err != nil {\n\t\treturn nil, fmt.Errorf(\"load catalog: %%w\", err)\n\t}\n\treturn spec, nil\n}\n\n")
-	fmt.Fprintf(&b, "func configValue(cfg sourcecdk.Config, key string) string {\n\tvalue, _ := cfg.Lookup(key)\n\treturn value\n}\n\n")
 	fmt.Fprintf(&b, "func firstNonEmpty(values ...string) string {\n\tfor _, value := range values {\n\t\tif strings.TrimSpace(value) != \"\" {\n\t\t\treturn strings.TrimSpace(value)\n\t\t}\n\t}\n\treturn \"\"\n}\n\n")
 	fmt.Fprintf(&b, "func (s *Source) allowLoopbackForTest() {\n\tif s != nil && s.inner != nil {\n\t\ts.inner.AllowLoopbackBaseURL = true\n\t\ts.allowLoopback = true\n\t}\n}\n")
 	return b.String()

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -52,6 +52,8 @@ func TestGenerateWritesSourceRuntimeSDKScaffold(t *testing.T) {
 		"- demo_source.asset_host",
 		"- demo_source.finding_vulnerability",
 		"- demo_source.evidence_cas_reference",
+		"kind_lifecycle:",
+		"status: active",
 		"coverage_contract:",
 		"authority_domain: demo_source",
 		"families: [asset_host]",
@@ -449,7 +451,7 @@ func TestGenerateDefinitionWritesOAuthClientCredentialsSource(t *testing.T) {
 		"TokenURLTemplate: oauthTokenURLTemplate",
 		"sourcehttp.ClientCredentialsCache",
 		"oauthTokenExpirationBuffer",
-		"renderTemplate(defaultBaseURLTemplate",
+		"sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate",
 	} {
 		if !strings.Contains(source, want) {
 			t.Fatalf("source.go missing %q:\n%s", want, source)

--- a/internal/sourceidentity/identity.go
+++ b/internal/sourceidentity/identity.go
@@ -1,18 +1,9 @@
 package sourceidentity
 
-import (
-	"crypto/sha256"
-	"encoding/hex"
-	"strings"
-)
+import "github.com/writer/cerebro/internal/sourcecdk"
 
 // HashedExternalIDKey returns a stable graph/event-safe key for provider IDs
 // whose native values may contain URI or event-id delimiters.
 func HashedExternalIDKey(value string, emptyFallback string) string {
-	normalized := strings.TrimSpace(value)
-	if normalized == "" {
-		return emptyFallback
-	}
-	sum := sha256.Sum256([]byte(normalized))
-	return "id-" + hex.EncodeToString(sum[:16])
+	return sourcecdk.StableExternalID(value, emptyFallback)
 }

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -158,7 +158,7 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (_
 }
 
 func sourceOperationError(err error) error {
-	if errors.Is(err, sourcecdk.ErrInvalidConfig) {
+	if errors.Is(err, sourcecdk.ErrInvalidConfig) || sourcecdk.SourceErrorKind(err) == sourcecdk.ErrorKindInvalidConfig {
 		return fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 	}
 	return err
@@ -258,6 +258,10 @@ func annotateMainSourceOperation(ctx context.Context, operation string, status s
 }
 
 func sourceOperationTelemetryErrorKind(err error) string {
+	var sourceErr *sourcecdk.SourceError
+	if errors.As(err, &sourceErr) && sourceErr != nil && sourceErr.Kind != "" {
+		return string(sourceErr.Kind)
+	}
 	switch {
 	case errors.Is(err, ErrSourceNotFound):
 		return "source_not_found"

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -146,6 +146,26 @@ func TestSourceOperationTelemetryRecordsFailures(t *testing.T) {
 	}
 }
 
+func TestSourceOperationTelemetryUsesSourceErrorKind(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(&errorSource{err: sourcecdk.WrapSourceError(sourcecdk.ErrorKindRateLimited, "failing", "read", errors.New("slow down"))})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := New(registry)
+
+	stderr := captureSourceOpsStderr(t, func() {
+		_, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "failing"})
+		if err == nil {
+			t.Fatal("Check() error = nil, want source error")
+		}
+	})
+
+	payload := sourceOpsTelemetryPayload(t, stderr, "source.check")
+	if got := payload["error_kind"]; got != string(sourcecdk.ErrorKindRateLimited) {
+		t.Fatalf("error_kind = %#v, want %q; payload=%#v", got, sourcecdk.ErrorKindRateLimited, payload)
+	}
+}
+
 func TestCheckRejectsInternalRuntimeConfigKeys(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {

--- a/tools/archtests/source_cdk_contracts_test.go
+++ b/tools/archtests/source_cdk_contracts_test.go
@@ -1,0 +1,93 @@
+package archtests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var helperDuplicationGrandfatheredSources = map[string]struct{}{
+	"akeyless":          {},
+	"archetype":         {},
+	"aurelius":          {},
+	"aws":               {},
+	"auth0":             {},
+	"azure":             {},
+	"cerebro":           {},
+	"cosmo":             {},
+	"doppler":           {},
+	"emaildomainhealth": {},
+	"evidencecas":       {},
+	"gcp":               {},
+	"github":            {},
+	"googleworkspace":   {},
+	"grc":               {},
+	"hashicorp_vault":   {},
+	"okta":              {},
+	"panopticon":        {},
+	"sentinelone":       {},
+	"vulnview":          {},
+}
+
+func TestNewSourcesDoNotDuplicateSourceCDKHelpers(t *testing.T) {
+	root := repoRoot(t)
+	sourceRoot := filepath.Join(root, "sources")
+	entries, err := os.ReadDir(sourceRoot)
+	if err != nil {
+		t.Fatalf("ReadDir(sources): %v", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == "internal" {
+			continue
+		}
+		if _, ok := helperDuplicationGrandfatheredSources[entry.Name()]; ok {
+			continue
+		}
+		sourcePath := filepath.Join(sourceRoot, entry.Name(), "source.go")
+		body, err := os.ReadFile(sourcePath)
+		if err != nil {
+			t.Fatalf("read %s: %v", sourcePath, err)
+		}
+		text := string(body)
+		for _, duplicated := range []string{
+			"func renderTemplate(",
+			"func requiredConfigValue(",
+			"func configValue(",
+			"func isUnsafeHost(",
+			"func isLoopbackHost(",
+			"func parseTimeSelector(",
+		} {
+			if strings.Contains(text, duplicated) {
+				t.Fatalf("sources/%s duplicates Source CDK helper %s", entry.Name(), duplicated)
+			}
+		}
+	}
+}
+
+func TestGeneratedSourceUsesSourceCDKTemplateHelpers(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "internal", "sourcegen", "generator.go"))
+	if err != nil {
+		t.Fatalf("read generator.go: %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"sourcecdk.RenderConfigTemplate",
+		"sourcecdk.ConfigValue",
+		"kind_lifecycle:",
+		"status: active",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("generator.go missing %q", want)
+		}
+	}
+	for _, duplicated := range []string{
+		"func renderTemplate(template string, cfg sourcecdk.Config)",
+		"func requiredConfigValue(cfg sourcecdk.Config, key string)",
+	} {
+		if strings.Contains(text, duplicated) {
+			t.Fatalf("generator.go still emits duplicated helper %q", duplicated)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds Source CDK lifecycle contracts, typed source errors, stable identity/event helpers, config template helpers, provider page-reader primitives, fixture-suite validation, and bounded pull observability stats.
- Registers catalog-backed lifecycle contracts through the source registry alongside existing event and coverage contracts.
- Updates sourcegen to emit active kind lifecycle entries and use shared Source CDK template helpers, plus adds architecture guardrails against new helper duplication.

## Test Plan

- `make sourcegen-test`
- `make catalog-check`
- `make check-arch`
- `make check-structural`
- `make test`
- `make lint`
- `go test ./internal/sourcecdk ./internal/sourceidentity ./internal/sourceops ./internal/sourcegen ./tools/archtests -count=1`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed Source CDK contracts, sourcegen output, sourceops error telemetry, and new arch guardrails.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
