### PR TITLE
Fix dashboard evidence count windowed by preview limit

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -247,7 +247,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		var err error
 		ctx, aggregateSpan := telemetry.Start(parent, "grc.dashboard.aggregate", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}))
 		aggregateRequest := r.WithContext(ctx)
-		aggregate, err = a.grcDashboardAggregate(aggregateRequest, runtimes, grcFindingFilter{Status: "open"}, grcEvidenceFilter{FindingIDs: findingIDs})
+		aggregate, err = a.grcDashboardAggregate(aggregateRequest, runtimes, grcFindingFilter{Status: "open"}, grcEvidenceFilter{})
 		if err == nil && aggregate == nil {
 			findingSummary, err = a.grcFindingSummary(aggregateRequest, runtimes, grcFindingFilter{Status: "open"})
 			if err == nil {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -498,6 +498,9 @@ func TestGRCDashboardCapsPreviewWorkToRenderedLimit(t *testing.T) {
 	if payload.Summary.OpenFindings != 40 {
 		t.Fatalf("summary open findings = %d, want unpaginated total 40", payload.Summary.OpenFindings)
 	}
+	if payload.Summary.EvidenceItems != 40 {
+		t.Fatalf("summary evidence items = %d, want unpaginated total 40 (not the %d-row preview)", payload.Summary.EvidenceItems, grcDashboardPreviewLimit)
+	}
 	if store.aggregateCalls != 1 {
 		t.Fatalf("aggregate calls = %d, want 1", store.aggregateCalls)
 	}
@@ -965,22 +968,26 @@ func (s *stubGRCAggregateStore) SummarizeGRCDashboard(ctx context.Context, reque
 	if err != nil {
 		return ports.GRCDashboardAggregate{}, err
 	}
-	count, err := s.CountFindingEvidence(ctx, request.EvidenceRequest)
-	if err != nil {
-		return ports.GRCDashboardAggregate{}, err
-	}
+	// Mirror the real aggregate query: evidence counts follow the open finding
+	// scope (every matching finding), not the windowed preview finding-id list.
 	countsByFindingID := map[string]int{}
+	total := 0
+	status := strings.TrimSpace(request.FindingRequest.Status)
 	for _, evidence := range s.findingEvidence {
-		if evidence == nil {
+		if evidence == nil || !findingEvidenceMatches(request.EvidenceRequest, evidence) {
 			continue
 		}
-		for _, findingID := range request.EvidenceRequest.FindingIDs {
-			if evidence.GetFindingId() == findingID {
-				countsByFindingID[findingID]++
-			}
+		finding, ok := s.findings[evidence.GetFindingId()]
+		if !ok {
+			continue
 		}
+		if status != "" && !strings.EqualFold(strings.TrimSpace(finding.Status), status) {
+			continue
+		}
+		countsByFindingID[evidence.GetFindingId()]++
+		total++
 	}
-	return ports.GRCDashboardAggregate{FindingSummary: summary, EvidenceCount: count, EvidenceCountsByFindingID: countsByFindingID}, nil
+	return ports.GRCDashboardAggregate{FindingSummary: summary, EvidenceCount: total, EvidenceCountsByFindingID: countsByFindingID}, nil
 }
 
 type stubGRCEvidenceHeaderStore struct {

--- a/internal/statestore/postgres/grc_dashboard.go
+++ b/internal/statestore/postgres/grc_dashboard.go
@@ -130,7 +130,7 @@ func grcDashboardAggregateQuery(request ports.GRCDashboardAggregateRequest) (str
 	effectiveSeverity := findingEffectiveSeveritySQL()
 	query := `
 WITH finding_scope AS (
-  SELECT status, ` + effectiveSeverity + ` AS effective_severity, due_at, assignee, control_refs_json
+  SELECT id, status, ` + effectiveSeverity + ` AS effective_severity, due_at, assignee, control_refs_json
   FROM findings
   WHERE ` + whereFindings + `
 ),
@@ -165,6 +165,7 @@ evidence_summary AS (
     SELECT finding_id, COUNT(*) AS evidence_count
     FROM finding_evidence
     WHERE ` + whereEvidence + `
+      AND finding_id IN (SELECT id FROM finding_scope)
     GROUP BY finding_id
   ) counts
 )

--- a/internal/statestore/postgres/grc_dashboard_test.go
+++ b/internal/statestore/postgres/grc_dashboard_test.go
@@ -16,7 +16,6 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 		},
 		EvidenceRequest: ports.ListFindingEvidenceRequest{
 			RuntimeIDs: []string{"tenant-runtime-a", "tenant-runtime-b"},
-			FindingIDs: []string{"finding-1", "finding-2"},
 		},
 	})
 	if err != nil {
@@ -24,6 +23,7 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 	}
 	for _, fragment := range []string{
 		"WITH finding_scope AS",
+		"SELECT id, status,",
 		"COUNT(*) FILTER (WHERE LOWER(status) = 'open') AS open_findings",
 		"jsonb_array_elements",
 		"jsonb_build_object('framework_name', framework_name, 'control_id', control_id)",
@@ -32,19 +32,21 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 		"GROUP BY finding_id",
 		"FROM finding_evidence",
 		"runtime_id IN ($5, $6)",
-		"finding_id IN ($7, $8)",
+		"finding_id IN (SELECT id FROM finding_scope)",
 	} {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("aggregate query missing %q:\n%s", fragment, query)
 		}
 	}
-	for _, forbidden := range []string{`E'\x00'`, `|| E'`, "control_key"} {
+	// The dashboard evidence total must follow finding_scope (all open findings),
+	// not a windowed preview finding-id list, so no positional finding_id filter.
+	for _, forbidden := range []string{`E'\x00'`, `|| E'`, "control_key", "finding_id IN ($7"} {
 		if strings.Contains(query, forbidden) {
 			t.Fatalf("aggregate query must not contain %q:\n%s", forbidden, query)
 		}
 	}
-	if len(args) != 8 {
-		t.Fatalf("aggregate query args len = %d, want 8 (%v)", len(args), args)
+	if len(args) != 6 {
+		t.Fatalf("aggregate query args len = %d, want 6 (%v)", len(args), args)
 	}
 }
 


### PR DESCRIPTION
## Problem

The GRC dashboard reports a global `evidence_items` stat alongside open/critical/overdue finding counts. The finding counts are computed over **all** open findings, but the evidence total (and the per-finding evidence map) was scoped to the **preview-limited finding IDs**, which the handler caps at the 25-row preview window (`grcDashboardPreviewLimit = 25`).

As a result, any tenant with more than 25 open findings saw an under-reported "Evidence Items" number on the dashboard, even though the finding summary was correct. The two stats were computed from inconsistent finding sets.

## Fix

Scope the dashboard evidence aggregate to `finding_scope` (the same open-finding set the summary uses) instead of the preview finding-id list:

- `internal/statestore/postgres/grc_dashboard.go`: `finding_scope` now also selects `id`, and the evidence sub-query adds `AND finding_id IN (SELECT id FROM finding_scope)`. The evidence total and per-finding map therefore cover all open findings in scope.
- `internal/bootstrap/grc.go`: the dashboard handler no longer passes the preview finding-ids into the aggregate's evidence filter (the scope constraint now comes from `finding_scope`). The preview finding/evidence **lists** are still capped at the preview limit for rendering.

## Tests

- `grc_dashboard_test.go`: updated the aggregate-query test to assert the evidence sub-query follows `finding_scope` (and carries no positional finding-id filter).
- `grc_test.go`: `TestGRCDashboardCapsPreviewWorkToRenderedLimit` now also asserts `evidence_items == 40` for a 40-open-finding / 25-preview tenant (previously this would have reported 25), and the aggregate stub was updated to mirror the corrected finding-scope scoping.
- `go test ./internal/bootstrap/ ./internal/statestore/postgres/` passes; `gofmt` and `go vet` clean.