### PR TITLE
Add inventory surface guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,14 @@
 - Do not hand-edit generated or contract-governed outputs without running `make contracts-check` or the matching focused `Makefile` check/sync target.
 - Public-facing config/example changes should run `make oss-audit`; generated docs changes should also run `make docs-drift-check`.
 
+## API Defaults And Inventory Surfaces
+
+- Preserve omitted query-parameter behavior for existing public endpoints. If a view needs a narrower default, make the client send the narrowing parameter explicitly instead of changing the server's omitted-parameter semantics.
+- For inventory endpoints, omitted `surface` means all records for API compatibility. The review queue and inventory UI must request `surface=asset` when they need reviewable assets only.
+- Inventory surface classification should be an explicit allowlist. Do not use broad suffix rules such as `.alert`, `_alert`, `.finding`, `_finding`, `.threat`, `_threat`, `.evidence`, `_evidence`, `.advisory`, or `_advisory` to demote future entity types out of the asset surface.
+- Metrics over mixed inventory records must use a denominator from the same population as the numerator. Owner/accountability coverage is asset-surface coverage; supporting records belong in `surface_counts` and record totals, not the owner-required denominator.
+- When changing inventory surface behavior, add focused tests for omitted `surface`, explicit `surface=asset`, unknown future entity types, and mixed-surface summaries. Run `go test ./internal/graphquery ./internal/grcinventory ./internal/bootstrap -count=1`, `make check-structural check-structural-test check-arch`, and `make contracts-check`.
+
 ## Public PR Data Safety
 
 - Treat public PR titles, descriptions, comments, commit messages, and check summaries as public internet content.

--- a/tools/archtests/inventory_surface_guardrails_test.go
+++ b/tools/archtests/inventory_surface_guardrails_test.go
@@ -1,0 +1,85 @@
+package archtests
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/graphquery"
+)
+
+func TestInventorySurfaceDefaultsRemainCompatible(t *testing.T) {
+	if got := graphquery.NormalizeInventorySurface(""); got != graphquery.InventorySurfaceAll {
+		t.Fatalf("omitted inventory surface = %q, want %q for API compatibility", got, graphquery.InventorySurfaceAll)
+	}
+	if got := graphquery.NormalizeInventorySurface("unknown"); got != graphquery.InventorySurfaceAsset {
+		t.Fatalf("unknown inventory surface = %q, want conservative %q", got, graphquery.InventorySurfaceAsset)
+	}
+}
+
+func TestInventorySurfaceClassifierKeepsFutureSignalNamesReviewable(t *testing.T) {
+	for _, entityType := range []string{"custom_vendor.alert", "internal.finding", "partner_threat"} {
+		if got := graphquery.InventorySurfaceForEntityType(entityType); got != graphquery.InventorySurfaceAsset {
+			t.Fatalf("future entity type %q surface = %q, want %q until explicitly allowlisted", entityType, got, graphquery.InventorySurfaceAsset)
+		}
+	}
+	for _, entityType := range []string{"aws.securityhub.finding", "panopticon.alert", "github.secret_scanning_alert"} {
+		if got := graphquery.InventorySurfaceForEntityType(entityType); got != graphquery.InventorySurfaceSignal {
+			t.Fatalf("known signal entity type %q surface = %q, want %q", entityType, got, graphquery.InventorySurfaceSignal)
+		}
+	}
+}
+
+func TestInventorySurfaceRulesDoNotUseBroadSuffixDemotion(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, "internal", "graphquery", "inventory_surface.go")
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse inventory_surface.go: %v", err)
+	}
+	forbidden := map[string]struct{}{
+		".alert": {}, "_alert": {},
+		".advisory": {}, "_advisory": {},
+		".evidence": {}, "_evidence": {},
+		".finding": {}, "_finding": {},
+		".threat": {}, "_threat": {},
+	}
+	ast.Inspect(file, func(node ast.Node) bool {
+		value, ok := inventorySurfaceStringLiteralValue(node)
+		if !ok {
+			return true
+		}
+		if _, blocked := forbidden[value]; blocked {
+			t.Fatalf("inventory surface string literal %q is too broad; add exact or narrow prefix rules instead", value)
+		}
+		return true
+	})
+}
+
+func TestInventorySurfaceOpenAPIDocumentsOmittedAllRecords(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "api", "openapi.yaml"))
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	if !strings.Contains(string(body), "description: Inventory record surface. Omit for all records; pass asset for reviewable assets only.") {
+		t.Fatal("inventory surface OpenAPI parameter must document omitted surface as all records and asset as the reviewable-asset filter")
+	}
+}
+
+func inventorySurfaceStringLiteralValue(node ast.Node) (string, bool) {
+	basic, ok := node.(*ast.BasicLit)
+	if !ok || basic.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(basic.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}


### PR DESCRIPTION
## Summary
- document inventory surface API defaults in AGENTS.md
- add arch tests for omitted surface behavior, future entity type classification, broad suffix rules, and OpenAPI documentation

## Tests
- go test ./internal/graphquery ./internal/grcinventory ./internal/bootstrap -count=1
- make check-structural check-structural-test check-arch
- make contracts-check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->