### PR TITLE
refactor(sources): extract watermark string formatting into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -22,7 +22,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 
 | Source | Current LOC Budget | Extraction Pressure |
 | --- | ---: | --- |
-| `aurelius` | 623 | Split source orchestration from record mapping and shared request plumbing. |
+| `aurelius` | 612 | Split source orchestration from record mapping and shared request plumbing. |
 | `aws` | 19070 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
 | `azure` | 2842 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 1011 | Move shared API pagination and response normalization into reusable source helpers. |
@@ -31,7 +31,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
 | `grc` | 1321 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2257 | Extract client, pagination, and identity/group/application readers into smaller units. |
-| `panopticon` | 781 | Separate request plumbing from emitted record construction. |
+| `panopticon` | 770 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2077 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1020 | Split feed/client access from vulnerability record normalization. |
 
@@ -50,7 +50,6 @@ shared logic is lifted into the Source CDK. The current extraction backlog is:
 
 | Shared behavior | Sources | Disposition |
 | --- | --- | --- |
-| `watermarkString` formatting | `aurelius`, `panopticon` | Extract into Source CDK watermark helper |
 | `valueString` JSON scalar formatting | `cosmo`, `vulnview` | Fold into Source CDK JSON value helpers |
 | provider URN parsing | `aws`, `azure` | Consolidate cautiously (provider-specific identifiers) |
 | provider URN construction | `okta`, `sentinelone` | Consolidate into Source CDK URN helper |

--- a/internal/sourcecdk/watermark.go
+++ b/internal/sourcecdk/watermark.go
@@ -314,6 +314,21 @@ func IncrementalCursor(source string, family string, token string, checkpoint *c
 	return opaque
 }
 
+// WatermarkString returns the later of watermark and fallback, rendered as a
+// UTC RFC3339Nano string. It prefers watermark on ties and returns an empty
+// string when both times are zero.
+func WatermarkString(watermark time.Time, fallback time.Time) string {
+	if !watermark.IsZero() && !fallback.IsZero() && fallback.After(watermark) {
+		watermark = fallback
+	} else if watermark.IsZero() {
+		watermark = fallback
+	}
+	if watermark.IsZero() {
+		return ""
+	}
+	return watermark.UTC().Format(time.RFC3339Nano)
+}
+
 func checkpointHasWatermark(checkpoint *cerebrov1.SourceCheckpoint) bool {
 	return checkpoint != nil && checkpoint.GetWatermark() != nil && !checkpoint.GetWatermark().AsTime().IsZero()
 }

--- a/internal/sourcecdk/watermark_string_test.go
+++ b/internal/sourcecdk/watermark_string_test.go
@@ -1,0 +1,32 @@
+package sourcecdk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWatermarkString(t *testing.T) {
+	early := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	late := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name      string
+		watermark time.Time
+		fallback  time.Time
+		want      string
+	}{
+		{name: "prefers later fallback", watermark: early, fallback: late, want: late.Format(time.RFC3339Nano)},
+		{name: "keeps later watermark", watermark: late, fallback: early, want: late.Format(time.RFC3339Nano)},
+		{name: "keeps watermark on tie", watermark: late, fallback: late, want: late.Format(time.RFC3339Nano)},
+		{name: "uses fallback when watermark zero", watermark: time.Time{}, fallback: late, want: late.Format(time.RFC3339Nano)},
+		{name: "keeps watermark when fallback zero", watermark: late, fallback: time.Time{}, want: late.Format(time.RFC3339Nano)},
+		{name: "empty when both zero", watermark: time.Time{}, fallback: time.Time{}, want: ""},
+		{name: "renders as utc", watermark: time.Date(2026, 6, 15, 14, 0, 0, 0, time.FixedZone("CEST", 2*3600)), fallback: time.Time{}, want: late.Format(time.RFC3339Nano)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := WatermarkString(tc.watermark, tc.fallback); got != tc.want {
+				t.Fatalf("WatermarkString(%v, %v) = %q, want %q", tc.watermark, tc.fallback, got, tc.want)
+			}
+		})
+	}
+}

--- a/sources/aurelius/source.go
+++ b/sources/aurelius/source.go
@@ -381,18 +381,6 @@ func cursorWatermark(cursor aureliusCursor) time.Time {
 	return value.UTC()
 }
 
-func watermarkString(watermark time.Time, fallback time.Time) string {
-	if !watermark.IsZero() && !fallback.IsZero() && fallback.After(watermark) {
-		watermark = fallback
-	} else if watermark.IsZero() {
-		watermark = fallback
-	}
-	if watermark.IsZero() {
-		return ""
-	}
-	return watermark.UTC().Format(time.RFC3339Nano)
-}
-
 func discoverFamily(st settings, urnPrefix string) ([]sourcecdk.URN, error) {
 	urnRaw := urnPrefix + url.PathEscape(st.bucket+"/"+strings.TrimSuffix(st.prefix, "/"))
 	urn, err := sourcecdk.ParseURN(urnRaw)
@@ -489,12 +477,12 @@ func (s *Source) readFamily(ctx context.Context, st settings, cursor *cerebrov1.
 						LastKey:      lastKey,
 						PartialKey:   key,
 						RecordOffset: nextRecord,
-						Watermark:    watermarkString(watermark, priorWatermark),
+						Watermark:    sourcecdk.WatermarkString(watermark, priorWatermark),
 					})
 				} else {
 					lastKey = key
 					if objectIndex < len(listing.Contents)-1 || awssdk.ToBool(listing.IsTruncated) {
-						nextCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: watermarkString(watermark, priorWatermark)})
+						nextCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: sourcecdk.WatermarkString(watermark, priorWatermark)})
 					}
 				}
 				break
@@ -507,14 +495,14 @@ func (s *Source) readFamily(ctx context.Context, st settings, cursor *cerebrov1.
 	}
 	pull := sourcecdk.Pull{Events: events}
 	if nextCursor == "" && awssdk.ToBool(listing.IsTruncated) && lastKey != "" {
-		nextCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: watermarkString(watermark, priorWatermark)})
+		nextCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: sourcecdk.WatermarkString(watermark, priorWatermark)})
 	}
 	if nextCursor != "" {
 		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextCursor}
 	}
 	checkpointCursor := nextCursor
 	if checkpointCursor == "" && lastKey != "" {
-		checkpointCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: watermarkString(watermark, priorWatermark)})
+		checkpointCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: sourcecdk.WatermarkString(watermark, priorWatermark)})
 	}
 	madeProgress := lastKey != "" && lastKey != startAfter
 	if checkpointCursor != "" && (!watermark.IsZero() || cursor != nil || nextCursor != "" || madeProgress) {

--- a/sources/panopticon/api.go
+++ b/sources/panopticon/api.go
@@ -222,7 +222,7 @@ func recordsPull(records []panopticonRecord, cursorState, next panopticonAPICurs
 		}
 	}
 	pull := sourcecdk.Pull{Events: events}
-	watermarkValue := watermarkString(watermark, parseAPIWatermark(cursorState.Watermark))
+	watermarkValue := sourcecdk.WatermarkString(watermark, parseAPIWatermark(cursorState.Watermark))
 	if next.hasMore() {
 		next.Watermark = watermarkValue
 		opaque := encodeAPICursor(next)

--- a/sources/panopticon/source.go
+++ b/sources/panopticon/source.go
@@ -261,18 +261,6 @@ func firstConfigValue(cfg sourcecdk.Config, keys ...string) string {
 	return ""
 }
 
-func watermarkString(watermark time.Time, fallback time.Time) string {
-	if !watermark.IsZero() && !fallback.IsZero() && fallback.After(watermark) {
-		watermark = fallback
-	} else if watermark.IsZero() {
-		watermark = fallback
-	}
-	if watermark.IsZero() {
-		return ""
-	}
-	return watermark.UTC().Format(time.RFC3339Nano)
-}
-
 func buildEvent(rec panopticonRecord, kind, schemaRef string) (*primitives.Event, error) {
 	if strings.TrimSpace(rec.ID) == "" {
 		return nil, errors.New("id is required")

--- a/tools/archtests/source_helper_duplication_test.go
+++ b/tools/archtests/source_helper_duplication_test.go
@@ -29,12 +29,11 @@ const duplicateFunctionMinNodes = 50
 // add new entries to silence a fresh copy-paste; instead lift the shared logic
 // into internal/sourcecdk. Remove an entry when its extraction lands.
 var allowlistedSourceDuplicates = map[string]string{
-	"aurelius.watermarkString|panopticon.watermarkString": "watermark formatting; extract into Source CDK watermark helper (#956)",
-	"cosmo.valueString|vulnview.valueString":              "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
-	"aws.parseAWSURNs|azure.parseAzureURNs":               "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",
-	"okta.oktaURNsFor|sentinelone.urnsFor":                "provider URN construction; consolidate into Source CDK URN helper (#956)",
-	"azure.New|gcp.New|googleworkspace.New":               "constructor scaffold building a concrete *Source; needs a generic CDK builder to deduplicate (#684)",
-	"archetype.New|sdk.New|trustedendpoint.New":           "constructor scaffold for sample/fixture sources; structural boilerplate (#684)",
+	"cosmo.valueString|vulnview.valueString":    "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
+	"aws.parseAWSURNs|azure.parseAzureURNs":     "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",
+	"okta.oktaURNsFor|sentinelone.urnsFor":      "provider URN construction; consolidate into Source CDK URN helper (#956)",
+	"azure.New|gcp.New|googleworkspace.New":     "constructor scaffold building a concrete *Source; needs a generic CDK builder to deduplicate (#684)",
+	"archetype.New|sdk.New|trustedendpoint.New": "constructor scaffold for sample/fixture sources; structural boilerplate (#684)",
 }
 
 // TestSourcePackagesDoNotDuplicateExtractableHelpers fails when the same

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -14,7 +14,7 @@ const newSourcePackageLOCBudget = 300
 // sources. If a source shrinks, lower its ceiling in the same change; if a
 // source grows, move shared behavior into the Source CDK instead of raising it.
 var grandfatheredSourcePackageLOCBudgets = map[string]int{
-	"aurelius":        623,
+	"aurelius":        612,
 	"aws":             19070,
 	"azure":           2842,
 	"cosmo":           1011,
@@ -23,7 +23,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"googleworkspace": 815,
 	"grc":             1321,
 	"okta":            2257,
-	"panopticon":      781,
+	"panopticon":      770,
 	"sentinelone":     2077,
 	"vulnview":        1020,
 }


### PR DESCRIPTION
## Summary

Extract the shared watermark-string formatting used by the `aurelius` and `panopticon` sources into a new Source CDK helper, `sourcecdk.WatermarkString`, and delete the duplicated local `watermarkString` from both sources.

`WatermarkString(watermark, fallback time.Time) string` returns the later of the two times (preferring `watermark` on ties), rendered as a UTC RFC3339Nano string, and returns an empty string when both times are zero. Each source's call sites now call the helper directly.

> Stacked on #1345, #1346, and #1348. Base branch is `cdk-extract-checkpointcursor-20260621` so this PR shows only the watermark-formatting delta; it should merge after the PRs below it.

## Why

- Collapses an identical watermark-formatting helper that lived in two sources into the canonical Source CDK.
- Removes the corresponding entry from the cross-source duplication allowlist in `tools/archtests/source_helper_duplication_test.go` (and the matching backlog row), so the guardrail now enforces that this logic stays deduplicated.
- Ratchets the grandfathered per-source LOC budgets down to the new sizes (and updates the documented markers) to lock in the reduction.

## Behavior

No functional change. The helper is a behavior-preserving move of the previous logic, including UTC normalization.

## Tests

- `go build ./...`
- `go test ./internal/sourcecdk/... ./sources/aurelius/... ./sources/panopticon/... -count=1` (includes a new `WatermarkString` unit test covering later-of-two, tie, zero-input, both-zero, and UTC rendering cases)
- `go test ./tools/archtests/ -count=1` (duplication guardrail passes with the allowlist entry removed; LOC-budget ratchet and extraction-plan checks pass)
- `make check-structural`, `make docs-drift-check`, `make oss-audit`

Refs #956.
