### PR TITLE
feat: add fabric contract guardrails

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install Semgrep
         run: |
-          python3 -m pip install --user semgrep
+          python3 -m pip install --user semgrep==1.167.0
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run Semgrep

--- a/internal/fabriccontract/entities.go
+++ b/internal/fabriccontract/entities.go
@@ -1,0 +1,9 @@
+package fabriccontract
+
+const (
+	EntityTypeFinding              = "finding"
+	EntityTypeGithubCodeRepository = "github.code.repository"
+	EntityTypeIdentityEmail        = "identity.email"
+	EntityTypeIdentityLogin        = "identity.login"
+	EntityTypeSource               = "source"
+)

--- a/internal/fabriccontract/relations.go
+++ b/internal/fabriccontract/relations.go
@@ -1,0 +1,94 @@
+package fabriccontract
+
+import (
+	"sort"
+	"strings"
+)
+
+const (
+	RelationActedOn            = "acted_on"
+	RelationAffectedBy         = "affected_by"
+	RelationAffects            = "affects"
+	RelationAssignedTo         = "assigned_to"
+	RelationAssociatedWith     = "associated_with"
+	RelationAttachedTo         = "attached_to"
+	RelationAuthored           = "authored"
+	RelationBelongsTo          = "belongs_to"
+	RelationCanAdmin           = "can_admin"
+	RelationCanAssume          = "can_assume"
+	RelationCanImpersonate     = "can_impersonate"
+	RelationCanPerform         = "can_perform"
+	RelationCanReach           = "can_reach"
+	RelationCNAMETo            = "cname_to"
+	RelationConfersCapability  = "confers_capability"
+	RelationContains           = "contains"
+	RelationDependsOn          = "depends_on"
+	RelationGrantsEntitlement  = "grants_entitlement"
+	RelationHasClassification  = "has_classification"
+	RelationHasDNSRecord       = "has_dns_record"
+	RelationHasEvidence        = "has_evidence"
+	RelationHasFinding         = "has_finding"
+	RelationHasIdentifier      = "has_identifier"
+	RelationMemberOf           = "member_of"
+	RelationObservedOn         = "observed_on"
+	RelationOwnedBy            = "owned_by"
+	RelationRepresents         = "represents"
+	RelationRepresentsIdentity = "represents_identity"
+	RelationResolvesTo         = "resolves_to"
+	RelationRunsAs             = "runs_as"
+	RelationSameActor          = "same_actor"
+	RelationSupports           = "supports"
+	RelationTaggedAs           = "tagged_as"
+	RelationTargeted           = "targeted"
+)
+
+var relationSet = map[string]struct{}{
+	RelationActedOn:            {},
+	RelationAffectedBy:         {},
+	RelationAffects:            {},
+	RelationAssignedTo:         {},
+	RelationAssociatedWith:     {},
+	RelationAttachedTo:         {},
+	RelationAuthored:           {},
+	RelationBelongsTo:          {},
+	RelationCanAdmin:           {},
+	RelationCanAssume:          {},
+	RelationCanImpersonate:     {},
+	RelationCanPerform:         {},
+	RelationCanReach:           {},
+	RelationCNAMETo:            {},
+	RelationConfersCapability:  {},
+	RelationContains:           {},
+	RelationDependsOn:          {},
+	RelationGrantsEntitlement:  {},
+	RelationHasClassification:  {},
+	RelationHasDNSRecord:       {},
+	RelationHasEvidence:        {},
+	RelationHasFinding:         {},
+	RelationHasIdentifier:      {},
+	RelationMemberOf:           {},
+	RelationObservedOn:         {},
+	RelationOwnedBy:            {},
+	RelationRepresents:         {},
+	RelationRepresentsIdentity: {},
+	RelationResolvesTo:         {},
+	RelationRunsAs:             {},
+	RelationSameActor:          {},
+	RelationSupports:           {},
+	RelationTaggedAs:           {},
+	RelationTargeted:           {},
+}
+
+func IsRelation(value string) bool {
+	_, ok := relationSet[strings.TrimSpace(value)]
+	return ok
+}
+
+func Relations() []string {
+	relations := make([]string, 0, len(relationSet))
+	for relation := range relationSet {
+		relations = append(relations, relation)
+	}
+	sort.Strings(relations)
+	return relations
+}

--- a/internal/fabriccontract/relations_test.go
+++ b/internal/fabriccontract/relations_test.go
@@ -1,0 +1,23 @@
+package fabriccontract
+
+import "testing"
+
+func TestRelationsAreSortedAndKnown(t *testing.T) {
+	relations := Relations()
+	if len(relations) == 0 {
+		t.Fatal("Relations() empty")
+	}
+	for i := 1; i < len(relations); i++ {
+		if relations[i-1] > relations[i] {
+			t.Fatalf("Relations() not sorted: %q before %q", relations[i-1], relations[i])
+		}
+	}
+	for _, relation := range []string{RelationBelongsTo, RelationDependsOn, RelationHasFinding, RelationRepresentsIdentity} {
+		if !IsRelation(relation) {
+			t.Fatalf("IsRelation(%q) = false", relation)
+		}
+	}
+	if IsRelation("BELONGS_TO") || IsRelation("not_a_relation") {
+		t.Fatal("IsRelation accepted non-canonical relation")
+	}
+}

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -3,6 +3,8 @@ package graphagent
 import (
 	"fmt"
 	"strings"
+
+	"github.com/writer/cerebro/internal/fabriccontract"
 )
 
 type OntologyEntity struct {
@@ -33,35 +35,35 @@ var canonicalGraphOntology = GraphOntology{
 	Properties: []string{"tenant_id", "urn", "source_id", "runtime_id", "entity_type", "label", "attributes_json"},
 	Entities: []OntologyEntity{
 		{
-			Type:        "finding",
+			Type:        fabriccontract.EntityTypeFinding,
 			Description: "Workflow finding anchors. Active findings are linked from affected resources via relation 'has_finding'.",
 			Aliases:     []string{"Finding", "FINDING", "finding", "alert", "issue"},
 			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
 			Examples:    []string{"urn:cerebro:writer:finding:finding-1"},
 		},
 		{
-			Type:        "github.code.repository",
+			Type:        fabriccontract.EntityTypeGithubCodeRepository,
 			Description: "GitHub code repository resources emitted by code-repository events; repository metadata is stored in attributes_json.",
 			Aliases:     []string{"repo", "repository", "github repo", "code repository"},
 			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
 			Examples:    []string{"urn:cerebro:writer:github_code_repository:1"},
 		},
 		{
-			Type:        "identity.email",
+			Type:        fabriccontract.EntityTypeIdentityEmail,
 			Description: "Canonical email identity anchors linked from concrete principals through represents_identity.",
 			Aliases:     []string{"email identity", "canonical email", "identity email", "principal email"},
 			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
 			Examples:    []string{"urn:cerebro:writer:identity:email:alice@writer.com"},
 		},
 		{
-			Type:        "identity.login",
+			Type:        fabriccontract.EntityTypeIdentityLogin,
 			Description: "Canonical login identity anchors linked from concrete principals through represents_identity.",
 			Aliases:     []string{"login identity", "canonical login", "identity login", "username identity"},
 			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
 			Examples:    []string{"urn:cerebro:writer:identity:login:alice"},
 		},
 		{
-			Type:        "source",
+			Type:        fabriccontract.EntityTypeSource,
 			Description: "Projected source/integration nodes used for connector health. Freshness and health metadata are stored in attributes_json.",
 			Aliases:     []string{"source", "source runtime", "runtime", "connector"},
 			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
@@ -70,28 +72,28 @@ var canonicalGraphOntology = GraphOntology{
 	},
 	Relations: []OntologyRelation{
 		{
-			Relation:    "has_finding",
+			Relation:    fabriccontract.RelationHasFinding,
 			Description: "Active edge from an affected resource Entity to a finding Entity.",
 			Aliases:     []string{"HAS_FINDING", "finding", "has finding"},
 			FromTypes:   []string{"*"},
 			ToTypes:     []string{"finding"},
 		},
 		{
-			Relation:    "belongs_to",
+			Relation:    fabriccontract.RelationBelongsTo,
 			Description: "Ownership/scope edge, such as repository to org, finding to scan, or runtime child to parent.",
 			Aliases:     []string{"BELONGS_TO", "BELONGS_TO_SOURCE", "belongs to source", "source"},
 			FromTypes:   []string{"*"},
 			ToTypes:     []string{"*"},
 		},
 		{
-			Relation:    "has_identifier",
+			Relation:    fabriccontract.RelationHasIdentifier,
 			Description: "Edge from a concrete identity/resource node to a normalized identifier node.",
 			Aliases:     []string{"HAS_IDENTIFIER", "identity_email", "email", "identifier"},
 			FromTypes:   []string{"*"},
 			ToTypes:     []string{"identifier"},
 		},
 		{
-			Relation:    "represents_identity",
+			Relation:    fabriccontract.RelationRepresentsIdentity,
 			Description: "Edge between concrete principals, identifier anchors, and canonical identity.email/identity.login nodes.",
 			Aliases:     []string{"REPRESENTS_IDENTITY", "represents"},
 			FromTypes:   []string{"*"},

--- a/internal/graphprovenance/provenance.go
+++ b/internal/graphprovenance/provenance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/projectionmeta"
+	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
 
 type Request struct {
@@ -76,11 +77,7 @@ LIMIT 1`,
 }
 
 func TenantIDFromURN(urn string) string {
-	parts := strings.SplitN(strings.TrimSpace(urn), ":", 5)
-	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
-		return ""
-	}
-	return strings.TrimSpace(parts[2])
+	return cerebrourn.TenantID(urn)
 }
 
 func fromRow(row ports.CypherRow) (Response, error) {

--- a/internal/graphprovenance/provenance.go
+++ b/internal/graphprovenance/provenance.go
@@ -77,7 +77,11 @@ LIMIT 1`,
 }
 
 func TenantIDFromURN(urn string) string {
-	return cerebrourn.TenantID(urn)
+	parsed, err := cerebrourn.Parse(urn)
+	if err != nil || len(parsed.Parts) == 0 {
+		return ""
+	}
+	return parsed.TenantID
 }
 
 func fromRow(row ports.CypherRow) (Response, error) {

--- a/internal/graphprovenance/provenance_test.go
+++ b/internal/graphprovenance/provenance_test.go
@@ -2,8 +2,10 @@ package graphprovenance
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -42,14 +44,29 @@ func TestTenantIDFromURNRejectsMalformedURN(t *testing.T) {
 	if got := TenantIDFromURN("not-a-urn"); got != "" {
 		t.Fatalf("TenantIDFromURN malformed = %q, want empty", got)
 	}
+	if got := TenantIDFromURN("urn:cerebro:tenant-a:asset"); got != "" {
+		t.Fatalf("TenantIDFromURN kind-only = %q, want empty", got)
+	}
 	if got := TenantIDFromURN("urn:cerebro:tenant-a:asset:one"); got != "tenant-a" {
 		t.Fatalf("TenantIDFromURN = %q, want tenant-a", got)
+	}
+}
+
+func TestServiceGetRejectsKindOnlyURN(t *testing.T) {
+	store := &recordingStore{}
+	_, err := New(store).Get(context.Background(), Request{URN: "urn:cerebro:tenant-a:asset"})
+	if !errors.Is(err, graphquery.ErrInvalidRequest) {
+		t.Fatalf("Get() error = %v, want ErrInvalidRequest", err)
+	}
+	if store.called {
+		t.Fatal("Get() queried store for kind-only URN")
 	}
 }
 
 type recordingStore struct {
 	rows    []ports.CypherRow
 	request ports.CypherQueryRequest
+	called  bool
 }
 
 func (s *recordingStore) Ping(context.Context) error { return nil }
@@ -59,6 +76,7 @@ func (s *recordingStore) GetEntityNeighborhood(context.Context, string, int) (*p
 }
 
 func (s *recordingStore) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	s.called = true
 	s.request = request
 	return s.rows, nil
 }

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -6,9 +6,8 @@ import (
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
-
-const cerebroURNPrefix = "urn:cerebro:"
 
 // ProjectedEntity is the normalized current-state and graph entity shape.
 type ProjectedEntity struct {
@@ -72,17 +71,15 @@ func ValidateProjectedLinkTenantScope(link *ProjectedLink) error {
 func validateProjectedCerebroURNScope(field string, rawURN string, rawTenantID string) error {
 	urn := strings.TrimSpace(rawURN)
 	tenantID := strings.TrimSpace(rawTenantID)
-	if urn == "" || tenantID == "" || !strings.HasPrefix(urn, cerebroURNPrefix) {
+	if urn == "" || tenantID == "" || !strings.HasPrefix(urn, cerebrourn.Prefix) {
 		return nil
 	}
-	remainder := strings.TrimPrefix(urn, cerebroURNPrefix)
-	urnTenantID, _, ok := strings.Cut(remainder, ":")
-	urnTenantID = strings.TrimSpace(urnTenantID)
-	if !ok || urnTenantID == "" {
-		return fmt.Errorf("%s %q is missing a Cerebro tenant scope", field, urn)
+	parsed, err := cerebrourn.Parse(urn)
+	if err != nil {
+		return fmt.Errorf("%s %q is invalid: %w", field, urn, err)
 	}
-	if urnTenantID != tenantID {
-		return fmt.Errorf("%s %q is scoped to tenant %q, not projection tenant %q", field, urn, urnTenantID, tenantID)
+	if parsed.TenantID != tenantID {
+		return fmt.Errorf("%s %q is scoped to tenant %q, not projection tenant %q", field, urn, parsed.TenantID, tenantID)
 	}
 	return nil
 }

--- a/internal/sourcecdk/identity.go
+++ b/internal/sourcecdk/identity.go
@@ -1,20 +1,15 @@
 package sourcecdk
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"strings"
+
+	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
 
 // StableExternalID returns a deterministic, delimiter-safe key for provider IDs.
 func StableExternalID(value string, emptyFallback string) string {
-	normalized := strings.TrimSpace(value)
-	if normalized == "" {
-		return emptyFallback
-	}
-	sum := sha256.Sum256([]byte(normalized))
-	return "id-" + hex.EncodeToString(sum[:16])
+	return cerebrourn.StableExternalID(value, emptyFallback)
 }
 
 // URNFor builds and validates a tenant-scoped source entity URN.
@@ -31,7 +26,11 @@ func URNFor(tenant, kind, providerID string) (URN, error) {
 	if providerID == "" {
 		return "", fmt.Errorf("provider id is required")
 	}
-	return ParseURN("urn:cerebro:" + tenant + ":" + kind + ":" + providerID)
+	raw, err := cerebrourn.Mint(tenant, kind, providerID)
+	if err != nil {
+		return "", err
+	}
+	return URN(raw), nil
 }
 
 // URNForEscaped builds a URN after hashing provider-controlled parts that may

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -10,6 +10,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
+	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
 
 var ErrInvalidConfig = errors.New("invalid source config")
@@ -19,29 +20,14 @@ type URN string
 
 // ParseURN validates the canonical Cerebro URN format.
 func ParseURN(raw string) (URN, error) {
-	value := strings.TrimSpace(raw)
-	if value == "" {
-		return "", fmt.Errorf("urn is required")
+	parsed, err := cerebrourn.Parse(raw)
+	if err != nil {
+		return "", err
 	}
-	if !strings.HasPrefix(value, "urn:cerebro:") {
-		return "", fmt.Errorf("invalid cerebro urn %q", value)
+	if len(parsed.Parts) == 0 {
+		return "", fmt.Errorf("invalid cerebro urn %q", strings.TrimSpace(raw))
 	}
-	parts := strings.Split(value, ":")
-	if len(parts) > 3 && parts[3] == "runtime" && (len(parts) < 7 || parts[5] == "") {
-		return "", fmt.Errorf("invalid cerebro urn %q", value)
-	}
-	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
-		return "", fmt.Errorf("invalid cerebro urn %q", value)
-	}
-	if parts[len(parts)-1] == "" {
-		return "", fmt.Errorf("invalid cerebro urn %q", value)
-	}
-	for i, part := range parts[2:] {
-		if strings.TrimSpace(part) != part || (i < 3 && part == "") {
-			return "", fmt.Errorf("invalid cerebro urn %q", value)
-		}
-	}
-	return URN(value), nil
+	return URN(parsed.String()), nil
 }
 
 // String returns the raw URN string.

--- a/internal/sourcecdk/source_test.go
+++ b/internal/sourcecdk/source_test.go
@@ -52,6 +52,7 @@ func TestParseURNRejectsInvalidValue(t *testing.T) {
 		"urn:cerebro:tenant:user",
 		"urn:cerebro::user:123",
 		"urn:cerebro:tenant::123",
+		"urn:cerebro:tenant:user::123",
 		"urn:cerebro:tenant:runtime:runtime-id::entity-id",
 		"urn:cerebro:tenant:user:",
 		"urn:cerebro: tenant:user:123",

--- a/internal/sourceprojection/catalogruntime_test.go
+++ b/internal/sourceprojection/catalogruntime_test.go
@@ -214,6 +214,68 @@ func TestRegistryRegistersConnectorDefinitionProjectors(t *testing.T) {
 	}
 }
 
+func TestRegistrySkipsUnnormalizedConnectorDefinitionWithUnsupportedRelationship(t *testing.T) {
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	registry.RegisterConnectorDefinitions(connectordefinitions.Definition{
+		TenantID: "tenant-a",
+		SourceID: "example_dynamic",
+		Auth:     connectordefinitions.AuthSpec{Model: "none"},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:        "assets",
+			Path:      "/v1/assets",
+			IDField:   "id",
+			NameField: "name",
+			Event:     connectordefinitions.EventMappingSpec{Kind: "example_dynamic.asset"},
+			Projection: &connectordefinitions.ProjectionSpec{
+				Fields: map[string]string{
+					"owner_id":   "owner.id",
+					"owner_name": "owner.name",
+				},
+				Entity: &connectordefinitions.ProjectionEntitySpec{
+					EntityType:     "example.dynamic.asset",
+					URNKind:        "example_dynamic_asset",
+					IDAttributes:   []string{"id"},
+					LabelAttribute: "name",
+				},
+				Relationships: []connectordefinitions.ProjectionRelationshipSpec{{
+					Relation: "custom relation",
+					To: connectordefinitions.ProjectionEntitySpec{
+						EntityType:     "example.dynamic.owner",
+						URNKind:        "example_dynamic_owner",
+						IDAttributes:   []string{"owner_id"},
+						LabelAttribute: "owner_name",
+					},
+					MatchType: "owner",
+				}},
+			},
+		}},
+	})
+	if len(registry.connectorDefinitionFingerprints) != 0 {
+		t.Fatalf("registered blocked connector definition fingerprints = %#v", registry.connectorDefinitionFingerprints)
+	}
+	entities, links, err := registry.Project(&cerebrov1.EventEnvelope{
+		Id:       "event-1",
+		TenantId: "tenant-a",
+		SourceId: "example_dynamic",
+		Kind:     "example_dynamic.asset",
+		Attributes: map[string]string{
+			"id":         "asset-1",
+			"name":       "Asset One",
+			"owner_id":   "owner-1",
+			"owner_name": "Owner One",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if len(entities) != 0 || len(links) != 0 {
+		t.Fatalf("blocked connector definition projected entities=%#v links=%#v", entities, links)
+	}
+}
+
 func TestRegistryUpdatesConnectorDefinitionProjectors(t *testing.T) {
 	registry, err := NewRegistry()
 	if err != nil {

--- a/internal/sourceprojection/fabric_contract_test.go
+++ b/internal/sourceprojection/fabric_contract_test.go
@@ -1,0 +1,65 @@
+package sourceprojection
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestProjectRecordsRejectsUnknownFabricRelation(t *testing.T) {
+	registry, err := NewRegistry(EventProjector{
+		Kind: "test.event",
+		Project: func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+			return nil, []*ports.ProjectedLink{{
+				TenantID: "writer",
+				SourceID: "test",
+				FromURN:  "urn:cerebro:writer:test:from",
+				ToURN:    "urn:cerebro:writer:test:to",
+				Relation: "made_up_relation",
+			}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(nil, nil, registry)
+	_, _, err = service.ProjectRecords(&cerebrov1.EventEnvelope{Kind: "test.event", TenantId: "writer", SourceId: "test"})
+	if err == nil {
+		t.Fatalf("ProjectRecords() error = %v, want fabric contract rejection", err)
+	}
+}
+
+func TestProjectAllowsKnownFabricRelation(t *testing.T) {
+	store := &projectionRecorder{}
+	registry, err := NewRegistry(EventProjector{
+		Kind: "test.event",
+		Project: func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+			return []*ports.ProjectedEntity{{
+					URN:        "urn:cerebro:writer:test:from",
+					TenantID:   "writer",
+					SourceID:   "test",
+					EntityType: "test",
+					Label:      "from",
+				}}, []*ports.ProjectedLink{{
+					TenantID: "writer",
+					SourceID: "test",
+					FromURN:  "urn:cerebro:writer:test:from",
+					ToURN:    "urn:cerebro:writer:test:to",
+					Relation: relationBelongsTo,
+				}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(store, nil, registry)
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{Kind: "test.event", TenantId: "writer", SourceId: "test"})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.LinksProjected != 1 {
+		t.Fatalf("LinksProjected = %d, want 1", result.LinksProjected)
+	}
+}

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -14,47 +14,50 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/connectordefinitions"
+	"github.com/writer/cerebro/internal/fabriccontract"
 	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcehealth"
 	"github.com/writer/cerebro/internal/telemetry"
+	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
 
 var emailIdentifierPattern = regexp.MustCompile(`(?i)[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}`)
 
 const (
-	relationActedOn            = "acted_on"
-	relationAffectedBy         = "affected_by"
-	relationAffects            = "affects"
-	relationAuthored           = "authored"
-	relationBelongsTo          = "belongs_to"
-	relationCanPerform         = "can_perform"
-	relationHasIdentifier      = "has_identifier"
-	relationAssignedTo         = "assigned_to"
-	relationAssociatedWith     = "associated_with"
-	relationAttachedTo         = "attached_to"
-	relationCanAssume          = "can_assume"
-	relationCanAdmin           = "can_admin"
-	relationCanImpersonate     = "can_impersonate"
-	relationCanReach           = "can_reach"
-	relationContains           = "contains"
-	relationConfersCapability  = "confers_capability"
-	relationGrantsEntitlement  = "grants_entitlement"
-	relationHasClassification  = "has_classification"
-	relationHasDNSRecord       = "has_dns_record"
-	relationHasEvidence        = "has_evidence"
-	relationMemberOf           = "member_of"
-	relationObservedOn         = "observed_on"
-	relationOwnedBy            = "owned_by"
-	relationRepresents         = "represents"
-	relationRepresentsIdentity = "represents_identity"
-	relationResolvesTo         = "resolves_to"
-	relationRunsAs             = "runs_as"
-	relationSameActor          = "same_actor"
-	relationSupports           = "supports"
-	relationTaggedAs           = "tagged_as"
-	relationTargeted           = "targeted"
-	relationCNAMETo            = "cname_to"
+	relationActedOn            = fabriccontract.RelationActedOn
+	relationAffectedBy         = fabriccontract.RelationAffectedBy
+	relationAffects            = fabriccontract.RelationAffects
+	relationAuthored           = fabriccontract.RelationAuthored
+	relationBelongsTo          = fabriccontract.RelationBelongsTo
+	relationCanPerform         = fabriccontract.RelationCanPerform
+	relationHasIdentifier      = fabriccontract.RelationHasIdentifier
+	relationAssignedTo         = fabriccontract.RelationAssignedTo
+	relationAssociatedWith     = fabriccontract.RelationAssociatedWith
+	relationAttachedTo         = fabriccontract.RelationAttachedTo
+	relationCanAssume          = fabriccontract.RelationCanAssume
+	relationCanAdmin           = fabriccontract.RelationCanAdmin
+	relationCanImpersonate     = fabriccontract.RelationCanImpersonate
+	relationCanReach           = fabriccontract.RelationCanReach
+	relationContains           = fabriccontract.RelationContains
+	relationConfersCapability  = fabriccontract.RelationConfersCapability
+	relationDependsOn          = fabriccontract.RelationDependsOn
+	relationGrantsEntitlement  = fabriccontract.RelationGrantsEntitlement
+	relationHasClassification  = fabriccontract.RelationHasClassification
+	relationHasDNSRecord       = fabriccontract.RelationHasDNSRecord
+	relationHasEvidence        = fabriccontract.RelationHasEvidence
+	relationMemberOf           = fabriccontract.RelationMemberOf
+	relationObservedOn         = fabriccontract.RelationObservedOn
+	relationOwnedBy            = fabriccontract.RelationOwnedBy
+	relationRepresents         = fabriccontract.RelationRepresents
+	relationRepresentsIdentity = fabriccontract.RelationRepresentsIdentity
+	relationResolvesTo         = fabriccontract.RelationResolvesTo
+	relationRunsAs             = fabriccontract.RelationRunsAs
+	relationSameActor          = fabriccontract.RelationSameActor
+	relationSupports           = fabriccontract.RelationSupports
+	relationTaggedAs           = fabriccontract.RelationTaggedAs
+	relationTargeted           = fabriccontract.RelationTargeted
+	relationCNAMETo            = fabriccontract.RelationCNAMETo
 	defaultCleanupLimit        = 1000
 )
 
@@ -507,7 +510,26 @@ func (s *Service) ProjectRecords(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	}
 	normalizeProjectedEntityTypes(entities)
 	stampProjectionRuntime(event, entities, links)
+	if err := validateProjectedFabricContract(links); err != nil {
+		return nil, nil, err
+	}
 	return entities, links, nil
+}
+
+func validateProjectedFabricContract(links []*ports.ProjectedLink) error {
+	for _, link := range links {
+		if link == nil {
+			continue
+		}
+		relation := strings.TrimSpace(link.Relation)
+		if relation == "" {
+			return fmt.Errorf("projected link relation is required")
+		}
+		if !fabriccontract.IsRelation(relation) {
+			return fmt.Errorf("projected link relation %q is outside the fabric contract", relation)
+		}
+	}
+	return nil
 }
 
 // ProjectCleanupRecords returns stale projection entity URNs that should be
@@ -935,21 +957,11 @@ func projectedLink(tenantID string, sourceID string, fromURN string, toURN strin
 }
 
 func projectionURN(tenantID string, kind string, parts ...string) string {
-	tenant := strings.TrimSpace(tenantID)
-	entityKind := strings.TrimSpace(kind)
-	if tenant == "" || entityKind == "" {
+	value, err := cerebrourn.Mint(tenantID, kind, parts...)
+	if err != nil {
 		return ""
 	}
-	values := make([]string, 0, len(parts)+3)
-	values = append(values, "urn", "cerebro", tenant, entityKind)
-	for _, part := range parts {
-		value := strings.TrimSpace(part)
-		if value == "" {
-			continue
-		}
-		values = append(values, value)
-	}
-	return strings.Join(values, ":")
+	return value
 }
 
 func identifierURN(tenantID string, raw string) (string, string, string) {

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -75,6 +75,11 @@ func (r *Registry) RegisterConnectorDefinitions(definitions ...connectordefiniti
 	defer r.mu.Unlock()
 	r.ensureConnectorDefinitionState()
 	for _, definition := range definitions {
+		normalized, err := connectordefinitions.Normalize(definition)
+		if err != nil {
+			continue
+		}
+		definition = normalized
 		sourceID := strings.TrimSpace(definition.SourceID)
 		if sourceID == "" || definition.Validation.Status == connectordefinitions.ValidationBlocked {
 			continue

--- a/internal/sourceprojection/security_spine.go
+++ b/internal/sourceprojection/security_spine.go
@@ -10,8 +10,6 @@ import (
 	"github.com/writer/cerebro/internal/securitytooling"
 )
 
-const relationDependsOn = "depends_on"
-
 func backstageComponentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	tenantID, err := tenantID(event)
 	if err != nil {

--- a/internal/urn/urn.go
+++ b/internal/urn/urn.go
@@ -61,8 +61,7 @@ func Mint(tenantID string, kind string, parts ...string) (string, error) {
 	if entityKind == "" {
 		return "", fmt.Errorf("urn kind is required")
 	}
-	values := make([]string, 0, len(parts)+4)
-	values = append(values, "urn", "cerebro", tenant, entityKind)
+	values := []string{"urn", "cerebro", tenant, entityKind}
 	for _, part := range parts {
 		value := strings.TrimSpace(part)
 		if value == "" {

--- a/internal/urn/urn.go
+++ b/internal/urn/urn.go
@@ -39,7 +39,7 @@ func Parse(raw string) (URN, error) {
 		return URN{}, fmt.Errorf("invalid cerebro urn %q", value)
 	}
 	for i, part := range parts[2:] {
-		if strings.TrimSpace(part) != part || (i < 2 && part == "") {
+		if strings.TrimSpace(part) != part || (i < 3 && part == "") {
 			return URN{}, fmt.Errorf("invalid cerebro urn %q", value)
 		}
 	}

--- a/internal/urn/urn.go
+++ b/internal/urn/urn.go
@@ -1,0 +1,100 @@
+package urn
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const Prefix = "urn:cerebro:"
+
+type URN struct {
+	Raw      string
+	TenantID string
+	Kind     string
+	Parts    []string
+}
+
+func (u URN) String() string {
+	return u.Raw
+}
+
+func Parse(raw string) (URN, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return URN{}, fmt.Errorf("urn is required")
+	}
+	if !strings.HasPrefix(value, Prefix) {
+		return URN{}, fmt.Errorf("invalid cerebro urn %q", value)
+	}
+	parts := strings.Split(value, ":")
+	if len(parts) > 3 && parts[3] == "runtime" && (len(parts) < 7 || parts[5] == "") {
+		return URN{}, fmt.Errorf("invalid cerebro urn %q", value)
+	}
+	if len(parts) < 4 || parts[0] != "urn" || parts[1] != "cerebro" {
+		return URN{}, fmt.Errorf("invalid cerebro urn %q", value)
+	}
+	if parts[len(parts)-1] == "" {
+		return URN{}, fmt.Errorf("invalid cerebro urn %q", value)
+	}
+	for i, part := range parts[2:] {
+		if strings.TrimSpace(part) != part || (i < 2 && part == "") {
+			return URN{}, fmt.Errorf("invalid cerebro urn %q", value)
+		}
+	}
+	parsed := URN{
+		Raw:      value,
+		TenantID: parts[2],
+		Kind:     parts[3],
+		Parts:    append([]string(nil), parts[4:]...),
+	}
+	return parsed, nil
+}
+
+func Mint(tenantID string, kind string, parts ...string) (string, error) {
+	tenant := strings.TrimSpace(tenantID)
+	entityKind := strings.TrimSpace(kind)
+	if tenant == "" {
+		return "", fmt.Errorf("tenant is required")
+	}
+	if entityKind == "" {
+		return "", fmt.Errorf("urn kind is required")
+	}
+	values := make([]string, 0, len(parts)+4)
+	values = append(values, "urn", "cerebro", tenant, entityKind)
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		values = append(values, value)
+	}
+	raw := strings.Join(values, ":")
+	if _, err := Parse(raw); err != nil {
+		return "", err
+	}
+	return raw, nil
+}
+
+func TenantID(raw string) string {
+	parsed, err := Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return parsed.TenantID
+}
+
+func SameTenant(raw string, tenantID string) bool {
+	tenant := strings.TrimSpace(tenantID)
+	return tenant != "" && TenantID(raw) == tenant
+}
+
+func StableExternalID(value string, emptyFallback string) string {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return emptyFallback
+	}
+	sum := sha256.Sum256([]byte(normalized))
+	return "id-" + hex.EncodeToString(sum[:16])
+}

--- a/internal/urn/urn_test.go
+++ b/internal/urn/urn_test.go
@@ -1,0 +1,78 @@
+package urn
+
+import "testing"
+
+func TestMintAndParse(t *testing.T) {
+	raw, err := Mint("writer", "github_code_repository", "writer/cerebro")
+	if err != nil {
+		t.Fatalf("Mint() error = %v", err)
+	}
+	if raw != "urn:cerebro:writer:github_code_repository:writer/cerebro" {
+		t.Fatalf("Mint() = %q", raw)
+	}
+	parsed, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if parsed.TenantID != "writer" || parsed.Kind != "github_code_repository" || len(parsed.Parts) != 1 || parsed.Parts[0] != "writer/cerebro" {
+		t.Fatalf("Parse() = %#v", parsed)
+	}
+}
+
+func TestParseAllowsColonDelimitedIDs(t *testing.T) {
+	raw := "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/AdminRole"
+	parsed, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if parsed.Raw != raw || parsed.TenantID != "writer" || parsed.Kind != "aws_role" {
+		t.Fatalf("Parse() = %#v", parsed)
+	}
+}
+
+func TestMintAllowsKindOnlyProjectionURNs(t *testing.T) {
+	raw, err := Mint("writer", "data_classification")
+	if err != nil {
+		t.Fatalf("Mint() error = %v", err)
+	}
+	if raw != "urn:cerebro:writer:data_classification" {
+		t.Fatalf("Mint() = %q", raw)
+	}
+	parsed, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if parsed.TenantID != "writer" || parsed.Kind != "data_classification" || len(parsed.Parts) != 0 {
+		t.Fatalf("Parse() = %#v", parsed)
+	}
+}
+
+func TestParseRejectsInvalidValue(t *testing.T) {
+	for _, raw := range []string{
+		"",
+		"user:123",
+		"urn:other:tenant:user:123",
+		"urn:cerebro::user:123",
+		"urn:cerebro:tenant::123",
+		"urn:cerebro:tenant:runtime:runtime-id::entity-id",
+		"urn:cerebro:tenant:user:",
+		"urn:cerebro: tenant:user:123",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := Parse(raw); err == nil {
+				t.Fatal("Parse() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestStableExternalID(t *testing.T) {
+	first := StableExternalID("owner/name\x00repo:1", "fallback")
+	second := StableExternalID("owner/name\x00repo:1", "fallback")
+	if first == "" || first != second {
+		t.Fatalf("StableExternalID() unstable: %q vs %q", first, second)
+	}
+	if got := StableExternalID("", "fallback"); got != "fallback" {
+		t.Fatalf("StableExternalID(empty) = %q", got)
+	}
+}

--- a/internal/urn/urn_test.go
+++ b/internal/urn/urn_test.go
@@ -54,6 +54,7 @@ func TestParseRejectsInvalidValue(t *testing.T) {
 		"urn:other:tenant:user:123",
 		"urn:cerebro::user:123",
 		"urn:cerebro:tenant::123",
+		"urn:cerebro:tenant:user::123",
 		"urn:cerebro:tenant:runtime:runtime-id::entity-id",
 		"urn:cerebro:tenant:user:",
 		"urn:cerebro: tenant:user:123",

--- a/tools/archtests/fabric_contract_test.go
+++ b/tools/archtests/fabric_contract_test.go
@@ -1,0 +1,64 @@
+package archtests
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSourceProjectionRelationConstantsUseFabricContract(t *testing.T) {
+	root := repoRoot(t)
+	sourceProjectionDir := filepath.Join(root, "internal", "sourceprojection")
+	if err := filepath.WalkDir(sourceProjectionDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			return err
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			decl, ok := node.(*ast.GenDecl)
+			if !ok || decl.Tok != token.CONST {
+				return true
+			}
+			for _, spec := range decl.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range valueSpec.Names {
+					if !strings.HasPrefix(name.Name, "relation") {
+						continue
+					}
+					if filepath.Base(path) != "projector.go" {
+						t.Fatalf("%s defines %s; sourceprojection relation constants must live in projector.go and alias internal/fabriccontract", path, name.Name)
+					}
+					if i >= len(valueSpec.Values) || !selectorFromPackage(valueSpec.Values[i], "fabriccontract") {
+						t.Fatalf("%s defines %s without aliasing internal/fabriccontract", path, name.Name)
+					}
+				}
+			}
+			return true
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("walk sourceprojection: %v", err)
+	}
+}
+
+func selectorFromPackage(expr ast.Expr, packageName string) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := selector.X.(*ast.Ident)
+	return ok && ident.Name == packageName
+}


### PR DESCRIPTION
## Summary

- Add shared `internal/urn` parsing and minting helpers for Cerebro URNs.
- Add `internal/fabriccontract` relation and entity constants as a first contract surface.
- Repoint source projection, graph provenance, source CDK, and graph-agent ontology code to the shared primitives.
- Add projection-time validation and an architecture guardrail so source projection relations stay aligned with the fabric contract.

## Test Plan

- `go test -race ./internal/urn ./internal/fabriccontract ./internal/sourcecdk ./internal/ports ./internal/graphprovenance ./internal/graphagent ./internal/sourceprojection ./tools/archtests -count=1`
- `make verify`
- `git diff --check`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->