### PR TITLE
[codex] Consolidate GRC projection helpers

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -29,7 +29,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `gcp` | 2130 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2029 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
-| `grc` | 1270 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
+| `grc` | 1217 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2256 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 765 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2112 | Extract API paging, agent/application readers, and shared response normalization. |

--- a/internal/sourceprojection/grc_assurance.go
+++ b/internal/sourceprojection/grc_assurance.go
@@ -8,225 +8,187 @@ import (
 )
 
 func grcDocumentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	documentID := firstAttribute(attrs, "document_id", "external_id")
+	documentID := firstAttribute(ctx.attrs, "document_id", "external_id")
 	if documentID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	documentURN := projectionURN(tenantID, "document", provider, documentID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        documentURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "document",
-		Label:      firstAttribute(attrs, "title", "document_id"),
-		Attributes: grcAttributes(attrs, map[string]string{"document_id": documentID, "source_system": provider}),
-	})
-	if ownerID := firstAttribute(attrs, "owner_id"); ownerID != "" {
-		addGRCUserOwnerLink(entities, links, tenantID, event.GetSourceId(), event, documentURN, provider, ownerID)
-	}
-	addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, documentURN, relationHasIdentifier, firstAttribute(attrs, "url"), "grc_document_url_host", "0.9")
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, documentURN, "grc_category", firstAttribute(attrs, "category"))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+	documentURN := ctx.resourceURN("document", documentID)
+	ctx.addResourceEntity(
+		documentURN,
+		"document",
+		firstAttribute(ctx.attrs, "title", "document_id"),
+		map[string]string{"document_id": documentID, "source_system": ctx.provider},
+	)
+	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id"))
+	addInternetHostLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, relationHasIdentifier, firstAttribute(ctx.attrs, "url"), "grc_document_url_host", "0.9")
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, "grc_category", firstAttribute(ctx.attrs, "category"))
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcContractProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	contractID := firstAttribute(attrs, "contract_id", "external_id")
+	contractID := firstAttribute(ctx.attrs, "contract_id", "external_id")
 	if contractID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	contractURN := projectionURN(tenantID, "contract", provider, contractID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        contractURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "contract",
-		Label:      firstAttribute(attrs, "name", "title", "vendor_name", "contract_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
+	contractURN := ctx.resourceURN("contract", contractID)
+	ctx.addResourceEntity(
+		contractURN,
+		"contract",
+		firstAttribute(ctx.attrs, "name", "title", "vendor_name", "contract_id"),
+		map[string]string{
 			"contract_id":   contractID,
-			"contract_type": firstAttribute(attrs, "contract_type", "agreement_type"),
-			"source_system": provider,
-			"status":        firstAttribute(attrs, "status"),
-		}),
-	})
-	addGRCUserOwnerLink(entities, links, tenantID, event.GetSourceId(), event, contractURN, provider, firstAttribute(attrs, "owner_id", "business_owner_user_id"))
-	addGRCVendorAssociationLink(entities, links, tenantID, event.GetSourceId(), event, contractURN, provider, attrs)
-	addGRCTargetReferenceLink(entities, links, tenantID, event.GetSourceId(), event, contractURN, provider, attrs, relationAssociatedWith, "grc_contract")
-	addGRCControlSupportLinks(entities, links, tenantID, event.GetSourceId(), event, contractURN, provider)
-	addGRCEvidenceLink(entities, links, tenantID, event.GetSourceId(), event, contractURN, provider, attrs)
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, contractURN, "grc_contract_category", firstAttribute(attrs, "category"))
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, contractURN, "grc_contract_tag", strings.Join([]string{attrs["tags"], attrs["data_types"], attrs["jurisdictions"]}, ","))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+			"contract_type": firstAttribute(ctx.attrs, "contract_type", "agreement_type"),
+			"source_system": ctx.provider,
+			"status":        firstAttribute(ctx.attrs, "status"),
+		},
+	)
+	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, contractURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id", "business_owner_user_id"))
+	addGRCVendorAssociationLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, contractURN, ctx.provider, ctx.attrs)
+	addGRCTargetReferenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, contractURN, ctx.provider, ctx.attrs, relationAssociatedWith, "grc_contract")
+	addGRCControlSupportLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, contractURN, ctx.provider)
+	addGRCEvidenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, contractURN, ctx.provider, ctx.attrs)
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, contractURN, "grc_contract_category", firstAttribute(ctx.attrs, "category"))
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, contractURN, "grc_contract_tag", strings.Join([]string{ctx.attrs["tags"], ctx.attrs["data_types"], ctx.attrs["jurisdictions"]}, ","))
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcSecurityReviewProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	reviewID := firstAttribute(attrs, "security_review_id", "review_id", "assessment_id", "external_id")
+	reviewID := firstAttribute(ctx.attrs, "security_review_id", "review_id", "assessment_id", "external_id")
 	if reviewID == "" {
-		reviewID = grcDerivedID(firstAttribute(attrs, "vendor_id", "third_party_id"), firstAttribute(attrs, "review_type", "assessment_type"), firstAttribute(attrs, "started_at", "completed_at", "created_at"))
+		reviewID = grcDerivedID(firstAttribute(ctx.attrs, "vendor_id", "third_party_id"), firstAttribute(ctx.attrs, "review_type", "assessment_type"), firstAttribute(ctx.attrs, "started_at", "completed_at", "created_at"))
 	}
 	if reviewID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
 	reviewKind := grcAssuranceArtifactSecurityReview
-	reviewURN := projectionURN(tenantID, reviewKind.String(), provider, reviewID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        reviewURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: reviewKind.entityType(),
-		Label:      firstAttribute(attrs, "name", "title", "review_type", "assessment_type", "security_review_id", "review_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
-			"review_type":        firstAttribute(attrs, "review_type", "assessment_type"),
-			"risk_level":         firstAttribute(attrs, "risk_level", "inherent_risk_level", "residual_risk_level"),
+	reviewURN := ctx.resourceURN(reviewKind.String(), reviewID)
+	ctx.addResourceEntity(
+		reviewURN,
+		reviewKind.entityType(),
+		firstAttribute(ctx.attrs, "name", "title", "review_type", "assessment_type", "security_review_id", "review_id"),
+		map[string]string{
+			"review_type":        firstAttribute(ctx.attrs, "review_type", "assessment_type"),
+			"risk_level":         firstAttribute(ctx.attrs, "risk_level", "inherent_risk_level", "residual_risk_level"),
 			"security_review_id": reviewID,
-			"source_system":      provider,
-			"status":             firstAttribute(attrs, "status", "review_status", "assessment_status"),
-		}),
-	})
-	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, reviewURN, provider, attrs, relationAssociatedWith, "grc_security_review", "grc_security_review_url_host", reviewKind,
-		grcJoinedAttributeValues(attrs, "review_type", "assessment_type", "status", "review_status", "risk_level", "inherent_risk_level", "residual_risk_level"))
-	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, reviewURN, provider, attrs, reviewKind)
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+			"source_system":      ctx.provider,
+			"status":             firstAttribute(ctx.attrs, "status", "review_status", "assessment_status"),
+		},
+	)
+	addGRCAssuranceArtifactLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, reviewURN, ctx.provider, ctx.attrs, relationAssociatedWith, "grc_security_review", "grc_security_review_url_host", reviewKind,
+		grcJoinedAttributeValues(ctx.attrs, "review_type", "assessment_type", "status", "review_status", "risk_level", "inherent_risk_level", "residual_risk_level"))
+	addGRCRelatedAssuranceArtifactLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, reviewURN, ctx.provider, ctx.attrs, reviewKind)
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcSecurityQuestionnaireProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	questionnaireID := firstAttribute(attrs, "security_questionnaire_id", "questionnaire_id", "external_id")
+	questionnaireID := firstAttribute(ctx.attrs, "security_questionnaire_id", "questionnaire_id", "external_id")
 	if questionnaireID == "" {
-		questionnaireID = grcDerivedID(firstAttribute(attrs, "customer_trust_account_id", "account_id", "vendor_id"), firstAttribute(attrs, "questionnaire_type"), firstAttribute(attrs, "submitted_at", "created_at"))
+		questionnaireID = grcDerivedID(firstAttribute(ctx.attrs, "customer_trust_account_id", "account_id", "vendor_id"), firstAttribute(ctx.attrs, "questionnaire_type"), firstAttribute(ctx.attrs, "submitted_at", "created_at"))
 	}
 	if questionnaireID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
 	questionnaireKind := grcAssuranceArtifactSecurityQuestionnaire
-	questionnaireURN := projectionURN(tenantID, questionnaireKind.String(), provider, questionnaireID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        questionnaireURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: questionnaireKind.entityType(),
-		Label:      firstAttribute(attrs, "name", "title", "questionnaire_type", "security_questionnaire_id", "questionnaire_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
-			"questionnaire_type":        firstAttribute(attrs, "questionnaire_type", "assessment_type"),
+	questionnaireURN := ctx.resourceURN(questionnaireKind.String(), questionnaireID)
+	ctx.addResourceEntity(
+		questionnaireURN,
+		questionnaireKind.entityType(),
+		firstAttribute(ctx.attrs, "name", "title", "questionnaire_type", "security_questionnaire_id", "questionnaire_id"),
+		map[string]string{
+			"questionnaire_type":        firstAttribute(ctx.attrs, "questionnaire_type", "assessment_type"),
 			"security_questionnaire_id": questionnaireID,
-			"source_system":             provider,
-			"status":                    firstAttribute(attrs, "status", "questionnaire_status", "response_status"),
-		}),
-	})
-	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, questionnaireURN, provider, attrs, relationAssociatedWith, "grc_security_questionnaire", "grc_security_questionnaire_url_host", questionnaireKind,
-		grcJoinedAttributeValues(attrs, "questionnaire_type", "assessment_type", "status", "questionnaire_status", "response_status"))
-	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, questionnaireURN, provider, attrs, questionnaireKind)
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+			"source_system":             ctx.provider,
+			"status":                    firstAttribute(ctx.attrs, "status", "questionnaire_status", "response_status"),
+		},
+	)
+	addGRCAssuranceArtifactLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, questionnaireURN, ctx.provider, ctx.attrs, relationAssociatedWith, "grc_security_questionnaire", "grc_security_questionnaire_url_host", questionnaireKind,
+		grcJoinedAttributeValues(ctx.attrs, "questionnaire_type", "assessment_type", "status", "questionnaire_status", "response_status"))
+	addGRCRelatedAssuranceArtifactLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, questionnaireURN, ctx.provider, ctx.attrs, questionnaireKind)
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcPenetrationTestProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	testID := firstAttribute(attrs, "penetration_test_id", "pentest_id", "test_id", "external_id")
+	testID := firstAttribute(ctx.attrs, "penetration_test_id", "pentest_id", "test_id", "external_id")
 	if testID == "" {
-		testID = grcDerivedID(firstAttribute(attrs, "target_id", "resource_id", "asset_id", "system_id"), firstAttribute(attrs, "test_type", "assessment_type"), firstAttribute(attrs, "started_at", "completed_at"))
+		testID = grcDerivedID(firstAttribute(ctx.attrs, "target_id", "resource_id", "asset_id", "system_id"), firstAttribute(ctx.attrs, "test_type", "assessment_type"), firstAttribute(ctx.attrs, "started_at", "completed_at"))
 	}
 	if testID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
 	testKind := grcAssuranceArtifactPenetrationTest
-	testURN := projectionURN(tenantID, testKind.String(), provider, testID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        testURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: testKind.entityType(),
-		Label:      firstAttribute(attrs, "name", "title", "test_type", "penetration_test_id", "pentest_id", "test_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
+	testURN := ctx.resourceURN(testKind.String(), testID)
+	ctx.addResourceEntity(
+		testURN,
+		testKind.entityType(),
+		firstAttribute(ctx.attrs, "name", "title", "test_type", "penetration_test_id", "pentest_id", "test_id"),
+		map[string]string{
 			"penetration_test_id": testID,
-			"source_system":       provider,
-			"status":              firstAttribute(attrs, "status", "test_status", "assessment_status"),
-			"test_type":           firstAttribute(attrs, "test_type", "assessment_type"),
-		}),
-	})
-	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, testURN, provider, attrs, relationTargeted, "grc_penetration_test", "grc_penetration_test_url_host", testKind,
-		grcJoinedAttributeValues(attrs, "test_type", "assessment_type", "status", "test_status", "scope", "severity"))
-	addGRCPenetrationTestFindingLinks(entities, links, tenantID, event.GetSourceId(), event, testURN, provider, attrs)
-	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, testURN, provider, attrs, testKind)
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+			"source_system":       ctx.provider,
+			"status":              firstAttribute(ctx.attrs, "status", "test_status", "assessment_status"),
+			"test_type":           firstAttribute(ctx.attrs, "test_type", "assessment_type"),
+		},
+	)
+	addGRCAssuranceArtifactLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, testURN, ctx.provider, ctx.attrs, relationTargeted, "grc_penetration_test", "grc_penetration_test_url_host", testKind,
+		grcJoinedAttributeValues(ctx.attrs, "test_type", "assessment_type", "status", "test_status", "scope", "severity"))
+	addGRCPenetrationTestFindingLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, testURN, ctx.provider, ctx.attrs)
+	addGRCRelatedAssuranceArtifactLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, testURN, ctx.provider, ctx.attrs, testKind)
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcAssuranceDocumentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	documentID := firstAttribute(attrs, "assurance_document_id", "document_id", "upload_id", "external_id")
+	documentID := firstAttribute(ctx.attrs, "assurance_document_id", "document_id", "upload_id", "external_id")
 	if documentID == "" {
-		documentID = grcDerivedID(firstAttribute(attrs, "url", "document_url", "download_url"), firstAttribute(attrs, "title", "name"))
+		documentID = grcDerivedID(firstAttribute(ctx.attrs, "url", "document_url", "download_url"), firstAttribute(ctx.attrs, "title", "name"))
 	}
 	if documentID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
 	documentKind := grcAssuranceArtifactDocument
-	documentURN := projectionURN(tenantID, documentKind.String(), provider, documentID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        documentURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: documentKind.entityType(),
-		Label:      firstAttribute(attrs, "title", "name", "document_type", "assurance_document_id", "document_id", "upload_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
+	documentURN := ctx.resourceURN(documentKind.String(), documentID)
+	ctx.addResourceEntity(
+		documentURN,
+		documentKind.entityType(),
+		firstAttribute(ctx.attrs, "title", "name", "document_type", "assurance_document_id", "document_id", "upload_id"),
+		map[string]string{
 			"assurance_document_id": documentID,
-			"document_type":         firstAttribute(attrs, "document_type", "artifact_type", "evidence_type"),
-			"source_system":         provider,
-			"status":                firstAttribute(attrs, "status", "upload_status", "review_status"),
-		}),
-	})
-	addGRCAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, documentURN, provider, attrs, relationAssociatedWith, "grc_assurance_document", "grc_assurance_document_url_host", documentKind,
-		grcJoinedAttributeValues(attrs, "document_type", "artifact_type", "evidence_type", "category", "status", "upload_status", "tags"))
-	addGRCUserActionLink(entities, links, tenantID, event.GetSourceId(), event, provider, firstAttribute(attrs, "uploaded_by_user_id", "uploader_user_id"), documentURN, "uploaded")
-	addGRCRelatedAssuranceArtifactLinks(entities, links, tenantID, event.GetSourceId(), event, documentURN, provider, attrs, documentKind)
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+			"document_type":         firstAttribute(ctx.attrs, "document_type", "artifact_type", "evidence_type"),
+			"source_system":         ctx.provider,
+			"status":                firstAttribute(ctx.attrs, "status", "upload_status", "review_status"),
+		},
+	)
+	addGRCAssuranceArtifactLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, ctx.provider, ctx.attrs, relationAssociatedWith, "grc_assurance_document", "grc_assurance_document_url_host", documentKind,
+		grcJoinedAttributeValues(ctx.attrs, "document_type", "artifact_type", "evidence_type", "category", "status", "upload_status", "tags"))
+	addGRCUserActionLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, ctx.provider, firstAttribute(ctx.attrs, "uploaded_by_user_id", "uploader_user_id"), documentURN, "uploaded")
+	addGRCRelatedAssuranceArtifactLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, ctx.provider, ctx.attrs, documentKind)
+	entities, links := ctx.done()
+	return entities, links, nil
 }

--- a/internal/sourceprojection/grc_compliance_program.go
+++ b/internal/sourceprojection/grc_compliance_program.go
@@ -63,7 +63,7 @@ func grcRegulatoryNotificationProjections(event *cerebrov1.EventEnvelope) ([]*po
 			firstAttribute(ctx.attrs, "incident_title", "incident_name", "incident_id", "case_id"),
 			map[string]string{"incident_id": incidentID, "source_system": ctx.provider},
 		)
-		ctx.addEventLink(notificationURN, incidentURN, relationObservedOn, nil)
+		ctx.addEventLink(notificationURN, incidentURN, relationObservedOn)
 	}
 	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, notificationURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id"))
 	addGRCControlSupportLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, notificationURN, ctx.provider)
@@ -104,7 +104,7 @@ func grcRecoveryObjectiveProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 			processName,
 			map[string]string{"business_process": processName, "source_system": ctx.provider},
 		)
-		ctx.addEventLink(objectiveURN, processURN, relationSupports, nil)
+		ctx.addEventLink(objectiveURN, processURN, relationSupports)
 	}
 	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, objectiveURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id"))
 	addGRCTargetReferenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, objectiveURN, ctx.provider, ctx.attrs, relationTargeted, "grc_recovery_objective")
@@ -176,7 +176,7 @@ func grcPOAMItemProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 			firstAttribute(ctx.attrs, "finding_name", "title", "finding_id"),
 			map[string]string{"finding_id": findingID, "source_system": ctx.provider},
 		)
-		ctx.addEventLink(itemURN, findingURN, relationAssociatedWith, nil)
+		ctx.addEventLink(itemURN, findingURN, relationAssociatedWith)
 	}
 	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, itemURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id"))
 	addGRCTargetReferenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, itemURN, ctx.provider, ctx.attrs, relationTargeted, "grc_poam_item")
@@ -218,14 +218,14 @@ func grcTrainingAttestationProjections(event *cerebrov1.EventEnvelope) ([]*ports
 			firstAttribute(ctx.attrs, "person_name", "email", "person_id"),
 			map[string]string{"person_id": personID, "source_system": ctx.provider},
 		)
-		ctx.addEventLink(personURN, attestationURN, relationHasEvidence, nil)
-		ctx.addEventLink(attestationURN, personURN, relationObservedOn, nil)
+		ctx.addEventLink(personURN, attestationURN, relationHasEvidence)
+		ctx.addEventLink(attestationURN, personURN, relationObservedOn)
 	}
 	if userID := firstAttribute(ctx.attrs, "user_id"); userID != "" {
 		userURN := grcUserURN(ctx.tenantID, ctx.provider, userID)
 		addEntity(ctx.entities, grcUserEntity(ctx.tenantID, ctx.sourceID, userURN, firstAttribute(ctx.attrs, "display_name", "email", "user_id"), grcAttributes(nil, map[string]string{"user_id": userID, "source_system": ctx.provider})))
-		ctx.addEventLink(userURN, attestationURN, relationHasEvidence, nil)
-		ctx.addEventLink(attestationURN, userURN, relationObservedOn, nil)
+		ctx.addEventLink(userURN, attestationURN, relationHasEvidence)
+		ctx.addEventLink(attestationURN, userURN, relationObservedOn)
 	}
 	addGRCControlSupportLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, attestationURN, ctx.provider)
 	addGRCEvidenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, attestationURN, ctx.provider, ctx.attrs)

--- a/internal/sourceprojection/grc_compliance_program.go
+++ b/internal/sourceprojection/grc_compliance_program.go
@@ -8,273 +8,228 @@ import (
 )
 
 func grcGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	groupID := firstAttribute(attrs, "group_id", "external_id")
+	groupID := firstAttribute(ctx.attrs, "group_id", "external_id")
 	if groupID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	groupURN := projectionURN(tenantID, "grc_group", provider, groupID)
-	entities := map[string]*ports.ProjectedEntity{}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        groupURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "group",
-		Label:      firstAttribute(attrs, "group_name", "name", "group_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
+	ctx.addResourceEntity(
+		ctx.resourceURN("grc_group", groupID),
+		"group",
+		firstAttribute(ctx.attrs, "group_name", "name", "group_id"),
+		map[string]string{
 			"group_id":      groupID,
-			"group_name":    firstAttribute(attrs, "group_name", "name"),
-			"source_system": provider,
-		}),
-	})
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, nil)
-	return projectedEntities, projectedLinks, nil
+			"group_name":    firstAttribute(ctx.attrs, "group_name", "name"),
+			"source_system": ctx.provider,
+		},
+	)
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcRegulatoryNotificationProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	notificationID := firstAttribute(attrs, "notification_id", "external_id")
+	notificationID := firstAttribute(ctx.attrs, "notification_id", "external_id")
 	if notificationID == "" {
-		notificationID = grcDerivedID(firstAttribute(attrs, "framework"), firstAttribute(attrs, "incident_id", "case_id"), firstAttribute(attrs, "notification_type", "report_type"))
+		notificationID = grcDerivedID(firstAttribute(ctx.attrs, "framework"), firstAttribute(ctx.attrs, "incident_id", "case_id"), firstAttribute(ctx.attrs, "notification_type", "report_type"))
 	}
 	if notificationID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	notificationURN := projectionURN(tenantID, "regulatory_notification", provider, notificationID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        notificationURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "regulatory.notification",
-		Label:      firstAttribute(attrs, "title", "notification_type", "report_type", "notification_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
-			"incident_id":       firstAttribute(attrs, "incident_id", "case_id"),
+	notificationURN := ctx.resourceURN("regulatory_notification", notificationID)
+	ctx.addResourceEntity(
+		notificationURN,
+		"regulatory.notification",
+		firstAttribute(ctx.attrs, "title", "notification_type", "report_type", "notification_id"),
+		map[string]string{
+			"incident_id":       firstAttribute(ctx.attrs, "incident_id", "case_id"),
 			"notification_id":   notificationID,
-			"notification_type": firstAttribute(attrs, "notification_type", "report_type"),
-			"source_system":     provider,
-			"status":            firstAttribute(attrs, "status", "notification_status"),
-		}),
-	})
-	if incidentID := firstAttribute(attrs, "incident_id", "case_id"); incidentID != "" {
-		incidentURN := projectionURN(tenantID, "incident", provider, incidentID)
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        incidentURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: "incident",
-			Label:      firstAttribute(attrs, "incident_title", "incident_name", "incident_id", "case_id"),
-			Attributes: grcAttributes(nil, map[string]string{"incident_id": incidentID, "source_system": provider}),
-		})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), notificationURN, incidentURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
+			"notification_type": firstAttribute(ctx.attrs, "notification_type", "report_type"),
+			"source_system":     ctx.provider,
+			"status":            firstAttribute(ctx.attrs, "status", "notification_status"),
+		},
+	)
+	if incidentID := firstAttribute(ctx.attrs, "incident_id", "case_id"); incidentID != "" {
+		incidentURN := ctx.resourceURN("incident", incidentID)
+		ctx.addReferenceEntity(
+			incidentURN,
+			"incident",
+			firstAttribute(ctx.attrs, "incident_title", "incident_name", "incident_id", "case_id"),
+			map[string]string{"incident_id": incidentID, "source_system": ctx.provider},
+		)
+		ctx.addEventLink(notificationURN, incidentURN, relationObservedOn, nil)
 	}
-	addGRCUserOwnerLink(entities, links, tenantID, event.GetSourceId(), event, notificationURN, provider, firstAttribute(attrs, "owner_id"))
-	addGRCControlSupportLinks(entities, links, tenantID, event.GetSourceId(), event, notificationURN, provider)
-	addGRCEvidenceLink(entities, links, tenantID, event.GetSourceId(), event, notificationURN, provider, attrs)
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, notificationURN, "regulatory_notification", strings.Join([]string{attrs["framework"], attrs["regulator"], attrs["notification_type"], attrs["report_type"]}, ","))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, notificationURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id"))
+	addGRCControlSupportLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, notificationURN, ctx.provider)
+	addGRCEvidenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, notificationURN, ctx.provider, ctx.attrs)
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, notificationURN, "regulatory_notification", strings.Join([]string{ctx.attrs["framework"], ctx.attrs["regulator"], ctx.attrs["notification_type"], ctx.attrs["report_type"]}, ","))
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcRecoveryObjectiveProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	objectiveID := firstAttribute(attrs, "recovery_objective_id", "objective_id", "bia_id", "external_id")
+	objectiveID := firstAttribute(ctx.attrs, "recovery_objective_id", "objective_id", "bia_id", "external_id")
 	if objectiveID == "" {
-		objectiveID = grcDerivedID(firstAttribute(attrs, "service_id", "target_id", "resource_id", "asset_id"), firstAttribute(attrs, "business_process"), firstAttribute(attrs, "rto_minutes"), firstAttribute(attrs, "rpo_minutes"))
+		objectiveID = grcDerivedID(firstAttribute(ctx.attrs, "service_id", "target_id", "resource_id", "asset_id"), firstAttribute(ctx.attrs, "business_process"), firstAttribute(ctx.attrs, "rto_minutes"), firstAttribute(ctx.attrs, "rpo_minutes"))
 	}
 	if objectiveID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	objectiveURN := projectionURN(tenantID, "resilience_recovery_objective", provider, objectiveID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        objectiveURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "resilience.recovery_objective",
-		Label:      firstAttribute(attrs, "name", "business_process", "service_id", "objective_id", "recovery_objective_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
+	objectiveURN := ctx.resourceURN("resilience_recovery_objective", objectiveID)
+	ctx.addResourceEntity(
+		objectiveURN,
+		"resilience.recovery_objective",
+		firstAttribute(ctx.attrs, "name", "business_process", "service_id", "objective_id", "recovery_objective_id"),
+		map[string]string{
 			"recovery_objective_id": objectiveID,
-			"source_system":         provider,
-			"status":                firstAttribute(attrs, "status"),
-		}),
-	})
-	if processName := firstAttribute(attrs, "business_process", "process_name"); processName != "" {
-		processID := grcDerivedID(processName)
-		processURN := projectionURN(tenantID, "business_process", provider, processID)
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        processURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: "business.process",
-			Label:      processName,
-			Attributes: grcAttributes(nil, map[string]string{"business_process": processName, "source_system": provider}),
-		})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), objectiveURN, processURN, relationSupports, map[string]string{"event_id": event.GetId()}))
+			"source_system":         ctx.provider,
+			"status":                firstAttribute(ctx.attrs, "status"),
+		},
+	)
+	if processName := firstAttribute(ctx.attrs, "business_process", "process_name"); processName != "" {
+		processURN := ctx.resourceURN("business_process", grcDerivedID(processName))
+		ctx.addReferenceEntity(
+			processURN,
+			"business.process",
+			processName,
+			map[string]string{"business_process": processName, "source_system": ctx.provider},
+		)
+		ctx.addEventLink(objectiveURN, processURN, relationSupports, nil)
 	}
-	addGRCUserOwnerLink(entities, links, tenantID, event.GetSourceId(), event, objectiveURN, provider, firstAttribute(attrs, "owner_id"))
-	addGRCTargetReferenceLink(entities, links, tenantID, event.GetSourceId(), event, objectiveURN, provider, attrs, relationTargeted, "grc_recovery_objective")
-	addGRCControlSupportLinks(entities, links, tenantID, event.GetSourceId(), event, objectiveURN, provider)
-	addGRCEvidenceLink(entities, links, tenantID, event.GetSourceId(), event, objectiveURN, provider, attrs)
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, objectiveURN, "resilience_tier", strings.Join([]string{attrs["impact_tier"], attrs["criticality"], attrs["recovery_priority"]}, ","))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, objectiveURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id"))
+	addGRCTargetReferenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, objectiveURN, ctx.provider, ctx.attrs, relationTargeted, "grc_recovery_objective")
+	addGRCControlSupportLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, objectiveURN, ctx.provider)
+	addGRCEvidenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, objectiveURN, ctx.provider, ctx.attrs)
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, objectiveURN, "resilience_tier", strings.Join([]string{ctx.attrs["impact_tier"], ctx.attrs["criticality"], ctx.attrs["recovery_priority"]}, ","))
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcAuthorizationPackageProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	packageID := firstAttribute(attrs, "authorization_package_id", "package_id", "ato_id", "ssp_id", "external_id")
+	packageID := firstAttribute(ctx.attrs, "authorization_package_id", "package_id", "ato_id", "ssp_id", "external_id")
 	if packageID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	packageURN := projectionURN(tenantID, "authorization_package", provider, packageID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        packageURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "authorization.package",
-		Label:      firstAttribute(attrs, "name", "system_name", "package_name", "package_id", "authorization_package_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
+	packageURN := ctx.resourceURN("authorization_package", packageID)
+	ctx.addResourceEntity(
+		packageURN,
+		"authorization.package",
+		firstAttribute(ctx.attrs, "name", "system_name", "package_name", "package_id", "authorization_package_id"),
+		map[string]string{
 			"authorization_package_id": packageID,
-			"framework":                firstAttribute(attrs, "framework"),
-			"impact_level":             firstAttribute(attrs, "impact_level"),
-			"source_system":            provider,
-			"status":                   firstAttribute(attrs, "status", "authorization_status"),
-		}),
-	})
-	addGRCUserOwnerLink(entities, links, tenantID, event.GetSourceId(), event, packageURN, provider, firstAttribute(attrs, "owner_id", "system_owner_user_id"))
-	addGRCTargetReferenceLink(entities, links, tenantID, event.GetSourceId(), event, packageURN, provider, attrs, relationTargeted, "grc_authorization_package")
-	addGRCControlSupportLinks(entities, links, tenantID, event.GetSourceId(), event, packageURN, provider)
-	addGRCEvidenceLink(entities, links, tenantID, event.GetSourceId(), event, packageURN, provider, attrs)
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, packageURN, "authorization_package", strings.Join([]string{attrs["framework"], attrs["impact_level"], attrs["status"], attrs["authorization_status"]}, ","))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+			"framework":                firstAttribute(ctx.attrs, "framework"),
+			"impact_level":             firstAttribute(ctx.attrs, "impact_level"),
+			"source_system":            ctx.provider,
+			"status":                   firstAttribute(ctx.attrs, "status", "authorization_status"),
+		},
+	)
+	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, packageURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id", "system_owner_user_id"))
+	addGRCTargetReferenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, packageURN, ctx.provider, ctx.attrs, relationTargeted, "grc_authorization_package")
+	addGRCControlSupportLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, packageURN, ctx.provider)
+	addGRCEvidenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, packageURN, ctx.provider, ctx.attrs)
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, packageURN, "authorization_package", strings.Join([]string{ctx.attrs["framework"], ctx.attrs["impact_level"], ctx.attrs["status"], ctx.attrs["authorization_status"]}, ","))
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcPOAMItemProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	itemID := firstAttribute(attrs, "poam_item_id", "weakness_id", "finding_id", "external_id")
+	itemID := firstAttribute(ctx.attrs, "poam_item_id", "weakness_id", "finding_id", "external_id")
 	if itemID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	itemURN := projectionURN(tenantID, "poam_item", provider, itemID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        itemURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "poam.item",
-		Label:      firstAttribute(attrs, "title", "weakness_name", "finding_name", "poam_item_id", "weakness_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
+	itemURN := ctx.resourceURN("poam_item", itemID)
+	ctx.addResourceEntity(
+		itemURN,
+		"poam.item",
+		firstAttribute(ctx.attrs, "title", "weakness_name", "finding_name", "poam_item_id", "weakness_id"),
+		map[string]string{
 			"poam_item_id":  itemID,
-			"risk_rating":   firstAttribute(attrs, "risk_rating", "severity"),
-			"source_system": provider,
-			"status":        firstAttribute(attrs, "status"),
-			"weakness_id":   firstAttribute(attrs, "weakness_id"),
-		}),
-	})
-	if findingID := firstAttribute(attrs, "finding_id"); findingID != "" {
-		findingURN := projectionURN(tenantID, "finding", findingID)
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        findingURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: "finding",
-			Label:      firstAttribute(attrs, "finding_name", "title", "finding_id"),
-			Attributes: grcAttributes(nil, map[string]string{"finding_id": findingID, "source_system": provider}),
-		})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), itemURN, findingURN, relationAssociatedWith, map[string]string{"event_id": event.GetId()}))
+			"risk_rating":   firstAttribute(ctx.attrs, "risk_rating", "severity"),
+			"source_system": ctx.provider,
+			"status":        firstAttribute(ctx.attrs, "status"),
+			"weakness_id":   firstAttribute(ctx.attrs, "weakness_id"),
+		},
+	)
+	if findingID := firstAttribute(ctx.attrs, "finding_id"); findingID != "" {
+		findingURN := ctx.globalURN("finding", findingID)
+		ctx.addReferenceEntity(
+			findingURN,
+			"finding",
+			firstAttribute(ctx.attrs, "finding_name", "title", "finding_id"),
+			map[string]string{"finding_id": findingID, "source_system": ctx.provider},
+		)
+		ctx.addEventLink(itemURN, findingURN, relationAssociatedWith, nil)
 	}
-	addGRCUserOwnerLink(entities, links, tenantID, event.GetSourceId(), event, itemURN, provider, firstAttribute(attrs, "owner_id"))
-	addGRCTargetReferenceLink(entities, links, tenantID, event.GetSourceId(), event, itemURN, provider, attrs, relationTargeted, "grc_poam_item")
-	addGRCControlSupportLinks(entities, links, tenantID, event.GetSourceId(), event, itemURN, provider)
-	addGRCEvidenceLink(entities, links, tenantID, event.GetSourceId(), event, itemURN, provider, attrs)
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, itemURN, "poam_risk", strings.Join([]string{attrs["risk_rating"], attrs["severity"], attrs["status"]}, ","))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, itemURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id"))
+	addGRCTargetReferenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, itemURN, ctx.provider, ctx.attrs, relationTargeted, "grc_poam_item")
+	addGRCControlSupportLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, itemURN, ctx.provider)
+	addGRCEvidenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, itemURN, ctx.provider, ctx.attrs)
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, itemURN, "poam_risk", strings.Join([]string{ctx.attrs["risk_rating"], ctx.attrs["severity"], ctx.attrs["status"]}, ","))
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcTrainingAttestationProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	attestationID := firstAttribute(attrs, "attestation_id", "training_attestation_id", "external_id")
+	attestationID := firstAttribute(ctx.attrs, "attestation_id", "training_attestation_id", "external_id")
 	if attestationID == "" {
-		attestationID = grcDerivedID(firstAttribute(attrs, "person_id", "user_id", "email"), firstAttribute(attrs, "course_id", "training_type"), firstAttribute(attrs, "completed_at", "expires_at"))
+		attestationID = grcDerivedID(firstAttribute(ctx.attrs, "person_id", "user_id", "email"), firstAttribute(ctx.attrs, "course_id", "training_type"), firstAttribute(ctx.attrs, "completed_at", "expires_at"))
 	}
 	if attestationID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	attestationURN := projectionURN(tenantID, "training_attestation", provider, attestationID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        attestationURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "training.attestation",
-		Label:      firstAttribute(attrs, "course_name", "training_type", "course_id", "attestation_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
+	attestationURN := ctx.resourceURN("training_attestation", attestationID)
+	ctx.addResourceEntity(
+		attestationURN,
+		"training.attestation",
+		firstAttribute(ctx.attrs, "course_name", "training_type", "course_id", "attestation_id"),
+		map[string]string{
 			"attestation_id": attestationID,
-			"source_system":  provider,
-			"status":         firstAttribute(attrs, "status"),
-		}),
-	})
-	if personID := firstAttribute(attrs, "person_id"); personID != "" {
-		personURN := projectionURN(tenantID, "person", provider, personID)
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        personURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: "person",
-			Label:      firstAttribute(attrs, "person_name", "email", "person_id"),
-			Attributes: grcAttributes(nil, map[string]string{"person_id": personID, "source_system": provider}),
-		})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), personURN, attestationURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), attestationURN, personURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
+			"source_system":  ctx.provider,
+			"status":         firstAttribute(ctx.attrs, "status"),
+		},
+	)
+	if personID := firstAttribute(ctx.attrs, "person_id"); personID != "" {
+		personURN := ctx.resourceURN("person", personID)
+		ctx.addReferenceEntity(
+			personURN,
+			"person",
+			firstAttribute(ctx.attrs, "person_name", "email", "person_id"),
+			map[string]string{"person_id": personID, "source_system": ctx.provider},
+		)
+		ctx.addEventLink(personURN, attestationURN, relationHasEvidence, nil)
+		ctx.addEventLink(attestationURN, personURN, relationObservedOn, nil)
 	}
-	if userID := firstAttribute(attrs, "user_id"); userID != "" {
-		userURN := grcUserURN(tenantID, provider, userID)
-		addEntity(entities, grcUserEntity(tenantID, event.GetSourceId(), userURN, firstAttribute(attrs, "display_name", "email", "user_id"), grcAttributes(nil, map[string]string{"user_id": userID, "source_system": provider})))
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), userURN, attestationURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), attestationURN, userURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
+	if userID := firstAttribute(ctx.attrs, "user_id"); userID != "" {
+		userURN := grcUserURN(ctx.tenantID, ctx.provider, userID)
+		addEntity(ctx.entities, grcUserEntity(ctx.tenantID, ctx.sourceID, userURN, firstAttribute(ctx.attrs, "display_name", "email", "user_id"), grcAttributes(nil, map[string]string{"user_id": userID, "source_system": ctx.provider})))
+		ctx.addEventLink(userURN, attestationURN, relationHasEvidence, nil)
+		ctx.addEventLink(attestationURN, userURN, relationObservedOn, nil)
 	}
-	addGRCControlSupportLinks(entities, links, tenantID, event.GetSourceId(), event, attestationURN, provider)
-	addGRCEvidenceLink(entities, links, tenantID, event.GetSourceId(), event, attestationURN, provider, attrs)
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, attestationURN, "training_type", firstAttribute(attrs, "training_type", "course_type"))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+	addGRCControlSupportLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, attestationURN, ctx.provider)
+	addGRCEvidenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, attestationURN, ctx.provider, ctx.attrs)
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, attestationURN, "training_type", firstAttribute(ctx.attrs, "training_type", "course_type"))
+	entities, links := ctx.done()
+	return entities, links, nil
 }

--- a/internal/sourceprojection/grc_shared.go
+++ b/internal/sourceprojection/grc_shared.go
@@ -61,18 +61,12 @@ func (ctx *grcProjectionContext) addEntity(urn string, entityType string, label 
 	})
 }
 
-func (ctx *grcProjectionContext) addEventLink(fromURN string, toURN string, relation string, attrs map[string]string) {
-	addLink(ctx.links, projectedLink(ctx.tenantID, ctx.sourceID, fromURN, toURN, relation, ctx.eventLinkAttributes(attrs)))
+func (ctx *grcProjectionContext) addEventLink(fromURN string, toURN string, relation string) {
+	addLink(ctx.links, projectedLink(ctx.tenantID, ctx.sourceID, fromURN, toURN, relation, ctx.eventLinkAttributes()))
 }
 
-func (ctx *grcProjectionContext) eventLinkAttributes(attrs map[string]string) map[string]string {
-	merged := map[string]string{"event_id": ctx.event.GetId()}
-	for key, value := range attrs {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			merged[key] = trimmed
-		}
-	}
-	return merged
+func (ctx *grcProjectionContext) eventLinkAttributes() map[string]string {
+	return map[string]string{"event_id": ctx.event.GetId()}
 }
 
 func (ctx *grcProjectionContext) done() ([]*ports.ProjectedEntity, []*ports.ProjectedLink) {

--- a/internal/sourceprojection/grc_shared.go
+++ b/internal/sourceprojection/grc_shared.go
@@ -7,6 +7,78 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
+type grcProjectionContext struct {
+	event    *cerebrov1.EventEnvelope
+	tenantID string
+	sourceID string
+	provider string
+	attrs    map[string]string
+	entities map[string]*ports.ProjectedEntity
+	links    map[string]*ports.ProjectedLink
+}
+
+func newGRCProjectionContext(event *cerebrov1.EventEnvelope) (*grcProjectionContext, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, err
+	}
+	attrs := event.GetAttributes()
+	return &grcProjectionContext{
+		event:    event,
+		tenantID: tenantID,
+		sourceID: event.GetSourceId(),
+		provider: grcProvider(attrs),
+		attrs:    attrs,
+		entities: map[string]*ports.ProjectedEntity{},
+		links:    map[string]*ports.ProjectedLink{},
+	}, nil
+}
+
+func (ctx *grcProjectionContext) resourceURN(kind string, id string) string {
+	return projectionURN(ctx.tenantID, kind, ctx.provider, id)
+}
+
+func (ctx *grcProjectionContext) globalURN(kind string, parts ...string) string {
+	return projectionURN(ctx.tenantID, kind, parts...)
+}
+
+func (ctx *grcProjectionContext) addResourceEntity(urn string, entityType string, label string, extra map[string]string) {
+	ctx.addEntity(urn, entityType, label, grcAttributes(ctx.attrs, extra))
+}
+
+func (ctx *grcProjectionContext) addReferenceEntity(urn string, entityType string, label string, attrs map[string]string) {
+	ctx.addEntity(urn, entityType, label, grcAttributes(nil, attrs))
+}
+
+func (ctx *grcProjectionContext) addEntity(urn string, entityType string, label string, attrs map[string]string) {
+	addEntity(ctx.entities, &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   ctx.tenantID,
+		SourceID:   ctx.sourceID,
+		EntityType: entityType,
+		Label:      label,
+		Attributes: attrs,
+	})
+}
+
+func (ctx *grcProjectionContext) addEventLink(fromURN string, toURN string, relation string, attrs map[string]string) {
+	addLink(ctx.links, projectedLink(ctx.tenantID, ctx.sourceID, fromURN, toURN, relation, ctx.eventLinkAttributes(attrs)))
+}
+
+func (ctx *grcProjectionContext) eventLinkAttributes(attrs map[string]string) map[string]string {
+	merged := map[string]string{"event_id": ctx.event.GetId()}
+	for key, value := range attrs {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			merged[key] = trimmed
+		}
+	}
+	return merged
+}
+
+func (ctx *grcProjectionContext) done() ([]*ports.ProjectedEntity, []*ports.ProjectedLink) {
+	return entitiesAndLinks(ctx.entities, ctx.links)
+}
+
 func grcAttributeList(value string) []string {
 	values := []string{}
 	seen := map[string]struct{}{}

--- a/internal/sourceprojection/grc_vendor.go
+++ b/internal/sourceprojection/grc_vendor.go
@@ -6,108 +6,90 @@ import (
 )
 
 func grcVendorProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	vendorID := firstAttribute(attrs, "vendor_id", "external_id")
+	vendorID := firstAttribute(ctx.attrs, "vendor_id", "external_id")
 	if vendorID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	vendorURN := projectionURN(tenantID, "vendor", provider, vendorID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        vendorURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "vendor",
-		Label:      firstAttribute(attrs, "name", "vendor_id"),
-		Attributes: grcAttributes(attrs, map[string]string{"vendor_id": vendorID, "source_system": provider}),
-	})
-	addVendorAliasLink(entities, links, tenantID, event.GetSourceId(), event, vendorURN, firstAttribute(attrs, "name"), "grc_vendor_name_alias", "0.90")
-	addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, vendorURN, relationHasIdentifier, firstAttribute(attrs, "website_url", "website", "url", "domain"), "grc_vendor_website_host", "0.95")
-	for _, ownerID := range []string{firstAttribute(attrs, "security_owner_user_id"), firstAttribute(attrs, "business_owner_user_id")} {
+	vendorURN := ctx.resourceURN("vendor", vendorID)
+	ctx.addResourceEntity(
+		vendorURN,
+		"vendor",
+		firstAttribute(ctx.attrs, "name", "vendor_id"),
+		map[string]string{"vendor_id": vendorID, "source_system": ctx.provider},
+	)
+	addVendorAliasLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, vendorURN, firstAttribute(ctx.attrs, "name"), "grc_vendor_name_alias", "0.90")
+	addInternetHostLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, vendorURN, relationHasIdentifier, firstAttribute(ctx.attrs, "website_url", "website", "url", "domain"), "grc_vendor_website_host", "0.95")
+	for _, ownerID := range []string{firstAttribute(ctx.attrs, "security_owner_user_id"), firstAttribute(ctx.attrs, "business_owner_user_id")} {
 		if ownerID == "" {
 			continue
 		}
-		ownerURN := grcUserURN(tenantID, provider, ownerID)
-		addEntity(entities, grcUserEntity(tenantID, event.GetSourceId(), ownerURN, ownerID, map[string]string{"user_id": ownerID, "source_system": provider}))
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), vendorURN, ownerURN, relationOwnedBy, map[string]string{"event_id": event.GetId()}))
+		ownerURN := grcUserURN(ctx.tenantID, ctx.provider, ownerID)
+		addEntity(ctx.entities, grcUserEntity(ctx.tenantID, ctx.sourceID, ownerURN, ownerID, map[string]string{"user_id": ownerID, "source_system": ctx.provider}))
+		ctx.addEventLink(vendorURN, ownerURN, relationOwnedBy, nil)
 	}
-	addSecurityContactEmailLink(entities, links, tenantID, event.GetSourceId(), event, vendorURN, firstAttribute(attrs, "account_manager_email", "security_contact_email", "contact_email"), "account_manager")
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+	addSecurityContactEmailLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, vendorURN, firstAttribute(ctx.attrs, "account_manager_email", "security_contact_email", "contact_email"), "account_manager")
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcDiscoveredVendorProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	discoveryID := firstAttribute(attrs, "discovered_vendor_id", "vendor_id", "external_id")
+	discoveryID := firstAttribute(ctx.attrs, "discovered_vendor_id", "vendor_id", "external_id")
 	if discoveryID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	discoveryURN := projectionURN(tenantID, "vendor_discovery", provider, discoveryID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        discoveryURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "vendor.discovery",
-		Label:      firstAttribute(attrs, "name", "normalized_name", "discovered_vendor_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
+	discoveryURN := ctx.resourceURN("vendor_discovery", discoveryID)
+	ctx.addResourceEntity(
+		discoveryURN,
+		"vendor.discovery",
+		firstAttribute(ctx.attrs, "name", "normalized_name", "discovered_vendor_id"),
+		map[string]string{
 			"discovered_vendor_id": discoveryID,
-			"source_system":        provider,
-			"status":               discoveredVendorStatus(attrs),
-		}),
-	})
-	addVendorAliasLink(entities, links, tenantID, event.GetSourceId(), event, discoveryURN, firstAttribute(attrs, "name"), "grc_discovered_vendor_name", "0.90")
-	addVendorAliasLink(entities, links, tenantID, event.GetSourceId(), event, discoveryURN, firstAttribute(attrs, "normalized_name"), "grc_discovered_vendor_normalized_name", "0.95")
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, discoveryURN, "vendor_category", firstAttribute(attrs, "category"))
-	addGRCUserActionLink(entities, links, tenantID, event.GetSourceId(), event, provider, firstAttribute(attrs, "ignored_by_user_id"), discoveryURN, "ignored")
-	addGRCUserActionLink(entities, links, tenantID, event.GetSourceId(), event, provider, firstAttribute(attrs, "rejected_by_user_id"), discoveryURN, "rejected")
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+			"source_system":        ctx.provider,
+			"status":               discoveredVendorStatus(ctx.attrs),
+		},
+	)
+	addVendorAliasLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, discoveryURN, firstAttribute(ctx.attrs, "name"), "grc_discovered_vendor_name", "0.90")
+	addVendorAliasLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, discoveryURN, firstAttribute(ctx.attrs, "normalized_name"), "grc_discovered_vendor_normalized_name", "0.95")
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, discoveryURN, "vendor_category", firstAttribute(ctx.attrs, "category"))
+	addGRCUserActionLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, ctx.provider, firstAttribute(ctx.attrs, "ignored_by_user_id"), discoveryURN, "ignored")
+	addGRCUserActionLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, ctx.provider, firstAttribute(ctx.attrs, "rejected_by_user_id"), discoveryURN, "rejected")
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func grcVendorRiskAttributeProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	attributeID := firstAttribute(attrs, "vendor_risk_attribute_id", "external_id")
+	attributeID := firstAttribute(ctx.attrs, "vendor_risk_attribute_id", "external_id")
 	if attributeID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	attributeURN := projectionURN(tenantID, "vendor_risk_attribute", provider, attributeID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        attributeURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "vendor.risk_attribute",
-		Label:      firstAttribute(attrs, "name", "vendor_risk_attribute_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
-			"enabled":                  firstAttribute(attrs, "enabled"),
-			"risk_level":               firstAttribute(attrs, "risk_level"),
-			"source_system":            provider,
+	attributeURN := ctx.resourceURN("vendor_risk_attribute", attributeID)
+	ctx.addResourceEntity(
+		attributeURN,
+		"vendor.risk_attribute",
+		firstAttribute(ctx.attrs, "name", "vendor_risk_attribute_id"),
+		map[string]string{
+			"enabled":                  firstAttribute(ctx.attrs, "enabled"),
+			"risk_level":               firstAttribute(ctx.attrs, "risk_level"),
+			"source_system":            ctx.provider,
 			"vendor_risk_attribute_id": attributeID,
-		}),
-	})
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, attributeURN, "vendor_category", firstAttribute(attrs, "vendor_categories"))
-	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, attributeURN, "vendor_risk_level", firstAttribute(attrs, "risk_level"))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+		},
+	)
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, attributeURN, "vendor_category", firstAttribute(ctx.attrs, "vendor_categories"))
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, attributeURN, "vendor_risk_level", firstAttribute(ctx.attrs, "risk_level"))
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func discoveredVendorStatus(attrs map[string]string) string {

--- a/internal/sourceprojection/grc_vendor.go
+++ b/internal/sourceprojection/grc_vendor.go
@@ -29,7 +29,7 @@ func grcVendorProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		}
 		ownerURN := grcUserURN(ctx.tenantID, ctx.provider, ownerID)
 		addEntity(ctx.entities, grcUserEntity(ctx.tenantID, ctx.sourceID, ownerURN, ownerID, map[string]string{"user_id": ownerID, "source_system": ctx.provider}))
-		ctx.addEventLink(vendorURN, ownerURN, relationOwnedBy, nil)
+		ctx.addEventLink(vendorURN, ownerURN, relationOwnedBy)
 	}
 	addSecurityContactEmailLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, vendorURN, firstAttribute(ctx.attrs, "account_manager_email", "security_contact_email", "contact_email"), "account_manager")
 	entities, links := ctx.done()

--- a/sources/grc/records.go
+++ b/sources/grc/records.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -172,66 +171,13 @@ var timestampKeySets = map[grcFamily][]string{
 }
 
 func fieldString(values map[string]any, path string) string {
-	value, ok := fieldValue(values, path)
-	if !ok {
-		return ""
-	}
-	return valueString(value)
-}
-
-func fieldValue(values map[string]any, path string) (any, bool) {
-	var current any = values
-	for _, part := range strings.Split(path, ".") {
-		object, ok := current.(map[string]any)
-		if !ok {
-			return nil, false
-		}
-		current, ok = object[part]
-		if !ok {
-			return nil, false
-		}
-	}
-	return current, true
+	return sourcecdk.JSONObject(values).FieldString(path)
 }
 
 func valueString(value any) string {
-	switch typed := value.(type) {
-	case nil:
-		return ""
-	case string:
-		return strings.TrimSpace(typed)
-	case bool:
-		return strconv.FormatBool(typed)
-	case float64:
-		return strconv.FormatFloat(typed, 'f', -1, 64)
-	case []any:
-		values := make([]string, 0, len(typed))
-		for _, item := range typed {
-			if value := valueString(item); value != "" {
-				values = append(values, value)
-			}
-		}
-		return strings.Join(values, ",")
-	case map[string]any:
-		for _, key := range []string{"displayName", "name", "id", "email"} {
-			if value := valueString(typed[key]); value != "" {
-				return value
-			}
-		}
-		return ""
-	default:
-		return fmt.Sprint(typed)
-	}
+	return (sourcecdk.JSONScalar{Value: value}).SourceString()
 }
 
 func arrayValue(values map[string]any, key string) []any {
-	value, ok := values[key]
-	if !ok {
-		return nil
-	}
-	items, ok := value.([]any)
-	if !ok {
-		return nil
-	}
-	return items
+	return []any(sourcecdk.JSONObject(values).Array(key))
 }

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -21,7 +21,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"gcp":             2130,
 	"github":          2029,
 	"googleworkspace": 815,
-	"grc":             1270,
+	"grc":             1217,
 	"okta":            2256,
 	"panopticon":      765,
 	"sentinelone":     2112,


### PR DESCRIPTION
## Summary
- Add a shared GRC projection context for provider, tenant, entity, link, and event-attribute plumbing.
- Move assurance, compliance-program, and vendor-risk projections onto the shared context so new GRC domains can follow one platform pattern.
- Reuse Source CDK JSON object/scalar helpers in the GRC source and ratchet the GRC source LOC ceiling down to the new exact size.

## Validation
- `go test ./sources/grc ./internal/sourceprojection -count=1`
- `go test ./internal/sourcecdk -count=1`
- `go test ./tools/archtests -count=1`
- `go test ./... -count=1`