### PR TITLE
[codex] Type GRC families and assurance artifacts

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -29,7 +29,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `gcp` | 2130 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2029 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
-| `grc` | 1239 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
+| `grc` | 1238 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2256 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 765 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2112 | Extract API paging, agent/application readers, and shared response normalization. |

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -201,6 +201,85 @@ func maxInt(values ...int) int {
 	return max
 }
 
+type grcAssuranceArtifactKind string
+
+const (
+	grcAssuranceArtifactSecurityReview        grcAssuranceArtifactKind = "security_review"
+	grcAssuranceArtifactSecurityQuestionnaire grcAssuranceArtifactKind = "security_questionnaire"
+	grcAssuranceArtifactPenetrationTest       grcAssuranceArtifactKind = "penetration_test"
+	grcAssuranceArtifactDocument              grcAssuranceArtifactKind = "assurance_document"
+)
+
+var grcAssuranceArtifactKinds = []grcAssuranceArtifactKind{
+	grcAssuranceArtifactSecurityReview,
+	grcAssuranceArtifactSecurityQuestionnaire,
+	grcAssuranceArtifactPenetrationTest,
+	grcAssuranceArtifactDocument,
+}
+
+func (kind grcAssuranceArtifactKind) String() string {
+	return string(kind)
+}
+
+func (kind grcAssuranceArtifactKind) entityType() string {
+	switch kind {
+	case grcAssuranceArtifactSecurityReview:
+		return "security.review"
+	case grcAssuranceArtifactSecurityQuestionnaire:
+		return "security.questionnaire"
+	case grcAssuranceArtifactPenetrationTest:
+		return "penetration.test"
+	case grcAssuranceArtifactDocument:
+		return "assurance.document"
+	default:
+		return ""
+	}
+}
+
+func (kind grcAssuranceArtifactKind) idAttribute() string {
+	switch kind {
+	case grcAssuranceArtifactSecurityReview:
+		return "security_review_id"
+	case grcAssuranceArtifactSecurityQuestionnaire:
+		return "security_questionnaire_id"
+	case grcAssuranceArtifactPenetrationTest:
+		return "penetration_test_id"
+	case grcAssuranceArtifactDocument:
+		return "assurance_document_id"
+	default:
+		return ""
+	}
+}
+
+func (kind grcAssuranceArtifactKind) relatedIDAttributes() []string {
+	switch kind {
+	case grcAssuranceArtifactSecurityReview:
+		return []string{"related_security_review_id", "security_review_id", "review_id"}
+	case grcAssuranceArtifactSecurityQuestionnaire:
+		return []string{"related_security_questionnaire_id", "security_questionnaire_id", "questionnaire_id"}
+	case grcAssuranceArtifactPenetrationTest:
+		return []string{"related_penetration_test_id", "penetration_test_id", "pentest_id"}
+	case grcAssuranceArtifactDocument:
+		return []string{"related_assurance_document_id", "assurance_document_id"}
+	default:
+		return nil
+	}
+}
+
+func (kind grcAssuranceArtifactKind) candidateIDAttributes(currentKind grcAssuranceArtifactKind) []string {
+	if kind == grcAssuranceArtifactDocument && currentKind == grcAssuranceArtifactSecurityQuestionnaire {
+		return append(kind.relatedIDAttributes(), "document_id", "upload_id")
+	}
+	return kind.relatedIDAttributes()
+}
+
+func (kind grcAssuranceArtifactKind) relatedMatchType() string {
+	if kind == "" {
+		return ""
+	}
+	return "grc_related_" + kind.String()
+}
+
 func grcDocumentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	tenantID, err := tenantID(event)
 	if err != nil {
@@ -286,12 +365,13 @@ func grcSecurityReviewProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 	provider := grcProvider(attrs)
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
-	reviewURN := projectionURN(tenantID, "security_review", provider, reviewID)
+	reviewKind := grcAssuranceArtifactSecurityReview
+	reviewURN := projectionURN(tenantID, reviewKind.String(), provider, reviewID)
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        reviewURN,
 		TenantID:   tenantID,
 		SourceID:   event.GetSourceId(),
-		EntityType: "security.review",
+		EntityType: reviewKind.entityType(),
 		Label:      firstAttribute(attrs, "name", "title", "review_type", "assessment_type", "security_review_id", "review_id"),
 		Attributes: grcAttributes(attrs, map[string]string{
 			"review_type":        firstAttribute(attrs, "review_type", "assessment_type"),
@@ -301,9 +381,9 @@ func grcSecurityReviewProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 			"status":             firstAttribute(attrs, "status", "review_status", "assessment_status"),
 		}),
 	})
-	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, reviewURN, provider, attrs, relationAssociatedWith, "grc_security_review", "grc_security_review_url_host", "security_review",
+	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, reviewURN, provider, attrs, relationAssociatedWith, "grc_security_review", "grc_security_review_url_host", reviewKind,
 		grcJoinedAttributeValues(attrs, "review_type", "assessment_type", "status", "review_status", "risk_level", "inherent_risk_level", "residual_risk_level"))
-	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, reviewURN, provider, attrs, "security_review")
+	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, reviewURN, provider, attrs, reviewKind)
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
@@ -324,12 +404,13 @@ func grcSecurityQuestionnaireProjections(event *cerebrov1.EventEnvelope) ([]*por
 	provider := grcProvider(attrs)
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
-	questionnaireURN := projectionURN(tenantID, "security_questionnaire", provider, questionnaireID)
+	questionnaireKind := grcAssuranceArtifactSecurityQuestionnaire
+	questionnaireURN := projectionURN(tenantID, questionnaireKind.String(), provider, questionnaireID)
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        questionnaireURN,
 		TenantID:   tenantID,
 		SourceID:   event.GetSourceId(),
-		EntityType: "security.questionnaire",
+		EntityType: questionnaireKind.entityType(),
 		Label:      firstAttribute(attrs, "name", "title", "questionnaire_type", "security_questionnaire_id", "questionnaire_id"),
 		Attributes: grcAttributes(attrs, map[string]string{
 			"questionnaire_type":        firstAttribute(attrs, "questionnaire_type", "assessment_type"),
@@ -338,9 +419,9 @@ func grcSecurityQuestionnaireProjections(event *cerebrov1.EventEnvelope) ([]*por
 			"status":                    firstAttribute(attrs, "status", "questionnaire_status", "response_status"),
 		}),
 	})
-	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, questionnaireURN, provider, attrs, relationAssociatedWith, "grc_security_questionnaire", "grc_security_questionnaire_url_host", "security_questionnaire",
+	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, questionnaireURN, provider, attrs, relationAssociatedWith, "grc_security_questionnaire", "grc_security_questionnaire_url_host", questionnaireKind,
 		grcJoinedAttributeValues(attrs, "questionnaire_type", "assessment_type", "status", "questionnaire_status", "response_status"))
-	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, questionnaireURN, provider, attrs, "security_questionnaire")
+	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, questionnaireURN, provider, attrs, questionnaireKind)
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
@@ -361,12 +442,13 @@ func grcPenetrationTestProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 	provider := grcProvider(attrs)
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
-	testURN := projectionURN(tenantID, "penetration_test", provider, testID)
+	testKind := grcAssuranceArtifactPenetrationTest
+	testURN := projectionURN(tenantID, testKind.String(), provider, testID)
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        testURN,
 		TenantID:   tenantID,
 		SourceID:   event.GetSourceId(),
-		EntityType: "penetration.test",
+		EntityType: testKind.entityType(),
 		Label:      firstAttribute(attrs, "name", "title", "test_type", "penetration_test_id", "pentest_id", "test_id"),
 		Attributes: grcAttributes(attrs, map[string]string{
 			"penetration_test_id": testID,
@@ -375,10 +457,10 @@ func grcPenetrationTestProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 			"test_type":           firstAttribute(attrs, "test_type", "assessment_type"),
 		}),
 	})
-	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, testURN, provider, attrs, relationTargeted, "grc_penetration_test", "grc_penetration_test_url_host", "penetration_test",
+	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, testURN, provider, attrs, relationTargeted, "grc_penetration_test", "grc_penetration_test_url_host", testKind,
 		grcJoinedAttributeValues(attrs, "test_type", "assessment_type", "status", "test_status", "scope", "severity"))
 	addGRCPenetrationTestFindingLinks(entities, links, tenantID, event.GetSourceId(), event, testURN, provider, attrs)
-	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, testURN, provider, attrs, "penetration_test")
+	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, testURN, provider, attrs, testKind)
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
@@ -399,12 +481,13 @@ func grcAssuranceDocumentProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 	provider := grcProvider(attrs)
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
-	documentURN := projectionURN(tenantID, "assurance_document", provider, documentID)
+	documentKind := grcAssuranceArtifactDocument
+	documentURN := projectionURN(tenantID, documentKind.String(), provider, documentID)
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        documentURN,
 		TenantID:   tenantID,
 		SourceID:   event.GetSourceId(),
-		EntityType: "assurance.document",
+		EntityType: documentKind.entityType(),
 		Label:      firstAttribute(attrs, "title", "name", "document_type", "assurance_document_id", "document_id", "upload_id"),
 		Attributes: grcAttributes(attrs, map[string]string{
 			"assurance_document_id": documentID,
@@ -413,10 +496,10 @@ func grcAssuranceDocumentProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 			"status":                firstAttribute(attrs, "status", "upload_status", "review_status"),
 		}),
 	})
-	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, documentURN, provider, attrs, relationAssociatedWith, "grc_assurance_document", "grc_assurance_document_url_host", "assurance_document",
+	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, documentURN, provider, attrs, relationAssociatedWith, "grc_assurance_document", "grc_assurance_document_url_host", documentKind,
 		grcJoinedAttributeValues(attrs, "document_type", "artifact_type", "evidence_type", "category", "status", "upload_status", "tags"))
 	addGRCUserActionLink(entities, links, tenantID, event.GetSourceId(), event, provider, firstAttribute(attrs, "uploaded_by_user_id", "uploader_user_id"), documentURN, "uploaded")
-	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, documentURN, provider, attrs, "assurance_document")
+	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, documentURN, provider, attrs, documentKind)
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
@@ -1931,7 +2014,7 @@ func addSecurityContactEmailLink(entities map[string]*ports.ProjectedEntity, lin
 	addLink(links, projectedLink(tenantID, sourceID, fromURN, identityURN, relationAssociatedWith, linkAttrs))
 }
 
-func addGRCAssuranceArtifactLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, artifactURN string, provider string, attrs map[string]string, targetRelation string, targetRelationshipBy string, urlMatchType string, tagNamespace string, tagValues string) {
+func addGRCAssuranceArtifactLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, artifactURN string, provider string, attrs map[string]string, targetRelation string, targetRelationshipBy string, urlMatchType string, artifactKind grcAssuranceArtifactKind, tagValues string) {
 	if strings.TrimSpace(artifactURN) == "" {
 		return
 	}
@@ -1944,7 +2027,7 @@ func addGRCAssuranceArtifactLinks(entities map[string]*ports.ProjectedEntity, li
 	addGRCControlSupportLinks(entities, links, tenantID, sourceID, event, artifactURN, provider)
 	addGRCEvidenceLink(entities, links, tenantID, sourceID, event, artifactURN, provider, attrs)
 	addInternetHostLink(entities, links, tenantID, sourceID, event, artifactURN, relationHasIdentifier, firstAttribute(attrs, "url", "document_url", "report_url", "artifact_url", "download_url", "external_url"), urlMatchType, "0.90")
-	addGRCAssetTagLinks(entities, links, tenantID, sourceID, event, artifactURN, tagNamespace, tagValues)
+	addGRCAssetTagLinks(entities, links, tenantID, sourceID, event, artifactURN, artifactKind.String(), tagValues)
 }
 
 func addGRCCustomerTrustAccountLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, provider string, attrs map[string]string) {
@@ -1973,21 +2056,6 @@ func addGRCCustomerTrustAccountLink(entities map[string]*ports.ProjectedEntity, 
 	}))
 }
 
-type grcRelatedAssuranceArtifactRef struct {
-	urnType    string
-	entityType string
-	idAttr     string
-	idAttrs    []string
-	matchType  string
-}
-
-func (ref grcRelatedAssuranceArtifactRef) candidateIDAttrs(currentURNType string) []string {
-	if ref.urnType == "assurance_document" && currentURNType == "security_questionnaire" {
-		return append(ref.idAttrs, "document_id", "upload_id")
-	}
-	return ref.idAttrs
-}
-
 func firstGRCAttributeMatch(attrs map[string]string, keys ...string) (string, string) {
 	for _, key := range keys {
 		if value := strings.TrimSpace(attrs[key]); value != "" {
@@ -1997,65 +2065,35 @@ func firstGRCAttributeMatch(attrs map[string]string, keys ...string) (string, st
 	return "", ""
 }
 
-func addGRCRelatedAssuranceArtifactLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, provider string, attrs map[string]string, currentURNType string) {
+func addGRCRelatedAssuranceArtifactLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, provider string, attrs map[string]string, currentKind grcAssuranceArtifactKind) {
 	if strings.TrimSpace(fromURN) == "" {
 		return
 	}
-	refs := []grcRelatedAssuranceArtifactRef{
-		{
-			urnType:    "security_review",
-			entityType: "security.review",
-			idAttr:     "security_review_id",
-			idAttrs:    []string{"related_security_review_id", "security_review_id", "review_id"},
-			matchType:  "grc_related_security_review",
-		},
-		{
-			urnType:    "security_questionnaire",
-			entityType: "security.questionnaire",
-			idAttr:     "security_questionnaire_id",
-			idAttrs:    []string{"related_security_questionnaire_id", "security_questionnaire_id", "questionnaire_id"},
-			matchType:  "grc_related_security_questionnaire",
-		},
-		{
-			urnType:    "penetration_test",
-			entityType: "penetration.test",
-			idAttr:     "penetration_test_id",
-			idAttrs:    []string{"related_penetration_test_id", "penetration_test_id", "pentest_id"},
-			matchType:  "grc_related_penetration_test",
-		},
-		{
-			urnType:    "assurance_document",
-			entityType: "assurance.document",
-			idAttr:     "assurance_document_id",
-			idAttrs:    []string{"related_assurance_document_id", "assurance_document_id"},
-			matchType:  "grc_related_assurance_document",
-		},
-	}
-	for _, ref := range refs {
-		if ref.urnType == currentURNType {
+	for _, kind := range grcAssuranceArtifactKinds {
+		if kind == currentKind {
 			continue
 		}
-		sourceReference, relatedID := firstGRCAttributeMatch(attrs, ref.candidateIDAttrs(currentURNType)...)
+		sourceReference, relatedID := firstGRCAttributeMatch(attrs, kind.candidateIDAttributes(currentKind)...)
 		if relatedID == "" {
 			continue
 		}
-		relatedURN := projectionURN(tenantID, ref.urnType, provider, relatedID)
+		relatedURN := projectionURN(tenantID, kind.String(), provider, relatedID)
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        relatedURN,
 			TenantID:   tenantID,
 			SourceID:   sourceID,
-			EntityType: ref.entityType,
+			EntityType: kind.entityType(),
 			Label:      relatedID,
 			Attributes: grcAttributes(nil, map[string]string{
-				ref.idAttr:      relatedID,
-				"source_system": provider,
+				kind.idAttribute(): relatedID,
+				"source_system":    provider,
 			}),
 		})
 		addLink(links, projectedLink(tenantID, sourceID, fromURN, relatedURN, relationAssociatedWith, map[string]string{
 			"event_id":         event.GetId(),
-			"match_type":       ref.matchType,
+			"match_type":       kind.relatedMatchType(),
 			"related_id":       relatedID,
-			"related_family":   ref.urnType,
+			"related_family":   kind.String(),
 			"source_reference": sourceReference,
 		}))
 	}

--- a/sources/grc/attributes.go
+++ b/sources/grc/attributes.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var attributeFieldMappings = map[string][]string{
+var attributeFieldMappings = map[grcFamily][]string{
 	familyFramework:                {"framework_id", "id", "display_name", "displayName", "name", "shorthandName", "description", "description", "num_controls_completed", "numControlsCompleted", "num_controls_total", "numControlsTotal", "num_documents_passing", "numDocumentsPassing", "num_documents_total", "numDocumentsTotal", "num_tests_passing", "numTestsPassing", "num_tests_total", "numTestsTotal"},
 	familyControl:                  {"control_id", "id", "control_external_id", "externalId", "name", "name", "description", "description", "source", "source", "domains", "domains", "owner_id", "owner.id", "role", "role", "created_at", "creationDate", "modified_at", "modificationDate"},
 	familyControlTest:              {"test_id", "id", "name", "name", "description", "description", "control_id", "controlId", "control_ids", "controlIds", "control_external_id", "controlExternalId", "control_external_ids", "controlExternalIds", "last_run_at", "lastTestRunDate", "latest_flip_at", "latestFlipDate", "failure_description", "failureDescription", "remediation_description", "remediationDescription", "version", "version", "category", "category", "integrations", "integrations", "status", "status", "owner_id", "owner.id"},
@@ -31,7 +31,7 @@ var attributeFieldMappings = map[string][]string{
 	familyIntegration:              {"integration_id", "integrationId", "display_name", "displayName", "resource_kinds", "resourceKinds"},
 }
 
-func attributesFor(settings settings, family string, record grcRecord) map[string]string {
+func attributesFor(settings settings, family grcFamily, record grcRecord) map[string]string {
 	values := record.Values
 	attrs := map[string]string{
 		"provider":        settings.provider,

--- a/sources/grc/family.go
+++ b/sources/grc/family.go
@@ -1,0 +1,3 @@
+package grc
+
+type grcFamily string

--- a/sources/grc/settings.go
+++ b/sources/grc/settings.go
@@ -12,7 +12,7 @@ import (
 type settings struct {
 	provider     string
 	tenantID     string
-	family       string
+	family       grcFamily
 	baseURL      string
 	tokenURL     string
 	clientID     string
@@ -29,7 +29,7 @@ func parseSettings(cfg sourcecdk.Config, allowLoopbackBaseURL bool) (settings, e
 	resolved := settings{
 		provider:     sourcecdk.ConfigValue(cfg, "provider"),
 		tenantID:     firstNonEmptyString(sourcecdk.ConfigValue(cfg, "tenant_id"), sourcecdk.ConfigValue(cfg, "__cerebro_runtime_tenant_id")),
-		family:       sourcecdk.ConfigValue(cfg, "family"),
+		family:       grcFamily(strings.TrimSpace(sourcecdk.ConfigValue(cfg, "family"))),
 		baseURL:      sourcecdk.ConfigValue(cfg, "base_url"),
 		tokenURL:     sourcecdk.ConfigValue(cfg, "token_url"),
 		clientID:     sourcecdk.ConfigValue(cfg, "client_id"),
@@ -100,14 +100,14 @@ func parseSettings(cfg sourcecdk.Config, allowLoopbackBaseURL bool) (settings, e
 func supportedFamilies() []string {
 	families := make([]string, 0, len(familyEndpoints))
 	for _, endpoint := range familyEndpoints {
-		families = append(families, endpoint.name)
+		families = append(families, string(endpoint.name))
 	}
 	return families
 }
 
-func isSupportedFamily(family string) bool {
+func isSupportedFamily(family grcFamily) bool {
 	for _, candidate := range supportedFamilies() {
-		if family == candidate {
+		if string(family) == candidate {
 			return true
 		}
 	}

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -66,7 +66,7 @@ const (
 )
 
 var familyEndpoints = []struct {
-	name string
+	name grcFamily
 	path string
 }{
 	{familyFramework, "/v1/frameworks"}, {familyControl, "/v1/controls"}, {familyControlTest, "/v1/tests"},
@@ -160,30 +160,30 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 	for _, endpoint := range familyEndpoints {
 		families = append(families, s.family(endpoint.name, endpoint.path))
 	}
-	return sourcecdk.NewFamilyEngine(s.parseSettings, func(settings settings) string { return settings.family }, families...)
+	return sourcecdk.NewFamilyEngine(s.parseSettings, func(settings settings) string { return string(settings.family) }, families...)
 }
 
-func (s *Source) family(name string, path string) sourcecdk.Family[settings] {
+func (s *Source) family(name grcFamily, path string) sourcecdk.Family[settings] {
 	return sourcecdk.Family[settings]{
-		Name: name,
+		Name: string(name),
 		Check: func(ctx context.Context, settings settings) error {
 			_, _, err := s.list(ctx, settings, path, "", 1)
 			if err != nil {
-				return fmt.Errorf("grc %s for %s: %w", name, settings.provider, err)
+				return fmt.Errorf("grc %s for %s: %w", string(name), settings.provider, err)
 			}
 			return nil
 		},
 		Discover: func(ctx context.Context, settings settings) ([]sourcecdk.URN, error) {
 			records, _, err := s.list(ctx, settings, path, "", settings.perPage)
 			if err != nil {
-				return nil, fmt.Errorf("grc %s for %s: %w", name, settings.provider, err)
+				return nil, fmt.Errorf("grc %s for %s: %w", string(name), settings.provider, err)
 			}
 			return urnsFor(settings, name, records)
 		},
 		Read: func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 			records, next, err := s.list(ctx, settings, path, strings.TrimSpace(cursor.GetOpaque()), settings.perPage)
 			if err != nil {
-				return sourcecdk.Pull{}, fmt.Errorf("grc %s for %s: %w", name, settings.provider, err)
+				return sourcecdk.Pull{}, fmt.Errorf("grc %s for %s: %w", string(name), settings.provider, err)
 			}
 			return pullFromRecords(settings, name, records, next)
 		},
@@ -279,10 +279,10 @@ func (s *Source) doJSON(req *http.Request, target any) error {
 	return nil
 }
 
-func parseRecord(family string, raw json.RawMessage) (grcRecord, error) {
+func parseRecord(family grcFamily, raw json.RawMessage) (grcRecord, error) {
 	values := map[string]any{}
 	if err := json.Unmarshal(raw, &values); err != nil {
-		return grcRecord{}, fmt.Errorf("decode grc %s record: %w", family, err)
+		return grcRecord{}, fmt.Errorf("decode grc %s record: %w", string(family), err)
 	}
 	id := recordID(family, values, raw)
 	return grcRecord{
@@ -292,10 +292,10 @@ func parseRecord(family string, raw json.RawMessage) (grcRecord, error) {
 	}, nil
 }
 
-func urnsFor(settings settings, family string, records []grcRecord) ([]sourcecdk.URN, error) {
+func urnsFor(settings settings, family grcFamily, records []grcRecord) ([]sourcecdk.URN, error) {
 	urns := make([]sourcecdk.URN, 0, len(records))
 	for _, record := range records {
-		urn, err := sourcecdk.ParseURN(fmt.Sprintf("urn:cerebro:%s:grc_%s:%s:%s", settings.tenantID, family, settings.provider, record.ID))
+		urn, err := sourcecdk.ParseURN(fmt.Sprintf("urn:cerebro:%s:grc_%s:%s:%s", settings.tenantID, string(family), settings.provider, record.ID))
 		if err != nil {
 			return nil, err
 		}
@@ -304,7 +304,7 @@ func urnsFor(settings settings, family string, records []grcRecord) ([]sourcecdk
 	return urns, nil
 }
 
-func pullFromRecords(settings settings, family string, records []grcRecord, next string) (sourcecdk.Pull, error) {
+func pullFromRecords(settings settings, family grcFamily, records []grcRecord, next string) (sourcecdk.Pull, error) {
 	return sourcecdk.PullFromRecords(records, next,
 		func(rec grcRecord) (*primitives.Event, error) {
 			return eventFromRecord(settings, family, rec), nil
@@ -313,28 +313,28 @@ func pullFromRecords(settings settings, family string, records []grcRecord, next
 	)
 }
 
-func eventFromRecord(settings settings, family string, record grcRecord) *primitives.Event {
+func eventFromRecord(settings settings, family grcFamily, record grcRecord) *primitives.Event {
 	occurredAt := occurredAtFor(family, record.Values)
 	payload := append([]byte(nil), record.Raw...)
 	return &primitives.Event{
 		Id:         grcEventID(settings, family, record.ID),
 		TenantId:   settings.tenantID,
 		SourceId:   sourceID,
-		Kind:       "grc." + family,
+		Kind:       "grc." + string(family),
 		OccurredAt: timestamppb.New(occurredAt),
-		SchemaRef:  "grc/" + family + "/v1",
+		SchemaRef:  "grc/" + string(family) + "/v1",
 		Payload:    payload,
 		Attributes: attributesFor(settings, family, record),
 	}
 }
 
-func grcEventID(settings settings, family string, recordID string) string {
+func grcEventID(settings settings, family grcFamily, recordID string) string {
 	return strings.Join([]string{
 		"grc",
 		normalizeID(settings.provider),
 		normalizeID(settings.tenantID),
 		grcRuntimeScope(settings),
-		normalizeID(family),
+		normalizeID(string(family)),
 		normalizeID(recordID),
 	}, "-")
 }
@@ -357,7 +357,7 @@ func firstNonEmptyString(values ...string) string {
 	return ""
 }
 
-func recordID(family string, values map[string]any, raw json.RawMessage) string {
+func recordID(family grcFamily, values map[string]any, raw json.RawMessage) string {
 	for _, key := range recordIDKeys(family) {
 		if value := fieldString(values, key); value != "" {
 			return normalizeID(value)
@@ -367,7 +367,7 @@ func recordID(family string, values map[string]any, raw json.RawMessage) string 
 	return hex.EncodeToString(sum[:])[:16]
 }
 
-func recordIDKeys(family string) []string {
+func recordIDKeys(family grcFamily) []string {
 	switch family {
 	case familyRiskScenario:
 		return []string{"riskId", "id"}
@@ -400,8 +400,8 @@ func normalizeID(value string) string {
 	return strings.ReplaceAll(value, " ", "_")
 }
 
-func occurredAtFor(family string, values map[string]any) time.Time {
-	for _, key := range timestampKeys(family) {
+func occurredAtFor(family grcFamily, values map[string]any) time.Time {
+	for _, key := range timestampKeySets[family] {
 		if value := fieldString(values, key); value != "" {
 			if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
 				return parsed.UTC()
@@ -414,7 +414,7 @@ func occurredAtFor(family string, values map[string]any) time.Time {
 	return time.Now().UTC()
 }
 
-var timestampKeySets = map[string][]string{
+var timestampKeySets = map[grcFamily][]string{
 	familyControl: {"modificationDate", "creationDate"}, familyControlTest: {"lastTestRunDate", "latestFlipDate"},
 	familyPolicy: {"approvedAtDate"}, familyDocument: {"uploadStatusDate"}, familyContract: {"executedDate", "creationDate"},
 	familyRegulatoryNotification: {"sentAt", "submittedAt", "notificationDate", "createdAt", "updatedAt"},
@@ -425,10 +425,6 @@ var timestampKeySets = map[string][]string{
 	familyVulnerability: {"lastDetectedDate", "sourceDetectedDate", "firstDetectedDate"}, familyVulnerabilityRemediation: {"remediationDate", "detectedDate"},
 	familyVulnerableAsset: {"lastDetectedDate", "lastSeenDate", "updatedAt"}, familyRiskScenario: {"identificationDate"},
 	familyPerson: {"employment.startDate", "employment.endDate"},
-}
-
-func timestampKeys(family string) []string {
-	return timestampKeySets[family]
 }
 
 func fieldString(values map[string]any, path string) string {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -21,7 +21,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"gcp":             2130,
 	"github":          2029,
 	"googleworkspace": 815,
-	"grc":             1239,
+	"grc":             1238,
 	"okta":            2256,
 	"panopticon":      765,
 	"sentinelone":     2112,


### PR DESCRIPTION
## Summary
- type GRC source family routing through settings, family endpoints, attribute maps, record IDs, timestamps, event kinds, and schema refs
- centralize assurance artifact kind metadata for URN families, entity types, id attributes, related-artifact matching, and tag namespaces
- lower the GRC source LOC ratchet after removing the timestamp wrapper

## Validation
- go test ./sources/grc
- go test ./internal/sourceprojection
- go test ./internal/sourcecdk ./tools/archtests ./tools/catalogcheck
- git diff --check origin/codex/grc-assurance-artifact-models...HEAD
- provider-name scan on the base diff

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->