### PR TITLE
feat: add graph observability metrics

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/jobs"
+	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcehealth"
@@ -772,6 +773,14 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 		}
 		captureOrchestratorError(phaseCtx, name+".error", iteration, runtime, name, err)
 	}
+	observability.RecordOrchestratorPhase(phaseCtx, observability.OrchestratorPhaseMetrics{
+		PhaseKey:        phaseKey,
+		SourceID:        runtime.GetSourceId(),
+		Status:          status,
+		ErrorKind:       errorKindForMetric(err),
+		Duration:        time.Since(started),
+		TimeoutExceeded: errors.Is(err, context.DeadlineExceeded) || errors.Is(phaseCtx.Err(), context.DeadlineExceeded),
+	})
 	emitOrchestratorJobPhaseEnded(phaseCtx, name, status, iteration, runtime, time.Since(started), timeout, endAttrs)
 	telemetry.AnnotateMainPhase(phaseCtx, name, status, endAttrs.
 		WithField(telemetryField("phase.iteration", iteration)).
@@ -780,6 +789,13 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 		WithField(telemetryField("phase.tenant_id", runtime.GetTenantId())))
 	telemetry.End(span, status, endAttrs)
 	return result, err
+}
+
+func errorKindForMetric(err error) string {
+	if err == nil {
+		return ""
+	}
+	return telemetry.ErrorKind(err)
 }
 
 func annotateOrchestratorRuntimeMain(ctx context.Context, result *orchestratorRuntimeResult, status string, attrs telemetry.Attributes) {

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 // EvaluateGraphRulesRequest scopes one graph-rule evaluation pass over one runtime.
@@ -77,8 +79,30 @@ func (s *Service) EvaluateSourceRuntimeGraphRules(ctx context.Context, request E
 	return result, firstErr
 }
 
-func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule GraphRule, startedAt time.Time) (*GraphRuleEvaluationResult, error) {
+func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule GraphRule, startedAt time.Time) (evaluation *GraphRuleEvaluationResult, err error) {
 	spec := rule.Spec()
+	metricsStartedAt := time.Now()
+	defer func() {
+		status := "completed"
+		errorKind := ""
+		if err != nil {
+			status = "failed"
+			errorKind = telemetry.ErrorKind(err)
+		}
+		metrics := observability.GraphRuleEvaluationMetrics{
+			SourceID:  strings.TrimSpace(runtime.GetSourceId()),
+			RuleID:    strings.TrimSpace(spec.GetId()),
+			Status:    status,
+			ErrorKind: errorKind,
+			Duration:  time.Since(metricsStartedAt),
+		}
+		if evaluation != nil {
+			metrics.RowsRead = evaluation.RowsRead
+			metrics.Findings = len(evaluation.Findings)
+			metrics.Truncated = evaluation.Truncated
+		}
+		observability.RecordGraphRuleEvaluation(ctx, metrics)
+	}()
 	run := newGraphFindingEvaluationRun(strings.TrimSpace(runtime.GetId()), spec.GetId(), startedAt)
 	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
 		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/projectionmeta"
 	"github.com/writer/cerebro/internal/telemetry"
@@ -1294,6 +1295,7 @@ func (s *Store) read(ctx context.Context, work func(context.Context, neo4jdriver
 		ctx, cancel = context.WithTimeout(ctx, s.queryTimeout)
 		defer cancel()
 	}
+	started := time.Now()
 	ctx, span := telemetry.Start(ctx, "neo4j.read", attrs)
 	session := s.driver.NewSession(ctx, neo4jdriver.SessionConfig{DatabaseName: s.database})
 	defer func() { _ = session.Close(ctx) }()
@@ -1301,26 +1303,41 @@ func (s *Store) read(ctx context.Context, work func(context.Context, neo4jdriver
 		return work(ctx, tx)
 	})
 	if err != nil {
+		recordNeo4jOperation(ctx, s.database, "read", "failed", telemetry.ErrorKind(err), time.Since(started))
 		neo4jTelemetryError(ctx, span, s.database, "read", err)
 		return nil, err
 	}
+	recordNeo4jOperation(ctx, s.database, "read", "completed", "", time.Since(started))
 	neo4jAnnotateMain(ctx, s.database, "read", "completed")
 	telemetry.End(span, "completed", telemetry.Attrs())
 	return result, nil
 }
 
 func (s *Store) write(ctx context.Context, work neo4jdriver.ManagedTransactionWork) (any, error) {
-	ctx, span := telemetry.Start(ctx, "neo4j.write", neo4jTelemetryAttrs("write", s.database, 0))
+	started := time.Now()
+	ctx, span := telemetry.StartQuiet(ctx, "neo4j.write", neo4jTelemetryAttrs("write", s.database, 0))
 	session := s.driver.NewSession(ctx, neo4jdriver.SessionConfig{DatabaseName: s.database})
 	defer func() { _ = session.Close(ctx) }()
 	result, err := session.ExecuteWrite(ctx, work)
 	if err != nil {
+		recordNeo4jOperation(ctx, s.database, "write", "failed", telemetry.ErrorKind(err), time.Since(started))
 		neo4jTelemetryError(ctx, span, s.database, "write", err)
 		return nil, err
 	}
+	recordNeo4jOperation(ctx, s.database, "write", "completed", "", time.Since(started))
 	neo4jAnnotateMain(ctx, s.database, "write", "completed")
-	telemetry.End(span, "completed", telemetry.Attrs())
+	telemetry.EndQuiet(span, "completed", telemetry.Attrs())
 	return result, nil
+}
+
+func recordNeo4jOperation(ctx context.Context, database string, operation string, status string, errorKind string, duration time.Duration) {
+	observability.RecordNeo4jOperation(ctx, observability.Neo4jOperationMetrics{
+		Operation:          operation,
+		Status:             status,
+		ErrorKind:          errorKind,
+		Duration:           duration,
+		DatabaseConfigured: strings.TrimSpace(database) != "",
+	})
 }
 
 func neo4jTelemetryAttrs(operation string, database string, timeout time.Duration) telemetry.Attributes {

--- a/internal/observability/domain_metrics.go
+++ b/internal/observability/domain_metrics.go
@@ -77,6 +77,65 @@ func otelGraphActionRecorded() otelmetric.Int64Counter {
 	return instrument
 }
 
+func otelGraphRuleEvaluations() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.graph_rule.evaluations",
+		otelmetric.WithDescription("Total graph rule evaluations by bounded source, rule, status, and error class."),
+	)
+	return instrument
+}
+
+func otelGraphRuleDuration() otelmetric.Float64Histogram {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Float64Histogram(
+		"cerebro.graph_rule.duration",
+		otelmetric.WithDescription("Graph rule evaluation duration by bounded source, rule, status, and error class."),
+		otelmetric.WithUnit("s"),
+	)
+	return instrument
+}
+
+func otelGraphRuleRecords() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.graph_rule.records",
+		otelmetric.WithDescription("Graph rule rows read and findings emitted by bounded source, rule, status, and error class."),
+	)
+	return instrument
+}
+
+func otelNeo4jOperations() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.neo4j.operations",
+		otelmetric.WithDescription("Total Neo4j operations by operation, status, and error class."),
+	)
+	return instrument
+}
+
+func otelNeo4jOperationDuration() otelmetric.Float64Histogram {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Float64Histogram(
+		"cerebro.neo4j.operation.duration",
+		otelmetric.WithDescription("Neo4j operation duration by operation, status, and error class."),
+		otelmetric.WithUnit("s"),
+	)
+	return instrument
+}
+
+func otelOrchestratorPhaseRuns() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.orchestrator.phase.runs",
+		otelmetric.WithDescription("Total orchestrator phase attempts by bounded phase, source, status, and error class."),
+	)
+	return instrument
+}
+
+func otelOrchestratorPhaseDuration() otelmetric.Float64Histogram {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Float64Histogram(
+		"cerebro.orchestrator.phase.duration",
+		otelmetric.WithDescription("Orchestrator phase duration by bounded phase, source, status, and error class."),
+		otelmetric.WithUnit("s"),
+	)
+	return instrument
+}
+
 func otelJetStreamPublishRequests() otelmetric.Int64Counter {
 	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
 		"cerebro.jetstream.publish.requests",
@@ -178,6 +237,42 @@ type GraphActionMetrics struct {
 	DryRun         bool
 }
 
+// GraphRuleEvaluationMetrics is intentionally scoped to bounded catalog data.
+// Tenant IDs, runtime IDs, finding IDs, graph URNs, trace IDs, and evidence IDs
+// belong in spans/wide events rather than metric labels.
+type GraphRuleEvaluationMetrics struct {
+	SourceID  string
+	RuleID    string
+	Status    string
+	ErrorKind string
+	Duration  time.Duration
+	RowsRead  uint32
+	Findings  int
+	Truncated bool
+}
+
+// Neo4jOperationMetrics keeps database telemetry low-cardinality. Database
+// names, query text, parameters, and resource identifiers belong in traces or
+// local diagnostics, not metric labels.
+type Neo4jOperationMetrics struct {
+	Operation          string
+	Status             string
+	ErrorKind          string
+	Duration           time.Duration
+	DatabaseConfigured bool
+}
+
+// OrchestratorPhaseMetrics records the SLO boundary around each orchestrator
+// phase without promoting tenant/runtime IDs into metrics.
+type OrchestratorPhaseMetrics struct {
+	PhaseKey        string
+	SourceID        string
+	Status          string
+	ErrorKind       string
+	Duration        time.Duration
+	TimeoutExceeded bool
+}
+
 // JetStreamPublishMetrics is intentionally scoped to bounded operational
 // dimensions. Message IDs, tenant IDs, runtime IDs, and resource identifiers
 // belong in spans/wide events rather than metric labels.
@@ -259,6 +354,49 @@ func RecordGraphAction(ctx context.Context, metrics GraphActionMetrics) {
 	otelGraphActionRecorded().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
 }
 
+func RecordGraphRuleEvaluation(ctx context.Context, metrics GraphRuleEvaluationMetrics) {
+	attrs := []attribute.KeyValue{
+		attribute.String("source_id", boundedMetricValue(metrics.SourceID, "unknown")),
+		attribute.String("rule_id", boundedMetricValue(metrics.RuleID, "unknown")),
+		attribute.String("status", boundedMetricValue(metrics.Status, "unknown")),
+		attribute.String("error_kind", boundedMetricValue(metrics.ErrorKind, "none")),
+		attribute.Bool("truncated", metrics.Truncated),
+	}
+	otelGraphRuleEvaluations().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+	if metrics.Duration >= 0 {
+		otelGraphRuleDuration().Record(ctx, metrics.Duration.Seconds(), otelmetric.WithAttributes(attrs...))
+	}
+	recordGraphRuleRecordCount(ctx, attrs, "row_read", int64(metrics.RowsRead))
+	recordGraphRuleRecordCount(ctx, attrs, "finding_emitted", int64(metrics.Findings))
+}
+
+func RecordNeo4jOperation(ctx context.Context, metrics Neo4jOperationMetrics) {
+	attrs := []attribute.KeyValue{
+		attribute.String("operation", boundedMetricValue(metrics.Operation, "unknown")),
+		attribute.String("status", boundedMetricValue(metrics.Status, "unknown")),
+		attribute.String("error_kind", boundedMetricValue(metrics.ErrorKind, "none")),
+		attribute.Bool("database_configured", metrics.DatabaseConfigured),
+	}
+	otelNeo4jOperations().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+	if metrics.Duration >= 0 {
+		otelNeo4jOperationDuration().Record(ctx, metrics.Duration.Seconds(), otelmetric.WithAttributes(attrs...))
+	}
+}
+
+func RecordOrchestratorPhase(ctx context.Context, metrics OrchestratorPhaseMetrics) {
+	attrs := []attribute.KeyValue{
+		attribute.String("phase_key", boundedMetricValue(metrics.PhaseKey, "unknown")),
+		attribute.String("source_id", boundedMetricValue(metrics.SourceID, "unknown")),
+		attribute.String("status", boundedMetricValue(metrics.Status, "unknown")),
+		attribute.String("error_kind", boundedMetricValue(metrics.ErrorKind, "none")),
+		attribute.Bool("timeout_exceeded", metrics.TimeoutExceeded),
+	}
+	otelOrchestratorPhaseRuns().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+	if metrics.Duration >= 0 {
+		otelOrchestratorPhaseDuration().Record(ctx, metrics.Duration.Seconds(), otelmetric.WithAttributes(attrs...))
+	}
+}
+
 func RecordJetStreamPublish(ctx context.Context, metrics JetStreamPublishMetrics) {
 	attrs := []attribute.KeyValue{
 		attribute.String("subject", boundedJetStreamMetricSubject(metrics.Subject)),
@@ -312,6 +450,14 @@ func recordSourceProjectionRecordCount(ctx context.Context, base []attribute.Key
 	}
 	attrs := append(cloneMetricAttributes(base), attribute.String("record.kind", kind))
 	otelSourceProjectionRecords().Add(ctx, count, otelmetric.WithAttributes(attrs...))
+}
+
+func recordGraphRuleRecordCount(ctx context.Context, base []attribute.KeyValue, kind string, count int64) {
+	if count <= 0 {
+		return
+	}
+	attrs := append(cloneMetricAttributes(base), attribute.String("record.kind", kind))
+	otelGraphRuleRecords().Add(ctx, count, otelmetric.WithAttributes(attrs...))
 }
 
 func recordJetStreamReplayRecordCount(ctx context.Context, base []attribute.KeyValue, kind string, count uint64) {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -300,6 +300,10 @@ func Start(ctx context.Context, name string, attributes Attributes) (context.Con
 	return StartWithOptions(ctx, name, attributes)
 }
 
+func StartQuiet(ctx context.Context, name string, attributes Attributes) (context.Context, *Span) {
+	return start(ctx, name, attributes, false)
+}
+
 func StartMain(ctx context.Context, name string, attributes Attributes, options ...oteltrace.SpanStartOption) (context.Context, *Span) {
 	attributes = RuntimeAttributes().With(wideEventBaseAttributes(name)).With(attributes).
 		WithField(Field{Key: "main", Value: true}).
@@ -312,6 +316,10 @@ func StartMain(ctx context.Context, name string, attributes Attributes, options 
 }
 
 func StartWithOptions(ctx context.Context, name string, attributes Attributes, options ...oteltrace.SpanStartOption) (context.Context, *Span) {
+	return start(ctx, name, attributes, true, options...)
+}
+
+func start(ctx context.Context, name string, attributes Attributes, emitStart bool, options ...oteltrace.SpanStartOption) (context.Context, *Span) {
 	attributes = spanBaseAttributes(name).With(attributes)
 	parent, _ := ctx.Value(spanContextKey{}).(spanContext)
 	traceID := parent.TraceID
@@ -335,7 +343,9 @@ func StartWithOptions(ctx context.Context, name string, attributes Attributes, o
 		span.spanID = spanContext.SpanID().String()
 	}
 	next := context.WithValue(otelCtx, spanContextKey{}, spanContext{TraceID: span.traceID, SpanID: span.spanID})
-	emit("span_start", span, attributes)
+	if emitStart {
+		emit("span_start", span, attributes)
+	}
 	return next, span
 }
 
@@ -553,6 +563,14 @@ func fingerprintAttribute(attributes Attributes, key string) string {
 }
 
 func End(span *Span, status string, attributes Attributes) {
+	end(span, status, attributes, true)
+}
+
+func EndQuiet(span *Span, status string, attributes Attributes) {
+	end(span, status, attributes, false)
+}
+
+func end(span *Span, status string, attributes Attributes, emitEnd bool) {
 	if span == nil {
 		return
 	}
@@ -583,7 +601,9 @@ func End(span *Span, status string, attributes Attributes) {
 		}
 		span.otelSpan.End()
 	}
-	emit("span_end", span, attributes)
+	if emitEnd {
+		emit("span_end", span, attributes)
+	}
 }
 
 func (s *Span) annotate(attributes Attributes) {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -44,6 +44,28 @@ func TestEventEmitsParseableJSONLineOnStderr(t *testing.T) {
 	}
 }
 
+func TestQuietSpanStillExportsOpenTelemetryWithoutWideEvents(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	oldProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(oldProvider)
+		_ = provider.Shutdown(context.Background())
+	})
+
+	_, stderr := captureOutput(t, func() {
+		_, span := StartQuiet(context.Background(), "test.quiet", Attrs(Field{Key: "operation", Value: "write"}))
+		EndQuiet(span, "completed", Attrs(Field{Key: "status_detail", Value: "sampled_out"}))
+	})
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("quiet span emitted stderr = %q, want empty", stderr)
+	}
+	if ended := recorder.Ended(); len(ended) != 1 || ended[0].Name() != "test.quiet" {
+		t.Fatalf("quiet span did not reach OTEL recorder: %#v", ended)
+	}
+}
+
 func TestTelemetryFieldsDoNotUseRawErrorKey(t *testing.T) {
 	_, currentFile, _, ok := runtime.Caller(0)
 	if !ok {


### PR DESCRIPTION
## Summary\n- Add low-cardinality graph rule, orchestrator phase, and Neo4j operation metrics.\n- Reduce high-volume successful Neo4j write log events while preserving OTEL spans and error events.\n\n## Tests\n- go test ./...
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->