### PR TITLE
feat(sources): import Archetype library notes

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -5144,6 +5144,17 @@ func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
 				"analyzer_label": "high-confidence",
 				"created_at":     "2026-06-17T12:06:00Z",
 			}})
+		case "/api/v1/repositories/7/knowledge":
+			writeTestJSON(t, w, map[string]any{
+				"entries": []map[string]any{{
+					"slug":            "repository-commit-learning",
+					"title":           "Repository commit learning",
+					"summary":         "Archetype learned the latest repository head.",
+					"repository_id":   7,
+					"repository_name": "Archetype",
+					"owner":           "WriterInternal",
+				}},
+			})
 		default:
 			http.NotFound(w, r)
 		}
@@ -5199,14 +5210,14 @@ func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
 	if !ok {
 		t.Fatalf("graph ingest details = %#v, want object", resultPayload["ingest"])
 	}
-	if got := ingestPayload["events_read"]; got != float64(2) {
-		t.Fatalf("events_read = %#v, want 2", got)
+	if got := ingestPayload["events_read"]; got != float64(3) {
+		t.Fatalf("events_read = %#v, want 3", got)
 	}
-	if got := ingestPayload["entities_projected"]; got != float64(3) {
-		t.Fatalf("entities_projected = %#v, want 3", got)
+	if got := ingestPayload["entities_projected"]; got != float64(4) {
+		t.Fatalf("entities_projected = %#v, want 4", got)
 	}
-	if got := ingestPayload["links_projected"]; got != float64(5) {
-		t.Fatalf("links_projected = %#v, want 5", got)
+	if got := ingestPayload["links_projected"]; got != float64(7) {
+		t.Fatalf("links_projected = %#v, want 7", got)
 	}
 	if !sawAuth.Load() {
 		t.Fatal("Archetype API did not receive bearer token")
@@ -5215,19 +5226,25 @@ func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
 	repoURN := "urn:cerebro:writer:github_code_repository:WriterInternal/Archetype"
 	scanURN := "urn:cerebro:writer:archetype_scan:1"
 	findingURN := "urn:cerebro:writer:archetype_finding:10"
+	noteURN := "urn:cerebro:writer:archetype_library_note:WriterInternal/Archetype:repository-commit-learning"
 	if entity := graphStore.entities[findingURN]; entity == nil || entity.EntityType != "archetype.finding" {
 		t.Fatalf("projected finding entity = %#v, want archetype.finding", entity)
 	}
 	if entity := graphStore.entities[scanURN]; entity == nil || entity.EntityType != "archetype.scan" {
 		t.Fatalf("projected scan entity = %#v, want archetype.scan", entity)
 	}
+	if entity := graphStore.entities[noteURN]; entity == nil || entity.EntityType != "archetype.library_note" {
+		t.Fatalf("projected library note entity = %#v, want archetype.library_note", entity)
+	}
 	if entity := graphStore.entities[repoURN]; entity == nil || entity.EntityType != "github.code.repository" {
 		t.Fatalf("projected repository entity = %#v, want github.code.repository", entity)
 	}
 	assertBootstrapProjectedLink(t, graphStore, repoURN, "has_evidence", scanURN)
 	assertBootstrapProjectedLink(t, graphStore, repoURN, "has_evidence", findingURN)
+	assertBootstrapProjectedLink(t, graphStore, repoURN, "has_evidence", noteURN)
 	assertBootstrapProjectedLink(t, graphStore, findingURN, "belongs_to", scanURN)
 	assertBootstrapProjectedLink(t, graphStore, findingURN, "affects", repoURN)
+	assertBootstrapProjectedLink(t, graphStore, noteURN, "belongs_to", scanURN)
 
 	neighborhoodResp, err := server.Client().Get(server.URL + "/platform/graph/neighborhood?root_urn=" + url.QueryEscape(findingURN) + "&limit=10")
 	if err != nil {

--- a/internal/sourceprojection/archetype.go
+++ b/internal/sourceprojection/archetype.go
@@ -1,6 +1,7 @@
 package sourceprojection
 
 import (
+	"net/url"
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -87,6 +88,63 @@ func archetypeVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports
 	return projectedEntities, projectedLinks, nil
 }
 
+func archetypeLibraryNoteProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	payload := payloadMap(event)
+	slug := firstNonEmpty(attrs["knowledge_slug"], stringValue(payload, "slug"))
+	if slug == "" {
+		return nil, nil, nil
+	}
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	repository := firstNonEmpty(attrs["repository"], joinRepo(attrs["owner"], attrs["repo"]))
+	noteURN := projectionURN(tenantID, "archetype_library_note", repository, url.QueryEscape(slug))
+	if noteURN == "" {
+		return nil, nil, nil
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        noteURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "archetype.library_note",
+		Label:      firstNonEmpty(attrs["title"], stringValue(payload, "title"), slug),
+		Attributes: compactAttributes(map[string]string{
+			"knowledge_slug":    slug,
+			"title":             firstNonEmpty(attrs["title"], stringValue(payload, "title")),
+			"summary":           stringValue(payload, "summary"),
+			"topics":            firstNonEmpty(attrs["topics"], archetypeStringSliceValue(payload, "topics")),
+			"repository":        repository,
+			"repository_id":     attrs["repository_id"],
+			"scan_id":           attrs["scan_id"],
+			"dominant_severity": attrs["dominant_severity"],
+			"source_product":    "archetype",
+			"at":                eventObservedAt(event),
+		}),
+	})
+	if repoURN := archetypeRepoURN(tenantID, attrs); repoURN != "" {
+		addArchetypeRepo(entities, tenantID, event.GetSourceId(), repoURN, attrs)
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), repoURN, noteURN, relationHasEvidence, map[string]string{"event_id": event.GetId(), "evidence_type": "archetype_library_note"}))
+	}
+	if scanID := strings.TrimSpace(attrs["scan_id"]); scanID != "" {
+		scanURN := projectionURN(tenantID, "archetype_scan", scanID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        scanURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "archetype.scan",
+			Label:      "Archetype scan " + scanID,
+			Attributes: map[string]string{"scan_id": scanID},
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), noteURN, scanURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
 func archetypeRepoURN(tenantID string, attrs map[string]string) string {
 	repository := firstNonEmpty(attrs["repository"], joinRepo(attrs["owner"], attrs["repo"]))
 	return projectionURN(tenantID, "github_code_repository", repository)
@@ -121,4 +179,25 @@ func joinRepo(owner string, repo string) string {
 		return ""
 	}
 	return strings.TrimSpace(owner) + "/" + strings.TrimSpace(repo)
+}
+
+func archetypeStringSliceValue(values map[string]any, key string) string {
+	raw, ok := values[key]
+	if !ok {
+		return ""
+	}
+	switch typed := raw.(type) {
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if value, ok := item.(string); ok && strings.TrimSpace(value) != "" {
+				parts = append(parts, strings.TrimSpace(value))
+			}
+		}
+		return strings.Join(parts, ",")
+	case []string:
+		return strings.Join(typed, ",")
+	default:
+		return ""
+	}
 }

--- a/internal/sourceprojection/archetype_test.go
+++ b/internal/sourceprojection/archetype_test.go
@@ -73,3 +73,114 @@ func TestProjectArchetypeScanLinksRepositoryEvidence(t *testing.T) {
 	assertProjectedLink(t, state, repoURN, relationHasEvidence, scanURN)
 	assertProjectedLink(t, state, scanURN, relationObservedOn, repoURN)
 }
+
+func TestProjectArchetypeLibraryNoteLinksRepositoryContext(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "archetype-library-7-repository-commit-learning",
+		TenantId: "writer",
+		SourceId: "archetype",
+		Kind:     "archetype.library_note",
+		Attributes: map[string]string{
+			"knowledge_slug":    "repository-commit-learning",
+			"repository_id":     "7",
+			"scan_id":           "1",
+			"owner":             "WriterInternal",
+			"repo":              "Archetype",
+			"dominant_severity": "info",
+		},
+		Payload: []byte(`{"slug":"repository-commit-learning","title":"Repository commit learning","summary":"Archetype learned the latest repository head.","topics":["gitops","commits","librarian"]}`),
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	repoURN := "urn:cerebro:writer:github_code_repository:WriterInternal/Archetype"
+	noteURN := "urn:cerebro:writer:archetype_library_note:WriterInternal/Archetype:repository-commit-learning"
+	scanURN := "urn:cerebro:writer:archetype_scan:1"
+	if entity := state.entities[noteURN]; entity == nil || entity.EntityType != "archetype.library_note" {
+		t.Fatalf("library note entity missing: %#v", entity)
+	} else {
+		if got := entity.Attributes["repository_id"]; got != "7" {
+			t.Fatalf("repository_id attr = %q, want 7", got)
+		}
+		if got := entity.Attributes["repository"]; got != "WriterInternal/Archetype" {
+			t.Fatalf("repository attr = %q, want WriterInternal/Archetype", got)
+		}
+		if got := entity.Attributes["title"]; got != "Repository commit learning" {
+			t.Fatalf("title attr = %q, want Repository commit learning", got)
+		}
+		if got := entity.Attributes["topics"]; got != "gitops,commits,librarian" {
+			t.Fatalf("topics attr = %q, want gitops,commits,librarian", got)
+		}
+		if got := entity.Attributes["dominant_severity"]; got != "info" {
+			t.Fatalf("dominant_severity attr = %q, want info", got)
+		}
+	}
+	if entity := state.entities[scanURN]; entity == nil || entity.EntityType != "archetype.scan" {
+		t.Fatalf("scan entity missing: %#v", entity)
+	}
+	assertProjectedLink(t, state, repoURN, relationHasEvidence, noteURN)
+	assertProjectedLink(t, state, noteURN, relationBelongsTo, scanURN)
+}
+
+func TestProjectArchetypeLibraryNoteWithoutScanIDDoesNotCreateScan(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "archetype-library-7-repository-commit-learning",
+		TenantId: "writer",
+		SourceId: "archetype",
+		Kind:     "archetype.library_note",
+		Attributes: map[string]string{
+			"knowledge_slug": "repository-commit-learning",
+			"repository_id":  "7",
+			"owner":          "WriterInternal",
+			"repo":           "Archetype",
+		},
+		Payload: []byte(`{"slug":"repository-commit-learning","title":"Repository commit learning","summary":"Archetype learned the latest repository head."}`),
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	repoURN := "urn:cerebro:writer:github_code_repository:WriterInternal/Archetype"
+	noteURN := "urn:cerebro:writer:archetype_library_note:WriterInternal/Archetype:repository-commit-learning"
+	phantomScanURN := "urn:cerebro:writer:archetype_scan"
+	if entity := state.entities[phantomScanURN]; entity != nil {
+		t.Fatalf("phantom scan entity = %#v, want none", entity)
+	}
+	assertProjectedLink(t, state, repoURN, relationHasEvidence, noteURN)
+	assertProjectedLinkMissing(t, state, noteURN, relationBelongsTo, phantomScanURN)
+}
+
+func TestProjectArchetypeLibraryNoteEscapesSlugURNPart(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "archetype-library-7-security%3Asql-injection",
+		TenantId: "writer",
+		SourceId: "archetype",
+		Kind:     "archetype.library_note",
+		Attributes: map[string]string{
+			"knowledge_slug": "security:sql-injection",
+			"repository_id":  "7",
+			"owner":          "WriterInternal",
+			"repo":           "Archetype",
+		},
+		Payload: []byte(`{"slug":"security:sql-injection","title":"SQL injection context","summary":"Repository query handling context."}`),
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	noteURN := "urn:cerebro:writer:archetype_library_note:WriterInternal/Archetype:security%3Asql-injection"
+	unescapedURN := "urn:cerebro:writer:archetype_library_note:WriterInternal/Archetype:security:sql-injection"
+	if entity := state.entities[noteURN]; entity == nil || entity.EntityType != "archetype.library_note" {
+		t.Fatalf("escaped slug note entity missing: %#v", entity)
+	}
+	if entity := state.entities[unescapedURN]; entity != nil {
+		t.Fatalf("unescaped slug entity = %#v, want none", entity)
+	}
+}

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -196,6 +196,7 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"auth0.users":                                   auth0UsersProjections,
 	"archetype.scan":                                archetypeScanProjections,
 	"archetype.vulnerability":                       archetypeVulnerabilityProjections,
+	"archetype.library_note":                        archetypeLibraryNoteProjections,
 	"aurelius.catalog_promotion":                    aureliusCatalogPromotionProjections,
 	"aurelius.finding":                              aureliusFindingProjections,
 	"aurelius.image_scan":                           aureliusImageScanProjections,

--- a/sources/archetype/catalog.yaml
+++ b/sources/archetype/catalog.yaml
@@ -4,6 +4,7 @@ description: Archetype code security scan lifecycle and vulnerability findings.
 emitted_kinds:
   - archetype.scan
   - archetype.vulnerability
+  - archetype.library_note
 coverage_contract:
   owner_domain: code_security
   authority_domain: archetype
@@ -24,6 +25,16 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
+    - id: library_notes
+      type: entity_family
+      title: Archetype repository library notes
+      # Library notes are imported with the vulnerability runtime so GitOps
+      # does not need a second Archetype source family for repository context.
+      families: [vulnerability]
+      support: supported
+      high_value: true
+      evidence_types: [knowledge_context]
+      control_domains: [asset_inventory]
 event_contracts:
   - kind: archetype.scan
     schema_ref: archetype/scan/v1
@@ -33,3 +44,7 @@ event_contracts:
     schema_ref: archetype/vulnerability/v1
     required_attributes: [vulnerability_id, scan_id, severity, category, file_path]
     required_payload_fields: [id, scan_id, severity, category, file_path]
+  - kind: archetype.library_note
+    schema_ref: archetype/library-note/v1
+    required_attributes: [knowledge_slug, owner, repo]
+    required_payload_fields: [slug, title, summary]

--- a/sources/archetype/source.go
+++ b/sources/archetype/source.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -58,6 +59,16 @@ type vulnerabilityRecord struct {
 	AnalyzerLabel string  `json:"analyzer_label"`
 	CreatedAt     string  `json:"created_at"`
 }
+type knowledgeEntryRecord struct {
+	Slug             string   `json:"slug"`
+	Title            string   `json:"title"`
+	Summary          string   `json:"summary"`
+	Topics           []string `json:"topics,omitempty"`
+	DominantSeverity string   `json:"dominant_severity,omitempty"`
+	RepositoryID     int      `json:"repository_id"`
+	RepositoryName   string   `json:"repository_name"`
+	Owner            string   `json:"owner"`
+}
 type repositoryRecord struct {
 	ID    int    `json:"id"`
 	Owner string `json:"owner"`
@@ -81,8 +92,7 @@ func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 	if err != nil {
 		return err
 	}
-	var scans []scanRecord
-	return s.get(ctx, st, "/scans", &scans)
+	return s.get(ctx, st, "/scans", new([]scanRecord))
 }
 func (s *Source) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
 	return nil, nil
@@ -102,6 +112,7 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 	sort.Slice(scans, func(i, j int) bool { return scans[i].ID < scans[j].ID })
 	last := lastScanID(cursor, checkpoint)
 	repos := map[int]repositoryRecord{}
+	knowledgeRepos := map[int]bool{}
 	events := []*primitives.Event{}
 	for _, scan := range scans {
 		if scan.ID <= last {
@@ -121,11 +132,23 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 		for _, vuln := range vulns {
 			events = append(events, vulnerabilityEvent(st, scan, vuln, repos[scan.RepositoryID]))
 		}
+		if !knowledgeRepos[scan.RepositoryID] {
+			entries, cacheable := s.repositoryKnowledge(ctx, st, scan.RepositoryID)
+			knowledgeRepos[scan.RepositoryID] = cacheable
+			for _, entry := range entries {
+				if event := libraryNoteEvent(st, scan, entry, repos[scan.RepositoryID]); event != nil {
+					events = append(events, event)
+				}
+			}
+			if err := ctx.Err(); err != nil {
+				return sourcecdk.Pull{}, err
+			}
+		}
 	}
 	if len(events) == 0 {
 		return sourcecdk.NotModifiedPull(checkpoint), nil
 	}
-	next := strconv.Itoa(maxScanID(scans))
+	next := strconv.Itoa(scans[len(scans)-1].ID)
 	return sourcecdk.Pull{Events: events, Checkpoint: &cerebrov1.SourceCheckpoint{CursorOpaque: next, Watermark: events[len(events)-1].OccurredAt}}, nil
 }
 func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
@@ -157,8 +180,7 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 	if err != nil {
 		return st, err
 	}
-	st.baseURL = baseURL
-	st.apiPrefix = strings.TrimRight(apiPrefix, "/")
+	st.baseURL, st.apiPrefix = baseURL, strings.TrimRight(apiPrefix, "/")
 	st.privateEndpointAllowlist = privateEndpointAllowlist
 	return st, nil
 }
@@ -184,7 +206,7 @@ func (s *Source) get(ctx context.Context, st settings, path string, out any) err
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("archetype GET %s failed with status %d", path, resp.StatusCode)
+		return &sourcecdk.HTTPStatusError{Code: resp.StatusCode, Message: fmt.Sprintf("archetype GET %s failed with status %d", path, resp.StatusCode)}
 	}
 	return json.Unmarshal(resp.Body, out)
 }
@@ -199,13 +221,45 @@ func (s *Source) repositories(ctx context.Context, st settings) map[int]reposito
 	}
 	return out
 }
+func (s *Source) repositoryKnowledge(ctx context.Context, st settings, repositoryID int) ([]knowledgeEntryRecord, bool) {
+	var response struct {
+		Entries []knowledgeEntryRecord `json:"entries"`
+	}
+	if err := s.get(ctx, st, fmt.Sprintf("/repositories/%d/knowledge", repositoryID), &response); err != nil {
+		if sourcecdk.IsHTTPStatus(err, http.StatusNotFound) || sourcecdk.IsHTTPStatus(err, http.StatusForbidden) || sourcecdk.IsRetryableHTTPStatus(err) {
+			return nil, !sourcecdk.IsRetryableHTTPStatus(err)
+		}
+		return nil, false
+	}
+	return response.Entries, true
+}
 func scanEvent(st settings, scan scanRecord, repo repositoryRecord) *primitives.Event {
-	attrs := map[string]string{"scan_id": itoa(scan.ID), "repository_id": itoa(scan.RepositoryID), "status": scan.Status, "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}
-	return event(st, "archetype.scan", "archetype-scan-"+itoa(scan.ID), "archetype/scan/v1", scanTime(scan), attrs, scan)
+	attrs := map[string]string{"scan_id": strconv.Itoa(scan.ID), "repository_id": strconv.Itoa(scan.RepositoryID), "status": scan.Status, "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}
+	return event(st, "archetype.scan", "archetype-scan-"+strconv.Itoa(scan.ID), "archetype/scan/v1", scanTime(scan), attrs, scan)
 }
 func vulnerabilityEvent(st settings, scan scanRecord, vuln vulnerabilityRecord, repo repositoryRecord) *primitives.Event {
-	attrs := map[string]string{"vulnerability_id": itoa(vuln.ID), "scan_id": itoa(vuln.ScanID), "repository_id": itoa(scan.RepositoryID), "severity": vuln.Severity, "category": vuln.Category, "file_path": vuln.FilePath, "line_number": itoa(vuln.LineNumber), "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}
-	return event(st, "archetype.vulnerability", "archetype-vulnerability-"+itoa(vuln.ID), "archetype/vulnerability/v1", parseTime(vuln.CreatedAt, scanTime(scan)), attrs, vuln)
+	attrs := map[string]string{"vulnerability_id": strconv.Itoa(vuln.ID), "scan_id": strconv.Itoa(vuln.ScanID), "repository_id": strconv.Itoa(scan.RepositoryID), "severity": vuln.Severity, "category": vuln.Category, "file_path": vuln.FilePath, "line_number": strconv.Itoa(vuln.LineNumber), "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}
+	return event(st, "archetype.vulnerability", "archetype-vulnerability-"+strconv.Itoa(vuln.ID), "archetype/vulnerability/v1", parseTime(vuln.CreatedAt, scanTime(scan)), attrs, vuln)
+}
+func libraryNoteEvent(st settings, scan scanRecord, entry knowledgeEntryRecord, repo repositoryRecord) *primitives.Event {
+	entry.Slug = first(entry.Slug)
+	entry.Owner, entry.RepositoryName = first(entry.Owner, repo.Owner), first(entry.RepositoryName, repo.Name)
+	if entry.RepositoryID == 0 {
+		entry.RepositoryID = scan.RepositoryID
+	}
+	if entry.Owner == "" || entry.RepositoryName == "" || entry.Slug == "" {
+		return nil
+	}
+	attrs := map[string]string{
+		"knowledge_slug":    entry.Slug,
+		"scan_id":           strconv.Itoa(scan.ID),
+		"repository_id":     strconv.Itoa(entry.RepositoryID),
+		"dominant_severity": entry.DominantSeverity,
+		"owner":             entry.Owner,
+		"repo":              entry.RepositoryName,
+	}
+	eventID := "archetype-library-" + strconv.Itoa(entry.RepositoryID) + "-" + url.QueryEscape(entry.Slug)
+	return event(st, "archetype.library_note", eventID, "archetype/library-note/v1", scanTime(scan), attrs, entry)
 }
 func event(st settings, kind, id, schema string, at time.Time, attrs map[string]string, payload any) *primitives.Event {
 	body, _ := json.Marshal(payload)
@@ -215,15 +269,6 @@ func lastScanID(cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceChec
 	value := first(sourcecdk.CursorToken(cursor), checkpoint.GetCursorOpaque())
 	id, _ := strconv.Atoi(value)
 	return id
-}
-func maxScanID(scans []scanRecord) int {
-	max := 0
-	for _, scan := range scans {
-		if scan.ID > max {
-			max = scan.ID
-		}
-	}
-	return max
 }
 func scanTime(scan scanRecord) time.Time {
 	return parseTime(first(scan.CompletedAt, scan.StartedAt, scan.CreatedAt), time.Now().UTC())
@@ -250,4 +295,3 @@ func compact(attrs map[string]string) map[string]string {
 	}
 	return attrs
 }
-func itoa(value int) string { return strconv.Itoa(value) }

--- a/sources/archetype/source_test.go
+++ b/sources/archetype/source_test.go
@@ -3,6 +3,7 @@ package archetype
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -30,6 +31,17 @@ func TestSourceReadEmitsScanAndVulnerabilityEvents(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte("[" + string(body) + "]"))
+		case "/api/v1/repositories/7/knowledge":
+			writeJSON(t, w, map[string]any{
+				"entries": []map[string]any{{
+					"slug":            "repository-commit-learning",
+					"title":           "Repository commit learning",
+					"summary":         "Archetype learned the latest repository head.",
+					"repository_id":   7,
+					"repository_name": "Archetype",
+					"owner":           "WriterInternal",
+				}},
+			})
 		default:
 			http.NotFound(w, r)
 		}
@@ -52,17 +64,415 @@ func TestSourceReadEmitsScanAndVulnerabilityEvents(t *testing.T) {
 	if !sawAuth {
 		t.Fatal("server did not receive bearer token")
 	}
-	if len(pull.Events) != 2 {
-		t.Fatalf("len(Events) = %d, want 2", len(pull.Events))
+	if len(pull.Events) != 3 {
+		t.Fatalf("len(Events) = %d, want 3", len(pull.Events))
 	}
-	if pull.Events[0].GetKind() != "archetype.scan" || pull.Events[1].GetKind() != "archetype.vulnerability" {
-		t.Fatalf("event kinds = %q, %q", pull.Events[0].GetKind(), pull.Events[1].GetKind())
+	if pull.Events[0].GetKind() != "archetype.scan" || pull.Events[1].GetKind() != "archetype.vulnerability" || pull.Events[2].GetKind() != "archetype.library_note" {
+		t.Fatalf("event kinds = %q, %q, %q", pull.Events[0].GetKind(), pull.Events[1].GetKind(), pull.Events[2].GetKind())
 	}
 	if got := pull.Events[1].GetAttributes()["repo"]; got != "Archetype" {
 		t.Fatalf("vulnerability repo attr = %q, want Archetype", got)
 	}
 	if got := pull.Checkpoint.GetCursorOpaque(); got != "1" {
 		t.Fatalf("checkpoint cursor = %q, want 1", got)
+	}
+}
+
+func TestSourceReadEmitsLibraryNoteEvents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"}})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		case "/api/v1/scans/1/vulnerabilities":
+			writeJSON(t, w, []map[string]any{})
+		case "/api/v1/repositories/7/knowledge":
+			writeJSON(t, w, map[string]any{
+				"entries": []map[string]any{{
+					"slug":              "repository-commit-learning",
+					"title":             "Repository commit learning",
+					"summary":           "Archetype learned the latest repository head.",
+					"topics":            []string{"gitops", "commits", "librarian"},
+					"generated_at":      "2026-06-17T12:04:00Z",
+					"repository_id":     7,
+					"repository_name":   "Archetype",
+					"owner":             "WriterInternal",
+					"dominant_severity": "info",
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "base_url": server.URL}), nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(Events) = %d, want 2", len(pull.Events))
+	}
+	if pull.Events[0].GetKind() != "archetype.scan" || pull.Events[1].GetKind() != "archetype.library_note" {
+		t.Fatalf("event kinds = %q, %q", pull.Events[0].GetKind(), pull.Events[1].GetKind())
+	}
+	attrs := pull.Events[1].GetAttributes()
+	if got := attrs["owner"] + "/" + attrs["repo"]; got != "WriterInternal/Archetype" {
+		t.Fatalf("library repository attrs = %q, want WriterInternal/Archetype", got)
+	}
+	if got := attrs["knowledge_slug"]; got != "repository-commit-learning" {
+		t.Fatalf("library slug attr = %q, want repository-commit-learning", got)
+	}
+	if got := pull.Events[1].GetId(); got != "archetype-library-7-repository-commit-learning" {
+		t.Fatalf("library event id = %q, want stable repository note id", got)
+	}
+	if got := attrs["repository_id"]; got != "7" {
+		t.Fatalf("library repository_id attr = %q, want 7", got)
+	}
+	if got := attrs["dominant_severity"]; got != "info" {
+		t.Fatalf("library dominant_severity attr = %q, want info", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(pull.Events[1].GetPayload(), &payload); err != nil {
+		t.Fatalf("decode library payload: %v", err)
+	}
+	topics, ok := payload["topics"].([]any)
+	if !ok || len(topics) != 3 || topics[0] != "gitops" {
+		t.Fatalf("library payload topics = %#v, want gitops/commits/librarian", payload["topics"])
+	}
+}
+
+func TestLibraryNoteEventEscapesProviderSlugInID(t *testing.T) {
+	event := libraryNoteEvent(settings{tenantID: "writer"}, scanRecord{ID: 1, RepositoryID: 7}, knowledgeEntryRecord{
+		Slug:           "security:sql/injection",
+		Title:          "SQL injection context",
+		Summary:        "Repository query handling context.",
+		RepositoryID:   7,
+		RepositoryName: "Archetype",
+		Owner:          "WriterInternal",
+	}, repositoryRecord{ID: 7, Owner: "WriterInternal", Name: "Archetype"})
+	if event == nil {
+		t.Fatal("libraryNoteEvent() = nil")
+	}
+	if got, want := event.GetId(), "archetype-library-7-security%3Asql%2Finjection"; got != want {
+		t.Fatalf("event ID = %q, want %q", got, want)
+	}
+	if got := event.GetAttributes()["knowledge_slug"]; got != "security:sql/injection" {
+		t.Fatalf("knowledge_slug attr = %q, want raw provider slug", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(event.GetPayload(), &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if got := payload["slug"]; got != "security:sql/injection" {
+		t.Fatalf("payload slug = %q, want raw provider slug", got)
+	}
+}
+
+func TestSourceReadFetchesRepositoryKnowledgeOncePerRepo(t *testing.T) {
+	knowledgeRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{
+				{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"},
+				{"id": 2, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T13:05:00Z"},
+			})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		case "/api/v1/scans/1/vulnerabilities", "/api/v1/scans/2/vulnerabilities":
+			writeJSON(t, w, []map[string]any{})
+		case "/api/v1/repositories/7/knowledge":
+			knowledgeRequests++
+			writeJSON(t, w, map[string]any{
+				"entries": []map[string]any{{
+					"slug":            "repository-commit-learning",
+					"title":           "Repository commit learning",
+					"summary":         "Archetype learned the latest repository head.",
+					"repository_id":   7,
+					"repository_name": "Archetype",
+					"owner":           "WriterInternal",
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "base_url": server.URL}), nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if knowledgeRequests != 1 {
+		t.Fatalf("knowledge requests = %d, want 1", knowledgeRequests)
+	}
+	var libraryEvents int
+	for _, event := range pull.Events {
+		if event.GetKind() == "archetype.library_note" {
+			libraryEvents++
+		}
+	}
+	if libraryEvents != 1 {
+		t.Fatalf("library note events = %d, want 1", libraryEvents)
+	}
+}
+
+func TestSourceReadSkipsLibraryNoteWithoutRepositoryIdentity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"}})
+		case "/api/v1/scans/1/vulnerabilities":
+			writeJSON(t, w, []map[string]any{})
+		case "/api/v1/repositories/7/knowledge":
+			writeJSON(t, w, map[string]any{
+				"entries": []map[string]any{
+					{
+						"slug":    "repository-commit-learning",
+						"title":   "Repository commit learning",
+						"summary": "Archetype learned the latest repository head.",
+					},
+					{
+						"slug":            " ",
+						"title":           "Repository commit learning",
+						"summary":         "Archetype learned the latest repository head.",
+						"repository_name": "Archetype",
+						"owner":           "WriterInternal",
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "base_url": server.URL}), nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 1 || pull.Events[0].GetKind() != "archetype.scan" {
+		t.Fatalf("events = %#v, want only scan event", pull.Events)
+	}
+}
+
+func TestSourceReadContinuesWhenKnowledgeEndpointIsMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"}})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		case "/api/v1/scans/1/vulnerabilities":
+			body, err := os.ReadFile("testdata/sample_vulnerability.json")
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[" + string(body) + "]"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "base_url": server.URL}), nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(Events) = %d, want scan and vulnerability events", len(pull.Events))
+	}
+	if pull.Events[0].GetKind() != "archetype.scan" || pull.Events[1].GetKind() != "archetype.vulnerability" {
+		t.Fatalf("event kinds = %q, %q", pull.Events[0].GetKind(), pull.Events[1].GetKind())
+	}
+}
+
+func TestSourceReadContinuesWhenKnowledgeEndpointFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"}})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		case "/api/v1/scans/1/vulnerabilities":
+			body, err := os.ReadFile("testdata/sample_vulnerability.json")
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[" + string(body) + "]"))
+		case "/api/v1/repositories/7/knowledge":
+			http.Error(w, "try later", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "base_url": server.URL}), nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(Events) = %d, want scan and vulnerability events", len(pull.Events))
+	}
+	if pull.Events[0].GetKind() != "archetype.scan" || pull.Events[1].GetKind() != "archetype.vulnerability" {
+		t.Fatalf("event kinds = %q, %q", pull.Events[0].GetKind(), pull.Events[1].GetKind())
+	}
+}
+
+func TestSourceReadContinuesWhenKnowledgeEndpointReturnsMalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"}})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		case "/api/v1/scans/1/vulnerabilities":
+			body, err := os.ReadFile("testdata/sample_vulnerability.json")
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[" + string(body) + "]"))
+		case "/api/v1/repositories/7/knowledge":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"entries":[`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "base_url": server.URL}), nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(Events) = %d, want scan and vulnerability events", len(pull.Events))
+	}
+	if pull.Events[0].GetKind() != "archetype.scan" || pull.Events[1].GetKind() != "archetype.vulnerability" {
+		t.Fatalf("event kinds = %q, %q", pull.Events[0].GetKind(), pull.Events[1].GetKind())
+	}
+}
+
+func TestSourceReadReturnsCanceledContextAfterKnowledgeFetch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"}})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		case "/api/v1/scans/1/vulnerabilities":
+			writeJSON(t, w, []map[string]any{})
+		case "/api/v1/repositories/7/knowledge":
+			cancel()
+			writeJSON(t, w, map[string]any{"entries": []map[string]any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	if _, err := source.ReadWithCheckpoint(ctx, sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "base_url": server.URL}), nil, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ReadWithCheckpoint() error = %v, want context canceled", err)
+	}
+}
+
+func TestSourceReadRetriesKnowledgeAfterTransientMissWithinRead(t *testing.T) {
+	knowledgeRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{
+				{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"},
+				{"id": 2, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T13:05:00Z"},
+			})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		case "/api/v1/scans/1/vulnerabilities", "/api/v1/scans/2/vulnerabilities":
+			writeJSON(t, w, []map[string]any{})
+		case "/api/v1/repositories/7/knowledge":
+			knowledgeRequests++
+			if knowledgeRequests <= 3 {
+				http.Error(w, "try later", http.StatusInternalServerError)
+				return
+			}
+			writeJSON(t, w, map[string]any{
+				"entries": []map[string]any{{
+					"slug":            "repository-commit-learning",
+					"title":           "Repository commit learning",
+					"summary":         "Archetype learned the latest repository head.",
+					"repository_id":   7,
+					"repository_name": "Archetype",
+					"owner":           "WriterInternal",
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "writer", "base_url": server.URL}), nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if knowledgeRequests != 4 {
+		t.Fatalf("knowledge requests = %d, want exhausted retry plus second scan retry", knowledgeRequests)
+	}
+	var libraryEvents int
+	for _, event := range pull.Events {
+		if event.GetKind() == "archetype.library_note" {
+			libraryEvents++
+		}
+	}
+	if libraryEvents != 1 {
+		t.Fatalf("library note events = %d, want 1", libraryEvents)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extend the existing Archetype `vulnerability` source read to also fetch `/api/v1/repositories/{id}/knowledge` and emit `archetype.library_note` events for each new scan.
- Treat a missing repository knowledge endpoint as optional during rollout, so older Archetype deployments still import scans and vulnerabilities.
- Register the new event contract in the Archetype source catalog.
- Project library-note events into `archetype.library_note` entities linked to the canonical `github.code.repository` node and, when present, the originating scan.

## Why
Archetype is producing repository-level librarian context. Cerebro's pull adapter needs to import that context onto the existing repository graph instead of only importing scans and vulnerabilities. Keeping this on the existing vulnerability runtime avoids adding a new runtime family/release-contract gate.

## Validation
- `go test ./sources/archetype ./internal/sourceprojection ./internal/bootstrap -count=1`
- `go test -race ./sources/archetype ./internal/sourceprojection ./internal/bootstrap -run 'GraphIngestArchetype|SourceRead|ProjectArchetype' -count=1`
- `make catalog-check`
- `make check-arch`
- `make test`

## Related
- Complements the direct Archetype push publisher changes in WriterInternal/archetype#127.
- Enables WriterInternal/cerebro#1774 to schedule the existing Archetype vulnerability runtime for both vulnerability and library-note import.