### PR TITLE
perf: run tenant-scoped graph rules once per tenant per orchestrator cycle

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -514,6 +514,14 @@ func runOrchestratorIteration(
 	))
 	var runErr error
 	var acquiredCount uint32
+	// Graph rules are tenant-scoped: each one queries the whole tenant graph,
+	// not just the triggering runtime's slice. Running them once per runtime
+	// re-evaluates the identical tenant-wide rule for every runtime in the
+	// tenant (hundreds, for large multi-account tenants), which is the dominant
+	// load on the graph-rule phase. Track which rules already ran for a tenant
+	// this iteration and exclude them so each rule runs at most once per tenant
+	// per cycle while still covering rules contributed by other sources.
+	graphRulesEvaluatedByTenant := map[string]map[string]struct{}{}
 	for _, runtime := range runtimes {
 		if targetLimit > 0 && acquiredCount >= targetLimit {
 			break
@@ -670,10 +678,16 @@ func runOrchestratorIteration(
 		// reached by source sync, even if a trailing PutIngestRun(completed) write
 		// failed. The graph is fresh enough for read-only rules at that point.
 		if graphIngestReadyForGraphRules(graphResult, syncResult.GetRuntime().GetNextCursor()) {
+			excludedGraphRuleIDs := orchestratorEvaluatedGraphRuleIDs(graphRulesEvaluatedByTenant[runtimeResult.TenantID])
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_deduped_count", len(excludedGraphRuleIDs))
 			graphRulesResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_rules", iteration, runtime, options.PhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateGraphRulesResult, error) {
-				return findingService.EvaluateSourceRuntimeGraphRules(phaseCtx, findings.EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
+				return findingService.EvaluateSourceRuntimeGraphRules(phaseCtx, findings.EvaluateGraphRulesRequest{RuntimeID: runtime.GetId(), ExcludeRuleIDs: excludedGraphRuleIDs})
 			})
 			runtimeSpanAttrs = applyGraphRuleCounters(runtimeResult, graphRulesResult, runtimeSpanAttrs)
+			// Mark every rule that was attempted (success or failure) so a slow
+			// or failing rule is retried at most once per tenant per cycle
+			// rather than re-running for every remaining runtime in the tenant.
+			markOrchestratorTenantGraphRulesEvaluated(graphRulesEvaluatedByTenant, runtimeResult.TenantID, graphRulesResult)
 			if err != nil {
 				if errors.Is(err, findings.ErrGraphRuntimeUnavailable) || errors.Is(err, findings.ErrRuntimeUnavailable) {
 					runtimeResult.GraphRules = "skipped"
@@ -1098,6 +1112,41 @@ func applyGraphRuleCounters(runtimeResult *orchestratorRuntimeResult, graphRules
 	attrs = withTelemetryField(attrs, "graph_rule_findings", runtimeResult.GraphRuleFindings)
 	attrs = withTelemetryField(attrs, "graph_rule_rows_read", runtimeResult.GraphRuleRowsRead)
 	return attrs
+}
+
+// orchestratorEvaluatedGraphRuleIDs returns the graph-rule IDs already evaluated
+// for a tenant this iteration, to be excluded from the next runtime's pass.
+func orchestratorEvaluatedGraphRuleIDs(evaluated map[string]struct{}) []string {
+	if len(evaluated) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(evaluated))
+	for id := range evaluated {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// markOrchestratorTenantGraphRulesEvaluated records every graph rule attempted
+// in a pass against the tenant so subsequent runtimes in the same iteration
+// exclude it.
+func markOrchestratorTenantGraphRulesEvaluated(evaluatedByTenant map[string]map[string]struct{}, tenantID string, result *findings.EvaluateGraphRulesResult) {
+	if evaluatedByTenant == nil || result == nil {
+		return
+	}
+	evaluated := evaluatedByTenant[tenantID]
+	if evaluated == nil {
+		evaluated = map[string]struct{}{}
+		evaluatedByTenant[tenantID] = evaluated
+	}
+	for _, evaluation := range result.Evaluations {
+		if evaluation == nil || evaluation.Rule == nil {
+			continue
+		}
+		if id := strings.TrimSpace(evaluation.Rule.GetId()); id != "" {
+			evaluated[id] = struct{}{}
+		}
+	}
 }
 
 func orchestratorListFilter(filter ports.SourceRuntimeFilter) ports.SourceRuntimeFilter {

--- a/cmd/cerebro/orchestrator_graph_dedup_test.go
+++ b/cmd/cerebro/orchestrator_graph_dedup_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"sort"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findings"
+)
+
+func TestMarkOrchestratorTenantGraphRulesEvaluatedTracksRuleIDsPerTenant(t *testing.T) {
+	evaluatedByTenant := map[string]map[string]struct{}{}
+
+	markOrchestratorTenantGraphRulesEvaluated(evaluatedByTenant, "writer", &findings.EvaluateGraphRulesResult{
+		Evaluations: []*findings.GraphRuleEvaluationResult{
+			{Rule: &cerebrov1.RuleSpec{Id: "rule-a"}},
+			{Rule: &cerebrov1.RuleSpec{Id: "rule-b"}},
+			nil,
+			{Rule: nil},
+			{Rule: &cerebrov1.RuleSpec{Id: "  "}},
+		},
+	})
+
+	got := orchestratorEvaluatedGraphRuleIDs(evaluatedByTenant["writer"])
+	sort.Strings(got)
+	if want := []string{"rule-a", "rule-b"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("evaluated rule ids = %v, want %v", got, want)
+	}
+
+	// A second runtime in the same tenant accumulates without dropping prior ids.
+	markOrchestratorTenantGraphRulesEvaluated(evaluatedByTenant, "writer", &findings.EvaluateGraphRulesResult{
+		Evaluations: []*findings.GraphRuleEvaluationResult{{Rule: &cerebrov1.RuleSpec{Id: "rule-c"}}},
+	})
+	if got := len(evaluatedByTenant["writer"]); got != 3 {
+		t.Fatalf("tenant rule count = %d, want 3", got)
+	}
+
+	// A different tenant is tracked independently.
+	if got := orchestratorEvaluatedGraphRuleIDs(evaluatedByTenant["other"]); got != nil {
+		t.Fatalf("untracked tenant ids = %v, want nil", got)
+	}
+}
+
+func TestOrchestratorEvaluatedGraphRuleIDsEmpty(t *testing.T) {
+	if got := orchestratorEvaluatedGraphRuleIDs(nil); got != nil {
+		t.Fatalf("orchestratorEvaluatedGraphRuleIDs(nil) = %v, want nil", got)
+	}
+	if got := orchestratorEvaluatedGraphRuleIDs(map[string]struct{}{}); got != nil {
+		t.Fatalf("orchestratorEvaluatedGraphRuleIDs(empty) = %v, want nil", got)
+	}
+}

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -16,6 +16,12 @@ import (
 type EvaluateGraphRulesRequest struct {
 	RuntimeID string
 	RuleIDs   []string
+	// ExcludeRuleIDs drops the named graph rules from the default
+	// (ForRuntime) selection. The orchestrator uses this to run each
+	// tenant-scoped graph rule at most once per cycle even when many runtimes
+	// in the tenant would otherwise each trigger the same rule. It is ignored
+	// when RuleIDs is set explicitly.
+	ExcludeRuleIDs []string
 }
 
 // GraphRuleEvaluationResult reports one graph rule's outputs inside a multi-rule pass.
@@ -57,7 +63,7 @@ func (s *Service) EvaluateSourceRuntimeGraphRules(ctx context.Context, request E
 	if err != nil {
 		return nil, err
 	}
-	candidates, err := s.selectGraphRules(runtime, request.RuleIDs)
+	candidates, err := s.selectGraphRules(runtime, request.RuleIDs, request.ExcludeRuleIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -242,13 +248,24 @@ func cypherRowsTruncated(request ports.CypherQueryRequest, rowsReturned int) boo
 	return rowsReturned >= cap
 }
 
-func (s *Service) selectGraphRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string) ([]GraphRule, error) {
+func (s *Service) selectGraphRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string, excludeRuleIDs []string) ([]GraphRule, error) {
 	if len(ruleIDs) == 0 {
+		excluded := make(map[string]struct{}, len(excludeRuleIDs))
+		for _, id := range excludeRuleIDs {
+			if trimmed := strings.TrimSpace(id); trimmed != "" {
+				excluded[trimmed] = struct{}{}
+			}
+		}
 		var graphRules []GraphRule
 		for _, rule := range s.rules.ForRuntime(runtime) {
-			if graphRule, ok := asGraphRule(rule); ok {
-				graphRules = append(graphRules, graphRule)
+			graphRule, ok := asGraphRule(rule)
+			if !ok {
+				continue
 			}
+			if _, skip := excluded[strings.TrimSpace(graphRule.Spec().GetId())]; skip {
+				continue
+			}
+			graphRules = append(graphRules, graphRule)
 		}
 		return graphRules, nil
 	}

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -55,6 +55,41 @@ func (r *stubGraphRule) EvaluateRows(_ context.Context, _ *cerebrov1.SourceRunti
 	return r.emit, nil
 }
 
+func TestEvaluateSourceRuntimeGraphRulesExcludesNamedRules(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphStore := &stubGraphStore{}
+	ruleA := &stubGraphRule{spec: &cerebrov1.RuleSpec{Id: "rule-a"}, sourceID: "okta", query: ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"}}
+	ruleB := &stubGraphRule{spec: &cerebrov1.RuleSpec{Id: "rule-b"}, sourceID: "okta", query: ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"}}
+	registry, err := NewRegistry(ruleA, ruleB)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+
+	// Excluding rule-a leaves only rule-b (coverage for the other rule is kept).
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta", ExcludeRuleIDs: []string{"rule-a"}})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if got := len(result.Evaluations); got != 1 {
+		t.Fatalf("len(Evaluations) = %d, want 1", got)
+	}
+	if got := result.Evaluations[0].Rule.GetId(); got != "rule-b" {
+		t.Fatalf("evaluated rule = %q, want rule-b", got)
+	}
+
+	// Excluding every supported rule evaluates nothing, without error: the
+	// tenant already ran them this cycle.
+	empty, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta", ExcludeRuleIDs: []string{"rule-a", "rule-b"}})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if got := len(empty.Evaluations); got != 0 {
+		t.Fatalf("len(Evaluations) = %d, want 0 when all rules excluded", got)
+	}
+}
+
 func TestAsGraphRuleNarrows(t *testing.T) {
 	if _, ok := asGraphRule(nil); ok {
 		t.Fatalf("asGraphRule(nil) should be false")


### PR DESCRIPTION
## Summary

> Stacked on #1437 (base branch `droid/neo4j-graph-rule-performance`). Parallel to #1438. Review/merge #1437 first.

Graph rules are **tenant-scoped**: each one queries the whole tenant graph, not just the triggering runtime's slice. The orchestrator, however, evaluated them once per runtime, so a tenant with hundreds of runtimes (large multi-account estates) re-ran the identical tenant-wide rule hundreds of times per cycle. That redundant fan-out is the dominant load on the graph-rule phase and a primary contributor to the phase-budget exhaustion this work addresses.

Change:
- The orchestrator tracks, per tenant per iteration, which graph rules already ran, and passes them as `EvaluateGraphRulesRequest.ExcludeRuleIDs` so each rule runs **at most once per tenant per cycle**.
- Dedup is at `(tenant, rule)` granularity rather than "first runtime only", so rules contributed only by *other* sources in the tenant (e.g. an Okta rule when the first runtime was AWS) are still covered.
- Rules are marked attempted on success **or** failure, so a slow/failing rule is retried at most once per tenant per cycle instead of for every remaining runtime (preventing a retry storm of exactly the pathological rules this stack fixes).
- `findings.selectGraphRules` honors `ExcludeRuleIDs` only on the default (`ForRuntime`) selection path; an explicit `RuleIDs` request is unaffected.

Behavior preserved: findings are tenant-scoped and idempotent (fingerprint-keyed), so running a rule once per tenant converges to the same state as the previous once-per-runtime scheme, at a fraction of the load. Within a cycle, sibling-runtime data synced later in the same iteration is reflected one cycle later, the same eventual-consistency the per-runtime scheme already had for all but the last runtime.

## Test Plan

- `internal/findings`: `TestEvaluateSourceRuntimeGraphRulesExcludesNamedRules` (excluding one rule leaves the other; excluding all evaluates nothing without error).
- `cmd/cerebro`: `TestMarkOrchestratorTenantGraphRulesEvaluatedTracksRuleIDsPerTenant` and `TestOrchestratorEvaluatedGraphRuleIDsEmpty` (per-tenant accumulation, nil/empty handling, independent tenants).
- `go test ./internal/findings/... ./cmd/cerebro/... ./tools/archtests/...` pass.
- `make detection-catalog-check catalog-check check-structural check-arch` and `make lint` (0 issues) pass.

## Known Invariants

- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated. (Unchanged; this only changes how often each rule is invoked.)
- Candidate finding lifecycle writes remain atomic and idempotent. (Idempotent fingerprint-keyed findings make once-per-tenant equivalent to the prior once-per-runtime convergence.)

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on the `(tenant, rule)` dedup correctness (coverage across sources) and the mark-on-attempt semantics.
- Cross-replica note: dedup state is per orchestrator replica per iteration, so a tenant whose runtimes are split across replicas may run a rule once per replica; still bounded and idempotent, versus the previous once-per-runtime fan-out.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->