### PR TITLE
perf: use sargable typed-property predicates in graph exposure/no-mfa rules

### DIFF
--- a/internal/findings/cloud_current_public_exposure_review_rule.go
+++ b/internal/findings/cloud_current_public_exposure_review_rule.go
@@ -62,14 +62,7 @@ func newCloudPublicResourceExposureGraphRule() Rule {
 WHERE public.entity_type IN ['aws.public_principal', 'gcp.public_principal', 'azure.public_principal']
   AND resource.entity_type <> 'cloud.account'
   AND NOT resource.entity_type IN ['aws.public_principal', 'gcp.public_principal', 'azure.public_principal']
-  AND (
-    resource.internet_exposed = true
-    OR (resource.internet_exposed IS NULL AND (
-      coalesce(resource.attributes_json, '') CONTAINS '"internet_exposed":"true"'
-      OR coalesce(resource.attributes_json, '') CONTAINS '"external_exposure":"true"'
-      OR coalesce(resource.attributes_json, '') CONTAINS '"public":"true"'
-    ))
-  )
+  AND resource.internet_exposed = true
   AND coalesce(reach.attributes_json, '') CONTAINS '"at":"'
   AND datetime(split(split(coalesce(reach.attributes_json, ''), '"at":"')[1], '"')[0]) >= datetime() - duration('P30D')
   AND NOT EXISTS {

--- a/internal/findings/coordination_graph_rule_test.go
+++ b/internal/findings/coordination_graph_rule_test.go
@@ -132,7 +132,7 @@ func TestReviewCoordinationGraphRulesHaveDirectCoverage(t *testing.T) {
 		{name: "okta threat insight", rule: newOktaThreatInsightNotBlockingRule(), sourceID: "okta", family: "threat_insight", querySnippet: `"action":"block"`},
 		{name: "sentinelone stale agent", rule: newSentinelOneAgentNotUpToDateRule(), sourceID: "sentinelone", family: "agent", querySnippet: `"is_up_to_date":"false"`},
 		{name: "sentinelone unmitigated threat", rule: newSentinelOneUnmitigatedThreatRule(), sourceID: "sentinelone", family: "threat", querySnippet: `"mitigation_status":"not_mitigated"`},
-		{name: "cloud current public exposure", rule: newCloudPublicResourceExposureGraphRule(), sourceID: "aws", family: "resource_exposure", querySnippet: `"internet_exposed":"true"`},
+		{name: "cloud current public exposure", rule: newCloudPublicResourceExposureGraphRule(), sourceID: "aws", family: "resource_exposure", querySnippet: `resource.internet_exposed = true`},
 		{name: "graph aws eni link missing", rule: newGraphAWSEC2ENILinkMissingRule(), sourceID: "graph", querySnippet: "attached_instance_id"},
 	}
 

--- a/internal/findings/current_state_graph_rules_test.go
+++ b/internal/findings/current_state_graph_rules_test.go
@@ -270,7 +270,7 @@ func TestCurrentStateGraphRuleQueriesUseEnrichedCurrentState(t *testing.T) {
 		{
 			name: "cloud exposure uses recent reachability edge and current attributes",
 			rule: newCloudPublicResourceExposureGraphRule(),
-			want: []string{"relation: 'can_reach'", ".public_principal", `"internet_exposed":"true"`, `duration('P30D')`, "WITH DISTINCT resource"},
+			want: []string{"relation: 'can_reach'", ".public_principal", `resource.internet_exposed = true`, `duration('P30D')`, "WITH DISTINCT resource"},
 		},
 		{
 			name: "cloud exposed privileged compute links reachability to runtime role privilege",

--- a/internal/findings/graph_typed_property_test.go
+++ b/internal/findings/graph_typed_property_test.go
@@ -7,40 +7,49 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-// The hot boolean predicates were promoted to typed, indexed node properties
-// (projectionmeta.DerivedEntityProperties). Each rule must prefer the typed
-// property but retain an `IS NULL` fallback to the legacy attributes_json scan,
-// so the result set is identical for entities not yet re-projected since the
-// promotion shipped.
-func TestGraphRulesPreferTypedPropertyWithJSONFallback(t *testing.T) {
+// The hot boolean predicates are promoted to typed, indexed node properties
+// (projectionmeta.DerivedEntityProperties) and backfilled across every entity,
+// so each rule filters on the sargable typed property alone. The legacy
+// `IS NULL` attributes_json full-scan fallback was removed once the backfill
+// completed; these queries must use the indexed equality and must not
+// reintroduce the fallback.
+func TestGraphRulesUseSargableTypedProperties(t *testing.T) {
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime", SourceId: "graph", TenantId: "writer"}
 
 	exposure := mustGraphRule(t, newCloudPublicResourceExposureGraphRule()).QueryFor(runtime).Query
+	if !strings.Contains(exposure, "resource.internet_exposed = true") {
+		t.Fatalf("cloud public-exposure query missing sargable predicate:\n%s", exposure)
+	}
 	for _, fragment := range []string{
-		"resource.internet_exposed = true",
 		"resource.internet_exposed IS NULL",
 		`coalesce(resource.attributes_json, '') CONTAINS '"internet_exposed":"true"'`,
 		`coalesce(resource.attributes_json, '') CONTAINS '"external_exposure":"true"'`,
 		`coalesce(resource.attributes_json, '') CONTAINS '"public":"true"'`,
 	} {
-		if !strings.Contains(exposure, fragment) {
-			t.Fatalf("cloud public-exposure query missing %q:\n%s", fragment, exposure)
+		if strings.Contains(exposure, fragment) {
+			t.Fatalf("cloud public-exposure query must not retain legacy fallback %q:\n%s", fragment, exposure)
 		}
 	}
 
 	identity := mustGraphRule(t, newIdentityPrivilegedNoMFAAccessRule()).QueryFor(runtime).Query
 	for _, fragment := range []string{
 		"user.is_privileged_identity = true",
-		"user.is_privileged_identity IS NULL",
 		"user.mfa_disabled = true",
-		"user.mfa_disabled IS NULL",
-		`user_attrs CONTAINS '"is_admin":"true"'`,
-		`user_attrs CONTAINS '"is_delegated_admin":"true"'`,
-		`user_attrs CONTAINS '"mfa_enrolled":"false"'`,
-		`user_attrs CONTAINS '"is_enforced_in_2sv":"false"'`,
 	} {
 		if !strings.Contains(identity, fragment) {
-			t.Fatalf("identity no-MFA query missing %q:\n%s", fragment, identity)
+			t.Fatalf("identity no-MFA query missing sargable predicate %q:\n%s", fragment, identity)
+		}
+	}
+	for _, fragment := range []string{
+		"user.is_privileged_identity IS NULL",
+		"user.mfa_disabled IS NULL",
+		"user_attrs",
+		`CONTAINS '"is_admin":"true"'`,
+		`CONTAINS '"mfa_enrolled":"false"'`,
+		`CONTAINS '"is_enforced_in_2sv":"false"'`,
+	} {
+		if strings.Contains(identity, fragment) {
+			t.Fatalf("identity no-MFA query must not retain legacy fallback %q:\n%s", fragment, identity)
 		}
 	}
 }

--- a/internal/findings/identity_privileged_no_mfa_sensitive_access_rule.go
+++ b/internal/findings/identity_privileged_no_mfa_sensitive_access_rule.go
@@ -112,7 +112,6 @@ WHERE marker.entity_type IN ['asset.tag', 'data.classification']
 MATCH (resource:Entity {tenant_id: $tenant_id})-[sensitivity:RELATION]->(marker)
 MATCH (user:Entity {tenant_id: $tenant_id})-[access:RELATION]->(resource)
 WITH user, access, resource, sensitivity, marker,
-     toLower(coalesce(user.attributes_json, '')) AS user_attrs,
      coalesce(access.attributes_json, '') AS access_attrs
 WHERE user.entity_type IN ['okta.user','google_workspace.user','gcp.service_account']
   AND access.relation IN ['acted_on','assigned_to','can_admin','can_perform']
@@ -127,28 +126,8 @@ WHERE user.entity_type IN ['okta.user','google_workspace.user','gcp.service_acco
       END
     ) > $acted_on_since
   )
-  AND (
-    user.is_privileged_identity = true
-    OR (user.is_privileged_identity IS NULL AND (
-      user_attrs CONTAINS '"is_admin":"true"'
-      OR user_attrs CONTAINS '"is_admin":true'
-      OR user_attrs CONTAINS '"is_delegated_admin":"true"'
-      OR user_attrs CONTAINS '"is_delegated_admin":true'
-    ))
-  )
-  AND (
-    user.mfa_disabled = true
-    OR (user.mfa_disabled IS NULL AND (
-      user_attrs CONTAINS '"mfa_enrolled":"false"'
-      OR user_attrs CONTAINS '"mfa_enrolled":false'
-      OR user_attrs CONTAINS '"mfa_enforced":"false"'
-      OR user_attrs CONTAINS '"mfa_enforced":false'
-      OR user_attrs CONTAINS '"is_enrolled_in_2sv":"false"'
-      OR user_attrs CONTAINS '"is_enrolled_in_2sv":false'
-      OR user_attrs CONTAINS '"is_enforced_in_2sv":"false"'
-      OR user_attrs CONTAINS '"is_enforced_in_2sv":false'
-    ))
-  )
+  AND user.is_privileged_identity = true
+  AND user.mfa_disabled = true
   AND (
     (sensitivity.relation = 'tagged_as' AND marker.entity_type = 'asset.tag' AND toLower(marker.label) = 'crown_jewel')
     OR

--- a/internal/findings/identity_privileged_no_mfa_sensitive_access_rule_test.go
+++ b/internal/findings/identity_privileged_no_mfa_sensitive_access_rule_test.go
@@ -124,15 +124,8 @@ func TestIdentityPrivilegedNoMfaSensitiveAccess_PrefilterCoversAllMFAFlags(t *te
 	}
 	runtime := &cerebrov1.SourceRuntime{Id: "example-google-workspace-user", SourceId: "google_workspace", TenantId: "writer", Config: map[string]string{"family": "user"}}
 	query := graphRule.QueryFor(runtime)
-	for _, fragment := range []string{
-		`"mfa_enforced":"false"`,
-		`"mfa_enforced":false`,
-		`"is_enforced_in_2sv":"false"`,
-		`"is_enforced_in_2sv":false`,
-	} {
-		if !strings.Contains(query.Query, fragment) {
-			t.Fatalf("QueryFor() missing MFA posture prefilter fragment %q:\n%s", fragment, query.Query)
-		}
+	if !strings.Contains(query.Query, "user.mfa_disabled = true") {
+		t.Fatalf("QueryFor() missing sargable MFA predicate:\n%s", query.Query)
 	}
 
 	for _, tc := range []struct {


### PR DESCRIPTION
## Summary

`internet_exposed`, `is_privileged_identity`, and `mfa_disabled` were promoted to typed, indexed `:Entity` node properties (`projectionmeta.DerivedEntityProperties`) and have now been **backfilled across the entire production graph** (476,139 entities updated; a verify recount returns 0 entities missing the typed property). Live ingestion keeps the typed properties in sync on every upsert.

With every entity now carrying the typed property, this PR removes the legacy `IS NULL` → `attributes_json CONTAINS ...` full-scan fallback from the two hot graph rules and filters on the sargable indexed equality instead.

**Updates**
- `cloud_current_public_exposure_review_rule.go`: predicate collapses to `AND resource.internet_exposed = true` (drops the `IS NULL` branch and 3 `attributes_json CONTAINS` scans).
- `identity_privileged_no_mfa_sensitive_access_rule.go`: predicates collapse to `AND user.is_privileged_identity = true` and `AND user.mfa_disabled = true`; the now-unused `user_attrs` projection is dropped from the `WITH` clause.

**Removes**
- The `attributes_json` full-scan fallback fragments, which forced Neo4j to scan rather than use the range indexes on the typed boolean properties.

This is the final step (P1b) of #1437; it depends on the typed-property promotion (P1a) and the production backfill having completed.

The Go post-filter (`EvaluateRows`) is unchanged and still authoritatively validates each row's attributes, so the sargable Cypher pre-filter can only narrow the candidate set, never admit false positives.

## Test Plan

- `gofmt`, `go build ./...`, `go vet ./internal/findings/` — clean
- `go test ./internal/findings/ -count=1` — `ok`
- `golangci-lint run ./internal/findings/...` — 0 issues
- `make check-arch`, `make check-structural` — pass
- Pinning tests updated to assert the sargable predicates are present and the legacy fallback fragments are absent (`graph_typed_property_test.go`, `coordination_graph_rule_test.go`, `current_state_graph_rules_test.go`, `identity_privileged_no_mfa_sensitive_access_rule_test.go`).
- Empirically verified in production: dry-run matched 481,223 entities; apply updated 476,139 (239 batches); verify recount returned 0 remaining.

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->