### PR TITLE
[codex] Batch MCP graph neighborhood fetches

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -97,6 +97,13 @@ func fetchMCPGraphStoreNeighborhoods(ctx context.Context, graphStore ports.Graph
 		return nil
 	}
 	results := make([]mcpGraphStoreNeighborhoodResult, len(roots))
+	if batchStore, ok := graphStore.(ports.GraphNeighborhoodBatchStore); ok {
+		neighborhoods, err := batchStore.GetEntityNeighborhoods(ctx, roots, limit)
+		for index, rootURN := range roots {
+			results[index] = mcpGraphStoreNeighborhoodResult{urn: rootURN, neighborhood: neighborhoods[rootURN], err: err}
+		}
+		return results
+	}
 	sem := make(chan struct{}, mcpMaxConcurrentGraphFetches)
 	var wg sync.WaitGroup
 	for index, rootURN := range roots {
@@ -1323,11 +1330,9 @@ func (app *App) mcpBuildRiskActionPlan(r *http.Request, args map[string]any) (mc
 		for _, result := range fetchMCPGraphStoreNeighborhoods(r.Context(), graphStore, roots, graphLimit) {
 			switch {
 			case result.err == nil:
-				neighborhood := result.neighborhood
-				if neighborhood == nil {
-					neighborhood = &ports.EntityNeighborhood{}
+				if result.neighborhood != nil {
+					graphNeighborhoods[result.urn] = result.neighborhood
 				}
-				graphNeighborhoods[result.urn] = neighborhood
 			case errors.Is(result.err, ports.ErrGraphEntityNotFound):
 				continue
 			default:

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -45,6 +45,64 @@ func TestMCPRequiresAuth(t *testing.T) {
 	}
 }
 
+type mcpBatchGraphStore struct {
+	batchCalls  [][]string
+	singleCalls []string
+	neighbors   map[string]*ports.EntityNeighborhood
+}
+
+func (s *mcpBatchGraphStore) Ping(context.Context) error { return nil }
+
+func (s *mcpBatchGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string, _ int) (*ports.EntityNeighborhood, error) {
+	s.singleCalls = append(s.singleCalls, rootURN)
+	if neighborhood := s.neighbors[rootURN]; neighborhood != nil {
+		return neighborhood, nil
+	}
+	return nil, ports.ErrGraphEntityNotFound
+}
+
+func (s *mcpBatchGraphStore) GetEntityNeighborhoods(_ context.Context, roots []string, _ int) (map[string]*ports.EntityNeighborhood, error) {
+	s.batchCalls = append(s.batchCalls, append([]string(nil), roots...))
+	result := make(map[string]*ports.EntityNeighborhood, len(roots))
+	for _, rootURN := range roots {
+		if neighborhood := s.neighbors[rootURN]; neighborhood != nil {
+			result[rootURN] = neighborhood
+		}
+	}
+	return result, nil
+}
+
+func (s *mcpBatchGraphStore) ExecuteReadCypher(context.Context, ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	return nil, nil
+}
+
+func TestFetchMCPGraphStoreNeighborhoodsUsesBatchStore(t *testing.T) {
+	firstURN := "urn:cerebro:writer:asset:first"
+	secondURN := "urn:cerebro:writer:asset:second"
+	store := &mcpBatchGraphStore{neighbors: map[string]*ports.EntityNeighborhood{
+		firstURN:  {Root: &ports.NeighborhoodNode{URN: firstURN}},
+		secondURN: {Root: &ports.NeighborhoodNode{URN: secondURN}},
+	}}
+
+	results := fetchMCPGraphStoreNeighborhoods(context.Background(), store, []string{firstURN, secondURN}, 3)
+
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	if len(store.batchCalls) != 1 {
+		t.Fatalf("batchCalls = %#v, want one batch call", store.batchCalls)
+	}
+	if len(store.singleCalls) != 0 {
+		t.Fatalf("singleCalls = %#v, want batched path only", store.singleCalls)
+	}
+	if results[0].err != nil || results[0].neighborhood.Root.URN != firstURN {
+		t.Fatalf("first result = %#v, err=%v", results[0], results[0].err)
+	}
+	if results[1].err != nil || results[1].neighborhood.Root.URN != secondURN {
+		t.Fatalf("second result = %#v, err=%v", results[1], results[1].err)
+	}
+}
+
 func TestMCPInitializeAndToolsList(t *testing.T) {
 	server := newMCPTestServer(t, &stubRuntimeStore{})
 	defer server.Close()

--- a/internal/graphquery/impact.go
+++ b/internal/graphquery/impact.go
@@ -25,10 +25,6 @@ const (
 	impactNeighborhoodConcurrency = 8
 )
 
-type impactBatchNeighborhoodStore interface {
-	GetEntityNeighborhoods(context.Context, []string, int) (map[string]*ports.EntityNeighborhood, error)
-}
-
 type ImpactRequest struct {
 	Kind       string
 	TenantID   string
@@ -75,12 +71,12 @@ func (s *Service) GetImpact(ctx context.Context, request ImpactRequest) (*Impact
 		Relations: sortedImpactRelations(relations),
 	}
 	for _, node := range sortedImpactNodes(nodes) {
-		switch {
-		case classifyImpactNode(node) == ImpactKindPackage:
+		switch classifyImpactNode(node) {
+		case ImpactKindPackage:
 			result.Packages = append(result.Packages, node)
-		case classifyImpactNode(node) == ImpactKindVulnerability:
+		case ImpactKindVulnerability:
 			result.Vulnerabilities = append(result.Vulnerabilities, node)
-		case classifyImpactNode(node) == "evidence":
+		case "evidence":
 			result.Evidence = append(result.Evidence, node)
 		default:
 			result.Assets = append(result.Assets, node)
@@ -90,9 +86,9 @@ func (s *Service) GetImpact(ctx context.Context, request ImpactRequest) (*Impact
 }
 
 func (s *Service) collectImpactGraph(ctx context.Context, rootURN string, depth int, limit int) (map[string]*ports.NeighborhoodNode, map[string]*ports.NeighborhoodRelation, error) {
-	nodes := map[string]*ports.NeighborhoodNode{}
-	relations := map[string]*ports.NeighborhoodRelation{}
-	visited := map[string]bool{}
+	nodes := make(map[string]*ports.NeighborhoodNode, limit)
+	relations := make(map[string]*ports.NeighborhoodRelation, limit*2)
+	visited := make(map[string]bool, limit)
 	frontier := []string{rootURN}
 	for hop := 0; hop < depth && len(frontier) > 0 && len(nodes) < limit; hop++ {
 		roots := make([]string, 0, len(frontier))
@@ -106,7 +102,7 @@ func (s *Service) collectImpactGraph(ctx context.Context, rootURN string, depth 
 		if len(roots) == 0 {
 			break
 		}
-		next := []string{}
+		next := make([]string, 0, min(limit-len(nodes), len(roots)*defaultNeighborhoodLimit))
 		for start := 0; start < len(roots) && len(nodes) < limit; start += impactNeighborhoodConcurrency {
 			end := min(start+impactNeighborhoodConcurrency, len(roots))
 			neighborhoods, err := s.collectImpactNeighborhoods(ctx, roots[start:end], limit)
@@ -142,7 +138,7 @@ func (s *Service) collectImpactGraph(ctx context.Context, rootURN string, depth 
 
 func (s *Service) collectImpactNeighborhoods(ctx context.Context, roots []string, limit int) ([]*ports.EntityNeighborhood, error) {
 	results := make([]*ports.EntityNeighborhood, len(roots))
-	if batchStore, ok := s.store.(impactBatchNeighborhoodStore); ok {
+	if batchStore, ok := s.store.(ports.GraphNeighborhoodBatchStore); ok {
 		neighborhoods, err := batchStore.GetEntityNeighborhoods(ctx, roots, limit)
 		if err != nil {
 			return nil, err
@@ -184,7 +180,7 @@ func (s *Service) collectImpactNeighborhoods(ctx context.Context, roots []string
 }
 
 func filterImpactRelations(nodes map[string]*ports.NeighborhoodNode, relations map[string]*ports.NeighborhoodRelation) map[string]*ports.NeighborhoodRelation {
-	filtered := map[string]*ports.NeighborhoodRelation{}
+	filtered := make(map[string]*ports.NeighborhoodRelation, len(relations))
 	for key, relation := range relations {
 		if relation == nil {
 			continue

--- a/internal/ports/graphquery.go
+++ b/internal/ports/graphquery.go
@@ -63,3 +63,8 @@ type GraphQueryStore interface {
 	GetEntityNeighborhood(context.Context, string, int) (*EntityNeighborhood, error)
 	ExecuteReadCypher(context.Context, CypherQueryRequest) ([]CypherRow, error)
 }
+
+// GraphNeighborhoodBatchStore exposes batched bounded graph neighborhood reads.
+type GraphNeighborhoodBatchStore interface {
+	GetEntityNeighborhoods(context.Context, []string, int) (map[string]*EntityNeighborhood, error)
+}

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -62,10 +62,6 @@ type Service struct {
 	reportStore  ports.ReportStore
 }
 
-type graphNeighborhoodBatchStore interface {
-	GetEntityNeighborhoods(context.Context, []string, int) (map[string]*ports.EntityNeighborhood, error)
-}
-
 // New constructs the report service.
 func New(findingStore ports.FindingStore, graphStore ports.GraphQueryStore, reportStore ports.ReportStore) *Service {
 	return &Service{
@@ -603,7 +599,7 @@ func (s *Service) batchGraphNeighborhoods(ctx context.Context, roots []string, g
 	if len(roots) == 0 {
 		return map[string]*ports.EntityNeighborhood{}, true, nil
 	}
-	batchStore, ok := s.graphStore.(graphNeighborhoodBatchStore)
+	batchStore, ok := s.graphStore.(ports.GraphNeighborhoodBatchStore)
 	if !ok {
 		return nil, false, nil
 	}


### PR DESCRIPTION
## Summary
- use Neo4j/store batch neighborhood reads for MCP graph evidence when the graph store supports them
- preserve per-root result/error behavior for callers while avoiding per-root fan-out queries
- reduce small impact graph allocations by sizing bounded maps and classifying nodes once

## Why
This targets graph hot paths after the earlier graph-layer performance wave. MCP risk-action graph evidence can request several target neighborhoods; on Neo4j we already have a batched neighborhood API, but this path still used single-root fan-out. The new path collapses those reads into the batch API where available and keeps the existing bounded-concurrency fallback for stores without batch support.

## Validation
- go test ./internal/graphquery ./internal/bootstrap -run 'TestFetchMCPGraphStoreNeighborhoodsUsesBatchStore|Test.*MCP|Test.*Graph|Test.*Impact' -count=1
- /Users/jonathan/go/bin/golangci-lint run --timeout 10m ./internal/graphquery ./internal/bootstrap
- go test ./internal/graphquery ./internal/bootstrap -count=1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->