### PR TITLE
Require indexed replay for finding rules

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -353,7 +353,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		findingEvaluationRunStore(deps.StateStore),
 		findingEvidenceStore(deps.StateStore),
 		claimStore(deps.StateStore),
-	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(findingGraphQueryStore(deps.GraphStore)).WithAppendLog(deps.AppendLog).WithGraphRuleQueryTimeout(graphRuleQueryBudgetForPhase(options.PhaseTimeout))
+	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(findingGraphQueryStore(deps.GraphStore)).WithAppendLog(deps.AppendLog).WithGraphRuleQueryTimeout(graphRuleQueryBudgetForPhase(options.PhaseTimeout)).WithRuntimeIndexReplayPreparer(cfg.AppendLog.JetStreamRuntimeIndexEnabled, deps.AppendLog, deps.StateStore)
 	graphService := graphingest.New(
 		registry,
 		lister,

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -53,6 +53,8 @@ const (
 	replayStrategyRuntimeIndex      = "runtime_index"
 )
 
+var errRuntimeReplayIndexRequired = errors.New("runtime replay index required")
+
 var waitBeforePublishRetryFunc = waitBeforePublishRetry
 
 type publisher interface {
@@ -726,14 +728,14 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	runtimeIndexEligible := runtimeIndexReplayEligible(request)
 	if requireRuntimeIndex && !runtimeIndexEligible {
 		scan = replayScanStats{strategy: replayStrategyRuntimeIndex, subjectFilterCount: len(subjectFilters)}
-		err = errors.New("runtime replay index required for ineligible replay request")
+		err = fmt.Errorf("%w: ineligible replay request", errRuntimeReplayIndexRequired)
 		recordJetStreamReplayMetrics(ctx, scan, "failed", jetstreamErrorCategory(err), time.Since(started), 0)
 		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(scan.attrs(limit, candidateLimit, ctx)))
 		return nil, err
 	}
 	if requireRuntimeIndex && l.runtimeIndex == nil {
 		scan = replayScanStats{strategy: replayStrategyRuntimeIndex, subjectFilterCount: len(subjectFilters)}
-		err = errors.New("runtime replay index required but not configured")
+		err = fmt.Errorf("%w: not configured", errRuntimeReplayIndexRequired)
 		recordJetStreamReplayMetrics(ctx, scan, "failed", jetstreamErrorCategory(err), time.Since(started), 0)
 		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(scan.attrs(limit, candidateLimit, ctx)))
 		return nil, err
@@ -745,9 +747,9 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		} else if requireRuntimeIndex {
 			scan = indexScan
 			if indexErr != nil {
-				err = fmt.Errorf("runtime replay index lookup: %w", indexErr)
+				err = fmt.Errorf("%w: lookup: %w", errRuntimeReplayIndexRequired, indexErr)
 			} else {
-				err = errors.New("runtime replay index required but unavailable")
+				err = fmt.Errorf("%w: unavailable", errRuntimeReplayIndexRequired)
 			}
 			recordJetStreamReplayMetrics(ctx, scan, "failed", jetstreamErrorCategory(err), time.Since(started), 0)
 			jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(scan.attrs(limit, candidateLimit, ctx)))

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -722,10 +722,36 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		return nil, nil
 	}
 	resolved := false
-	if l.runtimeIndex != nil && runtimeIndexReplayEligible(request) {
+	requireRuntimeIndex := request.RequireRuntimeIndex
+	runtimeIndexEligible := runtimeIndexReplayEligible(request)
+	if requireRuntimeIndex && !runtimeIndexEligible {
+		scan = replayScanStats{strategy: replayStrategyRuntimeIndex, subjectFilterCount: len(subjectFilters)}
+		err = errors.New("runtime replay index required for ineligible replay request")
+		recordJetStreamReplayMetrics(ctx, scan, "failed", jetstreamErrorCategory(err), time.Since(started), 0)
+		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(scan.attrs(limit, candidateLimit, ctx)))
+		return nil, err
+	}
+	if requireRuntimeIndex && l.runtimeIndex == nil {
+		scan = replayScanStats{strategy: replayStrategyRuntimeIndex, subjectFilterCount: len(subjectFilters)}
+		err = errors.New("runtime replay index required but not configured")
+		recordJetStreamReplayMetrics(ctx, scan, "failed", jetstreamErrorCategory(err), time.Since(started), 0)
+		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(scan.attrs(limit, candidateLimit, ctx)))
+		return nil, err
+	}
+	if l.runtimeIndex != nil && runtimeIndexEligible {
 		indexed, indexScan, ok, indexErr := replayRuntimeIndexed(ctx, l.runtimeIndex, stream.Config.Name, stream.State, streamRef, subjectFilters, useSubjectIndex, subjectPrefixes, request, candidateLimit)
 		if indexErr == nil && ok {
 			candidates, scan, resolved = indexed, indexScan, true
+		} else if requireRuntimeIndex {
+			scan = indexScan
+			if indexErr != nil {
+				err = fmt.Errorf("runtime replay index lookup: %w", indexErr)
+			} else {
+				err = errors.New("runtime replay index required but unavailable")
+			}
+			recordJetStreamReplayMetrics(ctx, scan, "failed", jetstreamErrorCategory(err), time.Since(started), 0)
+			jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(scan.attrs(limit, candidateLimit, ctx)))
+			return nil, err
 		}
 	}
 	if !resolved {
@@ -1253,6 +1279,7 @@ func jetstreamReplayRequestAttrs(request ports.ReplayRequest) telemetry.Attribut
 		telemetry.Field{Key: "replay.kind_prefix", Value: request.KindPrefix},
 		telemetry.Field{Key: "replay.kind_prefixes", Value: strings.Join(kindPrefixes, ",")},
 		telemetry.Field{Key: "replay.attribute_filter_keys", Value: strings.Join(filterKeys, ",")},
+		telemetry.Field{Key: "replay.require_runtime_index", Value: request.RequireRuntimeIndex},
 	)
 }
 
@@ -1630,13 +1657,14 @@ func normalizeReplayLimit(limit uint32) uint32 {
 
 func normalizeReplayRequest(req ports.ReplayRequest) ports.ReplayRequest {
 	normalized := ports.ReplayRequest{
-		RuntimeID:        strings.TrimSpace(req.RuntimeID),
-		KindPrefix:       strings.TrimSpace(req.KindPrefix),
-		KindPrefixes:     normalizeReplayKindPrefixes(req.KindPrefixes),
-		ExactKindFilters: req.ExactKindFilters,
-		TenantID:         strings.TrimSpace(req.TenantID),
-		AttributeEquals:  make(map[string]string, len(req.AttributeEquals)),
-		Limit:            req.Limit,
+		RuntimeID:           strings.TrimSpace(req.RuntimeID),
+		KindPrefix:          strings.TrimSpace(req.KindPrefix),
+		KindPrefixes:        normalizeReplayKindPrefixes(req.KindPrefixes),
+		ExactKindFilters:    req.ExactKindFilters,
+		RequireRuntimeIndex: req.RequireRuntimeIndex,
+		TenantID:            strings.TrimSpace(req.TenantID),
+		AttributeEquals:     make(map[string]string, len(req.AttributeEquals)),
+		Limit:               req.Limit,
 	}
 	for key, value := range req.AttributeEquals {
 		trimmedKey := strings.TrimSpace(key)

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -1608,6 +1608,70 @@ func TestReplayRuntimeIndexedFallsBackWhenUnavailable(t *testing.T) {
 	}
 }
 
+func TestReplayRequiresRuntimeIndexRejectsUnconfiguredIndex(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+				State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 2, Msgs: 2},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				2: rawReplayMsg(t, "events.github.audit", replayEvent("evt-2", "github.audit", "other-runtime")),
+			},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	_, err := log.Replay(context.Background(), ports.ReplayRequest{
+		RuntimeID:           "writer-github",
+		RequireRuntimeIndex: true,
+		Limit:               10,
+	})
+	if err == nil || !strings.Contains(err.Error(), "runtime replay index required but not configured") {
+		t.Fatalf("Replay() error = %v, want required runtime index configuration error", err)
+	}
+	if replay.getMsgCalls != 0 {
+		t.Fatalf("GetMsg calls = %d, want 0 fallback scans", replay.getMsgCalls)
+	}
+}
+
+func TestReplayRequiresRuntimeIndexRejectsUnavailableIndex(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+				State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 2, Msgs: 2},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				2: rawReplayMsg(t, "events.github.audit", replayEvent("evt-2", "github.audit", "other-runtime")),
+			},
+		},
+	}
+	index := &fakeRuntimeReplayIndex{result: ports.RuntimeIndexResult{Available: false}}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events", runtimeIndex: index}
+
+	_, err := log.Replay(context.Background(), ports.ReplayRequest{
+		RuntimeID:           "writer-github",
+		RequireRuntimeIndex: true,
+		Limit:               10,
+	})
+	if err == nil || !strings.Contains(err.Error(), "runtime replay index required but unavailable") {
+		t.Fatalf("Replay() error = %v, want unavailable runtime index error", err)
+	}
+	if index.calls != 1 {
+		t.Fatalf("index lookup calls = %d, want 1", index.calls)
+	}
+	if replay.getMsgCalls != 0 {
+		t.Fatalf("GetMsg calls = %d, want 0 fallback scans", replay.getMsgCalls)
+	}
+}
+
 func TestReplayRuntimeIndexedSkipsPurgedSequences(t *testing.T) {
 	replay := &fakeReplayManager{
 		streams: []*natsjetstream.StreamInfo{

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -1630,8 +1630,8 @@ func TestReplayRequiresRuntimeIndexRejectsUnconfiguredIndex(t *testing.T) {
 		RequireRuntimeIndex: true,
 		Limit:               10,
 	})
-	if err == nil || !strings.Contains(err.Error(), "runtime replay index required but not configured") {
-		t.Fatalf("Replay() error = %v, want required runtime index configuration error", err)
+	if !errors.Is(err, errRuntimeReplayIndexRequired) {
+		t.Fatalf("Replay() error = %v, want errRuntimeReplayIndexRequired", err)
 	}
 	if replay.getMsgCalls != 0 {
 		t.Fatalf("GetMsg calls = %d, want 0 fallback scans", replay.getMsgCalls)
@@ -1661,8 +1661,8 @@ func TestReplayRequiresRuntimeIndexRejectsUnavailableIndex(t *testing.T) {
 		RequireRuntimeIndex: true,
 		Limit:               10,
 	})
-	if err == nil || !strings.Contains(err.Error(), "runtime replay index required but unavailable") {
-		t.Fatalf("Replay() error = %v, want unavailable runtime index error", err)
+	if !errors.Is(err, errRuntimeReplayIndexRequired) {
+		t.Fatalf("Replay() error = %v, want errRuntimeReplayIndexRequired", err)
 	}
 	if index.calls != 1 {
 		t.Fatalf("index lookup calls = %d, want 1", index.calls)

--- a/internal/appendlogindex/indexer.go
+++ b/internal/appendlogindex/indexer.go
@@ -10,9 +10,17 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
-// DefaultMaxBatches bounds how many scan windows a single population run
-// advances before yielding, keeping each job invocation bounded.
-const DefaultMaxBatches = 20
+const (
+	// DefaultMaxBatches bounds how many scan windows a single population run
+	// advances before yielding, keeping each job invocation bounded.
+	DefaultMaxBatches = 20
+
+	// DefaultReplayPrepareBatch and DefaultReplayPrepareMaxBatches are larger
+	// than the maintenance-job defaults because user-facing evaluations need a
+	// bounded cold-start catch-up attempt before failing as still warming.
+	DefaultReplayPrepareBatch      = 5000
+	DefaultReplayPrepareMaxBatches = 200
+)
 
 // ErrWarming indicates that a bounded index preparation advanced the index but
 // did not catch up to the append-log tail in this invocation.
@@ -70,6 +78,12 @@ func Populate(ctx context.Context, source ports.RuntimeIndexSource, writer ports
 // evaluations. It stays bounded, so callers can retry instead of falling back to
 // broad stream scans while the index is still catching up.
 func PrepareReplay(ctx context.Context, source ports.RuntimeIndexSource, writer ports.RuntimeIndexWriter, batch uint32, maxBatches uint32) error {
+	if batch == 0 {
+		batch = DefaultReplayPrepareBatch
+	}
+	if maxBatches == 0 {
+		maxBatches = DefaultReplayPrepareMaxBatches
+	}
 	result, err := Populate(ctx, source, writer, batch, maxBatches)
 	if err != nil {
 		return err

--- a/internal/appendlogindex/indexer.go
+++ b/internal/appendlogindex/indexer.go
@@ -4,6 +4,8 @@ package appendlogindex
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -11,6 +13,10 @@ import (
 // DefaultMaxBatches bounds how many scan windows a single population run
 // advances before yielding, keeping each job invocation bounded.
 const DefaultMaxBatches = 20
+
+// ErrWarming indicates that a bounded index preparation advanced the index but
+// did not catch up to the append-log tail in this invocation.
+var ErrWarming = errors.New("append log runtime index is warming")
 
 // Result summarizes one population run.
 type Result struct {
@@ -58,4 +64,18 @@ func Populate(ctx context.Context, source ports.RuntimeIndexSource, writer ports
 		}
 	}
 	return result, nil
+}
+
+// PrepareReplay advances the runtime replay index before replay-backed
+// evaluations. It stays bounded, so callers can retry instead of falling back to
+// broad stream scans while the index is still catching up.
+func PrepareReplay(ctx context.Context, source ports.RuntimeIndexSource, writer ports.RuntimeIndexWriter, batch uint32, maxBatches uint32) error {
+	result, err := Populate(ctx, source, writer, batch, maxBatches)
+	if err != nil {
+		return err
+	}
+	if !result.CaughtUp {
+		return fmt.Errorf("%w: watermark %d after %d batches", ErrWarming, result.Watermark, result.Batches)
+	}
+	return nil
 }

--- a/internal/appendlogindex/indexer_test.go
+++ b/internal/appendlogindex/indexer_test.go
@@ -125,3 +125,28 @@ func TestPopulatePropagatesPutError(t *testing.T) {
 		t.Fatalf("Populate() error = %v, want put boom", err)
 	}
 }
+
+func TestPrepareReplaySucceedsWhenCaughtUp(t *testing.T) {
+	source := &fakeIndexSource{scans: []ports.RuntimeIndexScan{
+		{Entries: []ports.RuntimeIndexEntry{entry(1)}, Watermark: 100, CaughtUp: true},
+	}}
+	writer := &fakeIndexWriter{}
+
+	if err := PrepareReplay(context.Background(), source, writer, 0, 0); err != nil {
+		t.Fatalf("PrepareReplay() error = %v", err)
+	}
+}
+
+func TestPrepareReplayReturnsWarmingWhenStillBehind(t *testing.T) {
+	source := &fakeIndexSource{scans: []ports.RuntimeIndexScan{
+		{Entries: []ports.RuntimeIndexEntry{entry(1)}, Watermark: 100},
+	}}
+	writer := &fakeIndexWriter{}
+
+	if err := PrepareReplay(context.Background(), source, writer, 0, 1); !errors.Is(err, ErrWarming) {
+		t.Fatalf("PrepareReplay() error = %v, want ErrWarming", err)
+	}
+	if got := writer.putWatermarks; len(got) != 1 || got[0] != 100 {
+		t.Fatalf("put watermarks = %#v, want [100]", got)
+	}
+}

--- a/internal/appendlogindex/indexer_test.go
+++ b/internal/appendlogindex/indexer_test.go
@@ -9,12 +9,14 @@ import (
 )
 
 type fakeIndexSource struct {
-	scans []ports.RuntimeIndexScan
-	calls []uint64
+	scans   []ports.RuntimeIndexScan
+	calls   []uint64
+	batches []uint32
 }
 
-func (f *fakeIndexSource) ScanRuntimeIndex(_ context.Context, fromSeq uint64, _ uint32) (ports.RuntimeIndexScan, error) {
+func (f *fakeIndexSource) ScanRuntimeIndex(_ context.Context, fromSeq uint64, batch uint32) (ports.RuntimeIndexScan, error) {
 	f.calls = append(f.calls, fromSeq)
+	f.batches = append(f.batches, batch)
 	idx := len(f.calls) - 1
 	if idx < len(f.scans) {
 		return f.scans[idx], nil
@@ -134,6 +136,9 @@ func TestPrepareReplaySucceedsWhenCaughtUp(t *testing.T) {
 
 	if err := PrepareReplay(context.Background(), source, writer, 0, 0); err != nil {
 		t.Fatalf("PrepareReplay() error = %v", err)
+	}
+	if got := source.batches; len(got) != 1 || got[0] != DefaultReplayPrepareBatch {
+		t.Fatalf("scan batches = %#v, want default replay prepare batch %d", got, DefaultReplayPrepareBatch)
 	}
 }
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1522,7 +1522,7 @@ func (a *App) findingService() *findings.Service {
 }
 
 func (a *App) newFindingService() *findings.Service {
-	return newFindingWorkflowFeatureService(newFindingFeatureDeps(a.deps))
+	return newFindingWorkflowFeatureService(newFindingFeatureDeps(a.deps)).WithRuntimeIndexReplayPreparer(a.cfg.AppendLog.JetStreamRuntimeIndexEnabled, a.deps.AppendLog, a.deps.StateStore)
 }
 
 func (s *bootstrapService) findingCoreService() *findings.Service {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1526,15 +1526,15 @@ func (a *App) newFindingService() *findings.Service {
 }
 
 func (s *bootstrapService) findingCoreService() *findings.Service {
-	return newFindingCoreFeatureService(newFindingFeatureDeps(s.deps))
+	return newFindingCoreFeatureService(newFindingFeatureDeps(s.deps)).WithRuntimeIndexReplayPreparer(s.cfg.AppendLog.JetStreamRuntimeIndexEnabled, s.deps.AppendLog, s.deps.StateStore)
 }
 
 func (s *bootstrapService) findingCandidateService() *findings.Service {
-	return newFindingCandidateFeatureService(newFindingFeatureDeps(s.deps))
+	return newFindingCandidateFeatureService(newFindingFeatureDeps(s.deps)).WithRuntimeIndexReplayPreparer(s.cfg.AppendLog.JetStreamRuntimeIndexEnabled, s.deps.AppendLog, s.deps.StateStore)
 }
 
 func (s *bootstrapService) findingWorkflowService() *findings.Service {
-	return newFindingWorkflowFeatureService(newFindingFeatureDeps(s.deps))
+	return newFindingWorkflowFeatureService(newFindingFeatureDeps(s.deps)).WithRuntimeIndexReplayPreparer(s.cfg.AppendLog.JetStreamRuntimeIndexEnabled, s.deps.AppendLog, s.deps.StateStore)
 }
 
 const (

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -626,6 +626,8 @@ type recordingAppendLog struct {
 	replayRequests []ports.ReplayRequest
 	indexScans     []ports.RuntimeIndexScan
 	indexScanCalls int
+	enforceIndex   bool
+	indexReady     bool
 }
 
 func (s *recordingAppendLog) Ping(context.Context) error { return s.err }
@@ -641,6 +643,9 @@ func (s *recordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnv
 func (s *recordingAppendLog) Replay(_ context.Context, request ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
 	if s.err != nil {
 		return nil, s.err
+	}
+	if s.enforceIndex && request.RequireRuntimeIndex && !s.indexReady {
+		return nil, errors.New("runtime index required but not ready")
 	}
 	s.replayRequests = append(s.replayRequests, request)
 	source := s.events
@@ -676,7 +681,11 @@ func (s *recordingAppendLog) ScanRuntimeIndex(_ context.Context, fromSeq uint64,
 	s.indexScanCalls++
 	idx := s.indexScanCalls - 1
 	if idx < len(s.indexScans) {
-		return s.indexScans[idx], nil
+		scan := s.indexScans[idx]
+		if scan.Watermark > 0 {
+			s.indexReady = true
+		}
+		return scan, nil
 	}
 	return ports.RuntimeIndexScan{Watermark: fromSeq, CaughtUp: true}, nil
 }
@@ -5375,7 +5384,8 @@ func TestBootstrapServiceFindingCoreServicePreparesRuntimeIndexReplay(t *testing
 				replayEvents: []*cerebrov1.EventEnvelope{
 					findingPolicyRuleTestEvent("okta-policy-rule-inactive", "INACTIVE"),
 				},
-				indexScans: []ports.RuntimeIndexScan{{Watermark: 1, CaughtUp: true}},
+				indexScans:   []ports.RuntimeIndexScan{{Watermark: 1, CaughtUp: true}},
+				enforceIndex: true,
 			}
 			store := &stubRuntimeStore{
 				runtimes: map[string]*cerebrov1.SourceRuntime{
@@ -5417,6 +5427,64 @@ func TestBootstrapServiceFindingCoreServicePreparesRuntimeIndexReplay(t *testing
 			}
 			if !appendLog.replayRequests[0].RequireRuntimeIndex {
 				t.Fatal("replay request RequireRuntimeIndex = false, want true")
+			}
+		})
+	}
+}
+
+func TestBootstrapServiceFindingCoreServiceAllowsReplayWhenRuntimeIndexDisabled(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		service func(*bootstrapService) *findings.Service
+	}{
+		{name: "core", service: (*bootstrapService).findingCoreService},
+		{name: "candidate", service: (*bootstrapService).findingCandidateService},
+		{name: "workflow", service: (*bootstrapService).findingWorkflowService},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			appendLog := &recordingAppendLog{
+				replayEvents: []*cerebrov1.EventEnvelope{
+					findingPolicyRuleTestEvent("okta-policy-rule-inactive", "INACTIVE"),
+				},
+				enforceIndex: true,
+			}
+			store := &stubRuntimeStore{
+				runtimes: map[string]*cerebrov1.SourceRuntime{
+					"writer-okta-policy-rule": {
+						Id:       "writer-okta-policy-rule",
+						SourceId: "okta",
+						TenantId: "writer",
+						Config:   map[string]string{"family": "policy_rule"},
+					},
+				},
+				claims:                map[string]*ports.ClaimRecord{},
+				findings:              map[string]*ports.FindingRecord{},
+				findingEvidence:       map[string]*cerebrov1.FindingEvidence{},
+				findingEvaluationRuns: map[string]*cerebrov1.FindingEvaluationRun{},
+			}
+			service := tc.service(&bootstrapService{
+				cfg: config.Config{AppendLog: config.AppendLogConfig{JetStreamRuntimeIndexEnabled: false}},
+				deps: Dependencies{
+					AppendLog:  appendLog,
+					StateStore: store,
+				},
+			})
+
+			_, err := service.EvaluateSourceRuntimeRules(context.Background(), findings.EvaluateRulesRequest{
+				RuntimeID: "writer-okta-policy-rule",
+				RuleIDs:   []string{"identity-okta-policy-rule-lifecycle-tampering"},
+			})
+			if err != nil {
+				t.Fatalf("EvaluateSourceRuntimeRules() error = %v", err)
+			}
+			if appendLog.indexScanCalls != 0 {
+				t.Fatalf("runtime index scan calls = %d, want 0 when disabled", appendLog.indexScanCalls)
+			}
+			if len(appendLog.replayRequests) != 1 {
+				t.Fatalf("replay requests = %d, want 1", len(appendLog.replayRequests))
+			}
+			if appendLog.replayRequests[0].RequireRuntimeIndex {
+				t.Fatal("replay request RequireRuntimeIndex = true, want false when runtime index is disabled")
 			}
 		})
 	}

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -624,6 +624,8 @@ type recordingAppendLog struct {
 	events         []*cerebrov1.EventEnvelope
 	replayEvents   []*cerebrov1.EventEnvelope
 	replayRequests []ports.ReplayRequest
+	indexScans     []ports.RuntimeIndexScan
+	indexScanCalls int
 }
 
 func (s *recordingAppendLog) Ping(context.Context) error { return s.err }
@@ -670,6 +672,15 @@ func (s *recordingAppendLog) Replay(_ context.Context, request ports.ReplayReque
 	return events, nil
 }
 
+func (s *recordingAppendLog) ScanRuntimeIndex(_ context.Context, fromSeq uint64, _ uint32) (ports.RuntimeIndexScan, error) {
+	s.indexScanCalls++
+	idx := s.indexScanCalls - 1
+	if idx < len(s.indexScans) {
+		return s.indexScans[idx], nil
+	}
+	return ports.RuntimeIndexScan{Watermark: fromSeq, CaughtUp: true}, nil
+}
+
 func replayEventMatchesKindPrefixes(kind string, kindPrefix string, kindPrefixes []string) bool {
 	if strings.TrimSpace(kindPrefix) == "" && len(kindPrefixes) == 0 {
 		return true
@@ -713,6 +724,8 @@ type stubRuntimeStore struct {
 	findingCandidates               map[string]*ports.FindingCandidateRecord
 	findingCandidateListRequest     ports.ListFindingCandidatesRequest
 	reportRuns                      map[string]*cerebrov1.ReportRun
+	runtimeIndexWatermark           uint64
+	runtimeIndexWatermarks          []uint64
 }
 
 // leaseAwareRuntimeStore embeds stubRuntimeStore and additionally
@@ -753,6 +766,22 @@ func (s *leaseAwareRuntimeStore) ReleaseSourceRuntimeLease(_ context.Context, _ 
 }
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
+
+func (s *stubRuntimeStore) RuntimeIndexWatermark(context.Context) (uint64, error) {
+	if s.err != nil {
+		return 0, s.err
+	}
+	return s.runtimeIndexWatermark, nil
+}
+
+func (s *stubRuntimeStore) PutRuntimeIndexEntries(_ context.Context, _ []ports.RuntimeIndexEntry, watermark uint64) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.runtimeIndexWatermark = watermark
+	s.runtimeIndexWatermarks = append(s.runtimeIndexWatermarks, watermark)
+	return nil
+}
 
 func (s *stubRuntimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {
 	if s.err != nil {
@@ -5329,6 +5358,67 @@ func TestFindingRuleEndpoints(t *testing.T) {
 		if _, ok := connectRuleIDs[ruleID]; !ok {
 			t.Fatalf("ListFindingRules() missing %q in %#v", ruleID, connectRuleIDs)
 		}
+	}
+}
+
+func TestBootstrapServiceFindingCoreServicePreparesRuntimeIndexReplay(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		service func(*bootstrapService) *findings.Service
+	}{
+		{name: "core", service: (*bootstrapService).findingCoreService},
+		{name: "candidate", service: (*bootstrapService).findingCandidateService},
+		{name: "workflow", service: (*bootstrapService).findingWorkflowService},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			appendLog := &recordingAppendLog{
+				replayEvents: []*cerebrov1.EventEnvelope{
+					findingPolicyRuleTestEvent("okta-policy-rule-inactive", "INACTIVE"),
+				},
+				indexScans: []ports.RuntimeIndexScan{{Watermark: 1, CaughtUp: true}},
+			}
+			store := &stubRuntimeStore{
+				runtimes: map[string]*cerebrov1.SourceRuntime{
+					"writer-okta-policy-rule": {
+						Id:       "writer-okta-policy-rule",
+						SourceId: "okta",
+						TenantId: "writer",
+						Config:   map[string]string{"family": "policy_rule"},
+					},
+				},
+				claims:                map[string]*ports.ClaimRecord{},
+				findings:              map[string]*ports.FindingRecord{},
+				findingEvidence:       map[string]*cerebrov1.FindingEvidence{},
+				findingEvaluationRuns: map[string]*cerebrov1.FindingEvaluationRun{},
+			}
+			service := tc.service(&bootstrapService{
+				cfg: config.Config{AppendLog: config.AppendLogConfig{JetStreamRuntimeIndexEnabled: true}},
+				deps: Dependencies{
+					AppendLog:  appendLog,
+					StateStore: store,
+				},
+			})
+
+			_, err := service.EvaluateSourceRuntimeRules(context.Background(), findings.EvaluateRulesRequest{
+				RuntimeID: "writer-okta-policy-rule",
+				RuleIDs:   []string{"identity-okta-policy-rule-lifecycle-tampering"},
+			})
+			if err != nil {
+				t.Fatalf("EvaluateSourceRuntimeRules() error = %v", err)
+			}
+			if appendLog.indexScanCalls != 1 {
+				t.Fatalf("runtime index scan calls = %d, want 1", appendLog.indexScanCalls)
+			}
+			if got := store.runtimeIndexWatermarks; len(got) != 1 || got[0] != 1 {
+				t.Fatalf("runtime index watermarks = %#v, want [1]", got)
+			}
+			if len(appendLog.replayRequests) != 1 {
+				t.Fatalf("replay requests = %d, want 1", len(appendLog.replayRequests))
+			}
+			if !appendLog.replayRequests[0].RequireRuntimeIndex {
+				t.Fatal("replay request RequireRuntimeIndex = false, want true")
+			}
+		})
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -559,7 +559,7 @@ func Load() (Config, error) {
 	if cfg.AppendLog.JetStreamPublishMaxInFlight, err = parseIntEnv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", 0); err != nil {
 		return Config{}, err
 	}
-	if cfg.AppendLog.JetStreamRuntimeIndexEnabled, err = parseBoolEnv("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED"); err != nil {
+	if cfg.AppendLog.JetStreamRuntimeIndexEnabled, err = parseBoolEnvDefault("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED", true); err != nil {
 		return Config{}, err
 	}
 	if cfg.AppendLog.JetStreamPublishRetryAttempts, err = parseIntEnv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", 0); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.AppendLog.Driver != "" {
 		t.Fatalf("AppendLog.Driver = %q, want empty", cfg.AppendLog.Driver)
 	}
+	if !cfg.AppendLog.JetStreamRuntimeIndexEnabled {
+		t.Fatal("AppendLog.JetStreamRuntimeIndexEnabled = false, want true default")
+	}
 	if cfg.StateStore.Driver != "" {
 		t.Fatalf("StateStore.Driver = %q, want empty", cfg.StateStore.Driver)
 	}
@@ -384,6 +387,19 @@ func TestLoadFromEnv(t *testing.T) {
 		cfg.ConnectorSecretStores.AWSSecretsManager.ExternalID != "external-writer" ||
 		cfg.ConnectorSecretStores.AWSSecretsManager.Endpoint != "http://127.0.0.1:4566" {
 		t.Fatalf("ConnectorSecretStores.AWSSecretsManager = %#v", cfg.ConnectorSecretStores.AWSSecretsManager)
+	}
+}
+
+func TestLoadAllowsDisablingJetStreamRuntimeIndex(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED", "false")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.AppendLog.JetStreamRuntimeIndexEnabled {
+		t.Fatal("JetStreamRuntimeIndexEnabled = true, want false when explicitly disabled")
 	}
 }
 

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -156,6 +156,10 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 	}
 	var events []*cerebrov1.EventEnvelope
 	if rulesNeedReplay(runtime, ruleEvaluationStatesFromCandidateStates(states)) {
+		if err := s.prepareReplay(ctx); err != nil {
+			evaluationErr := fmt.Errorf("prepare replay runtime %q events for candidates: %w", runtimeID, err)
+			return nil, s.markCandidateEvaluationsFailed(ctx, states, evaluationErr)
+		}
 		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, rulesFromCandidateStates(states)))
 		if err != nil {
 			evaluationErr := fmt.Errorf("replay runtime %q events for candidates: %w", runtimeID, err)

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -160,7 +160,7 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 			evaluationErr := fmt.Errorf("prepare replay runtime %q events for candidates: %w", runtimeID, err)
 			return nil, s.markCandidateEvaluationsFailed(ctx, states, evaluationErr)
 		}
-		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, rulesFromCandidateStates(states)))
+		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, rulesFromCandidateStates(states), s.requireRuntimeIndexReplay))
 		if err != nil {
 			evaluationErr := fmt.Errorf("replay runtime %q events for candidates: %w", runtimeID, err)
 			return nil, s.markCandidateEvaluationsFailed(ctx, states, evaluationErr)

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -64,6 +64,7 @@ type Service struct {
 	runtimeStore              ports.SourceRuntimeStore
 	replayer                  ports.EventReplayer
 	replayPreparer            ReplayPreparer
+	requireRuntimeIndexReplay bool
 	store                     ports.FindingStore
 	runStore                  ports.FindingEvaluationRunStore
 	evidenceStore             ports.FindingEvidenceStore
@@ -277,6 +278,7 @@ func (s *Service) WithRuntimeIndexReplayPreparer(enabled bool, appendLog ports.A
 	if s == nil || !enabled {
 		return s
 	}
+	s.requireRuntimeIndexReplay = true
 	source, sourceOK := appendLog.(ports.RuntimeIndexSource)
 	writer, writerOK := stateStore.(ports.RuntimeIndexWriter)
 	return s.WithReplayPreparer(func(ctx context.Context) error {
@@ -386,7 +388,7 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 			evaluationErr := fmt.Errorf("prepare replay runtime %q events: %w", runtimeID, err)
 			return nil, s.finishFailedRun(ctx, run, 0, 0, nil, evaluationErr)
 		}
-		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, []Rule{rule}))
+		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, []Rule{rule}, s.requireRuntimeIndexReplay))
 		if err != nil {
 			evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
 			return nil, s.finishFailedRun(ctx, run, 0, 0, nil, evaluationErr)
@@ -524,7 +526,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 			evaluationErr := fmt.Errorf("prepare replay runtime %q events: %w", runtimeID, err)
 			return nil, s.markRuleEvaluationsFailed(ctx, states, evaluationErr)
 		}
-		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, rulesFromEvaluationStates(states)))
+		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, rulesFromEvaluationStates(states), s.requireRuntimeIndexReplay))
 		if err != nil {
 			evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
 			return nil, s.markRuleEvaluationsFailed(ctx, states, evaluationErr)
@@ -642,10 +644,10 @@ func rulesNeedReplay(runtime *cerebrov1.SourceRuntime, states []*ruleEvaluationS
 	return false
 }
 
-func replayRequestForRules(runtime *cerebrov1.SourceRuntime, runtimeID string, limit uint32, rules []Rule) ports.ReplayRequest {
+func replayRequestForRules(runtime *cerebrov1.SourceRuntime, runtimeID string, limit uint32, rules []Rule, requireRuntimeIndex bool) ports.ReplayRequest {
 	request := ports.ReplayRequest{
 		RuntimeID:           strings.TrimSpace(runtimeID),
-		RequireRuntimeIndex: true,
+		RequireRuntimeIndex: requireRuntimeIndex,
 		Limit:               limit,
 	}
 	kindPrefixes := replayExactKindFiltersForRules(runtime, rules)

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/appendlogindex"
 	"github.com/writer/cerebro/internal/findingevidence"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/telemetry"
@@ -62,6 +63,7 @@ var (
 type Service struct {
 	runtimeStore              ports.SourceRuntimeStore
 	replayer                  ports.EventReplayer
+	replayPreparer            ReplayPreparer
 	store                     ports.FindingStore
 	runStore                  ports.FindingEvaluationRunStore
 	evidenceStore             ports.FindingEvidenceStore
@@ -78,6 +80,10 @@ type Service struct {
 	ttlClock                  ttlClock
 	ttlLogSink                ttlLogSink
 }
+
+// ReplayPreparer runs before replay-backed finding evaluation to make required
+// replay indexes ready without hiding failures behind fallback scans.
+type ReplayPreparer func(context.Context) error
 
 // defaultGraphRuleQueryTimeout bounds a single graph rule's Cypher read so one
 // pathological rule cannot consume the entire orchestrator phase budget. A stuck
@@ -256,6 +262,44 @@ func (s *Service) WithAppendLog(appendLog ports.AppendLog) *Service {
 	return s
 }
 
+// WithReplayPreparer wires an optional pre-replay readiness hook.
+func (s *Service) WithReplayPreparer(preparer ReplayPreparer) *Service {
+	if s == nil {
+		return nil
+	}
+	s.replayPreparer = preparer
+	return s
+}
+
+// WithRuntimeIndexReplayPreparer wires the runtime-index warmup required by
+// replay-backed rules when JetStream runtime indexing is enabled.
+func (s *Service) WithRuntimeIndexReplayPreparer(enabled bool, appendLog ports.AppendLog, stateStore ports.StateStore) *Service {
+	if s == nil || !enabled {
+		return s
+	}
+	source, sourceOK := appendLog.(ports.RuntimeIndexSource)
+	writer, writerOK := stateStore.(ports.RuntimeIndexWriter)
+	return s.WithReplayPreparer(func(ctx context.Context) error {
+		if !sourceOK || source == nil {
+			return fmt.Errorf("%w: append log does not support runtime indexing", ErrRuntimeUnavailable)
+		}
+		if !writerOK || writer == nil {
+			return fmt.Errorf("%w: state store does not support runtime indexing", ErrRuntimeUnavailable)
+		}
+		if err := appendlogindex.PrepareReplay(ctx, source, writer, 0, 0); err != nil {
+			return fmt.Errorf("prepare append log runtime index: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *Service) prepareReplay(ctx context.Context) error {
+	if s == nil || s.replayPreparer == nil {
+		return nil
+	}
+	return s.replayPreparer(ctx)
+}
+
 // WithFindingCandidateStore wires the isolated candidate-finding persistence
 // boundary. Candidate evaluations do not write production findings until an
 // explicit promotion call uses the production store.
@@ -338,6 +382,10 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	}
 	var events []*cerebrov1.EventEnvelope
 	if rule.SupportsRuntime(runtime) {
+		if err := s.prepareReplay(ctx); err != nil {
+			evaluationErr := fmt.Errorf("prepare replay runtime %q events: %w", runtimeID, err)
+			return nil, s.finishFailedRun(ctx, run, 0, 0, nil, evaluationErr)
+		}
 		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, []Rule{rule}))
 		if err != nil {
 			evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
@@ -472,6 +520,10 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 	}
 	var events []*cerebrov1.EventEnvelope
 	if rulesNeedReplay(runtime, states) {
+		if err := s.prepareReplay(ctx); err != nil {
+			evaluationErr := fmt.Errorf("prepare replay runtime %q events: %w", runtimeID, err)
+			return nil, s.markRuleEvaluationsFailed(ctx, states, evaluationErr)
+		}
 		events, err = s.replayer.Replay(ctx, replayRequestForRules(runtime, runtimeID, normalizedLimit, rulesFromEvaluationStates(states)))
 		if err != nil {
 			evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -592,8 +592,9 @@ func rulesNeedReplay(runtime *cerebrov1.SourceRuntime, states []*ruleEvaluationS
 
 func replayRequestForRules(runtime *cerebrov1.SourceRuntime, runtimeID string, limit uint32, rules []Rule) ports.ReplayRequest {
 	request := ports.ReplayRequest{
-		RuntimeID: strings.TrimSpace(runtimeID),
-		Limit:     limit,
+		RuntimeID:           strings.TrimSpace(runtimeID),
+		RequireRuntimeIndex: true,
+		Limit:               limit,
 	}
 	kindPrefixes := replayExactKindFiltersForRules(runtime, rules)
 	if len(kindPrefixes) > 0 {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -880,7 +880,7 @@ func TestReplayExactKindFiltersForRulesIntersectRuntimeKind(t *testing.T) {
 		},
 	}
 
-	request := replayRequestForRules(runtime, runtime.GetId(), 25, rules)
+	request := replayRequestForRules(runtime, runtime.GetId(), 25, rules, true)
 	if !request.ExactKindFilters {
 		t.Fatal("ExactKindFilters = false, want true")
 	}

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -893,6 +893,9 @@ func TestReplayExactKindFiltersForRulesIntersectRuntimeKind(t *testing.T) {
 	if got := request.Limit; got != uint32(25) {
 		t.Fatalf("Limit = %d, want 25", got)
 	}
+	if !request.RequireRuntimeIndex {
+		t.Fatal("RequireRuntimeIndex = false, want true")
+	}
 }
 
 func TestReplayExactKindFiltersForRulesRequireSupportingRuleCoverage(t *testing.T) {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2867,6 +2867,87 @@ func TestEvaluateSourceRuntimeRulesReplaysOnceAcrossMultipleRules(t *testing.T) 
 	}
 }
 
+func TestEvaluateSourceRuntimeRulesPreparesReplayBeforeReplaying(t *testing.T) {
+	registry, err := NewRegistry(&emittingRule{
+		spec:               &cerebrov1.RuleSpec{Id: "rule-a", Name: "Rule A"},
+		supportedSourceIDs: map[string]struct{}{"okta": {}},
+		triggerEventID:     "okta-audit-1",
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	replayer := &stubReplayer{}
+	store := &stubFindingStore{}
+	prepareCalls := 0
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		replayer,
+		store,
+		store,
+		store,
+		store,
+		registry,
+	).WithReplayPreparer(func(context.Context) error {
+		prepareCalls++
+		return nil
+	})
+
+	if _, err := service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "writer-okta-audit"}); err != nil {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v", err)
+	}
+	if prepareCalls != 1 {
+		t.Fatalf("prepare calls = %d, want 1", prepareCalls)
+	}
+	if replayer.calls != 1 {
+		t.Fatalf("Replay() calls = %d, want 1", replayer.calls)
+	}
+}
+
+func TestEvaluateSourceRuntimeRulesDoesNotReplayWhenPrepareFails(t *testing.T) {
+	registry, err := NewRegistry(&emittingRule{
+		spec:               &cerebrov1.RuleSpec{Id: "rule-a", Name: "Rule A"},
+		supportedSourceIDs: map[string]struct{}{"okta": {}},
+		triggerEventID:     "okta-audit-1",
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	prepareErr := errors.New("runtime index warming")
+	replayer := &stubReplayer{err: errors.New("unexpected replay")}
+	store := &stubFindingStore{}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		replayer,
+		store,
+		store,
+		store,
+		store,
+		registry,
+	).WithReplayPreparer(func(context.Context) error {
+		return prepareErr
+	})
+
+	_, err = service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "writer-okta-audit"})
+	if !errors.Is(err, prepareErr) {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v, want %v", err, prepareErr)
+	}
+	if replayer.calls != 0 {
+		t.Fatalf("Replay() calls = %d, want 0", replayer.calls)
+	}
+	if got := len(store.runs); got != 1 {
+		t.Fatalf("len(store.runs) = %d, want 1 failed run", got)
+	}
+	for _, run := range store.runs {
+		if run.GetStatus() != "failed" {
+			t.Fatalf("run status = %q, want failed", run.GetStatus())
+		}
+	}
+}
+
 func TestEvaluateSourceRuntimeCandidateRulesDoesNotWriteProductionFindings(t *testing.T) {
 	registry, err := NewRegistry(&emittingRule{
 		spec:               &cerebrov1.RuleSpec{Id: "rule-a", Name: "Rule A"},

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -17,13 +17,14 @@ type AppendLog interface {
 
 // ReplayRequest scopes a bounded event replay from the append log.
 type ReplayRequest struct {
-	RuntimeID        string
-	KindPrefix       string
-	KindPrefixes     []string
-	ExactKindFilters bool
-	TenantID         string
-	AttributeEquals  map[string]string
-	Limit            uint32
+	RuntimeID           string
+	KindPrefix          string
+	KindPrefixes        []string
+	ExactKindFilters    bool
+	RequireRuntimeIndex bool
+	TenantID            string
+	AttributeEquals     map[string]string
+	Limit               uint32
 }
 
 // EventReplayer replays stored event envelopes from the append log.


### PR DESCRIPTION
## Summary
- require runtime-indexed append-log replay for finding-rule evaluations
- fail fast when required runtime-index replay is unavailable instead of falling back to broad scans
- enable the JetStream runtime replay index by default, with an explicit env override to disable it

## Tests
- make -C /Users/jonathan/cerebro test
- make -C /Users/jonathan/cerebro lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->