### PR TITLE
Fix source runtime graph backfill blockers

### DIFF
--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -445,6 +445,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			}
 			acceptedEvents = append(acceptedEvents, syncedEvent)
 		}
+		acceptedEvents = dedupeAcceptedEvents(acceptedEvents)
 		ledger, ledgerEnabled := s.store.(ports.SourceRuntimePageLedgerStore)
 		attemptID := sourceRuntimePageAttemptID(runtime.GetId(), pageNumber, started)
 		if ledgerEnabled {
@@ -1045,6 +1046,25 @@ func readSourcePull(ctx context.Context, source sourcecdk.Source, cfg sourcecdk.
 		return reader.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
 	}
 	return source.Read(ctx, cfg, cursor)
+}
+
+func dedupeAcceptedEvents(events []*cerebrov1.EventEnvelope) []*cerebrov1.EventEnvelope {
+	if len(events) < 2 {
+		return events
+	}
+	seen := make(map[string]struct{}, len(events))
+	deduped := events[:0]
+	for _, event := range events {
+		eventID := strings.TrimSpace(event.GetId())
+		if eventID != "" {
+			if _, ok := seen[eventID]; ok {
+				continue
+			}
+			seen[eventID] = struct{}{}
+		}
+		deduped = append(deduped, event)
+	}
+	return deduped
 }
 
 func pullShortCircuitReason(pull sourcecdk.Pull) sourcecdk.PullShortCircuitReason {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -289,6 +289,27 @@ func (nilEventSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceC
 	}}, nil
 }
 
+type duplicateEventSource struct{}
+
+func (duplicateEventSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "duplicate_event"}
+}
+
+func (duplicateEventSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (duplicateEventSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (duplicateEventSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{Events: []*cerebrov1.EventEnvelope{
+		runtimeTestEvent("duplicate-event", "duplicate_event", "duplicate_event.event"),
+		runtimeTestEvent("duplicate-event", "duplicate_event", "duplicate_event.event"),
+	}}, nil
+}
+
 type invalidEventSource struct{}
 
 func (invalidEventSource) Spec() *cerebrov1.SourceSpec {
@@ -1906,6 +1927,39 @@ func TestSyncRuntimeSkipsNilEvents(t *testing.T) {
 	}
 	if got := log.events[0].GetAttributes()[ports.EventAttributeSourceRuntimeID]; got != "writer-nil-event" {
 		t.Fatalf("appended event source_runtime_id = %q, want writer-nil-event", got)
+	}
+}
+
+func TestSyncRuntimeDedupesAcceptedEventsByID(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(duplicateEventSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-duplicate-event": {
+				Id:       "writer-duplicate-event",
+				SourceId: "duplicate_event",
+				TenantId: "writer",
+			},
+		},
+	}
+	log := &appendLog{}
+	projector := &projector{result: ports.ProjectionResult{EntitiesProjected: 1, LinksProjected: 1}}
+	service := New(registry, store, log, projector)
+
+	resp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-duplicate-event"})
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if resp.GetEventsAppended() != 1 {
+		t.Fatalf("Sync().EventsAppended = %d, want 1", resp.GetEventsAppended())
+	}
+	if len(log.events) != 1 || len(projector.events) != 1 {
+		t.Fatalf("append/project counts = %d/%d, want 1/1", len(log.events), len(projector.events))
+	}
+	if got := log.events[0].GetId(); got != "duplicate-event" {
+		t.Fatalf("appended event id = %q, want duplicate-event", got)
 	}
 }
 

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -47,7 +47,7 @@ type auditPayload struct {
 }
 
 func (s *Source) checkAudit(ctx context.Context, client *gogithub.Client, settings settings) error {
-	_, _, err := client.Organizations.GetAuditLog(ctx, settings.owner, githubaudit.Options(settings.auditInclude, settings.auditPhrase, settings.auditOrder, "", 1))
+	_, _, err := githubaudit.GetAuditLog(ctx, client, settings.owner, githubaudit.Options(settings.auditInclude, settings.auditPhrase, settings.auditOrder, "", 1))
 	if err != nil {
 		return wrapLookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
 	}
@@ -68,7 +68,7 @@ func (s *Source) discoverAudit(ctx context.Context, client *gogithub.Client, set
 func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
 	readCheckpoint, shortCircuit, err := sourcecdk.BeginFamilyFreshnessReadWithOptions("github", familyAudit, cursor, checkpoint, func(checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.ChangeProbe, error) {
 		probe, err := githubaudit.LatestEventChangeProbe(ctx, settings.owner, settings.auditInclude, settings.auditPhrase, checkpoint, func(ctx context.Context, opts *gogithub.GetAuditLogOptions) ([]*gogithub.AuditEntry, *gogithub.Response, error) {
-			return client.Organizations.GetAuditLog(ctx, settings.owner, opts)
+			return githubaudit.GetAuditLog(ctx, client, settings.owner, opts)
 		})
 		if err != nil {
 			return sourcecdk.ChangeProbe{}, wrapLookupError(fmt.Sprintf("github audit log canary for org %s", settings.owner), err)
@@ -82,7 +82,7 @@ func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, setting
 		return *shortCircuit, nil
 	}
 	after := readAuditCursor(cursor)
-	entries, resp, err := client.Organizations.GetAuditLog(ctx, settings.owner, githubaudit.Options(settings.auditInclude, settings.auditPhrase, settings.auditOrder, after, settings.perPage))
+	entries, resp, err := githubaudit.GetAuditLog(ctx, client, settings.owner, githubaudit.Options(settings.auditInclude, settings.auditPhrase, settings.auditOrder, after, settings.perPage))
 	if err != nil {
 		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
 	}

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -1276,6 +1276,52 @@ func TestGitHubAuditFreshnessProbeFailsOpenToFullRead(t *testing.T) {
 	}
 }
 
+func TestGitHubAuditUnavailableDoesNotFailCheckOrRead(t *testing.T) {
+	auditRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v3/orgs/writer/audit-log" {
+			http.NotFound(w, r)
+			return
+		}
+		auditRequests++
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familyAudit,
+		"owner":    "writer",
+		"token":    "test-token",
+	})
+
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check(audit unavailable) error = %v", err)
+	}
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(audit unavailable) error = %v", err)
+	}
+	if len(pull.Events) != 0 {
+		t.Fatalf("len(pull.Events) = %d, want 0", len(pull.Events))
+	}
+	if pull.ShortCircuitReason != sourcecdk.PullShortCircuitReasonNotModified {
+		t.Fatalf("ShortCircuitReason = %q, want not_modified", pull.ShortCircuitReason)
+	}
+	if pull.Checkpoint == nil {
+		t.Fatal("pull.Checkpoint = nil, want freshness checkpoint for unavailable audit log")
+	}
+	if auditRequests < 2 {
+		t.Fatalf("audit requests = %d, want check and read attempts", auditRequests)
+	}
+}
+
 func TestGitHubAuditFreshnessCheckpointDoesNotExposeProviderMetadata(t *testing.T) {
 	auditEntry := map[string]any{
 		"@timestamp":   1776916397852,

--- a/sources/internal/githubaudit/client.go
+++ b/sources/internal/githubaudit/client.go
@@ -1,0 +1,32 @@
+package githubaudit
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	gogithub "github.com/google/go-github/v66/github"
+)
+
+// GetAuditLog fetches an audit-log page and treats unavailable audit-log
+// access as an empty page so source runtimes can record a completed run.
+func GetAuditLog(ctx context.Context, client *gogithub.Client, owner string, opts *gogithub.GetAuditLogOptions) ([]*gogithub.AuditEntry, *gogithub.Response, error) {
+	entries, resp, err := client.Organizations.GetAuditLog(ctx, owner, opts)
+	if AuditLogUnavailable(err) {
+		return nil, nil, nil
+	}
+	return entries, resp, err
+}
+
+func AuditLogUnavailable(err error) bool {
+	var apiErr *gogithub.ErrorResponse
+	if !errors.As(err, &apiErr) || apiErr.Response == nil {
+		return false
+	}
+	switch apiErr.Response.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary
- Dedupe accepted source-runtime events by ID before ledger/outbox, append-log, and projection writes.
- Treat unavailable GitHub audit-log access (401/403/404) as an empty audit page via the shared githubaudit helper so scheduled runtimes can record completed ingest history.
- Add regressions for duplicate event IDs and unavailable GitHub audit reads.

## Incident context
Sec-dev graph backfill run WriterInternal/cerebro#28210981633 failed on:
- `writer-aurelius-catalog-promotions`: duplicate `source_runtime_page_outbox` event IDs in one attempt.
- `writer-github-audit-writerinternal`: GitHub audit-log endpoint returned 404 and the runtime failed before writing run history.

## Validation
- `go test ./sources/github ./internal/sourceruntime ./sources/internal/githubaudit -count=1`
- `make check-structural check-structural-test check-arch`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->