### PR TITLE
feat: surface source health on GRC dashboard

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -37,14 +37,15 @@ type grcScope struct {
 }
 
 type grcDashboardResponse struct {
-	Summary            grcSummary               `json:"summary"`
-	Findings           []grcFindingItem         `json:"findings"`
-	Controls           []grcControlItem         `json:"controls"`
-	Evidence           []grcEvidenceItem        `json:"evidence"`
-	Connectors         []grcConnector           `json:"connectors"`
-	CoverageBlindSpots []sourcecoverage.Record  `json:"coverage_blind_spots,omitempty"`
-	CoverageSummaries  []sourcecoverage.Summary `json:"coverage_summaries,omitempty"`
-	GeneratedAt        time.Time                `json:"generated_at"`
+	Summary            grcSummary                   `json:"summary"`
+	Findings           []grcFindingItem             `json:"findings"`
+	Controls           []grcControlItem             `json:"controls"`
+	Evidence           []grcEvidenceItem            `json:"evidence"`
+	Connectors         []grcConnector               `json:"connectors"`
+	SourceSummaries    []sourceRuntimeHealthSummary `json:"source_summaries,omitempty"`
+	CoverageBlindSpots []sourcecoverage.Record      `json:"coverage_blind_spots,omitempty"`
+	CoverageSummaries  []sourcecoverage.Summary     `json:"coverage_summaries,omitempty"`
+	GeneratedAt        time.Time                    `json:"generated_at"`
 }
 
 type grcSummary struct {
@@ -285,7 +286,15 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	findingItems := grcFindingItems(findings, runtimeSourceIDs, evidenceCounts)
 	evidenceItems := grcEvidenceItems(evidence, grcFindingTitleMap(findings))
 	controls := grcControlItems(findingItems, evidenceItems)
-	coverage := a.sourceCoverageRecords(runtimes, ports.SourceRuntimeFilter{TenantID: scope.TenantID, SourceID: scope.SourceID}, time.Now().UTC())
+	generatedAt := time.Now().UTC()
+	sourceSummaries, err := a.grcSourceRuntimeHealthSummaries(r.Context(), runtimes, generatedAt)
+	if err != nil {
+		statusCode = grcHTTPStatusCode(err)
+		status, endAttrs = grcTelemetryError(endAttrs, err)
+		writeGRCError(w, err)
+		return
+	}
+	coverage := a.sourceCoverageRecords(runtimes, ports.SourceRuntimeFilter{TenantID: scope.TenantID, SourceID: scope.SourceID}, generatedAt)
 	coverageBlindSpots := sourcecoverage.BlindSpots(coverage)
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "runtime_count", Value: len(runtimes)})
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "finding_count", Value: len(findingItems)})
@@ -297,10 +306,26 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		Controls:           grcLimitControls(controls, 25),
 		Evidence:           grcLimitEvidence(evidenceItems, 25),
 		Connectors:         grcConnectorItems(runtimes),
+		SourceSummaries:    sourceSummaries,
 		CoverageBlindSpots: coverageBlindSpots,
 		CoverageSummaries:  sourcecoverage.Summaries(coverage),
-		GeneratedAt:        time.Now().UTC(),
+		GeneratedAt:        generatedAt,
 	})
+}
+
+func (a *App) grcSourceRuntimeHealthSummaries(ctx context.Context, runtimes []*cerebrov1.SourceRuntime, generatedAt time.Time) ([]sourceRuntimeHealthSummary, error) {
+	records := make([]sourceRuntimeHealthRecord, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		record, err := a.sourceRuntimeHealthRecord(ctx, runtime, generatedAt)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return sourceRuntimeHealthSummaries(records), nil
 }
 
 func grcDashboardPreviewLimitFor(limit uint32) uint32 {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -55,6 +55,10 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 				TenantId:     "writer",
 				LastSyncedAt: timestamppb.New(now.Add(-30 * time.Minute)),
 				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now.Add(-48 * time.Hour))},
+				NextCursor:   &cerebrov1.SourceCursor{Opaque: "next-page"},
+				Config: map[string]string{
+					"stale_after_seconds": "60",
+				},
 			},
 		},
 		findings: map[string]*ports.FindingRecord{
@@ -157,6 +161,17 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	}
 	if len(payload.Connectors) != 2 {
 		t.Fatalf("connectors len = %d, want 2", len(payload.Connectors))
+	}
+	if len(payload.SourceSummaries) != 2 {
+		t.Fatalf("source summaries len = %d, want 2", len(payload.SourceSummaries))
+	}
+	summaries := map[string]sourceRuntimeHealthSummary{}
+	for _, summary := range payload.SourceSummaries {
+		summaries[summary.SourceID] = summary
+	}
+	githubSummary := summaries["github"]
+	if githubSummary.Total != 1 || githubSummary.Stale != 1 || githubSummary.CursorPending != 1 || githubSummary.ContractProbeNotConfigured != 1 || githubSummary.GraphNotObserved != 1 {
+		t.Fatalf("github source summary = %+v, want stale cursor-pending contract-not-configured graph-not-observed rollup", githubSummary)
 	}
 	connectors := map[string]grcConnector{}
 	for _, connector := range payload.Connectors {

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -103,7 +103,7 @@ func (app *App) registerAskQueryRoutes(mux *http.ServeMux) {
 }
 
 func (app *App) registerGRCRoutes(mux *http.ServeMux) {
-	registerHTTPRoute(mux, "GET /grc/dashboard", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("dashboard", 30*time.Second, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCDashboard))
+	registerHTTPRoute(mux, "GET /grc/dashboard", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("dashboard", 30*time.Second, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime, grcCacheScopeGraph), app.handleGRCDashboard))
 	registerHTTPRoute(mux, "GET /grc/trends", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("trends", time.Minute, grcCacheScopeFindings, grcCacheScopeRuntime), app.handleGRCTrends))
 	registerHTTPRoute(mux, "POST /grc/ask", routeSurfacePlatformHTTP, app.handleGRCAsk)
 	registerHTTPRoute(mux, "GET /grc/findings", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("findings", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCFindings))


### PR DESCRIPTION
## Summary

- Adds `source_summaries` to `/grc/dashboard` using the existing source runtime health rollup shape.
- Reuses source runtime health records so dashboard consumers can see source stale, cursor, graph, and contract probe rollups beside existing connector cards.
- Adds graph cache scope to the dashboard cache policy because source summaries can include graph ingest state.

## Test Plan

- `go -C "/Users/jonathan/cerebro" test ./internal/bootstrap -run 'GRCDashboard|SourceRuntimeHealth' -count=1`
- `make -C "/Users/jonathan/cerebro" openapi-check`
- `make -C "/Users/jonathan/cerebro" check-arch`
- `make -C "/Users/jonathan/cerebro" verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
