### PR TITLE
refactor(sources): extract checkpoint cursor resolution into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -30,9 +30,9 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `github` | 2028 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
 | `grc` | 1321 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
-| `okta` | 2269 | Extract client, pagination, and identity/group/application readers into smaller units. |
+| `okta` | 2257 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 781 | Separate request plumbing from emitted record construction. |
-| `sentinelone` | 2089 | Extract API paging, agent/application readers, and shared response normalization. |
+| `sentinelone` | 2077 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1020 | Split feed/client access from vulnerability record normalization. |
 
 ## Cross-Source Duplication Guardrail
@@ -50,7 +50,6 @@ shared logic is lifted into the Source CDK. The current extraction backlog is:
 
 | Shared behavior | Sources | Disposition |
 | --- | --- | --- |
-| `checkpointCursor` encode/decode | `okta`, `sentinelone` | Extract into Source CDK cursor |
 | `watermarkString` formatting | `aurelius`, `panopticon` | Extract into Source CDK watermark helper |
 | `valueString` JSON scalar formatting | `cosmo`, `vulnview` | Fold into Source CDK JSON value helpers |
 | provider URN parsing | `aws`, `azure` | Consolidate cautiously (provider-specific identifiers) |

--- a/internal/sourcecdk/cursor.go
+++ b/internal/sourcecdk/cursor.go
@@ -161,6 +161,23 @@ func NextAfterOrPageCursor(after string, nextPageToken string, nextPage int) str
 	return ""
 }
 
+// ResolveCursorOpaque resolves the opaque checkpoint cursor for record-paging
+// sources: it prefers the trimmed next page token, then the trimmed fallback id,
+// then the latest observed event time rendered as RFC3339Nano. It returns an
+// empty string when none are available.
+func ResolveCursorOpaque(next string, fallback string, occurredAt time.Time) string {
+	if next = strings.TrimSpace(next); next != "" {
+		return next
+	}
+	if fallback = strings.TrimSpace(fallback); fallback != "" {
+		return fallback
+	}
+	if occurredAt.IsZero() {
+		return ""
+	}
+	return occurredAt.UTC().Format(time.RFC3339Nano)
+}
+
 func normalizedCursorValues(values []string) []string {
 	if len(values) == 0 {
 		return nil

--- a/internal/sourcecdk/cursor_resolve_test.go
+++ b/internal/sourcecdk/cursor_resolve_test.go
@@ -1,0 +1,30 @@
+package sourcecdk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveCursorOpaque(t *testing.T) {
+	occurred := time.Date(2026, 6, 15, 12, 34, 56, 123456789, time.UTC)
+	cases := []struct {
+		name       string
+		next       string
+		fallback   string
+		occurredAt time.Time
+		want       string
+	}{
+		{name: "prefers trimmed next", next: "  tok-2  ", fallback: "id-9", occurredAt: occurred, want: "tok-2"},
+		{name: "falls back to trimmed fallback", next: "   ", fallback: "  id-9  ", occurredAt: occurred, want: "id-9"},
+		{name: "falls back to event time", next: "", fallback: "", occurredAt: occurred, want: occurred.Format(time.RFC3339Nano)},
+		{name: "renders event time as utc", next: "", fallback: "", occurredAt: time.Date(2026, 6, 15, 14, 34, 56, 0, time.FixedZone("CEST", 2*3600)), want: time.Date(2026, 6, 15, 12, 34, 56, 0, time.UTC).Format(time.RFC3339Nano)},
+		{name: "empty when nothing available", next: "  ", fallback: "", occurredAt: time.Time{}, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveCursorOpaque(tc.next, tc.fallback, tc.occurredAt); got != tc.want {
+				t.Fatalf("ResolveCursorOpaque(%q, %q, %v) = %q, want %q", tc.next, tc.fallback, tc.occurredAt, got, tc.want)
+			}
+		})
+	}
+}

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -1282,7 +1282,7 @@ func oktaPullFromRecordsWithCursor[T any](records []T, next string, build func(T
 		Events: events,
 		Checkpoint: &cerebrov1.SourceCheckpoint{
 			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: checkpointCursor(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
+			CursorOpaque: sourcecdk.ResolveCursorOpaque(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
 		},
 	}
 	if next != "" {
@@ -1722,19 +1722,6 @@ func parseLink(value string) (string, string) {
 		return link, strings.Trim(rawValue, "\"")
 	}
 	return link, ""
-}
-
-func checkpointCursor(next string, fallback string, occurredAt time.Time) string {
-	if strings.TrimSpace(next) != "" {
-		return strings.TrimSpace(next)
-	}
-	if strings.TrimSpace(fallback) != "" {
-		return strings.TrimSpace(fallback)
-	}
-	if occurredAt.IsZero() {
-		return ""
-	}
-	return occurredAt.UTC().Format(time.RFC3339Nano)
 }
 
 func utcTime(value *time.Time) *time.Time {

--- a/sources/sentinelone/source.go
+++ b/sources/sentinelone/source.go
@@ -424,7 +424,7 @@ func pullFromRecords[T any](records []T, next string, build func(T) (*primitives
 		Events: events,
 		Checkpoint: &cerebrov1.SourceCheckpoint{
 			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: checkpointCursor(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
+			CursorOpaque: sourcecdk.ResolveCursorOpaque(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
 		},
 	}
 	if next != "" {
@@ -668,19 +668,6 @@ func wrapLookupError(subject string, err error) error {
 		return fmt.Errorf("%s not found", subject)
 	}
 	return fmt.Errorf("%s: %w", subject, err)
-}
-
-func checkpointCursor(next string, fallback string, occurredAt time.Time) string {
-	if strings.TrimSpace(next) != "" {
-		return strings.TrimSpace(next)
-	}
-	if strings.TrimSpace(fallback) != "" {
-		return strings.TrimSpace(fallback)
-	}
-	if occurredAt.IsZero() {
-		return ""
-	}
-	return occurredAt.UTC().Format(time.RFC3339Nano)
 }
 
 func firstNonEmpty(values ...string) string {

--- a/tools/archtests/source_helper_duplication_test.go
+++ b/tools/archtests/source_helper_duplication_test.go
@@ -29,7 +29,6 @@ const duplicateFunctionMinNodes = 50
 // add new entries to silence a fresh copy-paste; instead lift the shared logic
 // into internal/sourcecdk. Remove an entry when its extraction lands.
 var allowlistedSourceDuplicates = map[string]string{
-	"okta.checkpointCursor|sentinelone.checkpointCursor":  "checkpoint cursor encode/decode; extract into Source CDK cursor (#956)",
 	"aurelius.watermarkString|panopticon.watermarkString": "watermark formatting; extract into Source CDK watermark helper (#956)",
 	"cosmo.valueString|vulnview.valueString":              "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
 	"aws.parseAWSURNs|azure.parseAzureURNs":               "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -22,9 +22,9 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"github":          2028,
 	"googleworkspace": 815,
 	"grc":             1321,
-	"okta":            2269,
+	"okta":            2257,
 	"panopticon":      781,
-	"sentinelone":     2089,
+	"sentinelone":     2077,
 	"vulnview":        1020,
 }
 


### PR DESCRIPTION
## Summary

Extract the shared checkpoint-cursor resolution used by the `okta` and `sentinelone` sources into a new Source CDK helper, `sourcecdk.ResolveCursorOpaque`, and delete the duplicated local `checkpointCursor` from both sources.

`ResolveCursorOpaque(next, fallback string, occurredAt time.Time) string` prefers the trimmed next page token, then the trimmed fallback id, then the latest observed event time rendered as RFC3339Nano (UTC), and returns empty when none are available. Each source's single call site now calls the helper directly.

> Stacked on #1345 and #1346. Base branch is `cdk-extract-pullfromrecords-20260621` so this PR shows only the checkpoint-cursor delta; it should merge after the PRs below it.

## Why

- Collapses an identical cursor-resolution helper that lived in two sources into the canonical Source CDK.
- Removes the corresponding entry from the cross-source duplication allowlist in `tools/archtests/source_helper_duplication_test.go` (and the matching backlog row), so the guardrail now enforces that this logic stays deduplicated.
- Ratchets the grandfathered per-source LOC budgets down to the new sizes (and updates the documented markers) to lock in the reduction.

## Behavior

No functional change. The helper is a behavior-preserving move of the previous logic, including UTC normalization of the timestamp fallback.

## Tests

- `go build ./...`
- `go test ./internal/sourcecdk/... ./sources/okta/... ./sources/sentinelone/... -count=1` (includes a new `ResolveCursorOpaque` unit test covering token, fallback-id, UTC timestamp fallback, and empty cases)
- `go test ./tools/archtests/ -count=1` (duplication guardrail passes with the allowlist entry removed; LOC-budget ratchet and extraction-plan checks pass)
- `make check-structural`, `make docs-drift-check`, `make oss-audit`

Refs #956.
