### PR TITLE
[codex] Batch impact graph neighborhood expansion

### DIFF
--- a/internal/graphquery/impact.go
+++ b/internal/graphquery/impact.go
@@ -25,6 +25,10 @@ const (
 	impactNeighborhoodConcurrency = 8
 )
 
+type impactBatchNeighborhoodStore interface {
+	GetEntityNeighborhoods(context.Context, []string, int) (map[string]*ports.EntityNeighborhood, error)
+}
+
 type ImpactRequest struct {
 	Kind       string
 	TenantID   string
@@ -138,6 +142,20 @@ func (s *Service) collectImpactGraph(ctx context.Context, rootURN string, depth 
 
 func (s *Service) collectImpactNeighborhoods(ctx context.Context, roots []string, limit int) ([]*ports.EntityNeighborhood, error) {
 	results := make([]*ports.EntityNeighborhood, len(roots))
+	if batchStore, ok := s.store.(impactBatchNeighborhoodStore); ok {
+		neighborhoods, err := batchStore.GetEntityNeighborhoods(ctx, roots, limit)
+		if err != nil {
+			return nil, err
+		}
+		for index, urn := range roots {
+			neighborhood, ok := neighborhoods[urn]
+			if !ok {
+				return nil, fmt.Errorf("%w: %s", ports.ErrGraphEntityNotFound, urn)
+			}
+			results[index] = neighborhood
+		}
+		return results, nil
+	}
 	if len(roots) == 1 {
 		neighborhood, err := s.store.GetEntityNeighborhood(ctx, roots[0], limit)
 		if err != nil {

--- a/internal/graphquery/impact_test.go
+++ b/internal/graphquery/impact_test.go
@@ -62,6 +62,40 @@ func (s *impactStubStore) maxConcurrentLookups() int {
 	return s.maxLookups
 }
 
+type impactBatchStubStore struct {
+	impactStubStore
+
+	batchMu    sync.Mutex
+	batchCalls [][]string
+}
+
+func (s *impactBatchStubStore) GetEntityNeighborhoods(_ context.Context, rootURNs []string, _ int) (map[string]*ports.EntityNeighborhood, error) {
+	roots := append([]string(nil), rootURNs...)
+	s.batchMu.Lock()
+	s.batchCalls = append(s.batchCalls, roots)
+	s.batchMu.Unlock()
+
+	neighborhoods := make(map[string]*ports.EntityNeighborhood, len(roots))
+	for _, rootURN := range roots {
+		neighborhood, ok := s.neighborhoods[rootURN]
+		if !ok {
+			return nil, ports.ErrGraphEntityNotFound
+		}
+		neighborhoods[rootURN] = neighborhood
+	}
+	return neighborhoods, nil
+}
+
+func (s *impactBatchStubStore) batchedRoots() [][]string {
+	s.batchMu.Lock()
+	defer s.batchMu.Unlock()
+	calls := make([][]string, 0, len(s.batchCalls))
+	for _, roots := range s.batchCalls {
+		calls = append(calls, append([]string(nil), roots...))
+	}
+	return calls
+}
+
 func TestGetImpactVulnerabilityGroupsCanonicalPackageAssetsAndEvidence(t *testing.T) {
 	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
 	canonicalPackageURN := "urn:cerebro:writer:package:canonical:golang.org/x/crypto"
@@ -114,6 +148,45 @@ func TestGetImpactVulnerabilityGroupsCanonicalPackageAssetsAndEvidence(t *testin
 	}
 	if len(result.Evidence) != 1 || result.Evidence[0].URN != alertURN {
 		t.Fatalf("Evidence = %#v, want GitHub alert", result.Evidence)
+	}
+}
+
+func TestGetImpactUsesBatchedFrontierLookupWhenAvailable(t *testing.T) {
+	rootURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+	firstPackageURN := "urn:cerebro:writer:package:canonical:pkg:npm/foo"
+	secondPackageURN := "urn:cerebro:writer:package:canonical:pkg:npm/bar"
+	store := &impactBatchStubStore{impactStubStore: impactStubStore{neighborhoods: map[string]*ports.EntityNeighborhood{
+		rootURN: {
+			Root: node(rootURN, "vulnerability", "CVE-2026-4242"),
+			Neighbors: []*ports.NeighborhoodNode{
+				node(firstPackageURN, "package", "foo"),
+				node(secondPackageURN, "package", "bar"),
+			},
+		},
+		firstPackageURN:  emptyNeighborhood(firstPackageURN, "package"),
+		secondPackageURN: emptyNeighborhood(secondPackageURN, "package"),
+	}}}
+
+	if _, err := New(store).GetImpact(context.Background(), ImpactRequest{
+		Kind:       ImpactKindVulnerability,
+		TenantID:   "writer",
+		Identifier: "CVE-2026-4242",
+		Depth:      2,
+	}); err != nil {
+		t.Fatalf("GetImpact() error = %v", err)
+	}
+	if queries := store.queryURNs(); len(queries) != 0 {
+		t.Fatalf("single-root queries = %#v, want batched path only", queries)
+	}
+	calls := store.batchedRoots()
+	if len(calls) != 2 {
+		t.Fatalf("batch calls = %#v, want root and frontier batches", calls)
+	}
+	if len(calls[0]) != 1 || calls[0][0] != rootURN {
+		t.Fatalf("first batch = %#v, want root", calls[0])
+	}
+	if len(calls[1]) != 2 || calls[1][0] != firstPackageURN || calls[1][1] != secondPackageURN {
+		t.Fatalf("second batch = %#v, want package frontier", calls[1])
 	}
 }
 

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1037,14 +1037,20 @@ RETURN e.urn, e.entity_type, e.label`, map[string]any{"root_urns": roots})
 			if err := collectBatchedNeighborhoodRows(ctx, tx, outgoingNeighborhoodBatchQuery, params, accumulators); err != nil {
 				return nil, err
 			}
-			incomingRoots := make([]string, 0, len(roots))
+			incomingRootsByLimit := make(map[int][]string)
 			for _, rootURN := range roots {
-				if accumulators[rootURN].remaining > 0 {
-					incomingRoots = append(incomingRoots, rootURN)
+				remaining := accumulators[rootURN].remaining
+				if remaining > 0 {
+					incomingRootsByLimit[remaining] = append(incomingRootsByLimit[remaining], rootURN)
 				}
 			}
-			if len(incomingRoots) > 0 {
-				params := map[string]any{"root_urns": incomingRoots, "limit": limit}
+			incomingLimits := make([]int, 0, len(incomingRootsByLimit))
+			for remaining := range incomingRootsByLimit {
+				incomingLimits = append(incomingLimits, remaining)
+			}
+			slices.Sort(incomingLimits)
+			for _, remaining := range incomingLimits {
+				params := map[string]any{"root_urns": incomingRootsByLimit[remaining], "limit": remaining}
 				if err := collectBatchedNeighborhoodRows(ctx, tx, incomingNeighborhoodBatchQuery, params, accumulators); err != nil {
 					return nil, err
 				}

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -985,6 +985,84 @@ ORDER BY neighbor.urn, r.relation LIMIT $limit`, map[string]any{"root_urn": norm
 	return neighborhood, nil
 }
 
+// GetEntityNeighborhoods returns bounded root-centered graph neighborhoods for
+// a batch of roots. It preserves the same per-root edge ordering as
+// GetEntityNeighborhood while collapsing frontier expansion into three read
+// queries instead of three queries per root.
+func (s *Store) GetEntityNeighborhoods(ctx context.Context, rootURNs []string, limit int) (map[string]*ports.EntityNeighborhood, error) {
+	roots := normalizeNeighborhoodRootURNs(rootURNs)
+	if len(roots) == 0 {
+		return map[string]*ports.EntityNeighborhood{}, nil
+	}
+	if err := s.requireConfigured(); err != nil {
+		return nil, err
+	}
+	neighborhoods := make(map[string]*ports.EntityNeighborhood, len(roots))
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
+		accumulators := make(map[string]*neighborhoodAccumulator, len(roots))
+		result, err := tx.Run(ctx, `MATCH (e:Entity)
+WHERE e.urn IN $root_urns
+RETURN e.urn, e.entity_type, e.label`, map[string]any{"root_urns": roots})
+		if err != nil {
+			return nil, fmt.Errorf("query graph roots: %w", err)
+		}
+		for result.Next(ctx) {
+			record := result.Record()
+			root := &ports.NeighborhoodNode{
+				URN:        stringValue(record.Values[0]),
+				EntityType: stringValue(record.Values[1]),
+				Label:      stringValue(record.Values[2]),
+			}
+			accumulators[root.URN] = &neighborhoodAccumulator{
+				neighborhood: &ports.EntityNeighborhood{
+					Root:      root,
+					Neighbors: []*ports.NeighborhoodNode{},
+					Relations: []*ports.NeighborhoodRelation{},
+				},
+				neighbors: make(map[string]*ports.NeighborhoodNode),
+				relations: make(map[string]*ports.NeighborhoodRelation),
+				remaining: limit,
+			}
+		}
+		if err := result.Err(); err != nil {
+			return nil, fmt.Errorf("query graph roots: %w", err)
+		}
+		for _, rootURN := range roots {
+			if accumulators[rootURN] == nil {
+				return nil, fmt.Errorf("%w: %s", ports.ErrGraphEntityNotFound, rootURN)
+			}
+		}
+		if limit > 0 {
+			params := map[string]any{"root_urns": roots, "limit": limit}
+			if err := collectBatchedNeighborhoodRows(ctx, tx, outgoingNeighborhoodBatchQuery, params, accumulators); err != nil {
+				return nil, err
+			}
+			incomingRoots := make([]string, 0, len(roots))
+			for _, rootURN := range roots {
+				if accumulators[rootURN].remaining > 0 {
+					incomingRoots = append(incomingRoots, rootURN)
+				}
+			}
+			if len(incomingRoots) > 0 {
+				params := map[string]any{"root_urns": incomingRoots, "limit": limit}
+				if err := collectBatchedNeighborhoodRows(ctx, tx, incomingNeighborhoodBatchQuery, params, accumulators); err != nil {
+					return nil, err
+				}
+			}
+		}
+		for _, rootURN := range roots {
+			accumulator := accumulators[rootURN]
+			accumulator.neighborhood.Neighbors = neighborhoodNodes(accumulator.neighbors)
+			accumulator.neighborhood.Relations = neighborhoodRelations(accumulator.relations)
+			neighborhoods[rootURN] = accumulator.neighborhood
+		}
+		return nil, nil
+	}); err != nil {
+		return nil, err
+	}
+	return neighborhoods, nil
+}
+
 // ExecuteReadCypher runs one bounded read-only Cypher query and returns its rows.
 //
 // The store enforces a row cap to keep graph rules from accidentally pulling unbounded result
@@ -1790,6 +1868,53 @@ func lookupNeighborhoodNode(ctx context.Context, tx neo4jdriver.ManagedTransacti
 	}, result.Err()
 }
 
+type neighborhoodAccumulator struct {
+	neighborhood *ports.EntityNeighborhood
+	neighbors    map[string]*ports.NeighborhoodNode
+	relations    map[string]*ports.NeighborhoodRelation
+	remaining    int
+}
+
+const outgoingNeighborhoodBatchQuery = `UNWIND $root_urns AS root_urn
+MATCH (root:Entity {urn: root_urn})
+CALL {
+  WITH root
+  MATCH (root)-[r:RELATION]->(neighbor:Entity)
+  RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label,
+         root.urn AS from_urn, r.relation AS relation_type, neighbor.urn AS to_urn, coalesce(r.attributes_json, '{}') AS attributes_json
+  ORDER BY neighbor.urn, r.relation
+  LIMIT $limit
+}
+RETURN root_urn, neighbor_urn, neighbor_type, neighbor_label, from_urn, relation_type, to_urn, attributes_json
+ORDER BY root_urn, neighbor_urn, relation_type`
+
+const incomingNeighborhoodBatchQuery = `UNWIND $root_urns AS root_urn
+MATCH (root:Entity {urn: root_urn})
+CALL {
+  WITH root
+  MATCH (neighbor:Entity)-[r:RELATION]->(root)
+  RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label,
+         neighbor.urn AS from_urn, r.relation AS relation_type, root.urn AS to_urn, coalesce(r.attributes_json, '{}') AS attributes_json
+  ORDER BY neighbor.urn, r.relation
+  LIMIT $limit
+}
+RETURN root_urn, neighbor_urn, neighbor_type, neighbor_label, from_urn, relation_type, to_urn, attributes_json
+ORDER BY root_urn, neighbor_urn, relation_type`
+
+func normalizeNeighborhoodRootURNs(rootURNs []string) []string {
+	roots := make([]string, 0, len(rootURNs))
+	seen := make(map[string]bool, len(rootURNs))
+	for _, raw := range rootURNs {
+		rootURN := strings.TrimSpace(raw)
+		if rootURN == "" || seen[rootURN] {
+			continue
+		}
+		seen[rootURN] = true
+		roots = append(roots, rootURN)
+	}
+	return roots
+}
+
 func collectNeighborhoodRows(ctx context.Context, tx neo4jdriver.ManagedTransaction, query string, params map[string]any, remaining int, neighbors map[string]*ports.NeighborhoodNode, relations map[string]*ports.NeighborhoodRelation) (int, error) {
 	result, err := tx.Run(ctx, query, params)
 	if err != nil {
@@ -1820,6 +1945,40 @@ func collectNeighborhoodRows(ctx context.Context, tx neo4jdriver.ManagedTransact
 		}
 	}
 	return remaining, result.Err()
+}
+
+func collectBatchedNeighborhoodRows(ctx context.Context, tx neo4jdriver.ManagedTransaction, query string, params map[string]any, accumulators map[string]*neighborhoodAccumulator) error {
+	result, err := tx.Run(ctx, query, params)
+	if err != nil {
+		return fmt.Errorf("query graph neighborhoods: %w", err)
+	}
+	for result.Next(ctx) {
+		record := result.Record()
+		rootURN := stringValue(record.Values[0])
+		accumulator := accumulators[rootURN]
+		if accumulator == nil || accumulator.remaining <= 0 {
+			continue
+		}
+		neighbor := &ports.NeighborhoodNode{
+			URN:        stringValue(record.Values[1]),
+			EntityType: stringValue(record.Values[2]),
+			Label:      stringValue(record.Values[3]),
+		}
+		attributes, err := decodeGraphAttributes(stringValue(record.Values[7]))
+		if err != nil {
+			return fmt.Errorf("decode graph neighborhood relation attributes: %w", err)
+		}
+		relation := &ports.NeighborhoodRelation{
+			FromURN:    stringValue(record.Values[4]),
+			Relation:   stringValue(record.Values[5]),
+			ToURN:      stringValue(record.Values[6]),
+			Attributes: attributes,
+		}
+		accumulator.neighbors[neighbor.URN] = neighbor
+		accumulator.relations[relation.FromURN+"|"+relation.Relation+"|"+relation.ToURN] = relation
+		accumulator.remaining--
+	}
+	return result.Err()
 }
 
 func graphAttributesJSON(attributes map[string]string) (string, error) {


### PR DESCRIPTION
## Summary
- add a Neo4j batched neighborhood read for impact graph frontier expansion
- use the batched path from graphquery impact traversal when the store supports it
- keep existing single-root fallback for stores without batching

## Performance
- collapses each impact frontier chunk from roughly 3 queries per root to 3 queries per chunk
- preserves per-root outgoing-before-incoming ordering and limits

## Tests
- go test ./internal/graphquery ./internal/graphstore/neo4j
- /Users/jonathan/go/bin/golangci-lint run --timeout 10m ./internal/graphquery ./internal/graphstore/neo4j

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->