### PR TITLE
[codex] Add GRC product area contract

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2041,6 +2041,10 @@ paths:
       responses:
         '200':
           description: GRC dashboard summary, priority findings, controls, evidence, and connector health.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GRCDashboardResponse'
   /grc/program-readiness:
     get:
       summary: GRC program readiness
@@ -2066,6 +2070,10 @@ paths:
       responses:
         '200':
           description: Program-level audit readiness, prioritized work items, proof bundle links, and connector coverage.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GRCProgramReadinessResponse'
   /grc/dashboards:
     get:
       summary: List custom GRC dashboards
@@ -7421,6 +7429,156 @@ components:
         blind_spots:
           type: integer
           minimum: 0
+    GRCDashboardResponse:
+      type: object
+      properties:
+        summary:
+          type: object
+          additionalProperties: true
+        findings:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        controls:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        evidence:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        connectors:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        source_summaries:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        coverage_blind_spots:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageRecord'
+        coverage_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageSummary'
+        product_areas:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCProductArea'
+        generated_at:
+          type: string
+          format: date-time
+    GRCProgramReadinessResponse:
+      type: object
+      properties:
+        profile:
+          type: object
+          additionalProperties: true
+        summary:
+          type: object
+          additionalProperties: true
+        frameworks:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        controls:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        work_items:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        proof_bundle:
+          type: object
+          additionalProperties: true
+        connectors:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        product_areas:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCProductArea'
+        metadata:
+          type: object
+          additionalProperties: true
+        generated_at:
+          type: string
+          format: date-time
+        source_summaries:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        coverage_blind_spots:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageRecord'
+        coverage_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageSummary'
+    GRCProductAreaWorkflow:
+      type: object
+      properties:
+        label:
+          type: string
+        href:
+          type: string
+    GRCProductArea:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        href:
+          type: string
+        workflows:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCProductAreaWorkflow'
+        source_families:
+          type: array
+          items:
+            type: string
+        coverage_dimensions:
+          type: array
+          items:
+            type: string
+        evidence_types:
+          type: array
+          items:
+            type: string
+        control_domains:
+          type: array
+          items:
+            type: string
+        blind_spots:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageRecord'
+        detail:
+          type: string
+        signal:
+          type: string
+        status:
+          type: string
+          enum: [attention, mapped, quiet]
     SourceCoverageRecord:
       type: object
       properties:

--- a/docs/reference/api-contracts.md
+++ b/docs/reference/api-contracts.md
@@ -19,7 +19,7 @@ Generated-by-hand snapshot for the current bootstrap service. Source of truth: `
 | Source runtimes | `/source-runtimes/{runtimeID}`, `/source-runtimes/{runtimeID}/sync`, `/source-runtimes/{runtimeID}/graph-ingest-runs` |
 | Claims/findings | `/source-runtimes/{runtimeID}/claims`, `/source-runtimes/{runtimeID}/findings`, finding lifecycle routes |
 | Reports | `/reports`, `/reports/{reportID}/runs`, `/report-runs/{runID}` |
-| GRC/compliance | `/grc/dashboard`, `/grc/findings`, `/grc/controls`, `/grc/evidence`, `/grc/control-archetypes`, `/grc/control-profiles`, `/grc/control-coverage`, `/grc/control-packs*`, `/grc/audit-packets/{packetID}` |
+| GRC/compliance | `/grc/dashboard`, `/grc/program-readiness`, `/grc/findings`, `/grc/controls`, `/grc/evidence`, `/grc/control-archetypes`, `/grc/control-profiles`, `/grc/control-coverage`, `/grc/control-packs*`, `/grc/audit-packets/{packetID}` |
 | Platform knowledge | `/platform/knowledge/decisions`, `/platform/knowledge/actions`, `/platform/knowledge/outcomes` |
 | Platform workflow | `/platform/workflow/replay` |
 | Platform graph | `/platform/graph/neighborhood`, `/platform/graph/ingest-health`, `/platform/graph/ingest-runs*` |

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -8224,8 +8224,12 @@ func captureBootstrapStderr(t *testing.T, fn func()) string {
 	return string(payload)
 }
 
-func decodeBootstrapTelemetryPayload(t *testing.T, stderr string) map[string]any {
+func decodeBootstrapTelemetryPayload(t *testing.T, stderr string, names ...string) map[string]any {
 	t.Helper()
+	wantName := ""
+	if len(names) > 0 {
+		wantName = names[0]
+	}
 	lines := strings.Split(strings.TrimSpace(stderr), "\n")
 	if len(lines) == 0 || strings.TrimSpace(lines[0]) == "" {
 		t.Fatal("telemetry stderr is empty")
@@ -8245,7 +8249,13 @@ func decodeBootstrapTelemetryPayload(t *testing.T, stderr string) map[string]any
 		if payload["kind"] == "span_start" {
 			continue
 		}
+		if wantName != "" && payload["name"] != wantName {
+			continue
+		}
 		return payload
+	}
+	if wantName != "" {
+		t.Fatalf("telemetry payload %q not found in stderr: %s", wantName, stderr)
 	}
 	t.Fatalf("non-http telemetry payload not found in stderr: %s", stderr)
 	return nil

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/grccontrol"
+	"github.com/writer/cerebro/internal/grcproductareas"
 	"github.com/writer/cerebro/internal/grctrends"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecoverage"
@@ -47,6 +48,7 @@ type grcDashboardResponse struct {
 	SourceSummaries    []sourceRuntimeHealthSummary `json:"source_summaries,omitempty"`
 	CoverageBlindSpots []sourcecoverage.Record      `json:"coverage_blind_spots,omitempty"`
 	CoverageSummaries  []sourcecoverage.Summary     `json:"coverage_summaries,omitempty"`
+	ProductAreas       []grcproductareas.View       `json:"product_areas,omitempty"`
 	GeneratedAt        time.Time                    `json:"generated_at"`
 }
 
@@ -296,12 +298,11 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	coverage := a.sourceCoverageRecords(runtimes, ports.SourceRuntimeFilter{TenantID: scope.TenantID, SourceID: scope.SourceID}, generatedAt)
+	coverage := a.sourceCoverageRecords(runtimes, ports.SourceRuntimeFilter{RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID, SourceID: scope.SourceID, Limit: scope.Limit}, generatedAt)
 	coverageBlindSpots := sourcecoverage.BlindSpots(coverage)
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "runtime_count", Value: len(runtimes)})
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "finding_count", Value: len(findingItems)})
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "evidence_count", Value: len(evidenceItems)})
-
 	writeJSON(w, http.StatusOK, grcDashboardResponse{
 		Summary:            grcBuildSummary(findingItems, controls, evidenceItems, runtimes, findingSummary, evidenceCount),
 		Findings:           grcLimitFindings(findingItems, 25),
@@ -311,6 +312,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		SourceSummaries:    sourceSummaries,
 		CoverageBlindSpots: coverageBlindSpots,
 		CoverageSummaries:  sourcecoverage.Summaries(coverage),
+		ProductAreas:       grcproductareas.BuildCoverageViews(coverage),
 		GeneratedAt:        generatedAt,
 	})
 }

--- a/internal/bootstrap/grc_program_readiness.go
+++ b/internal/bootstrap/grc_program_readiness.go
@@ -52,6 +52,7 @@ func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) 
 		TenantID:           scope.TenantID,
 		Connectors:         grcProgramConnectors(grcConnectorItems(runtimes)),
 		CoverageBlindSpots: len(coverageBlindSpots),
+		CoverageRecords:    coverage,
 		GeneratedAt:        generatedAt,
 	})
 	writeJSON(w, http.StatusOK, grcProgramReadinessResponse{

--- a/internal/bootstrap/grc_program_readiness_test.go
+++ b/internal/bootstrap/grc_program_readiness_test.go
@@ -90,4 +90,10 @@ func TestGRCProgramReadinessEndpointReturnsProofBundleWorkQueue(t *testing.T) {
 	if len(payload.Frameworks) == 0 || payload.Frameworks[0].FrameworkName == "" {
 		t.Fatalf("frameworks = %+v, want readiness rollup", payload.Frameworks)
 	}
+	if len(payload.ProductAreas) == 0 {
+		t.Fatalf("product areas = 0, want backend product area taxonomy")
+	}
+	if payload.ProductAreas[0].ID != "compliance" || payload.ProductAreas[0].Status == "" {
+		t.Fatalf("first product area = %+v, want compliance area with status", payload.ProductAreas[0])
+	}
 }

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -165,6 +165,12 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	if len(payload.SourceSummaries) != 2 {
 		t.Fatalf("source summaries len = %d, want 2", len(payload.SourceSummaries))
 	}
+	if len(payload.ProductAreas) == 0 {
+		t.Fatalf("product areas = 0, want backend product area taxonomy")
+	}
+	if payload.ProductAreas[0].ID != "compliance" || payload.ProductAreas[0].Status == "" {
+		t.Fatalf("first product area = %+v, want compliance area with status", payload.ProductAreas[0])
+	}
 	summaries := map[string]sourceRuntimeHealthSummary{}
 	for _, summary := range payload.SourceSummaries {
 		summaries[summary.SourceID] = summary

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -227,9 +227,9 @@ func TestGRCDashboardEmitsLatencyTelemetry(t *testing.T) {
 	}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
 	server := httptest.NewServer(app.Handler())
-	defer server.Close()
 
 	stderr := captureBootstrapStderr(t, func() {
+		defer server.Close()
 		resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=writer&limit=1")
 		if err != nil {
 			t.Fatalf("GET /grc/dashboard error = %v", err)
@@ -238,9 +238,12 @@ func TestGRCDashboardEmitsLatencyTelemetry(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("GET /grc/dashboard status = %d, want %d", resp.StatusCode, http.StatusOK)
 		}
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			t.Fatalf("read /grc/dashboard body: %v", err)
+		}
 	})
 
-	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	payload := decodeBootstrapTelemetryPayload(t, stderr, "grc.dashboard")
 	for key, want := range map[string]any{
 		"kind":           "span_end",
 		"name":           "grc.dashboard",
@@ -266,9 +269,9 @@ func TestGRCDashboardEmitsLatencyTelemetry(t *testing.T) {
 func TestGRCDashboardTelemetryRecordsHTTPErrorStatus(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: &stubRuntimeStore{}}, nil)
 	server := httptest.NewServer(app.Handler())
-	defer server.Close()
 
 	stderr := captureBootstrapStderr(t, func() {
+		defer server.Close()
 		resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=writer&limit=501")
 		if err != nil {
 			t.Fatalf("GET /grc/dashboard error = %v", err)
@@ -276,6 +279,9 @@ func TestGRCDashboardTelemetryRecordsHTTPErrorStatus(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Fatalf("GET /grc/dashboard status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+		}
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			t.Fatalf("read /grc/dashboard body: %v", err)
 		}
 	})
 

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -285,7 +285,7 @@ func TestGRCDashboardTelemetryRecordsHTTPErrorStatus(t *testing.T) {
 		}
 	})
 
-	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	payload := decodeBootstrapTelemetryPayload(t, stderr, "grc.dashboard")
 	if got := payload["status"]; got != "failed" {
 		t.Fatalf("telemetry status = %#v, want failed; payload=%#v", got, payload)
 	}

--- a/internal/grcproductareas/product_areas.go
+++ b/internal/grcproductareas/product_areas.go
@@ -1,0 +1,366 @@
+package grcproductareas
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/sourcecoverage"
+)
+
+type Status string
+
+const (
+	StatusAttention Status = "attention"
+	StatusMapped    Status = "mapped"
+	StatusQuiet     Status = "quiet"
+)
+
+type Workflow struct {
+	Label string `json:"label"`
+	Href  string `json:"href"`
+}
+
+type Area struct {
+	ID                 string     `json:"id"`
+	Title              string     `json:"title"`
+	Description        string     `json:"description"`
+	Href               string     `json:"href"`
+	Workflows          []Workflow `json:"workflows"`
+	SourceFamilies     []string   `json:"source_families"`
+	CoverageDimensions []string   `json:"coverage_dimensions"`
+	EvidenceTypes      []string   `json:"evidence_types"`
+	ControlDomains     []string   `json:"control_domains"`
+}
+
+type View struct {
+	Area
+	BlindSpots []sourcecoverage.Record `json:"blind_spots,omitempty"`
+	Detail     string                  `json:"detail"`
+	Signal     string                  `json:"signal"`
+	Status     Status                  `json:"status"`
+}
+
+type BuildInput struct {
+	CoverageBlindSpots []sourcecoverage.Record
+	HasCoverageContext bool
+}
+
+var registry = []Area{
+	{
+		ID:          "compliance",
+		Title:       "Compliance",
+		Description: "Frameworks, common controls, tests, policies, documents, audits, and issues.",
+		Href:        "/frameworks",
+		Workflows: []Workflow{
+			{Label: "Frameworks", Href: "/frameworks"},
+			{Label: "Controls", Href: "/controls"},
+			{Label: "Documents", Href: "/evidence"},
+			{Label: "Audits", Href: "/reports"},
+			{Label: "Issues", Href: "/risk-inbox"},
+		},
+		SourceFamilies:     []string{"framework", "control", "control_test", "policy", "document", "authorization_package", "poam_item"},
+		CoverageDimensions: []string{"frameworks", "controls", "control_tests", "policies", "authorization_packages", "poam_items"},
+		EvidenceTypes:      []string{"control_catalog", "control_assessment", "policy_document", "configuration_state"},
+		ControlDomains:     []string{"compliance_operations", "security_operations"},
+	},
+	{
+		ID:          "customer_trust",
+		Title:       "Customer Trust",
+		Description: "Trust packets, customer accounts, questionnaires, commitments, knowledge base content, and activity.",
+		Href:        "/reports",
+		Workflows: []Workflow{
+			{Label: "Reports", Href: "/reports"},
+			{Label: "Evidence", Href: "/evidence"},
+			{Label: "Schedules", Href: "/reports/schedules"},
+			{Label: "Questionnaires", Href: "/risk-inbox?source_id=grc&q=questionnaire"},
+			{Label: "Activity", Href: "/developer/audit-log"},
+		},
+		SourceFamilies:     []string{"document", "contract", "control_test", "policy", "authorization_package", "assurance_document", "security_questionnaire", "customer_commitment", "event_log"},
+		CoverageDimensions: []string{"policies", "contracts", "control_tests", "authorization_packages", "assurance_documents", "security_questionnaires", "customer_commitments", "audit_event_logs"},
+		EvidenceTypes:      []string{"control_assessment", "policy_document", "source_snapshot", "assurance_package", "questionnaire_response", "audit_event"},
+		ControlDomains:     []string{"compliance_operations", "customer_assurance"},
+	},
+	{
+		ID:          "risk",
+		Title:       "Risk",
+		Description: "Risk register, risk library, action tracker, resilience objectives, notifications, and POA&M plans.",
+		Href:        "/risk-inbox",
+		Workflows: []Workflow{
+			{Label: "Risk Inbox", Href: "/risk-inbox"},
+			{Label: "Impact Map", Href: "/impact"},
+			{Label: "Risk Scoring", Href: "/developer/risk-scoring"},
+			{Label: "Trends", Href: "/trends"},
+		},
+		SourceFamilies:     []string{"risk_scenario", "recovery_objective", "regulatory_notification", "poam_item"},
+		CoverageDimensions: []string{"risk_scenarios", "recovery_objectives", "regulatory_notifications", "poam_items"},
+		EvidenceTypes:      []string{"source_snapshot", "configuration_state", "risk_register", "risk_treatment"},
+		ControlDomains:     []string{"security_operations", "asset_inventory", "risk_management"},
+	},
+	{
+		ID:          "vendors",
+		Title:       "Vendors",
+		Description: "Vendor inventory, security reviews, discovered vendors, contracts, and vendor risk attributes.",
+		Href:        "/risk-inbox?source_id=grc&q=vendor",
+		Workflows: []Workflow{
+			{Label: "Vendor Findings", Href: "/risk-inbox?source_id=grc&q=vendor"},
+			{Label: "Contracts", Href: "/evidence?source_id=grc&q=contract"},
+			{Label: "Assessments", Href: "/risk-inbox?source_id=grc&q=assessment"},
+			{Label: "Connector Scope", Href: "/connectors/grc?tab=scope"},
+		},
+		SourceFamilies:     []string{"vendor", "discovered_vendor", "vendor_risk_attribute", "contract", "security_review"},
+		CoverageDimensions: []string{"vendors", "discovered_vendors", "vendor_risk_attributes", "contracts", "security_reviews"},
+		EvidenceTypes:      []string{"third_party_risk", "source_snapshot", "security_review"},
+		ControlDomains:     []string{"vendor_risk"},
+	},
+	{
+		ID:          "privacy",
+		Title:       "Privacy",
+		Description: "Data inventory, privacy assessments, processing evidence, contracts, and policy coverage.",
+		Href:        "/evidence?source_id=grc&q=privacy",
+		Workflows: []Workflow{
+			{Label: "Data Inventory", Href: "/inventory?q=data"},
+			{Label: "Assessments", Href: "/risk-inbox?source_id=grc&q=privacy"},
+			{Label: "Policies", Href: "/evidence?source_id=grc&q=policy"},
+			{Label: "Vendors", Href: "/risk-inbox?source_id=grc&q=vendor"},
+		},
+		SourceFamilies:     []string{"data_inventory", "privacy_assessment", "policy", "document", "contract", "vendor", "risk_scenario"},
+		CoverageDimensions: []string{"data_inventory", "privacy_assessments", "policies", "contracts", "vendors", "risk_scenarios"},
+		EvidenceTypes:      []string{"privacy_assessment", "policy_document", "source_snapshot", "third_party_risk"},
+		ControlDomains:     []string{"privacy_operations", "compliance_operations", "vendor_risk"},
+	},
+	{
+		ID:          "assets",
+		Title:       "Assets",
+		Description: "Asset inventory, code changes, vulnerabilities, affected assets, and security alerts.",
+		Href:        "/inventory",
+		Workflows: []Workflow{
+			{Label: "Inventory", Href: "/inventory"},
+			{Label: "Vulnerabilities", Href: "/risk-inbox?source_id=grc&q=vulnerability"},
+			{Label: "Impact", Href: "/impact"},
+			{Label: "Trends", Href: "/trends"},
+		},
+		SourceFamilies:     []string{"integration", "vulnerability", "vulnerable_asset", "vulnerability_remediation", "event_log"},
+		CoverageDimensions: []string{"integrations", "vulnerabilities", "vulnerable_assets", "vulnerability_remediations", "audit_event_logs"},
+		EvidenceTypes:      []string{"source_snapshot", "relationship_evidence", "vulnerability_management", "audit_event", "code_change"},
+		ControlDomains:     []string{"asset_inventory", "vulnerability_management", "security_operations"},
+	},
+	{
+		ID:          "personnel",
+		Title:       "Personnel",
+		Description: "People, users, groups, device ownership, access posture, and training attestations.",
+		Href:        "/inventory?q=people",
+		Workflows: []Workflow{
+			{Label: "People", Href: "/inventory?q=people"},
+			{Label: "Access", Href: "/risk-inbox?source_id=grc&q=access"},
+			{Label: "Groups", Href: "/connectors/grc?tab=scope&q=group"},
+			{Label: "Training", Href: "/evidence?source_id=grc&q=training"},
+		},
+		SourceFamilies:     []string{"person", "user", "group", "training_attestation"},
+		CoverageDimensions: []string{"people", "users", "groups", "training_attestations"},
+		EvidenceTypes:      []string{"source_snapshot", "configuration_state", "access_review", "training_attestation"},
+		ControlDomains:     []string{"identity_access", "security_operations"},
+	},
+	{
+		ID:          "integrations",
+		Title:       "Integrations",
+		Description: "Connector health, source scope, collection activity, event logs, and source-CDK onboarding.",
+		Href:        "/connectors",
+		Workflows: []Workflow{
+			{Label: "Connectors", Href: "/connectors"},
+			{Label: "Source CDK", Href: "/connectors/source-cdk"},
+			{Label: "Mission Control", Href: "/mission-control"},
+			{Label: "Audit Log", Href: "/developer/audit-log"},
+		},
+		SourceFamilies:     []string{"integration", "event_log"},
+		CoverageDimensions: []string{"integrations", "audit_event_logs"},
+		EvidenceTypes:      []string{"source_snapshot", "audit_event", "runtime_activity"},
+		ControlDomains:     []string{"asset_inventory", "security_operations"},
+	},
+}
+
+var (
+	knownCoverageDimensions = stringSet(flatMapAreas(func(area Area) []string { return area.CoverageDimensions }))
+	knownSourceFamilies     = stringSet(flatMapAreas(func(area Area) []string { return area.SourceFamilies }))
+)
+
+func Catalog() []Area {
+	areas := make([]Area, 0, len(registry))
+	for _, area := range registry {
+		areas = append(areas, cloneArea(area))
+	}
+	return areas
+}
+
+func BuildCoverageViews(coverage []sourcecoverage.Record) []View {
+	return BuildViews(BuildInput{
+		CoverageBlindSpots: sourcecoverage.BlindSpots(coverage),
+		HasCoverageContext: len(coverage) > 0,
+	})
+}
+
+func BuildViews(input BuildInput) []View {
+	views := make([]View, 0, len(registry))
+	for _, area := range registry {
+		blindSpots := matchingBlindSpots(area, input.CoverageBlindSpots)
+		status := statusFor(len(blindSpots), input.HasCoverageContext)
+		views = append(views, View{
+			Area:       cloneArea(area),
+			BlindSpots: cloneRecords(blindSpots),
+			Detail:     detailFor(area, len(blindSpots)),
+			Signal:     signalFor(status, len(blindSpots)),
+			Status:     status,
+		})
+	}
+	return views
+}
+
+func MatchesCoverage(area Area, record sourcecoverage.Record) bool {
+	dimensionID := strings.TrimSpace(record.DimensionID)
+	family := strings.TrimSpace(record.Family)
+	if contains(area.CoverageDimensions, dimensionID) || contains(area.SourceFamilies, family) {
+		return true
+	}
+	if knownCoverageDimensions[dimensionID] || (family != "" && knownSourceFamilies[family]) {
+		return false
+	}
+	return fallbackOwner(record) == area.ID
+}
+
+func matchingBlindSpots(area Area, records []sourcecoverage.Record) []sourcecoverage.Record {
+	matches := make([]sourcecoverage.Record, 0)
+	for _, record := range records {
+		if MatchesCoverage(area, record) {
+			matches = append(matches, record)
+		}
+	}
+	return matches
+}
+
+func statusFor(blindSpotCount int, hasCoverageContext bool) Status {
+	if blindSpotCount > 0 {
+		return StatusAttention
+	}
+	if hasCoverageContext {
+		return StatusMapped
+	}
+	return StatusQuiet
+}
+
+func detailFor(area Area, blindSpotCount int) string {
+	if blindSpotCount > 0 {
+		return fmt.Sprintf("%d coverage gap%s", blindSpotCount, pluralSuffix(blindSpotCount))
+	}
+	return fmt.Sprintf("%d workflows | %d dimensions | %d families", len(area.Workflows), len(area.CoverageDimensions), len(area.SourceFamilies))
+}
+
+func signalFor(status Status, blindSpotCount int) string {
+	switch status {
+	case StatusAttention:
+		return fmt.Sprintf("%d gap%s", blindSpotCount, pluralSuffix(blindSpotCount))
+	case StatusMapped:
+		return "mapped"
+	default:
+		return "awaiting coverage"
+	}
+}
+
+func fallbackOwner(record sourcecoverage.Record) string {
+	owner := ""
+	for _, area := range registry {
+		if !fallbackMatches(area, record) {
+			continue
+		}
+		if owner != "" {
+			return ""
+		}
+		owner = area.ID
+	}
+	return owner
+}
+
+func fallbackMatches(area Area, record sourcecoverage.Record) bool {
+	return intersects(area.EvidenceTypes, record.EvidenceTypes) || intersects(area.ControlDomains, record.ControlDomains)
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func flatMapAreas(values func(Area) []string) []string {
+	var out []string
+	for _, area := range registry {
+		out = append(out, values(area)...)
+	}
+	return out
+}
+
+func stringSet(values []string) map[string]bool {
+	set := make(map[string]bool, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			set[value] = true
+		}
+	}
+	return set
+}
+
+func contains(values []string, needle string) bool {
+	needle = strings.TrimSpace(needle)
+	if needle == "" {
+		return false
+	}
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func intersects(left, right []string) bool {
+	if len(left) == 0 || len(right) == 0 {
+		return false
+	}
+	lookup := stringSet(left)
+	for _, value := range right {
+		if lookup[strings.TrimSpace(value)] {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneArea(area Area) Area {
+	area.Workflows = cloneWorkflows(area.Workflows)
+	area.SourceFamilies = cloneStrings(area.SourceFamilies)
+	area.CoverageDimensions = cloneStrings(area.CoverageDimensions)
+	area.EvidenceTypes = cloneStrings(area.EvidenceTypes)
+	area.ControlDomains = cloneStrings(area.ControlDomains)
+	return area
+}
+
+func cloneWorkflows(workflows []Workflow) []Workflow {
+	return append([]Workflow(nil), workflows...)
+}
+
+func cloneStrings(values []string) []string {
+	return append([]string(nil), values...)
+}
+
+func cloneRecords(records []sourcecoverage.Record) []sourcecoverage.Record {
+	out := make([]sourcecoverage.Record, 0, len(records))
+	for _, record := range records {
+		record.KnownUnsupportedFields = cloneStrings(record.KnownUnsupportedFields)
+		record.Notes = cloneStrings(record.Notes)
+		record.EvidenceTypes = cloneStrings(record.EvidenceTypes)
+		record.ControlDomains = cloneStrings(record.ControlDomains)
+		record.ControlRefs = append(record.ControlRefs[:0:0], record.ControlRefs...)
+		record.SupportedRuntimeFamilies = cloneStrings(record.SupportedRuntimeFamilies)
+		out = append(out, record)
+	}
+	return out
+}

--- a/internal/grcproductareas/product_areas_test.go
+++ b/internal/grcproductareas/product_areas_test.go
@@ -1,0 +1,204 @@
+package grcproductareas
+
+import (
+	"testing"
+
+	"github.com/writer/cerebro/internal/sourcecoverage"
+)
+
+func coverageRecord(overrides sourcecoverage.Record) sourcecoverage.Record {
+	record := sourcecoverage.Record{
+		SourceID:      "grc",
+		DimensionID:   "vendors",
+		DimensionType: "entity_family",
+		Title:         "Vendors",
+		State:         sourcecoverage.StateUnconfigured,
+		SupportLevel:  "supported",
+		BlindSpot:     true,
+	}
+	if overrides.SourceID != "" {
+		record.SourceID = overrides.SourceID
+	}
+	if overrides.DimensionID != "" {
+		record.DimensionID = overrides.DimensionID
+	}
+	if overrides.DimensionType != "" {
+		record.DimensionType = overrides.DimensionType
+	}
+	if overrides.Title != "" {
+		record.Title = overrides.Title
+	}
+	if overrides.Family != "" {
+		record.Family = overrides.Family
+	}
+	if overrides.EvidenceTypes != nil {
+		record.EvidenceTypes = overrides.EvidenceTypes
+	}
+	if overrides.ControlDomains != nil {
+		record.ControlDomains = overrides.ControlDomains
+	}
+	return record
+}
+
+func TestCatalogDefinesStableProductAreas(t *testing.T) {
+	areas := Catalog()
+	got := make([]string, 0, len(areas))
+	seen := map[string]bool{}
+	for _, area := range areas {
+		if area.ID == "" || area.Title == "" || area.Href == "" || area.Description == "" {
+			t.Fatalf("area has incomplete identity fields: %#v", area)
+		}
+		if len(area.Workflows) == 0 || len(area.SourceFamilies) == 0 || len(area.CoverageDimensions) == 0 {
+			t.Fatalf("area %q is missing workflow, family, or dimension coverage", area.ID)
+		}
+		if seen[area.ID] {
+			t.Fatalf("duplicate area id %q", area.ID)
+		}
+		seen[area.ID] = true
+		got = append(got, area.ID)
+	}
+	want := []string{"compliance", "customer_trust", "risk", "vendors", "privacy", "assets", "personnel", "integrations"}
+	if len(got) != len(want) {
+		t.Fatalf("product area ids = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("product area ids = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestMatchesCoverageByDimensionFamilyEvidenceAndDomain(t *testing.T) {
+	var vendors Area
+	for _, area := range Catalog() {
+		if area.ID == "vendors" {
+			vendors = area
+		}
+	}
+	if vendors.ID == "" {
+		t.Fatal("vendors area not found")
+	}
+	if !MatchesCoverage(vendors, coverageRecord(sourcecoverage.Record{DimensionID: "discovered_vendors"})) {
+		t.Fatal("vendors should match discovered_vendors dimension")
+	}
+	if !MatchesCoverage(vendors, coverageRecord(sourcecoverage.Record{DimensionID: "other", Family: "vendor_risk_attribute"})) {
+		t.Fatal("vendors should match vendor_risk_attribute family")
+	}
+	if MatchesCoverage(vendors, coverageRecord(sourcecoverage.Record{DimensionID: "vulnerability_remediations"})) {
+		t.Fatal("vendors should not claim known asset dimensions")
+	}
+}
+
+func TestUnknownCoverageFallbackRequiresSingleOwner(t *testing.T) {
+	views := BuildViews(BuildInput{
+		CoverageBlindSpots: []sourcecoverage.Record{
+			coverageRecord(sourcecoverage.Record{
+				DimensionID:   "new_generic_snapshot_gap",
+				EvidenceTypes: []string{"source_snapshot"},
+				Title:         "Generic source snapshot gap",
+			}),
+		},
+		HasCoverageContext: true,
+	})
+	for _, view := range views {
+		if len(view.BlindSpots) != 0 {
+			t.Fatalf("%s claimed ambiguous generic snapshot gap: %+v", view.ID, view.BlindSpots)
+		}
+	}
+}
+
+func TestPersonnelOwnsUsersDimensionWithoutFamily(t *testing.T) {
+	var personnel Area
+	for _, area := range Catalog() {
+		if area.ID == "personnel" {
+			personnel = area
+		}
+	}
+	if personnel.ID == "" {
+		t.Fatal("personnel area not found")
+	}
+	if !MatchesCoverage(personnel, coverageRecord(sourcecoverage.Record{DimensionID: "users"})) {
+		t.Fatal("personnel should match users dimension without requiring a family tag")
+	}
+}
+
+func TestKnownDimensionsStayScopedToOwningArea(t *testing.T) {
+	var customerTrust Area
+	for _, area := range Catalog() {
+		if area.ID == "customer_trust" {
+			customerTrust = area
+		}
+	}
+	if customerTrust.ID == "" {
+		t.Fatal("customer trust area not found")
+	}
+	if MatchesCoverage(customerTrust, coverageRecord(sourcecoverage.Record{
+		DimensionID:    "vendor_risk_attributes",
+		EvidenceTypes:  []string{"third_party_risk"},
+		ControlDomains: []string{"vendor_risk"},
+	})) {
+		t.Fatal("customer trust should not claim a known vendor dimension through shared evidence or domain tags")
+	}
+	if !MatchesCoverage(customerTrust, coverageRecord(sourcecoverage.Record{
+		DimensionID: "security_questionnaires",
+		Family:      "security_questionnaire",
+	})) {
+		t.Fatal("customer trust should claim security questionnaires")
+	}
+}
+
+func TestBuildViewsAnnotatesBlindSpotsAndStatuses(t *testing.T) {
+	views := BuildViews(BuildInput{
+		CoverageBlindSpots: []sourcecoverage.Record{
+			coverageRecord(sourcecoverage.Record{DimensionID: "vendor_risk_attributes", Title: "Vendor risk attributes"}),
+			coverageRecord(sourcecoverage.Record{DimensionID: "vulnerability_remediations", Title: "Vulnerability remediations"}),
+		},
+		HasCoverageContext: true,
+	})
+	byID := map[string]View{}
+	for _, view := range views {
+		byID[view.ID] = view
+	}
+	if got := byID["vendors"].Status; got != StatusAttention {
+		t.Fatalf("vendors status = %q, want %q", got, StatusAttention)
+	}
+	if got := len(byID["vendors"].BlindSpots); got != 1 {
+		t.Fatalf("vendors blind spots = %d, want 1", got)
+	}
+	if got := byID["assets"].Status; got != StatusAttention {
+		t.Fatalf("assets status = %q, want %q", got, StatusAttention)
+	}
+	if got := byID["compliance"].Status; got != StatusMapped {
+		t.Fatalf("compliance status = %q, want %q", got, StatusMapped)
+	}
+}
+
+func TestBuildViewsUsesQuietStateUntilCoverageContextExists(t *testing.T) {
+	views := BuildViews(BuildInput{})
+	for _, view := range views {
+		if view.Status != StatusQuiet {
+			t.Fatalf("%s status = %q, want %q", view.ID, view.Status, StatusQuiet)
+		}
+	}
+}
+
+func TestBuildCoverageViewsDistinguishesNoCoverageFromNoGaps(t *testing.T) {
+	for _, view := range BuildCoverageViews(nil) {
+		if view.Status != StatusQuiet {
+			t.Fatalf("%s status = %q, want %q without evaluated coverage", view.ID, view.Status, StatusQuiet)
+		}
+	}
+	views := BuildCoverageViews([]sourcecoverage.Record{{
+		SourceID:      "grc",
+		DimensionID:   "vendors",
+		DimensionType: "entity_family",
+		Title:         "Vendors",
+		State:         sourcecoverage.StateHealthy,
+		SupportLevel:  "supported",
+	}})
+	for _, view := range views {
+		if view.ID == "vendors" && view.Status != StatusMapped {
+			t.Fatalf("vendors status = %q, want %q when coverage is evaluated with no gaps", view.Status, StatusMapped)
+		}
+	}
+}

--- a/internal/grcprogram/readiness.go
+++ b/internal/grcprogram/readiness.go
@@ -7,20 +7,23 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/grccontrol"
+	"github.com/writer/cerebro/internal/grcproductareas"
+	"github.com/writer/cerebro/internal/sourcecoverage"
 )
 
 const workItemLimit = 12
 
 type Readiness struct {
-	Profile     grccontrol.Profile        `json:"profile"`
-	Summary     Summary                   `json:"summary"`
-	Frameworks  []Framework               `json:"frameworks"`
-	Controls    []Control                 `json:"controls"`
-	WorkItems   []WorkItem                `json:"work_items"`
-	ProofBundle ProofBundle               `json:"proof_bundle"`
-	Connectors  []Connector               `json:"connectors"`
-	Metadata    grccontrol.ReportMetadata `json:"metadata"`
-	GeneratedAt time.Time                 `json:"generated_at"`
+	Profile      grccontrol.Profile        `json:"profile"`
+	Summary      Summary                   `json:"summary"`
+	Frameworks   []Framework               `json:"frameworks"`
+	Controls     []Control                 `json:"controls"`
+	WorkItems    []WorkItem                `json:"work_items"`
+	ProofBundle  ProofBundle               `json:"proof_bundle"`
+	Connectors   []Connector               `json:"connectors"`
+	ProductAreas []grcproductareas.View    `json:"product_areas,omitempty"`
+	Metadata     grccontrol.ReportMetadata `json:"metadata"`
+	GeneratedAt  time.Time                 `json:"generated_at"`
 }
 
 type Summary struct {
@@ -135,6 +138,7 @@ type BuildInput struct {
 	TenantID           string
 	Connectors         []Connector
 	CoverageBlindSpots int
+	CoverageRecords    []sourcecoverage.Record
 	GeneratedAt        time.Time
 }
 
@@ -151,15 +155,16 @@ func Build(input BuildInput) Readiness {
 	controls := buildControls(input.Result.Controls, input.Result.Profile.ID, input.TenantID)
 	summary := buildSummary(input.Result, input.Connectors, input.CoverageBlindSpots)
 	return Readiness{
-		Profile:     input.Result.Profile,
-		Summary:     summary,
-		Frameworks:  buildFrameworks(controls),
-		Controls:    controls,
-		WorkItems:   buildWorkItems(controls),
-		ProofBundle: buildProofBundle(input.Result, summary, input.Query, generatedAt),
-		Connectors:  input.Connectors,
-		Metadata:    input.Result.Metadata,
-		GeneratedAt: generatedAt,
+		Profile:      input.Result.Profile,
+		Summary:      summary,
+		Frameworks:   buildFrameworks(controls),
+		Controls:     controls,
+		WorkItems:    buildWorkItems(controls),
+		ProofBundle:  buildProofBundle(input.Result, summary, input.Query, generatedAt),
+		Connectors:   input.Connectors,
+		ProductAreas: grcproductareas.BuildCoverageViews(input.CoverageRecords),
+		Metadata:     input.Result.Metadata,
+		GeneratedAt:  generatedAt,
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a backend GRC product-area registry that ties product areas to coverage dimensions, source families, evidence types, and control domains
- include product areas on `/grc/dashboard` and `/grc/program-readiness` so clients can render the same platform taxonomy as the backend
- document the `product_areas` response shape in OpenAPI and cover dashboard/readiness serialization in tests

## Validation
- `go test ./internal/grcproductareas ./internal/grcprogram ./internal/bootstrap ./tools/archtests -count=1`
- `go test ./... -count=1`
- `make lint`
- `make openapi-check && make openapi-lint && make docs-drift-check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->