### PR TITLE
refactor: extract source HTTP client helper

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -27,12 +27,12 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `azure` | 2842 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 992 | Move shared API pagination and response normalization into reusable source helpers. |
 | `gcp` | 2095 | Extract project traversal, service clients, and resource-family pagination helpers. |
-| `github` | 2028 | Split audit/event readers from repository/user normalization and shared pagination. |
+| `github` | 2023 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
 | `grc` | 1321 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
-| `okta` | 2257 | Extract client, pagination, and identity/group/application readers into smaller units. |
+| `okta` | 2252 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 770 | Separate request plumbing from emitted record construction. |
-| `sentinelone` | 2077 | Extract API paging, agent/application readers, and shared response normalization. |
+| `sentinelone` | 2072 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1001 | Split feed/client access from vulnerability record normalization. |
 
 ## Cross-Source Duplication Guardrail

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -92,6 +92,15 @@ func HardenClient(client *http.Client, options ClientOptions) *http.Client {
 	return &cloned
 }
 
+func HardenSourceClient(client *http.Client, sourceID string, timeout time.Duration, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
+	return HardenClient(client, ClientOptions{
+		SourceID:      sourceID,
+		Timeout:       timeout,
+		AllowLoopback: allowLoopback,
+		LookupIPAddrs: lookupIPAddrs,
+	})
+}
+
 func firstDuration(values ...time.Duration) time.Duration {
 	for _, value := range values {
 		if value > 0 {

--- a/internal/sourcehttp/safe_test.go
+++ b/internal/sourcehttp/safe_test.go
@@ -22,6 +22,12 @@ func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }
 
+type recordingRoundTripper struct{}
+
+func (*recordingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: http.StatusNoContent, Body: io.NopCloser(strings.NewReader(""))}, nil
+}
+
 func TestNormalizeBaseURLRejectsUnsafeHosts(t *testing.T) {
 	for _, raw := range []string{
 		"http://169.254.169.254",
@@ -138,6 +144,43 @@ func TestNewJSONRequestSetsJSONHeadersAndBody(t *testing.T) {
 	}
 	if string(body) != `{"id":"123"}` {
 		t.Fatalf("body = %q, want JSON payload", string(body))
+	}
+}
+
+func TestHardenSourceClientAppliesSourceDefaults(t *testing.T) {
+	base := &recordingRoundTripper{}
+	lookup := func(context.Context, string) ([]net.IPAddr, error) {
+		return nil, nil
+	}
+	original := &http.Client{Timeout: 2 * time.Second, Transport: base}
+
+	client := HardenSourceClient(original, "github", 5*time.Second, true, lookup)
+	if client == original {
+		t.Fatal("HardenSourceClient returned original client pointer")
+	}
+	if client.Timeout != 2*time.Second {
+		t.Fatalf("Timeout = %s, want original timeout", client.Timeout)
+	}
+	if client.CheckRedirect == nil {
+		t.Fatal("CheckRedirect = nil, want no-redirect policy")
+	}
+	if err := client.CheckRedirect(httptest.NewRequest(http.MethodGet, "/", nil), nil); !errors.Is(err, http.ErrUseLastResponse) {
+		t.Fatalf("CheckRedirect error = %v, want http.ErrUseLastResponse", err)
+	}
+	transport, ok := client.Transport.(SafeRoundTripper)
+	if !ok {
+		t.Fatalf("Transport = %T, want SafeRoundTripper", client.Transport)
+	}
+	if transport.Base != base {
+		t.Fatalf("Base transport = %#v, want provided transport", transport.Base)
+	}
+	if transport.SourceID != "github" || !transport.AllowLoopback || transport.LookupIPAddrs == nil {
+		t.Fatalf("SafeRoundTripper options = %#v, want source id, loopback, and resolver", transport)
+	}
+
+	defaulted := HardenSourceClient(nil, "okta", 7*time.Second, false, nil)
+	if defaulted.Timeout != 7*time.Second {
+		t.Fatalf("defaulted Timeout = %s, want requested timeout", defaulted.Timeout)
 	}
 }
 

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -306,12 +306,7 @@ func (s *Source) newClient(cfg sourcecdk.Config, requireRepo bool) (*gogithub.Cl
 }
 
 func sourceHTTPClientNoRedirect(client *http.Client, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
-	return sourcehttp.HardenClient(client, sourcehttp.ClientOptions{
-		SourceID:      "github",
-		Timeout:       sourceHTTPTimeout,
-		AllowLoopback: allowLoopback,
-		LookupIPAddrs: lookupIPAddrs,
-	})
+	return sourcehttp.HardenSourceClient(client, "github", sourceHTTPTimeout, allowLoopback, lookupIPAddrs)
 }
 
 func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL bool) (_ settings, err error) {

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -978,12 +978,7 @@ func sleepContext(ctx context.Context, delay time.Duration) error {
 }
 
 func oktaHTTPClientNoRedirect(client *http.Client, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
-	return sourcehttp.HardenClient(client, sourcehttp.ClientOptions{
-		SourceID:      "okta",
-		Timeout:       oktaHTTPTimeout,
-		AllowLoopback: allowLoopback,
-		LookupIPAddrs: lookupIPAddrs,
-	})
+	return sourcehttp.HardenSourceClient(client, "okta", oktaHTTPTimeout, allowLoopback, lookupIPAddrs)
 }
 
 func oktaLookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {

--- a/sources/sentinelone/source.go
+++ b/sources/sentinelone/source.go
@@ -484,12 +484,7 @@ func (s *Source) getJSON(ctx context.Context, settings settings, requestPath str
 }
 
 func httpClientNoRedirect(client *http.Client, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
-	return sourcehttp.HardenClient(client, sourcehttp.ClientOptions{
-		SourceID:      "sentinelone",
-		Timeout:       httpTimeout,
-		AllowLoopback: allowLoopback,
-		LookupIPAddrs: lookupIPAddrs,
-	})
+	return sourcehttp.HardenSourceClient(client, "sentinelone", httpTimeout, allowLoopback, lookupIPAddrs)
 }
 
 func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -19,12 +19,12 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"azure":           2842,
 	"cosmo":           992,
 	"gcp":             2095,
-	"github":          2028,
+	"github":          2023,
 	"googleworkspace": 815,
 	"grc":             1321,
-	"okta":            2257,
+	"okta":            2252,
 	"panopticon":      770,
-	"sentinelone":     2077,
+	"sentinelone":     2072,
 	"vulnview":        1001,
 }
 


### PR DESCRIPTION
## Summary

- Adds a shared `sourcehttp.HardenSourceClient` helper for source HTTP client hardening.
- Moves GitHub, Okta, and SentinelOne source client setup onto the shared helper.
- Ratchets the affected legacy source LOC budgets after the extraction.

## Test Plan

- `go -C "/Users/jonathan/cerebro" test ./internal/sourcehttp ./sources/github ./sources/okta ./sources/sentinelone -count=1`
- `make -C "/Users/jonathan/cerebro" check-arch`
- `make -C "/Users/jonathan/cerebro" catalog-check`
- `make -C "/Users/jonathan/cerebro" docs-drift-check`
- `make -C "/Users/jonathan/cerebro" verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
