### PR TITLE
feat: add Okta-derived SaaS application projection

### DIFF
--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -525,6 +525,7 @@ func grcVendorProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		Label:      firstAttribute(attrs, "name", "vendor_id"),
 		Attributes: grcAttributes(attrs, map[string]string{"vendor_id": vendorID, "source_system": provider}),
 	})
+	addVendorAliasLink(entities, links, tenantID, event.GetSourceId(), event, vendorURN, firstAttribute(attrs, "name"), "grc_vendor_name_alias", "0.90")
 	addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, vendorURN, relationHasIdentifier, firstAttribute(attrs, "website_url", "website", "url", "domain"), "grc_vendor_website_host", "0.95")
 	for _, ownerID := range []string{firstAttribute(attrs, "security_owner_user_id"), firstAttribute(attrs, "business_owner_user_id")} {
 		if ownerID == "" {

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -52,6 +52,7 @@ func TestProjectGRCVendorWithOwner(t *testing.T) {
 	vendorURN := "urn:cerebro:writer:vendor:vanta:vendor-1"
 	ownerURN := "urn:cerebro:writer:user:vanta:user-1"
 	hostURN := "urn:cerebro:writer:internet_host:app.writer.com"
+	aliasURN := "urn:cerebro:writer:vendor_alias:acme-saas"
 	if entity := state.entities[vendorURN]; entity == nil || entity.EntityType != "vendor" {
 		t.Fatalf("vendor entity missing: %#v", entity)
 	}
@@ -64,8 +65,12 @@ func TestProjectGRCVendorWithOwner(t *testing.T) {
 	if entity := state.entities[hostURN]; entity == nil || entity.EntityType != "internet.host" {
 		t.Fatalf("internet host entity missing: %#v", entity)
 	}
+	if entity := state.entities[aliasURN]; entity == nil || entity.EntityType != "vendor.alias" {
+		t.Fatalf("vendor alias entity missing: %#v", entity)
+	}
 	assertProjectedLink(t, state, vendorURN, relationOwnedBy, ownerURN)
 	assertProjectedLink(t, state, vendorURN, relationHasIdentifier, hostURN)
+	assertProjectedLink(t, state, vendorURN, relationHasIdentifier, aliasURN)
 }
 
 func TestProjectGRCVendorLinksAccountManagerEmail(t *testing.T) {

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -150,19 +150,14 @@ func oktaSaaSApplicationClassificationFor(attributes map[string]string) (oktaSaa
 		attributes["app_label"],
 		attributes["name"],
 	}, " "))
-	for _, marker := range []string{"test", "sandbox", "dev", "internal"} {
-		if strings.Contains(name, marker) {
-			return oktaSaaSApplicationClassification{}, false
-		}
+	if containsAnyNormalizedToken(name, "test", "sandbox", "dev", "internal") {
+		return oktaSaaSApplicationClassification{}, false
 	}
 	status := strings.ToLower(strings.TrimSpace(firstNonEmpty(attributes["status"], "active")))
 	classification := oktaSaaSApplicationClassification{
 		Active:         status == "active" || status == "enabled",
 		Confidence:     "0.75",
 		LifecycleState: status,
-	}
-	if classification.LifecycleState == "" {
-		classification.LifecycleState = "active"
 	}
 	signOnMode := strings.ToLower(strings.TrimSpace(attributes["sign_on_mode"]))
 	for _, marker := range []string{"saml", "oidc", "oauth", "openid"} {

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -37,17 +37,20 @@ func oktaApplicationProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 	if err != nil {
 		return nil, nil, err
 	}
-	saasEntity, saasLink, err := oktaSaaSApplicationProjection(event)
+	saasEntities, saasLinks, err := oktaSaaSApplicationProjections(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	if saasEntity != nil {
-		entities = append(entities, saasEntity)
+	entityMap := map[string]*ports.ProjectedEntity{}
+	linkMap := map[string]*ports.ProjectedLink{}
+	for _, entity := range append(entities, saasEntities...) {
+		addEntity(entityMap, entity)
 	}
-	if saasLink != nil {
-		links = append(links, saasLink)
+	for _, link := range append(links, saasLinks...) {
+		addLink(linkMap, link)
 	}
-	return entities, links, nil
+	projectedEntities, projectedLinks := entitiesAndLinks(entityMap, linkMap)
+	return projectedEntities, projectedLinks, nil
 }
 
 func oktaPolicyRuleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -62,14 +65,22 @@ func oktaAdminRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projecte
 	return identityRoleAssignmentProjections(event, oktaIdentityProfile)
 }
 
-func oktaSaaSApplicationProjection(event *cerebrov1.EventEnvelope) (*ports.ProjectedEntity, *ports.ProjectedLink, error) {
+type oktaSaaSApplicationClassification struct {
+	Active         bool
+	Confidence     string
+	LifecycleState string
+	Reasons        []string
+}
+
+func oktaSaaSApplicationProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	tenantID, err := tenantID(event)
 	if err != nil {
 		return nil, nil, err
 	}
 	attributes := event.GetAttributes()
 	appID := firstNonEmpty(attributes["app_id"], attributes["application_id"], attributes["client_id"], attributes["id"])
-	if appID == "" || !oktaApplicationLooksLikeSaaS(attributes) {
+	classification, ok := oktaSaaSApplicationClassificationFor(attributes)
+	if appID == "" || !ok {
 		return nil, nil, nil
 	}
 	appURN := identityApplicationURN(tenantID, oktaIdentityProfile.Provider, appID)
@@ -77,44 +88,63 @@ func oktaSaaSApplicationProjection(event *cerebrov1.EventEnvelope) (*ports.Proje
 	if appURN == "" || saasURN == "" {
 		return nil, nil, nil
 	}
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
 	appName := firstNonEmpty(attributes["app_name"], attributes["app_label"], attributes["name"], attributes["client_id"], appID)
+	matchReason := strings.Join(classification.Reasons, ",")
 	saasAttributes := map[string]string{
-		"app_id":          appID,
-		"app_label":       strings.TrimSpace(attributes["app_label"]),
-		"app_name":        appName,
-		"client_id":       strings.TrimSpace(attributes["client_id"]),
-		"domain":          strings.TrimSpace(attributes["domain"]),
-		"name":            strings.TrimSpace(attributes["name"]),
-		"oauth2":          strings.TrimSpace(attributes["oauth2"]),
-		"saml":            strings.TrimSpace(attributes["saml"]),
-		"sign_on_mode":    strings.TrimSpace(attributes["sign_on_mode"]),
-		"source_app_id":   appID,
-		"source_provider": oktaIdentityProfile.Provider,
-		"status":          strings.TrimSpace(attributes["status"]),
+		"active":                         boolString(classification.Active),
+		"app_id":                         appID,
+		"app_label":                      strings.TrimSpace(attributes["app_label"]),
+		"app_name":                       appName,
+		"classification_confidence":      classification.Confidence,
+		"client_id":                      strings.TrimSpace(attributes["client_id"]),
+		"domain":                         strings.TrimSpace(attributes["domain"]),
+		"lifecycle_state":                classification.LifecycleState,
+		"match_reason":                   matchReason,
+		"name":                           strings.TrimSpace(attributes["name"]),
+		"oauth2":                         strings.TrimSpace(attributes["oauth2"]),
+		"post_logout_redirect_uri_hosts": strings.TrimSpace(attributes["post_logout_redirect_uri_hosts"]),
+		"redirect_uri_hosts":             strings.TrimSpace(attributes["redirect_uri_hosts"]),
+		"saml":                           strings.TrimSpace(attributes["saml"]),
+		"sign_on_mode":                   strings.TrimSpace(attributes["sign_on_mode"]),
+		"source_app_id":                  appID,
+		"source_provider":                oktaIdentityProfile.Provider,
+		"status":                         strings.TrimSpace(attributes["status"]),
 	}
 	trimEmptyProjectionAttributes(saasAttributes)
-	entity := &ports.ProjectedEntity{
+	addEntity(entities, &ports.ProjectedEntity{
 		URN:        saasURN,
 		TenantID:   tenantID,
 		SourceID:   event.GetSourceId(),
 		EntityType: "saas.application",
 		Label:      appName,
 		Attributes: saasAttributes,
-	}
-	link := projectedLink(tenantID, event.GetSourceId(), appURN, saasURN, relationRepresents, map[string]string{
+	})
+	linkAttrs := map[string]string{
+		"active":          boolString(classification.Active),
+		"confidence":      classification.Confidence,
 		"event_id":        event.GetId(),
+		"match_reason":    matchReason,
 		"match_type":      "okta_saas_application",
 		"source_app_id":   appID,
 		"source_provider": oktaIdentityProfile.Provider,
-	})
-	return entity, link, nil
+	}
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), appURN, saasURN, relationRepresents, linkAttrs))
+	addVendorAliasLink(entities, links, tenantID, event.GetSourceId(), event, saasURN, appName, "okta_saas_application_name", "0.80")
+	for _, host := range splitCSV(attributes["redirect_uri_hosts"]) {
+		addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, saasURN, relationHasIdentifier, host, "okta_saas_application_redirect_host", "0.95")
+		addInternetHostDomainLink(entities, links, tenantID, event.GetSourceId(), event, host, "okta_saas_application_redirect_domain", "0.95")
+	}
+	for _, host := range splitCSV(attributes["post_logout_redirect_uri_hosts"]) {
+		addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, saasURN, relationHasIdentifier, host, "okta_saas_application_post_logout_redirect_host", "0.90")
+		addInternetHostDomainLink(entities, links, tenantID, event.GetSourceId(), event, host, "okta_saas_application_post_logout_redirect_domain", "0.90")
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
 }
 
-func oktaApplicationLooksLikeSaaS(attributes map[string]string) bool {
-	status := strings.ToLower(strings.TrimSpace(firstNonEmpty(attributes["status"], "active")))
-	if status != "active" && status != "enabled" {
-		return false
-	}
+func oktaSaaSApplicationClassificationFor(attributes map[string]string) (oktaSaaSApplicationClassification, bool) {
 	name := strings.ToLower(strings.Join([]string{
 		attributes["app_name"],
 		attributes["app_label"],
@@ -122,24 +152,39 @@ func oktaApplicationLooksLikeSaaS(attributes map[string]string) bool {
 	}, " "))
 	for _, marker := range []string{"test", "sandbox", "dev", "internal"} {
 		if strings.Contains(name, marker) {
-			return false
+			return oktaSaaSApplicationClassification{}, false
 		}
+	}
+	status := strings.ToLower(strings.TrimSpace(firstNonEmpty(attributes["status"], "active")))
+	classification := oktaSaaSApplicationClassification{
+		Active:         status == "active" || status == "enabled",
+		Confidence:     "0.75",
+		LifecycleState: status,
+	}
+	if classification.LifecycleState == "" {
+		classification.LifecycleState = "active"
 	}
 	signOnMode := strings.ToLower(strings.TrimSpace(attributes["sign_on_mode"]))
 	for _, marker := range []string{"saml", "oidc", "oauth", "openid"} {
-		if strings.Contains(signOnMode, marker) || strings.Contains(name, marker) {
-			return true
+		if strings.Contains(signOnMode, marker) {
+			classification.Reasons = append(classification.Reasons, "sign_on_mode_"+marker)
+			classification.Confidence = "0.95"
 		}
 	}
-	if projectionBool(attributes["saml"]) || projectionBool(attributes["oauth2"]) {
-		return true
+	if projectionBool(attributes["saml"]) {
+		classification.Reasons = append(classification.Reasons, "saml_enabled")
+		classification.Confidence = "0.95"
+	}
+	if projectionBool(attributes["oauth2"]) {
+		classification.Reasons = append(classification.Reasons, "oauth2_enabled")
+		classification.Confidence = "0.95"
 	}
 	for _, marker := range []string{"org2org", "vendor", "partner", "supplier", "contractor", "external"} {
 		if strings.Contains(name, marker) {
-			return true
+			classification.Reasons = append(classification.Reasons, "name_hint_"+marker)
 		}
 	}
-	return false
+	return classification, len(classification.Reasons) != 0
 }
 
 func awsIAMUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -174,8 +174,12 @@ func oktaSaaSApplicationClassificationFor(attributes map[string]string) (oktaSaa
 		classification.Reasons = append(classification.Reasons, "oauth2_enabled")
 		classification.Confidence = "0.95"
 	}
+	nameTokens := map[string]struct{}{}
+	for _, token := range normalizedTokens(name) {
+		nameTokens[token] = struct{}{}
+	}
 	for _, marker := range []string{"org2org", "vendor", "partner", "supplier", "contractor", "external"} {
-		if strings.Contains(name, marker) {
+		if _, ok := nameTokens[marker]; ok {
 			classification.Reasons = append(classification.Reasons, "name_hint_"+marker)
 		}
 	}

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -90,7 +90,8 @@ func oktaSaaSApplicationProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pr
 	}
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
-	appName := firstNonEmpty(attributes["app_name"], attributes["app_label"], attributes["name"], attributes["client_id"], appID)
+	appDisplayName := firstNonEmpty(attributes["app_name"], attributes["app_label"], attributes["name"])
+	appName := firstNonEmpty(appDisplayName, attributes["client_id"], appID)
 	matchReason := strings.Join(classification.Reasons, ",")
 	saasAttributes := map[string]string{
 		"active":                         boolString(classification.Active),
@@ -131,7 +132,7 @@ func oktaSaaSApplicationProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pr
 		"source_provider": oktaIdentityProfile.Provider,
 	}
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), appURN, saasURN, relationRepresents, linkAttrs))
-	addVendorAliasLink(entities, links, tenantID, event.GetSourceId(), event, saasURN, appName, "okta_saas_application_name", "0.80")
+	addVendorAliasLink(entities, links, tenantID, event.GetSourceId(), event, saasURN, appDisplayName, "okta_saas_application_name", "0.80")
 	for _, host := range splitCSV(attributes["redirect_uri_hosts"]) {
 		addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, saasURN, relationHasIdentifier, host, "okta_saas_application_redirect_host", "0.95")
 		addInternetHostDomainLink(entities, links, tenantID, event.GetSourceId(), event, host, "okta_saas_application_redirect_domain", "0.95")

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -33,7 +33,21 @@ func oktaGroupMembershipProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pr
 }
 
 func oktaApplicationProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityApplicationProjections(event, oktaIdentityProfile)
+	entities, links, err := identityApplicationProjections(event, oktaIdentityProfile)
+	if err != nil {
+		return nil, nil, err
+	}
+	saasEntity, saasLink, err := oktaSaaSApplicationProjection(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	if saasEntity != nil {
+		entities = append(entities, saasEntity)
+	}
+	if saasLink != nil {
+		links = append(links, saasLink)
+	}
+	return entities, links, nil
 }
 
 func oktaPolicyRuleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -46,6 +60,86 @@ func oktaAppAssignmentProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 
 func oktaAdminRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return identityRoleAssignmentProjections(event, oktaIdentityProfile)
+}
+
+func oktaSaaSApplicationProjection(event *cerebrov1.EventEnvelope) (*ports.ProjectedEntity, *ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	appID := firstNonEmpty(attributes["app_id"], attributes["application_id"], attributes["client_id"], attributes["id"])
+	if appID == "" || !oktaApplicationLooksLikeSaaS(attributes) {
+		return nil, nil, nil
+	}
+	appURN := identityApplicationURN(tenantID, oktaIdentityProfile.Provider, appID)
+	saasURN := projectionURN(tenantID, "saas_application", oktaIdentityProfile.Provider, appID)
+	if appURN == "" || saasURN == "" {
+		return nil, nil, nil
+	}
+	appName := firstNonEmpty(attributes["app_name"], attributes["app_label"], attributes["name"], attributes["client_id"], appID)
+	saasAttributes := map[string]string{
+		"app_id":          appID,
+		"app_label":       strings.TrimSpace(attributes["app_label"]),
+		"app_name":        appName,
+		"client_id":       strings.TrimSpace(attributes["client_id"]),
+		"domain":          strings.TrimSpace(attributes["domain"]),
+		"name":            strings.TrimSpace(attributes["name"]),
+		"oauth2":          strings.TrimSpace(attributes["oauth2"]),
+		"saml":            strings.TrimSpace(attributes["saml"]),
+		"sign_on_mode":    strings.TrimSpace(attributes["sign_on_mode"]),
+		"source_app_id":   appID,
+		"source_provider": oktaIdentityProfile.Provider,
+		"status":          strings.TrimSpace(attributes["status"]),
+	}
+	trimEmptyProjectionAttributes(saasAttributes)
+	entity := &ports.ProjectedEntity{
+		URN:        saasURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "saas.application",
+		Label:      appName,
+		Attributes: saasAttributes,
+	}
+	link := projectedLink(tenantID, event.GetSourceId(), appURN, saasURN, relationRepresents, map[string]string{
+		"event_id":        event.GetId(),
+		"match_type":      "okta_saas_application",
+		"source_app_id":   appID,
+		"source_provider": oktaIdentityProfile.Provider,
+	})
+	return entity, link, nil
+}
+
+func oktaApplicationLooksLikeSaaS(attributes map[string]string) bool {
+	status := strings.ToLower(strings.TrimSpace(firstNonEmpty(attributes["status"], "active")))
+	if status != "active" && status != "enabled" {
+		return false
+	}
+	name := strings.ToLower(strings.Join([]string{
+		attributes["app_name"],
+		attributes["app_label"],
+		attributes["name"],
+	}, " "))
+	for _, marker := range []string{"test", "sandbox", "dev", "internal"} {
+		if strings.Contains(name, marker) {
+			return false
+		}
+	}
+	signOnMode := strings.ToLower(strings.TrimSpace(attributes["sign_on_mode"]))
+	for _, marker := range []string{"saml", "oidc", "oauth", "openid"} {
+		if strings.Contains(signOnMode, marker) || strings.Contains(name, marker) {
+			return true
+		}
+	}
+	if projectionBool(attributes["saml"]) || projectionBool(attributes["oauth2"]) {
+		return true
+	}
+	for _, marker := range []string{"org2org", "vendor", "partner", "supplier", "contractor", "external"} {
+		if strings.Contains(name, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func awsIAMUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -983,6 +983,26 @@ func TestProjectOktaApplicationSaaSClassification(t *testing.T) {
 			wantActive: "true",
 		},
 		{
+			name: "partnerships substring is not a name hint",
+			attrs: map[string]string{
+				"app_id":   "0oa-partnerships",
+				"app_name": "Partnerships Directory",
+				"status":   "ACTIVE",
+			},
+			wantAppID:  "0oa-partnerships",
+			wantAppURN: "urn:cerebro:writer:okta_application:0oa-partnerships",
+		},
+		{
+			name: "externallyhosted substring is not a name hint",
+			attrs: map[string]string{
+				"app_id":   "0oa-externallyhosted",
+				"app_name": "Externallyhosted Portal",
+				"status":   "ACTIVE",
+			},
+			wantAppID:  "0oa-externallyhosted",
+			wantAppURN: "urn:cerebro:writer:okta_application:0oa-externallyhosted",
+		},
+		{
 			name: "inactive saml app",
 			attrs: map[string]string{
 				"app_id":       "0oa-inactive",

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -1090,6 +1090,38 @@ func TestProjectOktaApplicationSaaSClassification(t *testing.T) {
 	}
 }
 
+func TestProjectOktaApplicationSaaSSkipsOpaqueVendorAlias(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "okta-application-opaque",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.application",
+		Attributes: map[string]string{
+			"app_id":       "0oa-opaque",
+			"client_id":    "opaque-client-id",
+			"domain":       "writer.okta.com",
+			"sign_on_mode": "SAML_2_0",
+			"status":       "ACTIVE",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	saasURN := "urn:cerebro:writer:saas_application:okta:0oa-opaque"
+	if entity := state.entities[saasURN]; entity == nil || entity.EntityType != "saas.application" {
+		t.Fatalf("saas entity missing or wrong: %#v", entity)
+	}
+	for urn, entity := range state.entities {
+		if entity.EntityType == "vendor.alias" {
+			t.Fatalf("unexpected vendor alias %q: %#v", urn, entity)
+		}
+	}
+	assertProjectedLinkMissing(t, state, saasURN, relationHasIdentifier, "urn:cerebro:writer:vendor_alias:"+vendorAliasKey("opaque-client-id"))
+	assertProjectedLinkMissing(t, state, saasURN, relationHasIdentifier, "urn:cerebro:writer:vendor_alias:"+vendorAliasKey("0oa-opaque"))
+}
+
 func TestProjectOktaPolicyRule(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -882,12 +882,13 @@ func TestProjectOktaApplicationIncludesLifecycleAttributes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 7 {
-		t.Fatalf("Project().EntitiesProjected = %d, want 7", result.EntitiesProjected)
+	if result.EntitiesProjected != 8 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 8", result.EntitiesProjected)
 	}
 
 	clientURN := "urn:cerebro:writer:okta_application:0oa-client"
 	saasURN := "urn:cerebro:writer:saas_application:okta:0oa-client"
+	aliasURN := "urn:cerebro:writer:vendor_alias:production-client"
 	orgURN := "urn:cerebro:writer:okta_org:writer.okta.com"
 	entity, ok := state.entities[clientURN]
 	if !ok {
@@ -916,20 +917,30 @@ func TestProjectOktaApplicationIncludesLifecycleAttributes(t *testing.T) {
 		t.Fatalf("saas entity type = %q, want saas.application", got)
 	}
 	saasAttributes := map[string]string{
-		"app_id":          "0oa-client",
-		"app_name":        "Production Client",
-		"source_app_id":   "0oa-client",
-		"source_provider": "okta",
-		"status":          "ACTIVE",
-		"sign_on_mode":    "OPENID_CONNECT",
+		"active":                    "true",
+		"app_id":                    "0oa-client",
+		"app_name":                  "Production Client",
+		"classification_confidence": "0.95",
+		"lifecycle_state":           "active",
+		"match_reason":              "sign_on_mode_openid",
+		"source_app_id":             "0oa-client",
+		"source_provider":           "okta",
+		"status":                    "ACTIVE",
+		"sign_on_mode":              "OPENID_CONNECT",
 	}
 	for key, want := range saasAttributes {
 		if got := saasEntity.Attributes[key]; got != want {
 			t.Fatalf("saas Attributes[%q] = %q, want %q", key, got, want)
 		}
 	}
+	if alias := state.entities[aliasURN]; alias == nil || alias.EntityType != "vendor.alias" {
+		t.Fatalf("vendor alias entity missing or wrong: %#v", alias)
+	}
 	assertProjectedLink(t, state, clientURN, relationBelongsTo, orgURN)
 	assertProjectedLink(t, state, clientURN, relationRepresents, saasURN)
+	assertProjectedLink(t, state, saasURN, relationHasIdentifier, aliasURN)
+	assertProjectedLink(t, state, saasURN, relationHasIdentifier, "urn:cerebro:writer:internet_host:app.example.com")
+	assertProjectedLink(t, state, saasURN, relationHasIdentifier, "urn:cerebro:writer:internet_host:logout.example.com")
 	assertProjectedLink(t, state, clientURN, relationHasIdentifier, "urn:cerebro:writer:internet_host:app.example.com")
 	assertProjectedLink(t, state, clientURN, relationHasIdentifier, "urn:cerebro:writer:internet_host:logout.example.com")
 	assertProjectedLink(t, state, clientURN, relationContains, "urn:cerebro:writer:okta_oauth_client:0oa-client-id")
@@ -944,6 +955,7 @@ func TestProjectOktaApplicationSaaSClassification(t *testing.T) {
 		wantSaaS   bool
 		wantAppID  string
 		wantAppURN string
+		wantActive string
 	}{
 		{
 			name: "active saml app",
@@ -956,6 +968,7 @@ func TestProjectOktaApplicationSaaSClassification(t *testing.T) {
 			wantSaaS:   true,
 			wantAppID:  "0oa-saml",
 			wantAppURN: "urn:cerebro:writer:okta_application:0oa-saml",
+			wantActive: "true",
 		},
 		{
 			name: "enabled vendor name",
@@ -967,6 +980,7 @@ func TestProjectOktaApplicationSaaSClassification(t *testing.T) {
 			wantSaaS:   true,
 			wantAppID:  "0oa-vendor",
 			wantAppURN: "urn:cerebro:writer:okta_application:0oa-vendor",
+			wantActive: "true",
 		},
 		{
 			name: "inactive saml app",
@@ -976,8 +990,10 @@ func TestProjectOktaApplicationSaaSClassification(t *testing.T) {
 				"sign_on_mode": "SAML_2_0",
 				"status":       "INACTIVE",
 			},
+			wantSaaS:   true,
 			wantAppID:  "0oa-inactive",
 			wantAppURN: "urn:cerebro:writer:okta_application:0oa-inactive",
+			wantActive: "false",
 		},
 		{
 			name: "internal dev sandbox app",
@@ -1016,6 +1032,10 @@ func TestProjectOktaApplicationSaaSClassification(t *testing.T) {
 				t.Fatalf("saas entity exists = %v, want %v; entities=%v", exists, tt.wantSaaS, state.entities)
 			}
 			if tt.wantSaaS {
+				if got := state.entities[saasURN].Attributes["active"]; got != tt.wantActive {
+					t.Fatalf("saas active = %q, want %q", got, tt.wantActive)
+				}
+				assertProjectedLink(t, state, saasURN, relationHasIdentifier, "urn:cerebro:writer:vendor_alias:"+vendorAliasKey(attrs["app_name"]))
 				assertProjectedLink(t, state, tt.wantAppURN, relationRepresents, saasURN)
 				return
 			}

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -996,6 +996,32 @@ func TestProjectOktaApplicationSaaSClassification(t *testing.T) {
 			wantActive: "false",
 		},
 		{
+			name: "device substring is not excluded",
+			attrs: map[string]string{
+				"app_id":       "0oa-device",
+				"app_name":     "Jamf Device Management",
+				"sign_on_mode": "SAML_2_0",
+				"status":       "ACTIVE",
+			},
+			wantSaaS:   true,
+			wantAppID:  "0oa-device",
+			wantAppURN: "urn:cerebro:writer:okta_application:0oa-device",
+			wantActive: "true",
+		},
+		{
+			name: "international substring is not excluded",
+			attrs: map[string]string{
+				"app_id":       "0oa-international",
+				"app_name":     "International Banking Portal",
+				"sign_on_mode": "OPENID_CONNECT",
+				"status":       "ACTIVE",
+			},
+			wantSaaS:   true,
+			wantAppID:  "0oa-international",
+			wantAppURN: "urn:cerebro:writer:okta_application:0oa-international",
+			wantActive: "true",
+		},
+		{
 			name: "internal dev sandbox app",
 			attrs: map[string]string{
 				"app_id":       "0oa-internal",

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -882,11 +882,12 @@ func TestProjectOktaApplicationIncludesLifecycleAttributes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 6 {
-		t.Fatalf("Project().EntitiesProjected = %d, want 6", result.EntitiesProjected)
+	if result.EntitiesProjected != 7 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 7", result.EntitiesProjected)
 	}
 
 	clientURN := "urn:cerebro:writer:okta_application:0oa-client"
+	saasURN := "urn:cerebro:writer:saas_application:okta:0oa-client"
 	orgURN := "urn:cerebro:writer:okta_org:writer.okta.com"
 	entity, ok := state.entities[clientURN]
 	if !ok {
@@ -907,12 +908,120 @@ func TestProjectOktaApplicationIncludesLifecycleAttributes(t *testing.T) {
 			t.Fatalf("Attributes[%q] = %q, want %q", key, got, want)
 		}
 	}
+	saasEntity, ok := state.entities[saasURN]
+	if !ok {
+		t.Fatalf("state entity %q missing", saasURN)
+	}
+	if got := saasEntity.EntityType; got != "saas.application" {
+		t.Fatalf("saas entity type = %q, want saas.application", got)
+	}
+	saasAttributes := map[string]string{
+		"app_id":          "0oa-client",
+		"app_name":        "Production Client",
+		"source_app_id":   "0oa-client",
+		"source_provider": "okta",
+		"status":          "ACTIVE",
+		"sign_on_mode":    "OPENID_CONNECT",
+	}
+	for key, want := range saasAttributes {
+		if got := saasEntity.Attributes[key]; got != want {
+			t.Fatalf("saas Attributes[%q] = %q, want %q", key, got, want)
+		}
+	}
 	assertProjectedLink(t, state, clientURN, relationBelongsTo, orgURN)
+	assertProjectedLink(t, state, clientURN, relationRepresents, saasURN)
 	assertProjectedLink(t, state, clientURN, relationHasIdentifier, "urn:cerebro:writer:internet_host:app.example.com")
 	assertProjectedLink(t, state, clientURN, relationHasIdentifier, "urn:cerebro:writer:internet_host:logout.example.com")
 	assertProjectedLink(t, state, clientURN, relationContains, "urn:cerebro:writer:okta_oauth_client:0oa-client-id")
 	assertProjectedLink(t, state, "urn:cerebro:writer:internet_host:app.example.com", relationBelongsTo, "urn:cerebro:writer:internet_domain:example.com")
 	assertProjectedLink(t, state, "urn:cerebro:writer:internet_host:logout.example.com", relationBelongsTo, "urn:cerebro:writer:internet_domain:example.com")
+}
+
+func TestProjectOktaApplicationSaaSClassification(t *testing.T) {
+	tests := []struct {
+		name       string
+		attrs      map[string]string
+		wantSaaS   bool
+		wantAppID  string
+		wantAppURN string
+	}{
+		{
+			name: "active saml app",
+			attrs: map[string]string{
+				"app_id":       "0oa-saml",
+				"app_name":     "Acme",
+				"sign_on_mode": "SAML_2_0",
+				"status":       "ACTIVE",
+			},
+			wantSaaS:   true,
+			wantAppID:  "0oa-saml",
+			wantAppURN: "urn:cerebro:writer:okta_application:0oa-saml",
+		},
+		{
+			name: "enabled vendor name",
+			attrs: map[string]string{
+				"app_id":   "0oa-vendor",
+				"app_name": "Vendor Portal",
+				"status":   "ENABLED",
+			},
+			wantSaaS:   true,
+			wantAppID:  "0oa-vendor",
+			wantAppURN: "urn:cerebro:writer:okta_application:0oa-vendor",
+		},
+		{
+			name: "inactive saml app",
+			attrs: map[string]string{
+				"app_id":       "0oa-inactive",
+				"app_name":     "Acme",
+				"sign_on_mode": "SAML_2_0",
+				"status":       "INACTIVE",
+			},
+			wantAppID:  "0oa-inactive",
+			wantAppURN: "urn:cerebro:writer:okta_application:0oa-inactive",
+		},
+		{
+			name: "internal dev sandbox app",
+			attrs: map[string]string{
+				"app_id":       "0oa-internal",
+				"app_name":     "Internal Dev Sandbox",
+				"sign_on_mode": "OPENID_CONNECT",
+				"status":       "ACTIVE",
+			},
+			wantAppID:  "0oa-internal",
+			wantAppURN: "urn:cerebro:writer:okta_application:0oa-internal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &projectionRecorder{}
+			service := New(state, nil)
+			attrs := map[string]string{"domain": "writer.okta.com"}
+			for key, value := range tt.attrs {
+				attrs[key] = value
+			}
+			_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+				Id:         "okta-application-" + tt.wantAppID,
+				TenantId:   "writer",
+				SourceId:   "okta",
+				Kind:       "okta.application",
+				Attributes: attrs,
+			})
+			if err != nil {
+				t.Fatalf("Project() error = %v", err)
+			}
+			saasURN := "urn:cerebro:writer:saas_application:okta:" + tt.wantAppID
+			_, exists := state.entities[saasURN]
+			if exists != tt.wantSaaS {
+				t.Fatalf("saas entity exists = %v, want %v; entities=%v", exists, tt.wantSaaS, state.entities)
+			}
+			if tt.wantSaaS {
+				assertProjectedLink(t, state, tt.wantAppURN, relationRepresents, saasURN)
+				return
+			}
+			assertProjectedLinkMissing(t, state, tt.wantAppURN, relationRepresents, saasURN)
+		})
+	}
 }
 
 func TestProjectOktaPolicyRule(t *testing.T) {

--- a/internal/sourceprojection/vendor_alias.go
+++ b/internal/sourceprojection/vendor_alias.go
@@ -1,0 +1,52 @@
+package sourceprojection
+
+import (
+	"strings"
+	"unicode"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func addVendorAliasLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, rawAlias string, matchType string, confidence string) {
+	alias := strings.TrimSpace(rawAlias)
+	aliasKey := vendorAliasKey(alias)
+	if aliasKey == "" || strings.TrimSpace(fromURN) == "" {
+		return
+	}
+	aliasURN := projectionURN(tenantID, "vendor_alias", aliasKey)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        aliasURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "vendor.alias",
+		Label:      alias,
+		Attributes: map[string]string{
+			"alias":     alias,
+			"alias_key": aliasKey,
+		},
+	})
+	addLink(links, projectedLink(tenantID, sourceID, fromURN, aliasURN, relationHasIdentifier, map[string]string{
+		"alias":      alias,
+		"alias_key":  aliasKey,
+		"confidence": confidence,
+		"event_id":   event.GetId(),
+		"match_type": matchType,
+	}))
+}
+
+func vendorAliasKey(value string) string {
+	var builder strings.Builder
+	lastSeparator := false
+	for _, r := range strings.ToLower(strings.TrimSpace(value)) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			builder.WriteRune(r)
+			lastSeparator = false
+		case !lastSeparator && builder.Len() != 0:
+			builder.WriteByte('-')
+			lastSeparator = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}

--- a/internal/sourceprojection/vendor_alias.go
+++ b/internal/sourceprojection/vendor_alias.go
@@ -50,3 +50,43 @@ func vendorAliasKey(value string) string {
 	}
 	return strings.Trim(builder.String(), "-")
 }
+
+func containsAnyNormalizedToken(value string, markers ...string) bool {
+	markerSet := map[string]struct{}{}
+	for _, marker := range markers {
+		normalized := strings.ToLower(strings.TrimSpace(marker))
+		if normalized != "" {
+			markerSet[normalized] = struct{}{}
+		}
+	}
+	if len(markerSet) == 0 {
+		return false
+	}
+	for _, token := range normalizedTokens(value) {
+		if _, ok := markerSet[token]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizedTokens(value string) []string {
+	var tokens []string
+	var builder strings.Builder
+	flush := func() {
+		if builder.Len() == 0 {
+			return
+		}
+		tokens = append(tokens, builder.String())
+		builder.Reset()
+	}
+	for _, r := range strings.ToLower(strings.TrimSpace(value)) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			builder.WriteRune(r)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return tokens
+}


### PR DESCRIPTION
## Summary

- Derive provider-neutral `saas.application` graph entities from qualifying Okta application snapshots.
- Link each source `okta.application` to the derived SaaS application with `represents`.
- Add classification metadata (`match_reason`, confidence, active/lifecycle state) and host/domain identifiers on SaaS app nodes.
- Add vendor alias identifiers shared by Okta-derived SaaS apps and GRC vendors to support graph-side vendor/app correlation.
- Add projection tests for SAML/OIDC/vendor-like apps, inactive lifecycle handling, internal exclusions, and GRC vendor aliases.

## Test Plan

- `go -C "/Users/jonathan/cerebro-okta-saas-pr" test ./internal/sourceprojection`
- `make -C "/Users/jonathan/cerebro-okta-saas-pr" verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on Okta SaaS classification, neutral entity/link shape, and vendor alias correlation.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
