### PR TITLE
refactor: extract connector definition record mapping

### DIFF
--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -1501,6 +1501,8 @@ func fallbackAccessAuditRoute(method string, path string) string {
 		return prefix + "/connector-definitions/{definitionID}/promotion-plan"
 	case strings.HasPrefix(path, "/connector-definitions/") && strings.HasSuffix(path, "/promote"):
 		return prefix + "/connector-definitions/{definitionID}/promote"
+	case strings.HasPrefix(path, "/connector-definitions/") && strings.HasSuffix(path, "/versions"):
+		return prefix + "/connector-definitions/{definitionID}/versions"
 	case strings.HasPrefix(path, "/connector-definitions/"):
 		return prefix + "/connector-definitions/{definitionID}"
 	case strings.HasPrefix(path, "/connectors/") && strings.HasSuffix(path, "/activity"):

--- a/internal/bootstrap/connector_definitions.go
+++ b/internal/bootstrap/connector_definitions.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/connectorcredentials"
+	"github.com/writer/cerebro/internal/connectordefinitionrecords"
 	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/connectorpreview"
 	"github.com/writer/cerebro/internal/ports"
@@ -96,7 +97,7 @@ func (a *App) handleListConnectorDefinitions(w http.ResponseWriter, r *http.Requ
 	}
 	definitions := make([]connectordefinitions.Definition, 0, len(records))
 	for _, record := range records {
-		definition, err := connectorDefinitionFromRecord(record)
+		definition, err := connectordefinitionrecords.FromRecord(record)
 		if err != nil {
 			writeConnectorError(w, err)
 			return
@@ -213,7 +214,7 @@ func (a *App) handleGetConnectorDefinition(w http.ResponseWriter, r *http.Reques
 		writeConnectorError(w, err)
 		return
 	}
-	definition, err := connectorDefinitionFromRecord(record)
+	definition, err := connectordefinitionrecords.FromRecord(record)
 	if err != nil {
 		writeConnectorError(w, err)
 		return
@@ -255,7 +256,7 @@ func (a *App) handleListConnectorDefinitionVersions(w http.ResponseWriter, r *ht
 	}
 	entries := make([]connectorDefinitionVersionEntry, 0, len(versions))
 	for _, version := range versions {
-		definition, err := connectorDefinitionFromVersion(version)
+		definition, err := connectordefinitionrecords.FromVersionRecord(version)
 		if err != nil {
 			writeConnectorError(w, err)
 			return
@@ -326,7 +327,7 @@ func (a *App) handlePromoteConnectorDefinition(w http.ResponseWriter, r *http.Re
 		writeConnectorError(w, err)
 		return
 	}
-	definition, err := connectorDefinitionFromRecord(record)
+	definition, err := connectordefinitionrecords.FromRecord(record)
 	if err != nil {
 		writeConnectorError(w, err)
 		return
@@ -410,63 +411,7 @@ func (a *App) saveConnectorDefinition(ctx context.Context, definition connectord
 	if err != nil {
 		return connectordefinitions.Definition{}, err
 	}
-	return connectorDefinitionFromRecord(record)
-}
-
-func connectorDefinitionFromRecord(record *ports.ConnectorDefinitionRecord) (connectordefinitions.Definition, error) {
-	if record == nil {
-		return connectordefinitions.Definition{}, fmt.Errorf("%w: definition record is required", connectorcredentials.ErrInvalidRequest)
-	}
-	definition := connectordefinitions.Definition{}
-	if err := json.Unmarshal(record.DefinitionJSON, &definition); err != nil {
-		return connectordefinitions.Definition{}, fmt.Errorf("decode connector definition %q: %w", record.ID, err)
-	}
-	definition.ID = record.ID
-	definition.TenantID = record.TenantID
-	definition.SourceID = record.SourceID
-	definition.DisplayName = record.DisplayName
-	definition.Runtime = record.Runtime
-	definition.Stage = record.Stage
-	definition.CurrentVersion = record.CurrentVersion
-	if !record.CreatedAt.IsZero() {
-		definition.CreatedAt = record.CreatedAt.UTC().Format(time.RFC3339)
-	}
-	if !record.UpdatedAt.IsZero() {
-		definition.UpdatedAt = record.UpdatedAt.UTC().Format(time.RFC3339)
-	}
-	normalized, err := connectordefinitions.Normalize(definition)
-	if err != nil {
-		return connectordefinitions.Definition{}, fmt.Errorf("normalize connector definition %q: %w", record.ID, err)
-	}
-	normalized.CurrentVersion = record.CurrentVersion
-	normalized.CreatedAt = definition.CreatedAt
-	normalized.UpdatedAt = definition.UpdatedAt
-	return normalized, nil
-}
-
-func connectorDefinitionFromVersion(version *ports.ConnectorDefinitionVersionRecord) (connectordefinitions.Definition, error) {
-	if version == nil {
-		return connectordefinitions.Definition{}, fmt.Errorf("%w: definition version record is required", connectorcredentials.ErrInvalidRequest)
-	}
-	definition := connectordefinitions.Definition{}
-	if err := json.Unmarshal(version.DefinitionJSON, &definition); err != nil {
-		return connectordefinitions.Definition{}, fmt.Errorf("decode connector definition version %q/%d: %w", version.DefinitionID, version.Version, err)
-	}
-	definition.ID = version.DefinitionID
-	definition.TenantID = version.TenantID
-	definition.SourceID = version.SourceID
-	definition.Stage = version.Stage
-	definition.CurrentVersion = version.Version
-	if !version.CreatedAt.IsZero() {
-		definition.CreatedAt = version.CreatedAt.UTC().Format(time.RFC3339)
-	}
-	normalized, err := connectordefinitions.Normalize(definition)
-	if err != nil {
-		return connectordefinitions.Definition{}, fmt.Errorf("normalize connector definition version %q/%d: %w", version.DefinitionID, version.Version, err)
-	}
-	normalized.CurrentVersion = version.Version
-	normalized.CreatedAt = definition.CreatedAt
-	return normalized, nil
+	return connectordefinitionrecords.FromRecord(record)
 }
 
 func (a *App) connectorTenantDefinitions(ctx context.Context, tenantID string) []connectordefinitions.Definition {
@@ -484,7 +429,7 @@ func (a *App) connectorTenantDefinitions(ctx context.Context, tenantID string) [
 	}
 	definitions := make([]connectordefinitions.Definition, 0, len(records))
 	for _, record := range records {
-		definition, err := connectorDefinitionFromRecord(record)
+		definition, err := connectordefinitionrecords.FromRecord(record)
 		if err != nil || authorizeTenantID(ctx, definition.TenantID) != nil {
 			continue
 		}

--- a/internal/bootstrap/connector_definitions_test.go
+++ b/internal/bootstrap/connector_definitions_test.go
@@ -272,6 +272,93 @@ func TestConnectorDefinitionVersionsEndpointListsImmutableHistory(t *testing.T) 
 	}
 }
 
+func TestConnectorDefinitionVersionsEndpointReturnsNotFound(t *testing.T) {
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connector-definitions/missing-definition/versions")
+	if err != nil {
+		t.Fatalf("GET /connector-definitions/{id}/versions error = %v", err)
+	}
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET versions status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestConnectorDefinitionVersionsEndpointRejectsCrossTenantPrincipal(t *testing.T) {
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	definition := putTestConnectorDefinition(t, store, connectordefinitions.Definition{
+		TenantID:    "tenant-b",
+		SourceID:    "example_api",
+		DisplayName: "Example API",
+		Auth:        connectordefinitions.AuthSpec{Model: "none"},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:      "assets",
+			Path:    "/v1/assets",
+			IDField: "id",
+		}},
+	})
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APIKeys: []config.APIKey{{
+				Key:       "tenant-a-key",
+				Principal: "tenant-a-admin",
+				TenantID:  "tenant-a",
+			}},
+		},
+	}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/connector-definitions/"+definition.ID+"/versions", nil)
+	if err != nil {
+		t.Fatalf("NewRequest versions: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer tenant-a-key")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /connector-definitions/{id}/versions error = %v", err)
+	}
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("GET versions status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestConnectorDefinitionVersionsEndpointRejectsMalformedSnapshot(t *testing.T) {
+	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
+	definition := putTestConnectorDefinition(t, store, connectordefinitions.Definition{
+		TenantID:    "tenant-a",
+		SourceID:    "example_api",
+		DisplayName: "Example API",
+		Auth:        connectordefinitions.AuthSpec{Model: "none"},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:      "assets",
+			Path:    "/v1/assets",
+			IDField: "id",
+		}},
+	})
+	store.definitionVersions[definition.ID][0].DefinitionJSON = []byte(`{"source_id":`)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connector-definitions/" + definition.ID + "/versions")
+	if err != nil {
+		t.Fatalf("GET /connector-definitions/{id}/versions error = %v", err)
+	}
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("GET versions status = %d, want 500", resp.StatusCode)
+	}
+}
+
 func TestTenantConnectorDefinitionAppearsAsRunnableConnector(t *testing.T) {
 	store := &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
@@ -834,6 +921,32 @@ func TestConnectorDefinitionListRequiresDefinitionStore(t *testing.T) {
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("GET /connector-definitions status = %d, want 503", resp.StatusCode)
 	}
+}
+
+func putTestConnectorDefinition(t *testing.T, store *connectorTestStore, definition connectordefinitions.Definition) connectordefinitions.Definition {
+	t.Helper()
+	normalized, err := connectordefinitions.Normalize(definition)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	payload, err := json.Marshal(normalized)
+	if err != nil {
+		t.Fatalf("marshal connector definition: %v", err)
+	}
+	record, err := store.PutConnectorDefinition(context.Background(), &ports.ConnectorDefinitionRecord{
+		ID:             normalized.ID,
+		TenantID:       normalized.TenantID,
+		SourceID:       normalized.SourceID,
+		DisplayName:    normalized.DisplayName,
+		Runtime:        normalized.Runtime,
+		Stage:          normalized.Stage,
+		DefinitionJSON: payload,
+	})
+	if err != nil {
+		t.Fatalf("PutConnectorDefinition() error = %v", err)
+	}
+	normalized.CurrentVersion = record.CurrentVersion
+	return normalized
 }
 
 func cloneConnectorDefinitionRecord(record *ports.ConnectorDefinitionRecord) *ports.ConnectorDefinitionRecord {

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -18,6 +18,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/agentplatform"
 	"github.com/writer/cerebro/internal/buildinfo"
+	"github.com/writer/cerebro/internal/connectordefinitionrecords"
 	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/findingapi"
 	findingdomain "github.com/writer/cerebro/internal/findings"
@@ -682,7 +683,7 @@ func (app *App) mcpListConnectorDefinitions(r *http.Request, args map[string]any
 	}
 	definitions := make([]any, 0, len(records))
 	for _, record := range records {
-		definition, err := connectorDefinitionFromRecord(record)
+		definition, err := connectordefinitionrecords.FromRecord(record)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -10,6 +10,7 @@ import (
 	cerebrov1connect "github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/connectorcredentials"
+	"github.com/writer/cerebro/internal/connectordefinitionrecords"
 	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceplanapi"
@@ -206,7 +207,7 @@ func (app *App) connectorDefinitionForPlan(ctx context.Context, definitionID str
 	if err != nil {
 		return connectordefinitions.Definition{}, err
 	}
-	definition, err := connectorDefinitionFromRecord(record)
+	definition, err := connectordefinitionrecords.FromRecord(record)
 	if err != nil {
 		return connectordefinitions.Definition{}, err
 	}

--- a/internal/connectordefinitionrecords/records.go
+++ b/internal/connectordefinitionrecords/records.go
@@ -1,0 +1,67 @@
+package connectordefinitionrecords
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/writer/cerebro/internal/connectorcredentials"
+	"github.com/writer/cerebro/internal/connectordefinitions"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func FromRecord(record *ports.ConnectorDefinitionRecord) (connectordefinitions.Definition, error) {
+	if record == nil {
+		return connectordefinitions.Definition{}, fmt.Errorf("%w: definition record is required", connectorcredentials.ErrInvalidRequest)
+	}
+	definition := connectordefinitions.Definition{}
+	if err := json.Unmarshal(record.DefinitionJSON, &definition); err != nil {
+		return connectordefinitions.Definition{}, fmt.Errorf("decode connector definition %q: %w", record.ID, err)
+	}
+	definition.ID = record.ID
+	definition.TenantID = record.TenantID
+	definition.SourceID = record.SourceID
+	definition.DisplayName = record.DisplayName
+	definition.Runtime = record.Runtime
+	definition.Stage = record.Stage
+	definition.CurrentVersion = record.CurrentVersion
+	if !record.CreatedAt.IsZero() {
+		definition.CreatedAt = record.CreatedAt.UTC().Format(time.RFC3339)
+	}
+	if !record.UpdatedAt.IsZero() {
+		definition.UpdatedAt = record.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	normalized, err := connectordefinitions.Normalize(definition)
+	if err != nil {
+		return connectordefinitions.Definition{}, fmt.Errorf("normalize connector definition %q: %w", record.ID, err)
+	}
+	normalized.CurrentVersion = record.CurrentVersion
+	normalized.CreatedAt = definition.CreatedAt
+	normalized.UpdatedAt = definition.UpdatedAt
+	return normalized, nil
+}
+
+func FromVersionRecord(version *ports.ConnectorDefinitionVersionRecord) (connectordefinitions.Definition, error) {
+	if version == nil {
+		return connectordefinitions.Definition{}, fmt.Errorf("%w: definition version record is required", connectorcredentials.ErrInvalidRequest)
+	}
+	definition := connectordefinitions.Definition{}
+	if err := json.Unmarshal(version.DefinitionJSON, &definition); err != nil {
+		return connectordefinitions.Definition{}, fmt.Errorf("decode connector definition version %q/%d: %w", version.DefinitionID, version.Version, err)
+	}
+	definition.ID = version.DefinitionID
+	definition.TenantID = version.TenantID
+	definition.SourceID = version.SourceID
+	definition.Stage = version.Stage
+	definition.CurrentVersion = version.Version
+	if !version.CreatedAt.IsZero() {
+		definition.CreatedAt = version.CreatedAt.UTC().Format(time.RFC3339)
+	}
+	normalized, err := connectordefinitions.Normalize(definition)
+	if err != nil {
+		return connectordefinitions.Definition{}, fmt.Errorf("normalize connector definition version %q/%d: %w", version.DefinitionID, version.Version, err)
+	}
+	normalized.CurrentVersion = version.Version
+	normalized.CreatedAt = definition.CreatedAt
+	return normalized, nil
+}


### PR DESCRIPTION
## Summary

- Move connector definition record-to-domain mapping into internal/connectordefinitionrecords to keep bootstrap focused on HTTP wiring.
- Add version-history endpoint coverage for missing definitions, cross-tenant access, and malformed stored snapshots.
- Add the version-history endpoint to fallback access-audit route labeling.

## Test Plan

- `go test ./internal/bootstrap ./internal/connectordefinitionrecords ./internal/connectordefinitions ./internal/ports ./internal/statestore/postgres -count=1`
- `make openapi-check`
- `make check-arch check-structural-test`
- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->