### PR TITLE
Document persona enrichment model

### DIFF
--- a/docs/domains/persona-view-lenses.md
+++ b/docs/domains/persona-view-lenses.md
@@ -30,6 +30,9 @@ A persona lens may change:
 - page copy,
 - default filters,
 - prioritized work queues,
+- prioritized signal ordering,
+- decision criteria,
+- recommended next actions,
 - suggested questions,
 - saved dashboard layouts,
 - report profile selection,
@@ -56,6 +59,30 @@ A persona lens must not change:
 
 Clients can add more lenses when a new audience has a distinct first question
 and can be served by composing existing contracts.
+
+## Enrichment Model
+
+Shallow lenses only rename the same dashboard for different audiences. Useful
+lenses enrich the same graph facts into a different operating frame. Client
+implementations should define the following persona-level fields before adding
+new backend contracts:
+
+- first question: the sentence the page should answer before showing
+  navigation,
+- promoted signals: the ordered metrics that matter most to the audience,
+- decision frame: the criteria that explain why those signals are promoted,
+- work queue: the items the audience should act on next,
+- next actions: links that move directly from the briefing to work,
+- question starters: useful prompts that teach the user what Cerebro can answer.
+
+For example, the same missing owner fact means different things by audience:
+
+| Audience | Enriched meaning |
+| --- | --- |
+| Security | Remediation may stall unless the finding has an accountable owner. |
+| Audit | Control evidence may not be defensible without an accountable owner. |
+| Platform | Inventory and source ownership need cleanup before downstream teams rely on the graph. |
+| Leadership | The program review needs a named follow-up owner before the risk can leave the agenda. |
 
 ## Design Rules
 


### PR DESCRIPTION
## Summary
- Add the persona enrichment model to the Cerebro persona-view-lenses domain doc.
- Clarify that lenses should enrich the same graph facts into audience-specific first questions, promoted signals, decision frames, work queues, next actions, and question starters.
- Add an example showing how the same missing-owner fact means different things for Security, Audit, Platform, and Leadership.

## Validation
- make docs-drift-check
- make readme-check
- make oss-audit

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->