### PR TITLE
Add NHI coverage report

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4241,6 +4241,10 @@ paths:
       responses:
         '200':
           description: Tenant-scoped connector coverage report with per-dimension state, summaries, and blind spots.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorCoverageResponse'
   /platform/graph/provenance:
     get:
       summary: Explain graph entity projection provenance
@@ -7499,6 +7503,234 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SourceCoverageSummary'
+    ConnectorCoverageResponse:
+      allOf:
+        - $ref: '#/components/schemas/SourceCoverageReport'
+        - type: object
+          properties:
+            nhi_coverage:
+              $ref: '#/components/schemas/NHICoverageReport'
+    SourceCoverageReport:
+      type: object
+      properties:
+        version:
+          type: string
+        generated_at:
+          type: string
+          format: date-time
+        tenant_id:
+          type: string
+        source_id:
+          type: string
+        totals:
+          $ref: '#/components/schemas/SourceCoverageTotals'
+        gate:
+          $ref: '#/components/schemas/SourceCoverageGate'
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageRecord'
+        blind_spots:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageRecord'
+        summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageSummary'
+        blind_spot_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceCoverageSummary'
+    SourceCoverageTotals:
+      type: object
+      properties:
+        dimensions:
+          type: integer
+          minimum: 0
+        high_value_dimensions:
+          type: integer
+          minimum: 0
+        healthy:
+          type: integer
+          minimum: 0
+        partial:
+          type: integer
+          minimum: 0
+        unsupported:
+          type: integer
+          minimum: 0
+        unconfigured:
+          type: integer
+          minimum: 0
+        stale:
+          type: integer
+          minimum: 0
+        failed:
+          type: integer
+          minimum: 0
+        unknown:
+          type: integer
+          minimum: 0
+        blind_spots:
+          type: integer
+          minimum: 0
+    SourceCoverageGate:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [pass, warn, fail]
+        blocking_reason:
+          type: string
+          enum: [none, failed, blind_spot, stale, unconfigured, unsupported, partial, unknown]
+    NHICoverageReport:
+      type: object
+      properties:
+        version:
+          type: string
+        generated_at:
+          type: string
+          format: date-time
+        tenant_id:
+          type: string
+        source_id:
+          type: string
+        totals:
+          $ref: '#/components/schemas/NHICoverageTotals'
+        gate:
+          $ref: '#/components/schemas/SourceCoverageGate'
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/NHICoverageRecord'
+        blind_spots:
+          type: array
+          items:
+            $ref: '#/components/schemas/NHICoverageRecord'
+        summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/NHICoverageSummary'
+        lane_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/NHICoverageLaneSummary'
+        blind_spot_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/NHICoverageSummary'
+    NHICoverageTotals:
+      type: object
+      properties:
+        dimensions:
+          type: integer
+          minimum: 0
+        high_value_dimensions:
+          type: integer
+          minimum: 0
+        healthy:
+          type: integer
+          minimum: 0
+        partial:
+          type: integer
+          minimum: 0
+        unsupported:
+          type: integer
+          minimum: 0
+        unconfigured:
+          type: integer
+          minimum: 0
+        stale:
+          type: integer
+          minimum: 0
+        failed:
+          type: integer
+          minimum: 0
+        unknown:
+          type: integer
+          minimum: 0
+        blind_spots:
+          type: integer
+          minimum: 0
+    NHICoverageRecord:
+      allOf:
+        - $ref: '#/components/schemas/SourceCoverageRecord'
+        - type: object
+          properties:
+            lane:
+              type: string
+              enum: [inventory, credential, entitlement, trust, exposure, activity]
+            subject_kind:
+              type: string
+    NHICoverageSummary:
+      type: object
+      properties:
+        source_id:
+          type: string
+        lane:
+          type: string
+          enum: [inventory, credential, entitlement, trust, exposure, activity]
+        total:
+          type: integer
+          minimum: 0
+        healthy:
+          type: integer
+          minimum: 0
+        partial:
+          type: integer
+          minimum: 0
+        unsupported:
+          type: integer
+          minimum: 0
+        unconfigured:
+          type: integer
+          minimum: 0
+        stale:
+          type: integer
+          minimum: 0
+        failed:
+          type: integer
+          minimum: 0
+        unknown:
+          type: integer
+          minimum: 0
+        blind_spots:
+          type: integer
+          minimum: 0
+    NHICoverageLaneSummary:
+      type: object
+      properties:
+        lane:
+          type: string
+          enum: [inventory, credential, entitlement, trust, exposure, activity]
+        total:
+          type: integer
+          minimum: 0
+        healthy:
+          type: integer
+          minimum: 0
+        partial:
+          type: integer
+          minimum: 0
+        unsupported:
+          type: integer
+          minimum: 0
+        unconfigured:
+          type: integer
+          minimum: 0
+        stale:
+          type: integer
+          minimum: 0
+        failed:
+          type: integer
+          minimum: 0
+        unknown:
+          type: integer
+          minimum: 0
+        blind_spots:
+          type: integer
+          minimum: 0
     SourceCoverageSummary:
       type: object
       properties:

--- a/docs/domains/source-health-and-coverage.md
+++ b/docs/domains/source-health-and-coverage.md
@@ -60,6 +60,36 @@ Generated detections consume those same coverage contracts. The public detection
 
 `source_manager` (reports run, sources preview), `viewer` (read)
 
+## nhicoverage — Non-Human Identity Coverage
+
+`internal/nhicoverage` derives an NHI coverage report from the existing source coverage report. It does not introduce a new store or source of truth. It filters source coverage dimensions into NHI lanes and keeps the original coverage record fields so operators can trace each NHI gap back to the source contract, runtime family, evidence type, and control domain that produced it.
+
+The `/connectors/coverage` response includes this derived report as `nhi_coverage` alongside the existing source coverage fields.
+
+### NHI Lanes
+
+| Lane | Coverage represented |
+| --- | --- |
+| `inventory` | Applications, service accounts, service principals, managed identities, OAuth clients, and machine users |
+| `credential` | API keys, access keys, service account keys, API tokens, client secrets, external keys, and secret records |
+| `entitlement` | RBAC bindings, permission sets, app assignments, policy assignments, and service account roles |
+| `trust` | Workload identity, federation, identity providers, impersonation, and trusted-origin relationships |
+| `exposure` | External principals, public or internet exposure, cross-account trust, and shared secrets |
+| `activity` | Audit-event coverage for NHI credential and principal activity |
+
+### Key Types
+
+- `Report` — derived NHI coverage report with totals, gate, records, blind spots, source/lane summaries, and lane summaries
+- `Record` — source coverage record plus `lane` and `subject_kind`
+- `Totals`, `Summary`, `LaneSummary` — NHI coverage aggregate views
+
+### Boundaries
+
+- NHI coverage is a report projection over `sourcecoverage.Report`
+- Remediation dimensions are excluded from NHI coverage
+- Finding rules and graph projections remain the owners of detections and entity relationships
+- Source coverage contracts remain the source of truth for support, runtime family, evidence type, and control mapping
+
 ## sourcehealth — Runtime Health Evaluation
 
 `internal/sourcehealth` evaluates source runtime health from raw runtime protobuf data. It computes lifecycle, schedule, freshness, source-sync, graph-ingest, and finding-evaluation states, plus backfill eligibility and recommended next actions.
@@ -148,6 +178,7 @@ Protobuf types from `gen/cerebro/v1`; no internal package dependencies
 ## Code Map
 
 - `internal/sourcecoverage/coverage.go` — coverage contract evaluation and report builder
+- `internal/nhicoverage/coverage.go` — NHI coverage projection over source coverage
 - `internal/sourcehealth/health.go` — runtime health evaluation and state computation
 - `internal/sourcehealthview/types.go` — health dashboard view model types
 - `internal/resourcescope/policy.go` — resource exclusion policy definition and management

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -32,12 +32,6 @@ type sourceRuntimeHealthResponse struct {
 	Coverage        []sourcecoverage.Record      `json:"coverage,omitempty"`
 	CoverageSummary []sourcecoverage.Summary     `json:"coverage_summaries,omitempty"`
 }
-
-type connectorCoverageResponse struct {
-	sourcecoverage.Report
-	NHICoverage nhicoverage.Report `json:"nhi_coverage"`
-}
-
 type runtimeFreshnessResponse struct {
 	GeneratedAt          string                    `json:"generated_at"`
 	Status               string                    `json:"status"`
@@ -178,10 +172,7 @@ func (a *App) handleGetConnectorCoverage(w http.ResponseWriter, r *http.Request)
 	}
 	report := sourcecoverage.BuildScopedReport(health.Coverage, r.URL.Query().Get("tenant_id"), r.URL.Query().Get("source_id"), health.GeneratedAt)
 	emitSourceCoverageGateTelemetry(r.Context(), report)
-	writeJSON(w, http.StatusOK, connectorCoverageResponse{
-		Report:      report,
-		NHICoverage: nhicoverage.FromSourceCoverage(report),
-	})
+	writeJSON(w, http.StatusOK, nhicoverage.WithSourceCoverage(report))
 }
 func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthResponse, error) {
 	limit, err := uint32QueryParam(r, "limit")

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/nhicoverage"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecoverage"
@@ -30,6 +31,11 @@ type sourceRuntimeHealthResponse struct {
 	SourceSummaries []sourceRuntimeHealthSummary `json:"source_summaries"`
 	Coverage        []sourcecoverage.Record      `json:"coverage,omitempty"`
 	CoverageSummary []sourcecoverage.Summary     `json:"coverage_summaries,omitempty"`
+}
+
+type connectorCoverageResponse struct {
+	sourcecoverage.Report
+	NHICoverage nhicoverage.Report `json:"nhi_coverage"`
 }
 
 type runtimeFreshnessResponse struct {
@@ -172,7 +178,10 @@ func (a *App) handleGetConnectorCoverage(w http.ResponseWriter, r *http.Request)
 	}
 	report := sourcecoverage.BuildScopedReport(health.Coverage, r.URL.Query().Get("tenant_id"), r.URL.Query().Get("source_id"), health.GeneratedAt)
 	emitSourceCoverageGateTelemetry(r.Context(), report)
-	writeJSON(w, http.StatusOK, report)
+	writeJSON(w, http.StatusOK, connectorCoverageResponse{
+		Report:      report,
+		NHICoverage: nhicoverage.FromSourceCoverage(report),
+	})
 }
 func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthResponse, error) {
 	limit, err := uint32QueryParam(r, "limit")

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -509,10 +509,7 @@ func TestConnectorCoverageReportUsesAuthenticatedTenantAndBlindSpotTotals(t *tes
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
 	}
-	var report struct {
-		sourcecoverage.Report
-		NHICoverage nhicoverage.Report `json:"nhi_coverage"`
-	}
+	var report nhicoverage.SourceCoverageResponse
 	if err := json.NewDecoder(recorder.Body).Decode(&report); err != nil {
 		t.Fatalf("decode report: %v", err)
 	}

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -12,6 +12,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/nhicoverage"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -508,7 +509,10 @@ func TestConnectorCoverageReportUsesAuthenticatedTenantAndBlindSpotTotals(t *tes
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
 	}
-	var report sourcecoverage.Report
+	var report struct {
+		sourcecoverage.Report
+		NHICoverage nhicoverage.Report `json:"nhi_coverage"`
+	}
 	if err := json.NewDecoder(recorder.Body).Decode(&report); err != nil {
 		t.Fatalf("decode report: %v", err)
 	}
@@ -520,6 +524,18 @@ func TestConnectorCoverageReportUsesAuthenticatedTenantAndBlindSpotTotals(t *tes
 	}
 	if report.Gate.Status != "fail" || report.Gate.BlockingReason != "blind_spot" {
 		t.Fatalf("report gate = %#v, want blind_spot failure", report.Gate)
+	}
+	if report.NHICoverage.Version != nhicoverage.Version {
+		t.Fatalf("NHI coverage version = %q, want %q", report.NHICoverage.Version, nhicoverage.Version)
+	}
+	if report.NHICoverage.Totals.Dimensions != 1 || report.NHICoverage.Totals.BlindSpots != 1 {
+		t.Fatalf("NHI coverage totals = %#v", report.NHICoverage.Totals)
+	}
+	if len(report.NHICoverage.Records) != 1 {
+		t.Fatalf("NHI coverage records = %#v, want one application identity record", report.NHICoverage.Records)
+	}
+	if got := report.NHICoverage.Records[0]; got.DimensionID != "applications" || got.Lane != nhicoverage.LaneInventory || got.SubjectKind != "application" {
+		t.Fatalf("NHI coverage record = %#v, want application inventory", got)
 	}
 	for _, record := range report.Records {
 		if record.TenantID == "other" || record.RuntimeID == "other-okta-application" {

--- a/internal/nhicoverage/coverage.go
+++ b/internal/nhicoverage/coverage.go
@@ -32,6 +32,11 @@ type Report struct {
 	BlindSpotSummaries []Summary           `json:"blind_spot_summaries"`
 }
 
+type SourceCoverageResponse struct {
+	sourcecoverage.Report
+	NHICoverage Report `json:"nhi_coverage"`
+}
+
 type Record struct {
 	sourcecoverage.Record
 	Lane        string `json:"lane"`
@@ -81,6 +86,13 @@ type LaneSummary struct {
 type classification struct {
 	lane        string
 	subjectKind string
+}
+
+func WithSourceCoverage(report sourcecoverage.Report) SourceCoverageResponse {
+	return SourceCoverageResponse{
+		Report:      report,
+		NHICoverage: FromSourceCoverage(report),
+	}
 }
 
 func FromSourceCoverage(report sourcecoverage.Report) Report {

--- a/internal/nhicoverage/coverage.go
+++ b/internal/nhicoverage/coverage.go
@@ -1,0 +1,597 @@
+package nhicoverage
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/writer/cerebro/internal/sourcecoverage"
+)
+
+const Version = "nhi-coverage/v1"
+
+const (
+	LaneInventory   = "inventory"
+	LaneCredential  = "credential"
+	LaneEntitlement = "entitlement"
+	LaneTrust       = "trust"
+	LaneExposure    = "exposure"
+	LaneActivity    = "activity"
+)
+
+type Report struct {
+	Version            string              `json:"version"`
+	GeneratedAt        string              `json:"generated_at,omitempty"`
+	TenantID           string              `json:"tenant_id,omitempty"`
+	SourceID           string              `json:"source_id,omitempty"`
+	Totals             Totals              `json:"totals"`
+	Gate               sourcecoverage.Gate `json:"gate"`
+	Records            []Record            `json:"records"`
+	BlindSpots         []Record            `json:"blind_spots"`
+	Summaries          []Summary           `json:"summaries"`
+	LaneSummaries      []LaneSummary       `json:"lane_summaries"`
+	BlindSpotSummaries []Summary           `json:"blind_spot_summaries"`
+}
+
+type Record struct {
+	sourcecoverage.Record
+	Lane        string `json:"lane"`
+	SubjectKind string `json:"subject_kind"`
+}
+
+type Totals struct {
+	Dimensions          int `json:"dimensions"`
+	HighValueDimensions int `json:"high_value_dimensions"`
+	Healthy             int `json:"healthy"`
+	Partial             int `json:"partial"`
+	Unsupported         int `json:"unsupported"`
+	Unconfigured        int `json:"unconfigured"`
+	Stale               int `json:"stale"`
+	Failed              int `json:"failed"`
+	Unknown             int `json:"unknown"`
+	BlindSpots          int `json:"blind_spots"`
+}
+
+type Summary struct {
+	SourceID     string `json:"source_id"`
+	Lane         string `json:"lane"`
+	Total        int    `json:"total"`
+	Healthy      int    `json:"healthy"`
+	Partial      int    `json:"partial"`
+	Unsupported  int    `json:"unsupported"`
+	Unconfigured int    `json:"unconfigured"`
+	Stale        int    `json:"stale"`
+	Failed       int    `json:"failed"`
+	Unknown      int    `json:"unknown"`
+	BlindSpots   int    `json:"blind_spots"`
+}
+
+type LaneSummary struct {
+	Lane         string `json:"lane"`
+	Total        int    `json:"total"`
+	Healthy      int    `json:"healthy"`
+	Partial      int    `json:"partial"`
+	Unsupported  int    `json:"unsupported"`
+	Unconfigured int    `json:"unconfigured"`
+	Stale        int    `json:"stale"`
+	Failed       int    `json:"failed"`
+	Unknown      int    `json:"unknown"`
+	BlindSpots   int    `json:"blind_spots"`
+}
+
+type classification struct {
+	lane        string
+	subjectKind string
+}
+
+func FromSourceCoverage(report sourcecoverage.Report) Report {
+	records := RecordsFromCoverage(report.Records)
+	blindSpots := BlindSpots(records)
+	totals := TotalsFor(records)
+	return Report{
+		Version:            Version,
+		GeneratedAt:        report.GeneratedAt,
+		TenantID:           report.TenantID,
+		SourceID:           report.SourceID,
+		Totals:             totals,
+		Gate:               GateForTotals(totals),
+		Records:            records,
+		BlindSpots:         blindSpots,
+		Summaries:          Summaries(records),
+		LaneSummaries:      LaneSummaries(records),
+		BlindSpotSummaries: Summaries(blindSpots),
+	}
+}
+
+func RecordsFromCoverage(records []sourcecoverage.Record) []Record {
+	out := make([]Record, 0, len(records))
+	for _, record := range records {
+		class, ok := classify(record)
+		if !ok {
+			continue
+		}
+		out = append(out, Record{
+			Record:      cloneCoverageRecord(record),
+			Lane:        class.lane,
+			SubjectKind: class.subjectKind,
+		})
+	}
+	sortRecords(out)
+	return out
+}
+
+func BlindSpots(records []Record) []Record {
+	out := make([]Record, 0)
+	for _, record := range records {
+		if record.BlindSpot {
+			out = append(out, cloneRecord(record))
+		}
+	}
+	return out
+}
+
+func TotalsFor(records []Record) Totals {
+	var totals Totals
+	for _, record := range records {
+		totals.Dimensions++
+		if record.HighValue {
+			totals.HighValueDimensions++
+		}
+		addStateToTotals(record.State, &totals)
+		if record.BlindSpot {
+			totals.BlindSpots++
+		}
+	}
+	return totals
+}
+
+func GateForTotals(totals Totals) sourcecoverage.Gate {
+	switch {
+	case totals.Failed > 0:
+		return sourcecoverage.Gate{Status: "fail", BlockingReason: "failed"}
+	case totals.BlindSpots > 0:
+		return sourcecoverage.Gate{Status: "fail", BlockingReason: "blind_spot"}
+	case totals.Stale > 0:
+		return sourcecoverage.Gate{Status: "warn", BlockingReason: "stale"}
+	case totals.Unconfigured > 0:
+		return sourcecoverage.Gate{Status: "warn", BlockingReason: "unconfigured"}
+	case totals.Unsupported > 0:
+		return sourcecoverage.Gate{Status: "warn", BlockingReason: "unsupported"}
+	case totals.Partial > 0:
+		return sourcecoverage.Gate{Status: "warn", BlockingReason: "partial"}
+	case totals.Unknown > 0:
+		return sourcecoverage.Gate{Status: "warn", BlockingReason: "unknown"}
+	default:
+		return sourcecoverage.Gate{Status: "pass", BlockingReason: "none"}
+	}
+}
+
+func Summaries(records []Record) []Summary {
+	bySourceLane := map[string]*Summary{}
+	for _, record := range records {
+		sourceID := strings.TrimSpace(record.SourceID)
+		if sourceID == "" {
+			sourceID = "unknown"
+		}
+		lane := strings.TrimSpace(record.Lane)
+		if lane == "" {
+			lane = "unknown"
+		}
+		key := sourceID + "\x00" + lane
+		summary := bySourceLane[key]
+		if summary == nil {
+			summary = &Summary{SourceID: sourceID, Lane: lane}
+			bySourceLane[key] = summary
+		}
+		addRecordToSummary(record, summary)
+	}
+	summaries := make([]Summary, 0, len(bySourceLane))
+	for _, summary := range bySourceLane {
+		summaries = append(summaries, *summary)
+	}
+	sort.Slice(summaries, func(i int, j int) bool {
+		if summaries[i].BlindSpots != summaries[j].BlindSpots {
+			return summaries[i].BlindSpots > summaries[j].BlindSpots
+		}
+		if summaries[i].Total != summaries[j].Total {
+			return summaries[i].Total > summaries[j].Total
+		}
+		if summaries[i].SourceID != summaries[j].SourceID {
+			return summaries[i].SourceID < summaries[j].SourceID
+		}
+		return summaries[i].Lane < summaries[j].Lane
+	})
+	return summaries
+}
+
+func LaneSummaries(records []Record) []LaneSummary {
+	byLane := map[string]*LaneSummary{}
+	for _, record := range records {
+		lane := strings.TrimSpace(record.Lane)
+		if lane == "" {
+			lane = "unknown"
+		}
+		summary := byLane[lane]
+		if summary == nil {
+			summary = &LaneSummary{Lane: lane}
+			byLane[lane] = summary
+		}
+		addRecordToLaneSummary(record, summary)
+	}
+	summaries := make([]LaneSummary, 0, len(byLane))
+	for _, summary := range byLane {
+		summaries = append(summaries, *summary)
+	}
+	sort.Slice(summaries, func(i int, j int) bool {
+		if summaries[i].BlindSpots != summaries[j].BlindSpots {
+			return summaries[i].BlindSpots > summaries[j].BlindSpots
+		}
+		if summaries[i].Total != summaries[j].Total {
+			return summaries[i].Total > summaries[j].Total
+		}
+		return summaries[i].Lane < summaries[j].Lane
+	})
+	return summaries
+}
+
+func classify(record sourcecoverage.Record) (classification, bool) {
+	if strings.TrimSpace(record.DimensionType) == "remediation_state" {
+		return classification{}, false
+	}
+	text := normalizedRecordText(record)
+	if text == "" {
+		return classification{}, false
+	}
+	if record.DimensionType == "audit_event" && hasAny(text, activityTerms) {
+		return classification{lane: LaneActivity, subjectKind: subjectKindFor(text, LaneActivity)}, true
+	}
+	if hasAny(text, credentialTerms) {
+		return classification{lane: LaneCredential, subjectKind: subjectKindFor(text, LaneCredential)}, true
+	}
+	if hasAny(text, trustTerms) {
+		return classification{lane: LaneTrust, subjectKind: subjectKindFor(text, LaneTrust)}, true
+	}
+	if hasAny(text, entitlementTerms) || (record.DimensionType == "app_entitlement" && hasAny(text, identityTerms)) {
+		return classification{lane: LaneEntitlement, subjectKind: subjectKindFor(text, LaneEntitlement)}, true
+	}
+	if hasAny(text, exposureTerms) {
+		return classification{lane: LaneExposure, subjectKind: subjectKindFor(text, LaneExposure)}, true
+	}
+	if hasAny(text, identityTerms) {
+		return classification{lane: LaneInventory, subjectKind: subjectKindFor(text, LaneInventory)}, true
+	}
+	return classification{}, false
+}
+
+var identityTerms = []string{
+	"application",
+	"applications",
+	"app_registration",
+	"app_registrations",
+	"bot",
+	"client_application",
+	"managed_identity",
+	"managed_identities",
+	"machine_user",
+	"oauth_app",
+	"oauth_apps",
+	"oauth_client",
+	"oauth_clients",
+	"service_account",
+	"service_accounts",
+	"service_principal",
+	"service_principals",
+}
+
+var credentialTerms = []string{
+	"access_key",
+	"access_keys",
+	"admin_api_key",
+	"api_key",
+	"api_keys",
+	"api_token",
+	"api_tokens",
+	"application_credential",
+	"application_credentials",
+	"client_secret",
+	"client_secrets",
+	"codebuild_source_credential",
+	"external_key",
+	"external_keys",
+	"key_vault_secret",
+	"key_vault_secrets",
+	"project_api_key",
+	"secret_manager_secret",
+	"secret_manager_secrets",
+	"service_account_key",
+	"service_account_keys",
+	"service_principal_credential",
+	"service_principal_credentials",
+	"source_credential",
+	"source_credentials",
+	"tokens_and_keys",
+}
+
+var trustTerms = []string{
+	"federated",
+	"federation",
+	"federations",
+	"iam_role_trust",
+	"identity_pool",
+	"identity_pools",
+	"identity_provider",
+	"identity_providers",
+	"impersonation",
+	"impersonations",
+	"oidc",
+	"saml_provider",
+	"trusted_origin",
+	"workload_identity",
+	"workload_identities",
+}
+
+var entitlementTerms = []string{
+	"account_assignment",
+	"account_assignments",
+	"app_assignment",
+	"app_assignments",
+	"cluster_role",
+	"cluster_roles",
+	"permission",
+	"permissions",
+	"permission_set",
+	"permission_sets",
+	"policy_assignment",
+	"policy_assignments",
+	"rbac",
+	"role_binding",
+	"role_bindings",
+	"service_account_role",
+	"service_account_roles",
+}
+
+var exposureTerms = []string{
+	"cross_account",
+	"external_principal",
+	"external_principals",
+	"internet",
+	"public",
+	"shared_secret",
+}
+
+var activityTerms = []string{
+	"access_key",
+	"api_key",
+	"api_token",
+	"client_secret",
+	"codebuild_source_credential",
+	"external_key",
+	"impersonation",
+	"service_account",
+	"service_principal",
+	"service_principal_credential",
+	"workload_identity",
+}
+
+func subjectKindFor(text string, lane string) string {
+	switch {
+	case hasAny(text, []string{"service_account_key", "service_account_keys"}):
+		return "service_account_key"
+	case hasAny(text, []string{"service_account", "service_accounts"}):
+		return "service_account"
+	case hasAny(text, []string{"service_principal", "service_principals"}):
+		return "service_principal"
+	case hasAny(text, []string{"managed_identity", "managed_identities"}):
+		return "managed_identity"
+	case hasAny(text, []string{"workload_identity", "workload_identities"}):
+		return "workload_identity"
+	case hasAny(text, []string{"api_token", "api_tokens"}):
+		return "api_token"
+	case hasAny(text, []string{"api_key", "api_keys", "project_api_key", "admin_api_key", "tokens_and_keys"}):
+		return "api_key"
+	case hasAny(text, []string{"access_key", "access_keys"}):
+		return "access_key"
+	case hasAny(text, []string{"oauth_client", "oauth_clients", "oauth_app", "oauth_apps"}):
+		return "oauth_client"
+	case hasAny(text, []string{"client_secret", "client_secrets"}):
+		return "client_secret"
+	case hasAny(text, []string{"external_key", "external_keys"}):
+		return "external_key"
+	case hasAny(text, []string{"credential", "credentials"}):
+		return "credential"
+	case hasAny(text, []string{"token", "tokens"}):
+		return "token"
+	case hasAny(text, []string{"secret", "secrets"}):
+		return "secret"
+	case hasAny(text, []string{"rbac", "role_binding", "role_bindings", "cluster_role", "cluster_roles"}):
+		return "rbac"
+	case hasAny(text, []string{"permission", "permissions", "permission_set", "permission_sets"}):
+		return "permission"
+	case hasAny(text, []string{"federation", "federations", "federated"}):
+		return "federation"
+	case hasAny(text, []string{"impersonation", "impersonations"}):
+		return "impersonation"
+	case hasAny(text, []string{"external_principal", "external_principals"}):
+		return "external_principal"
+	case hasAny(text, []string{"application", "applications", "app_registration", "app_registrations", "client_application"}):
+		return "application"
+	case lane == LaneCredential:
+		return "credential"
+	case lane == LaneEntitlement:
+		return "entitlement"
+	case lane == LaneTrust:
+		return "trust"
+	default:
+		return "identity"
+	}
+}
+
+func normalizedRecordText(record sourcecoverage.Record) string {
+	parts := []string{
+		record.SourceID,
+		record.DimensionID,
+		record.DimensionType,
+		record.Title,
+		record.Family,
+	}
+	parts = append(parts, record.EvidenceTypes...)
+	parts = append(parts, record.ControlDomains...)
+	parts = append(parts, record.SupportedRuntimeFamilies...)
+	return normalize(strings.Join(parts, " "))
+}
+
+func normalize(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	replacer := strings.NewReplacer("-", "_", ".", "_", "/", "_", " ", "_", ":", "_")
+	value = replacer.Replace(value)
+	for strings.Contains(value, "__") {
+		value = strings.ReplaceAll(value, "__", "_")
+	}
+	return value
+}
+
+func hasAny(value string, terms []string) bool {
+	for _, term := range terms {
+		if containsTerm(value, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsTerm(value string, term string) bool {
+	value = "_" + normalize(value) + "_"
+	term = "_" + normalize(term) + "_"
+	return strings.Contains(value, term)
+}
+
+func sortRecords(records []Record) {
+	sort.Slice(records, func(i int, j int) bool {
+		if records[i].SourceID != records[j].SourceID {
+			return records[i].SourceID < records[j].SourceID
+		}
+		if records[i].Lane != records[j].Lane {
+			return records[i].Lane < records[j].Lane
+		}
+		if records[i].BlindSpot != records[j].BlindSpot {
+			return records[i].BlindSpot
+		}
+		if stateRank(records[i].State) != stateRank(records[j].State) {
+			return stateRank(records[i].State) < stateRank(records[j].State)
+		}
+		return records[i].DimensionID < records[j].DimensionID
+	})
+}
+
+func addRecordToSummary(record Record, summary *Summary) {
+	summary.Total++
+	addStateToSummary(record.State, summary)
+	if record.BlindSpot {
+		summary.BlindSpots++
+	}
+}
+
+func addRecordToLaneSummary(record Record, summary *LaneSummary) {
+	summary.Total++
+	addStateToLaneSummary(record.State, summary)
+	if record.BlindSpot {
+		summary.BlindSpots++
+	}
+}
+
+func addStateToTotals(state string, totals *Totals) {
+	switch state {
+	case sourcecoverage.StateHealthy:
+		totals.Healthy++
+	case sourcecoverage.StatePartial:
+		totals.Partial++
+	case sourcecoverage.StateUnsupported:
+		totals.Unsupported++
+	case sourcecoverage.StateUnconfigured:
+		totals.Unconfigured++
+	case sourcecoverage.StateStale:
+		totals.Stale++
+	case sourcecoverage.StateFailed:
+		totals.Failed++
+	default:
+		totals.Unknown++
+	}
+}
+
+func addStateToSummary(state string, summary *Summary) {
+	switch state {
+	case sourcecoverage.StateHealthy:
+		summary.Healthy++
+	case sourcecoverage.StatePartial:
+		summary.Partial++
+	case sourcecoverage.StateUnsupported:
+		summary.Unsupported++
+	case sourcecoverage.StateUnconfigured:
+		summary.Unconfigured++
+	case sourcecoverage.StateStale:
+		summary.Stale++
+	case sourcecoverage.StateFailed:
+		summary.Failed++
+	default:
+		summary.Unknown++
+	}
+}
+
+func addStateToLaneSummary(state string, summary *LaneSummary) {
+	switch state {
+	case sourcecoverage.StateHealthy:
+		summary.Healthy++
+	case sourcecoverage.StatePartial:
+		summary.Partial++
+	case sourcecoverage.StateUnsupported:
+		summary.Unsupported++
+	case sourcecoverage.StateUnconfigured:
+		summary.Unconfigured++
+	case sourcecoverage.StateStale:
+		summary.Stale++
+	case sourcecoverage.StateFailed:
+		summary.Failed++
+	default:
+		summary.Unknown++
+	}
+}
+
+func stateRank(state string) int {
+	switch state {
+	case sourcecoverage.StateFailed:
+		return 0
+	case sourcecoverage.StateStale:
+		return 1
+	case sourcecoverage.StateUnconfigured:
+		return 2
+	case sourcecoverage.StateUnsupported:
+		return 3
+	case sourcecoverage.StatePartial:
+		return 4
+	case sourcecoverage.StateUnknown:
+		return 5
+	case sourcecoverage.StateHealthy:
+		return 6
+	default:
+		return 7
+	}
+}
+
+func cloneRecord(record Record) Record {
+	return Record{
+		Record:      cloneCoverageRecord(record.Record),
+		Lane:        record.Lane,
+		SubjectKind: record.SubjectKind,
+	}
+}
+
+func cloneCoverageRecord(record sourcecoverage.Record) sourcecoverage.Record {
+	record.KnownUnsupportedFields = append([]string(nil), record.KnownUnsupportedFields...)
+	record.Notes = append([]string(nil), record.Notes...)
+	record.EvidenceTypes = append([]string(nil), record.EvidenceTypes...)
+	record.ControlDomains = append([]string(nil), record.ControlDomains...)
+	if len(record.ControlRefs) > 0 {
+		record.ControlRefs = append(record.ControlRefs[:0:0], record.ControlRefs...)
+	}
+	record.SupportedRuntimeFamilies = append([]string(nil), record.SupportedRuntimeFamilies...)
+	return record
+}

--- a/internal/nhicoverage/coverage_test.go
+++ b/internal/nhicoverage/coverage_test.go
@@ -1,0 +1,180 @@
+package nhicoverage
+
+import (
+	"testing"
+
+	"github.com/writer/cerebro/internal/sourcecoverage"
+)
+
+func TestFromSourceCoverageBuildsNHILanesAndExcludesRemediation(t *testing.T) {
+	report := sourcecoverage.Report{
+		Version:     "source-coverage/v1",
+		GeneratedAt: "2026-06-15T12:00:00Z",
+		TenantID:    "writer",
+		Records: []sourcecoverage.Record{
+			{
+				SourceID:                 "openai",
+				TenantID:                 "writer",
+				DimensionID:              "service_accounts",
+				DimensionType:            "entity_family",
+				Title:                    "Service accounts",
+				State:                    sourcecoverage.StateHealthy,
+				SupportLevel:             "supported",
+				HighValue:                true,
+				SupportedRuntimeFamilies: []string{"service_account"},
+			},
+			{
+				SourceID:      "openai",
+				TenantID:      "writer",
+				DimensionID:   "tokens_and_keys",
+				DimensionType: "entity_family",
+				Title:         "API keys",
+				State:         sourcecoverage.StateUnconfigured,
+				SupportLevel:  "supported",
+				HighValue:     true,
+				BlindSpot:     true,
+				Warning:       "API keys coverage is unconfigured for tenant writer",
+			},
+			{
+				SourceID:      "gcp",
+				TenantID:      "writer",
+				DimensionID:   "workload_identity_pool",
+				DimensionType: "relationship",
+				Title:         "Workload identity pools",
+				State:         sourcecoverage.StatePartial,
+				SupportLevel:  "partial",
+				HighValue:     true,
+				BlindSpot:     true,
+			},
+			{
+				SourceID:      "kubernetes",
+				TenantID:      "writer",
+				DimensionID:   "rbac_bindings",
+				DimensionType: "app_entitlement",
+				Title:         "RBAC bindings",
+				State:         sourcecoverage.StateFailed,
+				SupportLevel:  "supported",
+				HighValue:     true,
+				BlindSpot:     true,
+			},
+			{
+				SourceID:                 "azure",
+				TenantID:                 "writer",
+				DimensionID:              "credential",
+				DimensionType:            "entity_family",
+				Title:                    "Azure application and service principal credentials",
+				State:                    sourcecoverage.StateHealthy,
+				SupportLevel:             "supported",
+				HighValue:                true,
+				SupportedRuntimeFamilies: []string{"credential"},
+			},
+			{
+				SourceID:      "okta",
+				TenantID:      "writer",
+				DimensionID:   "users",
+				DimensionType: "entity_family",
+				Title:         "Users",
+				State:         sourcecoverage.StateHealthy,
+				SupportLevel:  "supported",
+				HighValue:     true,
+			},
+			{
+				SourceID:                 "duo",
+				TenantID:                 "writer",
+				DimensionID:              "mfa_devices",
+				DimensionType:            "entity_family",
+				Title:                    "MFA phones, hardware tokens, and WebAuthn credentials",
+				State:                    sourcecoverage.StateHealthy,
+				SupportLevel:             "supported",
+				HighValue:                true,
+				SupportedRuntimeFamilies: []string{"token", "web_authn_credential"},
+			},
+			{
+				SourceID:      "okta",
+				TenantID:      "writer",
+				DimensionID:   "remediation",
+				DimensionType: "remediation_state",
+				Title:         "Remediation lifecycle",
+				State:         sourcecoverage.StateUnsupported,
+				SupportLevel:  "unsupported",
+				HighValue:     true,
+				BlindSpot:     true,
+			},
+		},
+	}
+
+	nhi := FromSourceCoverage(report)
+
+	if nhi.Version != Version || nhi.GeneratedAt != report.GeneratedAt || nhi.TenantID != report.TenantID {
+		t.Fatalf("report identity = %#v", nhi)
+	}
+	if nhi.Totals.Dimensions != 5 || nhi.Totals.HighValueDimensions != 5 || nhi.Totals.BlindSpots != 3 {
+		t.Fatalf("totals = %#v", nhi.Totals)
+	}
+	if nhi.Gate.Status != "fail" || nhi.Gate.BlockingReason != "failed" {
+		t.Fatalf("gate = %#v, want failed gate", nhi.Gate)
+	}
+	assertRecord(t, nhi.Records, "service_accounts", LaneInventory, "service_account")
+	assertRecord(t, nhi.Records, "tokens_and_keys", LaneCredential, "api_key")
+	assertRecord(t, nhi.Records, "workload_identity_pool", LaneTrust, "workload_identity")
+	assertRecord(t, nhi.Records, "rbac_bindings", LaneEntitlement, "rbac")
+	assertRecord(t, nhi.Records, "credential", LaneCredential, "service_principal")
+	assertMissingRecord(t, nhi.Records, "users")
+	assertMissingRecord(t, nhi.Records, "mfa_devices")
+	assertMissingRecord(t, nhi.Records, "remediation")
+	if len(nhi.BlindSpots) != 3 {
+		t.Fatalf("blind spot count = %d, want 3: %#v", len(nhi.BlindSpots), nhi.BlindSpots)
+	}
+	if len(nhi.Summaries) != 5 {
+		t.Fatalf("summaries = %#v, want one source/lane summary per included record", nhi.Summaries)
+	}
+	if len(nhi.LaneSummaries) != 4 {
+		t.Fatalf("lane summaries = %#v, want four lanes", nhi.LaneSummaries)
+	}
+}
+
+func TestRecordsFromCoverageClassifiesActivityAndExposure(t *testing.T) {
+	records := RecordsFromCoverage([]sourcecoverage.Record{
+		{
+			SourceID:      "aws",
+			DimensionID:   "access_key_audit_events",
+			DimensionType: "audit_event",
+			Title:         "Access key audit events",
+			State:         sourcecoverage.StateHealthy,
+		},
+		{
+			SourceID:      "aws",
+			DimensionID:   "external_principal_trust",
+			DimensionType: "relationship",
+			Title:         "External principals",
+			State:         sourcecoverage.StateUnconfigured,
+			BlindSpot:     true,
+		},
+	})
+
+	assertRecord(t, records, "access_key_audit_events", LaneActivity, "access_key")
+	assertRecord(t, records, "external_principal_trust", LaneExposure, "external_principal")
+}
+
+func assertRecord(t *testing.T, records []Record, dimensionID string, lane string, subjectKind string) {
+	t.Helper()
+	for _, record := range records {
+		if record.DimensionID != dimensionID {
+			continue
+		}
+		if record.Lane != lane || record.SubjectKind != subjectKind {
+			t.Fatalf("%s classification = lane:%q subject:%q, want lane:%q subject:%q", dimensionID, record.Lane, record.SubjectKind, lane, subjectKind)
+		}
+		return
+	}
+	t.Fatalf("missing NHI record %q in %#v", dimensionID, records)
+}
+
+func assertMissingRecord(t *testing.T, records []Record, dimensionID string) {
+	t.Helper()
+	for _, record := range records {
+		if record.DimensionID == dimensionID {
+			t.Fatalf("unexpected NHI record %q: %#v", dimensionID, record)
+		}
+	}
+}

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -525,6 +525,20 @@ export type Claim = {
   valid_to?: string;
 };
 
+export type ConnectorCoverageResponse = {
+  blind_spot_summaries?: SourceCoverageSummary[];
+  blind_spots?: SourceCoverageRecord[];
+  gate?: SourceCoverageGate;
+  generated_at?: string;
+  nhi_coverage?: NHICoverageReport;
+  records?: SourceCoverageRecord[];
+  source_id?: string;
+  summaries?: SourceCoverageSummary[];
+  tenant_id?: string;
+  totals?: SourceCoverageTotals;
+  version?: string;
+};
+
 export type ConnectorCredential = {
   auth_method: string;
   created_at?: string;
@@ -1043,6 +1057,56 @@ export type GRCAskRequest = {
   tenant_id: string;
 };
 
+export type GRCDashboardResponse = {
+  connectors?: Record<string, unknown>[];
+  controls?: Record<string, unknown>[];
+  coverage_blind_spots?: SourceCoverageRecord[];
+  coverage_summaries?: SourceCoverageSummary[];
+  evidence?: Record<string, unknown>[];
+  findings?: Record<string, unknown>[];
+  generated_at?: string;
+  product_areas?: GRCProductArea[];
+  source_summaries?: Record<string, unknown>[];
+  summary?: Record<string, unknown>;
+};
+
+export type GRCProductArea = {
+  blind_spots?: SourceCoverageRecord[];
+  control_domains?: string[];
+  coverage_dimensions?: string[];
+  description?: string;
+  detail?: string;
+  evidence_types?: string[];
+  href?: string;
+  id?: string;
+  signal?: string;
+  source_families?: string[];
+  status?: "attention" | "mapped" | "quiet";
+  title?: string;
+  workflows?: GRCProductAreaWorkflow[];
+};
+
+export type GRCProductAreaWorkflow = {
+  href?: string;
+  label?: string;
+};
+
+export type GRCProgramReadinessResponse = {
+  connectors?: Record<string, unknown>[];
+  controls?: Record<string, unknown>[];
+  coverage_blind_spots?: SourceCoverageRecord[];
+  coverage_summaries?: SourceCoverageSummary[];
+  frameworks?: Record<string, unknown>[];
+  generated_at?: string;
+  metadata?: Record<string, unknown>;
+  product_areas?: GRCProductArea[];
+  profile?: Record<string, unknown>;
+  proof_bundle?: Record<string, unknown>;
+  source_summaries?: Record<string, unknown>[];
+  summary?: Record<string, unknown>;
+  work_items?: Record<string, unknown>[];
+};
+
 export type GetEntityNeighborhoodResponse = {
   neighbors?: GraphEntity[];
   relations?: GraphRelation[];
@@ -1151,6 +1215,86 @@ export type IssueBootstrapTokenResponse = {
 
 export type ListClaimsResponse = {
   claims?: Claim[];
+};
+
+export type NHICoverageLaneSummary = {
+  blind_spots?: number;
+  failed?: number;
+  healthy?: number;
+  lane?: "inventory" | "credential" | "entitlement" | "trust" | "exposure" | "activity";
+  partial?: number;
+  stale?: number;
+  total?: number;
+  unconfigured?: number;
+  unknown?: number;
+  unsupported?: number;
+};
+
+export type NHICoverageRecord = {
+  authority_domain?: string;
+  blind_spot?: boolean;
+  control_domains?: string[];
+  control_refs?: CoverageControlRef[];
+  dimension_id?: string;
+  dimension_type?: "alert_state" | "app_entitlement" | "audit_event" | "deployment_state" | "entity_family" | "incremental_sync" | "lifecycle_state" | "relationship" | "remediation_state";
+  evidence_types?: string[];
+  family?: string;
+  high_value?: boolean;
+  known_unsupported_fields?: string[];
+  lane?: "inventory" | "credential" | "entitlement" | "trust" | "exposure" | "activity";
+  last_synced_at?: string;
+  notes?: string[];
+  owner_domain?: string;
+  runtime_id?: string;
+  source_id?: string;
+  state?: "healthy" | "partial" | "unsupported" | "unconfigured" | "stale" | "failed" | "unknown";
+  subject_kind?: string;
+  support_level?: "supported" | "partial" | "unsupported" | "planned";
+  supported_runtime_families?: string[];
+  tenant_id?: string;
+  title?: string;
+  warning?: string;
+};
+
+export type NHICoverageReport = {
+  blind_spot_summaries?: NHICoverageSummary[];
+  blind_spots?: NHICoverageRecord[];
+  gate?: SourceCoverageGate;
+  generated_at?: string;
+  lane_summaries?: NHICoverageLaneSummary[];
+  records?: NHICoverageRecord[];
+  source_id?: string;
+  summaries?: NHICoverageSummary[];
+  tenant_id?: string;
+  totals?: NHICoverageTotals;
+  version?: string;
+};
+
+export type NHICoverageSummary = {
+  blind_spots?: number;
+  failed?: number;
+  healthy?: number;
+  lane?: "inventory" | "credential" | "entitlement" | "trust" | "exposure" | "activity";
+  partial?: number;
+  source_id?: string;
+  stale?: number;
+  total?: number;
+  unconfigured?: number;
+  unknown?: number;
+  unsupported?: number;
+};
+
+export type NHICoverageTotals = {
+  blind_spots?: number;
+  dimensions?: number;
+  failed?: number;
+  healthy?: number;
+  high_value_dimensions?: number;
+  partial?: number;
+  stale?: number;
+  unconfigured?: number;
+  unknown?: number;
+  unsupported?: number;
 };
 
 export type PlatformJob = {
@@ -1426,6 +1570,11 @@ export type SourceCDKScaffoldPlan = {
   source_type?: string;
 };
 
+export type SourceCoverageGate = {
+  blocking_reason?: "none" | "failed" | "blind_spot" | "stale" | "unconfigured" | "unsupported" | "partial" | "unknown";
+  status?: "pass" | "warn" | "fail";
+};
+
 export type SourceCoverageRecord = {
   authority_domain?: string;
   blind_spot?: boolean;
@@ -1450,6 +1599,19 @@ export type SourceCoverageRecord = {
   warning?: string;
 };
 
+export type SourceCoverageReport = {
+  blind_spot_summaries?: SourceCoverageSummary[];
+  blind_spots?: SourceCoverageRecord[];
+  gate?: SourceCoverageGate;
+  generated_at?: string;
+  records?: SourceCoverageRecord[];
+  source_id?: string;
+  summaries?: SourceCoverageSummary[];
+  tenant_id?: string;
+  totals?: SourceCoverageTotals;
+  version?: string;
+};
+
 export type SourceCoverageSummary = {
   blind_spots?: number;
   failed?: number;
@@ -1458,6 +1620,19 @@ export type SourceCoverageSummary = {
   source_id?: string;
   stale?: number;
   total?: number;
+  unconfigured?: number;
+  unknown?: number;
+  unsupported?: number;
+};
+
+export type SourceCoverageTotals = {
+  blind_spots?: number;
+  dimensions?: number;
+  failed?: number;
+  healthy?: number;
+  high_value_dimensions?: number;
+  partial?: number;
+  stale?: number;
   unconfigured?: number;
   unknown?: number;
   unsupported?: number;


### PR DESCRIPTION
## Summary
- add `internal/nhicoverage`, a derived NHI coverage report over the existing source coverage report
- return `nhi_coverage` from `GET /connectors/coverage` without adding storage or remediation workflows
- document NHI lanes, add OpenAPI schemas, and regenerate TypeScript API types

## Validation
- `go test ./internal/nhicoverage ./internal/bootstrap -count=1`
- `make openapi-check openapi-lint docs-drift-check openapi-ts-check`