### PR TITLE
[codex] optimize trends and query cache

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -371,20 +372,33 @@ func (a *App) handleGRCTrends(w http.ResponseWriter, r *http.Request) {
 		Severity:  params.Severity,
 		Framework: params.Framework,
 	}
-	trends, err := a.grcFindingTrends(r, runtimes, start, end, params.Interval, filter)
-	if err != nil {
+	var trends *ports.GRCFindingTrends
+	var previous *ports.GRCFindingTrends
+	var comparison *grctrends.Comparison
+	var previousStart time.Time
+	var previousEnd time.Time
+	if params.Compare {
+		previousEnd = start
+		previousStart = previousEnd.Add(end.Sub(start) * -1)
+	}
+	group, trendsCtx := errgroup.WithContext(r.Context())
+	group.Go(func() error {
+		var err error
+		trends, err = a.grcFindingTrends(r.WithContext(trendsCtx), runtimes, start, end, params.Interval, filter)
+		return err
+	})
+	if params.Compare {
+		group.Go(func() error {
+			var err error
+			previous, err = a.grcFindingTrends(r.WithContext(trendsCtx), runtimes, previousStart, previousEnd, params.Interval, filter)
+			return err
+		})
+	}
+	if err := group.Wait(); err != nil {
 		writeGRCError(w, err)
 		return
 	}
-	var comparison *grctrends.Comparison
 	if params.Compare {
-		previousEnd := start
-		previousStart := previousEnd.Add(end.Sub(start) * -1)
-		previous, err := a.grcFindingTrends(r, runtimes, previousStart, previousEnd, params.Interval, filter)
-		if err != nil {
-			writeGRCError(w, err)
-			return
-		}
 		comparison = grctrends.BuildComparison(previous, trends, previousStart, previousEnd)
 	}
 	writeJSON(w, http.StatusOK, grctrends.Response{
@@ -393,6 +407,7 @@ func (a *App) handleGRCTrends(w http.ResponseWriter, r *http.Request) {
 		End:          end,
 		Points:       grctrends.BuildPoints(trends),
 		AgingBuckets: grctrends.BuildAgingBuckets(trends),
+		Summary:      grctrends.BuildSummary(trends),
 		Targets:      grctrends.BuildTargets(params.TargetParams),
 		Comparison:   comparison,
 		Accuracy: grctrends.Accuracy{

--- a/internal/bootstrap/grc_cache.go
+++ b/internal/bootstrap/grc_cache.go
@@ -32,6 +32,10 @@ type queryCacheRefreshGroup struct {
 	group singleflight.Group
 }
 
+type queryCacheVersionBatcher interface {
+	Versions(context.Context, []string) (map[string]string, error)
+}
+
 func (g *queryCacheRefreshGroup) Do(key string, fn func() (*capturedHTTPResponse, error)) (*capturedHTTPResponse, error) {
 	value, err, _ := g.group.Do(key, func() (any, error) {
 		return fn()
@@ -162,6 +166,20 @@ func (a *App) grcCacheVersions(r *http.Request, tenantID string, scopes []string
 	}
 	sort.Strings(versionScopes)
 	versions := map[string]string{}
+	if batcher, ok := cache.(queryCacheVersionBatcher); ok {
+		batched, err := batcher.Versions(r.Context(), versionScopes)
+		if err == nil {
+			for _, scope := range versionScopes {
+				version := strings.TrimSpace(batched[scope])
+				if version == "" {
+					version = "0"
+				}
+				versions[scope] = version
+			}
+			return versions
+		}
+		log.Printf("grc: cache version batch failed: %v", err)
+	}
 	for _, scope := range versionScopes {
 		version, err := cache.Version(r.Context(), scope)
 		if err != nil || strings.TrimSpace(version) == "" {

--- a/internal/grctrends/trends.go
+++ b/internal/grctrends/trends.go
@@ -11,7 +11,10 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"golang.org/x/sync/errgroup"
 )
+
+const mergeTenantConcurrency = 4
 
 type RequestParams struct {
 	Interval  string
@@ -226,6 +229,21 @@ type Comparison struct {
 	ClosedSLABreachedDelta     int       `json:"closed_sla_breached_delta"`
 }
 
+type Summary struct {
+	TotalOpened           int     `json:"total_opened"`
+	TotalClosed           int     `json:"total_closed"`
+	Net                   int     `json:"net"`
+	CurrentOpen           int     `json:"current_open"`
+	PeakOpen              int     `json:"peak_open"`
+	OpenedCritical        int     `json:"opened_critical"`
+	OpenedHigh            int     `json:"opened_high"`
+	ClosedCritical        int     `json:"closed_critical"`
+	ClosedHigh            int     `json:"closed_high"`
+	ClosedSLABreached     int     `json:"closed_sla_breached"`
+	AvgTimeToCloseSeconds float64 `json:"avg_time_to_close_seconds"`
+	ClosedSLABreachedRate float64 `json:"closed_sla_breached_rate"`
+}
+
 type Accuracy struct {
 	StatusHistory string `json:"status_history"`
 	Caveat        string `json:"caveat"`
@@ -237,6 +255,7 @@ type Response struct {
 	End          time.Time     `json:"end"`
 	Points       []Point       `json:"points"`
 	AgingBuckets []AgingBucket `json:"aging_buckets"`
+	Summary      Summary       `json:"summary"`
 	Targets      Targets       `json:"targets,omitempty"`
 	Comparison   *Comparison   `json:"comparison,omitempty"`
 	Accuracy     Accuracy      `json:"accuracy"`
@@ -301,6 +320,24 @@ func BuildTargets(params TargetParams) Targets {
 	return targets
 }
 
+func BuildSummary(trends *ports.GRCFindingTrends) Summary {
+	values := summarize(trends)
+	return Summary{
+		TotalOpened:           values.Opened,
+		TotalClosed:           values.Closed,
+		Net:                   values.Opened - values.Closed,
+		CurrentOpen:           values.CurrentOpen,
+		PeakOpen:              values.PeakOpen,
+		OpenedCritical:        values.OpenedCritical,
+		OpenedHigh:            values.OpenedHigh,
+		ClosedCritical:        values.ClosedCritical,
+		ClosedHigh:            values.ClosedHigh,
+		ClosedSLABreached:     values.ClosedSLABreached,
+		AvgTimeToCloseSeconds: values.AvgTimeToCloseSeconds,
+		ClosedSLABreachedRate: rate(values.ClosedSLABreached, values.Closed),
+	}
+}
+
 func BuildComparison(previous *ports.GRCFindingTrends, current *ports.GRCFindingTrends, previousStart time.Time, previousEnd time.Time) *Comparison {
 	prev := summarize(previous)
 	next := summarize(current)
@@ -328,24 +365,47 @@ func Merge(ctx context.Context, provider Provider, runtimes []*cerebrov1.SourceR
 		}
 		runtimeIDsByTenant[tenantID] = append(runtimeIDsByTenant[tenantID], runtimeID)
 	}
+	tenantIDs := make([]string, 0, len(runtimeIDsByTenant))
+	for tenantID, runtimeIDs := range runtimeIDsByTenant {
+		sort.Strings(runtimeIDs)
+		runtimeIDsByTenant[tenantID] = runtimeIDs
+		tenantIDs = append(tenantIDs, tenantID)
+	}
+	sort.Strings(tenantIDs)
+
+	results := make([]ports.GRCFindingTrends, len(tenantIDs))
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(mergeTenantConcurrency)
+	for index, tenantID := range tenantIDs {
+		index, tenantID := index, tenantID
+		runtimeIDs := append([]string(nil), runtimeIDsByTenant[tenantID]...)
+		group.Go(func() error {
+			trends, err := provider.SummarizeGRCFindingTrends(groupCtx, ports.GRCFindingTrendsRequest{
+				FindingRequest: ports.ListFindingsRequest{
+					TenantID:   tenantID,
+					RuntimeIDs: runtimeIDs,
+					Severity:   filter.Severity,
+					Framework:  filter.Framework,
+				},
+				Start:    start,
+				End:      end,
+				Interval: interval,
+			})
+			if err != nil {
+				return err
+			}
+			results[index] = trends
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
 	merged := map[time.Time]*ports.GRCFindingTrendPoint{}
 	agingByID := map[string]ports.GRCAgingBucket{}
 	openAtStart := 0
-	for tenantID, runtimeIDs := range runtimeIDsByTenant {
-		trends, err := provider.SummarizeGRCFindingTrends(ctx, ports.GRCFindingTrendsRequest{
-			FindingRequest: ports.ListFindingsRequest{
-				TenantID:   tenantID,
-				RuntimeIDs: runtimeIDs,
-				Severity:   filter.Severity,
-				Framework:  filter.Framework,
-			},
-			Start:    start,
-			End:      end,
-			Interval: interval,
-		})
-		if err != nil {
-			return nil, err
-		}
+	for _, trends := range results {
 		openAtStart += trends.OpenAtStart
 		for _, point := range trends.Points {
 			key := point.BucketStart.UTC()
@@ -397,8 +457,13 @@ func Merge(ctx context.Context, provider Provider, runtimes []*cerebrov1.SourceR
 
 type summaryValues struct {
 	Opened                int
+	OpenedCritical        int
+	OpenedHigh            int
 	Closed                int
+	ClosedCritical        int
+	ClosedHigh            int
 	CurrentOpen           int
+	PeakOpen              int
 	ClosedSLABreached     int
 	AvgTimeToCloseSeconds float64
 	durationSecondsTotal  float64
@@ -409,16 +474,23 @@ func summarize(trends *ports.GRCFindingTrends) summaryValues {
 	if trends == nil {
 		return summaryValues{}
 	}
-	summary := summaryValues{CurrentOpen: trends.OpenAtStart}
+	summary := summaryValues{CurrentOpen: trends.OpenAtStart, PeakOpen: trends.OpenAtStart}
 	for _, point := range trends.Points {
 		summary.Opened += point.Opened
+		summary.OpenedCritical += point.OpenedCritical
+		summary.OpenedHigh += point.OpenedHigh
 		summary.Closed += point.Closed
+		summary.ClosedCritical += point.ClosedCritical
+		summary.ClosedHigh += point.ClosedHigh
 		summary.ClosedSLABreached += point.ClosedSLABreached
 		summary.durationSecondsTotal += point.ClosedDurationSecondsTotal
 		summary.durationSecondsCount += point.ClosedDurationCount
 		summary.CurrentOpen += point.Opened - point.Closed
 		if summary.CurrentOpen < 0 {
 			summary.CurrentOpen = 0
+		}
+		if summary.CurrentOpen > summary.PeakOpen {
+			summary.PeakOpen = summary.CurrentOpen
 		}
 	}
 	summary.AvgTimeToCloseSeconds = averageSeconds(summary.durationSecondsTotal, summary.durationSecondsCount)
@@ -430,4 +502,11 @@ func averageSeconds(total float64, count int) float64 {
 		return 0
 	}
 	return total / float64(count)
+}
+
+func rate(numerator int, denominator int) float64 {
+	if denominator <= 0 || numerator <= 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
 }

--- a/internal/grctrends/trends_test.go
+++ b/internal/grctrends/trends_test.go
@@ -1,0 +1,145 @@
+package grctrends
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestBuildSummaryAggregatesFlowBacklogAndSLA(t *testing.T) {
+	base := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	trends := &ports.GRCFindingTrends{
+		OpenAtStart: 10,
+		Points: []ports.GRCFindingTrendPoint{
+			{
+				BucketStart:                base,
+				Opened:                     5,
+				OpenedCritical:             2,
+				OpenedHigh:                 1,
+				Closed:                     1,
+				ClosedDurationSecondsTotal: float64((2 * time.Hour).Seconds()),
+				ClosedDurationCount:        1,
+			},
+			{
+				BucketStart:                base.AddDate(0, 0, 1),
+				Opened:                     1,
+				Closed:                     4,
+				ClosedCritical:             1,
+				ClosedHigh:                 2,
+				ClosedSLABreached:          2,
+				ClosedDurationSecondsTotal: float64((8 * time.Hour).Seconds()),
+				ClosedDurationCount:        4,
+			},
+		},
+	}
+
+	summary := BuildSummary(trends)
+	if summary.TotalOpened != 6 || summary.TotalClosed != 5 || summary.Net != 1 {
+		t.Fatalf("flow summary = opened %d closed %d net %d, want 6/5/1", summary.TotalOpened, summary.TotalClosed, summary.Net)
+	}
+	if summary.CurrentOpen != 11 || summary.PeakOpen != 14 {
+		t.Fatalf("backlog summary = current %d peak %d, want 11/14", summary.CurrentOpen, summary.PeakOpen)
+	}
+	if summary.OpenedCritical != 2 || summary.OpenedHigh != 1 || summary.ClosedCritical != 1 || summary.ClosedHigh != 2 {
+		t.Fatalf("severity summary = %#v, want opened critical/high 2/1 closed critical/high 1/2", summary)
+	}
+	if summary.ClosedSLABreached != 2 || summary.ClosedSLABreachedRate != 0.4 {
+		t.Fatalf("sla summary = %d rate %v, want 2/0.4", summary.ClosedSLABreached, summary.ClosedSLABreachedRate)
+	}
+	if summary.AvgTimeToCloseSeconds != float64((10*time.Hour).Seconds())/5 {
+		t.Fatalf("avg close seconds = %v, want %v", summary.AvgTimeToCloseSeconds, float64((10*time.Hour).Seconds())/5)
+	}
+}
+
+func TestMergeAggregatesTenantsDeterministically(t *testing.T) {
+	base := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	provider := &recordingTrendProvider{
+		responses: map[string]ports.GRCFindingTrends{
+			"alpha": {
+				OpenAtStart: 3,
+				Points: []ports.GRCFindingTrendPoint{
+					{BucketStart: base, Opened: 1, Closed: 1, ClosedDurationSecondsTotal: float64(time.Hour.Seconds()), ClosedDurationCount: 1},
+					{BucketStart: base.AddDate(0, 0, 1), Opened: 2, OpenedHigh: 1},
+				},
+				AgingBuckets: []ports.GRCAgingBucket{{ID: "0-7", Label: "0-7 days", MinDays: 0, MaxDays: 7, Count: 2}},
+			},
+			"beta": {
+				OpenAtStart: 5,
+				Points: []ports.GRCFindingTrendPoint{
+					{BucketStart: base, Opened: 4, OpenedCritical: 1, Closed: 2, ClosedHigh: 1, ClosedSLABreached: 1, ClosedDurationSecondsTotal: float64((3 * time.Hour).Seconds()), ClosedDurationCount: 2},
+				},
+				AgingBuckets: []ports.GRCAgingBucket{{ID: "0-7", Label: "0-7 days", MinDays: 0, MaxDays: 7, Count: 4}},
+			},
+		},
+	}
+	runtimes := []*cerebrov1.SourceRuntime{
+		{Id: "beta-2", TenantId: "beta"},
+		nil,
+		{Id: "alpha-2", TenantId: "alpha"},
+		{Id: "alpha-1", TenantId: "alpha"},
+		{Id: "beta-1", TenantId: "beta"},
+		{Id: "", TenantId: "ignored"},
+	}
+
+	merged, err := Merge(context.Background(), provider, runtimes, base, base.AddDate(0, 0, 7), "day", Filter{Severity: "HIGH", Framework: "SOC 2"})
+	if err != nil {
+		t.Fatalf("Merge error = %v", err)
+	}
+	if merged.OpenAtStart != 8 {
+		t.Fatalf("OpenAtStart = %d, want 8", merged.OpenAtStart)
+	}
+	if len(merged.Points) != 2 {
+		t.Fatalf("points = %d, want 2", len(merged.Points))
+	}
+	first := merged.Points[0]
+	if !first.BucketStart.Equal(base) || first.Opened != 5 || first.OpenedCritical != 1 || first.Closed != 3 || first.ClosedHigh != 1 || first.ClosedSLABreached != 1 {
+		t.Fatalf("first merged point = %#v, want base opened/closed aggregate", first)
+	}
+	if first.ClosedDurationSecondsTotal != float64((4*time.Hour).Seconds()) || first.ClosedDurationCount != 3 {
+		t.Fatalf("first duration aggregate = %v/%d, want 4h/3", first.ClosedDurationSecondsTotal, first.ClosedDurationCount)
+	}
+	if !merged.Points[1].BucketStart.Equal(base.AddDate(0, 0, 1)) || merged.Points[1].OpenedHigh != 1 {
+		t.Fatalf("second merged point = %#v, want next-day alpha high open", merged.Points[1])
+	}
+	if len(merged.AgingBuckets) != 1 || merged.AgingBuckets[0].Count != 6 {
+		t.Fatalf("aging buckets = %#v, want one count=6", merged.AgingBuckets)
+	}
+	provider.assertRuntimeIDs(t, map[string][]string{
+		"alpha": {"alpha-1", "alpha-2"},
+		"beta":  {"beta-1", "beta-2"},
+	})
+}
+
+type recordingTrendProvider struct {
+	mu        sync.Mutex
+	responses map[string]ports.GRCFindingTrends
+	requests  []ports.GRCFindingTrendsRequest
+}
+
+func (p *recordingTrendProvider) SummarizeGRCFindingTrends(_ context.Context, request ports.GRCFindingTrendsRequest) (ports.GRCFindingTrends, error) {
+	p.mu.Lock()
+	p.requests = append(p.requests, request)
+	p.mu.Unlock()
+	return p.responses[request.FindingRequest.TenantID], nil
+}
+
+func (p *recordingTrendProvider) assertRuntimeIDs(t *testing.T, want map[string][]string) {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	got := map[string][]string{}
+	for _, request := range p.requests {
+		got[request.FindingRequest.TenantID] = request.FindingRequest.RuntimeIDs
+		if request.FindingRequest.Severity != "HIGH" || request.FindingRequest.Framework != "SOC 2" {
+			t.Fatalf("filter = severity %q framework %q, want HIGH/SOC 2", request.FindingRequest.Severity, request.FindingRequest.Framework)
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("runtime IDs = %#v, want %#v", got, want)
+	}
+}

--- a/internal/querycache/memory.go
+++ b/internal/querycache/memory.go
@@ -7,11 +7,14 @@ import (
 	"time"
 )
 
+const memoryCacheSweepInterval = time.Second
+
 type MemoryCache struct {
-	mu       sync.Mutex
-	options  Options
-	entries  map[string]Entry
-	versions map[string]uint64
+	mu          sync.Mutex
+	options     Options
+	entries     map[string]Entry
+	versions    map[string]uint64
+	nextSweepAt time.Time
 }
 
 func NewMemory(options Options) *MemoryCache {
@@ -28,13 +31,14 @@ func (c *MemoryCache) Get(_ context.Context, key string) (Entry, error) {
 	defer c.mu.Unlock()
 
 	now := time.Now().UTC()
-	c.deleteExpiredLocked(now)
 	fullKey := cacheKey(c.options.Namespace, key)
 	entry, ok := c.entries[fullKey]
 	if !ok || entry.State(now) == StateMiss {
 		delete(c.entries, fullKey)
+		c.sweepExpiredLocked(now)
 		return Entry{}, ErrMiss
 	}
+	c.sweepExpiredLocked(now)
 	entry.Payload = append([]byte(nil), entry.Payload...)
 	return entry, nil
 }
@@ -58,7 +62,7 @@ func (c *MemoryCache) Set(_ context.Context, key string, payload []byte, ttl tim
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.deleteExpiredLocked(now)
+	c.sweepExpiredLocked(now)
 	c.entries[cacheKey(c.options.Namespace, key)] = entry
 	c.evictOverflowLocked()
 	return nil
@@ -68,6 +72,16 @@ func (c *MemoryCache) Version(_ context.Context, scope string) (string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return strconv.FormatUint(c.versions[versionKey(c.options.Namespace, scope)], 10), nil
+}
+
+func (c *MemoryCache) Versions(_ context.Context, scopes []string) (map[string]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	versions := make(map[string]string, len(scopes))
+	for _, scope := range scopes {
+		versions[scope] = strconv.FormatUint(c.versions[versionKey(c.options.Namespace, scope)], 10)
+	}
+	return versions, nil
 }
 
 func (c *MemoryCache) BumpVersion(_ context.Context, scope string) (string, error) {
@@ -84,6 +98,14 @@ func (c *MemoryCache) Ping(context.Context) error {
 
 func (c *MemoryCache) Close(context.Context) error {
 	return nil
+}
+
+func (c *MemoryCache) sweepExpiredLocked(now time.Time) {
+	if !c.nextSweepAt.IsZero() && now.Before(c.nextSweepAt) {
+		return
+	}
+	c.deleteExpiredLocked(now)
+	c.nextSweepAt = now.Add(memoryCacheSweepInterval)
 }
 
 func (c *MemoryCache) deleteExpiredLocked(now time.Time) {

--- a/internal/querycache/memory_test.go
+++ b/internal/querycache/memory_test.go
@@ -2,6 +2,7 @@ package querycache
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -51,6 +52,62 @@ func TestMemoryCacheEvictsOldestEntryWhenCapped(t *testing.T) {
 	for _, key := range []string{"middle", "newest"} {
 		if _, ok := cache.entries[cacheKey("test", key)]; !ok {
 			t.Fatalf("entry %q missing after eviction", key)
+		}
+	}
+}
+
+func TestMemoryCacheGetRemovesRequestedExpiredEntryBetweenSweeps(t *testing.T) {
+	cache := NewMemory(Options{Namespace: "test", MaxEntries: 10})
+	now := time.Now()
+	cache.nextSweepAt = now.Add(time.Hour)
+	cache.entries[cacheKey("test", "expired")] = Entry{
+		Payload:    []byte("old"),
+		CreatedAt:  now.Add(-2 * time.Second),
+		ExpiresAt:  now.Add(-2 * time.Second),
+		StaleUntil: now.Add(-time.Second),
+	}
+
+	_, err := cache.Get(context.Background(), "expired")
+	if err == nil {
+		t.Fatal("Get(expired) error = nil, want miss")
+	}
+	if _, ok := cache.entries[cacheKey("test", "expired")]; ok {
+		t.Fatal("expired requested entry was not removed")
+	}
+}
+
+func TestMemoryCacheVersionsReturnsBatchWithMissingScopes(t *testing.T) {
+	cache := NewMemory(Options{Namespace: "test"})
+	if _, err := cache.BumpVersion(context.Background(), "findings"); err != nil {
+		t.Fatalf("BumpVersion() error = %v", err)
+	}
+
+	versions, err := cache.Versions(context.Background(), []string{"findings", "evidence"})
+	if err != nil {
+		t.Fatalf("Versions() error = %v", err)
+	}
+	if versions["findings"] != "1" {
+		t.Fatalf("Versions(findings) = %q, want 1", versions["findings"])
+	}
+	if versions["evidence"] != "0" {
+		t.Fatalf("Versions(evidence) = %q, want 0", versions["evidence"])
+	}
+}
+
+func BenchmarkMemoryCacheGetFreshManyEntries(b *testing.B) {
+	cache := NewMemory(Options{Namespace: "bench", MaxEntries: 8192})
+	ctx := context.Background()
+	for i := 0; i < 4096; i++ {
+		if err := cache.Set(ctx, strconv.Itoa(i), []byte("payload"), time.Hour, time.Hour); err != nil {
+			b.Fatalf("Set() error = %v", err)
+		}
+	}
+	cache.nextSweepAt = time.Now().Add(time.Hour)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := cache.Get(ctx, "2048"); err != nil {
+			b.Fatalf("Get() error = %v", err)
 		}
 	}
 }

--- a/internal/querycache/redis.go
+++ b/internal/querycache/redis.go
@@ -107,6 +107,34 @@ func (c *RedisCache) Version(ctx context.Context, scope string) (string, error) 
 	return value, err
 }
 
+func (c *RedisCache) Versions(ctx context.Context, scopes []string) (map[string]string, error) {
+	ctx, span := telemetry.Start(ctx, "redis.cache.versions", redisTelemetryAttrs("versions", c.options.Namespace))
+	versions := make(map[string]string, len(scopes))
+	if len(scopes) == 0 {
+		redisAnnotateMain(ctx, c.options.Namespace, "versions", "completed")
+		telemetry.End(span, "completed", telemetry.Attrs())
+		return versions, nil
+	}
+	keys := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		keys = append(keys, versionKey(c.options.Namespace, scope))
+		versions[scope] = "0"
+	}
+	values, err := c.client.MGet(ctx, keys...).Result()
+	if err != nil {
+		redisTelemetryError(ctx, span, c.options.Namespace, "versions", err)
+		return versions, err
+	}
+	for i, value := range values {
+		if raw, ok := value.(string); ok && strings.TrimSpace(raw) != "" {
+			versions[scopes[i]] = raw
+		}
+	}
+	redisAnnotateMain(ctx, c.options.Namespace, "versions", "completed")
+	telemetry.End(span, "completed", telemetry.Attrs(telemetry.Field{Key: "cache.version_scope_count", Value: len(scopes)}))
+	return versions, nil
+}
+
 func (c *RedisCache) BumpVersion(ctx context.Context, scope string) (string, error) {
 	ctx, span := telemetry.Start(ctx, "redis.cache.bump_version", redisTelemetryAttrs("bump_version", c.options.Namespace))
 	value, err := c.client.Incr(ctx, versionKey(c.options.Namespace, scope)).Result()


### PR DESCRIPTION
## Summary
- Parallelize GRC trend aggregation across tenants with bounded concurrency and deterministic merge ordering.
- Run current and previous trend windows concurrently for comparison requests.
- Add a canonical trend summary to `/grc/trends` responses.
- Reduce query-cache overhead by batching Redis version reads and sweeping expired in-memory entries periodically instead of on every cache access.

## Impact
Trend-heavy GRC requests should spend less time waiting on serial tenant/window aggregation, and cache lookups avoid unnecessary full-map sweeps under load.

## Validation
- `go test ./...`
- `go test ./internal/querycache ./internal/grctrends ./internal/bootstrap ./internal/statestore/postgres -count=1`
- `go test ./internal/querycache -bench BenchmarkMemoryCacheGetFreshManyEntries -benchmem -run '^$' -count=3`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->