### PR TITLE
fix: require trusted preference user identity

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4363,6 +4363,8 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
+        '401':
+          description: Authenticated user identity is required.
     put:
       summary: Save current user preferences
       tags:
@@ -4411,6 +4413,8 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
+        '401':
+          description: Authenticated user identity is required.
 
 components:
   securitySchemes:

--- a/internal/bootstrap/custom_dashboards.go
+++ b/internal/bootstrap/custom_dashboards.go
@@ -22,5 +22,5 @@ func userPreferenceActorID(ctx context.Context) string {
 			return name
 		}
 	}
-	return "anonymous"
+	return ""
 }

--- a/internal/bootstrap/custom_dashboards_test.go
+++ b/internal/bootstrap/custom_dashboards_test.go
@@ -82,6 +82,26 @@ func customDashboardTestHandler(app *App) *customdashboards.Handler {
 	return customdashboards.NewHandler(app.deps.StateStore, effectiveTenantFilter, authorizeTenantID, customDashboardActorID)
 }
 
+func TestUserPreferenceActorIDRequiresHumanPrincipal(t *testing.T) {
+	humanContext := context.WithValue(context.Background(), authContextKey{}, authContext{
+		principal: authPrincipal{Name: "person@example.test", ClientID: "client-1"},
+	})
+	if got := userPreferenceActorID(humanContext); got != "person@example.test" {
+		t.Fatalf("userPreferenceActorID() = %q, want human principal name", got)
+	}
+
+	machineContext := context.WithValue(context.Background(), authContextKey{}, authContext{
+		principal: authPrincipal{
+			ClientID:     "client-1",
+			DeviceID:     "device-1",
+			CredentialID: "credential-id-fixture", // #nosec G101 -- credential identifier fixture, not a secret.
+		},
+	})
+	if got := userPreferenceActorID(machineContext); got != "" {
+		t.Fatalf("userPreferenceActorID() = %q, want empty machine identity", got)
+	}
+}
+
 func TestHandleCreateCustomDashboardValidatesAndPersists(t *testing.T) {
 	store := newStubCustomDashboardStore()
 	app := askQueryTestApp(store)

--- a/internal/sourcehttp/userpreferences/handler.go
+++ b/internal/sourcehttp/userpreferences/handler.go
@@ -18,6 +18,8 @@ import (
 const maxPreferenceBytes = 64 * 1024
 const maxUserIDBytes = 240
 
+var errUserIdentityUnavailable = errors.New("authenticated user identity is required")
+
 // TenantResolver returns the effective tenant for a request body or query value.
 type TenantResolver func(context.Context, string) (string, error)
 
@@ -147,16 +149,21 @@ func (h Handler) keyForRequest(r *http.Request, requestedTenantID string) (ports
 	if tenantID == "" {
 		tenantID = "default"
 	}
-	return ports.UserPreferenceKey{TenantID: tenantID, UserID: h.userIDForContext(ctx)}, nil
+	userID, err := h.userIDForContext(ctx)
+	if err != nil {
+		return ports.UserPreferenceKey{}, err
+	}
+	return ports.UserPreferenceKey{TenantID: tenantID, UserID: userID}, nil
 }
 
-func (h Handler) userIDForContext(ctx context.Context) string {
+func (h Handler) userIDForContext(ctx context.Context) (string, error) {
 	if h.userResolver != nil {
 		if value := cleanUserID(h.userResolver(ctx)); value != "" {
-			return value
+			return value, nil
 		}
+		return "", errUserIdentityUnavailable
 	}
-	return "anonymous"
+	return "anonymous", nil
 }
 
 func cleanUserID(value string) string {

--- a/internal/sourcehttp/userpreferences/handler.go
+++ b/internal/sourcehttp/userpreferences/handler.go
@@ -219,7 +219,10 @@ func responseFor(tenantID string, userID string, preferences []byte, persisted b
 	return response
 }
 
-func statusForKeyError(error) int {
+func statusForKeyError(err error) int {
+	if errors.Is(err, errUserIdentityUnavailable) {
+		return http.StatusUnauthorized
+	}
 	return http.StatusForbidden
 }
 

--- a/internal/sourcehttp/userpreferences/handler_test.go
+++ b/internal/sourcehttp/userpreferences/handler_test.go
@@ -150,6 +150,19 @@ func TestKeyUsesTrustedResolverInsteadOfHeaders(t *testing.T) {
 	}
 }
 
+func TestKeyRejectsMissingTrustedUser(t *testing.T) {
+	handler := NewHandler(newStubStore(), func(context.Context, string) (string, error) {
+		return "local", nil
+	}, func(context.Context) string {
+		return ""
+	})
+
+	_, err := handler.keyForRequest(httptest.NewRequest(http.MethodGet, "/user/preferences", nil), "")
+	if !errors.Is(err, errUserIdentityUnavailable) {
+		t.Fatalf("keyForRequest() error = %v, want %v", err, errUserIdentityUnavailable)
+	}
+}
+
 func TestKeyFallsBackToAnonymousUser(t *testing.T) {
 	handler := NewHandler(newStubStore(), func(context.Context, string) (string, error) {
 		return "local", nil

--- a/internal/sourcehttp/userpreferences/handler_test.go
+++ b/internal/sourcehttp/userpreferences/handler_test.go
@@ -163,6 +163,26 @@ func TestKeyRejectsMissingTrustedUser(t *testing.T) {
 	}
 }
 
+func TestMissingTrustedUserReturnsUnauthorized(t *testing.T) {
+	handler := NewHandler(newStubStore(), func(context.Context, string) (string, error) {
+		return "local", nil
+	}, func(context.Context) string {
+		return ""
+	})
+
+	getRecorder := httptest.NewRecorder()
+	handler.Get(getRecorder, testRequest(http.MethodGet, ""))
+	if getRecorder.Code != http.StatusUnauthorized {
+		t.Fatalf("get status = %d, want 401", getRecorder.Code)
+	}
+
+	putRecorder := httptest.NewRecorder()
+	handler.Put(putRecorder, testRequest(http.MethodPut, `{"preferences":{}}`))
+	if putRecorder.Code != http.StatusUnauthorized {
+		t.Fatalf("put status = %d, want 401", putRecorder.Code)
+	}
+}
+
 func TestKeyFallsBackToAnonymousUser(t *testing.T) {
 	handler := NewHandler(newStubStore(), func(context.Context, string) (string, error) {
 		return "local", nil


### PR DESCRIPTION
## Summary

Require user preferences requests with a configured trusted user resolver to have a non-empty authenticated user identity, so non-human credentials do not share an anonymous preferences row.

## Test Plan

- go test ./internal/sourcehttp/userpreferences -count=1
- go test ./internal/bootstrap -count=1
- go test ./internal/sourcehttp/userpreferences ./internal/bootstrap ./internal/authz ./internal/statestore/postgres -count=1
- make lint
- make check-arch

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

Follow-up to #1474.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->