### PR TITLE
[codex] parallelize rebuild graph summary

### DIFF
--- a/internal/graphrebuild/memory_graph.go
+++ b/internal/graphrebuild/memory_graph.go
@@ -12,7 +12,7 @@ import (
 )
 
 type memoryGraphStore struct {
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	entities map[string]memoryEntity
 	links    map[string]memoryLink
 }
@@ -134,14 +134,14 @@ func (s *memoryGraphStore) UpsertProjectedLink(_ context.Context, link *ports.Pr
 }
 
 func (s *memoryGraphStore) Counts(context.Context) (graphstore.Counts, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return graphstore.Counts{Nodes: int64(len(s.entities)), Relations: int64(len(s.links))}, nil
 }
 
 func (s *memoryGraphStore) IntegrityChecks(context.Context) ([]graphstore.IntegrityCheck, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	checks := []graphstore.IntegrityCheck{
 		{Name: "tenant_mismatched_relations", Expected: 0},
 		{Name: "blank_entity_labels", Expected: 0},
@@ -302,8 +302,8 @@ func (s *memoryGraphStore) memoryEntityHasOutgoingLinkTo(urn string, relation st
 }
 
 func (s *memoryGraphStore) PathPatterns(_ context.Context, limit int) ([]graphstore.PathPattern, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	counts := make(map[string]graphstore.PathPattern)
 	for _, first := range s.links {
 		for _, second := range s.links {
@@ -345,8 +345,8 @@ func (s *memoryGraphStore) PathPatterns(_ context.Context, limit int) ([]graphst
 }
 
 func (s *memoryGraphStore) Topology(context.Context) (graphstore.Topology, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	inDegree := make(map[string]int)
 	outDegree := make(map[string]int)
 	for _, link := range s.links {
@@ -372,8 +372,8 @@ func (s *memoryGraphStore) Topology(context.Context) (graphstore.Topology, error
 }
 
 func (s *memoryGraphStore) SampleTraversals(_ context.Context, limit int) ([]graphstore.Traversal, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	traversals := []graphstore.Traversal{}
 	for _, first := range s.links {
 		for _, second := range s.links {

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -28,6 +29,7 @@ const (
 	maxEventLimit       = 1000
 	defaultPreviewLimit = 5
 	maxPreviewLimit     = 20
+	graphSummaryLimit   = 5
 	stageStatusSuccess  = "success"
 )
 
@@ -39,6 +41,46 @@ type graphStore interface {
 	PathPatterns(context.Context, int) ([]graphstore.PathPattern, error)
 	Topology(context.Context) (graphstore.Topology, error)
 	SampleTraversals(context.Context, int) ([]graphstore.Traversal, error)
+}
+
+type graphSummaryStore interface {
+	Counts(context.Context) (graphstore.Counts, error)
+	IntegrityChecks(context.Context) ([]graphstore.IntegrityCheck, error)
+	PathPatterns(context.Context, int) ([]graphstore.PathPattern, error)
+	Topology(context.Context) (graphstore.Topology, error)
+	SampleTraversals(context.Context, int) ([]graphstore.Traversal, error)
+}
+
+type graphSummary struct {
+	counts                  graphstore.Counts
+	integrityChecks         []graphstore.IntegrityCheck
+	pathPatterns            []graphstore.PathPattern
+	topology                graphstore.Topology
+	traversals              []graphstore.Traversal
+	countDurationMillis     int64
+	integrityDurationMillis int64
+	patternDurationMillis   int64
+	topologyDurationMillis  int64
+	traversalDurationMillis int64
+}
+
+type graphSummaryReadError struct {
+	stage string
+	err   error
+}
+
+func (e *graphSummaryReadError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s: %v", e.stage, e.err)
+}
+
+func (e *graphSummaryReadError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
 }
 
 // Request configures one local graph rebuild dry-run.
@@ -314,75 +356,117 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 		LinksProjected:    projectSummary.LinksProjected,
 	})
 
-	countStart := time.Now()
-	counts, err := graph.Counts(ctx)
+	summary, err := collectGraphSummary(ctx, graph, previewLimit)
 	if err != nil {
 		return nil, err
 	}
-	result.GraphNodes = counts.Nodes
-	result.GraphLinks = counts.Relations
+	result.GraphNodes = summary.counts.Nodes
+	result.GraphLinks = summary.counts.Relations
 	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
 		Name:           "count_graph",
 		Status:         stageStatusSuccess,
-		DurationMillis: durationMillis(countStart),
-		GraphNodes:     counts.Nodes,
-		GraphLinks:     counts.Relations,
+		DurationMillis: summary.countDurationMillis,
+		GraphNodes:     summary.counts.Nodes,
+		GraphLinks:     summary.counts.Relations,
 	})
 
-	integrityStart := time.Now()
-	checks, err := graph.IntegrityChecks(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result.GraphAssertions = assertionPreviews(checks)
+	result.GraphAssertions = assertionPreviews(summary.integrityChecks)
 	assertionsPassed, assertionsFailed := assertionCounts(result.GraphAssertions)
 	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
 		Name:             "verify_integrity",
 		Status:           stageStatusSuccess,
-		DurationMillis:   durationMillis(integrityStart),
+		DurationMillis:   summary.integrityDurationMillis,
 		AssertionsPassed: assertionsPassed,
 		AssertionsFailed: assertionsFailed,
 	})
 
-	patternStart := time.Now()
-	patterns, err := graph.PathPatterns(ctx, previewLimit)
-	if err != nil {
-		return nil, err
-	}
-	result.GraphPathPatterns = pathPatternPreviews(patterns)
+	result.GraphPathPatterns = pathPatternPreviews(summary.pathPatterns)
 	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
 		Name:             "verify_path_patterns",
 		Status:           stageStatusSuccess,
-		DurationMillis:   durationMillis(patternStart),
+		DurationMillis:   summary.patternDurationMillis,
 		PatternsVerified: boundedUint32(len(result.GraphPathPatterns)),
 	})
 
-	topologyStart := time.Now()
-	topology, err := graph.Topology(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result.GraphTopology = topologyPreviews(topology)
+	result.GraphTopology = topologyPreviews(summary.topology)
 	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
 		Name:            "verify_topology",
 		Status:          stageStatusSuccess,
-		DurationMillis:  durationMillis(topologyStart),
+		DurationMillis:  summary.topologyDurationMillis,
 		TopologyBuckets: boundedUint32(len(result.GraphTopology)),
 	})
 
-	traversalStart := time.Now()
-	traversals, err := graph.SampleTraversals(ctx, previewLimit)
-	if err != nil {
-		return nil, err
-	}
-	result.GraphTraversals = traversalPreviews(traversals)
+	result.GraphTraversals = traversalPreviews(summary.traversals)
 	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
 		Name:               "verify_traversals",
 		Status:             stageStatusSuccess,
-		DurationMillis:     durationMillis(traversalStart),
+		DurationMillis:     summary.traversalDurationMillis,
 		TraversalsVerified: boundedUint32(len(result.GraphTraversals)),
 	})
 	return result, nil
+}
+
+func collectGraphSummary(ctx context.Context, graph graphSummaryStore, previewLimit int) (*graphSummary, error) {
+	if graph == nil {
+		return nil, fmt.Errorf("graph summary store is required")
+	}
+	summary := &graphSummary{}
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(graphSummaryLimit)
+	group.Go(func() error {
+		start := time.Now()
+		counts, err := graph.Counts(groupCtx)
+		if err != nil {
+			return &graphSummaryReadError{stage: "count graph", err: err}
+		}
+		summary.counts = counts
+		summary.countDurationMillis = durationMillis(start)
+		return nil
+	})
+	group.Go(func() error {
+		start := time.Now()
+		checks, err := graph.IntegrityChecks(groupCtx)
+		if err != nil {
+			return &graphSummaryReadError{stage: "verify graph integrity", err: err}
+		}
+		summary.integrityChecks = checks
+		summary.integrityDurationMillis = durationMillis(start)
+		return nil
+	})
+	group.Go(func() error {
+		start := time.Now()
+		patterns, err := graph.PathPatterns(groupCtx, previewLimit)
+		if err != nil {
+			return &graphSummaryReadError{stage: "verify graph path patterns", err: err}
+		}
+		summary.pathPatterns = patterns
+		summary.patternDurationMillis = durationMillis(start)
+		return nil
+	})
+	group.Go(func() error {
+		start := time.Now()
+		topology, err := graph.Topology(groupCtx)
+		if err != nil {
+			return &graphSummaryReadError{stage: "verify graph topology", err: err}
+		}
+		summary.topology = topology
+		summary.topologyDurationMillis = durationMillis(start)
+		return nil
+	})
+	group.Go(func() error {
+		start := time.Now()
+		traversals, err := graph.SampleTraversals(groupCtx, previewLimit)
+		if err != nil {
+			return &graphSummaryReadError{stage: "sample graph traversals", err: err}
+		}
+		summary.traversals = traversals
+		summary.traversalDurationMillis = durationMillis(start)
+		return nil
+	})
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return summary, nil
 }
 
 func boundedUint32(value int) uint32 {

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -2,9 +2,11 @@ package graphrebuild
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
@@ -119,6 +122,143 @@ func (r *eventReplayer) Replay(_ context.Context, req ports.ReplayRequest) ([]*c
 		}
 	}
 	return replayed, nil
+}
+
+var errSummaryProbe = errors.New("summary probe failure")
+
+type summaryProbeStore struct {
+	delay     time.Duration
+	failStage string
+	mu        sync.Mutex
+	active    int
+	maxActive int
+}
+
+func (s *summaryProbeStore) observe(ctx context.Context, stage string) error {
+	s.mu.Lock()
+	s.active++
+	if s.active > s.maxActive {
+		s.maxActive = s.active
+	}
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.active--
+		s.mu.Unlock()
+	}()
+	if s.delay > 0 {
+		timer := time.NewTimer(s.delay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if s.failStage == stage {
+		return errSummaryProbe
+	}
+	return nil
+}
+
+func (s *summaryProbeStore) maxObservedActive() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxActive
+}
+
+func (s *summaryProbeStore) Counts(ctx context.Context) (graphstore.Counts, error) {
+	if err := s.observe(ctx, "counts"); err != nil {
+		return graphstore.Counts{}, err
+	}
+	return graphstore.Counts{Nodes: 7, Relations: 11}, nil
+}
+
+func (s *summaryProbeStore) IntegrityChecks(ctx context.Context) ([]graphstore.IntegrityCheck, error) {
+	if err := s.observe(ctx, "integrity"); err != nil {
+		return nil, err
+	}
+	return []graphstore.IntegrityCheck{{Name: "fixture_check", Passed: true}}, nil
+}
+
+func (s *summaryProbeStore) PathPatterns(ctx context.Context, _ int) ([]graphstore.PathPattern, error) {
+	if err := s.observe(ctx, "patterns"); err != nil {
+		return nil, err
+	}
+	return []graphstore.PathPattern{{
+		FromType:       "github.user",
+		FirstRelation:  "authored",
+		ViaType:        "github.pull_request",
+		SecondRelation: "belongs_to",
+		ToType:         "github.code.repository",
+		Count:          2,
+	}}, nil
+}
+
+func (s *summaryProbeStore) Topology(ctx context.Context) (graphstore.Topology, error) {
+	if err := s.observe(ctx, "topology"); err != nil {
+		return graphstore.Topology{}, err
+	}
+	return graphstore.Topology{SourcesOnly: 2, SinksOnly: 3, Intermediates: 4}, nil
+}
+
+func (s *summaryProbeStore) SampleTraversals(ctx context.Context, _ int) ([]graphstore.Traversal, error) {
+	if err := s.observe(ctx, "traversals"); err != nil {
+		return nil, err
+	}
+	return []graphstore.Traversal{{
+		FromURN:        "user:octocat",
+		FirstRelation:  "authored",
+		ViaURN:         "pr:418",
+		SecondRelation: "belongs_to",
+		ToURN:          "repo:cerebro",
+	}}, nil
+}
+
+func TestCollectGraphSummaryRunsReadsConcurrently(t *testing.T) {
+	store := &summaryProbeStore{delay: 20 * time.Millisecond}
+
+	summary, err := collectGraphSummary(context.Background(), store, 3)
+	if err != nil {
+		t.Fatalf("collectGraphSummary() error = %v", err)
+	}
+	if got := store.maxObservedActive(); got < 2 {
+		t.Fatalf("max concurrent summary reads = %d, want at least 2", got)
+	}
+	if summary.counts.Nodes != 7 || summary.counts.Relations != 11 {
+		t.Fatalf("summary counts = %#v, want fixture counts", summary.counts)
+	}
+	if len(summary.integrityChecks) != 1 {
+		t.Fatalf("len(integrityChecks) = %d, want 1", len(summary.integrityChecks))
+	}
+	if len(summary.pathPatterns) != 1 {
+		t.Fatalf("len(pathPatterns) = %d, want 1", len(summary.pathPatterns))
+	}
+	if summary.topology.Intermediates != 4 {
+		t.Fatalf("topology.Intermediates = %d, want 4", summary.topology.Intermediates)
+	}
+	if len(summary.traversals) != 1 {
+		t.Fatalf("len(traversals) = %d, want 1", len(summary.traversals))
+	}
+	if summary.countDurationMillis == 0 || summary.integrityDurationMillis == 0 || summary.patternDurationMillis == 0 || summary.topologyDurationMillis == 0 || summary.traversalDurationMillis == 0 {
+		t.Fatalf("summary durations include zero values: %#v", summary)
+	}
+}
+
+func TestCollectGraphSummaryPropagatesReadErrors(t *testing.T) {
+	store := &summaryProbeStore{failStage: "patterns"}
+
+	_, err := collectGraphSummary(context.Background(), store, 3)
+	if !errors.Is(err, errSummaryProbe) {
+		t.Fatalf("collectGraphSummary() error = %v, want %v", err, errSummaryProbe)
+	}
+	var summaryErr *graphSummaryReadError
+	if !errors.As(err, &summaryErr) {
+		t.Fatalf("collectGraphSummary() error = %v, want graphSummaryReadError", err)
+	}
+	if summaryErr.stage != "verify graph path patterns" {
+		t.Fatalf("summary error stage = %q, want path pattern context", summaryErr.stage)
+	}
 }
 
 func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {


### PR DESCRIPTION
## Summary
- fan out dry-run graph summary reads for counts, integrity, path patterns, topology, and traversals after projection completes
- keep result fields and stage confirmations in the existing deterministic order while timing each read independently
- switch the in-memory scratch graph to read locks for read-only graph traversals so summary calls can overlap safely

## Validation
- go test ./internal/graphrebuild -count=1
- go test -race ./internal/graphrebuild -run 'TestCollectGraphSummary|TestRebuildDryRun' -count=1\n- go test ./internal/graphquery ./internal/graphstore/... ./internal/graphrebuild ./internal/graphingest -count=1\n- go test -race ./internal/graphrebuild -count=1\n- go test ./... -count=1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->