### PR TITLE
feat: add upcoming GRC framework lifecycle

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2316,7 +2316,7 @@ paths:
         - GRC
       responses:
         '200':
-          description: Built-in GRC frameworks with lifecycle metadata. Upcoming frameworks are discoverable but not measured until controls are available.
+          description: Built-in GRC frameworks with lifecycle, maturity, coverage, readiness, and gap-action metadata. Upcoming frameworks are discoverable but not measured until controls are available.
   /grc/control-profiles:
     get:
       summary: Control profile coverage

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2309,6 +2309,14 @@ paths:
       responses:
         '200':
           description: Reusable auditor-facing control archetypes for custom framework generation.
+  /grc/frameworks:
+    get:
+      summary: GRC frameworks
+      tags:
+        - GRC
+      responses:
+        '200':
+          description: Built-in GRC frameworks with lifecycle metadata. Upcoming frameworks are discoverable but not measured until controls are available.
   /grc/control-profiles:
     get:
       summary: Control profile coverage

--- a/internal/bootstrap/grc_control_packs.go
+++ b/internal/bootstrap/grc_control_packs.go
@@ -22,6 +22,15 @@ func (a *App) handleGRCControlArchetypes(w http.ResponseWriter, _ *http.Request)
 	writeJSON(w, http.StatusOK, response)
 }
 
+func (a *App) handleGRCFrameworks(w http.ResponseWriter, _ *http.Request) {
+	response, err := compliance.BuiltinFrameworks(time.Now().UTC())
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
 func (a *App) handleGRCControlProfiles(w http.ResponseWriter, r *http.Request) {
 	response, err := compliance.BuiltinControlProfiles(r.URL.Query()["profile"], time.Now().UTC())
 	if err != nil {

--- a/internal/bootstrap/grc_control_packs_test.go
+++ b/internal/bootstrap/grc_control_packs_test.go
@@ -46,6 +46,34 @@ func TestGRCControlArchetypesEndpointReturnsReusableControls(t *testing.T) {
 	}
 }
 
+func TestGRCFrameworksEndpointReturnsLifecycleMetadata(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/frameworks")
+	if err != nil {
+		t.Fatalf("GET /grc/frameworks error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/frameworks status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload compliance.FrameworksResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode frameworks: %v", err)
+	}
+	var foundUpcoming bool
+	for _, framework := range payload.Frameworks {
+		if framework.Name == "NIST AI RMF 1.0" && framework.Lifecycle == compliance.FrameworkLifecycleUpcoming {
+			foundUpcoming = true
+		}
+	}
+	if !foundUpcoming {
+		t.Fatalf("frameworks = %#v, want upcoming NIST AI RMF", payload.Frameworks)
+	}
+}
+
 func TestGRCControlPackPreviewEndpointReturnsYAMLFilesAndCoverage(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, nil)
 	server := httptest.NewServer(app.Handler())

--- a/internal/bootstrap/grc_control_packs_test.go
+++ b/internal/bootstrap/grc_control_packs_test.go
@@ -63,14 +63,31 @@ func TestGRCFrameworksEndpointReturnsLifecycleMetadata(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode frameworks: %v", err)
 	}
-	var foundUpcoming bool
+	var foundNIST, foundCSA, foundActive bool
 	for _, framework := range payload.Frameworks {
-		if framework.Name == "NIST AI RMF 1.0" && framework.Lifecycle == compliance.FrameworkLifecycleUpcoming {
-			foundUpcoming = true
+		switch {
+		case framework.Name == "NIST AI RMF 1.0":
+			foundNIST = true
+			if framework.Lifecycle != compliance.FrameworkLifecycleUpcoming {
+				t.Fatalf("NIST AI RMF lifecycle = %q, want upcoming", framework.Lifecycle)
+			}
+		case framework.Name == "CSA CCM v4.0":
+			foundCSA = true
+			if framework.Lifecycle != compliance.FrameworkLifecycleUpcoming {
+				t.Fatalf("CSA CCM lifecycle = %q, want upcoming", framework.Lifecycle)
+			}
+		case framework.Lifecycle == compliance.FrameworkLifecycleActive:
+			foundActive = true
 		}
 	}
-	if !foundUpcoming {
-		t.Fatalf("frameworks = %#v, want upcoming NIST AI RMF", payload.Frameworks)
+	if !foundNIST {
+		t.Fatal("NIST AI RMF 1.0 not found in /grc/frameworks response")
+	}
+	if !foundCSA {
+		t.Fatal("CSA CCM v4.0 not found in /grc/frameworks response")
+	}
+	if !foundActive {
+		t.Fatal("no active frameworks found in /grc/frameworks response")
 	}
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -115,6 +115,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /grc/controls", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("controls", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCControls))
 	registerHTTPRoute(mux, "GET /grc/controls/export", routeSurfacePlatformHTTP, app.handleGRCControlsExport)
 	registerHTTPRoute(mux, "GET /grc/evidence", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("evidence", time.Minute, grcCacheScopeEvidence, grcCacheScopeFindings, grcCacheScopeRuntime), app.handleGRCEvidence))
+	registerHTTPRoute(mux, "GET /grc/frameworks", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("frameworks", 5*time.Minute), app.handleGRCFrameworks))
 	registerHTTPRoute(mux, "GET /grc/control-archetypes", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("control.archetypes", 5*time.Minute), app.handleGRCControlArchetypes))
 	registerHTTPRoute(mux, "GET /grc/control-profiles", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("control.profiles", 5*time.Minute), app.handleGRCControlProfiles))
 	registerHTTPRoute(mux, "GET /grc/control-coverage", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("control.coverage", 5*time.Minute), app.handleGRCControlCoverage))

--- a/internal/compliance/catalog.go
+++ b/internal/compliance/catalog.go
@@ -12,6 +12,11 @@ import (
 
 const DefaultControlCatalogPath = "internal/compliance/control_families.yaml"
 
+const (
+	FrameworkLifecycleActive   = "active"
+	FrameworkLifecycleUpcoming = "upcoming"
+)
+
 type ValidationIssue struct {
 	Path    string `json:"path,omitempty" yaml:"path,omitempty"`
 	Message string `json:"message" yaml:"message"`
@@ -33,6 +38,7 @@ type Framework struct {
 	ID          string   `json:"id,omitempty" yaml:"id,omitempty"`
 	Name        string   `json:"name" yaml:"name"`
 	Version     string   `json:"framework_version,omitempty" yaml:"framework_version,omitempty"`
+	Lifecycle   string   `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
 	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
 	Tags        []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Families    []Family `json:"families" yaml:"families"`
@@ -86,14 +92,15 @@ type ControlRef struct {
 }
 
 type ResolvedControl struct {
-	FrameworkID      string                `json:"framework_id,omitempty"`
-	FrameworkName    string                `json:"framework_name"`
-	FrameworkVersion string                `json:"framework_version,omitempty"`
-	FamilyID         string                `json:"family_id"`
-	FamilyName       string                `json:"family_name"`
-	Control          Control               `json:"control"`
-	EffectiveTags    []string              `json:"effective_tags,omitempty"`
-	Evidence         []EvidenceExpectation `json:"evidence_expectations,omitempty"`
+	FrameworkID        string                `json:"framework_id,omitempty"`
+	FrameworkName      string                `json:"framework_name"`
+	FrameworkVersion   string                `json:"framework_version,omitempty"`
+	FrameworkLifecycle string                `json:"framework_lifecycle,omitempty"`
+	FamilyID           string                `json:"family_id"`
+	FamilyName         string                `json:"family_name"`
+	Control            Control               `json:"control"`
+	EffectiveTags      []string              `json:"effective_tags,omitempty"`
+	Evidence           []EvidenceExpectation `json:"evidence_expectations,omitempty"`
 }
 
 type CatalogIndex struct {
@@ -169,6 +176,7 @@ func BuildCatalogIndex(catalog ControlCatalog) (*CatalogIndex, []ValidationIssue
 			continue
 		}
 		frameworkID := strings.TrimSpace(framework.ID)
+		frameworkLifecycle := normalizeFrameworkLifecycle(framework.Lifecycle)
 		index.frameworksByName[frameworkName] = framework
 		if frameworkID != "" {
 			index.frameworksByID[frameworkID] = framework
@@ -192,14 +200,15 @@ func BuildCatalogIndex(catalog ControlCatalog) (*CatalogIndex, []ValidationIssue
 				control = cloneControl(control)
 				refKey := controlKey(frameworkName, control.ID)
 				resolved := &ResolvedControl{
-					FrameworkID:      frameworkID,
-					FrameworkName:    frameworkName,
-					FrameworkVersion: strings.TrimSpace(framework.Version),
-					FamilyID:         familyID,
-					FamilyName:       strings.TrimSpace(family.Name),
-					Control:          control,
-					EffectiveTags:    mergedTags(framework.Tags, family.Tags, control.Tags),
-					Evidence:         append([]EvidenceExpectation(nil), control.EvidenceExpectations...),
+					FrameworkID:        frameworkID,
+					FrameworkName:      frameworkName,
+					FrameworkVersion:   strings.TrimSpace(framework.Version),
+					FrameworkLifecycle: frameworkLifecycleForJSON(frameworkLifecycle),
+					FamilyID:           familyID,
+					FamilyName:         strings.TrimSpace(family.Name),
+					Control:            control,
+					EffectiveTags:      mergedTags(framework.Tags, family.Tags, control.Tags),
+					Evidence:           append([]EvidenceExpectation(nil), control.EvidenceExpectations...),
 				}
 				index.controls[frameworkKey][control.ID] = resolved
 				index.controlKeys = append(index.controlKeys, refKey)
@@ -240,7 +249,12 @@ func ValidateControlCatalog(catalog ControlCatalog) []ValidationIssue {
 			frameworkIDs[frameworkID] = struct{}{}
 		}
 		if len(framework.Families) == 0 {
-			issues = append(issues, ValidationIssue{Message: fmt.Sprintf("framework %q requires at least one family", frameworkName)})
+			if normalizeFrameworkLifecycle(framework.Lifecycle) != FrameworkLifecycleUpcoming {
+				issues = append(issues, ValidationIssue{Message: fmt.Sprintf("framework %q requires at least one family", frameworkName)})
+			}
+		}
+		if lifecycleIssues := validateFrameworkLifecycle(frameworkPath+".lifecycle", framework.Lifecycle); len(lifecycleIssues) != 0 {
+			issues = append(issues, lifecycleIssues...)
 		}
 		issues = append(issues, validateTags(frameworkPath+".tags", framework.Tags)...)
 		familyIDs := map[string]struct{}{}
@@ -435,6 +449,34 @@ func validateControl(path string, control Control) []ValidationIssue {
 		}
 	}
 	return issues
+}
+
+func normalizeFrameworkLifecycle(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", FrameworkLifecycleActive:
+		return FrameworkLifecycleActive
+	case FrameworkLifecycleUpcoming:
+		return FrameworkLifecycleUpcoming
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func frameworkLifecycleForJSON(value string) string {
+	value = normalizeFrameworkLifecycle(value)
+	if value == FrameworkLifecycleActive {
+		return ""
+	}
+	return value
+}
+
+func validateFrameworkLifecycle(path, value string) []ValidationIssue {
+	switch normalizeFrameworkLifecycle(value) {
+	case FrameworkLifecycleActive, FrameworkLifecycleUpcoming:
+		return nil
+	default:
+		return []ValidationIssue{{Message: fmt.Sprintf("%s must be one of active, upcoming", path)}}
+	}
 }
 
 func validateControlMappings(catalog ControlCatalog, index *CatalogIndex) []ValidationIssue {

--- a/internal/compliance/catalog_test.go
+++ b/internal/compliance/catalog_test.go
@@ -143,21 +143,54 @@ func TestBuiltinFrameworksIncludesUpcomingFrameworks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuiltinFrameworks() error = %v", err)
 	}
-	var found bool
+	var foundNIST, foundCSA bool
 	for _, framework := range response.Frameworks {
-		if framework.Name != "NIST AI RMF 1.0" {
-			continue
-		}
-		found = true
-		if framework.Lifecycle != FrameworkLifecycleUpcoming {
-			t.Fatalf("NIST AI RMF lifecycle = %q, want upcoming", framework.Lifecycle)
-		}
-		if framework.ControlCount != 0 || framework.FamilyCount != 0 {
-			t.Fatalf("NIST AI RMF counts = %d/%d, want 0/0", framework.FamilyCount, framework.ControlCount)
+		switch framework.Name {
+		case "NIST AI RMF 1.0":
+			foundNIST = true
+			if framework.Lifecycle != FrameworkLifecycleUpcoming {
+				t.Fatalf("NIST AI RMF lifecycle = %q, want upcoming", framework.Lifecycle)
+			}
+			if framework.ControlCount != 0 || framework.FamilyCount != 0 {
+				t.Fatalf("NIST AI RMF counts = %d/%d, want 0/0", framework.FamilyCount, framework.ControlCount)
+			}
+		case "CSA CCM v4.0":
+			foundCSA = true
+			if framework.Lifecycle != FrameworkLifecycleUpcoming {
+				t.Fatalf("CSA CCM lifecycle = %q, want upcoming", framework.Lifecycle)
+			}
+			if framework.ControlCount != 0 || framework.FamilyCount != 0 {
+				t.Fatalf("CSA CCM counts = %d/%d, want 0/0", framework.FamilyCount, framework.ControlCount)
+			}
 		}
 	}
-	if !found {
+	if !foundNIST {
 		t.Fatal("NIST AI RMF 1.0 not found")
+	}
+	if !foundCSA {
+		t.Fatal("CSA CCM v4.0 not found")
+	}
+}
+
+func TestBuiltinFrameworksActiveFrameworksHaveActiveLifecycle(t *testing.T) {
+	response, err := BuiltinFrameworks(time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatalf("BuiltinFrameworks() error = %v", err)
+	}
+	var foundActive bool
+	for _, framework := range response.Frameworks {
+		if framework.Lifecycle == FrameworkLifecycleActive {
+			foundActive = true
+			if framework.FamilyCount == 0 {
+				t.Fatalf("active framework %q has 0 families", framework.Name)
+			}
+		}
+		if framework.Lifecycle != FrameworkLifecycleActive && framework.Lifecycle != FrameworkLifecycleUpcoming {
+			t.Fatalf("framework %q lifecycle = %q, want active or upcoming", framework.Name, framework.Lifecycle)
+		}
+	}
+	if !foundActive {
+		t.Fatal("no active frameworks found")
 	}
 }
 

--- a/internal/compliance/catalog_test.go
+++ b/internal/compliance/catalog_test.go
@@ -3,6 +3,7 @@ package compliance
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBuildCatalogIndexAcceptsRichCustomControlPack(t *testing.T) {
@@ -99,6 +100,64 @@ frameworks:
 	}
 	if !issueContains(issues, "maps_to[0] Missing M-1 is not declared") {
 		t.Fatalf("issues = %#v, want missing mapping target", issues)
+	}
+}
+
+func TestBuildCatalogIndexAllowsUpcomingFrameworkWithoutControls(t *testing.T) {
+	catalog := loadTestCatalog(t, `
+version: "2026-06-17"
+frameworks:
+  - id: planned
+    name: Planned Framework
+    lifecycle: upcoming
+`)
+	index, issues := BuildCatalogIndex(catalog)
+	if len(issues) != 0 {
+		t.Fatalf("BuildCatalogIndex() issues = %#v, want none", issues)
+	}
+	controls, ok := index.FrameworkControls(ControlRef{FrameworkID: "planned"})
+	if !ok {
+		t.Fatal("FrameworkControls(planned) not found")
+	}
+	if len(controls) != 0 {
+		t.Fatalf("FrameworkControls(planned) = %#v, want no controls", controls)
+	}
+}
+
+func TestBuildCatalogIndexRejectsUnknownFrameworkLifecycle(t *testing.T) {
+	catalog := loadTestCatalog(t, `
+version: "2026-06-17"
+frameworks:
+  - id: planned
+    name: Planned Framework
+    lifecycle: later
+`)
+	_, issues := BuildCatalogIndex(catalog)
+	if !issueContains(issues, "frameworks[0].lifecycle must be one of active, upcoming") {
+		t.Fatalf("issues = %#v, want invalid lifecycle", issues)
+	}
+}
+
+func TestBuiltinFrameworksIncludesUpcomingFrameworks(t *testing.T) {
+	response, err := BuiltinFrameworks(time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatalf("BuiltinFrameworks() error = %v", err)
+	}
+	var found bool
+	for _, framework := range response.Frameworks {
+		if framework.Name != "NIST AI RMF 1.0" {
+			continue
+		}
+		found = true
+		if framework.Lifecycle != FrameworkLifecycleUpcoming {
+			t.Fatalf("NIST AI RMF lifecycle = %q, want upcoming", framework.Lifecycle)
+		}
+		if framework.ControlCount != 0 || framework.FamilyCount != 0 {
+			t.Fatalf("NIST AI RMF counts = %d/%d, want 0/0", framework.FamilyCount, framework.ControlCount)
+		}
+	}
+	if !found {
+		t.Fatal("NIST AI RMF 1.0 not found")
 	}
 }
 

--- a/internal/compliance/catalog_test.go
+++ b/internal/compliance/catalog_test.go
@@ -161,6 +161,44 @@ func TestBuiltinFrameworksIncludesUpcomingFrameworks(t *testing.T) {
 	}
 }
 
+func TestBuiltinFrameworksIncludesMaturityAndGapActions(t *testing.T) {
+	response, err := BuiltinFrameworks(time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatalf("BuiltinFrameworks() error = %v", err)
+	}
+	var soc2, upcoming *FrameworkSummary
+	for idx := range response.Frameworks {
+		framework := &response.Frameworks[idx]
+		switch framework.Name {
+		case "SOC 2":
+			soc2 = framework
+		case "NIST AI RMF 1.0":
+			upcoming = framework
+		}
+	}
+	if soc2 == nil {
+		t.Fatal("SOC 2 framework not found")
+	}
+	if soc2.Coverage.SelectedControls == 0 {
+		t.Fatalf("SOC 2 selected controls = %d, want non-zero", soc2.Coverage.SelectedControls)
+	}
+	if soc2.Maturity.Status == "" || soc2.Maturity.Summary == "" {
+		t.Fatalf("SOC 2 maturity = %#v, want populated status and summary", soc2.Maturity)
+	}
+	if len(soc2.GapActions) == 0 {
+		t.Fatal("SOC 2 gap actions empty")
+	}
+	if upcoming == nil {
+		t.Fatal("NIST AI RMF 1.0 framework not found")
+	}
+	if upcoming.Maturity.Status != "planning" {
+		t.Fatalf("upcoming maturity status = %q, want planning", upcoming.Maturity.Status)
+	}
+	if len(upcoming.GapActions) != 1 || upcoming.GapActions[0].Code != "plan_framework_scope" {
+		t.Fatalf("upcoming gap actions = %#v, want planning action", upcoming.GapActions)
+	}
+}
+
 func TestMergeControlCatalogsAllowsCustomPacksToMapToBuiltins(t *testing.T) {
 	builtin := loadTestCatalog(t, `
 version: "2026-06-17"

--- a/internal/compliance/control_families.yaml
+++ b/internal/compliance/control_families.yaml
@@ -3814,3 +3814,15 @@ frameworks:
         name: TLS-MAIL Controls
         controls:
           - id: TLS-MAIL
+  - id: nist-ai-rmf-1.0
+    name: NIST AI RMF 1.0
+    framework_version: "1.0"
+    lifecycle: upcoming
+    description: Planned AI risk-management framework coverage.
+    tags: [ai, risk-management]
+  - id: csa-ccm-v4.0
+    name: CSA CCM v4.0
+    framework_version: "4.0"
+    lifecycle: upcoming
+    description: Planned Cloud Controls Matrix coverage.
+    tags: [cloud, security, third-party]

--- a/internal/compliance/control_pack_service.go
+++ b/internal/compliance/control_pack_service.go
@@ -2,9 +2,27 @@ package compliance
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
+
+type FrameworkSummary struct {
+	ID           string   `json:"id,omitempty"`
+	Name         string   `json:"name"`
+	Version      string   `json:"framework_version,omitempty"`
+	Lifecycle    string   `json:"lifecycle"`
+	Description  string   `json:"description,omitempty"`
+	Tags         []string `json:"tags,omitempty"`
+	FamilyCount  int      `json:"family_count"`
+	ControlCount int      `json:"control_count"`
+}
+
+type FrameworksResponse struct {
+	Version     string             `json:"version"`
+	Frameworks  []FrameworkSummary `json:"frameworks"`
+	GeneratedAt time.Time          `json:"generated_at"`
+}
 
 type ControlArchetypesResponse struct {
 	Version     string             `json:"version"`
@@ -31,6 +49,40 @@ type ControlPackResponse struct {
 type ControlPackIssueResponse struct {
 	Issues      []ValidationIssue `json:"issues"`
 	GeneratedAt time.Time         `json:"generated_at"`
+}
+
+func BuiltinFrameworks(generatedAt time.Time) (FrameworksResponse, error) {
+	catalog, err := LoadBuiltinControlCatalog()
+	if err != nil {
+		return FrameworksResponse{}, fmt.Errorf("load control catalog: %w", err)
+	}
+	frameworks := make([]FrameworkSummary, 0, len(catalog.Frameworks))
+	for _, framework := range catalog.Frameworks {
+		summary := FrameworkSummary{
+			ID:          strings.TrimSpace(framework.ID),
+			Name:        strings.TrimSpace(framework.Name),
+			Version:     strings.TrimSpace(framework.Version),
+			Lifecycle:   normalizeFrameworkLifecycle(framework.Lifecycle),
+			Description: strings.TrimSpace(framework.Description),
+			Tags:        sortedUniqueStrings(framework.Tags),
+			FamilyCount: len(framework.Families),
+		}
+		for _, family := range framework.Families {
+			summary.ControlCount += len(family.Controls)
+		}
+		frameworks = append(frameworks, summary)
+	}
+	sort.Slice(frameworks, func(i, j int) bool {
+		if frameworks[i].Lifecycle != frameworks[j].Lifecycle {
+			return frameworks[i].Lifecycle < frameworks[j].Lifecycle
+		}
+		return frameworks[i].Name < frameworks[j].Name
+	})
+	return FrameworksResponse{
+		Version:     strings.TrimSpace(catalog.Version),
+		Frameworks:  frameworks,
+		GeneratedAt: generatedAt,
+	}, nil
 }
 
 func BuiltinControlArchetypes(generatedAt time.Time) (ControlArchetypesResponse, error) {

--- a/internal/compliance/control_pack_service.go
+++ b/internal/compliance/control_pack_service.go
@@ -8,14 +8,44 @@ import (
 )
 
 type FrameworkSummary struct {
-	ID           string   `json:"id,omitempty"`
-	Name         string   `json:"name"`
-	Version      string   `json:"framework_version,omitempty"`
-	Lifecycle    string   `json:"lifecycle"`
-	Description  string   `json:"description,omitempty"`
-	Tags         []string `json:"tags,omitempty"`
-	FamilyCount  int      `json:"family_count"`
-	ControlCount int      `json:"control_count"`
+	ID           string               `json:"id,omitempty"`
+	Name         string               `json:"name"`
+	Version      string               `json:"framework_version,omitempty"`
+	Lifecycle    string               `json:"lifecycle"`
+	Description  string               `json:"description,omitempty"`
+	Tags         []string             `json:"tags,omitempty"`
+	FamilyCount  int                  `json:"family_count"`
+	ControlCount int                  `json:"control_count"`
+	Maturity     FrameworkMaturity    `json:"maturity"`
+	Coverage     FrameworkCoverage    `json:"coverage"`
+	Readiness    FrameworkReadiness   `json:"readiness"`
+	GapActions   []FrameworkGapAction `json:"gap_actions,omitempty"`
+}
+
+type FrameworkMaturity struct {
+	Status  string `json:"status"`
+	Score   int    `json:"score"`
+	Summary string `json:"summary,omitempty"`
+}
+
+type FrameworkCoverage struct {
+	SelectedControls int `json:"selected_controls"`
+	MappedControls   int `json:"mapped_controls"`
+	UnmappedControls int `json:"unmapped_controls"`
+	MappedRules      int `json:"mapped_rules"`
+}
+
+type FrameworkReadiness struct {
+	AuditorReadyControls    int `json:"auditor_ready_controls"`
+	NeedsEnrichmentControls int `json:"needs_enrichment_controls"`
+	PlaceholderControls     int `json:"placeholder_controls"`
+}
+
+type FrameworkGapAction struct {
+	Code     string `json:"code"`
+	Label    string `json:"label"`
+	Priority int    `json:"priority"`
+	Count    int    `json:"count,omitempty"`
 }
 
 type FrameworksResponse struct {
@@ -56,13 +86,19 @@ func BuiltinFrameworks(generatedAt time.Time) (FrameworksResponse, error) {
 	if err != nil {
 		return FrameworksResponse{}, fmt.Errorf("load control catalog: %w", err)
 	}
+	coverageIndex, err := LoadBuiltinControlCoverageIndex()
+	if err != nil {
+		return FrameworksResponse{}, fmt.Errorf("load control coverage index: %w", err)
+	}
+	coverageByFramework := aggregateFrameworkCoverage(coverageIndex.Profiles)
 	frameworks := make([]FrameworkSummary, 0, len(catalog.Frameworks))
 	for _, framework := range catalog.Frameworks {
+		lifecycle := normalizeFrameworkLifecycle(framework.Lifecycle)
 		summary := FrameworkSummary{
 			ID:          strings.TrimSpace(framework.ID),
 			Name:        strings.TrimSpace(framework.Name),
 			Version:     strings.TrimSpace(framework.Version),
-			Lifecycle:   normalizeFrameworkLifecycle(framework.Lifecycle),
+			Lifecycle:   lifecycle,
 			Description: strings.TrimSpace(framework.Description),
 			Tags:        sortedUniqueStrings(framework.Tags),
 			FamilyCount: len(framework.Families),
@@ -70,6 +106,22 @@ func BuiltinFrameworks(generatedAt time.Time) (FrameworksResponse, error) {
 		for _, family := range framework.Families {
 			summary.ControlCount += len(family.Controls)
 		}
+		aggregate := coverageByFramework[frameworkAggregationKey(summary.ID, summary.Name)]
+		if aggregate != nil {
+			summary.Coverage = FrameworkCoverage{
+				SelectedControls: aggregate.selectedControls,
+				MappedControls:   aggregate.mappedControls,
+				UnmappedControls: aggregate.unmappedControls,
+				MappedRules:      len(aggregate.mappedRules),
+			}
+			summary.Readiness = FrameworkReadiness{
+				AuditorReadyControls:    aggregate.auditorReadyControls,
+				NeedsEnrichmentControls: aggregate.needsEnrichmentControls,
+				PlaceholderControls:     aggregate.placeholderControls,
+			}
+		}
+		summary.Maturity = frameworkMaturity(lifecycle, summary.Coverage, summary.Readiness)
+		summary.GapActions = frameworkGapActions(lifecycle, summary.Coverage, summary.Readiness)
 		frameworks = append(frameworks, summary)
 	}
 	sort.Slice(frameworks, func(i, j int) bool {
@@ -83,6 +135,173 @@ func BuiltinFrameworks(generatedAt time.Time) (FrameworksResponse, error) {
 		Frameworks:  frameworks,
 		GeneratedAt: generatedAt,
 	}, nil
+}
+
+type frameworkCoverageAggregate struct {
+	selectedControls        int
+	mappedControls          int
+	unmappedControls        int
+	auditorReadyControls    int
+	needsEnrichmentControls int
+	placeholderControls     int
+	mappedRules             map[string]struct{}
+	seenControls            map[string]struct{}
+}
+
+func aggregateFrameworkCoverage(profiles []ControlCoverageProfile) map[string]*frameworkCoverageAggregate {
+	aggregates := map[string]*frameworkCoverageAggregate{}
+	for _, profile := range profiles {
+		for _, control := range profile.Controls {
+			key := frameworkAggregationKey(control.FrameworkID, control.FrameworkName)
+			if key == "" {
+				continue
+			}
+			aggregate := aggregates[key]
+			if aggregate == nil {
+				aggregate = &frameworkCoverageAggregate{
+					mappedRules:  map[string]struct{}{},
+					seenControls: map[string]struct{}{},
+				}
+				aggregates[key] = aggregate
+			}
+			controlKey := strings.ToLower(strings.TrimSpace(control.FamilyID)) + "\x00" + strings.ToLower(strings.TrimSpace(control.ControlID))
+			if _, seen := aggregate.seenControls[controlKey]; seen {
+				for _, ruleID := range control.MappedRules {
+					if ruleID = strings.TrimSpace(ruleID); ruleID != "" {
+						aggregate.mappedRules[ruleID] = struct{}{}
+					}
+				}
+				continue
+			}
+			aggregate.seenControls[controlKey] = struct{}{}
+			aggregate.selectedControls++
+			if len(control.MappedRules) != 0 || len(control.MappedControlRefs) != 0 || control.RuleCount > 0 || strings.EqualFold(control.CoverageStatus, "mapped") {
+				aggregate.mappedControls++
+			} else {
+				aggregate.unmappedControls++
+			}
+			switch control.AuditReadiness.Status {
+			case ControlReadinessAuditorReady:
+				aggregate.auditorReadyControls++
+			case ControlReadinessNeedsEnrichment:
+				aggregate.needsEnrichmentControls++
+			case ControlReadinessPlaceholder:
+				aggregate.placeholderControls++
+			}
+			for _, ruleID := range control.MappedRules {
+				if ruleID = strings.TrimSpace(ruleID); ruleID != "" {
+					aggregate.mappedRules[ruleID] = struct{}{}
+				}
+			}
+		}
+	}
+	return aggregates
+}
+
+func frameworkAggregationKey(id, name string) string {
+	if id = strings.ToLower(strings.TrimSpace(id)); id != "" {
+		return "id:" + id
+	}
+	if name = strings.ToLower(strings.TrimSpace(name)); name != "" {
+		return "name:" + name
+	}
+	return ""
+}
+
+func frameworkMaturity(lifecycle string, coverage FrameworkCoverage, readiness FrameworkReadiness) FrameworkMaturity {
+	if lifecycle == FrameworkLifecycleUpcoming {
+		return FrameworkMaturity{
+			Status:  "planning",
+			Score:   0,
+			Summary: "Framework is discoverable for scoping, but controls are not measured yet.",
+		}
+	}
+	if coverage.SelectedControls == 0 {
+		return FrameworkMaturity{
+			Status:  "not_configured",
+			Score:   0,
+			Summary: "No measured controls are available yet.",
+		}
+	}
+	if readiness.AuditorReadyControls == coverage.SelectedControls {
+		return FrameworkMaturity{
+			Status:  "audit_ready",
+			Score:   100,
+			Summary: "All selected controls are auditor-ready.",
+		}
+	}
+	score := (readiness.AuditorReadyControls*100 + readiness.NeedsEnrichmentControls*60 + readiness.PlaceholderControls*20) / coverage.SelectedControls
+	if score > 100 {
+		score = 100
+	}
+	if score < 0 {
+		score = 0
+	}
+	status := "mapped"
+	summary := "Controls are mapped and ready for evidence review."
+	if readiness.PlaceholderControls > 0 {
+		status = "needs_catalog_work"
+		summary = "Some controls still need catalog metadata before audit use."
+	} else if readiness.NeedsEnrichmentControls > 0 {
+		status = "needs_evidence_plan"
+		summary = "Some controls need richer evidence plans before audit use."
+	} else if coverage.UnmappedControls > 0 {
+		status = "needs_mapping"
+		summary = "Some controls still need rule or evidence mapping."
+	}
+	return FrameworkMaturity{Status: status, Score: score, Summary: summary}
+}
+
+func frameworkGapActions(lifecycle string, coverage FrameworkCoverage, readiness FrameworkReadiness) []FrameworkGapAction {
+	if lifecycle == FrameworkLifecycleUpcoming {
+		return []FrameworkGapAction{{
+			Code:     "plan_framework_scope",
+			Label:    "Define applicability, owners, and initial control scope.",
+			Priority: 1,
+		}}
+	}
+	actions := []FrameworkGapAction{}
+	if coverage.SelectedControls == 0 {
+		return []FrameworkGapAction{{
+			Code:     "select_controls",
+			Label:    "Select controls for the framework tracking scope.",
+			Priority: 1,
+		}}
+	}
+	if coverage.UnmappedControls > 0 {
+		actions = append(actions, FrameworkGapAction{
+			Code:     "map_controls",
+			Label:    "Map controls to rules or evidence sources.",
+			Priority: 1,
+			Count:    coverage.UnmappedControls,
+		})
+	}
+	incompleteReadiness := readiness.NeedsEnrichmentControls + readiness.PlaceholderControls
+	if incompleteReadiness > 0 {
+		actions = append(actions, FrameworkGapAction{
+			Code:     "enrich_evidence_plan",
+			Label:    "Complete audit objectives, procedures, and evidence expectations.",
+			Priority: 2,
+			Count:    incompleteReadiness,
+		})
+	}
+	notAuditorReady := coverage.SelectedControls - readiness.AuditorReadyControls
+	if notAuditorReady > 0 {
+		actions = append(actions, FrameworkGapAction{
+			Code:     "close_readiness_gaps",
+			Label:    "Review non-ready controls and close audit readiness gaps.",
+			Priority: 3,
+			Count:    notAuditorReady,
+		})
+	}
+	if len(actions) == 0 {
+		actions = append(actions, FrameworkGapAction{
+			Code:     "export_audit_packet",
+			Label:    "Export an audit packet for review.",
+			Priority: 4,
+		})
+	}
+	return actions
 }
 
 func BuiltinControlArchetypes(generatedAt time.Time) (ControlArchetypesResponse, error) {

--- a/internal/compliance/posture.go
+++ b/internal/compliance/posture.go
@@ -75,14 +75,15 @@ type ControlPosture struct {
 }
 
 type ControlPostureControl struct {
-	FrameworkID      string `json:"framework_id,omitempty"`
-	FrameworkName    string `json:"framework_name"`
-	FrameworkVersion string `json:"framework_version,omitempty"`
-	FamilyID         string `json:"family_id"`
-	FamilyName       string `json:"family_name"`
-	ControlID        string `json:"control_id"`
-	Title            string `json:"title,omitempty"`
-	OwnerDomain      string `json:"owner_domain,omitempty"`
+	FrameworkID        string `json:"framework_id,omitempty"`
+	FrameworkName      string `json:"framework_name"`
+	FrameworkVersion   string `json:"framework_version,omitempty"`
+	FrameworkLifecycle string `json:"framework_lifecycle,omitempty"`
+	FamilyID           string `json:"family_id"`
+	FamilyName         string `json:"family_name"`
+	ControlID          string `json:"control_id"`
+	Title              string `json:"title,omitempty"`
+	OwnerDomain        string `json:"owner_domain,omitempty"`
 }
 
 type ControlPostureFindingSummary struct {
@@ -273,14 +274,15 @@ func evaluateControlPosture(selectionID string, bucket *controlPostureBucket, no
 	posture := ControlPosture{
 		SelectionID: strings.TrimSpace(selectionID),
 		Control: ControlPostureControl{
-			FrameworkID:      control.FrameworkID,
-			FrameworkName:    control.FrameworkName,
-			FrameworkVersion: control.FrameworkVersion,
-			FamilyID:         control.FamilyID,
-			FamilyName:       control.FamilyName,
-			ControlID:        control.Control.ID,
-			Title:            control.Control.Title,
-			OwnerDomain:      control.Control.OwnerDomain,
+			FrameworkID:        control.FrameworkID,
+			FrameworkName:      control.FrameworkName,
+			FrameworkVersion:   control.FrameworkVersion,
+			FrameworkLifecycle: frameworkLifecycleForJSON(control.FrameworkLifecycle),
+			FamilyID:           control.FamilyID,
+			FamilyName:         control.FamilyName,
+			ControlID:          control.Control.ID,
+			Title:              control.Control.Title,
+			OwnerDomain:        control.Control.OwnerDomain,
 		},
 		Status:      ControlPosturePassing,
 		Tags:        append([]string(nil), control.EffectiveTags...),

--- a/internal/compliance/profile.go
+++ b/internal/compliance/profile.go
@@ -56,6 +56,7 @@ type ControlCoverageControl struct {
 	FrameworkID            string                       `json:"framework_id,omitempty" yaml:"framework_id,omitempty"`
 	FrameworkName          string                       `json:"framework_name" yaml:"framework_name"`
 	FrameworkVersion       string                       `json:"framework_version,omitempty" yaml:"framework_version,omitempty"`
+	FrameworkLifecycle     string                       `json:"framework_lifecycle,omitempty" yaml:"framework_lifecycle,omitempty"`
 	FamilyID               string                       `json:"family_id" yaml:"family_id"`
 	FamilyName             string                       `json:"family_name" yaml:"family_name"`
 	ControlID              string                       `json:"control_id" yaml:"control_id"`
@@ -277,6 +278,7 @@ func BuildControlCoverageProfile(selection ControlSelection, resolution Selectio
 			FrameworkID:            strings.TrimSpace(control.FrameworkID),
 			FrameworkName:          strings.TrimSpace(control.FrameworkName),
 			FrameworkVersion:       strings.TrimSpace(control.FrameworkVersion),
+			FrameworkLifecycle:     frameworkLifecycleForJSON(control.FrameworkLifecycle),
 			FamilyID:               strings.TrimSpace(control.FamilyID),
 			FamilyName:             strings.TrimSpace(control.FamilyName),
 			ControlID:              strings.TrimSpace(control.Control.ID),

--- a/internal/grccontrol/packets.go
+++ b/internal/grccontrol/packets.go
@@ -82,29 +82,30 @@ type FindingItem struct {
 }
 
 type ControlItem struct {
-	FrameworkName    string        `json:"framework_name"`
-	FrameworkID      string        `json:"framework_id,omitempty"`
-	FrameworkVersion string        `json:"framework_version,omitempty"`
-	FamilyID         string        `json:"family_id,omitempty"`
-	FamilyName       string        `json:"family_name,omitempty"`
-	ControlID        string        `json:"control_id"`
-	Title            string        `json:"title,omitempty"`
-	OwnerDomain      string        `json:"owner_domain,omitempty"`
-	Status           string        `json:"status"`
-	OpenFindings     int           `json:"open_findings"`
-	CriticalFindings int           `json:"critical_findings"`
-	HighFindings     int           `json:"high_findings"`
-	EvidenceItems    int           `json:"evidence_items"`
-	MissingEvidence  int           `json:"missing_evidence_items,omitempty"`
-	StaleEvidence    int           `json:"stale_evidence_items,omitempty"`
-	Expectations     int           `json:"evidence_expectations,omitempty"`
-	EvidenceScore    int           `json:"evidence_score"`
-	EvidenceQuality  string        `json:"evidence_quality,omitempty"`
-	AuditSummary     string        `json:"audit_summary,omitempty"`
-	MappedRules      []string      `json:"mapped_rules,omitempty"`
-	Reasons          []string      `json:"reasons,omitempty"`
-	Tags             []string      `json:"tags,omitempty"`
-	Findings         []FindingItem `json:"findings,omitempty"`
+	FrameworkName      string        `json:"framework_name"`
+	FrameworkID        string        `json:"framework_id,omitempty"`
+	FrameworkVersion   string        `json:"framework_version,omitempty"`
+	FrameworkLifecycle string        `json:"framework_lifecycle,omitempty"`
+	FamilyID           string        `json:"family_id,omitempty"`
+	FamilyName         string        `json:"family_name,omitempty"`
+	ControlID          string        `json:"control_id"`
+	Title              string        `json:"title,omitempty"`
+	OwnerDomain        string        `json:"owner_domain,omitempty"`
+	Status             string        `json:"status"`
+	OpenFindings       int           `json:"open_findings"`
+	CriticalFindings   int           `json:"critical_findings"`
+	HighFindings       int           `json:"high_findings"`
+	EvidenceItems      int           `json:"evidence_items"`
+	MissingEvidence    int           `json:"missing_evidence_items,omitempty"`
+	StaleEvidence      int           `json:"stale_evidence_items,omitempty"`
+	Expectations       int           `json:"evidence_expectations,omitempty"`
+	EvidenceScore      int           `json:"evidence_score"`
+	EvidenceQuality    string        `json:"evidence_quality,omitempty"`
+	AuditSummary       string        `json:"audit_summary,omitempty"`
+	MappedRules        []string      `json:"mapped_rules,omitempty"`
+	Reasons            []string      `json:"reasons,omitempty"`
+	Tags               []string      `json:"tags,omitempty"`
+	Findings           []FindingItem `json:"findings,omitempty"`
 }
 
 type ReportMetadata struct {
@@ -369,25 +370,26 @@ func ControlItemsFromPacket(packetControls []compliance.ControlEvidencePacketCon
 	controls := make([]ControlItem, 0, len(packetControls))
 	for _, packetControl := range packetControls {
 		item := ControlItem{
-			FrameworkName:    packetControl.Control.FrameworkName,
-			FrameworkID:      packetControl.Control.FrameworkID,
-			FrameworkVersion: packetControl.Control.FrameworkVersion,
-			FamilyID:         packetControl.Control.FamilyID,
-			FamilyName:       packetControl.Control.FamilyName,
-			ControlID:        packetControl.Control.ControlID,
-			Title:            packetControl.Control.Title,
-			OwnerDomain:      packetControl.Control.OwnerDomain,
-			Status:           string(packetControl.Status),
-			EvidenceItems:    len(packetControl.Evidence.Summary.EvidenceIDs),
-			MissingEvidence:  len(packetControl.Evidence.Summary.MissingEvidenceIDs),
-			StaleEvidence:    len(packetControl.Evidence.Summary.StaleEvidenceIDs),
-			Expectations:     len(packetControl.Evidence.Expectations),
-			EvidenceScore:    packetControl.Readiness.Score,
-			EvidenceQuality:  string(packetControl.Readiness.Rating),
-			AuditSummary:     packetControl.Readiness.Summary,
-			MappedRules:      append([]string(nil), packetControl.MappedRules...),
-			Reasons:          append([]string(nil), packetControl.Reasons...),
-			Tags:             append([]string(nil), packetControl.Tags...),
+			FrameworkName:      packetControl.Control.FrameworkName,
+			FrameworkID:        packetControl.Control.FrameworkID,
+			FrameworkVersion:   packetControl.Control.FrameworkVersion,
+			FrameworkLifecycle: packetControl.Control.FrameworkLifecycle,
+			FamilyID:           packetControl.Control.FamilyID,
+			FamilyName:         packetControl.Control.FamilyName,
+			ControlID:          packetControl.Control.ControlID,
+			Title:              packetControl.Control.Title,
+			OwnerDomain:        packetControl.Control.OwnerDomain,
+			Status:             string(packetControl.Status),
+			EvidenceItems:      len(packetControl.Evidence.Summary.EvidenceIDs),
+			MissingEvidence:    len(packetControl.Evidence.Summary.MissingEvidenceIDs),
+			StaleEvidence:      len(packetControl.Evidence.Summary.StaleEvidenceIDs),
+			Expectations:       len(packetControl.Evidence.Expectations),
+			EvidenceScore:      packetControl.Readiness.Score,
+			EvidenceQuality:    string(packetControl.Readiness.Rating),
+			AuditSummary:       packetControl.Readiness.Summary,
+			MappedRules:        append([]string(nil), packetControl.MappedRules...),
+			Reasons:            append([]string(nil), packetControl.Reasons...),
+			Tags:               append([]string(nil), packetControl.Tags...),
 		}
 		for _, packetFinding := range packetControl.Findings {
 			finding := findingsByID[packetFinding.ID]


### PR DESCRIPTION
## Summary

- Add framework lifecycle metadata with `active` as the default and `upcoming` for planned frameworks.
- Expose `/grc/frameworks` with framework lifecycle and coverage counts.
- Add NIST AI RMF 1.0 and CSA CCM v4.0 as upcoming frameworks without measured controls.

## Test Plan

- `go -C /Users/jonathan/cerebro-upcoming-frameworks-pr test ./internal/compliance ./internal/bootstrap ./internal/grccontrol`
- Earlier full validation on the source branch: `make test`, `make lint`, `make openapi-check`, `make catalog-check control-index-check`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on framework lifecycle contract, `/grc/frameworks`, and control packet/profile propagation.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
