### PR TITLE
feat: add connector diagnostic timeline

### DIFF
--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -22,6 +22,7 @@ import (
 	"github.com/writer/cerebro/internal/connectorcatalog"
 	"github.com/writer/cerebro/internal/connectorcredentials"
 	"github.com/writer/cerebro/internal/connectordefinitions"
+	"github.com/writer/cerebro/internal/connectordiagnostics"
 	"github.com/writer/cerebro/internal/connectorpreflight"
 	"github.com/writer/cerebro/internal/connectorsecretstores"
 	"github.com/writer/cerebro/internal/ports"
@@ -151,19 +152,21 @@ type connectorLibraryResponse struct {
 }
 
 type connectorDetailResponse struct {
-	GeneratedAt string                     `json:"generated_at"`
-	TenantID    string                     `json:"tenant_id,omitempty"`
-	Connector   connectorCatalogEntry      `json:"connector"`
-	Summary     connectorOperationsSummary `json:"summary"`
-	Connections []connectorConnectionView  `json:"connections"`
-	Activity    []connectorActivityView    `json:"activity"`
+	GeneratedAt        string                       `json:"generated_at"`
+	TenantID           string                       `json:"tenant_id,omitempty"`
+	Connector          connectorCatalogEntry        `json:"connector"`
+	Summary            connectorOperationsSummary   `json:"summary"`
+	Connections        []connectorConnectionView    `json:"connections"`
+	Activity           []connectorActivityView      `json:"activity"`
+	DiagnosticTimeline []connectordiagnostics.Entry `json:"diagnostic_timeline,omitempty"`
 }
 
 type connectorActivityResponse struct {
-	GeneratedAt string                  `json:"generated_at"`
-	TenantID    string                  `json:"tenant_id,omitempty"`
-	SourceID    string                  `json:"source_id"`
-	Activity    []connectorActivityView `json:"activity"`
+	GeneratedAt        string                       `json:"generated_at"`
+	TenantID           string                       `json:"tenant_id,omitempty"`
+	SourceID           string                       `json:"source_id"`
+	Activity           []connectorActivityView      `json:"activity"`
+	DiagnosticTimeline []connectordiagnostics.Entry `json:"diagnostic_timeline,omitempty"`
 }
 
 type connectorOperationsSummary struct {
@@ -404,6 +407,7 @@ type connectorPreflightResponse struct {
 	Checks             []connectorPreflightCheckView   `json:"checks"`
 	ScopePreview       connectorScopePreviewView       `json:"scope_preview"`
 	CredentialBoundary connectorCredentialBoundaryView `json:"credential_boundary"`
+	DiagnosticTimeline []connectordiagnostics.Entry    `json:"diagnostic_timeline,omitempty"`
 }
 
 type connectorPreflightCheckView struct {
@@ -653,13 +657,15 @@ func (a *App) handleGetConnector(w http.ResponseWriter, r *http.Request) {
 	}
 	connections := connectorConnectionsFromHealth(health.Runtimes)
 	activity := connectorActivityFromHealth(health.Runtimes)
+	timeline := connectordiagnostics.FromHealth(health.Runtimes)
 	writeJSON(w, http.StatusOK, connectorDetailResponse{
-		GeneratedAt: health.GeneratedAt,
-		TenantID:    tenantID,
-		Connector:   entry,
-		Summary:     connectorOperationsSummaryFromHealth(entry, health.Runtimes),
-		Connections: connections,
-		Activity:    activity,
+		GeneratedAt:        health.GeneratedAt,
+		TenantID:           tenantID,
+		Connector:          entry,
+		Summary:            connectorOperationsSummaryFromHealth(entry, health.Runtimes),
+		Connections:        connections,
+		Activity:           activity,
+		DiagnosticTimeline: timeline,
 	})
 }
 
@@ -695,11 +701,13 @@ func (a *App) handleListConnectorActivity(w http.ResponseWriter, r *http.Request
 		}
 	}
 	activity := connectorActivityFromHealth(health.Runtimes)
+	timeline := connectordiagnostics.FromHealth(health.Runtimes)
 	writeJSON(w, http.StatusOK, connectorActivityResponse{
-		GeneratedAt: health.GeneratedAt,
-		TenantID:    tenantID,
-		SourceID:    entry.SourceID,
-		Activity:    limitConnectorActivity(activity, activityLimit),
+		GeneratedAt:        health.GeneratedAt,
+		TenantID:           tenantID,
+		SourceID:           entry.SourceID,
+		Activity:           limitConnectorActivity(activity, activityLimit),
+		DiagnosticTimeline: connectordiagnostics.Limit(timeline, activityLimit),
 	})
 }
 
@@ -2212,6 +2220,30 @@ func (r *connectorPreflightResponse) finalizePreflight() {
 		r.Summary = "Preflight passed. This connection is ready to save."
 		r.NextAction = "save_connection"
 	}
+	r.DiagnosticTimeline = connectordiagnostics.FromPreflight(connectordiagnostics.Preflight{
+		GeneratedAt: r.GeneratedAt,
+		SourceID:    r.SourceID,
+		RuntimeID:   r.RuntimeID,
+		TenantID:    r.TenantID,
+		Status:      r.Status,
+		Summary:     r.Summary,
+		NextAction:  r.NextAction,
+		Checks:      connectorPreflightDiagnosticChecks(r.Checks),
+	})
+}
+
+func connectorPreflightDiagnosticChecks(checks []connectorPreflightCheckView) []connectordiagnostics.PreflightCheck {
+	diagnostics := make([]connectordiagnostics.PreflightCheck, 0, len(checks))
+	for _, check := range checks {
+		diagnostics = append(diagnostics, connectordiagnostics.PreflightCheck{
+			ID:         check.ID,
+			Label:      check.Label,
+			Status:     check.Status,
+			Detail:     check.Detail,
+			NextAction: check.NextAction,
+		})
+	}
+	return diagnostics
 }
 
 func (a *App) connectorPreflightStore(storeID string) (connectorStoreView, bool) {

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -707,7 +707,7 @@ func (a *App) handleListConnectorActivity(w http.ResponseWriter, r *http.Request
 		TenantID:           tenantID,
 		SourceID:           entry.SourceID,
 		Activity:           limitConnectorActivity(activity, activityLimit),
-		DiagnosticTimeline: connectordiagnostics.Limit(timeline, activityLimit),
+		DiagnosticTimeline: timeline,
 	})
 }
 

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -2280,6 +2280,9 @@ func TestConnectorActivityLimitTruncatesActivityRows(t *testing.T) {
 			Type      string `json:"type"`
 			RuntimeID string `json:"runtime_id"`
 		} `json:"activity"`
+		DiagnosticTimeline []struct {
+			Stage string `json:"stage"`
+		} `json:"diagnostic_timeline"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode response: %v", err)
@@ -2289,6 +2292,18 @@ func TestConnectorActivityLimitTruncatesActivityRows(t *testing.T) {
 	}
 	if got := payload.Activity[0].RuntimeID; got != "runtime-a" {
 		t.Fatalf("activity[0].runtime_id = %q, want runtime-a", got)
+	}
+	if len(payload.DiagnosticTimeline) <= len(payload.Activity) {
+		t.Fatalf("diagnostic timeline length = %d, want more than limited activity rows", len(payload.DiagnosticTimeline))
+	}
+	hasGraphStage := false
+	for _, entry := range payload.DiagnosticTimeline {
+		if entry.Stage == "graph_projection" {
+			hasGraphStage = true
+		}
+	}
+	if !hasGraphStage {
+		t.Fatalf("diagnostic timeline missing graph_projection stage: %#v", payload.DiagnosticTimeline)
 	}
 	if got := store.sourceRuntimeListFilter.Limit; got != connectorActivityMaxLimit {
 		t.Fatalf("runtime list limit = %d, want connector fetch limit %d", got, connectorActivityMaxLimit)
@@ -2336,7 +2351,7 @@ func TestConnectorActivityIncludesDiagnosticTimeline(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	resp, err := server.Client().Get(server.URL + "/connectors/bootstrap_token/activity?tenant_id=tenant-a")
+	resp, err := server.Client().Get(server.URL + "/connectors/bootstrap_token/activity?tenant_id=tenant-a&limit=2")
 	if err != nil {
 		t.Fatalf("GET /connectors/{sourceID}/activity error = %v", err)
 	}

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -2298,6 +2298,153 @@ func TestConnectorActivityLimitTruncatesActivityRows(t *testing.T) {
 	}
 }
 
+func TestConnectorActivityIncludesDiagnosticTimeline(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	now := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-a": {
+			Id:           "runtime-a",
+			SourceId:     "bootstrap_token",
+			TenantId:     "tenant-a",
+			LastSyncedAt: timestamppb.New(now.Add(-time.Hour)),
+			Config: map[string]string{
+				"family":                           "audit",
+				runtimeContractProbeStateConfigKey: "passing",
+				runtimeRecordsAcceptedConfigKey:    "10",
+			},
+		},
+	}}}
+	graph := &stubGraphStore{ingestRuns: map[string]graphstore.IngestRun{
+		"graph-a": {
+			ID:                "graph-a",
+			RuntimeID:         "runtime-a",
+			Status:            "completed",
+			StartedAt:         now.Add(-30 * time.Minute).Format(time.RFC3339Nano),
+			FinishedAt:        now.Add(-25 * time.Minute).Format(time.RFC3339Nano),
+			EntitiesProjected: 12,
+			LinksProjected:    7,
+		},
+	}}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: store, GraphStore: graph}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors/bootstrap_token/activity?tenant_id=tenant-a")
+	if err != nil {
+		t.Fatalf("GET /connectors/{sourceID}/activity error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /connectors/{sourceID}/activity status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		DiagnosticTimeline []struct {
+			Stage             string `json:"stage"`
+			StageOrder        int    `json:"stage_order"`
+			Status            string `json:"status"`
+			CorrelationID     string `json:"correlation_id"`
+			EntitiesProjected int64  `json:"entities_projected"`
+		} `json:"diagnostic_timeline"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.DiagnosticTimeline) < 4 {
+		t.Fatalf("diagnostic timeline length = %d, want at least 4: %#v", len(payload.DiagnosticTimeline), payload.DiagnosticTimeline)
+	}
+	stages := map[string]struct {
+		status            string
+		correlationID     string
+		entitiesProjected int64
+	}{}
+	for _, entry := range payload.DiagnosticTimeline {
+		stages[entry.Stage] = struct {
+			status            string
+			correlationID     string
+			entitiesProjected int64
+		}{status: entry.Status, correlationID: entry.CorrelationID, entitiesProjected: entry.EntitiesProjected}
+	}
+	for _, stage := range []string{"setup", "source_sync", "contract_probe", "graph_projection"} {
+		if _, ok := stages[stage]; !ok {
+			t.Fatalf("diagnostic timeline missing stage %q: %#v", stage, payload.DiagnosticTimeline)
+		}
+	}
+	if got := stages["graph_projection"].correlationID; got != "graph-a" {
+		t.Fatalf("graph correlation_id = %q, want graph-a", got)
+	}
+	if got := stages["graph_projection"].entitiesProjected; got != 12 {
+		t.Fatalf("graph entities_projected = %d, want 12", got)
+	}
+	if got := stages["contract_probe"].status; got != "success" {
+		t.Fatalf("contract probe status = %q, want success", got)
+	}
+}
+
+func TestConnectorPreflightIncludesDiagnosticTimeline(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/preflight", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("POST /connectors/{sourceID}/preflight error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /connectors/{sourceID}/preflight status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		Status             string `json:"status"`
+		DiagnosticTimeline []struct {
+			Stage        string `json:"stage"`
+			Status       string `json:"status"`
+			FailureClass string `json:"failure_class"`
+			NextAction   string `json:"next_action"`
+		} `json:"diagnostic_timeline"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Status != "blocked" {
+		t.Fatalf("preflight status = %q, want blocked", payload.Status)
+	}
+	if len(payload.DiagnosticTimeline) < 2 {
+		t.Fatalf("diagnostic timeline length = %d, want at least 2: %#v", len(payload.DiagnosticTimeline), payload.DiagnosticTimeline)
+	}
+	if got := payload.DiagnosticTimeline[0].Stage; got != "preflight" {
+		t.Fatalf("timeline[0].stage = %q, want preflight", got)
+	}
+	if got := payload.DiagnosticTimeline[0].FailureClass; got != "preflight_blocked" {
+		t.Fatalf("timeline[0].failure_class = %q, want preflight_blocked", got)
+	}
+	if got := payload.DiagnosticTimeline[0].NextAction; got != "fix_blocking_checks" {
+		t.Fatalf("timeline[0].next_action = %q, want fix_blocking_checks", got)
+	}
+}
+
 func TestConnectorConnectionStoresEnvironmentManagedReference(t *testing.T) {
 	source := &bootstrapTokenSource{id: "bootstrap_token"}
 	registry, err := sourcecdk.NewRegistry(source)

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -17,6 +17,7 @@ import (
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourcehealth"
+	"github.com/writer/cerebro/internal/sourcehealthview"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -120,76 +121,10 @@ type sourceRuntimeHealthSummary struct {
 	ContractProbeNotConfigured int    `json:"contract_probe_not_configured"`
 }
 
-type sourceRuntimeHealthRecord struct {
-	RuntimeID                 string                                `json:"runtime_id"`
-	SourceID                  string                                `json:"source_id"`
-	TenantID                  string                                `json:"tenant_id"`
-	Family                    string                                `json:"family,omitempty"`
-	ScopePolicy               *resourcescope.Policy                 `json:"scope_policy,omitempty"`
-	EnabledState              string                                `json:"enabled_state"`
-	Status                    string                                `json:"status"`
-	LastSyncedAt              string                                `json:"last_synced_at,omitempty"`
-	SyncLagSeconds            *int64                                `json:"sync_lag_seconds,omitempty"`
-	CheckpointWatermark       string                                `json:"checkpoint_watermark,omitempty"`
-	WatermarkLagSeconds       *int64                                `json:"watermark_lag_seconds,omitempty"`
-	RecentSync                sourceRuntimeHealthSync               `json:"recent_sync"`
-	LastFailureCategory       string                                `json:"last_failure_category,omitempty"`
-	ContractProbeState        string                                `json:"contract_probe_state"`
-	CursorPending             bool                                  `json:"cursor_pending"`
-	CheckpointCursorPresent   bool                                  `json:"checkpoint_cursor_present"`
-	LatestGraphRun            *sourceRuntimeHealthGraphRun          `json:"latest_graph_run,omitempty"`
-	GraphLagSeconds           *int64                                `json:"graph_lag_seconds,omitempty"`
-	LatestFindingEvaluation   *sourceRuntimeHealthFindingEvaluation `json:"latest_finding_evaluation,omitempty"`
-	ExpectedCadenceSeconds    *int64                                `json:"expected_cadence_seconds,omitempty"`
-	StaleAfterSeconds         *int64                                `json:"stale_after_seconds,omitempty"`
-	ScheduleContextConfigured bool                                  `json:"schedule_context_configured"`
-	GeneratedAt               string                                `json:"generated_at"`
-}
-
-type sourceRuntimeHealthSync struct {
-	RecordsScanned    uint32 `json:"records_scanned"`
-	RecordsAccepted   uint32 `json:"records_accepted"`
-	RecordsRejected   uint32 `json:"records_rejected"`
-	EntitiesProjected uint32 `json:"entities_projected"`
-	LinksProjected    uint32 `json:"links_projected"`
-}
-
-type sourceRuntimeHealthGraphRun struct {
-	ID                string `json:"id"`
-	Status            string `json:"status"`
-	StartedAt         string `json:"started_at,omitempty"`
-	FinishedAt        string `json:"finished_at,omitempty"`
-	Error             string `json:"error,omitempty"`
-	PagesRead         int64  `json:"pages_read"`
-	EventsRead        int64  `json:"events_read"`
-	EntitiesProjected int64  `json:"entities_projected"`
-	LinksProjected    int64  `json:"links_projected"`
-	GraphNodesBefore  int64  `json:"graph_nodes_before"`
-	GraphLinksBefore  int64  `json:"graph_links_before"`
-	GraphNodesAfter   int64  `json:"graph_nodes_after"`
-	GraphLinksAfter   int64  `json:"graph_links_after"`
-	GraphNodeDelta    int64  `json:"graph_node_delta"`
-	GraphLinkDelta    int64  `json:"graph_link_delta"`
-	DurationSeconds   *int64 `json:"duration_seconds,omitempty"`
-}
-
-type sourceRuntimeHealthFindingEvaluation struct {
-	ID               string `json:"id"`
-	RuntimeID        string `json:"runtime_id"`
-	RuleID           string `json:"rule_id,omitempty"`
-	Status           string `json:"status"`
-	StartedAt        string `json:"started_at,omitempty"`
-	FinishedAt       string `json:"finished_at,omitempty"`
-	Error            string `json:"error,omitempty"`
-	EventsEvaluated  uint32 `json:"events_evaluated"`
-	EventsProcessed  uint32 `json:"events_processed"`
-	EventsMatched    uint32 `json:"events_matched"`
-	FindingsUpserted uint32 `json:"findings_upserted"`
-	FindingsEmitted  uint32 `json:"findings_emitted"`
-	GraphRule        *bool  `json:"graph_rule,omitempty"`
-	GraphRowsRead    uint32 `json:"graph_rows_read,omitempty"`
-	DurationSeconds  *int64 `json:"duration_seconds,omitempty"`
-}
+type sourceRuntimeHealthRecord = sourcehealthview.Record
+type sourceRuntimeHealthSync = sourcehealthview.Sync
+type sourceRuntimeHealthGraphRun = sourcehealthview.GraphRun
+type sourceRuntimeHealthFindingEvaluation = sourcehealthview.FindingEvaluation
 
 const (
 	runtimeStatusConfigKey                = "__cerebro_runtime_status"

--- a/internal/connectordiagnostics/timeline.go
+++ b/internal/connectordiagnostics/timeline.go
@@ -1,0 +1,530 @@
+package connectordiagnostics
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/sourcehealthview"
+)
+
+type Entry struct {
+	ID                string `json:"id"`
+	RuntimeID         string `json:"runtime_id,omitempty"`
+	SourceID          string `json:"source_id"`
+	TenantID          string `json:"tenant_id,omitempty"`
+	Family            string `json:"family,omitempty"`
+	Stage             string `json:"stage"`
+	StageOrder        int    `json:"stage_order"`
+	Status            string `json:"status"`
+	Title             string `json:"title"`
+	Description       string `json:"description,omitempty"`
+	OccurredAt        string `json:"occurred_at,omitempty"`
+	DurationSeconds   *int64 `json:"duration_seconds,omitempty"`
+	RecordsAccepted   uint32 `json:"records_accepted,omitempty"`
+	RecordsRejected   uint32 `json:"records_rejected,omitempty"`
+	EntitiesProjected int64  `json:"entities_projected,omitempty"`
+	LinksProjected    int64  `json:"links_projected,omitempty"`
+	FindingsEvaluated uint32 `json:"findings_evaluated,omitempty"`
+	FindingsOpened    uint32 `json:"findings_opened,omitempty"`
+	FailureClass      string `json:"failure_class,omitempty"`
+	CorrelationID     string `json:"correlation_id,omitempty"`
+	NextAction        string `json:"next_action,omitempty"`
+}
+
+type Preflight struct {
+	GeneratedAt string
+	SourceID    string
+	RuntimeID   string
+	TenantID    string
+	Status      string
+	Summary     string
+	NextAction  string
+	Checks      []PreflightCheck
+}
+
+type PreflightCheck struct {
+	ID         string
+	Label      string
+	Status     string
+	Detail     string
+	NextAction string
+}
+
+func FromPreflight(response Preflight) []Entry {
+	timeline := make([]Entry, 0, len(response.Checks)+1)
+	timeline = append(timeline, Entry{
+		ID:            timelineID(response.RuntimeID, "preflight", response.GeneratedAt),
+		RuntimeID:     response.RuntimeID,
+		SourceID:      response.SourceID,
+		TenantID:      response.TenantID,
+		Stage:         "preflight",
+		StageOrder:    20,
+		Status:        preflightTimelineStatus(response.Status),
+		Title:         "Setup preflight",
+		Description:   response.Summary,
+		OccurredAt:    response.GeneratedAt,
+		FailureClass:  preflightFailureClass(response.Status),
+		CorrelationID: response.RuntimeID,
+		NextAction:    response.NextAction,
+	})
+	for index, check := range response.Checks {
+		timeline = append(timeline, Entry{
+			ID:            timelineID(response.RuntimeID, "preflight_"+check.ID, response.GeneratedAt),
+			RuntimeID:     response.RuntimeID,
+			SourceID:      response.SourceID,
+			TenantID:      response.TenantID,
+			Stage:         "preflight_check",
+			StageOrder:    21 + index,
+			Status:        preflightTimelineStatus(check.Status),
+			Title:         check.Label,
+			Description:   check.Detail,
+			OccurredAt:    response.GeneratedAt,
+			FailureClass:  preflightFailureClass(check.Status),
+			CorrelationID: response.RuntimeID,
+			NextAction:    check.NextAction,
+		})
+	}
+	return timeline
+}
+
+func FromHealth(records []sourcehealthview.Record) []Entry {
+	timeline := make([]Entry, 0, len(records)*5)
+	for _, record := range records {
+		readiness := connectionReadiness(record)
+		timeline = append(timeline, Entry{
+			ID:          timelineID(record.RuntimeID, "setup", ""),
+			RuntimeID:   record.RuntimeID,
+			SourceID:    record.SourceID,
+			TenantID:    record.TenantID,
+			Family:      record.Family,
+			Stage:       "setup",
+			StageOrder:  10,
+			Status:      "success",
+			Title:       "Connection configured",
+			Description: "Runtime configuration exists for this connector.",
+			NextAction:  connectionNextAction(readiness, record),
+		})
+		syncStatus := syncActivityStatus(record)
+		timeline = append(timeline, Entry{
+			ID:              timelineID(record.RuntimeID, "source_sync", recordLastActivity(record)),
+			RuntimeID:       record.RuntimeID,
+			SourceID:        record.SourceID,
+			TenantID:        record.TenantID,
+			Family:          record.Family,
+			Stage:           "source_sync",
+			StageOrder:      30,
+			Status:          syncStatus,
+			Title:           syncActivityTitle(syncStatus),
+			Description:     syncActivityDescription(record),
+			OccurredAt:      recordLastActivity(record),
+			RecordsAccepted: record.RecentSync.RecordsAccepted,
+			RecordsRejected: record.RecentSync.RecordsRejected,
+			FailureClass:    failureClass(record),
+			CorrelationID:   record.RuntimeID,
+			NextAction:      connectionNextAction(readiness, record),
+		})
+		appendContractProbe(&timeline, record)
+		appendGraphProjection(&timeline, record)
+		appendFindingEvaluation(&timeline, record)
+	}
+	sort.SliceStable(timeline, func(i, j int) bool {
+		if timeline[i].RuntimeID != timeline[j].RuntimeID {
+			return timeline[i].RuntimeID < timeline[j].RuntimeID
+		}
+		if timeline[i].StageOrder != timeline[j].StageOrder {
+			return timeline[i].StageOrder < timeline[j].StageOrder
+		}
+		return timeline[i].ID < timeline[j].ID
+	})
+	return timeline
+}
+
+func Limit(timeline []Entry, limit int) []Entry {
+	if limit <= 0 || len(timeline) <= limit {
+		return timeline
+	}
+	return timeline[:limit]
+}
+
+func appendContractProbe(timeline *[]Entry, record sourcehealthview.Record) {
+	if strings.TrimSpace(record.ContractProbeState) == "" {
+		return
+	}
+	probeStatus := contractProbeTimelineStatus(record.ContractProbeState)
+	*timeline = append(*timeline, Entry{
+		ID:            timelineID(record.RuntimeID, "contract_probe", record.LastSyncedAt),
+		RuntimeID:     record.RuntimeID,
+		SourceID:      record.SourceID,
+		TenantID:      record.TenantID,
+		Family:        record.Family,
+		Stage:         "contract_probe",
+		StageOrder:    35,
+		Status:        probeStatus,
+		Title:         contractProbeTimelineTitle(probeStatus),
+		Description:   "Runtime event contract probe signal for this connection.",
+		OccurredAt:    record.LastSyncedAt,
+		FailureClass:  contractProbeFailureClass(probeStatus),
+		CorrelationID: record.RuntimeID,
+	})
+}
+
+func appendGraphProjection(timeline *[]Entry, record sourcehealthview.Record) {
+	if record.LatestGraphRun == nil {
+		return
+	}
+	graphStatus := graphActivityStatus(record.LatestGraphRun.Status)
+	*timeline = append(*timeline, Entry{
+		ID:                timelineID(record.RuntimeID, "graph_projection", graphActivityTime(record.LatestGraphRun)),
+		RuntimeID:         record.RuntimeID,
+		SourceID:          record.SourceID,
+		TenantID:          record.TenantID,
+		Family:            record.Family,
+		Stage:             "graph_projection",
+		StageOrder:        40,
+		Status:            graphStatus,
+		Title:             graphActivityTitle(graphStatus),
+		Description:       "Graph projection activity for this connection.",
+		OccurredAt:        graphActivityTime(record.LatestGraphRun),
+		DurationSeconds:   record.LatestGraphRun.DurationSeconds,
+		EntitiesProjected: record.LatestGraphRun.EntitiesProjected,
+		LinksProjected:    record.LatestGraphRun.LinksProjected,
+		FailureClass:      graphFailureClass(record.LatestGraphRun.Status),
+		CorrelationID:     record.LatestGraphRun.ID,
+		NextAction:        graphTimelineNextAction(graphStatus),
+	})
+}
+
+func appendFindingEvaluation(timeline *[]Entry, record sourcehealthview.Record) {
+	if record.LatestFindingEvaluation == nil {
+		return
+	}
+	evaluation := record.LatestFindingEvaluation
+	evaluationStatus := findingEvaluationTimelineStatus(evaluation.Status)
+	*timeline = append(*timeline, Entry{
+		ID:                timelineID(record.RuntimeID, "finding_evaluation", findingEvaluationTimelineTime(evaluation)),
+		RuntimeID:         record.RuntimeID,
+		SourceID:          record.SourceID,
+		TenantID:          record.TenantID,
+		Family:            record.Family,
+		Stage:             "finding_evaluation",
+		StageOrder:        50,
+		Status:            evaluationStatus,
+		Title:             findingEvaluationTimelineTitle(evaluationStatus),
+		Description:       "Finding evaluation activity for this connection.",
+		OccurredAt:        findingEvaluationTimelineTime(evaluation),
+		DurationSeconds:   evaluation.DurationSeconds,
+		FindingsEvaluated: evaluation.EventsEvaluated + evaluation.GraphRowsRead,
+		FindingsOpened:    evaluation.FindingsUpserted,
+		FailureClass:      findingEvaluationFailureClass(evaluationStatus),
+		CorrelationID:     evaluation.ID,
+		NextAction:        findingEvaluationNextAction(evaluationStatus),
+	})
+}
+
+func connectionReadiness(record sourcehealthview.Record) string {
+	if strings.EqualFold(record.Status, "failing") || sourceRuntimeGraphState(record) == "failed" || strings.EqualFold(record.ContractProbeState, "failure") {
+		return "bad"
+	}
+	if strings.EqualFold(record.Status, "stale") || record.CursorPending || sourceRuntimeGraphState(record) == "behind" || sourceRuntimeGraphState(record) == "not_observed" {
+		return "needs_refresh"
+	}
+	if strings.EqualFold(record.Status, "healthy") && sourceRuntimeGraphState(record) == "current" {
+		return "healthy"
+	}
+	return "poor"
+}
+
+func connectionNextAction(status string, record sourcehealthview.Record) string {
+	switch status {
+	case "bad":
+		return "fix_connection"
+	case "needs_refresh":
+		if sourceRuntimeGraphState(record) == "not_observed" || sourceRuntimeGraphState(record) == "behind" {
+			return "run_graph_ingest"
+		}
+		return "run_sync"
+	case "healthy":
+		return "monitor"
+	default:
+		return "inspect_connection"
+	}
+}
+
+func recordLastActivity(record sourcehealthview.Record) string {
+	if observedAt, ok := recordLastActivityTime(record); ok {
+		return observedAt.UTC().Format(time.RFC3339Nano)
+	}
+	return ""
+}
+
+func recordLastActivityTime(record sourcehealthview.Record) (time.Time, bool) {
+	var latest time.Time
+	for _, value := range []string{record.LastSyncedAt, record.CheckpointWatermark, graphActivityTime(record.LatestGraphRun)} {
+		parsed, ok := parseRFC3339(value)
+		if !ok {
+			continue
+		}
+		if parsed.After(latest) {
+			latest = parsed
+		}
+	}
+	if latest.IsZero() {
+		return time.Time{}, false
+	}
+	return latest, true
+}
+
+func syncActivityStatus(record sourcehealthview.Record) string {
+	switch connectionReadiness(record) {
+	case "healthy":
+		return "success"
+	case "bad":
+		return "failed"
+	case "needs_refresh":
+		return "needs_refresh"
+	default:
+		return "incomplete"
+	}
+}
+
+func syncActivityTitle(status string) string {
+	switch status {
+	case "success":
+		return "Successful sync"
+	case "failed":
+		return "Sync needs attention"
+	case "needs_refresh":
+		return "Sync refresh needed"
+	default:
+		return "Sync signal incomplete"
+	}
+}
+
+func syncActivityDescription(record sourcehealthview.Record) string {
+	switch syncActivityStatus(record) {
+	case "success":
+		return "Runtime sync completed with current source telemetry."
+	case "failed":
+		return "Runtime sync or validation is failing."
+	case "needs_refresh":
+		return "Runtime sync, cursor, or graph projection is behind."
+	default:
+		return "Runtime telemetry has not produced enough signal yet."
+	}
+}
+
+func graphActivityStatus(status string) string {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	if strings.Contains(normalized, "fail") || strings.Contains(normalized, "error") || strings.Contains(normalized, "cancel") {
+		return "failed"
+	}
+	if strings.Contains(normalized, "running") || strings.Contains(normalized, "pending") {
+		return "running"
+	}
+	if normalized == "" {
+		return "not_observed"
+	}
+	return "success"
+}
+
+func graphActivityTitle(status string) string {
+	switch status {
+	case "success":
+		return "Graph projection complete"
+	case "failed":
+		return "Graph projection failed"
+	case "running":
+		return "Graph projection running"
+	default:
+		return "Graph projection not observed"
+	}
+}
+
+func graphActivityTime(run *sourcehealthview.GraphRun) string {
+	if run == nil {
+		return ""
+	}
+	if strings.TrimSpace(run.FinishedAt) != "" {
+		return strings.TrimSpace(run.FinishedAt)
+	}
+	return strings.TrimSpace(run.StartedAt)
+}
+
+func failureClass(record sourcehealthview.Record) string {
+	if value := strings.TrimSpace(record.LastFailureCategory); value != "" {
+		return value
+	}
+	if strings.EqualFold(record.ContractProbeState, "failure") {
+		return "contract_probe_failure"
+	}
+	if connectionReadiness(record) == "needs_refresh" {
+		return "freshness"
+	}
+	return ""
+}
+
+func graphFailureClass(status string) string {
+	if graphActivityStatus(status) == "failed" {
+		return "graph_ingest_failed"
+	}
+	return ""
+}
+
+func sourceRuntimeGraphState(record sourcehealthview.Record) string {
+	if record.LatestGraphRun == nil {
+		if record.RecentSync.EntitiesProjected > 0 || record.RecentSync.LinksProjected > 0 {
+			return "current"
+		}
+		return "not_observed"
+	}
+	status := graphActivityStatus(record.LatestGraphRun.Status)
+	if status == "failed" || status == "running" {
+		return status
+	}
+	if record.GraphLagSeconds != nil && *record.GraphLagSeconds > 0 {
+		return "behind"
+	}
+	return "current"
+}
+
+func preflightTimelineStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "ready", "passed", "success":
+		return "success"
+	case "warning":
+		return "warning"
+	case "blocked", "failed", "error":
+		return "failed"
+	default:
+		return "incomplete"
+	}
+}
+
+func preflightFailureClass(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "blocked", "failed", "error":
+		return "preflight_blocked"
+	default:
+		return ""
+	}
+}
+
+func contractProbeTimelineStatus(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "passing", "passed", "success":
+		return "success"
+	case "failure", "failed":
+		return "failed"
+	case "not_configured":
+		return "not_configured"
+	default:
+		return "incomplete"
+	}
+}
+
+func contractProbeTimelineTitle(status string) string {
+	switch status {
+	case "success":
+		return "Contract probe passed"
+	case "failed":
+		return "Contract probe failed"
+	case "not_configured":
+		return "Contract probe not configured"
+	default:
+		return "Contract probe incomplete"
+	}
+}
+
+func contractProbeFailureClass(status string) string {
+	if status == "failed" {
+		return "contract_probe_failure"
+	}
+	return ""
+}
+
+func graphTimelineNextAction(status string) string {
+	switch status {
+	case "failed":
+		return "inspect_graph_ingest"
+	case "running":
+		return "wait_for_graph_ingest"
+	case "success":
+		return "monitor"
+	default:
+		return "run_graph_ingest"
+	}
+}
+
+func findingEvaluationTimelineStatus(status string) string {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	if strings.Contains(normalized, "fail") || strings.Contains(normalized, "error") || strings.Contains(normalized, "cancel") {
+		return "failed"
+	}
+	if strings.Contains(normalized, "running") || strings.Contains(normalized, "pending") {
+		return "running"
+	}
+	if normalized == "" {
+		return "not_observed"
+	}
+	return "success"
+}
+
+func findingEvaluationTimelineTitle(status string) string {
+	switch status {
+	case "success":
+		return "Finding evaluation complete"
+	case "failed":
+		return "Finding evaluation failed"
+	case "running":
+		return "Finding evaluation running"
+	default:
+		return "Finding evaluation not observed"
+	}
+}
+
+func findingEvaluationTimelineTime(evaluation *sourcehealthview.FindingEvaluation) string {
+	if evaluation == nil {
+		return ""
+	}
+	if strings.TrimSpace(evaluation.FinishedAt) != "" {
+		return strings.TrimSpace(evaluation.FinishedAt)
+	}
+	return strings.TrimSpace(evaluation.StartedAt)
+}
+
+func findingEvaluationFailureClass(status string) string {
+	if status == "failed" {
+		return "finding_evaluation_failed"
+	}
+	return ""
+}
+
+func findingEvaluationNextAction(status string) string {
+	switch status {
+	case "failed":
+		return "inspect_finding_evaluation"
+	case "running":
+		return "wait_for_finding_evaluation"
+	case "success":
+		return "monitor"
+	default:
+		return "run_finding_evaluation"
+	}
+}
+
+func timelineID(runtimeID string, stage string, occurredAt string) string {
+	parts := []string{strings.TrimSpace(runtimeID), strings.TrimSpace(stage), strings.TrimSpace(occurredAt)}
+	return strings.Trim(strings.Join(parts, ":"), ":")
+}
+
+func parseRFC3339(value string) (time.Time, bool) {
+	if strings.TrimSpace(value) == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}

--- a/internal/connectordiagnostics/timeline_test.go
+++ b/internal/connectordiagnostics/timeline_test.go
@@ -1,0 +1,92 @@
+package connectordiagnostics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/sourcehealthview"
+)
+
+func TestFromHealthBuildsOrderedRuntimeTimeline(t *testing.T) {
+	now := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	duration := int64(12)
+	timeline := FromHealth([]sourcehealthview.Record{{
+		RuntimeID:          "runtime-a",
+		SourceID:           "github",
+		TenantID:           "tenant-a",
+		Status:             "healthy",
+		LastSyncedAt:       now.Format(time.RFC3339Nano),
+		ContractProbeState: "passing",
+		RecentSync:         sourcehealthview.Sync{RecordsAccepted: 4},
+		LatestGraphRun: &sourcehealthview.GraphRun{
+			ID:                "graph-a",
+			Status:            "completed",
+			StartedAt:         now.Add(-time.Minute).Format(time.RFC3339Nano),
+			FinishedAt:        now.Format(time.RFC3339Nano),
+			EntitiesProjected: 7,
+			LinksProjected:    3,
+			DurationSeconds:   &duration,
+		},
+		LatestFindingEvaluation: &sourcehealthview.FindingEvaluation{
+			ID:               "eval-a",
+			Status:           "completed",
+			FinishedAt:       now.Add(time.Minute).Format(time.RFC3339Nano),
+			EventsEvaluated:  5,
+			GraphRowsRead:    2,
+			FindingsUpserted: 1,
+		},
+	}})
+
+	wantStages := []string{"setup", "source_sync", "contract_probe", "graph_projection", "finding_evaluation"}
+	if len(timeline) != len(wantStages) {
+		t.Fatalf("timeline length = %d, want %d: %#v", len(timeline), len(wantStages), timeline)
+	}
+	for i, stage := range wantStages {
+		if got := timeline[i].Stage; got != stage {
+			t.Fatalf("timeline[%d].stage = %q, want %q", i, got, stage)
+		}
+		if got := timeline[i].Status; got != "success" {
+			t.Fatalf("timeline[%d].status = %q, want success", i, got)
+		}
+	}
+	if got := timeline[3].CorrelationID; got != "graph-a" {
+		t.Fatalf("graph correlation_id = %q, want graph-a", got)
+	}
+	if got := timeline[4].FindingsEvaluated; got != 7 {
+		t.Fatalf("findings_evaluated = %d, want 7", got)
+	}
+	if got := timeline[4].FindingsOpened; got != 1 {
+		t.Fatalf("findings_opened = %d, want 1", got)
+	}
+}
+
+func TestFromPreflightClassifiesBlockedChecks(t *testing.T) {
+	timeline := FromPreflight(Preflight{
+		GeneratedAt: "2026-06-15T10:00:00Z",
+		SourceID:    "github",
+		RuntimeID:   "runtime-a",
+		TenantID:    "tenant-a",
+		Status:      "blocked",
+		Summary:     "Fix blocking checks.",
+		NextAction:  "fix_blocking_checks",
+		Checks: []PreflightCheck{{
+			ID:         "credential",
+			Label:      "Credential",
+			Status:     "blocked",
+			Detail:     "Credential is unavailable.",
+			NextAction: "configure_credential",
+		}},
+	})
+
+	if len(timeline) != 2 {
+		t.Fatalf("timeline length = %d, want 2", len(timeline))
+	}
+	for i, entry := range timeline {
+		if entry.Status != "failed" {
+			t.Fatalf("timeline[%d].status = %q, want failed", i, entry.Status)
+		}
+		if entry.FailureClass != "preflight_blocked" {
+			t.Fatalf("timeline[%d].failure_class = %q, want preflight_blocked", i, entry.FailureClass)
+		}
+	}
+}

--- a/internal/sourcehealthview/types.go
+++ b/internal/sourcehealthview/types.go
@@ -1,0 +1,74 @@
+package sourcehealthview
+
+import "github.com/writer/cerebro/internal/resourcescope"
+
+type Record struct {
+	RuntimeID                 string                `json:"runtime_id"`
+	SourceID                  string                `json:"source_id"`
+	TenantID                  string                `json:"tenant_id"`
+	Family                    string                `json:"family,omitempty"`
+	ScopePolicy               *resourcescope.Policy `json:"scope_policy,omitempty"`
+	EnabledState              string                `json:"enabled_state"`
+	Status                    string                `json:"status"`
+	LastSyncedAt              string                `json:"last_synced_at,omitempty"`
+	SyncLagSeconds            *int64                `json:"sync_lag_seconds,omitempty"`
+	CheckpointWatermark       string                `json:"checkpoint_watermark,omitempty"`
+	WatermarkLagSeconds       *int64                `json:"watermark_lag_seconds,omitempty"`
+	RecentSync                Sync                  `json:"recent_sync"`
+	LastFailureCategory       string                `json:"last_failure_category,omitempty"`
+	ContractProbeState        string                `json:"contract_probe_state"`
+	CursorPending             bool                  `json:"cursor_pending"`
+	CheckpointCursorPresent   bool                  `json:"checkpoint_cursor_present"`
+	LatestGraphRun            *GraphRun             `json:"latest_graph_run,omitempty"`
+	GraphLagSeconds           *int64                `json:"graph_lag_seconds,omitempty"`
+	LatestFindingEvaluation   *FindingEvaluation    `json:"latest_finding_evaluation,omitempty"`
+	ExpectedCadenceSeconds    *int64                `json:"expected_cadence_seconds,omitempty"`
+	StaleAfterSeconds         *int64                `json:"stale_after_seconds,omitempty"`
+	ScheduleContextConfigured bool                  `json:"schedule_context_configured"`
+	GeneratedAt               string                `json:"generated_at"`
+}
+
+type Sync struct {
+	RecordsScanned    uint32 `json:"records_scanned"`
+	RecordsAccepted   uint32 `json:"records_accepted"`
+	RecordsRejected   uint32 `json:"records_rejected"`
+	EntitiesProjected uint32 `json:"entities_projected"`
+	LinksProjected    uint32 `json:"links_projected"`
+}
+
+type GraphRun struct {
+	ID                string `json:"id"`
+	Status            string `json:"status"`
+	StartedAt         string `json:"started_at,omitempty"`
+	FinishedAt        string `json:"finished_at,omitempty"`
+	Error             string `json:"error,omitempty"`
+	PagesRead         int64  `json:"pages_read"`
+	EventsRead        int64  `json:"events_read"`
+	EntitiesProjected int64  `json:"entities_projected"`
+	LinksProjected    int64  `json:"links_projected"`
+	GraphNodesBefore  int64  `json:"graph_nodes_before"`
+	GraphLinksBefore  int64  `json:"graph_links_before"`
+	GraphNodesAfter   int64  `json:"graph_nodes_after"`
+	GraphLinksAfter   int64  `json:"graph_links_after"`
+	GraphNodeDelta    int64  `json:"graph_node_delta"`
+	GraphLinkDelta    int64  `json:"graph_link_delta"`
+	DurationSeconds   *int64 `json:"duration_seconds,omitempty"`
+}
+
+type FindingEvaluation struct {
+	ID               string `json:"id"`
+	RuntimeID        string `json:"runtime_id"`
+	RuleID           string `json:"rule_id,omitempty"`
+	Status           string `json:"status"`
+	StartedAt        string `json:"started_at,omitempty"`
+	FinishedAt       string `json:"finished_at,omitempty"`
+	Error            string `json:"error,omitempty"`
+	EventsEvaluated  uint32 `json:"events_evaluated"`
+	EventsProcessed  uint32 `json:"events_processed"`
+	EventsMatched    uint32 `json:"events_matched"`
+	FindingsUpserted uint32 `json:"findings_upserted"`
+	FindingsEmitted  uint32 `json:"findings_emitted"`
+	GraphRule        *bool  `json:"graph_rule,omitempty"`
+	GraphRowsRead    uint32 `json:"graph_rows_read,omitempty"`
+	DurationSeconds  *int64 `json:"duration_seconds,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Adds provider-neutral connector diagnostic timeline responses for connector detail, activity, and setup preflight.
- Moves diagnostic timeline assembly into `internal/connectordiagnostics` and shares runtime health DTOs through `internal/sourcehealthview`.
- Adds regression coverage for timeline payloads and stage classification.

## Test Plan

- `go test ./internal/connectordiagnostics ./internal/sourcehealthview ./internal/bootstrap -count=1`
- `go test ./tools/archtests -run TestBootstrapProductionSurfaceDoesNotGrow -count=1`
- `make lint`
- `make test`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
