### PR TITLE
Expand finding correlation coverage

### DIFF
--- a/internal/correlation/runtime/identity_tamper_then_cred_change.go
+++ b/internal/correlation/runtime/identity_tamper_then_cred_change.go
@@ -4,6 +4,8 @@ import "time"
 
 const IdentityTamperThenCredentialChangeHintID = "identity-control-tamper-with-credential-change"
 
+const RuntimeActiveThreatWithPublicExposureHintID = "runtime-active-threat-with-public-exposure"
+
 type CorrelationHint struct {
 	ID         string
 	Name       string
@@ -24,6 +26,7 @@ type CorrelationHintTest struct {
 func BuiltinHints() []CorrelationHint {
 	return []CorrelationHint{
 		IdentityTamperThenCredentialChangeHint(),
+		RuntimeActiveThreatWithPublicExposureHint(),
 	}
 }
 
@@ -43,6 +46,28 @@ func IdentityTamperThenCredentialChangeHint() CorrelationHint {
 			{
 				Name:        "shared-actor-positive",
 				Description: "Matches when the same actor changes an identity control and creates a credential inside the window.",
+				ExpectMatch: true,
+			},
+		},
+	}
+}
+
+func RuntimeActiveThreatWithPublicExposureHint() CorrelationHint {
+	return CorrelationHint{
+		ID:   RuntimeActiveThreatWithPublicExposureHintID,
+		Name: "Runtime active threat with public exposure",
+		RuleIDs: []string{
+			"cloud-public-resource-exposure",
+			"runtime-active-threat-evidence",
+		},
+		Dimensions: []string{"resource"},
+		Window:     24 * time.Hour,
+		ScoreBonus: 14,
+		Reasons:    []string{"active_threat", "external_exposure"},
+		Tests: []CorrelationHintTest{
+			{
+				Name:        "shared-resource-positive",
+				Description: "Matches when runtime threat evidence and public exposure share the same workload or resource inside the window.",
 				ExpectMatch: true,
 			},
 		},

--- a/internal/correlation/runtime/identity_tamper_then_cred_change_test.go
+++ b/internal/correlation/runtime/identity_tamper_then_cred_change_test.go
@@ -34,6 +34,44 @@ func TestIdentityTamperThenCredentialChangeHint(t *testing.T) {
 	}
 }
 
+func TestRuntimeActiveThreatWithPublicExposureHint(t *testing.T) {
+	hint := RuntimeActiveThreatWithPublicExposureHint()
+	if hint.ID != RuntimeActiveThreatWithPublicExposureHintID {
+		t.Fatalf("ID = %q, want %q", hint.ID, RuntimeActiveThreatWithPublicExposureHintID)
+	}
+	wantRules := []string{
+		"cloud-public-resource-exposure",
+		"runtime-active-threat-evidence",
+	}
+	if !slices.Equal(hint.RuleIDs, wantRules) {
+		t.Fatalf("RuleIDs = %#v, want %#v", hint.RuleIDs, wantRules)
+	}
+	if !slices.Equal(hint.Dimensions, []string{"resource"}) {
+		t.Fatalf("Dimensions = %#v, want resource", hint.Dimensions)
+	}
+	if hint.Window != 24*time.Hour {
+		t.Fatalf("Window = %v, want 24h", hint.Window)
+	}
+	for _, reason := range []string{"active_threat", "external_exposure"} {
+		if !slices.Contains(hint.Reasons, reason) {
+			t.Fatalf("Reasons = %#v, want %q", hint.Reasons, reason)
+		}
+	}
+	if len(hint.Tests) == 0 {
+		t.Fatal("Tests = 0, want at least one catalog test")
+	}
+}
+
+func TestBuiltinHintsIncludeRuntimeExposureHint(t *testing.T) {
+	hints := BuiltinHints()
+	for _, hint := range hints {
+		if hint.ID == RuntimeActiveThreatWithPublicExposureHintID {
+			return
+		}
+	}
+	t.Fatalf("BuiltinHints() = %#v, want %q", hints, RuntimeActiveThreatWithPublicExposureHintID)
+}
+
 func TestBuiltinHintsReturnsIsolatedCopies(t *testing.T) {
 	first := BuiltinHints()
 	if len(first) == 0 || len(first[0].RuleIDs) == 0 || len(first[0].Tests) == 0 {

--- a/internal/findings/aurelius_promoted_vulnerability_active_rule.go
+++ b/internal/findings/aurelius_promoted_vulnerability_active_rule.go
@@ -192,6 +192,7 @@ func aureliusPromotedVulnerabilityActiveFinding(event *cerebrov1.EventEnvelope, 
 	attributes := map[string]string{
 		"aurelius_vulnerability_urn": vulnerabilityURN,
 		"aurelius_image_urn":         imageURN,
+		"container_image_urn":        imageURN,
 		"image_digest":               imageDigest,
 		"image_uri":                  strings.TrimSpace(attrs["image_uri"]),
 		"cve_id":                     cveID,
@@ -325,12 +326,7 @@ func aureliusVulnerabilityFindingKey(imageDigest string, cveID string, pkg strin
 }
 
 func aureliusImageFindingURN(tenantID string, imageDigest string) string {
-	tenantID = strings.TrimSpace(tenantID)
-	imageDigest = strings.TrimSpace(imageDigest)
-	if tenantID == "" || imageDigest == "" {
-		return ""
-	}
-	return fmt.Sprintf("urn:cerebro:%s:container_image_digest:%s", tenantID, imageDigest)
+	return normalizedContainerImageURN(tenantID, imageDigest)
 }
 
 func aureliusPromotedVulnerabilityAnchor(attributes map[string]string) string {

--- a/internal/findings/compound_risk.go
+++ b/internal/findings/compound_risk.go
@@ -8,11 +8,12 @@ import (
 )
 
 const (
-	compoundRiskKindActor      = "actor"
-	compoundRiskKindResource   = "resource"
-	compoundRiskKindRepository = "repository"
-	compoundRiskKindSource     = "source"
-	compoundRiskKindType       = "resource_type"
+	compoundRiskKindActor          = "actor"
+	compoundRiskKindResource       = "resource"
+	compoundRiskKindRepository     = "repository"
+	compoundRiskKindContainerImage = "container_image"
+	compoundRiskKindSource         = "source"
+	compoundRiskKindType           = "resource_type"
 )
 
 // CompoundRiskOptions scopes how many correlated risk groups and samples are returned.
@@ -23,11 +24,12 @@ type CompoundRiskOptions struct {
 
 // CompoundRiskReport summarizes correlated findings across common graph dimensions.
 type CompoundRiskReport struct {
-	Actors        []CompoundRiskGroup `json:"actors"`
-	Resources     []CompoundRiskGroup `json:"resources"`
-	Repositories  []CompoundRiskGroup `json:"repositories"`
-	Sources       []CompoundRiskGroup `json:"sources"`
-	ResourceTypes []CompoundRiskGroup `json:"resource_types"`
+	Actors          []CompoundRiskGroup `json:"actors"`
+	Resources       []CompoundRiskGroup `json:"resources"`
+	Repositories    []CompoundRiskGroup `json:"repositories"`
+	ContainerImages []CompoundRiskGroup `json:"container_images"`
+	Sources         []CompoundRiskGroup `json:"sources"`
+	ResourceTypes   []CompoundRiskGroup `json:"resource_types"`
 }
 
 // CompoundRiskGroup captures one correlated set of findings sharing the same dimension.
@@ -63,11 +65,12 @@ type compoundRiskBucket struct {
 func AnalyzeCompoundRisks(records []*ports.FindingRecord, options CompoundRiskOptions) CompoundRiskReport {
 	records = dedupeCompoundRiskFindings(records)
 	return CompoundRiskReport{
-		Actors:        buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindActor), options),
-		Resources:     buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindResource), options),
-		Repositories:  buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindRepository), options),
-		Sources:       buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindSource), options),
-		ResourceTypes: buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindType), options),
+		Actors:          buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindActor), options),
+		Resources:       buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindResource), options),
+		Repositories:    buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindRepository), options),
+		ContainerImages: buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindContainerImage), options),
+		Sources:         buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindSource), options),
+		ResourceTypes:   buildCompoundRiskGroups(groupCompoundRiskFindings(records, compoundRiskKindType), options),
 	}
 }
 
@@ -144,6 +147,12 @@ func compoundRiskDimensionFor(record *ports.FindingRecord, kind string) compound
 	case compoundRiskKindRepository:
 		key := repositoryFromFinding(record)
 		return compoundRiskDimension{key: key, label: key}
+	case compoundRiskKindContainerImage:
+		key := containerImageFromFinding(record)
+		return compoundRiskDimension{
+			key:   key,
+			label: firstNonEmpty(attributes["image_uri"], attributes["image_digest"], key),
+		}
 	case compoundRiskKindResource:
 		key := firstNonEmpty(attributes["primary_resource_urn"], firstFindingResourceURN(record))
 		return compoundRiskDimension{
@@ -354,6 +363,34 @@ func repositoryFromURN(value string) string {
 	}
 	if strings.Contains(repository, "/") {
 		return repository
+	}
+	return ""
+}
+
+func containerImageFromFinding(record *ports.FindingRecord) string {
+	if record == nil {
+		return ""
+	}
+	attributes := record.Attributes
+	if imageURN := firstNonEmpty(
+		attributes["container_image_urn"],
+		attributes["image_urn"],
+	); imageURN != "" {
+		return imageURN
+	}
+	if imageDigest := strings.TrimSpace(attributes["image_digest"]); imageDigest != "" {
+		if imageURN := normalizedContainerImageURN(record.TenantID, imageDigest); imageURN != "" {
+			return imageURN
+		}
+		return imageDigest
+	}
+	if imageURN := firstNonEmpty(attributes["aurelius_image_urn"], attributes["trivy_image_urn"]); imageURN != "" {
+		return imageURN
+	}
+	for _, resourceURN := range record.ResourceURNs {
+		if resourceType := resourceTypeFromURN(resourceURN); resourceType == "container_image_digest" || resourceType == "container_image" {
+			return strings.TrimSpace(resourceURN)
+		}
 	}
 	return ""
 }

--- a/internal/findings/compound_risk_test.go
+++ b/internal/findings/compound_risk_test.go
@@ -136,6 +136,31 @@ func TestAnalyzeCompoundRisksNormalizesCrossSourceDimensions(t *testing.T) {
 	}
 }
 
+func TestAnalyzeCompoundRisksGroupsContainerImagesByNormalizedDigest(t *testing.T) {
+	trivy := compoundRiskFinding("trivy-1", trivyImageVulnerabilityActiveRuleID, "HIGH", "", "", "urn:cerebro:writer:trivy_vulnerability:sha256:abc:CVE-2026-1:openssl", "scan.detected")
+	trivy.Attributes["trivy_image_urn"] = "urn:cerebro:writer:trivy_image:sha256:abc"
+	trivy.Attributes["image_digest"] = "sha256:abc"
+	trivy.Attributes["image_uri"] = "registry.example/app@sha256:abc"
+
+	aurelius := compoundRiskFinding("aurelius-1", aureliusPromotedVulnerabilityActiveRuleID, "HIGH", "", "", "urn:cerebro:writer:aurelius_vulnerability:vuln-1", "promoted")
+	aurelius.Attributes["aurelius_image_urn"] = "urn:cerebro:writer:container_image_digest:sha256:abc"
+	aurelius.Attributes["container_image_urn"] = "urn:cerebro:writer:container_image_digest:sha256:abc"
+	aurelius.Attributes["image_digest"] = "sha256:abc"
+	aurelius.Attributes["image_uri"] = "registry.example/app@sha256:abc"
+
+	report := AnalyzeCompoundRisks([]*ports.FindingRecord{trivy, aurelius}, CompoundRiskOptions{Limit: 10})
+	if got := len(report.ContainerImages); got != 1 {
+		t.Fatalf("len(ContainerImages) = %d, want 1; report=%#v", got, report.ContainerImages)
+	}
+	group := report.ContainerImages[0]
+	if got := group.Key; got != "urn:cerebro:writer:container_image_digest:sha256:abc" {
+		t.Fatalf("ContainerImages[0].Key = %q, want normalized container image urn", got)
+	}
+	if got := group.FindingCount; got != 2 {
+		t.Fatalf("ContainerImages[0].FindingCount = %d, want 2", got)
+	}
+}
+
 func compoundRiskFinding(id string, ruleID string, severity string, actor string, repo string, resourceURN string, action string) *ports.FindingRecord {
 	return &ports.FindingRecord{
 		ID:           id,

--- a/internal/findings/container_image_identity.go
+++ b/internal/findings/container_image_identity.go
@@ -1,0 +1,15 @@
+package findings
+
+import (
+	"fmt"
+	"strings"
+)
+
+func normalizedContainerImageURN(tenantID string, imageDigest string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	imageDigest = strings.TrimSpace(imageDigest)
+	if tenantID == "" || imageDigest == "" {
+		return ""
+	}
+	return fmt.Sprintf("urn:cerebro:%s:container_image_digest:%s", tenantID, imageDigest)
+}

--- a/internal/findings/correlation_catalog.go
+++ b/internal/findings/correlation_catalog.go
@@ -261,7 +261,7 @@ func cloneFindingCorrelationPatternTests(tests []FindingCorrelationPatternTest) 
 
 func validCorrelationDimension(value string) bool {
 	switch value {
-	case compoundRiskKindActor, compoundRiskKindResource, compoundRiskKindRepository, compoundRiskKindSource, compoundRiskKindType:
+	case compoundRiskKindActor, compoundRiskKindResource, compoundRiskKindRepository, compoundRiskKindContainerImage, compoundRiskKindSource, compoundRiskKindType:
 		return true
 	default:
 		return false

--- a/internal/findings/correlation_catalog_test.go
+++ b/internal/findings/correlation_catalog_test.go
@@ -72,6 +72,26 @@ func TestBuiltinFindingCorrelationPatternsIncludeRuntimeHints(t *testing.T) {
 	}
 }
 
+func TestBuiltinFindingCorrelationPatternsIncludeSupplyChainAndContainerGaps(t *testing.T) {
+	patterns := BuiltinFindingCorrelationPatterns()
+	byID := map[string]FindingCorrelationPattern{}
+	for _, pattern := range patterns {
+		byID[pattern.ID] = pattern
+	}
+	for _, patternID := range []string{
+		"github-code-security-control-disabled-with-dependabot-alert",
+		"container-image-promoted-vulnerability-with-trivy-scan",
+		"runtime-active-threat-with-public-exposure",
+	} {
+		if _, ok := byID[patternID]; !ok {
+			t.Fatalf("BuiltinFindingCorrelationPatterns() missing %q", patternID)
+		}
+	}
+	if pattern := byID["container-image-promoted-vulnerability-with-trivy-scan"]; !cloudStringSlicesEqual(pattern.Dimensions, []string{compoundRiskKindContainerImage}) {
+		t.Fatalf("container pattern Dimensions = %#v, want container_image", pattern.Dimensions)
+	}
+}
+
 func TestLoadFindingCorrelationPatternsRejectsIncompletePattern(t *testing.T) {
 	_, err := LoadFindingCorrelationPatterns([]byte(`{"version":"test","patterns":[{"id":"bad","name":"Bad","rule_ids":["one"],"dimensions":["resource"],"window":"1h","score_bonus":1,"reasons":["x"],"tests":[{"name":"t","description":"d","expect_match":true}]}]}`))
 	if err == nil {

--- a/internal/findings/correlation_patterns/builtin.json
+++ b/internal/findings/correlation_patterns/builtin.json
@@ -54,6 +54,54 @@
           "expect_match": false
         }
       ]
+    },
+    {
+      "id": "github-code-security-control-disabled-with-dependabot-alert",
+      "name": "GitHub code security control disabled with Dependabot alert",
+      "rule_ids": [
+        "github-code-security-controls-disabled",
+        "github-dependabot-open-alert"
+      ],
+      "dimensions": [
+        "repository"
+      ],
+      "window": "24h",
+      "score_bonus": 12,
+      "reasons": [
+        "control_disabled",
+        "vulnerable_dependency"
+      ],
+      "tests": [
+        {
+          "name": "shared-repository-positive",
+          "description": "Matches when code security controls are disabled and an open Dependabot alert exists on the same repository inside the window.",
+          "expect_match": true
+        }
+      ]
+    },
+    {
+      "id": "container-image-promoted-vulnerability-with-trivy-scan",
+      "name": "Container image promoted vulnerability with Trivy scan",
+      "rule_ids": [
+        "aurelius-promoted-vulnerability-active",
+        "trivy-image-vulnerability-active"
+      ],
+      "dimensions": [
+        "container_image"
+      ],
+      "window": "24h",
+      "score_bonus": 14,
+      "reasons": [
+        "promoted_image",
+        "container_vulnerability"
+      ],
+      "tests": [
+        {
+          "name": "shared-container-image-positive",
+          "description": "Matches when Aurelius promotion risk and Trivy vulnerability evidence share the same normalized container image digest.",
+          "expect_match": true
+        }
+      ]
     }
   ]
 }

--- a/internal/findings/risk_analysis.go
+++ b/internal/findings/risk_analysis.go
@@ -35,9 +35,10 @@ type FindingExposureAnalysisOptions struct {
 
 // FindingExposureAnalysisReport combines generic compound risk, temporal correlation, and graph path summaries.
 type FindingExposureAnalysisReport struct {
-	CompoundRisks CompoundRiskReport   `json:"compound_risks"`
-	Correlations  []FindingCorrelation `json:"correlations"`
-	AttackPaths   []FindingAttackPath  `json:"attack_paths"`
+	CompoundRisks    CompoundRiskReport       `json:"compound_risks"`
+	Correlations     []FindingCorrelation     `json:"correlations"`
+	AttackPaths      []FindingAttackPath      `json:"attack_paths"`
+	ActionCandidates []FindingActionCandidate `json:"action_candidates"`
 }
 
 // FindingRiskContext captures contextual scoring signals for one finding or correlated group.
@@ -65,6 +66,20 @@ type FindingEvidenceBundle struct {
 	FindingCount    int      `json:"finding_count"`
 	EventCount      int      `json:"event_count"`
 	ResourceCount   int      `json:"resource_count"`
+}
+
+// FindingActionCandidate is a read-only recommendation derived from correlated evidence.
+type FindingActionCandidate struct {
+	ActionType  string                `json:"action_type"`
+	Source      string                `json:"source"`
+	TargetURN   string                `json:"target_urn"`
+	TargetLabel string                `json:"target_label,omitempty"`
+	Owner       string                `json:"owner,omitempty"`
+	Score       int                   `json:"score"`
+	FindingIDs  []string              `json:"finding_ids"`
+	RuleIDs     []string              `json:"rule_ids"`
+	Reason      string                `json:"reason,omitempty"`
+	Evidence    FindingEvidenceBundle `json:"evidence"`
 }
 
 // FindingCorrelation captures a generic stateful/temporal correlation over normalized finding dimensions.
@@ -123,10 +138,14 @@ type FindingAttackPathStep struct {
 // AnalyzeFindingExposure summarizes source-agnostic compound risk, temporal correlations, and graph paths.
 func AnalyzeFindingExposure(records []*ports.FindingRecord, options FindingExposureAnalysisOptions) FindingExposureAnalysisReport {
 	compoundOptions := CompoundRiskOptions{Limit: options.Limit, SampleLimit: options.SampleLimit}
+	compoundRisks := AnalyzeCompoundRisks(records, compoundOptions)
+	correlations := AnalyzeFindingCorrelations(records, options)
+	attackPaths := AnalyzeFindingAttackPaths(records, options.GraphNeighborhoods, options)
 	return FindingExposureAnalysisReport{
-		CompoundRisks: AnalyzeCompoundRisks(records, compoundOptions),
-		Correlations:  AnalyzeFindingCorrelations(records, options),
-		AttackPaths:   AnalyzeFindingAttackPaths(records, options.GraphNeighborhoods, options),
+		CompoundRisks:    compoundRisks,
+		Correlations:     correlations,
+		AttackPaths:      attackPaths,
+		ActionCandidates: buildFindingActionCandidates(records, correlations, attackPaths, options),
 	}
 }
 
@@ -142,6 +161,7 @@ func AnalyzeFindingCorrelations(records []*ports.FindingRecord, options FindingE
 		compoundRiskKindActor,
 		compoundRiskKindResource,
 		compoundRiskKindRepository,
+		compoundRiskKindContainerImage,
 		compoundRiskKindSource,
 		compoundRiskKindType,
 	} {
@@ -378,6 +398,172 @@ func newFindingCorrelation(bucket compoundRiskBucket, window time.Duration, conf
 		Evidence:        evidence,
 		Reasons:         uniqueSortedStrings(reasons),
 	}
+}
+
+func buildFindingActionCandidates(records []*ports.FindingRecord, correlations []FindingCorrelation, attackPaths []FindingAttackPath, options FindingExposureAnalysisOptions) []FindingActionCandidate {
+	recordsByID := map[string]*ports.FindingRecord{}
+	for _, record := range nonNilFindings(records) {
+		if id := strings.TrimSpace(record.ID); id != "" {
+			recordsByID[id] = record
+		}
+	}
+	candidates := []FindingActionCandidate{}
+	seen := map[string]struct{}{}
+	for _, correlation := range correlations {
+		targetURN := actionCandidateTargetURN(correlation.Key, correlation.Evidence.ResourceURNs)
+		if targetURN == "" {
+			continue
+		}
+		candidate := FindingActionCandidate{
+			ActionType:  recommendedActionType(correlation.RuleIDs, correlation.Reasons),
+			Source:      "correlation:" + correlation.Kind,
+			TargetURN:   targetURN,
+			TargetLabel: correlation.Label,
+			Owner:       actionCandidateOwner(correlation.FindingIDs, recordsByID),
+			Score:       correlation.Score,
+			FindingIDs:  uniqueSortedStrings(correlation.FindingIDs),
+			RuleIDs:     uniqueSortedStrings(correlation.RuleIDs),
+			Reason:      firstNonEmpty(correlation.PatternName, strings.Join(correlation.Reasons, ",")),
+			Evidence:    correlation.Evidence,
+		}
+		candidates = appendUniqueFindingActionCandidate(candidates, seen, candidate)
+	}
+	for _, path := range attackPaths {
+		targetURN := actionCandidateTargetURN(actionPathTargetURN(path), path.Evidence.ResourceURNs)
+		if targetURN == "" {
+			continue
+		}
+		candidate := FindingActionCandidate{
+			ActionType: recommendedActionType(path.Evidence.RuleIDs, path.Reasons),
+			Source:     "attack_path",
+			TargetURN:  targetURN,
+			Owner:      actionCandidateOwner(path.Evidence.FindingIDs, recordsByID),
+			Score:      path.Score,
+			FindingIDs: uniqueSortedStrings(path.Evidence.FindingIDs),
+			RuleIDs:    uniqueSortedStrings(path.Evidence.RuleIDs),
+			Reason:     firstNonEmpty(path.Pattern, strings.Join(path.Reasons, ",")),
+			Evidence:   path.Evidence,
+		}
+		candidates = appendUniqueFindingActionCandidate(candidates, seen, candidate)
+	}
+	sort.Slice(candidates, func(i int, j int) bool {
+		left := candidates[i]
+		right := candidates[j]
+		switch {
+		case left.Score != right.Score:
+			return left.Score > right.Score
+		case len(left.FindingIDs) != len(right.FindingIDs):
+			return len(left.FindingIDs) > len(right.FindingIDs)
+		case left.ActionType != right.ActionType:
+			return left.ActionType < right.ActionType
+		default:
+			return left.TargetURN < right.TargetURN
+		}
+	})
+	if options.Limit > 0 && len(candidates) > options.Limit {
+		candidates = candidates[:options.Limit]
+	}
+	return candidates
+}
+
+func appendUniqueFindingActionCandidate(candidates []FindingActionCandidate, seen map[string]struct{}, candidate FindingActionCandidate) []FindingActionCandidate {
+	if candidate.TargetURN == "" || len(candidate.FindingIDs) == 0 {
+		return candidates
+	}
+	key := strings.Join([]string{
+		candidate.ActionType,
+		candidate.Source,
+		candidate.TargetURN,
+		strings.Join(candidate.FindingIDs, "|"),
+		strings.Join(candidate.RuleIDs, "|"),
+	}, "\n")
+	if _, ok := seen[key]; ok {
+		return candidates
+	}
+	seen[key] = struct{}{}
+	return append(candidates, candidate)
+}
+
+func actionCandidateTargetURN(primary string, resourceURNs []string) string {
+	if value := strings.TrimSpace(primary); strings.HasPrefix(value, "urn:") {
+		return value
+	}
+	for _, resourceURN := range resourceURNs {
+		if value := strings.TrimSpace(resourceURN); strings.HasPrefix(value, "urn:") {
+			return value
+		}
+	}
+	return ""
+}
+
+func actionPathTargetURN(path FindingAttackPath) string {
+	for idx := len(path.Steps) - 1; idx >= 0; idx-- {
+		step := path.Steps[idx]
+		if step.Relation == "has_finding" {
+			if target := strings.TrimSpace(step.FromURN); strings.HasPrefix(target, "urn:") {
+				return target
+			}
+			continue
+		}
+		if target := strings.TrimSpace(step.ToURN); strings.HasPrefix(target, "urn:") {
+			return target
+		}
+		if target := strings.TrimSpace(step.FromURN); strings.HasPrefix(target, "urn:") {
+			return target
+		}
+	}
+	return path.FindingURN
+}
+
+func actionCandidateOwner(findingIDs []string, recordsByID map[string]*ports.FindingRecord) string {
+	for _, findingID := range uniqueSortedStrings(findingIDs) {
+		record := recordsByID[findingID]
+		if record == nil {
+			continue
+		}
+		if owner := firstNonEmpty(
+			record.Attributes["owner"],
+			record.Attributes["service_owner"],
+			record.Attributes["repo_owner"],
+			record.Attributes["repository_owner"],
+			record.Attributes["owning_team"],
+			record.Attributes["team"],
+			record.Assignee,
+		); owner != "" {
+			return owner
+		}
+	}
+	return ""
+}
+
+func recommendedActionType(ruleIDs []string, reasons []string) string {
+	ruleSet := map[string]struct{}{}
+	for _, ruleID := range ruleIDs {
+		ruleSet[strings.TrimSpace(ruleID)] = struct{}{}
+	}
+	if _, ok := ruleSet[runtimeActiveThreatEvidenceRuleID]; ok {
+		return "investigate_runtime_threat"
+	}
+	if _, ok := ruleSet[githubSecretScanningAlertCreatedRuleID]; ok {
+		return "rotate_secret_and_restore_control"
+	}
+	if _, hasAurelius := ruleSet[aureliusPromotedVulnerabilityActiveRuleID]; hasAurelius {
+		if _, hasTrivy := ruleSet[trivyImageVulnerabilityActiveRuleID]; hasTrivy {
+			return "remediate_promoted_container_vulnerability"
+		}
+	}
+	if _, ok := ruleSet[githubDependabotOpenAlertRuleID]; ok {
+		return "remediate_vulnerable_dependency"
+	}
+	if _, ok := ruleSet[cloudPublicResourceExposureRuleID]; ok {
+		return "review_public_exposure_path"
+	}
+	for _, reason := range reasons {
+		if strings.Contains(reason, "external_exposure") {
+			return "review_public_exposure_path"
+		}
+	}
+	return "review_correlated_findings"
 }
 
 // AnalyzeFindingAttackPaths extracts bounded, source-agnostic paths from supplied graph neighborhoods.

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -146,6 +146,72 @@ func TestAnalyzeFindingPatternCorrelationsDetectsGitHubSecretExposurePattern(t *
 	}
 }
 
+func TestAnalyzeFindingPatternCorrelationsDetectsDependabotControlPattern(t *testing.T) {
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	controlDisabled := compoundRiskFinding("gh-control", githubCodeSecurityControlsDisabledRuleID, "HIGH", "admin@example.com", "example/cerebro", "urn:cerebro:example:github_code_repository:example/cerebro", "repository_code_scanning.disable")
+	controlDisabled.FirstObservedAt = base
+	controlDisabled.LastObservedAt = base
+	controlDisabled.EventIDs = []string{"event-control"}
+	controlDisabled.Attributes["repository"] = "example/cerebro"
+	controlDisabled.Attributes["repo_owner"] = "appsec"
+	delete(controlDisabled.Attributes, "repo")
+
+	dependabot := compoundRiskFinding("gh-dependabot", githubDependabotOpenAlertRuleID, "HIGH", "", "example/cerebro", "urn:cerebro:example:github_dependabot_alert:example/cerebro:7", "dependabot_alert.open")
+	dependabot.FirstObservedAt = base.Add(30 * time.Minute)
+	dependabot.LastObservedAt = base.Add(30 * time.Minute)
+	dependabot.EventIDs = []string{"event-dependabot"}
+	dependabot.Attributes["repository"] = "example/cerebro"
+	delete(dependabot.Attributes, "repo")
+
+	correlations := AnalyzeFindingPatternCorrelations([]*ports.FindingRecord{controlDisabled, dependabot}, FindingExposureAnalysisOptions{
+		CorrelationWindow: time.Hour,
+	})
+	correlation := findingCorrelationByPattern(correlations, "github-code-security-control-disabled-with-dependabot-alert")
+	if correlation == nil {
+		t.Fatalf("Correlations = %#v, want GitHub Dependabot control pattern", correlations)
+	}
+	if correlation.Dimension != compoundRiskKindRepository {
+		t.Fatalf("Correlation.Dimension = %q, want repository", correlation.Dimension)
+	}
+	if !stringSliceContains(correlation.Reasons, "vulnerable_dependency") {
+		t.Fatalf("Correlation.Reasons = %#v, want vulnerable_dependency", correlation.Reasons)
+	}
+}
+
+func TestAnalyzeFindingPatternCorrelationsDetectsContainerImagePatternUsingNormalizedImageURN(t *testing.T) {
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	trivy := compoundRiskFinding("trivy-1", trivyImageVulnerabilityActiveRuleID, "HIGH", "", "", "urn:cerebro:writer:trivy_vulnerability:sha256:abc:CVE-2026-1:openssl", "scan.detected")
+	trivy.FirstObservedAt = base
+	trivy.LastObservedAt = base
+	trivy.EventIDs = []string{"event-trivy"}
+	trivy.Attributes["trivy_image_urn"] = "urn:cerebro:writer:trivy_image:sha256:abc"
+	trivy.Attributes["image_digest"] = "sha256:abc"
+	trivy.Attributes["image_uri"] = "registry.example/app@sha256:abc"
+
+	aurelius := compoundRiskFinding("aurelius-1", aureliusPromotedVulnerabilityActiveRuleID, "HIGH", "", "", "urn:cerebro:writer:aurelius_vulnerability:vuln-1", "promoted")
+	aurelius.FirstObservedAt = base.Add(20 * time.Minute)
+	aurelius.LastObservedAt = base.Add(20 * time.Minute)
+	aurelius.EventIDs = []string{"event-aurelius"}
+	aurelius.Attributes["container_image_urn"] = "urn:cerebro:writer:container_image_digest:sha256:abc"
+	aurelius.Attributes["aurelius_image_urn"] = "urn:cerebro:writer:container_image_digest:sha256:abc"
+	aurelius.Attributes["image_digest"] = "sha256:abc"
+	aurelius.Attributes["image_uri"] = "registry.example/app@sha256:abc"
+
+	correlations := AnalyzeFindingPatternCorrelations([]*ports.FindingRecord{trivy, aurelius}, FindingExposureAnalysisOptions{
+		CorrelationWindow: time.Hour,
+	})
+	correlation := findingCorrelationByPattern(correlations, "container-image-promoted-vulnerability-with-trivy-scan")
+	if correlation == nil {
+		t.Fatalf("Correlations = %#v, want container image pattern", correlations)
+	}
+	if correlation.Dimension != compoundRiskKindContainerImage {
+		t.Fatalf("Correlation.Dimension = %q, want container_image", correlation.Dimension)
+	}
+	if got := correlation.Key; got != "urn:cerebro:writer:container_image_digest:sha256:abc" {
+		t.Fatalf("Correlation.Key = %q, want normalized container image urn", got)
+	}
+}
+
 func TestAnalyzeFindingPatternCorrelationsDetectsIdentityTamperCredentialHint(t *testing.T) {
 	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
 	controlTamper := compoundRiskFinding("identity-control", identityAuthControlLifecycleTamperingRuleID, "HIGH", "admin@writer.com", "", "urn:cerebro:writer:okta_resource:policy:pol-1", "policy.rule.deactivate")
@@ -183,6 +249,81 @@ func TestAnalyzeFindingPatternCorrelationsDetectsIdentityTamperCredentialHint(t 
 	for _, reason := range []string{"control_tamper", "credential_change"} {
 		if !stringSliceContains(correlation.Reasons, reason) {
 			t.Fatalf("Correlation.Reasons = %#v, want %q", correlation.Reasons, reason)
+		}
+	}
+}
+
+func TestAnalyzeFindingPatternCorrelationsDetectsRuntimeThreatExposurePattern(t *testing.T) {
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	publicExposure := compoundRiskFinding("cloud-public", cloudPublicResourceExposureRuleID, "HIGH", "", "", "urn:cerebro:writer:kubernetes_workload:prod/api", "public_network_ingress")
+	publicExposure.FirstObservedAt = base
+	publicExposure.LastObservedAt = base
+	publicExposure.EventIDs = []string{"event-cloud"}
+	publicExposure.Attributes["internet_exposed"] = "true"
+
+	runtimeThreat := compoundRiskFinding("runtime-threat", runtimeActiveThreatEvidenceRuleID, "HIGH", "", "", "urn:cerebro:writer:kubernetes_workload:prod/api", "credential_use")
+	runtimeThreat.FirstObservedAt = base.Add(15 * time.Minute)
+	runtimeThreat.LastObservedAt = base.Add(15 * time.Minute)
+	runtimeThreat.EventIDs = []string{"event-runtime"}
+	runtimeThreat.Attributes["evidence_type"] = "credential_use"
+	runtimeThreat.Attributes["verdict"] = "active"
+
+	correlations := AnalyzeFindingPatternCorrelations([]*ports.FindingRecord{publicExposure, runtimeThreat}, FindingExposureAnalysisOptions{
+		CorrelationWindow: time.Hour,
+	})
+	correlation := findingCorrelationByPattern(correlations, "runtime-active-threat-with-public-exposure")
+	if correlation == nil {
+		t.Fatalf("Correlations = %#v, want runtime threat exposure hint", correlations)
+	}
+	if correlation.Dimension != compoundRiskKindResource {
+		t.Fatalf("Correlation.Dimension = %q, want resource", correlation.Dimension)
+	}
+	for _, reason := range []string{"active_threat", "external_exposure"} {
+		if !stringSliceContains(correlation.Reasons, reason) {
+			t.Fatalf("Correlation.Reasons = %#v, want %q", correlation.Reasons, reason)
+		}
+	}
+}
+
+func TestAnalyzeFindingExposureReturnsActionCandidatesForCorrelatedFindings(t *testing.T) {
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	trivy := compoundRiskFinding("trivy-1", trivyImageVulnerabilityActiveRuleID, "HIGH", "", "", "urn:cerebro:writer:trivy_vulnerability:sha256:abc:CVE-2026-1:openssl", "scan.detected")
+	trivy.FirstObservedAt = base
+	trivy.LastObservedAt = base
+	trivy.EventIDs = []string{"event-trivy"}
+	trivy.Attributes["image_digest"] = "sha256:abc"
+	trivy.Attributes["service_owner"] = "containers"
+
+	aurelius := compoundRiskFinding("aurelius-1", aureliusPromotedVulnerabilityActiveRuleID, "HIGH", "", "", "urn:cerebro:writer:aurelius_vulnerability:vuln-1", "promoted")
+	aurelius.FirstObservedAt = base.Add(20 * time.Minute)
+	aurelius.LastObservedAt = base.Add(20 * time.Minute)
+	aurelius.EventIDs = []string{"event-aurelius"}
+	aurelius.Attributes["container_image_urn"] = "urn:cerebro:writer:container_image_digest:sha256:abc"
+	aurelius.Attributes["image_digest"] = "sha256:abc"
+
+	report := AnalyzeFindingExposure([]*ports.FindingRecord{trivy, aurelius}, FindingExposureAnalysisOptions{
+		Limit:             10,
+		CorrelationWindow: time.Hour,
+	})
+	if len(report.ActionCandidates) == 0 {
+		t.Fatalf("ActionCandidates = 0, want correlated remediation candidate; report=%#v", report)
+	}
+	candidate := report.ActionCandidates[0]
+	if candidate.ActionType != "remediate_promoted_container_vulnerability" {
+		t.Fatalf("ActionType = %q, want remediate_promoted_container_vulnerability", candidate.ActionType)
+	}
+	if candidate.TargetURN != "urn:cerebro:writer:container_image_digest:sha256:abc" {
+		t.Fatalf("TargetURN = %q, want normalized container image urn", candidate.TargetURN)
+	}
+	if candidate.Owner != "containers" {
+		t.Fatalf("Owner = %q, want containers", candidate.Owner)
+	}
+	if got := candidate.Evidence.FindingCount; got != 2 {
+		t.Fatalf("Evidence.FindingCount = %d, want 2", got)
+	}
+	for _, ruleID := range []string{trivyImageVulnerabilityActiveRuleID, aureliusPromotedVulnerabilityActiveRuleID} {
+		if !stringSliceContains(candidate.RuleIDs, ruleID) {
+			t.Fatalf("RuleIDs = %#v, want %q", candidate.RuleIDs, ruleID)
 		}
 	}
 }

--- a/internal/findings/trivy_image_vulnerability_rule.go
+++ b/internal/findings/trivy_image_vulnerability_rule.go
@@ -107,12 +107,14 @@ func trivyImageVulnerabilityActiveFinding(event *cerebrov1.EventEnvelope, runtim
 	tenantID := strings.TrimSpace(event.GetTenantId())
 	vulnerabilityURN := trivyVulnerabilityFindingURN(tenantID, imageDigest, vulnerabilityID, pkg)
 	imageURN := trivyImageFindingURN(tenantID, imageDigest)
+	containerImageURN := normalizedContainerImageURN(tenantID, imageDigest)
 	if vulnerabilityURN == "" {
 		return nil, nil
 	}
 	attributes := map[string]string{
 		"trivy_vulnerability_urn": vulnerabilityURN,
 		"trivy_image_urn":         imageURN,
+		"container_image_urn":     containerImageURN,
 		"image_digest":            imageDigest,
 		"image_uri":               strings.TrimSpace(attrs["image_uri"]),
 		"vulnerability_id":        vulnerabilityID,
@@ -138,6 +140,9 @@ func trivyImageVulnerabilityActiveFinding(event *cerebrov1.EventEnvelope, runtim
 	resourceURNs := []string{vulnerabilityURN}
 	if imageURN != "" {
 		resourceURNs = append(resourceURNs, imageURN)
+	}
+	if containerImageURN != "" && containerImageURN != imageURN {
+		resourceURNs = append(resourceURNs, containerImageURN)
 	}
 	return &ports.FindingRecord{
 		ID:              fingerprint,


### PR DESCRIPTION
## Summary


## Test Plan


## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->