### PR TITLE
[codex] Reduce graph relation sort allocations

### DIFF
--- a/internal/graphquery/impact.go
+++ b/internal/graphquery/impact.go
@@ -315,11 +315,28 @@ func sortedImpactRelations(relations map[string]*ports.NeighborhoodRelation) []*
 		result = append(result, relation)
 	}
 	sort.Slice(result, func(i, j int) bool {
-		left := result[i].FromURN + "|" + result[i].Relation + "|" + result[i].ToURN
-		right := result[j].FromURN + "|" + result[j].Relation + "|" + result[j].ToURN
-		return left < right
+		return compareImpactRelations(result[i], result[j]) < 0
 	})
 	return result
+}
+
+func compareImpactRelations(left *ports.NeighborhoodRelation, right *ports.NeighborhoodRelation) int {
+	switch {
+	case left.FromURN < right.FromURN:
+		return -1
+	case left.FromURN > right.FromURN:
+		return 1
+	case left.Relation < right.Relation:
+		return -1
+	case left.Relation > right.Relation:
+		return 1
+	case left.ToURN < right.ToURN:
+		return -1
+	case left.ToURN > right.ToURN:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func canonicalPackageImpactIdentity(value string) string {

--- a/internal/graphquery/impact_test.go
+++ b/internal/graphquery/impact_test.go
@@ -50,6 +50,29 @@ func (s *impactStubStore) ExecuteReadCypher(_ context.Context, _ ports.CypherQue
 	return nil, nil
 }
 
+func TestSortedImpactRelationsOrdersByRelationFields(t *testing.T) {
+	relations := map[string]*ports.NeighborhoodRelation{
+		"shuffled-1": rel("urn:cerebro:writer:asset:b", "depends_on", "urn:cerebro:writer:asset:a"),
+		"shuffled-2": rel("urn:cerebro:writer:asset:a", "owns", "urn:cerebro:writer:asset:c"),
+		"shuffled-3": rel("urn:cerebro:writer:asset:a", "depends_on", "urn:cerebro:writer:asset:b"),
+	}
+
+	result := sortedImpactRelations(relations)
+
+	if len(result) != 3 {
+		t.Fatalf("sortedImpactRelations() len = %d, want 3", len(result))
+	}
+	if result[0].FromURN != "urn:cerebro:writer:asset:a" || result[0].Relation != "depends_on" || result[0].ToURN != "urn:cerebro:writer:asset:b" {
+		t.Fatalf("sortedImpactRelations()[0] = %#v, want asset:a depends_on asset:b", result[0])
+	}
+	if result[1].FromURN != "urn:cerebro:writer:asset:a" || result[1].Relation != "owns" || result[1].ToURN != "urn:cerebro:writer:asset:c" {
+		t.Fatalf("sortedImpactRelations()[1] = %#v, want asset:a owns asset:c", result[1])
+	}
+	if result[2].FromURN != "urn:cerebro:writer:asset:b" || result[2].Relation != "depends_on" || result[2].ToURN != "urn:cerebro:writer:asset:a" {
+		t.Fatalf("sortedImpactRelations()[2] = %#v, want asset:b depends_on asset:a", result[2])
+	}
+}
+
 func (s *impactStubStore) queryURNs() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -2136,22 +2136,15 @@ func neighborhoodNodes(values map[string]*ports.NeighborhoodNode) []*ports.Neigh
 }
 
 func neighborhoodRelations(values map[string]*ports.NeighborhoodRelation) []*ports.NeighborhoodRelation {
-	relations := make([]*ports.NeighborhoodRelation, 0, len(values))
-	for _, relation := range values {
-		relations = append(relations, relation)
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
 	}
-	slices.SortFunc(relations, func(left *ports.NeighborhoodRelation, right *ports.NeighborhoodRelation) int {
-		leftKey := left.FromURN + "|" + left.Relation + "|" + left.ToURN
-		rightKey := right.FromURN + "|" + right.Relation + "|" + right.ToURN
-		switch {
-		case leftKey < rightKey:
-			return -1
-		case leftKey > rightKey:
-			return 1
-		default:
-			return 0
-		}
-	})
+	slices.Sort(keys)
+	relations := make([]*ports.NeighborhoodRelation, 0, len(keys))
+	for _, key := range keys {
+		relations = append(relations, values[key])
+	}
 	return relations
 }
 

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -37,6 +37,41 @@ func TestProjectedEntityMergePreservesExistingLabelsForFallbackLabels(t *testing
 	}
 }
 
+func TestNeighborhoodRelationsOrdersByStoredRelationKey(t *testing.T) {
+	relations := map[string]*ports.NeighborhoodRelation{
+		"urn:cerebro:writer:asset:b|depends_on|urn:cerebro:writer:asset:a": {
+			FromURN:  "urn:cerebro:writer:asset:b",
+			Relation: "depends_on",
+			ToURN:    "urn:cerebro:writer:asset:a",
+		},
+		"urn:cerebro:writer:asset:a|owns|urn:cerebro:writer:asset:c": {
+			FromURN:  "urn:cerebro:writer:asset:a",
+			Relation: "owns",
+			ToURN:    "urn:cerebro:writer:asset:c",
+		},
+		"urn:cerebro:writer:asset:a|depends_on|urn:cerebro:writer:asset:b": {
+			FromURN:  "urn:cerebro:writer:asset:a",
+			Relation: "depends_on",
+			ToURN:    "urn:cerebro:writer:asset:b",
+		},
+	}
+
+	result := neighborhoodRelations(relations)
+
+	if len(result) != 3 {
+		t.Fatalf("neighborhoodRelations() len = %d, want 3", len(result))
+	}
+	if result[0].FromURN != "urn:cerebro:writer:asset:a" || result[0].Relation != "depends_on" || result[0].ToURN != "urn:cerebro:writer:asset:b" {
+		t.Fatalf("neighborhoodRelations()[0] = %#v, want asset:a depends_on asset:b", result[0])
+	}
+	if result[1].FromURN != "urn:cerebro:writer:asset:a" || result[1].Relation != "owns" || result[1].ToURN != "urn:cerebro:writer:asset:c" {
+		t.Fatalf("neighborhoodRelations()[1] = %#v, want asset:a owns asset:c", result[1])
+	}
+	if result[2].FromURN != "urn:cerebro:writer:asset:b" || result[2].Relation != "depends_on" || result[2].ToURN != "urn:cerebro:writer:asset:a" {
+		t.Fatalf("neighborhoodRelations()[2] = %#v, want asset:b depends_on asset:a", result[2])
+	}
+}
+
 func TestUpsertProjectedEntityRejectsCrossTenantCerebroURNBeforeConnection(t *testing.T) {
 	store := &Store{}
 	err := store.UpsertProjectedEntity(context.Background(), &ports.ProjectedEntity{


### PR DESCRIPTION
## Summary
- sort Neo4j neighborhood relation maps by their existing relation keys instead of rebuilding keys during every comparison
- switch impact relation ordering to field-wise comparison instead of concatenated comparison keys
- add ordering tests for both graph relation sort paths

## Performance
- avoids repeated `from|relation|to` string allocations during neighborhood and impact relation sorting
- keeps deterministic ordering for graph API responses

## Validation
- go test ./internal/graphquery ./internal/graphstore/neo4j
- /Users/jonathan/go/bin/golangci-lint run --timeout 10m ./internal/graphquery ./internal/graphstore/neo4j
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->