### PR TITLE
fix: validate source health receipt paths

### DIFF
--- a/tools/archtests/source_deploy_test.go
+++ b/tools/archtests/source_deploy_test.go
@@ -110,6 +110,7 @@ func TestPrioritySourcesDeclareHealthReceipts(t *testing.T) {
 		requirePositiveHealthReceiptSeconds(t, id, receipt, "expected_cadence_seconds")
 		requirePositiveHealthReceiptSeconds(t, id, receipt, "stale_after_seconds")
 		requireNonEmptyHealthReceiptList(t, id, receipt, "failure_modes")
+		requireAdapterHealthPathMatchesSourceType(t, id, receipt)
 	}
 	sort.Strings(missing)
 	if len(missing) > 0 {
@@ -236,6 +237,18 @@ func requireNonEmptyHealthReceiptList(t *testing.T, sourceID string, receipt map
 		if text, ok := value.(string); !ok || strings.TrimSpace(text) == "" {
 			t.Fatalf("%s health receipt %s contains %#v, want non-empty strings", sourceID, key, value)
 		}
+	}
+}
+
+func requireAdapterHealthPathMatchesSourceType(t *testing.T, sourceID string, receipt map[string]any) {
+	t.Helper()
+	sourceType := strings.TrimSpace(receipt["source_type"].(string))
+	adapterHealthPath := strings.TrimSpace(receipt["adapter_health_path"].(string))
+	if sourceType == "json_api" && !strings.HasPrefix(adapterHealthPath, "/") {
+		t.Fatalf("%s json_api health receipt adapter_health_path = %q, want leading /", sourceID, adapterHealthPath)
+	}
+	if sourceType == "cloud_api" && adapterHealthPath == "" {
+		t.Fatalf("%s cloud_api health receipt adapter_health_path is empty", sourceID)
 	}
 }
 

--- a/tools/sourcedeploy/contract.go
+++ b/tools/sourcedeploy/contract.go
@@ -151,6 +151,12 @@ func sourceHealthReceipt(sourcesRoot string, sourceID string) (map[string]any, e
 	if rawSourceID, ok := receipt["source_id"].(string); ok && strings.TrimSpace(rawSourceID) != "" && strings.TrimSpace(rawSourceID) != sourceID {
 		return nil, fmt.Errorf("decode source health receipt %s: source_id %q does not match catalog %q", path, rawSourceID, sourceID)
 	}
+	sourceType := strings.TrimSpace(fmt.Sprint(receipt["source_type"]))
+	adapterHealthPath, _ := receipt["adapter_health_path"].(string)
+	adapterHealthPath = strings.TrimSpace(adapterHealthPath)
+	if sourceType == "json_api" && adapterHealthPath != "" && !strings.HasPrefix(adapterHealthPath, "/") {
+		return nil, fmt.Errorf("decode source health receipt %s: json_api adapter_health_path must start with /", path)
+	}
 	receipt["source_id"] = sourceID
 	return receipt, nil
 }

--- a/tools/sourcedeploy/contract_test.go
+++ b/tools/sourcedeploy/contract_test.go
@@ -175,6 +175,72 @@ runtimes:
 	}
 }
 
+func TestRenderContractRejectsRelativeJSONAPIHealthPath(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkSource(t, root, "okta", "id: okta\nemitted_kinds:\n  - okta.audit\n", "")
+	mkSourceHealthReceipt(t, root, "okta", `{
+  "receipt_kind": "source_health.receipt",
+  "source_type": "json_api",
+  "adapter_health_path": "healthz",
+  "expected_cadence_seconds": 3600,
+  "stale_after_seconds": 7200
+}`)
+
+	manifests, err := Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if _, err := RenderContract(root, manifests, ContractOptions{Environment: "dev", TenantID: "example"}); err == nil {
+		t.Fatal("RenderContract error = nil, want json_api adapter health path error")
+	}
+}
+
+func TestRenderContractAllowsCloudAPIOperationHealthPath(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkSource(t, root, "aws", "id: aws\nemitted_kinds:\n  - aws.public_endpoint\n", "")
+	mkSourceHealthReceipt(t, root, "aws", `{
+  "receipt_kind": "source_health.receipt",
+  "source_type": "cloud_api",
+  "adapter_health_path": "sts:GetCallerIdentity",
+  "expected_cadence_seconds": 86400,
+  "stale_after_seconds": 86400
+}`)
+
+	manifests, err := Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	contract, err := RenderContract(root, manifests, ContractOptions{Environment: "dev", TenantID: "example"})
+	if err != nil {
+		t.Fatalf("RenderContract: %v", err)
+	}
+	if got := contract.Sources[0].SourceHealthReceipt["adapter_health_path"]; got != "sts:GetCallerIdentity" {
+		t.Fatalf("adapter_health_path = %v, want sts:GetCallerIdentity", got)
+	}
+}
+
+func TestRenderContractAllowsJSONAPIReceiptWithoutHealthPath(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkSource(t, root, "okta", "id: okta\nemitted_kinds:\n  - okta.audit\n", "")
+	mkSourceHealthReceipt(t, root, "okta", `{
+  "receipt_kind": "source_health.receipt",
+  "source_type": "json_api",
+  "expected_cadence_seconds": 3600,
+  "stale_after_seconds": 7200
+}`)
+
+	manifests, err := Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if _, err := RenderContract(root, manifests, ContractOptions{Environment: "dev", TenantID: "example"}); err != nil {
+		t.Fatalf("RenderContract: %v", err)
+	}
+}
+
 func TestRenderContractStampsMissingSourceHealthReceiptSourceID(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()


### PR DESCRIPTION
## Summary

- Validate source-health receipt path semantics when rendering deploy contracts.
- Keep HTTP-style source receipts slash-prefixed while allowing non-HTTP operation identifiers.
- Add architecture coverage for priority source receipts.

## Test Plan

- go test ./tools/sourcedeploy ./tools/archtests -run 'Test(RenderContract(RejectsInvalidSourceHealthReceipt|RejectsRelativeJSONAPIHealthPath|AllowsCloudAPIOperationHealthPath|StampsMissingSourceHealthReceiptSourceID)|PrioritySourcesDeclareHealthReceipts)' -count=1 -v
- go test ./tools/sourcedeploy ./tools/archtests -count=1
- make check-arch

## Known Invariants

- Source connectors use internal/sourcehttp for outbound HTTP safety.
- Production body reads are bounded with io.LimitReader or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP htu, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: make droid-review-preflight.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with make land-pr PR=<number> so Droid finishes before branch deletion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->