### PR TITLE
[codex] Advertise Aperio response capabilities

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6913,6 +6913,28 @@ components:
           type: boolean
         requires_trusted_scope:
           type: boolean
+        provider:
+          type: string
+          description: SaaS provider for externally owned response workflows.
+        external_owner:
+          type: string
+          description: Product or workflow owner for capabilities that Cerebro advertises but does not execute directly.
+        target_types:
+          type: array
+          items:
+            type: string
+          description: Supported target resource types for this response action.
+        required_context_keys:
+          type: array
+          items:
+            type: string
+          description: Finding or incident context keys required to propose or execute this action.
+        dry_run:
+          type: boolean
+          description: Whether the capability is exposed as a dry-run proposal workflow.
+        approval_required:
+          type: boolean
+          description: Whether mutating execution requires explicit human approval.
     RuntimeBlocklistEntryResponse:
       type: object
       required:

--- a/docs/domains/aperio-integration-contract.md
+++ b/docs/domains/aperio-integration-contract.md
@@ -108,6 +108,7 @@ github.revoke_oauth_app
 okta.suspend_user
 microsoft_365.revoke_sessions
 atlassian.revoke_user_access
+salesforce.remove_admin_role
 ```
 
 Actions that are still owned by Aperio should still be represented as external refs and workflow events so Cerebro

--- a/docs/domains/aperio-integration-contract.md
+++ b/docs/domains/aperio-integration-contract.md
@@ -113,6 +113,13 @@ atlassian.revoke_user_access
 Actions that are still owned by Aperio should still be represented as external refs and workflow events so Cerebro
 evidence packets, reports, audit logs, and Ask can explain what happened.
 
+`GET /platform/runtime-response/capabilities` advertises those Aperio-owned SaaS response actions with
+`mode=external_aperio_workflow`, `external_owner=aperio`, `supported=false`, `dry_run=true`, and
+`approval_required=true`. That lets Web and agents discover the action vocabulary, target types, and required context
+keys while preserving Aperio as the workflow owner. Until a specific provider adapter moves into Cerebro, callers
+should use the Aperio MCP proposal path, especially `aperio.propose_cerebro_response`, rather than POSTing those
+external workflow actions to `/platform/runtime-response/actions`.
+
 ## Detection Pack And Coverage Metadata
 
 Aperio detection packs should publish stable pack metadata alongside findings:
@@ -156,4 +163,3 @@ search, and cite Cerebro tools or evidence packets when they are used.
 Aperio should propagate W3C `traceparent` into Cerebro claim writes, external-ref updates, action requests, MCP calls,
 and Web deep links. Cerebro Web should surface the returned trace id so an analyst can follow a detection from Aperio
 sync through claim projection, graph reasoning, evidence packet generation, and response action reconciliation.
-

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -54,7 +54,8 @@ Set `CEREBRO_API_AUTH_ENABLED=true` and pass `Authorization: Bearer <key>` or `X
 Runtime response capabilities include locally executable blocklist actions plus external workflow actions owned by
 Aperio, such as `google_workspace.revoke_oauth_grant`, `slack.revoke_app_install`, and
 `github.revoke_oauth_app`. External Aperio actions are advertised with provider, target type, required context key,
-dry-run, and approval metadata; they remain proposal workflows rather than direct Cerebro runtime mutations.
+dry-run, and approval metadata; they remain proposal workflows through `aperio.propose_cerebro_response` rather than
+direct Cerebro runtime mutations.
 - `GET /grc/control-archetypes`
 - `GET /grc/control-profiles`
 - `GET /grc/control-coverage`

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -50,6 +50,11 @@ Set `CEREBRO_API_AUTH_ENABLED=true` and pass `Authorization: Bearer <key>` or `X
 - `POST /platform/runtime-response/actions`
 - `GET /platform/runtime-response/blocklist`
 - `POST /platform/runtime-response/blocklist/{entryID}/revoke`
+
+Runtime response capabilities include locally executable blocklist actions plus external workflow actions owned by
+Aperio, such as `google_workspace.revoke_oauth_grant`, `slack.revoke_app_install`, and
+`github.revoke_oauth_app`. External Aperio actions are advertised with provider, target type, required context key,
+dry-run, and approval metadata; they remain proposal workflows rather than direct Cerebro runtime mutations.
 - `GET /grc/control-archetypes`
 - `GET /grc/control-profiles`
 - `GET /grc/control-coverage`

--- a/internal/runtimeresponse/service.go
+++ b/internal/runtimeresponse/service.go
@@ -20,15 +20,28 @@ var (
 )
 
 const (
-	ActionBlockIP     = "block_ip"
-	ActionBlockDomain = "block_domain"
+	ActionBlockIP                         = "block_ip"
+	ActionBlockDomain                     = "block_domain"
+	ActionGoogleWorkspaceRevokeOAuthGrant = "google_workspace.revoke_oauth_grant"
+	ActionSlackRevokeAppInstall           = "slack.revoke_app_install"
+	ActionGitHubRevokeOAuthApp            = "github.revoke_oauth_app"
+	ActionOktaSuspendUser                 = "okta.suspend_user"
+	ActionMicrosoft365RevokeSessions      = "microsoft_365.revoke_sessions"
+	ActionAtlassianRevokeUserAccess       = "atlassian.revoke_user_access"
+	ActionSalesforceRemoveAdminRole       = "salesforce.remove_admin_role"
 )
 
 type Capability struct {
-	Action        string `json:"action"`
-	Mode          string `json:"mode"`
-	Supported     bool   `json:"supported"`
-	RequiresScope bool   `json:"requires_trusted_scope"`
+	Action              string   `json:"action"`
+	Mode                string   `json:"mode"`
+	Supported           bool     `json:"supported"`
+	RequiresScope       bool     `json:"requires_trusted_scope"`
+	Provider            string   `json:"provider,omitempty"`
+	ExternalOwner       string   `json:"external_owner,omitempty"`
+	TargetTypes         []string `json:"target_types,omitempty"`
+	RequiredContextKeys []string `json:"required_context_keys,omitempty"`
+	DryRun              bool     `json:"dry_run"`
+	ApprovalRequired    bool     `json:"approval_required"`
 }
 
 type ExecuteRequest struct {
@@ -53,7 +66,7 @@ func New(store ports.RuntimeBlocklistStore) *Service {
 }
 
 func (s *Service) Capabilities() []Capability {
-	return []Capability{
+	capabilities := []Capability{
 		{Action: ActionBlockIP, Mode: "local_blocklist", Supported: s != nil && s.store != nil, RequiresScope: true},
 		{Action: ActionBlockDomain, Mode: "local_blocklist", Supported: s != nil && s.store != nil, RequiresScope: true},
 		{Action: "scale_down", Mode: "remote_or_provider", Supported: false, RequiresScope: true},
@@ -62,6 +75,96 @@ func (s *Service) Capabilities() []Capability {
 		{Action: "isolate_host", Mode: "remote_tool", Supported: false, RequiresScope: true},
 		{Action: "quarantine_file", Mode: "remote_tool", Supported: false, RequiresScope: true},
 		{Action: "revoke_credentials", Mode: "remote_tool", Supported: false, RequiresScope: true},
+	}
+	return append(capabilities, aperioExternalWorkflowCapabilities()...)
+}
+
+func aperioExternalWorkflowCapabilities() []Capability {
+	return []Capability{
+		{
+			Action:              ActionGoogleWorkspaceRevokeOAuthGrant,
+			Mode:                "external_aperio_workflow",
+			Supported:           false,
+			RequiresScope:       true,
+			Provider:            "GOOGLE_WORKSPACE",
+			ExternalOwner:       "aperio",
+			TargetTypes:         []string{"oauth_grant", "oauth_app"},
+			RequiredContextKeys: []string{"oauth_grant_id", "oauth_app_id", "oauth_user_email"},
+			DryRun:              true,
+			ApprovalRequired:    true,
+		},
+		{
+			Action:              ActionSlackRevokeAppInstall,
+			Mode:                "external_aperio_workflow",
+			Supported:           false,
+			RequiresScope:       true,
+			Provider:            "SLACK",
+			ExternalOwner:       "aperio",
+			TargetTypes:         []string{"oauth_app", "slack_app"},
+			RequiredContextKeys: []string{"oauth_app_id", "slack_app_id", "workspace_id"},
+			DryRun:              true,
+			ApprovalRequired:    true,
+		},
+		{
+			Action:              ActionGitHubRevokeOAuthApp,
+			Mode:                "external_aperio_workflow",
+			Supported:           false,
+			RequiresScope:       true,
+			Provider:            "GITHUB",
+			ExternalOwner:       "aperio",
+			TargetTypes:         []string{"oauth_app", "github_oauth_app"},
+			RequiredContextKeys: []string{"oauth_app_id", "github_org", "github_user"},
+			DryRun:              true,
+			ApprovalRequired:    true,
+		},
+		{
+			Action:              ActionOktaSuspendUser,
+			Mode:                "external_aperio_workflow",
+			Supported:           false,
+			RequiresScope:       true,
+			Provider:            "OKTA",
+			ExternalOwner:       "aperio",
+			TargetTypes:         []string{"user", "identity"},
+			RequiredContextKeys: []string{"okta_user_id", "user_email"},
+			DryRun:              true,
+			ApprovalRequired:    true,
+		},
+		{
+			Action:              ActionMicrosoft365RevokeSessions,
+			Mode:                "external_aperio_workflow",
+			Supported:           false,
+			RequiresScope:       true,
+			Provider:            "MICROSOFT_365",
+			ExternalOwner:       "aperio",
+			TargetTypes:         []string{"user", "identity"},
+			RequiredContextKeys: []string{"user_id", "user_principal_name"},
+			DryRun:              true,
+			ApprovalRequired:    true,
+		},
+		{
+			Action:              ActionAtlassianRevokeUserAccess,
+			Mode:                "external_aperio_workflow",
+			Supported:           false,
+			RequiresScope:       true,
+			Provider:            "ATLASSIAN",
+			ExternalOwner:       "aperio",
+			TargetTypes:         []string{"user", "group", "project"},
+			RequiredContextKeys: []string{"atlassian_account_id", "resource_id"},
+			DryRun:              true,
+			ApprovalRequired:    true,
+		},
+		{
+			Action:              ActionSalesforceRemoveAdminRole,
+			Mode:                "external_aperio_workflow",
+			Supported:           false,
+			RequiresScope:       true,
+			Provider:            "SALESFORCE",
+			ExternalOwner:       "aperio",
+			TargetTypes:         []string{"user", "permission_set", "profile"},
+			RequiredContextKeys: []string{"salesforce_user_id", "permission_set_id"},
+			DryRun:              true,
+			ApprovalRequired:    true,
+		},
 	}
 }
 

--- a/internal/runtimeresponse/service.go
+++ b/internal/runtimeresponse/service.go
@@ -40,8 +40,8 @@ type Capability struct {
 	ExternalOwner       string   `json:"external_owner,omitempty"`
 	TargetTypes         []string `json:"target_types,omitempty"`
 	RequiredContextKeys []string `json:"required_context_keys,omitempty"`
-	DryRun              bool     `json:"dry_run"`
-	ApprovalRequired    bool     `json:"approval_required"`
+	DryRun              bool     `json:"dry_run,omitempty"`
+	ApprovalRequired    bool     `json:"approval_required,omitempty"`
 }
 
 type ExecuteRequest struct {

--- a/internal/runtimeresponse/service_test.go
+++ b/internal/runtimeresponse/service_test.go
@@ -194,6 +194,46 @@ func TestCapabilitiesRequireTrustedScope(t *testing.T) {
 	}
 }
 
+func TestCapabilitiesAdvertiseAperioExternalWorkflowActions(t *testing.T) {
+	capabilities := New(&recordingRuntimeBlocklistStore{}).Capabilities()
+	capability, ok := capabilityByAction(capabilities, ActionGoogleWorkspaceRevokeOAuthGrant)
+	if !ok {
+		t.Fatalf("Capabilities() missing %s: %#v", ActionGoogleWorkspaceRevokeOAuthGrant, capabilities)
+	}
+	if capability.Mode != "external_aperio_workflow" ||
+		capability.Supported ||
+		!capability.RequiresScope ||
+		capability.Provider != "GOOGLE_WORKSPACE" ||
+		capability.ExternalOwner != "aperio" ||
+		!capability.DryRun ||
+		!capability.ApprovalRequired {
+		t.Fatalf("Aperio Google Workspace capability drifted: %#v", capability)
+	}
+	if len(capability.TargetTypes) != 2 || capability.TargetTypes[0] != "oauth_grant" {
+		t.Fatalf("Aperio target types drifted: %#v", capability.TargetTypes)
+	}
+	if len(capability.RequiredContextKeys) == 0 || capability.RequiredContextKeys[0] != "oauth_grant_id" {
+		t.Fatalf("Aperio required context keys drifted: %#v", capability.RequiredContextKeys)
+	}
+
+	for _, action := range []string{
+		ActionSlackRevokeAppInstall,
+		ActionGitHubRevokeOAuthApp,
+		ActionOktaSuspendUser,
+		ActionMicrosoft365RevokeSessions,
+		ActionAtlassianRevokeUserAccess,
+		ActionSalesforceRemoveAdminRole,
+	} {
+		capability, ok := capabilityByAction(capabilities, action)
+		if !ok {
+			t.Fatalf("Capabilities() missing %s", action)
+		}
+		if capability.Mode != "external_aperio_workflow" || capability.ExternalOwner != "aperio" || !capability.ApprovalRequired || !capability.DryRun {
+			t.Fatalf("Aperio external workflow capability %s drifted: %#v", action, capability)
+		}
+	}
+}
+
 func TestListDelegatesFilterToStore(t *testing.T) {
 	entry := &ports.RuntimeBlocklistEntry{ID: "rr-1", TenantID: "writer", Type: "ip", Value: "192.0.2.1"}
 	store := &recordingRuntimeBlocklistStore{listEntries: []*ports.RuntimeBlocklistEntry{entry}}
@@ -245,4 +285,13 @@ func TestListAndRevokeRequireStore(t *testing.T) {
 	if _, err := service.Revoke(context.Background(), "writer", "rr-1"); !errors.Is(err, ErrRuntimeUnavailable) {
 		t.Fatalf("Revoke(nil store) error = %v, want ErrRuntimeUnavailable", err)
 	}
+}
+
+func capabilityByAction(capabilities []Capability, action string) (Capability, bool) {
+	for _, capability := range capabilities {
+		if capability.Action == action {
+			return capability, true
+		}
+	}
+	return Capability{}, false
 }

--- a/internal/runtimeresponse/service_test.go
+++ b/internal/runtimeresponse/service_test.go
@@ -2,6 +2,7 @@ package runtimeresponse
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -230,6 +231,24 @@ func TestCapabilitiesAdvertiseAperioExternalWorkflowActions(t *testing.T) {
 		}
 		if capability.Mode != "external_aperio_workflow" || capability.ExternalOwner != "aperio" || !capability.ApprovalRequired || !capability.DryRun {
 			t.Fatalf("Aperio external workflow capability %s drifted: %#v", action, capability)
+		}
+	}
+}
+
+func TestCapabilitiesDoNotEmitAperioApprovalFieldsForLocalActions(t *testing.T) {
+	capabilities := New(&recordingRuntimeBlocklistStore{}).Capabilities()
+	capability, ok := capabilityByAction(capabilities, ActionBlockIP)
+	if !ok {
+		t.Fatalf("Capabilities() missing %s", ActionBlockIP)
+	}
+	payload, err := json.Marshal(capability)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	encoded := string(payload)
+	for _, field := range []string{"dry_run", "approval_required", "external_owner"} {
+		if strings.Contains(encoded, field) {
+			t.Fatalf("local capability encoded %s in %s", field, encoded)
 		}
 	}
 }

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -676,7 +676,10 @@ export type ConnectorDefinitionResponse = {
 };
 
 export type ConnectorDefinitionScopeOption = {
+  control_domains?: string[];
+  control_refs?: CoverageControlRef[];
   default_enabled?: boolean;
+  evidence_types?: string[];
   families?: string[];
   id?: string;
   label?: string;
@@ -746,6 +749,12 @@ export type ConnectorDepositResponse = {
   runtime_id: string;
   source_id: string;
   tenant_id: string;
+};
+
+export type CoverageControlRef = {
+  control_id?: string;
+  framework_id?: string;
+  framework_name?: string;
 };
 
 export type CreatePlatformJobRequest = {
@@ -1346,9 +1355,15 @@ export type RuntimeResponseCapabilitiesResponse = {
 
 export type RuntimeResponseCapability = {
   action: string;
+  approval_required?: boolean;
+  dry_run?: boolean;
+  external_owner?: string;
   mode: string;
+  provider?: string;
+  required_context_keys?: string[];
   requires_trusted_scope: boolean;
   supported: boolean;
+  target_types?: string[];
 };
 
 export type RuntimeResponseExecuteRequest = {
@@ -1414,8 +1429,11 @@ export type SourceCDKScaffoldPlan = {
 export type SourceCoverageRecord = {
   authority_domain?: string;
   blind_spot?: boolean;
+  control_domains?: string[];
+  control_refs?: CoverageControlRef[];
   dimension_id?: string;
-  dimension_type?: "app_entitlement" | "audit_event" | "entity_family" | "incremental_sync" | "lifecycle_state" | "relationship" | "remediation_state";
+  dimension_type?: "alert_state" | "app_entitlement" | "audit_event" | "deployment_state" | "entity_family" | "incremental_sync" | "lifecycle_state" | "relationship" | "remediation_state";
+  evidence_types?: string[];
   family?: string;
   high_value?: boolean;
   known_unsupported_fields?: string[];


### PR DESCRIPTION
## Summary
- Adds Aperio-owned SaaS response actions to the runtime-response capability list with provider, target type, required context key, dry-run, approval, and external-owner metadata.
- Keeps these actions unsupported for direct Cerebro execution while preserving local blocklist behavior.
- Documents the external Aperio workflow boundary in the Aperio integration contract and API reference.

## Impact
Cerebro Web and agents can discover the shared response vocabulary while still routing mutating SaaS response through Aperio proposal workflows.

## Validation
- `go test ./internal/runtimeresponse`
- `go test ./...` was attempted but the local Go build temp area ran out of disk space (`no space left on device`) after the touched package passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->