### PR TITLE
[codex] Enforce explicit coverage metadata declarations

### DIFF
--- a/internal/connectorcatalog/catalog.go
+++ b/internal/connectorcatalog/catalog.go
@@ -222,6 +222,7 @@ func analyzeEntries(raw []loadedEntry, options Options) Analysis {
 		if declared == "" {
 			analysis.Issues = append(analysis.Issues, Issue{Path: path, Message: "classifier_output is required"})
 		}
+		analysis.Issues = append(analysis.Issues, proofGateIssues(path, loaded.entry.Definition)...)
 		definition, err := connectordefinitions.Normalize(loaded.entry.Definition)
 		if err != nil {
 			analysis.Issues = append(analysis.Issues, Issue{Path: path, Message: "normalize definition: " + err.Error()})
@@ -256,7 +257,6 @@ func analyzeEntries(raw []loadedEntry, options Options) Analysis {
 		if overlap := intersect(report.SupportedFeatures, report.MissingFeatures); len(overlap) != 0 {
 			analysis.Issues = append(analysis.Issues, Issue{Path: path, Message: "classifier report has contradictory supported and missing features: " + strings.Join(overlap, ", ")})
 		}
-		analysis.Issues = append(analysis.Issues, proofGateIssues(path, definition)...)
 		if options.DryRunSourcegen && report.Verdict == connectordefinitions.SupportVerdictSupported {
 			entry.SourcegenDryRun = true
 			if _, err := sourcegen.GenerateDefinition(sourcegen.DefinitionRequest{Definition: definition, OutputDir: ".", DryRun: true}); err != nil {
@@ -418,19 +418,20 @@ func proofGateIssues(path string, definition connectordefinitions.Definition) []
 			continue
 		}
 		for _, dimension := range family.Coverage {
+			dimensionID := proofGateDimensionID(family.ID, dimension)
 			if dimension.HighValue {
 				highValue = true
 			}
 			if !dimension.HighValue {
 				continue
 			}
-			switch dimension.Support {
+			switch strings.ToLower(strings.TrimSpace(dimension.Support)) {
 			case "supported", "partial":
 				if len(dimension.EvidenceTypes) == 0 {
-					issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("resource family %q high-value coverage dimension %q must declare evidence types", family.ID, dimension.ID)})
+					issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("resource family %q high-value coverage dimension %q must declare evidence types", family.ID, dimensionID)})
 				}
 				if len(dimension.ControlDomains) == 0 {
-					issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("resource family %q high-value coverage dimension %q must declare control domains", family.ID, dimension.ID)})
+					issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("resource family %q high-value coverage dimension %q must declare control domains", family.ID, dimensionID)})
 				}
 			}
 		}
@@ -439,6 +440,17 @@ func proofGateIssues(path string, definition connectordefinitions.Definition) []
 		issues = append(issues, Issue{Path: path, Message: "at least one high-value coverage dimension is required"})
 	}
 	return issues
+}
+
+func proofGateDimensionID(familyID string, dimension connectordefinitions.CoverageDimensionSpec) string {
+	if id := strings.TrimSpace(dimension.ID); id != "" {
+		return id
+	}
+	dimensionType := strings.TrimSpace(dimension.Type)
+	if familyID == "" || dimensionType == "" {
+		return ""
+	}
+	return strings.Trim(familyID+"_"+dimensionType, "_")
 }
 
 func verificationPath(definition connectordefinitions.Definition) string {

--- a/internal/connectorcatalog/catalog/business-data-grc.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc.yaml
@@ -46,6 +46,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -70,6 +72,8 @@ entries:
               families: [controls]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -94,6 +98,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -142,6 +148,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -166,6 +174,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -190,6 +200,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -238,6 +250,8 @@ entries:
               families: [transactions]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -262,6 +276,8 @@ entries:
               families: [customers]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -286,6 +302,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -335,6 +353,8 @@ entries:
               families: [cards]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -359,6 +379,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -383,6 +405,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -431,6 +455,8 @@ entries:
               families: [bookings]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -455,6 +481,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -479,6 +507,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -530,6 +560,8 @@ entries:
               families: [subscriptions]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -554,6 +586,8 @@ entries:
               families: [customers]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -578,6 +612,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -627,6 +663,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -651,6 +689,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -675,6 +715,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -723,6 +765,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -747,6 +791,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -771,6 +817,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -819,6 +867,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -843,6 +893,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -867,6 +919,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -915,6 +969,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -939,6 +995,8 @@ entries:
               families: [controls]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -963,6 +1021,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1011,6 +1071,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1035,6 +1097,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1059,6 +1123,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1107,6 +1173,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1131,6 +1199,8 @@ entries:
               families: [tickets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1155,6 +1225,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1203,6 +1275,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1227,6 +1301,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1251,6 +1327,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1303,6 +1381,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1327,6 +1407,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1351,6 +1433,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1406,6 +1490,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: page
             page_param: page
@@ -1431,6 +1517,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: page
             page_param: page
@@ -1455,6 +1543,8 @@ entries:
               families: [training_enrollments]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: page
             page_param: page
@@ -1480,6 +1570,8 @@ entries:
               families: [phishing_campaigns]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: page
             page_param: page
@@ -1528,6 +1620,8 @@ entries:
               families: [accounts]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1552,6 +1646,8 @@ entries:
               families: [transactions]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1576,6 +1672,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1626,6 +1724,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1650,6 +1750,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1674,6 +1776,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1724,6 +1828,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1748,6 +1854,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1772,6 +1880,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1823,6 +1933,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1847,6 +1959,8 @@ entries:
               families: [controls]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1871,6 +1985,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1919,6 +2035,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1943,6 +2061,8 @@ entries:
               families: [tickets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1967,6 +2087,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2022,6 +2144,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2046,6 +2170,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2070,6 +2196,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2118,6 +2246,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2142,6 +2272,8 @@ entries:
               families: [devices]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2166,6 +2298,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2218,6 +2352,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2242,6 +2378,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2266,6 +2404,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2314,6 +2454,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2338,6 +2480,8 @@ entries:
               families: [controls]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2362,6 +2506,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2410,6 +2556,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2434,6 +2582,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2458,6 +2608,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2510,6 +2662,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2534,6 +2688,8 @@ entries:
               families: [tickets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2558,6 +2714,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2609,6 +2767,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2633,6 +2793,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2657,6 +2819,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2705,6 +2869,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2729,6 +2895,8 @@ entries:
               families: [tickets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2753,6 +2921,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2801,6 +2971,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2825,6 +2997,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2849,6 +3023,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2900,6 +3076,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2924,6 +3102,8 @@ entries:
               families: [controls]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2948,6 +3128,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2999,6 +3181,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -3023,6 +3207,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -3047,6 +3233,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -3097,6 +3285,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -3121,6 +3311,8 @@ entries:
               families: [tickets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -3145,6 +3337,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -3172,6 +3366,8 @@ entries:
             - families:
                 - attribute_group_list_json
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: attribute_group_list_json
               support: partial
               title: Attribute Group List Json
@@ -3293,6 +3489,8 @@ entries:
             - families:
                 - ledger_account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: ledger_account
               support: partial
               title: Ledger Account
@@ -3513,6 +3711,8 @@ entries:
             - families:
                 - logo
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Logo
@@ -3545,6 +3745,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -3577,6 +3779,8 @@ entries:
             - families:
                 - add_to_data
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: add_to_data
               support: partial
               title: Add To Data
@@ -3611,6 +3815,8 @@ entries:
             - families:
                 - alert
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Alert
@@ -3704,6 +3910,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -3736,6 +3944,8 @@ entries:
             - families:
                 - ownertypegroup
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: ownertypegroup
               support: partial
               title: Ownertypegroup
@@ -3800,6 +4010,8 @@ entries:
             - families:
                 - bankaccount
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: bankaccount
               support: partial
               title: Bankaccount
@@ -3889,6 +4101,8 @@ entries:
             - families:
                 - bank_account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: bank_account
               support: partial
               title: Bank Account
@@ -4105,6 +4319,8 @@ entries:
             - families:
                 - event
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Event
@@ -4136,6 +4352,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -4167,6 +4385,8 @@ entries:
             - families:
                 - credential_password_ip
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Credential Password Ip
@@ -4202,6 +4422,8 @@ entries:
             - families:
                 - notification_filter_push
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Notification Filter Push
@@ -4299,6 +4521,8 @@ entries:
             - families:
                 - bcc_email_archive
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: bcc_email_archive
               support: partial
               title: Bcc Email Archive
@@ -4333,6 +4557,8 @@ entries:
             - families:
                 - signing_group
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: signing_group
               support: partial
               title: Signing Group
@@ -4365,6 +4591,8 @@ entries:
             - families:
                 - request_log
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Request Log
@@ -4397,6 +4625,8 @@ entries:
             - families:
                 - permission_profile
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: permission_profile
               support: partial
               title: Permission Profile
@@ -4489,6 +4719,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -4557,6 +4789,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -4689,6 +4923,8 @@ entries:
             - families:
                 - integration
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Integration
@@ -4721,6 +4957,8 @@ entries:
             - families:
                 - actualorganizationalentity
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: actualorganizationalentity
               support: partial
               title: Actualorganizationalentity
@@ -4755,6 +4993,8 @@ entries:
             - families:
                 - emailidentity
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: emailidentity
               support: partial
               title: Emailidentity
@@ -4789,6 +5029,8 @@ entries:
             - families:
                 - customnotification
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Customnotification
@@ -4884,6 +5126,8 @@ entries:
             - families:
                 - attribute
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Attribute
@@ -4916,6 +5160,8 @@ entries:
             - families:
                 - role
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: role
               support: partial
               title: Role
@@ -4948,6 +5194,8 @@ entries:
             - families:
                 - search
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Search
@@ -4983,6 +5231,8 @@ entries:
             - families:
                 - coupons_search
               high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
               id: policies
               support: partial
               title: Coupons Search
@@ -5079,6 +5329,8 @@ entries:
             - families:
                 - token
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Token
@@ -5268,6 +5520,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -5338,6 +5592,8 @@ entries:
             - families:
                 - enduser
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: enduser
               support: partial
               title: Enduser
@@ -5469,6 +5725,8 @@ entries:
             - families:
                 - event
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Event
@@ -5652,6 +5910,8 @@ entries:
             - families:
                 - organization
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: organization
               support: partial
               title: Organization
@@ -5835,6 +6095,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -5907,6 +6169,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -6033,6 +6297,8 @@ entries:
             - families:
                 - customer_timeline_custom_event
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Customer Timeline Custom Event
@@ -6070,6 +6336,8 @@ entries:
             - families:
                 - authentication_token
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Authentication Token
@@ -6112,6 +6380,8 @@ entries:
             - families:
                 - bank_account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: bank_account
               support: partial
               title: Bank Account
@@ -6248,6 +6518,8 @@ entries:
             - families:
                 - crm_activity_fields_json
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Crm Activity Fields Json
@@ -6284,6 +6556,8 @@ entries:
             - families:
                 - account_stages_json
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account_stages_json
               support: partial
               title: Account Stages Json
@@ -6320,6 +6594,8 @@ entries:
             - families:
                 - cadence_memberships_json
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: cadence_memberships_json
               support: partial
               title: Cadence Memberships Json
@@ -6356,6 +6632,8 @@ entries:
             - families:
                 - groups_json
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: groups_json
               support: partial
               title: Groups Json
@@ -6450,6 +6728,8 @@ entries:
             - families:
                 - tracking
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Tracking
@@ -6484,6 +6764,8 @@ entries:
             - families:
                 - package
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: package
               support: partial
               title: Package
@@ -6520,6 +6802,8 @@ entries:
             - families:
                 - track
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Track
@@ -6554,6 +6838,8 @@ entries:
             - families:
                 - webhook
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: webhook
               support: partial
               title: Webhook
@@ -6652,6 +6938,8 @@ entries:
             - families:
                 - payment
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: payment
               support: partial
               title: Payment
@@ -6689,6 +6977,8 @@ entries:
             - families:
                 - refund
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: refund
               support: partial
               title: Refund
@@ -6760,6 +7050,8 @@ entries:
             - families:
                 - vy
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: vy
               support: partial
               title: Vy
@@ -6851,6 +7143,8 @@ entries:
             - families:
                 - hook
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: hook
               support: partial
               title: Hook
@@ -6887,6 +7181,8 @@ entries:
             - families:
                 - report
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: report
               support: partial
               title: Report
@@ -7055,6 +7351,8 @@ entries:
             - families:
                 - delta
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Delta
@@ -7094,6 +7392,8 @@ entries:
             - families:
                 - sourceaccount
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: sourceaccount
               support: partial
               title: Sourceaccount
@@ -7133,6 +7433,8 @@ entries:
             - families:
                 - paymentchannelrule
               high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
               id: policies
               support: partial
               title: Paymentchannelrule
@@ -7169,6 +7471,8 @@ entries:
             - families:
                 - webhook
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: webhook
               support: partial
               title: Webhook

--- a/internal/connectorcatalog/catalog/collaboration-productivity.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity.yaml
@@ -43,6 +43,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -67,6 +69,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -91,6 +95,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -139,6 +145,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -163,6 +171,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -187,6 +197,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -237,6 +249,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -261,6 +275,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -285,6 +301,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -337,6 +355,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -361,6 +381,8 @@ entries:
               families: [content_assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -385,6 +407,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -433,6 +457,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -457,6 +483,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -481,6 +509,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -536,6 +566,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: pageToken
@@ -560,6 +592,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: pageToken
@@ -584,6 +618,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: pageToken
@@ -634,6 +670,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -658,6 +696,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -682,6 +722,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -730,6 +772,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -754,6 +798,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -778,6 +824,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -829,6 +877,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -853,6 +903,8 @@ entries:
               families: [content_assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -877,6 +929,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -928,6 +982,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -952,6 +1008,8 @@ entries:
               families: [content_assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -976,6 +1034,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1028,6 +1088,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1052,6 +1114,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1076,6 +1140,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1124,6 +1190,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1148,6 +1216,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1172,6 +1242,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1220,6 +1292,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1244,6 +1318,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1268,6 +1344,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1319,6 +1397,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1343,6 +1423,8 @@ entries:
               families: [content_assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1367,6 +1449,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1399,6 +1483,8 @@ entries:
             - families:
                 - field
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Field
@@ -1431,6 +1517,8 @@ entries:
             - families:
                 - userdefinedfield
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: userdefinedfield
               support: partial
               title: Userdefinedfield
@@ -1463,6 +1551,8 @@ entries:
             - families:
                 - excludedrole
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: excludedrole
               support: partial
               title: Excludedrole
@@ -1495,6 +1585,8 @@ entries:
             - families:
                 - entityinformation_field
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Entityinformation Field
@@ -1597,6 +1689,8 @@ entries:
             - families:
                 - webhook
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: webhook
               support: partial
               title: Webhook
@@ -1792,6 +1886,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -1824,6 +1920,8 @@ entries:
             - families:
                 - credential
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Credential
@@ -1987,6 +2085,8 @@ entries:
             - families:
                 - groups_json
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: groups_json
               support: partial
               title: Groups Json
@@ -2019,6 +2119,8 @@ entries:
             - families:
                 - user_actions_json
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user_actions_json
               support: partial
               title: User Actions Json
@@ -2053,6 +2155,8 @@ entries:
             - families:
                 - notifications_json
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Notifications Json
@@ -2187,6 +2291,8 @@ entries:
             - families:
                 - event_type
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Event Type
@@ -2219,6 +2325,8 @@ entries:
             - families:
                 - group
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: group
               support: partial
               title: Group
@@ -2256,6 +2364,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -2291,6 +2401,8 @@ entries:
             - families:
                 - channel
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Channel
@@ -2391,6 +2503,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -2426,6 +2540,8 @@ entries:
             - families:
                 - activity
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Activity
@@ -2457,6 +2573,8 @@ entries:
             - families:
                 - verify_credential
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Verify Credential
@@ -2493,6 +2611,8 @@ entries:
             - families:
                 - notification
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Notification
@@ -2604,6 +2724,8 @@ entries:
             - families:
                 - webhook
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: webhook
               support: partial
               title: Webhook
@@ -2806,6 +2928,8 @@ entries:
             - families:
                 - activity
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Activity
@@ -2842,6 +2966,8 @@ entries:
             - families:
                 - api_key
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Api Key
@@ -2880,6 +3006,8 @@ entries:
             - families:
                 - group
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: group
               support: partial
               title: Group
@@ -2913,6 +3041,8 @@ entries:
             - families:
                 - invalid_email
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: invalid_email
               support: partial
               title: Invalid Email
@@ -3079,6 +3209,8 @@ entries:
             - families:
                 - usergroups_list
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: usergroups_list
               support: partial
               title: Usergroups List
@@ -3113,6 +3245,8 @@ entries:
             - families:
                 - team_accesslog
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Team Accesslog
@@ -3150,6 +3284,8 @@ entries:
             - families:
                 - admin_conversations_getteam
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: admin_conversations_getteam
               support: partial
               title: Admin Conversations Getteam
@@ -3185,6 +3321,8 @@ entries:
             - families:
                 - apps_permissions_resources_list
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: apps_permissions_resources_list
               support: partial
               title: Apps Permissions Resources List
@@ -3287,6 +3425,8 @@ entries:
             - families:
                 - list_membership
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: list_membership
               support: partial
               title: List Membership
@@ -3327,6 +3467,8 @@ entries:
             - families:
                 - member
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: member
               support: partial
               title: Member
@@ -3367,6 +3509,8 @@ entries:
             - families:
                 - job
               high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
               id: policies
               support: partial
               title: Job
@@ -3403,6 +3547,8 @@ entries:
             - families:
                 - dm_event
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Dm Event
@@ -3509,6 +3655,8 @@ entries:
             - families:
                 - group
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: group
               support: partial
               title: Group
@@ -3543,6 +3691,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -3577,6 +3727,8 @@ entries:
             - families:
                 - invite
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: invite
               support: partial
               title: Invite
@@ -3613,6 +3765,8 @@ entries:
             - families:
                 - group_2
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: group_2
               support: partial
               title: Group 2
@@ -3705,6 +3859,8 @@ entries:
             - families:
                 - subaccount
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: subaccount
               support: partial
               title: Subaccount

--- a/internal/connectorcatalog/catalog/devops-ci-cd.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd.yaml
@@ -43,6 +43,8 @@ entries:
               families: [pipelines]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -67,6 +69,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -91,6 +95,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -143,6 +149,8 @@ entries:
               families: [repositories]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -167,6 +175,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -191,6 +201,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -243,6 +255,8 @@ entries:
               families: [repositories]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -267,6 +281,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -291,6 +307,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -339,6 +357,8 @@ entries:
               families: [pipelines]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -363,6 +383,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -387,6 +409,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -435,6 +459,8 @@ entries:
               families: [pipelines]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -459,6 +485,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -483,6 +511,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -531,6 +561,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -555,6 +587,8 @@ entries:
               families: [builds]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -579,6 +613,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -628,6 +664,8 @@ entries:
               families: [droplets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -652,6 +690,8 @@ entries:
               families: [teams]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -676,6 +716,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -725,6 +767,8 @@ entries:
               families: [repositories]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -749,6 +793,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -773,6 +819,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -821,6 +869,8 @@ entries:
               families: [services]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -845,6 +895,8 @@ entries:
               families: [acl_entries]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -869,6 +921,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -918,6 +972,8 @@ entries:
               families: [repositories]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -942,6 +998,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -966,6 +1024,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1014,6 +1074,8 @@ entries:
               families: [pipelines]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1038,6 +1100,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1062,6 +1126,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1110,6 +1176,8 @@ entries:
               families: [apps]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1134,6 +1202,8 @@ entries:
               families: [collaborators]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1158,6 +1228,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1209,6 +1281,8 @@ entries:
               families: [pipelines]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1233,6 +1307,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1257,6 +1333,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1305,6 +1383,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1329,6 +1409,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1353,6 +1435,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1401,6 +1485,8 @@ entries:
               families: [repositories]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1425,6 +1511,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1449,6 +1537,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1497,6 +1587,8 @@ entries:
               families: [collections]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1521,6 +1613,8 @@ entries:
               families: [environments]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1545,6 +1639,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1593,6 +1689,8 @@ entries:
               families: [repositories]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1617,6 +1715,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1641,6 +1741,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1689,6 +1791,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1713,6 +1817,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1737,6 +1843,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1785,6 +1893,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1809,6 +1919,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1833,6 +1945,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1881,6 +1995,8 @@ entries:
               families: [repositories]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1905,6 +2021,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1929,6 +2047,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1977,6 +2097,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2001,6 +2123,8 @@ entries:
               families: [deployments]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2025,6 +2149,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2056,6 +2182,8 @@ entries:
             - families:
                 - eventlog
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Eventlog
@@ -2091,6 +2219,8 @@ entries:
             - families:
                 - role
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: role
               support: partial
               title: Role
@@ -2126,6 +2256,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -2161,6 +2293,8 @@ entries:
             - families:
                 - permission
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: permission
               support: partial
               title: Permission
@@ -2261,6 +2395,8 @@ entries:
             - families:
                 - role
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: role
               support: partial
               title: Role
@@ -2294,6 +2430,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -2329,6 +2467,8 @@ entries:
             - families:
                 - artifact
               high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
               id: deployments
               support: partial
               title: Artifact
@@ -2460,6 +2600,8 @@ entries:
             - families:
                 - team
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: team
               support: partial
               title: Team
@@ -2498,6 +2640,8 @@ entries:
             - families:
                 - log
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Log
@@ -2533,6 +2677,8 @@ entries:
             - families:
                 - membership
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: membership
               support: partial
               title: Membership
@@ -2672,6 +2818,8 @@ entries:
             - families:
                 - email
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: email
               support: partial
               title: Email
@@ -2701,6 +2849,8 @@ entries:
             - families:
                 - token
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Token
@@ -2736,6 +2886,8 @@ entries:
             - families:
                 - networkgroup
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: networkgroup
               support: partial
               title: Networkgroup
@@ -2765,6 +2917,8 @@ entries:
             - families:
                 - deployment
               high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
               id: deployments
               support: partial
               title: Deployment
@@ -2867,6 +3021,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -2935,6 +3091,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -2966,6 +3124,8 @@ entries:
             - families:
                 - account_2
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account_2
               support: partial
               title: Account 2
@@ -3068,6 +3228,8 @@ entries:
             - families:
                 - auditlog
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Auditlog
@@ -3101,6 +3263,8 @@ entries:
             - families:
                 - organization
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: organization
               support: partial
               title: Organization
@@ -3134,6 +3298,8 @@ entries:
             - families:
                 - member
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: member
               support: partial
               title: Member
@@ -3167,6 +3333,8 @@ entries:
             - families:
                 - permission
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: permission
               support: partial
               title: Permission
@@ -3260,6 +3428,8 @@ entries:
             - families:
                 - email_list
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: email_list
               support: partial
               title: Email List
@@ -3292,6 +3462,8 @@ entries:
             - families:
                 - notification
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Notification
@@ -3330,6 +3502,8 @@ entries:
             - families:
                 - session
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Session
@@ -3365,6 +3539,8 @@ entries:
             - families:
                 - ssh_key
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: ssh_key
               support: partial
               title: Ssh Key
@@ -3473,6 +3649,8 @@ entries:
             - families:
                 - search
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
               id: findings
               support: partial
               title: Search
@@ -3518,6 +3696,8 @@ entries:
             - families:
                 - email
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: email
               support: partial
               title: Email
@@ -3557,6 +3737,8 @@ entries:
             - families:
                 - team
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: team
               support: partial
               title: Team
@@ -3601,6 +3783,8 @@ entries:
             - families:
                 - timeline
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Timeline
@@ -3701,6 +3885,8 @@ entries:
             - families:
                 - issue
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
               id: findings
               support: partial
               title: Issue
@@ -3740,6 +3926,8 @@ entries:
             - families:
                 - event
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Event
@@ -3776,6 +3964,8 @@ entries:
             - families:
                 - email
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: email
               support: partial
               title: Email
@@ -3812,6 +4002,8 @@ entries:
             - families:
                 - organization
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: organization
               support: partial
               title: Organization
@@ -3908,6 +4100,8 @@ entries:
             - families:
                 - optin
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Optin
@@ -4093,6 +4287,8 @@ entries:
             - families:
                 - placement_group
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: placement_group
               support: partial
               title: Placement Group
@@ -4125,6 +4321,8 @@ entries:
             - families:
                 - certificate
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: certificate
               support: partial
               title: Certificate
@@ -4159,6 +4357,8 @@ entries:
             - families:
                 - firewall
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: firewall
               support: partial
               title: Firewall
@@ -4193,6 +4393,8 @@ entries:
             - families:
                 - ssh_key
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: ssh_key
               support: partial
               title: Ssh Key
@@ -4285,6 +4487,8 @@ entries:
             - families:
                 - event
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Event
@@ -4321,6 +4525,8 @@ entries:
             - families:
                 - clusterrole
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: clusterrole
               support: partial
               title: Clusterrole
@@ -4357,6 +4563,8 @@ entries:
             - families:
                 - secret
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Secret
@@ -4395,6 +4603,8 @@ entries:
             - families:
                 - serviceaccount
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: serviceaccount
               support: partial
               title: Serviceaccount
@@ -4502,6 +4712,8 @@ entries:
             - families:
                 - profile
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Profile
@@ -4696,6 +4908,8 @@ entries:
             - families:
                 - eventtype
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Eventtype
@@ -4727,6 +4941,8 @@ entries:
             - families:
                 - organization
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: organization
               support: partial
               title: Organization
@@ -4758,6 +4974,8 @@ entries:
             - families:
                 - merakiauthuser
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: merakiauthuser
               support: partial
               title: Merakiauthuser
@@ -4789,6 +5007,8 @@ entries:
             - families:
                 - accesspolicy
               high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
               id: policies
               support: partial
               title: Accesspolicy
@@ -4885,6 +5105,8 @@ entries:
             - families:
                 - call_event
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Call Event
@@ -4919,6 +5141,8 @@ entries:
             - families:
                 - sitegroup
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: sitegroup
               support: partial
               title: Sitegroup
@@ -4953,6 +5177,8 @@ entries:
             - families:
                 - alarmtemplate
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Alarmtemplate
@@ -4990,6 +5216,8 @@ entries:
             - families:
                 - secpolicy
               high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
               id: policies
               support: partial
               title: Secpolicy
@@ -5084,6 +5312,8 @@ entries:
             - families:
                 - cluster_group
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: cluster_group
               support: partial
               title: Cluster Group
@@ -5121,6 +5351,8 @@ entries:
             - families:
                 - secret
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Secret
@@ -5160,6 +5392,8 @@ entries:
             - families:
                 - connected_device
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: connected_device
               support: partial
               title: Connected Device
@@ -5194,6 +5428,8 @@ entries:
             - families:
                 - device_role
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: device_role
               support: partial
               title: Device Role
@@ -5289,6 +5525,8 @@ entries:
             - families:
                 - member
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: member
               support: partial
               title: Member
@@ -5325,6 +5563,8 @@ entries:
             - families:
                 - role
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: role
               support: partial
               title: Role
@@ -5361,6 +5601,8 @@ entries:
             - families:
                 - device
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: device
               support: partial
               title: Device
@@ -5399,6 +5641,8 @@ entries:
             - families:
                 - query_banned_user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: query_banned_user
               support: partial
               title: Query Banned User
@@ -5510,6 +5754,8 @@ entries:
             - families:
                 - event_type
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Event Type
@@ -5546,6 +5792,8 @@ entries:
             - families:
                 - endpoint
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: endpoint
               support: partial
               title: Endpoint
@@ -5584,6 +5832,8 @@ entries:
             - families:
                 - msg_endpoint
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: msg_endpoint
               support: partial
               title: Msg Endpoint
@@ -5622,6 +5872,8 @@ entries:
             - families:
                 - msg
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: msg
               support: partial
               title: Msg

--- a/internal/connectorcatalog/catalog/identity-access-secrets.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets.yaml
@@ -43,6 +43,8 @@ entries:
               families: [items]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -67,6 +69,8 @@ entries:
               families: [auth_methods]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -91,6 +95,8 @@ entries:
               families: [roles]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -115,6 +121,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -180,6 +188,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: page
             page_param: page
@@ -205,6 +215,8 @@ entries:
               families: [roles]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: page
             page_param: page
@@ -229,6 +241,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: from
@@ -280,6 +294,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -304,6 +320,8 @@ entries:
               families: [secrets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -328,6 +346,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -376,6 +396,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -400,6 +422,8 @@ entries:
               families: [secrets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -424,6 +448,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -475,6 +501,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -499,6 +527,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -523,6 +553,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -574,6 +606,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -598,6 +632,8 @@ entries:
               families: [secrets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -622,6 +658,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -685,6 +723,8 @@ entries:
               families: [secrets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -714,6 +754,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -738,6 +780,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -787,6 +831,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -826,6 +872,8 @@ entries:
               families: [secrets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -850,6 +898,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -898,6 +948,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -922,6 +974,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -946,6 +1000,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -994,6 +1050,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1018,6 +1076,8 @@ entries:
               families: [secrets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1042,6 +1102,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1090,6 +1152,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1114,6 +1178,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1138,6 +1204,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1187,6 +1255,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1211,6 +1281,8 @@ entries:
               families: [secrets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1235,6 +1307,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1286,6 +1360,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1310,6 +1386,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1334,6 +1412,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1385,6 +1465,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1409,6 +1491,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1433,6 +1517,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1481,6 +1567,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1505,6 +1593,8 @@ entries:
               families: [secrets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1529,6 +1619,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1580,6 +1672,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1604,6 +1698,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1628,6 +1724,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1676,6 +1774,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1700,6 +1800,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1724,6 +1826,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1772,6 +1876,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1796,6 +1902,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1820,6 +1928,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1868,6 +1978,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1892,6 +2004,8 @@ entries:
               families: [groups]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1916,6 +2030,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1948,6 +2064,8 @@ entries:
             - families:
                 - apikey
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Apikey
@@ -1985,6 +2103,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -2022,6 +2142,8 @@ entries:
             - families:
                 - permission
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: permission
               support: partial
               title: Permission
@@ -2059,6 +2181,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -2160,6 +2284,8 @@ entries:
             - families:
                 - configuration
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Configuration
@@ -2194,6 +2320,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -2228,6 +2356,8 @@ entries:
             - families:
                 - integration
               high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
               id: policies
               support: partial
               title: Integration
@@ -2266,6 +2396,8 @@ entries:
             - families:
                 - device
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: device
               support: partial
               title: Device

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel.yaml
@@ -43,6 +43,8 @@ entries:
               families: [reports]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -67,6 +69,8 @@ entries:
               families: [ip_addresses]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -91,6 +95,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -140,6 +146,8 @@ entries:
               families: [projects]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -164,6 +172,8 @@ entries:
               families: [errors]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -188,6 +198,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -237,6 +249,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -261,6 +275,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -285,6 +301,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -333,6 +351,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -357,6 +377,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -381,6 +403,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -429,6 +453,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -453,6 +479,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -477,6 +505,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -525,6 +555,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -549,6 +581,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -573,6 +607,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -621,6 +657,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -645,6 +683,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -669,6 +709,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -716,6 +758,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -740,6 +784,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -764,6 +810,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -812,6 +860,8 @@ entries:
               families: [breaches]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -836,6 +886,8 @@ entries:
               families: [affected_accounts]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -860,6 +912,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -909,6 +963,8 @@ entries:
               families: [infostealers]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -933,6 +989,8 @@ entries:
               families: [domains]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -957,6 +1015,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1006,6 +1066,8 @@ entries:
               families: [lists]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1030,6 +1092,8 @@ entries:
               families: [members]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1054,6 +1118,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1106,6 +1172,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1130,6 +1198,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1154,6 +1224,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1201,6 +1273,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1225,6 +1299,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1249,6 +1325,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1297,6 +1375,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1321,6 +1401,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1345,6 +1427,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1393,6 +1477,8 @@ entries:
               families: [servers]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1417,6 +1503,8 @@ entries:
               families: [domains]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1441,6 +1529,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1489,6 +1579,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1513,6 +1605,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1537,6 +1631,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1585,6 +1681,8 @@ entries:
               families: [domains]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1609,6 +1707,8 @@ entries:
               families: [api_keys]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1633,6 +1733,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1681,6 +1783,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1705,6 +1809,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1729,6 +1835,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1779,6 +1887,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1803,6 +1913,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1827,6 +1939,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1875,6 +1989,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1899,6 +2015,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1923,6 +2041,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1974,6 +2094,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1998,6 +2120,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2022,6 +2146,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2070,6 +2196,8 @@ entries:
               families: [monitors]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2094,6 +2222,8 @@ entries:
               families: [alert_contacts]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2118,6 +2248,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2167,6 +2299,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2191,6 +2325,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2215,6 +2351,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2251,6 +2389,8 @@ entries:
             - families:
                 - log
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Log
@@ -2284,6 +2424,8 @@ entries:
             - families:
                 - deployment
               high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
               id: deployments
               support: partial
               title: Deployment
@@ -2353,6 +2495,8 @@ entries:
             - families:
                 - message
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Message
@@ -2459,6 +2603,8 @@ entries:
             - families:
                 - log
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Log
@@ -2491,6 +2637,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -2526,6 +2674,8 @@ entries:
             - families:
                 - secret
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: secrets
               support: partial
               title: Secret
@@ -2558,6 +2708,8 @@ entries:
             - families:
                 - dbrp
               high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
               id: policies
               support: partial
               title: Dbrp
@@ -2683,6 +2835,8 @@ entries:
             - families:
                 - host_reputation
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: host_reputation
               support: partial
               title: Host Reputation
@@ -2857,6 +3011,8 @@ entries:
             - families:
                 - team
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: team
               support: partial
               title: Team
@@ -2892,6 +3048,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -2927,6 +3085,8 @@ entries:
             - families:
                 - membership
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: membership
               support: partial
               title: Membership
@@ -2962,6 +3122,8 @@ entries:
             - families:
                 - image
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Image
@@ -3063,6 +3225,8 @@ entries:
             - families:
                 - activity
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Activity
@@ -3102,6 +3266,8 @@ entries:
             - families:
                 - all
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: all
               support: partial
               title: All
@@ -3138,6 +3304,8 @@ entries:
             - families:
                 - ip
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
               id: findings
               support: partial
               title: Ip
@@ -3171,6 +3339,8 @@ entries:
             - families:
                 - reported_ip
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: reported_ip
               support: partial
               title: Reported Ip
@@ -3270,6 +3440,8 @@ entries:
             - families:
                 - log
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Log
@@ -3302,6 +3474,8 @@ entries:
             - families:
                 - team
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: team
               support: partial
               title: Team
@@ -3333,6 +3507,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -3367,6 +3543,8 @@ entries:
             - families:
                 - incident
               high_value: true
+              evidence_types: [security_monitoring]
+              control_domains: [logging_monitoring, security_operations]
               id: alerts
               support: partial
               title: Incident

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability.yaml
@@ -45,6 +45,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -69,6 +71,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -93,6 +97,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -141,6 +147,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -165,6 +173,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -189,6 +199,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -239,6 +251,8 @@ entries:
               families: [computers]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -263,6 +277,8 @@ entries:
               families: [sites]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -287,6 +303,8 @@ entries:
               families: [analyses]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -338,6 +356,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -362,6 +382,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -386,6 +408,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -437,6 +461,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -461,6 +487,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -485,6 +513,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -536,6 +566,8 @@ entries:
               families: [endpoint_devices]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -560,6 +592,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -584,6 +618,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -632,6 +668,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -656,6 +694,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -680,6 +720,8 @@ entries:
               families: [scan_profiles]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -729,6 +771,8 @@ entries:
               families: [hosts]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -753,6 +797,8 @@ entries:
               families: [policies]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -777,6 +823,8 @@ entries:
               families: [audit_activities]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -826,6 +874,8 @@ entries:
               families: [incidents]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -850,6 +900,8 @@ entries:
               families: [members]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -874,6 +926,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -923,6 +977,8 @@ entries:
               families: [secrets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -947,6 +1003,8 @@ entries:
               families: [sources]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -971,6 +1029,8 @@ entries:
               families: [audit_events]
               support: partial
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1020,6 +1080,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1044,6 +1106,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1068,6 +1132,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1116,6 +1182,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1140,6 +1208,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1164,6 +1234,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1215,6 +1287,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1239,6 +1313,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1263,6 +1339,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1314,6 +1392,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1338,6 +1418,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1362,6 +1444,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1413,6 +1497,8 @@ entries:
               families: [endpoint_devices]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1437,6 +1523,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1461,6 +1549,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1509,6 +1599,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1533,6 +1625,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1557,6 +1651,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1605,6 +1701,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1629,6 +1727,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1653,6 +1753,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1703,6 +1805,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1727,6 +1831,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1751,6 +1857,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1799,6 +1907,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1823,6 +1933,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1847,6 +1959,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1895,6 +2009,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1919,6 +2035,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1943,6 +2061,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -1991,6 +2111,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2015,6 +2137,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2039,6 +2163,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2087,6 +2213,8 @@ entries:
               families: [users]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2111,6 +2239,8 @@ entries:
               families: [devices]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2135,6 +2265,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2183,6 +2315,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2207,6 +2341,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2231,6 +2367,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2279,6 +2417,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2303,6 +2443,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2327,6 +2469,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2377,6 +2521,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2401,6 +2547,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2425,6 +2573,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2476,6 +2626,8 @@ entries:
               families: [assets]
               support: partial
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2500,6 +2652,8 @@ entries:
               families: [findings]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2524,6 +2678,8 @@ entries:
               families: [vulnerabilities]
               support: partial
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
           pagination:
             type: cursor
             cursor_param: cursor
@@ -2557,6 +2713,8 @@ entries:
             - families:
                 - asn
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
               id: findings
               support: partial
               title: Asn
@@ -2596,6 +2754,8 @@ entries:
             - families:
                 - event
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Event
@@ -2632,6 +2792,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -2672,6 +2834,8 @@ entries:
             - families:
                 - organization
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: organization
               support: partial
               title: Organization
@@ -2772,6 +2936,8 @@ entries:
             - families:
                 - config_issue
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
               id: findings
               support: partial
               title: Config Issue
@@ -2808,6 +2974,8 @@ entries:
             - families:
                 - account
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: account
               support: partial
               title: Account
@@ -2841,6 +3009,8 @@ entries:
             - families:
                 - private_key
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: private_key
               support: partial
               title: Private Key
@@ -2876,6 +3046,8 @@ entries:
             - families:
                 - risk
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
               id: findings
               support: partial
               title: Risk
@@ -2980,6 +3152,8 @@ entries:
             - families:
                 - policy
               high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
               id: policies
               support: partial
               title: Policy
@@ -3046,6 +3220,8 @@ entries:
             - families:
                 - v1_policy
               high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
               id: policies
               support: partial
               title: V1 Policy
@@ -3168,6 +3344,8 @@ entries:
             - families:
                 - needs_attention_top
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
               id: findings
               support: partial
               title: Needs Attention Top
@@ -3204,6 +3382,8 @@ entries:
             - families:
                 - event
               high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
               id: audit_events
               support: partial
               title: Event
@@ -3238,6 +3418,8 @@ entries:
             - families:
                 - user
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: user
               support: partial
               title: User
@@ -3276,6 +3458,8 @@ entries:
             - families:
                 - framework
               high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
               id: policies
               support: partial
               title: Framework
@@ -3379,6 +3563,8 @@ entries:
             - families:
                 - advisory
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
               id: findings
               support: partial
               title: Advisory
@@ -3415,6 +3601,8 @@ entries:
             - families:
                 - package
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: package
               support: partial
               title: Package
@@ -3450,6 +3638,8 @@ entries:
             - families:
                 - systems_advisory
               high_value: true
+              evidence_types: [remediation_state]
+              control_domains: [remediation]
               id: findings
               support: partial
               title: Systems Advisory
@@ -3486,6 +3676,8 @@ entries:
             - families:
                 - v1_package
               high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
               id: v1_package
               support: partial
               title: V1 Package

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -38,7 +38,7 @@ entries:
           event: {kind: example_idp.user, schema_ref: example_idp/user/v1}
           projection: {template: identity_user}
           coverage:
-            - {type: entity_family, support: partial, high_value: true}
+            - {type: entity_family, support: partial, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
         - id: groups
           path: /v1/groups
           record_selector: $.data[*]
@@ -46,7 +46,7 @@ entries:
           event: {kind: example_idp.group, schema_ref: example_idp/group/v1}
           projection: {template: identity_group}
           coverage:
-            - {type: entity_family, support: partial, high_value: true}
+            - {type: entity_family, support: partial, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
 `)
 
 	analysis, err := AnalyzeDir(root, Options{DryRunSourcegen: true})
@@ -117,6 +117,22 @@ entries:
 		if !issuesContain(analysis.Issues, want) {
 			t.Fatalf("issues = %#v, want %q", analysis.Issues, want)
 		}
+	}
+}
+
+func TestAnalyzeDirRequiresExplicitHighValueCoverageMetadata(t *testing.T) {
+	root := t.TempDir()
+	writeCatalogFile(t, root, strings.ReplaceAll(minimalDefinitionYAML(), "evidence_types: [source_snapshot], control_domains: [asset_inventory]", ""))
+
+	analysis, err := AnalyzeDir(root, Options{})
+	if err != nil {
+		t.Fatalf("AnalyzeDir() error = %v", err)
+	}
+	if !issuesContain(analysis.Issues, `high-value coverage dimension "users_entity_family" must declare evidence types`) {
+		t.Fatalf("issues = %#v, want missing evidence types issue", analysis.Issues)
+	}
+	if !issuesContain(analysis.Issues, `high-value coverage dimension "users_entity_family" must declare control domains`) {
+		t.Fatalf("issues = %#v, want missing control domains issue", analysis.Issues)
 	}
 }
 
@@ -387,7 +403,7 @@ entries:
           event: {kind: example.user, schema_ref: example/user/v1}
           projection: {template: identity_user}
           coverage:
-            - {type: entity_family, support: partial, high_value: true}
+            - {type: entity_family, support: partial, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
         - id: groups
           path: /v1/groups
           record_selector: $.data[*]
@@ -395,7 +411,7 @@ entries:
           event: {kind: example.group, schema_ref: example/group/v1}
           projection: {template: identity_group}
           coverage:
-            - {type: entity_family, support: partial, high_value: true}
+            - {type: entity_family, support: partial, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
 `
 }
 

--- a/sources/akeyless/catalog.yaml
+++ b/sources/akeyless/catalog.yaml
@@ -16,6 +16,8 @@ coverage_contract:
       families: [items]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: auth_methods
@@ -24,6 +26,8 @@ coverage_contract:
       families: [auth_methods]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: roles
@@ -32,6 +36,8 @@ coverage_contract:
       families: [roles]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
@@ -40,6 +46,8 @@ coverage_contract:
       families: [audit_events]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/anthropic/catalog.yaml
+++ b/sources/anthropic/catalog.yaml
@@ -40,78 +40,104 @@ coverage_contract:
       families: [api_key]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: compliance_activity
       type: audit_event
       title: Compliance activity feed
       families: [compliance_activity]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
     - id: compliance_directory
       type: app_entitlement
       title: Compliance organizations, users, roles, role permissions, groups, and group members
       families: [compliance_organization, compliance_organization_user, compliance_role, compliance_role_permission, compliance_group, compliance_group_member]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: compliance_settings
       type: lifecycle_state
       title: Effective compliance organization settings
       families: [compliance_organization_setting]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: compliance_projects
       type: app_entitlement
       title: Claude projects and active collaborator role assignments
       families: [compliance_project, compliance_project_collaborator]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: external_keys
       type: lifecycle_state
       title: External key configurations
       families: [external_key]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: organization_profile
       type: entity_family
       title: Current organization
       families: [organization]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: rate_limits
       type: lifecycle_state
       title: Organization and workspace rate limits
       families: [rate_limit, workspace_rate_limit]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: spend_limits
       type: lifecycle_state
       title: Effective spend limits and increase requests
       families: [spend_limit, spend_limit_increase_request]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: usage_and_costs
       type: entity_family
       title: Usage, Claude Code analytics, and cost report buckets
       families: [usage_report_message, usage_report_claude_code, cost_report, analytics_cost]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: users_and_access
       type: app_entitlement
       title: Organization users, invites, and workspace membership
       families: [user, invite, workspace_member]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: workload_identity
       type: app_entitlement
       title: Service accounts and workload identity federation
       families: [service_account, federation_issuer, federation_rule]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: workspaces
       type: entity_family
       title: Workspaces
       families: [workspace]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: anthropic.organization
     schema_ref: anthropic/organization/v1

--- a/sources/archetype/catalog.yaml
+++ b/sources/archetype/catalog.yaml
@@ -14,12 +14,16 @@ coverage_contract:
       families: [scan]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: vulnerabilities
       type: entity_family
       title: Archetype code vulnerabilities
       families: [vulnerability]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: archetype.scan
     schema_ref: archetype/scan/v1

--- a/sources/asana/catalog.yaml
+++ b/sources/asana/catalog.yaml
@@ -22,6 +22,8 @@ coverage_contract:
       families: [users]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: projects
@@ -30,6 +32,8 @@ coverage_contract:
       families: [projects]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
@@ -38,6 +42,8 @@ coverage_contract:
       families: [audit_events]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/aurelius/catalog.yaml
+++ b/sources/aurelius/catalog.yaml
@@ -17,30 +17,40 @@ coverage_contract:
       families: [catalog_promotion]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: findings
       type: entity_family
       title: Findings
       families: [finding]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: image_scans
       type: entity_family
       title: Image scans
       families: [image_scan]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: policy_exceptions
       type: app_entitlement
       title: Policy exceptions
       families: [policy_exception]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: verdicts
       type: lifecycle_state
       title: Image policy verdicts
       families: [verdict]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
 event_contracts:
   - kind: aurelius.verdict
     schema_ref: aurelius/verdict/v1

--- a/sources/auth0/catalog.yaml
+++ b/sources/auth0/catalog.yaml
@@ -22,6 +22,8 @@ coverage_contract:
       families: [users]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: roles
@@ -30,6 +32,8 @@ coverage_contract:
       families: [roles]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
@@ -38,6 +42,8 @@ coverage_contract:
       families: [audit_events]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync
@@ -46,6 +52,8 @@ coverage_contract:
       families: [users, roles, audit_events]
       support: supported
       high_value: true
+      evidence_types: [source_sync_status]
+      control_domains: [source_operations]
       notes:
         - Watermark filtering is applied from durable source checkpoints; provider page continuation cursors are preserved when present.
 event_contracts:

--- a/sources/aws/catalog.yaml
+++ b/sources/aws/catalog.yaml
@@ -987,156 +987,208 @@ coverage_contract:
       families: [access_analyzer]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: access_key
       type: entity_family
       title: AWS IAM access keys
       families: [access_key]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: acm_certificate
       type: entity_family
       title: AWS ACM certificates
       families: [acm_certificate]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: asset_metadata
       type: entity_family
       title: AWS asset metadata and data sensitivity
       families: [asset_metadata]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: apigateway_integration
       type: entity_family
       title: AWS API Gateway integrations
       families: [apigateway_integration]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: apigateway_route
       type: entity_family
       title: AWS API Gateway routes
       families: [apigateway_route]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: apigateway_stage
       type: entity_family
       title: AWS API Gateway stages
       families: [apigateway_stage]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: apprunner_service
       type: entity_family
       title: AWS App Runner services
       families: [apprunner_service]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: athena_data_catalog
       type: entity_family
       title: AWS Athena data catalogs
       families: [athena_data_catalog]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: athena_workgroup
       type: entity_family
       title: AWS Athena workgroups
       families: [athena_workgroup]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: apigateway_method
       type: entity_family
       title: AWS API Gateway methods
       families: [apigateway_method]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: apigateway_rest_api
       type: entity_family
       title: AWS API Gateway REST APIs
       families: [apigateway_rest_api]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: appsync_graphql_api
       type: entity_family
       title: AWS AppSync GraphQL APIs
       families: [appsync_graphql_api]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: backup_vault
       type: entity_family
       title: AWS Backup vaults
       families: [backup_vault]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: backup_plan
       type: entity_family
       title: AWS Backup plans
       families: [backup_plan]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: backup_protected_resource
       type: entity_family
       title: AWS Backup protected resources
       families: [backup_protected_resource]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: backup_recovery_point
       type: entity_family
       title: AWS Backup recovery points
       families: [backup_recovery_point]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: batch_compute_environment
       type: entity_family
       title: AWS Batch compute environments
       families: [batch_compute_environment]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: batch_job_queue
       type: entity_family
       title: AWS Batch job queues
       families: [batch_job_queue]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: bedrock_custom_model
       type: entity_family
       title: Amazon Bedrock custom models
       families: [bedrock_custom_model]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: bedrock_provisioned_model_throughput
       type: entity_family
       title: Amazon Bedrock provisioned model throughput
       families: [bedrock_provisioned_model_throughput]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloudfront_distribution
       type: entity_family
       title: AWS CloudFront distributions
       families: [cloudfront_distribution]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloudfront_key_group
       type: entity_family
       title: AWS CloudFront key groups
       families: [cloudfront_key_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloudfront_origin_access_control
       type: entity_family
       title: AWS CloudFront origin access controls
       families: [cloudfront_origin_access_control]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloudfront_public_key
       type: entity_family
       title: AWS CloudFront public keys
       families: [cloudfront_public_key]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloudfront_response_headers_policy
       type: entity_family
       title: AWS CloudFront response headers policies
       families: [cloudfront_response_headers_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloudtrail
       type: audit_event
       title: AWS CloudTrail trails and events
@@ -1158,24 +1210,32 @@ coverage_contract:
       families: [cloudwatch_alarm]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloudwatch_log_group
       type: entity_family
       title: AWS CloudWatch log groups
       families: [cloudwatch_log_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: codebuild_project
       type: entity_family
       title: AWS CodeBuild projects
       families: [codebuild_project]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: codebuild_source_credential
       type: entity_family
       title: AWS CodeBuild source credentials
       families: [codebuild_source_credential]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: config_recorder
       type: entity_family
       title: AWS Config recorders
@@ -1210,198 +1270,264 @@ coverage_contract:
       families: [datasync_location]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: datasync_task
       type: entity_family
       title: AWS DataSync tasks
       families: [datasync_task]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: docdb_cluster
       type: entity_family
       title: AWS DocumentDB clusters
       families: [docdb_cluster]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: docdb_instance
       type: entity_family
       title: AWS DocumentDB instances
       families: [docdb_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: dynamodb_backup
       type: entity_family
       title: AWS DynamoDB backups
       families: [dynamodb_backup]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: dynamodb_stream
       type: entity_family
       title: AWS DynamoDB streams
       families: [dynamodb_stream]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: dynamodb_table
       type: entity_family
       title: AWS DynamoDB tables
       families: [dynamodb_table]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ebs_snapshot
       type: entity_family
       title: AWS EBS snapshots
       families: [ebs_snapshot]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ebs_volume
       type: entity_family
       title: AWS EBS volumes
       families: [ebs_volume]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ec2_ami
       type: entity_family
       title: AWS EC2 AMIs
       families: [ec2_ami]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ec2_ebs_encryption_by_default
       type: entity_family
       title: AWS EC2 EBS encryption by default
       families: [ec2_ebs_encryption_by_default]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ec2_instance
       type: entity_family
       title: AWS EC2 instances
       families: [ec2_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ecr_public_repository
       type: entity_family
       title: AWS ECR public repositories
       families: [ecr_public_repository]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ecr_repository
       type: entity_family
       title: AWS ECR repositories
       families: [ecr_repository]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ecs_service
       type: entity_family
       title: AWS ECS services
       families: [ecs_service]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ecs_task
       type: entity_family
       title: AWS ECS tasks
       families: [ecs_task]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ecs_task_definition
       type: entity_family
       title: AWS ECS task definitions
       families: [ecs_task_definition]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: efs_file_system
       type: entity_family
       title: AWS EFS file systems
       families: [efs_file_system]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: efs_access_point
       type: entity_family
       title: AWS EFS access points
       families: [efs_access_point]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: efs_mount_target
       type: entity_family
       title: AWS EFS mount targets
       families: [efs_mount_target]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: eks_cluster
       type: entity_family
       title: AWS EKS clusters
       families: [eks_cluster]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: eks_fargate_profile
       type: entity_family
       title: AWS EKS Fargate profiles
       families: [eks_fargate_profile]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: eks_node
       type: entity_family
       title: AWS EKS nodes
       families: [ec2_instance, eks_nodegroup]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: eks_nodegroup
       type: entity_family
       title: AWS EKS node groups
       families: [eks_nodegroup]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: eks_pod_identity_association
       type: relationship
       title: AWS EKS pod identity associations
       families: [eks_pod_identity_association]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: elasticache_cluster
       type: entity_family
       title: AWS ElastiCache clusters
       families: [elasticache_cluster]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: elasticache_replication_group
       type: entity_family
       title: AWS ElastiCache replication groups
       families: [elasticache_replication_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: elasticache_subnet_group
       type: entity_family
       title: AWS ElastiCache subnet groups
       families: [elasticache_subnet_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: elbv2_listener
       type: entity_family
       title: AWS ELBv2 listeners
       families: [elbv2_listener]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: elbv2_load_balancer
       type: entity_family
       title: AWS ELBv2 load balancers
       families: [elbv2_load_balancer]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: elbv2_target_group
       type: entity_family
       title: AWS ELBv2 target groups
       families: [elbv2_target_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: fargate_service
       type: entity_family
       title: AWS Fargate services and tasks
       families: [ecs_service, ecs_task, ecs_task_definition]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: guardduty_detector
       type: entity_family
       title: AWS GuardDuty detectors
       families: [guardduty_detector]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: guardduty_finding
       type: entity_family
       title: AWS GuardDuty findings
@@ -1423,24 +1549,32 @@ coverage_contract:
       families: [eventbridge_archive]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: eventbridge_event_bus
       type: entity_family
       title: AWS EventBridge event buses
       families: [eventbridge_event_bus]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: eventbridge_pipe
       type: entity_family
       title: AWS EventBridge pipes
       families: [eventbridge_pipe]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: eventbridge_rule
       type: entity_family
       title: AWS EventBridge rules
       families: [eventbridge_rule]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: effective_permission
       type: app_entitlement
       title: AWS effective IAM permissions
@@ -1462,66 +1596,88 @@ coverage_contract:
       families: [firehose_delivery_stream]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: fsx_file_system
       type: entity_family
       title: AWS FSx file systems
       families: [fsx_file_system]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: globalaccelerator_accelerator
       type: entity_family
       title: AWS Global Accelerator accelerators
       families: [globalaccelerator_accelerator]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: globalaccelerator_endpoint_group
       type: entity_family
       title: AWS Global Accelerator endpoint groups
       families: [globalaccelerator_endpoint_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: globalaccelerator_listener
       type: entity_family
       title: AWS Global Accelerator listeners
       families: [globalaccelerator_listener]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: glue_crawler
       type: entity_family
       title: AWS Glue crawlers
       families: [glue_crawler]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: glue_database
       type: entity_family
       title: AWS Glue databases
       families: [glue_database]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: glue_job
       type: entity_family
       title: AWS Glue jobs
       families: [glue_job]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: glue_table
       type: entity_family
       title: AWS Glue tables
       families: [glue_table]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: iam_account_password_policy
       type: entity_family
       title: AWS IAM account password policy
       families: [iam_account_password_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: iam_account_summary
       type: entity_family
       title: AWS IAM account summary
       families: [iam_account_summary]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: iam_credential_report
       type: entity_family
       title: AWS IAM credential reports
@@ -1541,12 +1697,16 @@ coverage_contract:
       families: [iam_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: iam_group_membership
       type: relationship
       title: AWS IAM group memberships
       families: [iam_group_membership]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: iam_policy
       type: app_entitlement
       title: AWS IAM policies
@@ -1566,6 +1726,8 @@ coverage_contract:
       families: [iam_role]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: iam_role_assignment
       type: app_entitlement
       title: AWS IAM role assignments
@@ -1598,42 +1760,56 @@ coverage_contract:
       families: [iam_saml_provider]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: iam_user
       type: entity_family
       title: AWS IAM users
       families: [iam_user]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: identity_center_account_assignment
       type: app_entitlement
       title: AWS IAM Identity Center account assignments
       families: [identity_center_account_assignment, sso_account_assignment]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: identity_center_permission_set
       type: app_entitlement
       title: AWS IAM Identity Center permission sets
       families: [identity_center_permission_set, sso_permission_set]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: identitystore_user
       type: entity_family
       title: AWS Identity Store users
       families: [identitystore_user]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: identitystore_group
       type: entity_family
       title: AWS Identity Store groups
       families: [identitystore_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: identitystore_group_membership
       type: relationship
       title: AWS Identity Store group memberships
       families: [identitystore_group_membership]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: inspector2_finding
       type: entity_family
       title: AWS Inspector findings
@@ -1655,12 +1831,16 @@ coverage_contract:
       families: [internet_gateway]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: kinesis_stream
       type: entity_family
       title: AWS Kinesis streams
       families: [kinesis_stream]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: kms_key
       type: entity_family
       title: AWS KMS keys
@@ -1680,108 +1860,144 @@ coverage_contract:
       families: [lakeformation_lf_tag]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: lakeformation_permission
       type: app_entitlement
       title: AWS Lake Formation permissions
       families: [lakeformation_permission]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: lakeformation_resource
       type: entity_family
       title: AWS Lake Formation resources
       families: [lakeformation_resource]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: lambda_function
       type: entity_family
       title: AWS Lambda functions
       families: [lambda_function]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: macie2_finding
       type: entity_family
       title: AWS Macie findings
       families: [macie2_finding]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: msk_cluster
       type: entity_family
       title: AWS MSK clusters
       families: [msk_cluster]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: nat_gateway
       type: entity_family
       title: AWS NAT gateways
       families: [nat_gateway]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: neptune_cluster
       type: entity_family
       title: AWS Neptune clusters
       families: [neptune_cluster]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: neptune_instance
       type: entity_family
       title: AWS Neptune instances
       families: [neptune_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: network_firewall
       type: entity_family
       title: AWS Network Firewall firewalls
       families: [network_firewall]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: network_acl
       type: entity_family
       title: AWS network ACLs
       families: [network_acl]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: opensearch_domain
       type: entity_family
       title: AWS OpenSearch domains
       families: [opensearch_domain]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: opensearch_serverless_collection
       type: entity_family
       title: AWS OpenSearch Serverless collections
       families: [opensearch_serverless_collection]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: opensearch_serverless_security_policy
       type: entity_family
       title: AWS OpenSearch Serverless security policies
       families: [opensearch_serverless_security_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: organizations_account
       type: entity_family
       title: AWS Organizations accounts
       families: [organizations_account]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: organizations_organizational_unit
       type: entity_family
       title: AWS Organizations organizational units
       families: [organizations_organizational_unit]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: organizations_policy
       type: entity_family
       title: AWS Organizations policies
       families: [organizations_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: organizations_root
       type: entity_family
       title: AWS Organizations roots
       families: [organizations_root]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: public_endpoint
       type: entity_family
       title: AWS public endpoints
@@ -1801,18 +2017,24 @@ coverage_contract:
       families: [rds_db_snapshot]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: rds_instance
       type: entity_family
       title: AWS RDS instances
       families: [rds_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: redshift_cluster
       type: entity_family
       title: AWS Redshift clusters
       families: [redshift_cluster]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: resource_exposure
       type: relationship
       title: AWS public resource exposure
@@ -1832,18 +2054,24 @@ coverage_contract:
       families: [route53_resolver_endpoint]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: route53_resolver_rule
       type: entity_family
       title: AWS Route 53 Resolver rules
       families: [route53_resolver_rule]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: route_table
       type: entity_family
       title: AWS route tables
       families: [route_table]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: s3_bucket
       type: entity_family
       title: AWS S3 buckets
@@ -1865,18 +2093,24 @@ coverage_contract:
       families: [s3_access_point]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: s3_multi_region_access_point
       type: entity_family
       title: AWS S3 Multi-Region Access Points
       families: [s3_multi_region_access_point]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: s3_object
       type: entity_family
       title: AWS S3 objects
       families: [asset_metadata]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       known_unsupported_fields: [object-level ACLs and content inspection]
     - id: sagemaker_endpoint_configuration
       type: entity_family
@@ -1884,30 +2118,40 @@ coverage_contract:
       families: [sagemaker_endpoint_configuration]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sagemaker_model
       type: entity_family
       title: AWS SageMaker models
       families: [sagemaker_model]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sagemaker_model_package_group
       type: entity_family
       title: AWS SageMaker model package groups
       families: [sagemaker_model_package_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sagemaker_notebook_instance
       type: entity_family
       title: AWS SageMaker notebook instances
       families: [sagemaker_notebook_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sagemaker_training_job
       type: entity_family
       title: AWS SageMaker training jobs
       families: [sagemaker_training_job]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: secret
       type: entity_family
       title: AWS Secrets Manager secrets
@@ -1955,118 +2199,158 @@ coverage_contract:
       families: [scheduler_schedule]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: scheduler_schedule_group
       type: entity_family
       title: AWS Scheduler schedule groups
       families: [scheduler_schedule_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sns_topic
       type: entity_family
       title: AWS SNS topics
       families: [sns_topic]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sqs_queue
       type: entity_family
       title: AWS SQS queues
       families: [sqs_queue]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ssm_association
       type: entity_family
       title: AWS Systems Manager associations
       families: [ssm_association]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ssm_document
       type: entity_family
       title: AWS Systems Manager documents
       families: [ssm_document]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ssm_managed_instance
       type: entity_family
       title: AWS Systems Manager managed instances
       families: [ssm_managed_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ssm_parameter
       type: entity_family
       title: AWS Systems Manager parameters
       families: [ssm_parameter]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sso_instance
       type: entity_family
       title: AWS IAM Identity Center instances
       families: [sso_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: stepfunctions_activity
       type: entity_family
       title: AWS Step Functions activities
       families: [stepfunctions_activity]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: stepfunctions_state_machine
       type: entity_family
       title: AWS Step Functions state machines
       families: [stepfunctions_state_machine]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: subnet
       type: entity_family
       title: AWS subnets
       families: [subnet]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: support_role
       type: entity_family
       title: AWS Support incident management role
       families: [iam_role]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: vpc
       type: entity_family
       title: AWS VPCs
       families: [vpc]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: vpc_endpoint
       type: entity_family
       title: AWS VPC endpoints
       families: [vpc_endpoint]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: vpc_flow_log
       type: entity_family
       title: AWS VPC Flow Logs
       families: [vpc_flow_log]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: vpclattice_listener
       type: entity_family
       title: AWS VPC Lattice listeners
       families: [vpclattice_listener]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: vpclattice_service
       type: entity_family
       title: AWS VPC Lattice services
       families: [vpclattice_service]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: vpclattice_target_group
       type: entity_family
       title: AWS VPC Lattice target groups
       families: [vpclattice_target_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: wafv2_web_acl
       type: entity_family
       title: AWS WAFv2 web ACLs
       families: [wafv2_web_acl]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     # awscollectorgen:coverage-dimensions (insert new dimensions above this line)

--- a/sources/azure/catalog.yaml
+++ b/sources/azure/catalog.yaml
@@ -428,84 +428,112 @@ coverage_contract:
       families: [activity_log]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
     - id: activity_log_alert
       type: entity_family
       title: Azure Activity Log Alert
       families: [activity_log_alert]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ad_authorization_policy
       type: entity_family
       title: Azure authorization policy
       families: [authorization_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: aks_cluster
       type: entity_family
       title: Azure AKS clusters
       families: [aks_cluster]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: aks_node
       type: entity_family
       title: Azure AKS nodes and node pools
       families: [aks_cluster, aks_node_pool, virtual_machine_scale_set_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: app_service
       type: entity_family
       title: Azure App Service apps
       families: [app_service]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: app_role_assignment
       type: app_entitlement
       title: Azure app role assignments
       families: [app_role_assignment]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: application
       type: entity_family
       title: Azure applications
       families: [application]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: application_container
       type: entity_family
       title: Azure application containers
       families: [application_container]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: application_gateway
       type: entity_family
       title: Azure Application Gateway
       families: [application_gateway]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: application_insight
       type: entity_family
       title: Azure Application Insights
       families: [application_insight, activity_log_alert, log_alert, metric_alert_rule]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cognitive_services_account
       type: entity_family
       title: Azure Cognitive Services accounts
       families: [cognitive_services_account, cognitive_services_deployment]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: container_registry
       type: entity_family
       title: Azure Container Registry
       families: [container_registry]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: container_repository
       type: entity_family
       title: Azure container repositories
       families: [container_registry]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       known_unsupported_fields: [per-repository metadata and image tags]
     - id: container_vulnerability
       type: entity_family
@@ -513,246 +541,328 @@ coverage_contract:
       families: [server_vulnerability, server_vulnerability_subassessment]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cosmos_account
       type: entity_family
       title: Azure Cosmos DB accounts
       families: [cosmos_account]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cosmos_postgresql
       type: entity_family
       title: Azure Cosmos DB for PostgreSQL
       families: [cosmos_postgresql, cosmos_postgresql_firewall_rule]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: credential
       type: entity_family
       title: Azure application and service principal credentials
       families: [credential]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: database
       type: entity_family
       title: Azure database services
       families: [cosmos_postgresql, mysql_server, postgresql_server, sql_database, sql_managed_instance, synapse_sql_pool]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: databricks_workspace
       type: entity_family
       title: Azure Databricks workspaces
       families: [databricks_workspace]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: diagnostic_setting
       type: entity_family
       title: Azure diagnostic settings
       families: [diagnostic_setting, diagnostic_setting_resource]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: directory_audit
       type: audit_event
       title: Azure directory audits
       families: [directory_audit]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
     - id: directory_role_assignment
       type: app_entitlement
       title: Azure directory role assignments
       families: [directory_role_assignment]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: effective_permission
       type: app_entitlement
       title: Azure effective permissions
       families: [effective_permission]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: foundry_model_deployment
       type: entity_family
       title: Azure Foundry model deployments
       families: [cognitive_services_deployment]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: function_app
       type: entity_family
       title: Azure Functions
       families: [function_app]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: group
       type: entity_family
       title: Azure groups
       families: [group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: group_membership
       type: relationship
       title: Azure group memberships
       families: [group_membership]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: iam_role_assignment
       type: app_entitlement
       title: Azure RBAC role assignments
       families: [iam_role_assignment]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: key_vault
       type: entity_family
       title: Azure Key Vaults
       families: [key_vault]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: key_vault_key
       type: entity_family
       title: Azure Key Vault keys
       families: [key_vault_key]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: key_vault_secret
       type: entity_family
       title: Azure Key Vault secrets
       families: [key_vault_secret]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: load_balancer
       type: entity_family
       title: Azure Load Balancers
       families: [load_balancer]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: log_alert
       type: entity_family
       title: Azure log alert rules
       families: [log_alert]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: machine_learning_workspace
       type: entity_family
       title: Azure Machine Learning workspaces
       families: [machine_learning_workspace, machine_learning_compute]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: managed_disk
       type: entity_family
       title: Azure managed disks
       families: [managed_disk]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: metric_alert_rule
       type: entity_family
       title: Azure metric alert rules
       families: [metric_alert_rule]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: defender_config
       type: entity_family
       title: Microsoft Defender for Cloud configuration
       families: [defender_config, security_setting]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: network_security_group
       type: entity_family
       title: Azure Network Security Groups
       families: [network_security_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: postgresql_server
       type: entity_family
       title: Azure PostgreSQL servers
       families: [postgresql_server, postgresql_firewall_rule]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: public_ip_address
       type: entity_family
       title: Azure public IP addresses
       families: [public_ip_address]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: queue
       type: entity_family
       title: Azure Storage queues
       families: [storage_queue]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: resource_exposure
       type: relationship
       title: Azure public resource exposure
       families: [resource_exposure]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: role
       type: app_entitlement
       title: Azure role definitions
       families: [role]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: route_table
       type: entity_family
       title: Azure route tables
       families: [route_table]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: scale_set_virtual_machine
       type: entity_family
       title: Azure scale set virtual machines
       families: [virtual_machine_scale_set_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: security_contact
       type: entity_family
       title: Azure security contacts
       families: [security_contact]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: server_vulnerability
       type: entity_family
       title: Azure server vulnerabilities
       families: [server_vulnerability, server_vulnerability_subassessment]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: service_principal
       type: entity_family
       title: Azure service principals
       families: [service_principal]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sql_database
       type: entity_family
       title: Azure SQL databases
       families: [sql_database]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sql_managed_instance
       type: entity_family
       title: Azure SQL managed instances
       families: [sql_managed_instance, sql_managed_instance_tde]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sql_server
       type: entity_family
       title: Azure SQL servers
       families: [sql_server]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sql_server_on_virtual_machine
       type: entity_family
       title: Azure SQL Server on virtual machines
       families: [sql_server_on_virtual_machine]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: storage_account
       type: entity_family
       title: Azure Storage accounts
       families: [storage_account]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: storage_blob
       type: entity_family
       title: Azure Storage blobs
       families: [asset_metadata]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       known_unsupported_fields: [object-level ACLs and content inspection]
     - id: storage_container
       type: entity_family
@@ -760,51 +870,69 @@ coverage_contract:
       families: [storage_container]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: subnet
       type: entity_family
       title: Azure subnets
       families: [subnet]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: subscription
       type: entity_family
       title: Azure subscriptions
       families: [asset_metadata, policy_assignment, security_contact]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: synapse_warehouse
       type: entity_family
       title: Azure Synapse warehouses
       families: [synapse_sql_pool]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: user
       type: entity_family
       title: Azure users
       families: [user]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: virtual_machine
       type: entity_family
       title: Azure virtual machines
       families: [virtual_machine]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: virtual_machine_extension
       type: entity_family
       title: Azure virtual machine extensions
       families: [virtual_machine_extension]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: virtual_machine_scale_set
       type: entity_family
       title: Azure virtual machine scale sets
       families: [virtual_machine_scale_set, virtual_machine_scale_set_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: virtual_network
       type: entity_family
       title: Azure virtual networks
       families: [virtual_network]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]

--- a/sources/backstage/catalog.yaml
+++ b/sources/backstage/catalog.yaml
@@ -13,12 +13,16 @@ coverage_contract:
       families: [component]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ownership_relationships
       type: relationship
       title: Component ownership relationships
       families: [component]
       support: partial
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
       known_unsupported_fields:
         - non-component catalog ownership entities
         - transitive group membership expansion
@@ -28,6 +32,8 @@ coverage_contract:
       families: [component]
       support: partial
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
       known_unsupported_fields:
         - provider-specific runtime inventory expansion
 event_contracts:

--- a/sources/box/catalog.yaml
+++ b/sources/box/catalog.yaml
@@ -22,6 +22,8 @@ coverage_contract:
       families: [users]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: content_assets
@@ -30,6 +32,8 @@ coverage_contract:
       families: [content_assets]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
@@ -38,6 +42,8 @@ coverage_contract:
       families: [audit_events]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/catalogruntime/catalog.yaml
+++ b/sources/catalogruntime/catalog.yaml
@@ -13,6 +13,8 @@ coverage_contract:
       families: [definition]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: catalogruntime.definition
     schema_ref: catalogruntime/definition/v1

--- a/sources/cerebro/catalog.yaml
+++ b/sources/cerebro/catalog.yaml
@@ -13,6 +13,8 @@ coverage_contract:
       families: [access]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
 event_contracts:
   - kind: cerebro.api_access
     schema_ref: cerebro/api_access/v1

--- a/sources/cloudflare/catalog.yaml
+++ b/sources/cloudflare/catalog.yaml
@@ -28,42 +28,56 @@ coverage_contract:
       families: [access_application, zone_access_application]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: access_groups
       type: app_entitlement
       title: Zero Trust Access groups
       families: [access_group, zone_access_group]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: accounts
       type: entity_family
       title: Accounts
       families: [account]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: account_rulesets
       type: entity_family
       title: Account rulesets
       families: [account_ruleset]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: audit_logs
       type: audit_event
       title: Account audit logs
       families: [audit_log]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
     - id: dns_records
       type: entity_family
       title: DNS records
       families: [dns_record]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: gateway_rules
       type: entity_family
       title: Zero Trust Gateway rules
       families: [gateway_rule]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       known_unsupported_fields: [inherited parent account rules]
       notes:
         - Configured account Gateway rule metadata, filters, actions, precedence, enabled state, and traffic settings are surfaced.
@@ -73,30 +87,40 @@ coverage_contract:
       families: [load_balancer_pool]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: load_balancers
       type: entity_family
       title: Load balancers
       families: [load_balancer]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: members
       type: app_entitlement
       title: Account members
       families: [member]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: roles
       type: app_entitlement
       title: Account roles
       families: [role]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: worker_scripts
       type: entity_family
       title: Workers scripts
       families: [worker_script]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       known_unsupported_fields: [script content and secret binding values]
       notes:
         - Worker script metadata and binding names/types are surfaced; source code and secret values remain intentionally out of scope.
@@ -106,12 +130,16 @@ coverage_contract:
       families: [zone]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: zone_rulesets
       type: entity_family
       title: Zone rulesets
       families: [zone_ruleset]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: cloudflare.access_application
     schema_ref: cloudflare/access_application/v1

--- a/sources/conjur/catalog.yaml
+++ b/sources/conjur/catalog.yaml
@@ -25,6 +25,8 @@ coverage_contract:
       families: [resource]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: authenticator
@@ -33,6 +35,8 @@ coverage_contract:
       families: [authenticator]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: resource_2
@@ -41,6 +45,8 @@ coverage_contract:
       families: [resource_2]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: resource_3
@@ -49,6 +55,8 @@ coverage_contract:
       families: [resource_3]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/cosmo/catalog.yaml
+++ b/sources/cosmo/catalog.yaml
@@ -33,18 +33,24 @@ coverage_contract:
       families: [fact]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: messages
       type: audit_event
       title: Message exports
       families: [message]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
     - id: sessions
       type: entity_family
       title: Memory sessions
       families: [session]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: survey_feedback
       type: entity_family
       title: Survey feedback

--- a/sources/discord/catalog.yaml
+++ b/sources/discord/catalog.yaml
@@ -25,6 +25,8 @@ coverage_contract:
       families: [audit_log]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: member
@@ -33,6 +35,8 @@ coverage_contract:
       families: [member]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: role
@@ -41,6 +45,8 @@ coverage_contract:
       families: [role]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: permission
@@ -49,6 +55,8 @@ coverage_contract:
       families: [permission]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/doppler/catalog.yaml
+++ b/sources/doppler/catalog.yaml
@@ -15,6 +15,8 @@ coverage_contract:
       families: [secrets]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: projects
@@ -23,6 +25,8 @@ coverage_contract:
       families: [projects]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
@@ -31,6 +35,8 @@ coverage_contract:
       families: [audit_events]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/duo/catalog.yaml
+++ b/sources/duo/catalog.yaml
@@ -18,24 +18,32 @@ coverage_contract:
       families: [endpoint]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: groups
       type: entity_family
       title: Groups
       families: [group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: mfa_devices
       type: entity_family
       title: MFA phones, hardware tokens, and WebAuthn credentials
       families: [phone, token, web_authn_credential]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: users
       type: entity_family
       title: Users
       families: [user]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: duo.user
     schema_ref: duo/user/v1

--- a/sources/emaildomainhealth/catalog.yaml
+++ b/sources/emaildomainhealth/catalog.yaml
@@ -13,12 +13,16 @@ coverage_contract:
       families: [health]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: dns_record_checks
       type: entity_family
       title: SPF, DKIM, DMARC, MX, and related DNS checks
       families: [health]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: remediation_state
       type: remediation_state
       title: Domain remediation lifecycle state

--- a/sources/evidencecas/catalog.yaml
+++ b/sources/evidencecas/catalog.yaml
@@ -13,18 +13,24 @@ coverage_contract:
       families: [object]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: integrity_metadata
       type: entity_family
       title: Evidence URI and digest metadata
       families: [object]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: source_event_links
       type: relationship
       title: Source event evidence links
       families: [object]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: evidence_cas.object
     schema_ref: evidence_cas/object/v1

--- a/sources/gcp/catalog.yaml
+++ b/sources/gcp/catalog.yaml
@@ -560,543 +560,725 @@ coverage_contract:
       families: [aiplatform_dataset]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: aiplatform_endpoint
       type: entity_family
       title: Vertex AI endpoints
       families: [aiplatform_endpoint]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: artifact_registry_repository
       type: entity_family
       title: Artifact Registry repositories
       families: [artifact_registry_repository]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: artifact_registry_image
       type: entity_family
       title: Artifact Registry images
       families: [artifact_registry_image]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: audit
       type: audit_event
       title: GCP audit logs
       families: [audit]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
     - id: binary_authorization_attestor
       type: entity_family
       title: Binary Authorization attestors
       families: [binary_authorization_attestor]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: binary_authorization_policy
       type: entity_family
       title: Binary Authorization policy
       families: [binary_authorization_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: bigquery_dataset
       type: entity_family
       title: BigQuery datasets
       families: [bigquery_dataset]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: bigquery_table
       type: entity_family
       title: BigQuery tables
       families: [bigquery_table]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: bigtable_instance
       type: entity_family
       title: Bigtable instances
       families: [bigtable_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: bigtable_table
       type: entity_family
       title: Bigtable tables
       families: [bigtable_table]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: certificate_manager_certificate
       type: entity_family
       title: Certificate Manager certificates
       families: [certificate_manager_certificate]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: certificate_manager_certificate_map
       type: entity_family
       title: Certificate Manager certificate maps
       families: [certificate_manager_certificate_map]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: certificate_manager_certificate_map_entry
       type: entity_family
       title: Certificate Manager certificate map entries
       families: [certificate_manager_certificate_map_entry]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: certificate_manager_dns_authorization
       type: entity_family
       title: Certificate Manager DNS authorizations
       families: [certificate_manager_dns_authorization]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloud_function
       type: entity_family
       title: Cloud Functions
       families: [cloud_function]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloud_ids_endpoint
       type: entity_family
       title: Cloud IDS endpoints
       families: [cloud_ids_endpoint]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloud_scheduler_job
       type: entity_family
       title: Cloud Scheduler jobs
       families: [cloud_scheduler_job]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloud_run_revision
       type: entity_family
       title: Cloud Run revisions
       families: [cloud_run_revision]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloud_run_service
       type: entity_family
       title: Cloud Run services
       families: [cloud_run_service]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloud_sql_instance
       type: entity_family
       title: Cloud SQL instances
       families: [cloud_sql_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloud_sql_database
       type: entity_family
       title: Cloud SQL databases
       families: [cloud_sql_database]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: cloud_sql_user
       type: entity_family
       title: Cloud SQL users
       families: [cloud_sql_user]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_address
       type: entity_family
       title: Compute addresses
       families: [compute_address]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_backend_bucket
       type: entity_family
       title: Compute backend buckets
       families: [compute_backend_bucket]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_backend_service
       type: entity_family
       title: Compute backend services
       families: [compute_backend_service]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_disk
       type: entity_family
       title: Compute disks
       families: [compute_disk]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_external_vpn_gateway
       type: entity_family
       title: Compute external VPN gateways
       families: [compute_external_vpn_gateway]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_firewall
       type: entity_family
       title: Compute firewall rules
       families: [compute_firewall]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_forwarding_rule
       type: entity_family
       title: Compute forwarding rules
       families: [compute_forwarding_rule]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_health_check
       type: entity_family
       title: Compute health checks
       families: [compute_health_check]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_instance
       type: entity_family
       title: Compute instances
       families: [compute_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_instance_group
       type: entity_family
       title: Compute instance groups
       families: [compute_instance_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_instance_group_manager
       type: entity_family
       title: Compute instance group managers
       families: [compute_instance_group_manager]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_instance_template
       type: entity_family
       title: Compute instance templates
       families: [compute_instance_template]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_interconnect
       type: entity_family
       title: Compute interconnects
       families: [compute_interconnect]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_interconnect_attachment
       type: entity_family
       title: Compute interconnect attachments
       families: [compute_interconnect_attachment]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_network_endpoint_group
       type: entity_family
       title: Compute network endpoint groups
       families: [compute_network_endpoint_group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_network
       type: entity_family
       title: Compute networks
       families: [compute_network]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_network_firewall_policy
       type: entity_family
       title: Compute network firewall policies
       families: [compute_network_firewall_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_packet_mirroring
       type: entity_family
       title: Compute packet mirrorings
       families: [compute_packet_mirroring]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_route
       type: entity_family
       title: Compute routes
       families: [compute_route]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_router
       type: entity_family
       title: Compute routers
       families: [compute_router]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_security_policy
       type: entity_family
       title: Compute security policies
       families: [compute_security_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_ssl_certificate
       type: entity_family
       title: Compute SSL certificates
       families: [compute_ssl_certificate]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_ssl_policy
       type: entity_family
       title: Compute SSL policies
       families: [compute_ssl_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_subnetwork
       type: entity_family
       title: Compute subnetworks
       families: [compute_subnetwork]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_target_grpc_proxy
       type: entity_family
       title: Compute target gRPC proxies
       families: [compute_target_grpc_proxy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_target_http_proxy
       type: entity_family
       title: Compute target HTTP proxies
       families: [compute_target_http_proxy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_target_https_proxy
       type: entity_family
       title: Compute target HTTPS proxies
       families: [compute_target_https_proxy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_target_ssl_proxy
       type: entity_family
       title: Compute target SSL proxies
       families: [compute_target_ssl_proxy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_target_tcp_proxy
       type: entity_family
       title: Compute target TCP proxies
       families: [compute_target_tcp_proxy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_target_vpn_gateway
       type: entity_family
       title: Compute target VPN gateways
       families: [compute_target_vpn_gateway]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_url_map
       type: entity_family
       title: Compute URL maps
       families: [compute_url_map]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_vpn_gateway
       type: entity_family
       title: Compute VPN gateways
       families: [compute_vpn_gateway]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: compute_vpn_tunnel
       type: entity_family
       title: Compute VPN tunnels
       families: [compute_vpn_tunnel]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: container_vulnerability
       type: entity_family
       title: Container image vulnerabilities
       families: [container_vulnerability]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: container_registry
       type: entity_family
       title: Container Registry registries
       families: [container_registry]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: dns_managed_zone
       type: entity_family
       title: Cloud DNS managed zones
       families: [dns_managed_zone]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: dns_record_set
       type: entity_family
       title: Cloud DNS record sets
       families: [dns_record_set]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: gcs_bucket
       type: entity_family
       title: Cloud Storage buckets
       families: [gcs_bucket]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: gcs_object
       type: entity_family
       title: Cloud Storage objects
       families: [gcs_object]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: gke_cluster
       type: entity_family
       title: GKE clusters
       families: [gke_cluster]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: gke_node_pool
       type: entity_family
       title: GKE node pools
       families: [gke_node_pool]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: group
       type: entity_family
       title: Cloud Identity groups
       families: [group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: group_membership
       type: relationship
       title: Cloud Identity group memberships
       families: [group_membership]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: iam_role_assignment
       type: app_entitlement
       title: IAM policy bindings
       families: [iam_role_assignment]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: effective_permission
       type: app_entitlement
       title: Effective IAM permissions
       families: [effective_permission]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: asset_metadata
       type: entity_family
       title: Cloud Asset metadata and data sensitivity
       families: [asset_metadata]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: kms_key
       type: entity_family
       title: Cloud KMS keys
       families: [kms_key]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: logging_project_sink
       type: entity_family
       title: Cloud Logging project sinks
       families: [logging_project_sink]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: logging_metric
       type: entity_family
       title: Cloud Logging log-based metrics
       families: [logging_metric]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: monitoring_alert_policy
       type: entity_family
       title: Cloud Monitoring alert policies
       families: [monitoring_alert_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: monitoring_notification_channel
       type: entity_family
       title: Cloud Monitoring notification channels
       families: [monitoring_notification_channel]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: org_policy
       type: entity_family
       title: Organization Policy constraints
       families: [org_policy]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: pubsub_subscription
       type: entity_family
       title: Pub/Sub subscriptions
       families: [pubsub_subscription]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: pubsub_topic
       type: entity_family
       title: Pub/Sub topics
       families: [pubsub_topic]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: resourcemanager_project
       type: entity_family
       title: Resource Manager projects
       families: [resourcemanager_project]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: resource_exposure
       type: relationship
       title: GCP public resource exposure
       families: [resource_exposure]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: secret_manager_secret
       type: entity_family
       title: Secret Manager secrets
       families: [secret_manager_secret]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: secret_manager_version
       type: entity_family
       title: Secret Manager versions
       families: [secret_manager_version]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: security_center_finding
       type: entity_family
       title: Security Command Center findings
       families: [security_center_finding]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: service_account
       type: entity_family
       title: Service accounts
       families: [service_account]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: service_account_impersonation
       type: relationship
       title: Service account impersonation bindings
       families: [service_account_impersonation]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: service_account_key
       type: entity_family
       title: Service account keys
       families: [service_account_key]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: service_usage_service
       type: entity_family
       title: Enabled Service Usage APIs
       families: [service_usage_service]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: spanner_database
       type: entity_family
       title: Spanner databases
       families: [spanner_database]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: spanner_instance
       type: entity_family
       title: Spanner instances
       families: [spanner_instance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: vpc_access_connector
       type: entity_family
       title: Serverless VPC Access connectors
       families: [vpc_access_connector]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: workload_identity_pool
       type: entity_family
       title: Workload Identity pools
       families: [workload_identity_pool]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: workload_identity_provider
       type: entity_family
       title: Workload Identity providers
       families: [workload_identity_provider]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]

--- a/sources/github/catalog.yaml
+++ b/sources/github/catalog.yaml
@@ -92,6 +92,8 @@ coverage_contract:
       title: Incremental cursor sync
       support: partial
       high_value: true
+      evidence_types: [source_sync_status]
+      control_domains: [source_operations]
       known_unsupported_fields:
         - org inventory snapshot deltas
     - id: organization_members
@@ -100,6 +102,8 @@ coverage_contract:
       families: [org_inventory]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: pull_requests
       type: lifecycle_state
       title: Pull request lifecycle

--- a/sources/googleworkspace/catalog.yaml
+++ b/sources/googleworkspace/catalog.yaml
@@ -49,24 +49,32 @@ coverage_contract:
       families: [audit]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
     - id: groups
       type: entity_family
       title: Groups
       families: [group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: group_memberships
       type: relationship
       title: Group memberships
       families: [group_member]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync
       families: [audit, group, group_member, role_assignment, user]
       support: partial
       high_value: true
+      evidence_types: [source_sync_status]
+      control_domains: [source_operations]
       known_unsupported_fields:
         - full Directory API deletion tombstones
     - id: remediation_state
@@ -75,6 +83,8 @@ coverage_contract:
       families: [audit, group_member, user]
       support: partial
       high_value: true
+      evidence_types: [remediation_state]
+      control_domains: [remediation]
       known_unsupported_fields:
         - Cerebro remediation workflow assignment, exception, SLA, and approval state
       notes:
@@ -86,9 +96,13 @@ coverage_contract:
       families: [role_assignment]
       support: partial
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: users
       type: entity_family
       title: Users
       families: [user]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]

--- a/sources/grc/catalog.yaml
+++ b/sources/grc/catalog.yaml
@@ -135,36 +135,48 @@ coverage_contract:
       families: [contract]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: regulatory_notifications
       type: lifecycle_state
       title: Regulatory notification status
       families: [regulatory_notification]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: recovery_objectives
       type: entity_family
       title: Recovery objectives and BIA records
       families: [recovery_objective]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: authorization_packages
       type: entity_family
       title: Authorization packages and ATO records
       families: [authorization_package]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: poam_items
       type: lifecycle_state
       title: POA&M weakness remediation items
       families: [poam_item]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: training_attestations
       type: lifecycle_state
       title: Security training attestations
       families: [training_attestation]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: vendors
       type: entity_family
       title: Vendors
@@ -195,15 +207,21 @@ coverage_contract:
       families: [risk_scenario]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: people
       type: entity_family
       title: People and users
       families: [person, user]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: integrations
       type: entity_family
       title: GRC integrations
       families: [integration]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]

--- a/sources/hashicorp_vault/catalog.yaml
+++ b/sources/hashicorp_vault/catalog.yaml
@@ -15,6 +15,8 @@ coverage_contract:
       families: [users]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: secrets
@@ -23,6 +25,8 @@ coverage_contract:
       families: [secrets]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
@@ -31,6 +35,8 @@ coverage_contract:
       families: [audit_events]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/kandji/catalog.yaml
+++ b/sources/kandji/catalog.yaml
@@ -28,24 +28,32 @@ coverage_contract:
       families: [device]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: applications
       type: entity_family
       title: Installed applications
       families: [application]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: vulnerabilities
       type: entity_family
       title: Endpoint application vulnerabilities
       families: [vulnerability]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: remediation_state
       type: remediation_state
       title: Vulnerability remediation lifecycle state
       families: [vulnerability]
       support: partial
       high_value: true
+      evidence_types: [remediation_state]
+      control_domains: [remediation]
       known_unsupported_fields:
         - Cerebro remediation workflow assignment, exception, SLA, and approval state
       notes:

--- a/sources/kolide/catalog.yaml
+++ b/sources/kolide/catalog.yaml
@@ -43,33 +43,45 @@ coverage_contract:
       families: [device]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: checks
       type: lifecycle_state
       title: Device compliance checks
       families: [check]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: issues
       type: lifecycle_state
       title: Open and resolved device check issues
       families: [issue]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: software_inventory
       type: entity_family
       title: Installed software inventory
       families: [software]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: user_device_relationships
       type: relationship
       title: User to device relationships
       families: [user_device]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: vulnerabilities
       type: entity_family
       title: Endpoint software vulnerabilities
       families: [vulnerability]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]

--- a/sources/kubernetes/catalog.yaml
+++ b/sources/kubernetes/catalog.yaml
@@ -144,63 +144,85 @@ coverage_contract:
       families: [cluster]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: namespaces
       type: entity_family
       title: Kubernetes namespaces
       families: [namespace]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ingresses
       type: entity_family
       title: Kubernetes ingresses
       families: [ingress]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: nodes
       type: entity_family
       title: Kubernetes nodes
       families: [node]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: pods
       type: entity_family
       title: Kubernetes pods
       families: [pod, container]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: service_accounts
       type: entity_family
       title: Kubernetes service accounts
       families: [service_account]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: services
       type: entity_family
       title: Kubernetes services
       families: [service]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: workloads
       type: entity_family
       title: Kubernetes workloads
       families: [workload]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: workload_identity_bindings
       type: relationship
       title: Kubernetes workload identity bindings
       families: [workload_identity_binding]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: rbac_roles
       type: app_entitlement
       title: Kubernetes RBAC roles
       families: [rbac_role]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: rbac_bindings
       type: relationship
       title: Kubernetes RBAC bindings
       families: [rbac_binding]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]

--- a/sources/langchain/catalog.yaml
+++ b/sources/langchain/catalog.yaml
@@ -25,36 +25,48 @@ coverage_contract:
       families: [organization]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: workspaces
       type: entity_family
       title: LangSmith workspaces
       families: [workspace]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: users_and_access
       type: app_entitlement
       title: Organization and workspace membership
       families: [organization_member, workspace_member, role]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: workload_identity
       type: app_entitlement
       title: Service keys and service accounts
       families: [api_key, service_account]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: tracing_projects
       type: entity_family
       title: LangSmith tracing projects
       families: [project]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: observability_activity
       type: audit_event
       title: Runs, feedback, datasets, usage limits, and audit logs
       families: [run, feedback, dataset, usage_limit, audit_log]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
 event_contracts:
   - kind: langchain.organization
     schema_ref: langchain/organization/v1

--- a/sources/langfuse/catalog.yaml
+++ b/sources/langfuse/catalog.yaml
@@ -22,18 +22,24 @@ coverage_contract:
       families: [project]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: users_and_access
       type: app_entitlement
       title: Project memberships and project API keys
       families: [project_member, api_key]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: observability_activity
       type: audit_event
       title: Traces, observations, scores, sessions, metrics, prompts, and annotation queues
       families: [trace, observation, score, prompt, session, metric, annotation_queue]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
 event_contracts:
   - kind: langfuse.project
     schema_ref: langfuse/project/v1

--- a/sources/linode/catalog.yaml
+++ b/sources/linode/catalog.yaml
@@ -25,6 +25,8 @@ coverage_contract:
       families: [issue]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: event
@@ -33,6 +35,8 @@ coverage_contract:
       families: [event]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: credential
@@ -41,6 +45,8 @@ coverage_contract:
       families: [credential]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: user
@@ -49,6 +55,8 @@ coverage_contract:
       families: [user]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/meraki/catalog.yaml
+++ b/sources/meraki/catalog.yaml
@@ -25,6 +25,8 @@ coverage_contract:
       families: [eventtype]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: organization
@@ -33,6 +35,8 @@ coverage_contract:
       families: [organization]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: merakiauthuser
@@ -41,6 +45,8 @@ coverage_contract:
       families: [merakiauthuser]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: accesspolicy
@@ -49,6 +55,8 @@ coverage_contract:
       families: [accesspolicy]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/okta/catalog.yaml
+++ b/sources/okta/catalog.yaml
@@ -130,6 +130,8 @@ coverage_contract:
       families: [app_assignment]
       support: partial
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
       known_unsupported_fields:
         - app-specific fine-grained entitlement payloads
     - id: api_tokens
@@ -138,6 +140,8 @@ coverage_contract:
       families: [api_token]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Token values are never collected; only token metadata, creator user, timestamps, and network conditions are surfaced.
     - id: applications
@@ -146,12 +150,16 @@ coverage_contract:
       families: [application]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: authorization_servers
       type: entity_family
       title: Authorization servers
       families: [authorization_server]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: authenticators
       type: entity_family
       title: Authenticators
@@ -171,18 +179,24 @@ coverage_contract:
       families: [brand]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: device_assurance
       type: entity_family
       title: Device assurance policies
       families: [device_assurance]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: event_hooks
       type: entity_family
       title: Event hooks
       families: [event_hook]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: audit_events
       type: audit_event
       title: Audit events
@@ -204,6 +218,8 @@ coverage_contract:
       families: [group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: group_memberships
       type: relationship
       title: Group memberships
@@ -223,29 +239,39 @@ coverage_contract:
       families: [identity_provider]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: inline_hooks
       type: entity_family
       title: Inline hooks
       families: [inline_hook]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync
       support: supported
       high_value: true
+      evidence_types: [source_sync_status]
+      control_domains: [source_operations]
     - id: network_zones
       type: entity_family
       title: Network zones
       families: [network_zone]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: log_streams
       type: entity_family
       title: Log streams
       families: [log_stream]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: policy_rules
       type: entity_family
       title: Policy rules
@@ -265,6 +291,8 @@ coverage_contract:
       families: [admin_role, app_assignment, application, audit, identity_provider, network_zone, policy_rule, trusted_origin, user]
       support: partial
       high_value: true
+      evidence_types: [remediation_state]
+      control_domains: [remediation]
       known_unsupported_fields:
         - Cerebro remediation workflow assignment, exception, SLA, and approval state
       notes:
@@ -276,12 +304,16 @@ coverage_contract:
       families: [threat_insight]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: trusted_origins
       type: entity_family
       title: Trusted origins
       families: [trusted_origin]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: users
       type: entity_family
       title: Users

--- a/sources/openai/catalog.yaml
+++ b/sources/openai/catalog.yaml
@@ -51,66 +51,88 @@ coverage_contract:
       families: [audit_log]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
     - id: certificates
       type: lifecycle_state
       title: Organization and project certificates
       families: [certificate, project_certificate]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: data_retention
       type: lifecycle_state
       title: Organization and project data-retention settings
       families: [data_retention, project_data_retention]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: identity_access
       type: app_entitlement
       title: Organization users, groups, roles, and assignments
       families: [user, invite, group, group_user, role, user_role, group_role]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: project_access
       type: app_entitlement
       title: Project users, groups, roles, and assignments
       families: [project_user, project_user_role, project_group, project_group_role, project_role]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: project_controls
       type: lifecycle_state
       title: Project rate limits and model/tool permissions
       families: [project_rate_limit, project_model_permission, project_hosted_tool_permission]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: projects
       type: entity_family
       title: Projects
       families: [project]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: service_accounts
       type: entity_family
       title: Organization and project service accounts
       families: [service_account, project_service_account]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: spend_controls
       type: lifecycle_state
       title: Organization and project spend alerts
       families: [spend_alert, project_spend_alert]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: tokens_and_keys
       type: app_entitlement
       title: Organization, project, and admin API keys
       families: [api_key, admin_api_key, project_api_key]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: usage_and_costs
       type: entity_family
       title: Usage and cost report buckets
       families: [usage_audio_speech, usage_audio_transcription, usage_code_interpreter_session, usage_completion, usage_embedding, usage_image, usage_moderation, usage_vector_store, usage_file_search_call, usage_web_search_call, cost]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: openai.user
     schema_ref: openai/user/v1

--- a/sources/pagerduty/catalog.yaml
+++ b/sources/pagerduty/catalog.yaml
@@ -19,36 +19,48 @@ coverage_contract:
       families: [escalation_policy]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: integrations
       type: entity_family
       title: Service integrations
       families: [integration]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: schedules
       type: entity_family
       title: Schedules
       families: [schedule]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: services
       type: entity_family
       title: Services
       families: [service]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: teams
       type: entity_family
       title: Teams
       families: [team]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: users
       type: entity_family
       title: Users
       families: [user]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: vendors
       type: entity_family
       title: Vendors

--- a/sources/panopticon/catalog.yaml
+++ b/sources/panopticon/catalog.yaml
@@ -21,12 +21,16 @@ coverage_contract:
       families: [case]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: iocs
       type: entity_family
       title: Indicators of compromise
       families: [ioc]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: panopticon.alert
     schema_ref: panopticon/alert/v1

--- a/sources/probely/catalog.yaml
+++ b/sources/probely/catalog.yaml
@@ -25,6 +25,8 @@ coverage_contract:
       families: [needs_attention_top]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: event
@@ -33,6 +35,8 @@ coverage_contract:
       families: [event]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: user
@@ -41,6 +45,8 @@ coverage_contract:
       families: [user]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: framework
@@ -49,6 +55,8 @@ coverage_contract:
       families: [framework]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/sdk/catalog.yaml
+++ b/sources/sdk/catalog.yaml
@@ -18,6 +18,8 @@ coverage_contract:
       families: [inventory]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       known_unsupported_fields:
         - SDK source does not pull third-party provider APIs.
       notes:
@@ -28,5 +30,7 @@ coverage_contract:
       title: SDK push ingestion surface
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
       notes:
         - SDK source validates push runtime configuration and accepts application-owned claim writes through source runtime routes.

--- a/sources/securitytoolingmap/catalog.yaml
+++ b/sources/securitytoolingmap/catalog.yaml
@@ -14,12 +14,16 @@ coverage_contract:
       families: [tool]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: control_mappings
       type: relationship
       title: Tool to control mappings
       families: [control_mapping]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: security_tooling_map.tool
     schema_ref: security_tooling_map/tool/v1

--- a/sources/sentinelone/catalog.yaml
+++ b/sources/sentinelone/catalog.yaml
@@ -56,48 +56,64 @@ coverage_contract:
       families: [activity]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
     - id: agents
       type: entity_family
       title: SentinelOne agents
       families: [agent]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: applications
       type: entity_family
       title: Application inventory
       families: [application]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: exclusions
       type: entity_family
       title: Security exclusions
       families: [exclusion]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: groups
       type: entity_family
       title: SentinelOne groups
       families: [group]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: sites
       type: entity_family
       title: SentinelOne sites
       families: [site]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: threats
       type: entity_family
       title: Threat detections
       families: [threat]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: remediation_state
       type: remediation_state
       title: Threat remediation lifecycle state
       families: [threat]
       support: partial
       high_value: true
+      evidence_types: [remediation_state]
+      control_domains: [remediation]
       known_unsupported_fields:
         - Cerebro remediation workflow assignment, exception, SLA, and approval state
       notes:

--- a/sources/slack/catalog.yaml
+++ b/sources/slack/catalog.yaml
@@ -16,24 +16,32 @@ coverage_contract:
       families: [channel]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: teams
       type: entity_family
       title: Teams
       families: [team]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: user_groups
       type: relationship
       title: User groups
       families: [user_group]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: users
       type: entity_family
       title: Users
       families: [user]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: slack.team
     schema_ref: slack/team/v1

--- a/sources/tailscale/catalog.yaml
+++ b/sources/tailscale/catalog.yaml
@@ -19,42 +19,56 @@ coverage_contract:
       families: [grant]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: devices
       type: entity_family
       title: Devices
       families: [device]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: groups
       type: relationship
       title: ACL groups
       families: [group]
       support: supported
       high_value: true
+      evidence_types: [relationship_evidence]
+      control_domains: [asset_inventory]
     - id: services
       type: entity_family
       title: Services
       families: [service]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: tag_owners
       type: app_entitlement
       title: Tag owners
       families: [tag]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: tailnet
       type: entity_family
       title: Tailnet settings
       families: [tailnet]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: users
       type: entity_family
       title: Users
       families: [user]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: tailscale.tailnet
     schema_ref: tailscale/tailnet/v1

--- a/sources/trivy/catalog.yaml
+++ b/sources/trivy/catalog.yaml
@@ -16,24 +16,32 @@ coverage_contract:
       families: [fix]
       support: supported
       high_value: true
+      evidence_types: [remediation_state]
+      control_domains: [remediation]
     - id: image_packages
       type: entity_family
       title: Image packages
       families: [image_package]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: image_scans
       type: entity_family
       title: Image scan reports
       families: [image_scan]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: image_vulnerabilities
       type: entity_family
       title: Image vulnerabilities
       families: [image_vulnerability]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: trivy.image_scan
     schema_ref: trivy/image_scan/v1

--- a/sources/trustedendpoint/catalog.yaml
+++ b/sources/trustedendpoint/catalog.yaml
@@ -21,54 +21,72 @@ coverage_contract:
       families: [agent_identity]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: host_posture
       type: entity_family
       title: Host posture observations
       families: [host_posture]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: repo_worktree_context
       type: entity_family
       title: Repository worktree context
       families: [repo_worktree_context]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: ai_session_risk
       type: lifecycle_state
       title: AI session risk summaries
       families: [ai_session_summary]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: ai_workflow_risk
       type: lifecycle_state
       title: AI workflow risk assessments
       families: [ai_workflow_risk]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: security_findings
       type: entity_family
       title: Endpoint security findings
       families: [security_finding]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: grc_evidence
       type: entity_family
       title: GRC evidence records
       families: [grc_evidence]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: trust_gate_decisions
       type: lifecycle_state
       title: Trust gate decisions
       families: [trust_gate_decision]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: action_outcomes
       type: audit_event
       title: Trusted endpoint action outcomes
       families: [action_outcome]
       support: supported
       high_value: true
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
 event_contracts:
   - kind: trusted_endpoint.agent_identity
     schema_ref: trusted_endpoint/agent_identity/v1

--- a/sources/twilio/catalog.yaml
+++ b/sources/twilio/catalog.yaml
@@ -22,6 +22,8 @@ coverage_contract:
       families: [accounts]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: keys
@@ -30,6 +32,8 @@ coverage_contract:
       families: [keys]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
@@ -38,6 +42,8 @@ coverage_contract:
       families: [audit_events]
       support: partial
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/vulnview/catalog.yaml
+++ b/sources/vulnview/catalog.yaml
@@ -38,36 +38,48 @@ coverage_contract:
       families: [site]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: scans
       type: lifecycle_state
       title: Scan lifecycle state
       families: [scan]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: vulnerabilities
       type: entity_family
       title: Vulnerabilities
       families: [vulnerability]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: assets
       type: entity_family
       title: Attack-surface assets
       families: [asset]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: dns_alerts
       type: entity_family
       title: DNS alerts
       families: [dns_alert]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: remediation_state
       type: remediation_state
       title: Vulnerability remediation lifecycle state
       families: [vulnerability, dns_alert]
       support: partial
       high_value: true
+      evidence_types: [remediation_state]
+      control_domains: [remediation]
       known_unsupported_fields:
         - Cerebro remediation workflow assignment, exception, SLA, and approval state
       notes:

--- a/sources/writer/catalog.yaml
+++ b/sources/writer/catalog.yaml
@@ -18,36 +18,48 @@ coverage_contract:
       families: [application]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: application_graphs
       type: app_entitlement
       title: Application Knowledge Graph associations
       families: [application_graph]
       support: supported
       high_value: true
+      evidence_types: [identity_configuration]
+      control_domains: [identity_access]
     - id: application_jobs
       type: lifecycle_state
       title: Async application jobs
       families: [application_job]
       support: supported
       high_value: true
+      evidence_types: [configuration_state]
+      control_domains: [security_operations]
     - id: files
       type: entity_family
       title: Uploaded files
       families: [file]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: graphs
       type: entity_family
       title: Knowledge Graphs
       families: [graph]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
     - id: models
       type: entity_family
       title: Available models
       families: [model]
       support: supported
       high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: writer.model
     schema_ref: writer/model/v1

--- a/tools/catalogcheck/catalogcheck.go
+++ b/tools/catalogcheck/catalogcheck.go
@@ -414,23 +414,24 @@ func checkSourceCatalogsWithControlCatalog(root string, controlCatalog *complian
 		if err != nil {
 			return fmt.Errorf("read %s: %w", rel, err)
 		}
+		var runtimeCatalog struct {
+			RuntimeFamilies  []string                    `yaml:"runtime_families"`
+			CoverageContract *sourcecdk.CoverageContract `yaml:"coverage_contract"`
+		}
+		if err := yaml.Unmarshal(content, &runtimeCatalog); err != nil {
+			issues = append(issues, issue{path: rel, message: "unmarshal source catalog fields: " + err.Error()})
+			return nil
+		}
 		catalog, err := sourcecdk.LoadSourceCatalog(content)
 		if err != nil {
 			issues = append(issues, issue{path: rel, message: err.Error()})
-			return nil
-		}
-		var runtimeCatalog struct {
-			RuntimeFamilies []string `yaml:"runtime_families"`
-		}
-		if err := yaml.Unmarshal(content, &runtimeCatalog); err != nil {
-			issues = append(issues, issue{path: rel, message: "unmarshal runtime families: " + err.Error()})
 			return nil
 		}
 		spec := catalog.Spec
 		if catalog.CoverageContract == nil {
 			issues = append(issues, issue{path: rel, message: "coverage_contract is required for built-in sources"})
 		} else {
-			issues = append(issues, validateSourceCoverageDeepContract(rel, catalog.CoverageContract, controlCatalog)...)
+			issues = append(issues, validateSourceCoverageDeepContract(rel, runtimeCatalog.CoverageContract, controlCatalog)...)
 		}
 		if spec.GetId() != "sdk" && len(spec.GetEmittedKinds()) == 0 {
 			issues = append(issues, issue{path: rel, message: "emitted_kinds is required for built-in pull sources"})
@@ -470,7 +471,7 @@ func validateSourceCoverageDeepContract(path string, contract *sourcecdk.Coverag
 			continue
 		}
 		prefix := fmt.Sprintf("coverage_contract dimension %q", dimension.ID)
-		switch dimension.Support {
+		switch strings.ToLower(strings.TrimSpace(dimension.Support)) {
 		case sourcecdk.CoverageSupportSupported, sourcecdk.CoverageSupportPartial:
 			if len(dimension.EvidenceTypes) == 0 {
 				issues = append(issues, issue{path: path, message: prefix + " must declare evidence_types"})

--- a/tools/catalogcheck/catalogcheck_test.go
+++ b/tools/catalogcheck/catalogcheck_test.go
@@ -286,6 +286,38 @@ coverage_contract:
 	}
 }
 
+func TestCheckSourceCatalogsRequiresExplicitHighValueCoverageMetadata(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "sources/github/catalog.yaml", `
+id: github
+name: GitHub
+description: GitHub source
+emitted_kinds:
+  - github.audit
+coverage_contract:
+  owner_domain: source_control
+  authority_domain: github
+  dimensions:
+    - id: audit_events
+      type: audit_event
+      title: Audit events
+      families: [audit]
+      support: supported
+      high_value: true
+`)
+
+	issues, err := checkSourceCatalogs(root)
+	if err != nil {
+		t.Fatalf("checkSourceCatalogs() error = %v", err)
+	}
+	if !issueMessagesContain(issues, `coverage_contract dimension "audit_events" must declare evidence_types`) {
+		t.Fatalf("issues = %#v, want missing evidence_types issue", issues)
+	}
+	if !issueMessagesContain(issues, `coverage_contract dimension "audit_events" must declare control_domains`) {
+		t.Fatalf("issues = %#v, want missing control_domains issue", issues)
+	}
+}
+
 func TestCheckSourceCatalogsSkipsCatalogRuntimeAdapter(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "sources/catalogruntime/catalog.yaml", `


### PR DESCRIPTION
Follow-up to #1435 addressing the remaining proof-gate feedback from Devin review.

Summary:
- Run high-value connector proof-gate validation against raw definitions before normalization fills defaults.
- Validate source catalog high-value coverage metadata against raw coverage contracts before sourcecdk defaults apply.
- Add explicit evidence_types and control_domains to high-value supported/partial connector and source catalog dimensions, including the langchain/langfuse catalogs now on main.
- Add regression tests for missing explicit high-value metadata in connector and source catalog validation.

Verification:
- go test ./internal/connectorcatalog ./tools/catalogcheck ./internal/connectordefinitions ./internal/sourcecdk -count=1
- make catalog-check
- make sourcegen-check
- make policy-rule-check
- make detection-catalog-check
- go test ./internal/compliance ./internal/findings ./tools/catalogcheck -count=1
- go test ./internal/sourcecdk ./internal/sourceprojection ./internal/sourceruntime -count=1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->