### PR TITLE
feat: Add GRC trends velocity metrics

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1992,6 +1992,14 @@ paths:
         - $ref: '#/components/parameters/tenantIDQuery'
         - $ref: '#/components/parameters/runtimeIDQuery'
         - $ref: '#/components/parameters/sourceIDQuery'
+        - name: severity
+          in: query
+          schema:
+            type: string
+        - name: framework
+          in: query
+          schema:
+            type: string
         - name: interval
           in: query
           schema:
@@ -2008,9 +2016,29 @@ paths:
             minimum: 1
             maximum: 366
             default: 90
+        - name: compare
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: mttr_target_days
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+        - name: backlog_target
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+        - name: sla_target_days
+          in: query
+          schema:
+            type: integer
+            minimum: 1
       responses:
         '200':
-          description: Time-bucketed finding flow series with opened, closed, severity splits, and a reconstructed open backlog per bucket.
+          description: Time-bucketed finding flow series with opened, closed, severity splits, aging buckets, MTTR, target overlays, comparison deltas, and a reconstructed open backlog per bucket.
   /grc/ask:
     post:
       summary: Ask natural-language questions over the GRC graph
@@ -2060,6 +2088,44 @@ paths:
           schema:
             type: string
         - name: policy_id
+          in: query
+          schema:
+            type: string
+        - name: framework
+          in: query
+          schema:
+            type: string
+        - name: opened_after
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: opened_before
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: closed_after
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: closed_before
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: age_min_days
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+        - name: age_max_days
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+        - name: sla_status
           in: query
           schema:
             type: string

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/grccontrol"
+	"github.com/writer/cerebro/internal/grctrends"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourceruntime"
@@ -319,26 +320,9 @@ func joinGRCErrors(errs <-chan error) error {
 }
 
 const (
-	grcTrendsDefaultDays = uint32(90)
-	grcTrendsMaxDays     = uint32(366)
+	grcTrendsDefaultDays = 90
+	grcTrendsMaxDays     = 366
 )
-
-type grcTrendPoint struct {
-	Date           string `json:"date"`
-	Opened         int    `json:"opened"`
-	OpenedCritical int    `json:"opened_critical"`
-	OpenedHigh     int    `json:"opened_high"`
-	Closed         int    `json:"closed"`
-	OpenTotal      int    `json:"open_total"`
-}
-
-type grcTrendsResponse struct {
-	Interval    string          `json:"interval"`
-	Start       time.Time       `json:"start"`
-	End         time.Time       `json:"end"`
-	Points      []grcTrendPoint `json:"points"`
-	GeneratedAt time.Time       `json:"generated_at"`
-}
 
 func (a *App) handleGRCTrends(w http.ResponseWriter, r *http.Request) {
 	scope, err := grcScopeFromRequest(r)
@@ -346,130 +330,64 @@ func (a *App) handleGRCTrends(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	interval, days, err := grcTrendsParamsFromRequest(r)
+	params, err := grctrends.ParseParams(r.URL.Query(), grcTrendsDefaultDays, grcTrendsMaxDays)
 	if err != nil {
-		writeGRCError(w, err)
+		writeGRCError(w, fmt.Errorf("%w: %w", errInvalidHTTPRequest, err))
 		return
 	}
 	end := time.Now().UTC()
-	start := end.AddDate(0, 0, -int(days))
+	start := end.AddDate(0, 0, -params.Days)
 	runtimes, err := a.grcListRuntimes(r, scope)
 	if err != nil {
 		writeGRCError(w, err)
 		return
 	}
-	trends, err := a.grcFindingTrends(r, runtimes, start, end, interval)
+	filter := grcFindingFilter{
+		Severity:  params.Severity,
+		Framework: params.Framework,
+	}
+	trends, err := a.grcFindingTrends(r, runtimes, start, end, params.Interval, filter)
 	if err != nil {
 		writeGRCError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, grcTrendsResponse{
-		Interval:    interval,
-		Start:       start,
-		End:         end,
-		Points:      grcBuildTrendPoints(trends),
+	var comparison *grctrends.Comparison
+	if params.Compare {
+		previousEnd := start
+		previousStart := previousEnd.Add(end.Sub(start) * -1)
+		previous, err := a.grcFindingTrends(r, runtimes, previousStart, previousEnd, params.Interval, filter)
+		if err != nil {
+			writeGRCError(w, err)
+			return
+		}
+		comparison = grctrends.BuildComparison(previous, trends, previousStart, previousEnd)
+	}
+	writeJSON(w, http.StatusOK, grctrends.Response{
+		Interval:     params.Interval,
+		Start:        start,
+		End:          end,
+		Points:       grctrends.BuildPoints(trends),
+		AgingBuckets: grctrends.BuildAgingBuckets(trends),
+		Targets:      grctrends.BuildTargets(params.TargetParams),
+		Comparison:   comparison,
+		Accuracy: grctrends.Accuracy{
+			StatusHistory: "current_state_with_status_history_forward_capture",
+			Caveat:        "Trend points use first_observed_at and the latest status_updated_at for existing rows; durable status history is captured for new lifecycle transitions, so reopen accuracy improves as history accrues.",
+		},
 		GeneratedAt: time.Now().UTC(),
 	})
 }
 
-func grcTrendsParamsFromRequest(r *http.Request) (string, uint32, error) {
-	interval := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("interval")))
-	if interval == "" {
-		interval = "day"
-	}
-	switch interval {
-	case "day", "week", "month":
-	default:
-		return "", 0, fmt.Errorf("%w: interval must be day, week, or month", errInvalidHTTPRequest)
-	}
-	days, err := uint32QueryParam(r, "days")
-	if err != nil {
-		return "", 0, err
-	}
-	if days == 0 {
-		days = grcTrendsDefaultDays
-	}
-	if days > grcTrendsMaxDays {
-		days = grcTrendsMaxDays
-	}
-	return interval, days, nil
-}
-
-func (a *App) grcFindingTrends(r *http.Request, runtimes []*cerebrov1.SourceRuntime, start, end time.Time, interval string) (*ports.GRCFindingTrends, error) {
+func (a *App) grcFindingTrends(r *http.Request, runtimes []*cerebrov1.SourceRuntime, start, end time.Time, interval string, filter grcFindingFilter) (*ports.GRCFindingTrends, error) {
 	store := findingStore(a.deps.StateStore)
 	provider, ok := store.(grcFindingTrendsProvider)
 	if !ok {
 		return nil, findings.ErrRuntimeUnavailable
 	}
-	runtimeIDsByTenant := map[string][]string{}
-	for _, runtime := range runtimes {
-		if runtime == nil {
-			continue
-		}
-		tenantID := strings.TrimSpace(runtime.GetTenantId())
-		runtimeID := strings.TrimSpace(runtime.GetId())
-		if tenantID == "" || runtimeID == "" {
-			continue
-		}
-		runtimeIDsByTenant[tenantID] = append(runtimeIDsByTenant[tenantID], runtimeID)
-	}
-	merged := map[time.Time]*ports.GRCFindingTrendPoint{}
-	openAtStart := 0
-	for tenantID, runtimeIDs := range runtimeIDsByTenant {
-		trends, err := provider.SummarizeGRCFindingTrends(r.Context(), ports.GRCFindingTrendsRequest{
-			FindingRequest: ports.ListFindingsRequest{TenantID: tenantID, RuntimeIDs: runtimeIDs},
-			Start:          start,
-			End:            end,
-			Interval:       interval,
-		})
-		if err != nil {
-			return nil, err
-		}
-		openAtStart += trends.OpenAtStart
-		for _, point := range trends.Points {
-			key := point.BucketStart.UTC()
-			agg := merged[key]
-			if agg == nil {
-				agg = &ports.GRCFindingTrendPoint{BucketStart: key}
-				merged[key] = agg
-			}
-			agg.Opened += point.Opened
-			agg.OpenedCritical += point.OpenedCritical
-			agg.OpenedHigh += point.OpenedHigh
-			agg.Closed += point.Closed
-		}
-	}
-	points := make([]ports.GRCFindingTrendPoint, 0, len(merged))
-	for _, point := range merged {
-		points = append(points, *point)
-	}
-	sort.Slice(points, func(i, j int) bool {
-		return points[i].BucketStart.Before(points[j].BucketStart)
+	return grctrends.Merge(r.Context(), provider, runtimes, start, end, interval, grctrends.Filter{
+		Severity:  filter.Severity,
+		Framework: filter.Framework,
 	})
-	return &ports.GRCFindingTrends{Points: points, OpenAtStart: openAtStart}, nil
-}
-
-func grcBuildTrendPoints(trends *ports.GRCFindingTrends) []grcTrendPoint {
-	if trends == nil {
-		return []grcTrendPoint{}
-	}
-	running := trends.OpenAtStart
-	points := make([]grcTrendPoint, 0, len(trends.Points))
-	for _, point := range trends.Points {
-		running += point.Opened - point.Closed
-		if running < 0 {
-			running = 0
-		}
-		points = append(points, grcTrendPoint{
-			Date:           point.BucketStart.UTC().Format("2006-01-02"),
-			Opened:         point.Opened,
-			OpenedCritical: point.OpenedCritical,
-			OpenedHigh:     point.OpenedHigh,
-			Closed:         point.Closed,
-			OpenTotal:      running,
-		})
-	}
-	return points
 }
 
 func (a *App) handleGRCFindings(w http.ResponseWriter, r *http.Request) {
@@ -506,15 +424,27 @@ func (a *App) grcFindingItemsFromRequest(r *http.Request, limitOverride uint32) 
 	} else if strings.EqualFold(status, "all") {
 		status = ""
 	}
+	drilldown, err := grctrends.ParseDrilldownFilters(r.URL.Query())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidHTTPRequest, err)
+	}
 	findings, err := a.grcListFindingRecords(r, runtimes, grcFindingFilter{
-		FindingID:   strings.TrimSpace(r.URL.Query().Get("finding_id")),
-		RuleID:      strings.TrimSpace(r.URL.Query().Get("rule_id")),
-		Severity:    strings.TrimSpace(r.URL.Query().Get("severity")),
-		Status:      status,
-		ResourceURN: strings.TrimSpace(r.URL.Query().Get("resource_urn")),
-		EventID:     strings.TrimSpace(r.URL.Query().Get("event_id")),
-		PolicyID:    strings.TrimSpace(r.URL.Query().Get("policy_id")),
-		Limit:       limit,
+		FindingID:           strings.TrimSpace(r.URL.Query().Get("finding_id")),
+		RuleID:              strings.TrimSpace(r.URL.Query().Get("rule_id")),
+		Severity:            strings.TrimSpace(r.URL.Query().Get("severity")),
+		Status:              status,
+		ResourceURN:         strings.TrimSpace(r.URL.Query().Get("resource_urn")),
+		EventID:             strings.TrimSpace(r.URL.Query().Get("event_id")),
+		PolicyID:            strings.TrimSpace(r.URL.Query().Get("policy_id")),
+		Framework:           strings.TrimSpace(r.URL.Query().Get("framework")),
+		FirstObservedFrom:   drilldown.FirstObservedFrom,
+		FirstObservedBefore: drilldown.FirstObservedBefore,
+		StatusUpdatedFrom:   drilldown.StatusUpdatedFrom,
+		StatusUpdatedBefore: drilldown.StatusUpdatedBefore,
+		MinAgeDays:          drilldown.MinAgeDays,
+		MaxAgeDays:          drilldown.MaxAgeDays,
+		SLAStatus:           drilldown.SLAStatus,
+		Limit:               limit,
 	})
 	if err != nil {
 		return nil, err
@@ -795,16 +725,7 @@ func grcFindingAuditMarkdownInput(packet grcAuditPacketResponse) grccontrol.Find
 	}
 }
 
-type grcFindingFilter struct {
-	FindingID   string
-	RuleID      string
-	Severity    string
-	Status      string
-	ResourceURN string
-	EventID     string
-	PolicyID    string
-	Limit       uint32
-}
+type grcFindingFilter = ports.ListFindingsRequest
 
 type grcEvidenceFilter struct {
 	FindingID    string
@@ -1014,18 +935,26 @@ func (a *App) grcListFindingRecords(r *http.Request, runtimes []*cerebrov1.Sourc
 	var records []*ports.FindingRecord
 	for tenantID, runtimeIDs := range runtimeIDsByTenant {
 		request := ports.ListFindingsRequest{
-			TenantID:      tenantID,
-			RuntimeIDs:    runtimeIDs,
-			FindingID:     filter.FindingID,
-			RuleID:        filter.RuleID,
-			Severity:      filter.Severity,
-			Status:        filter.Status,
-			ResourceURN:   filter.ResourceURN,
-			EventID:       filter.EventID,
-			PolicyID:      filter.PolicyID,
-			Limit:         limit,
-			PriorityOrder: true,
-			Order:         ports.FindingOrderRiskScore,
+			TenantID:            tenantID,
+			RuntimeIDs:          runtimeIDs,
+			FindingID:           filter.FindingID,
+			RuleID:              filter.RuleID,
+			Severity:            filter.Severity,
+			Status:              filter.Status,
+			ResourceURN:         filter.ResourceURN,
+			EventID:             filter.EventID,
+			PolicyID:            filter.PolicyID,
+			Framework:           filter.Framework,
+			FirstObservedFrom:   filter.FirstObservedFrom,
+			FirstObservedBefore: filter.FirstObservedBefore,
+			StatusUpdatedFrom:   filter.StatusUpdatedFrom,
+			StatusUpdatedBefore: filter.StatusUpdatedBefore,
+			MinAgeDays:          filter.MinAgeDays,
+			MaxAgeDays:          filter.MaxAgeDays,
+			SLAStatus:           filter.SLAStatus,
+			Limit:               limit,
+			PriorityOrder:       true,
+			Order:               ports.FindingOrderRiskScore,
 		}
 		var (
 			items []*ports.FindingRecord
@@ -1083,15 +1012,23 @@ func (a *App) grcFindingSummary(r *http.Request, runtimes []*cerebrov1.SourceRun
 	}
 	for tenantID, runtimeIDs := range runtimeIDsByTenant {
 		item, err := provider.SummarizeFindings(r.Context(), ports.ListFindingsRequest{
-			TenantID:    tenantID,
-			RuntimeIDs:  runtimeIDs,
-			FindingID:   filter.FindingID,
-			RuleID:      filter.RuleID,
-			Severity:    filter.Severity,
-			Status:      filter.Status,
-			ResourceURN: filter.ResourceURN,
-			EventID:     filter.EventID,
-			PolicyID:    filter.PolicyID,
+			TenantID:            tenantID,
+			RuntimeIDs:          runtimeIDs,
+			FindingID:           filter.FindingID,
+			RuleID:              filter.RuleID,
+			Severity:            filter.Severity,
+			Status:              filter.Status,
+			ResourceURN:         filter.ResourceURN,
+			EventID:             filter.EventID,
+			PolicyID:            filter.PolicyID,
+			Framework:           filter.Framework,
+			FirstObservedFrom:   filter.FirstObservedFrom,
+			FirstObservedBefore: filter.FirstObservedBefore,
+			StatusUpdatedFrom:   filter.StatusUpdatedFrom,
+			StatusUpdatedBefore: filter.StatusUpdatedBefore,
+			MinAgeDays:          filter.MinAgeDays,
+			MaxAgeDays:          filter.MaxAgeDays,
+			SLAStatus:           filter.SLAStatus,
 		})
 		if err != nil {
 			return nil, err
@@ -1277,15 +1214,23 @@ func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.Sourc
 	for tenantID, runtimeIDs := range runtimeIDsByTenant {
 		item, err := provider.SummarizeGRCDashboard(r.Context(), ports.GRCDashboardAggregateRequest{
 			FindingRequest: ports.ListFindingsRequest{
-				TenantID:    tenantID,
-				RuntimeIDs:  runtimeIDs,
-				FindingID:   findingFilter.FindingID,
-				RuleID:      findingFilter.RuleID,
-				Severity:    findingFilter.Severity,
-				Status:      findingFilter.Status,
-				ResourceURN: findingFilter.ResourceURN,
-				EventID:     findingFilter.EventID,
-				PolicyID:    findingFilter.PolicyID,
+				TenantID:            tenantID,
+				RuntimeIDs:          runtimeIDs,
+				FindingID:           findingFilter.FindingID,
+				RuleID:              findingFilter.RuleID,
+				Severity:            findingFilter.Severity,
+				Status:              findingFilter.Status,
+				ResourceURN:         findingFilter.ResourceURN,
+				EventID:             findingFilter.EventID,
+				PolicyID:            findingFilter.PolicyID,
+				Framework:           findingFilter.Framework,
+				FirstObservedFrom:   findingFilter.FirstObservedFrom,
+				FirstObservedBefore: findingFilter.FirstObservedBefore,
+				StatusUpdatedFrom:   findingFilter.StatusUpdatedFrom,
+				StatusUpdatedBefore: findingFilter.StatusUpdatedBefore,
+				MinAgeDays:          findingFilter.MinAgeDays,
+				MaxAgeDays:          findingFilter.MaxAgeDays,
+				SLAStatus:           findingFilter.SLAStatus,
 			},
 			EvidenceRequest: ports.ListFindingEvidenceRequest{
 				RuntimeIDs:   runtimeIDs,

--- a/internal/bootstrap/grc_trends_test.go
+++ b/internal/bootstrap/grc_trends_test.go
@@ -10,6 +10,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/grctrends"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -19,17 +20,20 @@ func TestGRCBuildTrendPointsReconstructsRunningBacklog(t *testing.T) {
 		OpenAtStart: 10,
 		Points: []ports.GRCFindingTrendPoint{
 			{BucketStart: base, Opened: 3, OpenedCritical: 1, OpenedHigh: 1, Closed: 1},
-			{BucketStart: base.AddDate(0, 0, 1), Opened: 0, Closed: 4},
+			{BucketStart: base.AddDate(0, 0, 1), Opened: 0, Closed: 4, ClosedDurationSecondsTotal: float64((2 * time.Hour).Seconds()), ClosedDurationCount: 1},
 			{BucketStart: base.AddDate(0, 0, 2), Opened: 2, Closed: 0},
 		},
 	}
 
-	points := grcBuildTrendPoints(trends)
+	points := grctrends.BuildPoints(trends)
 	if len(points) != 3 {
 		t.Fatalf("points = %d, want 3", len(points))
 	}
 	if points[0].Date != "2026-03-01" {
 		t.Fatalf("points[0].Date = %q, want 2026-03-01", points[0].Date)
+	}
+	if points[1].AvgTimeToCloseSeconds != (2 * time.Hour).Seconds() {
+		t.Fatalf("points[1].AvgTimeToCloseSeconds = %v, want %v", points[1].AvgTimeToCloseSeconds, (2 * time.Hour).Seconds())
 	}
 	for i, want := range []int{12, 8, 10} { // 10+3-1; 12+0-4; 8+2-0
 		if points[i].OpenTotal != want {
@@ -45,13 +49,13 @@ func TestGRCBuildTrendPointsClampsBacklogAtZero(t *testing.T) {
 			{BucketStart: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), Closed: 5},
 		},
 	}
-	if got := grcBuildTrendPoints(trends)[0].OpenTotal; got != 0 {
+	if got := grctrends.BuildPoints(trends)[0].OpenTotal; got != 0 {
 		t.Fatalf("OpenTotal = %d, want 0 (clamped)", got)
 	}
 }
 
 func TestGRCBuildTrendPointsNilReturnsEmptySlice(t *testing.T) {
-	points := grcBuildTrendPoints(nil)
+	points := grctrends.BuildPoints(nil)
 	if points == nil || len(points) != 0 {
 		t.Fatalf("points = %#v, want empty non-nil slice", points)
 	}
@@ -59,29 +63,29 @@ func TestGRCBuildTrendPointsNilReturnsEmptySlice(t *testing.T) {
 
 func TestGRCTrendsParamsFromRequestDefaults(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/grc/trends", nil)
-	interval, days, err := grcTrendsParamsFromRequest(r)
+	params, err := grctrends.ParseParams(r.URL.Query(), grcTrendsDefaultDays, grcTrendsMaxDays)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
-	if interval != "day" || days != grcTrendsDefaultDays {
-		t.Fatalf("interval=%q days=%d, want day/%d", interval, days, grcTrendsDefaultDays)
+	if params.Interval != "day" || params.Days != grcTrendsDefaultDays {
+		t.Fatalf("interval=%q days=%d, want day/%d", params.Interval, params.Days, grcTrendsDefaultDays)
 	}
 }
 
 func TestGRCTrendsParamsFromRequestClampsDays(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/grc/trends?days=100000&interval=week", nil)
-	interval, days, err := grcTrendsParamsFromRequest(r)
+	params, err := grctrends.ParseParams(r.URL.Query(), grcTrendsDefaultDays, grcTrendsMaxDays)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
-	if interval != "week" || days != grcTrendsMaxDays {
-		t.Fatalf("interval=%q days=%d, want week/%d", interval, days, grcTrendsMaxDays)
+	if params.Interval != "week" || params.Days != grcTrendsMaxDays {
+		t.Fatalf("interval=%q days=%d, want week/%d", params.Interval, params.Days, grcTrendsMaxDays)
 	}
 }
 
 func TestGRCTrendsParamsFromRequestRejectsInterval(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/grc/trends?interval=hour", nil)
-	if _, _, err := grcTrendsParamsFromRequest(r); err == nil {
+	if _, err := grctrends.ParseParams(r.URL.Query(), grcTrendsDefaultDays, grcTrendsMaxDays); err == nil {
 		t.Fatalf("expected error for unsupported interval")
 	}
 }
@@ -100,8 +104,9 @@ func (s *stubGRCTrendsStore) SummarizeGRCFindingTrends(_ context.Context, reques
 		OpenAtStart: 5,
 		Points: []ports.GRCFindingTrendPoint{
 			{BucketStart: base, Opened: 2, OpenedCritical: 1, Closed: 0},
-			{BucketStart: base.AddDate(0, 0, 1), Opened: 0, Closed: 3},
+			{BucketStart: base.AddDate(0, 0, 1), Opened: 0, Closed: 3, ClosedHigh: 1, ClosedSLABreached: 1, ClosedDurationSecondsTotal: float64(time.Hour.Seconds()), ClosedDurationCount: 1},
 		},
+		AgingBuckets: []ports.GRCAgingBucket{{ID: "0-7", Label: "0-7 days", MaxDays: 7, Count: 2}},
 	}, nil
 }
 
@@ -123,7 +128,7 @@ func TestHandleGRCTrendsReturnsSeries(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("GET /grc/trends status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
-	var payload grcTrendsResponse
+	var payload grctrends.Response
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode /grc/trends: %v", err)
 	}
@@ -138,6 +143,12 @@ func TestHandleGRCTrendsReturnsSeries(t *testing.T) {
 	}
 	if payload.Points[0].OpenedCritical != 1 {
 		t.Fatalf("opened_critical = %d, want 1", payload.Points[0].OpenedCritical)
+	}
+	if payload.Points[1].ClosedHigh != 1 || payload.Points[1].ClosedSLABreached != 1 {
+		t.Fatalf("closed high/sla = %d/%d, want 1/1", payload.Points[1].ClosedHigh, payload.Points[1].ClosedSLABreached)
+	}
+	if len(payload.AgingBuckets) != 1 || payload.AgingBuckets[0].Count != 2 {
+		t.Fatalf("aging buckets = %#v, want one count=2", payload.AgingBuckets)
 	}
 	if store.calls != 1 {
 		t.Fatalf("trends store calls = %d, want 1", store.calls)

--- a/internal/grctrends/trends.go
+++ b/internal/grctrends/trends.go
@@ -1,0 +1,433 @@
+package grctrends
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type RequestParams struct {
+	Interval  string
+	Days      int
+	Compare   bool
+	Severity  string
+	Framework string
+	TargetParams
+}
+
+type DrilldownFilters struct {
+	FirstObservedFrom   time.Time
+	FirstObservedBefore time.Time
+	StatusUpdatedFrom   time.Time
+	StatusUpdatedBefore time.Time
+	MinAgeDays          uint32
+	MaxAgeDays          uint32
+	SLAStatus           string
+}
+
+type Filter struct {
+	Severity  string
+	Framework string
+}
+
+type Provider interface {
+	SummarizeGRCFindingTrends(context.Context, ports.GRCFindingTrendsRequest) (ports.GRCFindingTrends, error)
+}
+
+type Point struct {
+	Date                  string  `json:"date"`
+	Opened                int     `json:"opened"`
+	OpenedCritical        int     `json:"opened_critical"`
+	OpenedHigh            int     `json:"opened_high"`
+	Closed                int     `json:"closed"`
+	ClosedCritical        int     `json:"closed_critical"`
+	ClosedHigh            int     `json:"closed_high"`
+	ClosedSLABreached     int     `json:"closed_sla_breached"`
+	AvgTimeToCloseSeconds float64 `json:"avg_time_to_close_seconds"`
+	OpenTotal             int     `json:"open_total"`
+}
+
+type AgingBucket struct {
+	ID      string `json:"id"`
+	Label   string `json:"label"`
+	MinDays int    `json:"min_days"`
+	MaxDays int    `json:"max_days,omitempty"`
+	Count   int    `json:"count"`
+}
+
+type Targets struct {
+	MTTRSeconds int `json:"mttr_seconds,omitempty"`
+	Backlog     int `json:"backlog,omitempty"`
+	SLADays     int `json:"sla_days,omitempty"`
+}
+
+type TargetParams struct {
+	MTTRTargetDays int
+	BacklogTarget  int
+	SLATargetDays  int
+}
+
+func ParseParams(values url.Values, defaultDays int, maxDays int) (RequestParams, error) {
+	interval := strings.ToLower(strings.TrimSpace(values.Get("interval")))
+	if interval == "" {
+		interval = "day"
+	}
+	switch interval {
+	case "day", "week", "month":
+	default:
+		return RequestParams{}, fmt.Errorf("interval must be day, week, or month")
+	}
+	days, err := positiveInt(values, "days")
+	if err != nil {
+		return RequestParams{}, err
+	}
+	if days == 0 {
+		days = defaultDays
+	}
+	if days > maxDays {
+		days = maxDays
+	}
+	compare, err := boolValue(values, "compare")
+	if err != nil {
+		return RequestParams{}, err
+	}
+	mttrTargetDays, err := positiveInt(values, "mttr_target_days")
+	if err != nil {
+		return RequestParams{}, err
+	}
+	backlogTarget, err := positiveInt(values, "backlog_target")
+	if err != nil {
+		return RequestParams{}, err
+	}
+	slaTargetDays, err := positiveInt(values, "sla_target_days")
+	if err != nil {
+		return RequestParams{}, err
+	}
+	return RequestParams{
+		Interval:  interval,
+		Days:      days,
+		Compare:   compare,
+		Severity:  strings.TrimSpace(values.Get("severity")),
+		Framework: strings.TrimSpace(values.Get("framework")),
+		TargetParams: TargetParams{
+			MTTRTargetDays: mttrTargetDays,
+			BacklogTarget:  backlogTarget,
+			SLATargetDays:  slaTargetDays,
+		},
+	}, nil
+}
+
+func positiveInt(values url.Values, key string) (int, error) {
+	value := strings.TrimSpace(values.Get(key))
+	if value == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s", key)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("%s must be at least 1", key)
+	}
+	return parsed, nil
+}
+
+func ParseDrilldownFilters(values url.Values) (DrilldownFilters, error) {
+	openedAfter, err := timeValue(values, "opened_after")
+	if err != nil {
+		return DrilldownFilters{}, err
+	}
+	openedBefore, err := timeValue(values, "opened_before")
+	if err != nil {
+		return DrilldownFilters{}, err
+	}
+	closedAfter, err := timeValue(values, "closed_after")
+	if err != nil {
+		return DrilldownFilters{}, err
+	}
+	closedBefore, err := timeValue(values, "closed_before")
+	if err != nil {
+		return DrilldownFilters{}, err
+	}
+	minAgeDays, err := positiveUint32(values, "age_min_days")
+	if err != nil {
+		return DrilldownFilters{}, err
+	}
+	maxAgeDays, err := positiveUint32(values, "age_max_days")
+	if err != nil {
+		return DrilldownFilters{}, err
+	}
+	return DrilldownFilters{
+		FirstObservedFrom:   openedAfter,
+		FirstObservedBefore: openedBefore,
+		StatusUpdatedFrom:   closedAfter,
+		StatusUpdatedBefore: closedBefore,
+		MinAgeDays:          minAgeDays,
+		MaxAgeDays:          maxAgeDays,
+		SLAStatus:           strings.TrimSpace(values.Get("sla_status")),
+	}, nil
+}
+
+func positiveUint32(values url.Values, key string) (uint32, error) {
+	value := strings.TrimSpace(values.Get(key))
+	if value == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s", key)
+	}
+	if parsed == 0 {
+		return 0, fmt.Errorf("%s must be at least 1", key)
+	}
+	return uint32(parsed), nil
+}
+
+func boolValue(values url.Values, key string) (bool, error) {
+	value := strings.TrimSpace(values.Get(key))
+	if value == "" {
+		return false, nil
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("invalid %s", key)
+	}
+	return parsed, nil
+}
+
+func timeValue(values url.Values, key string) (time.Time, error) {
+	value := strings.TrimSpace(values.Get(key))
+	if value == "" {
+		return time.Time{}, nil
+	}
+	if parsed, err := time.Parse(time.RFC3339, value); err == nil {
+		return parsed.UTC(), nil
+	}
+	if parsed, err := time.Parse("2006-01-02", value); err == nil {
+		return parsed.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("invalid %s", key)
+}
+
+type Comparison struct {
+	PreviousStart              time.Time `json:"previous_start"`
+	PreviousEnd                time.Time `json:"previous_end"`
+	OpenedDelta                int       `json:"opened_delta"`
+	ClosedDelta                int       `json:"closed_delta"`
+	CurrentOpenDelta           int       `json:"current_open_delta"`
+	AvgTimeToCloseSecondsDelta float64   `json:"avg_time_to_close_seconds_delta"`
+	ClosedSLABreachedDelta     int       `json:"closed_sla_breached_delta"`
+}
+
+type Accuracy struct {
+	StatusHistory string `json:"status_history"`
+	Caveat        string `json:"caveat"`
+}
+
+type Response struct {
+	Interval     string        `json:"interval"`
+	Start        time.Time     `json:"start"`
+	End          time.Time     `json:"end"`
+	Points       []Point       `json:"points"`
+	AgingBuckets []AgingBucket `json:"aging_buckets"`
+	Targets      Targets       `json:"targets,omitempty"`
+	Comparison   *Comparison   `json:"comparison,omitempty"`
+	Accuracy     Accuracy      `json:"accuracy"`
+	GeneratedAt  time.Time     `json:"generated_at"`
+}
+
+func BuildPoints(trends *ports.GRCFindingTrends) []Point {
+	if trends == nil {
+		return []Point{}
+	}
+	running := trends.OpenAtStart
+	points := make([]Point, 0, len(trends.Points))
+	for _, point := range trends.Points {
+		running += point.Opened - point.Closed
+		if running < 0 {
+			running = 0
+		}
+		points = append(points, Point{
+			Date:                  point.BucketStart.UTC().Format("2006-01-02"),
+			Opened:                point.Opened,
+			OpenedCritical:        point.OpenedCritical,
+			OpenedHigh:            point.OpenedHigh,
+			Closed:                point.Closed,
+			ClosedCritical:        point.ClosedCritical,
+			ClosedHigh:            point.ClosedHigh,
+			ClosedSLABreached:     point.ClosedSLABreached,
+			AvgTimeToCloseSeconds: averageSeconds(point.ClosedDurationSecondsTotal, point.ClosedDurationCount),
+			OpenTotal:             running,
+		})
+	}
+	return points
+}
+
+func BuildAgingBuckets(trends *ports.GRCFindingTrends) []AgingBucket {
+	if trends == nil {
+		return []AgingBucket{}
+	}
+	buckets := make([]AgingBucket, 0, len(trends.AgingBuckets))
+	for _, bucket := range trends.AgingBuckets {
+		buckets = append(buckets, AgingBucket{
+			ID:      bucket.ID,
+			Label:   bucket.Label,
+			MinDays: bucket.MinDays,
+			MaxDays: bucket.MaxDays,
+			Count:   bucket.Count,
+		})
+	}
+	return buckets
+}
+
+func BuildTargets(params TargetParams) Targets {
+	targets := Targets{}
+	if params.MTTRTargetDays > 0 {
+		targets.MTTRSeconds = params.MTTRTargetDays * int((24 * time.Hour).Seconds())
+	}
+	if params.BacklogTarget > 0 {
+		targets.Backlog = params.BacklogTarget
+	}
+	if params.SLATargetDays > 0 {
+		targets.SLADays = params.SLATargetDays
+	}
+	return targets
+}
+
+func BuildComparison(previous *ports.GRCFindingTrends, current *ports.GRCFindingTrends, previousStart time.Time, previousEnd time.Time) *Comparison {
+	prev := summarize(previous)
+	next := summarize(current)
+	return &Comparison{
+		PreviousStart:              previousStart.UTC(),
+		PreviousEnd:                previousEnd.UTC(),
+		OpenedDelta:                next.Opened - prev.Opened,
+		ClosedDelta:                next.Closed - prev.Closed,
+		CurrentOpenDelta:           next.CurrentOpen - prev.CurrentOpen,
+		AvgTimeToCloseSecondsDelta: next.AvgTimeToCloseSeconds - prev.AvgTimeToCloseSeconds,
+		ClosedSLABreachedDelta:     next.ClosedSLABreached - prev.ClosedSLABreached,
+	}
+}
+
+func Merge(ctx context.Context, provider Provider, runtimes []*cerebrov1.SourceRuntime, start time.Time, end time.Time, interval string, filter Filter) (*ports.GRCFindingTrends, error) {
+	runtimeIDsByTenant := map[string][]string{}
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		tenantID := strings.TrimSpace(runtime.GetTenantId())
+		runtimeID := strings.TrimSpace(runtime.GetId())
+		if tenantID == "" || runtimeID == "" {
+			continue
+		}
+		runtimeIDsByTenant[tenantID] = append(runtimeIDsByTenant[tenantID], runtimeID)
+	}
+	merged := map[time.Time]*ports.GRCFindingTrendPoint{}
+	agingByID := map[string]ports.GRCAgingBucket{}
+	openAtStart := 0
+	for tenantID, runtimeIDs := range runtimeIDsByTenant {
+		trends, err := provider.SummarizeGRCFindingTrends(ctx, ports.GRCFindingTrendsRequest{
+			FindingRequest: ports.ListFindingsRequest{
+				TenantID:   tenantID,
+				RuntimeIDs: runtimeIDs,
+				Severity:   filter.Severity,
+				Framework:  filter.Framework,
+			},
+			Start:    start,
+			End:      end,
+			Interval: interval,
+		})
+		if err != nil {
+			return nil, err
+		}
+		openAtStart += trends.OpenAtStart
+		for _, point := range trends.Points {
+			key := point.BucketStart.UTC()
+			agg := merged[key]
+			if agg == nil {
+				agg = &ports.GRCFindingTrendPoint{BucketStart: key}
+				merged[key] = agg
+			}
+			agg.Opened += point.Opened
+			agg.OpenedCritical += point.OpenedCritical
+			agg.OpenedHigh += point.OpenedHigh
+			agg.Closed += point.Closed
+			agg.ClosedCritical += point.ClosedCritical
+			agg.ClosedHigh += point.ClosedHigh
+			agg.ClosedSLABreached += point.ClosedSLABreached
+			agg.ClosedDurationSecondsTotal += point.ClosedDurationSecondsTotal
+			agg.ClosedDurationCount += point.ClosedDurationCount
+		}
+		for _, bucket := range trends.AgingBuckets {
+			id := strings.TrimSpace(bucket.ID)
+			if id == "" {
+				continue
+			}
+			agg := agingByID[id]
+			if agg.ID == "" {
+				agg = bucket
+				agg.Count = 0
+			}
+			agg.Count += bucket.Count
+			agingByID[id] = agg
+		}
+	}
+	points := make([]ports.GRCFindingTrendPoint, 0, len(merged))
+	for _, point := range merged {
+		points = append(points, *point)
+	}
+	sort.Slice(points, func(i, j int) bool {
+		return points[i].BucketStart.Before(points[j].BucketStart)
+	})
+	agingBuckets := make([]ports.GRCAgingBucket, 0, len(agingByID))
+	for _, bucket := range agingByID {
+		agingBuckets = append(agingBuckets, bucket)
+	}
+	sort.Slice(agingBuckets, func(i, j int) bool {
+		return agingBuckets[i].MinDays < agingBuckets[j].MinDays
+	})
+	return &ports.GRCFindingTrends{Points: points, OpenAtStart: openAtStart, AgingBuckets: agingBuckets}, nil
+}
+
+type summaryValues struct {
+	Opened                int
+	Closed                int
+	CurrentOpen           int
+	ClosedSLABreached     int
+	AvgTimeToCloseSeconds float64
+	durationSecondsTotal  float64
+	durationSecondsCount  int
+}
+
+func summarize(trends *ports.GRCFindingTrends) summaryValues {
+	if trends == nil {
+		return summaryValues{}
+	}
+	summary := summaryValues{CurrentOpen: trends.OpenAtStart}
+	for _, point := range trends.Points {
+		summary.Opened += point.Opened
+		summary.Closed += point.Closed
+		summary.ClosedSLABreached += point.ClosedSLABreached
+		summary.durationSecondsTotal += point.ClosedDurationSecondsTotal
+		summary.durationSecondsCount += point.ClosedDurationCount
+		summary.CurrentOpen += point.Opened - point.Closed
+		if summary.CurrentOpen < 0 {
+			summary.CurrentOpen = 0
+		}
+	}
+	summary.AvgTimeToCloseSeconds = averageSeconds(summary.durationSecondsTotal, summary.durationSecondsCount)
+	return summary
+}
+
+func averageSeconds(total float64, count int) float64 {
+	if count <= 0 || total <= 0 {
+		return 0
+	}
+	return total / float64(count)
+}

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -118,20 +118,28 @@ type FindingRecord struct {
 
 // ListFindingsRequest scopes one finding query.
 type ListFindingsRequest struct {
-	TenantID           string
-	RuntimeID          string
-	RuntimeIDs         []string
-	FindingID          string
-	RuleID             string
-	Severity           string
-	Status             string
-	ResourceURN        string
-	EventID            string
-	PolicyID           string
-	LastObservedBefore time.Time
-	Limit              uint32
-	PriorityOrder      bool
-	Order              FindingOrder
+	TenantID            string
+	RuntimeID           string
+	RuntimeIDs          []string
+	FindingID           string
+	RuleID              string
+	Severity            string
+	Status              string
+	ResourceURN         string
+	EventID             string
+	PolicyID            string
+	Framework           string
+	FirstObservedFrom   time.Time
+	FirstObservedBefore time.Time
+	StatusUpdatedFrom   time.Time
+	StatusUpdatedBefore time.Time
+	LastObservedBefore  time.Time
+	MinAgeDays          uint32
+	MaxAgeDays          uint32
+	SLAStatus           string
+	Limit               uint32
+	PriorityOrder       bool
+	Order               FindingOrder
 }
 
 // FindingOrder controls persisted finding list sort order.

--- a/internal/ports/grc.go
+++ b/internal/ports/grc.go
@@ -35,20 +35,35 @@ type GRCFindingTrendsRequest struct {
 	Interval       string
 }
 
+// GRCAgingBucket summarizes the age distribution of currently open findings.
+type GRCAgingBucket struct {
+	ID      string
+	Label   string
+	MinDays int
+	MaxDays int
+	Count   int
+}
+
 // GRCFindingTrendPoint holds one bucket of finding flow counts.
 type GRCFindingTrendPoint struct {
-	BucketStart    time.Time
-	Opened         int
-	OpenedCritical int
-	OpenedHigh     int
-	Closed         int
+	BucketStart                time.Time
+	Opened                     int
+	OpenedCritical             int
+	OpenedHigh                 int
+	Closed                     int
+	ClosedCritical             int
+	ClosedHigh                 int
+	ClosedSLABreached          int
+	ClosedDurationSecondsTotal float64
+	ClosedDurationCount        int
 }
 
 // GRCFindingTrends is the bucketed trend series plus the open backlog at the
 // window start, which lets callers reconstruct a running open total.
 type GRCFindingTrends struct {
-	Points      []GRCFindingTrendPoint
-	OpenAtStart int
+	Points       []GRCFindingTrendPoint
+	OpenAtStart  int
+	AgingBuckets []GRCAgingBucket
 }
 
 // GRCFindingTrendsStore provides a purpose-built time-bucketed trend aggregation.

--- a/internal/statestore/postgres/closeout.go
+++ b/internal/statestore/postgres/closeout.go
@@ -494,7 +494,18 @@ RETURNING `+findingSelectColumns,
 		}
 		return nil, err
 	}
-	return row.record()
+	record, err := row.record()
+	if err != nil {
+		return nil, err
+	}
+	priorStatus := strings.TrimSpace(t.PriorStatus)
+	if priorStatus == "" {
+		priorStatus = strings.TrimSpace(record.PriorStatus)
+	}
+	if err := insertFindingStatusHistory(ctx, tx, record.ID, record.TenantID, record.RuntimeID, priorStatus, record.Status, record.StatusReason, updatedAt, request.EventIDs); err != nil {
+		return nil, fmt.Errorf("record finding %q tombstone status history: %w", record.ID, err)
+	}
+	return record, nil
 }
 
 func updateFindingRiskInTx(ctx context.Context, tx *sql.Tx, findingID string, risk ports.FindingRisk, attributes map[string]string) (*ports.FindingRecord, error) {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -142,6 +142,22 @@ END $$`,
         ON finding_tombstone_events (run_id, tombstoned_at)`,
 	`CREATE INDEX IF NOT EXISTS finding_tombstone_events_finding_idx
         ON finding_tombstone_events (finding_id, tombstoned_at)`,
+	`CREATE TABLE IF NOT EXISTS finding_status_history (
+        id TEXT PRIMARY KEY,
+        finding_id TEXT NOT NULL,
+        tenant_id TEXT NOT NULL,
+        runtime_id TEXT NOT NULL,
+        from_status TEXT NOT NULL DEFAULT '',
+        to_status TEXT NOT NULL,
+        reason TEXT NOT NULL DEFAULT '',
+        changed_at TIMESTAMPTZ NOT NULL,
+        event_ids_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`,
+	`CREATE INDEX IF NOT EXISTS finding_status_history_finding_idx
+        ON finding_status_history (finding_id, changed_at)`,
+	`CREATE INDEX IF NOT EXISTS finding_status_history_tenant_runtime_idx
+        ON finding_status_history (tenant_id, runtime_id, changed_at)`,
 	`CREATE TABLE IF NOT EXISTS closeout_run (
         run_id TEXT PRIMARY KEY,
         actor TEXT NOT NULL,
@@ -398,52 +414,88 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord)
 	const maxAttempts = 4
 	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		targetID, generation, err := s.resolveUpsertTarget(ctx, tenantID, fingerprint, id)
-		if err != nil {
-			return nil, fmt.Errorf("upsert finding %q: %w", id, err)
-		}
-		var stored findingRow
-		err = scanFindingRow(s.db.QueryRowContext(ctx, upsertFindingStatement,
-			targetID,
-			fingerprint,
-			tenantID,
-			runtimeID,
-			ruleID,
-			title,
-			severity,
-			status,
-			summary,
-			finding.RiskScore,
-			finding.LikelihoodScore,
-			finding.ImpactScore,
-			finding.ConfidenceScore,
-			strings.TrimSpace(finding.LikelihoodLevel),
-			strings.TrimSpace(finding.ImpactLevel),
-			riskReasonsJSON,
-			strings.TrimSpace(finding.RiskModelVersion),
-			resourceURNsJSON,
-			eventIDsJSON,
-			observedPolicyIDsJSON,
-			controlRefsJSON,
-			notesJSON,
-			ticketsJSON,
-			externalRefsJSON,
-			attributesJSON,
-			policyID,
-			policyName,
-			checkID,
-			checkName,
-			assignee,
-			dueAt,
-			statusReason,
-			statusUpdatedAt,
-			firstObservedAt,
-			lastObservedAt,
-			generation,
-			reopenResolvedOnOpenEmit,
-		), &stored)
+		record, err := func() (_ *ports.FindingRecord, err error) {
+			tx, err := s.db.BeginTx(ctx, nil)
+			if err != nil {
+				return nil, fmt.Errorf("begin upsert finding %q: %w", id, err)
+			}
+			committed := false
+			defer func() {
+				if !committed {
+					_ = tx.Rollback()
+				}
+			}()
+
+			targetID, generation, err := resolveUpsertTargetWithQuerier(ctx, tx, tenantID, fingerprint, id)
+			if err != nil {
+				return nil, err
+			}
+			priorStatus, err := findingStatusForHistoryWithQuerier(ctx, tx, targetID)
+			if err != nil {
+				return nil, fmt.Errorf("load finding %q prior status: %w", targetID, err)
+			}
+			var stored findingRow
+			err = scanFindingRow(tx.QueryRowContext(ctx, upsertFindingStatement,
+				targetID,
+				fingerprint,
+				tenantID,
+				runtimeID,
+				ruleID,
+				title,
+				severity,
+				status,
+				summary,
+				finding.RiskScore,
+				finding.LikelihoodScore,
+				finding.ImpactScore,
+				finding.ConfidenceScore,
+				strings.TrimSpace(finding.LikelihoodLevel),
+				strings.TrimSpace(finding.ImpactLevel),
+				riskReasonsJSON,
+				strings.TrimSpace(finding.RiskModelVersion),
+				resourceURNsJSON,
+				eventIDsJSON,
+				observedPolicyIDsJSON,
+				controlRefsJSON,
+				notesJSON,
+				ticketsJSON,
+				externalRefsJSON,
+				attributesJSON,
+				policyID,
+				policyName,
+				checkID,
+				checkName,
+				assignee,
+				dueAt,
+				statusReason,
+				statusUpdatedAt,
+				firstObservedAt,
+				lastObservedAt,
+				generation,
+				reopenResolvedOnOpenEmit,
+			), &stored)
+			if err != nil {
+				return nil, err
+			}
+			record, err := stored.record()
+			if err != nil {
+				return nil, err
+			}
+			changedAt := record.StatusUpdatedAt
+			if changedAt.IsZero() {
+				changedAt = record.FirstObservedAt
+			}
+			if err := insertFindingStatusHistory(ctx, tx, record.ID, record.TenantID, record.RuntimeID, priorStatus, record.Status, record.StatusReason, changedAt, finding.EventIDs); err != nil {
+				return nil, fmt.Errorf("record finding %q status history: %w", record.ID, err)
+			}
+			if err := tx.Commit(); err != nil {
+				return nil, fmt.Errorf("commit upsert finding %q: %w", id, err)
+			}
+			committed = true
+			return record, nil
+		}()
 		if err == nil {
-			return stored.record()
+			return record, nil
 		}
 		lastErr = err
 		if errors.Is(err, sql.ErrNoRows) && attempt < maxAttempts-1 {
@@ -457,15 +509,19 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord)
 	return nil, fmt.Errorf("upsert finding %q: %w", id, lastErr)
 }
 
-// resolveUpsertTarget resolves the row identity for an emit on the given tenant/fingerprint:
+type findingQueryRower interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+// resolveUpsertTargetWithQuerier resolves the row identity for an emit on the given tenant/fingerprint:
 // if a non-tombstoned row already exists for that tenant it reuses that row's id (the ON CONFLICT (id)
 // path then updates it). Otherwise it mints a fresh id derived from baseID with a
 // "#g<N+1>" generation suffix where N is the max tombstone_generation observed for the
 // tenant/fingerprint, and returns N+1 as the new row's tombstone_generation.
-func (s *Store) resolveUpsertTarget(ctx context.Context, tenantID, fingerprint, baseID string) (string, int, error) {
+func resolveUpsertTargetWithQuerier(ctx context.Context, querier findingQueryRower, tenantID, fingerprint, baseID string) (string, int, error) {
 	var activeID sql.NullString
-	err := s.db.QueryRowContext(ctx,
-		`SELECT id FROM findings WHERE tenant_id = $1 AND fingerprint = $2 AND tombstoned = FALSE LIMIT 1`,
+	err := querier.QueryRowContext(ctx,
+		`SELECT id FROM findings WHERE tenant_id = $1 AND fingerprint = $2 AND tombstoned = FALSE LIMIT 1 FOR UPDATE`,
 		tenantID,
 		fingerprint,
 	).Scan(&activeID)
@@ -478,7 +534,7 @@ func (s *Store) resolveUpsertTarget(ctx context.Context, tenantID, fingerprint, 
 		return activeID.String, 0, nil
 	}
 	var maxGen sql.NullInt64
-	if err := s.db.QueryRowContext(ctx,
+	if err := querier.QueryRowContext(ctx,
 		`SELECT MAX(tombstone_generation) FROM findings WHERE tenant_id = $1 AND fingerprint = $2`,
 		tenantID,
 		fingerprint,
@@ -490,6 +546,22 @@ func (s *Store) resolveUpsertTarget(ctx context.Context, tenantID, fingerprint, 
 	}
 	next := int(maxGen.Int64) + 1
 	return fmt.Sprintf("%s#g%d", findingBaseID(baseID), next), next, nil
+}
+
+func findingStatusForHistoryWithQuerier(ctx context.Context, querier findingQueryRower, findingID string) (string, error) {
+	findingID = strings.TrimSpace(findingID)
+	if findingID == "" || querier == nil {
+		return "", nil
+	}
+	var status sql.NullString
+	err := querier.QueryRowContext(ctx, `SELECT status FROM findings WHERE id = $1 AND tombstoned = FALSE FOR UPDATE`, findingID).Scan(&status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(status.String), nil
 }
 
 var findingGenerationSuffix = regexp.MustCompile(`#g\d+$`)
@@ -840,6 +912,20 @@ func (s *Store) UpdateFindingStatus(ctx context.Context, request ports.FindingSt
 	if err != nil {
 		return nil, fmt.Errorf("marshal finding status event ids: %w", err)
 	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin update finding %q status: %w", findingID, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	priorStatus, err := findingStatusForHistoryWithQuerier(ctx, tx, findingID)
+	if err != nil {
+		return nil, fmt.Errorf("load finding %q prior status: %w", findingID, err)
+	}
 	expectedStatus := strings.TrimSpace(request.ExpectedStatus)
 	lastObservedBefore := request.LastObservedBefore.UTC()
 	if request.Tombstone != nil {
@@ -862,7 +948,7 @@ func (s *Store) UpdateFindingStatus(ctx context.Context, request ports.FindingSt
 		}
 		whereClause, args, preconditioned := findingStatusWhereClause(args, expectedStatus, lastObservedBefore)
 		var row findingRow
-		if err := scanFindingRow(s.db.QueryRowContext(ctx, `
+		if err := scanFindingRow(tx.QueryRowContext(ctx, `
 UPDATE findings
 SET status = $2,
     status_reason = $3,
@@ -892,7 +978,18 @@ RETURNING `+findingSelectColumns, args...), &row); err != nil {
 			}
 			return nil, fmt.Errorf("update finding %q tombstone status: %w", findingID, err)
 		}
-		return row.record()
+		record, err := row.record()
+		if err != nil {
+			return nil, err
+		}
+		if err := insertFindingStatusHistory(ctx, tx, record.ID, record.TenantID, record.RuntimeID, priorStatus, record.Status, record.StatusReason, updatedAt, request.EventIDs); err != nil {
+			return nil, fmt.Errorf("record finding %q tombstone status history: %w", record.ID, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit finding %q tombstone status: %w", findingID, err)
+		}
+		committed = true
+		return record, nil
 	}
 	args := []any{
 		findingID,
@@ -903,7 +1000,7 @@ RETURNING `+findingSelectColumns, args...), &row); err != nil {
 	}
 	whereClause, args, preconditioned := findingStatusWhereClause(args, expectedStatus, lastObservedBefore)
 	var row findingRow
-	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
+	if err := scanFindingRow(tx.QueryRowContext(ctx, `
 UPDATE findings
 SET status = $2,
     status_reason = $3,
@@ -927,7 +1024,18 @@ RETURNING `+findingSelectColumns, args...), &row); err != nil {
 		}
 		return nil, fmt.Errorf("update finding %q status: %w", findingID, err)
 	}
-	return row.record()
+	record, err := row.record()
+	if err != nil {
+		return nil, err
+	}
+	if err := insertFindingStatusHistory(ctx, tx, record.ID, record.TenantID, record.RuntimeID, priorStatus, record.Status, record.StatusReason, updatedAt, request.EventIDs); err != nil {
+		return nil, fmt.Errorf("record finding %q status history: %w", record.ID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit finding %q status: %w", findingID, err)
+	}
+	committed = true
+	return record, nil
 }
 
 func findingStatusWhereClause(args []any, expectedStatus string, lastObservedBefore time.Time) (string, []any, bool) {
@@ -951,6 +1059,58 @@ func findingStatusNoRowsError(preconditioned bool) error {
 		return ports.ErrFindingStatusPreconditionFailed
 	}
 	return ports.ErrFindingNotFound
+}
+
+type findingStatusHistoryExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func insertFindingStatusHistory(ctx context.Context, execer findingStatusHistoryExecer, findingID, tenantID, runtimeID, fromStatus, toStatus, reason string, changedAt time.Time, eventIDs []string) error {
+	findingID = strings.TrimSpace(findingID)
+	tenantID = strings.TrimSpace(tenantID)
+	runtimeID = strings.TrimSpace(runtimeID)
+	fromStatus = strings.TrimSpace(fromStatus)
+	toStatus = strings.TrimSpace(toStatus)
+	if findingID == "" || tenantID == "" || runtimeID == "" || toStatus == "" || strings.EqualFold(fromStatus, toStatus) {
+		return nil
+	}
+	if changedAt.IsZero() {
+		changedAt = time.Now().UTC()
+	}
+	eventIDsJSON, err := findingStringsJSON(eventIDs)
+	if err != nil {
+		return fmt.Errorf("marshal finding status history event ids: %w", err)
+	}
+	id := findingStatusHistoryID(findingID, fromStatus, toStatus, changedAt, eventIDsJSON)
+	_, err = execer.ExecContext(ctx, `
+INSERT INTO finding_status_history (id, finding_id, tenant_id, runtime_id, from_status, to_status, reason, changed_at, event_ids_json)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
+ON CONFLICT (id) DO NOTHING`,
+		id,
+		findingID,
+		tenantID,
+		runtimeID,
+		fromStatus,
+		toStatus,
+		strings.TrimSpace(reason),
+		changedAt.UTC(),
+		eventIDsJSON,
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func findingStatusHistoryID(findingID, fromStatus, toStatus string, changedAt time.Time, eventIDsJSON string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		strings.TrimSpace(findingID),
+		strings.TrimSpace(fromStatus),
+		strings.TrimSpace(toStatus),
+		changedAt.UTC().Format(time.RFC3339Nano),
+		strings.TrimSpace(eventIDsJSON),
+	}, "\x00")))
+	return "finding-status-history-" + hex.EncodeToString(sum[:16])
 }
 
 // UpdateFindingAssignee updates or clears one persisted finding assignee.
@@ -1229,7 +1389,7 @@ func findingGRCListQuery(request ports.ListFindingsRequest) (string, []any, erro
 	query := `
 SELECT id, tenant_id, runtime_id, rule_id, title, ` + findingEffectiveSeveritySQL() + ` AS severity, status, summary,
   risk_score, likelihood_score, impact_score, confidence_score, likelihood_level, impact_level, risk_reasons_json::text, risk_model_version,
-  resource_urns_json::text, control_refs_json::text, policy_id, policy_name, assignee, due_at, first_observed_at, last_observed_at
+  resource_urns_json::text, control_refs_json::text, policy_id, policy_name, assignee, due_at, status_updated_at, first_observed_at, last_observed_at
 FROM findings
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY ` + findingOrderClause(request)
@@ -1259,10 +1419,17 @@ func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, e
 	addFindingSeverityFilter(&clauses, &args, request.Severity)
 	addFindingFilter(&clauses, &args, "status", request.Status)
 	addFindingFilter(&clauses, &args, "policy_id", request.PolicyID)
+	addFindingFrameworkFilter(&clauses, &args, request.Framework)
+	addFindingTimeLowerBoundFilter(&clauses, &args, "first_observed_at", request.FirstObservedFrom)
+	addFindingTimeUpperBoundFilter(&clauses, &args, "first_observed_at", request.FirstObservedBefore)
+	addFindingTimeLowerBoundFilter(&clauses, &args, "status_updated_at", request.StatusUpdatedFrom)
+	addFindingTimeUpperBoundFilter(&clauses, &args, "status_updated_at", request.StatusUpdatedBefore)
 	if !request.LastObservedBefore.IsZero() {
 		args = append(args, request.LastObservedBefore.UTC())
 		clauses = append(clauses, fmt.Sprintf("last_observed_at < $%d", len(args)))
 	}
+	addFindingAgeFilter(&clauses, &args, request.MinAgeDays, request.MaxAgeDays)
+	addFindingSLAStatusFilter(&clauses, &args, request.SLAStatus)
 	if err := addFindingArrayContainsFilter(&clauses, &args, "resource_urns_json", request.ResourceURN); err != nil {
 		return nil, nil, err
 	}
@@ -2265,6 +2432,66 @@ func addFindingSeverityFilter(clauses *[]string, args *[]any, value string) {
 	*clauses = append(*clauses, fmt.Sprintf("%s = $%d", findingEffectiveSeveritySQL(), len(*args)))
 }
 
+func addFindingFrameworkFilter(clauses *[]string, args *[]any, value string) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return
+	}
+	*args = append(*args, strings.ToLower(trimmed))
+	*clauses = append(*clauses, fmt.Sprintf(`EXISTS (
+  SELECT 1
+  FROM jsonb_array_elements(COALESCE(control_refs_json, '[]'::jsonb)) AS ref
+  WHERE LOWER(TRIM(COALESCE(ref->>'framework_name', ref->>'framework_id', ''))) = $%d
+)`, len(*args)))
+}
+
+func addFindingTimeLowerBoundFilter(clauses *[]string, args *[]any, column string, value time.Time) {
+	if value.IsZero() {
+		return
+	}
+	*args = append(*args, value.UTC())
+	*clauses = append(*clauses, fmt.Sprintf("%s >= $%d", column, len(*args)))
+}
+
+func addFindingTimeUpperBoundFilter(clauses *[]string, args *[]any, column string, value time.Time) {
+	if value.IsZero() {
+		return
+	}
+	*args = append(*args, value.UTC())
+	*clauses = append(*clauses, fmt.Sprintf("%s < $%d", column, len(*args)))
+}
+
+func addFindingAgeFilter(clauses *[]string, args *[]any, minDays uint32, maxDays uint32) {
+	if minDays > 0 {
+		*args = append(*args, int64(minDays))
+		*clauses = append(*clauses, fmt.Sprintf("first_observed_at <= NOW() - ($%d::int * INTERVAL '1 day')", len(*args)))
+	}
+	if maxDays > 0 {
+		*args = append(*args, int64(maxDays))
+		*clauses = append(*clauses, fmt.Sprintf("first_observed_at > NOW() - (($%d::int + 1) * INTERVAL '1 day')", len(*args)))
+	}
+}
+
+func addFindingSLAStatusFilter(clauses *[]string, args *[]any, value string) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return
+	case "overdue":
+		*clauses = append(*clauses, "LOWER(status) = 'open' AND due_at IS NOT NULL AND due_at < NOW()")
+	case "due_soon":
+		*clauses = append(*clauses, "LOWER(status) = 'open' AND due_at IS NOT NULL AND due_at >= NOW() AND due_at <= NOW() + INTERVAL '72 hours'")
+	case "no_due_date":
+		*clauses = append(*clauses, "LOWER(status) = 'open' AND due_at IS NULL")
+	case "on_track":
+		*clauses = append(*clauses, "LOWER(status) = 'open' AND due_at IS NOT NULL AND due_at > NOW() + INTERVAL '72 hours'")
+	case "closed":
+		*clauses = append(*clauses, "LOWER(status) <> 'open'")
+	default:
+		*args = append(*args, strings.ToLower(strings.TrimSpace(value)))
+		*clauses = append(*clauses, fmt.Sprintf("LOWER(status) = $%d", len(*args)))
+	}
+}
+
 func addFindingArrayContainsFilter(clauses *[]string, args *[]any, column string, value string) error {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -2356,6 +2583,7 @@ type grcFindingRow struct {
 	PolicyName       string
 	Assignee         string
 	DueAt            sql.NullTime
+	StatusUpdatedAt  sql.NullTime
 	FirstObservedAt  time.Time
 	LastObservedAt   time.Time
 }
@@ -2432,6 +2660,7 @@ func scanGRCFindingRow(scanner findingRowScanner) (*ports.FindingRecord, error) 
 		&row.PolicyName,
 		&row.Assignee,
 		&row.DueAt,
+		&row.StatusUpdatedAt,
 		&row.FirstObservedAt,
 		&row.LastObservedAt,
 	); err != nil {
@@ -2475,8 +2704,9 @@ func scanGRCFindingRow(scanner findingRowScanner) (*ports.FindingRecord, error) 
 		PolicyName:   row.PolicyName,
 		ControlRefs:  controlRefs,
 		FindingWorkflow: ports.FindingWorkflow{
-			Assignee: row.Assignee,
-			DueAt:    findingTimestamp(row.DueAt),
+			Assignee:        row.Assignee,
+			DueAt:           findingTimestamp(row.DueAt),
+			StatusUpdatedAt: findingTimestamp(row.StatusUpdatedAt),
 		},
 		FirstObservedAt: row.FirstObservedAt.UTC(),
 		LastObservedAt:  row.LastObservedAt.UTC(),

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -323,6 +323,46 @@ func TestFindingGRCListQueryAvoidsFullPayload(t *testing.T) {
 	}
 }
 
+func TestFindingFilterClausesSupportTrendDrilldownFilters(t *testing.T) {
+	openedAfter := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	openedBefore := openedAfter.AddDate(0, 0, 7)
+	closedAfter := time.Date(2026, 3, 8, 0, 0, 0, 0, time.UTC)
+	closedBefore := closedAfter.AddDate(0, 0, 7)
+	clauses, args, err := findingFilterClauses(ports.ListFindingsRequest{
+		TenantID:            "tenant",
+		RuntimeIDs:          []string{"runtime-alpha"},
+		Framework:           "SOC 2",
+		FirstObservedFrom:   openedAfter,
+		FirstObservedBefore: openedBefore,
+		StatusUpdatedFrom:   closedAfter,
+		StatusUpdatedBefore: closedBefore,
+		MinAgeDays:          8,
+		MaxAgeDays:          30,
+		SLAStatus:           "overdue",
+	})
+	if err != nil {
+		t.Fatalf("findingFilterClauses() error = %v", err)
+	}
+	query := strings.Join(clauses, " AND ")
+	for _, fragment := range []string{
+		"jsonb_array_elements",
+		"first_observed_at >= $4",
+		"first_observed_at < $5",
+		"status_updated_at >= $6",
+		"status_updated_at < $7",
+		"first_observed_at <= NOW() - ($8::int * INTERVAL '1 day')",
+		"first_observed_at > NOW() - (($9::int + 1) * INTERVAL '1 day')",
+		"due_at < NOW()",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingFilterClauses() missing %q in %s", fragment, query)
+		}
+	}
+	if got := len(args); got != 9 {
+		t.Fatalf("len(args) = %d, want 9", got)
+	}
+}
+
 func TestFindingCandidateListQueryRequiresTenantAndScope(t *testing.T) {
 	if _, _, err := findingCandidateListQuery(ports.ListFindingCandidatesRequest{RuntimeID: "writer-okta-audit"}); err == nil {
 		t.Fatal("findingCandidateListQuery() error = nil, want tenant error")

--- a/internal/statestore/postgres/grc_trends.go
+++ b/internal/statestore/postgres/grc_trends.go
@@ -16,6 +16,14 @@ var grcTrendIntervals = map[string]struct{}{
 	"month": {},
 }
 
+var grcTrendAgingBuckets = []ports.GRCAgingBucket{
+	{ID: "0-7", Label: "0-7 days", MinDays: 0, MaxDays: 7},
+	{ID: "8-30", Label: "8-30 days", MinDays: 8, MaxDays: 30},
+	{ID: "31-60", Label: "31-60 days", MinDays: 31, MaxDays: 60},
+	{ID: "61-90", Label: "61-90 days", MinDays: 61, MaxDays: 90},
+	{ID: "90-plus", Label: "90+ days", MinDays: 91, MaxDays: 0},
+}
+
 // SummarizeGRCFindingTrends derives a time-bucketed finding flow series from the
 // findings table. Findings are bucketed as opened by first_observed_at and as
 // closed by status_updated_at for non-open rows; the baseline counts findings
@@ -54,7 +62,18 @@ func (s *Store) SummarizeGRCFindingTrends(ctx context.Context, request ports.GRC
 	var points []ports.GRCFindingTrendPoint
 	for rows.Next() {
 		var point ports.GRCFindingTrendPoint
-		if err := rows.Scan(&point.BucketStart, &point.Opened, &point.OpenedCritical, &point.OpenedHigh, &point.Closed); err != nil {
+		if err := rows.Scan(
+			&point.BucketStart,
+			&point.Opened,
+			&point.OpenedCritical,
+			&point.OpenedHigh,
+			&point.Closed,
+			&point.ClosedCritical,
+			&point.ClosedHigh,
+			&point.ClosedSLABreached,
+			&point.ClosedDurationSecondsTotal,
+			&point.ClosedDurationCount,
+		); err != nil {
 			return ports.GRCFindingTrends{}, fmt.Errorf("scan grc finding trend point: %w", err)
 		}
 		point.BucketStart = point.BucketStart.UTC()
@@ -70,7 +89,13 @@ func (s *Store) SummarizeGRCFindingTrends(ctx context.Context, request ports.GRC
 		return ports.GRCFindingTrends{}, fmt.Errorf("summarize grc finding trends baseline: %w", err)
 	}
 
-	return ports.GRCFindingTrends{Points: points, OpenAtStart: openAtStart}, nil
+	agingQuery, agingArgs := grcFindingTrendsAgingQuery(whereFindings, findingArgs, request.End)
+	agingBuckets, err := s.summarizeGRCAgingBuckets(ctx, agingQuery, agingArgs)
+	if err != nil {
+		return ports.GRCFindingTrends{}, err
+	}
+
+	return ports.GRCFindingTrends{Points: points, OpenAtStart: openAtStart, AgingBuckets: agingBuckets}, nil
 }
 
 func grcFindingTrendsSeriesQuery(whereFindings string, findingArgs []any, interval string, start, end time.Time) (string, []any) {
@@ -84,7 +109,7 @@ func grcFindingTrendsSeriesQuery(whereFindings string, findingArgs []any, interv
 	effectiveSeverity := findingEffectiveSeveritySQL()
 	query := `
 WITH scope AS (
-  SELECT status, ` + effectiveSeverity + ` AS effective_severity, first_observed_at, status_updated_at
+  SELECT status, ` + effectiveSeverity + ` AS effective_severity, first_observed_at, status_updated_at, due_at
   FROM findings
   WHERE ` + whereFindings + `
 ),
@@ -110,7 +135,12 @@ opened AS (
 closed AS (
   SELECT
     date_trunc(` + intervalArg + `, scope.status_updated_at) AS bucket_start,
-    COUNT(*) AS closed
+    COUNT(*) AS closed,
+    COUNT(*) FILTER (WHERE scope.effective_severity = 'CRITICAL') AS closed_critical,
+    COUNT(*) FILTER (WHERE scope.effective_severity = 'HIGH') AS closed_high,
+    COUNT(*) FILTER (WHERE scope.due_at IS NOT NULL AND scope.status_updated_at > scope.due_at) AS closed_sla_breached,
+    COALESCE(SUM(EXTRACT(EPOCH FROM (scope.status_updated_at - scope.first_observed_at))::double precision), 0)::double precision AS closed_duration_seconds_total,
+    COUNT(*) FILTER (WHERE scope.status_updated_at IS NOT NULL AND scope.first_observed_at IS NOT NULL) AS closed_duration_count
   FROM scope, bounds b
   WHERE LOWER(scope.status) <> 'open'
     AND scope.status_updated_at IS NOT NULL
@@ -122,7 +152,12 @@ SELECT
   COALESCE(opened.opened, 0),
   COALESCE(opened.opened_critical, 0),
   COALESCE(opened.opened_high, 0),
-  COALESCE(closed.closed, 0)
+  COALESCE(closed.closed, 0),
+  COALESCE(closed.closed_critical, 0),
+  COALESCE(closed.closed_high, 0),
+  COALESCE(closed.closed_sla_breached, 0),
+  COALESCE(closed.closed_duration_seconds_total, 0),
+  COALESCE(closed.closed_duration_count, 0)
 FROM buckets
 LEFT JOIN opened ON opened.bucket_start = buckets.bucket_start
 LEFT JOIN closed ON closed.bucket_start = buckets.bucket_start
@@ -146,4 +181,51 @@ WHERE ` + whereFindings + `
     OR (status_updated_at IS NOT NULL AND status_updated_at >= date_trunc(` + intervalArg + `, ` + startArg + `::timestamptz))
   )`
 	return query, args
+}
+
+func grcFindingTrendsAgingQuery(whereFindings string, findingArgs []any, end time.Time) (string, []any) {
+	args := append([]any{}, findingArgs...)
+	endArg := fmt.Sprintf("$%d", len(args)+1)
+	args = append(args, end.UTC())
+	query := `
+SELECT
+  CASE
+    WHEN EXTRACT(EPOCH FROM (` + endArg + `::timestamptz - first_observed_at)) / 86400 < 8 THEN '0-7'
+    WHEN EXTRACT(EPOCH FROM (` + endArg + `::timestamptz - first_observed_at)) / 86400 < 31 THEN '8-30'
+    WHEN EXTRACT(EPOCH FROM (` + endArg + `::timestamptz - first_observed_at)) / 86400 < 61 THEN '31-60'
+    WHEN EXTRACT(EPOCH FROM (` + endArg + `::timestamptz - first_observed_at)) / 86400 < 91 THEN '61-90'
+    ELSE '90-plus'
+  END AS bucket_id,
+  COUNT(*) AS count
+FROM findings
+WHERE ` + whereFindings + `
+  AND LOWER(status) = 'open'
+GROUP BY bucket_id`
+	return query, args
+}
+
+func (s *Store) summarizeGRCAgingBuckets(ctx context.Context, query string, args []any) ([]ports.GRCAgingBucket, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("summarize grc finding aging buckets: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	counts := map[string]int{}
+	for rows.Next() {
+		var id string
+		var count int
+		if err := rows.Scan(&id, &count); err != nil {
+			return nil, fmt.Errorf("scan grc finding aging bucket: %w", err)
+		}
+		counts[strings.TrimSpace(id)] += count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate grc finding aging buckets: %w", err)
+	}
+	buckets := make([]ports.GRCAgingBucket, 0, len(grcTrendAgingBuckets))
+	for _, bucket := range grcTrendAgingBuckets {
+		bucket.Count = counts[bucket.ID]
+		buckets = append(buckets, bucket)
+	}
+	return buckets, nil
 }

--- a/internal/statestore/postgres/grc_trends_test.go
+++ b/internal/statestore/postgres/grc_trends_test.go
@@ -27,6 +27,8 @@ func TestGRCFindingTrendsSeriesQueryStructure(t *testing.T) {
 		"FILTER (WHERE scope.effective_severity = 'HIGH')",
 		"LOWER(scope.status) <> 'open'",
 		"scope.status_updated_at IS NOT NULL",
+		"closed_sla_breached",
+		"closed_duration_seconds_total",
 		"LEFT JOIN opened",
 		"LEFT JOIN closed",
 		"ORDER BY buckets.bucket_start",


### PR DESCRIPTION
## Summary

- Extends GRC trends with MTTR, closed severity/SLA splits, aging buckets, comparison, targets, and accuracy metadata.
- Adds reusable Trends request/response helpers plus forward status-history capture for lifecycle transitions.
- Adds finding filters that support drill-down by opened/closed windows, age, SLA, and framework.

## Test Plan

- `make test`
- `make openapi-check`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
