### PR TITLE
feat: add KnowBe4 security training catalog

### DIFF
--- a/internal/connectorcatalog/catalog/business-data-grc.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc.yaml
@@ -1452,7 +1452,7 @@ entries:
             - id: training_enrollments
               type: audit_event
               title: Training enrollments
-              families: [audit_events]
+              families: [training_enrollments]
               support: partial
               high_value: true
           pagination:

--- a/internal/connectorcatalog/catalog/business-data-grc.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc.yaml
@@ -1360,6 +1360,135 @@ entries:
   - classifier_output: supported
     definition:
       schema_version: cerebro.integration/v1
+      id: builtin-knowbe4
+      tenant_id: builtin_catalog
+      source_id: knowbe4
+      display_name: KnowBe4
+      description: "KnowBe4 connector definition catalog entry for high-value security awareness training, learner, and phishing campaign resources."
+      categories:
+        - security_training
+        - grc
+      config_fields:
+        - key: region
+          label: API region
+          required: true
+          help: "KnowBe4 Reporting API region host prefix, such as us, eu, ca, uk, or de."
+          placeholder: us
+      auth:
+        model: bearer_token
+        credential_fields:
+          - key: token
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://${config.region}.api.knowbe4.com/v1"
+        verification:
+          method: GET
+          path: /users
+          expect_status: [200]
+      resource_families:
+        - id: users
+          label: Learners
+          path: /users
+          method: GET
+          record_selector: "$[*]"
+          id_field: id
+          name_field: email
+          event:
+            kind: knowbe4.users
+            schema_ref: knowbe4/users/v1
+          projection:
+            template: identity_user
+          coverage:
+            - id: users
+              type: entity_family
+              title: Learners
+              families: [users]
+              support: partial
+              high_value: true
+          pagination:
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 1
+            page_size: 100
+        - id: groups
+          label: Groups
+          path: /groups
+          method: GET
+          record_selector: "$[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: knowbe4.groups
+            schema_ref: knowbe4/groups/v1
+          projection:
+            template: identity_group
+          coverage:
+            - id: groups
+              type: entity_family
+              title: Groups
+              families: [groups]
+              support: partial
+              high_value: true
+          pagination:
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 1
+            page_size: 100
+        - id: training_enrollments
+          label: Training enrollments
+          path: /training/enrollments
+          method: GET
+          record_selector: "$[*]"
+          id_field: id
+          event:
+            kind: knowbe4.training_enrollments
+            schema_ref: knowbe4/training_enrollments/v1
+          projection:
+            template: audit_event
+          coverage:
+            - id: training_enrollments
+              type: audit_event
+              title: Training enrollments
+              families: [audit_events]
+              support: partial
+              high_value: true
+          pagination:
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 1
+            page_size: 100
+        - id: phishing_campaigns
+          label: Phishing campaigns
+          path: /phishing/campaigns
+          method: GET
+          record_selector: "$[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: knowbe4.phishing_campaigns
+            schema_ref: knowbe4/phishing_campaigns/v1
+          projection:
+            template: asset
+          coverage:
+            - id: phishing_campaigns
+              type: entity_family
+              title: Phishing campaigns
+              families: [phishing_campaigns]
+              support: partial
+              high_value: true
+          pagination:
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 1
+            page_size: 100
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
       id: builtin-mercury
       tenant_id: builtin_catalog
       source_id: mercury

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -149,13 +149,13 @@ func TestBuiltinCatalogSeedSummary(t *testing.T) {
 	if len(analysis.Issues) != 0 {
 		t.Fatalf("issues = %#v, want none", analysis.Issues)
 	}
-	if analysis.Summary.Total != 198 {
-		t.Fatalf("summary total = %d, want 198", analysis.Summary.Total)
+	if analysis.Summary.Total != 199 {
+		t.Fatalf("summary total = %d, want 199", analysis.Summary.Total)
 	}
-	if len(analysis.Entries) != 198 {
-		t.Fatalf("entries len = %d, want 198", len(analysis.Entries))
+	if len(analysis.Entries) != 199 {
+		t.Fatalf("entries len = %d, want 199", len(analysis.Entries))
 	}
-	if analysis.Summary.Generateable != 198 {
+	if analysis.Summary.Generateable != 199 {
 		t.Fatalf("summary = %#v, want all entries generateable", analysis.Summary)
 	}
 	if analysis.Summary.NeedsAuthExtension != 0 {
@@ -182,10 +182,10 @@ func TestBuiltinRuntimeSkipsSourcegenDryRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuiltinRuntime() error = %v; issues = %#v", err, analysis.Issues)
 	}
-	if analysis.Summary.Total != 198 || len(analysis.Entries) != 198 {
-		t.Fatalf("runtime catalog size = total %d entries %d, want 198", analysis.Summary.Total, len(analysis.Entries))
+	if analysis.Summary.Total != 199 || len(analysis.Entries) != 199 {
+		t.Fatalf("runtime catalog size = total %d entries %d, want 199", analysis.Summary.Total, len(analysis.Entries))
 	}
-	if analysis.Summary.CatalogReady != 198 || analysis.Summary.Generateable != 0 {
+	if analysis.Summary.CatalogReady != 199 || analysis.Summary.Generateable != 0 {
 		t.Fatalf("runtime summary = %#v, want catalog-ready entries without sourcegen dry-run", analysis.Summary)
 	}
 	for _, entry := range analysis.Entries {
@@ -229,19 +229,53 @@ func TestBuiltinCatalogAuth0UsesManagementAPIShape(t *testing.T) {
 	if len(definition.ConfigFields) != 1 || definition.ConfigFields[0].Key != "domain" || !definition.ConfigFields[0].Required {
 		t.Fatalf("auth0 config fields = %#v, want required domain", definition.ConfigFields)
 	}
-	assertCatalogFamily(t, definition.ResourceFamilies, "users", "/users", "$[*]", "user_id")
-	assertCatalogFamily(t, definition.ResourceFamilies, "roles", "/roles", "$[*]", "id")
-	assertCatalogFamily(t, definition.ResourceFamilies, "audit_events", "/logs", "$[*]", "log_id")
+	assertCatalogFamily(t, definition.ResourceFamilies, "users", "/users", "user_id")
+	assertCatalogFamily(t, definition.ResourceFamilies, "roles", "/roles", "id")
+	assertCatalogFamily(t, definition.ResourceFamilies, "audit_events", "/logs", "log_id")
 }
 
-func assertCatalogFamily(t *testing.T, families []connectordefinitions.ResourceFamily, id string, path string, selector string, idField string) {
+func TestBuiltinCatalogKnowBe4SecurityAwarenessShape(t *testing.T) {
+	entry, ok, err := BuiltinEntry("knowbe4")
+	if err != nil {
+		t.Fatalf("BuiltinEntry() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("BuiltinEntry(knowbe4) ok = false, want true")
+	}
+	definition := entry.Definition
+	if definition.Transport == nil || definition.Transport.BaseURL != "https://${config.region}.api.knowbe4.com/v1" {
+		t.Fatalf("knowbe4 transport = %#v, want regional Reporting API base", definition.Transport)
+	}
+	if definition.Transport.Verification == nil || definition.Transport.Verification.Path != "/users" {
+		t.Fatalf("knowbe4 verification = %#v, want /users", definition.Transport.Verification)
+	}
+	if definition.Auth.Model != "bearer_token" {
+		t.Fatalf("knowbe4 auth model = %q, want bearer_token", definition.Auth.Model)
+	}
+	if len(definition.ConfigFields) != 1 || definition.ConfigFields[0].Key != "region" || !definition.ConfigFields[0].Required {
+		t.Fatalf("knowbe4 config fields = %#v, want required region", definition.ConfigFields)
+	}
+	if !hasString(definition.Categories, "security_training") {
+		t.Fatalf("knowbe4 categories = %#v, want security_training", definition.Categories)
+	}
+	assertCatalogFamily(t, definition.ResourceFamilies, "users", "/users", "id")
+	assertCatalogFamily(t, definition.ResourceFamilies, "groups", "/groups", "id")
+	assertCatalogFamily(t, definition.ResourceFamilies, "training_enrollments", "/training/enrollments", "id")
+	assertCatalogFamily(t, definition.ResourceFamilies, "phishing_campaigns", "/phishing/campaigns", "id")
+	enrollments := catalogFamily(t, definition.ResourceFamilies, "training_enrollments")
+	if enrollments.Pagination == nil || enrollments.Pagination.Type != "page" || enrollments.Pagination.PageParam != "page" || enrollments.Pagination.PageSizeParam != "per_page" || enrollments.Pagination.StartPage != 1 {
+		t.Fatalf("training enrollments pagination = %#v, want page/per_page starting at 1", enrollments.Pagination)
+	}
+}
+
+func assertCatalogFamily(t *testing.T, families []connectordefinitions.ResourceFamily, id string, path string, idField string) {
 	t.Helper()
 	for _, family := range families {
 		if family.ID != id {
 			continue
 		}
-		if family.Path != path || family.RecordSelector != selector || family.IDField != idField {
-			t.Fatalf("family %s = %#v, want path=%s selector=%s id_field=%s", id, family, path, selector, idField)
+		if family.Path != path || family.RecordSelector != "$[*]" || family.IDField != idField {
+			t.Fatalf("family %s = %#v, want path=%s selector=$[*] id_field=%s", id, family, path, idField)
 		}
 		return
 	}
@@ -254,6 +288,7 @@ func TestBuiltinCatalogIncludesAdditionalGapEntries(t *testing.T) {
 		"ethena":        StatusGenerateable,
 		"google_drive":  StatusGenerateable,
 		"hitrust_mycsf": StatusGenerateable,
+		"knowbe4":       StatusGenerateable,
 		"ramp":          StatusGenerateable,
 		"rippling":      StatusGenerateable,
 		"segment":       StatusGenerateable,
@@ -311,6 +346,15 @@ func TestBuiltinCatalogPreviouslyBlockedEntriesAreGenerateable(t *testing.T) {
 			}
 		})
 	}
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func minimalDefinitionYAML() string {

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -266,6 +266,9 @@ func TestBuiltinCatalogKnowBe4SecurityAwarenessShape(t *testing.T) {
 	if enrollments.Pagination == nil || enrollments.Pagination.Type != "page" || enrollments.Pagination.PageParam != "page" || enrollments.Pagination.PageSizeParam != "per_page" || enrollments.Pagination.StartPage != 1 {
 		t.Fatalf("training enrollments pagination = %#v, want page/per_page starting at 1", enrollments.Pagination)
 	}
+	if len(enrollments.Coverage) != 1 || !hasString(enrollments.Coverage[0].Families, "training_enrollments") {
+		t.Fatalf("training enrollments coverage = %#v, want family reference to training_enrollments", enrollments.Coverage)
+	}
 }
 
 func assertCatalogFamily(t *testing.T, families []connectordefinitions.ResourceFamily, id string, path string, idField string) {

--- a/sources/internal/catalogruntime/source.go
+++ b/sources/internal/catalogruntime/source.go
@@ -122,6 +122,8 @@ func jsonapiFamily(sourceID string, resource connectordefinitions.ResourceFamily
 		Name:             name,
 		Path:             resource.Path,
 		CursorParam:      cursorParam(resource.Pagination),
+		PagePagination:   isPagePagination(resource.Pagination),
+		PageStart:        pageStart(resource.Pagination),
 		URNKind:          firstNonEmpty(resource.Event.URNKind, "runtime_"+name),
 		IDKeys:           idKeys(resource, class),
 		TimestampKeys:    timestampKeys(resource),
@@ -137,6 +139,17 @@ func cursorParam(pagination *connectordefinitions.PaginationSpec) string {
 		return ""
 	}
 	return firstNonEmpty(pagination.CursorParam, pagination.PageParam, pagination.OffsetParam)
+}
+
+func isPagePagination(pagination *connectordefinitions.PaginationSpec) bool {
+	return pagination != nil && strings.TrimSpace(pagination.Type) == "page"
+}
+
+func pageStart(pagination *connectordefinitions.PaginationSpec) int {
+	if pagination == nil {
+		return 0
+	}
+	return pagination.StartPage
 }
 
 func pageSizeParams(pagination *connectordefinitions.PaginationSpec) []string {

--- a/sources/internal/catalogruntime/source.go
+++ b/sources/internal/catalogruntime/source.go
@@ -142,7 +142,7 @@ func cursorParam(pagination *connectordefinitions.PaginationSpec) string {
 }
 
 func pageFirstCursor(pagination *connectordefinitions.PaginationSpec) string {
-	if pagination == nil || strings.TrimSpace(pagination.Type) != "page" {
+	if pagination == nil || strings.TrimSpace(pagination.Type) != "page" || strings.TrimSpace(pagination.PageParam) == "" {
 		return ""
 	}
 	return strconv.Itoa(pagination.StartPage)

--- a/sources/internal/catalogruntime/source.go
+++ b/sources/internal/catalogruntime/source.go
@@ -3,6 +3,7 @@ package catalogruntime
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -122,8 +123,7 @@ func jsonapiFamily(sourceID string, resource connectordefinitions.ResourceFamily
 		Name:             name,
 		Path:             resource.Path,
 		CursorParam:      cursorParam(resource.Pagination),
-		PagePagination:   isPagePagination(resource.Pagination),
-		PageStart:        pageStart(resource.Pagination),
+		PageFirstCursor:  pageFirstCursor(resource.Pagination),
 		URNKind:          firstNonEmpty(resource.Event.URNKind, "runtime_"+name),
 		IDKeys:           idKeys(resource, class),
 		TimestampKeys:    timestampKeys(resource),
@@ -141,15 +141,11 @@ func cursorParam(pagination *connectordefinitions.PaginationSpec) string {
 	return firstNonEmpty(pagination.CursorParam, pagination.PageParam, pagination.OffsetParam)
 }
 
-func isPagePagination(pagination *connectordefinitions.PaginationSpec) bool {
-	return pagination != nil && strings.TrimSpace(pagination.Type) == "page"
-}
-
-func pageStart(pagination *connectordefinitions.PaginationSpec) int {
-	if pagination == nil {
-		return 0
+func pageFirstCursor(pagination *connectordefinitions.PaginationSpec) string {
+	if pagination == nil || strings.TrimSpace(pagination.Type) != "page" {
+		return ""
 	}
-	return pagination.StartPage
+	return strconv.Itoa(pagination.StartPage)
 }
 
 func pageSizeParams(pagination *connectordefinitions.PaginationSpec) []string {

--- a/sources/internal/catalogruntime/source_test.go
+++ b/sources/internal/catalogruntime/source_test.go
@@ -153,6 +153,56 @@ func TestSourceDefinitionUsesPagePagination(t *testing.T) {
 	}
 }
 
+func TestSourceDefinitionDoesNotSynthesizeCursorWithoutPageParam(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("cursor"); got != "" {
+			t.Fatalf("cursor query = %q, want empty", got)
+		}
+		if got := r.URL.Query().Get("per_page"); got != "2" {
+			t.Fatalf("per_page query = %q, want 2", got)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "A"}, {"id": "B"}})
+	}))
+	defer server.Close()
+
+	source, err := NewDefinition(connectordefinitions.Definition{
+		ID:          "tenant-example",
+		TenantID:    "tenant",
+		SourceID:    "example",
+		DisplayName: "Example",
+		Auth:        connectordefinitions.AuthSpec{Model: "bearer_token"},
+		Transport:   &connectordefinitions.TransportSpec{BaseURL: server.URL},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:             "records",
+			Path:           "/records",
+			RecordSelector: "$[*]",
+			IDField:        "id",
+			Event:          connectordefinitions.EventMappingSpec{Kind: "example.records", SchemaRef: "example/records/v1"},
+			Projection:     &connectordefinitions.ProjectionSpec{Template: "audit_event"},
+			Coverage:       []connectordefinitions.CoverageDimensionSpec{{Type: "audit_event", Support: "partial"}},
+			Pagination: &connectordefinitions.PaginationSpec{
+				Type:          "page",
+				PageSizeParam: "per_page",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewDefinition() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "tenant",
+		"token":     "token",
+		"per_page":  "2",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if pull.NextCursor != nil {
+		t.Fatalf("NextCursor = %#v, want nil", pull.NextCursor)
+	}
+}
+
 func TestSourceAuthModels(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/sources/internal/catalogruntime/source_test.go
+++ b/sources/internal/catalogruntime/source_test.go
@@ -81,6 +81,78 @@ func TestSourceCheckAndReadDefinition(t *testing.T) {
 	}
 }
 
+func TestSourceDefinitionUsesPagePagination(t *testing.T) {
+	requests := make([]*http.Request, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Clone(r.Context()))
+		if got := r.URL.Query().Get("per_page"); got != "2" {
+			t.Fatalf("per_page query = %q, want 2", got)
+		}
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "A"}, {"id": "B"}})
+		case "2":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "C"}})
+		default:
+			t.Fatalf("unexpected page %q", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	source, err := NewDefinition(connectordefinitions.Definition{
+		ID:          "tenant-example",
+		TenantID:    "tenant",
+		SourceID:    "example",
+		DisplayName: "Example",
+		Auth:        connectordefinitions.AuthSpec{Model: "bearer_token"},
+		Transport:   &connectordefinitions.TransportSpec{BaseURL: server.URL},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:             "training_enrollments",
+			Path:           "/training/enrollments",
+			RecordSelector: "$[*]",
+			IDField:        "id",
+			Event: connectordefinitions.EventMappingSpec{
+				Kind:      "example.training_enrollments",
+				SchemaRef: "example/training_enrollments/v1",
+			},
+			Projection: &connectordefinitions.ProjectionSpec{Template: "audit_event"},
+			Coverage:   []connectordefinitions.CoverageDimensionSpec{{Type: "audit_event", Support: "partial"}},
+			Pagination: &connectordefinitions.PaginationSpec{
+				Type:          "page",
+				PageParam:     "page",
+				PageSizeParam: "per_page",
+				StartPage:     1,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewDefinition() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "tenant",
+		"token":     "token",
+		"per_page":  "2",
+	})
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if first.NextCursor.GetOpaque() != "2" {
+		t.Fatalf("first NextCursor = %q, want 2", first.NextCursor.GetOpaque())
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second NextCursor = %#v, want nil", second.NextCursor)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests len = %d, want 2", len(requests))
+	}
+}
+
 func TestSourceAuthModels(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/sources/internal/jsonapi/http.go
+++ b/sources/internal/jsonapi/http.go
@@ -49,8 +49,8 @@ func (s *Source) list(ctx context.Context, family Family, settings settings, cur
 		}
 	}
 	pageCursor := strings.TrimSpace(cursor)
-	if family.PagePagination && pageCursor == "" {
-		pageCursor = strconv.Itoa(family.PageStart)
+	if pageCursor == "" {
+		pageCursor = strings.TrimSpace(family.PageFirstCursor)
 	}
 	if pageCursor != "" {
 		query.Set(cursorParam(family), pageCursor)
@@ -145,12 +145,12 @@ func cursorParam(family Family) string {
 }
 
 func synthesizePageCursor(family Family, cursor string, pageSize int, itemCount int, next string) string {
-	if !family.PagePagination || strings.TrimSpace(next) != "" || pageSize < 1 || itemCount < pageSize {
+	if strings.TrimSpace(family.PageFirstCursor) == "" || strings.TrimSpace(next) != "" || pageSize < 1 || itemCount < pageSize {
 		return next
 	}
 	current := strings.TrimSpace(cursor)
 	if current == "" {
-		current = strconv.Itoa(family.PageStart)
+		current = strings.TrimSpace(family.PageFirstCursor)
 	}
 	page, err := strconv.Atoi(current)
 	if err != nil {

--- a/sources/internal/jsonapi/http.go
+++ b/sources/internal/jsonapi/http.go
@@ -48,8 +48,12 @@ func (s *Source) list(ctx context.Context, family Family, settings settings, cur
 			query.Set(param, strconv.Itoa(pageSize))
 		}
 	}
-	if cursor := strings.TrimSpace(cursor); cursor != "" {
-		query.Set(cursorParam(family), cursor)
+	pageCursor := strings.TrimSpace(cursor)
+	if family.PagePagination && pageCursor == "" {
+		pageCursor = strconv.Itoa(family.PageStart)
+	}
+	if pageCursor != "" {
+		query.Set(cursorParam(family), pageCursor)
 	}
 	var body json.RawMessage
 	if err := s.getJSON(ctx, settings, query, &body); err != nil {
@@ -59,6 +63,7 @@ func (s *Source) list(ctx context.Context, family Family, settings settings, cur
 	if err != nil {
 		return nil, "", fmt.Errorf("%s %s: %w", s.options.SourceID, settings.family, err)
 	}
+	next = synthesizePageCursor(family, pageCursor, pageSize, len(items), next)
 	records := make([]record, 0, len(items))
 	for _, item := range items {
 		item, err = rawWithPathParams(item, settings.pathParams)
@@ -137,6 +142,21 @@ func cursorParam(family Family) string {
 		return param
 	}
 	return "cursor"
+}
+
+func synthesizePageCursor(family Family, cursor string, pageSize int, itemCount int, next string) string {
+	if !family.PagePagination || strings.TrimSpace(next) != "" || pageSize < 1 || itemCount < pageSize {
+		return next
+	}
+	current := strings.TrimSpace(cursor)
+	if current == "" {
+		current = strconv.Itoa(family.PageStart)
+	}
+	page, err := strconv.Atoi(current)
+	if err != nil {
+		return next
+	}
+	return strconv.Itoa(page + 1)
 }
 
 func queryFromConfig(cfg sourcecdk.Config, configQuery map[string]string) url.Values {

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -22,6 +22,8 @@ type Family struct {
 	CursorParam           string
 	NextCursorKeys        []string
 	HasMoreKey            string
+	PagePagination        bool
+	PageStart             int
 	URNKind               string
 	IDKeys                []string
 	TimestampKeys         []string

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -22,8 +22,7 @@ type Family struct {
 	CursorParam           string
 	NextCursorKeys        []string
 	HasMoreKey            string
-	PagePagination        bool
-	PageStart             int
+	PageFirstCursor       string
 	URNKind               string
 	IDKeys                []string
 	TimestampKeys         []string

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -144,14 +144,13 @@ func TestReadSynthesizesPageCursorForFullPages(t *testing.T) {
 	defer server.Close()
 
 	source := newCustomTestSource(t, server.URL, Family{
-		Name:           "enrollments",
-		Path:           "/enrollments",
-		CursorParam:    "page",
-		PageSizeParams: []string{"per_page"},
-		PagePagination: true,
-		PageStart:      1,
-		URNKind:        "test_enrollment",
-		IDKeys:         []string{"id"},
+		Name:            "enrollments",
+		Path:            "/enrollments",
+		CursorParam:     "page",
+		PageSizeParams:  []string{"per_page"},
+		PageFirstCursor: "1",
+		URNKind:         "test_enrollment",
+		IDKeys:          []string{"id"},
 	})
 	cfg := sourcecdk.NewConfig(map[string]string{
 		"tenant_id": "writer",

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -124,6 +124,65 @@ func TestReadPagesJSONAPIRecords(t *testing.T) {
 	}
 }
 
+func TestReadSynthesizesPageCursorForFullPages(t *testing.T) {
+	requests := make([]*http.Request, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Clone(r.Context()))
+		if got := r.URL.Query().Get("per_page"); got != "2" {
+			t.Fatalf("per_page query = %q, want 2", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "enrollment-1"}, {"id": "enrollment-2"}})
+		case "2":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "enrollment-3"}})
+		default:
+			t.Fatalf("unexpected page %q", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	source := newCustomTestSource(t, server.URL, Family{
+		Name:           "enrollments",
+		Path:           "/enrollments",
+		CursorParam:    "page",
+		PageSizeParams: []string{"per_page"},
+		PagePagination: true,
+		PageStart:      1,
+		URNKind:        "test_enrollment",
+		IDKeys:         []string{"id"},
+	})
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"token":     "token-1",
+		"per_page":  "2",
+	})
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if first.NextCursor.GetOpaque() != "2" {
+		t.Fatalf("first NextCursor = %q, want 2", first.NextCursor.GetOpaque())
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second NextCursor = %#v, want nil", second.NextCursor)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests len = %d, want 2", len(requests))
+	}
+	if got := requests[0].URL.Query().Get("page"); got != "1" {
+		t.Fatalf("first page query = %q, want 1", got)
+	}
+	if got := requests[1].URL.Query().Get("page"); got != "2" {
+		t.Fatalf("second page query = %q, want 2", got)
+	}
+}
+
 func TestReadMergesBareDetailObjectWhenAllowed(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {


### PR DESCRIPTION
## Summary

- Adds a KnowBe4 connector catalog entry for security awareness learners, groups, training enrollments, and phishing campaigns.
- Adds page/per_page pagination support to the generic catalog JSON API runtime.
- Adds regression coverage for the KnowBe4 catalog shape and page pagination behavior.

## Test Plan

- `GOFLAGS=-mod=readonly go test ./internal/connectorcatalog ./sources/internal/catalogruntime ./sources/internal/jsonapi ./internal/sourceregistry -count=1`
- `GOFLAGS=-mod=readonly make catalog-check`
- `GOFLAGS=-mod=readonly make sourcegen-check`
- `GOFLAGS=-mod=readonly make sourcegen-test`
- `GOFLAGS=-mod=readonly make test`
- `GOFLAGS=-mod=readonly make lint`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->