### PR TITLE
feat: add runtime connector ingest preview

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -796,6 +796,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConnectorDefinitionValidationResponse'
+  /connector-definitions/preview:
+    post:
+      summary: Run a bounded live preview for a dynamic connector definition
+      tags:
+        - Connectors
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConnectorDefinitionPreviewRequest'
+      responses:
+        '200':
+          description: Bounded check/read preview for a runtime connector definition.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorDefinitionPreviewResponse'
   /connector-definitions/plan:
     post:
       summary: Build a Source CDK promotion plan without persisting it
@@ -5814,6 +5832,47 @@ components:
           $ref: '#/components/schemas/ConnectorDefinitionValidation'
         promotion:
           $ref: '#/components/schemas/ConnectorDefinitionPromotion'
+    ConnectorDefinitionPreviewRequest:
+      type: object
+      required:
+        - definition
+      properties:
+        definition:
+          $ref: '#/components/schemas/ConnectorDefinition'
+        config:
+          type: object
+          additionalProperties:
+            type: string
+        page_limit:
+          type: integer
+          minimum: 0
+          maximum: 3
+        check_only:
+          type: boolean
+    ConnectorDefinitionPreviewResponse:
+      type: object
+      required:
+        - definition
+        - status
+      properties:
+        generated_at:
+          type: string
+          format: date-time
+        definition:
+          $ref: '#/components/schemas/ConnectorDefinition'
+        status:
+          type: string
+          enum: [checked, previewed]
+        events:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        pages_read:
+          type: integer
+          minimum: 0
+        next_cursor:
+          type: string
     ConnectorDefinitionPlanRequest:
       type: object
       required:
@@ -6054,6 +6113,8 @@ components:
                 type: string
             requires_references:
               type: boolean
+        ingest:
+          $ref: '#/components/schemas/ConnectorDefinitionIngest'
         resource_families:
           type: array
           items:
@@ -6072,6 +6133,21 @@ components:
         updated_at:
           type: string
           format: date-time
+    ConnectorDefinitionIngest:
+      type: object
+      properties:
+        mode:
+          type: string
+          enum: [pull, deposit]
+        deposit:
+          type: object
+          properties:
+            resource_families:
+              type: array
+              items:
+                type: string
+            full_state_sync:
+              type: boolean
     ConnectorDefinitionField:
       type: object
       required:
@@ -6095,7 +6171,6 @@ components:
       type: object
       required:
         - id
-        - path
         - id_field
       properties:
         id:
@@ -6106,7 +6181,7 @@ components:
           type: string
         method:
           type: string
-          enum: [GET]
+          enum: [GET, POST]
         list_key:
           type: string
         id_field:

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -1493,6 +1493,8 @@ func fallbackAccessAuditRoute(method string, path string) string {
 		return prefix + "/connector-definitions"
 	case path == "/connector-definitions/plan":
 		return prefix + "/connector-definitions/plan"
+	case path == "/connector-definitions/preview":
+		return prefix + "/connector-definitions/preview"
 	case path == "/connector-definitions/validate":
 		return prefix + "/connector-definitions/validate"
 	case strings.HasPrefix(path, "/connector-definitions/") && strings.HasSuffix(path, "/promotion-plan"):

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -52,6 +52,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodGet, Exact: "/connector-definitions", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/connector-definitions", Scope: scopeConnectorDefinitionsWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/connector-definitions/plan", Scope: scopeConnectorDefinitionsWrite, Static: true},
+	{Method: http.MethodPost, Exact: "/connector-definitions/preview", Scope: scopeConnectorDefinitionsWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/connector-definitions/validate", Scope: scopeConnectorDefinitionsWrite, Static: true},
 	{Method: http.MethodGet, Prefix: "/connector-definitions/", Suffix: "/promotion-plan", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Prefix: "/connector-definitions/", Scope: scopeCosmoSecurityRead, Static: true},

--- a/internal/bootstrap/connector_definitions.go
+++ b/internal/bootstrap/connector_definitions.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/writer/cerebro/internal/connectorcredentials"
 	"github.com/writer/cerebro/internal/connectordefinitions"
+	"github.com/writer/cerebro/internal/connectorpreview"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourceruntime"
 )
@@ -36,6 +37,13 @@ type connectorDefinitionValidationResponse struct {
 	Validation  connectordefinitions.ValidationResult `json:"validation"`
 	Promotion   connectordefinitions.PromotionState   `json:"promotion"`
 	Support     connectordefinitions.SupportReport    `json:"support"`
+}
+
+type connectorDefinitionPreviewRequest struct {
+	Definition connectordefinitions.Definition `json:"definition"`
+	Config     map[string]string               `json:"config,omitempty"`
+	PageLimit  uint32                          `json:"page_limit,omitempty"`
+	CheckOnly  bool                            `json:"check_only,omitempty"`
 }
 
 type connectorDefinitionPromotionResponse struct {
@@ -122,6 +130,40 @@ func (a *App) handleValidateConnectorDefinition(w http.ResponseWriter, r *http.R
 		Promotion:   normalized.Promotion,
 		Support:     support,
 	})
+}
+
+func (a *App) handlePreviewConnectorDefinition(w http.ResponseWriter, r *http.Request) {
+	var request connectorDefinitionPreviewRequest
+	if err := readConnectorJSON(r, &request); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	tenantID, err := effectiveTenantFilter(r.Context(), request.Definition.TenantID)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	request.Definition.TenantID = tenantID
+	normalized, err := connectordefinitions.Normalize(request.Definition)
+	if err != nil {
+		writeConnectorError(w, fmt.Errorf("%w: %w", connectorcredentials.ErrInvalidRequest, err))
+		return
+	}
+	if err := authorizeTenantID(r.Context(), normalized.TenantID); err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	config, err := connectorRuntimeConfig(request.Config)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	response, err := connectorpreview.Run(r.Context(), normalized, config, request.PageLimit, request.CheckOnly)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
 }
 
 func (a *App) handleCreateConnectorDefinition(w http.ResponseWriter, r *http.Request) {

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -174,6 +174,7 @@ func (app *App) registerConnectorRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /connector-definitions", routeSurfacePlatformHTTP, app.handleListConnectorDefinitions)
 	registerHTTPRoute(mux, "POST /connector-definitions", routeSurfacePlatformHTTP, app.handleCreateConnectorDefinition)
 	registerHTTPRoute(mux, "POST /connector-definitions/plan", routeSurfacePlatformHTTP, sourceplanapi.HandleDefinitionPlan(app.sourcePlanAPIDeps()))
+	registerHTTPRoute(mux, "POST /connector-definitions/preview", routeSurfacePlatformHTTP, app.handlePreviewConnectorDefinition)
 	registerHTTPRoute(mux, "POST /connector-definitions/validate", routeSurfacePlatformHTTP, app.handleValidateConnectorDefinition)
 	registerHTTPRoute(mux, "GET /connector-definitions/{definitionID}", routeSurfacePlatformHTTP, app.handleGetConnectorDefinition)
 	registerHTTPRoute(mux, "PUT /connector-definitions/{definitionID}", routeSurfacePlatformHTTP, app.handlePutConnectorDefinition)

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -1004,10 +1004,27 @@ func normalizeIngestSpec(ingest IngestSpec) IngestSpec {
 	}
 	if ingest.Deposit != nil {
 		deposit := *ingest.Deposit
-		deposit.ResourceFamilies = normalizeOrderedStringList(deposit.ResourceFamilies)
+		deposit.ResourceFamilies = normalizeIngestResourceFamilies(deposit.ResourceFamilies)
 		ingest.Deposit = &deposit
 	}
 	return ingest
+}
+
+func normalizeIngestResourceFamilies(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		family := normalizeIdentifier(value)
+		if family == "" {
+			continue
+		}
+		if _, ok := seen[family]; ok {
+			continue
+		}
+		seen[family] = struct{}{}
+		normalized = append(normalized, family)
+	}
+	return normalized
 }
 
 func normalizePaginationSpec(pagination *PaginationSpec) *PaginationSpec {

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -24,6 +24,9 @@ const (
 	ValidationReady   = "ready"
 	ValidationWarning = "warning"
 	ValidationBlocked = "blocked"
+
+	IngestModePull    = "pull"
+	IngestModeDeposit = "deposit"
 )
 
 var (
@@ -38,6 +41,7 @@ var (
 	supportedMethods    = map[string]struct{}{"GET": {}, "POST": {}}
 	paginationTypes     = map[string]struct{}{"": {}, "none": {}, "cursor": {}, "page": {}, "offset": {}, "link": {}, "next_url": {}}
 	incrementalStates   = map[string]struct{}{"": {}, "high_watermark": {}, "opaque_cursor": {}}
+	ingestModes         = map[string]struct{}{IngestModePull: {}, IngestModeDeposit: {}}
 	projectionRelations = map[string]struct{}{
 		"attached_to": {},
 		"belongs_to":  {},
@@ -101,12 +105,25 @@ type Definition struct {
 	ConfigFields     []Field          `json:"config_fields,omitempty"`
 	Auth             AuthSpec         `json:"auth"`
 	Transport        *TransportSpec   `json:"transport,omitempty"`
+	Ingest           IngestSpec       `json:"ingest,omitempty"`
 	ResourceFamilies []ResourceFamily `json:"resource_families,omitempty"`
 	ScopeOptions     []ScopeOption    `json:"scope_options,omitempty"`
 	Validation       ValidationResult `json:"validation"`
 	Promotion        PromotionState   `json:"promotion"`
 	CreatedAt        string           `json:"created_at,omitempty"`
 	UpdatedAt        string           `json:"updated_at,omitempty"`
+}
+
+// IngestSpec selects the transport direction for a dynamic connector definition.
+type IngestSpec struct {
+	Mode    string             `json:"mode,omitempty"`
+	Deposit *DepositIngestSpec `json:"deposit,omitempty"`
+}
+
+// DepositIngestSpec describes customer-pushed records accepted for unreachable data.
+type DepositIngestSpec struct {
+	ResourceFamilies []string `json:"resource_families,omitempty"`
+	FullStateSync    bool     `json:"full_state_sync,omitempty"`
 }
 
 // Field describes non-secret configuration or credential references required by a connector definition.
@@ -356,6 +373,7 @@ func Normalize(definition Definition) (Definition, error) {
 	definition.Auth.TokenParams = normalizeStringMap(definition.Auth.TokenParams)
 	definition.Auth.RefreshParams = normalizeStringMap(definition.Auth.RefreshParams)
 	definition.Transport = normalizeTransportSpec(definition.Transport)
+	definition.Ingest = normalizeIngestSpec(definition.Ingest)
 	definition.ConfigFields = normalizeFields(definition.ConfigFields)
 	definition.Auth.CredentialFields = normalizeFields(definition.Auth.CredentialFields)
 	definition.Auth.SupportedStoreIDs = normalizeStringList(definition.Auth.SupportedStoreIDs)
@@ -417,6 +435,7 @@ func Validate(definition Definition) ValidationResult {
 		}
 	}
 	validateTransport(definition.Transport, add)
+	validateIngest(definition, add)
 	if len(definition.ResourceFamilies) == 0 {
 		add(blocking("resources", "Resource families", "Add at least one read-only resource family."))
 	} else {
@@ -427,8 +446,12 @@ func Validate(definition Definition) ValidationResult {
 			add(blocking("family_"+family.ID, "Resource family ID", "Family ids must be lowercase identifiers."))
 		}
 		path := strings.TrimSpace(family.Path)
-		if path == "" || !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") || strings.Contains(path, "\\") || strings.Contains(path, "://") {
+		depositFamily := isDepositResourceFamily(definition, family.ID)
+		if !depositFamily && (path == "" || !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") || strings.Contains(path, "\\") || strings.Contains(path, "://")) {
 			add(blocking("path_"+family.ID, "Resource path", "Resource paths must be relative API paths such as /v1/assets."))
+		}
+		if depositFamily && path != "" && (!strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") || strings.Contains(path, "\\") || strings.Contains(path, "://")) {
+			add(blocking("path_"+family.ID, "Resource path", "Deposit resource paths may be omitted; when present they must be relative API paths."))
 		}
 		if method := strings.ToUpper(strings.TrimSpace(family.Method)); method != "" {
 			if _, ok := supportedMethods[method]; !ok {
@@ -628,6 +651,50 @@ func validateTransport(transport *TransportSpec, add func(ValidationCheck)) {
 			add(blocking("retry_attempts", "Retry attempts", "Retry attempts must not be negative."))
 		}
 	}
+}
+
+func validateIngest(definition Definition, add func(ValidationCheck)) {
+	mode := strings.TrimSpace(definition.Ingest.Mode)
+	if mode == "" {
+		mode = IngestModePull
+	}
+	if _, ok := ingestModes[mode]; !ok {
+		add(blocking("ingest_mode", "Ingest mode", "Ingest mode must be pull or deposit."))
+		return
+	}
+	if mode == IngestModePull {
+		add(passing("ingest_mode", "Ingest mode", "Cerebro pulls records from the provider with the declarative runtime."))
+		return
+	}
+	add(passing("ingest_mode", "Ingest mode", "Connector accepts deposit records through a typed, connector-scoped ingest surface."))
+	if definition.Ingest.Deposit == nil || len(definition.Ingest.Deposit.ResourceFamilies) == 0 {
+		return
+	}
+	families := map[string]struct{}{}
+	for _, family := range definition.ResourceFamilies {
+		families[strings.TrimSpace(family.ID)] = struct{}{}
+	}
+	for _, familyID := range definition.Ingest.Deposit.ResourceFamilies {
+		if _, ok := families[strings.TrimSpace(familyID)]; !ok {
+			add(blocking("ingest_deposit_family_"+familyID, "Deposit family", "Deposit resource families must reference a modeled resource family."))
+		}
+	}
+}
+
+func isDepositResourceFamily(definition Definition, familyID string) bool {
+	if strings.TrimSpace(definition.Ingest.Mode) != IngestModeDeposit {
+		return false
+	}
+	if definition.Ingest.Deposit == nil || len(definition.Ingest.Deposit.ResourceFamilies) == 0 {
+		return true
+	}
+	familyID = strings.TrimSpace(familyID)
+	for _, candidate := range definition.Ingest.Deposit.ResourceFamilies {
+		if strings.TrimSpace(candidate) == familyID {
+			return true
+		}
+	}
+	return false
 }
 
 func validateFamilyIntegrationFields(family ResourceFamily, add func(ValidationCheck)) {
@@ -928,6 +995,19 @@ func normalizeTransportSpec(transport *TransportSpec) *TransportSpec {
 		next.Retry = &retry
 	}
 	return &next
+}
+
+func normalizeIngestSpec(ingest IngestSpec) IngestSpec {
+	ingest.Mode = strings.ToLower(strings.TrimSpace(ingest.Mode))
+	if ingest.Mode == "" {
+		ingest.Mode = IngestModePull
+	}
+	if ingest.Deposit != nil {
+		deposit := *ingest.Deposit
+		deposit.ResourceFamilies = normalizeOrderedStringList(deposit.ResourceFamilies)
+		ingest.Deposit = &deposit
+	}
+	return ingest
 }
 
 func normalizePaginationSpec(pagination *PaginationSpec) *PaginationSpec {

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -148,6 +148,61 @@ func TestValidateBlocksUnsupportedResourceMethods(t *testing.T) {
 	}
 }
 
+func TestValidateDepositFamilyAllowsOmittedPullPath(t *testing.T) {
+	definition, err := Normalize(Definition{
+		TenantID: "tenant-a",
+		SourceID: "example",
+		Auth:     AuthSpec{Model: "none"},
+		Ingest: IngestSpec{
+			Mode: IngestModeDeposit,
+			Deposit: &DepositIngestSpec{
+				ResourceFamilies: []string{"assets"},
+			},
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:      "assets",
+			IDField: "id",
+			Event:   EventMappingSpec{Kind: "example.assets"},
+			Projection: &ProjectionSpec{
+				Entity: &ProjectionEntitySpec{
+					EntityType:   "example.asset",
+					URNKind:      "example_asset",
+					IDAttributes: []string{"id"},
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if definition.Validation.Status != ValidationReady {
+		t.Fatalf("validation status = %q, want ready: %#v", definition.Validation.Status, definition.Validation.Checks)
+	}
+}
+
+func TestValidateDepositBlocksUnknownFamily(t *testing.T) {
+	definition, err := Normalize(Definition{
+		TenantID: "tenant-a",
+		SourceID: "example",
+		Auth:     AuthSpec{Model: "none"},
+		Ingest: IngestSpec{
+			Mode:    IngestModeDeposit,
+			Deposit: &DepositIngestSpec{ResourceFamilies: []string{"missing"}},
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:      "assets",
+			Path:    "/v1/assets",
+			IDField: "id",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if !hasBlockingCheck(definition.Validation.Checks, "ingest_deposit_family_missing") {
+		t.Fatalf("validation checks = %#v, want ingest_deposit_family_missing blocker", definition.Validation.Checks)
+	}
+}
+
 func TestValidateAcceptsProjectionRelationships(t *testing.T) {
 	definition, err := Normalize(Definition{
 		TenantID: "tenant-a",

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -180,6 +180,41 @@ func TestValidateDepositFamilyAllowsOmittedPullPath(t *testing.T) {
 	}
 }
 
+func TestValidateDepositFamilyReferencesNormalizeWithFamilyIDs(t *testing.T) {
+	definition, err := Normalize(Definition{
+		TenantID: "tenant-a",
+		SourceID: "example",
+		Auth:     AuthSpec{Model: "none"},
+		Ingest: IngestSpec{
+			Mode: IngestModeDeposit,
+			Deposit: &DepositIngestSpec{
+				ResourceFamilies: []string{"Assets"},
+			},
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:      "Assets",
+			IDField: "id",
+			Event:   EventMappingSpec{Kind: "example.assets"},
+			Projection: &ProjectionSpec{
+				Entity: &ProjectionEntitySpec{
+					EntityType:   "example.asset",
+					URNKind:      "example_asset",
+					IDAttributes: []string{"id"},
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if got := definition.Ingest.Deposit.ResourceFamilies; len(got) != 1 || got[0] != "assets" {
+		t.Fatalf("deposit resource families = %#v, want [assets]", got)
+	}
+	if definition.Validation.Status != ValidationReady {
+		t.Fatalf("validation status = %q, want ready: %#v", definition.Validation.Status, definition.Validation.Checks)
+	}
+}
+
 func TestValidateDepositBlocksUnknownFamily(t *testing.T) {
 	definition, err := Normalize(Definition{
 		TenantID: "tenant-a",

--- a/internal/connectorpreview/preview.go
+++ b/internal/connectorpreview/preview.go
@@ -1,0 +1,92 @@
+package connectorpreview
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/connectorcredentials"
+	"github.com/writer/cerebro/internal/connectordefinitions"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceregistry"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const (
+	maxPages  = 3
+	maxEvents = 25
+)
+
+type Response struct {
+	GeneratedAt string                          `json:"generated_at"`
+	Definition  connectordefinitions.Definition `json:"definition"`
+	Status      string                          `json:"status"`
+	Events      []json.RawMessage               `json:"events,omitempty"`
+	PagesRead   uint32                          `json:"pages_read,omitempty"`
+	NextCursor  string                          `json:"next_cursor,omitempty"`
+}
+
+func Run(ctx context.Context, definition connectordefinitions.Definition, config map[string]string, pageLimit uint32, checkOnly bool) (Response, error) {
+	if definition.Validation.Status == connectordefinitions.ValidationBlocked {
+		return Response{}, fmt.Errorf("%w: connector definition is not previewable until blocking validation checks pass", connectorcredentials.ErrInvalidRequest)
+	}
+	source, err := sourceregistry.DynamicDefinitionSource(definition)
+	if err != nil {
+		return Response{}, fmt.Errorf("%w: %w", connectorcredentials.ErrInvalidRequest, err)
+	}
+	sourceConfig := sourcecdk.NewConfig(config)
+	if err := source.Check(ctx, sourceConfig); err != nil {
+		return Response{}, fmt.Errorf("%w: check failed: %w", connectorcredentials.ErrInvalidRequest, err)
+	}
+	response := Response{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Definition:  definition,
+		Status:      "checked",
+	}
+	if checkOnly {
+		return response, nil
+	}
+	if pageLimit == 0 {
+		pageLimit = 1
+	}
+	if pageLimit > maxPages {
+		pageLimit = maxPages
+	}
+	var cursor *cerebrov1.SourceCursor
+	marshal := protojson.MarshalOptions{UseProtoNames: true}
+	for i := uint32(0); i < pageLimit; i++ {
+		pull, err := source.Read(ctx, sourceConfig, cursor)
+		if err != nil {
+			return Response{}, fmt.Errorf("%w: preview read failed: %w", connectorcredentials.ErrInvalidRequest, err)
+		}
+		response.PagesRead++
+		for _, event := range pull.Events {
+			if event == nil {
+				continue
+			}
+			body, err := marshal.Marshal(event)
+			if err != nil {
+				return Response{}, err
+			}
+			response.Events = append(response.Events, json.RawMessage(body))
+			if len(response.Events) >= maxEvents {
+				break
+			}
+		}
+		if pull.NextCursor == nil || len(response.Events) >= maxEvents {
+			cursor = pull.NextCursor
+			break
+		}
+		cursor = pull.NextCursor
+	}
+	if cursor != nil {
+		response.NextCursor = strings.TrimSpace(cursor.GetOpaque())
+	}
+	if len(response.Events) > 0 {
+		response.Status = "previewed"
+	}
+	return response, nil
+}

--- a/internal/sourceprojection/catalogruntime.go
+++ b/internal/sourceprojection/catalogruntime.go
@@ -51,50 +51,23 @@ func registerCatalogRuntimeProjectorsForEntries(projectors map[string]ProjectFun
 	}
 }
 
-func registerCatalogRuntimeProjectorsForDefinitions(projectors map[string]ProjectFunc, definitions []connectordefinitions.Definition) {
-	if projectors == nil {
-		return
-	}
-	for _, definition := range definitions {
-		sourceID := strings.TrimSpace(definition.SourceID)
-		if sourceID == "" || definition.Validation.Status == connectordefinitions.ValidationBlocked {
-			continue
-		}
-		for _, resource := range definition.ResourceFamilies {
-			kind := catalogRuntimeEventKind(sourceID, resource)
-			if kind == "" {
-				continue
-			}
-			if existing, exists := projectors[kind]; exists {
-				if existing != nil {
-					projectors[kind] = augmentCatalogRuntimeProjector(sourceID, resource, existing)
-				}
-				continue
-			}
-			projectors[kind] = catalogRuntimeProjectorFor(sourceID, resource)
-		}
-	}
-}
-
-func catalogRuntimeDefinitionProjectorKinds(definition connectordefinitions.Definition) []string {
+func catalogRuntimeDefinitionProjectors(definition connectordefinitions.Definition) map[string]ProjectFunc {
 	sourceID := strings.TrimSpace(definition.SourceID)
 	if sourceID == "" || definition.Validation.Status == connectordefinitions.ValidationBlocked {
 		return nil
 	}
-	kinds := make([]string, 0, len(definition.ResourceFamilies))
-	seen := map[string]struct{}{}
+	projectors := make(map[string]ProjectFunc, len(definition.ResourceFamilies))
 	for _, resource := range definition.ResourceFamilies {
 		kind := catalogRuntimeEventKind(sourceID, resource)
 		if kind == "" {
 			continue
 		}
-		if _, ok := seen[kind]; ok {
+		if _, ok := projectors[kind]; ok {
 			continue
 		}
-		seen[kind] = struct{}{}
-		kinds = append(kinds, kind)
+		projectors[kind] = catalogRuntimeProjectorFor(sourceID, resource)
 	}
-	return kinds
+	return projectors
 }
 
 func catalogRuntimeEventKind(sourceID string, resource connectordefinitions.ResourceFamily) string {

--- a/internal/sourceprojection/catalogruntime.go
+++ b/internal/sourceprojection/catalogruntime.go
@@ -76,6 +76,27 @@ func registerCatalogRuntimeProjectorsForDefinitions(projectors map[string]Projec
 	}
 }
 
+func catalogRuntimeDefinitionProjectorKinds(definition connectordefinitions.Definition) []string {
+	sourceID := strings.TrimSpace(definition.SourceID)
+	if sourceID == "" || definition.Validation.Status == connectordefinitions.ValidationBlocked {
+		return nil
+	}
+	kinds := make([]string, 0, len(definition.ResourceFamilies))
+	seen := map[string]struct{}{}
+	for _, resource := range definition.ResourceFamilies {
+		kind := catalogRuntimeEventKind(sourceID, resource)
+		if kind == "" {
+			continue
+		}
+		if _, ok := seen[kind]; ok {
+			continue
+		}
+		seen[kind] = struct{}{}
+		kinds = append(kinds, kind)
+	}
+	return kinds
+}
+
 func catalogRuntimeEventKind(sourceID string, resource connectordefinitions.ResourceFamily) string {
 	if kind := strings.TrimSpace(resource.Event.Kind); kind != "" {
 		return kind

--- a/internal/sourceprojection/catalogruntime.go
+++ b/internal/sourceprojection/catalogruntime.go
@@ -51,6 +51,31 @@ func registerCatalogRuntimeProjectorsForEntries(projectors map[string]ProjectFun
 	}
 }
 
+func registerCatalogRuntimeProjectorsForDefinitions(projectors map[string]ProjectFunc, definitions []connectordefinitions.Definition) {
+	if projectors == nil {
+		return
+	}
+	for _, definition := range definitions {
+		sourceID := strings.TrimSpace(definition.SourceID)
+		if sourceID == "" || definition.Validation.Status == connectordefinitions.ValidationBlocked {
+			continue
+		}
+		for _, resource := range definition.ResourceFamilies {
+			kind := catalogRuntimeEventKind(sourceID, resource)
+			if kind == "" {
+				continue
+			}
+			if existing, exists := projectors[kind]; exists {
+				if existing != nil {
+					projectors[kind] = augmentCatalogRuntimeProjector(sourceID, resource, existing)
+				}
+				continue
+			}
+			projectors[kind] = catalogRuntimeProjectorFor(sourceID, resource)
+		}
+	}
+}
+
 func catalogRuntimeEventKind(sourceID string, resource connectordefinitions.ResourceFamily) string {
 	if kind := strings.TrimSpace(resource.Event.Kind); kind != "" {
 		return kind

--- a/internal/sourceprojection/catalogruntime_test.go
+++ b/internal/sourceprojection/catalogruntime_test.go
@@ -143,6 +143,56 @@ func TestCatalogRuntimeProjectorRegistrationDoesNotOverrideStaticProjector(t *te
 	}
 }
 
+func TestRegistryRegistersConnectorDefinitionProjectors(t *testing.T) {
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	definition, err := connectordefinitions.Normalize(connectordefinitions.Definition{
+		TenantID: "tenant-a",
+		SourceID: "example_dynamic",
+		Auth:     connectordefinitions.AuthSpec{Model: "none"},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:        "assets",
+			Path:      "/v1/assets",
+			IDField:   "id",
+			NameField: "name",
+			Event:     connectordefinitions.EventMappingSpec{Kind: "example_dynamic.asset"},
+			Projection: &connectordefinitions.ProjectionSpec{
+				Entity: &connectordefinitions.ProjectionEntitySpec{
+					EntityType:     "example.dynamic.asset",
+					URNKind:        "example_dynamic_asset",
+					IDAttributes:   []string{"id"},
+					LabelAttribute: "name",
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if definition.Validation.Status == connectordefinitions.ValidationBlocked {
+		t.Fatalf("definition blocked unexpectedly: %#v", definition.Validation.Checks)
+	}
+	registry.RegisterConnectorDefinitions(definition)
+	entities, _, err := registry.Project(&cerebrov1.EventEnvelope{
+		Id:       "event-1",
+		TenantId: "tenant-a",
+		SourceId: "example_dynamic",
+		Kind:     "example_dynamic.asset",
+		Attributes: map[string]string{
+			"id":   "asset-1",
+			"name": "Asset One",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if !hasProjectedEntityType(entities, "example.dynamic.asset") {
+		t.Fatalf("projected entities missing dynamic asset type: %#v", entities)
+	}
+}
+
 func TestCatalogRuntimeAssetProjectionRequiresStableResourceIdentity(t *testing.T) {
 	entities, links, err := catalogRuntimeAssetProjections(&cerebrov1.EventEnvelope{
 		Id:       "event-ephemeral",

--- a/internal/sourceprojection/catalogruntime_test.go
+++ b/internal/sourceprojection/catalogruntime_test.go
@@ -176,8 +176,8 @@ func TestRegistryRegistersConnectorDefinitionProjectors(t *testing.T) {
 	}
 	registry.RegisterConnectorDefinitions(definition)
 	registry.RegisterConnectorDefinitions(definition)
-	if got := len(registry.connectorDefinitionSources); got != 1 {
-		t.Fatalf("registered connector sources = %d, want 1", got)
+	if got := len(registry.connectorDefinitionFingerprints); got != 1 {
+		t.Fatalf("registered connector fingerprints = %d, want 1", got)
 	}
 	entities, _, err := registry.Project(&cerebrov1.EventEnvelope{
 		Id:       "event-1",
@@ -194,6 +194,75 @@ func TestRegistryRegistersConnectorDefinitionProjectors(t *testing.T) {
 	}
 	if !hasProjectedEntityType(entities, "example.dynamic.asset") {
 		t.Fatalf("projected entities missing dynamic asset type: %#v", entities)
+	}
+}
+
+func TestRegistryUpdatesConnectorDefinitionProjectors(t *testing.T) {
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	base := connectordefinitions.Definition{
+		TenantID: "tenant-a",
+		SourceID: "example_dynamic",
+		Auth:     connectordefinitions.AuthSpec{Model: "none"},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:        "assets",
+			Path:      "/v1/assets",
+			IDField:   "id",
+			NameField: "name",
+			Event:     connectordefinitions.EventMappingSpec{Kind: "example_dynamic.asset"},
+			Projection: &connectordefinitions.ProjectionSpec{
+				Entity: &connectordefinitions.ProjectionEntitySpec{
+					EntityType:     "example.dynamic.asset",
+					URNKind:        "example_dynamic_asset",
+					IDAttributes:   []string{"id"},
+					LabelAttribute: "name",
+				},
+			},
+		}},
+	}
+	initial, err := connectordefinitions.Normalize(base)
+	if err != nil {
+		t.Fatalf("Normalize(initial) error = %v", err)
+	}
+	registry.RegisterConnectorDefinitions(initial)
+	updated := base
+	updated.ResourceFamilies = append(updated.ResourceFamilies, connectordefinitions.ResourceFamily{
+		ID:        "findings",
+		Path:      "/v1/findings",
+		IDField:   "id",
+		NameField: "name",
+		Event:     connectordefinitions.EventMappingSpec{Kind: "example_dynamic.finding"},
+		Projection: &connectordefinitions.ProjectionSpec{
+			Entity: &connectordefinitions.ProjectionEntitySpec{
+				EntityType:     "example.dynamic.finding",
+				URNKind:        "example_dynamic_finding",
+				IDAttributes:   []string{"id"},
+				LabelAttribute: "name",
+			},
+		},
+	})
+	normalized, err := connectordefinitions.Normalize(updated)
+	if err != nil {
+		t.Fatalf("Normalize(updated) error = %v", err)
+	}
+	registry.RegisterConnectorDefinitions(normalized)
+	entities, _, err := registry.Project(&cerebrov1.EventEnvelope{
+		Id:       "event-2",
+		TenantId: "tenant-a",
+		SourceId: "example_dynamic",
+		Kind:     "example_dynamic.finding",
+		Attributes: map[string]string{
+			"id":   "finding-1",
+			"name": "Finding One",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if !hasProjectedEntityType(entities, "example.dynamic.finding") {
+		t.Fatalf("projected entities missing updated finding type: %#v", entities)
 	}
 }
 

--- a/internal/sourceprojection/catalogruntime_test.go
+++ b/internal/sourceprojection/catalogruntime_test.go
@@ -175,6 +175,10 @@ func TestRegistryRegistersConnectorDefinitionProjectors(t *testing.T) {
 		t.Fatalf("definition blocked unexpectedly: %#v", definition.Validation.Checks)
 	}
 	registry.RegisterConnectorDefinitions(definition)
+	registry.RegisterConnectorDefinitions(definition)
+	if got := len(registry.connectorDefinitionSources); got != 1 {
+		t.Fatalf("registered connector sources = %d, want 1", got)
+	}
 	entities, _, err := registry.Project(&cerebrov1.EventEnvelope{
 		Id:       "event-1",
 		TenantId: "tenant-a",

--- a/internal/sourceprojection/catalogruntime_test.go
+++ b/internal/sourceprojection/catalogruntime_test.go
@@ -266,6 +266,85 @@ func TestRegistryUpdatesConnectorDefinitionProjectors(t *testing.T) {
 	}
 }
 
+func TestRegistryKeepsSharedKindProjectorsAcrossUpdates(t *testing.T) {
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	sourceA, err := connectordefinitions.Normalize(sharedKindDefinition("source_a", "shared.source_a.asset"))
+	if err != nil {
+		t.Fatalf("Normalize(sourceA) error = %v", err)
+	}
+	sourceB, err := connectordefinitions.Normalize(sharedKindDefinition("source_b", "shared.source_b.asset"))
+	if err != nil {
+		t.Fatalf("Normalize(sourceB) error = %v", err)
+	}
+	registry.RegisterConnectorDefinitions(sourceA, sourceB)
+
+	updatedA, err := connectordefinitions.Normalize(sharedKindDefinition("source_a", "shared.source_a.updated"))
+	if err != nil {
+		t.Fatalf("Normalize(updatedA) error = %v", err)
+	}
+	registry.RegisterConnectorDefinitions(updatedA)
+
+	entities, _, err := registry.Project(&cerebrov1.EventEnvelope{
+		Id:       "event-a",
+		TenantId: "tenant-a",
+		SourceId: "source_a",
+		Kind:     "shared.asset",
+		Attributes: map[string]string{
+			"id":   "asset-a",
+			"name": "Asset A",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project(source_a) error = %v", err)
+	}
+	if !hasProjectedEntityType(entities, "shared.source_a.updated") {
+		t.Fatalf("source_a projected entities = %#v, want updated type", entities)
+	}
+
+	entities, _, err = registry.Project(&cerebrov1.EventEnvelope{
+		Id:       "event-b",
+		TenantId: "tenant-a",
+		SourceId: "source_b",
+		Kind:     "shared.asset",
+		Attributes: map[string]string{
+			"id":   "asset-b",
+			"name": "Asset B",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project(source_b) error = %v", err)
+	}
+	if !hasProjectedEntityType(entities, "shared.source_b.asset") {
+		t.Fatalf("source_b projected entities = %#v, want original type", entities)
+	}
+}
+
+func sharedKindDefinition(sourceID string, entityType string) connectordefinitions.Definition {
+	return connectordefinitions.Definition{
+		TenantID: "tenant-a",
+		SourceID: sourceID,
+		Auth:     connectordefinitions.AuthSpec{Model: "none"},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:        "assets",
+			Path:      "/v1/assets",
+			IDField:   "id",
+			NameField: "name",
+			Event:     connectordefinitions.EventMappingSpec{Kind: "shared.asset"},
+			Projection: &connectordefinitions.ProjectionSpec{
+				Entity: &connectordefinitions.ProjectionEntitySpec{
+					EntityType:     entityType,
+					URNKind:        sourceID + "_asset",
+					IDAttributes:   []string{"id"},
+					LabelAttribute: "name",
+				},
+			},
+		}},
+	}
+}
+
 func TestCatalogRuntimeAssetProjectionRequiresStableResourceIdentity(t *testing.T) {
 	entities, links, err := catalogRuntimeAssetProjections(&cerebrov1.EventEnvelope{
 		Id:       "event-ephemeral",

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcehealth"
@@ -75,6 +76,14 @@ func NewWithRegistry(state ports.ProjectionStateStore, graph ports.ProjectionGra
 		registry = BuiltinRegistry()
 	}
 	return &Service{state: state, graph: graph, registry: registry}
+}
+
+// RegisterConnectorDefinition makes a tenant-authored connector definition projectable.
+func (s *Service) RegisterConnectorDefinition(definition connectordefinitions.Definition) {
+	if s == nil || s.registry == nil {
+		return
+	}
+	s.registry.RegisterConnectorDefinitions(definition)
 }
 
 // Project applies one source event to the configured state and graph stores.

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -1,6 +1,9 @@
 package sourceprojection
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -22,16 +25,20 @@ type EventProjector struct {
 
 // Registry indexes projectors by event kind.
 type Registry struct {
-	mu                         sync.RWMutex
-	projectors                 map[string]ProjectFunc
-	connectorDefinitionSources map[string]struct{}
+	mu                              sync.RWMutex
+	projectors                      map[string]ProjectFunc
+	connectorDefinitionFingerprints map[string]string
+	connectorDefinitionKinds        map[string]map[string]struct{}
+	connectorDefinitionBases        map[string]ProjectFunc
 }
 
 // NewRegistry constructs an event projection registry.
 func NewRegistry(projectors ...EventProjector) (*Registry, error) {
 	registry := &Registry{
-		projectors:                 make(map[string]ProjectFunc, len(projectors)),
-		connectorDefinitionSources: map[string]struct{}{},
+		projectors:                      make(map[string]ProjectFunc, len(projectors)),
+		connectorDefinitionFingerprints: map[string]string{},
+		connectorDefinitionKinds:        map[string]map[string]struct{}{},
+		connectorDefinitionBases:        map[string]ProjectFunc{},
 	}
 	for _, projector := range projectors {
 		kind := strings.TrimSpace(projector.Kind)
@@ -56,22 +63,78 @@ func (r *Registry) RegisterConnectorDefinitions(definitions ...connectordefiniti
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.connectorDefinitionSources == nil {
-		r.connectorDefinitionSources = map[string]struct{}{}
-	}
-	pending := make([]connectordefinitions.Definition, 0, len(definitions))
+	r.ensureConnectorDefinitionState()
 	for _, definition := range definitions {
 		sourceID := strings.TrimSpace(definition.SourceID)
 		if sourceID == "" || definition.Validation.Status == connectordefinitions.ValidationBlocked {
 			continue
 		}
-		if _, ok := r.connectorDefinitionSources[sourceID]; ok {
+		fingerprint := connectorDefinitionProjectorFingerprint(definition)
+		if r.connectorDefinitionFingerprints[sourceID] == fingerprint {
 			continue
 		}
-		r.connectorDefinitionSources[sourceID] = struct{}{}
-		pending = append(pending, definition)
+		r.unregisterConnectorDefinitionProjectors(sourceID)
+		kinds := catalogRuntimeDefinitionProjectorKinds(definition)
+		if len(kinds) == 0 {
+			continue
+		}
+		for _, kind := range kinds {
+			if _, ok := r.connectorDefinitionBases[kind]; ok {
+				continue
+			}
+			r.connectorDefinitionBases[kind] = r.projectors[kind]
+		}
+		registerCatalogRuntimeProjectorsForDefinitions(r.projectors, []connectordefinitions.Definition{definition})
+		r.connectorDefinitionFingerprints[sourceID] = fingerprint
+		r.connectorDefinitionKinds[sourceID] = kindSet(kinds)
 	}
-	registerCatalogRuntimeProjectorsForDefinitions(r.projectors, pending)
+}
+
+func (r *Registry) ensureConnectorDefinitionState() {
+	if r.connectorDefinitionFingerprints == nil {
+		r.connectorDefinitionFingerprints = map[string]string{}
+	}
+	if r.connectorDefinitionKinds == nil {
+		r.connectorDefinitionKinds = map[string]map[string]struct{}{}
+	}
+	if r.connectorDefinitionBases == nil {
+		r.connectorDefinitionBases = map[string]ProjectFunc{}
+	}
+}
+
+func (r *Registry) unregisterConnectorDefinitionProjectors(sourceID string) {
+	kinds := r.connectorDefinitionKinds[sourceID]
+	for kind := range kinds {
+		base, ok := r.connectorDefinitionBases[kind]
+		if ok && base != nil {
+			r.projectors[kind] = base
+		} else {
+			delete(r.projectors, kind)
+		}
+		delete(r.connectorDefinitionBases, kind)
+	}
+	delete(r.connectorDefinitionKinds, sourceID)
+	delete(r.connectorDefinitionFingerprints, sourceID)
+}
+
+func connectorDefinitionProjectorFingerprint(definition connectordefinitions.Definition) string {
+	body, err := json.Marshal(struct {
+		SourceID         string                                `json:"source_id"`
+		ResourceFamilies []connectordefinitions.ResourceFamily `json:"resource_families"`
+	}{SourceID: strings.TrimSpace(definition.SourceID), ResourceFamilies: definition.ResourceFamilies})
+	if err != nil {
+		return strings.TrimSpace(definition.SourceID)
+	}
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}
+
+func kindSet(kinds []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(kinds))
+	for _, kind := range kinds {
+		out[kind] = struct{}{}
+	}
+	return out
 }
 
 var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -20,6 +22,7 @@ type EventProjector struct {
 
 // Registry indexes projectors by event kind.
 type Registry struct {
+	mu         sync.RWMutex
 	projectors map[string]ProjectFunc
 }
 
@@ -40,6 +43,16 @@ func NewRegistry(projectors ...EventProjector) (*Registry, error) {
 		registry.projectors[kind] = projector.Project
 	}
 	return registry, nil
+}
+
+// RegisterConnectorDefinitions adds declarative runtime connector projectors to the registry.
+func (r *Registry) RegisterConnectorDefinitions(definitions ...connectordefinitions.Definition) {
+	if r == nil || len(definitions) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	registerCatalogRuntimeProjectorsForDefinitions(r.projectors, definitions)
 }
 
 var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
@@ -628,6 +641,8 @@ func (r *Registry) Kinds() []string {
 	if r == nil {
 		return nil
 	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	kinds := make([]string, 0, len(r.projectors))
 	for kind := range r.projectors {
 		kinds = append(kinds, kind)
@@ -644,6 +659,8 @@ func (r *Registry) Project(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEn
 	if r == nil {
 		return nil, nil, nil
 	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	project, ok := r.projectors[strings.TrimSpace(event.GetKind())]
 	if !ok {
 		return nil, nil, nil

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -30,6 +30,7 @@ type Registry struct {
 	connectorDefinitionFingerprints map[string]string
 	connectorDefinitionKinds        map[string]map[string]struct{}
 	connectorDefinitionBases        map[string]ProjectFunc
+	connectorDefinitionProjectors   map[string]map[string]ProjectFunc
 }
 
 // NewRegistry constructs an event projection registry.
@@ -39,6 +40,7 @@ func NewRegistry(projectors ...EventProjector) (*Registry, error) {
 		connectorDefinitionFingerprints: map[string]string{},
 		connectorDefinitionKinds:        map[string]map[string]struct{}{},
 		connectorDefinitionBases:        map[string]ProjectFunc{},
+		connectorDefinitionProjectors:   map[string]map[string]ProjectFunc{},
 	}
 	for _, projector := range projectors {
 		kind := strings.TrimSpace(projector.Kind)
@@ -74,17 +76,20 @@ func (r *Registry) RegisterConnectorDefinitions(definitions ...connectordefiniti
 			continue
 		}
 		r.unregisterConnectorDefinitionProjectors(sourceID)
-		kinds := catalogRuntimeDefinitionProjectorKinds(definition)
-		if len(kinds) == 0 {
+		sourceProjectors := catalogRuntimeDefinitionProjectors(definition)
+		if len(sourceProjectors) == 0 {
 			continue
 		}
-		for _, kind := range kinds {
-			if _, ok := r.connectorDefinitionBases[kind]; ok {
-				continue
+		kinds := make([]string, 0, len(sourceProjectors))
+		for kind, projector := range sourceProjectors {
+			if _, ok := r.connectorDefinitionProjectors[kind]; !ok {
+				r.connectorDefinitionBases[kind] = r.projectors[kind]
+				r.connectorDefinitionProjectors[kind] = map[string]ProjectFunc{}
 			}
-			r.connectorDefinitionBases[kind] = r.projectors[kind]
+			r.connectorDefinitionProjectors[kind][sourceID] = projector
+			r.projectors[kind] = connectorDefinitionDispatchProjector(r.connectorDefinitionBases[kind], r.connectorDefinitionProjectors[kind])
+			kinds = append(kinds, kind)
 		}
-		registerCatalogRuntimeProjectorsForDefinitions(r.projectors, []connectordefinitions.Definition{definition})
 		r.connectorDefinitionFingerprints[sourceID] = fingerprint
 		r.connectorDefinitionKinds[sourceID] = kindSet(kinds)
 	}
@@ -100,11 +105,22 @@ func (r *Registry) ensureConnectorDefinitionState() {
 	if r.connectorDefinitionBases == nil {
 		r.connectorDefinitionBases = map[string]ProjectFunc{}
 	}
+	if r.connectorDefinitionProjectors == nil {
+		r.connectorDefinitionProjectors = map[string]map[string]ProjectFunc{}
+	}
 }
 
 func (r *Registry) unregisterConnectorDefinitionProjectors(sourceID string) {
 	kinds := r.connectorDefinitionKinds[sourceID]
 	for kind := range kinds {
+		sourceProjectors := r.connectorDefinitionProjectors[kind]
+		if sourceProjectors != nil {
+			delete(sourceProjectors, sourceID)
+			if len(sourceProjectors) > 0 {
+				r.projectors[kind] = connectorDefinitionDispatchProjector(r.connectorDefinitionBases[kind], sourceProjectors)
+				continue
+			}
+		}
 		base, ok := r.connectorDefinitionBases[kind]
 		if ok && base != nil {
 			r.projectors[kind] = base
@@ -112,9 +128,30 @@ func (r *Registry) unregisterConnectorDefinitionProjectors(sourceID string) {
 			delete(r.projectors, kind)
 		}
 		delete(r.connectorDefinitionBases, kind)
+		delete(r.connectorDefinitionProjectors, kind)
 	}
 	delete(r.connectorDefinitionKinds, sourceID)
 	delete(r.connectorDefinitionFingerprints, sourceID)
+}
+
+func connectorDefinitionDispatchProjector(base ProjectFunc, sourceProjectors map[string]ProjectFunc) ProjectFunc {
+	projectors := make(map[string]ProjectFunc, len(sourceProjectors))
+	for sourceID, projector := range sourceProjectors {
+		if projector != nil {
+			projectors[sourceID] = projector
+		}
+	}
+	return func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		if event != nil {
+			if projector := projectors[strings.TrimSpace(event.GetSourceId())]; projector != nil {
+				return projector(event)
+			}
+		}
+		if base != nil {
+			return base(event)
+		}
+		return nil, nil, nil
+	}
 }
 
 func connectorDefinitionProjectorFingerprint(definition connectordefinitions.Definition) string {

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -22,13 +22,17 @@ type EventProjector struct {
 
 // Registry indexes projectors by event kind.
 type Registry struct {
-	mu         sync.RWMutex
-	projectors map[string]ProjectFunc
+	mu                         sync.RWMutex
+	projectors                 map[string]ProjectFunc
+	connectorDefinitionSources map[string]struct{}
 }
 
 // NewRegistry constructs an event projection registry.
 func NewRegistry(projectors ...EventProjector) (*Registry, error) {
-	registry := &Registry{projectors: make(map[string]ProjectFunc, len(projectors))}
+	registry := &Registry{
+		projectors:                 make(map[string]ProjectFunc, len(projectors)),
+		connectorDefinitionSources: map[string]struct{}{},
+	}
 	for _, projector := range projectors {
 		kind := strings.TrimSpace(projector.Kind)
 		if kind == "" {
@@ -52,7 +56,22 @@ func (r *Registry) RegisterConnectorDefinitions(definitions ...connectordefiniti
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	registerCatalogRuntimeProjectorsForDefinitions(r.projectors, definitions)
+	if r.connectorDefinitionSources == nil {
+		r.connectorDefinitionSources = map[string]struct{}{}
+	}
+	pending := make([]connectordefinitions.Definition, 0, len(definitions))
+	for _, definition := range definitions {
+		sourceID := strings.TrimSpace(definition.SourceID)
+		if sourceID == "" || definition.Validation.Status == connectordefinitions.ValidationBlocked {
+			continue
+		}
+		if _, ok := r.connectorDefinitionSources[sourceID]; ok {
+			continue
+		}
+		r.connectorDefinitionSources[sourceID] = struct{}{}
+		pending = append(pending, definition)
+	}
+	registerCatalogRuntimeProjectorsForDefinitions(r.projectors, pending)
 }
 
 var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -75,6 +75,10 @@ type Service struct {
 	resolver        sourceconfig.Resolver
 }
 
+type connectorDefinitionProjectorRegistrar interface {
+	RegisterConnectorDefinition(connectordefinitions.Definition)
+}
+
 // PutRuntimesRequest contains source runtime definitions to validate and store together.
 type PutRuntimesRequest struct {
 	Runtimes []*cerebrov1.SourceRuntime
@@ -342,6 +346,11 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	}
 	spanAttributes = spanAttributes.With(observability.SourceRuntimeDiagnosticAttributes(runtimeContext))
 	telemetry.AnnotateMain(ctx, observability.SourceRuntimeDiagnosticAttributes(runtimeContext))
+	if sourcehealth.RuntimeEnabledState(runtime) == "disabled" {
+		status = "skipped"
+		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "source_runtime.sync.skip_reason", Value: "disabled"})
+		return &cerebrov1.SyncSourceRuntimeResponse{Runtime: redactRuntime(runtime)}, nil
+	}
 	source, err := s.lookupSource(ctx, runtime.GetSourceId(), runtime.GetTenantId())
 	if err != nil {
 		return nil, err
@@ -994,6 +1003,9 @@ func (s *Service) lookupDynamicConnectorSource(ctx context.Context, sourceID str
 		definition.DisplayName = record.DisplayName
 		definition.Runtime = record.Runtime
 		definition.Stage = record.Stage
+		if registrar, ok := s.projector.(connectorDefinitionProjectorRegistrar); ok {
+			registrar.RegisterConnectorDefinition(definition)
+		}
 		source, err := sourceregistry.DynamicDefinitionSource(definition)
 		if err != nil {
 			return nil, fmt.Errorf("%w: dynamic connector %s: %w", ErrInvalidRequest, sourceID, err)

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1269,6 +1269,41 @@ func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 	}
 }
 
+func TestSyncRuntimeSkipsDisabledRuntime(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				Config:   map[string]string{"enabled": "false"},
+			},
+		},
+	}
+	log := &appendLog{}
+	service := New(registry, store, log, nil)
+
+	resp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
+		Id:        "writer-github",
+		PageLimit: 2,
+	})
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if resp.GetEventsAppended() != 0 || resp.GetPagesRead() != 0 {
+		t.Fatalf("Sync() appended/pages = %d/%d, want 0/0", resp.GetEventsAppended(), resp.GetPagesRead())
+	}
+	if len(log.events) != 0 {
+		t.Fatalf("len(appendLog.events) = %d, want 0", len(log.events))
+	}
+	if store.putCount != 0 {
+		t.Fatalf("PutSourceRuntime calls = %d, want 0", store.putCount)
+	}
+}
+
 func TestSyncRuntimeUsesPageLedgerWhenStoreSupportsIt(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -38,7 +38,9 @@ import (
 // explicit error returns and guard clauses across bootstrap handlers. Tenant
 // dynamic connector runtimes add connector-library response mapping and setup
 // method shaping while runnable source construction stays behind internal/sourceregistry.
-const bootstrapProductionGoLineBudget = 25538
+// Runtime connector previews add thin HTTP request/response mapping while live
+// check/read behavior stays behind internal/connectorpreview.
+const bootstrapProductionGoLineBudget = 25584
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- register dynamic connector projectors when runtime definitions are used
- add pull/deposit ingest metadata and deposit validation groundwork
- add bounded connector definition preview endpoint and OpenAPI schema
- skip sync work for disabled source runtimes

## Validation
- make verify
- go test ./internal/sourceruntime -count=1