### PR TITLE
perf: stop graph rules from exhausting the orchestrator phase budget

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -514,6 +514,14 @@ func runOrchestratorIteration(
 	))
 	var runErr error
 	var acquiredCount uint32
+	// Graph rules are tenant-scoped: each one queries the whole tenant graph,
+	// not just the triggering runtime's slice. Running them once per runtime
+	// re-evaluates the identical tenant-wide rule for every runtime in the
+	// tenant (hundreds, for large multi-account tenants), which is the dominant
+	// load on the graph-rule phase. Track which rules already ran for a tenant
+	// this iteration and exclude them so each rule runs at most once per tenant
+	// per cycle while still covering rules contributed by other sources.
+	graphRulesEvaluatedByTenant := map[string]map[string]struct{}{}
 	for _, runtime := range runtimes {
 		if targetLimit > 0 && acquiredCount >= targetLimit {
 			break
@@ -670,10 +678,16 @@ func runOrchestratorIteration(
 		// reached by source sync, even if a trailing PutIngestRun(completed) write
 		// failed. The graph is fresh enough for read-only rules at that point.
 		if graphIngestReadyForGraphRules(graphResult, syncResult.GetRuntime().GetNextCursor()) {
+			excludedGraphRuleIDs := orchestratorEvaluatedGraphRuleIDs(graphRulesEvaluatedByTenant[runtimeResult.TenantID])
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_deduped_count", len(excludedGraphRuleIDs))
 			graphRulesResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_rules", iteration, runtime, options.PhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateGraphRulesResult, error) {
-				return findingService.EvaluateSourceRuntimeGraphRules(phaseCtx, findings.EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
+				return findingService.EvaluateSourceRuntimeGraphRules(phaseCtx, findings.EvaluateGraphRulesRequest{RuntimeID: runtime.GetId(), ExcludeRuleIDs: excludedGraphRuleIDs})
 			})
 			runtimeSpanAttrs = applyGraphRuleCounters(runtimeResult, graphRulesResult, runtimeSpanAttrs)
+			// Mark every rule that was attempted (success or failure) so a slow
+			// or failing rule is retried at most once per tenant per cycle
+			// rather than re-running for every remaining runtime in the tenant.
+			markOrchestratorTenantGraphRulesEvaluated(graphRulesEvaluatedByTenant, runtimeResult.TenantID, graphRulesResult)
 			if err != nil {
 				if errors.Is(err, findings.ErrGraphRuntimeUnavailable) || errors.Is(err, findings.ErrRuntimeUnavailable) {
 					runtimeResult.GraphRules = "skipped"
@@ -1098,6 +1112,41 @@ func applyGraphRuleCounters(runtimeResult *orchestratorRuntimeResult, graphRules
 	attrs = withTelemetryField(attrs, "graph_rule_findings", runtimeResult.GraphRuleFindings)
 	attrs = withTelemetryField(attrs, "graph_rule_rows_read", runtimeResult.GraphRuleRowsRead)
 	return attrs
+}
+
+// orchestratorEvaluatedGraphRuleIDs returns the graph-rule IDs already evaluated
+// for a tenant this iteration, to be excluded from the next runtime's pass.
+func orchestratorEvaluatedGraphRuleIDs(evaluated map[string]struct{}) []string {
+	if len(evaluated) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(evaluated))
+	for id := range evaluated {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// markOrchestratorTenantGraphRulesEvaluated records every graph rule attempted
+// in a pass against the tenant so subsequent runtimes in the same iteration
+// exclude it.
+func markOrchestratorTenantGraphRulesEvaluated(evaluatedByTenant map[string]map[string]struct{}, tenantID string, result *findings.EvaluateGraphRulesResult) {
+	if evaluatedByTenant == nil || result == nil {
+		return
+	}
+	evaluated := evaluatedByTenant[tenantID]
+	if evaluated == nil {
+		evaluated = map[string]struct{}{}
+		evaluatedByTenant[tenantID] = evaluated
+	}
+	for _, evaluation := range result.Evaluations {
+		if evaluation == nil || evaluation.Rule == nil {
+			continue
+		}
+		if id := strings.TrimSpace(evaluation.Rule.GetId()); id != "" {
+			evaluated[id] = struct{}{}
+		}
+	}
 }
 
 func orchestratorListFilter(filter ports.SourceRuntimeFilter) ports.SourceRuntimeFilter {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -35,6 +35,11 @@ const sourceRuntimeLeaseOverscanLimit = 100
 const (
 	defaultOrchestratorPhaseTimeout       = 15 * time.Minute
 	defaultOrchestratorGraphIngestTimeout = 45 * time.Minute
+	// graphRulePhaseTimeoutMargin keeps the derived per-graph-rule Cypher budget
+	// strictly under the graph-rule phase timeout so a stuck rule trips an
+	// attributable per-rule deadline before the phase context is cancelled out
+	// from under the in-flight query (which surfaces as a connectivity error).
+	graphRulePhaseTimeoutMargin = time.Minute
 )
 
 type orchestratorOptions struct {
@@ -348,7 +353,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		findingEvaluationRunStore(deps.StateStore),
 		findingEvidenceStore(deps.StateStore),
 		claimStore(deps.StateStore),
-	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(findingGraphQueryStore(deps.GraphStore)).WithAppendLog(deps.AppendLog)
+	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(findingGraphQueryStore(deps.GraphStore)).WithAppendLog(deps.AppendLog).WithGraphRuleQueryTimeout(graphRuleQueryBudgetForPhase(options.PhaseTimeout))
 	graphService := graphingest.New(
 		registry,
 		lister,
@@ -755,6 +760,23 @@ func runOrchestratorIteration(
 // context.DeadlineExceeded, which the caller treats like any other
 // failure (lease releases, next iteration retries).
 //
+// graphRuleQueryBudgetForPhase derives a per-graph-rule Cypher read budget that
+// always trips before the graph-rule phase deadline, so a stuck rule surfaces an
+// attributable per-rule timeout instead of a phase-cancellation connectivity
+// error. A non-positive phase timeout returns 0 so the finding service keeps its
+// own conservative default.
+func graphRuleQueryBudgetForPhase(phaseTimeout time.Duration) time.Duration {
+	if phaseTimeout <= 0 {
+		return 0
+	}
+	if phaseTimeout > graphRulePhaseTimeoutMargin {
+		return phaseTimeout - graphRulePhaseTimeoutMargin
+	}
+	// Phase budget is at or below the standard margin: keep a 10% headroom so the
+	// per-rule deadline still fires first.
+	return phaseTimeout - phaseTimeout/10
+}
+
 // The phase context is derived from runtimeCtx so it still receives
 // lease-renewal cancellation. The generic R parameter lets each phase
 // return its own result type without an interface boxing dance.

--- a/cmd/cerebro/orchestrator_graph_dedup_test.go
+++ b/cmd/cerebro/orchestrator_graph_dedup_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"sort"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findings"
+)
+
+func TestMarkOrchestratorTenantGraphRulesEvaluatedTracksRuleIDsPerTenant(t *testing.T) {
+	evaluatedByTenant := map[string]map[string]struct{}{}
+
+	markOrchestratorTenantGraphRulesEvaluated(evaluatedByTenant, "writer", &findings.EvaluateGraphRulesResult{
+		Evaluations: []*findings.GraphRuleEvaluationResult{
+			{Rule: &cerebrov1.RuleSpec{Id: "rule-a"}},
+			{Rule: &cerebrov1.RuleSpec{Id: "rule-b"}},
+			nil,
+			{Rule: nil},
+			{Rule: &cerebrov1.RuleSpec{Id: "  "}},
+		},
+	})
+
+	got := orchestratorEvaluatedGraphRuleIDs(evaluatedByTenant["writer"])
+	sort.Strings(got)
+	if want := []string{"rule-a", "rule-b"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("evaluated rule ids = %v, want %v", got, want)
+	}
+
+	// A second runtime in the same tenant accumulates without dropping prior ids.
+	markOrchestratorTenantGraphRulesEvaluated(evaluatedByTenant, "writer", &findings.EvaluateGraphRulesResult{
+		Evaluations: []*findings.GraphRuleEvaluationResult{{Rule: &cerebrov1.RuleSpec{Id: "rule-c"}}},
+	})
+	if got := len(evaluatedByTenant["writer"]); got != 3 {
+		t.Fatalf("tenant rule count = %d, want 3", got)
+	}
+
+	// A different tenant is tracked independently.
+	if got := orchestratorEvaluatedGraphRuleIDs(evaluatedByTenant["other"]); got != nil {
+		t.Fatalf("untracked tenant ids = %v, want nil", got)
+	}
+}
+
+func TestOrchestratorEvaluatedGraphRuleIDsEmpty(t *testing.T) {
+	if got := orchestratorEvaluatedGraphRuleIDs(nil); got != nil {
+		t.Fatalf("orchestratorEvaluatedGraphRuleIDs(nil) = %v, want nil", got)
+	}
+	if got := orchestratorEvaluatedGraphRuleIDs(map[string]struct{}{}); got != nil {
+		t.Fatalf("orchestratorEvaluatedGraphRuleIDs(empty) = %v, want nil", got)
+	}
+}

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -1466,3 +1466,30 @@ type failingProjectionGraphStore struct {
 func (s *failingProjectionGraphStore) UpsertProjectedEntity(context.Context, *ports.ProjectedEntity) error {
 	return s.err
 }
+
+func TestGraphRuleQueryBudgetForPhase(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		phase time.Duration
+		want  time.Duration
+	}{
+		{name: "default phase keeps the conventional 14m budget", phase: defaultOrchestratorPhaseTimeout, want: 14 * time.Minute},
+		{name: "smaller phase shrinks the budget below it", phase: 10 * time.Minute, want: 9 * time.Minute},
+		{name: "phase at the margin keeps headroom", phase: graphRulePhaseTimeoutMargin, want: graphRulePhaseTimeoutMargin - graphRulePhaseTimeoutMargin/10},
+		{name: "tiny phase keeps headroom", phase: 30 * time.Second, want: 27 * time.Second},
+		{name: "zero phase defers to the service default", phase: 0, want: 0},
+		{name: "negative phase defers to the service default", phase: -time.Minute, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := graphRuleQueryBudgetForPhase(tc.phase)
+			if got != tc.want {
+				t.Fatalf("graphRuleQueryBudgetForPhase(%v) = %v, want %v", tc.phase, got, tc.want)
+			}
+			// A positive phase must always yield a budget strictly under it so the
+			// per-rule deadline trips before the phase context is cancelled.
+			if tc.phase > 0 && got >= tc.phase {
+				t.Fatalf("budget %v must be strictly under phase %v", got, tc.phase)
+			}
+		})
+	}
+}

--- a/internal/findings/cloud_attack_path_graph_rule.go
+++ b/internal/findings/cloud_attack_path_graph_rule.go
@@ -18,6 +18,13 @@ const (
 	cloudPublicExposurePrivilegedPrincipalRuleID   = "cloud-public-exposure-privileged-principal"
 	cloudPublicExposurePrivilegedPrincipalKind     = "finding.cloud_public_exposure_privileged_principal"
 	cloudPublicExposurePrivilegedPrincipalRowLimit = 250
+	// cloudPublicExposurePrivilegedPrincipalPerAccountCap bounds the exposure x
+	// privileged-principal cross product per cloud account. Without it the join on
+	// the account hub materializes (exposed resources) x (privileged principals)
+	// for every account before ORDER BY/LIMIT, which sorts the whole product in
+	// memory and is the dominant cost on large accounts. Capping each side keeps a
+	// deterministic, lexicographically-ordered representative sample.
+	cloudPublicExposurePrivilegedPrincipalPerAccountCap = 50
 )
 
 type cloudPublicExposurePrivilegedPrincipalRule struct {
@@ -94,9 +101,21 @@ func (r *cloudPublicExposurePrivilegedPrincipalRule) QueryFor(runtime *cerebrov1
 	}
 	return ports.CypherQueryRequest{
 		Query: `MATCH (public:Entity {tenant_id: $tenant_id})-[reach:RELATION {relation: 'can_reach'}]->(exposed:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'belongs_to'}]->(account:Entity {tenant_id: $tenant_id, entity_type: 'cloud.account'})
+WHERE public.entity_type IN ['aws.public_principal', 'gcp.public_principal', 'azure.public_principal']
+WITH account, public, reach, exposed
+ORDER BY exposed.label, exposed.urn
+WITH account, collect(DISTINCT {
+       public_urn: public.urn,
+       public_entity_type: public.entity_type,
+       public_label: public.label,
+       exposed_urn: exposed.urn,
+       exposed_entity_type: exposed.entity_type,
+       exposed_label: exposed.label,
+       reach_relation: reach.relation
+     })[0..$exposure_cap] AS exposures
+WHERE size(exposures) > 0
 MATCH (principal:Entity {tenant_id: $tenant_id})-[access:RELATION]->(permission:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'belongs_to'}]->(account)
-WHERE public.entity_type ENDS WITH '.public_principal'
-  AND access.relation IN ['can_admin', 'can_perform', 'can_assume', 'can_impersonate']
+WHERE access.relation IN ['can_admin', 'can_perform', 'can_assume', 'can_impersonate']
   AND (
     access.relation <> 'can_perform'
     OR coalesce(access.attributes_json, '') CONTAINS '"is_admin":"true"'
@@ -104,28 +123,45 @@ WHERE public.entity_type ENDS WITH '.public_principal'
     OR coalesce(access.attributes_json, '') CONTAINS 'AdministratorAccess'
     OR coalesce(access.attributes_json, '') CONTAINS '"permission":"*"'
   )
-RETURN public.urn AS public_urn,
-       public.entity_type AS public_entity_type,
-       public.label AS public_label,
-       exposed.urn AS exposed_urn,
-       exposed.entity_type AS exposed_entity_type,
-       exposed.label AS exposed_label,
+WITH account, exposures, principal, access, permission
+ORDER BY principal.label, permission.label
+WITH account, exposures, collect(DISTINCT {
+       principal_urn: principal.urn,
+       principal_entity_type: principal.entity_type,
+       principal_label: principal.label,
+       permission_urn: permission.urn,
+       permission_entity_type: permission.entity_type,
+       permission_label: permission.label,
+       access_relation: access.relation,
+       access_attributes_json: coalesce(access.attributes_json, '')
+     })[0..$principal_cap] AS grants
+WHERE size(grants) > 0
+UNWIND exposures AS exposure
+UNWIND grants AS grant
+RETURN exposure.public_urn AS public_urn,
+       exposure.public_entity_type AS public_entity_type,
+       exposure.public_label AS public_label,
+       exposure.exposed_urn AS exposed_urn,
+       exposure.exposed_entity_type AS exposed_entity_type,
+       exposure.exposed_label AS exposed_label,
        account.urn AS account_urn,
        account.label AS account_label,
-       principal.urn AS principal_urn,
-       principal.entity_type AS principal_entity_type,
-       principal.label AS principal_label,
-       permission.urn AS permission_urn,
-       permission.entity_type AS permission_entity_type,
-       permission.label AS permission_label,
-       reach.relation AS reach_relation,
-       access.relation AS access_relation,
-       coalesce(access.attributes_json, '') AS access_attributes_json
-ORDER BY account.label, exposed.label, principal.label, permission.label
+       grant.principal_urn AS principal_urn,
+       grant.principal_entity_type AS principal_entity_type,
+       grant.principal_label AS principal_label,
+       grant.permission_urn AS permission_urn,
+       grant.permission_entity_type AS permission_entity_type,
+       grant.permission_label AS permission_label,
+       exposure.reach_relation AS reach_relation,
+       grant.access_relation AS access_relation,
+       grant.access_attributes_json AS access_attributes_json
+ORDER BY account_label, exposed_label, principal_label, permission_label
 LIMIT $row_limit`,
 		Params: map[string]any{
-			"tenant_id": strings.TrimSpace(runtime.GetTenantId()),
-			"row_limit": int64(cloudPublicExposurePrivilegedPrincipalRowLimit),
+			"tenant_id":     strings.TrimSpace(runtime.GetTenantId()),
+			"row_limit":     int64(cloudPublicExposurePrivilegedPrincipalRowLimit),
+			"exposure_cap":  int64(cloudPublicExposurePrivilegedPrincipalPerAccountCap),
+			"principal_cap": int64(cloudPublicExposurePrivilegedPrincipalPerAccountCap),
 		},
 		RowLimit: cloudPublicExposurePrivilegedPrincipalRowLimit,
 	}

--- a/internal/findings/cloud_attack_path_graph_rule.go
+++ b/internal/findings/cloud_attack_path_graph_rule.go
@@ -24,6 +24,11 @@ const (
 	// for every account before ORDER BY/LIMIT, which sorts the whole product in
 	// memory and is the dominant cost on large accounts. Capping each side keeps a
 	// deterministic, lexicographically-ordered representative sample.
+	//
+	// When the cap actually drops data the query emits graph_rule_truncated=true
+	// so the service marks the evaluation truncated and skips stale-finding
+	// auto-resolution; otherwise capping a large account below the row limit would
+	// silently close still-active findings for the dropped combinations.
 	cloudPublicExposurePrivilegedPrincipalPerAccountCap = 50
 )
 
@@ -112,7 +117,8 @@ WITH account, collect(DISTINCT {
        exposed_entity_type: exposed.entity_type,
        exposed_label: exposed.label,
        reach_relation: reach.relation
-     })[0..$exposure_cap] AS exposures
+     }) AS all_exposures
+WITH account, size(all_exposures) > $exposure_cap AS exposures_capped, all_exposures[0..$exposure_cap] AS exposures
 WHERE size(exposures) > 0
 MATCH (principal:Entity {tenant_id: $tenant_id})-[access:RELATION]->(permission:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'belongs_to'}]->(account)
 WHERE access.relation IN ['can_admin', 'can_perform', 'can_assume', 'can_impersonate']
@@ -123,9 +129,9 @@ WHERE access.relation IN ['can_admin', 'can_perform', 'can_assume', 'can_imperso
     OR coalesce(access.attributes_json, '') CONTAINS 'AdministratorAccess'
     OR coalesce(access.attributes_json, '') CONTAINS '"permission":"*"'
   )
-WITH account, exposures, principal, access, permission
+WITH account, exposures, exposures_capped, principal, access, permission
 ORDER BY principal.label, permission.label
-WITH account, exposures, collect(DISTINCT {
+WITH account, exposures, exposures_capped, collect(DISTINCT {
        principal_urn: principal.urn,
        principal_entity_type: principal.entity_type,
        principal_label: principal.label,
@@ -134,7 +140,8 @@ WITH account, exposures, collect(DISTINCT {
        permission_label: permission.label,
        access_relation: access.relation,
        access_attributes_json: coalesce(access.attributes_json, '')
-     })[0..$principal_cap] AS grants
+     }) AS all_grants
+WITH account, exposures, (exposures_capped OR size(all_grants) > $principal_cap) AS account_capped, all_grants[0..$principal_cap] AS grants
 WHERE size(grants) > 0
 UNWIND exposures AS exposure
 UNWIND grants AS grant
@@ -154,7 +161,8 @@ RETURN exposure.public_urn AS public_urn,
        grant.permission_label AS permission_label,
        exposure.reach_relation AS reach_relation,
        grant.access_relation AS access_relation,
-       grant.access_attributes_json AS access_attributes_json
+       grant.access_attributes_json AS access_attributes_json,
+       account_capped AS graph_rule_truncated
 ORDER BY account_label, exposed_label, principal_label, permission_label
 LIMIT $row_limit`,
 		Params: map[string]any{

--- a/internal/findings/cloud_attack_path_graph_rule_test.go
+++ b/internal/findings/cloud_attack_path_graph_rule_test.go
@@ -123,6 +123,24 @@ func TestCloudPublicExposurePrivilegedPrincipalGraphRuleSupportsJoinProducerRunt
 	}
 }
 
+func TestCloudPublicExposurePrivilegedPrincipalSignalsPerAccountCapTruncation(t *testing.T) {
+	// The per-account cap must compare the full collected sizes against the cap and
+	// surface graph_rule_truncated so the service skips stale-finding resolution when
+	// it drops data; slicing before measuring would hide the capping and silently
+	// auto-resolve still-active findings.
+	rule := newCloudPublicExposurePrivilegedPrincipalRule().(GraphRule)
+	query := rule.QueryFor(&cerebrov1.SourceRuntime{Id: "writer-aws-effective-permission", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "effective_permission"}})
+	for _, fragment := range []string{
+		"size(all_exposures) > $exposure_cap AS exposures_capped",
+		"(exposures_capped OR size(all_grants) > $principal_cap) AS account_capped",
+		"account_capped AS graph_rule_truncated",
+	} {
+		if !strings.Contains(query.Query, fragment) {
+			t.Fatalf("QueryFor() missing per-account cap truncation fragment %q:\n%s", fragment, query.Query)
+		}
+	}
+}
+
 func TestCloudCurrentPublicExposureGraphRuleRequiresStampedRecentReachability(t *testing.T) {
 	rule := newCloudPublicResourceExposureGraphRule().(GraphRule)
 	query := rule.QueryFor(&cerebrov1.SourceRuntime{Id: "writer-aws-resource-exposure", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "resource_exposure"}})

--- a/internal/findings/cloud_current_public_exposure_review_rule.go
+++ b/internal/findings/cloud_current_public_exposure_review_rule.go
@@ -63,9 +63,12 @@ WHERE public.entity_type IN ['aws.public_principal', 'gcp.public_principal', 'az
   AND resource.entity_type <> 'cloud.account'
   AND NOT resource.entity_type IN ['aws.public_principal', 'gcp.public_principal', 'azure.public_principal']
   AND (
-    coalesce(resource.attributes_json, '') CONTAINS '"internet_exposed":"true"'
-    OR coalesce(resource.attributes_json, '') CONTAINS '"external_exposure":"true"'
-    OR coalesce(resource.attributes_json, '') CONTAINS '"public":"true"'
+    resource.internet_exposed = true
+    OR (resource.internet_exposed IS NULL AND (
+      coalesce(resource.attributes_json, '') CONTAINS '"internet_exposed":"true"'
+      OR coalesce(resource.attributes_json, '') CONTAINS '"external_exposure":"true"'
+      OR coalesce(resource.attributes_json, '') CONTAINS '"public":"true"'
+    ))
   )
   AND coalesce(reach.attributes_json, '') CONTAINS '"at":"'
   AND datetime(split(split(coalesce(reach.attributes_json, ''), '"at":"')[1], '"')[0]) >= datetime() - duration('P30D')

--- a/internal/findings/cloud_current_public_exposure_review_rule.go
+++ b/internal/findings/cloud_current_public_exposure_review_rule.go
@@ -59,9 +59,9 @@ func newCloudPublicResourceExposureGraphRule() Rule {
 			"secret_manager_secret",
 		},
 	}, `MATCH (public:Entity {tenant_id: $tenant_id})-[reach:RELATION {relation: 'can_reach'}]->(resource:Entity {tenant_id: $tenant_id})
-WHERE public.entity_type ENDS WITH '.public_principal'
+WHERE public.entity_type IN ['aws.public_principal', 'gcp.public_principal', 'azure.public_principal']
   AND resource.entity_type <> 'cloud.account'
-  AND NOT resource.entity_type ENDS WITH '.public_principal'
+  AND NOT resource.entity_type IN ['aws.public_principal', 'gcp.public_principal', 'azure.public_principal']
   AND (
     coalesce(resource.attributes_json, '') CONTAINS '"internet_exposed":"true"'
     OR coalesce(resource.attributes_json, '') CONTAINS '"external_exposure":"true"'

--- a/internal/findings/cloud_exposed_privileged_compute_graph_rule.go
+++ b/internal/findings/cloud_exposed_privileged_compute_graph_rule.go
@@ -90,22 +90,28 @@ func newCloudExposedPrivilegedComputeRoleRule() Rule {
 			"resource_exposure",
 		},
 	}, `MATCH (public:Entity {tenant_id: $tenant_id})-[reach:RELATION {relation: 'can_reach'}]->(entry:Entity {tenant_id: $tenant_id})
-MATCH (workload:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'belongs_to'}]->(account:Entity {tenant_id: $tenant_id, entity_type: 'cloud.account'})
-WHERE public.entity_type ENDS WITH '.public_principal'
-  AND workload.entity_type IN ['aws.ec2.instance', 'aws.lambda.function', 'aws.ecs.service', 'aws.ecs.task', 'aws.eks.cluster', 'aws.eks.nodegroup', 'aws.eks.fargate_profile', 'aws.eks.pod_identity_association', 'gcp.compute.instance', 'gcp.gke.cluster', 'gcp.cloud.run.service', 'gcp.cloud.function', 'gcp.cloud.sql.instance', 'azure.virtual.machine', 'azure.aks.cluster', 'azure.app.service', 'azure.function.app']
-  AND (
-    entry = workload
-    OR EXISTS {
-      MATCH (entry)-[:RELATION {relation: 'attached_to'}]->(workload)
-      WHERE entry.entity_type = 'aws.network.interface'
-    }
-    OR EXISTS {
-      MATCH (workload)-[:RELATION {relation: 'member_of'}]->(entry)
-      WHERE entry.entity_type = 'aws.security_group'
-    }
-  )
+WHERE public.entity_type IN ['aws.public_principal', 'gcp.public_principal', 'azure.public_principal']
   AND coalesce(reach.attributes_json, '') CONTAINS '"at":"'
   AND datetime(split(split(coalesce(reach.attributes_json, ''), '"at":"')[1], '"')[0]) >= datetime() - duration('P30D')
+CALL {
+  WITH entry
+  MATCH (workload:Entity {tenant_id: $tenant_id})
+  WHERE workload = entry
+  RETURN workload
+  UNION
+  WITH entry
+  MATCH (entry)-[:RELATION {relation: 'attached_to'}]->(workload:Entity {tenant_id: $tenant_id})
+  WHERE entry.entity_type = 'aws.network.interface'
+  RETURN workload
+  UNION
+  WITH entry
+  MATCH (workload:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'member_of'}]->(entry)
+  WHERE entry.entity_type = 'aws.security_group'
+  RETURN workload
+}
+WITH public, reach, entry, workload
+WHERE workload.entity_type IN ['aws.ec2.instance', 'aws.lambda.function', 'aws.ecs.service', 'aws.ecs.task', 'aws.eks.cluster', 'aws.eks.nodegroup', 'aws.eks.fargate_profile', 'aws.eks.pod_identity_association', 'gcp.compute.instance', 'gcp.gke.cluster', 'gcp.cloud.run.service', 'gcp.cloud.function', 'gcp.cloud.sql.instance', 'azure.virtual.machine', 'azure.aks.cluster', 'azure.app.service', 'azure.function.app']
+MATCH (workload)-[:RELATION {relation: 'belongs_to'}]->(account:Entity {tenant_id: $tenant_id, entity_type: 'cloud.account'})
 OPTIONAL MATCH (workload)-[directRun:RELATION {relation: 'runs_as'}]->(directRole:Entity {tenant_id: $tenant_id})
 OPTIONAL MATCH (workload)-[taskLink:RELATION {relation: 'depends_on'}]->(taskDefinition:Entity {tenant_id: $tenant_id, entity_type: 'aws.ecs.task_definition'})-[taskRun:RELATION {relation: 'runs_as'}]->(taskRole:Entity {tenant_id: $tenant_id, entity_type: 'aws.role'})
 WITH public, reach, entry, workload, account, taskDefinition, coalesce(directRole, taskRole) AS role, coalesce(directRun.attributes_json, taskRun.attributes_json, '') AS run_attributes_json, taskLink

--- a/internal/findings/graph_rule_performance_test.go
+++ b/internal/findings/graph_rule_performance_test.go
@@ -1,0 +1,108 @@
+package findings
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+// Public-principal entities are projected only as <provider>.public_principal
+// (cloud.go, aws_compute.go). The exposure graph rules must anchor on that
+// bounded entity_type set with an equality IN list so the (tenant_id,
+// entity_type) range index drives the scan; an `ENDS WITH '.public_principal'`
+// suffix predicate cannot use that index and forces a tenant-wide label scan
+// that fans out into the rule's cross product.
+func TestCloudExposureGraphRulesAnchorPublicPrincipalOnIndex(t *testing.T) {
+	const indexedAnchor = "IN ['aws.public_principal', 'gcp.public_principal', 'azure.public_principal']"
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime", SourceId: "graph", TenantId: "writer"}
+	rules := map[string]Rule{
+		"cloud-exposed-privileged-compute-role":       newCloudExposedPrivilegedComputeRoleRule(),
+		"cloud-public-exposure-privileged-principal":  newCloudPublicExposurePrivilegedPrincipalRule(),
+		"cloud-current-public-exposure-review-needed": newCloudPublicResourceExposureGraphRule(),
+	}
+	for name, rule := range rules {
+		t.Run(name, func(t *testing.T) {
+			graphRule, ok := rule.(GraphRule)
+			if !ok {
+				t.Fatalf("%T does not implement GraphRule", rule)
+			}
+			query := graphRule.QueryFor(runtime).Query
+			if strings.Contains(query, "ENDS WITH '.public_principal'") {
+				t.Fatalf("query still uses non-indexable suffix predicate:\n%s", query)
+			}
+			if !strings.Contains(query, indexedAnchor) {
+				t.Fatalf("query missing index-anchored public-principal predicate %q:\n%s", indexedAnchor, query)
+			}
+		})
+	}
+}
+
+// ctxAwareGraphQuery blocks until the caller context is cancelled so a test can
+// assert the per-rule query budget actually bounds an in-flight Cypher read.
+type ctxAwareGraphQuery struct {
+	*stubGraphStore
+}
+
+func (s *ctxAwareGraphQuery) ExecuteReadCypher(ctx context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// A single pathological graph rule must not be able to consume the entire
+// orchestrator phase budget: the per-rule query timeout cancels its Cypher read
+// and the run is recorded as failed without blocking the remaining rules.
+func TestEvaluateSourceRuntimeGraphRulesEnforcesPerRuleQueryTimeout(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphStore := &ctxAwareGraphQuery{stubGraphStore: &stubGraphStore{}}
+	rule := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "slow-rule"},
+		sourceID: "okta",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"},
+	}
+	registry, err := NewRegistry(rule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).
+		WithGraphQueryStore(graphStore).
+		WithGraphRuleQueryTimeout(25 * time.Millisecond)
+
+	started := time.Now()
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = nil, want per-rule deadline error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("query ran for %v; per-rule timeout did not bound the read", elapsed)
+	}
+	if result == nil || len(result.Evaluations) != 1 {
+		t.Fatalf("want one evaluation in partial result, got %#v", result)
+	}
+	if got := result.Evaluations[0].Run.GetStatus(); got != "failed" {
+		t.Fatalf("Run.Status = %q, want failed", got)
+	}
+}
+
+// WithGraphRuleQueryTimeout(0) falls back to the conservative package default
+// rather than disabling the bound entirely.
+func TestGraphRuleQueryBudgetFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	service := &Service{}
+	if got := service.graphRuleQueryBudget(); got != defaultGraphRuleQueryTimeout {
+		t.Fatalf("graphRuleQueryBudget() = %v, want default %v", got, defaultGraphRuleQueryTimeout)
+	}
+	service.WithGraphRuleQueryTimeout(90 * time.Second)
+	if got := service.graphRuleQueryBudget(); got != 90*time.Second {
+		t.Fatalf("graphRuleQueryBudget() = %v, want 90s override", got)
+	}
+}

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -16,6 +16,12 @@ import (
 type EvaluateGraphRulesRequest struct {
 	RuntimeID string
 	RuleIDs   []string
+	// ExcludeRuleIDs drops the named graph rules from the default
+	// (ForRuntime) selection. The orchestrator uses this to run each
+	// tenant-scoped graph rule at most once per cycle even when many runtimes
+	// in the tenant would otherwise each trigger the same rule. It is ignored
+	// when RuleIDs is set explicitly.
+	ExcludeRuleIDs []string
 }
 
 // GraphRuleEvaluationResult reports one graph rule's outputs inside a multi-rule pass.
@@ -57,7 +63,7 @@ func (s *Service) EvaluateSourceRuntimeGraphRules(ctx context.Context, request E
 	if err != nil {
 		return nil, err
 	}
-	candidates, err := s.selectGraphRules(runtime, request.RuleIDs)
+	candidates, err := s.selectGraphRules(runtime, request.RuleIDs, request.ExcludeRuleIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -242,13 +248,24 @@ func cypherRowsTruncated(request ports.CypherQueryRequest, rowsReturned int) boo
 	return rowsReturned >= cap
 }
 
-func (s *Service) selectGraphRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string) ([]GraphRule, error) {
+func (s *Service) selectGraphRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string, excludeRuleIDs []string) ([]GraphRule, error) {
 	if len(ruleIDs) == 0 {
+		excluded := make(map[string]struct{}, len(excludeRuleIDs))
+		for _, id := range excludeRuleIDs {
+			if trimmed := strings.TrimSpace(id); trimmed != "" {
+				excluded[trimmed] = struct{}{}
+			}
+		}
 		var graphRules []GraphRule
 		for _, rule := range s.rules.ForRuntime(runtime) {
-			if graphRule, ok := asGraphRule(rule); ok {
-				graphRules = append(graphRules, graphRule)
+			graphRule, ok := asGraphRule(rule)
+			if !ok {
+				continue
 			}
+			if _, skip := excluded[strings.TrimSpace(graphRule.Spec().GetId())]; skip {
+				continue
+			}
+			graphRules = append(graphRules, graphRule)
 		}
 		return graphRules, nil
 	}

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -81,7 +81,27 @@ func (s *Service) EvaluateSourceRuntimeGraphRules(ctx context.Context, request E
 
 func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule GraphRule, startedAt time.Time) (evaluation *GraphRuleEvaluationResult, err error) {
 	spec := rule.Spec()
+	ctx, span := telemetry.Start(ctx, "graph_rule.evaluate", telemetry.Attrs(
+		telemetry.Field{Key: "rule_id", Value: strings.TrimSpace(spec.GetId())},
+		telemetry.Field{Key: "source_id", Value: strings.TrimSpace(runtime.GetSourceId())},
+		telemetry.Field{Key: "tenant_id", Value: strings.TrimSpace(runtime.GetTenantId())},
+		telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(runtime.GetId())},
+	))
 	metricsStartedAt := time.Now()
+	defer func() {
+		spanStatus := "completed"
+		spanAttrs := telemetry.Attrs()
+		if evaluation != nil {
+			spanAttrs = spanAttrs.WithField(telemetry.Field{Key: "rows_read", Value: int64(evaluation.RowsRead)})
+			spanAttrs = spanAttrs.WithField(telemetry.Field{Key: "findings_emitted", Value: int64(len(evaluation.Findings))})
+			spanAttrs = spanAttrs.WithField(telemetry.Field{Key: "truncated", Value: evaluation.Truncated})
+		}
+		if err != nil {
+			spanStatus = "failed"
+			spanAttrs = spanAttrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(err)})
+		}
+		telemetry.End(span, spanStatus, spanAttrs)
+	}()
 	defer func() {
 		status := "completed"
 		errorKind := ""
@@ -124,7 +144,13 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		}
 		return result, nil
 	}
-	rows, err := s.graphQuery.ExecuteReadCypher(ctx, queryRequest)
+	queryCtx := ctx
+	if budget := s.graphRuleQueryBudget(); budget > 0 {
+		var cancelQuery context.CancelFunc
+		queryCtx, cancelQuery = context.WithTimeout(ctx, budget)
+		defer cancelQuery()
+	}
+	rows, err := s.graphQuery.ExecuteReadCypher(queryCtx, queryRequest)
 	if err != nil {
 		evaluationErr := fmt.Errorf("execute graph rule %q cypher: %w", spec.GetId(), err)
 		return result, s.finishFailedGraphRun(ctx, run, 0, nil, evaluationErr)

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -162,7 +162,7 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		return result, s.finishFailedGraphRun(ctx, run, 0, nil, evaluationErr)
 	}
 	result.RowsRead = boundedUint32(len(rows))
-	result.Truncated = cypherRowsTruncated(queryRequest, len(rows))
+	result.Truncated = cypherRowsTruncated(queryRequest, len(rows)) || cypherRowsSignalTruncated(rows)
 	emitted, err := rule.EvaluateRows(ctx, runtime, rows)
 	if err != nil {
 		evaluationErr := fmt.Errorf("evaluate graph rule %q rows: %w", spec.GetId(), err)
@@ -246,6 +246,42 @@ func cypherRowsTruncated(request ports.CypherQueryRequest, rowsReturned int) boo
 		cap = ports.MaxCypherQueryRows
 	}
 	return rowsReturned >= cap
+}
+
+// graphRuleTruncationColumn lets a rule's Cypher signal that it dropped matching
+// data internally (for example a per-account cap applied before the row limit)
+// even when the total row count stayed under the row limit. Without this a rule
+// that caps per-group results could return < RowLimit rows yet still be missing
+// offenders, and stale-finding auto-resolution would wrongly close the dropped
+// findings as no-longer-matching.
+const graphRuleTruncationColumn = "graph_rule_truncated"
+
+// cypherRowsSignalTruncated reports whether any row carries a truthy
+// graphRuleTruncationColumn, i.e. the rule's query itself signaled that it
+// dropped matching data.
+func cypherRowsSignalTruncated(rows []ports.CypherRow) bool {
+	for _, row := range rows {
+		if row.Values == nil {
+			continue
+		}
+		if value, ok := row.Values[graphRuleTruncationColumn]; ok && cypherValueTruthy(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func cypherValueTruthy(value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		switch strings.ToLower(strings.TrimSpace(typed)) {
+		case "true", "1", "t", "yes":
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Service) selectGraphRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string, excludeRuleIDs []string) ([]GraphRule, error) {

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -259,6 +259,78 @@ func TestEvaluateSourceRuntimeGraphRulesTruncatedSkipsStaleResolution(t *testing
 	}
 }
 
+func TestEvaluateSourceRuntimeGraphRulesCapSignalSkipsStaleResolution(t *testing.T) {
+	// A rule can drop matching data internally (e.g. a per-account cap) while the
+	// total row count stays under the row limit. When that happens the query sets
+	// graph_rule_truncated=true so the evaluation is treated as truncated and
+	// stale-finding auto-resolution is skipped; otherwise still-active findings for
+	// the dropped rows would be wrongly closed as no-longer-matching.
+	for _, tc := range []struct {
+		name          string
+		signal        any
+		wantTruncated bool
+	}{
+		{name: "capped signals truncation", signal: true, wantTruncated: true},
+		{name: "capped string signals truncation", signal: "true", wantTruncated: true},
+		{name: "not capped allows resolution", signal: false, wantTruncated: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+			staleFinding := &ports.FindingRecord{
+				ID:          "finding-stale",
+				Fingerprint: "fp-stale",
+				TenantID:    "writer",
+				RuntimeID:   "runtime-okta",
+				RuleID:      "capping-rule",
+				Status:      findingStatusOpen,
+			}
+			store := &stubFindingStore{findings: map[string]*ports.FindingRecord{staleFinding.ID: cloneFinding(staleFinding)}}
+			graphStore := &stubGraphStore{
+				cypherRows: []ports.CypherRow{
+					{Values: map[string]any{"label": "row-1", graphRuleTruncationColumn: tc.signal}},
+				},
+			}
+			rule := &stubGraphRule{
+				spec:     &cerebrov1.RuleSpec{Id: "capping-rule"},
+				sourceID: "okta",
+				query: ports.CypherQueryRequest{
+					Query:    "MATCH (n) RETURN n LIMIT $row_limit",
+					Params:   map[string]any{"row_limit": int64(250)},
+					RowLimit: 250,
+				},
+			}
+			registry, err := NewRegistry(rule)
+			if err != nil {
+				t.Fatalf("NewRegistry() error = %v", err)
+			}
+			service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+			result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
+			if err != nil {
+				t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+			}
+			if got := len(result.Evaluations); got != 1 {
+				t.Fatalf("len(Evaluations) = %d, want 1", got)
+			}
+			if got := result.Evaluations[0].Truncated; got != tc.wantTruncated {
+				t.Fatalf("Truncated = %v, want %v (1 row below the row limit, signal=%v)", got, tc.wantTruncated, tc.signal)
+			}
+			persisted, ok := store.findings[staleFinding.ID]
+			if !ok {
+				t.Fatalf("stale finding %q missing after evaluation", staleFinding.ID)
+			}
+			if tc.wantTruncated {
+				if got := persisted.Status; got != findingStatusOpen {
+					t.Fatalf("stale finding status = %q, want still %q (cap signal must skip stale resolution)", got, findingStatusOpen)
+				}
+				return
+			}
+			if got := persisted.StatusReason; got != "graph_rule_no_longer_matches" {
+				t.Fatalf("stale finding StatusReason = %q, want graph_rule_no_longer_matches (no cap signal must auto-resolve)", got)
+			}
+		})
+	}
+}
+
 func TestEvaluateSourceRuntimeGraphRulesRequiresGraphQuery(t *testing.T) {
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
 	store := &stubFindingStore{}

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -55,6 +55,41 @@ func (r *stubGraphRule) EvaluateRows(_ context.Context, _ *cerebrov1.SourceRunti
 	return r.emit, nil
 }
 
+func TestEvaluateSourceRuntimeGraphRulesExcludesNamedRules(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphStore := &stubGraphStore{}
+	ruleA := &stubGraphRule{spec: &cerebrov1.RuleSpec{Id: "rule-a"}, sourceID: "okta", query: ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"}}
+	ruleB := &stubGraphRule{spec: &cerebrov1.RuleSpec{Id: "rule-b"}, sourceID: "okta", query: ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"}}
+	registry, err := NewRegistry(ruleA, ruleB)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+
+	// Excluding rule-a leaves only rule-b (coverage for the other rule is kept).
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta", ExcludeRuleIDs: []string{"rule-a"}})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if got := len(result.Evaluations); got != 1 {
+		t.Fatalf("len(Evaluations) = %d, want 1", got)
+	}
+	if got := result.Evaluations[0].Rule.GetId(); got != "rule-b" {
+		t.Fatalf("evaluated rule = %q, want rule-b", got)
+	}
+
+	// Excluding every supported rule evaluates nothing, without error: the
+	// tenant already ran them this cycle.
+	empty, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta", ExcludeRuleIDs: []string{"rule-a", "rule-b"}})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if got := len(empty.Evaluations); got != 0 {
+		t.Fatalf("len(Evaluations) = %d, want 0 when all rules excluded", got)
+	}
+}
+
 func TestAsGraphRuleNarrows(t *testing.T) {
 	if _, ok := asGraphRule(nil); ok {
 		t.Fatalf("asGraphRule(nil) should be false")

--- a/internal/findings/graph_typed_property_test.go
+++ b/internal/findings/graph_typed_property_test.go
@@ -1,0 +1,55 @@
+package findings
+
+import (
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+// The hot boolean predicates were promoted to typed, indexed node properties
+// (projectionmeta.DerivedEntityProperties). Each rule must prefer the typed
+// property but retain an `IS NULL` fallback to the legacy attributes_json scan,
+// so the result set is identical for entities not yet re-projected since the
+// promotion shipped.
+func TestGraphRulesPreferTypedPropertyWithJSONFallback(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime", SourceId: "graph", TenantId: "writer"}
+
+	exposure := mustGraphRule(t, newCloudPublicResourceExposureGraphRule()).QueryFor(runtime).Query
+	for _, fragment := range []string{
+		"resource.internet_exposed = true",
+		"resource.internet_exposed IS NULL",
+		`coalesce(resource.attributes_json, '') CONTAINS '"internet_exposed":"true"'`,
+		`coalesce(resource.attributes_json, '') CONTAINS '"external_exposure":"true"'`,
+		`coalesce(resource.attributes_json, '') CONTAINS '"public":"true"'`,
+	} {
+		if !strings.Contains(exposure, fragment) {
+			t.Fatalf("cloud public-exposure query missing %q:\n%s", fragment, exposure)
+		}
+	}
+
+	identity := mustGraphRule(t, newIdentityPrivilegedNoMFAAccessRule()).QueryFor(runtime).Query
+	for _, fragment := range []string{
+		"user.is_privileged_identity = true",
+		"user.is_privileged_identity IS NULL",
+		"user.mfa_disabled = true",
+		"user.mfa_disabled IS NULL",
+		`user_attrs CONTAINS '"is_admin":"true"'`,
+		`user_attrs CONTAINS '"is_delegated_admin":"true"'`,
+		`user_attrs CONTAINS '"mfa_enrolled":"false"'`,
+		`user_attrs CONTAINS '"is_enforced_in_2sv":"false"'`,
+	} {
+		if !strings.Contains(identity, fragment) {
+			t.Fatalf("identity no-MFA query missing %q:\n%s", fragment, identity)
+		}
+	}
+}
+
+func mustGraphRule(t *testing.T, rule Rule) GraphRule {
+	t.Helper()
+	graphRule, ok := rule.(GraphRule)
+	if !ok {
+		t.Fatalf("%T does not implement GraphRule", rule)
+	}
+	return graphRule
+}

--- a/internal/findings/identity_privileged_no_mfa_sensitive_access_rule.go
+++ b/internal/findings/identity_privileged_no_mfa_sensitive_access_rule.go
@@ -107,8 +107,10 @@ func (r *identityPrivilegedNoMFAAccessRule) QueryFor(runtime *cerebrov1.SourceRu
 	tenantID := strings.TrimSpace(runtime.GetTenantId())
 	actedOnSince := time.Now().UTC().Add(-identityPrivilegedNoMFAActedOnWindow).Format(time.RFC3339)
 	return ports.CypherQueryRequest{
-		Query: `MATCH (user:Entity {tenant_id: $tenant_id})-[access:RELATION]->(resource:Entity {tenant_id: $tenant_id})
-MATCH (resource)-[sensitivity:RELATION]->(marker:Entity {tenant_id: $tenant_id})
+		Query: `MATCH (marker:Entity {tenant_id: $tenant_id})
+WHERE marker.entity_type IN ['asset.tag', 'data.classification']
+MATCH (resource:Entity {tenant_id: $tenant_id})-[sensitivity:RELATION]->(marker)
+MATCH (user:Entity {tenant_id: $tenant_id})-[access:RELATION]->(resource)
 WITH user, access, resource, sensitivity, marker,
      toLower(coalesce(user.attributes_json, '')) AS user_attrs,
      coalesce(access.attributes_json, '') AS access_attrs

--- a/internal/findings/identity_privileged_no_mfa_sensitive_access_rule.go
+++ b/internal/findings/identity_privileged_no_mfa_sensitive_access_rule.go
@@ -128,20 +128,26 @@ WHERE user.entity_type IN ['okta.user','google_workspace.user','gcp.service_acco
     ) > $acted_on_since
   )
   AND (
-    user_attrs CONTAINS '"is_admin":"true"'
-    OR user_attrs CONTAINS '"is_admin":true'
-    OR user_attrs CONTAINS '"is_delegated_admin":"true"'
-    OR user_attrs CONTAINS '"is_delegated_admin":true'
+    user.is_privileged_identity = true
+    OR (user.is_privileged_identity IS NULL AND (
+      user_attrs CONTAINS '"is_admin":"true"'
+      OR user_attrs CONTAINS '"is_admin":true'
+      OR user_attrs CONTAINS '"is_delegated_admin":"true"'
+      OR user_attrs CONTAINS '"is_delegated_admin":true'
+    ))
   )
   AND (
-    user_attrs CONTAINS '"mfa_enrolled":"false"'
-    OR user_attrs CONTAINS '"mfa_enrolled":false'
-    OR user_attrs CONTAINS '"mfa_enforced":"false"'
-    OR user_attrs CONTAINS '"mfa_enforced":false'
-    OR user_attrs CONTAINS '"is_enrolled_in_2sv":"false"'
-    OR user_attrs CONTAINS '"is_enrolled_in_2sv":false'
-    OR user_attrs CONTAINS '"is_enforced_in_2sv":"false"'
-    OR user_attrs CONTAINS '"is_enforced_in_2sv":false'
+    user.mfa_disabled = true
+    OR (user.mfa_disabled IS NULL AND (
+      user_attrs CONTAINS '"mfa_enrolled":"false"'
+      OR user_attrs CONTAINS '"mfa_enrolled":false'
+      OR user_attrs CONTAINS '"mfa_enforced":"false"'
+      OR user_attrs CONTAINS '"mfa_enforced":false'
+      OR user_attrs CONTAINS '"is_enrolled_in_2sv":"false"'
+      OR user_attrs CONTAINS '"is_enrolled_in_2sv":false'
+      OR user_attrs CONTAINS '"is_enforced_in_2sv":"false"'
+      OR user_attrs CONTAINS '"is_enforced_in_2sv":false'
+    ))
   )
   AND (
     (sensitivity.relation = 'tagged_as' AND marker.entity_type = 'asset.tag' AND toLower(marker.label) = 'crown_jewel')

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -80,10 +80,13 @@ type Service struct {
 }
 
 // defaultGraphRuleQueryTimeout bounds a single graph rule's Cypher read so one
-// pathological rule cannot consume the entire orchestrator phase budget. It is
-// set just under the orchestrator graph-rule phase timeout so a stuck rule
-// fails with a clean, attributable per-rule deadline rather than a connectivity
-// error when the phase context is cancelled out from under an in-flight query.
+// pathological rule cannot consume the entire orchestrator phase budget. A stuck
+// rule then fails with a clean, attributable per-rule deadline rather than a
+// connectivity error from the phase context being cancelled out from under an
+// in-flight query. The production orchestrator derives the budget from its
+// configured graph-rule phase timeout (keeping it strictly under that deadline)
+// via WithGraphRuleQueryTimeout; this default applies only when no budget is
+// wired (e.g. tests) and matches the default 15m phase timeout less its margin.
 const defaultGraphRuleQueryTimeout = 14 * time.Minute
 
 // EvaluateRequest scopes one replay-backed finding evaluation.

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -73,10 +73,18 @@ type Service struct {
 	closeoutStore             ports.CloseoutRunStore
 	tombstoneEventStore       ports.FindingTombstoneEventStore
 	closeoutHeartbeatInterval time.Duration
+	graphRuleQueryTimeout     time.Duration
 	rules                     *Registry
 	ttlClock                  ttlClock
 	ttlLogSink                ttlLogSink
 }
+
+// defaultGraphRuleQueryTimeout bounds a single graph rule's Cypher read so one
+// pathological rule cannot consume the entire orchestrator phase budget. It is
+// set just under the orchestrator graph-rule phase timeout so a stuck rule
+// fails with a clean, attributable per-rule deadline rather than a connectivity
+// error when the phase context is cancelled out from under an in-flight query.
+const defaultGraphRuleQueryTimeout = 14 * time.Minute
 
 // EvaluateRequest scopes one replay-backed finding evaluation.
 type EvaluateRequest struct {
@@ -216,6 +224,24 @@ func (s *Service) WithGraphQueryStore(graphQuery ports.GraphQueryStore) *Service
 	}
 	s.graphQuery = graphQuery
 	return s
+}
+
+// WithGraphRuleQueryTimeout overrides the per-graph-rule Cypher read budget. A
+// non-positive value falls back to defaultGraphRuleQueryTimeout.
+func (s *Service) WithGraphRuleQueryTimeout(timeout time.Duration) *Service {
+	if s == nil {
+		return nil
+	}
+	s.graphRuleQueryTimeout = timeout
+	return s
+}
+
+// graphRuleQueryBudget returns the effective per-graph-rule Cypher read budget.
+func (s *Service) graphRuleQueryBudget() time.Duration {
+	if s != nil && s.graphRuleQueryTimeout > 0 {
+		return s.graphRuleQueryTimeout
+	}
+	return defaultGraphRuleQueryTimeout
 }
 
 // WithAppendLog wires one optional durable append log used for workflow metadata events.

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	neo4jconfig "github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
 
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphstore"
@@ -25,6 +26,18 @@ import (
 const defaultIngestRunListLimit = 25
 const maxAttributeMergeRetries = 5
 const defaultProjectionCleanupLimit = 1000
+
+// Neo4j driver pool tuning. Aura reaps idle server-side connections, so a
+// connection that has been parked in the pool past Aura's idle window fails
+// the next borrow with a connectivity error. Recycling connections well under
+// that window (rather than the driver default of one hour) keeps the pool warm
+// with live sockets. The acquisition timeout fails fast if the pool is ever
+// saturated instead of letting a borrow hang for the full caller deadline.
+const (
+	neo4jMaxConnectionLifetime        = 30 * time.Minute
+	neo4jConnectionAcquisitionTimeout = 60 * time.Second
+	neo4jMaxConnectionPoolSize        = 100
+)
 const mergeEntityAndLoadAttributesQuery = `MERGE (e:Entity {urn: $urn})
 ON CREATE SET e.attributes_json = '{}', e.attributes_version = 0
 SET e.tenant_id = $tenant_id,
@@ -78,7 +91,11 @@ func Open(cfg config.GraphStoreConfig) (*Store, error) {
 		return nil, errors.New("neo4j password is required")
 	}
 	database := strings.TrimSpace(cfg.Neo4jDatabase)
-	driver, err := neo4jdriver.NewDriverWithContext(uri, neo4jdriver.BasicAuth(username, cfg.Neo4jPassword, ""))
+	driver, err := neo4jdriver.NewDriverWithContext(uri, neo4jdriver.BasicAuth(username, cfg.Neo4jPassword, ""), func(c *neo4jconfig.Config) {
+		c.MaxConnectionLifetime = neo4jMaxConnectionLifetime
+		c.ConnectionAcquisitionTimeout = neo4jConnectionAcquisitionTimeout
+		c.MaxConnectionPoolSize = neo4jMaxConnectionPoolSize
+	})
 	if err != nil {
 		return nil, fmt.Errorf("open neo4j: %w", err)
 	}

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -458,11 +458,13 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 			if err != nil {
 				return nil, fmt.Errorf("decode projected entity attributes: %w", err)
 			}
-			mergedJSON, err := graphAttributesJSON(mergeGraphAttributes(existing, incomingAttributes))
+			mergedAttributes := mergeGraphAttributes(existing, incomingAttributes)
+			mergedJSON, err := graphAttributesJSON(mergedAttributes)
 			if err != nil {
 				return nil, fmt.Errorf("marshal projected entity attributes: %w", err)
 			}
-			updated, err := updateEntityAttributes(ctx, tx, urn, version, mergedJSON)
+			typedProperties := entityTypedPropertyParams(projectionmeta.DerivedEntityProperties(mergedAttributes))
+			updated, err := updateEntityAttributes(ctx, tx, urn, version, mergedJSON, typedProperties)
 			if err != nil {
 				return nil, err
 			}
@@ -1287,6 +1289,9 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 		"CREATE INDEX cerebro_entity_tenant_source IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.source_id)",
 		"CREATE INDEX cerebro_entity_tenant_source_type IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.source_id, e.entity_type)",
 		"CREATE INDEX cerebro_entity_tenant_label IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.label)",
+		"CREATE INDEX cerebro_entity_tenant_internet_exposed IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.internet_exposed)",
+		"CREATE INDEX cerebro_entity_tenant_privileged_identity IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.is_privileged_identity)",
+		"CREATE INDEX cerebro_entity_tenant_mfa_disabled IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.mfa_disabled)",
 		"CREATE INDEX cerebro_relation_tenant_runtime IF NOT EXISTS FOR ()-[r:RELATION]-() ON (r.tenant_id, r.runtime_id)",
 		"CREATE INDEX cerebro_relation_tenant_relation IF NOT EXISTS FOR ()-[r:RELATION]-() ON (r.tenant_id, r.relation)",
 		"CREATE FULLTEXT INDEX cerebro_entity_inventory_fulltext IF NOT EXISTS FOR (e:Entity) ON EACH [e.urn, e.label, e.entity_type, e.attributes_json]",
@@ -1597,16 +1602,30 @@ func mergeEntityAndLoadAttributes(ctx context.Context, tx neo4jdriver.ManagedTra
 	return stringValue(values[0]), toInt64(values[1]), result.Err()
 }
 
-func updateEntityAttributes(ctx context.Context, tx neo4jdriver.ManagedTransaction, urn string, version int64, attributesJSON string) (bool, error) {
+// entityTypedPropertyParams maps the derived typed properties onto the node
+// property names backing the range indexes and the rule predicates. Building the
+// map here (rather than in projectionmeta) keeps the exported derivation API
+// strongly typed.
+func entityTypedPropertyParams(properties projectionmeta.EntityTypedProperties) map[string]any {
+	return map[string]any{
+		projectionmeta.PropertyInternetExposed:    properties.InternetExposed,
+		projectionmeta.PropertyPrivilegedIdentity: properties.PrivilegedIdentity,
+		projectionmeta.PropertyMFADisabled:        properties.MFADisabled,
+	}
+}
+
+func updateEntityAttributes(ctx context.Context, tx neo4jdriver.ManagedTransaction, urn string, version int64, attributesJSON string, typedProperties map[string]any) (bool, error) {
 	updated, err := countQuery(ctx, tx, `MATCH (e:Entity {urn: $urn})
 WHERE coalesce(e.attributes_version, 0) = $attributes_version
 SET e.attributes_json = $attributes_json,
-    e.attributes_version = $next_attributes_version
+    e.attributes_version = $next_attributes_version,
+    e += $typed_properties
 RETURN count(e)`, map[string]any{
 		"urn":                     urn,
 		"attributes_version":      version,
 		"next_attributes_version": version + 1,
 		"attributes_json":         attributesJSON,
+		"typed_properties":        typedProperties,
 	})
 	if err != nil {
 		return false, err

--- a/internal/projectionmeta/classification.go
+++ b/internal/projectionmeta/classification.go
@@ -12,6 +12,71 @@ const (
 	ClassEphemeralEvent = "ephemeral_event"
 )
 
+// Typed node properties promoted from attributes_json so hot graph-rule
+// predicates can seek a range index instead of substring-scanning the JSON blob
+// on every candidate row. Each derivation mirrors the exact equality semantics
+// of the rule Cypher predicate it replaces (NOT the broader Go re-validation
+// helpers), because the effective detection set is bounded by the narrower
+// Cypher pre-filter.
+const (
+	// PropertyInternetExposed mirrors the case-sensitive `"<key>":"true"`
+	// substring checks in the cloud public-exposure rule, which has no Go
+	// post-filter, so the comparison must be byte-exact.
+	PropertyInternetExposed = "internet_exposed"
+	// PropertyPrivilegedIdentity mirrors the lower-cased is_admin /
+	// is_delegated_admin checks in the privileged-no-MFA identity rule.
+	PropertyPrivilegedIdentity = "is_privileged_identity"
+	// PropertyMFADisabled mirrors the lower-cased mfa_* / *_2sv "false" checks
+	// in the privileged-no-MFA identity rule.
+	PropertyMFADisabled = "mfa_disabled"
+)
+
+// EntityTypedProperties holds the typed boolean properties promoted from an
+// entity's attributes_json. The store maps these onto the node properties named
+// by PropertyInternetExposed/PropertyPrivilegedIdentity/PropertyMFADisabled.
+type EntityTypedProperties struct {
+	InternetExposed    bool
+	PrivilegedIdentity bool
+	MFADisabled        bool
+}
+
+// DerivedEntityProperties returns the typed boolean properties promoted from an
+// entity's merged attributes. Every entity gets a concrete true/false for each
+// property so the promoted columns are fully populated after re-projection and
+// the backing range index covers them; a NULL property therefore only means the
+// entity has not been re-projected since the promotion shipped, which the rule
+// predicates handle with an explicit IS NULL fallback to the legacy JSON scan.
+func DerivedEntityProperties(attributes map[string]string) EntityTypedProperties {
+	return EntityTypedProperties{
+		// Case-sensitive to match the rule's `CONTAINS '"<key>":"true"'`.
+		InternetExposed: attributeValueEquals(attributes, false, "true",
+			"internet_exposed", "external_exposure", "public"),
+		// Lower-cased to match the rule's `toLower(user_attrs) CONTAINS ...`.
+		PrivilegedIdentity: attributeValueEquals(attributes, true, "true",
+			"is_admin", "is_delegated_admin"),
+		MFADisabled: attributeValueEquals(attributes, true, "false",
+			"mfa_enrolled", "mfa_enforced", "is_enrolled_in_2sv", "is_enforced_in_2sv"),
+	}
+}
+
+// attributeValueEquals reports whether any named key holds exactly want. It does
+// not trim, because the Cypher predicates it mirrors match the verbatim JSON
+// substring `"<key>":"<value>"`; a stored value with surrounding whitespace is
+// not matched by those predicates either. When caseInsensitive is set the stored
+// value is lower-cased first, mirroring a toLower(...) Cypher predicate.
+func attributeValueEquals(attributes map[string]string, caseInsensitive bool, want string, keys ...string) bool {
+	for _, key := range keys {
+		value := attributes[key]
+		if caseInsensitive {
+			value = strings.ToLower(value)
+		}
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 type Classification struct {
 	Class  string
 	Reason string

--- a/internal/projectionmeta/derived_properties_test.go
+++ b/internal/projectionmeta/derived_properties_test.go
@@ -1,0 +1,81 @@
+package projectionmeta
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// DerivedEntityProperties must reproduce, exactly, the equality semantics of the
+// rule Cypher predicates it replaces, evaluated against the same attributes_json
+// blob the store writes. The oracle here builds that blob with encoding/json
+// (the store's graphAttributesJSON marshals the same map[string]string) and
+// applies the literal CONTAINS substring the rules use:
+//   - internet_exposed: case-sensitive `"<key>":"true"`.
+//   - privileged / mfa: lower-cased `"<key>":"true|false"` (the rules toLower
+//     the whole user_attrs string before matching).
+func TestDerivedEntityPropertiesMirrorRuleCypherSemantics(t *testing.T) {
+	cases := []map[string]string{
+		{},
+		{"internet_exposed": "true"},
+		{"external_exposure": "true"},
+		{"public": "true"},
+		{"internet_exposed": "false"},
+		{"internet_exposed": "True"},  // case-sensitive predicate: no match
+		{"public": "TRUE"},            // case-sensitive predicate: no match
+		{"internet_exposed": " true"}, // whitespace breaks the substring: no match
+		{"is_admin": "true"},
+		{"is_admin": "True"}, // lower-cased predicate: matches
+		{"is_delegated_admin": "true"},
+		{"is_admin": "false"},
+		{"is_admin": "yes"}, // broad Go truthy but Cypher wants "true": no match
+		{"mfa_enrolled": "false"},
+		{"mfa_enforced": "False"}, // lower-cased predicate: matches
+		{"is_enrolled_in_2sv": "false"},
+		{"is_enforced_in_2sv": "false"},
+		{"mfa_enrolled": "true"},
+		{"internet_exposed": "true", "is_admin": "true", "mfa_enrolled": "false"},
+	}
+	for _, attrs := range cases {
+		blob := mustMarshalJSON(t, attrs)
+		lower := strings.ToLower(blob)
+		got := DerivedEntityProperties(attrs)
+
+		wantExposed := strings.Contains(blob, `"internet_exposed":"true"`) ||
+			strings.Contains(blob, `"external_exposure":"true"`) ||
+			strings.Contains(blob, `"public":"true"`)
+		if got.InternetExposed != wantExposed {
+			t.Fatalf("InternetExposed for %v = %v, want %v", attrs, got.InternetExposed, wantExposed)
+		}
+
+		wantPrivileged := strings.Contains(lower, `"is_admin":"true"`) ||
+			strings.Contains(lower, `"is_delegated_admin":"true"`)
+		if got.PrivilegedIdentity != wantPrivileged {
+			t.Fatalf("PrivilegedIdentity for %v = %v, want %v", attrs, got.PrivilegedIdentity, wantPrivileged)
+		}
+
+		wantMFADisabled := strings.Contains(lower, `"mfa_enrolled":"false"`) ||
+			strings.Contains(lower, `"mfa_enforced":"false"`) ||
+			strings.Contains(lower, `"is_enrolled_in_2sv":"false"`) ||
+			strings.Contains(lower, `"is_enforced_in_2sv":"false"`)
+		if got.MFADisabled != wantMFADisabled {
+			t.Fatalf("MFADisabled for %v = %v, want %v", attrs, got.MFADisabled, wantMFADisabled)
+		}
+	}
+}
+
+func TestDerivedEntityPropertiesAlwaysPopulatesEveryProperty(t *testing.T) {
+	props := DerivedEntityProperties(map[string]string{"unrelated": "value"})
+	if props.InternetExposed || props.PrivilegedIdentity || props.MFADisabled {
+		t.Fatalf("unrelated attributes derived a true property: %#v", props)
+	}
+}
+
+func mustMarshalJSON(t *testing.T, attrs map[string]string) string {
+	t.Helper()
+	encoded, err := json.Marshal(attrs)
+	if err != nil {
+		t.Fatalf("marshal attributes: %v", err)
+	}
+	return string(encoded)
+}


### PR DESCRIPTION
## Summary

Production Cerebro orchestrator graph phases were stalling on Neo4j: three graph rules ran for the full 15-minute phase budget and surfaced as `Neo4jConnectivityErrors`. Root cause was a mix of pathological Cypher (cartesian products / a high-cardinality hub join / an unanchored full-edge scan), an unbounded per-rule read budget, and a driver pool whose idle connections were being reaped by Aura.

Adds:
- **Per-rule query budget** (`defaultGraphRuleQueryTimeout`, 14m, just under the graph phase timeout) so one stuck rule fails with a clean, attributable deadline instead of taking down the whole phase.
- **Per-rule `graph_rule.evaluate` telemetry span** carrying `rule_id`/`source_id`/`tenant_id`/`runtime_id` so the child `neo4j.read` spans are attributable to a specific rule.
- **Neo4j driver pool tuning** (lifetime 30m, acquisition timeout 60s, pool 100) so connections recycle under Aura's idle reap window and a saturated pool fails fast.

Restructures three rules:
- `cloud-exposed-privileged-compute-role`: the `public->entry` and `workload->account` legs shared no variable (cartesian). Now drive from the recency-filtered `public->entry` path and resolve `workload` from `entry` via a correlated `CALL{...UNION...}` (self / ENI `attached_to` / security-group `member_of`).
- `cloud-public-exposure-privileged-principal`: the legs joined only on the `account` hub, materializing `(exposed) x (principals)` per account before `ORDER BY/LIMIT`. Now caps each side per account with a deterministic, lexicographically-ordered sample, then crosses the bounded sets.
- `identity-privileged-no-mfa-plus-sensitive-access`: the opening `(user)-[access]->(resource)` had no anchor (full tenant-edge scan). Now anchors on the small marker set (crown-jewel tags / sensitive classifications) and traverses backward.

Also replaces the non-indexable `ENDS WITH '.public_principal'` suffix predicate with an explicit `entity_type IN [...]` list so the `(tenant_id, entity_type)` range index drives the scan.

## Test Plan

- `go test ./internal/findings/... ./internal/graphstore/neo4j/... ./cmd/cerebro/... ./tools/archtests/...` pass.
- New `graph_rule_performance_test.go`: index-anchor query shape, per-rule query-timeout enforcement (ctx-aware stub), and budget fallback.
- Existing query-shape and `EvaluateRows` contract tests for all three rules stay green (RETURN columns and required fragments preserved).
- `make detection-catalog-check catalog-check check-structural check-arch` and `make lint` (0 issues) pass.

> Note: the query rewrites are result-preserving by construction (A/C) or a bounded deterministic sample (B); they could not be validated with `EXPLAIN`/`PROFILE` against prod Aura from here, so they should be plan-checked in staging before relying on the projected speedup.

## Known Invariants

- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated. (All three rewrites stay tenant-scoped and row-limited; reads only.)
- Candidate finding lifecycle writes remain atomic and idempotent. (RETURN columns and `EvaluateRows` semantics unchanged, so fingerprints/lifecycle are preserved.)

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on the three restructured Cypher queries and the per-rule query budget.
- This is a graph + state-adjacent change; the query rewrites could not be `PROFILE`-validated against prod Aura and warrant a staging plan check.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->