### PR TITLE
[codex] parallelize runtime health records

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -695,6 +695,7 @@ func matchesReplayAttributes(event *cerebrov1.EventEnvelope, expected map[string
 }
 
 type stubRuntimeStore struct {
+	mu                              sync.Mutex
 	err                             error
 	runtimes                        map[string]*cerebrov1.SourceRuntime
 	sourceRuntimeListFilter         ports.SourceRuntimeFilter
@@ -1435,6 +1436,8 @@ func (s *stubRuntimeStore) GetFindingEvaluationRun(_ context.Context, id string)
 }
 
 func (s *stubRuntimeStore) ListFindingEvaluationRuns(_ context.Context, request ports.ListFindingEvaluationRunsRequest) ([]*cerebrov1.FindingEvaluationRun, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -1488,6 +1491,7 @@ func (s *stubRuntimeStore) GetReportRun(_ context.Context, id string) (*cerebrov
 }
 
 type stubGraphStore struct {
+	mu                  sync.Mutex
 	err                 error
 	entities            map[string]*ports.ProjectedEntity
 	links               map[string]*ports.ProjectedLink
@@ -1625,6 +1629,8 @@ func (s *stubGraphStore) GetIngestRun(_ context.Context, id string) (graphstore.
 }
 
 func (s *stubGraphStore) ListIngestRuns(_ context.Context, filter graphstore.IngestRunFilter) ([]graphstore.IngestRun, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.err != nil {
 		return nil, s.err
 	}

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -316,16 +316,9 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) grcSourceRuntimeHealthSummaries(ctx context.Context, runtimes []*cerebrov1.SourceRuntime, generatedAt time.Time) ([]sourceRuntimeHealthSummary, error) {
-	records := make([]sourceRuntimeHealthRecord, 0, len(runtimes))
-	for _, runtime := range runtimes {
-		if runtime == nil {
-			continue
-		}
-		record, err := a.sourceRuntimeHealthRecord(ctx, runtime, generatedAt)
-		if err != nil {
-			return nil, err
-		}
-		records = append(records, record)
+	records, err := a.sourceRuntimeHealthRecords(ctx, runtimes, generatedAt)
+	if err != nil {
+		return nil, err
 	}
 	return sourceRuntimeHealthSummaries(records), nil
 }

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcehealthview"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -142,6 +143,8 @@ const (
 	runtimeLastInvalidOccurredAtConfigKey = "__cerebro_runtime_last_invalid_occurred_at"
 	runtimeLastInvalidDiagnosticConfigKey = "__cerebro_runtime_last_invalid_diagnostic"
 	runtimeLastInvalidRetryableConfigKey  = "__cerebro_runtime_last_invalid_retryable"
+
+	sourceRuntimeHealthRecordConcurrency = 8
 )
 
 func (a *App) handleListSourceRuntimeHealth(w http.ResponseWriter, r *http.Request) {
@@ -230,7 +233,6 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 		return sourceRuntimeHealthResponse{}, err
 	}
 	generatedAt := time.Now().UTC()
-	records := make([]sourceRuntimeHealthRecord, 0, len(runtimes))
 	visibleRuntimes := make([]*cerebrov1.SourceRuntime, 0, len(runtimes))
 	for _, runtime := range runtimes {
 		if runtime == nil {
@@ -240,11 +242,10 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 			continue
 		}
 		visibleRuntimes = append(visibleRuntimes, runtime)
-		record, err := a.sourceRuntimeHealthRecord(r.Context(), runtime, generatedAt)
-		if err != nil {
-			return sourceRuntimeHealthResponse{}, err
-		}
-		records = append(records, record)
+	}
+	records, err := a.sourceRuntimeHealthRecords(r.Context(), visibleRuntimes, generatedAt)
+	if err != nil {
+		return sourceRuntimeHealthResponse{}, err
 	}
 	coverage := a.sourceCoverageRecords(visibleRuntimes, filter, generatedAt)
 	return sourceRuntimeHealthResponse{
@@ -530,6 +531,33 @@ func sourceRuntimeGraphState(record sourceRuntimeHealthRecord) string {
 	return sourcehealth.GraphIngestState(sourceHealthRecord(record))
 }
 
+func (a *App) sourceRuntimeHealthRecords(ctx context.Context, runtimes []*cerebrov1.SourceRuntime, generatedAt time.Time) ([]sourceRuntimeHealthRecord, error) {
+	visibleRuntimes := make([]*cerebrov1.SourceRuntime, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime != nil {
+			visibleRuntimes = append(visibleRuntimes, runtime)
+		}
+	}
+	records := make([]sourceRuntimeHealthRecord, len(visibleRuntimes))
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(sourceRuntimeHealthRecordConcurrency)
+	for index, runtime := range visibleRuntimes {
+		index, runtime := index, runtime
+		group.Go(func() error {
+			record, err := a.sourceRuntimeHealthRecord(groupCtx, runtime, generatedAt)
+			if err != nil {
+				return err
+			}
+			records[index] = record
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
 func (a *App) sourceRuntimeHealthRecord(ctx context.Context, runtime *cerebrov1.SourceRuntime, generatedAt time.Time) (sourceRuntimeHealthRecord, error) {
 	record := sourceRuntimeHealthRecord{
 		RuntimeID:    strings.TrimSpace(runtime.GetId()),
@@ -566,17 +594,25 @@ func (a *App) sourceRuntimeHealthRecord(ctx context.Context, runtime *cerebrov1.
 		record.CheckpointWatermark = watermark.Format(time.RFC3339Nano)
 		record.WatermarkLagSeconds = secondsSince(generatedAt, watermark)
 	}
-	graphRun, err := a.latestGraphIngestRun(ctx, record.RuntimeID)
-	if err != nil {
+	var graphRun *graphstore.IngestRun
+	var findingRun *cerebrov1.FindingEvaluationRun
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		var err error
+		graphRun, err = a.latestGraphIngestRun(groupCtx, record.RuntimeID)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		findingRun, err = a.latestFindingEvaluationRun(groupCtx, record.RuntimeID)
+		return err
+	})
+	if err := group.Wait(); err != nil {
 		return record, err
 	}
 	if graphRun != nil {
 		record.LatestGraphRun = sourceRuntimeGraphRunHealth(*graphRun)
 		record.GraphLagSeconds = graphRunLagSeconds(generatedAt, *graphRun)
-	}
-	findingRun, err := a.latestFindingEvaluationRun(ctx, record.RuntimeID)
-	if err != nil {
-		return record, err
 	}
 	if findingRun != nil {
 		record.LatestFindingEvaluation = sourceRuntimeFindingEvaluationHealth(findingRun)

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -146,6 +146,48 @@ func TestSourceRuntimeHealthRecordHandlesPartialAndInvalidScheduleReceipt(t *tes
 	}
 }
 
+func TestSourceRuntimeHealthRecordsPreserveOrderAndSkipNil(t *testing.T) {
+	now := time.Date(2026, 6, 16, 9, 30, 0, 0, time.UTC)
+	runtimes := []*cerebrov1.SourceRuntime{
+		{
+			Id:       "runtime-c",
+			SourceId: "slack",
+			TenantId: "writer",
+			Config:   map[string]string{"family": "conversation"},
+		},
+		nil,
+		{
+			Id:       "runtime-a",
+			SourceId: "okta",
+			TenantId: "writer",
+			Config:   map[string]string{"family": "user"},
+		},
+		{
+			Id:           "runtime-b",
+			SourceId:     "aws",
+			TenantId:     "writer",
+			LastSyncedAt: timestamppb.New(now.Add(-time.Minute)),
+			Config:       map[string]string{"family": "account"},
+		},
+	}
+
+	records, err := (&App{}).sourceRuntimeHealthRecords(context.Background(), runtimes, now)
+	if err != nil {
+		t.Fatalf("sourceRuntimeHealthRecords() error = %v", err)
+	}
+	if len(records) != 3 {
+		t.Fatalf("len(records) = %d, want 3", len(records))
+	}
+	for index, wantRuntimeID := range []string{"runtime-c", "runtime-a", "runtime-b"} {
+		if records[index].RuntimeID != wantRuntimeID {
+			t.Fatalf("records[%d].RuntimeID = %q, want %q; records=%#v", index, records[index].RuntimeID, wantRuntimeID, records)
+		}
+	}
+	if records[0].Family != "conversation" || records[2].Family != "account" {
+		t.Fatalf("records did not retain runtime metadata: %#v", records)
+	}
+}
+
 func TestRuntimeHealthStatusStaleBoundaryAndFailurePrecedence(t *testing.T) {
 	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Build source runtime health records with bounded concurrency while preserving response order.
- Reuse the concurrent record helper from GRC dashboard/program readiness summaries.
- Fetch each runtime latest graph ingest run and finding evaluation run in parallel.
- Add regression coverage for order preservation and nil runtime filtering.
- Make shared test stores safe for the new concurrent health-read path under race testing.

## Validation
- `go test ./internal/bootstrap -run 'TestSourceRuntimeHealth|TestListSourceRuntimeHealth|TestRuntimeFreshness|TestGRC' -count=1`\n- `go test -race ./internal/bootstrap -run 'TestSourceRuntimeHealth|TestListSourceRuntimeHealth|TestRuntimeFreshness|TestGRC' -count=1`\n- `go test ./internal/bootstrap ./internal/grctrends ./internal/querycache -count=1`\n- `go test ./... -count=1`