### PR TITLE
parallelize impact graph traversal

### DIFF
--- a/internal/graphquery/impact.go
+++ b/internal/graphquery/impact.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	packageurl "github.com/package-url/packageurl-go"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -20,6 +21,8 @@ const (
 	defaultImpactLimit = 100
 	maxImpactDepth     = 6
 	maxImpactLimit     = 250
+
+	impactNeighborhoodConcurrency = 8
 )
 
 type ImpactRequest struct {
@@ -88,36 +91,78 @@ func (s *Service) collectImpactGraph(ctx context.Context, rootURN string, depth 
 	visited := map[string]bool{}
 	frontier := []string{rootURN}
 	for hop := 0; hop < depth && len(frontier) > 0 && len(nodes) < limit; hop++ {
-		next := []string{}
+		roots := make([]string, 0, len(frontier))
 		for _, urn := range frontier {
-			if visited[urn] || len(nodes) >= limit {
+			if visited[urn] {
 				continue
 			}
 			visited[urn] = true
-			neighborhood, err := s.store.GetEntityNeighborhood(ctx, urn, limit)
+			roots = append(roots, urn)
+		}
+		if len(roots) == 0 {
+			break
+		}
+		next := []string{}
+		for start := 0; start < len(roots) && len(nodes) < limit; start += impactNeighborhoodConcurrency {
+			end := min(start+impactNeighborhoodConcurrency, len(roots))
+			neighborhoods, err := s.collectImpactNeighborhoods(ctx, roots[start:end], limit)
 			if err != nil {
 				return nil, nil, err
 			}
-			if neighborhood == nil {
-				continue
-			}
-			addImpactNode(nodes, neighborhood.Root, limit)
-			for _, neighbor := range neighborhood.Neighbors {
-				if addImpactNode(nodes, neighbor, limit) && !visited[neighbor.URN] {
-					next = append(next, neighbor.URN)
+			for _, neighborhood := range neighborhoods {
+				if len(nodes) >= limit {
+					break
 				}
-			}
-			for _, relation := range neighborhood.Relations {
-				if relation == nil {
+				if neighborhood == nil {
 					continue
 				}
-				key := relation.FromURN + "|" + relation.Relation + "|" + relation.ToURN
-				relations[key] = relation
+				addImpactNode(nodes, neighborhood.Root, limit)
+				for _, neighbor := range neighborhood.Neighbors {
+					if addImpactNode(nodes, neighbor, limit) && !visited[neighbor.URN] {
+						next = append(next, neighbor.URN)
+					}
+				}
+				for _, relation := range neighborhood.Relations {
+					if relation == nil {
+						continue
+					}
+					key := relation.FromURN + "|" + relation.Relation + "|" + relation.ToURN
+					relations[key] = relation
+				}
 			}
 		}
 		frontier = next
 	}
 	return nodes, filterImpactRelations(nodes, relations), nil
+}
+
+func (s *Service) collectImpactNeighborhoods(ctx context.Context, roots []string, limit int) ([]*ports.EntityNeighborhood, error) {
+	results := make([]*ports.EntityNeighborhood, len(roots))
+	if len(roots) == 1 {
+		neighborhood, err := s.store.GetEntityNeighborhood(ctx, roots[0], limit)
+		if err != nil {
+			return nil, err
+		}
+		results[0] = neighborhood
+		return results, nil
+	}
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(impactNeighborhoodConcurrency)
+	for index, urn := range roots {
+		index, urn := index, urn
+		group.Go(func() error {
+			neighborhood, err := s.store.GetEntityNeighborhood(groupCtx, urn, limit)
+			if err != nil {
+				return err
+			}
+			results[index] = neighborhood
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return results, nil
 }
 
 func filterImpactRelations(nodes map[string]*ports.NeighborhoodNode, relations map[string]*ports.NeighborhoodRelation) map[string]*ports.NeighborhoodRelation {

--- a/internal/graphquery/impact_test.go
+++ b/internal/graphquery/impact_test.go
@@ -3,20 +3,42 @@ package graphquery
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/writer/cerebro/internal/ports"
 )
 
 type impactStubStore struct {
 	neighborhoods map[string]*ports.EntityNeighborhood
+	lookupDelay   time.Duration
+
+	mu            sync.Mutex
 	queries       []string
+	activeLookups int
+	maxLookups    int
 }
 
 func (s *impactStubStore) Ping(context.Context) error { return nil }
 
 func (s *impactStubStore) GetEntityNeighborhood(_ context.Context, rootURN string, _ int) (*ports.EntityNeighborhood, error) {
+	s.mu.Lock()
 	s.queries = append(s.queries, rootURN)
+	s.activeLookups++
+	if s.activeLookups > s.maxLookups {
+		s.maxLookups = s.activeLookups
+	}
+	s.mu.Unlock()
+
+	if s.lookupDelay > 0 {
+		time.Sleep(s.lookupDelay)
+	}
+
+	s.mu.Lock()
+	s.activeLookups--
+	s.mu.Unlock()
+
 	neighborhood, ok := s.neighborhoods[rootURN]
 	if !ok {
 		return nil, ports.ErrGraphEntityNotFound
@@ -26,6 +48,18 @@ func (s *impactStubStore) GetEntityNeighborhood(_ context.Context, rootURN strin
 
 func (s *impactStubStore) ExecuteReadCypher(_ context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
 	return nil, nil
+}
+
+func (s *impactStubStore) queryURNs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.queries...)
+}
+
+func (s *impactStubStore) maxConcurrentLookups() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxLookups
 }
 
 func TestGetImpactVulnerabilityGroupsCanonicalPackageAssetsAndEvidence(t *testing.T) {
@@ -110,8 +144,9 @@ func TestGetImpactDepthDoesNotExpandPastRequestedHops(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetImpact() error = %v", err)
 	}
-	if len(store.queries) != 1 || store.queries[0] != rootURN {
-		t.Fatalf("queries = %#v, want only root lookup", store.queries)
+	queries := store.queryURNs()
+	if len(queries) != 1 || queries[0] != rootURN {
+		t.Fatalf("queries = %#v, want only root lookup", queries)
 	}
 	if len(result.Packages) != 1 || result.Packages[0].URN != directURN {
 		t.Fatalf("Packages = %#v, want direct package only", result.Packages)
@@ -215,8 +250,72 @@ func TestGetImpactPackageDoesNotFallbackToLegacyPURLIdentity(t *testing.T) {
 	if !errors.Is(err, ports.ErrGraphEntityNotFound) {
 		t.Fatalf("GetImpact() error = %v, want %v", err, ports.ErrGraphEntityNotFound)
 	}
-	if len(store.queries) != 1 {
-		t.Fatalf("queries = %#v, want no fallback lookup", store.queries)
+	if queries := store.queryURNs(); len(queries) != 1 {
+		t.Fatalf("queries = %#v, want no fallback lookup", queries)
+	}
+}
+
+func TestGetImpactExpandsFrontierConcurrently(t *testing.T) {
+	rootURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+	firstPackageURN := "urn:cerebro:writer:package:canonical:pkg:npm/foo"
+	secondPackageURN := "urn:cerebro:writer:package:canonical:pkg:npm/bar"
+	thirdPackageURN := "urn:cerebro:writer:package:canonical:pkg:npm/baz"
+	store := &impactStubStore{
+		lookupDelay: 10 * time.Millisecond,
+		neighborhoods: map[string]*ports.EntityNeighborhood{
+			rootURN: {
+				Root: node(rootURN, "vulnerability", "CVE-2026-4242"),
+				Neighbors: []*ports.NeighborhoodNode{
+					node(firstPackageURN, "package", "foo"),
+					node(secondPackageURN, "package", "bar"),
+					node(thirdPackageURN, "package", "baz"),
+				},
+			},
+			firstPackageURN:  emptyNeighborhood(firstPackageURN, "package"),
+			secondPackageURN: emptyNeighborhood(secondPackageURN, "package"),
+			thirdPackageURN:  emptyNeighborhood(thirdPackageURN, "package"),
+		},
+	}
+
+	if _, err := New(store).GetImpact(context.Background(), ImpactRequest{
+		Kind:       ImpactKindVulnerability,
+		TenantID:   "writer",
+		Identifier: "CVE-2026-4242",
+		Depth:      2,
+	}); err != nil {
+		t.Fatalf("GetImpact() error = %v", err)
+	}
+	if got := store.maxConcurrentLookups(); got < 2 {
+		t.Fatalf("max concurrent lookups = %d, want parallel frontier expansion", got)
+	}
+}
+
+func TestGetImpactReturnsParallelLookupErrors(t *testing.T) {
+	rootURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+	firstPackageURN := "urn:cerebro:writer:package:canonical:pkg:npm/foo"
+	secondPackageURN := "urn:cerebro:writer:package:canonical:pkg:npm/bar"
+	store := &impactStubStore{neighborhoods: map[string]*ports.EntityNeighborhood{
+		rootURN: {
+			Root: node(rootURN, "vulnerability", "CVE-2026-4242"),
+			Neighbors: []*ports.NeighborhoodNode{
+				node(firstPackageURN, "package", "foo"),
+				node(secondPackageURN, "package", "bar"),
+			},
+		},
+		firstPackageURN: {
+			Root: node(firstPackageURN, "package", "foo"),
+		},
+	}}
+
+	_, err := New(store).GetImpact(context.Background(), ImpactRequest{
+		Kind:       ImpactKindVulnerability,
+		TenantID:   "writer",
+		Identifier: "CVE-2026-4242",
+		Depth:      2,
+		Limit:      4,
+	})
+	if !errors.Is(err, ports.ErrGraphEntityNotFound) {
+		t.Fatalf("GetImpact() error = %v, want %v", err, ports.ErrGraphEntityNotFound)
 	}
 }
 


### PR DESCRIPTION
## Summary
- expand impact graph frontier neighborhoods with bounded parallelism
- preserve deterministic merge order and limit/error semantics
- make impact query tests concurrency-safe and cover parallel expansion

## Tests
- go test ./internal/graphquery -count=1
- go test -race ./internal/graphquery -run 'TestGetImpact' -count=1
- go test ./internal/graphquery ./internal/graphstore/... ./internal/graphrebuild ./internal/graphingest -count=1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->