### PR TITLE
fix: resolve stale graph findings per scope when only a per-account cap truncates

### DIFF
--- a/internal/findings/cloud_attack_path_graph_rule.go
+++ b/internal/findings/cloud_attack_path_graph_rule.go
@@ -12,7 +12,10 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
-var _ GraphRule = (*cloudPublicExposurePrivilegedPrincipalRule)(nil)
+var (
+	_ GraphRule           = (*cloudPublicExposurePrivilegedPrincipalRule)(nil)
+	_ ScopedStaleResolver = (*cloudPublicExposurePrivilegedPrincipalRule)(nil)
+)
 
 const (
 	cloudPublicExposurePrivilegedPrincipalRuleID   = "cloud-public-exposure-privileged-principal"
@@ -173,6 +176,32 @@ LIMIT $row_limit`,
 		},
 		RowLimit: cloudPublicExposurePrivilegedPrincipalRowLimit,
 	}
+}
+
+// StaleResolutionScopeAttribute groups stale-finding resolution by cloud account.
+// The per-account cap can drop exposure x principal combinations for some accounts
+// while leaving others fully represented, so resolution must only touch accounts
+// that came back complete.
+func (r *cloudPublicExposurePrivilegedPrincipalRule) StaleResolutionScopeAttribute() string {
+	return "cloud_account_urn"
+}
+
+// IncompleteStaleResolutionScopes returns the set of account URNs whose rows were
+// capped this evaluation (graph_rule_truncated=true). account_capped is computed at
+// the account grouping level, so every row of a capped account carries the flag.
+// Findings for these accounts must stay open; findings for any other account are
+// safe to resolve once they no longer match.
+func (r *cloudPublicExposurePrivilegedPrincipalRule) IncompleteStaleResolutionScopes(rows []ports.CypherRow) map[string]struct{} {
+	incomplete := make(map[string]struct{})
+	for _, row := range rows {
+		if !cypherValueTruthy(row.Values[graphRuleTruncationColumn]) {
+			continue
+		}
+		if account := cypherRowString(row, "account_urn"); account != "" {
+			incomplete[account] = struct{}{}
+		}
+	}
+	return incomplete
 }
 
 func (r *cloudPublicExposurePrivilegedPrincipalRule) EvaluateRows(_ context.Context, runtime *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {

--- a/internal/findings/cloud_attack_path_graph_rule_test.go
+++ b/internal/findings/cloud_attack_path_graph_rule_test.go
@@ -141,6 +141,36 @@ func TestCloudPublicExposurePrivilegedPrincipalSignalsPerAccountCapTruncation(t 
 	}
 }
 
+func TestCloudPublicExposurePrivilegedPrincipalScopedStaleResolution(t *testing.T) {
+	// The rule groups stale resolution by cloud account so the per-account cap only
+	// pins the accounts it actually truncated. The scope attribute must match the
+	// finding attribute buildFinding writes ("cloud_account_urn"), and only capped
+	// rows that carry an account become incomplete scopes.
+	resolver := newCloudPublicExposurePrivilegedPrincipalRule().(ScopedStaleResolver)
+	if got := resolver.StaleResolutionScopeAttribute(); got != "cloud_account_urn" {
+		t.Fatalf("StaleResolutionScopeAttribute() = %q, want cloud_account_urn", got)
+	}
+	incomplete := resolver.IncompleteStaleResolutionScopes([]ports.CypherRow{
+		{Values: map[string]any{"account_urn": "acct-capped", graphRuleTruncationColumn: true}},
+		{Values: map[string]any{"account_urn": "acct-capped", graphRuleTruncationColumn: true}},
+		{Values: map[string]any{"account_urn": "acct-string-capped", graphRuleTruncationColumn: "true"}},
+		{Values: map[string]any{"account_urn": "acct-complete", graphRuleTruncationColumn: false}},
+		{Values: map[string]any{graphRuleTruncationColumn: true}}, // capped row without an account: ignored
+	})
+	want := map[string]struct{}{"acct-capped": {}, "acct-string-capped": {}}
+	if len(incomplete) != len(want) {
+		t.Fatalf("IncompleteStaleResolutionScopes() = %v, want %v", incomplete, want)
+	}
+	for account := range want {
+		if _, ok := incomplete[account]; !ok {
+			t.Fatalf("IncompleteStaleResolutionScopes() missing capped account %q: %v", account, incomplete)
+		}
+	}
+	if _, ok := incomplete["acct-complete"]; ok {
+		t.Fatalf("IncompleteStaleResolutionScopes() included fully-represented account acct-complete: %v", incomplete)
+	}
+}
+
 func TestCloudCurrentPublicExposureGraphRuleRequiresStampedRecentReachability(t *testing.T) {
 	rule := newCloudPublicResourceExposureGraphRule().(GraphRule)
 	query := rule.QueryFor(&cerebrov1.SourceRuntime{Id: "writer-aws-resource-exposure", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "resource_exposure"}})

--- a/internal/findings/graph_rule.go
+++ b/internal/findings/graph_rule.go
@@ -28,3 +28,25 @@ func asGraphRule(rule Rule) (GraphRule, bool) {
 	graphRule, ok := rule.(GraphRule)
 	return graphRule, ok
 }
+
+// ScopedStaleResolver is an optional GraphRule capability for rules whose query
+// applies an internal per-scope cap (for example a per-account cap) that can drop
+// matching rows for some scopes while leaving others fully represented. It lets the
+// service auto-resolve stale findings for the fully-represented scopes instead of
+// skipping stale-finding resolution for the whole (tenant, rule) just because the
+// internal cap fired on one scope.
+//
+// It is only consulted when the global row limit was NOT hit. A row-limit truncation
+// can drop entire scopes past the cutoff, so a scope's absence in that case is not
+// evidence that it stopped matching; the service keeps the conservative global skip.
+type ScopedStaleResolver interface {
+	GraphRule
+	// StaleResolutionScopeAttribute is the finding attribute that carries the scope
+	// key the resolver groups on (for example "cloud_account_urn"). Open findings
+	// whose attribute is missing are treated as out-of-scope and left untouched.
+	StaleResolutionScopeAttribute() string
+	// IncompleteStaleResolutionScopes returns the set of scope keys whose rows were
+	// capped this evaluation, derived from the evaluated rows. A scope is incomplete
+	// if any of its rows was dropped by the internal cap.
+	IncompleteStaleResolutionScopes(rows []ports.CypherRow) map[string]struct{}
+}

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -140,7 +140,7 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 	queryRequest := rule.QueryFor(runtime)
 	if strings.TrimSpace(queryRequest.Query) == "" {
 		if retiredGraphRule(rule) {
-			if err := s.resolveStaleGraphFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), strings.TrimSpace(runtime.GetId()), spec.GetId(), nil); err != nil {
+			if err := s.resolveStaleGraphFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), strings.TrimSpace(runtime.GetId()), spec.GetId(), nil, nil); err != nil {
 				evaluationErr := fmt.Errorf("resolve retired graph findings for rule %q: %w", spec.GetId(), err)
 				return result, s.finishFailedGraphRun(ctx, run, 0, nil, evaluationErr)
 			}
@@ -162,7 +162,8 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		return result, s.finishFailedGraphRun(ctx, run, 0, nil, evaluationErr)
 	}
 	result.RowsRead = boundedUint32(len(rows))
-	result.Truncated = cypherRowsTruncated(queryRequest, len(rows)) || cypherRowsSignalTruncated(rows)
+	rowLimitTruncated := cypherRowsTruncated(queryRequest, len(rows))
+	result.Truncated = rowLimitTruncated || cypherRowsSignalTruncated(rows)
 	emitted, err := rule.EvaluateRows(ctx, runtime, rows)
 	if err != nil {
 		evaluationErr := fmt.Errorf("evaluate graph rule %q rows: %w", spec.GetId(), err)
@@ -215,8 +216,25 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 			}
 		}
 	}
-	if !result.Truncated {
-		if err := s.resolveStaleGraphFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), strings.TrimSpace(runtime.GetId()), spec.GetId(), emittedFindingIDs); err != nil {
+	resolveStale := !result.Truncated
+	var scopeFilter *staleScopeFilter
+	if result.Truncated && !rowLimitTruncated {
+		// Only an internal per-scope cap fired (not the global row limit). Scopes
+		// returned in full can still auto-resolve; scopes that were capped this pass
+		// must stay open because a still-matching row may have been dropped. The
+		// row-limit case keeps the conservative global skip above.
+		if scoped, ok := rule.(ScopedStaleResolver); ok {
+			if attribute := strings.TrimSpace(scoped.StaleResolutionScopeAttribute()); attribute != "" {
+				scopeFilter = &staleScopeFilter{
+					attribute:  attribute,
+					incomplete: scoped.IncompleteStaleResolutionScopes(rows),
+				}
+				resolveStale = true
+			}
+		}
+	}
+	if resolveStale {
+		if err := s.resolveStaleGraphFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), strings.TrimSpace(runtime.GetId()), spec.GetId(), emittedFindingIDs, scopeFilter); err != nil {
 			evaluationErr := fmt.Errorf("resolve stale graph findings for rule %q: %w", spec.GetId(), err)
 			return result, s.finishFailedGraphRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
 		}
@@ -335,6 +353,34 @@ func (s *Service) selectGraphRules(runtime *cerebrov1.SourceRuntime, ruleIDs []s
 	return graphRules, nil
 }
 
+// staleScopeFilter narrows stale-finding auto-resolution to scopes that were fully
+// represented during a per-scope-capped evaluation. A nil filter resolves every
+// non-emitted open finding, which is the default for rules without an internal cap
+// and for the row-limit-clean path.
+type staleScopeFilter struct {
+	attribute  string
+	incomplete map[string]struct{}
+}
+
+// shouldResolve reports whether a non-emitted open finding may be auto-resolved.
+// With no filter every candidate is resolvable. With a filter, a finding resolves
+// only when it carries a scope key that was NOT capped this pass; findings without
+// a scope key stay open because we cannot prove their scope was fully represented.
+func (f *staleScopeFilter) shouldResolve(finding *ports.FindingRecord) bool {
+	if f == nil {
+		return true
+	}
+	if finding == nil {
+		return false
+	}
+	key := strings.TrimSpace(finding.Attributes[f.attribute])
+	if key == "" {
+		return false
+	}
+	_, capped := f.incomplete[key]
+	return !capped
+}
+
 // resolveStaleGraphFindings closes any open finding emitted previously by one graph rule whose
 // source rows are no longer present in the latest evaluation. Without this, dormant findings
 // would never auto-resolve when an offending principal is finally deprovisioned in both
@@ -346,7 +392,7 @@ func (s *Service) selectGraphRules(runtime *cerebrov1.SourceRuntime, ruleIDs []s
 // rule would report. Scoping by runtime here would close a finding that runtime A emitted as
 // soon as runtime B syncs and finishes its own evaluation (because runtime B's emit set
 // doesn't include runtime A's finding under the runtime-keyed query).
-func (s *Service) resolveStaleGraphFindings(ctx context.Context, tenantID string, _ string, ruleID string, emittedFindingIDs map[string]struct{}) error {
+func (s *Service) resolveStaleGraphFindings(ctx context.Context, tenantID string, _ string, ruleID string, emittedFindingIDs map[string]struct{}, scopeFilter *staleScopeFilter) error {
 	findings, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
 		TenantID: strings.TrimSpace(tenantID),
 		RuleID:   strings.TrimSpace(ruleID),
@@ -360,6 +406,9 @@ func (s *Service) resolveStaleGraphFindings(ctx context.Context, tenantID string
 			continue
 		}
 		if _, emitted := emittedFindingIDs[strings.TrimSpace(finding.ID)]; emitted {
+			continue
+		}
+		if !scopeFilter.shouldResolve(finding) {
 			continue
 		}
 		updated, err := s.updateFindingStatusAndRisk(ctx, ports.FindingStatusUpdate{

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -55,6 +55,23 @@ func (r *stubGraphRule) EvaluateRows(_ context.Context, _ *cerebrov1.SourceRunti
 	return r.emit, nil
 }
 
+// scopedStubGraphRule opts into ScopedStaleResolver with an injectable scope
+// attribute and incomplete-scope set, so service tests can drive cap-aware stale
+// resolution without re-deriving scopes from rows.
+type scopedStubGraphRule struct {
+	stubGraphRule
+	scopeAttribute   string
+	incompleteScopes map[string]struct{}
+}
+
+func (r *scopedStubGraphRule) StaleResolutionScopeAttribute() string {
+	return r.scopeAttribute
+}
+
+func (r *scopedStubGraphRule) IncompleteStaleResolutionScopes(_ []ports.CypherRow) map[string]struct{} {
+	return r.incompleteScopes
+}
+
 func TestEvaluateSourceRuntimeGraphRulesExcludesNamedRules(t *testing.T) {
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
 	store := &stubFindingStore{}
@@ -328,6 +345,141 @@ func TestEvaluateSourceRuntimeGraphRulesCapSignalSkipsStaleResolution(t *testing
 				t.Fatalf("stale finding StatusReason = %q, want graph_rule_no_longer_matches (no cap signal must auto-resolve)", got)
 			}
 		})
+	}
+}
+
+func TestEvaluateSourceRuntimeGraphRulesCapAwareStaleResolutionResolvesCompleteScopes(t *testing.T) {
+	// A per-scope-capped rule (ScopedStaleResolver) drops data for SOME scopes while
+	// leaving others fully represented. When only the internal cap fired (the global
+	// row limit was not hit) stale resolution must run scope-by-scope: keep capped
+	// scopes open, resolve scopes that came back complete, resolve scopes that no
+	// longer match at all, and leave findings with no scope key untouched.
+	const scopeAttr = "cloud_account_urn"
+	cappedAccount := "urn:cerebro:writer:cloud_account:capped"
+	completeAccount := "urn:cerebro:writer:cloud_account:complete"
+	absentAccount := "urn:cerebro:writer:cloud_account:absent"
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-aws", SourceId: "aws", TenantId: "writer"}
+	openFinding := func(id, account string) *ports.FindingRecord {
+		finding := &ports.FindingRecord{
+			ID:          id,
+			Fingerprint: id,
+			TenantID:    "writer",
+			RuntimeID:   "runtime-aws",
+			RuleID:      "scoped-rule",
+			Status:      findingStatusOpen,
+		}
+		if account != "" {
+			finding.Attributes = map[string]string{scopeAttr: account}
+		}
+		return finding
+	}
+	store := &stubFindingStore{findings: map[string]*ports.FindingRecord{
+		"stale-capped":   openFinding("stale-capped", cappedAccount),
+		"stale-complete": openFinding("stale-complete", completeAccount),
+		"stale-absent":   openFinding("stale-absent", absentAccount),
+		"stale-noscope":  openFinding("stale-noscope", ""),
+	}}
+	graphStore := &stubGraphStore{cypherRows: []ports.CypherRow{
+		{Values: map[string]any{"account_urn": cappedAccount, graphRuleTruncationColumn: true}},
+		{Values: map[string]any{"account_urn": completeAccount, graphRuleTruncationColumn: false}},
+	}}
+	rule := &scopedStubGraphRule{
+		stubGraphRule: stubGraphRule{
+			spec:     &cerebrov1.RuleSpec{Id: "scoped-rule"},
+			sourceID: "aws",
+			query: ports.CypherQueryRequest{
+				Query:    "MATCH (n) RETURN n LIMIT $row_limit",
+				Params:   map[string]any{"row_limit": int64(250)},
+				RowLimit: 250,
+			},
+		},
+		scopeAttribute:   scopeAttr,
+		incompleteScopes: map[string]struct{}{cappedAccount: {}},
+	}
+	registry, err := NewRegistry(rule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-aws"})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if got := len(result.Evaluations); got != 1 {
+		t.Fatalf("len(Evaluations) = %d, want 1", got)
+	}
+	if !result.Evaluations[0].Truncated {
+		t.Fatalf("Truncated = false, want true (a capped row signals truncation)")
+	}
+	wantStatus := map[string]string{
+		"stale-capped":   findingStatusOpen,     // capped scope: a still-matching row may have been dropped
+		"stale-complete": findingStatusResolved, // fully-represented scope: safe to auto-resolve
+		"stale-absent":   findingStatusResolved, // scope no longer matches; cap cannot drop a whole scope
+		"stale-noscope":  findingStatusOpen,     // no scope key: cannot prove the scope was complete
+	}
+	for id, want := range wantStatus {
+		finding, ok := store.findings[id]
+		if !ok {
+			t.Fatalf("finding %q missing after evaluation", id)
+		}
+		if got := finding.Status; got != want {
+			t.Fatalf("finding %q status = %q, want %q", id, got, want)
+		}
+	}
+}
+
+func TestEvaluateSourceRuntimeGraphRulesCapAwareResolutionSkippedOnRowLimit(t *testing.T) {
+	// When the GLOBAL row limit is hit, entire scopes can fall past the cutoff, so even a
+	// ScopedStaleResolver must keep the conservative global skip and resolve nothing: an
+	// absent scope here is indistinguishable from one whose rows were simply truncated.
+	const (
+		scopeAttr = "cloud_account_urn"
+		rowLimit  = 2
+	)
+	cappedAccount := "urn:cerebro:writer:cloud_account:capped"
+	completeAccount := "urn:cerebro:writer:cloud_account:complete"
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-aws", SourceId: "aws", TenantId: "writer"}
+	staleComplete := &ports.FindingRecord{
+		ID:          "stale-complete",
+		Fingerprint: "stale-complete",
+		TenantID:    "writer",
+		RuntimeID:   "runtime-aws",
+		RuleID:      "scoped-rule",
+		Status:      findingStatusOpen,
+		Attributes:  map[string]string{scopeAttr: completeAccount},
+	}
+	store := &stubFindingStore{findings: map[string]*ports.FindingRecord{staleComplete.ID: cloneFinding(staleComplete)}}
+	graphStore := &stubGraphStore{cypherRows: []ports.CypherRow{
+		{Values: map[string]any{"account_urn": cappedAccount, graphRuleTruncationColumn: true}},
+		{Values: map[string]any{"account_urn": completeAccount, graphRuleTruncationColumn: false}},
+	}}
+	rule := &scopedStubGraphRule{
+		stubGraphRule: stubGraphRule{
+			spec:     &cerebrov1.RuleSpec{Id: "scoped-rule"},
+			sourceID: "aws",
+			query: ports.CypherQueryRequest{
+				Query:    "MATCH (n) RETURN n LIMIT $row_limit",
+				Params:   map[string]any{"row_limit": int64(rowLimit)},
+				RowLimit: rowLimit,
+			},
+		},
+		scopeAttribute:   scopeAttr,
+		incompleteScopes: map[string]struct{}{cappedAccount: {}},
+	}
+	registry, err := NewRegistry(rule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-aws"})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if !result.Evaluations[0].Truncated {
+		t.Fatalf("Truncated = false, want true (rows hit the row limit)")
+	}
+	if got := store.findings[staleComplete.ID].Status; got != findingStatusOpen {
+		t.Fatalf("stale finding status = %q, want still %q (row-limit truncation must skip scoped resolution)", got, findingStatusOpen)
 	}
 }
 


### PR DESCRIPTION
## Summary

Graph-rule stale-finding auto-resolution was skipped for the entire `(tenant, rule)` whenever a rule signalled truncation. The `cloud-public-exposure-privileged-principal` rule applies an internal **per-account cap** (50) and emits `graph_rule_truncated=true` on every row of any account it caps. On a large tenant where at least one account is always capped, this meant stale findings for **every** account (including fully-represented ones) never auto-closed.

This change makes stale resolution **cap-aware** by splitting truncation into two kinds:

- **Row-limit truncation** (the global `LIMIT` was hit): entire scopes can fall past the cutoff, so this keeps the existing conservative global skip.
- **Internal per-scope cap**: the cap only trims *within* a scope (each still-matching scope keeps at least one row), so fully-represented scopes are safe to resolve; only the capped scopes are incomplete.

Mechanism (minimal, generalizable, no SQL/contract changes):

- New optional `ScopedStaleResolver` interface in `graph_rule.go` (`StaleResolutionScopeAttribute()` + `IncompleteStaleResolutionScopes(rows)`).
- `evaluateGraphRule` computes `rowLimitTruncated` separately; when only the internal cap fired and the rule opts in, it resolves stale findings through a `staleScopeFilter` that keeps capped-account findings open, resolves complete accounts, still closes scopes that no longer match, and conservatively keeps any finding lacking a scope key.
- `cloud_attack_path_graph_rule.go` opts in (scope = `cloud_account_urn`). Every other graph rule is unaffected (`nil` filter = today's behaviour); only this rule applies an internal cap today.

## Test Plan

- `go test ./internal/findings/...` (full package) - pass
- New tests:
  - `TestEvaluateSourceRuntimeGraphRulesCapAwareStaleResolutionResolvesCompleteScopes` - capped account stays open, complete account resolves, never-appeared account resolves, no-scope-key finding stays open.
  - `TestEvaluateSourceRuntimeGraphRulesCapAwareResolutionSkippedOnRowLimit` - row-limit truncation still skips scoped resolution entirely.
  - `TestCloudPublicExposurePrivilegedPrincipalScopedStaleResolution` - rule contract: scope attribute matches the finding attribute, only truthy-capped rows with an account become incomplete scopes.
- `go vet`, `make check-structural`, `make check-arch`, `golangci-lint run ./internal/findings/...` (0 issues), `go build ./...` - all pass.

## Known Invariants

- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated. (unchanged: query text is untouched)
- Candidate finding lifecycle writes remain atomic and idempotent. (stale resolution still goes through `updateFindingStatusAndRisk` + `recordFindingStatusWorkflow`)

## Droid Review Context

- Focus review on the truncation split and the `staleScopeFilter` resolution gate in `graph_rule_service.go`.
- Land with `make land-pr PR=<number>`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->