### PR TITLE
feat: explain action candidate ranking

### DIFF
--- a/internal/findings/risk_analysis.go
+++ b/internal/findings/risk_analysis.go
@@ -1,6 +1,7 @@
 package findings
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -25,12 +26,15 @@ const FindingRiskGraphProjectedModelVersionAttribute = "risk_graph_projected_mod
 
 // FindingExposureAnalysisOptions scopes source-agnostic risk correlation output.
 type FindingExposureAnalysisOptions struct {
-	Limit               int
-	SampleLimit         int
-	CorrelationWindow   time.Duration
-	CorrelationPatterns []FindingCorrelationPattern
-	GraphNeighborhoods  map[string]*ports.EntityNeighborhood
-	RiskScoringConfig   *ports.RiskScoringConfig
+	Limit                int
+	CorrelationLimit     int
+	AttackPathLimit      int
+	ActionCandidateLimit int
+	SampleLimit          int
+	CorrelationWindow    time.Duration
+	CorrelationPatterns  []FindingCorrelationPattern
+	GraphNeighborhoods   map[string]*ports.EntityNeighborhood
+	RiskScoringConfig    *ports.RiskScoringConfig
 }
 
 // FindingExposureAnalysisReport combines generic compound risk, temporal correlation, and graph path summaries.
@@ -79,6 +83,8 @@ type FindingActionCandidate struct {
 	FindingIDs  []string              `json:"finding_ids"`
 	RuleIDs     []string              `json:"rule_ids"`
 	Reason      string                `json:"reason,omitempty"`
+	Reasons     []string              `json:"reasons,omitempty"`
+	RankFactors []string              `json:"rank_factors,omitempty"`
 	Evidence    FindingEvidenceBundle `json:"evidence"`
 }
 
@@ -140,13 +146,15 @@ func AnalyzeFindingExposure(records []*ports.FindingRecord, options FindingExpos
 	compoundOptions := CompoundRiskOptions{Limit: options.Limit, SampleLimit: options.SampleLimit}
 	candidateOptions := options
 	candidateOptions.Limit = 0
+	candidateOptions.CorrelationLimit = 0
+	candidateOptions.AttackPathLimit = 0
 	compoundRisks := AnalyzeCompoundRisks(records, compoundOptions)
 	correlations := AnalyzeFindingCorrelations(records, candidateOptions)
 	attackPaths := AnalyzeFindingAttackPaths(records, options.GraphNeighborhoods, candidateOptions)
 	return FindingExposureAnalysisReport{
 		CompoundRisks:    compoundRisks,
-		Correlations:     limitFindingCorrelations(correlations, options.Limit),
-		AttackPaths:      limitFindingAttackPaths(attackPaths, options.Limit),
+		Correlations:     limitFindingCorrelations(correlations, correlationOutputLimit(options)),
+		AttackPaths:      limitFindingAttackPaths(attackPaths, attackPathOutputLimit(options)),
 		ActionCandidates: buildFindingActionCandidates(records, correlations, attackPaths, options),
 	}
 }
@@ -189,7 +197,7 @@ func AnalyzeFindingCorrelations(records []*ports.FindingRecord, options FindingE
 			return left.Key < right.Key
 		}
 	})
-	return limitFindingCorrelations(correlations, options.Limit)
+	return limitFindingCorrelations(correlations, correlationOutputLimit(options))
 }
 
 func limitFindingCorrelations(correlations []FindingCorrelation, limit int) []FindingCorrelation {
@@ -432,6 +440,8 @@ func buildFindingActionCandidates(records []*ports.FindingRecord, correlations [
 			Reason:      firstNonEmpty(correlation.PatternName, strings.Join(correlation.Reasons, ",")),
 			Evidence:    correlation.Evidence,
 		}
+		candidate.Reasons = actionCandidateReasons(candidate, correlation.Reasons)
+		candidate.RankFactors = actionCandidateRankFactors(candidate)
 		candidates = appendUniqueFindingActionCandidate(candidates, seen, candidate)
 	}
 	for _, path := range attackPaths {
@@ -450,6 +460,8 @@ func buildFindingActionCandidates(records []*ports.FindingRecord, correlations [
 			Reason:     firstNonEmpty(path.Pattern, strings.Join(path.Reasons, ",")),
 			Evidence:   path.Evidence,
 		}
+		candidate.Reasons = actionCandidateReasons(candidate, path.Reasons)
+		candidate.RankFactors = actionCandidateRankFactors(candidate)
 		candidates = appendUniqueFindingActionCandidate(candidates, seen, candidate)
 	}
 	sort.Slice(candidates, func(i int, j int) bool {
@@ -466,10 +478,50 @@ func buildFindingActionCandidates(records []*ports.FindingRecord, correlations [
 			return left.TargetURN < right.TargetURN
 		}
 	})
-	if options.Limit > 0 && len(candidates) > options.Limit {
-		candidates = candidates[:options.Limit]
+	if limit := actionCandidateOutputLimit(options); limit > 0 && len(candidates) > limit {
+		candidates = candidates[:limit]
 	}
 	return candidates
+}
+
+func correlationOutputLimit(options FindingExposureAnalysisOptions) int {
+	if options.CorrelationLimit > 0 {
+		return options.CorrelationLimit
+	}
+	return options.Limit
+}
+
+func attackPathOutputLimit(options FindingExposureAnalysisOptions) int {
+	if options.AttackPathLimit > 0 {
+		return options.AttackPathLimit
+	}
+	return options.Limit
+}
+
+func actionCandidateOutputLimit(options FindingExposureAnalysisOptions) int {
+	if options.ActionCandidateLimit > 0 {
+		return options.ActionCandidateLimit
+	}
+	return options.Limit
+}
+
+func actionCandidateReasons(candidate FindingActionCandidate, sourceReasons []string) []string {
+	reasons := append([]string(nil), sourceReasons...)
+	reasons = append(reasons,
+		"action_type:"+candidate.ActionType,
+		"source:"+candidate.Source,
+	)
+	return uniqueSortedStrings(reasons)
+}
+
+func actionCandidateRankFactors(candidate FindingActionCandidate) []string {
+	return uniqueTrimmedStringsPreserveOrder([]string{
+		fmt.Sprintf("score:%d", candidate.Score),
+		fmt.Sprintf("finding_count:%d", len(candidate.FindingIDs)),
+		fmt.Sprintf("rule_count:%d", len(candidate.RuleIDs)),
+		"action_type:" + candidate.ActionType,
+		"source:" + candidate.Source,
+	})
 }
 
 func appendUniqueFindingActionCandidate(candidates []FindingActionCandidate, seen map[string]struct{}, candidate FindingActionCandidate) []FindingActionCandidate {
@@ -622,7 +674,7 @@ func AnalyzeFindingAttackPaths(records []*ports.FindingRecord, neighborhoods map
 			return left.FindingURN < right.FindingURN
 		}
 	})
-	return limitFindingAttackPaths(paths, options.Limit)
+	return limitFindingAttackPaths(paths, attackPathOutputLimit(options))
 }
 
 func limitFindingAttackPaths(paths []FindingAttackPath, limit int) []FindingAttackPath {

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -493,6 +493,52 @@ func TestBuildFindingActionCandidatesUsesIndependentLimitAndRankOrder(t *testing
 	}
 }
 
+func TestAnalyzeFindingExposureUsesIndependentCorrelationAndAttackPathLimits(t *testing.T) {
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	resourceURN := "urn:cerebro:writer:aws_secret_store:prod-secrets"
+	publicExposure := compoundRiskFinding("cloud-public", cloudPublicResourceExposureRuleID, "HIGH", "admin@example.com", "writer/cerebro", resourceURN, "public_network_ingress")
+	publicExposure.RuntimeID = "writer-cloud"
+	publicExposure.FirstObservedAt = base
+	publicExposure.LastObservedAt = base
+	publicExposure.EventIDs = []string{"event-public"}
+	publicExposure.Attributes["rule_source_id"] = "cloud"
+	publicExposure.Attributes["internet_exposed"] = "true"
+
+	privilegePath := compoundRiskFinding("cloud-privilege", cloudPrivilegePathGrantedRuleID, "HIGH", "admin@example.com", "writer/cerebro", resourceURN, "privilege_path_granted")
+	privilegePath.RuntimeID = "writer-cloud"
+	privilegePath.FirstObservedAt = base.Add(15 * time.Minute)
+	privilegePath.LastObservedAt = privilegePath.FirstObservedAt
+	privilegePath.EventIDs = []string{"event-privilege"}
+	privilegePath.Attributes["rule_source_id"] = "cloud"
+	privilegePath.Attributes["privileged"] = "true"
+
+	report := AnalyzeFindingExposure([]*ports.FindingRecord{publicExposure, privilegePath}, FindingExposureAnalysisOptions{
+		Limit:             1,
+		CorrelationLimit:  2,
+		AttackPathLimit:   2,
+		CorrelationWindow: time.Hour,
+		GraphNeighborhoods: map[string]*ports.EntityNeighborhood{
+			"cloud": {
+				Root: &ports.NeighborhoodNode{URN: resourceURN, EntityType: "aws.secret_store", Label: "prod-secrets"},
+				Neighbors: []*ports.NeighborhoodNode{
+					{URN: "urn:cerebro:writer:aws_public_principal:public_internet", EntityType: "aws.public_principal", Label: "public internet"},
+					{URN: "urn:cerebro:writer:aws_role:admin", EntityType: "aws.role", Label: "admin"},
+				},
+				Relations: []*ports.NeighborhoodRelation{
+					{FromURN: "urn:cerebro:writer:aws_public_principal:public_internet", Relation: "can_reach", ToURN: resourceURN},
+					{FromURN: "urn:cerebro:writer:aws_role:admin", Relation: "can_admin", ToURN: resourceURN},
+				},
+			},
+		},
+	})
+	if got := len(report.Correlations); got != 2 {
+		t.Fatalf("len(Correlations) = %d, want correlation limit to override global limit", got)
+	}
+	if got := len(report.AttackPaths); got != 2 {
+		t.Fatalf("len(AttackPaths) = %d, want attack path limit to override global limit", got)
+	}
+}
+
 func TestAnalyzeFindingExposureBuildsActionCandidatesBeforeApplyingOutputLimit(t *testing.T) {
 	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
 	noTargetFindings := []*ports.FindingRecord{

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -2,6 +2,7 @@ package findings
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -286,6 +287,113 @@ func TestAnalyzeFindingPatternCorrelationsDetectsRuntimeThreatExposurePattern(t 
 	}
 }
 
+func TestAnalyzeFindingPatternCorrelationsRejectsMismatchedDimensionsAndWindows(t *testing.T) {
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+
+	secretControl := compoundRiskFinding("gh-secret-control", githubCodeSecurityControlsDisabledRuleID, "HIGH", "admin@example.com", "example/cerebro", "urn:cerebro:example:github_code_repository:example/cerebro", "repository_secret_scanning.disable")
+	secretControl.FirstObservedAt = base
+	secretControl.LastObservedAt = base
+	secretControl.Attributes["repository"] = "example/cerebro"
+	delete(secretControl.Attributes, "repo")
+	secretAlertOtherRepo := compoundRiskFinding("gh-secret-alert", githubSecretScanningAlertCreatedRuleID, "HIGH", "", "example/other", "urn:cerebro:example:github_code_repository:example/other", "secret_scanning_alert.create")
+	secretAlertOtherRepo.FirstObservedAt = base.Add(30 * time.Minute)
+	secretAlertOtherRepo.LastObservedAt = base.Add(30 * time.Minute)
+	secretAlertOtherRepo.Attributes["repository"] = "example/other"
+	delete(secretAlertOtherRepo.Attributes, "repo")
+
+	dependabotControl := compoundRiskFinding("gh-dependabot-control", githubCodeSecurityControlsDisabledRuleID, "HIGH", "admin@example.com", "example/cerebro", "urn:cerebro:example:github_code_repository:example/cerebro", "repository_code_scanning.disable")
+	dependabotControl.FirstObservedAt = base
+	dependabotControl.LastObservedAt = base
+	dependabotControl.Attributes["repository"] = "example/cerebro"
+	delete(dependabotControl.Attributes, "repo")
+	dependabotOtherRepo := compoundRiskFinding("gh-dependabot-other", githubDependabotOpenAlertRuleID, "HIGH", "", "example/other", "urn:cerebro:example:github_dependabot_alert:example/other:7", "dependabot_alert.open")
+	dependabotOtherRepo.FirstObservedAt = base.Add(30 * time.Minute)
+	dependabotOtherRepo.LastObservedAt = base.Add(30 * time.Minute)
+	dependabotOtherRepo.Attributes["repository"] = "example/other"
+	delete(dependabotOtherRepo.Attributes, "repo")
+	dependabotLate := compoundRiskFinding("gh-dependabot-late", githubDependabotOpenAlertRuleID, "HIGH", "", "example/cerebro", "urn:cerebro:example:github_dependabot_alert:example/cerebro:8", "dependabot_alert.open")
+	dependabotLate.FirstObservedAt = base.Add(25 * time.Hour)
+	dependabotLate.LastObservedAt = base.Add(25 * time.Hour)
+	dependabotLate.Attributes["repository"] = "example/cerebro"
+	delete(dependabotLate.Attributes, "repo")
+
+	trivy := compoundRiskFinding("trivy-1", trivyImageVulnerabilityActiveRuleID, "HIGH", "", "", "urn:cerebro:writer:trivy_vulnerability:sha256:abc:CVE-2026-1:openssl", "scan.detected")
+	trivy.FirstObservedAt = base
+	trivy.LastObservedAt = base
+	trivy.Attributes["image_digest"] = "sha256:abc"
+	aureliusOtherImage := compoundRiskFinding("aurelius-1", aureliusPromotedVulnerabilityActiveRuleID, "HIGH", "", "", "urn:cerebro:writer:aurelius_vulnerability:vuln-1", "promoted")
+	aureliusOtherImage.FirstObservedAt = base.Add(20 * time.Minute)
+	aureliusOtherImage.LastObservedAt = base.Add(20 * time.Minute)
+	aureliusOtherImage.Attributes["container_image_urn"] = "urn:cerebro:writer:container_image_digest:sha256:def"
+	aureliusOtherImage.Attributes["image_digest"] = "sha256:def"
+
+	controlTamper := compoundRiskFinding("identity-control", identityAuthControlLifecycleTamperingRuleID, "HIGH", "admin@writer.com", "", "urn:cerebro:writer:okta_resource:policy:pol-1", "policy.rule.deactivate")
+	controlTamper.FirstObservedAt = base
+	controlTamper.LastObservedAt = base
+	controlTamper.Attributes["primary_actor_urn"] = "urn:cerebro:writer:okta_actor:user:00u-admin"
+	delete(controlTamper.Attributes, "repo")
+	credentialOtherActor := compoundRiskFinding("identity-credential", identityAPIOrOAuthCredentialCreatedRuleID, "HIGH", "other@writer.com", "", "urn:cerebro:writer:okta_resource:api_token:token-1", "system.api_token.create")
+	credentialOtherActor.FirstObservedAt = base.Add(30 * time.Minute)
+	credentialOtherActor.LastObservedAt = base.Add(30 * time.Minute)
+	credentialOtherActor.Attributes["primary_actor_urn"] = "urn:cerebro:writer:okta_actor:user:00u-other"
+	delete(credentialOtherActor.Attributes, "repo")
+
+	publicExposure := compoundRiskFinding("cloud-public", cloudPublicResourceExposureRuleID, "HIGH", "", "", "urn:cerebro:writer:kubernetes_workload:prod/api", "public_network_ingress")
+	publicExposure.FirstObservedAt = base
+	publicExposure.LastObservedAt = base
+	publicExposure.Attributes["internet_exposed"] = "true"
+	runtimeThreatOtherResource := compoundRiskFinding("runtime-threat", runtimeActiveThreatEvidenceRuleID, "HIGH", "", "", "urn:cerebro:writer:kubernetes_workload:prod/worker", "credential_use")
+	runtimeThreatOtherResource.FirstObservedAt = base.Add(15 * time.Minute)
+	runtimeThreatOtherResource.LastObservedAt = base.Add(15 * time.Minute)
+	runtimeThreatOtherResource.Attributes["evidence_type"] = "credential_use"
+
+	for _, tt := range []struct {
+		name      string
+		patternID string
+		records   []*ports.FindingRecord
+	}{
+		{
+			name:      "secret control and alert require same repository",
+			patternID: "github-code-security-control-disabled-with-secret-alert",
+			records:   []*ports.FindingRecord{secretControl, secretAlertOtherRepo},
+		},
+		{
+			name:      "dependabot control and alert require same repository",
+			patternID: "github-code-security-control-disabled-with-dependabot-alert",
+			records:   []*ports.FindingRecord{dependabotControl, dependabotOtherRepo},
+		},
+		{
+			name:      "dependabot control and alert require shared window",
+			patternID: "github-code-security-control-disabled-with-dependabot-alert",
+			records:   []*ports.FindingRecord{dependabotControl, dependabotLate},
+		},
+		{
+			name:      "container pattern requires same normalized image",
+			patternID: "container-image-promoted-vulnerability-with-trivy-scan",
+			records:   []*ports.FindingRecord{trivy, aureliusOtherImage},
+		},
+		{
+			name:      "identity hint requires same actor",
+			patternID: "identity-control-tamper-with-credential-change",
+			records:   []*ports.FindingRecord{controlTamper, credentialOtherActor},
+		},
+		{
+			name:      "runtime threat exposure requires same resource",
+			patternID: "runtime-active-threat-with-public-exposure",
+			records:   []*ports.FindingRecord{publicExposure, runtimeThreatOtherResource},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			correlations := AnalyzeFindingPatternCorrelations(tt.records, FindingExposureAnalysisOptions{
+				CorrelationWindow: time.Hour,
+			})
+			if correlation := findingCorrelationByPattern(correlations, tt.patternID); correlation != nil {
+				t.Fatalf("unexpected pattern correlation: %#v", correlation)
+			}
+		})
+	}
+}
+
 func TestAnalyzeFindingExposureReturnsActionCandidatesForCorrelatedFindings(t *testing.T) {
 	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
 	trivy := compoundRiskFinding("trivy-1", trivyImageVulnerabilityActiveRuleID, "HIGH", "", "", "urn:cerebro:writer:trivy_vulnerability:sha256:abc:CVE-2026-1:openssl", "scan.detected")
@@ -319,6 +427,16 @@ func TestAnalyzeFindingExposureReturnsActionCandidatesForCorrelatedFindings(t *t
 	if candidate.Owner != "containers" {
 		t.Fatalf("Owner = %q, want containers", candidate.Owner)
 	}
+	for _, reason := range []string{"action_type:remediate_promoted_container_vulnerability", "source:correlation:pattern", "pattern:container-image-promoted-vulnerability-with-trivy-scan"} {
+		if !stringSliceContains(candidate.Reasons, reason) {
+			t.Fatalf("Reasons = %#v, want %q", candidate.Reasons, reason)
+		}
+	}
+	for _, factor := range []string{"score:", "finding_count:2", "rule_count:2", "action_type:remediate_promoted_container_vulnerability", "source:correlation:pattern"} {
+		if !stringSliceContainsPrefix(candidate.RankFactors, factor) {
+			t.Fatalf("RankFactors = %#v, want prefix %q", candidate.RankFactors, factor)
+		}
+	}
 	if got := candidate.Evidence.FindingCount; got != 2 {
 		t.Fatalf("Evidence.FindingCount = %d, want 2", got)
 	}
@@ -326,6 +444,52 @@ func TestAnalyzeFindingExposureReturnsActionCandidatesForCorrelatedFindings(t *t
 		if !stringSliceContains(candidate.RuleIDs, ruleID) {
 			t.Fatalf("RuleIDs = %#v, want %q", candidate.RuleIDs, ruleID)
 		}
+	}
+}
+
+func TestBuildFindingActionCandidatesUsesIndependentLimitAndRankOrder(t *testing.T) {
+	first := compoundRiskFinding("first-1", runtimeActiveThreatEvidenceRuleID, "HIGH", "", "", "urn:cerebro:writer:kubernetes_workload:prod/api", "credential_use")
+	second := compoundRiskFinding("second-1", githubDependabotOpenAlertRuleID, "HIGH", "", "", "urn:cerebro:writer:github_dependabot_alert:example/cerebro:7", "dependabot_alert.open")
+	correlations := []FindingCorrelation{
+		{
+			Kind:       "pattern",
+			PatternID:  "lower",
+			Dimension:  compoundRiskKindResource,
+			Key:        "urn:cerebro:writer:github_dependabot_alert:example/cerebro:7",
+			Score:      50,
+			FindingIDs: []string{second.ID},
+			RuleIDs:    []string{githubDependabotOpenAlertRuleID},
+			Reasons:    []string{"vulnerable_dependency"},
+			Evidence:   newFindingEvidenceBundle([]*ports.FindingRecord{second}),
+		},
+		{
+			Kind:       "pattern",
+			PatternID:  "higher",
+			Dimension:  compoundRiskKindResource,
+			Key:        "urn:cerebro:writer:kubernetes_workload:prod/api",
+			Score:      90,
+			FindingIDs: []string{first.ID},
+			RuleIDs:    []string{runtimeActiveThreatEvidenceRuleID},
+			Reasons:    []string{"active_threat"},
+			Evidence:   newFindingEvidenceBundle([]*ports.FindingRecord{first}),
+		},
+	}
+
+	candidates := buildFindingActionCandidates([]*ports.FindingRecord{first, second}, correlations, nil, FindingExposureAnalysisOptions{
+		Limit:                1,
+		ActionCandidateLimit: 2,
+	})
+	if got := len(candidates); got != 2 {
+		t.Fatalf("len(candidates) = %d, want action candidate limit to override global limit", got)
+	}
+	if candidates[0].TargetURN != "urn:cerebro:writer:kubernetes_workload:prod/api" {
+		t.Fatalf("first candidate TargetURN = %q, want highest score first", candidates[0].TargetURN)
+	}
+	if !stringSliceContains(candidates[0].Reasons, "active_threat") {
+		t.Fatalf("first candidate Reasons = %#v, want active_threat", candidates[0].Reasons)
+	}
+	if !stringSliceContains(candidates[0].RankFactors, "score:90") {
+		t.Fatalf("first candidate RankFactors = %#v, want score:90", candidates[0].RankFactors)
 	}
 }
 
@@ -899,6 +1063,15 @@ func cloneFindingWithoutAttributes(finding *ports.FindingRecord, keys ...string)
 func stringSliceContains(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceContainsPrefix(values []string, wantPrefix string) bool {
+	for _, value := range values {
+		if strings.HasPrefix(value, wantPrefix) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Adds independent output limits for correlations, attack paths, and action candidates, plus action candidate explainability fields for source reasons and deterministic rank factors.

## Test Plan

- `go test ./internal/findings -run 'TestAnalyzeFinding(Exposure|PatternCorrelations)|TestBuildFindingActionCandidates' -count=1 -v`
- `go test ./internal/findings -count=1`
- `go test ./internal/reports -count=1`
- `make droid-review-preflight`
- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->