### PR TITLE
Fix GitHub provider-unavailable graph runtimes

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -27,7 +27,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `azure` | 2859 | Extract subscription traversal, client factories, and paginated resource readers. |
 | `cosmo` | 1006 | Move shared API pagination and response normalization into reusable source helpers. |
 | `gcp` | 2130 | Extract project traversal, service clients, and resource-family pagination helpers. |
-| `github` | 2029 | Split audit/event readers from repository/user normalization and shared pagination. |
+| `github` | 2025 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
 | `grc` | 1195 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2256 | Extract client, pagination, and identity/group/application readers into smaller units. |

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -16,6 +16,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/internal/githubapi"
 	"github.com/writer/cerebro/sources/internal/githubaudit"
 )
 
@@ -49,7 +50,7 @@ type auditPayload struct {
 func (s *Source) checkAudit(ctx context.Context, client *gogithub.Client, settings settings) error {
 	_, _, err := githubaudit.GetAuditLog(ctx, client, settings.owner, githubaudit.Options(settings.auditInclude, settings.auditPhrase, settings.auditOrder, "", 1))
 	if err != nil {
-		return wrapLookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
+		return githubapi.LookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
 	}
 	return nil
 }
@@ -71,7 +72,7 @@ func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, setting
 			return githubaudit.GetAuditLog(ctx, client, settings.owner, opts)
 		})
 		if err != nil {
-			return sourcecdk.ChangeProbe{}, wrapLookupError(fmt.Sprintf("github audit log canary for org %s", settings.owner), err)
+			return sourcecdk.ChangeProbe{}, githubapi.LookupError(fmt.Sprintf("github audit log canary for org %s", settings.owner), err)
 		}
 		return probe, nil
 	}, githubaudit.FreshnessReadOptions())
@@ -84,7 +85,7 @@ func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, setting
 	after := readAuditCursor(cursor)
 	entries, resp, err := githubaudit.GetAuditLog(ctx, client, settings.owner, githubaudit.Options(settings.auditInclude, settings.auditPhrase, settings.auditOrder, after, settings.perPage))
 	if err != nil {
-		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
+		return sourcecdk.Pull{}, githubapi.LookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
 	}
 	if len(entries) == 0 {
 		return sourcecdk.NotModifiedPull(readCheckpoint), nil

--- a/sources/github/client.go
+++ b/sources/github/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcehttp"
+	"github.com/writer/cerebro/sources/internal/githubapi"
 )
 
 func (s *Source) newClient(cfg sourcecdk.Config, requireRepo bool) (*gogithub.Client, settings, error) {
@@ -54,7 +55,7 @@ func sourceHTTPClientNoRedirect(client *http.Client, allowLoopback bool, lookupI
 func getRepo(ctx context.Context, client *gogithub.Client, owner string, repo string) (*gogithub.Repository, error) {
 	repository, _, err := client.Repositories.Get(ctx, owner, repo)
 	if err != nil {
-		return nil, wrapLookupError(fmt.Sprintf("github repo %s/%s", owner, repo), err)
+		return nil, githubapi.LookupError(fmt.Sprintf("github repo %s/%s", owner, repo), err)
 	}
 	return repository, nil
 }
@@ -77,7 +78,7 @@ func listReposPage(ctx context.Context, client *gogithub.Client, owner string, p
 	if err == nil {
 		return repos, resp, nil
 	}
-	if !isNotFound(err) {
+	if !githubapi.NotFound(err) {
 		return nil, nil, fmt.Errorf("list github org repos for %s: %w", owner, err)
 	}
 	repos, resp, err = client.Repositories.ListByUser(ctx, owner, &gogithub.RepositoryListByUserOptions{
@@ -90,7 +91,7 @@ func listReposPage(ctx context.Context, client *gogithub.Client, owner string, p
 		},
 	})
 	if err != nil {
-		return nil, nil, wrapLookupError(fmt.Sprintf("github owner %s", owner), err)
+		return nil, nil, githubapi.LookupError(fmt.Sprintf("github owner %s", owner), err)
 	}
 	return repos, resp, nil
 }

--- a/sources/github/dependabot_alert.go
+++ b/sources/github/dependabot_alert.go
@@ -14,6 +14,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/internal/githubapi"
 )
 
 type dependabotAlertPayload struct {
@@ -43,10 +44,7 @@ type dependabotAlertPayload struct {
 
 func (s *Source) checkDependabotAlerts(ctx context.Context, client *gogithub.Client, settings settings) error {
 	_, _, err := client.Dependabot.ListRepoAlerts(ctx, settings.owner, settings.repo, dependabotAlertOptions(settings, "", 1))
-	if err != nil {
-		return wrapLookupError(fmt.Sprintf("github dependabot alerts for repo %s/%s", settings.owner, settings.repo), err)
-	}
-	return nil
+	return githubapi.ProviderUnavailableLookupError(fmt.Sprintf("github dependabot alerts for repo %s/%s", settings.owner, settings.repo), err, settings.hasAuth())
 }
 
 func (s *Source) discoverDependabotAlerts(ctx context.Context, client *gogithub.Client, settings settings) ([]sourcecdk.URN, error) {
@@ -69,7 +67,10 @@ func (s *Source) readDependabotAlerts(ctx context.Context, client *gogithub.Clie
 	after := sourcecdk.CursorToken(cursor)
 	alerts, resp, err := client.Dependabot.ListRepoAlerts(ctx, settings.owner, settings.repo, dependabotAlertOptions(settings, after, settings.perPage))
 	if err != nil {
-		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github dependabot alerts for repo %s/%s", settings.owner, settings.repo), err)
+		if settings.hasAuth() && githubapi.ProviderUnavailable(err) {
+			return githubapi.ProviderUnavailablePull(readCheckpoint), nil
+		}
+		return sourcecdk.Pull{}, githubapi.LookupError(fmt.Sprintf("github dependabot alerts for repo %s/%s", settings.owner, settings.repo), err)
 	}
 	return sourcecdk.IncrementalPullFromRecords("github", familyDependabot, alerts, nextAuditCursor(resp), readCheckpoint, func(alert *gogithub.DependabotAlert) (*primitives.Event, error) {
 		return dependabotAlertEvent(settings, alert)

--- a/sources/github/org_inventory.go
+++ b/sources/github/org_inventory.go
@@ -14,6 +14,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/internal/githubapi"
 	"github.com/writer/cerebro/sources/internal/githubapp"
 	"github.com/writer/cerebro/sources/internal/githubcanary"
 )
@@ -45,10 +46,7 @@ func (s *Source) checkOrgInventory(ctx context.Context, client *gogithub.Client,
 	_, _, err := client.Organizations.ListMembers(ctx, settings.owner, &gogithub.ListMembersOptions{
 		ListOptions: gogithub.ListOptions{PerPage: 1},
 	})
-	if err != nil {
-		return wrapLookupError(fmt.Sprintf("github org members for %s", settings.owner), err)
-	}
-	return nil
+	return githubapi.ProviderUnavailableLookupError(fmt.Sprintf("github org members for %s", settings.owner), err, settings.hasAuth())
 }
 
 func (s *Source) discoverOrgInventory(ctx context.Context, client *gogithub.Client, settings settings) ([]sourcecdk.URN, error) {
@@ -78,7 +76,11 @@ func (s *Source) readOrgInventory(ctx context.Context, client *gogithub.Client, 
 		ListOptions: gogithub.ListOptions{PerPage: 100},
 	})
 	if err != nil {
-		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github org members for %s", settings.owner), err)
+		if settings.hasAuth() && githubapi.ProviderUnavailable(err) {
+			pull := githubapi.ProviderUnavailablePull(checkpoint)
+			return canary.Apply(pull, "github", familyOrgInventory), nil
+		}
+		return sourcecdk.Pull{}, githubapi.LookupError(fmt.Sprintf("github org members for %s", settings.owner), err)
 	}
 	for _, member := range members {
 		event, err := orgMemberEvent(settings, member, "member", now)

--- a/sources/github/secret_scanning_alert.go
+++ b/sources/github/secret_scanning_alert.go
@@ -14,6 +14,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/internal/githubapi"
 )
 
 const familySecretScanning = "secret_scanning_alert"
@@ -41,10 +42,7 @@ type secretScanningAlertPayload struct {
 
 func (s *Source) checkSecretScanningAlerts(ctx context.Context, client *gogithub.Client, settings settings) error {
 	_, _, err := listSecretScanningAlertsForOrg(ctx, client, settings, nil, 1)
-	if err != nil {
-		return wrapLookupError(fmt.Sprintf("github secret scanning alerts for org %s", settings.owner), err)
-	}
-	return nil
+	return githubapi.ProviderUnavailableLookupError(fmt.Sprintf("github secret scanning alerts for org %s", settings.owner), err, settings.hasAuth())
 }
 
 func (s *Source) discoverSecretScanningAlerts(ctx context.Context, client *gogithub.Client, settings settings) ([]sourcecdk.URN, error) {
@@ -58,7 +56,10 @@ func (s *Source) readSecretScanningAlerts(ctx context.Context, client *gogithub.
 	readCheckpoint := sourcecdk.IncrementalCheckpointForCursor("github", familySecretScanning, cursor, checkpoint)
 	alerts, resp, err := listSecretScanningAlertsForOrg(ctx, client, settings, cursor, settings.perPage)
 	if err != nil {
-		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github secret scanning alerts for org %s", settings.owner), err)
+		if settings.hasAuth() && githubapi.ProviderUnavailable(err) {
+			return githubapi.ProviderUnavailablePull(readCheckpoint), nil
+		}
+		return sourcecdk.Pull{}, githubapi.LookupError(fmt.Sprintf("github secret scanning alerts for org %s", settings.owner), err)
 	}
 	nextCursor := ""
 	if resp != nil {

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -18,6 +18,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/internal/githubapi"
 	"github.com/writer/cerebro/sources/internal/githubcanary"
 )
 
@@ -93,7 +94,6 @@ func New() (*Source, error) {
 	}, nil
 }
 
-// Spec returns static metadata for the GitHub source.
 func (s *Source) Spec() *cerebrov1.SourceSpec {
 	return s.spec
 }
@@ -119,10 +119,10 @@ func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 	if settings.family == familyRepository {
 		if settings.repo != "" {
 			_, err := getRepo(ctx, client, settings.owner, settings.repo)
-			return err
+			return githubapi.ProviderUnavailableOrError(err, settings.hasAuth())
 		}
 		_, err := listRepos(ctx, client, settings.owner, settings.perPage)
-		return err
+		return githubapi.ProviderUnavailableOrError(err, settings.hasAuth())
 	}
 	if settings.repo != "" {
 		_, err := getRepo(ctx, client, settings.owner, settings.repo)
@@ -222,7 +222,7 @@ func (s *Source) readPullRequests(ctx context.Context, client *gogithub.Client, 
 		},
 	})
 	if err != nil {
-		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github repo %s/%s", settings.owner, settings.repo), err)
+		return sourcecdk.Pull{}, githubapi.LookupError(fmt.Sprintf("github repo %s/%s", settings.owner, settings.repo), err)
 	}
 	nextCursor := ""
 	if resp != nil && resp.NextPage > 0 {
@@ -234,7 +234,7 @@ func (s *Source) readPullRequests(ctx context.Context, client *gogithub.Client, 
 }
 
 func (s *Source) readRepositories(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint, configHash string) (sourcecdk.Pull, error) {
-	options := githubcanary.RepositoryReadOptions{Owner: settings.owner, Repo: settings.repo, PerPage: settings.perPage, ConfigHash: configHash, Cursor: cursor, Checkpoint: checkpoint}
+	options := githubcanary.RepositoryReadOptions{Owner: settings.owner, Repo: settings.repo, PerPage: settings.perPage, ConfigHash: configHash, Cursor: cursor, Checkpoint: checkpoint, AllowProviderUnavailable: settings.hasAuth()}
 	options.Build = func(repo *gogithub.Repository) (*primitives.Event, error) { return repositoryEvent(settings, repo) }
 	return githubcanary.ReadRepositories(ctx, client, options)
 }
@@ -481,16 +481,4 @@ func timestamp(value *gogithub.Timestamp) *time.Time {
 	}
 	result := value.UTC()
 	return &result
-}
-
-func isNotFound(err error) bool {
-	var apiErr *gogithub.ErrorResponse
-	return errors.As(err, &apiErr) && apiErr.Response != nil && apiErr.Response.StatusCode == 404
-}
-
-func wrapLookupError(subject string, err error) error {
-	if isNotFound(err) {
-		return fmt.Errorf("%s not found", subject)
-	}
-	return fmt.Errorf("%s: %w", subject, err)
 }

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -1322,6 +1322,142 @@ func TestGitHubAuditUnavailableDoesNotFailCheckOrRead(t *testing.T) {
 	}
 }
 
+func TestGitHubProviderUnavailableDoesNotFailGraphRuntimeFamilies(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		family string
+		repo   string
+	}{
+		{name: "dependabot", family: familyDependabot, repo: "cerebro"},
+		{name: "org inventory", family: familyOrgInventory},
+		{name: "repository", family: familyRepository},
+		{name: "secret scanning", family: familySecretScanning},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				requests++
+				http.NotFound(w, r)
+			}))
+			defer server.Close()
+
+			source, err := New()
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			source.allowLoopbackBaseURL = true
+			values := map[string]string{
+				"base_url": server.URL,
+				"family":   tt.family,
+				"owner":    "writer",
+				"token":    "test-token",
+			}
+			if tt.repo != "" {
+				values["repo"] = tt.repo
+			}
+			cfg := sourcecdk.NewConfig(values)
+
+			if err := source.Check(context.Background(), cfg); err != nil {
+				t.Fatalf("Check(%s unavailable) error = %v", tt.family, err)
+			}
+			pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+			if err != nil {
+				t.Fatalf("ReadWithCheckpoint(%s unavailable) error = %v", tt.family, err)
+			}
+			if len(pull.Events) != 0 {
+				t.Fatalf("len(pull.Events) = %d, want 0", len(pull.Events))
+			}
+			if pull.ShortCircuitReason != sourcecdk.PullShortCircuitReasonNotModified {
+				t.Fatalf("ShortCircuitReason = %q, want not_modified", pull.ShortCircuitReason)
+			}
+			if requests == 0 {
+				t.Fatal("requests = 0, want provider probe attempted")
+			}
+		})
+	}
+}
+
+func TestGitHubPullRequestOwnerUnavailableStillFails(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		requests++
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   familyPullRequest,
+		"owner":    "writer",
+		"token":    "test-token",
+	})
+
+	if err := source.Check(context.Background(), cfg); err == nil {
+		t.Fatal("Check(pull_request unavailable owner) error = nil, want non-nil")
+	}
+	if _, err := source.Discover(context.Background(), cfg); err == nil {
+		t.Fatal("Discover(pull_request unavailable owner) error = nil, want non-nil")
+	}
+	if requests == 0 {
+		t.Fatal("requests = 0, want provider probe attempted")
+	}
+}
+
+func TestGitHubRepositoryCheckDoesNotDoubleWrapLookupErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, `{"message":"server error"}`, http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	for _, tt := range []struct {
+		name   string
+		values map[string]string
+	}{
+		{
+			name:   "repo",
+			values: map[string]string{"base_url": server.URL, "family": familyRepository, "owner": "writer", "repo": "cerebro"},
+		},
+		{
+			name:   "owner",
+			values: map[string]string{"base_url": server.URL, "family": familyRepository, "owner": "writer"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := source.Check(context.Background(), sourcecdk.NewConfig(tt.values))
+			if err == nil {
+				t.Fatal("Check() error = nil, want non-nil")
+			}
+			if got := errorWrapDepth(err); got != 1 {
+				t.Fatalf("error wrap depth = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func errorWrapDepth(err error) int {
+	depth := 0
+	for err != nil {
+		err = errors.Unwrap(err)
+		if err != nil {
+			depth++
+		}
+	}
+	return depth
+}
+
 func TestGitHubAuditFreshnessCheckpointDoesNotExposeProviderMetadata(t *testing.T) {
 	auditEntry := map[string]any{
 		"@timestamp":   1776916397852,

--- a/sources/internal/githubapi/errors.go
+++ b/sources/internal/githubapi/errors.go
@@ -1,0 +1,73 @@
+package githubapi
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	gogithub "github.com/google/go-github/v66/github"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+func NotFound(err error) bool {
+	status, ok := ErrorStatus(err)
+	return ok && status == http.StatusNotFound
+}
+
+func ProviderUnavailable(err error) bool {
+	status, ok := ErrorStatus(err)
+	if !ok {
+		return false
+	}
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return true
+	default:
+		return false
+	}
+}
+
+func ErrorStatus(err error) (int, bool) {
+	var apiErr *gogithub.ErrorResponse
+	if !errors.As(err, &apiErr) || apiErr.Response == nil {
+		return 0, false
+	}
+	return apiErr.Response.StatusCode, true
+}
+
+func LookupError(subject string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if NotFound(err) {
+		return fmt.Errorf("%s not found: %w", subject, err)
+	}
+	return fmt.Errorf("%s: %w", subject, err)
+}
+
+func ProviderUnavailableLookupError(subject string, err error, allow bool) error {
+	if err == nil {
+		return nil
+	}
+	if allow && ProviderUnavailable(err) {
+		return nil
+	}
+	return LookupError(subject, err)
+}
+
+func ProviderUnavailableOrError(err error, allow bool) error {
+	if allow && ProviderUnavailable(err) {
+		return nil
+	}
+	return err
+}
+
+func ProviderUnavailablePull(checkpoint *cerebrov1.SourceCheckpoint) sourcecdk.Pull {
+	pull := sourcecdk.NotModifiedPull(checkpoint)
+	if pull.ShortCircuitReason == "" {
+		pull.ShortCircuitReason = sourcecdk.PullShortCircuitReasonNotModified
+	}
+	return pull
+}

--- a/sources/internal/githubcanary/canary.go
+++ b/sources/internal/githubcanary/canary.go
@@ -2,9 +2,7 @@ package githubcanary
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +12,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/internal/githubapi"
 )
 
 const (
@@ -36,13 +35,14 @@ type Result struct {
 }
 
 type RepositoryReadOptions struct {
-	Owner      string
-	Repo       string
-	PerPage    int
-	ConfigHash string
-	Cursor     *cerebrov1.SourceCursor
-	Checkpoint *cerebrov1.SourceCheckpoint
-	Build      func(*gogithub.Repository) (*primitives.Event, error)
+	Owner                    string
+	Repo                     string
+	PerPage                  int
+	ConfigHash               string
+	Cursor                   *cerebrov1.SourceCursor
+	Checkpoint               *cerebrov1.SourceCheckpoint
+	AllowProviderUnavailable bool
+	Build                    func(*gogithub.Repository) (*primitives.Event, error)
 }
 
 func ReadRepositories(ctx context.Context, client *gogithub.Client, options RepositoryReadOptions) (sourcecdk.Pull, error) {
@@ -55,6 +55,9 @@ func ReadRepositories(ctx context.Context, client *gogithub.Client, options Repo
 	if strings.TrimSpace(options.Repo) == "" && page == 1 && sourcecdk.CursorToken(options.Cursor) == "" {
 		canary, err = ProbeRepository(ctx, client, options.Owner, options.Checkpoint, options.ConfigHash, time.Now().UTC())
 		if err != nil {
+			if options.AllowProviderUnavailable && githubapi.ProviderUnavailable(err) {
+				return githubapi.ProviderUnavailablePull(readCheckpoint), nil
+			}
 			return sourcecdk.Pull{}, err
 		}
 		if pull, ok := canary.ShortCircuitPull(); ok {
@@ -67,12 +70,18 @@ func ReadRepositories(ctx context.Context, client *gogithub.Client, options Repo
 		}
 		repo, err := getRepository(ctx, client, options.Owner, options.Repo)
 		if err != nil {
+			if options.AllowProviderUnavailable && githubapi.ProviderUnavailable(err) {
+				return githubapi.ProviderUnavailablePull(readCheckpoint), nil
+			}
 			return sourcecdk.Pull{}, err
 		}
 		return sourcecdk.IncrementalPullFromRecords("github", "repository", []*gogithub.Repository{repo}, "", readCheckpoint, options.Build)
 	}
 	repos, resp, err := listRepositoriesPage(ctx, client, options.Owner, page, options.PerPage)
 	if err != nil {
+		if options.AllowProviderUnavailable && githubapi.ProviderUnavailable(err) {
+			return githubapi.ProviderUnavailablePull(readCheckpoint), nil
+		}
 		return sourcecdk.Pull{}, err
 	}
 	nextCursor := ""
@@ -182,16 +191,7 @@ func AuditLogMetadata(owner string, entries []*gogithub.AuditEntry, configHash s
 }
 
 func AuditLogUnavailable(err error) bool {
-	var apiErr *gogithub.ErrorResponse
-	if !errors.As(err, &apiErr) || apiErr.Response == nil {
-		return false
-	}
-	switch apiErr.Response.StatusCode {
-	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
-		return true
-	default:
-		return false
-	}
+	return githubapi.ProviderUnavailable(err)
 }
 
 func evaluate(checkpoint *cerebrov1.SourceCheckpoint, source, family string, metadata map[string]string, watermark time.Time, observedAt time.Time, policy sourcecdk.CanaryReconciliationPolicy) *Result {
@@ -239,7 +239,7 @@ func listRepositoriesPage(ctx context.Context, client *gogithub.Client, owner st
 	if err == nil {
 		return repos, resp, nil
 	}
-	if !isNotFound(err) {
+	if !githubapi.NotFound(err) {
 		return nil, nil, fmt.Errorf("list github org repos for %s: %w", owner, err)
 	}
 	repos, resp, err = client.Repositories.ListByUser(ctx, owner, &gogithub.RepositoryListByUserOptions{
@@ -328,11 +328,6 @@ func timestamp(value *gogithub.Timestamp) *time.Time {
 	}
 	result := value.UTC()
 	return &result
-}
-
-func isNotFound(err error) bool {
-	var apiErr *gogithub.ErrorResponse
-	return errors.As(err, &apiErr) && apiErr.Response != nil && apiErr.Response.StatusCode == http.StatusNotFound
 }
 
 func firstNonEmpty(values ...string) string {

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -19,7 +19,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"azure":           2859,
 	"cosmo":           1006,
 	"gcp":             2130,
-	"github":          2029,
+	"github":          2025,
 	"googleworkspace": 815,
 	"grc":             1195,
 	"okta":            2256,


### PR DESCRIPTION
## Summary
- Treat GitHub 401/403/404 provider-unavailable responses as non-fatal for graph runtime GitHub security/org inventory dataplanes.
- Share GitHub API status helpers across the source and repository canary.
- Add regression coverage for dependabot, org inventory, repository, and secret scanning graph runtime families.

## Validation
- go test ./sources/github ./sources/internal/githubapi ./sources/internal/githubcanary ./sources/internal/githubaudit ./internal/sourceruntime -count=1
- make check-structural check-structural-test check-arch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->