### PR TITLE
Add inventory surface filtering

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2715,6 +2715,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/tenantIDQuery'
         - $ref: '#/components/parameters/sourceIDQuery'
+        - $ref: '#/components/parameters/inventorySurfaceQuery'
         - $ref: '#/components/parameters/limitQuery'
       responses:
         '200':
@@ -2727,6 +2728,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/tenantIDQuery'
         - $ref: '#/components/parameters/sourceIDQuery'
+        - $ref: '#/components/parameters/inventorySurfaceQuery'
         - $ref: '#/components/parameters/limitQuery'
         - name: category_id
           in: query
@@ -2787,6 +2789,7 @@ paths:
         - $ref: '#/components/parameters/tenantIDQuery'
         - $ref: '#/components/parameters/sourceIDQuery'
         - $ref: '#/components/parameters/runtimeIDQuery'
+        - $ref: '#/components/parameters/inventorySurfaceQuery'
         - $ref: '#/components/parameters/limitQuery'
         - name: category_id
           in: query
@@ -4413,6 +4416,13 @@ components:
       in: query
       schema:
         type: string
+    inventorySurfaceQuery:
+      name: surface
+      in: query
+      description: Inventory record surface. Omit for all records; pass asset for reviewable assets only.
+      schema:
+        type: string
+        enum: [asset, component, signal, alias, raw_record, all]
     limitQuery:
       name: limit
       in: query

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -190,9 +190,9 @@ func (a *App) handleGRCInventoryCategories(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	categories, err := a.graphQueryService().ListInventoryCategories(r.Context(), graphquery.InventoryCategoryRequest{
-		TenantID: scope.TenantID,
-		SourceID: scope.SourceID,
-		Limit:    scope.Limit,
+		TenantID: scope.TenantID, SourceID: scope.SourceID,
+		Surface: strings.TrimSpace(r.URL.Query().Get("surface")),
+		Limit:   scope.Limit,
 	})
 	if err != nil {
 		writeGRCError(w, err)
@@ -208,8 +208,8 @@ func (a *App) handleGRCInventoryAssets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	assets, err := a.graphQueryService().ListInventoryAssets(r.Context(), graphquery.InventoryAssetRequest{
-		TenantID:   scope.TenantID,
-		SourceID:   scope.SourceID,
+		TenantID: scope.TenantID, SourceID: scope.SourceID,
+		Surface:    strings.TrimSpace(r.URL.Query().Get("surface")),
 		CategoryID: strings.TrimSpace(r.URL.Query().Get("category_id")),
 		EntityType: strings.TrimSpace(r.URL.Query().Get("entity_type")),
 		Query:      strings.TrimSpace(r.URL.Query().Get("q")),
@@ -324,8 +324,8 @@ func (a *App) handleGRCResourceScope(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resources, err := a.graphQueryService().ListInventoryAssets(r.Context(), graphquery.InventoryAssetRequest{
-		TenantID:   scope.TenantID,
-		SourceID:   sourceID,
+		TenantID: scope.TenantID, SourceID: sourceID,
+		Surface:    strings.TrimSpace(r.URL.Query().Get("surface")),
 		CategoryID: strings.TrimSpace(r.URL.Query().Get("category_id")),
 		EntityType: strings.TrimSpace(r.URL.Query().Get("entity_type")),
 		Query:      strings.TrimSpace(r.URL.Query().Get("q")),

--- a/internal/bootstrap/grc_inventory_test.go
+++ b/internal/bootstrap/grc_inventory_test.go
@@ -57,6 +57,29 @@ func TestGRCInventoryReviewPostureRequiresOwnerForHighRiskUnownedAssets(t *testi
 	}
 }
 
+func TestGRCInventoryReviewPostureDoesNotRequireOwnerForSupportingRecords(t *testing.T) {
+	asset := graphquery.InventoryAsset{
+		URN:        "urn:cerebro:writer:sentinelone_installed_app:agent-1:app-1",
+		EntityType: "sentinelone.installed_application",
+		RiskScore:  90,
+		ScopeState: grcinventory.ScopeStateInScope,
+		Attributes: map[string]string{},
+	}
+	grcinventory.ApplyReviewPosture(&asset)
+	if asset.Surface != graphquery.InventorySurfaceComponent {
+		t.Fatalf("surface = %q, want %q", asset.Surface, graphquery.InventorySurfaceComponent)
+	}
+	if asset.ReviewDisposition == nil || asset.ReviewDisposition.State != grcinventory.ReviewBaseline {
+		t.Fatalf("review_disposition = %#v, want baseline", asset.ReviewDisposition)
+	}
+	if asset.Accountability == nil || asset.Accountability.State != grcinventory.AccountabilityNone {
+		t.Fatalf("accountability = %#v, want not_required", asset.Accountability)
+	}
+	if len(asset.Accountability.Reasons) == 0 || asset.Accountability.Reasons[0].Code != "supporting_record" {
+		t.Fatalf("accountability reasons = %#v, want supporting_record", asset.Accountability.Reasons)
+	}
+}
+
 func TestGRCInventoryAccountabilityOverrideMarksOwnerNotRequired(t *testing.T) {
 	asset := graphquery.InventoryAsset{
 		URN:        "urn:cerebro:writer:aws_s3_bucket:bucket-a",

--- a/internal/graphquery/inventory.go
+++ b/internal/graphquery/inventory.go
@@ -18,12 +18,14 @@ const (
 type InventoryCategoryRequest struct {
 	TenantID string
 	SourceID string
+	Surface  string
 	Limit    uint32
 }
 
 type InventoryAssetRequest struct {
 	TenantID   string
 	SourceID   string
+	Surface    string
 	CategoryID string
 	EntityType string
 	Query      string
@@ -38,6 +40,7 @@ type InventoryAssetDetailRequest struct {
 type InventoryCategory struct {
 	ID          string   `json:"id"`
 	Label       string   `json:"label"`
+	Surface     string   `json:"surface,omitempty"`
 	EntityTypes []string `json:"entity_types"`
 	Count       int      `json:"count"`
 }
@@ -45,6 +48,7 @@ type InventoryCategory struct {
 type InventoryAsset struct {
 	URN                        string                      `json:"urn"`
 	EntityType                 string                      `json:"entity_type"`
+	Surface                    string                      `json:"surface,omitempty"`
 	Label                      string                      `json:"label"`
 	SourceID                   string                      `json:"source_id,omitempty"`
 	RuntimeID                  string                      `json:"runtime_id,omitempty"`
@@ -105,20 +109,26 @@ func (s *Service) ListInventoryCategories(ctx context.Context, request Inventory
 		return nil, ErrRuntimeUnavailable
 	}
 	tenantID := strings.TrimSpace(request.TenantID)
+	surfaceClause, surfaceParams := inventorySurfaceParams(request.Surface)
+	params := map[string]any{
+		"tenant_id":             tenantID,
+		"source_id":             strings.TrimSpace(request.SourceID),
+		"excluded_entity_types": excludedInventoryEntityTypes(),
+		"limit":                 normalizeInventoryLimit(request.Limit),
+	}
+	for key, value := range surfaceParams {
+		params[key] = value
+	}
 	rows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
 		Query: `MATCH (e:Entity)
 WHERE ($tenant_id = '' OR e.tenant_id = $tenant_id)
   AND ($source_id = '' OR e.source_id = $source_id)
   AND NOT e.entity_type IN $excluded_entity_types
+` + surfaceClause + `
 RETURN e.entity_type AS entity_type, count(e) AS count
 ORDER BY count DESC, entity_type ASC
 LIMIT $limit`,
-		Params: map[string]any{
-			"tenant_id":             tenantID,
-			"source_id":             strings.TrimSpace(request.SourceID),
-			"excluded_entity_types": excludedInventoryEntityTypes(),
-			"limit":                 normalizeInventoryLimit(request.Limit),
-		},
+		Params:   params,
 		RowLimit: normalizeInventoryLimit(request.Limit),
 	})
 	if err != nil {
@@ -134,7 +144,7 @@ LIMIT $limit`,
 		id, label := inventoryCategoryForEntityType(entityType)
 		category := grouped[id]
 		if category == nil {
-			category = &InventoryCategory{ID: id, Label: label}
+			category = &InventoryCategory{ID: id, Label: label, Surface: InventorySurfaceForEntityType(entityType)}
 			grouped[id] = category
 		}
 		category.EntityTypes = append(category.EntityTypes, entityType)
@@ -160,24 +170,30 @@ func (s *Service) ListInventoryAssets(ctx context.Context, request InventoryAsse
 	}
 	entityTypes := inventoryEntityTypesForFilter(request.CategoryID, request.EntityType)
 	query := strings.ToLower(strings.TrimSpace(request.Query))
+	surfaceClause, surfaceParams := inventorySurfaceParams(request.Surface)
+	params := map[string]any{
+		"tenant_id":             strings.TrimSpace(request.TenantID),
+		"source_id":             strings.TrimSpace(request.SourceID),
+		"entity_types":          entityTypes,
+		"excluded_entity_types": excludedInventoryEntityTypes(),
+		"q":                     query,
+		"limit":                 normalizeInventoryLimit(request.Limit),
+	}
+	for key, value := range surfaceParams {
+		params[key] = value
+	}
 	rows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
 		Query: `MATCH (e:Entity)
 WHERE ($tenant_id = '' OR e.tenant_id = $tenant_id)
   AND ($source_id = '' OR e.source_id = $source_id)
   AND (size($entity_types) = 0 OR e.entity_type IN $entity_types)
   AND NOT e.entity_type IN $excluded_entity_types
+` + surfaceClause + `
   AND ($q = '' OR toLower(coalesce(e.label, '')) CONTAINS $q OR toLower(e.urn) CONTAINS $q OR toLower(coalesce(e.attributes_json, '')) CONTAINS $q)
 RETURN e.urn AS urn, e.entity_type AS entity_type, e.label AS label, e.source_id AS source_id, e.runtime_id AS runtime_id, coalesce(e.attributes_json, '{}') AS attributes_json
 ORDER BY e.entity_type ASC, e.label ASC, e.urn ASC
 LIMIT $limit`,
-		Params: map[string]any{
-			"tenant_id":             strings.TrimSpace(request.TenantID),
-			"source_id":             strings.TrimSpace(request.SourceID),
-			"entity_types":          entityTypes,
-			"excluded_entity_types": excludedInventoryEntityTypes(),
-			"q":                     query,
-			"limit":                 normalizeInventoryLimit(request.Limit),
-		},
+		Params:   params,
 		RowLimit: normalizeInventoryLimit(request.Limit),
 	})
 	if err != nil {
@@ -251,6 +267,7 @@ func inventoryAssetFromRow(row ports.CypherRow) InventoryAsset {
 	return InventoryAsset{
 		URN:         rowString(row, "urn"),
 		EntityType:  rowString(row, "entity_type"),
+		Surface:     InventorySurfaceForEntityType(rowString(row, "entity_type")),
 		Label:       firstInventoryString(rowString(row, "label"), rowString(row, "urn")),
 		SourceID:    rowString(row, "source_id"),
 		RuntimeID:   rowString(row, "runtime_id"),

--- a/internal/graphquery/inventory_surface.go
+++ b/internal/graphquery/inventory_surface.go
@@ -1,0 +1,295 @@
+package graphquery
+
+import (
+	"sort"
+	"strings"
+)
+
+const (
+	InventorySurfaceAsset     = "asset"
+	InventorySurfaceComponent = "component"
+	InventorySurfaceSignal    = "signal"
+	InventorySurfaceAlias     = "alias"
+	InventorySurfaceRawRecord = "raw_record"
+	InventorySurfaceAll       = "all"
+)
+
+type inventorySurfaceFilter struct {
+	Surface  string
+	Exact    []string
+	Prefixes []string
+	Suffixes []string
+}
+
+func NormalizeInventorySurface(surface string) string {
+	switch strings.ToLower(strings.TrimSpace(surface)) {
+	case "":
+		return InventorySurfaceAll
+	case InventorySurfaceAsset:
+		return InventorySurfaceAsset
+	case InventorySurfaceComponent:
+		return InventorySurfaceComponent
+	case InventorySurfaceSignal:
+		return InventorySurfaceSignal
+	case InventorySurfaceAlias:
+		return InventorySurfaceAlias
+	case InventorySurfaceRawRecord, "raw":
+		return InventorySurfaceRawRecord
+	case InventorySurfaceAll:
+		return InventorySurfaceAll
+	default:
+		return InventorySurfaceAsset
+	}
+}
+
+func InventorySurfaceForEntityType(entityType string) string {
+	entityType = strings.ToLower(strings.TrimSpace(entityType))
+	switch {
+	case entityType == "":
+		return InventorySurfaceAsset
+	case inventorySurfaceMatches(entityType, inventorySurfaceRules(InventorySurfaceAlias)):
+		return InventorySurfaceAlias
+	case inventorySurfaceMatches(entityType, inventorySurfaceRules(InventorySurfaceRawRecord)):
+		return InventorySurfaceRawRecord
+	case inventorySurfaceMatches(entityType, inventorySurfaceRules(InventorySurfaceComponent)):
+		return InventorySurfaceComponent
+	case inventorySurfaceMatches(entityType, inventorySurfaceRules(InventorySurfaceSignal)):
+		return InventorySurfaceSignal
+	default:
+		return InventorySurfaceAsset
+	}
+}
+
+func inventorySurfaceRules(surface string) inventorySurfaceFilter {
+	switch NormalizeInventorySurface(surface) {
+	case InventorySurfaceAlias:
+		return inventorySurfaceFilter{
+			Surface:  InventorySurfaceAlias,
+			Exact:    []string{"endpoint.identifier", "external.ref", "external_ref", "vendor.alias"},
+			Prefixes: []string{"identifier.", "identity."},
+		}
+	case InventorySurfaceRawRecord:
+		return inventorySurfaceFilter{
+			Surface: InventorySurfaceRawRecord,
+			Exact: []string{
+				"aws.resource",
+				"azure.resource",
+				"gcp.audited.resource",
+				"gcp.resource",
+				"github.resource",
+				"okta.resource",
+			},
+		}
+	case InventorySurfaceComponent:
+		return inventorySurfaceFilter{
+			Surface: InventorySurfaceComponent,
+			Exact: []string{
+				"asset.tag",
+				"aws.aws::dynamodb::table",
+				"aws.aws::ec2::networkinterface",
+				"aws.aws::ec2::securitygroup",
+				"aws.aws::ec2::subnet",
+				"aws.aws::ec2::volume",
+				"aws.aws::ec2::vpc",
+				"aws.aws::ecs::task",
+				"aws.aws::ecs::taskdefinition",
+				"aws.aws::elasticloadbalancingv2::listener",
+				"aws.aws::elasticloadbalancingv2::targetgroup",
+				"aws.aws::events::rule",
+				"aws.aws::kms::alias",
+				"aws.aws::kms::key",
+				"aws.aws::logs::loggroup",
+				"aws.awsec2networkinterface",
+				"aws.awsec2securitygroup",
+				"aws.awsec2subnet",
+				"aws.awsec2volume",
+				"aws.awsec2vpc",
+				"aws.awsecstask",
+				"aws.awsecstaskdefinition",
+				"aws.ecs.task",
+				"aws.ecs.task_definition",
+				"aws.ebs.snapshot",
+				"aws.eks.nodegroup",
+				"aws.eks.pod_identity_association",
+				"container.image_digest",
+				"data.classification",
+				"evidence.cas.pointer",
+				"gcp.artifact_registry_image",
+				"gcp.artifactregistry.googleapis.com.dockerimage",
+				"gcp.artifactregistry.googleapis.com.mavenartifact",
+				"gcp.artifactregistry.googleapis.com.npmpackage",
+				"gcp.artifactregistry.googleapis.com.pythonpackage",
+				"github.dependency",
+				"github.dependency_manifest",
+				"github.org_installation",
+				"kubernetes.config_map",
+				"kubernetes.cron_job",
+				"kubernetes.daemon_set",
+				"kubernetes.deployment",
+				"kubernetes.endpoint",
+				"kubernetes.ingress",
+				"kubernetes.job",
+				"kubernetes.namespace",
+				"kubernetes.persistent_volume",
+				"kubernetes.persistent_volume_claim",
+				"kubernetes.pod",
+				"kubernetes.pod_disruption_budget",
+				"kubernetes.replica_set",
+				"kubernetes.secret",
+				"kubernetes.stateful_set",
+				"kubernetes.storage_class",
+				"kubernetes.validating_webhook_configuration",
+				"kubernetes.mutating_webhook_configuration",
+				"okta.authenticator",
+				"okta.network_zone",
+				"okta.policy_rule",
+				"security.category",
+				"sentinelone.group",
+				"sentinelone.installed_application",
+				"sentinelone.site",
+			},
+			Prefixes: []string{
+				"aws.awselasticloadbalancingv2",
+				"aws.awskms",
+				"aws.awslogs",
+				"gcp.artifactregistry.googleapis.com.",
+				"gcp.compute.googleapis.com.disk.",
+				"gcp.container.googleapis.com.nodepool.",
+			},
+		}
+	case InventorySurfaceSignal:
+		return inventorySurfaceFilter{
+			Surface: InventorySurfaceSignal,
+			Exact: []string{
+				"action",
+				"audit.event",
+				"audit.target",
+				"archetype.finding",
+				"aws.action",
+				"aws.context",
+				"aws.guardduty.detector",
+				"aws.public_principal",
+				"aws.securityhub.finding",
+				"claim",
+				"contact",
+				"cosmo.alert",
+				"decision",
+				"github.credential",
+				"github.dependabot_alert",
+				"github.pull_request",
+				"github.secret_scanning_alert",
+				"github.security_advisory",
+				"kolide.issue",
+				"okta.threat_insight",
+				"openai.project_spend_alert",
+				"openai.spend_alert",
+				"outcome",
+				"panopticon.alert",
+				"panopticon.asset",
+				"panopticon.case",
+				"panopticon.ioc",
+				"runtime.evidence",
+				"runtime_evidence",
+				"sdk.integration_posture",
+				"security.finding",
+				"sentinelone.activity",
+				"sentinelone.exclusion",
+				"sentinelone.threat",
+				"twilio.secret",
+				"vulnview.dns_alert_type",
+			},
+			Prefixes: []string{
+				"aurelius.",
+				"cosmo.",
+				"panopticon.",
+				"sentinelone.threat.",
+				"vulnview.",
+			},
+		}
+	default:
+		return inventorySurfaceFilter{Surface: InventorySurfaceAsset}
+	}
+}
+
+func inventorySurfaceMatches(entityType string, filter inventorySurfaceFilter) bool {
+	entityType = strings.ToLower(strings.TrimSpace(entityType))
+	if entityType == "" {
+		return false
+	}
+	for _, exact := range filter.Exact {
+		if entityType == exact {
+			return true
+		}
+	}
+	for _, prefix := range filter.Prefixes {
+		if strings.HasPrefix(entityType, prefix) {
+			return true
+		}
+	}
+	for _, suffix := range filter.Suffixes {
+		if strings.HasSuffix(entityType, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func inventorySurfaceNonAssetRules() inventorySurfaceFilter {
+	combined := inventorySurfaceFilter{Surface: InventorySurfaceAsset}
+	for _, surface := range []string{InventorySurfaceComponent, InventorySurfaceSignal, InventorySurfaceAlias, InventorySurfaceRawRecord} {
+		rules := inventorySurfaceRules(surface)
+		combined.Exact = append(combined.Exact, rules.Exact...)
+		combined.Prefixes = append(combined.Prefixes, rules.Prefixes...)
+		combined.Suffixes = append(combined.Suffixes, rules.Suffixes...)
+	}
+	combined.Exact = uniqueSortedInventoryStrings(combined.Exact)
+	combined.Prefixes = uniqueSortedInventoryStrings(combined.Prefixes)
+	combined.Suffixes = uniqueSortedInventoryStrings(combined.Suffixes)
+	return combined
+}
+
+func inventorySurfaceParams(surface string) (string, map[string]any) {
+	surface = NormalizeInventorySurface(surface)
+	switch surface {
+	case InventorySurfaceAll:
+		return "", map[string]any{}
+	case InventorySurfaceAsset:
+		rules := inventorySurfaceNonAssetRules()
+		return `
+  AND NOT e.entity_type IN $surface_excluded_entity_types
+  AND none(prefix IN $surface_excluded_prefixes WHERE e.entity_type STARTS WITH prefix)
+  AND none(suffix IN $surface_excluded_suffixes WHERE e.entity_type ENDS WITH suffix)`, map[string]any{
+				"surface_excluded_entity_types": rules.Exact,
+				"surface_excluded_prefixes":     rules.Prefixes,
+				"surface_excluded_suffixes":     rules.Suffixes,
+			}
+	default:
+		rules := inventorySurfaceRules(surface)
+		return `
+  AND (e.entity_type IN $surface_included_entity_types
+    OR any(prefix IN $surface_included_prefixes WHERE e.entity_type STARTS WITH prefix)
+    OR any(suffix IN $surface_included_suffixes WHERE e.entity_type ENDS WITH suffix))`, map[string]any{
+				"surface_included_entity_types": rules.Exact,
+				"surface_included_prefixes":     rules.Prefixes,
+				"surface_included_suffixes":     rules.Suffixes,
+			}
+	}
+}
+
+func uniqueSortedInventoryStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/graphquery/inventory_test.go
+++ b/internal/graphquery/inventory_test.go
@@ -28,3 +28,73 @@ func TestInventoryEntityTypesForFilterEntityTypePrecedence(t *testing.T) {
 		t.Fatalf("inventoryEntityTypesForFilter() = %v, want %v", got, want)
 	}
 }
+
+func TestInventorySurfaceForEntityType(t *testing.T) {
+	tests := []struct {
+		name       string
+		entityType string
+		want       string
+	}{
+		{name: "reviewable asset", entityType: "sentinelone.agent", want: InventorySurfaceAsset},
+		{name: "component", entityType: "sentinelone.installed_application", want: InventorySurfaceComponent},
+		{name: "alias", entityType: "identifier.login", want: InventorySurfaceAlias},
+		{name: "signal", entityType: "panopticon.alert", want: InventorySurfaceSignal},
+		{name: "raw record", entityType: "okta.resource", want: InventorySurfaceRawRecord},
+		{name: "known finding signal", entityType: "aws.securityhub.finding", want: InventorySurfaceSignal},
+		{name: "unknown alert suffix", entityType: "custom_vendor.alert", want: InventorySurfaceAsset},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := InventorySurfaceForEntityType(tt.entityType); got != tt.want {
+				t.Fatalf("InventorySurfaceForEntityType(%q) = %q, want %q", tt.entityType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeInventorySurfaceDefaultsToAll(t *testing.T) {
+	if got := NormalizeInventorySurface(""); got != InventorySurfaceAll {
+		t.Fatalf("NormalizeInventorySurface(\"\") = %q, want %q", got, InventorySurfaceAll)
+	}
+	if got := NormalizeInventorySurface("unknown"); got != InventorySurfaceAsset {
+		t.Fatalf("NormalizeInventorySurface(\"unknown\") = %q, want %q", got, InventorySurfaceAsset)
+	}
+}
+
+func TestInventorySurfaceParamsDefaultKeepsAllRecords(t *testing.T) {
+	clause, params := inventorySurfaceParams("")
+	if clause != "" {
+		t.Fatalf("inventorySurfaceParams(\"\") clause = %q, want empty clause", clause)
+	}
+	if len(params) != 0 {
+		t.Fatalf("inventorySurfaceParams(\"\") params = %v, want none", params)
+	}
+}
+
+func TestInventorySurfaceParamsExcludeSupportingRecordsFromAssetSurface(t *testing.T) {
+	_, params := inventorySurfaceParams(InventorySurfaceAsset)
+	exact, _ := params["surface_excluded_entity_types"].([]string)
+	prefixes, _ := params["surface_excluded_prefixes"].([]string)
+	suffixes, _ := params["surface_excluded_suffixes"].([]string)
+	if !inventoryTestContains(exact, "sentinelone.installed_application") {
+		t.Fatalf("asset surface exclusions missing sentinelone.installed_application: %v", exact)
+	}
+	if !inventoryTestContains(prefixes, "identifier.") {
+		t.Fatalf("asset surface prefix exclusions missing identifier.: %v", prefixes)
+	}
+	if !inventoryTestContains(exact, "aws.securityhub.finding") {
+		t.Fatalf("asset surface exact exclusions missing aws.securityhub.finding: %v", exact)
+	}
+	if len(suffixes) != 0 {
+		t.Fatalf("asset surface suffix exclusions = %v, want none", suffixes)
+	}
+}
+
+func inventoryTestContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/grcinventory/posture.go
+++ b/internal/grcinventory/posture.go
@@ -30,20 +30,21 @@ const (
 )
 
 type Summary struct {
-	TotalAssets         int `json:"total_assets"`
-	InScopeAssets       int `json:"in_scope_assets"`
-	OutOfScopeAssets    int `json:"out_of_scope_assets"`
-	HighRiskAssets      int `json:"high_risk_assets"`
-	UnassignedAssets    int `json:"unassigned_assets"`
-	BaselineAssets      int `json:"baseline_assets"`
-	NeedsReviewAssets   int `json:"needs_review_assets"`
-	OwnerRequiredAssets int `json:"owner_required_assets"`
-	AccountableAssets   int `json:"accountable_assets"`
-	ReportedIssueAssets int `json:"reported_issue_assets"`
-	OrgGroups           int `json:"org_groups"`
-	PublicAssets        int `json:"public_assets"`
-	ScopedCoveragePct   int `json:"scoped_coverage_pct"`
-	AssignedCoveragePct int `json:"assigned_coverage_pct"`
+	TotalAssets         int            `json:"total_assets"`
+	InScopeAssets       int            `json:"in_scope_assets"`
+	OutOfScopeAssets    int            `json:"out_of_scope_assets"`
+	HighRiskAssets      int            `json:"high_risk_assets"`
+	UnassignedAssets    int            `json:"unassigned_assets"`
+	BaselineAssets      int            `json:"baseline_assets"`
+	NeedsReviewAssets   int            `json:"needs_review_assets"`
+	OwnerRequiredAssets int            `json:"owner_required_assets"`
+	AccountableAssets   int            `json:"accountable_assets"`
+	ReportedIssueAssets int            `json:"reported_issue_assets"`
+	OrgGroups           int            `json:"org_groups"`
+	PublicAssets        int            `json:"public_assets"`
+	ScopedCoveragePct   int            `json:"scoped_coverage_pct"`
+	AssignedCoveragePct int            `json:"assigned_coverage_pct"`
+	SurfaceCounts       map[string]int `json:"surface_counts,omitempty"`
 }
 
 func ApplyScope(asset *graphquery.InventoryAsset, record *ports.GRCInventoryScopeRecord) {
@@ -83,6 +84,8 @@ func ApplyReviewPosture(asset *graphquery.InventoryAsset) {
 	if strings.TrimSpace(asset.ScopeState) == "" {
 		asset.ScopeState = ScopeStateInScope
 	}
+	surface := inventorySurface(*asset)
+	asset.Surface = surface
 	owner := AssetOwnerPrincipal(*asset)
 	accountabilityReasons := accountabilityReasons(*asset)
 	if asset.ScopeState == ScopeStateOutScope {
@@ -96,6 +99,30 @@ func ApplyReviewPosture(asset *graphquery.InventoryAsset) {
 		asset.Accountability = &graphquery.InventoryAccountability{
 			State:   AccountabilityNone,
 			Label:   "Owner not required",
+			Reasons: []graphquery.InventoryReviewReason{reason},
+		}
+		return
+	}
+	if supportingInventorySurface(surface) {
+		reason := graphquery.InventoryReviewReason{Code: "supporting_record", Label: "Supporting record"}
+		asset.Accountability = &graphquery.InventoryAccountability{
+			State:   AccountabilityNone,
+			Label:   "Owner not required",
+			Reasons: []graphquery.InventoryReviewReason{reason},
+		}
+		if hasActiveReport(*asset) {
+			asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
+				State:   ReviewReportedIssue,
+				Label:   "Reported issue",
+				Detail:  fallback(asset.LatestAssetReportReason, "A reviewer reported this record for triage."),
+				Reasons: []graphquery.InventoryReviewReason{{Code: "reported_issue", Label: "Reviewer report"}},
+			}
+			return
+		}
+		asset.ReviewDisposition = &graphquery.InventoryReviewDisposition{
+			State:   ReviewBaseline,
+			Label:   "Baseline",
+			Detail:  "Linked to related assets. Owner review is not required.",
 			Reasons: []graphquery.InventoryReviewReason{reason},
 		}
 		return
@@ -202,9 +229,15 @@ func FilterByAccountability(assets []graphquery.InventoryAsset, state string) []
 }
 
 func Summarize(assets []graphquery.InventoryAsset) Summary {
-	summary := Summary{TotalAssets: len(assets)}
+	summary := Summary{TotalAssets: len(assets), SurfaceCounts: map[string]int{}}
 	orgs := map[string]struct{}{}
+	ownerTrackableAssets := 0
 	for _, asset := range assets {
+		surface := inventorySurface(asset)
+		summary.SurfaceCounts[surface]++
+		if surface == graphquery.InventorySurfaceAsset {
+			ownerTrackableAssets++
+		}
 		ApplyReviewPosture(&asset)
 		state := strings.TrimSpace(asset.ScopeState)
 		if state == ScopeStateInScope {
@@ -216,7 +249,7 @@ func Summarize(assets []graphquery.InventoryAsset) Summary {
 		if asset.RiskScore >= 70 {
 			summary.HighRiskAssets++
 		}
-		if AssetOwner(asset) == "Unassigned" {
+		if surface == graphquery.InventorySurfaceAsset && AssetOwner(asset) == "Unassigned" {
 			summary.UnassignedAssets++
 		}
 		if asset.ReviewDisposition != nil {
@@ -247,7 +280,12 @@ func Summarize(assets []graphquery.InventoryAsset) Summary {
 	summary.OrgGroups = len(orgs)
 	if summary.TotalAssets > 0 {
 		summary.ScopedCoveragePct = int(float64(summary.InScopeAssets) / float64(summary.TotalAssets) * 100)
-		summary.AssignedCoveragePct = int(float64(summary.TotalAssets-summary.UnassignedAssets) / float64(summary.TotalAssets) * 100)
+	}
+	if ownerTrackableAssets > 0 {
+		summary.AssignedCoveragePct = int(float64(ownerTrackableAssets-summary.UnassignedAssets) / float64(ownerTrackableAssets) * 100)
+	}
+	if len(summary.SurfaceCounts) == 0 {
+		summary.SurfaceCounts = nil
 	}
 	return summary
 }
@@ -308,6 +346,22 @@ func AssetOrg(asset graphquery.InventoryAsset) string {
 
 func AssetPublic(asset graphquery.InventoryAsset) bool {
 	return attributeTruthy(asset, "public", "publicly_accessible", "internet_exposed", "external")
+}
+
+func inventorySurface(asset graphquery.InventoryAsset) string {
+	if strings.TrimSpace(asset.Surface) != "" {
+		return graphquery.NormalizeInventorySurface(asset.Surface)
+	}
+	return graphquery.InventorySurfaceForEntityType(asset.EntityType)
+}
+
+func supportingInventorySurface(surface string) bool {
+	switch graphquery.NormalizeInventorySurface(surface) {
+	case graphquery.InventorySurfaceComponent, graphquery.InventorySurfaceSignal, graphquery.InventorySurfaceAlias, graphquery.InventorySurfaceRawRecord:
+		return true
+	default:
+		return false
+	}
 }
 
 func hasActiveReport(asset graphquery.InventoryAsset) bool {

--- a/internal/grcinventory/posture_test.go
+++ b/internal/grcinventory/posture_test.go
@@ -1,0 +1,51 @@
+package grcinventory
+
+import (
+	"testing"
+
+	"github.com/writer/cerebro/internal/graphquery"
+)
+
+func TestSummarizeAssignmentCoverageUsesAssetSurfaceDenominator(t *testing.T) {
+	summary := Summarize([]graphquery.InventoryAsset{
+		{
+			URN:        "urn:cerebro:writer:aws_s3_bucket:bucket-a",
+			Surface:    graphquery.InventorySurfaceAsset,
+			ScopeState: ScopeStateInScope,
+			Attributes: map[string]string{AttributeAccountabilityPrincipal: "platform@example.com"},
+		},
+		{
+			URN:        "urn:cerebro:writer:aws_s3_bucket:bucket-b",
+			Surface:    graphquery.InventorySurfaceAsset,
+			ScopeState: ScopeStateInScope,
+			Attributes: map[string]string{},
+		},
+		{
+			URN:        "urn:cerebro:writer:sentinelone_installed_app:agent-1:app-1",
+			Surface:    graphquery.InventorySurfaceComponent,
+			ScopeState: ScopeStateInScope,
+			Attributes: map[string]string{},
+		},
+		{
+			URN:        "urn:cerebro:writer:aws_account_alias:prod",
+			Surface:    graphquery.InventorySurfaceAlias,
+			ScopeState: ScopeStateInScope,
+			Attributes: map[string]string{},
+		},
+	})
+	if summary.TotalAssets != 4 {
+		t.Fatalf("total_assets = %d, want full record count 4", summary.TotalAssets)
+	}
+	if summary.UnassignedAssets != 1 {
+		t.Fatalf("unassigned_assets = %d, want only the unowned asset row", summary.UnassignedAssets)
+	}
+	if summary.AssignedCoveragePct != 50 {
+		t.Fatalf("assigned_coverage_pct = %d, want 50", summary.AssignedCoveragePct)
+	}
+	if got := summary.SurfaceCounts[graphquery.InventorySurfaceComponent]; got != 1 {
+		t.Fatalf("surface_counts[component] = %d, want 1", got)
+	}
+	if got := summary.SurfaceCounts[graphquery.InventorySurfaceAlias]; got != 1 {
+		t.Fatalf("surface_counts[alias] = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add an inventory surface classifier with assets as the default view and supporting components, signals, aliases, raw records, and all-record views available by query parameter.
- Keep supporting records in inventory responses while marking them baseline and owner-not-required unless they have an active report.
- Expose the surface filter in the OpenAPI contract and include surface counts in the inventory summary.

## Verification
- make contracts-check
- go test ./internal/graphquery ./internal/grcinventory ./internal/bootstrap -count=1