### PR TITLE
refactor(sources): migrate generated helpers to Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -25,7 +25,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `aurelius` | 623 | Split source orchestration from record mapping and shared request plumbing. |
 | `aws` | 19070 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
 | `azure` | 2842 | Extract subscription traversal, client factories, and paginated resource readers. |
-| `cosmo` | 1012 | Move shared API pagination and response normalization into reusable source helpers. |
+| `cosmo` | 1011 | Move shared API pagination and response normalization into reusable source helpers. |
 | `gcp` | 2095 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2028 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |

--- a/internal/sourcehttp/oauth_client_credentials.go
+++ b/internal/sourcehttp/oauth_client_credentials.go
@@ -44,11 +44,11 @@ func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config
 	if c == nil {
 		return "", fmt.Errorf("%s oauth token cache is required", sourceID(options.SourceID))
 	}
-	configuredTokenURL := configValue(cfg, "token_url")
+	configuredTokenURL := sourcecdk.ConfigValue(cfg, "token_url")
 	if strings.TrimSpace(configuredTokenURL) != "" && strings.TrimSpace(options.TokenURLTemplate) != "" && !providerManagedTokenURLOverrideAllowed(configuredTokenURL, options.AllowLoopback) {
 		return "", fmt.Errorf("%w: %s token_url is provider-managed and cannot be overridden", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID))
 	}
-	tokenURL, err := renderTemplate(firstNonEmpty(configuredTokenURL, options.TokenURLTemplate), cfg, options)
+	tokenURL, err := sourcecdk.RenderConfigTemplate(sourceID(options.SourceID), firstNonEmpty(configuredTokenURL, options.TokenURLTemplate), cfg, options.TemplateKeys)
 	if err != nil {
 		return "", err
 	}
@@ -56,11 +56,11 @@ func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config
 	if err != nil {
 		return "", err
 	}
-	clientID, err := requiredConfigValue(cfg, "client_id", options)
+	clientID, err := sourcecdk.RequiredConfigValue(sourceID(options.SourceID), cfg, "client_id")
 	if err != nil {
 		return "", err
 	}
-	clientSecret, err := requiredConfigValue(cfg, "client_secret", options)
+	clientSecret, err := sourcecdk.RequiredConfigValue(sourceID(options.SourceID), cfg, "client_secret")
 	if err != nil {
 		return "", err
 	}
@@ -69,7 +69,7 @@ func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config
 		form.Set("scope", scope)
 	}
 	for key, template := range options.TokenParams {
-		value, err := renderTemplate(template, cfg, options)
+		value, err := sourcecdk.RenderConfigTemplate(sourceID(options.SourceID), template, cfg, options.TemplateKeys)
 		if err != nil {
 			return "", err
 		}
@@ -145,27 +145,6 @@ func clientCredentialsCacheKey(sourceID string, tokenURL string, form url.Values
 	return hex.EncodeToString(sum[:])
 }
 
-func renderTemplate(template string, cfg sourcecdk.Config, options ClientCredentialsOptions) (string, error) {
-	rendered := strings.TrimSpace(template)
-	for _, key := range options.TemplateKeys {
-		for _, prefix := range []string{"config", "credential", "connection"} {
-			placeholder := "${" + prefix + "." + key + "}"
-			if !strings.Contains(rendered, placeholder) {
-				continue
-			}
-			value, err := requiredConfigValue(cfg, key, options)
-			if err != nil {
-				return "", err
-			}
-			rendered = strings.ReplaceAll(rendered, placeholder, value)
-		}
-	}
-	if strings.Contains(rendered, "${") {
-		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID), template)
-	}
-	return rendered, nil
-}
-
 func normalizeOAuthURL(raw string, options ClientCredentialsOptions) (string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
@@ -186,19 +165,6 @@ func normalizeOAuthURL(raw string, options ClientCredentialsOptions) (string, er
 		path = "/"
 	}
 	return baseURL + path, nil
-}
-
-func requiredConfigValue(cfg sourcecdk.Config, key string, options ClientCredentialsOptions) (string, error) {
-	value := strings.TrimSpace(configValue(cfg, key))
-	if value == "" {
-		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID), key)
-	}
-	return value, nil
-}
-
-func configValue(cfg sourcecdk.Config, key string) string {
-	value, _ := cfg.Lookup(key)
-	return value
 }
 
 func sourceID(value string) string {

--- a/sources/akeyless/source.go
+++ b/sources/akeyless/source.go
@@ -139,7 +139,7 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 	_ = ctx
 	values := cfg.Values()
 	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)
+		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 		if err != nil {
 			return sourcecdk.Config{}, err
 		}
@@ -149,37 +149,8 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 }
 
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
-	path := firstNonEmpty(configValue(cfg, "health_path"), defaultHealthPath)
+	path := firstNonEmpty(sourcecdk.ConfigValue(cfg, "health_path"), defaultHealthPath)
 	return s.inner.CheckPath(ctx, cfg, path, nil)
-}
-
-func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {
-	rendered := strings.TrimSpace(template)
-	for _, key := range templateKeys {
-		for _, prefix := range []string{"config", "credential", "connection"} {
-			placeholder := "${" + prefix + "." + key + "}"
-			if !strings.Contains(rendered, placeholder) {
-				continue
-			}
-			value, err := requiredConfigValue(cfg, key)
-			if err != nil {
-				return "", err
-			}
-			rendered = strings.ReplaceAll(rendered, placeholder, value)
-		}
-	}
-	if strings.Contains(rendered, "${") {
-		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID, template)
-	}
-	return rendered, nil
-}
-
-func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {
-	value := strings.TrimSpace(configValue(cfg, key))
-	if value == "" {
-		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID, key)
-	}
-	return value, nil
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {
@@ -192,11 +163,6 @@ func loadSpec() (*cerebrov1.SourceSpec, error) {
 		return nil, fmt.Errorf("load catalog: %w", err)
 	}
 	return spec, nil
-}
-
-func configValue(cfg sourcecdk.Config, key string) string {
-	value, _ := cfg.Lookup(key)
-	return value
 }
 
 func firstNonEmpty(values ...string) string {

--- a/sources/auth0/source.go
+++ b/sources/auth0/source.go
@@ -140,11 +140,11 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 
 func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourcecdk.Config, error) {
 	values := cfg.Values()
-	if err := validateAuth0Domain(configValue(cfg, "domain")); err != nil {
+	if err := validateAuth0Domain(sourcecdk.ConfigValue(cfg, "domain")); err != nil {
 		return sourcecdk.Config{}, err
 	}
 	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)
+		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 		if err != nil {
 			return sourcecdk.Config{}, err
 		}
@@ -185,11 +185,11 @@ func validateAuth0Domain(value string) error {
 }
 
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
-	baseURL, _, err := sourcehttp.NormalizeBaseURL(sourceID, configValue(cfg, "base_url"), s != nil && s.allowLoopback)
+	baseURL, _, err := sourcehttp.NormalizeBaseURL(sourceID, sourcecdk.ConfigValue(cfg, "base_url"), s != nil && s.allowLoopback)
 	if err != nil {
 		return err
 	}
-	path := firstNonEmpty(configValue(cfg, "health_path"), defaultHealthPath)
+	path := firstNonEmpty(sourcecdk.ConfigValue(cfg, "health_path"), defaultHealthPath)
 	path, err = sourcehttp.NormalizeRequestPath(sourceID, path)
 	if err != nil {
 		return err
@@ -199,7 +199,7 @@ func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
 		return fmt.Errorf("build %s health request: %w", sourceID, err)
 	}
 	req.Header.Set("Accept", "application/json")
-	if token := strings.TrimSpace(firstNonEmpty(configValue(cfg, "token"), configValue(cfg, "api_token"))); token != "" {
+	if token := strings.TrimSpace(firstNonEmpty(sourcecdk.ConfigValue(cfg, "token"), sourcecdk.ConfigValue(cfg, "api_token"))); token != "" {
 		req.Header.Set("Authorization", tokenScheme+" "+token)
 	}
 	client := sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: sourceID, AllowLoopback: s != nil && s.allowLoopback, Timeout: 10 * time.Second})
@@ -213,35 +213,6 @@ func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
 	return nil
 }
 
-func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {
-	rendered := strings.TrimSpace(template)
-	for _, key := range templateKeys {
-		for _, prefix := range []string{"config", "credential", "connection"} {
-			placeholder := "${" + prefix + "." + key + "}"
-			if !strings.Contains(rendered, placeholder) {
-				continue
-			}
-			value, err := requiredConfigValue(cfg, key)
-			if err != nil {
-				return "", err
-			}
-			rendered = strings.ReplaceAll(rendered, placeholder, value)
-		}
-	}
-	if strings.Contains(rendered, "${") {
-		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID, template)
-	}
-	return rendered, nil
-}
-
-func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {
-	value := strings.TrimSpace(configValue(cfg, key))
-	if value == "" {
-		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID, key)
-	}
-	return value, nil
-}
-
 func loadSpec() (*cerebrov1.SourceSpec, error) {
 	specBytes, err := catalogFS.ReadFile("catalog.yaml")
 	if err != nil {
@@ -252,11 +223,6 @@ func loadSpec() (*cerebrov1.SourceSpec, error) {
 		return nil, fmt.Errorf("load catalog: %w", err)
 	}
 	return spec, nil
-}
-
-func configValue(cfg sourcecdk.Config, key string) string {
-	value, _ := cfg.Lookup(key)
-	return value
 }
 
 func firstNonEmpty(values ...string) string {

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -20,7 +20,6 @@ import (
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcehttp"
-	"github.com/writer/cerebro/internal/sourceidentity"
 )
 
 //go:embed catalog.yaml
@@ -682,7 +681,7 @@ func urnsFor(settings settings, family string, records []record) ([]sourcecdk.UR
 }
 
 func recordURN(settings settings, family string, id string) (sourcecdk.URN, error) {
-	return sourcecdk.ParseURN(fmt.Sprintf("urn:cerebro:%s:%s:%s", normalizeID(settings.tenantID), family, sourceidentity.HashedExternalIDKey(id, "unknown")))
+	return sourcecdk.URNFor(normalizeID(settings.tenantID), family, sourcecdk.StableExternalID(id, "unknown"))
 }
 
 func pullFromRecords(settings settings, family string, records []record, next string) (sourcecdk.Pull, error) {
@@ -728,7 +727,7 @@ func eventFromRecord(settings settings, family string, record record) *primitive
 }
 
 func eventID(settings settings, family string, recordID string) string {
-	return strings.Join([]string{sourceID, normalizeID(settings.tenantID), family, sourceidentity.HashedExternalIDKey(recordID, "unknown")}, "-")
+	return strings.Join([]string{sourceID, normalizeID(settings.tenantID), family, sourcecdk.StableExternalID(recordID, "unknown")}, "-")
 }
 
 func attributesFor(family string, values map[string]any) map[string]string {

--- a/sources/doppler/source.go
+++ b/sources/doppler/source.go
@@ -126,7 +126,7 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 	_ = ctx
 	values := cfg.Values()
 	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)
+		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 		if err != nil {
 			return sourcecdk.Config{}, err
 		}
@@ -136,37 +136,8 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 }
 
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
-	path := firstNonEmpty(configValue(cfg, "health_path"), defaultHealthPath)
+	path := firstNonEmpty(sourcecdk.ConfigValue(cfg, "health_path"), defaultHealthPath)
 	return s.inner.CheckPath(ctx, cfg, path, nil)
-}
-
-func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {
-	rendered := strings.TrimSpace(template)
-	for _, key := range templateKeys {
-		for _, prefix := range []string{"config", "credential", "connection"} {
-			placeholder := "${" + prefix + "." + key + "}"
-			if !strings.Contains(rendered, placeholder) {
-				continue
-			}
-			value, err := requiredConfigValue(cfg, key)
-			if err != nil {
-				return "", err
-			}
-			rendered = strings.ReplaceAll(rendered, placeholder, value)
-		}
-	}
-	if strings.Contains(rendered, "${") {
-		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID, template)
-	}
-	return rendered, nil
-}
-
-func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {
-	value := strings.TrimSpace(configValue(cfg, key))
-	if value == "" {
-		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID, key)
-	}
-	return value, nil
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {
@@ -179,11 +150,6 @@ func loadSpec() (*cerebrov1.SourceSpec, error) {
 		return nil, fmt.Errorf("load catalog: %w", err)
 	}
 	return spec, nil
-}
-
-func configValue(cfg sourcecdk.Config, key string) string {
-	value, _ := cfg.Lookup(key)
-	return value
 }
 
 func firstNonEmpty(values ...string) string {

--- a/sources/hashicorp_vault/source.go
+++ b/sources/hashicorp_vault/source.go
@@ -126,7 +126,7 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 	_ = ctx
 	values := cfg.Values()
 	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)
+		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 		if err != nil {
 			return sourcecdk.Config{}, err
 		}
@@ -136,37 +136,8 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 }
 
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
-	path := firstNonEmpty(configValue(cfg, "health_path"), defaultHealthPath)
+	path := firstNonEmpty(sourcecdk.ConfigValue(cfg, "health_path"), defaultHealthPath)
 	return s.inner.CheckPath(ctx, cfg, path, nil)
-}
-
-func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {
-	rendered := strings.TrimSpace(template)
-	for _, key := range templateKeys {
-		for _, prefix := range []string{"config", "credential", "connection"} {
-			placeholder := "${" + prefix + "." + key + "}"
-			if !strings.Contains(rendered, placeholder) {
-				continue
-			}
-			value, err := requiredConfigValue(cfg, key)
-			if err != nil {
-				return "", err
-			}
-			rendered = strings.ReplaceAll(rendered, placeholder, value)
-		}
-	}
-	if strings.Contains(rendered, "${") {
-		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID, template)
-	}
-	return rendered, nil
-}
-
-func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {
-	value := strings.TrimSpace(configValue(cfg, key))
-	if value == "" {
-		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID, key)
-	}
-	return value, nil
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {
@@ -179,11 +150,6 @@ func loadSpec() (*cerebrov1.SourceSpec, error) {
 		return nil, fmt.Errorf("load catalog: %w", err)
 	}
 	return spec, nil
-}
-
-func configValue(cfg sourcecdk.Config, key string) string {
-	value, _ := cfg.Lookup(key)
-	return value
 }
 
 func firstNonEmpty(values ...string) string {

--- a/tools/archtests/source_cdk_contracts_test.go
+++ b/tools/archtests/source_cdk_contracts_test.go
@@ -8,22 +8,18 @@ import (
 )
 
 var helperDuplicationGrandfatheredSources = map[string]struct{}{
-	"akeyless":          {},
 	"archetype":         {},
 	"aurelius":          {},
 	"aws":               {},
-	"auth0":             {},
 	"azure":             {},
 	"cerebro":           {},
 	"cosmo":             {},
-	"doppler":           {},
 	"emaildomainhealth": {},
 	"evidencecas":       {},
 	"gcp":               {},
 	"github":            {},
 	"googleworkspace":   {},
 	"grc":               {},
-	"hashicorp_vault":   {},
 	"okta":              {},
 	"panopticon":        {},
 	"sentinelone":       {},

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -17,7 +17,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"aurelius":        623,
 	"aws":             19070,
 	"azure":           2842,
-	"cosmo":           1012,
+	"cosmo":           1011,
 	"gcp":             2095,
 	"github":          2028,
 	"googleworkspace": 815,


### PR DESCRIPTION
## Summary

- Migrates generated-style source helpers in Akeyless, Auth0, Doppler, and HashiCorp Vault to shared Source CDK config/template helpers.
- Moves OAuth client-credentials template rendering onto Source CDK helpers.
- Migrates Cosmo hashed record identity to `sourcecdk.StableExternalID` and ratchets the Source CDK LOC budget/guardrail allowlist.

## Test Plan

- `go test ./sources/akeyless ./sources/auth0 ./sources/cosmo ./sources/doppler ./sources/hashicorp_vault ./internal/sourcehttp -count=1`
- `make check-arch`
- `make lint`
- `make test`
- `make docs-drift-check`
- `make oss-audit`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on behavior parity for config template rendering and source identity helpers.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
