### PR TITLE
[codex] document persona view lenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ docker compose up --build
 | Use SDK helpers | [Python SDK](sdk/python/README.md), [TypeScript SDK](sdk/typescript/README.md), and `sources/sdk` |
 | Persist and sync source runtimes | [Source runtime guide](docs/domains/source-runtime-guide.md) |
 | Work on graph behavior | [Graph operations](docs/domains/graph-operations.md) |
+| Design persona-specific graph views | [Persona view lenses](docs/domains/persona-view-lenses.md) |
 | Integrate MCP clients | [MCP native Droid setup](docs/domains/mcp-droid-setup.md) |
 | Integrate endpoint telemetry | [Endpoint security platform integration](docs/domains/endpoint-security-platform-integration.md) |
 | Author policies, control mappings, or finding rules | [Policies](docs/domains/policies.md), [compliance controls](docs/domains/compliance-controls.md), `policies/`, `internal/findingdsl`, and `internal/findings` |

--- a/docs/domains/persona-view-lenses.md
+++ b/docs/domains/persona-view-lenses.md
@@ -1,0 +1,89 @@
+# Persona View Lenses
+
+Cerebro supports multiple product personas on the same tenant-scoped graph by
+letting clients present different lenses over the same runtime, finding,
+evidence, report, inventory, and graph contracts.
+
+This is a product-facing composition pattern. It is not a storage split, a graph
+schema fork, a tenant boundary, or an authorization model.
+
+## Core Boundary
+
+The shared substrate stays the same:
+
+- source runtimes collect and replay operational signals,
+- Postgres stores durable current state for claims, findings, evidence, reports,
+  inventory posture, and GRC views,
+- Neo4j/Aura stores the rebuildable graph projection,
+- API auth and tenant scoping remain enforced by the bootstrap service.
+
+A persona lens may change:
+
+- navigation order,
+- default entry points,
+- page copy,
+- default filters,
+- saved dashboard layouts,
+- report profile selection,
+- which graph-backed summaries appear first.
+
+A persona lens must not change:
+
+- tenant authorization,
+- RBAC permissions,
+- graph projection identity,
+- source runtime durability,
+- finding lifecycle semantics,
+- raw Cypher safety rules,
+- the set of backend stores.
+
+## Initial Lens Set
+
+| Lens | Primary question | First contracts to compose |
+| --- | --- | --- |
+| Security Ops | What active risk needs action first, and what graph path explains it? | `/grc/findings`, `/platform/graph/*`, `/grc/inventory`, `/grc/trends` |
+| Compliance & Audit | Are controls provable, fresh, and exportable? | `/grc/controls`, `/grc/evidence`, `/grc/control-packs*`, `/grc/reports*` |
+| Platform Owners | Are sources, runtimes, and graph projection healthy enough to trust? | `/sources`, `/source-runtimes/*`, `/platform/graph/ingest-*`, `/grc/inventory` |
+| Leadership | What is the program posture, trend direction, and material exposure? | `/grc/dashboard`, `/grc/trends`, `/grc/report-runs`, `/platform/graph/impact/*` |
+
+Clients can add more lenses when a new audience has a distinct first question
+and can be served by composing existing contracts.
+
+## Design Rules
+
+1. Keep the graph shared. Prefer route composition, report profiles, saved
+   dashboards, and product copy before adding backend fields.
+2. Keep RBAC separate. A lens is a wayfinding and prioritization layer; it does
+   not grant or deny permissions.
+3. Keep personas additive. Every graph-backed fact should be addressable from a
+   general route even when a lens hides it from primary navigation.
+4. Keep labels audience-specific, not platform-specific. Security can say
+   "risk" or "finding"; compliance can say "control" or "evidence"; platform
+   contracts should still expose graph, source runtime, report, claim, workflow,
+   and GRC route families.
+5. Keep examples public-safe. Do not document tenant names, hostnames, account
+   IDs, resource labels, URNs, graph counts, or environment-specific rollout
+   details in this repository.
+
+## When Backend Work Is Justified
+
+Most persona work should live in clients. Backend work is justified only when a
+lens needs a reusable, tenant-scoped contract that more than one client can use.
+Good candidates include:
+
+- named report profiles,
+- bounded dashboard source catalog entries,
+- explicit source coverage dimensions,
+- graph impact routes with fixed traversal limits,
+- typed readiness summaries.
+
+Avoid backend changes for presentation-only needs such as navigation grouping,
+marketing copy, card ordering, or default tabs.
+
+## Relation To Non-Goals
+
+Persona lenses reinforce the platform/application boundary in
+[`non-goals.md`](../engineering/non-goals.md): Cerebro is not exclusively a
+security product, and this repository does not ship an end-user web UI. Runtime
+contracts remain shared primitives; product-specific clients decide which
+routes, summaries, and report profiles should be prominent for each audience.

--- a/docs/domains/persona-view-lenses.md
+++ b/docs/domains/persona-view-lenses.md
@@ -7,6 +7,12 @@ evidence, report, inventory, and graph contracts.
 This is a product-facing composition pattern. It is not a storage split, a graph
 schema fork, a tenant boundary, or an authorization model.
 
+The UI should not make people learn Cerebro's persona model before it shows
+value. Persona selection is a prioritization preference. The first screen for a
+security operator should answer what is risky, what changed, who owns it, what
+evidence is missing, and what to fix first. The first screen for an auditor
+should answer which controls are provable, stale, blocked, or export-ready.
+
 ## Core Boundary
 
 The shared substrate stays the same:
@@ -23,6 +29,8 @@ A persona lens may change:
 - default entry points,
 - page copy,
 - default filters,
+- prioritized work queues,
+- suggested questions,
 - saved dashboard layouts,
 - report profile selection,
 - which graph-backed summaries appear first.
@@ -39,11 +47,11 @@ A persona lens must not change:
 
 ## Initial Lens Set
 
-| Lens | Primary question | First contracts to compose |
+| Audience | First question the product should answer | First contracts to compose |
 | --- | --- | --- |
-| Security Ops | What active risk needs action first, and what graph path explains it? | `/grc/findings`, `/platform/graph/*`, `/grc/inventory`, `/grc/trends` |
-| Compliance & Audit | Are controls provable, fresh, and exportable? | `/grc/controls`, `/grc/evidence`, `/grc/control-packs*`, `/grc/reports*` |
-| Platform Owners | Are sources, runtimes, and graph projection healthy enough to trust? | `/sources`, `/source-runtimes/*`, `/platform/graph/ingest-*`, `/grc/inventory` |
+| Security | What active risk needs action first, who owns it, and what assets or evidence make it urgent? | `/grc/findings`, `/platform/graph/*`, `/grc/inventory`, `/grc/trends` |
+| Audit | Which controls are provable, stale, blocked, or export-ready? | `/grc/controls`, `/grc/evidence`, `/grc/control-packs*`, `/grc/reports*` |
+| Platform | Are sources, runtimes, owners, and graph projection healthy enough to trust? | `/sources`, `/source-runtimes/*`, `/platform/graph/ingest-*`, `/grc/inventory` |
 | Leadership | What is the program posture, trend direction, and material exposure? | `/grc/dashboard`, `/grc/trends`, `/grc/report-runs`, `/platform/graph/impact/*` |
 
 Clients can add more lenses when a new audience has a distinct first question
@@ -51,17 +59,23 @@ and can be served by composing existing contracts.
 
 ## Design Rules
 
-1. Keep the graph shared. Prefer route composition, report profiles, saved
+1. Lead with work, not navigation. Home surfaces should show active risk,
+   changed signals, missing owners, stale or missing evidence, affected assets,
+   and useful questions before they show routes or product taxonomy.
+2. Keep the graph shared. Prefer route composition, report profiles, saved
    dashboards, and product copy before adding backend fields.
-2. Keep RBAC separate. A lens is a wayfinding and prioritization layer; it does
+3. Keep RBAC separate. A lens is a wayfinding and prioritization layer; it does
    not grant or deny permissions.
-3. Keep personas additive. Every graph-backed fact should be addressable from a
+4. Keep personas additive. Every graph-backed fact should be addressable from a
    general route even when a lens hides it from primary navigation.
-4. Keep labels audience-specific, not platform-specific. Security can say
-   "risk" or "finding"; compliance can say "control" or "evidence"; platform
-   contracts should still expose graph, source runtime, report, claim, workflow,
-   and GRC route families.
-5. Keep examples public-safe. Do not document tenant names, hostnames, account
+5. Keep labels audience-specific, not platform-specific. Security can say
+   "risk", "owner", "affected asset", or "fix first"; audit can say "control",
+   "evidence", or "export"; platform contracts should still expose graph,
+   source runtime, report, claim, workflow, and GRC route families.
+6. Keep the persona control quiet. Clients may expose a "prioritize for"
+   selector, but that control should not dominate the page or repeat the same
+   audience label in headers, cards, and explanatory copy.
+7. Keep examples public-safe. Do not document tenant names, hostnames, account
    IDs, resource labels, URNs, graph counts, or environment-specific rollout
    details in this repository.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ docker compose up --build
 | Built-in source integrations | [Source catalog](reference/sources.md) |
 | Source runtime sync | [Source runtime guide](domains/source-runtime-guide.md) |
 | Graph operations | [Graph operations](domains/graph-operations.md) |
+| Persona-specific graph views | [Persona view lenses](domains/persona-view-lenses.md) |
 | GRC architecture | [GRC architecture](domains/grc-architecture.md) |
 | Compliance control coverage | [Compliance controls](domains/compliance-controls.md) |
 | Policies | [Policies](domains/policies.md) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Domains:
       - Source Runtime Guide: domains/source-runtime-guide.md
       - Graph Operations: domains/graph-operations.md
+      - Persona View Lenses: domains/persona-view-lenses.md
       - Compliance Controls: domains/compliance-controls.md
       - Policies: domains/policies.md
       - Policy Rule Extensions: domains/policy-rule-extensions.md


### PR DESCRIPTION
## Summary
- document persona view lenses as a client-side composition pattern over shared Cerebro contracts
- clarify that lenses do not change RBAC, tenant boundaries, graph identity, or storage
- link the guidance from the README, docs index, and docs navigation

## Validation
- make docs-drift-check
- make readme-check
- make oss-audit