### PR TITLE
refactor(sources): extract base-URL config resolution into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -50,7 +50,6 @@ shared logic is lifted into the Source CDK. The current extraction backlog is:
 
 | Shared behavior | Sources | Disposition |
 | --- | --- | --- |
-| `runtimeConfig` accessor | `akeyless`, `doppler`, `hashicorp_vault` | Extract into Source CDK config helper |
 | `pullFromRecords` paging loop | `grc`, `vulnview` | Extract into Source CDK record pull |
 | `checkpointCursor` encode/decode | `okta`, `sentinelone` | Extract into Source CDK cursor |
 | `watermarkString` formatting | `aurelius`, `panopticon` | Extract into Source CDK watermark helper |

--- a/internal/sourcecdk/config_base_url_test.go
+++ b/internal/sourcecdk/config_base_url_test.go
@@ -1,0 +1,48 @@
+package sourcecdk
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolveBaseURLConfig(t *testing.T) {
+	t.Run("renders base_url from template when unset", func(t *testing.T) {
+		cfg := NewConfig(map[string]string{"token": "abc"})
+		got, err := ResolveBaseURLConfig("vault", "https://${config.token}.example", cfg, []string{"token"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v, _ := got.Lookup("base_url"); v != "https://abc.example" {
+			t.Fatalf("base_url = %q", v)
+		}
+	})
+
+	t.Run("keeps explicit base_url and ignores template", func(t *testing.T) {
+		cfg := NewConfig(map[string]string{"base_url": "https://explicit.example", "token": "abc"})
+		got, err := ResolveBaseURLConfig("vault", "https://${config.token}.example", cfg, []string{"token"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v, _ := got.Lookup("base_url"); v != "https://explicit.example" {
+			t.Fatalf("base_url = %q", v)
+		}
+	})
+
+	t.Run("empty template leaves config unchanged", func(t *testing.T) {
+		cfg := NewConfig(map[string]string{"token": "abc"})
+		got, err := ResolveBaseURLConfig("vault", "", cfg, []string{"token"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v, _ := got.Lookup("base_url"); v != "" {
+			t.Fatalf("expected no base_url, got %q", v)
+		}
+	})
+
+	t.Run("propagates render errors", func(t *testing.T) {
+		cfg := NewConfig(map[string]string{})
+		if _, err := ResolveBaseURLConfig("vault", "https://${config.token}.example", cfg, []string{"token"}); !errors.Is(err, ErrInvalidConfig) {
+			t.Fatalf("want ErrInvalidConfig, got %v", err)
+		}
+	})
+}

--- a/internal/sourcecdk/config_template.go
+++ b/internal/sourcecdk/config_template.go
@@ -47,3 +47,20 @@ func RenderConfigTemplate(sourceID string, template string, cfg Config, keys []s
 	}
 	return rendered, nil
 }
+
+// ResolveBaseURLConfig returns cfg with its "base_url" value rendered from
+// template when "base_url" is unset and template is non-empty. The template is
+// expanded with RenderConfigTemplate using keys, and sourceID labels validation
+// errors. When "base_url" is already set or template is empty, the configuration
+// values are returned unchanged.
+func ResolveBaseURLConfig(sourceID string, template string, cfg Config, keys []string) (Config, error) {
+	values := cfg.Values()
+	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(template) != "" {
+		baseURL, err := RenderConfigTemplate(sourceID, template, cfg, keys)
+		if err != nil {
+			return Config{}, err
+		}
+		values["base_url"] = baseURL
+	}
+	return NewConfig(values), nil
+}

--- a/sources/akeyless/source.go
+++ b/sources/akeyless/source.go
@@ -137,15 +137,7 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 
 func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourcecdk.Config, error) {
 	_ = ctx
-	values := cfg.Values()
-	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
-		if err != nil {
-			return sourcecdk.Config{}, err
-		}
-		values["base_url"] = baseURL
-	}
-	return sourcecdk.NewConfig(values), nil
+	return sourcecdk.ResolveBaseURLConfig(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 }
 
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {

--- a/sources/doppler/source.go
+++ b/sources/doppler/source.go
@@ -124,15 +124,7 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 
 func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourcecdk.Config, error) {
 	_ = ctx
-	values := cfg.Values()
-	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
-		if err != nil {
-			return sourcecdk.Config{}, err
-		}
-		values["base_url"] = baseURL
-	}
-	return sourcecdk.NewConfig(values), nil
+	return sourcecdk.ResolveBaseURLConfig(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 }
 
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {

--- a/sources/hashicorp_vault/source.go
+++ b/sources/hashicorp_vault/source.go
@@ -124,15 +124,7 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 
 func (s *Source) runtimeConfig(ctx context.Context, cfg sourcecdk.Config) (sourcecdk.Config, error) {
 	_ = ctx
-	values := cfg.Values()
-	if strings.TrimSpace(values["base_url"]) == "" && strings.TrimSpace(defaultBaseURLTemplate) != "" {
-		baseURL, err := sourcecdk.RenderConfigTemplate(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
-		if err != nil {
-			return sourcecdk.Config{}, err
-		}
-		values["base_url"] = baseURL
-	}
-	return sourcecdk.NewConfig(values), nil
+	return sourcecdk.ResolveBaseURLConfig(sourceID, defaultBaseURLTemplate, cfg, templateKeys)
 }
 
 func (s *Source) checkHealth(ctx context.Context, cfg sourcecdk.Config) error {

--- a/tools/archtests/source_helper_duplication_test.go
+++ b/tools/archtests/source_helper_duplication_test.go
@@ -29,15 +29,14 @@ const duplicateFunctionMinNodes = 50
 // add new entries to silence a fresh copy-paste; instead lift the shared logic
 // into internal/sourcecdk. Remove an entry when its extraction lands.
 var allowlistedSourceDuplicates = map[string]string{
-	"akeyless.*Source.runtimeConfig|doppler.*Source.runtimeConfig|hashicorp_vault.*Source.runtimeConfig": "runtimeConfig accessor shared by secrets sources; extract into Source CDK config helper (#956)",
-	"grc.pullFromRecords|vulnview.pullFromRecords":                                                       "record paging loop; extract into Source CDK record pull (#956)",
-	"okta.checkpointCursor|sentinelone.checkpointCursor":                                                 "checkpoint cursor encode/decode; extract into Source CDK cursor (#956)",
-	"aurelius.watermarkString|panopticon.watermarkString":                                                "watermark formatting; extract into Source CDK watermark helper (#956)",
-	"cosmo.valueString|vulnview.valueString":                                                             "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
-	"aws.parseAWSURNs|azure.parseAzureURNs":                                                              "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",
-	"okta.oktaURNsFor|sentinelone.urnsFor":                                                               "provider URN construction; consolidate into Source CDK URN helper (#956)",
-	"azure.New|gcp.New|googleworkspace.New":                                                              "constructor scaffold building a concrete *Source; needs a generic CDK builder to deduplicate (#684)",
-	"archetype.New|sdk.New|trustedendpoint.New":                                                          "constructor scaffold for sample/fixture sources; structural boilerplate (#684)",
+	"grc.pullFromRecords|vulnview.pullFromRecords":        "record paging loop; extract into Source CDK record pull (#956)",
+	"okta.checkpointCursor|sentinelone.checkpointCursor":  "checkpoint cursor encode/decode; extract into Source CDK cursor (#956)",
+	"aurelius.watermarkString|panopticon.watermarkString": "watermark formatting; extract into Source CDK watermark helper (#956)",
+	"cosmo.valueString|vulnview.valueString":              "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
+	"aws.parseAWSURNs|azure.parseAzureURNs":               "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",
+	"okta.oktaURNsFor|sentinelone.urnsFor":                "provider URN construction; consolidate into Source CDK URN helper (#956)",
+	"azure.New|gcp.New|googleworkspace.New":               "constructor scaffold building a concrete *Source; needs a generic CDK builder to deduplicate (#684)",
+	"archetype.New|sdk.New|trustedendpoint.New":           "constructor scaffold for sample/fixture sources; structural boilerplate (#684)",
 }
 
 // TestSourcePackagesDoNotDuplicateExtractableHelpers fails when the same


### PR DESCRIPTION
## Summary

Add `sourcecdk.ResolveBaseURLConfig` and migrate the three secrets sources (`akeyless`, `doppler`, `hashicorp_vault`) onto it, replacing the identical `runtimeConfig` method each of them carried.

The new helper renders a source's `base_url` from a config template (via the existing `RenderConfigTemplate`) when `base_url` is unset and a template is configured, and otherwise returns the configuration unchanged. Each source's `runtimeConfig` becomes a thin wrapper around it.

## Why

- Collapses a three-way copy-paste into the Source CDK, the canonical home for provider-agnostic source behavior.
- Removes the corresponding entry from the cross-source duplication allowlist in `tools/archtests/source_helper_duplication_test.go` (and the matching extraction-backlog row), so the guardrail now enforces that this logic is deduplicated rather than tolerating it as known debt. The remaining wrappers are below the guardrail's size threshold.

## Behavior

No functional change. The helper preserves the prior semantics exactly: skip when `base_url` is already set or the template is empty, otherwise expand the template and populate `base_url`, propagating validation errors.

## Tests

- `go build ./...`
- `go test ./internal/sourcecdk/... ./tools/archtests/ ./sources/akeyless/... ./sources/doppler/... ./sources/hashicorp_vault/... -count=1` (includes a new `ResolveBaseURLConfig` unit test covering render, explicit-value passthrough, empty template, and error propagation)
- The duplication guardrail passes with the allowlist entry removed (duplication eliminated, not allowlisted).
- `make check-structural`, `make docs-drift-check`, `make oss-audit`

Refs #956.
