### PR TITLE
[codex] Align source audit coverage dimensions

### DIFF
--- a/sources/akeyless/catalog.yaml
+++ b/sources/akeyless/catalog.yaml
@@ -41,13 +41,13 @@ coverage_contract:
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
-      type: entity_family
+      type: audit_event
       title: "Audit Events"
       families: [audit_events]
       support: partial
       high_value: true
-      evidence_types: [source_snapshot]
-      control_domains: [asset_inventory]
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/asana/catalog.yaml
+++ b/sources/asana/catalog.yaml
@@ -37,13 +37,13 @@ coverage_contract:
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
-      type: entity_family
+      type: audit_event
       title: "Audit Events"
       families: [audit_events]
       support: partial
       high_value: true
-      evidence_types: [source_snapshot]
-      control_domains: [asset_inventory]
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/auth0/catalog.yaml
+++ b/sources/auth0/catalog.yaml
@@ -37,13 +37,13 @@ coverage_contract:
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
-      type: entity_family
+      type: audit_event
       title: "Audit Events"
       families: [audit_events]
       support: partial
       high_value: true
-      evidence_types: [source_snapshot]
-      control_domains: [asset_inventory]
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/box/catalog.yaml
+++ b/sources/box/catalog.yaml
@@ -37,13 +37,13 @@ coverage_contract:
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
-      type: entity_family
+      type: audit_event
       title: "Audit Events"
       families: [audit_events]
       support: partial
       high_value: true
-      evidence_types: [source_snapshot]
-      control_domains: [asset_inventory]
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/discord/catalog.yaml
+++ b/sources/discord/catalog.yaml
@@ -20,13 +20,13 @@ coverage_contract:
   authority_domain: discord
   dimensions:
     - id: audit_log
-      type: entity_family
+      type: audit_event
       title: "Audit Log"
       families: [audit_log]
       support: partial
       high_value: true
-      evidence_types: [source_snapshot]
-      control_domains: [asset_inventory]
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: member

--- a/sources/doppler/catalog.yaml
+++ b/sources/doppler/catalog.yaml
@@ -30,13 +30,13 @@ coverage_contract:
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
-      type: entity_family
+      type: audit_event
       title: "Audit Events"
       families: [audit_events]
       support: partial
       high_value: true
-      evidence_types: [source_snapshot]
-      control_domains: [asset_inventory]
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/hashicorp_vault/catalog.yaml
+++ b/sources/hashicorp_vault/catalog.yaml
@@ -30,13 +30,13 @@ coverage_contract:
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
-      type: entity_family
+      type: audit_event
       title: "Audit Events"
       families: [audit_events]
       support: partial
       high_value: true
-      evidence_types: [source_snapshot]
-      control_domains: [asset_inventory]
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/sources/twilio/catalog.yaml
+++ b/sources/twilio/catalog.yaml
@@ -37,13 +37,13 @@ coverage_contract:
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: audit_events
-      type: entity_family
+      type: audit_event
       title: "Audit Events"
       families: [audit_events]
       support: partial
       high_value: true
-      evidence_types: [source_snapshot]
-      control_domains: [asset_inventory]
+      evidence_types: [logging_configuration]
+      control_domains: [logging_monitoring]
       notes:
         - Generated Source Runtime SDK mapping requires provider field review before certification.
     - id: incremental_sync

--- a/tools/catalogcheck/catalogcheck.go
+++ b/tools/catalogcheck/catalogcheck.go
@@ -471,6 +471,9 @@ func validateSourceCoverageDeepContract(path string, contract *sourcecdk.Coverag
 			continue
 		}
 		prefix := fmt.Sprintf("coverage_contract dimension %q", dimension.ID)
+		if auditEventLikeCoverageDimension(dimension) && strings.TrimSpace(dimension.Type) == "entity_family" {
+			issues = append(issues, issue{path: path, message: prefix + ` looks like audit event coverage and must use type "audit_event"`})
+		}
 		switch strings.ToLower(strings.TrimSpace(dimension.Support)) {
 		case sourcecdk.CoverageSupportSupported, sourcecdk.CoverageSupportPartial:
 			if len(dimension.EvidenceTypes) == 0 {
@@ -498,6 +501,22 @@ func validateSourceCoverageDeepContract(path string, contract *sourcecdk.Coverag
 		}
 	}
 	return issues
+}
+
+func auditEventLikeCoverageDimension(dimension sourcecdk.CoverageDimension) bool {
+	values := []string{dimension.ID, dimension.Title}
+	values = append(values, dimension.Families...)
+	for _, value := range values {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		normalized = strings.NewReplacer(" ", "_", "-", "_").Replace(normalized)
+		switch {
+		case normalized == "audit", normalized == "audit_event", normalized == "audit_events", normalized == "audit_log", normalized == "audit_logs":
+			return true
+		case strings.Contains(normalized, "audit_event"), strings.Contains(normalized, "audit_log"):
+			return true
+		}
+	}
+	return false
 }
 
 func validateRuntimeFamilyFixtures(root string, sourceDir string, runtimeFamilies []string) []issue {

--- a/tools/catalogcheck/catalogcheck_test.go
+++ b/tools/catalogcheck/catalogcheck_test.go
@@ -318,6 +318,37 @@ coverage_contract:
 	}
 }
 
+func TestCheckSourceCatalogsRejectsAuditEventsAsEntityFamily(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "sources/github/catalog.yaml", `
+id: github
+name: GitHub
+description: GitHub source
+emitted_kinds:
+  - github.audit
+coverage_contract:
+  owner_domain: source_control
+  authority_domain: github
+  dimensions:
+    - id: audit_events
+      type: entity_family
+      title: Audit events
+      families: [audit]
+      support: supported
+      high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
+`)
+
+	issues, err := checkSourceCatalogs(root)
+	if err != nil {
+		t.Fatalf("checkSourceCatalogs() error = %v", err)
+	}
+	if !issueMessagesContain(issues, `coverage_contract dimension "audit_events" looks like audit event coverage and must use type "audit_event"`) {
+		t.Fatalf("issues = %#v, want audit_event type issue", issues)
+	}
+}
+
 func TestCheckSourceCatalogsSkipsCatalogRuntimeAdapter(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "sources/catalogruntime/catalog.yaml", `


### PR DESCRIPTION
Follow-up to #1440 addressing the post-merge Devin feedback about source catalog audit event dimensions being typed as entity_family.

Summary:
- Reclassify Auth0, Akeyless, Asana, Box, Discord, Doppler, HashiCorp Vault, and Twilio audit/audit-log coverage dimensions as audit_event.
- Align their explicit evidence_types/control_domains with audit-event semantics: logging_configuration and logging_monitoring.
- Add catalogcheck validation so audit-like source coverage dimensions cannot be modeled as entity_family again.
- Add a regression test for audit_events declared as entity_family.

Verification:
- go test ./tools/catalogcheck ./internal/sourcecdk ./internal/sourceprojection ./internal/sourceruntime -count=1
- make catalog-check
- go test ./internal/compliance ./internal/findings ./tools/catalogcheck -count=1
- make lint
- source audit-like entity scan: 0 remaining audit-like entity_family dimensions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->