### PR TITLE
feat: add entity typed-property completeness integrity check

### DIFF
--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -394,10 +394,7 @@ func (s *Store) BackfillEntityTypedProperties(ctx context.Context, request graph
 	if batchSize <= 0 {
 		batchSize = defaultEntityTypedPropertyBackfillBatchSize
 	}
-	nullPredicate := fmt.Sprintf("e.%s IS NULL OR e.%s IS NULL OR e.%s IS NULL",
-		projectionmeta.PropertyInternetExposed,
-		projectionmeta.PropertyPrivilegedIdentity,
-		projectionmeta.PropertyMFADisabled)
+	nullPredicate := entityMissingTypedPropertiesPredicate()
 	result := graphstore.BackfillEntityTypedPropertiesResult{DryRun: request.DryRun}
 
 	if request.DryRun {
@@ -464,6 +461,16 @@ RETURN count(e)`
 	return result, nil
 }
 
+// entityMissingTypedPropertiesPredicate matches Entity nodes left with NULL typed properties from
+// before the typed-property promotion. It is shared by the backfill candidate scan and the
+// integrity check so the "must be zero once backfilled" invariant cannot drift. Bound to `e`.
+func entityMissingTypedPropertiesPredicate() string {
+	return fmt.Sprintf("e.%s IS NULL OR e.%s IS NULL OR e.%s IS NULL",
+		projectionmeta.PropertyInternetExposed,
+		projectionmeta.PropertyPrivilegedIdentity,
+		projectionmeta.PropertyMFADisabled)
+}
+
 func integrityCheckDefinitions() ([]IntegrityCheck, []string) {
 	checks := []IntegrityCheck{
 		{Name: "tenant_mismatched_relations", Expected: 0},
@@ -477,6 +484,7 @@ func integrityCheckDefinitions() ([]IntegrityCheck, []string) {
 		{Name: "github_workflow_job_runners_projected_as_assets", Expected: 0},
 		{Name: "sentinelone_activity_events_projected_as_assets", Expected: 0},
 		{Name: "ephemeral_event_entities_projected_as_inventory", Expected: 0},
+		{Name: "entities_missing_typed_properties", Expected: 0},
 	}
 	queries := []string{
 		"MATCH (src:Entity)-[r:RELATION]->(dst:Entity) WHERE src.tenant_id <> dst.tenant_id OR src.tenant_id <> r.tenant_id OR dst.tenant_id <> r.tenant_id RETURN count(r)",
@@ -490,6 +498,7 @@ func integrityCheckDefinitions() ([]IntegrityCheck, []string) {
 		"MATCH (e:Entity {entity_type: 'github.runner'}) WHERE coalesce(e.attributes_json, '') CONTAINS '\"action\":\"workflows.' RETURN count(e)",
 		"MATCH (e:Entity {entity_type: 'sentinelone.activity'}) RETURN count(e)",
 		"MATCH (e:Entity) WHERE coalesce(e.attributes_json, '') CONTAINS '\"projection_class\":\"ephemeral_event\"' RETURN count(e)",
+		fmt.Sprintf("MATCH (e:Entity) WHERE %s RETURN count(e)", entityMissingTypedPropertiesPredicate()),
 	}
 	return checks, queries
 }

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -215,6 +215,30 @@ func TestIntegrityChecksIncludeGenericEphemeralEventInvariant(t *testing.T) {
 	t.Fatalf("integrity checks missing generic ephemeral event invariant: %#v", checks)
 }
 
+func TestIntegrityChecksIncludeMissingTypedPropertiesInvariant(t *testing.T) {
+	checks, queries := integrityCheckDefinitions()
+	if len(checks) != len(queries) {
+		t.Fatalf("integrity check definitions have %d checks and %d queries", len(checks), len(queries))
+	}
+	for i, check := range checks {
+		if check.Name != "entities_missing_typed_properties" {
+			continue
+		}
+		query := queries[i]
+		for _, expected := range []string{
+			projectionmeta.PropertyInternetExposed + " IS NULL",
+			projectionmeta.PropertyPrivilegedIdentity + " IS NULL",
+			projectionmeta.PropertyMFADisabled + " IS NULL",
+		} {
+			if !strings.Contains(query, expected) {
+				t.Fatalf("missing typed properties integrity query missing %q:\n%s", expected, query)
+			}
+		}
+		return
+	}
+	t.Fatalf("integrity checks missing typed property backfill invariant: %#v", checks)
+}
+
 func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	if os.Getenv("CEREBRO_RUN_NEO4J_DOCKER") != "1" {
 		t.Skip("set CEREBRO_RUN_NEO4J_DOCKER=1 to run Neo4j Docker integration test")


### PR DESCRIPTION
## Summary

Adds an `entities_missing_typed_properties` integrity check that counts `:Entity` nodes still carrying NULL typed properties (`internet_exposed`, `is_privileged_identity`, `mfa_disabled`), expected `0`.

Why: the typed-property promotion only writes these properties when an entity is (re)projected, so nodes that predate the promotion keep them NULL. Profiling the `internet_exposed` rule predicate against 3,015 resources (15 truly exposed) showed the cost of that NULL state and, more importantly, why it is dangerous to remove the `attributes_json` fallback before it is cleared:

- Pre-backfill, fallback required: **13,284** db hits (full `NodeByLabelScan` + JSON `CONTAINS`).
- Backfill only, fallback kept: **7,284** db hits (the non-sargable `IS NULL` branch still forces a scan).
- Backfill + sargable predicate: **16** db hits (~830x fewer).

The order-of-magnitude win comes from dropping the fallback, but doing so before every node is backfilled would silently drop un-backfilled entities from detections (`<prop> = true` is NULL-blind). This check turns "did the backfill finish everywhere?" into an observable invariant (`cerebro graph integrity` green) and a hard deploy gate for that follow-up, and catches any regression that reintroduces NULL typed properties.

The check shares one predicate helper (`entityMissingTypedPropertiesPredicate`) with `BackfillEntityTypedProperties` so the candidate scan and the invariant cannot drift.

## Test Plan

- `gofmt -l`, `go build ./...`, `go vet ./internal/graphstore/neo4j/` clean.
- `go test ./internal/graphstore/neo4j/ ./cmd/cerebro/` pass (new `TestIntegrityChecksIncludeMissingTypedPropertiesInvariant` included).
- Live `CEREBRO_RUN_NEO4J_DOCKER=1` integration (`TestNeo4jDockerProjectionAndQueries`): the new check reads `0` on a store written through `UpsertProjectedEntity` (test progresses past the `IntegrityChecks` assertion). A pre-existing, unrelated delete-count assertion in that gated test fails identically on clean `main`.
- `make check-structural check-arch` pass; `make lint` reports `0 issues`.

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->