### PR TITLE
feat: add GRC finding triage disposition endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1848,6 +1848,31 @@ paths:
       responses:
         '200':
           description: GRC-friendly finding list.
+  /grc/findings/triage:
+    post:
+      summary: Bulk update finding triage dispositions
+      tags:
+        - GRC
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [tenant_id, finding_ids, disposition]
+              properties:
+                tenant_id:
+                  type: string
+                finding_ids:
+                  type: array
+                  items:
+                    type: string
+                disposition:
+                  type: string
+                  enum: [open, in_triage, risk_accepted, false_positive, resolved]
+      responses:
+        '200':
+          description: Updated finding triage dispositions.
   /grc/controls:
     get:
       summary: GRC control posture

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -116,6 +116,14 @@ tenants, and reconstructs the running open backlog before JSON response mapping.
 The time-bucketed aggregation, severity classification, and open-at-window-start
 baseline stay behind `internal/statestore/postgres`.
 
+The GRC finding-triage route adds a small HTTP adapter that decodes the bulk
+disposition request, validates the disposition, authorizes the target tenant,
+and maps the upserted records to JSON. Operator dispositions overlay projected
+findings through a dedicated `grc_finding_dispositions` table behind the
+`GRCFindingDispositionStore` port, so finding re-projection cannot clobber triage
+decisions; the bulk upsert, lookup, and disposition merge stay behind
+`internal/statestore/postgres`.
+
 The agent platform graph preflight contract lives in `internal/agentplatform`.
 The bootstrap budget includes the HTTP and MCP request/response mapping needed
 to force authenticated tenant context, expose preflight to agents, and attach

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -3429,6 +3429,14 @@ func grcInventoryAssetReportStore(store ports.StateStore) ports.GRCInventoryAsse
 	return reportStore
 }
 
+func grcFindingDispositionStore(store ports.StateStore) ports.GRCFindingDispositionStore {
+	dispositionStore, ok := store.(ports.GRCFindingDispositionStore)
+	if !ok || isNilInterface(dispositionStore) {
+		return nil
+	}
+	return dispositionStore
+}
+
 func eventReplayer(appendLog ports.AppendLog) ports.EventReplayer {
 	replayer, ok := appendLog.(ports.EventReplayer)
 	if !ok || isNilInterface(replayer) {

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -87,6 +87,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Exact: "/grc/control-packets", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/control-packets/export", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Prefix: "/grc/control-packs", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Exact: "/grc/findings/triage", Scope: scopeFindingLifecycleWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/inventory/resource-scope", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/inventory/accountability", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/inventory/asset-reports", Scope: scopeGRCInventoryWrite, Static: true},

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -84,6 +84,7 @@ type grcFindingItem struct {
 }
 
 type GRCFindingWorkflowMetadata struct {
+	Disposition     string                     `json:"disposition,omitempty"`
 	StatusReason    string                     `json:"status_reason,omitempty"`
 	Assignee        string                     `json:"assignee,omitempty"`
 	DueAt           *time.Time                 `json:"due_at,omitempty"`
@@ -515,8 +516,10 @@ func (a *App) handleGRCFindings(w http.ResponseWriter, r *http.Request) {
 		}
 		evidenceCounts = grcEvidenceCounts(evidence)
 	}
+	items := grcFindingItems(findings, grcRuntimeSourceIDs(runtimes), evidenceCounts)
+	grcApplyFindingDispositions(items, a.grcFindingDispositions(r, findings))
 	writeJSON(w, http.StatusOK, map[string]any{
-		"findings":     grcFindingItems(findings, grcRuntimeSourceIDs(runtimes), evidenceCounts),
+		"findings":     items,
 		"generated_at": time.Now().UTC(),
 	})
 }

--- a/internal/bootstrap/grc_finding_triage.go
+++ b/internal/bootstrap/grc_finding_triage.go
@@ -1,0 +1,139 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const maxGRCFindingTriageBodyBytes = 32 << 10
+
+type grcFindingTriageRequest struct {
+	TenantID    string   `json:"tenant_id"`
+	FindingIDs  []string `json:"finding_ids"`
+	Disposition string   `json:"disposition"`
+}
+
+type grcFindingDispositionItem struct {
+	FindingID   string    `json:"finding_id"`
+	Disposition string    `json:"disposition"`
+	UpdatedBy   string    `json:"updated_by,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type grcFindingTriageResponse struct {
+	Updated     []grcFindingDispositionItem `json:"updated"`
+	GeneratedAt time.Time                   `json:"generated_at"`
+}
+
+func (a *App) handleUpdateGRCFindingDispositions(w http.ResponseWriter, r *http.Request) {
+	var request grcFindingTriageRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxGRCFindingTriageBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeGRCError(w, fmt.Errorf("%w: decode finding triage request: %w", errInvalidHTTPRequest, err))
+		return
+	}
+	disposition := strings.TrimSpace(request.Disposition)
+	if !ports.IsGRCFindingDisposition(disposition) {
+		writeGRCError(w, fmt.Errorf("%w: disposition is invalid", errInvalidHTTPRequest))
+		return
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		writeGRCError(w, fmt.Errorf("%w: tenant_id is required", errInvalidHTTPRequest))
+		return
+	}
+	if len(grcNonEmptyFindingIDs(request.FindingIDs)) == 0 {
+		writeGRCError(w, fmt.Errorf("%w: at least one finding_id is required", errInvalidHTTPRequest))
+		return
+	}
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	store := grcFindingDispositionStore(a.deps.StateStore)
+	if store == nil {
+		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
+		return
+	}
+	records, err := store.UpsertGRCFindingDispositions(r.Context(), ports.GRCFindingDispositionBulkUpdate{
+		TenantID:    tenantID,
+		FindingIDs:  request.FindingIDs,
+		Disposition: disposition,
+		UpdatedBy:   grcInventoryUpdatedBy(r),
+	})
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeFindings)
+	writeJSON(w, http.StatusOK, grcFindingTriageResponse{
+		Updated:     grcFindingDispositionItems(records),
+		GeneratedAt: time.Now().UTC(),
+	})
+}
+
+func grcFindingDispositionItems(records []*ports.GRCFindingDispositionRecord) []grcFindingDispositionItem {
+	items := make([]grcFindingDispositionItem, 0, len(records))
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		items = append(items, grcFindingDispositionItem{
+			FindingID:   record.FindingID,
+			Disposition: record.Disposition,
+			UpdatedBy:   record.UpdatedBy,
+			UpdatedAt:   record.UpdatedAt,
+		})
+	}
+	return items
+}
+
+func grcApplyFindingDispositions(items []grcFindingItem, dispositions map[string]string) {
+	if len(dispositions) == 0 {
+		return
+	}
+	for i := range items {
+		if disposition, ok := dispositions[items[i].ID]; ok {
+			items[i].Disposition = disposition
+		}
+	}
+}
+
+func (a *App) grcFindingDispositions(r *http.Request, findings []*ports.FindingRecord) map[string]string {
+	store := grcFindingDispositionStore(a.deps.StateStore)
+	if store == nil {
+		return nil
+	}
+	idsByTenant := map[string][]string{}
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		tenantID := strings.TrimSpace(finding.TenantID)
+		findingID := strings.TrimSpace(finding.ID)
+		if tenantID == "" || findingID == "" {
+			continue
+		}
+		idsByTenant[tenantID] = append(idsByTenant[tenantID], findingID)
+	}
+	dispositions := map[string]string{}
+	for tenantID, ids := range idsByTenant {
+		records, err := store.ListGRCFindingDispositions(r.Context(), tenantID, ids)
+		if err != nil {
+			return dispositions
+		}
+		for _, record := range records {
+			if record != nil {
+				dispositions[record.FindingID] = record.Disposition
+			}
+		}
+	}
+	return dispositions
+}

--- a/internal/bootstrap/grc_finding_triage_test.go
+++ b/internal/bootstrap/grc_finding_triage_test.go
@@ -1,0 +1,57 @@
+package bootstrap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestGRCApplyFindingDispositions(t *testing.T) {
+	items := []grcFindingItem{{ID: "finding-1"}, {ID: "finding-2"}, {ID: "finding-3"}}
+	grcApplyFindingDispositions(items, map[string]string{
+		"finding-1": ports.GRCFindingDispositionRiskAccepted,
+		"finding-3": ports.GRCFindingDispositionFalsePositive,
+		"finding-x": ports.GRCFindingDispositionResolved,
+	})
+
+	if items[0].Disposition != ports.GRCFindingDispositionRiskAccepted {
+		t.Fatalf("items[0].Disposition = %q, want risk_accepted", items[0].Disposition)
+	}
+	if items[1].Disposition != "" {
+		t.Fatalf("items[1].Disposition = %q, want empty", items[1].Disposition)
+	}
+	if items[2].Disposition != ports.GRCFindingDispositionFalsePositive {
+		t.Fatalf("items[2].Disposition = %q, want false_positive", items[2].Disposition)
+	}
+}
+
+func TestGRCApplyFindingDispositionsNoop(t *testing.T) {
+	items := []grcFindingItem{{ID: "finding-1", GRCFindingWorkflowMetadata: GRCFindingWorkflowMetadata{Disposition: "open"}}}
+	grcApplyFindingDispositions(items, nil)
+	if items[0].Disposition != "open" {
+		t.Fatalf("items[0].Disposition = %q, want unchanged open", items[0].Disposition)
+	}
+}
+
+func TestGRCFindingDispositionItems(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	records := []*ports.GRCFindingDispositionRecord{
+		{FindingID: "finding-1", Disposition: "resolved", UpdatedBy: "alice", UpdatedAt: now},
+		nil,
+		{FindingID: "finding-2", Disposition: "in_triage", UpdatedAt: now},
+	}
+	items := grcFindingDispositionItems(records)
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	if items[0].FindingID != "finding-1" || items[0].Disposition != "resolved" || items[0].UpdatedBy != "alice" {
+		t.Fatalf("items[0] = %#v", items[0])
+	}
+	if !items[0].UpdatedAt.Equal(now) {
+		t.Fatalf("items[0].UpdatedAt = %v, want %v", items[0].UpdatedAt, now)
+	}
+	if items[1].FindingID != "finding-2" || items[1].Disposition != "in_triage" {
+		t.Fatalf("items[1] = %#v", items[1])
+	}
+}

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -89,6 +89,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /grc/trends", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("trends", time.Minute, grcCacheScopeFindings, grcCacheScopeRuntime), app.handleGRCTrends))
 	registerHTTPRoute(mux, "POST /grc/ask", routeSurfacePlatformHTTP, app.handleGRCAsk)
 	registerHTTPRoute(mux, "GET /grc/findings", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("findings", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCFindings))
+	registerHTTPRoute(mux, "POST /grc/findings/triage", routeSurfacePlatformHTTP, app.handleUpdateGRCFindingDispositions)
 	registerHTTPRoute(mux, "GET /grc/controls", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("controls", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCControls))
 	registerHTTPRoute(mux, "GET /grc/evidence", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("evidence", time.Minute, grcCacheScopeEvidence, grcCacheScopeFindings, grcCacheScopeRuntime), app.handleGRCEvidence))
 	registerHTTPRoute(mux, "GET /grc/control-archetypes", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("control.archetypes", 5*time.Minute), app.handleGRCControlArchetypes))

--- a/internal/ports/grc_finding_triage.go
+++ b/internal/ports/grc_finding_triage.go
@@ -1,0 +1,54 @@
+package ports
+
+import (
+	"context"
+	"time"
+)
+
+// Finding triage dispositions overlay operator decisions on projected findings.
+const (
+	GRCFindingDispositionOpen          = "open"
+	GRCFindingDispositionInTriage      = "in_triage"
+	GRCFindingDispositionRiskAccepted  = "risk_accepted"
+	GRCFindingDispositionFalsePositive = "false_positive"
+	GRCFindingDispositionResolved      = "resolved"
+)
+
+// IsGRCFindingDisposition reports whether value is a known finding disposition.
+func IsGRCFindingDisposition(value string) bool {
+	switch value {
+	case GRCFindingDispositionOpen,
+		GRCFindingDispositionInTriage,
+		GRCFindingDispositionRiskAccepted,
+		GRCFindingDispositionFalsePositive,
+		GRCFindingDispositionResolved:
+		return true
+	default:
+		return false
+	}
+}
+
+// GRCFindingDispositionRecord is an operator-set triage disposition for a finding.
+type GRCFindingDispositionRecord struct {
+	TenantID    string    `json:"tenant_id"`
+	FindingID   string    `json:"finding_id"`
+	Disposition string    `json:"disposition"`
+	UpdatedBy   string    `json:"updated_by,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// GRCFindingDispositionBulkUpdate applies one disposition to many findings in a tenant.
+type GRCFindingDispositionBulkUpdate struct {
+	TenantID    string
+	FindingIDs  []string
+	Disposition string
+	UpdatedBy   string
+}
+
+// GRCFindingDispositionStore persists operator triage dispositions for findings.
+type GRCFindingDispositionStore interface {
+	StateStore
+	UpsertGRCFindingDispositions(context.Context, GRCFindingDispositionBulkUpdate) ([]*GRCFindingDispositionRecord, error)
+	ListGRCFindingDispositions(ctx context.Context, tenantID string, findingIDs []string) ([]*GRCFindingDispositionRecord, error)
+}

--- a/internal/ports/grc_finding_triage_test.go
+++ b/internal/ports/grc_finding_triage_test.go
@@ -1,0 +1,23 @@
+package ports
+
+import "testing"
+
+func TestIsGRCFindingDisposition(t *testing.T) {
+	valid := []string{
+		GRCFindingDispositionOpen,
+		GRCFindingDispositionInTriage,
+		GRCFindingDispositionRiskAccepted,
+		GRCFindingDispositionFalsePositive,
+		GRCFindingDispositionResolved,
+	}
+	for _, value := range valid {
+		if !IsGRCFindingDisposition(value) {
+			t.Fatalf("IsGRCFindingDisposition(%q) = false, want true", value)
+		}
+	}
+	for _, value := range []string{"", "accepted", "OPEN", "snoozed", " open"} {
+		if IsGRCFindingDisposition(value) {
+			t.Fatalf("IsGRCFindingDisposition(%q) = true, want false", value)
+		}
+	}
+}

--- a/internal/statestore/postgres/grc_finding_triage.go
+++ b/internal/statestore/postgres/grc_finding_triage.go
@@ -1,0 +1,127 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureGRCFindingDispositionStatements = []string{
+	`CREATE TABLE IF NOT EXISTS grc_finding_dispositions (
+  tenant_id TEXT NOT NULL,
+  finding_id TEXT NOT NULL,
+  disposition TEXT NOT NULL,
+  updated_by TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, finding_id)
+)`,
+	`CREATE INDEX IF NOT EXISTS grc_finding_dispositions_tenant_disposition_idx ON grc_finding_dispositions (tenant_id, disposition, updated_at DESC)`,
+}
+
+func (s *Store) ensureGRCFindingDispositionTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.grcFindingDispositionReady, "grc finding disposition", ensureGRCFindingDispositionStatements)
+}
+
+func (s *Store) UpsertGRCFindingDispositions(ctx context.Context, update ports.GRCFindingDispositionBulkUpdate) ([]*ports.GRCFindingDispositionRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCFindingDispositionTables(ctx); err != nil {
+		return nil, err
+	}
+	tenantID := strings.TrimSpace(update.TenantID)
+	disposition := strings.TrimSpace(update.Disposition)
+	updatedBy := strings.TrimSpace(update.UpdatedBy)
+	findingIDs := sanitizedStringSlice(update.FindingIDs)
+	if tenantID == "" || disposition == "" {
+		return nil, errors.New("tenant_id and disposition are required")
+	}
+	if !ports.IsGRCFindingDisposition(disposition) {
+		return nil, errors.New("disposition is invalid")
+	}
+	if len(findingIDs) == 0 {
+		return nil, errors.New("at least one finding_id is required")
+	}
+	query, args := grcFindingDispositionUpsertQuery(tenantID, disposition, updatedBy, findingIDs)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("upsert finding dispositions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := []*ports.GRCFindingDispositionRecord{}
+	for rows.Next() {
+		record, err := scanGRCFindingDisposition(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+func (s *Store) ListGRCFindingDispositions(ctx context.Context, tenantID string, findingIDs []string) ([]*ports.GRCFindingDispositionRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCFindingDispositionTables(ctx); err != nil {
+		return nil, err
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	ids := sanitizedStringSlice(findingIDs)
+	if tenantID == "" || len(ids) == 0 {
+		return []*ports.GRCFindingDispositionRecord{}, nil
+	}
+	clauses := []string{"tenant_id = $1"}
+	args := []any{tenantID}
+	addStringInFilter(&clauses, &args, "finding_id", ids)
+	// #nosec G201 -- clauses are fixed column predicates and values remain parameterized.
+	query := fmt.Sprintf(`
+SELECT tenant_id, finding_id, disposition, updated_by, created_at, updated_at
+FROM grc_finding_dispositions
+WHERE %s`, strings.Join(clauses, " AND "))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list finding dispositions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := []*ports.GRCFindingDispositionRecord{}
+	for rows.Next() {
+		record, err := scanGRCFindingDisposition(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+func grcFindingDispositionUpsertQuery(tenantID, disposition, updatedBy string, findingIDs []string) (string, []any) {
+	args := []any{tenantID, disposition, updatedBy}
+	values := make([]string, 0, len(findingIDs))
+	for i, findingID := range findingIDs {
+		args = append(args, findingID)
+		values = append(values, fmt.Sprintf("($1, $%d, $2, $3)", i+4))
+	}
+	// #nosec G201 -- value tuples use fixed parameter placeholders; all values remain parameterized.
+	query := fmt.Sprintf(`
+INSERT INTO grc_finding_dispositions (tenant_id, finding_id, disposition, updated_by)
+VALUES %s
+ON CONFLICT (tenant_id, finding_id) DO UPDATE
+SET disposition = EXCLUDED.disposition,
+    updated_by = EXCLUDED.updated_by,
+    updated_at = NOW()
+RETURNING tenant_id, finding_id, disposition, updated_by, created_at, updated_at`, strings.Join(values, ", "))
+	return query, args
+}
+
+func scanGRCFindingDisposition(row scanner) (*ports.GRCFindingDispositionRecord, error) {
+	record := &ports.GRCFindingDispositionRecord{}
+	if err := row.Scan(&record.TenantID, &record.FindingID, &record.Disposition, &record.UpdatedBy, &record.CreatedAt, &record.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return record, nil
+}

--- a/internal/statestore/postgres/grc_finding_triage_test.go
+++ b/internal/statestore/postgres/grc_finding_triage_test.go
@@ -1,0 +1,34 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGRCFindingDispositionUpsertQuery(t *testing.T) {
+	query, args := grcFindingDispositionUpsertQuery("writer", "risk_accepted", "alice", []string{"finding-1", "finding-2"})
+
+	for _, fragment := range []string{
+		"INSERT INTO grc_finding_dispositions (tenant_id, finding_id, disposition, updated_by)",
+		"($1, $4, $2, $3)",
+		"($1, $5, $2, $3)",
+		"ON CONFLICT (tenant_id, finding_id) DO UPDATE",
+		"SET disposition = EXCLUDED.disposition",
+		"updated_at = NOW()",
+		"RETURNING tenant_id, finding_id, disposition, updated_by, created_at, updated_at",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("upsert query missing %q:\n%s", fragment, query)
+		}
+	}
+
+	if len(args) != 5 {
+		t.Fatalf("args = %d, want 5", len(args))
+	}
+	if args[0] != "writer" || args[1] != "risk_accepted" || args[2] != "alice" {
+		t.Fatalf("leading args = %v, want [writer risk_accepted alice]", args[:3])
+	}
+	if args[3] != "finding-1" || args[4] != "finding-2" {
+		t.Fatalf("finding args = %v, want [finding-1 finding-2]", args[3:])
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -38,6 +38,7 @@ type Store struct {
 	runtimeBlocklistReady        bool
 	grcInventoryScopeReady       bool
 	grcInventoryAssetReportReady bool
+	grcFindingDispositionReady   bool
 	connectorCredentialReady     bool
 	connectorDefinitionReady     bool
 	appendLogRuntimeIndexReady   bool

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-const bootstrapProductionGoLineBudget = 23526
+const bootstrapProductionGoLineBudget = 23678
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary

Adds a bulk **finding triage** capability so operators can disposition GRC findings (accept risk, mark false positive, resolve, etc.) directly from the risk inbox.

- New endpoint `POST /grc/findings/triage` applies one disposition to many findings in a tenant.
- Dispositions (`open`, `in_triage`, `risk_accepted`, `false_positive`, `resolved`) are stored in a dedicated `grc_finding_dispositions` overlay table behind a new `GRCFindingDispositionStore` port, so finding re-projection cannot clobber operator decisions.
- Current disposition is surfaced on `GET /grc/findings` (new `disposition` field on the finding workflow metadata).

## Design

Mirrors the existing inventory asset-report triage pattern:
- Overlay table keyed by `(tenant_id, finding_id)` with a bulk `ON CONFLICT` upsert.
- Handler decodes with `MaxBytesReader`+`DisallowUnknownFields`, validates the disposition, authorizes the tenant, records the acting principal, and bumps the findings cache.
- Reuses the existing `cerebro.findings.write` scope for the route policy.

## Tests
- `IsGRCFindingDisposition` validation.
- Postgres bulk-upsert query builder (placeholders/args).
- Bootstrap disposition merge + response mapping.
- OpenAPI route parity + auth-policy coverage.
- Bootstrap surface budget bumped with an architecture note.