### PR TITLE
perf: promote hot graph-rule booleans to typed indexed node properties

### DIFF
--- a/internal/findings/cloud_current_public_exposure_review_rule.go
+++ b/internal/findings/cloud_current_public_exposure_review_rule.go
@@ -63,9 +63,12 @@ WHERE public.entity_type IN ['aws.public_principal', 'gcp.public_principal', 'az
   AND resource.entity_type <> 'cloud.account'
   AND NOT resource.entity_type IN ['aws.public_principal', 'gcp.public_principal', 'azure.public_principal']
   AND (
-    coalesce(resource.attributes_json, '') CONTAINS '"internet_exposed":"true"'
-    OR coalesce(resource.attributes_json, '') CONTAINS '"external_exposure":"true"'
-    OR coalesce(resource.attributes_json, '') CONTAINS '"public":"true"'
+    resource.internet_exposed = true
+    OR (resource.internet_exposed IS NULL AND (
+      coalesce(resource.attributes_json, '') CONTAINS '"internet_exposed":"true"'
+      OR coalesce(resource.attributes_json, '') CONTAINS '"external_exposure":"true"'
+      OR coalesce(resource.attributes_json, '') CONTAINS '"public":"true"'
+    ))
   )
   AND coalesce(reach.attributes_json, '') CONTAINS '"at":"'
   AND datetime(split(split(coalesce(reach.attributes_json, ''), '"at":"')[1], '"')[0]) >= datetime() - duration('P30D')

--- a/internal/findings/graph_typed_property_test.go
+++ b/internal/findings/graph_typed_property_test.go
@@ -1,0 +1,55 @@
+package findings
+
+import (
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+// The hot boolean predicates were promoted to typed, indexed node properties
+// (projectionmeta.DerivedEntityProperties). Each rule must prefer the typed
+// property but retain an `IS NULL` fallback to the legacy attributes_json scan,
+// so the result set is identical for entities not yet re-projected since the
+// promotion shipped.
+func TestGraphRulesPreferTypedPropertyWithJSONFallback(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime", SourceId: "graph", TenantId: "writer"}
+
+	exposure := mustGraphRule(t, newCloudPublicResourceExposureGraphRule()).QueryFor(runtime).Query
+	for _, fragment := range []string{
+		"resource.internet_exposed = true",
+		"resource.internet_exposed IS NULL",
+		`coalesce(resource.attributes_json, '') CONTAINS '"internet_exposed":"true"'`,
+		`coalesce(resource.attributes_json, '') CONTAINS '"external_exposure":"true"'`,
+		`coalesce(resource.attributes_json, '') CONTAINS '"public":"true"'`,
+	} {
+		if !strings.Contains(exposure, fragment) {
+			t.Fatalf("cloud public-exposure query missing %q:\n%s", fragment, exposure)
+		}
+	}
+
+	identity := mustGraphRule(t, newIdentityPrivilegedNoMFAAccessRule()).QueryFor(runtime).Query
+	for _, fragment := range []string{
+		"user.is_privileged_identity = true",
+		"user.is_privileged_identity IS NULL",
+		"user.mfa_disabled = true",
+		"user.mfa_disabled IS NULL",
+		`user_attrs CONTAINS '"is_admin":"true"'`,
+		`user_attrs CONTAINS '"is_delegated_admin":"true"'`,
+		`user_attrs CONTAINS '"mfa_enrolled":"false"'`,
+		`user_attrs CONTAINS '"is_enforced_in_2sv":"false"'`,
+	} {
+		if !strings.Contains(identity, fragment) {
+			t.Fatalf("identity no-MFA query missing %q:\n%s", fragment, identity)
+		}
+	}
+}
+
+func mustGraphRule(t *testing.T, rule Rule) GraphRule {
+	t.Helper()
+	graphRule, ok := rule.(GraphRule)
+	if !ok {
+		t.Fatalf("%T does not implement GraphRule", rule)
+	}
+	return graphRule
+}

--- a/internal/findings/identity_privileged_no_mfa_sensitive_access_rule.go
+++ b/internal/findings/identity_privileged_no_mfa_sensitive_access_rule.go
@@ -128,20 +128,26 @@ WHERE user.entity_type IN ['okta.user','google_workspace.user','gcp.service_acco
     ) > $acted_on_since
   )
   AND (
-    user_attrs CONTAINS '"is_admin":"true"'
-    OR user_attrs CONTAINS '"is_admin":true'
-    OR user_attrs CONTAINS '"is_delegated_admin":"true"'
-    OR user_attrs CONTAINS '"is_delegated_admin":true'
+    user.is_privileged_identity = true
+    OR (user.is_privileged_identity IS NULL AND (
+      user_attrs CONTAINS '"is_admin":"true"'
+      OR user_attrs CONTAINS '"is_admin":true'
+      OR user_attrs CONTAINS '"is_delegated_admin":"true"'
+      OR user_attrs CONTAINS '"is_delegated_admin":true'
+    ))
   )
   AND (
-    user_attrs CONTAINS '"mfa_enrolled":"false"'
-    OR user_attrs CONTAINS '"mfa_enrolled":false'
-    OR user_attrs CONTAINS '"mfa_enforced":"false"'
-    OR user_attrs CONTAINS '"mfa_enforced":false'
-    OR user_attrs CONTAINS '"is_enrolled_in_2sv":"false"'
-    OR user_attrs CONTAINS '"is_enrolled_in_2sv":false'
-    OR user_attrs CONTAINS '"is_enforced_in_2sv":"false"'
-    OR user_attrs CONTAINS '"is_enforced_in_2sv":false'
+    user.mfa_disabled = true
+    OR (user.mfa_disabled IS NULL AND (
+      user_attrs CONTAINS '"mfa_enrolled":"false"'
+      OR user_attrs CONTAINS '"mfa_enrolled":false'
+      OR user_attrs CONTAINS '"mfa_enforced":"false"'
+      OR user_attrs CONTAINS '"mfa_enforced":false'
+      OR user_attrs CONTAINS '"is_enrolled_in_2sv":"false"'
+      OR user_attrs CONTAINS '"is_enrolled_in_2sv":false'
+      OR user_attrs CONTAINS '"is_enforced_in_2sv":"false"'
+      OR user_attrs CONTAINS '"is_enforced_in_2sv":false'
+    ))
   )
   AND (
     (sensitivity.relation = 'tagged_as' AND marker.entity_type = 'asset.tag' AND toLower(marker.label) = 'crown_jewel')

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -458,11 +458,13 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 			if err != nil {
 				return nil, fmt.Errorf("decode projected entity attributes: %w", err)
 			}
-			mergedJSON, err := graphAttributesJSON(mergeGraphAttributes(existing, incomingAttributes))
+			mergedAttributes := mergeGraphAttributes(existing, incomingAttributes)
+			mergedJSON, err := graphAttributesJSON(mergedAttributes)
 			if err != nil {
 				return nil, fmt.Errorf("marshal projected entity attributes: %w", err)
 			}
-			updated, err := updateEntityAttributes(ctx, tx, urn, version, mergedJSON)
+			typedProperties := entityTypedPropertyParams(projectionmeta.DerivedEntityProperties(mergedAttributes))
+			updated, err := updateEntityAttributes(ctx, tx, urn, version, mergedJSON, typedProperties)
 			if err != nil {
 				return nil, err
 			}
@@ -1287,6 +1289,9 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 		"CREATE INDEX cerebro_entity_tenant_source IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.source_id)",
 		"CREATE INDEX cerebro_entity_tenant_source_type IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.source_id, e.entity_type)",
 		"CREATE INDEX cerebro_entity_tenant_label IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.label)",
+		"CREATE INDEX cerebro_entity_tenant_internet_exposed IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.internet_exposed)",
+		"CREATE INDEX cerebro_entity_tenant_privileged_identity IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.is_privileged_identity)",
+		"CREATE INDEX cerebro_entity_tenant_mfa_disabled IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.mfa_disabled)",
 		"CREATE INDEX cerebro_relation_tenant_runtime IF NOT EXISTS FOR ()-[r:RELATION]-() ON (r.tenant_id, r.runtime_id)",
 		"CREATE INDEX cerebro_relation_tenant_relation IF NOT EXISTS FOR ()-[r:RELATION]-() ON (r.tenant_id, r.relation)",
 		"CREATE FULLTEXT INDEX cerebro_entity_inventory_fulltext IF NOT EXISTS FOR (e:Entity) ON EACH [e.urn, e.label, e.entity_type, e.attributes_json]",
@@ -1597,16 +1602,30 @@ func mergeEntityAndLoadAttributes(ctx context.Context, tx neo4jdriver.ManagedTra
 	return stringValue(values[0]), toInt64(values[1]), result.Err()
 }
 
-func updateEntityAttributes(ctx context.Context, tx neo4jdriver.ManagedTransaction, urn string, version int64, attributesJSON string) (bool, error) {
+// entityTypedPropertyParams maps the derived typed properties onto the node
+// property names backing the range indexes and the rule predicates. Building the
+// map here (rather than in projectionmeta) keeps the exported derivation API
+// strongly typed.
+func entityTypedPropertyParams(properties projectionmeta.EntityTypedProperties) map[string]any {
+	return map[string]any{
+		projectionmeta.PropertyInternetExposed:    properties.InternetExposed,
+		projectionmeta.PropertyPrivilegedIdentity: properties.PrivilegedIdentity,
+		projectionmeta.PropertyMFADisabled:        properties.MFADisabled,
+	}
+}
+
+func updateEntityAttributes(ctx context.Context, tx neo4jdriver.ManagedTransaction, urn string, version int64, attributesJSON string, typedProperties map[string]any) (bool, error) {
 	updated, err := countQuery(ctx, tx, `MATCH (e:Entity {urn: $urn})
 WHERE coalesce(e.attributes_version, 0) = $attributes_version
 SET e.attributes_json = $attributes_json,
-    e.attributes_version = $next_attributes_version
+    e.attributes_version = $next_attributes_version,
+    e += $typed_properties
 RETURN count(e)`, map[string]any{
 		"urn":                     urn,
 		"attributes_version":      version,
 		"next_attributes_version": version + 1,
 		"attributes_json":         attributesJSON,
+		"typed_properties":        typedProperties,
 	})
 	if err != nil {
 		return false, err

--- a/internal/projectionmeta/classification.go
+++ b/internal/projectionmeta/classification.go
@@ -12,6 +12,71 @@ const (
 	ClassEphemeralEvent = "ephemeral_event"
 )
 
+// Typed node properties promoted from attributes_json so hot graph-rule
+// predicates can seek a range index instead of substring-scanning the JSON blob
+// on every candidate row. Each derivation mirrors the exact equality semantics
+// of the rule Cypher predicate it replaces (NOT the broader Go re-validation
+// helpers), because the effective detection set is bounded by the narrower
+// Cypher pre-filter.
+const (
+	// PropertyInternetExposed mirrors the case-sensitive `"<key>":"true"`
+	// substring checks in the cloud public-exposure rule, which has no Go
+	// post-filter, so the comparison must be byte-exact.
+	PropertyInternetExposed = "internet_exposed"
+	// PropertyPrivilegedIdentity mirrors the lower-cased is_admin /
+	// is_delegated_admin checks in the privileged-no-MFA identity rule.
+	PropertyPrivilegedIdentity = "is_privileged_identity"
+	// PropertyMFADisabled mirrors the lower-cased mfa_* / *_2sv "false" checks
+	// in the privileged-no-MFA identity rule.
+	PropertyMFADisabled = "mfa_disabled"
+)
+
+// EntityTypedProperties holds the typed boolean properties promoted from an
+// entity's attributes_json. The store maps these onto the node properties named
+// by PropertyInternetExposed/PropertyPrivilegedIdentity/PropertyMFADisabled.
+type EntityTypedProperties struct {
+	InternetExposed    bool
+	PrivilegedIdentity bool
+	MFADisabled        bool
+}
+
+// DerivedEntityProperties returns the typed boolean properties promoted from an
+// entity's merged attributes. Every entity gets a concrete true/false for each
+// property so the promoted columns are fully populated after re-projection and
+// the backing range index covers them; a NULL property therefore only means the
+// entity has not been re-projected since the promotion shipped, which the rule
+// predicates handle with an explicit IS NULL fallback to the legacy JSON scan.
+func DerivedEntityProperties(attributes map[string]string) EntityTypedProperties {
+	return EntityTypedProperties{
+		// Case-sensitive to match the rule's `CONTAINS '"<key>":"true"'`.
+		InternetExposed: attributeValueEquals(attributes, false, "true",
+			"internet_exposed", "external_exposure", "public"),
+		// Lower-cased to match the rule's `toLower(user_attrs) CONTAINS ...`.
+		PrivilegedIdentity: attributeValueEquals(attributes, true, "true",
+			"is_admin", "is_delegated_admin"),
+		MFADisabled: attributeValueEquals(attributes, true, "false",
+			"mfa_enrolled", "mfa_enforced", "is_enrolled_in_2sv", "is_enforced_in_2sv"),
+	}
+}
+
+// attributeValueEquals reports whether any named key holds exactly want. It does
+// not trim, because the Cypher predicates it mirrors match the verbatim JSON
+// substring `"<key>":"<value>"`; a stored value with surrounding whitespace is
+// not matched by those predicates either. When caseInsensitive is set the stored
+// value is lower-cased first, mirroring a toLower(...) Cypher predicate.
+func attributeValueEquals(attributes map[string]string, caseInsensitive bool, want string, keys ...string) bool {
+	for _, key := range keys {
+		value := attributes[key]
+		if caseInsensitive {
+			value = strings.ToLower(value)
+		}
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 type Classification struct {
 	Class  string
 	Reason string

--- a/internal/projectionmeta/derived_properties_test.go
+++ b/internal/projectionmeta/derived_properties_test.go
@@ -1,0 +1,81 @@
+package projectionmeta
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// DerivedEntityProperties must reproduce, exactly, the equality semantics of the
+// rule Cypher predicates it replaces, evaluated against the same attributes_json
+// blob the store writes. The oracle here builds that blob with encoding/json
+// (the store's graphAttributesJSON marshals the same map[string]string) and
+// applies the literal CONTAINS substring the rules use:
+//   - internet_exposed: case-sensitive `"<key>":"true"`.
+//   - privileged / mfa: lower-cased `"<key>":"true|false"` (the rules toLower
+//     the whole user_attrs string before matching).
+func TestDerivedEntityPropertiesMirrorRuleCypherSemantics(t *testing.T) {
+	cases := []map[string]string{
+		{},
+		{"internet_exposed": "true"},
+		{"external_exposure": "true"},
+		{"public": "true"},
+		{"internet_exposed": "false"},
+		{"internet_exposed": "True"},  // case-sensitive predicate: no match
+		{"public": "TRUE"},            // case-sensitive predicate: no match
+		{"internet_exposed": " true"}, // whitespace breaks the substring: no match
+		{"is_admin": "true"},
+		{"is_admin": "True"}, // lower-cased predicate: matches
+		{"is_delegated_admin": "true"},
+		{"is_admin": "false"},
+		{"is_admin": "yes"}, // broad Go truthy but Cypher wants "true": no match
+		{"mfa_enrolled": "false"},
+		{"mfa_enforced": "False"}, // lower-cased predicate: matches
+		{"is_enrolled_in_2sv": "false"},
+		{"is_enforced_in_2sv": "false"},
+		{"mfa_enrolled": "true"},
+		{"internet_exposed": "true", "is_admin": "true", "mfa_enrolled": "false"},
+	}
+	for _, attrs := range cases {
+		blob := mustMarshalJSON(t, attrs)
+		lower := strings.ToLower(blob)
+		got := DerivedEntityProperties(attrs)
+
+		wantExposed := strings.Contains(blob, `"internet_exposed":"true"`) ||
+			strings.Contains(blob, `"external_exposure":"true"`) ||
+			strings.Contains(blob, `"public":"true"`)
+		if got.InternetExposed != wantExposed {
+			t.Fatalf("InternetExposed for %v = %v, want %v", attrs, got.InternetExposed, wantExposed)
+		}
+
+		wantPrivileged := strings.Contains(lower, `"is_admin":"true"`) ||
+			strings.Contains(lower, `"is_delegated_admin":"true"`)
+		if got.PrivilegedIdentity != wantPrivileged {
+			t.Fatalf("PrivilegedIdentity for %v = %v, want %v", attrs, got.PrivilegedIdentity, wantPrivileged)
+		}
+
+		wantMFADisabled := strings.Contains(lower, `"mfa_enrolled":"false"`) ||
+			strings.Contains(lower, `"mfa_enforced":"false"`) ||
+			strings.Contains(lower, `"is_enrolled_in_2sv":"false"`) ||
+			strings.Contains(lower, `"is_enforced_in_2sv":"false"`)
+		if got.MFADisabled != wantMFADisabled {
+			t.Fatalf("MFADisabled for %v = %v, want %v", attrs, got.MFADisabled, wantMFADisabled)
+		}
+	}
+}
+
+func TestDerivedEntityPropertiesAlwaysPopulatesEveryProperty(t *testing.T) {
+	props := DerivedEntityProperties(map[string]string{"unrelated": "value"})
+	if props.InternetExposed || props.PrivilegedIdentity || props.MFADisabled {
+		t.Fatalf("unrelated attributes derived a true property: %#v", props)
+	}
+}
+
+func mustMarshalJSON(t *testing.T, attrs map[string]string) string {
+	t.Helper()
+	encoded, err := json.Marshal(attrs)
+	if err != nil {
+		t.Fatalf("marshal attributes: %v", err)
+	}
+	return string(encoded)
+}


### PR DESCRIPTION
## Summary

> Stacked on #1437 (base branch `droid/neo4j-graph-rule-performance`). Review/merge that first.

Durable follow-up to the graph-rule performance work: remove the per-row `attributes_json` substring scans from the hot boolean predicates by promoting them to typed, indexed Neo4j node properties derived once at projection time.

Today the cloud public-exposure rule and the privileged-no-MFA identity rule pre-filter every candidate row with `CONTAINS` scans over `attributes_json` (internet exposure, `is_admin`/`is_delegated_admin`, `mfa_*`/`2sv` state). Those predicates cannot use an index and re-parse the JSON blob per row.

Adds:
- `projectionmeta.DerivedEntityProperties` returning `internet_exposed`, `is_privileged_identity`, `mfa_disabled`. Each mirrors the **exact** equality semantics of the Cypher predicate it replaces: case-sensitive for the exposure rule (which has no Go post-filter), lower-cased for the identity rule. The effective detection set is bounded by the narrow Cypher pre-filter, **not** the broader Go re-validation helpers (`findingAttributeBool` accepts `true/yes/enabled/...`), so the derivation deliberately mirrors the former.
- The Neo4j store writes these as node properties on every entity upsert (`SET e += $typed_properties`) and backs them with `(tenant_id, <prop>)` range indexes.

Migrates:
- The two rules now prefer the typed property and fall back to the legacy `attributes_json` scan **only when the property `IS NULL`** (entity not yet re-projected since this shipped). The result set is therefore identical regardless of backfill state, and the indexed fast path engages progressively as projection runs. No separate backfill job is required.

Intentionally deferred (need `EXPLAIN`/`PROFILE` against a real Neo4j before migration):
- The reachability/`acted_on` **datetime-recency** predicates (`datetime(split(...))`), because parse-equivalence with Cypher `datetime()` is not safe to assume blind.
- The **admin-grant** predicate on access edges (relation-dependent + an unscoped `AdministratorAccess` substring match).

## Test Plan

- `internal/projectionmeta`: `TestDerivedEntityPropertiesMirrorRuleCypherSemantics` checks the derivation against a literal-substring oracle over the marshaled `attributes_json` (case-sensitive vs lower-cased, whitespace, `True`/`TRUE`/`yes` edge cases); `TestDerivedEntityPropertiesAlwaysPopulatesEveryProperty`.
- `internal/findings`: `TestGraphRulesPreferTypedPropertyWithJSONFallback` asserts both rules carry the typed fast path **and** the `IS NULL` JSON fallback. Existing query-shape and `EvaluateRows` contract tests stay green (the legacy predicates are preserved in the fallback branch).
- `go test ./internal/projectionmeta/... ./internal/findings/... ./internal/graphstore/neo4j/... ./cmd/cerebro/...` pass.
- `make check-structural check-arch` and `make lint` (0 issues) pass.

> The `SET e += $typed_properties` write and the index-backed reads could not be exercised against a real Neo4j from here; they should be smoke-checked in staging (confirm the three indexes are `ONLINE` and the rule plans seek them).

## Known Invariants

- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated. (Predicates still tenant-scoped; reads only.)
- Candidate finding lifecycle writes remain atomic and idempotent. (RETURN columns unchanged; the `IS NULL` fallback keeps the result set identical to the legacy predicate, so fingerprints/lifecycle are preserved.)

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on the derivation/Cypher equality equivalence and the `IS NULL` fallback, plus the new range indexes.
- Graph + state-adjacent change; the typed-property write/read path warrants a staging index + plan check.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->