### PR TITLE
Add attested compute graph delta PoC

### DIFF
--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -1,0 +1,282 @@
+package attestedcompute
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type GraphDelta struct {
+	Attestation Attestation `json:"attestation"`
+	Entities    []Entity    `json:"entities"`
+	Links       []Link      `json:"links"`
+}
+
+type Attestation struct {
+	Format      string `json:"format"`
+	Measurement string `json:"measurement"`
+	KeyID       string `json:"key_id"`
+	ImageDigest string `json:"image_digest"`
+}
+
+type Entity struct {
+	URN        string            `json:"urn"`
+	EntityType string            `json:"entity_type"`
+	Label      string            `json:"label,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+}
+
+type Link struct {
+	FromURN    string            `json:"from_urn"`
+	ToURN      string            `json:"to_urn"`
+	Relation   string            `json:"relation"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+}
+
+func ProjectEvent(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	if event == nil {
+		return nil, nil, fmt.Errorf("attested compute event is required")
+	}
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	if tenantID == "" {
+		return nil, nil, fmt.Errorf("attested compute tenant_id is required")
+	}
+	if strings.TrimSpace(event.GetKind()) != EventKindGraphDelta {
+		return nil, nil, fmt.Errorf("attested compute event kind %q is unsupported", event.GetKind())
+	}
+	var delta GraphDelta
+	if err := json.Unmarshal(event.GetPayload(), &delta); err != nil {
+		return nil, nil, fmt.Errorf("decode attested compute graph delta: %w", err)
+	}
+	if len(delta.Entities) == 0 && len(delta.Links) == 0 {
+		return nil, nil, nil
+	}
+	if err := validateAttestation(delta.Attestation); err != nil {
+		return nil, nil, err
+	}
+	sourceID := strings.TrimSpace(event.GetSourceId())
+	entities := make([]*ports.ProjectedEntity, 0, len(delta.Entities))
+	for _, entity := range delta.Entities {
+		projected, err := projectEntity(tenantID, sourceID, delta.Attestation, entity)
+		if err != nil {
+			return nil, nil, err
+		}
+		entities = append(entities, projected)
+	}
+	links := make([]*ports.ProjectedLink, 0, len(delta.Links))
+	for _, link := range delta.Links {
+		projected, err := projectLink(tenantID, sourceID, delta.Attestation, link)
+		if err != nil {
+			return nil, nil, err
+		}
+		links = append(links, projected)
+	}
+	return entities, links, nil
+}
+
+func projectEntity(tenantID string, sourceID string, attestation Attestation, entity Entity) (*ports.ProjectedEntity, error) {
+	urn := strings.TrimSpace(entity.URN)
+	entityType := strings.TrimSpace(entity.EntityType)
+	if urn == "" || entityType == "" {
+		return nil, fmt.Errorf("attested compute entity urn and entity_type are required")
+	}
+	if !tenantScopedURN(tenantID, urn) {
+		return nil, fmt.Errorf("attested compute entity urn %q is outside tenant scope", urn)
+	}
+	if sensitiveEntityType(entityType) && !attestedURN(tenantID, urn) {
+		return nil, fmt.Errorf("attested compute sensitive entity %q must use an attested token urn", entityType)
+	}
+	label := strings.TrimSpace(entity.Label)
+	if sensitiveEntityType(entityType) && label != "" && !TokenLike(label) {
+		return nil, fmt.Errorf("attested compute sensitive entity %q label must be tokenized", entityType)
+	}
+	attributes, err := sanitizeAttributes(tenantID, entity.Attributes)
+	if err != nil {
+		return nil, fmt.Errorf("attested compute entity %q attributes: %w", urn, err)
+	}
+	stampAttestation(attributes, attestation)
+	return &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: entityType,
+		Label:      label,
+		Attributes: attributes,
+	}, nil
+}
+
+func projectLink(tenantID string, sourceID string, attestation Attestation, link Link) (*ports.ProjectedLink, error) {
+	fromURN := strings.TrimSpace(link.FromURN)
+	toURN := strings.TrimSpace(link.ToURN)
+	relation := strings.TrimSpace(link.Relation)
+	if fromURN == "" || toURN == "" || relation == "" {
+		return nil, fmt.Errorf("attested compute link from_urn, to_urn, and relation are required")
+	}
+	if !tenantScopedURN(tenantID, fromURN) || !tenantScopedURN(tenantID, toURN) {
+		return nil, fmt.Errorf("attested compute link endpoints must stay inside tenant scope")
+	}
+	if !allowedRelation(relation) {
+		return nil, fmt.Errorf("attested compute relation %q is not allowed", relation)
+	}
+	attributes, err := sanitizeAttributes(tenantID, link.Attributes)
+	if err != nil {
+		return nil, fmt.Errorf("attested compute link %q attributes: %w", relation, err)
+	}
+	stampAttestation(attributes, attestation)
+	return &ports.ProjectedLink{
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		FromURN:    fromURN,
+		ToURN:      toURN,
+		Relation:   relation,
+		Attributes: attributes,
+	}, nil
+}
+
+func validateAttestation(attestation Attestation) error {
+	if strings.TrimSpace(attestation.Format) == "" {
+		return fmt.Errorf("attested compute attestation format is required")
+	}
+	if strings.TrimSpace(attestation.Measurement) == "" && strings.TrimSpace(attestation.ImageDigest) == "" {
+		return fmt.Errorf("attested compute attestation measurement or image_digest is required")
+	}
+	return nil
+}
+
+func sanitizeAttributes(tenantID string, input map[string]string) (map[string]string, error) {
+	out := make(map[string]string, len(input)+4)
+	for rawKey, rawValue := range input {
+		key := strings.TrimSpace(rawKey)
+		value := strings.TrimSpace(rawValue)
+		if key == "" || value == "" {
+			continue
+		}
+		if sensitiveAttributeKey(key) && !blindedValue(tenantID, value) {
+			return nil, fmt.Errorf("%s must be tokenized or tenant-scoped attested urn", key)
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
+func stampAttestation(attributes map[string]string, attestation Attestation) {
+	if attributes == nil {
+		return
+	}
+	addAttribute(attributes, "attested_compute_format", attestation.Format)
+	addAttribute(attributes, "attested_compute_measurement", attestation.Measurement)
+	addAttribute(attributes, "attested_compute_key_id", attestation.KeyID)
+	addAttribute(attributes, "attested_compute_image_digest", attestation.ImageDigest)
+}
+
+func addAttribute(attributes map[string]string, key string, value string) {
+	value = strings.TrimSpace(value)
+	if value != "" {
+		attributes[key] = value
+	}
+}
+
+func tenantScopedURN(tenantID string, urn string) bool {
+	tenantID = strings.TrimSpace(tenantID)
+	urn = strings.TrimSpace(urn)
+	return tenantID != "" && strings.HasPrefix(urn, "urn:cerebro:"+tenantID+":")
+}
+
+func attestedURN(tenantID string, urn string) bool {
+	tenantID = strings.TrimSpace(tenantID)
+	urn = strings.TrimSpace(urn)
+	return tenantID != "" && strings.HasPrefix(urn, "urn:cerebro:"+tenantID+":attested:")
+}
+
+func blindedValue(tenantID string, value string) bool {
+	value = strings.TrimSpace(value)
+	return TokenLike(value) || attestedURN(tenantID, value)
+}
+
+func sensitiveEntityType(entityType string) bool {
+	entityType = strings.TrimSpace(entityType)
+	if entityType == "" {
+		return false
+	}
+	if entityType == "asset.tag" || entityType == "data.classification" {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(entityType, "aws."):
+		return true
+	case strings.HasPrefix(entityType, "azure."):
+		return true
+	case strings.HasPrefix(entityType, "gcp."):
+		return true
+	case strings.HasPrefix(entityType, "google_workspace."):
+		return true
+	case strings.HasPrefix(entityType, "okta."):
+		return true
+	case strings.Contains(entityType, "user"):
+		return true
+	case strings.Contains(entityType, "identity"):
+		return true
+	case strings.Contains(entityType, "principal"):
+		return true
+	default:
+		return false
+	}
+}
+
+func sensitiveAttributeKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	if normalized == "" {
+		return false
+	}
+	if strings.HasPrefix(normalized, "risk_") ||
+		strings.HasPrefix(normalized, "posture_") ||
+		strings.HasPrefix(normalized, "control_") ||
+		strings.HasPrefix(normalized, "classification_") ||
+		strings.HasPrefix(normalized, "attested_compute_") {
+		return false
+	}
+	switch normalized {
+	case "is_admin", "is_delegated_admin", "is_public", "mfa_enrolled", "mfa_enforced", "status", "severity", "confidence", "observed_at", "at", "last_observed_at", "sensitivity_label":
+		return false
+	}
+	for _, marker := range []string{"arn", "email", "hostname", "ip", "label", "name", "principal", "resource_id", "resource_urn", "user", "urn"} {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func allowedRelation(relation string) bool {
+	switch strings.TrimSpace(relation) {
+	case "acted_on",
+		"affected_by",
+		"affects",
+		"assigned_to",
+		"associated_with",
+		"attached_to",
+		"belongs_to",
+		"can_admin",
+		"can_assume",
+		"can_impersonate",
+		"can_perform",
+		"can_reach",
+		"contains",
+		"has_classification",
+		"has_evidence",
+		"has_identifier",
+		"member_of",
+		"observed_on",
+		"owned_by",
+		"represents_identity",
+		"runs_as",
+		"same_actor",
+		"tagged_as":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -86,6 +86,9 @@ func projectEntity(tenantID string, sourceID string, entity Entity) (*ports.Proj
 	if !tenantScopedURN(tenantID, urn) {
 		return nil, fmt.Errorf("attested compute entity urn %q is outside tenant scope", urn)
 	}
+	if attestedURN(tenantID, urn) && !attestedURNForEntity(tenantID, urn, entityType) {
+		return nil, fmt.Errorf("attested compute entity urn %q must match declared entity type %q", urn, entityType)
+	}
 	if sensitiveEntityType(entityType) && !attestedURNForEntity(tenantID, urn, entityType) {
 		return nil, fmt.Errorf("attested compute sensitive entity %q must use an attested token urn", entityType)
 	}

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -249,7 +249,7 @@ func sensitiveEntityType(entityType string) bool {
 	case strings.Contains(entityType, "principal"):
 		return true
 	default:
-		return false
+		return true
 	}
 }
 

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -118,6 +118,9 @@ func projectLink(tenantID string, sourceID string, attestation Attestation, link
 	if !tenantScopedURN(tenantID, fromURN) || !tenantScopedURN(tenantID, toURN) {
 		return nil, fmt.Errorf("attested compute link endpoints must stay inside tenant scope")
 	}
+	if unblindedSensitiveURN(tenantID, fromURN) || unblindedSensitiveURN(tenantID, toURN) {
+		return nil, fmt.Errorf("attested compute link endpoints for sensitive entity types must use attested token urns")
+	}
 	if !allowedRelation(relation) {
 		return nil, fmt.Errorf("attested compute relation %q is not allowed", relation)
 	}
@@ -154,6 +157,9 @@ func sanitizeAttributes(tenantID string, input map[string]string) (map[string]st
 		if key == "" || value == "" {
 			continue
 		}
+		if reservedAttestedComputeAttribute(key) {
+			continue
+		}
 		if sensitiveAttributeKey(key) && !blindedValue(tenantID, value) {
 			return nil, fmt.Errorf("%s must be tokenized or tenant-scoped attested urn", key)
 		}
@@ -166,10 +172,11 @@ func stampAttestation(attributes map[string]string, attestation Attestation) {
 	if attributes == nil {
 		return
 	}
-	addAttribute(attributes, "attested_compute_format", attestation.Format)
-	addAttribute(attributes, "attested_compute_measurement", attestation.Measurement)
-	addAttribute(attributes, "attested_compute_key_id", attestation.KeyID)
-	addAttribute(attributes, "attested_compute_image_digest", attestation.ImageDigest)
+	attributes["attested_compute_verification_status"] = "unverified_poc"
+	addAttribute(attributes, "attested_compute_claimed_format", attestation.Format)
+	addAttribute(attributes, "attested_compute_claimed_measurement", attestation.Measurement)
+	addAttribute(attributes, "attested_compute_claimed_key_id", attestation.KeyID)
+	addAttribute(attributes, "attested_compute_claimed_image_digest", attestation.ImageDigest)
 }
 
 func addAttribute(attributes map[string]string, key string, value string) {
@@ -191,13 +198,28 @@ func attestedURN(tenantID string, urn string) bool {
 	return tenantID != "" && strings.HasPrefix(urn, "urn:cerebro:"+tenantID+":attested:")
 }
 
+func unblindedSensitiveURN(tenantID string, urn string) bool {
+	tenantID = strings.TrimSpace(tenantID)
+	urn = strings.TrimSpace(urn)
+	if tenantID == "" || urn == "" || attestedURN(tenantID, urn) {
+		return false
+	}
+	prefix := "urn:cerebro:" + tenantID + ":"
+	if !strings.HasPrefix(urn, prefix) {
+		return false
+	}
+	rest := strings.TrimPrefix(urn, prefix)
+	entityType, _, _ := strings.Cut(rest, ":")
+	return sensitiveEntityType(entityType)
+}
+
 func blindedValue(tenantID string, value string) bool {
 	value = strings.TrimSpace(value)
 	return TokenLike(value) || attestedURN(tenantID, value)
 }
 
 func sensitiveEntityType(entityType string) bool {
-	entityType = strings.TrimSpace(entityType)
+	entityType = strings.ToLower(strings.TrimSpace(entityType))
 	if entityType == "" {
 		return false
 	}
@@ -224,6 +246,10 @@ func sensitiveEntityType(entityType string) bool {
 	default:
 		return false
 	}
+}
+
+func reservedAttestedComputeAttribute(key string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(key)), "attested_compute_")
 }
 
 func sensitiveAttributeKey(key string) bool {

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -95,6 +95,9 @@ func projectEntity(tenantID string, sourceID string, entity Entity) (*ports.Proj
 	if unblindedSensitiveURN(tenantID, urn) {
 		return nil, fmt.Errorf("attested compute entity urn %q contains a sensitive type and must use an attested token urn", urn)
 	}
+	if unsafePlainURNIdentifier(tenantID, urn) {
+		return nil, fmt.Errorf("attested compute entity urn %q contains an unsafe plain identifier", urn)
+	}
 	label := strings.TrimSpace(entity.Label)
 	if label != "" && !TokenLike(label) {
 		return nil, fmt.Errorf("attested compute entity %q label must be tokenized", entityType)
@@ -126,6 +129,9 @@ func projectLink(tenantID string, sourceID string, link Link) (*ports.ProjectedL
 	}
 	if unblindedSensitiveURN(tenantID, fromURN) || unblindedSensitiveURN(tenantID, toURN) {
 		return nil, fmt.Errorf("attested compute link endpoints for sensitive entity types must use attested token urns")
+	}
+	if unsafePlainURNIdentifier(tenantID, fromURN) || unsafePlainURNIdentifier(tenantID, toURN) {
+		return nil, fmt.Errorf("attested compute link endpoints must use safe plain identifiers or attested token urns")
 	}
 	if !allowedRelation(relation) {
 		return nil, fmt.Errorf("attested compute relation %q is not allowed", relation)
@@ -216,22 +222,78 @@ func parseAttestedURN(tenantID string, urn string) (string, bool) {
 	return entityType, true
 }
 
+func tenantURNParts(tenantID string, urn string) (string, string, bool) {
+	tenantID = strings.TrimSpace(tenantID)
+	urn = strings.TrimSpace(urn)
+	prefix := "urn:cerebro:" + tenantID + ":"
+	if tenantID == "" || !strings.HasPrefix(urn, prefix) {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(urn, prefix)
+	entityType, identifier, ok := strings.Cut(rest, ":")
+	entityType = strings.TrimSpace(entityType)
+	identifier = strings.TrimSpace(identifier)
+	if !ok || entityType == "" || identifier == "" {
+		return "", "", false
+	}
+	return entityType, identifier, true
+}
+
 func unblindedSensitiveURN(tenantID string, urn string) bool {
 	tenantID = strings.TrimSpace(tenantID)
 	urn = strings.TrimSpace(urn)
 	if tenantID == "" || urn == "" || attestedURN(tenantID, urn) {
 		return false
 	}
-	prefix := "urn:cerebro:" + tenantID + ":"
-	if !strings.HasPrefix(urn, prefix) {
+	entityType, _, ok := tenantURNParts(tenantID, urn)
+	if !ok {
 		return false
 	}
-	rest := strings.TrimPrefix(urn, prefix)
-	if strings.HasPrefix(strings.ToLower(rest), "attested:") {
+	if strings.EqualFold(entityType, "attested") {
 		return true
 	}
-	entityType, _, _ := strings.Cut(rest, ":")
 	return sensitiveEntityType(entityType)
+}
+
+func unsafePlainURNIdentifier(tenantID string, urn string) bool {
+	if attestedURN(tenantID, urn) {
+		return false
+	}
+	entityType, identifier, ok := tenantURNParts(tenantID, urn)
+	if !ok {
+		return true
+	}
+	if strings.EqualFold(entityType, "attested") || sensitiveEntityType(entityType) {
+		return false
+	}
+	return !safePlainURNIdentifier(entityType, identifier)
+}
+
+func safePlainURNIdentifier(entityType string, identifier string) bool {
+	switch strings.ToLower(strings.TrimSpace(entityType)) {
+	case "asset.tag", "data.classification":
+	default:
+		return false
+	}
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" || len(identifier) > 96 {
+		return false
+	}
+	hasAlnum := false
+	for _, char := range identifier {
+		switch {
+		case char >= 'a' && char <= 'z':
+			hasAlnum = true
+		case char >= 'A' && char <= 'Z':
+			hasAlnum = true
+		case char >= '0' && char <= '9':
+			hasAlnum = true
+		case char == '.' || char == '_' || char == '-':
+		default:
+			return false
+		}
+	}
+	return hasAlnum
 }
 
 func blindedValue(tenantID string, value string) bool {

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -60,7 +60,7 @@ func ProjectEvent(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*
 	sourceID := strings.TrimSpace(event.GetSourceId())
 	entities := make([]*ports.ProjectedEntity, 0, len(delta.Entities))
 	for _, entity := range delta.Entities {
-		projected, err := projectEntity(tenantID, sourceID, delta.Attestation, entity)
+		projected, err := projectEntity(tenantID, sourceID, entity)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -68,7 +68,7 @@ func ProjectEvent(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*
 	}
 	links := make([]*ports.ProjectedLink, 0, len(delta.Links))
 	for _, link := range delta.Links {
-		projected, err := projectLink(tenantID, sourceID, delta.Attestation, link)
+		projected, err := projectLink(tenantID, sourceID, link)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -77,7 +77,7 @@ func ProjectEvent(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*
 	return entities, links, nil
 }
 
-func projectEntity(tenantID string, sourceID string, attestation Attestation, entity Entity) (*ports.ProjectedEntity, error) {
+func projectEntity(tenantID string, sourceID string, entity Entity) (*ports.ProjectedEntity, error) {
 	urn := strings.TrimSpace(entity.URN)
 	entityType := strings.TrimSpace(entity.EntityType)
 	if urn == "" || entityType == "" {
@@ -97,7 +97,7 @@ func projectEntity(tenantID string, sourceID string, attestation Attestation, en
 	if err != nil {
 		return nil, fmt.Errorf("attested compute entity %q attributes: %w", urn, err)
 	}
-	stampAttestation(attributes, attestation)
+	stampAttestation(attributes)
 	return &ports.ProjectedEntity{
 		URN:        urn,
 		TenantID:   tenantID,
@@ -108,7 +108,7 @@ func projectEntity(tenantID string, sourceID string, attestation Attestation, en
 	}, nil
 }
 
-func projectLink(tenantID string, sourceID string, attestation Attestation, link Link) (*ports.ProjectedLink, error) {
+func projectLink(tenantID string, sourceID string, link Link) (*ports.ProjectedLink, error) {
 	fromURN := strings.TrimSpace(link.FromURN)
 	toURN := strings.TrimSpace(link.ToURN)
 	relation := strings.TrimSpace(link.Relation)
@@ -128,7 +128,7 @@ func projectLink(tenantID string, sourceID string, attestation Attestation, link
 	if err != nil {
 		return nil, fmt.Errorf("attested compute link %q attributes: %w", relation, err)
 	}
-	stampAttestation(attributes, attestation)
+	stampAttestation(attributes)
 	return &ports.ProjectedLink{
 		TenantID:   tenantID,
 		SourceID:   sourceID,
@@ -140,8 +140,12 @@ func projectLink(tenantID string, sourceID string, attestation Attestation, link
 }
 
 func validateAttestation(attestation Attestation) error {
-	if strings.TrimSpace(attestation.Format) == "" {
+	format := strings.TrimSpace(attestation.Format)
+	if format == "" {
 		return fmt.Errorf("attested compute attestation format is required")
+	}
+	if format != AttestationFormatAWSNitroEnclavePOC {
+		return fmt.Errorf("attested compute attestation format %q is unsupported", format)
 	}
 	if strings.TrimSpace(attestation.Measurement) == "" && strings.TrimSpace(attestation.ImageDigest) == "" {
 		return fmt.Errorf("attested compute attestation measurement or image_digest is required")
@@ -168,22 +172,11 @@ func sanitizeAttributes(tenantID string, input map[string]string) (map[string]st
 	return out, nil
 }
 
-func stampAttestation(attributes map[string]string, attestation Attestation) {
+func stampAttestation(attributes map[string]string) {
 	if attributes == nil {
 		return
 	}
 	attributes["attested_compute_verification_status"] = "unverified_poc"
-	addAttribute(attributes, "attested_compute_claimed_format", attestation.Format)
-	addAttribute(attributes, "attested_compute_claimed_measurement", attestation.Measurement)
-	addAttribute(attributes, "attested_compute_claimed_key_id", attestation.KeyID)
-	addAttribute(attributes, "attested_compute_claimed_image_digest", attestation.ImageDigest)
-}
-
-func addAttribute(attributes map[string]string, key string, value string) {
-	value = strings.TrimSpace(value)
-	if value != "" {
-		attributes[key] = value
-	}
 }
 
 func tenantScopedURN(tenantID string, urn string) bool {
@@ -266,6 +259,13 @@ func sensitiveAttributeKey(key string) bool {
 	if normalized == "" {
 		return false
 	}
+	switch normalized {
+	case "is_admin", "is_delegated_admin", "is_public", "mfa_enrolled", "mfa_enforced", "status", "severity", "confidence", "observed_at", "at", "last_observed_at", "sensitivity_label":
+		return false
+	}
+	if sensitiveAttributeMarker(normalized) {
+		return true
+	}
 	if strings.HasPrefix(normalized, "risk_") ||
 		strings.HasPrefix(normalized, "posture_") ||
 		strings.HasPrefix(normalized, "control_") ||
@@ -273,15 +273,15 @@ func sensitiveAttributeKey(key string) bool {
 		strings.HasPrefix(normalized, "attested_compute_") {
 		return false
 	}
-	switch normalized {
-	case "is_admin", "is_delegated_admin", "is_public", "mfa_enrolled", "mfa_enforced", "status", "severity", "confidence", "observed_at", "at", "last_observed_at", "sensitivity_label":
-		return false
-	}
-	if sensitiveIPAttributeKey(normalized) {
+	return false
+}
+
+func sensitiveAttributeMarker(key string) bool {
+	if sensitiveIPAttributeKey(key) {
 		return true
 	}
 	for _, marker := range []string{"arn", "email", "hostname", "label", "name", "principal", "resource_id", "resource_urn", "user", "urn"} {
-		if strings.Contains(normalized, marker) {
+		if strings.Contains(key, marker) {
 			return true
 		}
 	}

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -226,7 +226,7 @@ func blindedValue(tenantID string, value string) bool {
 func sensitiveEntityType(entityType string) bool {
 	entityType = strings.ToLower(strings.TrimSpace(entityType))
 	if entityType == "" {
-		return false
+		return true
 	}
 	if entityType == "asset.tag" || entityType == "data.classification" {
 		return false

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -195,7 +195,13 @@ func tenantScopedURN(tenantID string, urn string) bool {
 func attestedURN(tenantID string, urn string) bool {
 	tenantID = strings.TrimSpace(tenantID)
 	urn = strings.TrimSpace(urn)
-	return tenantID != "" && strings.HasPrefix(urn, "urn:cerebro:"+tenantID+":attested:")
+	prefix := "urn:cerebro:" + tenantID + ":attested:"
+	if tenantID == "" || !strings.HasPrefix(urn, prefix) {
+		return false
+	}
+	rest := strings.TrimPrefix(urn, prefix)
+	entityType, token, ok := strings.Cut(rest, ":")
+	return ok && strings.TrimSpace(entityType) != "" && TokenLike(token)
 }
 
 func unblindedSensitiveURN(tenantID string, urn string) bool {
@@ -209,6 +215,9 @@ func unblindedSensitiveURN(tenantID string, urn string) bool {
 		return false
 	}
 	rest := strings.TrimPrefix(urn, prefix)
+	if strings.HasPrefix(rest, "attested:") {
+		return true
+	}
 	entityType, _, _ := strings.Cut(rest, ":")
 	return sensitiveEntityType(entityType)
 }

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -89,6 +89,9 @@ func projectEntity(tenantID string, sourceID string, entity Entity) (*ports.Proj
 	if sensitiveEntityType(entityType) && !attestedURN(tenantID, urn) {
 		return nil, fmt.Errorf("attested compute sensitive entity %q must use an attested token urn", entityType)
 	}
+	if unblindedSensitiveURN(tenantID, urn) {
+		return nil, fmt.Errorf("attested compute entity urn %q contains a sensitive type and must use an attested token urn", urn)
+	}
 	label := strings.TrimSpace(entity.Label)
 	if sensitiveEntityType(entityType) && label != "" && !TokenLike(label) {
 		return nil, fmt.Errorf("attested compute sensitive entity %q label must be tokenized", entityType)

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -89,6 +89,9 @@ func projectEntity(tenantID string, sourceID string, entity Entity) (*ports.Proj
 	if attestedURN(tenantID, urn) && !attestedURNForEntity(tenantID, urn, entityType) {
 		return nil, fmt.Errorf("attested compute entity urn %q must match declared entity type %q", urn, entityType)
 	}
+	if !attestedURN(tenantID, urn) && !plainURNForEntity(tenantID, urn, entityType) {
+		return nil, fmt.Errorf("attested compute entity urn %q must match declared entity type %q", urn, entityType)
+	}
 	if sensitiveEntityType(entityType) && !attestedURNForEntity(tenantID, urn, entityType) {
 		return nil, fmt.Errorf("attested compute sensitive entity %q must use an attested token urn", entityType)
 	}
@@ -204,6 +207,11 @@ func attestedURN(tenantID string, urn string) bool {
 
 func attestedURNForEntity(tenantID string, urn string, entityType string) bool {
 	embeddedType, ok := parseAttestedURN(tenantID, urn)
+	return ok && strings.EqualFold(strings.TrimSpace(embeddedType), strings.TrimSpace(entityType))
+}
+
+func plainURNForEntity(tenantID string, urn string, entityType string) bool {
+	embeddedType, _, ok := tenantURNParts(tenantID, urn)
 	return ok && strings.EqualFold(strings.TrimSpace(embeddedType), strings.TrimSpace(entityType))
 }
 
@@ -341,18 +349,26 @@ func sensitiveAttributeKey(key string) bool {
 		return false
 	}
 	switch normalized {
-	case "is_admin", "is_delegated_admin", "is_public", "mfa_enrolled", "mfa_enforced", "status", "severity", "confidence", "observed_at", "at", "last_observed_at", "sensitivity_label":
+	case "classification_level",
+		"confidence",
+		"control_status",
+		"is_admin",
+		"is_delegated_admin",
+		"is_public",
+		"last_observed_at",
+		"mfa_enforced",
+		"mfa_enrolled",
+		"observed_at",
+		"posture_state",
+		"risk_score",
+		"severity",
+		"sensitivity_label",
+		"status",
+		"at":
 		return false
 	}
 	if sensitiveAttributeMarker(normalized) {
 		return true
-	}
-	if strings.HasPrefix(normalized, "risk_") ||
-		strings.HasPrefix(normalized, "posture_") ||
-		strings.HasPrefix(normalized, "control_") ||
-		strings.HasPrefix(normalized, "classification_") ||
-		strings.HasPrefix(normalized, "attested_compute_") {
-		return false
 	}
 	return true
 }

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -289,16 +289,17 @@ func sensitiveAttributeMarker(key string) bool {
 }
 
 func sensitiveIPAttributeKey(key string) bool {
-	switch key {
-	case "ip", "ipv4", "ipv6":
-		return true
-	}
-	for _, delimiter := range []string{"_", "-", "."} {
-		token := delimiter + "ip" + delimiter
-		if strings.HasPrefix(key, "ip"+delimiter) ||
-			strings.HasSuffix(key, delimiter+"ip") ||
-			strings.Contains(key, token) {
+	for _, marker := range []string{"ip", "ipv4", "ipv6"} {
+		if key == marker {
 			return true
+		}
+		for _, delimiter := range []string{"_", "-", "."} {
+			token := delimiter + marker + delimiter
+			if strings.HasPrefix(key, marker+delimiter) ||
+				strings.HasSuffix(key, delimiter+marker) ||
+				strings.Contains(key, token) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -86,15 +86,15 @@ func projectEntity(tenantID string, sourceID string, entity Entity) (*ports.Proj
 	if !tenantScopedURN(tenantID, urn) {
 		return nil, fmt.Errorf("attested compute entity urn %q is outside tenant scope", urn)
 	}
-	if sensitiveEntityType(entityType) && !attestedURN(tenantID, urn) {
+	if sensitiveEntityType(entityType) && !attestedURNForEntity(tenantID, urn, entityType) {
 		return nil, fmt.Errorf("attested compute sensitive entity %q must use an attested token urn", entityType)
 	}
 	if unblindedSensitiveURN(tenantID, urn) {
 		return nil, fmt.Errorf("attested compute entity urn %q contains a sensitive type and must use an attested token urn", urn)
 	}
 	label := strings.TrimSpace(entity.Label)
-	if sensitiveEntityType(entityType) && label != "" && !TokenLike(label) {
-		return nil, fmt.Errorf("attested compute sensitive entity %q label must be tokenized", entityType)
+	if label != "" && !TokenLike(label) {
+		return nil, fmt.Errorf("attested compute entity %q label must be tokenized", entityType)
 	}
 	attributes, err := sanitizeAttributes(tenantID, entity.Attributes)
 	if err != nil {
@@ -189,15 +189,28 @@ func tenantScopedURN(tenantID string, urn string) bool {
 }
 
 func attestedURN(tenantID string, urn string) bool {
+	_, ok := parseAttestedURN(tenantID, urn)
+	return ok
+}
+
+func attestedURNForEntity(tenantID string, urn string, entityType string) bool {
+	embeddedType, ok := parseAttestedURN(tenantID, urn)
+	return ok && strings.EqualFold(strings.TrimSpace(embeddedType), strings.TrimSpace(entityType))
+}
+
+func parseAttestedURN(tenantID string, urn string) (string, bool) {
 	tenantID = strings.TrimSpace(tenantID)
 	urn = strings.TrimSpace(urn)
 	prefix := "urn:cerebro:" + tenantID + ":attested:"
 	if tenantID == "" || !strings.HasPrefix(urn, prefix) {
-		return false
+		return "", false
 	}
 	rest := strings.TrimPrefix(urn, prefix)
 	entityType, token, ok := strings.Cut(rest, ":")
-	return ok && strings.TrimSpace(entityType) != "" && TokenLike(token)
+	if !ok || !safeEntityTypeSegment(entityType) || !TokenLike(token) {
+		return "", false
+	}
+	return entityType, true
 }
 
 func unblindedSensitiveURN(tenantID string, urn string) bool {

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -211,7 +211,7 @@ func unblindedSensitiveURN(tenantID string, urn string) bool {
 		return false
 	}
 	rest := strings.TrimPrefix(urn, prefix)
-	if strings.HasPrefix(rest, "attested:") {
+	if strings.HasPrefix(strings.ToLower(rest), "attested:") {
 		return true
 	}
 	entityType, _, _ := strings.Cut(rest, ":")
@@ -283,7 +283,7 @@ func sensitiveAttributeMarker(key string) bool {
 	if sensitiveIPAttributeKey(key) {
 		return true
 	}
-	for _, marker := range []string{"arn", "email", "hostname", "label", "name", "principal", "resource_id", "resource_urn", "user", "urn"} {
+	for _, marker := range []string{"arn", "email", "hostname", "label", "name", "owner", "principal", "resource_id", "resource_urn", "user", "urn"} {
 		if strings.Contains(key, marker) {
 			return true
 		}

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -276,7 +276,7 @@ func sensitiveAttributeKey(key string) bool {
 		strings.HasPrefix(normalized, "attested_compute_") {
 		return false
 	}
-	return false
+	return true
 }
 
 func sensitiveAttributeMarker(key string) bool {

--- a/internal/attestedcompute/delta.go
+++ b/internal/attestedcompute/delta.go
@@ -277,8 +277,27 @@ func sensitiveAttributeKey(key string) bool {
 	case "is_admin", "is_delegated_admin", "is_public", "mfa_enrolled", "mfa_enforced", "status", "severity", "confidence", "observed_at", "at", "last_observed_at", "sensitivity_label":
 		return false
 	}
-	for _, marker := range []string{"arn", "email", "hostname", "ip", "label", "name", "principal", "resource_id", "resource_urn", "user", "urn"} {
+	if sensitiveIPAttributeKey(normalized) {
+		return true
+	}
+	for _, marker := range []string{"arn", "email", "hostname", "label", "name", "principal", "resource_id", "resource_urn", "user", "urn"} {
 		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func sensitiveIPAttributeKey(key string) bool {
+	switch key {
+	case "ip", "ipv4", "ipv6":
+		return true
+	}
+	for _, delimiter := range []string{"_", "-", "."} {
+		token := delimiter + "ip" + delimiter
+		if strings.HasPrefix(key, "ip"+delimiter) ||
+			strings.HasSuffix(key, delimiter+"ip") ||
+			strings.Contains(key, token) {
 			return true
 		}
 	}

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -117,7 +117,7 @@ func TestProjectEventRejectsRawSensitiveAttribute(t *testing.T) {
 }
 
 func TestSensitiveAttributeKeyOnlyMatchesIPAsToken(t *testing.T) {
-	for _, key := range []string{"ip", "source_ip", "ip_address", "public-ip", "network.ip"} {
+	for _, key := range []string{"ip", "source_ip", "ip_address", "public-ip", "network.ip", "ipv4_address", "source_ipv6", "ipv4.src"} {
 		if !sensitiveAttributeKey(key) {
 			t.Fatalf("sensitiveAttributeKey(%q) = false, want true", key)
 		}

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -118,6 +118,37 @@ func TestProjectEventRejectsSensitiveURNWithBenignDeclaredType(t *testing.T) {
 	}
 }
 
+func TestProjectEventRejectsUnknownEntityTypeRawURN(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		delta GraphDelta
+	}{
+		{
+			name: "entity",
+			delta: GraphDelta{Entities: []Entity{{
+				URN:        "urn:cerebro:tenant-a:custom.person:alice@example.com",
+				EntityType: "custom.person",
+				Label:      "alice@example.com",
+			}}},
+		},
+		{
+			name: "link endpoint",
+			delta: GraphDelta{Links: []Link{{
+				FromURN:  "urn:cerebro:tenant-a:data.classification:restricted",
+				ToURN:    "urn:cerebro:tenant-a:custom.account:acct-123",
+				Relation: "associated_with",
+			}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.delta.Attestation = Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)}
+			if _, _, err := ProjectEvent(eventWithPayload(t, tc.delta)); err == nil {
+				t.Fatalf("ProjectEvent() error = nil, want unknown entity type raw URN rejection")
+			}
+		})
+	}
+}
+
 func TestProjectEventRejectsRawSensitiveAttribute(t *testing.T) {
 	payload := GraphDelta{
 		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -99,6 +99,20 @@ func TestProjectEventRejectsCaseInsensitiveSensitiveEntityBypass(t *testing.T) {
 	}
 }
 
+func TestProjectEventRejectsSensitiveURNWithBenignDeclaredType(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
+		Entities: []Entity{{
+			URN:        "urn:cerebro:tenant-a:okta.user:alice@example.com",
+			EntityType: "data.classification",
+			Label:      "restricted",
+		}},
+	}
+	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+		t.Fatalf("ProjectEvent() error = nil, want sensitive URN rejection")
+	}
+}
+
 func TestProjectEventRejectsRawSensitiveAttribute(t *testing.T) {
 	payload := GraphDelta{
 		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -45,7 +45,6 @@ func TestProjectEventAcceptsBlindedGraphDelta(t *testing.T) {
 			{
 				URN:        "urn:cerebro:tenant-a:data.classification:restricted",
 				EntityType: "data.classification",
-				Label:      "restricted",
 			},
 		},
 		Links: []Link{
@@ -82,6 +81,20 @@ func TestProjectEventRejectsRawSensitiveLabel(t *testing.T) {
 	}
 	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
 		t.Fatalf("ProjectEvent() error = nil, want raw label rejection")
+	}
+}
+
+func TestProjectEventRejectsRawLabelForNonSensitiveEntity(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
+		Entities: []Entity{{
+			URN:        "urn:cerebro:tenant-a:data.classification:restricted",
+			EntityType: "data.classification",
+			Label:      "alice@example.com",
+		}},
+	}
+	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+		t.Fatalf("ProjectEvent() error = nil, want raw non-sensitive label rejection")
 	}
 }
 
@@ -282,13 +295,77 @@ func TestProjectEventRejectsAttestedURNWithRawTokenSegment(t *testing.T) {
 	}
 }
 
+func TestProjectEventRejectsAttestedURNWithUnsafeEntityTypeSegment(t *testing.T) {
+	tokenizer, err := NewTokenizer([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("NewTokenizer() error = %v", err)
+	}
+	userToken := tokenizer.Token("identity.email", "alice@example.com")
+	rawTypeAttestedURN := "urn:cerebro:tenant-a:attested:alice@example.com:" + userToken
+	validTokenURN := TokenURN("tenant-a", "okta.user", userToken)
+	for _, tc := range []struct {
+		name  string
+		delta GraphDelta
+	}{
+		{
+			name: "entity urn",
+			delta: GraphDelta{
+				Entities: []Entity{{
+					URN:        rawTypeAttestedURN,
+					EntityType: "okta.user",
+					Label:      userToken,
+				}},
+			},
+		},
+		{
+			name: "entity urn declared type mismatch",
+			delta: GraphDelta{
+				Entities: []Entity{{
+					URN:        validTokenURN,
+					EntityType: "aws.iam_user",
+					Label:      userToken,
+				}},
+			},
+		},
+		{
+			name: "link endpoint",
+			delta: GraphDelta{
+				Links: []Link{{
+					FromURN:  rawTypeAttestedURN,
+					ToURN:    "urn:cerebro:tenant-a:data.classification:restricted",
+					Relation: "has_classification",
+				}},
+			},
+		},
+		{
+			name: "sensitive attribute",
+			delta: GraphDelta{
+				Entities: []Entity{{
+					URN:        validTokenURN,
+					EntityType: "okta.user",
+					Label:      userToken,
+					Attributes: map[string]string{
+						"user_urn": rawTypeAttestedURN,
+					},
+				}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.delta.Attestation = Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)}
+			if _, _, err := ProjectEvent(eventWithPayload(t, tc.delta)); err == nil {
+				t.Fatalf("ProjectEvent() error = nil, want unsafe attested URN entity type rejection")
+			}
+		})
+	}
+}
+
 func TestProjectEventDropsCallerSuppliedAttestationAttributes(t *testing.T) {
 	payload := GraphDelta{
 		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, ImageDigest: "sha256:abc"},
 		Entities: []Entity{{
 			URN:        "urn:cerebro:tenant-a:data.classification:restricted",
 			EntityType: "data.classification",
-			Label:      "restricted",
 			Attributes: map[string]string{
 				"attested_compute_claimed_key_id":      "fake-key",
 				"attested_compute_claimed_measurement": "fake-measurement",

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -131,6 +131,20 @@ func TestProjectEventRejectsSensitiveURNWithBenignDeclaredType(t *testing.T) {
 	}
 }
 
+func TestProjectEventRejectsAttestedURNDeclaredTypeMismatchForNonSensitiveType(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
+		Entities: []Entity{{
+			URN:        "urn:cerebro:tenant-a:attested:okta.user:tok_abc",
+			EntityType: "data.classification",
+			Label:      "tok_abc",
+		}},
+	}
+	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+		t.Fatalf("ProjectEvent() error = nil, want attested URN declared type mismatch rejection")
+	}
+}
+
 func TestProjectEventRejectsUnknownEntityTypeRawURN(t *testing.T) {
 	for _, tc := range []struct {
 		name  string

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -145,6 +145,19 @@ func TestProjectEventRejectsAttestedURNDeclaredTypeMismatchForNonSensitiveType(t
 	}
 }
 
+func TestProjectEventRejectsPlainURNDeclaredTypeMismatchForNonSensitiveType(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
+		Entities: []Entity{{
+			URN:        "urn:cerebro:tenant-a:asset.tag:restricted",
+			EntityType: "data.classification",
+		}},
+	}
+	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+		t.Fatalf("ProjectEvent() error = nil, want plain URN declared type mismatch rejection")
+	}
+}
+
 func TestProjectEventRejectsUnsafePlainURNIdentifierForNonSensitiveTypes(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -252,7 +265,7 @@ func TestSensitiveAttributeKeyFailsClosedForUnknownKeys(t *testing.T) {
 }
 
 func TestSensitiveAttributeKeyDoesNotAllowSafePrefixPIIBypass(t *testing.T) {
-	for _, key := range []string{"risk_email", "control_user_name", "classification_arn", "posture_principal", "risk_owner"} {
+	for _, key := range []string{"risk_email", "control_user_name", "classification_arn", "posture_principal", "risk_owner", "risk_phone", "posture_address", "control_ssn", "classification_geolocation"} {
 		if !sensitiveAttributeKey(key) {
 			t.Fatalf("sensitiveAttributeKey(%q) = false, want true", key)
 		}

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -117,6 +117,19 @@ func TestProjectEventRejectsRawSensitiveAttribute(t *testing.T) {
 	}
 }
 
+func TestSensitiveAttributeKeyOnlyMatchesIPAsToken(t *testing.T) {
+	for _, key := range []string{"ip", "source_ip", "ip_address", "public-ip", "network.ip"} {
+		if !sensitiveAttributeKey(key) {
+			t.Fatalf("sensitiveAttributeKey(%q) = false, want true", key)
+		}
+	}
+	for _, key := range []string{"description", "ownership", "ship_date"} {
+		if sensitiveAttributeKey(key) {
+			t.Fatalf("sensitiveAttributeKey(%q) = true, want false", key)
+		}
+	}
+}
+
 func TestProjectEventRejectsRawSensitiveLinkEndpoint(t *testing.T) {
 	payload := GraphDelta{
 		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -137,8 +137,16 @@ func TestSensitiveAttributeKeyOnlyMatchesIPAsToken(t *testing.T) {
 		}
 	}
 	for _, key := range []string{"description", "ownership", "ship_date"} {
-		if sensitiveAttributeKey(key) {
-			t.Fatalf("sensitiveAttributeKey(%q) = true, want false", key)
+		if sensitiveIPAttributeKey(key) {
+			t.Fatalf("sensitiveIPAttributeKey(%q) = true, want false", key)
+		}
+	}
+}
+
+func TestSensitiveAttributeKeyFailsClosedForUnknownKeys(t *testing.T) {
+	for _, key := range []string{"description", "ownership", "ship_date", "account_id"} {
+		if !sensitiveAttributeKey(key) {
+			t.Fatalf("sensitiveAttributeKey(%q) = false, want true", key)
 		}
 	}
 }

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -145,6 +145,60 @@ func TestProjectEventRejectsCrossTenantURN(t *testing.T) {
 	}
 }
 
+func TestProjectEventRejectsAttestedURNWithRawTokenSegment(t *testing.T) {
+	tokenizer, err := NewTokenizer([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("NewTokenizer() error = %v", err)
+	}
+	userToken := tokenizer.Token("identity.email", "alice@example.com")
+	rawAttestedURN := "urn:cerebro:tenant-a:attested:okta.user:alice@example.com"
+	validTokenURN := TokenURN("tenant-a", "okta.user", userToken)
+	for _, tc := range []struct {
+		name  string
+		delta GraphDelta
+	}{
+		{
+			name: "entity urn",
+			delta: GraphDelta{
+				Entities: []Entity{{
+					URN:        rawAttestedURN,
+					EntityType: "okta.user",
+				}},
+			},
+		},
+		{
+			name: "link endpoint",
+			delta: GraphDelta{
+				Links: []Link{{
+					FromURN:  rawAttestedURN,
+					ToURN:    "urn:cerebro:tenant-a:data.classification:restricted",
+					Relation: "has_classification",
+				}},
+			},
+		},
+		{
+			name: "sensitive attribute",
+			delta: GraphDelta{
+				Entities: []Entity{{
+					URN:        validTokenURN,
+					EntityType: "okta.user",
+					Label:      userToken,
+					Attributes: map[string]string{
+						"user_urn": rawAttestedURN,
+					},
+				}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.delta.Attestation = Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)}
+			if _, _, err := ProjectEvent(eventWithPayload(t, tc.delta)); err == nil {
+				t.Fatalf("ProjectEvent() error = nil, want raw attested URN token rejection")
+			}
+		})
+	}
+}
+
 func TestProjectEventDropsCallerSuppliedAttestationAttributes(t *testing.T) {
 	payload := GraphDelta{
 		Attestation: Attestation{Format: "aws-nitro-enclave-poc", ImageDigest: "sha256:abc"},

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -1,0 +1,130 @@
+package attestedcompute
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestProjectEventAcceptsBlindedGraphDelta(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	tokenizer, err := NewTokenizer(key)
+	if err != nil {
+		t.Fatalf("NewTokenizer() error = %v", err)
+	}
+	userToken := tokenizer.Token("identity.email", "alice@example.com")
+	resourceToken := tokenizer.Token("aws.arn", "arn:aws:s3:::sensitive-bucket")
+	payload := GraphDelta{
+		Attestation: Attestation{
+			Format:      "aws-nitro-enclave-poc",
+			Measurement: strings.Repeat("a", 96),
+			KeyID:       "collector-key",
+		},
+		Entities: []Entity{
+			{
+				URN:        TokenURN("tenant-a", "okta.user", userToken),
+				EntityType: "okta.user",
+				Label:      userToken,
+				Attributes: map[string]string{
+					"is_admin":     "true",
+					"mfa_enrolled": "false",
+					"user_urn":     TokenURN("tenant-a", "okta.user", userToken),
+				},
+			},
+			{
+				URN:        TokenURN("tenant-a", "aws.s3_bucket", resourceToken),
+				EntityType: "aws.s3_bucket",
+				Label:      resourceToken,
+				Attributes: map[string]string{
+					"classification_level": "restricted",
+					"resource_urn":         TokenURN("tenant-a", "aws.s3_bucket", resourceToken),
+				},
+			},
+			{
+				URN:        "urn:cerebro:tenant-a:data.classification:restricted",
+				EntityType: "data.classification",
+				Label:      "restricted",
+			},
+		},
+		Links: []Link{
+			{FromURN: TokenURN("tenant-a", "okta.user", userToken), ToURN: TokenURN("tenant-a", "aws.s3_bucket", resourceToken), Relation: "can_admin"},
+			{FromURN: TokenURN("tenant-a", "aws.s3_bucket", resourceToken), ToURN: "urn:cerebro:tenant-a:data.classification:restricted", Relation: "has_classification"},
+		},
+	}
+	event := eventWithPayload(t, payload)
+	entities, links, err := ProjectEvent(event)
+	if err != nil {
+		t.Fatalf("ProjectEvent() error = %v", err)
+	}
+	if len(entities) != 3 || len(links) != 2 {
+		t.Fatalf("ProjectEvent() produced %d entities/%d links, want 3/2", len(entities), len(links))
+	}
+	if got := entities[0].Attributes["attested_compute_measurement"]; got == "" {
+		t.Fatalf("attestation measurement not stamped on entity")
+	}
+	if got := links[0].Attributes["attested_compute_key_id"]; got != "collector-key" {
+		t.Fatalf("link attestation key = %q, want collector-key", got)
+	}
+}
+
+func TestProjectEventRejectsRawSensitiveLabel(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
+		Entities: []Entity{{
+			URN:        "urn:cerebro:tenant-a:attested:okta.user:tok_abc",
+			EntityType: "okta.user",
+			Label:      "alice@example.com",
+		}},
+	}
+	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+		t.Fatalf("ProjectEvent() error = nil, want raw label rejection")
+	}
+}
+
+func TestProjectEventRejectsRawSensitiveAttribute(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
+		Entities: []Entity{{
+			URN:        "urn:cerebro:tenant-a:attested:okta.user:tok_abc",
+			EntityType: "okta.user",
+			Label:      "tok_abc",
+			Attributes: map[string]string{
+				"email": "alice@example.com",
+			},
+		}},
+	}
+	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+		t.Fatalf("ProjectEvent() error = nil, want raw attribute rejection")
+	}
+}
+
+func TestProjectEventRejectsCrossTenantURN(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
+		Entities: []Entity{{
+			URN:        "urn:cerebro:other:attested:okta.user:tok_abc",
+			EntityType: "okta.user",
+			Label:      "tok_abc",
+		}},
+	}
+	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+		t.Fatalf("ProjectEvent() error = nil, want cross-tenant rejection")
+	}
+}
+
+func eventWithPayload(t *testing.T, delta GraphDelta) *cerebrov1.EventEnvelope {
+	t.Helper()
+	body, err := json.Marshal(delta)
+	if err != nil {
+		t.Fatalf("marshal delta: %v", err)
+	}
+	return &cerebrov1.EventEnvelope{
+		Id:       "evt-1",
+		TenantId: "tenant-a",
+		SourceId: "attested_compute",
+		Kind:     EventKindGraphDelta,
+		Payload:  body,
+	}
+}

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -145,6 +145,43 @@ func TestProjectEventRejectsAttestedURNDeclaredTypeMismatchForNonSensitiveType(t
 	}
 }
 
+func TestProjectEventRejectsUnsafePlainURNIdentifierForNonSensitiveTypes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		delta GraphDelta
+	}{
+		{
+			name: "asset tag email entity",
+			delta: GraphDelta{Entities: []Entity{{
+				URN:        "urn:cerebro:tenant-a:asset.tag:alice@example.com",
+				EntityType: "asset.tag",
+			}}},
+		},
+		{
+			name: "classification arn entity",
+			delta: GraphDelta{Entities: []Entity{{
+				URN:        "urn:cerebro:tenant-a:data.classification:arn:aws:iam::123456789012:root",
+				EntityType: "data.classification",
+			}}},
+		},
+		{
+			name: "link endpoint",
+			delta: GraphDelta{Links: []Link{{
+				FromURN:  "urn:cerebro:tenant-a:data.classification:restricted",
+				ToURN:    "urn:cerebro:tenant-a:asset.tag:alice@example.com",
+				Relation: "tagged_as",
+			}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.delta.Attestation = Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)}
+			if _, _, err := ProjectEvent(eventWithPayload(t, tc.delta)); err == nil {
+				t.Fatalf("ProjectEvent() error = nil, want unsafe plain URN identifier rejection")
+			}
+		})
+	}
+}
+
 func TestProjectEventRejectsUnknownEntityTypeRawURN(t *testing.T) {
 	for _, tc := range []struct {
 		name  string

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -18,7 +18,7 @@ func TestProjectEventAcceptsBlindedGraphDelta(t *testing.T) {
 	resourceToken := tokenizer.Token("aws.arn", "arn:aws:s3:::sensitive-bucket")
 	payload := GraphDelta{
 		Attestation: Attestation{
-			Format:      "aws-nitro-enclave-poc",
+			Format:      AttestationFormatAWSNitroEnclavePOC,
 			Measurement: strings.Repeat("a", 96),
 			KeyID:       "collector-key",
 		},
@@ -64,17 +64,16 @@ func TestProjectEventAcceptsBlindedGraphDelta(t *testing.T) {
 	if got := entities[0].Attributes["attested_compute_verification_status"]; got != "unverified_poc" {
 		t.Fatalf("attestation verification status = %q, want unverified_poc", got)
 	}
-	if got := entities[0].Attributes["attested_compute_claimed_measurement"]; got == "" {
-		t.Fatalf("claimed attestation measurement not stamped on entity")
-	}
-	if got := links[0].Attributes["attested_compute_claimed_key_id"]; got != "collector-key" {
-		t.Fatalf("link claimed attestation key = %q, want collector-key", got)
+	for _, key := range []string{"attested_compute_claimed_format", "attested_compute_claimed_measurement", "attested_compute_claimed_key_id", "attested_compute_claimed_image_digest"} {
+		if got := entities[0].Attributes[key]; got != "" {
+			t.Fatalf("%s = %q, want empty for unverified attestation", key, got)
+		}
 	}
 }
 
 func TestProjectEventRejectsRawSensitiveLabel(t *testing.T) {
 	payload := GraphDelta{
-		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
+		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
 		Entities: []Entity{{
 			URN:        "urn:cerebro:tenant-a:attested:okta.user:tok_abc",
 			EntityType: "okta.user",
@@ -88,7 +87,7 @@ func TestProjectEventRejectsRawSensitiveLabel(t *testing.T) {
 
 func TestProjectEventRejectsCaseInsensitiveSensitiveEntityBypass(t *testing.T) {
 	payload := GraphDelta{
-		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
+		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
 		Entities: []Entity{{
 			URN:        "urn:cerebro:tenant-a:okta.user:alice@example.com",
 			EntityType: "OKTA.USER",
@@ -102,7 +101,7 @@ func TestProjectEventRejectsCaseInsensitiveSensitiveEntityBypass(t *testing.T) {
 
 func TestProjectEventRejectsRawSensitiveAttribute(t *testing.T) {
 	payload := GraphDelta{
-		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
+		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
 		Entities: []Entity{{
 			URN:        "urn:cerebro:tenant-a:attested:okta.user:tok_abc",
 			EntityType: "okta.user",
@@ -130,9 +129,22 @@ func TestSensitiveAttributeKeyOnlyMatchesIPAsToken(t *testing.T) {
 	}
 }
 
+func TestSensitiveAttributeKeyDoesNotAllowSafePrefixPIIBypass(t *testing.T) {
+	for _, key := range []string{"risk_email", "control_user_name", "classification_arn", "posture_principal"} {
+		if !sensitiveAttributeKey(key) {
+			t.Fatalf("sensitiveAttributeKey(%q) = false, want true", key)
+		}
+	}
+	for _, key := range []string{"risk_score", "control_status", "classification_level", "posture_state"} {
+		if sensitiveAttributeKey(key) {
+			t.Fatalf("sensitiveAttributeKey(%q) = true, want false", key)
+		}
+	}
+}
+
 func TestProjectEventRejectsRawSensitiveLinkEndpoint(t *testing.T) {
 	payload := GraphDelta{
-		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
+		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
 		Links: []Link{{
 			FromURN:  "urn:cerebro:tenant-a:okta.user:alice@example.com",
 			ToURN:    "urn:cerebro:tenant-a:data.classification:restricted",
@@ -146,7 +158,7 @@ func TestProjectEventRejectsRawSensitiveLinkEndpoint(t *testing.T) {
 
 func TestProjectEventRejectsCrossTenantURN(t *testing.T) {
 	payload := GraphDelta{
-		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
+		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
 		Entities: []Entity{{
 			URN:        "urn:cerebro:other:attested:okta.user:tok_abc",
 			EntityType: "okta.user",
@@ -204,7 +216,7 @@ func TestProjectEventRejectsAttestedURNWithRawTokenSegment(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.delta.Attestation = Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)}
+			tc.delta.Attestation = Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)}
 			if _, _, err := ProjectEvent(eventWithPayload(t, tc.delta)); err == nil {
 				t.Fatalf("ProjectEvent() error = nil, want raw attested URN token rejection")
 			}
@@ -214,7 +226,7 @@ func TestProjectEventRejectsAttestedURNWithRawTokenSegment(t *testing.T) {
 
 func TestProjectEventDropsCallerSuppliedAttestationAttributes(t *testing.T) {
 	payload := GraphDelta{
-		Attestation: Attestation{Format: "aws-nitro-enclave-poc", ImageDigest: "sha256:abc"},
+		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, ImageDigest: "sha256:abc"},
 		Entities: []Entity{{
 			URN:        "urn:cerebro:tenant-a:data.classification:restricted",
 			EntityType: "data.classification",
@@ -236,8 +248,22 @@ func TestProjectEventDropsCallerSuppliedAttestationAttributes(t *testing.T) {
 	if got := attributes["attested_compute_claimed_measurement"]; got != "" {
 		t.Fatalf("caller-supplied claimed measurement survived = %q", got)
 	}
-	if got := attributes["attested_compute_claimed_image_digest"]; got != "sha256:abc" {
-		t.Fatalf("claimed image digest = %q, want sha256:abc", got)
+	if got := attributes["attested_compute_claimed_image_digest"]; got != "" {
+		t.Fatalf("claimed image digest = %q, want empty for unverified attestation", got)
+	}
+}
+
+func TestProjectEventRejectsUnsupportedAttestationFormat(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: "self-asserted", ImageDigest: "sha256:abc"},
+		Entities: []Entity{{
+			URN:        "urn:cerebro:tenant-a:data.classification:restricted",
+			EntityType: "data.classification",
+			Label:      "restricted",
+		}},
+	}
+	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+		t.Fatalf("ProjectEvent() error = nil, want unsupported attestation format rejection")
 	}
 }
 

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -100,16 +100,21 @@ func TestProjectEventRejectsCaseInsensitiveSensitiveEntityBypass(t *testing.T) {
 }
 
 func TestProjectEventRejectsSensitiveURNWithBenignDeclaredType(t *testing.T) {
-	payload := GraphDelta{
-		Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
-		Entities: []Entity{{
-			URN:        "urn:cerebro:tenant-a:okta.user:alice@example.com",
-			EntityType: "data.classification",
-			Label:      "restricted",
-		}},
-	}
-	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
-		t.Fatalf("ProjectEvent() error = nil, want sensitive URN rejection")
+	for _, urn := range []string{
+		"urn:cerebro:tenant-a:okta.user:alice@example.com",
+		"urn:cerebro:tenant-a:Attested:okta.user:alice@example.com",
+	} {
+		payload := GraphDelta{
+			Attestation: Attestation{Format: AttestationFormatAWSNitroEnclavePOC, Measurement: strings.Repeat("a", 96)},
+			Entities: []Entity{{
+				URN:        urn,
+				EntityType: "data.classification",
+				Label:      "restricted",
+			}},
+		}
+		if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+			t.Fatalf("ProjectEvent() error = nil for %q, want sensitive URN rejection", urn)
+		}
 	}
 }
 
@@ -152,7 +157,7 @@ func TestSensitiveAttributeKeyFailsClosedForUnknownKeys(t *testing.T) {
 }
 
 func TestSensitiveAttributeKeyDoesNotAllowSafePrefixPIIBypass(t *testing.T) {
-	for _, key := range []string{"risk_email", "control_user_name", "classification_arn", "posture_principal"} {
+	for _, key := range []string{"risk_email", "control_user_name", "classification_arn", "posture_principal", "risk_owner"} {
 		if !sensitiveAttributeKey(key) {
 			t.Fatalf("sensitiveAttributeKey(%q) = false, want true", key)
 		}

--- a/internal/attestedcompute/delta_test.go
+++ b/internal/attestedcompute/delta_test.go
@@ -61,11 +61,14 @@ func TestProjectEventAcceptsBlindedGraphDelta(t *testing.T) {
 	if len(entities) != 3 || len(links) != 2 {
 		t.Fatalf("ProjectEvent() produced %d entities/%d links, want 3/2", len(entities), len(links))
 	}
-	if got := entities[0].Attributes["attested_compute_measurement"]; got == "" {
-		t.Fatalf("attestation measurement not stamped on entity")
+	if got := entities[0].Attributes["attested_compute_verification_status"]; got != "unverified_poc" {
+		t.Fatalf("attestation verification status = %q, want unverified_poc", got)
 	}
-	if got := links[0].Attributes["attested_compute_key_id"]; got != "collector-key" {
-		t.Fatalf("link attestation key = %q, want collector-key", got)
+	if got := entities[0].Attributes["attested_compute_claimed_measurement"]; got == "" {
+		t.Fatalf("claimed attestation measurement not stamped on entity")
+	}
+	if got := links[0].Attributes["attested_compute_claimed_key_id"]; got != "collector-key" {
+		t.Fatalf("link claimed attestation key = %q, want collector-key", got)
 	}
 }
 
@@ -80,6 +83,20 @@ func TestProjectEventRejectsRawSensitiveLabel(t *testing.T) {
 	}
 	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
 		t.Fatalf("ProjectEvent() error = nil, want raw label rejection")
+	}
+}
+
+func TestProjectEventRejectsCaseInsensitiveSensitiveEntityBypass(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
+		Entities: []Entity{{
+			URN:        "urn:cerebro:tenant-a:okta.user:alice@example.com",
+			EntityType: "OKTA.USER",
+			Label:      "alice@example.com",
+		}},
+	}
+	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+		t.Fatalf("ProjectEvent() error = nil, want case-insensitive sensitive entity rejection")
 	}
 }
 
@@ -100,6 +117,20 @@ func TestProjectEventRejectsRawSensitiveAttribute(t *testing.T) {
 	}
 }
 
+func TestProjectEventRejectsRawSensitiveLinkEndpoint(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
+		Links: []Link{{
+			FromURN:  "urn:cerebro:tenant-a:okta.user:alice@example.com",
+			ToURN:    "urn:cerebro:tenant-a:data.classification:restricted",
+			Relation: "has_classification",
+		}},
+	}
+	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
+		t.Fatalf("ProjectEvent() error = nil, want raw sensitive link endpoint rejection")
+	}
+}
+
 func TestProjectEventRejectsCrossTenantURN(t *testing.T) {
 	payload := GraphDelta{
 		Attestation: Attestation{Format: "aws-nitro-enclave-poc", Measurement: strings.Repeat("a", 96)},
@@ -111,6 +142,35 @@ func TestProjectEventRejectsCrossTenantURN(t *testing.T) {
 	}
 	if _, _, err := ProjectEvent(eventWithPayload(t, payload)); err == nil {
 		t.Fatalf("ProjectEvent() error = nil, want cross-tenant rejection")
+	}
+}
+
+func TestProjectEventDropsCallerSuppliedAttestationAttributes(t *testing.T) {
+	payload := GraphDelta{
+		Attestation: Attestation{Format: "aws-nitro-enclave-poc", ImageDigest: "sha256:abc"},
+		Entities: []Entity{{
+			URN:        "urn:cerebro:tenant-a:data.classification:restricted",
+			EntityType: "data.classification",
+			Label:      "restricted",
+			Attributes: map[string]string{
+				"attested_compute_claimed_key_id":      "fake-key",
+				"attested_compute_claimed_measurement": "fake-measurement",
+			},
+		}},
+	}
+	entities, _, err := ProjectEvent(eventWithPayload(t, payload))
+	if err != nil {
+		t.Fatalf("ProjectEvent() error = %v", err)
+	}
+	attributes := entities[0].Attributes
+	if got := attributes["attested_compute_claimed_key_id"]; got != "" {
+		t.Fatalf("caller-supplied claimed key id survived = %q", got)
+	}
+	if got := attributes["attested_compute_claimed_measurement"]; got != "" {
+		t.Fatalf("caller-supplied claimed measurement survived = %q", got)
+	}
+	if got := attributes["attested_compute_claimed_image_digest"]; got != "sha256:abc" {
+		t.Fatalf("claimed image digest = %q, want sha256:abc", got)
 	}
 }
 

--- a/internal/attestedcompute/token.go
+++ b/internal/attestedcompute/token.go
@@ -50,10 +50,27 @@ func TokenURN(tenantID string, entityType string, token string) string {
 	tenantID = strings.TrimSpace(tenantID)
 	entityType = strings.TrimSpace(entityType)
 	token = strings.TrimSpace(token)
-	if tenantID == "" || entityType == "" || !TokenLike(token) {
+	if tenantID == "" || !safeEntityTypeSegment(entityType) || !TokenLike(token) {
 		return ""
 	}
 	return "urn:cerebro:" + tenantID + ":attested:" + entityType + ":" + token
+}
+
+func safeEntityTypeSegment(entityType string) bool {
+	entityType = strings.TrimSpace(entityType)
+	if entityType == "" || TokenLike(entityType) || !strings.Contains(entityType, ".") {
+		return false
+	}
+	for _, char := range strings.ToLower(entityType) {
+		switch {
+		case char >= 'a' && char <= 'z':
+		case char >= '0' && char <= '9':
+		case char == '.' || char == '_' || char == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func TokenLike(value string) bool {

--- a/internal/attestedcompute/token.go
+++ b/internal/attestedcompute/token.go
@@ -1,0 +1,77 @@
+package attestedcompute
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+const (
+	EventKindGraphDelta = "attested_compute.graph_delta"
+	TokenPrefix         = "tok_"
+)
+
+type Tokenizer struct {
+	key []byte
+}
+
+func NewTokenizer(key []byte) (*Tokenizer, error) {
+	if len(key) < 32 {
+		return nil, fmt.Errorf("attested compute token key must be at least 32 bytes")
+	}
+	return &Tokenizer{key: append([]byte(nil), key...)}, nil
+}
+
+func (t *Tokenizer) Token(domain string, value string) string {
+	if t == nil || len(t.key) == 0 {
+		return ""
+	}
+	domain = strings.TrimSpace(domain)
+	value = strings.TrimSpace(value)
+	if domain == "" || value == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, t.key)
+	_, _ = mac.Write([]byte("attested-compute"))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte("v1"))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(domain))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(value))
+	sum := mac.Sum(nil)
+	return TokenPrefix + base64.RawURLEncoding.EncodeToString(sum[:18])
+}
+
+func TokenURN(tenantID string, entityType string, token string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	entityType = strings.TrimSpace(entityType)
+	token = strings.TrimSpace(token)
+	if tenantID == "" || entityType == "" || !TokenLike(token) {
+		return ""
+	}
+	return "urn:cerebro:" + tenantID + ":attested:" + entityType + ":" + token
+}
+
+func TokenLike(value string) bool {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, TokenPrefix) {
+		return false
+	}
+	if len(value) <= len(TokenPrefix) {
+		return false
+	}
+	for _, char := range strings.TrimPrefix(value, TokenPrefix) {
+		switch {
+		case char >= 'a' && char <= 'z':
+		case char >= 'A' && char <= 'Z':
+		case char >= '0' && char <= '9':
+		case char == '-' || char == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/attestedcompute/token.go
+++ b/internal/attestedcompute/token.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	EventKindGraphDelta = "attested_compute.graph_delta"
-	TokenPrefix         = "tok_"
+	AttestationFormatAWSNitroEnclavePOC = "aws-nitro-enclave-poc"
+	EventKindGraphDelta                 = "attested_compute.graph_delta"
+	TokenPrefix                         = "tok_"
 )
 
 type Tokenizer struct {

--- a/internal/attestedcompute/token_test.go
+++ b/internal/attestedcompute/token_test.go
@@ -1,0 +1,32 @@
+package attestedcompute
+
+import "testing"
+
+func TestTokenizerDeterministicAndDomainSeparated(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	tokenizer, err := NewTokenizer(key)
+	if err != nil {
+		t.Fatalf("NewTokenizer() error = %v", err)
+	}
+	emailA := tokenizer.Token("identity.email", "alice@example.com")
+	emailB := tokenizer.Token("identity.email", "alice@example.com")
+	login := tokenizer.Token("identity.login", "alice@example.com")
+	if emailA == "" || emailA != emailB {
+		t.Fatalf("Token() not deterministic: %q vs %q", emailA, emailB)
+	}
+	if emailA == login {
+		t.Fatalf("Token() must be domain separated")
+	}
+	if !TokenLike(emailA) {
+		t.Fatalf("TokenLike(%q) = false, want true", emailA)
+	}
+	if got := TokenURN("tenant", "okta.user", emailA); got != "urn:cerebro:tenant:attested:okta.user:"+emailA {
+		t.Fatalf("TokenURN() = %q", got)
+	}
+}
+
+func TestNewTokenizerRejectsShortKey(t *testing.T) {
+	if _, err := NewTokenizer([]byte("short")); err == nil {
+		t.Fatalf("NewTokenizer() error = nil, want error")
+	}
+}

--- a/internal/attestedcompute/token_test.go
+++ b/internal/attestedcompute/token_test.go
@@ -25,6 +25,14 @@ func TestTokenizerDeterministicAndDomainSeparated(t *testing.T) {
 	}
 }
 
+func TestTokenURNRejectsUnsafeEntityTypeSegment(t *testing.T) {
+	for _, entityType := range []string{"alice", "alice@example.com", "okta:user", "tok_rawtype", ""} {
+		if got := TokenURN("tenant", entityType, "tok_abc"); got != "" {
+			t.Fatalf("TokenURN(%q) = %q, want empty", entityType, got)
+		}
+	}
+}
+
 func TestNewTokenizerRejectsShortKey(t *testing.T) {
 	if _, err := NewTokenizer([]byte("short")); err == nil {
 		t.Fatalf("NewTokenizer() error = nil, want error")

--- a/internal/deviceauth/attestation/nitro_poc.go
+++ b/internal/deviceauth/attestation/nitro_poc.go
@@ -81,7 +81,7 @@ func (v *NitroPOCVerifier) Verify(_ context.Context, in Input) (*Result, error) 
 	}
 	keyHash := sha256.Sum256(pubDER)
 	return &Result{
-		AssuranceLevel: "hardware",
+		AssuranceLevel: "software",
 		PublicKey:      pubDER,
 		KeyID:          hex.EncodeToString(keyHash[:]),
 		Vendor:         FormatAWSNitroEnclavePOC,

--- a/internal/deviceauth/attestation/nitro_poc.go
+++ b/internal/deviceauth/attestation/nitro_poc.go
@@ -1,0 +1,108 @@
+package attestation
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const FormatAWSNitroEnclavePOC = "aws-nitro-enclave-poc"
+
+type NitroPOCConfig struct {
+	Measurements []string
+}
+
+type NitroPOCVerifier struct {
+	measurements map[string]struct{}
+}
+
+type nitroPOCStatement struct {
+	ModuleID    string `json:"module_id"`
+	ImageSHA384 string `json:"image_sha384"`
+	PublicKey   string `json:"public_key_der"`
+	Nonce       string `json:"nonce"`
+}
+
+func NewNitroPOCVerifier(cfg NitroPOCConfig) (*NitroPOCVerifier, error) {
+	measurements := map[string]struct{}{}
+	for _, measurement := range cfg.Measurements {
+		measurement = strings.ToLower(strings.TrimSpace(measurement))
+		if measurement == "" {
+			continue
+		}
+		measurements[measurement] = struct{}{}
+	}
+	if len(measurements) == 0 {
+		return nil, errors.New("attestation: Nitro POC verifier requires at least one measurement")
+	}
+	return &NitroPOCVerifier{measurements: measurements}, nil
+}
+
+func (v *NitroPOCVerifier) Format() string { return FormatAWSNitroEnclavePOC }
+
+func (v *NitroPOCVerifier) Verify(_ context.Context, in Input) (*Result, error) {
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(in.Statement))
+	if err != nil {
+		raw, err = base64.RawStdEncoding.DecodeString(strings.TrimSpace(in.Statement))
+		if err != nil {
+			return nil, fmt.Errorf("%w: base64 decode", ErrInvalidStatement)
+		}
+	}
+	var stmt nitroPOCStatement
+	if err := json.Unmarshal(raw, &stmt); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidStatement, err)
+	}
+	measurement := strings.ToLower(strings.TrimSpace(stmt.ImageSHA384))
+	if measurement == "" {
+		return nil, fmt.Errorf("%w: image_sha384 is required", ErrInvalidStatement)
+	}
+	if _, ok := v.measurements[measurement]; !ok {
+		return nil, fmt.Errorf("%w: Nitro image measurement is not trusted", ErrChainInvalid)
+	}
+	nonce, err := decodeBase64AttestationField(stmt.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("%w: nonce", ErrInvalidStatement)
+	}
+	if len(nonce) != len(in.ClientDataHash) || !equalBytes(nonce, in.ClientDataHash[:]) {
+		return nil, ErrNonceMismatch
+	}
+	pubDER, err := decodeBase64AttestationField(stmt.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: public_key_der", ErrInvalidStatement)
+	}
+	if _, err := x509.ParsePKIXPublicKey(pubDER); err != nil {
+		return nil, fmt.Errorf("%w: public_key_der parse: %w", ErrInvalidStatement, err)
+	}
+	keyHash := sha256.Sum256(pubDER)
+	return &Result{
+		AssuranceLevel: "hardware",
+		PublicKey:      pubDER,
+		KeyID:          hex.EncodeToString(keyHash[:]),
+		Vendor:         FormatAWSNitroEnclavePOC,
+		Diagnostics: map[string]string{
+			"module_id":        strings.TrimSpace(stmt.ModuleID),
+			"image_sha384":     measurement,
+			"attestation_mode": "poc",
+		},
+	}, nil
+}
+
+func decodeBase64AttestationField(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	if decoded, err := base64.StdEncoding.DecodeString(value); err == nil {
+		return decoded, nil
+	}
+	if decoded, err := base64.RawStdEncoding.DecodeString(value); err == nil {
+		return decoded, nil
+	}
+	if decoded, err := base64.RawURLEncoding.DecodeString(value); err == nil {
+		return decoded, nil
+	}
+	return nil, errors.New("invalid base64")
+}

--- a/internal/deviceauth/attestation/nitro_poc_test.go
+++ b/internal/deviceauth/attestation/nitro_poc_test.go
@@ -35,7 +35,7 @@ func TestNitroPOCVerifierBindsMeasurementNonceAndKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Verify() error = %v", err)
 	}
-	if result.AssuranceLevel != "hardware" || result.Vendor != FormatAWSNitroEnclavePOC {
+	if result.AssuranceLevel != "software" || result.Vendor != FormatAWSNitroEnclavePOC {
 		t.Fatalf("unexpected result: %+v", result)
 	}
 	if len(result.PublicKey) == 0 || result.KeyID == "" {

--- a/internal/deviceauth/attestation/nitro_poc_test.go
+++ b/internal/deviceauth/attestation/nitro_poc_test.go
@@ -1,0 +1,105 @@
+package attestation
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNitroPOCVerifierBindsMeasurementNonceAndKey(t *testing.T) {
+	measurement := strings.Repeat("a", 96)
+	verifier, err := NewNitroPOCVerifier(NitroPOCConfig{Measurements: []string{measurement}})
+	if err != nil {
+		t.Fatalf("NewNitroPOCVerifier() error = %v", err)
+	}
+	clientHash := sha256.Sum256([]byte("collector-enroll"))
+	pubDER := testPublicKeyDER(t)
+	statement := testNitroPOCStatement(t, nitroPOCStatement{
+		ModuleID:    "collector",
+		ImageSHA384: measurement,
+		PublicKey:   base64.StdEncoding.EncodeToString(pubDER),
+		Nonce:       base64.StdEncoding.EncodeToString(clientHash[:]),
+	})
+	result, err := verifier.Verify(context.Background(), Input{
+		ClientDataHash: clientHash,
+		Format:         FormatAWSNitroEnclavePOC,
+		Statement:      statement,
+	})
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if result.AssuranceLevel != "hardware" || result.Vendor != FormatAWSNitroEnclavePOC {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if len(result.PublicKey) == 0 || result.KeyID == "" {
+		t.Fatalf("attested key was not bound: %+v", result)
+	}
+	if result.Diagnostics["image_sha384"] != measurement {
+		t.Fatalf("image_sha384 diagnostic = %q", result.Diagnostics["image_sha384"])
+	}
+}
+
+func TestNitroPOCVerifierRejectsUnexpectedMeasurement(t *testing.T) {
+	verifier, err := NewNitroPOCVerifier(NitroPOCConfig{Measurements: []string{strings.Repeat("a", 96)}})
+	if err != nil {
+		t.Fatalf("NewNitroPOCVerifier() error = %v", err)
+	}
+	clientHash := sha256.Sum256([]byte("collector-enroll"))
+	pubDER := testPublicKeyDER(t)
+	statement := testNitroPOCStatement(t, nitroPOCStatement{
+		ImageSHA384: strings.Repeat("b", 96),
+		PublicKey:   base64.StdEncoding.EncodeToString(pubDER),
+		Nonce:       base64.StdEncoding.EncodeToString(clientHash[:]),
+	})
+	if _, err := verifier.Verify(context.Background(), Input{ClientDataHash: clientHash, Format: FormatAWSNitroEnclavePOC, Statement: statement}); err == nil {
+		t.Fatalf("Verify() error = nil, want measurement rejection")
+	}
+}
+
+func TestNitroPOCVerifierRejectsNonceMismatch(t *testing.T) {
+	measurement := strings.Repeat("a", 96)
+	verifier, err := NewNitroPOCVerifier(NitroPOCConfig{Measurements: []string{measurement}})
+	if err != nil {
+		t.Fatalf("NewNitroPOCVerifier() error = %v", err)
+	}
+	clientHash := sha256.Sum256([]byte("collector-enroll"))
+	wrongHash := sha256.Sum256([]byte("wrong"))
+	pubDER := testPublicKeyDER(t)
+	statement := testNitroPOCStatement(t, nitroPOCStatement{
+		ImageSHA384: measurement,
+		PublicKey:   base64.StdEncoding.EncodeToString(pubDER),
+		Nonce:       base64.StdEncoding.EncodeToString(wrongHash[:]),
+	})
+	if _, err := verifier.Verify(context.Background(), Input{ClientDataHash: clientHash, Format: FormatAWSNitroEnclavePOC, Statement: statement}); err == nil {
+		t.Fatalf("Verify() error = nil, want nonce rejection")
+	}
+}
+
+func testPublicKeyDER(t *testing.T) []byte {
+	t.Helper()
+	private, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&private.PublicKey)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey() error = %v", err)
+	}
+	return der
+}
+
+func testNitroPOCStatement(t *testing.T, statement nitroPOCStatement) string {
+	t.Helper()
+	body, err := json.Marshal(statement)
+	if err != nil {
+		t.Fatalf("marshal statement: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(body)
+}

--- a/internal/sourceprojection/attested_compute.go
+++ b/internal/sourceprojection/attested_compute.go
@@ -1,0 +1,11 @@
+package sourceprojection
+
+import (
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/attestedcompute"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func attestedComputeGraphDeltaProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return attestedcompute.ProjectEvent(event)
+}

--- a/internal/sourceprojection/attested_compute_test.go
+++ b/internal/sourceprojection/attested_compute_test.go
@@ -21,7 +21,7 @@ func TestAttestedComputeGraphDeltaProjectsIntoGraphRecords(t *testing.T) {
 	resourceURN := attestedcompute.TokenURN("tenant-a", "aws.s3_bucket", resourceToken)
 	payload := attestedcompute.GraphDelta{
 		Attestation: attestedcompute.Attestation{
-			Format:      "aws-nitro-enclave-poc",
+			Format:      attestedcompute.AttestationFormatAWSNitroEnclavePOC,
 			Measurement: strings.Repeat("a", 96),
 			KeyID:       "collector-key",
 		},
@@ -69,7 +69,7 @@ func TestAttestedComputeGraphDeltaProjectsIntoGraphRecords(t *testing.T) {
 	if got := links[0].Attributes["attested_compute_verification_status"]; got != "unverified_poc" {
 		t.Fatalf("link attestation verification status = %q, want unverified_poc", got)
 	}
-	if got := links[0].Attributes["attested_compute_claimed_format"]; got != "aws-nitro-enclave-poc" {
-		t.Fatalf("link claimed attestation format = %q, want aws-nitro-enclave-poc", got)
+	if got := links[0].Attributes["attested_compute_claimed_format"]; got != "" {
+		t.Fatalf("link claimed attestation format = %q, want empty for unverified attestation", got)
 	}
 }

--- a/internal/sourceprojection/attested_compute_test.go
+++ b/internal/sourceprojection/attested_compute_test.go
@@ -11,10 +11,6 @@ import (
 )
 
 func TestAttestedComputeGraphDeltaProjectsIntoGraphRecords(t *testing.T) {
-	registry, err := NewRegistry(EventProjector{Kind: attestedcompute.EventKindGraphDelta, Project: attestedComputeGraphDeltaProjections})
-	if err != nil {
-		t.Fatalf("NewRegistry() error = %v", err)
-	}
 	tokenizer, err := attestedcompute.NewTokenizer([]byte("0123456789abcdef0123456789abcdef"))
 	if err != nil {
 		t.Fatalf("NewTokenizer() error = %v", err)
@@ -52,7 +48,7 @@ func TestAttestedComputeGraphDeltaProjectsIntoGraphRecords(t *testing.T) {
 		},
 	}
 
-	entities, links, err := NewWithRegistry(nil, nil, registry).ProjectRecords(event)
+	entities, links, err := NewWithRegistry(nil, nil, BuiltinRegistry()).ProjectRecords(event)
 	if err != nil {
 		t.Fatalf("ProjectRecords() error = %v", err)
 	}

--- a/internal/sourceprojection/attested_compute_test.go
+++ b/internal/sourceprojection/attested_compute_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestAttestedComputeGraphDeltaProjectsIntoGraphRecords(t *testing.T) {
+	registry, err := NewRegistry(EventProjector{Kind: attestedcompute.EventKindGraphDelta, Project: attestedComputeGraphDeltaProjections})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
 	tokenizer, err := attestedcompute.NewTokenizer([]byte("0123456789abcdef0123456789abcdef"))
 	if err != nil {
 		t.Fatalf("NewTokenizer() error = %v", err)
@@ -48,7 +52,7 @@ func TestAttestedComputeGraphDeltaProjectsIntoGraphRecords(t *testing.T) {
 		},
 	}
 
-	entities, links, err := New(nil, nil).ProjectRecords(event)
+	entities, links, err := NewWithRegistry(nil, nil, registry).ProjectRecords(event)
 	if err != nil {
 		t.Fatalf("ProjectRecords() error = %v", err)
 	}
@@ -66,7 +70,10 @@ func TestAttestedComputeGraphDeltaProjectsIntoGraphRecords(t *testing.T) {
 	if links[0].Relation != "can_admin" {
 		t.Fatalf("link relation = %q, want can_admin", links[0].Relation)
 	}
-	if got := links[0].Attributes["attested_compute_format"]; got != "aws-nitro-enclave-poc" {
-		t.Fatalf("link attestation format = %q, want aws-nitro-enclave-poc", got)
+	if got := links[0].Attributes["attested_compute_verification_status"]; got != "unverified_poc" {
+		t.Fatalf("link attestation verification status = %q, want unverified_poc", got)
+	}
+	if got := links[0].Attributes["attested_compute_claimed_format"]; got != "aws-nitro-enclave-poc" {
+		t.Fatalf("link claimed attestation format = %q, want aws-nitro-enclave-poc", got)
 	}
 }

--- a/internal/sourceprojection/attested_compute_test.go
+++ b/internal/sourceprojection/attested_compute_test.go
@@ -1,0 +1,72 @@
+package sourceprojection
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/attestedcompute"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestAttestedComputeGraphDeltaProjectsIntoGraphRecords(t *testing.T) {
+	tokenizer, err := attestedcompute.NewTokenizer([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("NewTokenizer() error = %v", err)
+	}
+	userToken := tokenizer.Token("identity.email", "alice@example.com")
+	resourceToken := tokenizer.Token("aws.arn", "arn:aws:s3:::sensitive-bucket")
+	userURN := attestedcompute.TokenURN("tenant-a", "okta.user", userToken)
+	resourceURN := attestedcompute.TokenURN("tenant-a", "aws.s3_bucket", resourceToken)
+	payload := attestedcompute.GraphDelta{
+		Attestation: attestedcompute.Attestation{
+			Format:      "aws-nitro-enclave-poc",
+			Measurement: strings.Repeat("a", 96),
+			KeyID:       "collector-key",
+		},
+		Entities: []attestedcompute.Entity{
+			{URN: userURN, EntityType: "okta.user", Label: userToken, Attributes: map[string]string{"is_admin": "true"}},
+			{URN: resourceURN, EntityType: "aws.s3_bucket", Label: resourceToken, Attributes: map[string]string{"is_public": "true"}},
+		},
+		Links: []attestedcompute.Link{
+			{FromURN: userURN, ToURN: resourceURN, Relation: "can_admin", Attributes: map[string]string{"observed_at": "2026-06-24T00:00:00Z"}},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	event := &cerebrov1.EventEnvelope{
+		Id:       "evt-attested",
+		TenantId: "tenant-a",
+		SourceId: "attested_compute",
+		Kind:     attestedcompute.EventKindGraphDelta,
+		Payload:  body,
+		Attributes: map[string]string{
+			ports.EventAttributeSourceRuntimeID: "runtime-attested",
+		},
+	}
+
+	entities, links, err := New(nil, nil).ProjectRecords(event)
+	if err != nil {
+		t.Fatalf("ProjectRecords() error = %v", err)
+	}
+	if len(entities) != 2 || len(links) != 1 {
+		t.Fatalf("ProjectRecords() produced %d entities/%d links, want 2/1", len(entities), len(links))
+	}
+	for _, entity := range entities {
+		if entity.RuntimeID != "runtime-attested" {
+			t.Fatalf("entity runtime_id = %q, want runtime-attested", entity.RuntimeID)
+		}
+		if strings.Contains(entity.Label, "alice") || strings.Contains(entity.Label, "sensitive-bucket") {
+			t.Fatalf("entity label leaked raw identifier: %q", entity.Label)
+		}
+	}
+	if links[0].Relation != "can_admin" {
+		t.Fatalf("link relation = %q, want can_admin", links[0].Relation)
+	}
+	if got := links[0].Attributes["attested_compute_format"]; got != "aws-nitro-enclave-poc" {
+		t.Fatalf("link attestation format = %q, want aws-nitro-enclave-poc", got)
+	}
+}

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/attestedcompute"
 	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -188,6 +189,7 @@ func kindSet(kinds []string) map[string]struct{} {
 }
 
 var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
+	attestedcompute.EventKindGraphDelta:             attestedComputeGraphDeltaProjections,
 	"backstage.component":                           backstageComponentProjections,
 	"auth0.audit_events":                            auth0AuditEventsProjections,
 	"auth0.roles":                                   auth0RolesProjections,

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -188,6 +188,7 @@ func kindSet(kinds []string) map[string]struct{} {
 }
 
 var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
+	"attested_compute.graph_delta":                  attestedComputeGraphDeltaProjections,
 	"backstage.component":                           backstageComponentProjections,
 	"auth0.audit_events":                            auth0AuditEventsProjections,
 	"auth0.roles":                                   auth0RolesProjections,

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -188,7 +188,6 @@ func kindSet(kinds []string) map[string]struct{} {
 }
 
 var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
-	"attested_compute.graph_delta":                  attestedComputeGraphDeltaProjections,
 	"backstage.component":                           backstageComponentProjections,
 	"auth0.audit_events":                            auth0AuditEventsProjections,
 	"auth0.roles":                                   auth0RolesProjections,


### PR DESCRIPTION
## Goal

Add a proof-of-concept path for externally hosted, attested compute to contribute blinded graph deltas into Cerebro's existing graph projection pipeline.

This PR is scoped to the build surface needed to demonstrate that externally produced compute can enter Cerebro as typed graph data without requiring raw asset identifiers to be present in the central graph. The goal is to make external compute contributions look like normal Cerebro projection inputs once they pass tenant scope, attestation metadata, relation, and tokenization checks.

## Build

- Adds `internal/attestedcompute` as the PoC contract package for externally produced graph deltas.
  - Defines the `attested_compute.graph_delta` event kind.
  - Defines a `GraphDelta` payload with attestation metadata, projected entities, and projected links.
  - Adds an HMAC tokenizer helper for stable opaque identifiers that can preserve graph joins across sources while hiding raw names, labels, ARNs, emails, and other identifying values.
  - Adds token URN helpers for tenant-scoped, attested graph anchors.
  - Validates that sensitive entity types use attested token URNs.
  - Validates that sensitive labels and identifier-like attributes are tokenized before projection.
  - Preserves non-identifying risk, posture, classification, and control attributes so graph rules can still reason over the data.

- Adds a source projection path for `attested_compute.graph_delta`.
  - Registers the new event kind in the built-in source projection registry.
  - Converts accepted graph deltas into existing `ProjectedEntity` and `ProjectedLink` records.
  - Reuses the existing projection runtime stamping and tenant-scope validation paths.
  - Keeps the central graph path unchanged after the blinded projection records are produced.

- Adds an AWS Nitro Enclave PoC verifier shape under the existing attestation package.
  - Introduces `aws-nitro-enclave-poc` as an attestation format for the PoC flow.
  - Binds a collector enrollment statement to an expected image measurement.
  - Binds the attested public key to the enrollment context through the existing client-data-hash nonce pattern.
  - Returns the same `attestation.Result` shape already used by the device-auth attestation registry, so the collector path can reuse the existing attestation abstraction.

- Adds focused tests for the PoC surfaces.
  - Token stability and domain separation.
  - Tenant-scoped token URN construction.
  - Rejection of raw sensitive labels and identifier attributes.
  - Rejection of cross-tenant projected URNs.
  - Projection of blinded attested graph deltas into graph records.
  - Nitro PoC measurement, nonce, and key binding checks.

## Value

- Establishes a typed seam for compute produced outside the central Cerebro runtime to enter the graph as normal projection data.
- Allows externally hosted collectors or compute environments to contribute graph structure, risk predicates, posture facts, classifications, and relationships while keeping raw identifiers out of the central graph path.
- Preserves existing graph projection and graph-rule machinery by converting attested external output into the same `ProjectedEntity` and `ProjectedLink` records Cerebro already understands.
- Creates an initial attestation binding point that can be hardened into a production Nitro verifier while keeping the caller-facing contract stable.
- Provides a foundation for multiple future external-compute modes, including cloud inventory collection, partner-provided evidence, customer-hosted analysis, and pre-processed graph facts.

## Validation

- `go test ./internal/attestedcompute ./internal/sourceprojection ./internal/deviceauth/attestation -run 'Test(Tokenizer|ProjectEvent|AttestedCompute|NitroPOC)' -count=1 -v`
- `go test ./internal/attestedcompute ./internal/sourceprojection ./internal/deviceauth/attestation -count=1`
- `make test`
- `make verify`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->