### PR TITLE
refactor(sources): extract JSON value formatting into Source CDK (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -25,7 +25,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `aurelius` | 612 | Split source orchestration from record mapping and shared request plumbing. |
 | `aws` | 19070 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
 | `azure` | 2842 | Extract subscription traversal, client factories, and paginated resource readers. |
-| `cosmo` | 1011 | Move shared API pagination and response normalization into reusable source helpers. |
+| `cosmo` | 992 | Move shared API pagination and response normalization into reusable source helpers. |
 | `gcp` | 2095 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2028 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
@@ -33,7 +33,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `okta` | 2257 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 770 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2077 | Extract API paging, agent/application readers, and shared response normalization. |
-| `vulnview` | 1020 | Split feed/client access from vulnerability record normalization. |
+| `vulnview` | 1001 | Split feed/client access from vulnerability record normalization. |
 
 ## Cross-Source Duplication Guardrail
 
@@ -50,7 +50,6 @@ shared logic is lifted into the Source CDK. The current extraction backlog is:
 
 | Shared behavior | Sources | Disposition |
 | --- | --- | --- |
-| `valueString` JSON scalar formatting | `cosmo`, `vulnview` | Fold into Source CDK JSON value helpers |
 | provider URN parsing | `aws`, `azure` | Consolidate cautiously (provider-specific identifiers) |
 | provider URN construction | `okta`, `sentinelone` | Consolidate into Source CDK URN helper |
 | `New` constructor scaffold | `azure`, `gcp`, `googleworkspace` | Needs a generic CDK builder to deduplicate |

--- a/internal/sourcecdk/json_value_string_test.go
+++ b/internal/sourcecdk/json_value_string_test.go
@@ -1,0 +1,27 @@
+package sourcecdk
+
+import "testing"
+
+func TestJSONScalarFlattened(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{name: "nil", value: nil, want: ""},
+		{name: "trims string", value: "  hi  ", want: "hi"},
+		{name: "float without exponent", value: float64(42), want: "42"},
+		{name: "float fractional", value: 3.5, want: "3.5"},
+		{name: "bool", value: true, want: "true"},
+		{name: "slice joins non-empty", value: []any{"a", "", "b", float64(2)}, want: "a,b,2"},
+		{name: "nested slice", value: []any{"a", []any{"b", "c"}}, want: "a,b,c"},
+		{name: "default via sprint", value: 7, want: "7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (JSONScalar{Value: tc.value}).Flattened(); got != tc.want {
+				t.Fatalf("JSONScalar{%#v}.Flattened() = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sourcecdk/json_values.go
+++ b/internal/sourcecdk/json_values.go
@@ -2,6 +2,7 @@ package sourcecdk
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -47,4 +48,24 @@ func (s JSONScalar) Time(layouts ...string) time.Time {
 		}
 	}
 	return time.Time{}
+}
+
+// Flattened renders the boxed JSON value as a string. Scalar values follow the
+// same rules as String; []any values become their comma-joined non-empty
+// elements; any other value is rendered via fmt.Sprint and trimmed.
+func (s JSONScalar) Flattened() string {
+	switch v := s.Value.(type) {
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			if value := (JSONScalar{Value: item}).Flattened(); value != "" {
+				parts = append(parts, value)
+			}
+		}
+		return strings.Join(parts, ",")
+	case nil, string, float64, bool:
+		return s.String()
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
 }

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -1003,26 +1003,7 @@ func firstValueString(values map[string]any, keys ...string) string {
 }
 
 func valueString(value any) string {
-	switch v := value.(type) {
-	case nil:
-		return ""
-	case string:
-		return strings.TrimSpace(v)
-	case float64:
-		return strconv.FormatFloat(v, 'f', -1, 64)
-	case bool:
-		return strconv.FormatBool(v)
-	case []any:
-		parts := make([]string, 0, len(v))
-		for _, item := range v {
-			if value := valueString(item); value != "" {
-				parts = append(parts, value)
-			}
-		}
-		return strings.Join(parts, ",")
-	default:
-		return strings.TrimSpace(fmt.Sprint(v))
-	}
+	return sourcecdk.JSONScalar{Value: value}.Flattened()
 }
 
 func configValue(cfg sourcecdk.Config, key string) string {

--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -1014,26 +1014,7 @@ func firstValueString(values map[string]any, keys ...string) string {
 }
 
 func valueString(value any) string {
-	switch v := value.(type) {
-	case nil:
-		return ""
-	case string:
-		return strings.TrimSpace(v)
-	case float64:
-		return strconv.FormatFloat(v, 'f', -1, 64)
-	case bool:
-		return strconv.FormatBool(v)
-	case []any:
-		parts := make([]string, 0, len(v))
-		for _, item := range v {
-			if value := valueString(item); value != "" {
-				parts = append(parts, value)
-			}
-		}
-		return strings.Join(parts, ",")
-	default:
-		return strings.TrimSpace(fmt.Sprint(v))
-	}
+	return sourcecdk.JSONScalar{Value: value}.Flattened()
 }
 
 func addQuery(query url.Values, key string, value string) {

--- a/tools/archtests/source_helper_duplication_test.go
+++ b/tools/archtests/source_helper_duplication_test.go
@@ -29,7 +29,6 @@ const duplicateFunctionMinNodes = 50
 // add new entries to silence a fresh copy-paste; instead lift the shared logic
 // into internal/sourcecdk. Remove an entry when its extraction lands.
 var allowlistedSourceDuplicates = map[string]string{
-	"cosmo.valueString|vulnview.valueString":    "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
 	"aws.parseAWSURNs|azure.parseAzureURNs":     "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",
 	"okta.oktaURNsFor|sentinelone.urnsFor":      "provider URN construction; consolidate into Source CDK URN helper (#956)",
 	"azure.New|gcp.New|googleworkspace.New":     "constructor scaffold building a concrete *Source; needs a generic CDK builder to deduplicate (#684)",

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -17,7 +17,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"aurelius":        612,
 	"aws":             19070,
 	"azure":           2842,
-	"cosmo":           1011,
+	"cosmo":           992,
 	"gcp":             2095,
 	"github":          2028,
 	"googleworkspace": 815,
@@ -25,7 +25,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"okta":            2257,
 	"panopticon":      770,
 	"sentinelone":     2077,
-	"vulnview":        1020,
+	"vulnview":        1001,
 }
 
 func TestSourcePackagesHaveCatalogFixturesAndTests(t *testing.T) {


### PR DESCRIPTION
## Summary

Extract the shared JSON value-to-string formatting used by the `cosmo` and `vulnview` sources into the Source CDK as a new `JSONScalar.Flattened()` method, and reduce each source's local `valueString` to a thin wrapper over it.

`Flattened()` renders a decoded JSON value (as produced by `encoding/json` into `map[string]any`): nil becomes empty, strings are trimmed, float64 values are formatted without an exponent, bools become `"true"`/`"false"`, `[]any` values become their comma-joined non-empty elements, and any other value is rendered via `fmt.Sprint` and trimmed. Scalar cases delegate to the existing `JSONScalar.String()`.

> Stacked on #1345, #1346, #1348, and #1349. Base branch is `cdk-extract-watermarkstring-20260621` so this PR shows only the JSON-value delta; it should merge after the PRs below it.

## Why

- Collapses an identical JSON value-formatting helper that lived in two sources into the canonical Source CDK, alongside the existing `JSONScalar` coercion helpers.
- Removes the corresponding entry from the cross-source duplication allowlist in `tools/archtests/source_helper_duplication_test.go` (and the matching backlog row), so the guardrail now enforces that this logic stays deduplicated. The remaining wrappers are below the guardrail threshold.
- Ratchets the grandfathered per-source LOC budgets down to the new sizes (and updates the documented markers) to lock in the reduction.

## Notes

The helper is exposed as a method on the existing `JSONScalar` box rather than a free function, to satisfy the Source CDK structural rule against exported functions with untyped (`any`) parameters.

## Behavior

No functional change; behavior-preserving move of the previous logic, including the recursive array handling.

## Tests

- `go build ./...`
- `go test ./internal/sourcecdk/... ./sources/cosmo/... ./sources/vulnview/... -count=1` (includes a new `JSONScalar.Flattened` unit test covering nil, trimmed string, float, bool, nested/empty-filtered slices, and the fmt.Sprint default)
- `go test ./tools/archtests/ -count=1` (duplication guardrail passes with the allowlist entry removed; LOC-budget ratchet and extraction-plan checks pass)
- `make check-structural`, `make docs-drift-check`, `make oss-audit`

Refs #956.
