### PR TITLE
[codex] Treat GitHub audit app-token 404 as unavailable

### DIFF
--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -50,7 +50,7 @@ type auditPayload struct {
 func (s *Source) checkAudit(ctx context.Context, client *gogithub.Client, settings settings) error {
 	_, _, err := githubaudit.GetAuditLog(ctx, client, settings.owner, githubaudit.Options(settings.auditInclude, settings.auditPhrase, settings.auditOrder, "", 1))
 	if err != nil {
-		return githubapi.LookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
+		return githubapi.ProviderUnavailableLookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err, settings.hasAuth())
 	}
 	return nil
 }
@@ -72,7 +72,7 @@ func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, setting
 			return githubaudit.GetAuditLog(ctx, client, settings.owner, opts)
 		})
 		if err != nil {
-			return sourcecdk.ChangeProbe{}, githubapi.LookupError(fmt.Sprintf("github audit log canary for org %s", settings.owner), err)
+			return sourcecdk.ChangeProbe{}, githubapi.ProviderUnavailableLookupError(fmt.Sprintf("github audit log canary for org %s", settings.owner), err, settings.hasAuth())
 		}
 		return probe, nil
 	}, githubaudit.FreshnessReadOptions())

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -1424,6 +1424,52 @@ func TestGitHubAppInstallationTokenUnavailableDoesNotFailRepositoryRuntime(t *te
 	}
 }
 
+func TestGitHubAppInstallationTokenUnavailableDoesNotFailAuditRuntime(t *testing.T) {
+	privateKey := testGitHubAppPrivateKeyPEM(t)
+	tokenRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v3/app/installations/123/access_tokens" {
+			tokenRequests++
+			http.NotFound(w, r)
+			return
+		}
+		t.Fatalf("unexpected GitHub API request after failed app token fetch: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"app_id":          "42",
+		"base_url":        server.URL,
+		"family":          familyAudit,
+		"installation_id": "123",
+		"owner":           "writer",
+		"private_key":     privateKey,
+	})
+
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check(audit app token unavailable) error = %v", err)
+	}
+	pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(audit app token unavailable) error = %v", err)
+	}
+	if len(pull.Events) != 0 {
+		t.Fatalf("len(pull.Events) = %d, want 0", len(pull.Events))
+	}
+	if pull.ShortCircuitReason != sourcecdk.PullShortCircuitReasonNotModified {
+		t.Fatalf("ShortCircuitReason = %q, want not_modified", pull.ShortCircuitReason)
+	}
+	if tokenRequests < 2 {
+		t.Fatalf("installation token requests = %d, want check and read attempts", tokenRequests)
+	}
+}
+
 func TestGitHubPullRequestOwnerUnavailableStillFails(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sources/internal/githubaudit/client.go
+++ b/sources/internal/githubaudit/client.go
@@ -2,10 +2,10 @@ package githubaudit
 
 import (
 	"context"
-	"errors"
-	"net/http"
 
 	gogithub "github.com/google/go-github/v66/github"
+
+	"github.com/writer/cerebro/sources/internal/githubapi"
 )
 
 // GetAuditLog fetches an audit-log page and treats unavailable audit-log
@@ -19,14 +19,5 @@ func GetAuditLog(ctx context.Context, client *gogithub.Client, owner string, opt
 }
 
 func AuditLogUnavailable(err error) bool {
-	var apiErr *gogithub.ErrorResponse
-	if !errors.As(err, &apiErr) || apiErr.Response == nil {
-		return false
-	}
-	switch apiErr.Response.StatusCode {
-	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
-		return true
-	default:
-		return false
-	}
+	return githubapi.ProviderUnavailable(err)
 }


### PR DESCRIPTION
## Summary
- make GitHub audit-log unavailable detection use the shared `githubapi.ProviderUnavailable` helper so GitHub App installation-token 401/403/404 errors are handled like audit endpoint 401/403/404s
- wrap audit check/canary errors with the provider-unavailable helper
- add a regression for audit runtime GitHub App installation-token 404 returning an empty/not-modified pull

## Root cause
The sec-dev graph-health follow-up was down to one runtime, `writer-github-audit-writerinternal`. Its focused backfill failed because the audit path still treated the auth transport's GitHub App installation-token HTTP 404 as a hard audit-log failure:

`source runtime 0: github audit log for org WriterInternal not found: Get ... github app installation token ... returned HTTP 404`

Repository/org/secret-scanning families were already covered by the previous fix; audit had its own helper that only recognized `go-github` response errors.

## Validation
- `go test ./internal/sourcehttp ./sources/internal/githubapi ./sources/internal/githubaudit ./sources/internal/githubcanary ./sources/github -count=1`
- `make check-structural check-structural-test check-arch`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->