### PR TITLE
perf: batch graph-ingest Neo4j upserts via UNWIND

### DIFF
--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -726,13 +726,36 @@ func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRe
 		}
 	}
 	entityKeys := sortedMapKeys(entities)
+	linkKeys := sortedMapKeys(links)
+	if batchStore, ok := graphStore.(ports.ProjectionGraphBatchStore); ok {
+		orderedEntities := make([]*ports.ProjectedEntity, 0, len(entityKeys))
+		for _, key := range entityKeys {
+			orderedEntities = append(orderedEntities, entities[key])
+		}
+		orderedLinks := make([]*ports.ProjectedLink, 0, len(linkKeys))
+		for _, key := range linkKeys {
+			orderedLinks = append(orderedLinks, links[key])
+		}
+		if err := batchStore.UpsertProjectedEntities(ctx, orderedEntities); err != nil {
+			return result, fmt.Errorf("upsert coalesced projected entities: %w", err)
+		}
+		if err := batchStore.UpsertProjectedLinks(ctx, orderedLinks); err != nil {
+			return result, fmt.Errorf("upsert coalesced projected links: %w", err)
+		}
+		for range orderedEntities {
+			result.EntitiesProjected++
+		}
+		for range orderedLinks {
+			result.LinksProjected++
+		}
+		return result, nil
+	}
 	for _, key := range entityKeys {
 		if err := graphStore.UpsertProjectedEntity(ctx, entities[key]); err != nil {
 			return result, fmt.Errorf("upsert coalesced projected entity %q: %w", key, err)
 		}
 		result.EntitiesProjected++
 	}
-	linkKeys := sortedMapKeys(links)
 	for _, key := range linkKeys {
 		if err := graphStore.UpsertProjectedLink(ctx, links[key]); err != nil {
 			return result, fmt.Errorf("upsert coalesced projected link %q: %w", key, err)

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -147,6 +147,34 @@ func (s *recordingProjectionGraphStore) UpsertProjectedLink(_ context.Context, l
 	return nil
 }
 
+type batchRecordingProjectionGraphStore struct {
+	recordingProjectionGraphStore
+	batchEntityCalls int
+	batchLinkCalls   int
+}
+
+func (s *batchRecordingProjectionGraphStore) UpsertProjectedEntities(ctx context.Context, entities []*ports.ProjectedEntity) error {
+	s.batchEntityCalls++
+	for _, entity := range entities {
+		if err := s.UpsertProjectedEntity(ctx, entity); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *batchRecordingProjectionGraphStore) UpsertProjectedLinks(ctx context.Context, links []*ports.ProjectedLink) error {
+	s.batchLinkCalls++
+	for _, link := range links {
+		if err := s.UpsertProjectedLink(ctx, link); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var _ ports.ProjectionGraphBatchStore = (*batchRecordingProjectionGraphStore)(nil)
+
 type checkpointProjectionGraphStore struct {
 	recordingProjectionGraphStore
 	checkpoints map[string]graphstore.IngestCheckpoint
@@ -432,6 +460,54 @@ func TestProjectResponseCoalescedUpsertsUniqueRecords(t *testing.T) {
 	}
 	if got := link.Attributes["event_id"]; got != "event-2" {
 		t.Fatalf("coalesced link event_id = %q, want latest event-2", got)
+	}
+}
+
+func TestProjectResponseCoalescedUsesBatchStoreWhenAvailable(t *testing.T) {
+	store := &batchRecordingProjectionGraphStore{}
+	service := &Service{graphStore: store}
+	projector := recordProjectorFunc(func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		return []*ports.ProjectedEntity{{
+				URN:        "urn:cerebro:writer:github_org:WriterInternal",
+				TenantID:   event.GetTenantId(),
+				SourceID:   event.GetSourceId(),
+				RuntimeID:  event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				EntityType: "github.org",
+				Label:      "WriterInternal",
+				Attributes: map[string]string{"event_id": event.GetId()},
+			}},
+			[]*ports.ProjectedLink{{
+				TenantID:   event.GetTenantId(),
+				SourceID:   event.GetSourceId(),
+				RuntimeID:  event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				FromURN:    "urn:cerebro:writer:github_code_repository:WriterInternal/k8s",
+				Relation:   "belongs_to",
+				ToURN:      "urn:cerebro:writer:github_org:WriterInternal",
+				Attributes: map[string]string{"event_id": event.GetId()},
+			}}, nil
+	})
+	result, err := service.projectResponseCoalesced(context.Background(), sourceRequest{
+		SourceID:  "github",
+		RuntimeID: "writer-github-audit",
+		TenantID:  "writer",
+	}, &cerebrov1.ReadSourceResponse{Events: []*cerebrov1.EventEnvelope{
+		{Id: "event-1", SourceId: "github"},
+		{Id: "event-2", SourceId: "github"},
+	}}, projector, nil)
+	if err != nil {
+		t.Fatalf("projectResponseCoalesced() error = %v", err)
+	}
+	if store.batchEntityCalls != 1 || store.batchLinkCalls != 1 {
+		t.Fatalf("batch calls = entities %d links %d, want 1 and 1 (batch path used)", store.batchEntityCalls, store.batchLinkCalls)
+	}
+	if result.EntitiesProjected != 1 || result.LinksProjected != 1 {
+		t.Fatalf("projected counts = entities %d links %d, want 1 and 1", result.EntitiesProjected, result.LinksProjected)
+	}
+	if entity := store.entities["urn:cerebro:writer:github_org:WriterInternal"]; entity == nil || entity.Attributes["event_id"] != "event-2" {
+		t.Fatalf("coalesced entity = %#v, want latest event-2", entity)
+	}
+	if link := store.links["urn:cerebro:writer:github_code_repository:WriterInternal/k8s|belongs_to|urn:cerebro:writer:github_org:WriterInternal"]; link == nil || link.Attributes["event_id"] != "event-2" {
+		t.Fatalf("coalesced link = %#v, want latest event-2", link)
 	}
 }
 

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -641,6 +641,423 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	return fmt.Errorf("upsert projected link %q %q %q: %w", fromURN, relation, toURN, errConcurrentAttributeMerge)
 }
 
+// projectionUpsertBatchSize bounds how many entities or links are written per
+// UNWIND transaction. Batching collapses the two round-trips per element of the
+// per-item upsert path (merge/load attributes, then version-checked update) into
+// two round-trips per batch, which is the dominant cost of graph ingest against
+// a remote Aura instance.
+const projectionUpsertBatchSize = 500
+
+// mergeProjectedEntitiesQuery is the batched counterpart of
+// mergeEntityAndLoadAttributesQuery: it MERGEs every entity in the batch and
+// returns each node's current attributes_json/version so the caller can deep-merge
+// client-side before the version-checked write. The label clause mirrors the
+// per-item query so existing labels survive fallback (urn-equal) labels.
+const mergeProjectedEntitiesQuery = `UNWIND $rows AS row
+MERGE (e:Entity {urn: row.urn})
+ON CREATE SET e.attributes_json = '{}', e.attributes_version = 0
+SET e.tenant_id = row.tenant_id,
+    e.source_id = row.source_id,
+    e.runtime_id = CASE WHEN row.runtime_id <> '' THEN row.runtime_id ELSE coalesce(e.runtime_id, '') END,
+    e.entity_type = row.entity_type,
+    e.label = CASE WHEN row.label <> row.urn THEN row.label ELSE coalesce(e.label, row.label) END
+RETURN row.urn AS urn, coalesce(e.attributes_json, '{}') AS attributes_json, coalesce(e.attributes_version, 0) AS attributes_version`
+
+// updateProjectedEntitiesQuery is the batched counterpart of updateEntityAttributes.
+// The version guard is redundant within a single transaction (the MERGE above
+// write-locks each node for the batch's duration) but is retained so the on-disk
+// write semantics and monotonic version increment match the per-item path exactly.
+const updateProjectedEntitiesQuery = `UNWIND $rows AS row
+MATCH (e:Entity {urn: row.urn})
+WHERE coalesce(e.attributes_version, 0) = row.attributes_version
+SET e.attributes_json = row.attributes_json,
+    e.attributes_version = row.next_attributes_version,
+    e += row.typed_properties
+RETURN count(e)`
+
+// mergeProjectedLinksQuery is the batched counterpart of mergeLinkAndLoadAttributes.
+// Rows whose endpoints do not both exist are dropped by the MATCH and therefore
+// never returned, preserving the per-item rule that a link is only materialized
+// when both endpoints exist. The relation_lock bump mirrors the per-item write so
+// concurrent relationship creation against the same source node stays serialized.
+const mergeProjectedLinksQuery = `UNWIND $rows AS row
+MATCH (src:Entity {urn: row.from_urn}), (dst:Entity {urn: row.to_urn})
+SET src.relation_lock = coalesce(src.relation_lock, 0) + 1
+MERGE (src)-[r:RELATION {relation: row.relation}]->(dst)
+ON CREATE SET r.attributes_json = '{}', r.attributes_version = 0
+SET r.tenant_id = row.tenant_id,
+    r.source_id = row.source_id,
+    r.runtime_id = CASE WHEN row.runtime_id <> '' THEN row.runtime_id ELSE coalesce(r.runtime_id, '') END
+RETURN row.from_urn AS from_urn, row.relation AS relation, row.to_urn AS to_urn, coalesce(r.attributes_json, '{}') AS attributes_json, coalesce(r.attributes_version, 0) AS attributes_version`
+
+// updateProjectedLinksQuery is the batched counterpart of updateLinkAttributes.
+const updateProjectedLinksQuery = `UNWIND $rows AS row
+MATCH (:Entity {urn: row.from_urn})-[r:RELATION {relation: row.relation}]->(:Entity {urn: row.to_urn})
+WHERE coalesce(r.attributes_version, 0) = row.attributes_version
+SET r.attributes_json = row.attributes_json,
+    r.attributes_version = row.next_attributes_version
+RETURN count(r)`
+
+type loadedAttributeRow struct {
+	attributesJSON string
+	version        int64
+}
+
+type preparedProjectedEntity struct {
+	urn        string
+	tenantID   string
+	sourceID   string
+	runtimeID  string
+	entityType string
+	label      string
+	attributes map[string]string
+}
+
+type preparedProjectedLink struct {
+	fromURN    string
+	toURN      string
+	relation   string
+	tenantID   string
+	sourceID   string
+	runtimeID  string
+	attributes map[string]string
+}
+
+// UpsertProjectedEntities upserts normalized entities in batches. It preserves
+// the exact semantics of UpsertProjectedEntity (tenant-scope validation, entity
+// metadata application, attribute deep-merge, typed-property derivation, and the
+// monotonic attributes_version) while collapsing the per-entity round-trips into
+// two round-trips per batch. Entities are coalesced by URN and written in URN
+// order so concurrent batches acquire node locks in a stable order.
+func (s *Store) UpsertProjectedEntities(ctx context.Context, entities []*ports.ProjectedEntity) error {
+	prepared, err := prepareProjectedEntities(entities)
+	if err != nil {
+		return err
+	}
+	if len(prepared) == 0 {
+		return nil
+	}
+	if err := s.requireConfigured(); err != nil {
+		return err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return err
+	}
+	for _, chunk := range chunkSlice(prepared, projectionUpsertBatchSize) {
+		if err := s.upsertProjectedEntityChunk(ctx, chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UpsertProjectedLinks upserts normalized links in batches, mirroring
+// UpsertProjectedLink (tenant-scope validation, attribute deep-merge, monotonic
+// attributes_version, and materializing a link only when both endpoints exist).
+func (s *Store) UpsertProjectedLinks(ctx context.Context, links []*ports.ProjectedLink) error {
+	prepared, err := prepareProjectedLinks(links)
+	if err != nil {
+		return err
+	}
+	if len(prepared) == 0 {
+		return nil
+	}
+	if err := s.requireConfigured(); err != nil {
+		return err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return err
+	}
+	for _, chunk := range chunkSlice(prepared, projectionUpsertBatchSize) {
+		if err := s.upsertProjectedLinkChunk(ctx, chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) upsertProjectedEntityChunk(ctx context.Context, chunk []*preparedProjectedEntity) error {
+	for attempt := 0; attempt < maxAttributeMergeRetries; attempt++ {
+		err := s.writeProjectedEntityChunk(ctx, chunk)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, errConcurrentAttributeMerge) {
+			return fmt.Errorf("upsert projected entities: %w", err)
+		}
+	}
+	return fmt.Errorf("upsert projected entities: %w", errConcurrentAttributeMerge)
+}
+
+func (s *Store) writeProjectedEntityChunk(ctx context.Context, chunk []*preparedProjectedEntity) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		mergeRows := make([]map[string]any, 0, len(chunk))
+		for _, entity := range chunk {
+			mergeRows = append(mergeRows, map[string]any{
+				"urn":         entity.urn,
+				"tenant_id":   entity.tenantID,
+				"source_id":   entity.sourceID,
+				"runtime_id":  entity.runtimeID,
+				"entity_type": entity.entityType,
+				"label":       entity.label,
+			})
+		}
+		loaded, err := loadAttributeRows(ctx, tx, mergeProjectedEntitiesQuery, mergeRows, entityAttributeRowKey)
+		if err != nil {
+			return nil, fmt.Errorf("load projected entity attributes: %w", err)
+		}
+		updateRows := make([]map[string]any, 0, len(chunk))
+		for _, entity := range chunk {
+			current, ok := loaded[entity.urn]
+			if !ok {
+				return nil, fmt.Errorf("merge projected entity %q returned no attributes", entity.urn)
+			}
+			existing, err := graphAttributesFromJSON(current.attributesJSON)
+			if err != nil {
+				return nil, fmt.Errorf("decode projected entity %q attributes: %w", entity.urn, err)
+			}
+			merged := mergeGraphAttributes(existing, entity.attributes)
+			mergedJSON, err := graphAttributesJSON(merged)
+			if err != nil {
+				return nil, fmt.Errorf("marshal projected entity %q attributes: %w", entity.urn, err)
+			}
+			updateRows = append(updateRows, map[string]any{
+				"urn":                     entity.urn,
+				"attributes_version":      current.version,
+				"next_attributes_version": current.version + 1,
+				"attributes_json":         mergedJSON,
+				"typed_properties":        entityTypedPropertyParams(projectionmeta.DerivedEntityProperties(merged)),
+			})
+		}
+		updated, err := countQuery(ctx, tx, updateProjectedEntitiesQuery, map[string]any{"rows": updateRows})
+		if err != nil {
+			return nil, err
+		}
+		if updated != int64(len(updateRows)) {
+			return nil, errConcurrentAttributeMerge
+		}
+		return nil, nil
+	})
+	return err
+}
+
+func (s *Store) upsertProjectedLinkChunk(ctx context.Context, chunk []*preparedProjectedLink) error {
+	for attempt := 0; attempt < maxAttributeMergeRetries; attempt++ {
+		err := s.writeProjectedLinkChunk(ctx, chunk)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, errConcurrentAttributeMerge) {
+			return fmt.Errorf("upsert projected links: %w", err)
+		}
+	}
+	return fmt.Errorf("upsert projected links: %w", errConcurrentAttributeMerge)
+}
+
+func (s *Store) writeProjectedLinkChunk(ctx context.Context, chunk []*preparedProjectedLink) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		mergeRows := make([]map[string]any, 0, len(chunk))
+		for _, link := range chunk {
+			mergeRows = append(mergeRows, map[string]any{
+				"from_urn":   link.fromURN,
+				"to_urn":     link.toURN,
+				"relation":   link.relation,
+				"tenant_id":  link.tenantID,
+				"source_id":  link.sourceID,
+				"runtime_id": link.runtimeID,
+			})
+		}
+		loaded, err := loadAttributeRows(ctx, tx, mergeProjectedLinksQuery, mergeRows, linkAttributeRowKey)
+		if err != nil {
+			return nil, fmt.Errorf("load projected link attributes: %w", err)
+		}
+		updateRows := make([]map[string]any, 0, len(loaded))
+		for _, link := range chunk {
+			key := projectedLinkKey(link.fromURN, link.relation, link.toURN)
+			current, ok := loaded[key]
+			if !ok {
+				continue
+			}
+			existing, err := graphAttributesFromJSON(current.attributesJSON)
+			if err != nil {
+				return nil, fmt.Errorf("decode projected link %q attributes: %w", key, err)
+			}
+			mergedJSON, err := graphAttributesJSON(mergeGraphAttributes(existing, link.attributes))
+			if err != nil {
+				return nil, fmt.Errorf("marshal projected link %q attributes: %w", key, err)
+			}
+			updateRows = append(updateRows, map[string]any{
+				"from_urn":                link.fromURN,
+				"to_urn":                  link.toURN,
+				"relation":                link.relation,
+				"attributes_version":      current.version,
+				"next_attributes_version": current.version + 1,
+				"attributes_json":         mergedJSON,
+			})
+		}
+		if len(updateRows) == 0 {
+			return nil, nil
+		}
+		updated, err := countQuery(ctx, tx, updateProjectedLinksQuery, map[string]any{"rows": updateRows})
+		if err != nil {
+			return nil, err
+		}
+		if updated != int64(len(updateRows)) {
+			return nil, errConcurrentAttributeMerge
+		}
+		return nil, nil
+	})
+	return err
+}
+
+func loadAttributeRows(ctx context.Context, tx neo4jdriver.ManagedTransaction, query string, rows []map[string]any, key func([]any) string) (map[string]loadedAttributeRow, error) {
+	result, err := tx.Run(ctx, query, map[string]any{"rows": rows})
+	if err != nil {
+		return nil, err
+	}
+	loaded := make(map[string]loadedAttributeRow, len(rows))
+	for result.Next(ctx) {
+		values := result.Record().Values
+		loaded[key(values)] = loadedAttributeRow{
+			attributesJSON: stringValue(values[len(values)-2]),
+			version:        toInt64(values[len(values)-1]),
+		}
+	}
+	return loaded, result.Err()
+}
+
+func entityAttributeRowKey(values []any) string {
+	return stringValue(values[0])
+}
+
+func linkAttributeRowKey(values []any) string {
+	return projectedLinkKey(stringValue(values[0]), stringValue(values[1]), stringValue(values[2]))
+}
+
+func projectedLinkKey(fromURN string, relation string, toURN string) string {
+	return fromURN + "|" + relation + "|" + toURN
+}
+
+func prepareProjectedEntities(entities []*ports.ProjectedEntity) ([]*preparedProjectedEntity, error) {
+	prepared := make([]*preparedProjectedEntity, 0, len(entities))
+	index := make(map[string]*preparedProjectedEntity, len(entities))
+	for _, entity := range entities {
+		if entity == nil {
+			return nil, errors.New("projected entity is required")
+		}
+		urn := strings.TrimSpace(entity.URN)
+		if urn == "" {
+			return nil, errors.New("projected entity urn is required")
+		}
+		tenantID := strings.TrimSpace(entity.TenantID)
+		if tenantID == "" {
+			return nil, errors.New("projected entity tenant id is required")
+		}
+		sourceID := strings.TrimSpace(entity.SourceID)
+		if sourceID == "" {
+			return nil, errors.New("projected entity source id is required")
+		}
+		entityType := strings.TrimSpace(entity.EntityType)
+		if entityType == "" {
+			return nil, errors.New("projected entity type is required")
+		}
+		if err := ports.ValidateProjectedEntityTenantScope(entity); err != nil {
+			return nil, err
+		}
+		label := strings.TrimSpace(entity.Label)
+		if label == "" {
+			label = urn
+		}
+		incoming := projectionmeta.ApplyEntityMetadata(entityType, entity.Attributes)
+		if existing, ok := index[urn]; ok {
+			existing.tenantID = tenantID
+			existing.sourceID = sourceID
+			existing.runtimeID = strings.TrimSpace(entity.RuntimeID)
+			existing.entityType = entityType
+			existing.label = label
+			existing.attributes = mergeGraphAttributes(existing.attributes, incoming)
+			continue
+		}
+		entry := &preparedProjectedEntity{
+			urn:        urn,
+			tenantID:   tenantID,
+			sourceID:   sourceID,
+			runtimeID:  strings.TrimSpace(entity.RuntimeID),
+			entityType: entityType,
+			label:      label,
+			attributes: incoming,
+		}
+		index[urn] = entry
+		prepared = append(prepared, entry)
+	}
+	slices.SortFunc(prepared, func(left *preparedProjectedEntity, right *preparedProjectedEntity) int {
+		return strings.Compare(left.urn, right.urn)
+	})
+	return prepared, nil
+}
+
+func prepareProjectedLinks(links []*ports.ProjectedLink) ([]*preparedProjectedLink, error) {
+	prepared := make([]*preparedProjectedLink, 0, len(links))
+	index := make(map[string]*preparedProjectedLink, len(links))
+	for _, link := range links {
+		fromURN, toURN, relation, tenantID, sourceID, err := validateProjectedLink(link)
+		if err != nil {
+			return nil, err
+		}
+		key := projectedLinkKey(fromURN, relation, toURN)
+		if existing, ok := index[key]; ok {
+			existing.tenantID = tenantID
+			existing.sourceID = sourceID
+			existing.runtimeID = strings.TrimSpace(link.RuntimeID)
+			existing.attributes = mergeGraphAttributes(existing.attributes, link.Attributes)
+			continue
+		}
+		entry := &preparedProjectedLink{
+			fromURN:    fromURN,
+			toURN:      toURN,
+			relation:   relation,
+			tenantID:   tenantID,
+			sourceID:   sourceID,
+			runtimeID:  strings.TrimSpace(link.RuntimeID),
+			attributes: mergeGraphAttributes(nil, link.Attributes),
+		}
+		index[key] = entry
+		prepared = append(prepared, entry)
+	}
+	slices.SortFunc(prepared, func(left *preparedProjectedLink, right *preparedProjectedLink) int {
+		if cmp := strings.Compare(left.fromURN, right.fromURN); cmp != 0 {
+			return cmp
+		}
+		if cmp := strings.Compare(left.relation, right.relation); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(left.toURN, right.toURN)
+	})
+	return prepared, nil
+}
+
+func chunkSlice[T any](items []T, size int) [][]T {
+	if size <= 0 {
+		size = len(items)
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	chunks := make([][]T, 0, (len(items)+size-1)/size)
+	for start := 0; start < len(items); start += size {
+		end := start + size
+		if end > len(items) {
+			end = len(items)
+		}
+		chunks = append(chunks, items[start:end])
+	}
+	return chunks
+}
+
 // DeleteProjectedLink removes one normalized link from the graph store.
 func (s *Store) DeleteProjectedLink(ctx context.Context, link *ports.ProjectedLink) error {
 	fromURN, toURN, relation, err := validateProjectedLinkIdentity(link)

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -1095,8 +1095,12 @@ func TestPrepareProjectedEntitiesValidationErrors(t *testing.T) {
 		"projected entity type is required": {URN: "urn:x", TenantID: "writer", SourceID: "github"},
 	}
 	for want, entity := range cases {
-		if _, err := prepareProjectedEntities([]*ports.ProjectedEntity{entity}); err == nil || !strings.Contains(err.Error(), want) {
-			t.Fatalf("prepareProjectedEntities(%#v) error = %v, want %q", entity, err, want)
+		_, err := prepareProjectedEntities([]*ports.ProjectedEntity{entity})
+		if err == nil {
+			t.Fatalf("prepareProjectedEntities(%#v) error = nil, want %q", entity, want)
+		}
+		if got := err.Error(); !strings.Contains(got, want) {
+			t.Fatalf("prepareProjectedEntities(%#v) error = %q, want %q", entity, got, want)
 		}
 	}
 }
@@ -1149,8 +1153,12 @@ func TestPrepareProjectedLinksValidationErrors(t *testing.T) {
 		"projected link relation is required": {TenantID: "writer", SourceID: "github", FromURN: "urn:x", ToURN: "urn:y"},
 	}
 	for want, link := range cases {
-		if _, err := prepareProjectedLinks([]*ports.ProjectedLink{link}); err == nil || !strings.Contains(err.Error(), want) {
-			t.Fatalf("prepareProjectedLinks(%#v) error = %v, want %q", link, err, want)
+		_, err := prepareProjectedLinks([]*ports.ProjectedLink{link})
+		if err == nil {
+			t.Fatalf("prepareProjectedLinks(%#v) error = nil, want %q", link, want)
+		}
+		if got := err.Error(); !strings.Contains(got, want) {
+			t.Fatalf("prepareProjectedLinks(%#v) error = %q, want %q", link, got, want)
 		}
 	}
 }

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -957,3 +957,294 @@ func waitForStore(t *testing.T, ctx context.Context, cfg config.GraphStoreConfig
 	t.Fatalf("neo4j did not become ready: %v", lastErr)
 	return nil
 }
+
+func TestProjectedEntitiesBatchQueryPreservesPerItemSemantics(t *testing.T) {
+	for _, clause := range []string{
+		"UNWIND $rows AS row",
+		"MERGE (e:Entity {urn: row.urn})",
+		"ON CREATE SET e.attributes_json = '{}', e.attributes_version = 0",
+		"e.label = CASE WHEN row.label <> row.urn THEN row.label ELSE coalesce(e.label, row.label) END",
+		"RETURN row.urn AS urn",
+	} {
+		if !strings.Contains(mergeProjectedEntitiesQuery, clause) {
+			t.Fatalf("mergeProjectedEntitiesQuery missing %q:\n%s", clause, mergeProjectedEntitiesQuery)
+		}
+	}
+	for _, clause := range []string{
+		"UNWIND $rows AS row",
+		"WHERE coalesce(e.attributes_version, 0) = row.attributes_version",
+		"e.attributes_version = row.next_attributes_version",
+		"e += row.typed_properties",
+		"RETURN count(e)",
+	} {
+		if !strings.Contains(updateProjectedEntitiesQuery, clause) {
+			t.Fatalf("updateProjectedEntitiesQuery missing %q:\n%s", clause, updateProjectedEntitiesQuery)
+		}
+	}
+}
+
+func TestProjectedLinksBatchQueryRequiresBothEndpoints(t *testing.T) {
+	for _, clause := range []string{
+		"UNWIND $rows AS row",
+		"MATCH (src:Entity {urn: row.from_urn}), (dst:Entity {urn: row.to_urn})",
+		"SET src.relation_lock = coalesce(src.relation_lock, 0) + 1",
+		"MERGE (src)-[r:RELATION {relation: row.relation}]->(dst)",
+		"RETURN row.from_urn AS from_urn",
+	} {
+		if !strings.Contains(mergeProjectedLinksQuery, clause) {
+			t.Fatalf("mergeProjectedLinksQuery missing %q:\n%s", clause, mergeProjectedLinksQuery)
+		}
+	}
+	for _, clause := range []string{
+		"UNWIND $rows AS row",
+		"WHERE coalesce(r.attributes_version, 0) = row.attributes_version",
+		"r.attributes_version = row.next_attributes_version",
+		"RETURN count(r)",
+	} {
+		if !strings.Contains(updateProjectedLinksQuery, clause) {
+			t.Fatalf("updateProjectedLinksQuery missing %q:\n%s", clause, updateProjectedLinksQuery)
+		}
+	}
+}
+
+func TestUpsertProjectedEntitiesRejectsCrossTenantCerebroURNBeforeConnection(t *testing.T) {
+	store := &Store{}
+	err := store.UpsertProjectedEntities(context.Background(), []*ports.ProjectedEntity{{
+		URN:        "urn:cerebro:victim:github_user:alice",
+		TenantID:   "writer",
+		SourceID:   "github",
+		EntityType: "github.user",
+	}})
+	if err == nil {
+		t.Fatal("UpsertProjectedEntities() error = nil, want cross-tenant Cerebro URN error")
+	}
+	if got := err.Error(); !strings.Contains(got, "urn:cerebro:victim:github_user:alice") || !strings.Contains(got, "not projection tenant") {
+		t.Fatalf("UpsertProjectedEntities() error = %q", got)
+	}
+}
+
+func TestUpsertProjectedLinksRejectsCrossTenantCerebroURNBeforeConnection(t *testing.T) {
+	store := &Store{}
+	err := store.UpsertProjectedLinks(context.Background(), []*ports.ProjectedLink{{
+		TenantID: "writer",
+		SourceID: "github",
+		FromURN:  "urn:cerebro:writer:github_user:alice",
+		ToURN:    "urn:cerebro:victim:github_code_repository:writer/cerebro",
+		Relation: "owns",
+	}})
+	if err == nil {
+		t.Fatal("UpsertProjectedLinks() error = nil, want cross-tenant Cerebro URN error")
+	}
+	if got := err.Error(); !strings.Contains(got, "urn:cerebro:victim:github_code_repository:writer/cerebro") || !strings.Contains(got, "not projection tenant") {
+		t.Fatalf("UpsertProjectedLinks() error = %q", got)
+	}
+}
+
+func TestPrepareProjectedEntitiesCoalescesValidatesAndSorts(t *testing.T) {
+	prepared, err := prepareProjectedEntities([]*ports.ProjectedEntity{
+		{
+			URN:        "urn:cerebro:writer:github_user:zoe",
+			TenantID:   "writer",
+			SourceID:   "github",
+			EntityType: "github.user",
+			Attributes: map[string]string{"login": "zoe"},
+		},
+		{
+			URN:        "urn:cerebro:writer:github_user:alice",
+			TenantID:   "writer",
+			SourceID:   "github",
+			EntityType: "github.user",
+			Attributes: map[string]string{"login": "alice"},
+		},
+		{
+			URN:        "urn:cerebro:writer:github_user:alice",
+			TenantID:   "writer",
+			SourceID:   "github",
+			RuntimeID:  "writer-github",
+			EntityType: "github.user",
+			Label:      "Alice",
+			Attributes: map[string]string{"email": "alice@example.com"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepareProjectedEntities() error = %v", err)
+	}
+	if len(prepared) != 2 {
+		t.Fatalf("prepared len = %d, want 2 (alice coalesced)", len(prepared))
+	}
+	if prepared[0].urn != "urn:cerebro:writer:github_user:alice" || prepared[1].urn != "urn:cerebro:writer:github_user:zoe" {
+		t.Fatalf("prepared not sorted by urn: %q, %q", prepared[0].urn, prepared[1].urn)
+	}
+	alice := prepared[0]
+	if alice.attributes["login"] != "alice" || alice.attributes["email"] != "alice@example.com" {
+		t.Fatalf("coalesced alice attributes = %#v, want merged login+email", alice.attributes)
+	}
+	if alice.label != "Alice" || alice.runtimeID != "writer-github" {
+		t.Fatalf("coalesced alice scalars = label %q runtime %q, want latest occurrence to win", alice.label, alice.runtimeID)
+	}
+	zoe := prepared[1]
+	if zoe.label != zoe.urn {
+		t.Fatalf("zoe label = %q, want fallback to urn", zoe.label)
+	}
+}
+
+func TestPrepareProjectedEntitiesValidationErrors(t *testing.T) {
+	cases := map[string]*ports.ProjectedEntity{
+		"projected entity is required":      nil,
+		"projected entity urn is required":  {TenantID: "writer", SourceID: "github", EntityType: "github.user"},
+		"projected entity type is required": {URN: "urn:x", TenantID: "writer", SourceID: "github"},
+	}
+	for want, entity := range cases {
+		if _, err := prepareProjectedEntities([]*ports.ProjectedEntity{entity}); err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("prepareProjectedEntities(%#v) error = %v, want %q", entity, err, want)
+		}
+	}
+}
+
+func TestPrepareProjectedLinksCoalescesValidatesAndSorts(t *testing.T) {
+	prepared, err := prepareProjectedLinks([]*ports.ProjectedLink{
+		{
+			TenantID: "writer", SourceID: "github",
+			FromURN:  "urn:cerebro:writer:github_user:zoe",
+			Relation: "maintains",
+			ToURN:    "urn:cerebro:writer:github_code_repository:writer/cerebro",
+		},
+		{
+			TenantID: "writer", SourceID: "github",
+			FromURN:    "urn:cerebro:writer:github_user:alice",
+			Relation:   "maintains",
+			ToURN:      "urn:cerebro:writer:github_code_repository:writer/cerebro",
+			Attributes: map[string]string{"role": "admin"},
+		},
+		{
+			TenantID: "writer", SourceID: "github", RuntimeID: "writer-github",
+			FromURN:    "urn:cerebro:writer:github_user:alice",
+			Relation:   "maintains",
+			ToURN:      "urn:cerebro:writer:github_code_repository:writer/cerebro",
+			Attributes: map[string]string{"since": "2025"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepareProjectedLinks() error = %v", err)
+	}
+	if len(prepared) != 2 {
+		t.Fatalf("prepared len = %d, want 2 (alice link coalesced)", len(prepared))
+	}
+	if prepared[0].fromURN != "urn:cerebro:writer:github_user:alice" || prepared[1].fromURN != "urn:cerebro:writer:github_user:zoe" {
+		t.Fatalf("prepared links not sorted by from urn: %q, %q", prepared[0].fromURN, prepared[1].fromURN)
+	}
+	alice := prepared[0]
+	if alice.attributes["role"] != "admin" || alice.attributes["since"] != "2025" {
+		t.Fatalf("coalesced alice link attributes = %#v, want merged role+since", alice.attributes)
+	}
+	if alice.runtimeID != "writer-github" {
+		t.Fatalf("coalesced alice link runtime = %q, want latest occurrence to win", alice.runtimeID)
+	}
+}
+
+func TestPrepareProjectedLinksValidationErrors(t *testing.T) {
+	cases := map[string]*ports.ProjectedLink{
+		"projected link is required":          nil,
+		"projected link from urn is required": {TenantID: "writer", SourceID: "github", Relation: "owns", ToURN: "urn:y"},
+		"projected link relation is required": {TenantID: "writer", SourceID: "github", FromURN: "urn:x", ToURN: "urn:y"},
+	}
+	for want, link := range cases {
+		if _, err := prepareProjectedLinks([]*ports.ProjectedLink{link}); err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("prepareProjectedLinks(%#v) error = %v, want %q", link, err, want)
+		}
+	}
+}
+
+func TestChunkSlice(t *testing.T) {
+	chunks := chunkSlice([]int{1, 2, 3, 4, 5}, 2)
+	if len(chunks) != 3 || len(chunks[0]) != 2 || len(chunks[2]) != 1 {
+		t.Fatalf("chunkSlice(5, 2) = %#v, want [[1 2] [3 4] [5]]", chunks)
+	}
+	if chunks[2][0] != 5 {
+		t.Fatalf("chunkSlice remainder = %#v, want [5]", chunks[2])
+	}
+	if got := chunkSlice([]int(nil), 2); got != nil {
+		t.Fatalf("chunkSlice(nil) = %#v, want nil", got)
+	}
+	if got := chunkSlice([]int{1, 2}, 0); len(got) != 1 || len(got[0]) != 2 {
+		t.Fatalf("chunkSlice with size 0 = %#v, want single chunk", got)
+	}
+}
+
+func TestNeo4jDockerBatchProjectionMatchesPerItem(t *testing.T) {
+	if os.Getenv("CEREBRO_RUN_NEO4J_DOCKER") != "1" {
+		t.Skip("set CEREBRO_RUN_NEO4J_DOCKER=1 to run Neo4j Docker integration test")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker is not installed")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	port := freePort(t)
+	name := fmt.Sprintf("cerebro-neo4j-batch-test-%d", time.Now().UnixNano())
+	password := "test-password"
+	image := os.Getenv("CEREBRO_NEO4J_DOCKER_IMAGE")
+	if image == "" {
+		image = "neo4j:5"
+	}
+	cmd := exec.CommandContext(ctx, "docker", "run", "-d", "--rm", "--name", name, // #nosec G204 G702 -- integration test invokes fixed docker binary with generated container arguments.
+		"-e", "NEO4J_AUTH=neo4j/"+password,
+		"-p", fmt.Sprintf("127.0.0.1:%d:7687", port),
+		image)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker run neo4j: %v\n%s", err, string(output))
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "rm", "-f", name).Run() // #nosec G204 -- integration test cleanup invokes fixed docker binary with generated container name.
+	})
+	store := waitForStore(t, ctx, config.GraphStoreConfig{
+		Neo4jURI:      fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		Neo4jUsername: "neo4j",
+		Neo4jPassword: password,
+	})
+	defer func() { _ = store.CloseContext(context.Background()) }()
+
+	user := &ports.ProjectedEntity{
+		URN: "urn:cerebro:writer:github_user:alice", TenantID: "writer", SourceID: "github",
+		EntityType: "github_user", Label: "alice", Attributes: map[string]string{"login": "alice"},
+	}
+	repo := &ports.ProjectedEntity{
+		URN: "urn:cerebro:writer:github_code_repository:writer/cerebro", TenantID: "writer", SourceID: "github",
+		EntityType: "github_code_repository", Label: "writer/cerebro",
+	}
+	if err := store.UpsertProjectedEntities(ctx, []*ports.ProjectedEntity{user, repo}); err != nil {
+		t.Fatalf("UpsertProjectedEntities() error = %v", err)
+	}
+	// Re-running the batch with new attributes must deep-merge, not clobber.
+	updatedUser := *user
+	updatedUser.Attributes = map[string]string{"team": "security"}
+	if err := store.UpsertProjectedEntities(ctx, []*ports.ProjectedEntity{&updatedUser}); err != nil {
+		t.Fatalf("UpsertProjectedEntities(update) error = %v", err)
+	}
+	userAttributes := projectedEntityAttributes(t, ctx, store, user.URN)
+	for key, want := range map[string]string{"login": "alice", "team": "security"} {
+		if userAttributes[key] != want {
+			t.Fatalf("batch user attributes[%q] = %q, want %q in %#v", key, userAttributes[key], want, userAttributes)
+		}
+	}
+
+	maintains := &ports.ProjectedLink{
+		TenantID: "writer", SourceID: "github", FromURN: user.URN, Relation: "maintains", ToURN: repo.URN,
+		Attributes: map[string]string{"role": "admin"},
+	}
+	dangling := &ports.ProjectedLink{
+		TenantID: "writer", SourceID: "github", FromURN: user.URN, Relation: "maintains",
+		ToURN: "urn:cerebro:writer:github_code_repository:writer/missing",
+	}
+	if err := store.UpsertProjectedLinks(ctx, []*ports.ProjectedLink{maintains, dangling}); err != nil {
+		t.Fatalf("UpsertProjectedLinks() error = %v", err)
+	}
+	linkAttributes := projectedLinkAttributes(t, ctx, store, maintains)
+	if linkAttributes["role"] != "admin" {
+		t.Fatalf("batch link attributes = %#v, want role=admin", linkAttributes)
+	}
+	if neo4jProjectedLinkExists(t, ctx, store, dangling) {
+		t.Fatal("dangling link was materialized; batch must skip links whose endpoints do not both exist")
+	}
+}

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -155,6 +155,19 @@ type ProjectionGraphStore interface {
 	UpsertProjectedLink(context.Context, *ProjectedLink) error
 }
 
+// ProjectionGraphBatchStore upserts coalesced entities and links in batches,
+// collapsing the per-element merge/load and version-checked update round-trips
+// of ProjectionGraphStore into a handful of UNWIND transactions. Graph stores
+// that implement it are preferred by the projection writer; callers fall back
+// to the per-element ProjectionGraphStore methods when it is not implemented.
+// Batch methods preserve the exact per-element semantics: tenant-scope
+// validation, attribute deep-merge, typed-property derivation, monotonic
+// attributes_version, and links materialized only when both endpoints exist.
+type ProjectionGraphBatchStore interface {
+	UpsertProjectedEntities(context.Context, []*ProjectedEntity) error
+	UpsertProjectedLinks(context.Context, []*ProjectedLink) error
+}
+
 // ProjectionLinkDeleter removes normalized links from projection stores that support deletion.
 type ProjectionLinkDeleter interface {
 	DeleteProjectedLink(context.Context, *ProjectedLink) error


### PR DESCRIPTION
## Problem

Graph ingest is the long pole of a source sync. On a recent sec-dev run it took **~35.7 min** (`graph_ingest` ~2,140,713 ms) to materialize **1,783 entities + 16,043 links (~17,826 writes)**.

Root cause is the write path, not an index: `UpsertProjectedEntity`/`UpsertProjectedLink` each (1) hold a process-global mutex (zero write concurrency), and (2) open a **new session + read-modify-write transaction per element** = **2 Cypher round-trips each**. `projectResponseCoalesced` then loops over the coalesced page one element at a time. ~17,826 elements x 2 serialized round-trips at Aura's ~60 ms RTT ≈ the observed 2.14M ms.

## Change

- Add `ports.ProjectionGraphBatchStore` (`UpsertProjectedEntities` / `UpsertProjectedLinks`).
- Implement it on the Neo4j store with **two-phase UNWIND** per batch of 500: phase 1 `UNWIND $rows MERGE ... RETURN attributes_json/version`, deep-merge client-side, phase 2 `UNWIND $rows MATCH ... SET` (version-checked). Both phases run in one `ExecuteWrite`, so the MERGE node-locks make the read-then-write consistent.
- Wire `projectResponseCoalesced` to prefer the batch path and **fall back to per-item** upserts when the store does not implement the interface (state store, test fakes), so behavior is unchanged where batching is unavailable. **On by default.**

This collapses ~17.8k round-trips into a few dozen. Expected graph-ingest time drops from ~35 min to well under a minute (~20-100x).

### Semantics preserved (1:1 with the per-item path)
- Tenant-scope validation (pre-connection), entity-metadata application, attribute **deep-merge** (incl. `at` chronological-max + observation-time coupling), typed-property derivation, monotonic `attributes_version`.
- `relation_lock` serialization trick retained; links materialized **only when both endpoints exist** (dropped by the `MATCH` in phase 1).
- Entities/links coalesced by key and written in sorted order (stable lock ordering); per-batch retry on the optimistic-merge guard mirrors the per-item loop.

## Tests
- Store unit tests: batch query-shape assertions (UNWIND/MERGE/version-guard/label-preservation/both-endpoint MATCH), pre-connection cross-tenant rejection for the batch methods, `prepare*` coalesce/validate/sort, `chunkSlice`.
- Ingest service test proving the **batch path is used** when the store implements the interface (existing tests continue to exercise the per-item fallback).
- Gated live-DB equivalence test (`CEREBRO_RUN_NEO4J_DOCKER=1`): deep-merge across re-runs + dangling-link skip.
- `go build ./...`, `go test -race` (ports/graphstore-neo4j/graphingest), `go vet`, `golangci-lint` all clean.

## Validation note
Validated with Go unit tests only (not live Aura from this environment). Recommend a sec-dev one-off ingest after merge to confirm the speedup end-to-end.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->