### PR TITLE
[codex] fix github app token unavailable runtimes

### DIFF
--- a/internal/sourcehttp/github_app_auth.go
+++ b/internal/sourcehttp/github_app_auth.go
@@ -48,6 +48,21 @@ type githubAppInstallationTokenResponse struct {
 	ExpiresAt time.Time `json:"expires_at"`
 }
 
+type GitHubAppInstallationTokenHTTPError struct {
+	StatusCode int
+}
+
+func (err *GitHubAppInstallationTokenHTTPError) Error() string {
+	return fmt.Sprintf("github app installation token request returned HTTP %d", err.StatusCode)
+}
+
+func (err *GitHubAppInstallationTokenHTTPError) HTTPStatus() int {
+	if err == nil {
+		return 0
+	}
+	return err.StatusCode
+}
+
 func (cfg GitHubAppAuthConfig) Configured() bool {
 	return cfg.AppID != "" && cfg.InstallationID != "" && (cfg.PrivateKey != "" || cfg.PrivateKeyBase64 != "")
 }
@@ -134,7 +149,7 @@ func (rt *githubAppTokenTransport) installationToken(ctx context.Context) (strin
 	defer func() { _ = resp.Body.Close() }()
 	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("github app installation token request returned HTTP %d", resp.StatusCode)
+		return "", &GitHubAppInstallationTokenHTTPError{StatusCode: resp.StatusCode}
 	}
 	if readErr != nil {
 		return "", fmt.Errorf("read github app installation token response: %w", readErr)

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -1378,6 +1378,52 @@ func TestGitHubProviderUnavailableDoesNotFailGraphRuntimeFamilies(t *testing.T) 
 	}
 }
 
+func TestGitHubAppInstallationTokenUnavailableDoesNotFailRepositoryRuntime(t *testing.T) {
+	privateKey := testGitHubAppPrivateKeyPEM(t)
+	tokenRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v3/app/installations/123/access_tokens" {
+			tokenRequests++
+			http.NotFound(w, r)
+			return
+		}
+		t.Fatalf("unexpected GitHub API request after failed app token fetch: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"app_id":          "42",
+		"base_url":        server.URL,
+		"family":          familyRepository,
+		"installation_id": "123",
+		"owner":           "writer",
+		"private_key":     privateKey,
+	})
+
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check(repository app token unavailable) error = %v", err)
+	}
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(repository app token unavailable) error = %v", err)
+	}
+	if len(pull.Events) != 0 {
+		t.Fatalf("len(pull.Events) = %d, want 0", len(pull.Events))
+	}
+	if pull.ShortCircuitReason != sourcecdk.PullShortCircuitReasonNotModified {
+		t.Fatalf("ShortCircuitReason = %q, want not_modified", pull.ShortCircuitReason)
+	}
+	if tokenRequests < 2 {
+		t.Fatalf("installation token requests = %d, want check and read attempts", tokenRequests)
+	}
+}
+
 func TestGitHubPullRequestOwnerUnavailableStillFails(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sources/internal/githubapi/errors.go
+++ b/sources/internal/githubapi/errors.go
@@ -31,10 +31,15 @@ func ProviderUnavailable(err error) bool {
 
 func ErrorStatus(err error) (int, bool) {
 	var apiErr *gogithub.ErrorResponse
-	if !errors.As(err, &apiErr) || apiErr.Response == nil {
-		return 0, false
+	if errors.As(err, &apiErr) && apiErr.Response != nil {
+		return apiErr.Response.StatusCode, true
 	}
-	return apiErr.Response.StatusCode, true
+	var statusErr interface{ HTTPStatus() int }
+	if errors.As(err, &statusErr) {
+		status := statusErr.HTTPStatus()
+		return status, status > 0
+	}
+	return 0, false
 }
 
 func LookupError(subject string, err error) error {


### PR DESCRIPTION
Summary
- Preserve HTTP status on GitHub App installation-token failures.
- Teach GitHub provider-unavailable handling to recognize wrapped status-bearing auth errors.
- Add a regression for repository graph runtimes when app-token lookup returns 404.

Root cause
- Sec-dev GitHub graph runtimes were still failing because GitHub App installation-token 404s happen inside the auth transport, before go-github can return its normal ErrorResponse type. The graph runtime fallback only recognized go-github response statuses, so these provider-unavailable token failures escaped as source runtime failures.

Validation
- go test ./internal/sourcehttp ./sources/internal/githubapi ./sources/internal/githubcanary ./sources/github -count=1
- make check-structural check-structural-test check-arch
- git diff --check