### PR TITLE
feat: add health receipts for priority sources

### DIFF
--- a/sources/aws/source_health_receipt.json
+++ b/sources/aws/source_health_receipt.json
@@ -1,0 +1,18 @@
+{
+  "adapter_health_path": "sts:GetCallerIdentity",
+  "auth_model": "aws_sigv4",
+  "evidence_cas_reference_kind": "aws.evidence_cas_reference",
+  "expected_cadence_seconds": 86400,
+  "failure_modes": [
+    "api_error",
+    "auth_error",
+    "rate_limit",
+    "role_assumption_error",
+    "schema_drift"
+  ],
+  "health_endpoint": "/source-runtimes/health?source_id=aws",
+  "receipt_kind": "source_health.receipt",
+  "source_id": "aws",
+  "source_type": "cloud_api",
+  "stale_after_seconds": 86400
+}

--- a/sources/github/source_health_receipt.json
+++ b/sources/github/source_health_receipt.json
@@ -1,0 +1,17 @@
+{
+  "adapter_health_path": "/orgs/{owner}/repos",
+  "auth_model": "api_key",
+  "evidence_cas_reference_kind": "github.evidence_cas_reference",
+  "expected_cadence_seconds": 86400,
+  "failure_modes": [
+    "api_error",
+    "auth_error",
+    "rate_limit",
+    "schema_drift"
+  ],
+  "health_endpoint": "/source-runtimes/health?source_id=github",
+  "receipt_kind": "source_health.receipt",
+  "source_id": "github",
+  "source_type": "json_api",
+  "stale_after_seconds": 86400
+}

--- a/sources/grc/source_health_receipt.json
+++ b/sources/grc/source_health_receipt.json
@@ -1,0 +1,17 @@
+{
+  "adapter_health_path": "/v1/controls",
+  "auth_model": "oauth_client_credentials",
+  "evidence_cas_reference_kind": "grc.evidence_cas_reference",
+  "expected_cadence_seconds": 86400,
+  "failure_modes": [
+    "api_error",
+    "auth_error",
+    "rate_limit",
+    "schema_drift"
+  ],
+  "health_endpoint": "/source-runtimes/health?source_id=grc",
+  "receipt_kind": "source_health.receipt",
+  "source_id": "grc",
+  "source_type": "json_api",
+  "stale_after_seconds": 86400
+}

--- a/sources/okta/source_health_receipt.json
+++ b/sources/okta/source_health_receipt.json
@@ -1,0 +1,17 @@
+{
+  "adapter_health_path": "/api/v1/users",
+  "auth_model": "api_token",
+  "evidence_cas_reference_kind": "okta.evidence_cas_reference",
+  "expected_cadence_seconds": 86400,
+  "failure_modes": [
+    "api_error",
+    "auth_error",
+    "rate_limit",
+    "schema_drift"
+  ],
+  "health_endpoint": "/source-runtimes/health?source_id=okta",
+  "receipt_kind": "source_health.receipt",
+  "source_id": "okta",
+  "source_type": "json_api",
+  "stale_after_seconds": 86400
+}

--- a/sources/sentinelone/source_health_receipt.json
+++ b/sources/sentinelone/source_health_receipt.json
@@ -1,0 +1,17 @@
+{
+  "adapter_health_path": "/web/api/v2.1/agents",
+  "auth_model": "api_token",
+  "evidence_cas_reference_kind": "sentinelone.evidence_cas_reference",
+  "expected_cadence_seconds": 86400,
+  "failure_modes": [
+    "api_error",
+    "auth_error",
+    "rate_limit",
+    "schema_drift"
+  ],
+  "health_endpoint": "/source-runtimes/health?source_id=sentinelone",
+  "receipt_kind": "source_health.receipt",
+  "source_id": "sentinelone",
+  "source_type": "json_api",
+  "stale_after_seconds": 86400
+}

--- a/tools/archtests/source_deploy_test.go
+++ b/tools/archtests/source_deploy_test.go
@@ -32,6 +32,14 @@ var requireDeployManifest = map[string]struct{}{
 	"vulnview":         {},
 }
 
+var requireSourceHealthReceipt = map[string]struct{}{
+	"aws":         {},
+	"github":      {},
+	"grc":         {},
+	"okta":        {},
+	"sentinelone": {},
+}
+
 func TestSourceDeployManifestsAreValid(t *testing.T) {
 	root := filepath.Join("..", "..", "sources")
 	manifests, err := sourcedeploy.Discover(root)
@@ -59,6 +67,51 @@ func TestSourceDeployManifestsAreValid(t *testing.T) {
 		if err := manifest.Validate(); err != nil {
 			t.Fatalf("source %s: %v", manifest.SourceID, err)
 		}
+	}
+}
+
+func TestPrioritySourcesDeclareHealthReceipts(t *testing.T) {
+	root := filepath.Join("..", "..", "sources")
+	manifests, err := sourcedeploy.Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	contract, err := sourcedeploy.RenderContract(root, manifests, sourcedeploy.ContractOptions{
+		Environment: "sec-dev",
+		TenantID:    "writer",
+	})
+	if err != nil {
+		t.Fatalf("RenderContract: %v", err)
+	}
+
+	receiptsBySource := make(map[string]map[string]any)
+	for _, source := range contract.Sources {
+		if source.SourceHealthReceipt != nil {
+			receiptsBySource[source.SourceID] = source.SourceHealthReceipt
+		}
+	}
+
+	missing := make([]string, 0)
+	for id := range requireSourceHealthReceipt {
+		receipt := receiptsBySource[id]
+		if len(receipt) == 0 {
+			missing = append(missing, id)
+			continue
+		}
+		requireHealthReceiptField(t, id, receipt, "receipt_kind", "source_health.receipt")
+		requireHealthReceiptField(t, id, receipt, "source_id", id)
+		requireHealthReceiptField(t, id, receipt, "health_endpoint", "/source-runtimes/health?source_id="+id)
+		requireNonEmptyHealthReceiptField(t, id, receipt, "source_type")
+		requireNonEmptyHealthReceiptField(t, id, receipt, "auth_model")
+		requireNonEmptyHealthReceiptField(t, id, receipt, "adapter_health_path")
+		requireNonEmptyHealthReceiptField(t, id, receipt, "evidence_cas_reference_kind")
+		requirePositiveHealthReceiptSeconds(t, id, receipt, "expected_cadence_seconds")
+		requirePositiveHealthReceiptSeconds(t, id, receipt, "stale_after_seconds")
+		requireNonEmptyHealthReceiptList(t, id, receipt, "failure_modes")
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("priority sources missing source_health_receipt.json: %v", missing)
 	}
 }
 
@@ -140,6 +193,48 @@ func loadRuntimeFamilyCatalog(t *testing.T, root string, sourceID string) runtim
 		t.Fatalf("decode %s catalog: %v", sourceID, err)
 	}
 	return catalog
+}
+
+func requireHealthReceiptField(t *testing.T, sourceID string, receipt map[string]any, key string, want string) {
+	t.Helper()
+	if got, ok := receipt[key].(string); !ok || strings.TrimSpace(got) != want {
+		t.Fatalf("%s health receipt %s = %#v, want %q", sourceID, key, receipt[key], want)
+	}
+}
+
+func requireNonEmptyHealthReceiptField(t *testing.T, sourceID string, receipt map[string]any, key string) {
+	t.Helper()
+	if got, ok := receipt[key].(string); !ok || strings.TrimSpace(got) == "" {
+		t.Fatalf("%s health receipt %s = %#v, want non-empty string", sourceID, key, receipt[key])
+	}
+}
+
+func requirePositiveHealthReceiptSeconds(t *testing.T, sourceID string, receipt map[string]any, key string) {
+	t.Helper()
+	switch got := receipt[key].(type) {
+	case float64:
+		if got > 0 {
+			return
+		}
+	case int:
+		if got > 0 {
+			return
+		}
+	}
+	t.Fatalf("%s health receipt %s = %#v, want positive seconds", sourceID, key, receipt[key])
+}
+
+func requireNonEmptyHealthReceiptList(t *testing.T, sourceID string, receipt map[string]any, key string) {
+	t.Helper()
+	values, ok := receipt[key].([]any)
+	if !ok || len(values) == 0 {
+		t.Fatalf("%s health receipt %s = %#v, want non-empty list", sourceID, key, receipt[key])
+	}
+	for _, value := range values {
+		if text, ok := value.(string); !ok || strings.TrimSpace(text) == "" {
+			t.Fatalf("%s health receipt %s contains %#v, want non-empty strings", sourceID, key, value)
+		}
+	}
 }
 
 func sortedSetDifference(left map[string]struct{}, right map[string]struct{}) []string {


### PR DESCRIPTION
## Summary

- Adds source-health receipts for AWS, GitHub, GRC, Okta, and SentinelOne so runtime deployment contracts include freshness and health metadata for priority sources.
- Adds an archtest ratchet requiring those receipts and validating required receipt fields.

## Test Plan

- `go -C "/Users/jonathan/cerebro" test ./tools/sourcedeploy ./tools/archtests -run 'SourceHealth|PrioritySources|SourceDeploy' -count=1`
- `make -C "/Users/jonathan/cerebro" check-arch`
- `make -C "/Users/jonathan/cerebro" catalog-check`
- `make -C "/Users/jonathan/cerebro" oss-audit`
- `make -C "/Users/jonathan/cerebro" verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
