### PR TITLE
[codex] Resolve legacy GRC impact URNs

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -7866,8 +7866,18 @@ func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRec
 	if request.Status != "" && strings.TrimSpace(finding.Status) != strings.TrimSpace(request.Status) {
 		return false
 	}
-	if request.ResourceURN != "" && !containsTrimmed(finding.ResourceURNs, request.ResourceURN) {
-		return false
+	resourceURNs := normalizedTestStrings(append(request.ResourceURNs, request.ResourceURN))
+	if len(resourceURNs) != 0 {
+		matched := false
+		for _, resourceURN := range resourceURNs {
+			if containsTrimmed(finding.ResourceURNs, resourceURN) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
 	}
 	if request.EventID != "" && !containsTrimmed(finding.EventIDs, request.EventID) {
 		return false

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -604,6 +604,18 @@ func (a *App) handleGRCEntityImpact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	graph, err := graphStore.GetEntityNeighborhood(r.Context(), entityURN, int(limit))
+	if errors.Is(err, ports.ErrGraphEntityNotFound) {
+		for _, candidateURN := range graphquery.LegacyEntityImpactFallbackURNs(entityURN) {
+			graph, err = graphStore.GetEntityNeighborhood(r.Context(), candidateURN, int(limit))
+			if err == nil {
+				entityURN = candidateURN
+				break
+			}
+			if !errors.Is(err, ports.ErrGraphEntityNotFound) {
+				break
+			}
+		}
+	}
 	if err != nil {
 		writeGRCError(w, err)
 		return

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -593,6 +593,7 @@ func (a *App) handleGRCEntityImpact(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
+	requestedEntityURN := entityURN
 	limit, err := grcLimitFromRequest(r)
 	if err != nil {
 		writeGRCError(w, err)
@@ -630,7 +631,12 @@ func (a *App) handleGRCEntityImpact(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	findings, err := a.grcListFindingRecords(r, runtimes, grcFindingFilter{ResourceURN: entityURN, Limit: limit})
+	findingFilter := grcFindingFilter{ResourceURN: entityURN, Limit: limit}
+	if requestedEntityURN != entityURN {
+		findingFilter.ResourceURN = ""
+		findingFilter.ResourceURNs = []string{entityURN, requestedEntityURN}
+	}
+	findings, err := a.grcListFindingRecords(r, runtimes, findingFilter)
 	if err != nil {
 		writeGRCError(w, err)
 		return
@@ -991,6 +997,7 @@ func (a *App) grcListFindingRecords(r *http.Request, runtimes []*cerebrov1.Sourc
 			Severity:            filter.Severity,
 			Status:              filter.Status,
 			ResourceURN:         filter.ResourceURN,
+			ResourceURNs:        filter.ResourceURNs,
 			EventID:             filter.EventID,
 			PolicyID:            filter.PolicyID,
 			Framework:           filter.Framework,
@@ -1068,6 +1075,7 @@ func (a *App) grcFindingSummary(r *http.Request, runtimes []*cerebrov1.SourceRun
 			Severity:            filter.Severity,
 			Status:              filter.Status,
 			ResourceURN:         filter.ResourceURN,
+			ResourceURNs:        filter.ResourceURNs,
 			EventID:             filter.EventID,
 			PolicyID:            filter.PolicyID,
 			Framework:           filter.Framework,
@@ -1270,6 +1278,7 @@ func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.Sourc
 				Severity:            findingFilter.Severity,
 				Status:              findingFilter.Status,
 				ResourceURN:         findingFilter.ResourceURN,
+				ResourceURNs:        findingFilter.ResourceURNs,
 				EventID:             findingFilter.EventID,
 				PolicyID:            findingFilter.PolicyID,
 				Framework:           findingFilter.Framework,

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -947,6 +947,34 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 func TestGRCEntityImpactResolvesLegacyGitHubRepoURN(t *testing.T) {
 	legacyURN := "urn:cerebro:writer:github_repo:sohalloran-writer"
 	canonicalURN := "urn:cerebro:writer:github_user:sohalloran-writer"
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {Id: "writer-github", SourceId: "github", TenantId: "writer"},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-canonical": {
+				ID:             "finding-canonical",
+				TenantID:       "writer",
+				RuntimeID:      "writer-github",
+				Title:          "Canonical identity finding",
+				Severity:       "HIGH",
+				Status:         "open",
+				ResourceURNs:   []string{canonicalURN},
+				LastObservedAt: now,
+			},
+			"finding-legacy": {
+				ID:             "finding-legacy",
+				TenantID:       "writer",
+				RuntimeID:      "writer-github",
+				Title:          "Legacy identity finding",
+				Severity:       "MEDIUM",
+				Status:         "open",
+				ResourceURNs:   []string{legacyURN},
+				LastObservedAt: now.Add(-time.Minute),
+			},
+		},
+	}
 	graphStore := &stubGraphStore{
 		entities: map[string]*ports.ProjectedEntity{
 			canonicalURN: {
@@ -958,7 +986,7 @@ func TestGRCEntityImpactResolvesLegacyGitHubRepoURN(t *testing.T) {
 			},
 		},
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: &stubRuntimeStore{}, GraphStore: graphStore}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -983,6 +1011,23 @@ func TestGRCEntityImpactResolvesLegacyGitHubRepoURN(t *testing.T) {
 	}
 	if graphStore.neighborhoodRootURN != canonicalURN {
 		t.Fatalf("queried root urn = %q, want %q", graphStore.neighborhoodRootURN, canonicalURN)
+	}
+	if got := store.findingListRequest.ResourceURN; got != "" {
+		t.Fatalf("finding resource urn = %q, want multi-resource lookup", got)
+	}
+	for _, want := range []string{canonicalURN, legacyURN} {
+		if !containsTrimmed(store.findingListRequest.ResourceURNs, want) {
+			t.Fatalf("finding resource urns = %#v, want %q", store.findingListRequest.ResourceURNs, want)
+		}
+	}
+	gotFindings := map[string]struct{}{}
+	for _, finding := range impact.Findings {
+		gotFindings[finding.ID] = struct{}{}
+	}
+	for _, want := range []string{"finding-canonical", "finding-legacy"} {
+		if _, ok := gotFindings[want]; !ok {
+			t.Fatalf("impact findings = %#v, want %q", impact.Findings, want)
+		}
 	}
 }
 

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -944,6 +944,48 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 	}
 }
 
+func TestGRCEntityImpactResolvesLegacyGitHubRepoURN(t *testing.T) {
+	legacyURN := "urn:cerebro:writer:github_repo:sohalloran-writer"
+	canonicalURN := "urn:cerebro:writer:github_user:sohalloran-writer"
+	graphStore := &stubGraphStore{
+		entities: map[string]*ports.ProjectedEntity{
+			canonicalURN: {
+				URN:        canonicalURN,
+				TenantID:   "writer",
+				SourceID:   "github",
+				EntityType: "github.user",
+				Label:      "sohalloran-writer",
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: &stubRuntimeStore{}, GraphStore: graphStore}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/entities/" + url.PathEscape(legacyURN) + "/impact?tenant_id=writer")
+	if err != nil {
+		t.Fatalf("GET /grc/entities legacy github repo impact error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /grc/entities legacy github repo impact status = %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
+	}
+	var impact grcEntityImpactResponse
+	if err := json.NewDecoder(resp.Body).Decode(&impact); err != nil {
+		t.Fatalf("decode impact: %v", err)
+	}
+	if impact.EntityURN != canonicalURN {
+		t.Fatalf("impact entity urn = %q, want %q", impact.EntityURN, canonicalURN)
+	}
+	if impact.Graph == nil || impact.Graph.Root == nil || impact.Graph.Root.URN != canonicalURN {
+		t.Fatalf("impact graph root = %#v, want %q", impact.Graph, canonicalURN)
+	}
+	if graphStore.neighborhoodRootURN != canonicalURN {
+		t.Fatalf("queried root urn = %q, want %q", graphStore.neighborhoodRootURN, canonicalURN)
+	}
+}
+
 func TestGRCAuditPacketNormalizesForeignFindingLookup(t *testing.T) {
 	store := &stubRuntimeStore{
 		findings: map[string]*ports.FindingRecord{

--- a/internal/graphquery/legacy_urn.go
+++ b/internal/graphquery/legacy_urn.go
@@ -1,0 +1,45 @@
+package graphquery
+
+import (
+	"strings"
+
+	cerebrourn "github.com/writer/cerebro/internal/urn"
+)
+
+// LegacyEntityImpactFallbackURNs returns current graph root candidates for
+// legacy impact URLs that were minted before GitHub entity kinds stabilized.
+func LegacyEntityImpactFallbackURNs(entityURN string) []string {
+	parsed, err := cerebrourn.Parse(entityURN)
+	if err != nil {
+		return nil
+	}
+	var candidates []string
+	addCandidate := func(kind string, parts ...string) {
+		candidate, err := cerebrourn.Mint(parsed.TenantID, kind, parts...)
+		if err != nil || candidate == "" || candidate == entityURN {
+			return
+		}
+		for _, existing := range candidates {
+			if existing == candidate {
+				return
+			}
+		}
+		candidates = append(candidates, candidate)
+	}
+	switch parsed.Kind {
+	case "github_repo", "github_repository", "repo":
+		addCandidate("github_code_repository", parsed.Parts...)
+		if len(parsed.Parts) > 1 {
+			addCandidate("github_code_repository", strings.Join(parsed.Parts, "/"))
+		}
+		if len(parsed.Parts) == 1 && !strings.Contains(parsed.Parts[0], "/") {
+			login := parsed.Parts[0]
+			addCandidate("github_user", login)
+			addCandidate("identity", "login", login)
+			addCandidate("identifier", "login", login)
+			addCandidate("github_resource", "team", login)
+			addCandidate("github_resource", "org", login)
+		}
+	}
+	return candidates
+}

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -126,6 +126,7 @@ type ListFindingsRequest struct {
 	Severity            string
 	Status              string
 	ResourceURN         string
+	ResourceURNs        []string
 	EventID             string
 	PolicyID            string
 	Framework           string

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -1430,7 +1430,7 @@ func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, e
 	}
 	addFindingAgeFilter(&clauses, &args, request.MinAgeDays, request.MaxAgeDays)
 	addFindingSLAStatusFilter(&clauses, &args, request.SLAStatus)
-	if err := addFindingArrayContainsFilter(&clauses, &args, "resource_urns_json", request.ResourceURN); err != nil {
+	if err := addFindingArrayContainsAnyFilter(&clauses, &args, "resource_urns_json", append([]string{request.ResourceURN}, request.ResourceURNs...)); err != nil {
 		return nil, nil, err
 	}
 	if err := addFindingArrayContainsFilter(&clauses, &args, "event_ids_json", request.EventID); err != nil {
@@ -2503,6 +2503,33 @@ func addFindingArrayContainsFilter(clauses *[]string, args *[]any, column string
 	}
 	*args = append(*args, payload)
 	*clauses = append(*clauses, fmt.Sprintf("%s @> $%d::jsonb", column, len(*args)))
+	return nil
+}
+
+func addFindingArrayContainsAnyFilter(clauses *[]string, args *[]any, column string, values []string) error {
+	itemClauses := []string{}
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		payload, err := findingStringsJSON([]string{trimmed})
+		if err != nil {
+			return fmt.Errorf("marshal %s filter: %w", column, err)
+		}
+		*args = append(*args, payload)
+		itemClauses = append(itemClauses, fmt.Sprintf("%s @> $%d::jsonb", column, len(*args)))
+	}
+	if len(itemClauses) == 1 {
+		*clauses = append(*clauses, itemClauses[0])
+	} else if len(itemClauses) > 1 {
+		*clauses = append(*clauses, "("+strings.Join(itemClauses, " OR ")+")")
+	}
 	return nil
 }
 

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -523,6 +523,25 @@ func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
 	}
 }
 
+func TestFindingListQueryMatchesAnyResourceURN(t *testing.T) {
+	query, args, err := findingListQuery(ports.ListFindingsRequest{
+		TenantID:     "tenant-a",
+		RuntimeID:    "runtime-audit",
+		ResourceURNs: []string{"urn:cerebro:writer:github_user:octo", "urn:cerebro:writer:github_repo:octo"},
+		Limit:        25,
+	})
+	if err != nil {
+		t.Fatalf("findingListQuery() error = %v", err)
+	}
+	want := "(resource_urns_json @> $3::jsonb OR resource_urns_json @> $4::jsonb)"
+	if !strings.Contains(query, want) {
+		t.Fatalf("findingListQuery() query missing %q: %s", want, query)
+	}
+	if got := len(args); got != 5 {
+		t.Fatalf("len(findingListQuery().args) = %d, want 5", got)
+	}
+}
+
 func TestFindingListQuerySupportsRuntimeBatchesAndPriorityOrder(t *testing.T) {
 	query, args, err := findingListQuery(ports.ListFindingsRequest{
 		TenantID:      "writer",


### PR DESCRIPTION
## Summary
- Add backend fallback resolution for legacy GitHub repo-style GRC impact URNs when the exact graph root is missing.
- Preserve current behavior for canonical entity URNs while allowing old repo-style seeds to resolve to current graph nodes.

## Root Cause
A graph exploration URL could be seeded with a legacy repo-style URN for an entity that is stored under a current GitHub identity/resource kind. The impact endpoint returned 404 before attempting compatible current URNs.

## Validation
- Focused GRC impact handler regression test passed locally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->