### PR TITLE
[codex] Batch report graph neighborhood evidence

### DIFF
--- a/internal/graphquery/impact_test.go
+++ b/internal/graphquery/impact_test.go
@@ -102,7 +102,7 @@ func (s *impactBatchStubStore) GetEntityNeighborhoods(_ context.Context, rootURN
 	for _, rootURN := range roots {
 		neighborhood, ok := s.neighborhoods[rootURN]
 		if !ok {
-			return nil, ports.ErrGraphEntityNotFound
+			continue
 		}
 		neighborhoods[rootURN] = neighborhood
 	}

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1027,18 +1027,19 @@ RETURN e.urn, e.entity_type, e.label`, map[string]any{"root_urns": roots})
 		if err := result.Err(); err != nil {
 			return nil, fmt.Errorf("query graph roots: %w", err)
 		}
+		presentRoots := make([]string, 0, len(roots))
 		for _, rootURN := range roots {
-			if accumulators[rootURN] == nil {
-				return nil, fmt.Errorf("%w: %s", ports.ErrGraphEntityNotFound, rootURN)
+			if accumulators[rootURN] != nil {
+				presentRoots = append(presentRoots, rootURN)
 			}
 		}
-		if limit > 0 {
-			params := map[string]any{"root_urns": roots, "limit": limit}
+		if limit > 0 && len(presentRoots) > 0 {
+			params := map[string]any{"root_urns": presentRoots, "limit": limit}
 			if err := collectBatchedNeighborhoodRows(ctx, tx, outgoingNeighborhoodBatchQuery, params, accumulators); err != nil {
 				return nil, err
 			}
 			incomingRootsByLimit := make(map[int][]string)
-			for _, rootURN := range roots {
+			for _, rootURN := range presentRoots {
 				remaining := accumulators[rootURN].remaining
 				if remaining > 0 {
 					incomingRootsByLimit[remaining] = append(incomingRootsByLimit[remaining], rootURN)
@@ -1056,7 +1057,7 @@ RETURN e.urn, e.entity_type, e.label`, map[string]any{"root_urns": roots})
 				}
 			}
 		}
-		for _, rootURN := range roots {
+		for _, rootURN := range presentRoots {
 			accumulator := accumulators[rootURN]
 			accumulator.neighborhood.Neighbors = neighborhoodNodes(accumulator.neighbors)
 			accumulator.neighborhood.Relations = neighborhoodRelations(accumulator.relations)

--- a/internal/reports/risk_action_plan.go
+++ b/internal/reports/risk_action_plan.go
@@ -3,7 +3,6 @@ package reports
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -186,34 +185,7 @@ func normalizeBoolParameter(raw string, defaultValue bool, parameterID string) (
 }
 
 func (s *Service) riskActionPlanGraphNeighborhoods(ctx context.Context, targetURNs []string, resourceLimit int, graphLimit int) (map[string]*ports.EntityNeighborhood, error) {
-	neighborhoods := map[string]*ports.EntityNeighborhood{}
-	seen := map[string]struct{}{}
-	for _, targetURN := range targetURNs {
-		if len(seen) >= resourceLimit {
-			break
-		}
-		targetURN = strings.TrimSpace(targetURN)
-		if targetURN == "" {
-			continue
-		}
-		if _, ok := seen[targetURN]; ok {
-			continue
-		}
-		seen[targetURN] = struct{}{}
-		neighborhood, err := s.graphStore.GetEntityNeighborhood(ctx, targetURN, graphLimit)
-		switch {
-		case err == nil:
-			if neighborhood == nil {
-				neighborhood = &ports.EntityNeighborhood{}
-			}
-			neighborhoods[targetURN] = neighborhood
-		case errors.Is(err, ports.ErrGraphEntityNotFound):
-			continue
-		default:
-			return nil, fmt.Errorf("load risk action plan graph neighborhood for %q: %w", targetURN, err)
-		}
-	}
-	return neighborhoods, nil
+	return s.graphNeighborhoods(ctx, targetURNs, resourceLimit, graphLimit, "risk action plan")
 }
 
 func riskActionPlanDefinition() *cerebrov1.ReportDefinition {

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -609,9 +609,6 @@ func (s *Service) batchGraphNeighborhoods(ctx context.Context, roots []string, g
 	}
 	neighborhoods, err := batchStore.GetEntityNeighborhoods(ctx, roots, graphLimit)
 	if err != nil {
-		if errors.Is(err, ports.ErrGraphEntityNotFound) {
-			return nil, false, nil
-		}
 		return nil, true, err
 	}
 	normalized := make(map[string]*ports.EntityNeighborhood, len(neighborhoods))

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -62,6 +62,10 @@ type Service struct {
 	reportStore  ports.ReportStore
 }
 
+type graphNeighborhoodBatchStore interface {
+	GetEntityNeighborhoods(context.Context, []string, int) (map[string]*ports.EntityNeighborhood, error)
+}
+
 // New constructs the report service.
 func New(findingStore ports.FindingStore, graphStore ports.GraphQueryStore, reportStore ports.ReportStore) *Service {
 	return &Service{
@@ -521,30 +525,34 @@ func (s *Service) graphEvidence(ctx context.Context, resourceCounts map[string]i
 	if len(entries) > resourceLimit {
 		entries = entries[:resourceLimit]
 	}
+	roots := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		roots = append(roots, entry.Key)
+	}
+	if batchNeighborhoods, ok, err := s.batchGraphNeighborhoods(ctx, roots, graphLimit); err != nil {
+		return nil, nil, fmt.Errorf("batch load graph evidence: %w", err)
+	} else if ok {
+		evidence := make([]any, 0, len(entries))
+		neighborhoods := make(map[string]*ports.EntityNeighborhood, len(entries))
+		for _, entry := range entries {
+			neighborhood, found := batchNeighborhoods[entry.Key]
+			if !found {
+				evidence = append(evidence, missingGraphEvidenceEntry(entry))
+				continue
+			}
+			evidence = appendIncludedGraphEvidence(evidence, neighborhoods, entry, neighborhood)
+		}
+		return evidence, neighborhoods, nil
+	}
 	evidence := make([]any, 0, len(entries))
 	neighborhoods := make(map[string]*ports.EntityNeighborhood, len(entries))
 	for _, entry := range entries {
 		neighborhood, err := s.graphStore.GetEntityNeighborhood(ctx, entry.Key, graphLimit)
 		switch {
 		case err == nil:
-			if neighborhood == nil {
-				neighborhood = &ports.EntityNeighborhood{}
-			}
-			neighborhoods[entry.Key] = neighborhood
-			evidence = append(evidence, map[string]any{
-				"resource_urn":  entry.Key,
-				"finding_count": entry.Count,
-				"status":        graphEvidenceEntryStatusIncluded,
-				"root":          graphNodePayload(neighborhood.Root),
-				"neighbors":     graphNodesPayload(neighborhood.Neighbors),
-				"relations":     graphRelationsPayload(neighborhood.Relations),
-			})
+			evidence = appendIncludedGraphEvidence(evidence, neighborhoods, entry, neighborhood)
 		case errors.Is(err, ports.ErrGraphEntityNotFound):
-			evidence = append(evidence, map[string]any{
-				"resource_urn":  entry.Key,
-				"finding_count": entry.Count,
-				"status":        graphEvidenceEntryStatusNotFound,
-			})
+			evidence = append(evidence, missingGraphEvidenceEntry(entry))
 		default:
 			return nil, nil, fmt.Errorf("load graph evidence for %q: %w", entry.Key, err)
 		}
@@ -566,10 +574,68 @@ func (s *Service) riskDeltaGraphNeighborhoods(ctx context.Context, targetURN str
 		}
 		roots = append(roots, entry.Key)
 	}
-	seen := map[string]struct{}{}
-	neighborhoods := map[string]*ports.EntityNeighborhood{}
+	return s.graphNeighborhoods(ctx, roots, resourceLimit, graphLimit, "risk delta")
+}
+
+func (s *Service) graphNeighborhoods(ctx context.Context, rawRoots []string, resourceLimit int, graphLimit int, label string) (map[string]*ports.EntityNeighborhood, error) {
+	roots := limitedGraphNeighborhoodRoots(rawRoots, resourceLimit)
+	if batchNeighborhoods, ok, err := s.batchGraphNeighborhoods(ctx, roots, graphLimit); err != nil {
+		return nil, fmt.Errorf("batch load %s graph neighborhoods: %w", label, err)
+	} else if ok {
+		return batchNeighborhoods, nil
+	}
+	neighborhoods := make(map[string]*ports.EntityNeighborhood, len(roots))
 	for _, rootURN := range roots {
-		rootURN = strings.TrimSpace(rootURN)
+		neighborhood, err := s.graphStore.GetEntityNeighborhood(ctx, rootURN, graphLimit)
+		switch {
+		case err == nil:
+			neighborhoods[rootURN] = normalizedNeighborhood(neighborhood)
+		case errors.Is(err, ports.ErrGraphEntityNotFound):
+			continue
+		default:
+			return nil, fmt.Errorf("load %s graph neighborhood for %q: %w", label, rootURN, err)
+		}
+	}
+	return neighborhoods, nil
+}
+
+func (s *Service) batchGraphNeighborhoods(ctx context.Context, roots []string, graphLimit int) (map[string]*ports.EntityNeighborhood, bool, error) {
+	if len(roots) == 0 {
+		return map[string]*ports.EntityNeighborhood{}, true, nil
+	}
+	batchStore, ok := s.graphStore.(graphNeighborhoodBatchStore)
+	if !ok {
+		return nil, false, nil
+	}
+	neighborhoods, err := batchStore.GetEntityNeighborhoods(ctx, roots, graphLimit)
+	if err != nil {
+		if errors.Is(err, ports.ErrGraphEntityNotFound) {
+			return nil, false, nil
+		}
+		return nil, true, err
+	}
+	normalized := make(map[string]*ports.EntityNeighborhood, len(neighborhoods))
+	for _, rootURN := range roots {
+		neighborhood, ok := neighborhoods[rootURN]
+		if !ok {
+			continue
+		}
+		normalized[rootURN] = normalizedNeighborhood(neighborhood)
+	}
+	return normalized, true, nil
+}
+
+func limitedGraphNeighborhoodRoots(rawRoots []string, limit int) []string {
+	if limit <= 0 {
+		return nil
+	}
+	roots := make([]string, 0, min(len(rawRoots), limit))
+	seen := map[string]struct{}{}
+	for _, rawRoot := range rawRoots {
+		if len(roots) >= limit {
+			break
+		}
+		rootURN := strings.TrimSpace(rawRoot)
 		if rootURN == "" {
 			continue
 		}
@@ -577,20 +643,37 @@ func (s *Service) riskDeltaGraphNeighborhoods(ctx context.Context, targetURN str
 			continue
 		}
 		seen[rootURN] = struct{}{}
-		neighborhood, err := s.graphStore.GetEntityNeighborhood(ctx, rootURN, graphLimit)
-		switch {
-		case err == nil:
-			if neighborhood == nil {
-				neighborhood = &ports.EntityNeighborhood{}
-			}
-			neighborhoods[rootURN] = neighborhood
-		case errors.Is(err, ports.ErrGraphEntityNotFound):
-			continue
-		default:
-			return nil, fmt.Errorf("load risk delta graph neighborhood for %q: %w", rootURN, err)
-		}
+		roots = append(roots, rootURN)
 	}
-	return neighborhoods, nil
+	return roots
+}
+
+func normalizedNeighborhood(neighborhood *ports.EntityNeighborhood) *ports.EntityNeighborhood {
+	if neighborhood == nil {
+		return &ports.EntityNeighborhood{}
+	}
+	return neighborhood
+}
+
+func appendIncludedGraphEvidence(evidence []any, neighborhoods map[string]*ports.EntityNeighborhood, entry countEntry, neighborhood *ports.EntityNeighborhood) []any {
+	neighborhood = normalizedNeighborhood(neighborhood)
+	neighborhoods[entry.Key] = neighborhood
+	return append(evidence, map[string]any{
+		"resource_urn":  entry.Key,
+		"finding_count": entry.Count,
+		"status":        graphEvidenceEntryStatusIncluded,
+		"root":          graphNodePayload(neighborhood.Root),
+		"neighbors":     graphNodesPayload(neighborhood.Neighbors),
+		"relations":     graphRelationsPayload(neighborhood.Relations),
+	})
+}
+
+func missingGraphEvidenceEntry(entry countEntry) map[string]any {
+	return map[string]any{
+		"resource_urn":  entry.Key,
+		"finding_count": entry.Count,
+		"status":        graphEvidenceEntryStatusNotFound,
+	}
 }
 
 func findingSummaryDefinition() *cerebrov1.ReportDefinition {

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -176,7 +176,7 @@ func (s *stubBatchGraphStore) GetEntityNeighborhoods(_ context.Context, rootURNs
 	for _, rootURN := range roots {
 		neighborhood, ok := s.neighborhoods[rootURN]
 		if !ok {
-			return nil, fmt.Errorf("%w: %s", ports.ErrGraphEntityNotFound, rootURN)
+			continue
 		}
 		neighborhoods[rootURN] = cloneNeighborhood(neighborhood)
 	}
@@ -565,6 +565,48 @@ func TestRunFindingSummaryReportBatchesGraphEvidenceNeighborhoods(t *testing.T) 
 	}
 	if graphStore.batchLimit != 4 {
 		t.Fatalf("GetEntityNeighborhoods().limit = %d, want 4", graphStore.batchLimit)
+	}
+	if len(graphStore.calls) != 0 {
+		t.Fatalf("GetEntityNeighborhood() calls = %#v, want no individual lookups", graphStore.calls)
+	}
+}
+
+func TestGraphEvidenceUsesBatchPartialResultsForMissingRoots(t *testing.T) {
+	present := "urn:cerebro:writer:test_resource:present"
+	missing := "urn:cerebro:writer:test_resource:missing"
+	graphStore := &stubBatchGraphStore{
+		stubGraphStore: &stubGraphStore{neighborhoods: map[string]*ports.EntityNeighborhood{
+			present: testNeighborhood(present),
+		}},
+	}
+	service := New(nil, graphStore, nil)
+
+	evidence, neighborhoods, err := service.graphEvidence(context.Background(), map[string]int{
+		present: 2,
+		missing: 1,
+	}, 2, 4)
+	if err != nil {
+		t.Fatalf("graphEvidence() error = %v", err)
+	}
+	if len(neighborhoods) != 1 || neighborhoods[present] == nil {
+		t.Fatalf("graphEvidence() neighborhoods = %#v, want only present root", neighborhoods)
+	}
+	if len(evidence) != 2 {
+		t.Fatalf("graphEvidence() evidence = %#v, want 2 entries", evidence)
+	}
+	included, ok := evidence[0].(map[string]any)
+	if !ok || included["resource_urn"] != present || included["status"] != graphEvidenceEntryStatusIncluded {
+		t.Fatalf("graphEvidence()[0] = %#v, want included present root", evidence[0])
+	}
+	notFound, ok := evidence[1].(map[string]any)
+	if !ok || notFound["resource_urn"] != missing || notFound["status"] != graphEvidenceEntryStatusNotFound {
+		t.Fatalf("graphEvidence()[1] = %#v, want missing root", evidence[1])
+	}
+	if len(graphStore.batchCalls) != 1 {
+		t.Fatalf("GetEntityNeighborhoods() calls = %#v, want one batch", graphStore.batchCalls)
+	}
+	if got := graphStore.batchCalls[0]; len(got) != 2 || got[0] != present || got[1] != missing {
+		t.Fatalf("GetEntityNeighborhoods().roots = %#v, want [%q %q]", got, present, missing)
 	}
 	if len(graphStore.calls) != 0 {
 		t.Fatalf("GetEntityNeighborhood() calls = %#v, want no individual lookups", graphStore.calls)

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -141,6 +141,7 @@ func (s *stubFindingStore) LinkFindingExternalRef(_ context.Context, request por
 type stubGraphStore struct {
 	rootURN       string
 	limit         int
+	calls         []string
 	neighborhoods map[string]*ports.EntityNeighborhood
 }
 
@@ -149,6 +150,7 @@ func (s *stubGraphStore) Ping(context.Context) error { return nil }
 func (s *stubGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
 	s.rootURN = rootURN
 	s.limit = limit
+	s.calls = append(s.calls, rootURN)
 	neighborhood, ok := s.neighborhoods[rootURN]
 	if !ok {
 		return nil, ports.ErrGraphEntityNotFound
@@ -158,6 +160,27 @@ func (s *stubGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string
 
 func (s *stubGraphStore) ExecuteReadCypher(_ context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
 	return nil, nil
+}
+
+type stubBatchGraphStore struct {
+	*stubGraphStore
+	batchCalls [][]string
+	batchLimit int
+}
+
+func (s *stubBatchGraphStore) GetEntityNeighborhoods(_ context.Context, rootURNs []string, limit int) (map[string]*ports.EntityNeighborhood, error) {
+	roots := append([]string(nil), rootURNs...)
+	s.batchCalls = append(s.batchCalls, roots)
+	s.batchLimit = limit
+	neighborhoods := make(map[string]*ports.EntityNeighborhood, len(roots))
+	for _, rootURN := range roots {
+		neighborhood, ok := s.neighborhoods[rootURN]
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", ports.ErrGraphEntityNotFound, rootURN)
+		}
+		neighborhoods[rootURN] = cloneNeighborhood(neighborhood)
+	}
+	return neighborhoods, nil
 }
 
 type stubReportStore struct {
@@ -479,6 +502,75 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 	}
 }
 
+func TestRunFindingSummaryReportBatchesGraphEvidenceNeighborhoods(t *testing.T) {
+	resourceOne := "urn:cerebro:writer:test_resource:one"
+	resourceTwo := "urn:cerebro:writer:test_resource:two"
+	findingStore := &stubFindingStore{
+		findings: []*ports.FindingRecord{
+			{
+				ID:           "finding-1",
+				TenantID:     "writer",
+				RuntimeID:    "writer-runtime",
+				RuleID:       "test-rule",
+				Severity:     "HIGH",
+				Status:       "open",
+				ResourceURNs: []string{resourceOne},
+				Attributes: map[string]string{
+					"primary_resource_urn": resourceOne,
+				},
+			},
+			{
+				ID:           "finding-2",
+				TenantID:     "writer",
+				RuntimeID:    "writer-runtime",
+				RuleID:       "test-rule",
+				Severity:     "MEDIUM",
+				Status:       "open",
+				ResourceURNs: []string{resourceTwo},
+				Attributes: map[string]string{
+					"primary_resource_urn": resourceTwo,
+				},
+			},
+		},
+	}
+	graphStore := &stubBatchGraphStore{
+		stubGraphStore: &stubGraphStore{neighborhoods: map[string]*ports.EntityNeighborhood{
+			resourceOne: testNeighborhood(resourceOne),
+			resourceTwo: testNeighborhood(resourceTwo),
+		}},
+	}
+	service := New(findingStore, graphStore, &stubReportStore{})
+
+	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: findingSummaryReportID,
+		Parameters: map[string]string{
+			reportParameterTenantID:      "writer",
+			reportParameterRuntimeIDs:    "writer-runtime",
+			reportParameterGraphLimit:    "4",
+			reportParameterResourceLimit: "2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	graphEvidence, ok := response.GetRun().GetResult().AsMap()["graph_evidence"].([]any)
+	if !ok || len(graphEvidence) != 2 {
+		t.Fatalf("graph_evidence = %#v, want 2 entries", response.GetRun().GetResult().AsMap()["graph_evidence"])
+	}
+	if len(graphStore.batchCalls) != 1 {
+		t.Fatalf("GetEntityNeighborhoods() calls = %#v, want one batch", graphStore.batchCalls)
+	}
+	if got := graphStore.batchCalls[0]; len(got) != 2 || got[0] != resourceOne || got[1] != resourceTwo {
+		t.Fatalf("GetEntityNeighborhoods().roots = %#v, want [%q %q]", got, resourceOne, resourceTwo)
+	}
+	if graphStore.batchLimit != 4 {
+		t.Fatalf("GetEntityNeighborhoods().limit = %d, want 4", graphStore.batchLimit)
+	}
+	if len(graphStore.calls) != 0 {
+		t.Fatalf("GetEntityNeighborhood() calls = %#v, want no individual lookups", graphStore.calls)
+	}
+}
+
 func TestRunFindingSummaryReportDoesNotPublishMultiRuntimeListAsRuntimeID(t *testing.T) {
 	findingStore := &stubFindingStore{findings: []*ports.FindingRecord{
 		{ID: "finding-1", TenantID: "example", RuntimeID: "example-github-audit", RuleID: "github-rule", Severity: "HIGH", Status: "OPEN"},
@@ -592,6 +684,40 @@ func TestRunRiskDeltaReportSimulatesPublicExposureRemoval(t *testing.T) {
 	}
 }
 
+func TestRiskDeltaGraphNeighborhoodsBatchesRoots(t *testing.T) {
+	target := "urn:cerebro:writer:test_resource:target"
+	related := "urn:cerebro:writer:test_resource:related"
+	graphStore := &stubBatchGraphStore{
+		stubGraphStore: &stubGraphStore{neighborhoods: map[string]*ports.EntityNeighborhood{
+			target:  testNeighborhood(target),
+			related: testNeighborhood(related),
+		}},
+	}
+	service := New(nil, graphStore, nil)
+
+	neighborhoods, err := service.riskDeltaGraphNeighborhoods(context.Background(), target, []*ports.FindingRecord{
+		{Attributes: map[string]string{"primary_resource_urn": related}},
+	}, 2, 6)
+	if err != nil {
+		t.Fatalf("riskDeltaGraphNeighborhoods() error = %v", err)
+	}
+	if len(neighborhoods) != 2 {
+		t.Fatalf("riskDeltaGraphNeighborhoods() = %#v, want 2 neighborhoods", neighborhoods)
+	}
+	if len(graphStore.batchCalls) != 1 {
+		t.Fatalf("GetEntityNeighborhoods() calls = %#v, want one batch", graphStore.batchCalls)
+	}
+	if got := graphStore.batchCalls[0]; len(got) != 2 || got[0] != target || got[1] != related {
+		t.Fatalf("GetEntityNeighborhoods().roots = %#v, want [%q %q]", got, target, related)
+	}
+	if graphStore.batchLimit != 6 {
+		t.Fatalf("GetEntityNeighborhoods().limit = %d, want 6", graphStore.batchLimit)
+	}
+	if len(graphStore.calls) != 0 {
+		t.Fatalf("GetEntityNeighborhood() calls = %#v, want no individual lookups", graphStore.calls)
+	}
+}
+
 func TestRunRiskDeltaReportRejectsCrossTenantTargetURN(t *testing.T) {
 	graphStore := &stubGraphStore{
 		neighborhoods: map[string]*ports.EntityNeighborhood{
@@ -616,6 +742,40 @@ func TestRunRiskDeltaReportRejectsCrossTenantTargetURN(t *testing.T) {
 	}
 	if graphStore.rootURN != "" {
 		t.Fatalf("GetEntityNeighborhood rootURN = %q, want no cross-tenant graph read", graphStore.rootURN)
+	}
+}
+
+func TestRiskActionPlanGraphNeighborhoodsBatchesUniqueLimitedRoots(t *testing.T) {
+	first := "urn:cerebro:writer:test_resource:first"
+	second := "urn:cerebro:writer:test_resource:second"
+	third := "urn:cerebro:writer:test_resource:third"
+	graphStore := &stubBatchGraphStore{
+		stubGraphStore: &stubGraphStore{neighborhoods: map[string]*ports.EntityNeighborhood{
+			first:  testNeighborhood(first),
+			second: testNeighborhood(second),
+			third:  testNeighborhood(third),
+		}},
+	}
+	service := New(nil, graphStore, nil)
+
+	neighborhoods, err := service.riskActionPlanGraphNeighborhoods(context.Background(), []string{first, "", first, second, third}, 2, 5)
+	if err != nil {
+		t.Fatalf("riskActionPlanGraphNeighborhoods() error = %v", err)
+	}
+	if len(neighborhoods) != 2 {
+		t.Fatalf("riskActionPlanGraphNeighborhoods() = %#v, want 2 neighborhoods", neighborhoods)
+	}
+	if len(graphStore.batchCalls) != 1 {
+		t.Fatalf("GetEntityNeighborhoods() calls = %#v, want one batch", graphStore.batchCalls)
+	}
+	if got := graphStore.batchCalls[0]; len(got) != 2 || got[0] != first || got[1] != second {
+		t.Fatalf("GetEntityNeighborhoods().roots = %#v, want [%q %q]", got, first, second)
+	}
+	if graphStore.batchLimit != 5 {
+		t.Fatalf("GetEntityNeighborhoods().limit = %d, want 5", graphStore.batchLimit)
+	}
+	if len(graphStore.calls) != 0 {
+		t.Fatalf("GetEntityNeighborhood() calls = %#v, want no individual lookups", graphStore.calls)
 	}
 }
 
@@ -1254,6 +1414,18 @@ func cloneNeighborhood(neighborhood *ports.EntityNeighborhood) *ports.EntityNeig
 		cloned.Relations = append(cloned.Relations, cloneNeighborhoodRelation(relation))
 	}
 	return cloned
+}
+
+func testNeighborhood(rootURN string) *ports.EntityNeighborhood {
+	return &ports.EntityNeighborhood{
+		Root: &ports.NeighborhoodNode{
+			URN:        rootURN,
+			EntityType: "test.resource",
+			Label:      rootURN,
+		},
+		Neighbors: []*ports.NeighborhoodNode{},
+		Relations: []*ports.NeighborhoodRelation{},
+	}
 }
 
 func cloneNeighborhoodNode(node *ports.NeighborhoodNode) *ports.NeighborhoodNode {


### PR DESCRIPTION
## Summary
- reuse the graph store batch neighborhood reader for finding-summary graph evidence
- batch risk-delta and risk-action-plan graph evidence roots
- return partial batched graph neighborhoods for missing roots so reports can mark not-found roots without falling back to individual reads
- cover batched report fanout and mixed present/missing roots with focused tests

## Performance
- collapses report graph evidence fanout from one neighborhood read per resource to a single batched read
- avoids the missing-root N+1 fallback by treating absent roots as missing map entries in the batch result

## Validation
- go test ./internal/reports ./internal/graphquery ./internal/graphstore/neo4j
- /Users/jonathan/go/bin/golangci-lint run --timeout 10m ./internal/reports ./internal/graphquery ./internal/graphstore/neo4j