### PR TITLE
feat: add GRC program readiness endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2041,6 +2041,31 @@ paths:
       responses:
         '200':
           description: GRC dashboard summary, priority findings, controls, evidence, and connector health.
+  /grc/program-readiness:
+    get:
+      summary: GRC program readiness
+      tags:
+        - GRC
+      parameters:
+        - $ref: '#/components/parameters/tenantIDQuery'
+        - $ref: '#/components/parameters/runtimeIDQuery'
+        - $ref: '#/components/parameters/sourceIDQuery'
+        - $ref: '#/components/parameters/limitQuery'
+        - name: profile
+          in: query
+          schema:
+            type: string
+        - name: framework
+          in: query
+          schema:
+            type: string
+        - name: control
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Program-level audit readiness, prioritized work items, proof bundle links, and connector coverage.
   /grc/dashboards:
     get:
       summary: List custom GRC dashboards

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -1537,7 +1537,7 @@ func fallbackAccessAuditRoute(method string, path string) string {
 		return prefix + "/grc/audit-packets/{packetID}"
 	case strings.HasPrefix(path, "/grc/"):
 		switch path {
-		case "/grc/dashboard", "/grc/ask", "/grc/findings", "/grc/controls", "/grc/evidence", "/grc/control-packets":
+		case "/grc/program-readiness", "/grc/dashboard", "/grc/ask", "/grc/findings", "/grc/controls", "/grc/evidence", "/grc/control-packets":
 			return prefix + path
 		default:
 			return prefix + "/grc/{subresource}"

--- a/internal/bootstrap/grc_control_packs.go
+++ b/internal/bootstrap/grc_control_packs.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/grccontrol"
 )
@@ -141,6 +142,10 @@ func (a *App) buildGRCControlEvidencePacket(r *http.Request) (grccontrol.PacketR
 	if err != nil {
 		return grccontrol.PacketResult{}, err
 	}
+	return a.buildGRCControlEvidencePacketWithScope(r, scope, runtimes)
+}
+
+func (a *App) buildGRCControlEvidencePacketWithScope(r *http.Request, scope grcScope, runtimes []*cerebrov1.SourceRuntime) (grccontrol.PacketResult, error) {
 	reportScopeRuntimes := a.grcReportScopeRuntimes(r, scope, runtimes)
 	findings, err := a.grcListFindingRecords(r, runtimes, grcFindingFilter{Status: "open", Limit: scope.Limit})
 	if err != nil {

--- a/internal/bootstrap/grc_program_readiness.go
+++ b/internal/bootstrap/grc_program_readiness.go
@@ -17,11 +17,6 @@ type grcProgramReadinessResponse struct {
 }
 
 func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) {
-	result, err := a.buildGRCControlEvidencePacket(r)
-	if err != nil {
-		writeGRCControlPacketError(w, err)
-		return
-	}
 	scope, err := grcScopeFromRequest(r)
 	if err != nil {
 		writeGRCError(w, err)
@@ -30,6 +25,11 @@ func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) 
 	runtimes, err := a.grcListRuntimes(r, scope)
 	if err != nil {
 		writeGRCError(w, err)
+		return
+	}
+	result, err := a.buildGRCControlEvidencePacketWithScope(r, scope, runtimes)
+	if err != nil {
+		writeGRCControlPacketError(w, err)
 		return
 	}
 	generatedAt := time.Now().UTC()
@@ -65,18 +65,7 @@ func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) 
 func grcProgramConnectors(connectors []grcConnector) []grcprogram.Connector {
 	items := make([]grcprogram.Connector, 0, len(connectors))
 	for _, connector := range connectors {
-		items = append(items, grcprogram.Connector{
-			RuntimeID:           connector.RuntimeID,
-			SourceID:            connector.SourceID,
-			TenantID:            connector.TenantID,
-			Status:              connector.Status,
-			Freshness:           connector.Freshness,
-			SyncLagSeconds:      connector.SyncLagSeconds,
-			CheckpointWatermark: connector.CheckpointWatermark,
-			WatermarkLagSeconds: connector.WatermarkLagSeconds,
-			WatermarkFreshness:  connector.WatermarkFreshness,
-			LastSyncedAt:        connector.LastSyncedAt,
-		})
+		items = append(items, grcprogram.Connector(connector))
 	}
 	return items
 }

--- a/internal/bootstrap/grc_program_readiness.go
+++ b/internal/bootstrap/grc_program_readiness.go
@@ -1,0 +1,517 @@
+package bootstrap
+
+import (
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/grccontrol"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecoverage"
+)
+
+const grcProgramWorkItemLimit = 12
+
+type grcProgramReadinessResponse struct {
+	Profile            grccontrol.Profile           `json:"profile"`
+	Summary            grcProgramReadinessSummary   `json:"summary"`
+	Frameworks         []grcProgramFramework        `json:"frameworks"`
+	Controls           []grcProgramControl          `json:"controls"`
+	WorkItems          []grcProgramWorkItem         `json:"work_items"`
+	ProofBundle        grcProgramProofBundle        `json:"proof_bundle"`
+	Connectors         []grcConnector               `json:"connectors"`
+	SourceSummaries    []sourceRuntimeHealthSummary `json:"source_summaries,omitempty"`
+	CoverageBlindSpots []sourcecoverage.Record      `json:"coverage_blind_spots,omitempty"`
+	CoverageSummaries  []sourcecoverage.Summary     `json:"coverage_summaries,omitempty"`
+	Metadata           grccontrol.ReportMetadata    `json:"metadata"`
+	GeneratedAt        time.Time                    `json:"generated_at"`
+}
+
+type grcProgramReadinessSummary struct {
+	Status                  string                              `json:"status"`
+	Score                   int                                 `json:"score"`
+	Controls                int                                 `json:"controls"`
+	PassingControls         int                                 `json:"passing_controls"`
+	FailingControls         int                                 `json:"failing_controls"`
+	MissingEvidenceControls int                                 `json:"missing_evidence_controls"`
+	StaleEvidenceControls   int                                 `json:"stale_evidence_controls"`
+	ManualReviewControls    int                                 `json:"manual_review_controls"`
+	EvidenceItems           int                                 `json:"evidence_items"`
+	MissingEvidenceItems    int                                 `json:"missing_evidence_items"`
+	StaleEvidenceItems      int                                 `json:"stale_evidence_items"`
+	OpenFindings            int                                 `json:"open_findings"`
+	CriticalFindings        int                                 `json:"critical_findings"`
+	HighFindings            int                                 `json:"high_findings"`
+	Connectors              int                                 `json:"connectors"`
+	StaleConnectors         int                                 `json:"stale_connectors"`
+	CoverageBlindSpots      int                                 `json:"coverage_blind_spots"`
+	ReadinessBlockers       []grccontrol.ReportReadinessBlocker `json:"readiness_blockers,omitempty"`
+}
+
+type grcProgramFramework struct {
+	FrameworkName           string `json:"framework_name"`
+	FrameworkID             string `json:"framework_id,omitempty"`
+	FrameworkVersion        string `json:"framework_version,omitempty"`
+	FrameworkLifecycle      string `json:"framework_lifecycle,omitempty"`
+	Status                  string `json:"status"`
+	Score                   int    `json:"score"`
+	Controls                int    `json:"controls"`
+	PassingControls         int    `json:"passing_controls"`
+	FailingControls         int    `json:"failing_controls"`
+	MissingEvidenceControls int    `json:"missing_evidence_controls"`
+	StaleEvidenceControls   int    `json:"stale_evidence_controls"`
+	ManualReviewControls    int    `json:"manual_review_controls"`
+	OpenFindings            int    `json:"open_findings"`
+	EvidenceItems           int    `json:"evidence_items"`
+}
+
+type grcProgramControl struct {
+	FrameworkName        string   `json:"framework_name"`
+	FrameworkID          string   `json:"framework_id,omitempty"`
+	FrameworkVersion     string   `json:"framework_version,omitempty"`
+	FrameworkLifecycle   string   `json:"framework_lifecycle,omitempty"`
+	ControlID            string   `json:"control_id"`
+	Title                string   `json:"title,omitempty"`
+	OwnerDomain          string   `json:"owner_domain,omitempty"`
+	Status               string   `json:"status"`
+	Score                int      `json:"score"`
+	OpenFindings         int      `json:"open_findings"`
+	CriticalFindings     int      `json:"critical_findings"`
+	HighFindings         int      `json:"high_findings"`
+	EvidenceItems        int      `json:"evidence_items"`
+	MissingEvidence      int      `json:"missing_evidence_items,omitempty"`
+	StaleEvidence        int      `json:"stale_evidence_items,omitempty"`
+	EvidenceExpectations int      `json:"evidence_expectations,omitempty"`
+	EvidenceQuality      string   `json:"evidence_quality,omitempty"`
+	Action               string   `json:"action"`
+	Href                 string   `json:"href,omitempty"`
+	Reasons              []string `json:"reasons,omitempty"`
+}
+
+type grcProgramWorkItem struct {
+	ID               string   `json:"id"`
+	Kind             string   `json:"kind"`
+	Title            string   `json:"title"`
+	FrameworkName    string   `json:"framework_name,omitempty"`
+	ControlID        string   `json:"control_id,omitempty"`
+	Status           string   `json:"status"`
+	Action           string   `json:"action"`
+	OwnerDomain      string   `json:"owner_domain,omitempty"`
+	OpenFindings     int      `json:"open_findings,omitempty"`
+	CriticalFindings int      `json:"critical_findings,omitempty"`
+	MissingEvidence  int      `json:"missing_evidence_items,omitempty"`
+	StaleEvidence    int      `json:"stale_evidence_items,omitempty"`
+	Href             string   `json:"href,omitempty"`
+	Reasons          []string `json:"reasons,omitempty"`
+}
+
+type grcProgramProofBundle struct {
+	ID                string                     `json:"id"`
+	Title             string                     `json:"title"`
+	Description       string                     `json:"description,omitempty"`
+	Status            string                     `json:"status"`
+	Score             int                        `json:"score"`
+	ControlPacketPath string                     `json:"control_packet_path"`
+	ExportPath        string                     `json:"export_path"`
+	ReportsPath       string                     `json:"reports_path"`
+	Readiness         grccontrol.ReportReadiness `json:"readiness"`
+	GeneratedAt       time.Time                  `json:"generated_at"`
+}
+
+type grcProgramFrameworkAccumulator struct {
+	grcProgramFramework
+	scoreTotal int
+}
+
+func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) {
+	result, err := a.buildGRCControlEvidencePacket(r)
+	if err != nil {
+		writeGRCControlPacketError(w, err)
+		return
+	}
+	scope, err := grcScopeFromRequest(r)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	runtimes, err := a.grcListRuntimes(r, scope)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	generatedAt := time.Now().UTC()
+	sourceSummaries, err := a.grcSourceRuntimeHealthSummaries(r.Context(), runtimes, generatedAt)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	coverage := a.sourceCoverageRecords(runtimes, portsSourceRuntimeFilter(scope), generatedAt)
+	connectors := grcConnectorItems(runtimes)
+	coverageBlindSpots := sourcecoverage.BlindSpots(coverage)
+	summary := grcBuildProgramReadinessSummary(result, connectors, len(coverageBlindSpots))
+	controls := grcBuildProgramControls(result.Controls, result.Profile.ID, scope.TenantID)
+	workItems := grcBuildProgramWorkItems(controls)
+
+	writeJSON(w, http.StatusOK, grcProgramReadinessResponse{
+		Profile:            result.Profile,
+		Summary:            summary,
+		Frameworks:         grcBuildProgramFrameworks(controls),
+		Controls:           controls,
+		WorkItems:          workItems,
+		ProofBundle:        grcBuildProgramProofBundle(result, r.URL.Query(), generatedAt),
+		Connectors:         connectors,
+		SourceSummaries:    sourceSummaries,
+		CoverageBlindSpots: coverageBlindSpots,
+		CoverageSummaries:  sourcecoverage.Summaries(coverage),
+		Metadata:           result.Metadata,
+		GeneratedAt:        generatedAt,
+	})
+}
+
+func grcBuildProgramReadinessSummary(result grccontrol.PacketResult, connectors []grcConnector, coverageBlindSpots int) grcProgramReadinessSummary {
+	summary := grcProgramReadinessSummary{
+		Status:             strings.TrimSpace(result.Metadata.Readiness.Status),
+		Score:              result.Metadata.Readiness.Score,
+		Controls:           len(result.Controls),
+		EvidenceItems:      result.Metadata.Provenance.EvidenceCount,
+		Connectors:         len(connectors),
+		CoverageBlindSpots: coverageBlindSpots,
+		ReadinessBlockers:  result.Metadata.Readiness.Blockers,
+	}
+	for _, connector := range connectors {
+		if grcProgramConnectorNeedsAttention(connector) {
+			summary.StaleConnectors++
+		}
+	}
+	for _, control := range result.Controls {
+		class := grcProgramControlClass(control)
+		switch class {
+		case "passing":
+			summary.PassingControls++
+		case "failing":
+			summary.FailingControls++
+		case "missing_evidence":
+			summary.MissingEvidenceControls++
+		case "stale_evidence":
+			summary.StaleEvidenceControls++
+		case "manual_review":
+			summary.ManualReviewControls++
+		}
+		summary.OpenFindings += control.OpenFindings
+		summary.CriticalFindings += control.CriticalFindings
+		summary.HighFindings += control.HighFindings
+		summary.MissingEvidenceItems += control.MissingEvidence
+		summary.StaleEvidenceItems += control.StaleEvidence
+	}
+	if summary.Score == 0 && len(result.Controls) > 0 {
+		total := 0
+		for _, control := range result.Controls {
+			total += grcProgramControlScore(control)
+		}
+		summary.Score = total / len(result.Controls)
+	}
+	if summary.Status == "" {
+		summary.Status = grcProgramReadinessStatus(summary.Score, summary)
+	}
+	return summary
+}
+
+func grcBuildProgramControls(controls []grccontrol.ControlItem, profileID, tenantID string) []grcProgramControl {
+	items := make([]grcProgramControl, 0, len(controls))
+	for _, control := range controls {
+		action := grcProgramControlAction(control)
+		items = append(items, grcProgramControl{
+			FrameworkName:        control.FrameworkName,
+			FrameworkID:          control.FrameworkID,
+			FrameworkVersion:     control.FrameworkVersion,
+			FrameworkLifecycle:   control.FrameworkLifecycle,
+			ControlID:            control.ControlID,
+			Title:                control.Title,
+			OwnerDomain:          control.OwnerDomain,
+			Status:               control.Status,
+			Score:                grcProgramControlScore(control),
+			OpenFindings:         control.OpenFindings,
+			CriticalFindings:     control.CriticalFindings,
+			HighFindings:         control.HighFindings,
+			EvidenceItems:        control.EvidenceItems,
+			MissingEvidence:      control.MissingEvidence,
+			StaleEvidence:        control.StaleEvidence,
+			EvidenceExpectations: control.Expectations,
+			EvidenceQuality:      control.EvidenceQuality,
+			Action:               action,
+			Href:                 grcProgramControlHref(profileID, tenantID, control.FrameworkName, control.ControlID),
+			Reasons:              control.Reasons,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		left := grcProgramControlRank(items[i])
+		right := grcProgramControlRank(items[j])
+		for index := range left {
+			if left[index] != right[index] {
+				return left[index] < right[index]
+			}
+		}
+		return items[i].FrameworkName+"\x00"+items[i].ControlID < items[j].FrameworkName+"\x00"+items[j].ControlID
+	})
+	return items
+}
+
+func grcBuildProgramFrameworks(controls []grcProgramControl) []grcProgramFramework {
+	frameworks := map[string]*grcProgramFrameworkAccumulator{}
+	for _, control := range controls {
+		key := control.FrameworkName + "\x00" + control.FrameworkID + "\x00" + control.FrameworkVersion
+		accumulator := frameworks[key]
+		if accumulator == nil {
+			accumulator = &grcProgramFrameworkAccumulator{grcProgramFramework: grcProgramFramework{
+				FrameworkName:      control.FrameworkName,
+				FrameworkID:        control.FrameworkID,
+				FrameworkVersion:   control.FrameworkVersion,
+				FrameworkLifecycle: control.FrameworkLifecycle,
+			}}
+			frameworks[key] = accumulator
+		}
+		accumulator.Controls++
+		accumulator.scoreTotal += control.Score
+		accumulator.OpenFindings += control.OpenFindings
+		accumulator.EvidenceItems += control.EvidenceItems
+		switch grcProgramControlClassFromStatus(control.Status, control.MissingEvidence, control.StaleEvidence) {
+		case "passing":
+			accumulator.PassingControls++
+		case "failing":
+			accumulator.FailingControls++
+		case "missing_evidence":
+			accumulator.MissingEvidenceControls++
+		case "stale_evidence":
+			accumulator.StaleEvidenceControls++
+		case "manual_review":
+			accumulator.ManualReviewControls++
+		}
+	}
+	items := make([]grcProgramFramework, 0, len(frameworks))
+	for _, accumulator := range frameworks {
+		if accumulator.Controls > 0 {
+			accumulator.Score = accumulator.scoreTotal / accumulator.Controls
+		}
+		accumulator.Status = grcProgramFrameworkStatus(accumulator.grcProgramFramework)
+		items = append(items, accumulator.grcProgramFramework)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Score != items[j].Score {
+			return items[i].Score < items[j].Score
+		}
+		return items[i].FrameworkName < items[j].FrameworkName
+	})
+	return items
+}
+
+func grcBuildProgramWorkItems(controls []grcProgramControl) []grcProgramWorkItem {
+	items := make([]grcProgramWorkItem, 0, len(controls))
+	for _, control := range controls {
+		if control.Action == "Keep audit-ready" {
+			continue
+		}
+		title := strings.TrimSpace(control.Title)
+		if title == "" {
+			title = strings.TrimSpace(control.FrameworkName + " " + control.ControlID)
+		}
+		items = append(items, grcProgramWorkItem{
+			ID:               control.FrameworkName + ":" + control.ControlID,
+			Kind:             "control",
+			Title:            title,
+			FrameworkName:    control.FrameworkName,
+			ControlID:        control.ControlID,
+			Status:           control.Status,
+			Action:           control.Action,
+			OwnerDomain:      control.OwnerDomain,
+			OpenFindings:     control.OpenFindings,
+			CriticalFindings: control.CriticalFindings,
+			MissingEvidence:  control.MissingEvidence,
+			StaleEvidence:    control.StaleEvidence,
+			Href:             control.Href,
+			Reasons:          control.Reasons,
+		})
+	}
+	if len(items) > grcProgramWorkItemLimit {
+		items = items[:grcProgramWorkItemLimit]
+	}
+	return items
+}
+
+func grcBuildProgramProofBundle(result grccontrol.PacketResult, query url.Values, generatedAt time.Time) grcProgramProofBundle {
+	profileID := strings.TrimSpace(result.Profile.ID)
+	if profileID == "" {
+		profileID = grccontrol.DefaultEvidenceProfileID
+	}
+	reportQuery := url.Values{}
+	for _, key := range []string{"tenant_id", "profile", "framework", "control"} {
+		if value := strings.TrimSpace(query.Get(key)); value != "" {
+			reportQuery.Set(key, value)
+		}
+	}
+	if reportQuery.Get("profile") == "" {
+		reportQuery.Set("profile", profileID)
+	}
+	return grcProgramProofBundle{
+		ID:                "proofbundle:" + profileID,
+		Title:             strings.TrimSpace(firstNonEmpty(result.Profile.Name, "Audit proof bundle")),
+		Description:       "Control packet, readiness metadata, source scope, and export paths for auditor review.",
+		Status:            result.Metadata.Readiness.Status,
+		Score:             result.Metadata.Readiness.Score,
+		ControlPacketPath: grcProgramAPIPath("/grc/control-packets", query),
+		ExportPath:        grcProgramAPIPath("/grc/control-packets/export", query),
+		ReportsPath:       grcProgramUIPath("/reports", reportQuery),
+		Readiness:         result.Metadata.Readiness,
+		GeneratedAt:       generatedAt,
+	}
+}
+
+func grcProgramControlClass(control grccontrol.ControlItem) string {
+	return grcProgramControlClassFromStatus(control.Status, control.MissingEvidence, control.StaleEvidence)
+}
+
+func grcProgramControlClassFromStatus(status string, missingEvidence, staleEvidence int) string {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	switch {
+	case normalized == "failing":
+		return "failing"
+	case missingEvidence > 0 || normalized == "missing_evidence":
+		return "missing_evidence"
+	case staleEvidence > 0 || normalized == "stale_evidence":
+		return "stale_evidence"
+	case normalized == "manual_review" || normalized == "manual":
+		return "manual_review"
+	case normalized == "passing" || normalized == "satisfied" || normalized == "ready" || normalized == "ok":
+		return "passing"
+	default:
+		return "manual_review"
+	}
+}
+
+func grcProgramControlAction(control grccontrol.ControlItem) string {
+	switch grcProgramControlClass(control) {
+	case "failing":
+		return "Remediate mapped findings"
+	case "missing_evidence":
+		return "Collect missing evidence"
+	case "stale_evidence":
+		return "Refresh stale evidence"
+	case "manual_review":
+		return "Complete manual assessment"
+	default:
+		return "Keep audit-ready"
+	}
+}
+
+func grcProgramControlScore(control grccontrol.ControlItem) int {
+	if control.EvidenceScore > 0 {
+		return control.EvidenceScore
+	}
+	switch grcProgramControlClass(control) {
+	case "passing":
+		return 100
+	case "stale_evidence":
+		return 70
+	case "manual_review":
+		return 65
+	case "missing_evidence":
+		return 45
+	case "failing":
+		return 25
+	default:
+		return 50
+	}
+}
+
+func grcProgramControlRank(control grcProgramControl) [5]int {
+	statusWeight := map[string]int{
+		"failing":          0,
+		"missing_evidence": 1,
+		"stale_evidence":   2,
+		"manual_review":    3,
+		"passing":          9,
+	}
+	class := grcProgramControlClassFromStatus(control.Status, control.MissingEvidence, control.StaleEvidence)
+	return [5]int{
+		statusWeight[class],
+		-control.CriticalFindings,
+		-control.OpenFindings,
+		-control.MissingEvidence,
+		control.Score,
+	}
+}
+
+func grcProgramReadinessStatus(score int, summary grcProgramReadinessSummary) string {
+	switch {
+	case summary.FailingControls > 0 || summary.StaleConnectors > 0:
+		return "blocked"
+	case summary.MissingEvidenceControls > 0 || summary.ManualReviewControls > 0 || summary.CoverageBlindSpots > 0:
+		return "needs_review"
+	case score >= 90:
+		return "ready"
+	default:
+		return "needs_review"
+	}
+}
+
+func grcProgramFrameworkStatus(framework grcProgramFramework) string {
+	switch {
+	case framework.FailingControls > 0:
+		return "blocked"
+	case framework.MissingEvidenceControls > 0 || framework.StaleEvidenceControls > 0 || framework.ManualReviewControls > 0:
+		return "needs_review"
+	case framework.Score >= 90:
+		return "ready"
+	default:
+		return "needs_review"
+	}
+}
+
+func grcProgramConnectorNeedsAttention(connector grcConnector) bool {
+	status := strings.ToLower(strings.TrimSpace(connector.Status))
+	freshness := strings.ToLower(strings.TrimSpace(connector.Freshness))
+	watermark := strings.ToLower(strings.TrimSpace(connector.WatermarkFreshness))
+	return status == "stale" || status == "failed" || freshness == "stale" || watermark == "stale"
+}
+
+func grcProgramControlHref(profileID, tenantID, frameworkName, controlID string) string {
+	values := url.Values{}
+	if strings.TrimSpace(profileID) != "" {
+		values.Set("profile", strings.TrimSpace(profileID))
+	}
+	if strings.TrimSpace(tenantID) != "" {
+		values.Set("tenant_id", strings.TrimSpace(tenantID))
+	}
+	if strings.TrimSpace(frameworkName) != "" {
+		values.Set("framework", strings.TrimSpace(frameworkName))
+	}
+	if strings.TrimSpace(controlID) != "" {
+		values.Set("control", strings.TrimSpace(controlID))
+	}
+	return grcProgramUIPath("/controls", values)
+}
+
+func grcProgramAPIPath(path string, query url.Values) string {
+	if encoded := query.Encode(); encoded != "" {
+		return path + "?" + encoded
+	}
+	return path
+}
+
+func grcProgramUIPath(path string, query url.Values) string {
+	if encoded := query.Encode(); encoded != "" {
+		return path + "?" + encoded
+	}
+	return path
+}
+
+func portsSourceRuntimeFilter(scope grcScope) ports.SourceRuntimeFilter {
+	return ports.SourceRuntimeFilter{
+		RuntimeID:  scope.RuntimeID,
+		RuntimeIDs: scope.RuntimeIDs,
+		TenantID:   scope.TenantID,
+		SourceID:   scope.SourceID,
+		Limit:      scope.Limit,
+	}
+}

--- a/internal/bootstrap/grc_program_readiness_test.go
+++ b/internal/bootstrap/grc_program_readiness_test.go
@@ -1,0 +1,93 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestGRCProgramReadinessEndpointReturnsProofBundleWorkQueue(t *testing.T) {
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {
+				Id:           "writer-okta-audit",
+				SourceId:     "okta",
+				TenantId:     "writer",
+				LastSyncedAt: timestamppb.New(now.Add(-20 * time.Minute)),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now.Add(-20 * time.Minute))},
+			},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-cc6": {
+				ID:             "finding-cc6",
+				TenantID:       "writer",
+				RuntimeID:      "writer-okta-audit",
+				RuleID:         "identity-api-token-or-oauth-app-created",
+				Title:          "Identity API token created",
+				Severity:       "HIGH",
+				Status:         "open",
+				ControlRefs:    []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+				LastObservedAt: now,
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-cc6": {
+				Id:            "evidence-cc6",
+				RuntimeId:     "writer-okta-audit",
+				RuleId:        "identity-api-token-or-oauth-app-created",
+				FindingId:     "finding-cc6",
+				GraphRootUrns: []string{"urn:cerebro:writer:okta_user:00u1"},
+				CreatedAt:     timestamppb.New(now),
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/program-readiness?tenant_id=writer&profile=soc2-security-core&framework=SOC%202")
+	if err != nil {
+		t.Fatalf("GET /grc/program-readiness error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/program-readiness status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload grcProgramReadinessResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode program readiness: %v", err)
+	}
+	if payload.Profile.ID != "soc2-security-core" {
+		t.Fatalf("profile id = %q, want soc2-security-core", payload.Profile.ID)
+	}
+	if payload.Summary.Controls == 0 || payload.Summary.OpenFindings == 0 || payload.Summary.EvidenceItems != 1 {
+		t.Fatalf("summary = %+v, want controls with mapped findings and one evidence item", payload.Summary)
+	}
+	if payload.Summary.Score == 0 || strings.TrimSpace(payload.Summary.Status) == "" {
+		t.Fatalf("readiness = %q/%d, want populated status and score", payload.Summary.Status, payload.Summary.Score)
+	}
+	if len(payload.WorkItems) == 0 {
+		t.Fatalf("work items = 0, want prioritized audit work")
+	}
+	if payload.ProofBundle.ID != "proofbundle:soc2-security-core" {
+		t.Fatalf("proof bundle id = %q, want deterministic profile bundle", payload.ProofBundle.ID)
+	}
+	if !strings.HasPrefix(payload.ProofBundle.ExportPath, "/grc/control-packets/export?") {
+		t.Fatalf("export path = %q, want control packet export path", payload.ProofBundle.ExportPath)
+	}
+	if len(payload.Connectors) != 1 || payload.Connectors[0].RuntimeID != "writer-okta-audit" {
+		t.Fatalf("connectors = %+v, want scoped runtime", payload.Connectors)
+	}
+	if len(payload.Frameworks) == 0 || payload.Frameworks[0].FrameworkName == "" {
+		t.Fatalf("frameworks = %+v, want readiness rollup", payload.Frameworks)
+	}
+}

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -112,6 +112,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "PATCH /grc/dashboards/{dashboardID}", routeSurfacePlatformHTTP, dashboards.Update)
 	registerHTTPRoute(mux, "DELETE /grc/dashboards/{dashboardID}", routeSurfacePlatformHTTP, dashboards.Delete)
 	registerHTTPRoute(mux, "POST /grc/dashboards/{dashboardID}/clone", routeSurfacePlatformHTTP, dashboards.Clone)
+	registerHTTPRoute(mux, "GET /grc/program-readiness", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("program.readiness", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime, grcCacheScopeGraph), app.handleGRCProgramReadiness))
 	registerHTTPRoute(mux, "GET /grc/dashboard", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("dashboard", 30*time.Second, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime, grcCacheScopeGraph), app.handleGRCDashboard))
 	registerHTTPRoute(mux, "GET /grc/trends", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("trends", time.Minute, grcCacheScopeFindings, grcCacheScopeRuntime), app.handleGRCTrends))
 	registerHTTPRoute(mux, "POST /grc/ask", routeSurfacePlatformHTTP, app.handleGRCAsk)

--- a/internal/grcprogram/readiness.go
+++ b/internal/grcprogram/readiness.go
@@ -178,7 +178,7 @@ func buildSummary(result grccontrol.PacketResult, connectors []Connector, covera
 	}
 	for _, control := range result.Controls {
 		switch controlClass(control) {
-		case "passing":
+		case "passing", "not_applicable":
 			summary.PassingControls++
 		case "failing":
 			summary.FailingControls++
@@ -266,7 +266,7 @@ func buildFrameworks(controls []Control) []Framework {
 		accumulator.OpenFindings += control.OpenFindings
 		accumulator.EvidenceItems += control.EvidenceItems
 		switch controlClassFromStatus(control.Status, control.MissingEvidence, control.StaleEvidence) {
-		case "passing":
+		case "passing", "not_applicable":
 			accumulator.PassingControls++
 		case "failing":
 			accumulator.FailingControls++
@@ -371,6 +371,10 @@ func controlClassFromStatus(status string, missingEvidence, staleEvidence int) s
 		return "stale_evidence"
 	case normalized == "manual_review" || normalized == "manual":
 		return "manual_review"
+	case normalized == "exception":
+		return "exception"
+	case normalized == "not_applicable":
+		return "not_applicable"
 	case normalized == "passing" || normalized == "satisfied" || normalized == "ready" || normalized == "ok":
 		return "passing"
 	default:
@@ -388,6 +392,8 @@ func controlAction(control grccontrol.ControlItem) string {
 		return "Refresh stale evidence"
 	case "manual_review":
 		return "Complete manual assessment"
+	case "exception":
+		return "Review accepted exception"
 	default:
 		return "Keep audit-ready"
 	}
@@ -398,12 +404,14 @@ func controlScore(control grccontrol.ControlItem) int {
 		return control.EvidenceScore
 	}
 	switch controlClass(control) {
-	case "passing":
+	case "passing", "not_applicable":
 		return 100
 	case "stale_evidence":
 		return 70
 	case "manual_review":
 		return 65
+	case "exception":
+		return 50
 	case "missing_evidence":
 		return 45
 	case "failing":
@@ -419,7 +427,9 @@ func controlRank(control Control) [5]int {
 		"missing_evidence": 1,
 		"stale_evidence":   2,
 		"manual_review":    3,
+		"exception":        4,
 		"passing":          9,
+		"not_applicable":   10,
 	}
 	class := controlClassFromStatus(control.Status, control.MissingEvidence, control.StaleEvidence)
 	return [5]int{

--- a/internal/grcprogram/readiness.go
+++ b/internal/grcprogram/readiness.go
@@ -147,13 +147,14 @@ func Build(input BuildInput) Readiness {
 		generatedAt = time.Now().UTC()
 	}
 	controls := buildControls(input.Result.Controls, input.Result.Profile.ID, input.TenantID)
+	summary := buildSummary(input.Result, input.Connectors, input.CoverageBlindSpots)
 	return Readiness{
 		Profile:     input.Result.Profile,
-		Summary:     buildSummary(input.Result, input.Connectors, input.CoverageBlindSpots),
+		Summary:     summary,
 		Frameworks:  buildFrameworks(controls),
 		Controls:    controls,
 		WorkItems:   buildWorkItems(controls),
-		ProofBundle: buildProofBundle(input.Result, input.Query, generatedAt),
+		ProofBundle: buildProofBundle(input.Result, summary, input.Query, generatedAt),
 		Connectors:  input.Connectors,
 		Metadata:    input.Result.Metadata,
 		GeneratedAt: generatedAt,
@@ -327,7 +328,7 @@ func buildWorkItems(controls []Control) []WorkItem {
 	return items
 }
 
-func buildProofBundle(result grccontrol.PacketResult, query url.Values, generatedAt time.Time) ProofBundle {
+func buildProofBundle(result grccontrol.PacketResult, summary Summary, query url.Values, generatedAt time.Time) ProofBundle {
 	profileID := strings.TrimSpace(result.Profile.ID)
 	if profileID == "" {
 		profileID = grccontrol.DefaultEvidenceProfileID
@@ -345,8 +346,8 @@ func buildProofBundle(result grccontrol.PacketResult, query url.Values, generate
 		ID:                "proofbundle:" + profileID,
 		Title:             strings.TrimSpace(firstNonEmpty(result.Profile.Name, "Audit proof bundle")),
 		Description:       "Control packet, readiness metadata, source scope, and export paths for auditor review.",
-		Status:            result.Metadata.Readiness.Status,
-		Score:             result.Metadata.Readiness.Score,
+		Status:            firstNonEmpty(result.Metadata.Readiness.Status, summary.Status),
+		Score:             summary.Score,
 		ControlPacketPath: pathWithQuery("/grc/control-packets", query),
 		ExportPath:        pathWithQuery("/grc/control-packets/export", query),
 		ReportsPath:       pathWithQuery("/reports", reportQuery),
@@ -434,7 +435,7 @@ func readinessStatus(score int, summary Summary) string {
 	switch {
 	case summary.FailingControls > 0 || summary.StaleConnectors > 0:
 		return "blocked"
-	case summary.MissingEvidenceControls > 0 || summary.ManualReviewControls > 0 || summary.CoverageBlindSpots > 0:
+	case summary.MissingEvidenceControls > 0 || summary.StaleEvidenceControls > 0 || summary.ManualReviewControls > 0 || summary.CoverageBlindSpots > 0:
 		return "needs_review"
 	case score >= 90:
 		return "ready"
@@ -477,7 +478,7 @@ func controlHref(profileID, tenantID, frameworkName, controlID string) string {
 	if strings.TrimSpace(controlID) != "" {
 		values.Set("control", strings.TrimSpace(controlID))
 	}
-	return pathWithQuery("/controls", values)
+	return pathWithQuery("/grc/controls", values)
 }
 
 func pathWithQuery(path string, query url.Values) string {

--- a/internal/grcprogram/readiness.go
+++ b/internal/grcprogram/readiness.go
@@ -32,6 +32,7 @@ type Summary struct {
 	MissingEvidenceControls int                                 `json:"missing_evidence_controls"`
 	StaleEvidenceControls   int                                 `json:"stale_evidence_controls"`
 	ManualReviewControls    int                                 `json:"manual_review_controls"`
+	ExceptionControls       int                                 `json:"exception_controls"`
 	EvidenceItems           int                                 `json:"evidence_items"`
 	MissingEvidenceItems    int                                 `json:"missing_evidence_items"`
 	StaleEvidenceItems      int                                 `json:"stale_evidence_items"`
@@ -57,6 +58,7 @@ type Framework struct {
 	MissingEvidenceControls int    `json:"missing_evidence_controls"`
 	StaleEvidenceControls   int    `json:"stale_evidence_controls"`
 	ManualReviewControls    int    `json:"manual_review_controls"`
+	ExceptionControls       int    `json:"exception_controls"`
 	OpenFindings            int    `json:"open_findings"`
 	EvidenceItems           int    `json:"evidence_items"`
 }
@@ -188,6 +190,8 @@ func buildSummary(result grccontrol.PacketResult, connectors []Connector, covera
 			summary.StaleEvidenceControls++
 		case "manual_review":
 			summary.ManualReviewControls++
+		case "exception":
+			summary.ExceptionControls++
 		}
 		summary.OpenFindings += control.OpenFindings
 		summary.CriticalFindings += control.CriticalFindings
@@ -276,6 +280,8 @@ func buildFrameworks(controls []Control) []Framework {
 			accumulator.StaleEvidenceControls++
 		case "manual_review":
 			accumulator.ManualReviewControls++
+		case "exception":
+			accumulator.ExceptionControls++
 		}
 	}
 	items := make([]Framework, 0, len(frameworks))
@@ -445,7 +451,7 @@ func readinessStatus(score int, summary Summary) string {
 	switch {
 	case summary.FailingControls > 0 || summary.StaleConnectors > 0:
 		return "blocked"
-	case summary.MissingEvidenceControls > 0 || summary.StaleEvidenceControls > 0 || summary.ManualReviewControls > 0 || summary.CoverageBlindSpots > 0:
+	case summary.MissingEvidenceControls > 0 || summary.StaleEvidenceControls > 0 || summary.ManualReviewControls > 0 || summary.ExceptionControls > 0 || summary.CoverageBlindSpots > 0:
 		return "needs_review"
 	case score >= 90:
 		return "ready"
@@ -458,7 +464,7 @@ func frameworkStatus(framework Framework) string {
 	switch {
 	case framework.FailingControls > 0:
 		return "blocked"
-	case framework.MissingEvidenceControls > 0 || framework.StaleEvidenceControls > 0 || framework.ManualReviewControls > 0:
+	case framework.MissingEvidenceControls > 0 || framework.StaleEvidenceControls > 0 || framework.ManualReviewControls > 0 || framework.ExceptionControls > 0:
 		return "needs_review"
 	case framework.Score >= 90:
 		return "ready"

--- a/internal/grcprogram/readiness_test.go
+++ b/internal/grcprogram/readiness_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/grccontrol"
 )
 
@@ -48,5 +49,43 @@ func TestBuildTreatsStaleEvidenceAsNeedsReview(t *testing.T) {
 	}
 	if len(readiness.WorkItems) != 1 || readiness.WorkItems[0].Action != "Refresh stale evidence" {
 		t.Fatalf("work items = %+v, want stale evidence work item", readiness.WorkItems)
+	}
+}
+
+func TestBuildDistinguishesExceptionsAndNotApplicableControls(t *testing.T) {
+	result := grccontrol.PacketResult{
+		Profile: grccontrol.Profile{ID: "soc2-security-core", Name: "SOC 2 Security"},
+		Controls: []grccontrol.ControlItem{
+			{
+				FrameworkName: "SOC 2",
+				ControlID:     "CC6.1",
+				Title:         "Logical access",
+				Status:        string(compliance.ControlPostureNotApplicable),
+			},
+			{
+				FrameworkName: "ISO 27001",
+				ControlID:     "A.5.1",
+				Title:         "Exception-managed control",
+				Status:        string(compliance.ControlPostureException),
+			},
+		},
+	}
+	readiness := Build(BuildInput{Result: result, GeneratedAt: time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)})
+
+	if readiness.Summary.ManualReviewControls != 0 {
+		t.Fatalf("manual review controls = %d, want 0", readiness.Summary.ManualReviewControls)
+	}
+	if readiness.Summary.PassingControls != 1 {
+		t.Fatalf("passing controls = %d, want not-applicable control counted as passing", readiness.Summary.PassingControls)
+	}
+	if len(readiness.WorkItems) != 1 || readiness.WorkItems[0].ControlID != "A.5.1" || readiness.WorkItems[0].Action == "Complete manual assessment" {
+		t.Fatalf("work items = %+v, want only exception follow-up and no manual assessment", readiness.WorkItems)
+	}
+	frameworkStatus := map[string]string{}
+	for _, framework := range readiness.Frameworks {
+		frameworkStatus[framework.FrameworkName] = framework.Status
+	}
+	if frameworkStatus["SOC 2"] != "ready" || frameworkStatus["ISO 27001"] != "needs_review" {
+		t.Fatalf("framework statuses = %+v, want not-applicable ready and exception needs_review", frameworkStatus)
 	}
 }

--- a/internal/grcprogram/readiness_test.go
+++ b/internal/grcprogram/readiness_test.go
@@ -78,6 +78,9 @@ func TestBuildDistinguishesExceptionsAndNotApplicableControls(t *testing.T) {
 	if readiness.Summary.PassingControls != 1 {
 		t.Fatalf("passing controls = %d, want not-applicable control counted as passing", readiness.Summary.PassingControls)
 	}
+	if readiness.Summary.ExceptionControls != 1 {
+		t.Fatalf("exception controls = %d, want 1", readiness.Summary.ExceptionControls)
+	}
 	if len(readiness.WorkItems) != 1 || readiness.WorkItems[0].ControlID != "A.5.1" || readiness.WorkItems[0].Action == "Complete manual assessment" {
 		t.Fatalf("work items = %+v, want only exception follow-up and no manual assessment", readiness.WorkItems)
 	}

--- a/internal/grcprogram/readiness_test.go
+++ b/internal/grcprogram/readiness_test.go
@@ -1,0 +1,52 @@
+package grcprogram
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/grccontrol"
+)
+
+func TestBuildTreatsStaleEvidenceAsNeedsReview(t *testing.T) {
+	result := grccontrol.PacketResult{
+		Profile: grccontrol.Profile{ID: "soc2-security-core", Name: "SOC 2 Security"},
+		Controls: []grccontrol.ControlItem{{
+			FrameworkName: "SOC 2",
+			ControlID:     "CC6.1",
+			Title:         "Logical access",
+			Status:        "passing",
+			EvidenceScore: 95,
+			StaleEvidence: 1,
+		}},
+		Metadata: grccontrol.ReportMetadata{
+			Readiness:  grccontrol.ReportReadiness{},
+			Provenance: grccontrol.ReportProvenance{EvidenceCount: 1},
+		},
+	}
+	readiness := Build(BuildInput{
+		Result:      result,
+		Query:       url.Values{"profile": []string{"soc2-security-core"}},
+		GeneratedAt: time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC),
+	})
+
+	if readiness.Summary.Status != "needs_review" {
+		t.Fatalf("summary status = %q, want needs_review", readiness.Summary.Status)
+	}
+	if readiness.Summary.Score != 95 || readiness.ProofBundle.Score != readiness.Summary.Score {
+		t.Fatalf("scores = summary %d proof %d, want matching fallback score 95", readiness.Summary.Score, readiness.ProofBundle.Score)
+	}
+	if readiness.ProofBundle.Status != readiness.Summary.Status {
+		t.Fatalf("proof status = %q, want summary status %q", readiness.ProofBundle.Status, readiness.Summary.Status)
+	}
+	if len(readiness.Frameworks) != 1 || readiness.Frameworks[0].Status != "needs_review" {
+		t.Fatalf("frameworks = %+v, want needs_review rollup", readiness.Frameworks)
+	}
+	if len(readiness.Controls) != 1 || !strings.HasPrefix(readiness.Controls[0].Href, "/grc/controls?") {
+		t.Fatalf("control href = %+v, want /grc/controls API path", readiness.Controls)
+	}
+	if len(readiness.WorkItems) != 1 || readiness.WorkItems[0].Action != "Refresh stale evidence" {
+		t.Fatalf("work items = %+v, want stale evidence work item", readiness.WorkItems)
+	}
+}

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -520,6 +520,7 @@ var exactRouteLabels = map[string]struct{}{
 	"/oauth/revoke":                                                       {},
 	"/oauth/register":                                                     {},
 	"/reports":                                                            {},
+	"/grc/program-readiness":                                              {},
 	"/grc/dashboard":                                                      {},
 	"/grc/ask":                                                            {},
 	"/grc/findings":                                                       {},


### PR DESCRIPTION
Summary: Adds /grc/program-readiness as a read-model over existing GRC control packets, connector health, coverage, and proof bundle metadata. Also adds OpenAPI, auth audit labeling, route metrics, and endpoint coverage tests. Validation: go test -C /Users/jonathan/cerebro ./internal/bootstrap ./internal/grccontrol ./internal/compliance ./internal/observability -timeout=60s; go run -C /Users/jonathan/cerebro ./scripts/openapi_route_parity.go.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->