### PR TITLE
refactor(sources): adopt sourcecdk.RenderConfigTemplate in config sources (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -50,7 +50,6 @@ shared logic is lifted into the Source CDK. The current extraction backlog is:
 
 | Shared behavior | Sources | Disposition |
 | --- | --- | --- |
-| `renderTemplate` config-placeholder expansion | `akeyless`, `auth0`, `doppler`, `hashicorp_vault` | Extract pure helper into Source CDK |
 | `runtimeConfig` accessor | `akeyless`, `doppler`, `hashicorp_vault` | Extract into Source CDK config helper |
 | `pullFromRecords` paging loop | `grc`, `vulnview` | Extract into Source CDK record pull |
 | `checkpointCursor` encode/decode | `okta`, `sentinelone` | Extract into Source CDK cursor |

--- a/sources/akeyless/source.go
+++ b/sources/akeyless/source.go
@@ -139,7 +139,7 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 	_ = ctx
 	values := cfg.Values()
 	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)
+		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 		if err != nil {
 			return sourcecdk.Config{}, err
 		}
@@ -151,35 +151,6 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
 	path := firstNonEmpty(configValue(cfg, "health_path"), defaultHealthPath)
 	return s.inner.CheckPath(ctx, cfg, path, nil)
-}
-
-func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {
-	rendered := strings.TrimSpace(template)
-	for _, key := range templateKeys {
-		for _, prefix := range []string{"config", "credential", "connection"} {
-			placeholder := "${" + prefix + "." + key + "}"
-			if !strings.Contains(rendered, placeholder) {
-				continue
-			}
-			value, err := requiredConfigValue(cfg, key)
-			if err != nil {
-				return "", err
-			}
-			rendered = strings.ReplaceAll(rendered, placeholder, value)
-		}
-	}
-	if strings.Contains(rendered, "${") {
-		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID, template)
-	}
-	return rendered, nil
-}
-
-func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {
-	value := strings.TrimSpace(configValue(cfg, key))
-	if value == "" {
-		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID, key)
-	}
-	return value, nil
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {

--- a/sources/auth0/source.go
+++ b/sources/auth0/source.go
@@ -144,7 +144,7 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 		return sourcecdk.Config{}, err
 	}
 	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)
+		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 		if err != nil {
 			return sourcecdk.Config{}, err
 		}
@@ -211,35 +211,6 @@ func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
 		return fmt.Errorf("%s health endpoint %s returned HTTP %d", sourceID, path, resp.StatusCode)
 	}
 	return nil
-}
-
-func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {
-	rendered := strings.TrimSpace(template)
-	for _, key := range templateKeys {
-		for _, prefix := range []string{"config", "credential", "connection"} {
-			placeholder := "${" + prefix + "." + key + "}"
-			if !strings.Contains(rendered, placeholder) {
-				continue
-			}
-			value, err := requiredConfigValue(cfg, key)
-			if err != nil {
-				return "", err
-			}
-			rendered = strings.ReplaceAll(rendered, placeholder, value)
-		}
-	}
-	if strings.Contains(rendered, "${") {
-		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID, template)
-	}
-	return rendered, nil
-}
-
-func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {
-	value := strings.TrimSpace(configValue(cfg, key))
-	if value == "" {
-		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID, key)
-	}
-	return value, nil
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {

--- a/sources/doppler/source.go
+++ b/sources/doppler/source.go
@@ -126,7 +126,7 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 	_ = ctx
 	values := cfg.Values()
 	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)
+		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 		if err != nil {
 			return sourcecdk.Config{}, err
 		}
@@ -138,35 +138,6 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
 	path := firstNonEmpty(configValue(cfg, "health_path"), defaultHealthPath)
 	return s.inner.CheckPath(ctx, cfg, path, nil)
-}
-
-func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {
-	rendered := strings.TrimSpace(template)
-	for _, key := range templateKeys {
-		for _, prefix := range []string{"config", "credential", "connection"} {
-			placeholder := "${" + prefix + "." + key + "}"
-			if !strings.Contains(rendered, placeholder) {
-				continue
-			}
-			value, err := requiredConfigValue(cfg, key)
-			if err != nil {
-				return "", err
-			}
-			rendered = strings.ReplaceAll(rendered, placeholder, value)
-		}
-	}
-	if strings.Contains(rendered, "${") {
-		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID, template)
-	}
-	return rendered, nil
-}
-
-func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {
-	value := strings.TrimSpace(configValue(cfg, key))
-	if value == "" {
-		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID, key)
-	}
-	return value, nil
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {

--- a/sources/hashicorp_vault/source.go
+++ b/sources/hashicorp_vault/source.go
@@ -126,7 +126,7 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 	_ = ctx
 	values := cfg.Values()
 	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := renderTemplate(defaultBaseURLTemplate, cfg)
+		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 		if err != nil {
 			return sourcecdk.Config{}, err
 		}
@@ -138,35 +138,6 @@ func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourc
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {
 	path := firstNonEmpty(configValue(cfg, "health_path"), defaultHealthPath)
 	return s.inner.CheckPath(ctx, cfg, path, nil)
-}
-
-func renderTemplate(template string, cfg sourcecdk.Config) (string, error) {
-	rendered := strings.TrimSpace(template)
-	for _, key := range templateKeys {
-		for _, prefix := range []string{"config", "credential", "connection"} {
-			placeholder := "${" + prefix + "." + key + "}"
-			if !strings.Contains(rendered, placeholder) {
-				continue
-			}
-			value, err := requiredConfigValue(cfg, key)
-			if err != nil {
-				return "", err
-			}
-			rendered = strings.ReplaceAll(rendered, placeholder, value)
-		}
-	}
-	if strings.Contains(rendered, "${") {
-		return "", fmt.Errorf("%w: %s template %q contains unresolved variable", sourcecdk.ErrInvalidConfig, sourceID, template)
-	}
-	return rendered, nil
-}
-
-func requiredConfigValue(cfg sourcecdk.Config, key string) (string, error) {
-	value := strings.TrimSpace(configValue(cfg, key))
-	if value == "" {
-		return "", fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID, key)
-	}
-	return value, nil
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {

--- a/tools/archtests/source_helper_duplication_test.go
+++ b/tools/archtests/source_helper_duplication_test.go
@@ -29,16 +29,15 @@ const duplicateFunctionMinNodes = 50
 // add new entries to silence a fresh copy-paste; instead lift the shared logic
 // into internal/sourcecdk. Remove an entry when its extraction lands.
 var allowlistedSourceDuplicates = map[string]string{
-	"akeyless.renderTemplate|auth0.renderTemplate|doppler.renderTemplate|hashicorp_vault.renderTemplate": "pure config-placeholder template expansion shared by 4 sources; extract into Source CDK (#956)",
-	"akeyless.*Source.runtimeConfig|doppler.*Source.runtimeConfig|hashicorp_vault.*Source.runtimeConfig":  "runtimeConfig accessor shared by secrets sources; extract into Source CDK config helper (#956)",
-	"grc.pullFromRecords|vulnview.pullFromRecords":                                                        "record paging loop; extract into Source CDK record pull (#956)",
-	"okta.checkpointCursor|sentinelone.checkpointCursor":                                                  "checkpoint cursor encode/decode; extract into Source CDK cursor (#956)",
-	"aurelius.watermarkString|panopticon.watermarkString":                                                 "watermark formatting; extract into Source CDK watermark helper (#956)",
-	"cosmo.valueString|vulnview.valueString":                                                              "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
-	"aws.parseAWSURNs|azure.parseAzureURNs":                                                                "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",
-	"okta.oktaURNsFor|sentinelone.urnsFor":                                                                "provider URN construction; consolidate into Source CDK URN helper (#956)",
-	"azure.New|gcp.New|googleworkspace.New":                                                               "constructor scaffold building a concrete *Source; needs a generic CDK builder to deduplicate (#684)",
-	"archetype.New|sdk.New|trustedendpoint.New":                                                           "constructor scaffold for sample/fixture sources; structural boilerplate (#684)",
+	"akeyless.*Source.runtimeConfig|doppler.*Source.runtimeConfig|hashicorp_vault.*Source.runtimeConfig": "runtimeConfig accessor shared by secrets sources; extract into Source CDK config helper (#956)",
+	"grc.pullFromRecords|vulnview.pullFromRecords":                                                       "record paging loop; extract into Source CDK record pull (#956)",
+	"okta.checkpointCursor|sentinelone.checkpointCursor":                                                 "checkpoint cursor encode/decode; extract into Source CDK cursor (#956)",
+	"aurelius.watermarkString|panopticon.watermarkString":                                                "watermark formatting; extract into Source CDK watermark helper (#956)",
+	"cosmo.valueString|vulnview.valueString":                                                             "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
+	"aws.parseAWSURNs|azure.parseAzureURNs":                                                              "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",
+	"okta.oktaURNsFor|sentinelone.urnsFor":                                                               "provider URN construction; consolidate into Source CDK URN helper (#956)",
+	"azure.New|gcp.New|googleworkspace.New":                                                              "constructor scaffold building a concrete *Source; needs a generic CDK builder to deduplicate (#684)",
+	"archetype.New|sdk.New|trustedendpoint.New":                                                          "constructor scaffold for sample/fixture sources; structural boilerplate (#684)",
 }
 
 // TestSourcePackagesDoNotDuplicateExtractableHelpers fails when the same


### PR DESCRIPTION
## Summary

Migrate the four config-driven sources (`akeyless`, `auth0`, `doppler`, `hashicorp_vault`) to the shared `sourcecdk.RenderConfigTemplate` helper instead of each carrying an identical local `renderTemplate` + `requiredConfigValue` pair.

The helper already exists in the Source CDK (added in #1340); this change makes the sources consume it and removes the duplicated copies.

## Why

- Collapses a four-way copy-paste into the Source CDK, the canonical home for provider-agnostic source behavior.
- Removes the corresponding entry from the cross-source duplication allowlist in `tools/archtests/source_helper_duplication_test.go` (and the matching extraction-backlog row), so the guardrail now enforces that this logic is deduplicated rather than tolerating it as known debt.

## Behavior

No functional change. Each call site passes the same inputs (source ID, default base-URL template, config, template keys), and the shared helper preserves the prior semantics: expand `config` / `credential` / `connection` placeholders, require non-empty values, and reject any unresolved placeholder token.

## Tests

- `go build ./...`
- `go test ./internal/sourcecdk/... ./tools/archtests/ ./sources/akeyless/... ./sources/auth0/... ./sources/doppler/... ./sources/hashicorp_vault/... -count=1`
- The duplication guardrail passes with the allowlist entry removed (duplication eliminated, not allowlisted).
- `make check-structural`, `make docs-drift-check`, `make oss-audit`

Refs #956.
