### PR TITLE
refactor(sources): consolidate Source CDK helper extractions (#956)

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -22,7 +22,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 
 | Source | Current LOC Budget | Extraction Pressure |
 | --- | ---: | --- |
-| `aurelius` | 623 | Split source orchestration from record mapping and shared request plumbing. |
+| `aurelius` | 612 | Split source orchestration from record mapping and shared request plumbing. |
 | `aws` | 19070 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
 | `azure` | 2842 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 1011 | Move shared API pagination and response normalization into reusable source helpers. |
@@ -31,7 +31,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
 | `grc` | 1321 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2257 | Extract client, pagination, and identity/group/application readers into smaller units. |
-| `panopticon` | 781 | Separate request plumbing from emitted record construction. |
+| `panopticon` | 770 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2077 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1020 | Split feed/client access from vulnerability record normalization. |
 
@@ -50,7 +50,6 @@ shared logic is lifted into the Source CDK. The current extraction backlog is:
 
 | Shared behavior | Sources | Disposition |
 | --- | --- | --- |
-| `watermarkString` formatting | `aurelius`, `panopticon` | Extract into Source CDK watermark helper |
 | `valueString` JSON scalar formatting | `cosmo`, `vulnview` | Fold into Source CDK JSON value helpers |
 | provider URN parsing | `aws`, `azure` | Consolidate cautiously (provider-specific identifiers) |
 | provider URN construction | `okta`, `sentinelone` | Consolidate into Source CDK URN helper |

--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -29,11 +29,11 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `gcp` | 2095 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2028 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
-| `grc` | 1343 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
+| `grc` | 1321 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2269 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 781 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2089 | Extract API paging, agent/application readers, and shared response normalization. |
-| `vulnview` | 1042 | Split feed/client access from vulnerability record normalization. |
+| `vulnview` | 1020 | Split feed/client access from vulnerability record normalization. |
 
 ## Cross-Source Duplication Guardrail
 
@@ -50,7 +50,6 @@ shared logic is lifted into the Source CDK. The current extraction backlog is:
 
 | Shared behavior | Sources | Disposition |
 | --- | --- | --- |
-| `pullFromRecords` paging loop | `grc`, `vulnview` | Extract into Source CDK record pull |
 | `checkpointCursor` encode/decode | `okta`, `sentinelone` | Extract into Source CDK cursor |
 | `watermarkString` formatting | `aurelius`, `panopticon` | Extract into Source CDK watermark helper |
 | `valueString` JSON scalar formatting | `cosmo`, `vulnview` | Fold into Source CDK JSON value helpers |

--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -25,7 +25,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `aurelius` | 612 | Split source orchestration from record mapping and shared request plumbing. |
 | `aws` | 19070 | Extract common AWS client/session, pagination, ARN parsing, and resource-family traversal helpers. |
 | `azure` | 2842 | Extract subscription traversal, client factories, and paginated resource readers. |
-| `cosmo` | 1011 | Move shared API pagination and response normalization into reusable source helpers. |
+| `cosmo` | 992 | Move shared API pagination and response normalization into reusable source helpers. |
 | `gcp` | 2095 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2028 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
@@ -33,7 +33,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `okta` | 2257 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 770 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2077 | Extract API paging, agent/application readers, and shared response normalization. |
-| `vulnview` | 1020 | Split feed/client access from vulnerability record normalization. |
+| `vulnview` | 1001 | Split feed/client access from vulnerability record normalization. |
 
 ## Cross-Source Duplication Guardrail
 
@@ -50,7 +50,6 @@ shared logic is lifted into the Source CDK. The current extraction backlog is:
 
 | Shared behavior | Sources | Disposition |
 | --- | --- | --- |
-| `valueString` JSON scalar formatting | `cosmo`, `vulnview` | Fold into Source CDK JSON value helpers |
 | provider URN parsing | `aws`, `azure` | Consolidate cautiously (provider-specific identifiers) |
 | provider URN construction | `okta`, `sentinelone` | Consolidate into Source CDK URN helper |
 | `New` constructor scaffold | `azure`, `gcp`, `googleworkspace` | Needs a generic CDK builder to deduplicate |

--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -30,9 +30,9 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `github` | 2028 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
 | `grc` | 1321 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
-| `okta` | 2269 | Extract client, pagination, and identity/group/application readers into smaller units. |
+| `okta` | 2257 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 781 | Separate request plumbing from emitted record construction. |
-| `sentinelone` | 2089 | Extract API paging, agent/application readers, and shared response normalization. |
+| `sentinelone` | 2077 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1020 | Split feed/client access from vulnerability record normalization. |
 
 ## Cross-Source Duplication Guardrail
@@ -50,7 +50,6 @@ shared logic is lifted into the Source CDK. The current extraction backlog is:
 
 | Shared behavior | Sources | Disposition |
 | --- | --- | --- |
-| `checkpointCursor` encode/decode | `okta`, `sentinelone` | Extract into Source CDK cursor |
 | `watermarkString` formatting | `aurelius`, `panopticon` | Extract into Source CDK watermark helper |
 | `valueString` JSON scalar formatting | `cosmo`, `vulnview` | Fold into Source CDK JSON value helpers |
 | provider URN parsing | `aws`, `azure` | Consolidate cautiously (provider-specific identifiers) |

--- a/internal/sourcecdk/cursor.go
+++ b/internal/sourcecdk/cursor.go
@@ -161,6 +161,23 @@ func NextAfterOrPageCursor(after string, nextPageToken string, nextPage int) str
 	return ""
 }
 
+// ResolveCursorOpaque resolves the opaque checkpoint cursor for record-paging
+// sources: it prefers the trimmed next page token, then the trimmed fallback id,
+// then the latest observed event time rendered as RFC3339Nano. It returns an
+// empty string when none are available.
+func ResolveCursorOpaque(next string, fallback string, occurredAt time.Time) string {
+	if next = strings.TrimSpace(next); next != "" {
+		return next
+	}
+	if fallback = strings.TrimSpace(fallback); fallback != "" {
+		return fallback
+	}
+	if occurredAt.IsZero() {
+		return ""
+	}
+	return occurredAt.UTC().Format(time.RFC3339Nano)
+}
+
 func normalizedCursorValues(values []string) []string {
 	if len(values) == 0 {
 		return nil

--- a/internal/sourcecdk/cursor_resolve_test.go
+++ b/internal/sourcecdk/cursor_resolve_test.go
@@ -1,0 +1,30 @@
+package sourcecdk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveCursorOpaque(t *testing.T) {
+	occurred := time.Date(2026, 6, 15, 12, 34, 56, 123456789, time.UTC)
+	cases := []struct {
+		name       string
+		next       string
+		fallback   string
+		occurredAt time.Time
+		want       string
+	}{
+		{name: "prefers trimmed next", next: "  tok-2  ", fallback: "id-9", occurredAt: occurred, want: "tok-2"},
+		{name: "falls back to trimmed fallback", next: "   ", fallback: "  id-9  ", occurredAt: occurred, want: "id-9"},
+		{name: "falls back to event time", next: "", fallback: "", occurredAt: occurred, want: occurred.Format(time.RFC3339Nano)},
+		{name: "renders event time as utc", next: "", fallback: "", occurredAt: time.Date(2026, 6, 15, 14, 34, 56, 0, time.FixedZone("CEST", 2*3600)), want: time.Date(2026, 6, 15, 12, 34, 56, 0, time.UTC).Format(time.RFC3339Nano)},
+		{name: "empty when nothing available", next: "  ", fallback: "", occurredAt: time.Time{}, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveCursorOpaque(tc.next, tc.fallback, tc.occurredAt); got != tc.want {
+				t.Fatalf("ResolveCursorOpaque(%q, %q, %v) = %q, want %q", tc.next, tc.fallback, tc.occurredAt, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sourcecdk/json_value_string_test.go
+++ b/internal/sourcecdk/json_value_string_test.go
@@ -1,0 +1,27 @@
+package sourcecdk
+
+import "testing"
+
+func TestJSONScalarFlattened(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{name: "nil", value: nil, want: ""},
+		{name: "trims string", value: "  hi  ", want: "hi"},
+		{name: "float without exponent", value: float64(42), want: "42"},
+		{name: "float fractional", value: 3.5, want: "3.5"},
+		{name: "bool", value: true, want: "true"},
+		{name: "slice joins non-empty", value: []any{"a", "", "b", float64(2)}, want: "a,b,2"},
+		{name: "nested slice", value: []any{"a", []any{"b", "c"}}, want: "a,b,c"},
+		{name: "default via sprint", value: 7, want: "7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (JSONScalar{Value: tc.value}).Flattened(); got != tc.want {
+				t.Fatalf("JSONScalar{%#v}.Flattened() = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sourcecdk/json_values.go
+++ b/internal/sourcecdk/json_values.go
@@ -2,6 +2,7 @@ package sourcecdk
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -47,4 +48,24 @@ func (s JSONScalar) Time(layouts ...string) time.Time {
 		}
 	}
 	return time.Time{}
+}
+
+// Flattened renders the boxed JSON value as a string. Scalar values follow the
+// same rules as String; []any values become their comma-joined non-empty
+// elements; any other value is rendered via fmt.Sprint and trimmed.
+func (s JSONScalar) Flattened() string {
+	switch v := s.Value.(type) {
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			if value := (JSONScalar{Value: item}).Flattened(); value != "" {
+				parts = append(parts, value)
+			}
+		}
+		return strings.Join(parts, ",")
+	case nil, string, float64, bool:
+		return s.String()
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
 }

--- a/internal/sourcecdk/watermark.go
+++ b/internal/sourcecdk/watermark.go
@@ -314,6 +314,21 @@ func IncrementalCursor(source string, family string, token string, checkpoint *c
 	return opaque
 }
 
+// WatermarkString returns the later of watermark and fallback, rendered as a
+// UTC RFC3339Nano string. It prefers watermark on ties and returns an empty
+// string when both times are zero.
+func WatermarkString(watermark time.Time, fallback time.Time) string {
+	if !watermark.IsZero() && !fallback.IsZero() && fallback.After(watermark) {
+		watermark = fallback
+	} else if watermark.IsZero() {
+		watermark = fallback
+	}
+	if watermark.IsZero() {
+		return ""
+	}
+	return watermark.UTC().Format(time.RFC3339Nano)
+}
+
 func checkpointHasWatermark(checkpoint *cerebrov1.SourceCheckpoint) bool {
 	return checkpoint != nil && checkpoint.GetWatermark() != nil && !checkpoint.GetWatermark().AsTime().IsZero()
 }

--- a/internal/sourcecdk/watermark_string_test.go
+++ b/internal/sourcecdk/watermark_string_test.go
@@ -1,0 +1,32 @@
+package sourcecdk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWatermarkString(t *testing.T) {
+	early := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	late := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name      string
+		watermark time.Time
+		fallback  time.Time
+		want      string
+	}{
+		{name: "prefers later fallback", watermark: early, fallback: late, want: late.Format(time.RFC3339Nano)},
+		{name: "keeps later watermark", watermark: late, fallback: early, want: late.Format(time.RFC3339Nano)},
+		{name: "keeps watermark on tie", watermark: late, fallback: late, want: late.Format(time.RFC3339Nano)},
+		{name: "uses fallback when watermark zero", watermark: time.Time{}, fallback: late, want: late.Format(time.RFC3339Nano)},
+		{name: "keeps watermark when fallback zero", watermark: late, fallback: time.Time{}, want: late.Format(time.RFC3339Nano)},
+		{name: "empty when both zero", watermark: time.Time{}, fallback: time.Time{}, want: ""},
+		{name: "renders as utc", watermark: time.Date(2026, 6, 15, 14, 0, 0, 0, time.FixedZone("CEST", 2*3600)), fallback: time.Time{}, want: late.Format(time.RFC3339Nano)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := WatermarkString(tc.watermark, tc.fallback); got != tc.want {
+				t.Fatalf("WatermarkString(%v, %v) = %q, want %q", tc.watermark, tc.fallback, got, tc.want)
+			}
+		})
+	}
+}

--- a/sources/aurelius/source.go
+++ b/sources/aurelius/source.go
@@ -381,18 +381,6 @@ func cursorWatermark(cursor aureliusCursor) time.Time {
 	return value.UTC()
 }
 
-func watermarkString(watermark time.Time, fallback time.Time) string {
-	if !watermark.IsZero() && !fallback.IsZero() && fallback.After(watermark) {
-		watermark = fallback
-	} else if watermark.IsZero() {
-		watermark = fallback
-	}
-	if watermark.IsZero() {
-		return ""
-	}
-	return watermark.UTC().Format(time.RFC3339Nano)
-}
-
 func discoverFamily(st settings, urnPrefix string) ([]sourcecdk.URN, error) {
 	urnRaw := urnPrefix + url.PathEscape(st.bucket+"/"+strings.TrimSuffix(st.prefix, "/"))
 	urn, err := sourcecdk.ParseURN(urnRaw)
@@ -489,12 +477,12 @@ func (s *Source) readFamily(ctx context.Context, st settings, cursor *cerebrov1.
 						LastKey:      lastKey,
 						PartialKey:   key,
 						RecordOffset: nextRecord,
-						Watermark:    watermarkString(watermark, priorWatermark),
+						Watermark:    sourcecdk.WatermarkString(watermark, priorWatermark),
 					})
 				} else {
 					lastKey = key
 					if objectIndex < len(listing.Contents)-1 || awssdk.ToBool(listing.IsTruncated) {
-						nextCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: watermarkString(watermark, priorWatermark)})
+						nextCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: sourcecdk.WatermarkString(watermark, priorWatermark)})
 					}
 				}
 				break
@@ -507,14 +495,14 @@ func (s *Source) readFamily(ctx context.Context, st settings, cursor *cerebrov1.
 	}
 	pull := sourcecdk.Pull{Events: events}
 	if nextCursor == "" && awssdk.ToBool(listing.IsTruncated) && lastKey != "" {
-		nextCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: watermarkString(watermark, priorWatermark)})
+		nextCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: sourcecdk.WatermarkString(watermark, priorWatermark)})
 	}
 	if nextCursor != "" {
 		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextCursor}
 	}
 	checkpointCursor := nextCursor
 	if checkpointCursor == "" && lastKey != "" {
-		checkpointCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: watermarkString(watermark, priorWatermark)})
+		checkpointCursor = encodeCursor(aureliusCursor{LastKey: lastKey, Watermark: sourcecdk.WatermarkString(watermark, priorWatermark)})
 	}
 	madeProgress := lastKey != "" && lastKey != startAfter
 	if checkpointCursor != "" && (!watermark.IsZero() || cursor != nil || nextCursor != "" || madeProgress) {

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -1003,26 +1003,7 @@ func firstValueString(values map[string]any, keys ...string) string {
 }
 
 func valueString(value any) string {
-	switch v := value.(type) {
-	case nil:
-		return ""
-	case string:
-		return strings.TrimSpace(v)
-	case float64:
-		return strconv.FormatFloat(v, 'f', -1, 64)
-	case bool:
-		return strconv.FormatBool(v)
-	case []any:
-		parts := make([]string, 0, len(v))
-		for _, item := range v {
-			if value := valueString(item); value != "" {
-				parts = append(parts, value)
-			}
-		}
-		return strings.Join(parts, ",")
-	default:
-		return strings.TrimSpace(fmt.Sprint(v))
-	}
+	return sourcecdk.JSONScalar{Value: value}.Flattened()
 }
 
 func configValue(cfg sourcecdk.Config, key string) string {

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -478,28 +478,12 @@ func urnsFor(settings settings, family string, records []grcRecord) ([]sourcecdk
 }
 
 func pullFromRecords(settings settings, family string, records []grcRecord, next string) (sourcecdk.Pull, error) {
-	if len(records) == 0 {
-		pull := sourcecdk.Pull{}
-		if strings.TrimSpace(next) != "" {
-			pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strings.TrimSpace(next)}
-		}
-		return pull, nil
-	}
-	events := make([]*primitives.Event, 0, len(records))
-	for _, record := range records {
-		events = append(events, eventFromRecord(settings, family, record))
-	}
-	pull := sourcecdk.Pull{
-		Events: events,
-		Checkpoint: &cerebrov1.SourceCheckpoint{
-			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: checkpointCursor(next, records[len(records)-1].ID),
+	return sourcecdk.PullFromRecords(records, next,
+		func(rec grcRecord) (*primitives.Event, error) {
+			return eventFromRecord(settings, family, rec), nil
 		},
-	}
-	if next != "" {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
-	}
-	return pull, nil
+		func(rec grcRecord) string { return strings.TrimSpace(rec.ID) },
+	)
 }
 
 func eventFromRecord(settings settings, family string, record grcRecord) *primitives.Event {
@@ -1231,13 +1215,6 @@ func timestampKeys(family string) []string {
 	default:
 		return nil
 	}
-}
-
-func checkpointCursor(next string, fallback string) string {
-	if strings.TrimSpace(next) != "" {
-		return strings.TrimSpace(next)
-	}
-	return strings.TrimSpace(fallback)
 }
 
 func fieldString(values map[string]any, path string) string {

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -1282,7 +1282,7 @@ func oktaPullFromRecordsWithCursor[T any](records []T, next string, build func(T
 		Events: events,
 		Checkpoint: &cerebrov1.SourceCheckpoint{
 			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: checkpointCursor(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
+			CursorOpaque: sourcecdk.ResolveCursorOpaque(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
 		},
 	}
 	if next != "" {
@@ -1722,19 +1722,6 @@ func parseLink(value string) (string, string) {
 		return link, strings.Trim(rawValue, "\"")
 	}
 	return link, ""
-}
-
-func checkpointCursor(next string, fallback string, occurredAt time.Time) string {
-	if strings.TrimSpace(next) != "" {
-		return strings.TrimSpace(next)
-	}
-	if strings.TrimSpace(fallback) != "" {
-		return strings.TrimSpace(fallback)
-	}
-	if occurredAt.IsZero() {
-		return ""
-	}
-	return occurredAt.UTC().Format(time.RFC3339Nano)
 }
 
 func utcTime(value *time.Time) *time.Time {

--- a/sources/panopticon/api.go
+++ b/sources/panopticon/api.go
@@ -222,7 +222,7 @@ func recordsPull(records []panopticonRecord, cursorState, next panopticonAPICurs
 		}
 	}
 	pull := sourcecdk.Pull{Events: events}
-	watermarkValue := watermarkString(watermark, parseAPIWatermark(cursorState.Watermark))
+	watermarkValue := sourcecdk.WatermarkString(watermark, parseAPIWatermark(cursorState.Watermark))
 	if next.hasMore() {
 		next.Watermark = watermarkValue
 		opaque := encodeAPICursor(next)

--- a/sources/panopticon/source.go
+++ b/sources/panopticon/source.go
@@ -261,18 +261,6 @@ func firstConfigValue(cfg sourcecdk.Config, keys ...string) string {
 	return ""
 }
 
-func watermarkString(watermark time.Time, fallback time.Time) string {
-	if !watermark.IsZero() && !fallback.IsZero() && fallback.After(watermark) {
-		watermark = fallback
-	} else if watermark.IsZero() {
-		watermark = fallback
-	}
-	if watermark.IsZero() {
-		return ""
-	}
-	return watermark.UTC().Format(time.RFC3339Nano)
-}
-
 func buildEvent(rec panopticonRecord, kind, schemaRef string) (*primitives.Event, error) {
 	if strings.TrimSpace(rec.ID) == "" {
 		return nil, errors.New("id is required")

--- a/sources/sentinelone/source.go
+++ b/sources/sentinelone/source.go
@@ -424,7 +424,7 @@ func pullFromRecords[T any](records []T, next string, build func(T) (*primitives
 		Events: events,
 		Checkpoint: &cerebrov1.SourceCheckpoint{
 			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: checkpointCursor(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
+			CursorOpaque: sourcecdk.ResolveCursorOpaque(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
 		},
 	}
 	if next != "" {
@@ -668,19 +668,6 @@ func wrapLookupError(subject string, err error) error {
 		return fmt.Errorf("%s not found", subject)
 	}
 	return fmt.Errorf("%s: %w", subject, err)
-}
-
-func checkpointCursor(next string, fallback string, occurredAt time.Time) string {
-	if strings.TrimSpace(next) != "" {
-		return strings.TrimSpace(next)
-	}
-	if strings.TrimSpace(fallback) != "" {
-		return strings.TrimSpace(fallback)
-	}
-	if occurredAt.IsZero() {
-		return ""
-	}
-	return occurredAt.UTC().Format(time.RFC3339Nano)
 }
 
 func firstNonEmpty(values ...string) string {

--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -699,28 +699,12 @@ func urnsFor(settings settings, family string, records []record) ([]sourcecdk.UR
 }
 
 func pullFromRecords(settings settings, family string, records []record, next string) (sourcecdk.Pull, error) {
-	if len(records) == 0 {
-		pull := sourcecdk.Pull{}
-		if strings.TrimSpace(next) != "" {
-			pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strings.TrimSpace(next)}
-		}
-		return pull, nil
-	}
-	events := make([]*primitives.Event, 0, len(records))
-	for _, record := range records {
-		events = append(events, eventFromRecord(settings, family, record))
-	}
-	pull := sourcecdk.Pull{
-		Events: events,
-		Checkpoint: &cerebrov1.SourceCheckpoint{
-			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: checkpointCursor(next, records[len(records)-1].ID),
+	return sourcecdk.PullFromRecords(records, next,
+		func(rec record) (*primitives.Event, error) {
+			return eventFromRecord(settings, family, rec), nil
 		},
-	}
-	if next != "" {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
-	}
-	return pull, nil
+		func(rec record) string { return strings.TrimSpace(rec.ID) },
+	)
 }
 
 func eventFromRecord(settings settings, family string, record record) *primitives.Event {
@@ -1056,13 +1040,6 @@ func addQuery(query url.Values, key string, value string) {
 	if strings.TrimSpace(value) != "" {
 		query.Set(key, strings.TrimSpace(value))
 	}
-}
-
-func checkpointCursor(next string, fallback string) string {
-	if strings.TrimSpace(next) != "" {
-		return strings.TrimSpace(next)
-	}
-	return strings.TrimSpace(fallback)
 }
 
 func stableID(parts ...string) string {

--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -1014,26 +1014,7 @@ func firstValueString(values map[string]any, keys ...string) string {
 }
 
 func valueString(value any) string {
-	switch v := value.(type) {
-	case nil:
-		return ""
-	case string:
-		return strings.TrimSpace(v)
-	case float64:
-		return strconv.FormatFloat(v, 'f', -1, 64)
-	case bool:
-		return strconv.FormatBool(v)
-	case []any:
-		parts := make([]string, 0, len(v))
-		for _, item := range v {
-			if value := valueString(item); value != "" {
-				parts = append(parts, value)
-			}
-		}
-		return strings.Join(parts, ",")
-	default:
-		return strings.TrimSpace(fmt.Sprint(v))
-	}
+	return sourcecdk.JSONScalar{Value: value}.Flattened()
 }
 
 func addQuery(query url.Values, key string, value string) {

--- a/tools/archtests/source_helper_duplication_test.go
+++ b/tools/archtests/source_helper_duplication_test.go
@@ -29,7 +29,6 @@ const duplicateFunctionMinNodes = 50
 // add new entries to silence a fresh copy-paste; instead lift the shared logic
 // into internal/sourcecdk. Remove an entry when its extraction lands.
 var allowlistedSourceDuplicates = map[string]string{
-	"cosmo.valueString|vulnview.valueString":    "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
 	"aws.parseAWSURNs|azure.parseAzureURNs":     "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",
 	"okta.oktaURNsFor|sentinelone.urnsFor":      "provider URN construction; consolidate into Source CDK URN helper (#956)",
 	"azure.New|gcp.New|googleworkspace.New":     "constructor scaffold building a concrete *Source; needs a generic CDK builder to deduplicate (#684)",

--- a/tools/archtests/source_helper_duplication_test.go
+++ b/tools/archtests/source_helper_duplication_test.go
@@ -29,12 +29,11 @@ const duplicateFunctionMinNodes = 50
 // add new entries to silence a fresh copy-paste; instead lift the shared logic
 // into internal/sourcecdk. Remove an entry when its extraction lands.
 var allowlistedSourceDuplicates = map[string]string{
-	"aurelius.watermarkString|panopticon.watermarkString": "watermark formatting; extract into Source CDK watermark helper (#956)",
-	"cosmo.valueString|vulnview.valueString":              "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
-	"aws.parseAWSURNs|azure.parseAzureURNs":               "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",
-	"okta.oktaURNsFor|sentinelone.urnsFor":                "provider URN construction; consolidate into Source CDK URN helper (#956)",
-	"azure.New|gcp.New|googleworkspace.New":               "constructor scaffold building a concrete *Source; needs a generic CDK builder to deduplicate (#684)",
-	"archetype.New|sdk.New|trustedendpoint.New":           "constructor scaffold for sample/fixture sources; structural boilerplate (#684)",
+	"cosmo.valueString|vulnview.valueString":    "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
+	"aws.parseAWSURNs|azure.parseAzureURNs":     "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",
+	"okta.oktaURNsFor|sentinelone.urnsFor":      "provider URN construction; consolidate into Source CDK URN helper (#956)",
+	"azure.New|gcp.New|googleworkspace.New":     "constructor scaffold building a concrete *Source; needs a generic CDK builder to deduplicate (#684)",
+	"archetype.New|sdk.New|trustedendpoint.New": "constructor scaffold for sample/fixture sources; structural boilerplate (#684)",
 }
 
 // TestSourcePackagesDoNotDuplicateExtractableHelpers fails when the same

--- a/tools/archtests/source_helper_duplication_test.go
+++ b/tools/archtests/source_helper_duplication_test.go
@@ -29,7 +29,6 @@ const duplicateFunctionMinNodes = 50
 // add new entries to silence a fresh copy-paste; instead lift the shared logic
 // into internal/sourcecdk. Remove an entry when its extraction lands.
 var allowlistedSourceDuplicates = map[string]string{
-	"grc.pullFromRecords|vulnview.pullFromRecords":        "record paging loop; extract into Source CDK record pull (#956)",
 	"okta.checkpointCursor|sentinelone.checkpointCursor":  "checkpoint cursor encode/decode; extract into Source CDK cursor (#956)",
 	"aurelius.watermarkString|panopticon.watermarkString": "watermark formatting; extract into Source CDK watermark helper (#956)",
 	"cosmo.valueString|vulnview.valueString":              "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",

--- a/tools/archtests/source_helper_duplication_test.go
+++ b/tools/archtests/source_helper_duplication_test.go
@@ -29,7 +29,6 @@ const duplicateFunctionMinNodes = 50
 // add new entries to silence a fresh copy-paste; instead lift the shared logic
 // into internal/sourcecdk. Remove an entry when its extraction lands.
 var allowlistedSourceDuplicates = map[string]string{
-	"okta.checkpointCursor|sentinelone.checkpointCursor":  "checkpoint cursor encode/decode; extract into Source CDK cursor (#956)",
 	"aurelius.watermarkString|panopticon.watermarkString": "watermark formatting; extract into Source CDK watermark helper (#956)",
 	"cosmo.valueString|vulnview.valueString":              "JSON scalar formatting; candidate for Source CDK JSON value helpers (#956)",
 	"aws.parseAWSURNs|azure.parseAzureURNs":               "provider URN parsing with provider-specific identifiers; consolidate cautiously (#956)",

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -22,9 +22,9 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"github":          2028,
 	"googleworkspace": 815,
 	"grc":             1321,
-	"okta":            2269,
+	"okta":            2257,
 	"panopticon":      781,
-	"sentinelone":     2089,
+	"sentinelone":     2077,
 	"vulnview":        1020,
 }
 

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -17,7 +17,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"aurelius":        612,
 	"aws":             19070,
 	"azure":           2842,
-	"cosmo":           1011,
+	"cosmo":           992,
 	"gcp":             2095,
 	"github":          2028,
 	"googleworkspace": 815,
@@ -25,7 +25,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"okta":            2257,
 	"panopticon":      770,
 	"sentinelone":     2077,
-	"vulnview":        1020,
+	"vulnview":        1001,
 }
 
 func TestSourcePackagesHaveCatalogFixturesAndTests(t *testing.T) {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -21,11 +21,11 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"gcp":             2095,
 	"github":          2028,
 	"googleworkspace": 815,
-	"grc":             1343,
+	"grc":             1321,
 	"okta":            2269,
 	"panopticon":      781,
 	"sentinelone":     2089,
-	"vulnview":        1042,
+	"vulnview":        1020,
 }
 
 func TestSourcePackagesHaveCatalogFixturesAndTests(t *testing.T) {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -14,7 +14,7 @@ const newSourcePackageLOCBudget = 300
 // sources. If a source shrinks, lower its ceiling in the same change; if a
 // source grows, move shared behavior into the Source CDK instead of raising it.
 var grandfatheredSourcePackageLOCBudgets = map[string]int{
-	"aurelius":        623,
+	"aurelius":        612,
 	"aws":             19070,
 	"azure":           2842,
 	"cosmo":           1011,
@@ -23,7 +23,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"googleworkspace": 815,
 	"grc":             1321,
 	"okta":            2257,
-	"panopticon":      781,
+	"panopticon":      770,
 	"sentinelone":     2077,
 	"vulnview":        1020,
 }


### PR DESCRIPTION
## Summary

Consolidates the remaining **Source CDK helper extractions** into a single PR targeting `main`. Each change replaces a duplicated per-source helper with a shared `internal/sourcecdk` primitive and removes the corresponding cross-source duplication allowlist entry, proving the dedup.

This supersedes the previously stacked PRs (#1346, #1348, #1349, #1350); their changes had not reached `main` because the stack was merged into intermediate branches rather than `main`. Rebased cleanly onto current `main` and squashed into four focused commits.

## Extractions

1. **PullFromRecords** (`#1346`) - `grc` and `vulnview` adopt the generic `sourcecdk.PullFromRecords[T]`; dead local `checkpointCursor` removed.
2. **ResolveCursorOpaque** (`#1348`) - `okta` and `sentinelone` adopt `sourcecdk.ResolveCursorOpaque`; identical local helpers deleted.
3. **WatermarkString** (`#1349`) - `aurelius` and `panopticon` adopt `sourcecdk.WatermarkString` (later-of-two-times, RFC3339Nano UTC).
4. **JSONScalar.Flattened** (`#1350`) - `cosmo` and `vulnview` adopt `sourcecdk.JSONScalar{Value: value}.Flattened()` for recursive JSON value formatting.

## Guardrail and budgets

- Removed 4 entries from the cross-source helper duplication allowlist (`tools/archtests/source_helper_duplication_test.go`).
- Ratcheted grandfathered LOC budgets to the new exact sizes (`tools/archtests/source_packages_test.go`) and updated the matching markers in `docs/engineering/source-cdk-extraction.md`.

## Validation

- `go build ./...`
- `go test ./tools/archtests/ ./internal/sourcecdk/... -count=1` (guardrail, LOC ratchet, extraction-plan doc, CDK unit tests)
- `make check-structural`

All green.
