### PR TITLE
fix: Omit default Bedrock temperature

### DIFF
--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -119,14 +119,15 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 	if graphAgentLLMConfigured(cfg.GraphAgentLLM) {
 		llm, err := graphagent.NewLLMClientWithSecrets(ctx, graphagent.LLMConfigWithSecrets{
 			LLMConfig: graphagent.LLMConfig{
-				Provider:    cfg.GraphAgentLLM.Provider,
-				Model:       cfg.GraphAgentLLM.Model,
-				SonnetModel: cfg.GraphAgentLLM.SonnetModel,
-				OpusModel:   cfg.GraphAgentLLM.OpusModel,
-				HaikuModel:  cfg.GraphAgentLLM.HaikuModel,
-				Region:      cfg.GraphAgentLLM.BedrockRegion,
-				MaxTokens:   cfg.GraphAgentLLM.MaxTokens,
-				Temperature: cfg.GraphAgentLLM.Temperature,
+				Provider:       cfg.GraphAgentLLM.Provider,
+				Model:          cfg.GraphAgentLLM.Model,
+				SonnetModel:    cfg.GraphAgentLLM.SonnetModel,
+				OpusModel:      cfg.GraphAgentLLM.OpusModel,
+				HaikuModel:     cfg.GraphAgentLLM.HaikuModel,
+				Region:         cfg.GraphAgentLLM.BedrockRegion,
+				MaxTokens:      cfg.GraphAgentLLM.MaxTokens,
+				Temperature:    cfg.GraphAgentLLM.Temperature,
+				TemperatureSet: cfg.GraphAgentLLM.TemperatureSet,
 			},
 			OpenRouterAPIKey: cfg.GraphAgentLLM.OpenRouterAPIKey,
 			HTTPDoer:         NewHTTPDoer(),
@@ -179,15 +180,10 @@ func OpenSourceRuntimeBootstrapDependencies(ctx context.Context, cfg config.Conf
 }
 
 func graphAgentLLMConfigured(cfg config.GraphAgentLLMConfig) bool {
-	return cfg.Provider != "" ||
-		cfg.Model != "" ||
-		cfg.SonnetModel != "" ||
-		cfg.OpusModel != "" ||
-		cfg.HaikuModel != "" ||
-		cfg.BedrockRegion != "" ||
-		cfg.OpenRouterAPIKey != "" ||
-		cfg.MaxTokens != 0 ||
-		cfg.Temperature != 0
+	return cfg.Provider != "" || cfg.Model != "" ||
+		cfg.SonnetModel != "" || cfg.OpusModel != "" || cfg.HaikuModel != "" ||
+		cfg.BedrockRegion != "" || cfg.OpenRouterAPIKey != "" || cfg.MaxTokens != 0 ||
+		cfg.TemperatureSet
 }
 
 // pingDependency runs Ping with its own dependencyPingTimeout-bounded context so

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,6 +127,7 @@ type GraphAgentLLMConfig struct {
 	HaikuModel       string
 	MaxTokens        int
 	Temperature      float64
+	TemperatureSet   bool
 	OpenRouterAPIKey string
 	BedrockRegion    string
 }
@@ -553,6 +554,7 @@ func Load() (Config, error) {
 	if cfg.GraphAgentLLM.Temperature, err = parseFloatEnv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", 0); err != nil {
 		return Config{}, err
 	}
+	cfg.GraphAgentLLM.TemperatureSet = envHasValue("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE")
 	if cfg.AppendLog.JetStreamDrainTimeout, err = parseDurationEnv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", 0); err != nil {
 		return Config{}, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,7 +106,7 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.GraphStore.Driver != "" {
 		t.Fatalf("GraphStore.Driver = %q, want empty", cfg.GraphStore.Driver)
 	}
-	if cfg.GraphAgentLLM.Provider != "" || cfg.GraphAgentLLM.MaxTokens != 0 {
+	if cfg.GraphAgentLLM.Provider != "" || cfg.GraphAgentLLM.MaxTokens != 0 || cfg.GraphAgentLLM.TemperatureSet {
 		t.Fatalf("GraphAgentLLM = %#v, want empty/default", cfg.GraphAgentLLM)
 	}
 	if cfg.GraphActions.AccessApprovals.Timeout != 10*time.Second || cfg.GraphActions.AccessApprovals.BaseURL != "" || cfg.GraphActions.AccessApprovals.BearerToken != "" {
@@ -138,6 +138,22 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if cfg.Auth.DeviceAuth.RefreshTTL != defaultDeviceAuthRefreshTTL {
 		t.Fatalf("DeviceAuth.RefreshTTL = %v, want %v", cfg.Auth.DeviceAuth.RefreshTTL, defaultDeviceAuthRefreshTTL)
+	}
+}
+
+func TestLoadPreservesExplicitZeroGraphAgentTemperature(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", "0")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !cfg.GraphAgentLLM.TemperatureSet {
+		t.Fatal("GraphAgentLLM.TemperatureSet = false, want true")
+	}
+	if cfg.GraphAgentLLM.Temperature != 0 {
+		t.Fatalf("GraphAgentLLM.Temperature = %v, want 0", cfg.GraphAgentLLM.Temperature)
 	}
 }
 
@@ -303,7 +319,7 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.GraphStore.Neo4jQueryTimeout != 45*time.Second {
 		t.Fatalf("Neo4jQueryTimeout = %v, want 45s", cfg.GraphStore.Neo4jQueryTimeout)
 	}
-	if cfg.GraphAgentLLM.Provider != "stub" || cfg.GraphAgentLLM.MaxTokens != 900 || cfg.GraphAgentLLM.Temperature != 0.25 {
+	if cfg.GraphAgentLLM.Provider != "stub" || cfg.GraphAgentLLM.MaxTokens != 900 || cfg.GraphAgentLLM.Temperature != 0.25 || !cfg.GraphAgentLLM.TemperatureSet {
 		t.Fatalf("GraphAgentLLM = %#v", cfg.GraphAgentLLM)
 	}
 	if cfg.GraphAgentLLM.SonnetModel != "anthropic.claude-sonnet-example" || cfg.GraphAgentLLM.OpusModel == "" || cfg.GraphAgentLLM.HaikuModel == "" {

--- a/internal/graphagent/llm.go
+++ b/internal/graphagent/llm.go
@@ -56,14 +56,15 @@ type LLMProber interface {
 }
 
 type LLMConfig struct {
-	Provider    string
-	Model       string
-	SonnetModel string
-	OpusModel   string
-	HaikuModel  string
-	Region      string
-	MaxTokens   int
-	Temperature float64
+	Provider       string
+	Model          string
+	SonnetModel    string
+	OpusModel      string
+	HaikuModel     string
+	Region         string
+	MaxTokens      int
+	Temperature    float64
+	TemperatureSet bool
 }
 
 type LLMConfigWithSecrets struct {
@@ -86,13 +87,14 @@ func NewLLMClientWithSecrets(ctx context.Context, cfg LLMConfigWithSecrets) (LLM
 		return NewStubLLMClient(), nil
 	case "bedrock":
 		client, err := NewBedrockLLMClient(ctx, BedrockConfig{
-			DefaultModel: cfg.Model,
-			SonnetModel:  cfg.SonnetModel,
-			OpusModel:    cfg.OpusModel,
-			HaikuModel:   cfg.HaikuModel,
-			Region:       cfg.Region,
-			MaxTokens:    cfg.MaxTokens,
-			Temperature:  cfg.Temperature,
+			DefaultModel:   cfg.Model,
+			SonnetModel:    cfg.SonnetModel,
+			OpusModel:      cfg.OpusModel,
+			HaikuModel:     cfg.HaikuModel,
+			Region:         cfg.Region,
+			MaxTokens:      cfg.MaxTokens,
+			Temperature:    cfg.Temperature,
+			TemperatureSet: cfg.TemperatureSet,
 		})
 		if err != nil {
 			return nil, err
@@ -100,14 +102,15 @@ func NewLLMClientWithSecrets(ctx context.Context, cfg LLMConfigWithSecrets) (LLM
 		return instrumentLLMClient(provider, client), nil
 	case "openrouter":
 		client, err := NewOpenRouterLLMClient(OpenRouterConfig{
-			APIKey:       cfg.OpenRouterAPIKey,
-			HTTPDoer:     cfg.HTTPDoer,
-			DefaultModel: cfg.Model,
-			SonnetModel:  cfg.SonnetModel,
-			OpusModel:    cfg.OpusModel,
-			HaikuModel:   cfg.HaikuModel,
-			MaxTokens:    cfg.MaxTokens,
-			Temperature:  cfg.Temperature,
+			APIKey:         cfg.OpenRouterAPIKey,
+			HTTPDoer:       cfg.HTTPDoer,
+			DefaultModel:   cfg.Model,
+			SonnetModel:    cfg.SonnetModel,
+			OpusModel:      cfg.OpusModel,
+			HaikuModel:     cfg.HaikuModel,
+			MaxTokens:      cfg.MaxTokens,
+			Temperature:    cfg.Temperature,
+			TemperatureSet: cfg.TemperatureSet,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/graphagent/llm_bedrock.go
+++ b/internal/graphagent/llm_bedrock.go
@@ -150,7 +150,13 @@ func (c *BedrockLLMClient) invokeMessages(ctx context.Context, modelID string, p
 	if err != nil {
 		return "", err
 	}
-	temperature32 := float32(c.temperature)
+	inferenceConfig := &bedrocktypes.InferenceConfiguration{
+		MaxTokens: &maxTokens32,
+	}
+	if c.temperature != 0 {
+		temperature32 := float32(c.temperature)
+		inferenceConfig.Temperature = &temperature32
+	}
 	out, err := c.client.Converse(ctx, &bedrockruntime.ConverseInput{
 		ModelId: aws.String(modelID),
 		Messages: []bedrocktypes.Message{{
@@ -159,10 +165,7 @@ func (c *BedrockLLMClient) invokeMessages(ctx context.Context, modelID string, p
 				&bedrocktypes.ContentBlockMemberText{Value: prompt},
 			},
 		}},
-		InferenceConfig: &bedrocktypes.InferenceConfiguration{
-			MaxTokens:   &maxTokens32,
-			Temperature: &temperature32,
-		},
+		InferenceConfig: inferenceConfig,
 	})
 	if err != nil {
 		return "", classifyBedrockInvokeError(err)

--- a/internal/graphagent/llm_bedrock.go
+++ b/internal/graphagent/llm_bedrock.go
@@ -24,24 +24,26 @@ type BedrockRuntimeInvoker interface {
 }
 
 type BedrockLLMClient struct {
-	client       BedrockRuntimeInvoker
-	defaultModel string
-	sonnetModel  string
-	opusModel    string
-	haikuModel   string
-	maxTokens    int
-	temperature  float64
+	client         BedrockRuntimeInvoker
+	defaultModel   string
+	sonnetModel    string
+	opusModel      string
+	haikuModel     string
+	maxTokens      int
+	temperature    float64
+	temperatureSet bool
 }
 
 type BedrockConfig struct {
-	DefaultModel string
-	SonnetModel  string
-	OpusModel    string
-	HaikuModel   string
-	Region       string
-	MaxTokens    int
-	Temperature  float64
-	Runtime      BedrockRuntimeInvoker
+	DefaultModel   string
+	SonnetModel    string
+	OpusModel      string
+	HaikuModel     string
+	Region         string
+	MaxTokens      int
+	Temperature    float64
+	TemperatureSet bool
+	Runtime        BedrockRuntimeInvoker
 }
 
 type BedrockAccessDeniedError struct {
@@ -92,13 +94,14 @@ func NewBedrockLLMClient(ctx context.Context, llmConfig BedrockConfig) (*Bedrock
 		llmConfig.MaxTokens = 1200
 	}
 	return &BedrockLLMClient{
-		client:       client,
-		defaultModel: strings.TrimSpace(llmConfig.DefaultModel),
-		sonnetModel:  strings.TrimSpace(llmConfig.SonnetModel),
-		opusModel:    strings.TrimSpace(llmConfig.OpusModel),
-		haikuModel:   strings.TrimSpace(llmConfig.HaikuModel),
-		maxTokens:    llmConfig.MaxTokens,
-		temperature:  llmConfig.Temperature,
+		client:         client,
+		defaultModel:   strings.TrimSpace(llmConfig.DefaultModel),
+		sonnetModel:    strings.TrimSpace(llmConfig.SonnetModel),
+		opusModel:      strings.TrimSpace(llmConfig.OpusModel),
+		haikuModel:     strings.TrimSpace(llmConfig.HaikuModel),
+		maxTokens:      llmConfig.MaxTokens,
+		temperature:    llmConfig.Temperature,
+		temperatureSet: llmConfig.TemperatureSet,
 	}, nil
 }
 
@@ -153,7 +156,7 @@ func (c *BedrockLLMClient) invokeMessages(ctx context.Context, modelID string, p
 	inferenceConfig := &bedrocktypes.InferenceConfiguration{
 		MaxTokens: &maxTokens32,
 	}
-	if c.temperature != 0 {
+	if c.temperatureSet {
 		temperature32 := float32(c.temperature)
 		inferenceConfig.Temperature = &temperature32
 	}

--- a/internal/graphagent/llm_bedrock_test.go
+++ b/internal/graphagent/llm_bedrock_test.go
@@ -83,11 +83,42 @@ func TestBedrockLLMClient_DraftCypherUsesInferenceProfile(t *testing.T) {
 	if runtime.lastInput.InferenceConfig == nil || aws.ToInt32(runtime.lastInput.InferenceConfig.MaxTokens) != 100 {
 		t.Fatalf("max_tokens = %#v, want 100", runtime.lastInput.InferenceConfig)
 	}
+	if runtime.lastInput.InferenceConfig.Temperature != nil {
+		t.Fatalf("temperature = %v, want omitted by default", aws.ToFloat32(runtime.lastInput.InferenceConfig.Temperature))
+	}
 	if len(runtime.lastInput.Messages) != 1 || len(runtime.lastInput.Messages[0].Content) != 1 {
 		t.Fatalf("messages = %#v", runtime.lastInput.Messages)
 	}
 	if !strings.Contains(bedrockContentText(runtime.lastInput.Messages[0].Content[0]), "Show risky assets") {
 		t.Fatalf("request message did not include question: %#v", runtime.lastInput.Messages)
+	}
+}
+
+func TestBedrockLLMClient_SendsConfiguredTemperature(t *testing.T) {
+	runtime := &stubBedrockRuntime{text: `{"rationale":"ok","cypher":"MATCH (n) RETURN n LIMIT 5","refusal":""}`}
+	client, err := NewBedrockLLMClient(context.Background(), BedrockConfig{
+		DefaultModel: "us.anthropic.claude-sonnet-4-6",
+		Runtime:      runtime,
+		MaxTokens:    100,
+		Temperature:  0.25,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.DraftCypher(context.Background(), DraftRequest{
+		TenantID: "test",
+		Question: "Show risky assets",
+		Model:    DefaultModel,
+	})
+	if err != nil {
+		t.Fatalf("draft cypher: %v", err)
+	}
+	if runtime.lastInput.InferenceConfig == nil || runtime.lastInput.InferenceConfig.Temperature == nil {
+		t.Fatalf("temperature = nil, want configured value")
+	}
+	if got := aws.ToFloat32(runtime.lastInput.InferenceConfig.Temperature); got != 0.25 {
+		t.Fatalf("temperature = %v, want 0.25", got)
 	}
 }
 

--- a/internal/graphagent/llm_bedrock_test.go
+++ b/internal/graphagent/llm_bedrock_test.go
@@ -97,10 +97,11 @@ func TestBedrockLLMClient_DraftCypherUsesInferenceProfile(t *testing.T) {
 func TestBedrockLLMClient_SendsConfiguredTemperature(t *testing.T) {
 	runtime := &stubBedrockRuntime{text: `{"rationale":"ok","cypher":"MATCH (n) RETURN n LIMIT 5","refusal":""}`}
 	client, err := NewBedrockLLMClient(context.Background(), BedrockConfig{
-		DefaultModel: "us.anthropic.claude-sonnet-4-6",
-		Runtime:      runtime,
-		MaxTokens:    100,
-		Temperature:  0.25,
+		DefaultModel:   "us.anthropic.claude-sonnet-4-6",
+		Runtime:        runtime,
+		MaxTokens:      100,
+		Temperature:    0.25,
+		TemperatureSet: true,
 	})
 	if err != nil {
 		t.Fatalf("create client: %v", err)
@@ -119,6 +120,35 @@ func TestBedrockLLMClient_SendsConfiguredTemperature(t *testing.T) {
 	}
 	if got := aws.ToFloat32(runtime.lastInput.InferenceConfig.Temperature); got != 0.25 {
 		t.Fatalf("temperature = %v, want 0.25", got)
+	}
+}
+
+func TestBedrockLLMClient_SendsExplicitZeroTemperature(t *testing.T) {
+	runtime := &stubBedrockRuntime{text: `{"rationale":"ok","cypher":"MATCH (n) RETURN n LIMIT 5","refusal":""}`}
+	client, err := NewBedrockLLMClient(context.Background(), BedrockConfig{
+		DefaultModel:   "us.anthropic.claude-sonnet-4-6",
+		Runtime:        runtime,
+		MaxTokens:      100,
+		Temperature:    0,
+		TemperatureSet: true,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.DraftCypher(context.Background(), DraftRequest{
+		TenantID: "test",
+		Question: "Show risky assets",
+		Model:    DefaultModel,
+	})
+	if err != nil {
+		t.Fatalf("draft cypher: %v", err)
+	}
+	if runtime.lastInput.InferenceConfig == nil || runtime.lastInput.InferenceConfig.Temperature == nil {
+		t.Fatalf("temperature = nil, want explicit zero")
+	}
+	if got := aws.ToFloat32(runtime.lastInput.InferenceConfig.Temperature); got != 0 {
+		t.Fatalf("temperature = %v, want 0", got)
 	}
 }
 

--- a/internal/graphagent/llm_openrouter.go
+++ b/internal/graphagent/llm_openrouter.go
@@ -18,25 +18,27 @@ type HTTPDoer interface {
 }
 
 type OpenRouterLLMClient struct {
-	apiKey       string
-	httpDoer     HTTPDoer
-	defaultModel string
-	sonnetModel  string
-	opusModel    string
-	haikuModel   string
-	maxTokens    int
-	temperature  float64
+	apiKey         string
+	httpDoer       HTTPDoer
+	defaultModel   string
+	sonnetModel    string
+	opusModel      string
+	haikuModel     string
+	maxTokens      int
+	temperature    float64
+	temperatureSet bool
 }
 
 type OpenRouterConfig struct {
-	APIKey       string
-	HTTPDoer     HTTPDoer
-	DefaultModel string
-	SonnetModel  string
-	OpusModel    string
-	HaikuModel   string
-	MaxTokens    int
-	Temperature  float64
+	APIKey         string
+	HTTPDoer       HTTPDoer
+	DefaultModel   string
+	SonnetModel    string
+	OpusModel      string
+	HaikuModel     string
+	MaxTokens      int
+	Temperature    float64
+	TemperatureSet bool
 }
 
 type OpenRouterAuthenticationError struct {
@@ -75,14 +77,15 @@ func NewOpenRouterLLMClient(cfg OpenRouterConfig) (*OpenRouterLLMClient, error) 
 		cfg.MaxTokens = 1200
 	}
 	return &OpenRouterLLMClient{
-		apiKey:       strings.TrimSpace(cfg.APIKey),
-		httpDoer:     cfg.HTTPDoer,
-		defaultModel: strings.TrimSpace(cfg.DefaultModel),
-		sonnetModel:  strings.TrimSpace(cfg.SonnetModel),
-		opusModel:    strings.TrimSpace(cfg.OpusModel),
-		haikuModel:   strings.TrimSpace(cfg.HaikuModel),
-		maxTokens:    cfg.MaxTokens,
-		temperature:  cfg.Temperature,
+		apiKey:         strings.TrimSpace(cfg.APIKey),
+		httpDoer:       cfg.HTTPDoer,
+		defaultModel:   strings.TrimSpace(cfg.DefaultModel),
+		sonnetModel:    strings.TrimSpace(cfg.SonnetModel),
+		opusModel:      strings.TrimSpace(cfg.OpusModel),
+		haikuModel:     strings.TrimSpace(cfg.HaikuModel),
+		maxTokens:      cfg.MaxTokens,
+		temperature:    cfg.Temperature,
+		temperatureSet: cfg.TemperatureSet,
 	}, nil
 }
 
@@ -131,13 +134,15 @@ func (c *OpenRouterLLMClient) modelID(requested string) (string, error) {
 
 func (c *OpenRouterLLMClient) chat(ctx context.Context, model string, prompt string, maxTokens int) (string, error) {
 	body := map[string]any{
-		"model":       model,
-		"max_tokens":  maxTokens,
-		"temperature": c.temperature,
+		"model":      model,
+		"max_tokens": maxTokens,
 		"messages": []map[string]any{{
 			"role":    "user",
 			"content": prompt,
 		}},
+	}
+	if c.temperatureSet {
+		body["temperature"] = c.temperature
 	}
 	payload, err := json.Marshal(body)
 	if err != nil {

--- a/internal/graphagent/llm_openrouter_test.go
+++ b/internal/graphagent/llm_openrouter_test.go
@@ -85,6 +85,71 @@ func TestOpenRouterLLMClient_DraftCypher(t *testing.T) {
 		t.Errorf("expected URL %s, got %s", openRouterBaseURL, doer.lastURL)
 	}
 	assertOpenRouterRequestModel(t, doer.lastBody, defaultOpenRouterModel)
+	if _, ok := openRouterRequestPayload(t, doer.lastBody)["temperature"]; ok {
+		t.Fatalf("temperature was sent by default: %s", string(doer.lastBody))
+	}
+}
+
+func TestOpenRouterLLMClient_SendsConfiguredTemperature(t *testing.T) {
+	respBody, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{{
+			"message": map[string]string{
+				"content": `{"rationale":"test rationale","cypher":"MATCH (n) RETURN n LIMIT 5","refusal":""}`,
+			},
+		}},
+	})
+	doer := &stubHTTPDoer{statusCode: 200, body: respBody}
+
+	client, err := NewOpenRouterLLMClient(OpenRouterConfig{
+		APIKey:         "test-key",
+		HTTPDoer:       doer,
+		MaxTokens:      100,
+		Temperature:    0.25,
+		TemperatureSet: true,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.DraftCypher(context.Background(), DraftRequest{TenantID: "test", Question: "Show all nodes"})
+	if err != nil {
+		t.Fatalf("draft cypher: %v", err)
+	}
+	payload := openRouterRequestPayload(t, doer.lastBody)
+	if got := payload["temperature"]; got != 0.25 {
+		t.Fatalf("temperature = %#v, want 0.25", got)
+	}
+}
+
+func TestOpenRouterLLMClient_SendsExplicitZeroTemperature(t *testing.T) {
+	respBody, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{{
+			"message": map[string]string{
+				"content": `{"rationale":"test rationale","cypher":"MATCH (n) RETURN n LIMIT 5","refusal":""}`,
+			},
+		}},
+	})
+	doer := &stubHTTPDoer{statusCode: 200, body: respBody}
+
+	client, err := NewOpenRouterLLMClient(OpenRouterConfig{
+		APIKey:         "test-key",
+		HTTPDoer:       doer,
+		MaxTokens:      100,
+		Temperature:    0,
+		TemperatureSet: true,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.DraftCypher(context.Background(), DraftRequest{TenantID: "test", Question: "Show all nodes"})
+	if err != nil {
+		t.Fatalf("draft cypher: %v", err)
+	}
+	payload := openRouterRequestPayload(t, doer.lastBody)
+	if got, ok := payload["temperature"]; !ok || got != float64(0) {
+		t.Fatalf("temperature = %#v (present %v), want explicit 0", got, ok)
+	}
 }
 
 func TestOpenRouterLLMClient_MapsAnthropicAliasToOpenRouterModel(t *testing.T) {
@@ -327,13 +392,17 @@ func TestOpenRouterLLMClient_HTTPDoerError(t *testing.T) {
 
 func assertOpenRouterRequestModel(t *testing.T, body []byte, want string) {
 	t.Helper()
-	var payload struct {
-		Model string `json:"model"`
+	payload := openRouterRequestPayload(t, body)
+	if got, _ := payload["model"].(string); got != want {
+		t.Fatalf("OpenRouter model = %q, want %q", got, want)
 	}
+}
+
+func openRouterRequestPayload(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var payload map[string]any
 	if err := json.Unmarshal(body, &payload); err != nil {
 		t.Fatalf("unmarshal OpenRouter request body: %v", err)
 	}
-	if payload.Model != want {
-		t.Fatalf("OpenRouter model = %q, want %q", payload.Model, want)
-	}
+	return payload
 }


### PR DESCRIPTION
## Summary

Fixes the graph-agent Bedrock client so default requests omit `temperature` unless it is explicitly configured. Opus 4.8 rejects `temperature`, which caused graph reasoning draft calls to fail before Cypher generation.

## Test Plan

- `go test ./internal/graphagent ./internal/bootstrap ./internal/config`
- `go test ./...`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on the Bedrock inference config change and Graph Ask LLM behavior.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->