### PR TITLE
[codex] Add monitored computer coverage

### DIFF
--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -2,6 +2,7 @@ package sourceprojection
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -9,6 +10,14 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+var grcMonitoredComputerEndpointProfile = endpointProjectionProfile{
+	Provider:          "vanta",
+	EndpointKind:      "grc_monitored_computer",
+	EndpointType:      "grc.monitored_computer",
+	EndpointIDKeys:    []string{"device_id", "computer_id", "device_uuid", "serial_number", "external_id"},
+	EndpointLabelKeys: []string{"hostname", "owner_display_name", "serial_number", "device_uuid", "computer_id"},
+}
 
 func grcFrameworkProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return grcPolicyLikeProjections(event, "framework", "framework_id", []string{"display_name", "name", "framework_id"})
@@ -1175,6 +1184,77 @@ func grcPackageTargetAttributes(event *cerebrov1.EventEnvelope, attrs map[string
 		"version":       firstAttribute(attrs, "version", "package_version", "application_version", "installed_version"),
 		"source_system": firstAttribute(attrs, "source_system", "provider", "source_provider"),
 	}
+}
+
+func grcMonitoredComputerProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	computerID := firstAttribute(attrs, "computer_id", "device_id", "external_id")
+	if computerID == "" {
+		return nil, nil, nil
+	}
+	provider := grcProvider(attrs)
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	endpointURN := addEndpointEntity(entities, tenantID, event.GetSourceId(), attrs, grcMonitoredComputerEndpointProfile)
+	addEndpointOwnerLinks(entities, links, tenantID, event.GetSourceId(), event, endpointURN, attrs)
+	addEndpointIdentifierLinks(entities, links, tenantID, event.GetSourceId(), event, endpointURN, attrs)
+	if integrationID := firstAttribute(attrs, "integration_id"); endpointURN != "" && integrationID != "" {
+		integrationURN := grcIntegrationURN(tenantID, provider, integrationID)
+		addEntity(entities, grcIntegrationReferenceEntity(tenantID, event.GetSourceId(), integrationURN, integrationID, provider))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), endpointURN, integrationURN, relationBelongsTo, map[string]string{
+			"event_id":   event.GetId(),
+			"match_type": "grc_monitored_computer_integration",
+		}))
+	}
+	for _, check := range []struct {
+		ID     string
+		Title  string
+		Status string
+	}{
+		{ID: "screenlock", Title: "Screen lock", Status: firstAttribute(attrs, "screenlock_status")},
+		{ID: "disk_encryption", Title: "Disk encryption", Status: firstAttribute(attrs, "disk_encryption_status")},
+		{ID: "password_manager", Title: "Password manager", Status: firstAttribute(attrs, "password_manager_status")},
+		{ID: "antivirus", Title: "Antivirus", Status: firstAttribute(attrs, "antivirus_status")},
+	} {
+		addGRCMonitoredComputerPostureEvidence(entities, links, tenantID, event.GetSourceId(), event, endpointURN, provider, computerID, check.ID, check.Title, check.Status)
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func addGRCMonitoredComputerPostureEvidence(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, endpointURN string, provider string, computerID string, checkID string, title string, status string) {
+	status = strings.TrimSpace(status)
+	if endpointURN == "" || computerID == "" || checkID == "" || status == "" {
+		return
+	}
+	evidenceURN := projectionURN(tenantID, "evidence", provider, "monitored_computer", computerID, checkID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        evidenceURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "evidence",
+		Label:      fmt.Sprintf("%s posture: %s", title, computerID),
+		Attributes: grcAttributes(nil, map[string]string{
+			"computer_id":        computerID,
+			"evidence_type":      "device_posture",
+			"posture_check":      checkID,
+			"posture_check_name": title,
+			"source_system":      provider,
+			"status":             status,
+		}),
+	})
+	linkAttrs := map[string]string{
+		"event_id":       event.GetId(),
+		"match_type":     "grc_monitored_computer_posture",
+		"posture_check":  checkID,
+		"posture_status": status,
+	}
+	addLink(links, projectedLink(tenantID, sourceID, endpointURN, evidenceURN, relationHasEvidence, linkAttrs))
+	addLink(links, projectedLink(tenantID, sourceID, evidenceURN, endpointURN, relationObservedOn, linkAttrs))
 }
 
 func grcRiskScenarioProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -1326,3 +1326,53 @@ func TestProjectGRCVulnerabilityDoesNotRegressIntegrationLabel(t *testing.T) {
 	}
 	t.Fatalf("target belongs_to integration link missing: %#v", links)
 }
+
+func TestProjectGRCMonitoredComputerLinksPostureEvidence(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-monitored-computer-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.monitored_computer",
+		Attributes: map[string]string{
+			"provider":                "vanta",
+			"computer_id":             "computer-1",
+			"device_id":               "computer-1",
+			"device_uuid":             "udid-1",
+			"serial_number":           "serial-1",
+			"integration_id":          "kandji",
+			"owner_email":             "designer@example.com",
+			"owner_id":                "person-1",
+			"screenlock_status":       "OK",
+			"disk_encryption_status":  "OK",
+			"password_manager_status": "NEEDS_ATTENTION",
+			"antivirus_status":        "OK",
+			"compliance_status":       "needs_attention",
+			"os":                      "MACOS",
+			"os_version":              "15.5",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	endpointURN := "urn:cerebro:writer:grc_monitored_computer:computer-1"
+	identityURN := "urn:cerebro:writer:identity:email:designer@example.com"
+	integrationURN := "urn:cerebro:writer:source:vanta:integration:kandji"
+	evidenceURN := "urn:cerebro:writer:evidence:vanta:monitored_computer:computer-1:password_manager"
+	if entity := state.entities[endpointURN]; entity == nil || entity.EntityType != "grc.monitored_computer" {
+		t.Fatalf("endpoint entity missing: %#v", entity)
+	}
+	if got := state.entities[endpointURN].Attributes["compliance_status"]; got != "needs_attention" {
+		t.Fatalf("endpoint compliance_status = %q, want needs_attention", got)
+	}
+	if entity := state.entities[evidenceURN]; entity == nil || entity.Attributes["posture_check"] != "password_manager" || entity.Attributes["status"] != "NEEDS_ATTENTION" {
+		t.Fatalf("password manager evidence missing or incomplete: %#v", entity)
+	}
+	assertProjectedLink(t, state, endpointURN, relationOwnedBy, identityURN)
+	assertProjectedLink(t, state, endpointURN, relationBelongsTo, integrationURN)
+	assertProjectedLink(t, state, endpointURN, relationHasEvidence, evidenceURN)
+	assertProjectedLink(t, state, evidenceURN, relationObservedOn, endpointURN)
+}

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -588,6 +588,7 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"grc.vendor":                                    grcVendorProjections,
 	"grc.vulnerability":                             grcVulnerabilityProjections,
 	"grc.vulnerable_asset":                          grcVulnerableAssetProjections,
+	"grc.monitored_computer":                        grcMonitoredComputerProjections,
 	"grc.risk_scenario":                             grcRiskScenarioProjections,
 	"grc.person":                                    grcPersonProjections,
 	"grc.user":                                      grcUserProjections,

--- a/sources/grc/attributes.go
+++ b/sources/grc/attributes.go
@@ -139,6 +139,27 @@ func attributesFor(settings settings, family string, record grcRecord) map[strin
 		copyFirstField(attrs, values, "last_detected_at", "lastDetectedDate", "lastSeenDate", "updatedAt")
 		copyVulnerableAssetPlatformReferences(attrs, values)
 		copyVulnerableAssetReferences(attrs, values)
+	case familyMonitoredComputer:
+		copyFields(attrs, values, map[string]string{
+			"computer_id":             "id",
+			"device_id":               "id",
+			"device_uuid":             "udid",
+			"serial_number":           "serialNumber",
+			"integration_id":          "integrationId",
+			"last_check_at":           "lastCheckDate",
+			"screenlock_status":       "screenlock.outcome",
+			"disk_encryption_status":  "diskEncryption.outcome",
+			"password_manager_status": "passwordManager.outcome",
+			"antivirus_status":        "antivirusInstallation.outcome",
+			"os":                      "operatingSystem.type",
+			"os_name":                 "operatingSystem.type",
+			"os_version":              "operatingSystem.version",
+			"owner_id":                "owner.id",
+			"owner_email":             "owner.emailAddress",
+			"owner_display_name":      "owner.displayName",
+		})
+		attrs["source_product"] = "vanta"
+		attrs["compliance_status"] = monitoredComputerComplianceStatus(attrs)
 	case familyRiskScenario:
 		copyFields(attrs, values, map[string]string{
 			"risk_id":             "riskId",
@@ -190,6 +211,26 @@ func attributesFor(settings settings, family string, record grcRecord) map[strin
 		attrs["connection_error_count"] = strconv.Itoa(countConnections(values, false, true))
 	}
 	return trimEmpty(attrs)
+}
+
+func monitoredComputerComplianceStatus(attrs map[string]string) string {
+	statuses := []string{
+		attrs["screenlock_status"],
+		attrs["disk_encryption_status"],
+		attrs["password_manager_status"],
+		attrs["antivirus_status"],
+	}
+	for _, status := range statuses {
+		if strings.EqualFold(strings.TrimSpace(status), "FAIL") || strings.EqualFold(strings.TrimSpace(status), "NEEDS_ATTENTION") {
+			return "needs_attention"
+		}
+	}
+	for _, status := range statuses {
+		if trimmed := strings.TrimSpace(status); trimmed != "" && !strings.EqualFold(trimmed, "OK") && !strings.EqualFold(trimmed, "PASS") {
+			return strings.ToLower(trimmed)
+		}
+	}
+	return "ok"
 }
 
 func copyFields(attrs map[string]string, values map[string]any, mapping map[string]string) {

--- a/sources/grc/catalog.yaml
+++ b/sources/grc/catalog.yaml
@@ -16,6 +16,7 @@ emitted_kinds:
   - grc.vendor
   - grc.vulnerability
   - grc.vulnerable_asset
+  - grc.monitored_computer
   - grc.risk_scenario
   - grc.person
   - grc.user
@@ -75,6 +76,10 @@ event_contracts:
       - family
   - kind: grc.vulnerable_asset
     schema_ref: grc/vulnerable_asset/v1
+    required_attributes:
+      - family
+  - kind: grc.monitored_computer
+    schema_ref: grc/monitored_computer/v1
     required_attributes:
       - family
   - kind: grc.risk_scenario
@@ -201,6 +206,14 @@ coverage_contract:
       high_value: true
       evidence_types: [relationship_evidence, vulnerability_management]
       control_domains: [vulnerability_management]
+    - id: monitored_computers
+      type: entity_family
+      title: Monitored endpoint computers
+      families: [monitored_computer]
+      support: supported
+      high_value: true
+      evidence_types: [device_posture, configuration_state]
+      control_domains: [endpoint_security, device_management]
     - id: risk_scenarios
       type: entity_family
       title: Risk scenarios

--- a/sources/grc/settings.go
+++ b/sources/grc/settings.go
@@ -107,6 +107,7 @@ func supportedFamilies() []string {
 		familyVendor,
 		familyVulnerability,
 		familyVulnerableAsset,
+		familyMonitoredComputer,
 		familyRiskScenario,
 		familyPerson,
 		familyUser,

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -27,28 +27,29 @@ import (
 var catalogFS embed.FS
 
 const (
-	sourceID              = "grc"
-	defaultProvider       = "vanta"
-	defaultBaseURL        = "https://api.vanta.com"
-	defaultReadScope      = "vanta-api.all:read"
-	defaultPageSize       = 10
-	maxPageSize           = 100
-	httpTimeout           = 30 * time.Second
-	maxBodyBytes          = 8 << 20
-	tokenRefreshLeeway    = time.Minute
-	defaultFamily         = familyControlTest
-	familyFramework       = "framework"
-	familyControl         = "control"
-	familyControlTest     = "control_test"
-	familyPolicy          = "policy"
-	familyDocument        = "document"
-	familyVendor          = "vendor"
-	familyVulnerability   = "vulnerability"
-	familyVulnerableAsset = "vulnerable_asset"
-	familyRiskScenario    = "risk_scenario"
-	familyPerson          = "person"
-	familyUser            = "user"
-	familyIntegration     = "integration"
+	sourceID                = "grc"
+	defaultProvider         = "vanta"
+	defaultBaseURL          = "https://api.vanta.com"
+	defaultReadScope        = "vanta-api.all:read"
+	defaultPageSize         = 10
+	maxPageSize             = 100
+	httpTimeout             = 30 * time.Second
+	maxBodyBytes            = 8 << 20
+	tokenRefreshLeeway      = time.Minute
+	defaultFamily           = familyControlTest
+	familyFramework         = "framework"
+	familyControl           = "control"
+	familyControlTest       = "control_test"
+	familyPolicy            = "policy"
+	familyDocument          = "document"
+	familyVendor            = "vendor"
+	familyVulnerability     = "vulnerability"
+	familyVulnerableAsset   = "vulnerable_asset"
+	familyMonitoredComputer = "monitored_computer"
+	familyRiskScenario      = "risk_scenario"
+	familyPerson            = "person"
+	familyUser              = "user"
+	familyIntegration       = "integration"
 )
 
 // Source is the provider-neutral GRC source. Provider-specific APIs are kept
@@ -137,6 +138,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 		s.family(familyVendor, "/v1/vendors"),
 		s.family(familyVulnerability, "/v1/vulnerabilities"),
 		s.family(familyVulnerableAsset, "/v1/vulnerable-assets"),
+		s.family(familyMonitoredComputer, "/v1/monitored-computers"),
 		s.family(familyRiskScenario, "/v1/risk-scenarios"),
 		s.family(familyPerson, "/v1/people"),
 		s.family(familyUser, "/v1/users"),
@@ -360,6 +362,8 @@ func recordIDKeys(family string) []string {
 		return []string{"id", "email"}
 	case familyVulnerableAsset:
 		return []string{"id", "assetId", "targetId", "externalId", "name"}
+	case familyMonitoredComputer:
+		return []string{"id", "serialNumber", "udid"}
 	default:
 		return []string{"id", "externalId", "name"}
 	}
@@ -401,6 +405,8 @@ func timestampKeys(family string) []string {
 		return []string{"lastDetectedDate", "sourceDetectedDate", "firstDetectedDate"}
 	case familyVulnerableAsset:
 		return []string{"lastDetectedDate", "lastSeenDate", "updatedAt"}
+	case familyMonitoredComputer:
+		return []string{"lastCheckDate"}
 	case familyRiskScenario:
 		return []string{"identificationDate"}
 	case familyPerson:

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -414,6 +414,51 @@ func TestReadVantaVulnerableAssetNormalizesFields(t *testing.T) {
 	}
 }
 
+func TestReadVantaMonitoredComputerNormalizesPostureFields(t *testing.T) {
+	server := httptest.NewServer(newTestAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := testConfig(server.URL, familyMonitoredComputer)
+
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(monitored_computer) error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Read(monitored_computer).Events) = %d, want 1", len(pull.Events))
+	}
+	event := pull.Events[0]
+	if event.Kind != "grc.monitored_computer" {
+		t.Fatalf("event kind = %q, want grc.monitored_computer", event.Kind)
+	}
+	attrs := event.Attributes
+	for key, want := range map[string]string{
+		"computer_id":             "computer-1",
+		"device_id":               "computer-1",
+		"device_uuid":             "udid-1",
+		"serial_number":           "serial-1",
+		"integration_id":          "kandji",
+		"screenlock_status":       "OK",
+		"disk_encryption_status":  "OK",
+		"password_manager_status": "NEEDS_ATTENTION",
+		"antivirus_status":        "OK",
+		"os":                      "MACOS",
+		"os_version":              "15.5",
+		"owner_id":                "person-1",
+		"owner_email":             "designer@example.com",
+		"compliance_status":       "needs_attention",
+	} {
+		if got := attrs[key]; got != want {
+			t.Fatalf("Attributes[%q] = %q, want %q", key, got, want)
+		}
+	}
+}
+
 func TestJoinedVulnerableAssetReferencesZipsFlatFields(t *testing.T) {
 	raw := joinedVulnerableAssetReferences(map[string]any{
 		"vulnerabilityIds":   []any{"CVE-2026-4242", "CVE-2026-4243"},
@@ -853,6 +898,21 @@ func newTestAPIHandler(t *testing.T) http.Handler {
 					"packageIdentifier": "pkg:golang/example/module@1.2.3",
 				}},
 				"lastSeenDate": "2026-05-11T00:00:00Z",
+			}})
+		case "/v1/monitored-computers":
+			requireBearer(t, r)
+			writePage(t, w, false, "", []map[string]any{{
+				"id":                    "computer-1",
+				"integrationId":         "kandji",
+				"lastCheckDate":         "2026-06-24T17:00:00Z",
+				"screenlock":            map[string]any{"outcome": "OK"},
+				"diskEncryption":        map[string]any{"outcome": "OK"},
+				"passwordManager":       map[string]any{"outcome": "NEEDS_ATTENTION"},
+				"antivirusInstallation": map[string]any{"outcome": "OK"},
+				"operatingSystem":       map[string]any{"type": "MACOS", "version": "15.5"},
+				"owner":                 map[string]any{"id": "person-1", "displayName": "Designer One", "emailAddress": "designer@example.com"},
+				"serialNumber":          "serial-1",
+				"udid":                  "udid-1",
 			}})
 		case "/v1/tests":
 			requireBearer(t, r)


### PR DESCRIPTION
## Summary

Adds monitored endpoint computers as a first-class GRC family so endpoint posture data can participate in the same source catalog, coverage contract, and graph projection paths as controls, tests, vulnerabilities, vendors, and evidence.

## What changed

- Added `grc.monitored_computer` ingestion with normalized device, owner, OS, integration, and posture attributes.
- Added source catalog coverage for monitored endpoint computers under endpoint security and device management domains.
- Added graph projection for monitored computers, including endpoint identity links, owner links, integration links, and posture evidence for screen lock, disk encryption, password manager, and antivirus checks.
- Added ingestion and projection tests using an API-shaped fixture.

## Why

The comparison pass showed monitored computers as a high-value compliance surface that was not represented in Cerebro. Pulling it into the source family and projection model gives audit readiness richer endpoint posture evidence instead of only dashboard-level summaries.

## Validation

- `go test ./sources/grc ./internal/sourceprojection ./tools/catalogcheck -count=1`
- `make catalog-check`
- `make sourcegen-check`
- `go test ./internal/compliance ./internal/findings ./internal/sourcecoverage ./internal/sourceprojection ./sources/grc ./tools/catalogcheck -count=1`
- `make lint`
- Narrow credential scan: no generated credential pattern found in the repo; one existing `vcs_url` field-name false positive only.
