### PR TITLE
feat: backfill Entity typed properties for pre-promotion nodes

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -76,6 +76,10 @@ type graphOpenFindingPrimaryLinkRepairStore interface {
 	RepairOpenFindingPrimaryLinks(context.Context, graphstore.OpenFindingPrimaryLinkRepairRequest) (graphstore.OpenFindingPrimaryLinkRepairResult, error)
 }
 
+type graphBackfillEntityTypedPropertiesStore interface {
+	BackfillEntityTypedProperties(context.Context, graphstore.BackfillEntityTypedPropertiesRequest) (graphstore.BackfillEntityTypedPropertiesResult, error)
+}
+
 type graphIngestRunStore interface {
 	ListIngestRuns(context.Context, graphstore.IngestRunFilter) ([]graphstore.IngestRun, error)
 }
@@ -208,6 +212,11 @@ type graphProjectedEntityCleanupOptions struct {
 type graphOpenFindingPrimaryLinkRepairOptions struct {
 	Limit  uint32
 	DryRun bool
+}
+
+type graphBackfillEntityTypedPropertiesOptions struct {
+	BatchSize uint32
+	DryRun    bool
 }
 
 type graphProjectedEntityCleanupResult struct {
@@ -347,6 +356,22 @@ func runGraph(args []string) error {
 			return printErr
 		}
 		return err
+	case "backfill-entity-typed-properties":
+		options, err := parseGraphBackfillEntityTypedPropertiesArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		ctx := context.Background()
+		deps, closeDeps, err := openGraphCleanupDependencies(ctx)
+		if err != nil {
+			return err
+		}
+		defer logClose(closeDeps)
+		result, err := backfillEntityTypedProperties(ctx, deps, options)
+		if printErr := printJSON(result); printErr != nil {
+			return printErr
+		}
+		return err
 	case "health":
 		return runGraphHealth(args[1:])
 	case "counts", "neighborhood", "paths", "relation-counts", "integrity":
@@ -409,7 +434,7 @@ func runGraph(args []string) error {
 }
 
 func graphUsage() string {
-	return fmt.Sprintf("usage: %s graph [health|counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|cleanup-endpoint-owner-id-links|cleanup-projected-entities|repair-open-finding-primary-links|rebuild|inspect] ...", os.Args[0])
+	return fmt.Sprintf("usage: %s graph [health|counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|cleanup-endpoint-owner-id-links|cleanup-projected-entities|repair-open-finding-primary-links|backfill-entity-typed-properties|rebuild|inspect] ...", os.Args[0])
 }
 
 func graphIngestUsage() string {
@@ -964,6 +989,17 @@ func repairOpenFindingPrimaryLinks(ctx context.Context, deps bootstrap.Dependenc
 	return repairer.RepairOpenFindingPrimaryLinks(ctx, graphstore.OpenFindingPrimaryLinkRepairRequest{
 		Limit:  options.Limit,
 		DryRun: options.DryRun,
+	})
+}
+
+func backfillEntityTypedProperties(ctx context.Context, deps bootstrap.Dependencies, options graphBackfillEntityTypedPropertiesOptions) (graphstore.BackfillEntityTypedPropertiesResult, error) {
+	backfiller, ok := deps.GraphStore.(graphBackfillEntityTypedPropertiesStore)
+	if !ok {
+		return graphstore.BackfillEntityTypedPropertiesResult{DryRun: options.DryRun}, fmt.Errorf("entity typed-property backfill is unsupported by configured graph store")
+	}
+	return backfiller.BackfillEntityTypedProperties(ctx, graphstore.BackfillEntityTypedPropertiesRequest{
+		BatchSize: options.BatchSize,
+		DryRun:    options.DryRun,
 	})
 }
 
@@ -1574,6 +1610,54 @@ func parseGraphOpenFindingPrimaryLinkRepairArgs(args []string) (graphOpenFinding
 	}
 	if !options.DryRun && !apply {
 		return graphOpenFindingPrimaryLinkRepairOptions{}, fmt.Errorf("apply=true is required before repairing open finding primary links")
+	}
+	return options, nil
+}
+
+func parseGraphBackfillEntityTypedPropertiesArgs(args []string) (graphBackfillEntityTypedPropertiesOptions, error) {
+	options := graphBackfillEntityTypedPropertiesOptions{DryRun: true}
+	apply := false
+	dryRunSet := false
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return graphBackfillEntityTypedPropertiesOptions{}, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		switch strings.TrimSpace(key) {
+		case "batch_size":
+			parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+			if err != nil {
+				return graphBackfillEntityTypedPropertiesOptions{}, fmt.Errorf("parse batch_size: %w", err)
+			}
+			if parsed == 0 {
+				return graphBackfillEntityTypedPropertiesOptions{}, fmt.Errorf("batch_size must be positive")
+			}
+			options.BatchSize = uint32(parsed)
+		case "dry_run":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphBackfillEntityTypedPropertiesOptions{}, fmt.Errorf("parse dry_run: %w", err)
+			}
+			options.DryRun = parsed
+			dryRunSet = true
+		case "apply":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphBackfillEntityTypedPropertiesOptions{}, fmt.Errorf("parse apply: %w", err)
+			}
+			apply = parsed
+		default:
+			return graphBackfillEntityTypedPropertiesOptions{}, usageError(fmt.Sprintf("unsupported graph backfill-entity-typed-properties argument %q", key))
+		}
+	}
+	if apply {
+		if dryRunSet && options.DryRun {
+			return graphBackfillEntityTypedPropertiesOptions{}, fmt.Errorf("apply=true conflicts with dry_run=true")
+		}
+		options.DryRun = false
+	}
+	if !options.DryRun && !apply {
+		return graphBackfillEntityTypedPropertiesOptions{}, fmt.Errorf("apply=true is required before backfilling entity typed properties")
 	}
 	return options, nil
 }

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -400,6 +400,66 @@ func TestRepairOpenFindingPrimaryLinksCreatesMissingEdge(t *testing.T) {
 	}
 }
 
+func TestParseGraphBackfillEntityTypedPropertiesArgsDefaultsDryRun(t *testing.T) {
+	options, err := parseGraphBackfillEntityTypedPropertiesArgs([]string{"batch_size=100"})
+	if err != nil {
+		t.Fatalf("parseGraphBackfillEntityTypedPropertiesArgs() error = %v", err)
+	}
+	if !options.DryRun || options.BatchSize != 100 {
+		t.Fatalf("options = %#v, want dry-run batch_size 100", options)
+	}
+}
+
+func TestParseGraphBackfillEntityTypedPropertiesArgsRequiresApply(t *testing.T) {
+	if _, err := parseGraphBackfillEntityTypedPropertiesArgs([]string{"dry_run=false"}); err == nil {
+		t.Fatal("parseGraphBackfillEntityTypedPropertiesArgs() error = nil, want apply requirement")
+	}
+	if _, err := parseGraphBackfillEntityTypedPropertiesArgs([]string{"apply=true", "dry_run=true"}); err == nil {
+		t.Fatal("parseGraphBackfillEntityTypedPropertiesArgs(apply+dry_run) error = nil, want conflict")
+	}
+	options, err := parseGraphBackfillEntityTypedPropertiesArgs([]string{"apply=true"})
+	if err != nil {
+		t.Fatalf("parseGraphBackfillEntityTypedPropertiesArgs(apply) error = %v", err)
+	}
+	if options.DryRun {
+		t.Fatalf("DryRun = true, want apply mode")
+	}
+}
+
+func TestBackfillEntityTypedPropertiesForwardsOptions(t *testing.T) {
+	store := newGraphTestStore()
+	if err := store.UpsertProjectedEntity(context.Background(), &ports.ProjectedEntity{
+		URN:        "urn:cerebro:writer:aws_user:admin",
+		TenantID:   "writer",
+		SourceID:   "aws",
+		EntityType: "aws.user",
+		Attributes: map[string]string{"is_admin": "true"},
+	}); err != nil {
+		t.Fatalf("UpsertProjectedEntity() error = %v", err)
+	}
+
+	dryRun, err := backfillEntityTypedProperties(context.Background(), bootstrap.Dependencies{GraphStore: store}, graphBackfillEntityTypedPropertiesOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("backfillEntityTypedProperties(dry-run) error = %v", err)
+	}
+	if dryRun.EntitiesMatched != 1 || dryRun.EntitiesUpdated != 0 || !dryRun.DryRun {
+		t.Fatalf("dryRun result = %#v, want one matched and no updates", dryRun)
+	}
+	applied, err := backfillEntityTypedProperties(context.Background(), bootstrap.Dependencies{GraphStore: store}, graphBackfillEntityTypedPropertiesOptions{DryRun: false})
+	if err != nil {
+		t.Fatalf("backfillEntityTypedProperties(apply) error = %v", err)
+	}
+	if applied.EntitiesUpdated != 1 || applied.Batches != 1 || applied.DryRun {
+		t.Fatalf("applied result = %#v, want one updated in one batch", applied)
+	}
+}
+
+func TestBackfillEntityTypedPropertiesUnsupportedStore(t *testing.T) {
+	if _, err := backfillEntityTypedProperties(context.Background(), bootstrap.Dependencies{}, graphBackfillEntityTypedPropertiesOptions{DryRun: true}); err == nil {
+		t.Fatal("backfillEntityTypedProperties() error = nil, want unsupported store error")
+	}
+}
+
 func TestGraphIngestCheckpointIDScrubsSensitiveConfig(t *testing.T) {
 	options := graphIngestOptions{
 		SourceID: "github",

--- a/cmd/cerebro/graph_test_store_test.go
+++ b/cmd/cerebro/graph_test_store_test.go
@@ -216,6 +216,23 @@ func (s *graphTestStore) RepairOpenFindingPrimaryLinks(_ context.Context, reques
 	return result, nil
 }
 
+func (s *graphTestStore) BackfillEntityTypedProperties(_ context.Context, request graphstore.BackfillEntityTypedPropertiesRequest) (graphstore.BackfillEntityTypedPropertiesResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := graphstore.BackfillEntityTypedPropertiesResult{DryRun: request.DryRun}
+	matched := uint32(len(s.entities)) // #nosec G115 -- test store entity count is statically bounded.
+	if request.DryRun {
+		result.EntitiesMatched = matched
+		return result, nil
+	}
+	if matched > 0 {
+		result.EntitiesMatched = matched
+		result.EntitiesUpdated = matched
+		result.Batches = 1
+	}
+	return result, nil
+}
+
 func (s *graphTestStore) PathPatterns(_ context.Context, limit int) ([]graphstore.PathPattern, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -373,6 +373,97 @@ RETURN count(r)`, params)
 	return result, nil
 }
 
+const defaultEntityTypedPropertyBackfillBatchSize = 500
+
+// BackfillEntityTypedProperties promotes the typed boolean properties onto Entity
+// nodes that predate the promotion and still carry NULL values for them, deriving
+// each from the node's stored attributes_json with the exact same code the projection
+// write path uses (graphAttributesFromJSON + projectionmeta.DerivedEntityProperties),
+// so the backfilled values can never drift from a re-projection. It is idempotent: a
+// node is only revisited until its typed properties are concrete booleans, so each
+// batch shrinks the candidate set and the loop terminates. With DryRun it only counts
+// the entities that still need the backfill.
+func (s *Store) BackfillEntityTypedProperties(ctx context.Context, request graphstore.BackfillEntityTypedPropertiesRequest) (graphstore.BackfillEntityTypedPropertiesResult, error) {
+	if err := s.requireConfigured(); err != nil {
+		return graphstore.BackfillEntityTypedPropertiesResult{}, err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return graphstore.BackfillEntityTypedPropertiesResult{}, err
+	}
+	batchSize := int64(request.BatchSize)
+	if batchSize <= 0 {
+		batchSize = defaultEntityTypedPropertyBackfillBatchSize
+	}
+	nullPredicate := fmt.Sprintf("e.%s IS NULL OR e.%s IS NULL OR e.%s IS NULL",
+		projectionmeta.PropertyInternetExposed,
+		projectionmeta.PropertyPrivilegedIdentity,
+		projectionmeta.PropertyMFADisabled)
+	result := graphstore.BackfillEntityTypedPropertiesResult{DryRun: request.DryRun}
+
+	if request.DryRun {
+		value, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
+			return queryOneValue(ctx, tx, fmt.Sprintf("MATCH (e:Entity) WHERE %s RETURN count(e)", nullPredicate), nil)
+		})
+		if err != nil {
+			return graphstore.BackfillEntityTypedPropertiesResult{}, fmt.Errorf("count entity typed-property backfill candidates: %w", err)
+		}
+		result.EntitiesMatched = uint32FromInt64(toInt64(value))
+		return result, nil
+	}
+
+	readCypher := fmt.Sprintf("MATCH (e:Entity) WHERE %s RETURN e.urn, coalesce(e.attributes_json, '') LIMIT $limit", nullPredicate)
+	const writeCypher = `UNWIND $rows AS row
+MATCH (e:Entity {urn: row.urn})
+SET e += row.typed_properties
+RETURN count(e)`
+	for {
+		processed, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+			readResult, err := tx.Run(ctx, readCypher, map[string]any{"limit": batchSize})
+			if err != nil {
+				return int64(0), err
+			}
+			type candidate struct {
+				urn   string
+				attrs string
+			}
+			var candidates []candidate
+			for readResult.Next(ctx) {
+				values := readResult.Record().Values
+				candidates = append(candidates, candidate{urn: stringValue(values[0]), attrs: stringValue(values[1])})
+			}
+			if err := readResult.Err(); err != nil {
+				return int64(0), err
+			}
+			if len(candidates) == 0 {
+				return int64(0), nil
+			}
+			rows := make([]map[string]any, 0, len(candidates))
+			for _, c := range candidates {
+				attributes, err := graphAttributesFromJSON(c.attrs)
+				if err != nil {
+					return int64(0), fmt.Errorf("decode attributes_json for %q: %w", c.urn, err)
+				}
+				rows = append(rows, map[string]any{
+					"urn":              c.urn,
+					"typed_properties": entityTypedPropertyParams(projectionmeta.DerivedEntityProperties(attributes)),
+				})
+			}
+			return countQuery(ctx, tx, writeCypher, map[string]any{"rows": rows})
+		})
+		if err != nil {
+			return graphstore.BackfillEntityTypedPropertiesResult{}, fmt.Errorf("backfill entity typed properties: %w", err)
+		}
+		written := toInt64(processed)
+		if written == 0 {
+			break
+		}
+		result.Batches++
+		result.EntitiesUpdated += uint32FromInt64(written)
+	}
+	result.EntitiesMatched = result.EntitiesUpdated
+	return result, nil
+}
+
 func integrityCheckDefinitions() ([]IntegrityCheck, []string) {
 	checks := []IntegrityCheck{
 		{Name: "tenant_mismatched_relations", Expected: 0},

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -14,6 +14,7 @@ import (
 	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/projectionmeta"
 
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -492,6 +493,109 @@ func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	}
 }
 
+func TestNeo4jDockerBackfillEntityTypedProperties(t *testing.T) {
+	if os.Getenv("CEREBRO_RUN_NEO4J_DOCKER") != "1" {
+		t.Skip("set CEREBRO_RUN_NEO4J_DOCKER=1 to run Neo4j Docker integration test")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker is not installed")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	port := freePort(t)
+	name := fmt.Sprintf("cerebro-neo4j-backfill-%d", time.Now().UnixNano())
+	password := "test-password"
+	image := os.Getenv("CEREBRO_NEO4J_DOCKER_IMAGE")
+	if image == "" {
+		image = "neo4j:5"
+	}
+	cmd := exec.CommandContext(ctx, "docker", "run", "-d", "--rm", "--name", name, // #nosec G204 G702 -- integration test invokes fixed docker binary with generated container arguments.
+		"-e", "NEO4J_AUTH=neo4j/"+password,
+		"-p", fmt.Sprintf("127.0.0.1:%d:7687", port),
+		image)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker run neo4j: %v\n%s", err, string(output))
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "rm", "-f", name).Run() // #nosec G204 -- integration test cleanup invokes fixed docker binary with generated container name.
+	})
+
+	store := waitForStore(t, ctx, config.GraphStoreConfig{
+		Neo4jURI:      fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		Neo4jUsername: "neo4j",
+		Neo4jPassword: password,
+	})
+	defer func() { _ = store.CloseContext(context.Background()) }()
+
+	seeds := []struct {
+		urn        string
+		entityType string
+		attributes map[string]string
+		want       projectionmeta.EntityTypedProperties
+	}{
+		{"urn:cerebro:writer:aws_network_interface:eni", "aws.network.interface", map[string]string{"internet_exposed": "true"}, projectionmeta.EntityTypedProperties{InternetExposed: true}},
+		{"urn:cerebro:writer:aws_user:admin", "aws.user", map[string]string{"is_admin": "true"}, projectionmeta.EntityTypedProperties{PrivilegedIdentity: true}},
+		{"urn:cerebro:writer:okta_user:nomfa", "okta.user", map[string]string{"mfa_enrolled": "false"}, projectionmeta.EntityTypedProperties{MFADisabled: true}},
+		{"urn:cerebro:writer:aws_s3_bucket:plain", "aws.s3.bucket", map[string]string{"team": "security"}, projectionmeta.EntityTypedProperties{}},
+	}
+	for _, seed := range seeds {
+		if err := store.UpsertProjectedEntity(ctx, &ports.ProjectedEntity{
+			URN:        seed.urn,
+			TenantID:   "writer",
+			SourceID:   "aws",
+			EntityType: seed.entityType,
+			Label:      seed.urn,
+			Attributes: seed.attributes,
+		}); err != nil {
+			t.Fatalf("UpsertProjectedEntity(%q) error = %v", seed.urn, err)
+		}
+	}
+
+	// Simulate pre-promotion nodes by clearing the typed properties the write path set.
+	if _, err := store.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		return consume(ctx, tx, fmt.Sprintf("MATCH (e:Entity) REMOVE e.%s, e.%s, e.%s",
+			projectionmeta.PropertyInternetExposed,
+			projectionmeta.PropertyPrivilegedIdentity,
+			projectionmeta.PropertyMFADisabled), nil)
+	}); err != nil {
+		t.Fatalf("clear typed properties: %v", err)
+	}
+
+	wantSeeds := uint32(len(seeds)) // #nosec G115 -- test fixture slice is statically bounded.
+	dryRun, err := store.BackfillEntityTypedProperties(ctx, graphstore.BackfillEntityTypedPropertiesRequest{DryRun: true})
+	if err != nil {
+		t.Fatalf("BackfillEntityTypedProperties(dry-run) error = %v", err)
+	}
+	if dryRun.EntitiesMatched != wantSeeds || dryRun.EntitiesUpdated != 0 || !dryRun.DryRun {
+		t.Fatalf("dry-run result = %#v, want %d matched and no updates", dryRun, wantSeeds)
+	}
+
+	applied, err := store.BackfillEntityTypedProperties(ctx, graphstore.BackfillEntityTypedPropertiesRequest{BatchSize: 2, DryRun: false})
+	if err != nil {
+		t.Fatalf("BackfillEntityTypedProperties(apply) error = %v", err)
+	}
+	if applied.EntitiesUpdated != wantSeeds || applied.Batches < 2 || applied.DryRun {
+		t.Fatalf("apply result = %#v, want %d updated across at least two batches", applied, wantSeeds)
+	}
+
+	for _, seed := range seeds {
+		got := projectedEntityTypedProperties(t, ctx, store, seed.urn)
+		if got != seed.want {
+			t.Fatalf("typed properties for %q = %#v, want %#v", seed.urn, got, seed.want)
+		}
+	}
+
+	after, err := store.BackfillEntityTypedProperties(ctx, graphstore.BackfillEntityTypedPropertiesRequest{DryRun: true})
+	if err != nil {
+		t.Fatalf("BackfillEntityTypedProperties(dry-run after) error = %v", err)
+	}
+	if after.EntitiesMatched != 0 {
+		t.Fatalf("dry-run after backfill matched %d entities, want 0", after.EntitiesMatched)
+	}
+}
+
 func projectedEntityAttributes(t *testing.T, ctx context.Context, store *Store, urn string) map[string]string {
 	t.Helper()
 	value, err := store.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
@@ -505,6 +609,39 @@ func projectedEntityAttributes(t *testing.T, ctx context.Context, store *Store, 
 		t.Fatalf("decode projected entity attributes: %v", err)
 	}
 	return attributes
+}
+
+func projectedEntityTypedProperties(t *testing.T, ctx context.Context, store *Store, urn string) projectionmeta.EntityTypedProperties {
+	t.Helper()
+	values, err := store.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
+		result, err := tx.Run(ctx, fmt.Sprintf("MATCH (e:Entity {urn: $urn}) RETURN e.%s, e.%s, e.%s",
+			projectionmeta.PropertyInternetExposed,
+			projectionmeta.PropertyPrivilegedIdentity,
+			projectionmeta.PropertyMFADisabled), map[string]any{"urn": urn})
+		if err != nil {
+			return nil, err
+		}
+		if !result.Next(ctx) {
+			return nil, result.Err()
+		}
+		return result.Record().Values, result.Err()
+	})
+	if err != nil {
+		t.Fatalf("query projected entity typed properties: %v", err)
+	}
+	row, ok := values.([]any)
+	if !ok || len(row) != 3 {
+		t.Fatalf("typed property query returned %#v, want three columns", values)
+	}
+	boolValue := func(v any) bool {
+		b, _ := v.(bool)
+		return b
+	}
+	return projectionmeta.EntityTypedProperties{
+		InternetExposed:    boolValue(row[0]),
+		PrivilegedIdentity: boolValue(row[1]),
+		MFADisabled:        boolValue(row[2]),
+	}
 }
 
 func projectedLinkAttributes(t *testing.T, ctx context.Context, store *Store, link *ports.ProjectedLink) map[string]string {

--- a/internal/graphstore/types.go
+++ b/internal/graphstore/types.go
@@ -42,6 +42,23 @@ type OpenFindingPrimaryLinkRepairResult struct {
 	DryRun       bool   `json:"dry_run"`
 }
 
+// BackfillEntityTypedPropertiesRequest scopes an idempotent pass that promotes the
+// typed boolean properties onto entities that predate the promotion and still hold
+// NULL values for them.
+type BackfillEntityTypedPropertiesRequest struct {
+	BatchSize uint32
+	DryRun    bool
+}
+
+// BackfillEntityTypedPropertiesResult reports how many entities still needed the
+// typed-property backfill and how many were updated.
+type BackfillEntityTypedPropertiesResult struct {
+	EntitiesMatched uint32 `json:"entities_matched"`
+	EntitiesUpdated uint32 `json:"entities_updated"`
+	Batches         uint32 `json:"batches"`
+	DryRun          bool   `json:"dry_run"`
+}
+
 // PathPattern captures one grouped two-hop graph pattern.
 type PathPattern struct {
 	FromType       string `json:"from_type"`


### PR DESCRIPTION
## Summary

Adds an idempotent `cerebro graph backfill-entity-typed-properties` command (and the backing `Store.BackfillEntityTypedProperties` method) that promotes the typed boolean properties (`internet_exposed`, `is_privileged_identity`, `mfa_disabled`) onto Entity nodes that predate the typed-property promotion and still carry `NULL` values for them.

### Why

The hot cloud/identity graph rules seek the `(tenant_id, <typed prop>)` range indexes when the typed property is set, but fall back to a substring scan of `attributes_json` (gated on `<prop> IS NULL`) when it is not. Typed properties are only written when an entity is re-projected, so full-snapshot sources repopulate them but delta/audit-sourced identities can stay `NULL` indefinitely, permanently stuck on the slow fallback path. This backfill populates those nodes so the rules use the index seek, and it is the prerequisite for later removing the `IS NULL` fallback entirely (a follow-up).

### How it stays correct

The backfill derives each node's typed properties from its stored `attributes_json` using the **exact same code the projection write path uses**: `graphAttributesFromJSON` + `projectionmeta.DerivedEntityProperties` + `entityTypedPropertyParams`. It does not re-implement the derivation in Cypher, so a backfilled value can never drift from what a re-projection would write (case-sensitive `internet_exposed`; lower-cased `is_privileged_identity`/`mfa_disabled`; the narrow key/value equality semantics, not the broader Go truthy helpers or the rule's defensive bare-bool arms).

It processes candidates in batches (`MATCH (e:Entity) WHERE <any typed prop> IS NULL ... LIMIT $batch_size`), writing derived values via `UNWIND ... SET e += row.typed_properties`. Because each write flips a node's properties from `NULL` to concrete booleans, the candidate set shrinks every batch and the loop terminates. It is fully idempotent and safe to re-run.

### Usage / safety

- `cerebro graph backfill-entity-typed-properties` (defaults to `dry_run=true`, reporting the candidate count).
- `cerebro graph backfill-entity-typed-properties apply=true [batch_size=N]` to write (mirrors the `apply=true` safety gate used by `repair-open-finding-primary-links`; `apply=true` conflicts with `dry_run=true`).

This is additive: the rule fallback predicates are unchanged, so behavior is identical before and after the backfill runs, except that backfilled nodes now use the index seek.

## Test Plan

- `go build ./...`, `go vet ./cmd/cerebro/ ./internal/graphstore/...` — clean.
- `gofmt -l` clean; `golangci-lint run ./cmd/cerebro/... ./internal/graphstore/...` — 0 issues.
- `make check-structural`, `make check-arch` — pass.
- `go test ./cmd/cerebro/ ./internal/graphstore/...` — pass (arg-parser gating tests, dispatch/forwarding test against the in-memory store).
- Live integration (`CEREBRO_RUN_NEO4J_DOCKER=1 go test ./internal/graphstore/neo4j/ -run TestNeo4jDockerBackfillEntityTypedProperties`): seeds four entities, clears their typed properties to simulate pre-promotion nodes, then asserts dry-run counts all four, apply updates all four across multiple batches (`batch_size=2`), each node ends with typed properties exactly equal to `DerivedEntityProperties(attributes)`, and a second dry-run finds zero remaining. PASS.

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Backfill derivation reuses the projection write path's functions verbatim, so review should confirm there is no second, drifting derivation. The Cypher only selects candidates and applies the precomputed property map.
- Operational note: a follow-up PR will reduce the rule predicates to the sargable `<prop> = true` form (dropping the `IS NULL` substring fallback). That follow-up must not be deployed until this backfill has been run to completion in every environment (a second dry-run reporting `entities_matched: 0`), otherwise un-backfilled nodes would silently drop out of detection.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->