### PR TITLE
feat: add credential governance risk actions

### DIFF
--- a/internal/riskplan/generators.go
+++ b/internal/riskplan/generators.go
@@ -42,6 +42,9 @@ func (privilegeGenerator) Generate(input CandidateGeneratorInput) []CandidateSee
 	if !findingSupportsAction(input.Finding, input.RiskContext, findinganalysis.RiskDeltaScenarioRemovePrivilege) {
 		return nil
 	}
+	if credentialGovernanceHandlesPrivilege(input) {
+		return nil
+	}
 	targetURN := actionTargetURN(input.TenantID, input.Finding, findinganalysis.RiskDeltaScenarioRemovePrivilege)
 	if targetURN == "" {
 		return nil
@@ -80,6 +83,67 @@ func (vulnerabilityGenerator) Generate(input CandidateGeneratorInput) []Candidat
 	}}
 }
 
+type credentialGovernanceGenerator struct{}
+
+func (credentialGovernanceGenerator) ID() string {
+	return "credential_governance"
+}
+
+func (credentialGovernanceGenerator) Generate(input CandidateGeneratorInput) []CandidateSeed {
+	if input.Finding == nil {
+		return nil
+	}
+	targetURN := credentialTargetURN(input.TenantID, input.Finding)
+	if targetURN == "" || credentialRevoked(input.Finding.Attributes) {
+		return nil
+	}
+	label := targetLabel(input.Finding, targetURN)
+	privileged := credentialPrivileged(input)
+	recentUse := credentialRecentlyUsed(input.Finding.Attributes, input.Now)
+	staleUse := credentialStaleUse(input.Finding.Attributes, input.Now)
+	missingOwner := credentialMissingOwner(input.Finding)
+	seeds := []CandidateSeed{}
+	if privileged || (recentUse && missingOwner) {
+		reasons := []string{"candidate_generator:credential_governance", "credential_rotation"}
+		if privileged {
+			reasons = append(reasons, "privileged_credential")
+		}
+		if recentUse {
+			reasons = append(reasons, "recent_credential_use")
+		}
+		if missingOwner {
+			reasons = append(reasons, "missing_credential_owner")
+		}
+		seeds = append(seeds, CandidateSeed{
+			Title:               "Rotate credential for " + label,
+			ActionType:          ActionTypeRotateCredential,
+			ScenarioType:        findinganalysis.RiskDeltaScenarioRemovePrivilege,
+			TargetURN:           targetURN,
+			SimulationSupported: findingSupportsAction(input.Finding, input.RiskContext, findinganalysis.RiskDeltaScenarioRemovePrivilege),
+			Reasons:             reasons,
+		})
+	}
+	if staleUse {
+		seeds = append(seeds, CandidateSeed{
+			Title:               "Revoke unused credential for " + label,
+			ActionType:          ActionTypeRevokeCredential,
+			TargetURN:           targetURN,
+			SimulationSupported: false,
+			Reasons:             []string{"candidate_generator:credential_governance", "stale_credential_use"},
+		})
+	}
+	if missingOwner {
+		seeds = append(seeds, CandidateSeed{
+			Title:               "Review credential owner for " + label,
+			ActionType:          ActionTypeReviewCredentialOwner,
+			TargetURN:           targetURN,
+			SimulationSupported: false,
+			Reasons:             []string{"candidate_generator:credential_governance", "missing_credential_owner"},
+		})
+	}
+	return seeds
+}
+
 type ownerAssignmentGenerator struct{}
 
 func (ownerAssignmentGenerator) ID() string {
@@ -88,6 +152,9 @@ func (ownerAssignmentGenerator) ID() string {
 
 func (ownerAssignmentGenerator) Generate(input CandidateGeneratorInput) []CandidateSeed {
 	if input.Finding == nil {
+		return nil
+	}
+	if credentialTargetURN(input.TenantID, input.Finding) != "" {
 		return nil
 	}
 	if owner, _ := findingOwner(input.Finding); owner != "" {
@@ -187,6 +254,8 @@ func actionTargetURN(tenantID string, finding *ports.FindingRecord, actionType s
 		return firstTenantScopedURN(tenantID, attributes["principal_urn"], attributes["identity_urn"], attributes["actor_urn"], attributes["permission_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
 	case findinganalysis.RiskDeltaScenarioPatchVulnerability:
 		return firstTenantScopedURN(tenantID, attributes["vulnerability_urn"], attributes["package_urn"], attributes["image_urn"], attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
+	case ActionTypeRotateCredential, ActionTypeRevokeCredential, ActionTypeReviewCredentialOwner:
+		return credentialTargetURN(tenantID, finding)
 	case ActionTypeAssignOwner, ActionTypeRefreshEvidence:
 		return firstTenantScopedURN(tenantID, attributes["target_urn"], attributes["asset_urn"], attributes["resource_urn"], attributes["primary_resource_urn"], primaryResourceURN(finding))
 	default:
@@ -215,6 +284,7 @@ func targetLabel(finding *ports.FindingRecord, targetURN string) string {
 			finding.Attributes["asset_name"],
 			finding.Attributes["repository"],
 			finding.Attributes["package"],
+			finding.Attributes["name"],
 			finding.Title,
 		} {
 			if trimmed := strings.TrimSpace(value); trimmed != "" {
@@ -251,4 +321,143 @@ func findingNeedsEvidenceRefresh(finding *ports.FindingRecord, context findingan
 		evidenceRefs += len(factor.EvidenceRefs)
 	}
 	return evidenceRefs == 0 && len(finding.EventIDs) == 0 && len(finding.GraphEvidenceRows) == 0
+}
+
+func credentialGovernanceHandlesPrivilege(input CandidateGeneratorInput) bool {
+	if input.Finding == nil {
+		return false
+	}
+	if credentialTargetURN(input.TenantID, input.Finding) == "" || credentialRevoked(input.Finding.Attributes) {
+		return false
+	}
+	return credentialPrivileged(input)
+}
+
+func credentialTargetURN(tenantID string, finding *ports.FindingRecord) string {
+	if finding == nil {
+		return ""
+	}
+	attributes := finding.Attributes
+	if targetURN := firstTenantScopedURN(
+		tenantID,
+		attributes["credential_urn"],
+		attributes["api_key_urn"],
+		attributes["openai_credential_urn"],
+		attributes["anthropic_credential_urn"],
+		attributes["github_credential_urn"],
+	); targetURN != "" {
+		return targetURN
+	}
+	if secretURN := firstTenantScopedURN(tenantID, attributes["secret_urn"]); secretURN != "" {
+		return secretURN
+	}
+	targetURN := firstTenantScopedURN(
+		tenantID,
+		attributes["secret_urn"],
+		attributes["target_urn"],
+		attributes["primary_resource_urn"],
+		primaryResourceURN(finding),
+	)
+	if !credentialLikeURN(targetURN) {
+		return ""
+	}
+	return targetURN
+}
+
+func credentialLikeURN(urn string) bool {
+	value := strings.ToLower(strings.TrimSpace(urn))
+	if value == "" {
+		return false
+	}
+	return strings.Contains(value, "credential") ||
+		strings.Contains(value, "api_key")
+}
+
+func credentialPrivileged(input CandidateGeneratorInput) bool {
+	if input.Finding == nil {
+		return false
+	}
+	if findingSupportsAction(input.Finding, input.RiskContext, findinganalysis.RiskDeltaScenarioRemovePrivilege) {
+		return true
+	}
+	attributes := input.Finding.Attributes
+	return strings.EqualFold(strings.TrimSpace(attributes["key_class"]), "admin") ||
+		containsAny(input.Finding.RuleID, "privileged", "admin") ||
+		containsAny(input.Finding.Title, "privileged", "admin")
+}
+
+func credentialMissingOwner(finding *ports.FindingRecord) bool {
+	if finding == nil {
+		return false
+	}
+	if owner, _ := findingOwner(finding); owner != "" {
+		return false
+	}
+	attributes := finding.Attributes
+	if attributeBool(attributes, "has_owner") {
+		return false
+	}
+	return strings.TrimSpace(attributes["owner_id"]) == "" &&
+		strings.TrimSpace(attributes["owner_user_id"]) == "" &&
+		strings.TrimSpace(attributes["owner_service_account_id"]) == ""
+}
+
+func credentialRevoked(attributes map[string]string) bool {
+	status := strings.ToLower(strings.TrimSpace(attributes["status"]))
+	if status == "" {
+		status = strings.ToLower(strings.TrimSpace(attributes["credential_status"]))
+	}
+	switch status {
+	case "deleted", "revoked", "disabled", "inactive", "expired", "suspended", "archived":
+		return true
+	default:
+		return false
+	}
+}
+
+func credentialRecentlyUsed(attributes map[string]string, now time.Time) bool {
+	lastUsedAt, ok := credentialLastUsedAt(attributes)
+	if ok && !now.IsZero() {
+		return !lastUsedAt.After(now) && now.Sub(lastUsedAt) <= 30*24*time.Hour
+	}
+	return attributeBool(attributes, "credential_use", "runtime_credential_use", "recent_credential_use")
+}
+
+func credentialStaleUse(attributes map[string]string, now time.Time) bool {
+	if now.IsZero() {
+		return false
+	}
+	lastUsedAt, ok := credentialLastUsedAt(attributes)
+	if !ok {
+		createdAt, created := parseCredentialTime(firstCredentialAttribute(attributes["created_at"], attributes["created"]))
+		return created && !createdAt.After(now) && now.Sub(createdAt) >= 90*24*time.Hour
+	}
+	return !lastUsedAt.After(now) && now.Sub(lastUsedAt) >= 90*24*time.Hour
+}
+
+func credentialLastUsedAt(attributes map[string]string) (time.Time, bool) {
+	return parseCredentialTime(firstCredentialAttribute(attributes["last_used_at"], attributes["last_used_time"], attributes["last_used"], attributes["last_seen_at"]))
+}
+
+func firstCredentialAttribute(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func parseCredentialTime(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed.UTC(), true
+		}
+	}
+	return time.Time{}, false
 }

--- a/internal/riskplan/planner.go
+++ b/internal/riskplan/planner.go
@@ -43,6 +43,7 @@ type riskFactorAggregate struct {
 func DefaultGenerators() []CandidateGenerator {
 	return []CandidateGenerator{
 		publicExposureGenerator{},
+		credentialGovernanceGenerator{},
 		privilegeGenerator{},
 		vulnerabilityGenerator{},
 		ownerAssignmentGenerator{},
@@ -452,6 +453,28 @@ func effortForAction(actionType string) Effort {
 			Reversible:        true,
 			PrimaryConstraint: "release_cycle",
 		}
+	case ActionTypeRotateCredential:
+		return Effort{
+			Level:             "medium",
+			Estimate:          "hours",
+			CostPoints:        14,
+			ApprovalRequired:  true,
+			ApprovalReason:    "credential rotation can affect integrations that still use the old secret",
+			Reversible:        true,
+			PrimaryConstraint: "access_review",
+		}
+	case ActionTypeRevokeCredential:
+		return Effort{
+			Level:             "medium",
+			Estimate:          "hours",
+			CostPoints:        12,
+			ApprovalRequired:  true,
+			ApprovalReason:    "credential revocation can break workloads if usage evidence is incomplete",
+			Reversible:        false,
+			PrimaryConstraint: "usage_validation",
+		}
+	case ActionTypeReviewCredentialOwner:
+		return Effort{Level: "small", Estimate: "minutes", CostPoints: 4, ApprovalRequired: false, Reversible: true, PrimaryConstraint: "routing"}
 	case ActionTypeAssignOwner:
 		return Effort{Level: "small", Estimate: "minutes", CostPoints: 5, ApprovalRequired: false, Reversible: true, PrimaryConstraint: "routing"}
 	case ActionTypeRefreshEvidence:

--- a/internal/riskplan/planner_test.go
+++ b/internal/riskplan/planner_test.go
@@ -292,6 +292,102 @@ func TestAnalyzeCanIncludeUnscoredPlanningBlockers(t *testing.T) {
 	}
 }
 
+func TestAnalyzeCredentialGovernanceActionsPreferRecentPrivilegedUse(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	recentCredentialURN := "urn:cerebro:writer:openai_credential:admin-runtime"     // #nosec G101 -- test credential identifier, not credential material.
+	staleCredentialURN := "urn:cerebro:writer:anthropic_credential:analytics-stale" // #nosec G101 -- test credential identifier, not credential material.
+	plan := Analyze([]*ports.FindingRecord{
+		{
+			ID:           "openai-admin-runtime",
+			TenantID:     "writer",
+			RuntimeID:    "writer-openai",
+			RuleID:       "openai-orphaned-privileged-api-key",
+			Title:        "OpenAI Orphaned Privileged API Key",
+			Severity:     "HIGH",
+			Status:       "open",
+			ResourceURNs: []string{recentCredentialURN},
+			EventIDs:     []string{"evt-openai-admin-runtime"},
+			FindingRisk: ports.FindingRisk{
+				RiskScore:       88,
+				ConfidenceScore: 92,
+				RiskReasons:     []string{"privileged_actor", "active_threat"},
+			},
+			Attributes: map[string]string{
+				"credential_use":        "true",
+				"has_owner":             "false",
+				"last_used_at":          now.Add(-2 * time.Hour).Format(time.RFC3339),
+				"name":                  "admin-runtime",
+				"openai_credential_urn": recentCredentialURN,
+				"primary_resource_urn":  recentCredentialURN,
+				"privileged":            "true",
+				"status":                "active",
+			},
+			LastObservedAt: now.Add(-2 * time.Hour),
+		},
+		{
+			ID:           "anthropic-stale-runtime",
+			TenantID:     "writer",
+			RuntimeID:    "writer-anthropic",
+			RuleID:       "anthropic-unmanaged-active-api-key",
+			Title:        "Anthropic Unmanaged Active API Key",
+			Severity:     "MEDIUM",
+			Status:       "open",
+			ResourceURNs: []string{staleCredentialURN},
+			EventIDs:     []string{"evt-anthropic-stale-runtime"},
+			FindingRisk: ports.FindingRisk{
+				RiskScore:       62,
+				ConfidenceScore: 84,
+				RiskReasons:     []string{"active"},
+			},
+			Attributes: map[string]string{
+				"anthropic_credential_urn": staleCredentialURN,
+				"has_owner":                "false",
+				"last_used_at":             now.Add(-120 * 24 * time.Hour).Format(time.RFC3339),
+				"name":                     "analytics-stale",
+				"primary_resource_urn":     staleCredentialURN,
+				"status":                   "active",
+			},
+			LastObservedAt: now.Add(-48 * time.Hour),
+		},
+	}, Options{
+		TenantID:        "writer",
+		RuntimeIDs:      []string{"writer-openai", "writer-anthropic"},
+		IncludeUnscored: true,
+		Now:             now,
+	})
+
+	if len(plan.ActionCandidates) == 0 {
+		t.Fatalf("ActionCandidates = nil, want credential governance candidates")
+	}
+	top := plan.ActionCandidates[0]
+	if top.ActionType != ActionTypeRotateCredential || top.TargetURN != recentCredentialURN {
+		t.Fatalf("top candidate = %#v, want rotate recent privileged credential", top)
+	}
+	if top.SimulationStatus != SimulationStatusSimulated || top.ExpectedRiskScoreReduction <= 0 {
+		t.Fatalf("top simulation = %q reduction = %d, want simulated risk reduction", top.SimulationStatus, top.ExpectedRiskScoreReduction)
+	}
+	if top.Effort.PrimaryConstraint != "access_review" || !top.Effort.ApprovalRequired {
+		t.Fatalf("top effort = %#v, want approval-aware credential rotation", top.Effort)
+	}
+	byActionTarget := map[string]Candidate{}
+	for _, candidate := range plan.ActionCandidates {
+		byActionTarget[candidate.ActionType+"|"+candidate.TargetURN] = candidate
+		if candidate.ActionType == findinganalysis.RiskDeltaScenarioRemovePrivilege && candidate.TargetURN == recentCredentialURN {
+			t.Fatalf("generic privilege candidate duplicated credential rotation: %#v", candidate)
+		}
+	}
+	stale := byActionTarget[ActionTypeRevokeCredential+"|"+staleCredentialURN]
+	if stale.ID == "" {
+		t.Fatalf("action candidates = %#v, want stale credential revoke recommendation", plan.ActionCandidates)
+	}
+	if stale.SimulationStatus != SimulationStatusUnsupported || stale.Effort.PrimaryConstraint != "usage_validation" {
+		t.Fatalf("stale credential candidate = %#v, want usage-validation recommendation", stale)
+	}
+	if top.PriorityScore <= stale.PriorityScore {
+		t.Fatalf("priority scores top=%d stale=%d, want recent privileged use ranked higher", top.PriorityScore, stale.PriorityScore)
+	}
+}
+
 func TestCompareCandidatesRanksNonSimulatedStatusesByScore(t *testing.T) {
 	unsupportedHigh := diffTestCandidate("unsupported-high", "Unsupported high", 100, 0, 0, SimulationStatusUnsupported)
 	noReductionLow := diffTestCandidate("no-reduction-low", "No reduction low", 10, 0, 0, SimulationStatusNoExpectedRisk)

--- a/internal/riskplan/types.go
+++ b/internal/riskplan/types.go
@@ -20,11 +20,14 @@ const (
 	// MaxSimulationSeedLimit caps simulation work before final ranking.
 	MaxSimulationSeedLimit = 50
 
-	ActionTypeAssignOwner          = "assign_owner"
-	ActionTypeRefreshEvidence      = "refresh_evidence"
-	SimulationStatusSimulated      = "simulated"
-	SimulationStatusUnsupported    = "unsupported"
-	SimulationStatusNoExpectedRisk = "no_expected_reduction"
+	ActionTypeAssignOwner           = "assign_owner"
+	ActionTypeRefreshEvidence       = "refresh_evidence"
+	ActionTypeRotateCredential      = "rotate_credential"        // #nosec G101 -- action type identifier, not credential material.
+	ActionTypeRevokeCredential      = "revoke_unused_credential" // #nosec G101 -- action type identifier, not credential material.
+	ActionTypeReviewCredentialOwner = "review_credential_owner"
+	SimulationStatusSimulated       = "simulated"
+	SimulationStatusUnsupported     = "unsupported"
+	SimulationStatusNoExpectedRisk  = "no_expected_reduction"
 )
 
 // Options controls deterministic risk action planning over already-scoped findings.

--- a/internal/sourceprojection/ai_access.go
+++ b/internal/sourceprojection/ai_access.go
@@ -1234,7 +1234,7 @@ func aiCredentialOwnerURN(entities map[string]*ports.ProjectedEntity, links map[
 		return ownerURN
 	}
 	if ownerUserID := firstNonEmpty(attrs["owner_user_id"], attrs["user_id"], aiTypedOwnerID(attrs, "user")); ownerUserID != "" || strings.TrimSpace(attrs["email"]) != "" {
-		return aiEnsureUser(entities, links, tenantID, event, profile, ownerUserID, attrs["email"], firstNonEmpty(attrs["owner_name"], attrs["name"]), "")
+		return aiEnsureUser(entities, links, tenantID, event, profile, ownerUserID, attrs["email"], attrs["owner_name"], "")
 	}
 	return ""
 }
@@ -1496,7 +1496,7 @@ func aiAuditResourceURN(entities map[string]*ports.ProjectedEntity, links map[st
 		orgAttrs["organization_id"] = resourceID
 		return aiEnsureOrganization(entities, tenantID, event.GetSourceId(), profile, orgAttrs)
 	case strings.Contains(normalizedType, "user"):
-		return aiEnsureUser(entities, links, tenantID, event, profile, resourceID, attrs["email"], attrs["name"], attrs["role"])
+		return aiEnsureUser(entities, links, tenantID, event, profile, resourceID, attrs["email"], "", attrs["role"])
 	default:
 		resourceType = firstNonEmpty(resourceType, "resource")
 		resourceURN := projectionURN(tenantID, profile.Provider+"_resource", resourceType, resourceID)
@@ -1508,7 +1508,7 @@ func aiAuditResourceURN(entities map[string]*ports.ProjectedEntity, links map[st
 			TenantID:   tenantID,
 			SourceID:   event.GetSourceId(),
 			EntityType: profile.Provider + ".resource",
-			Label:      firstNonEmpty(attrs["name"], resourceID),
+			Label:      resourceID,
 			Attributes: compactAttributes(map[string]string{
 				"activity_type":     attrs["activity_type"],
 				"claude_project_id": attrs["claude_project_id"],

--- a/internal/sourceprojection/ai_access.go
+++ b/internal/sourceprojection/ai_access.go
@@ -464,25 +464,17 @@ func aiCredentialProjections(event *cerebrov1.EventEnvelope, profile aiAccessPro
 	if credentialType == "" {
 		credentialType = "credential"
 	}
+	scopeKind := aiCredentialScopeKind(attrs, event.GetKind())
+	credentialAttrs := aiCredentialAttributes(attrs, credentialID, credentialType, true)
+	addProjectedAttribute(credentialAttrs, "scope_kind", scopeKind)
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        credentialURN,
 		TenantID:   tenantID,
 		SourceID:   event.GetSourceId(),
 		EntityType: profile.Provider + ".credential",
 		Label:      firstNonEmpty(attrs["name"], credentialID),
-		Attributes: aiPrincipalAttributes(attrs, map[string]string{
-			"credential_id":   credentialID,
-			"credential_type": credentialType,
-			"api_key_id":      strings.TrimSpace(attrs["api_key_id"]),
-			"external_key_id": strings.TrimSpace(attrs["external_key_id"]),
-			"name":            strings.TrimSpace(attrs["name"]),
-			"status":          strings.TrimSpace(attrs["status"]),
-			"provider":        strings.TrimSpace(attrs["provider"]),
-			"created_at":      strings.TrimSpace(attrs["created_at"]),
-			"last_used_at":    strings.TrimSpace(attrs["last_used_at"]),
-		}),
+		Attributes: credentialAttrs,
 	})
-	scopeKind := aiCredentialScopeKind(attrs, event.GetKind())
 	scopeURN := aiEnsureScope(entities, tenantID, event.GetSourceId(), profile, scopeKind, attrs)
 	if scopeURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), credentialURN, scopeURN, relationCanPerform, aiEventLinkAttributes(event, "credential_scope")))
@@ -1125,25 +1117,81 @@ func aiEnsureCredential(entities map[string]*ports.ProjectedEntity, tenantID str
 	if credentialURN == "" {
 		return ""
 	}
-	baseAttrs := map[string]string{
-		"credential_id":  strings.TrimSpace(credentialID),
-		"principal_type": "credential",
-		"api_key_id":     strings.TrimSpace(credentialID),
-	}
+	baseAttrs := aiCredentialAttributes(attrs, credentialID, firstNonEmpty(attrs["credential_type"], "credential"), false)
 	if credentialID == strings.TrimSpace(firstNonEmpty(attrs["actor_api_key_id"], attrs["actor_admin_api_key_id"])) {
 		baseAttrs["actor_user_id"] = strings.TrimSpace(attrs["actor_user_id"])
 		baseAttrs["actor_service_account_id"] = strings.TrimSpace(attrs["actor_service_account_id"])
 	}
-	credentialAttrs := aiPrincipalAttributes(attrs, baseAttrs)
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        credentialURN,
 		TenantID:   tenantID,
 		SourceID:   sourceID,
 		EntityType: profile.Provider + ".credential",
 		Label:      credentialID,
-		Attributes: credentialAttrs,
+		Attributes: baseAttrs,
 	})
 	return credentialURN
+}
+
+func aiCredentialAttributes(attrs map[string]string, credentialID string, credentialType string, allowUserIDOwner bool) map[string]string {
+	ownerUserID := firstNonEmpty(attrs["owner_user_id"], aiTypedOwnerID(attrs, "user"))
+	if allowUserIDOwner {
+		ownerUserID = firstNonEmpty(ownerUserID, attrs["user_id"])
+	}
+	ownerServiceAccountID := firstNonEmpty(attrs["owner_service_account_id"], aiTypedOwnerID(attrs, "service_account"))
+	lastUsedAt := firstNonEmpty(attrs["last_used_at"], attrs["last_used_time"], attrs["last_used"], attrs["end_time"], attrs["start_time"])
+	baseAttrs := map[string]string{
+		"credential_id":            strings.TrimSpace(credentialID),
+		"credential_type":          firstNonEmpty(credentialType, attrs["credential_type"], attrs["key_type"], "credential"),
+		"principal_type":           "credential",
+		"api_key_id":               strings.TrimSpace(credentialID),
+		"external_key_id":          strings.TrimSpace(attrs["external_key_id"]),
+		"name":                     strings.TrimSpace(attrs["name"]),
+		"status":                   strings.TrimSpace(attrs["status"]),
+		"provider":                 strings.TrimSpace(attrs["provider"]),
+		"created_at":               strings.TrimSpace(attrs["created_at"]),
+		"updated_at":               strings.TrimSpace(attrs["updated_at"]),
+		"expires_at":               strings.TrimSpace(attrs["expires_at"]),
+		"last_used_at":             strings.TrimSpace(lastUsedAt),
+		"key_class":                strings.TrimSpace(attrs["key_class"]),
+		"privileged":               strings.TrimSpace(attrs["privileged"]),
+		"owner_id":                 strings.TrimSpace(attrs["owner_id"]),
+		"owner_type":               strings.TrimSpace(attrs["owner_type"]),
+		"owner_object":             strings.TrimSpace(attrs["owner_object"]),
+		"owner_name":               strings.TrimSpace(attrs["owner_name"]),
+		"owner_role":               strings.TrimSpace(attrs["owner_role"]),
+		"owner_user_id":            strings.TrimSpace(ownerUserID),
+		"owner_service_account_id": strings.TrimSpace(ownerServiceAccountID),
+		"organization_id":          strings.TrimSpace(attrs["organization_id"]),
+		"org_id":                   strings.TrimSpace(attrs["org_id"]),
+		"project_id":               strings.TrimSpace(attrs["project_id"]),
+		"workspace_id":             strings.TrimSpace(attrs["workspace_id"]),
+	}
+	if firstNonEmpty(ownerUserID, ownerServiceAccountID, attrs["owner_id"]) != "" {
+		baseAttrs["has_owner"] = "true"
+	} else if allowUserIDOwner {
+		baseAttrs["has_owner"] = "false"
+	}
+	if aiCredentialUsageObserved(attrs) {
+		baseAttrs["credential_use"] = "true"
+	}
+	return aiPrincipalAttributes(attrs, baseAttrs)
+}
+
+func aiCredentialUsageObserved(attrs map[string]string) bool {
+	family := strings.ToLower(strings.TrimSpace(attrs["family"]))
+	if strings.HasPrefix(family, "usage") || strings.Contains(family, "usage_") || strings.Contains(family, "cost") {
+		return true
+	}
+	return firstNonEmpty(
+		attrs["input_tokens"],
+		attrs["output_tokens"],
+		attrs["num_model_requests"],
+		attrs["request_count"],
+		attrs["cost_usd"],
+		attrs["amount"],
+		attrs["line_item"],
+	) != "" && firstNonEmpty(attrs["start_time"], attrs["end_time"], attrs["model"]) != ""
 }
 
 func aiEnsureRole(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, profile aiAccessProfile, attrs map[string]string, scopeKind string) string {

--- a/internal/sourceprojection/ai_access_credential_test.go
+++ b/internal/sourceprojection/ai_access_credential_test.go
@@ -1,0 +1,56 @@
+package sourceprojection
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestProjectAIUsageMetricNormalizesCredentialRuntimeUsage(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	occurred := time.Date(2026, time.June, 18, 12, 45, 0, 0, time.UTC)
+
+	event := &cerebrov1.EventEnvelope{
+		Id:         "openai-usage-runtime-credential",
+		TenantId:   "writer",
+		SourceId:   "openai",
+		Kind:       "openai.usage_completion",
+		OccurredAt: timestamppb.New(occurred),
+		Attributes: map[string]string{
+			"api_key_id":         "usage_runtime_key",
+			"end_time":           "2026-06-18T13:00:00Z",
+			"family":             "usage_completion",
+			"id":                 "usage_runtime_1",
+			"input_tokens":       "1200",
+			"model":              "gpt-4o",
+			"num_model_requests": "5",
+			"project_id":         "proj_runtime",
+			"start_time":         "2026-06-18T12:00:00Z",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project(%q) error = %v", event.GetId(), err)
+	}
+
+	credentialURN := "urn:cerebro:writer:openai_credential:usage_runtime_key" // #nosec G101 -- test credential identifier, not credential material.
+	credential := state.entities[credentialURN]
+	if credential == nil {
+		t.Fatalf("credential entity %q missing", credentialURN)
+	}
+	for key, want := range map[string]string{ // #nosec G101 -- test credential identifier, not credential material.
+		"api_key_id":      "usage_runtime_key",
+		"credential_id":   "usage_runtime_key",
+		"credential_type": "credential",
+		"credential_use":  "true",
+		"last_used_at":    "2026-06-18T13:00:00Z",
+		"project_id":      "proj_runtime",
+	} {
+		if got := credential.Attributes[key]; got != want {
+			t.Fatalf("credential attribute %q = %q, want %q", key, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Normalize AI credential projection with runtime usage, owner, lifecycle, scope, and last-use attributes.
- Add recommendation-only credential governance risk-plan actions for rotate, revoke unused, and owner review.
- Add focused sourceprojection and riskplan tests.

## Validation
- go test ./...
- make changed-check
- make lint