### PR TITLE
[codex] bound rebuild traversal sampling

### DIFF
--- a/internal/graphrebuild/memory_graph.go
+++ b/internal/graphrebuild/memory_graph.go
@@ -39,6 +39,16 @@ type memoryURNPair struct {
 	second string
 }
 
+type memoryTraversalSample struct {
+	key       string
+	traversal graphstore.Traversal
+}
+
+type memoryTraversalSampler struct {
+	limit   int
+	samples []memoryTraversalSample
+}
+
 func newMemoryGraphStore() (graphStore, error) {
 	return &memoryGraphStore{
 		entities: make(map[string]memoryEntity),
@@ -366,12 +376,12 @@ func (s *memoryGraphStore) SampleTraversals(_ context.Context, limit int) ([]gra
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	outgoingLinks := s.memoryOutgoingLinksByFromURN()
-	traversals := []graphstore.Traversal{}
+	sampler := newMemoryTraversalSampler(limit)
 	s.visitMemoryTwoHopLinks(outgoingLinks, func(first memoryLink, second memoryLink) {
 		from := s.entities[first.FromURN]
 		via := s.entities[first.ToURN]
 		to := s.entities[second.ToURN]
-		traversals = append(traversals, graphstore.Traversal{
+		sampler.Add(graphstore.Traversal{
 			FromURN:        from.URN,
 			FromLabel:      from.Label,
 			FirstRelation:  first.Relation,
@@ -382,13 +392,7 @@ func (s *memoryGraphStore) SampleTraversals(_ context.Context, limit int) ([]gra
 			ToLabel:        to.Label,
 		})
 	})
-	sort.Slice(traversals, func(i, j int) bool {
-		return traversalKey(traversals[i]) < traversalKey(traversals[j])
-	})
-	if limit > 0 && len(traversals) > limit {
-		traversals = traversals[:limit]
-	}
-	return traversals, nil
+	return sampler.Traversals(), nil
 }
 
 func (s *memoryGraphStore) memoryOutgoingLinksByFromURN() map[string][]memoryLink {
@@ -428,6 +432,51 @@ func memoryLinkedURNPair(first string, second string) memoryURNPair {
 		first, second = second, first
 	}
 	return memoryURNPair{first: first, second: second}
+}
+
+func newMemoryTraversalSampler(limit int) *memoryTraversalSampler {
+	return &memoryTraversalSampler{
+		limit:   limit,
+		samples: make([]memoryTraversalSample, 0, max(limit, 0)),
+	}
+}
+
+func (s *memoryTraversalSampler) Add(traversal graphstore.Traversal) {
+	if s == nil {
+		return
+	}
+	sample := memoryTraversalSample{key: traversalKey(traversal), traversal: traversal}
+	if s.limit <= 0 {
+		s.samples = append(s.samples, sample)
+		return
+	}
+	if len(s.samples) < s.limit {
+		s.samples = append(s.samples, sample)
+		return
+	}
+	maxIndex := 0
+	for index := 1; index < len(s.samples); index++ {
+		if s.samples[index].key > s.samples[maxIndex].key {
+			maxIndex = index
+		}
+	}
+	if sample.key < s.samples[maxIndex].key {
+		s.samples[maxIndex] = sample
+	}
+}
+
+func (s *memoryTraversalSampler) Traversals() []graphstore.Traversal {
+	if s == nil || len(s.samples) == 0 {
+		return nil
+	}
+	sort.Slice(s.samples, func(i, j int) bool {
+		return s.samples[i].key < s.samples[j].key
+	})
+	traversals := make([]graphstore.Traversal, 0, len(s.samples))
+	for _, sample := range s.samples {
+		traversals = append(traversals, sample.traversal)
+	}
+	return traversals
 }
 
 func linkKey(fromURN string, relation string, toURN string) string {

--- a/internal/graphrebuild/memory_graph_test.go
+++ b/internal/graphrebuild/memory_graph_test.go
@@ -199,6 +199,48 @@ func TestMemoryGraphStoreSuppressesBroadTwoHopPathSummaries(t *testing.T) {
 	}
 }
 
+func TestMemoryGraphStoreSampleTraversalsKeepsLowestKeysWithinLimit(t *testing.T) {
+	store, err := newMemoryGraphStore()
+	if err != nil {
+		t.Fatalf("newMemoryGraphStore() error = %v", err)
+	}
+	scratch := store.(*memoryGraphStore)
+	ctx := context.Background()
+
+	for _, entity := range []*ports.ProjectedEntity{
+		{URN: "urn:a", TenantID: "writer", SourceID: "fixture", EntityType: "fixture.node", Label: "a"},
+		{URN: "urn:b", TenantID: "writer", SourceID: "fixture", EntityType: "fixture.node", Label: "b"},
+		{URN: "urn:c", TenantID: "writer", SourceID: "fixture", EntityType: "fixture.node", Label: "c"},
+		{URN: "urn:via", TenantID: "writer", SourceID: "fixture", EntityType: "fixture.via", Label: "via"},
+		{URN: "urn:z", TenantID: "writer", SourceID: "fixture", EntityType: "fixture.node", Label: "z"},
+	} {
+		if err := scratch.UpsertProjectedEntity(ctx, entity); err != nil {
+			t.Fatalf("UpsertProjectedEntity(%s) error = %v", entity.URN, err)
+		}
+	}
+	for _, link := range []*ports.ProjectedLink{
+		{TenantID: "writer", SourceID: "fixture", FromURN: "urn:c", Relation: "connected_to", ToURN: "urn:via"},
+		{TenantID: "writer", SourceID: "fixture", FromURN: "urn:b", Relation: "connected_to", ToURN: "urn:via"},
+		{TenantID: "writer", SourceID: "fixture", FromURN: "urn:a", Relation: "connected_to", ToURN: "urn:via"},
+		{TenantID: "writer", SourceID: "fixture", FromURN: "urn:via", Relation: "observes", ToURN: "urn:z"},
+	} {
+		if err := scratch.UpsertProjectedLink(ctx, link); err != nil {
+			t.Fatalf("UpsertProjectedLink(%s -> %s) error = %v", link.FromURN, link.ToURN, err)
+		}
+	}
+
+	traversals, err := scratch.SampleTraversals(ctx, 2)
+	if err != nil {
+		t.Fatalf("SampleTraversals() error = %v", err)
+	}
+	if len(traversals) != 2 {
+		t.Fatalf("len(traversals) = %d, want 2", len(traversals))
+	}
+	if traversals[0].FromURN != "urn:a" || traversals[1].FromURN != "urn:b" {
+		t.Fatalf("SampleTraversals() = %#v, want lowest traversal keys urn:a and urn:b", traversals)
+	}
+}
+
 func memoryIntegrityActual(checks []graphstore.IntegrityCheck, name string) int64 {
 	for _, check := range checks {
 		if check.Name == name {


### PR DESCRIPTION
## Summary
- keep only the lowest traversal sample keys while walking in-memory two-hop paths when a preview limit is set
- avoid materializing and sorting every traversal for small dry-run previews
- add a regression test proving limited traversal previews preserve the same sorted lowest-key behavior

## Validation
- go test ./internal/graphrebuild -run 'TestMemoryGraphStore|TestRebuildDryRun' -count=1\n- go test -race ./internal/graphrebuild -run 'TestMemoryGraphStore|TestRebuildDryRun' -count=1\n- go test ./internal/graphquery ./internal/graphstore/... ./internal/graphrebuild ./internal/graphingest -count=1\n- go test -race ./internal/graphrebuild -count=1\n- make check-structural check-structural-test check-arch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->