### PR TITLE
fix: improve GitHub credential finding context

### DIFF
--- a/internal/findings/coordination_graph_rule.go
+++ b/internal/findings/coordination_graph_rule.go
@@ -444,6 +444,11 @@ func (r *coordinationGraphRule) EvaluateRows(_ context.Context, runtime *cerebro
 		for key, value := range r.definition.AttributeMap() {
 			attributes["rule_"+key] = value
 		}
+		for key, value := range coordinationRowStringMap(row, "finding_attributes") {
+			if _, exists := attributes[key]; !exists {
+				attributes[key] = value
+			}
+		}
 		trimEmptyAttributes(attributes)
 		findings = append(findings, &ports.FindingRecord{
 			ID:                fingerprint,
@@ -499,6 +504,34 @@ func coordinationRowStrings(row ports.CypherRow, key string) []string {
 		if text != "" && text != "<nil>" {
 			result = append(result, text)
 		}
+	}
+	return result
+}
+
+func coordinationRowStringMap(row ports.CypherRow, key string) map[string]string {
+	if row.Values == nil {
+		return nil
+	}
+	value, ok := row.Values[key]
+	if !ok || value == nil {
+		return nil
+	}
+	result := map[string]string{}
+	switch typed := value.(type) {
+	case map[string]string:
+		for key, value := range typed {
+			result[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	case map[string]any:
+		for key, value := range typed {
+			result[strings.TrimSpace(key)] = strings.TrimSpace(fmt.Sprintf("%v", value))
+		}
+	default:
+		return nil
+	}
+	trimEmptyAttributes(result)
+	if len(result) == 0 {
+		return nil
 	}
 	return result
 }

--- a/internal/findings/current_state_graph_rules_test.go
+++ b/internal/findings/current_state_graph_rules_test.go
@@ -92,14 +92,26 @@ func TestCurrentStateGraphRulesEmitStableFindings(t *testing.T) {
 			rule:    newGitHubProgrammaticCredentialReviewRule(),
 			runtime: runtime,
 			row: ports.CypherRow{Values: map[string]any{
-				"primary_urn":     "urn:cerebro:writer:github_credential:deploy_key@repo",
-				"primary_label":   "deploy_key",
+				"primary_urn":     "urn:cerebro:writer:github_credential:personal_access_token:token-1",
+				"primary_label":   "token-1",
 				"primary_type":    "github.credential",
-				"fingerprint_key": "urn:cerebro:writer:github_credential:deploy_key@repo",
-				"severity":        "MEDIUM",
-				"summary":         "GitHub programmatic access resource deploy_key needs owner/scope review",
-				"action":          "review",
-				"resource_urns":   []any{"urn:cerebro:writer:github_credential:deploy_key@repo"},
+				"fingerprint_key": "urn:cerebro:writer:github_credential:personal_access_token:token-1",
+				"severity":        "HIGH",
+				"summary":         "Active GitHub personal access token token-1 needs owner, scope, and rotation review",
+				"action":          "Validate owner, business need, org/repo boundary, scopes in evidence, last use, and rotation; revoke unused or undocumented programmatic access",
+				"resource_urns": []any{
+					"urn:cerebro:writer:github_credential:personal_access_token:token-1",
+					"urn:cerebro:writer:github_code_repository:writer/cerebro",
+				},
+				"evidence": []any{
+					map[string]any{"urn": "urn:cerebro:writer:github_credential:personal_access_token:token-1", "label": "token-1", "entity_type": "github.credential", "relation": "credential", "attributes_json": `{"credential_type":"personal_access_token","repository":"writer/cerebro","scope":"repo,workflow","status":"active"}`},
+					map[string]any{"urn": "urn:cerebro:writer:github_code_repository:writer/cerebro", "label": "writer/cerebro", "entity_type": "github.code.repository", "relation": "belongs_to", "attributes_json": `{}`},
+				},
+				"finding_attributes": map[string]any{ // #nosec G101 -- test credential fields are graph identifiers, not secret material.
+					"github_credential_urn": "urn:cerebro:writer:github_credential:personal_access_token:token-1",
+					"credential_type":       "personal_access_token",
+					"credential_status":     "active",
+				},
 			}},
 		},
 		{
@@ -188,6 +200,67 @@ func TestCurrentStateGraphRulesEmitStableFindings(t *testing.T) {
 	}
 }
 
+func TestGitHubProgrammaticCredentialReviewRuleEmitsActionableContext(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime", SourceId: "github", TenantId: "writer", Config: map[string]string{"family": "audit"}}
+	graphRule, ok := newGitHubProgrammaticCredentialReviewRule().(GraphRule)
+	if !ok {
+		t.Fatal("GitHub credential rule does not implement GraphRule")
+	}
+	row := ports.CypherRow{Values: map[string]any{
+		"primary_urn":     "urn:cerebro:writer:github_credential:integration_installation:3263165911",
+		"primary_label":   "3263165911",
+		"primary_type":    "github.credential",
+		"fingerprint_key": "urn:cerebro:writer:github_credential:integration_installation:3263165911",
+		"severity":        "MEDIUM",
+		"summary":         "Active GitHub App installation 3263165911 needs owner, scope, and rotation review",
+		"action":          "Validate owner, business need, org/repo boundary, scopes in evidence, last use, and rotation; revoke unused or undocumented programmatic access",
+		"resource_urns": []any{
+			"urn:cerebro:writer:github_credential:integration_installation:3263165911",
+			"urn:cerebro:writer:github_org:writer",
+		},
+		"evidence": []any{
+			map[string]any{"urn": "urn:cerebro:writer:github_credential:integration_installation:3263165911", "label": "3263165911", "entity_type": "github.credential", "relation": "credential", "attributes_json": `{"credential_type":"integration_installation","github_app_id":"3263165911","org":"writer","status":"active"}`},
+			map[string]any{"urn": "urn:cerebro:writer:github_org:writer", "label": "writer", "entity_type": "github.org", "relation": "belongs_to", "attributes_json": `{}`},
+		},
+		"finding_attributes": map[string]any{ // #nosec G101 -- test credential fields are graph identifiers, not secret material.
+			"github_credential_urn":   "urn:cerebro:writer:github_credential:integration_installation:3263165911",
+			"credential_type":         "integration_installation",
+			"credential_status":       "active",
+			"credential_scope_source": "org_attribute",
+		},
+	}}
+	findings, err := graphRule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("EvaluateRows returned %d findings, want 1", len(findings))
+	}
+	finding := findings[0]
+	if strings.Contains(finding.Summary, "programmatic access resource") {
+		t.Fatalf("summary kept opaque fallback wording: %q", finding.Summary)
+	}
+	for _, want := range []string{"GitHub App installation", "3263165911", "owner, scope, and rotation"} {
+		if !strings.Contains(finding.Summary, want) {
+			t.Fatalf("summary missing %q: %q", want, finding.Summary)
+		}
+	}
+	for key, want := range map[string]string{ // #nosec G101 -- expected credential fields are graph identifiers, not secret material.
+		"github_credential_urn":   "urn:cerebro:writer:github_credential:integration_installation:3263165911",
+		"credential_type":         "integration_installation",
+		"credential_status":       "active",
+		"credential_scope_source": "org_attribute",
+		"graph_evidence_count":    "2",
+	} {
+		if got := finding.Attributes[key]; got != want {
+			t.Fatalf("Attributes[%q] = %q, want %q", key, got, want)
+		}
+	}
+	if len(finding.GraphEvidenceRows) != 2 {
+		t.Fatalf("GraphEvidenceRows length = %d, want 2", len(finding.GraphEvidenceRows))
+	}
+}
+
 func TestCurrentStateGraphRuleQueriesUseEnrichedCurrentState(t *testing.T) {
 	tests := []struct {
 		name string
@@ -205,9 +278,9 @@ func TestCurrentStateGraphRuleQueriesUseEnrichedCurrentState(t *testing.T) {
 			want: []string{`entity_type: 'aws.ecs.task_definition'`, `relation: 'runs_as'`, `relation: 'depends_on'`, `relation: 'can_reach'`, `relation: 'member_of'`, `relation: 'attached_to'`, `access.relation IN ['can_admin', 'can_assume', 'can_impersonate', 'can_perform']`, `duration('P30D')`},
 		},
 		{
-			name: "github credentials exclude inactive resources",
+			name: "github credentials require active non-public-key resources with evidence",
 			rule: newGitHubProgrammaticCredentialReviewRule(),
-			want: []string{`entity_type: 'github.credential'`, `"status":"inactive"`},
+			want: []string{`entity_type: 'github.credential'`, `"status":"active"`, `AND NOT attrs CONTAINS '"credential_type":"public_key"'`, `finding_attributes`, `attributes_json: attrs`, `relation: 'belongs_to'`, `relation: 'acted_on'`},
 		},
 		{
 			name: "okta threat insight checks for blocking mode",

--- a/internal/findings/github_programmatic_credential_review_rule.go
+++ b/internal/findings/github_programmatic_credential_review_rule.go
@@ -20,10 +20,9 @@ func newGitHubProgrammaticCredentialReviewRule() Rule {
 			"https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token",
 			"https://docs.github.com/en/apps/using-github-apps/reviewing-and-revoking-authorization-of-github-apps",
 		},
-		FalsePositives:     []string{"Approved deploy keys, service accounts, or GitHub Apps with documented owner, scope, and rotation process."},
-		Runbook:            "Confirm owner, scope, last-use/need, and rotation for the credential or integration; remove unused access or document the exception.",
-		RequiredAttributes: []string{"github_credential_urn", "credential_type", "credential_status"},
-		FingerprintFields:  []string{"github_credential_urn"},
+		FalsePositives:    []string{"Approved deploy keys, service accounts, or GitHub Apps with documented owner, scope, and rotation process."},
+		Runbook:           "Confirm owner, scope, last-use/need, and rotation for the credential or integration; remove unused access or document the exception.",
+		FingerprintFields: []string{"github_credential_urn"},
 		ControlRefs: []ports.FindingControlRef{
 			{FrameworkName: "SOC 2", ControlID: "CC6.2"},
 			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.18"},

--- a/internal/findings/github_programmatic_credential_review_rule.go
+++ b/internal/findings/github_programmatic_credential_review_rule.go
@@ -20,38 +20,81 @@ func newGitHubProgrammaticCredentialReviewRule() Rule {
 			"https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token",
 			"https://docs.github.com/en/apps/using-github-apps/reviewing-and-revoking-authorization-of-github-apps",
 		},
-		FalsePositives: []string{"Approved deploy keys, service accounts, or GitHub Apps with documented owner, scope, and rotation process."},
-		Runbook:        "Confirm owner, scope, last-use/need, and rotation for the credential or integration; remove unused access or document the exception.",
-		FingerprintFields: []string{
-			"github_credential_urn",
-		},
+		FalsePositives:     []string{"Approved deploy keys, service accounts, or GitHub Apps with documented owner, scope, and rotation process."},
+		Runbook:            "Confirm owner, scope, last-use/need, and rotation for the credential or integration; remove unused access or document the exception.",
+		RequiredAttributes: []string{"github_credential_urn", "credential_type", "credential_status"},
+		FingerprintFields:  []string{"github_credential_urn"},
 		ControlRefs: []ports.FindingControlRef{
 			{FrameworkName: "SOC 2", ControlID: "CC6.2"},
 			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.18"},
 		},
 	}, map[string][]string{"github": {"audit"}}, `MATCH (resource:Entity {tenant_id: $tenant_id, entity_type: 'github.credential'})
-WHERE (
-    coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"personal_access_token"'
-    OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"org_credential_authorization"'
-    OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"integration_installation"'
-    OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"integration_installation_request"'
-    OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"oauth_application"'
-    OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"integration"'
-    OR coalesce(resource.attributes_json, '') CONTAINS '"credential_type":"public_key"'
+WITH resource, coalesce(resource.attributes_json, '') AS attrs
+WHERE attrs CONTAINS '"status":"active"'
+  AND NOT attrs CONTAINS '"credential_type":"public_key"'
+  AND (
+    attrs CONTAINS '"resource_type":"personal_access_token"'
+    OR attrs CONTAINS '"resource_type":"org_credential_authorization"'
+    OR attrs CONTAINS '"resource_type":"integration_installation"'
+    OR attrs CONTAINS '"resource_type":"integration_installation_request"'
+    OR attrs CONTAINS '"resource_type":"oauth_application"'
+    OR attrs CONTAINS '"resource_type":"integration"'
   )
-  AND NOT coalesce(resource.attributes_json, '') CONTAINS '"status":"inactive"'
+WITH resource,
+     attrs,
+     CASE
+       WHEN attrs CONTAINS '"resource_type":"personal_access_token"' THEN 'personal_access_token'
+       WHEN attrs CONTAINS '"resource_type":"org_credential_authorization"' THEN 'org_credential_authorization'
+       WHEN attrs CONTAINS '"resource_type":"integration_installation_request"' THEN 'integration_installation_request'
+       WHEN attrs CONTAINS '"resource_type":"integration_installation"' THEN 'integration_installation'
+       WHEN attrs CONTAINS '"resource_type":"oauth_application"' THEN 'oauth_application'
+       ELSE 'integration'
+     END AS credential_type,
+     CASE
+       WHEN attrs CONTAINS '"resource_type":"personal_access_token"' THEN 'personal access token'
+       WHEN attrs CONTAINS '"resource_type":"org_credential_authorization"' THEN 'organization credential authorization'
+       WHEN attrs CONTAINS '"resource_type":"integration_installation_request"' THEN 'App installation request'
+       WHEN attrs CONTAINS '"resource_type":"integration_installation"' THEN 'App installation'
+       WHEN attrs CONTAINS '"resource_type":"oauth_application"' THEN 'OAuth application'
+       ELSE 'integration'
+     END AS credential_label
+OPTIONAL MATCH (resource)-[scopeRel:RELATION {relation: 'belongs_to'}]->(scopeEntity:Entity {tenant_id: $tenant_id})
+OPTIONAL MATCH (resource)-[actedRel:RELATION {relation: 'acted_on'}]->(targetEntity:Entity {tenant_id: $tenant_id})
+WITH resource,
+     attrs,
+     credential_type,
+     credential_label,
+     collect(DISTINCT {urn: scopeEntity.urn, label: scopeEntity.label, entity_type: scopeEntity.entity_type, relation: 'belongs_to', attributes_json: coalesce(scopeRel.attributes_json, '')}) AS scope_evidence,
+     collect(DISTINCT {urn: targetEntity.urn, label: targetEntity.label, entity_type: targetEntity.entity_type, relation: 'acted_on', attributes_json: coalesce(actedRel.attributes_json, '')}) AS target_evidence
+WITH resource,
+     attrs,
+     credential_type,
+     credential_label,
+     [scope IN scope_evidence WHERE scope.urn IS NOT NULL | scope] AS scope_evidence,
+     [target IN target_evidence WHERE target.urn IS NOT NULL | target] AS target_evidence
 RETURN resource.urn AS primary_urn,
        resource.label AS primary_label,
        resource.entity_type AS primary_type,
        resource.urn AS fingerprint_key,
        CASE
-         WHEN coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"personal_access_token"' THEN 'HIGH'
+         WHEN credential_type = 'personal_access_token' THEN 'HIGH'
          ELSE 'MEDIUM'
        END AS severity,
-       'GitHub programmatic access resource ' + coalesce(resource.label, resource.urn) + ' needs owner/scope review' AS summary,
-       'Review owner, scopes, last use, and rotation; revoke unused or undocumented programmatic access' AS action,
-       [resource.urn] AS resource_urns,
-       [] AS evidence
-ORDER BY severity DESC, resource.entity_type, resource.label, resource.urn
+       'Active GitHub ' + credential_label + ' ' + coalesce(resource.label, resource.urn) + ' needs owner, scope, and rotation review' AS summary,
+       'Validate owner, business need, org/repo boundary, scopes in evidence, last use, and rotation; revoke unused or undocumented programmatic access' AS action,
+       [resource.urn] + [scope IN scope_evidence | scope.urn] + [target IN target_evidence | target.urn] AS resource_urns,
+       [{urn: resource.urn, label: resource.label, entity_type: resource.entity_type, relation: 'credential', attributes_json: attrs}] + scope_evidence + target_evidence AS evidence,
+       {
+         github_credential_urn: resource.urn,
+         credential_type: credential_type,
+         credential_status: 'active',
+         credential_scope_source: CASE
+           WHEN attrs CONTAINS '"scope":"' THEN 'scope_attribute'
+           WHEN attrs CONTAINS '"repository":"' THEN 'repository_attribute'
+           WHEN attrs CONTAINS '"org":"' THEN 'org_attribute'
+           ELSE 'graph_relationship'
+         END
+       } AS finding_attributes
+ORDER BY severity DESC, credential_type, resource.label, resource.urn
 LIMIT $row_limit`, nil)
 }

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -1413,6 +1413,11 @@
         "Approved deploy keys, service accounts, or GitHub Apps with documented owner, scope, and rotation process."
       ],
       "runbook": "Confirm owner, scope, last-use/need, and rotation for the credential or integration; remove unused access or document the exception.",
+      "required_attributes": [
+        "credential_status",
+        "credential_type",
+        "github_credential_urn"
+      ],
       "fingerprint_fields": [
         "github_credential_urn"
       ],

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -1413,11 +1413,6 @@
         "Approved deploy keys, service accounts, or GitHub Apps with documented owner, scope, and rotation process."
       ],
       "runbook": "Confirm owner, scope, last-use/need, and rotation for the credential or integration; remove unused access or document the exception.",
-      "required_attributes": [
-        "credential_status",
-        "credential_type",
-        "github_credential_urn"
-      ],
       "fingerprint_fields": [
         "github_credential_urn"
       ],


### PR DESCRIPTION
## Summary

Improves the GitHub programmatic credential review finding so it is more actionable and less noisy.

Updates the rule to require active credential evidence, exclude public-key-only credential noise, return graph evidence, and carry normalized finding attributes for credential context.

## Test Plan

- `go test ./internal/findings -count=1 -timeout 60s`
- `make lint`
- `make detection-catalog-check`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
