### PR TITLE
Improve graph-ingest operations after batching

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -73,7 +73,37 @@ jobs:
             echo "Resolved automatic release tag ${RELEASE_TAG} from ${latest_tag}"
           fi
 
-          make verify
+          release_sha="$(git rev-parse HEAD)"
+          echo "Waiting for successful 'CI' workflow run for push to main at ${release_sha}"
+          for _ in {1..120}; do
+            ci_run="$(
+              gh run list \
+                --repo "${GITHUB_REPOSITORY}" \
+                --workflow "CI" \
+                --event push \
+                --branch main \
+                --limit 50 \
+                --json headSha,status,conclusion,url \
+                --jq ".[] | select(.headSha == \"${release_sha}\") | [.status, (.conclusion // \"\"), .url] | @tsv" \
+              | head -n 1
+            )" || true
+            if [ -n "${ci_run}" ]; then
+              IFS=$'\t' read -r ci_status ci_conclusion ci_url <<< "${ci_run}"
+              if [ "${ci_status}" = "completed" ] && [ "${ci_conclusion}" = "success" ]; then
+                echo "CI for ${release_sha} succeeded: ${ci_url}"
+                break
+              fi
+              if [ "${ci_status}" = "completed" ]; then
+                echo "ERROR: CI for ${release_sha} completed with ${ci_conclusion}: ${ci_url}" >&2
+                exit 1
+              fi
+            fi
+            sleep 15
+          done
+          if [ "${ci_status:-}" != "completed" ] || [ "${ci_conclusion:-}" != "success" ]; then
+            echo "ERROR: timed out waiting for successful 'CI' workflow run for push to main at ${release_sha}" >&2
+            exit 1
+          fi
 
           if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null; then
             echo "ERROR: tag '${RELEASE_TAG}' already exists"

--- a/docs/domains/findings-platform-architecture.md
+++ b/docs/domains/findings-platform-architecture.md
@@ -170,7 +170,7 @@ This reads normalized persisted findings, not transient rule output.
 
 ## Current Built-In Catalog
 
-The built-in public detection catalog currently contains 1585 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
+The built-in public detection catalog currently contains 1586 rules across cloud, identity, GitHub, GRC, runtime, endpoint, Panopticon/security-operations, vulnerability, data, email-domain, and generated policy domains. The generated public catalog lives at `internal/findings/public_detection_catalog.json`; `make detection-catalog-check` verifies that it stays in sync with the registered rule metadata.
 
 Rules live as small files under `internal/findings/` and register through the built-in registry. The original Okta lifecycle-tampering detector is now one example in a broader catalog, not the only supported rule. This shape keeps the service generic:
 

--- a/internal/compliance/control_coverage_index.yaml
+++ b/internal/compliance/control_coverage_index.yaml
@@ -74746,7 +74746,7 @@ profiles:
         selected_controls: 36
         mapped_controls: 21
         unmapped_controls: 15
-        mapped_rules: 513
+        mapped_rules: 514
         auditor_ready_controls: 0
         needs_enrichment_controls: 0
         placeholder_controls: 36
@@ -75555,8 +75555,9 @@ profiles:
             status: placeholder
             score: 0
           coverage_status: mapped
-          rule_count: 371
+          rule_count: 372
           mapped_rules:
+            - archetype-vulnerability-active
             - aurelius-promoted-vulnerability-active
             - aws-rds-auto-minor-upgrade
             - cicd-artifact-signature-required
@@ -76108,6 +76109,10 @@ profiles:
               control_id: A.8.21
             - framework_name: ISO 27001:2022
               control_id: A.8.28
+        - rule_id: archetype-vulnerability-active
+          controls:
+            - framework_name: ISO 27001:2022
+              control_id: A.8.8
         - rule_id: aurelius-promoted-vulnerability-active
           controls:
             - framework_name: ISO 27001:2022
@@ -108064,7 +108069,7 @@ profiles:
         selected_controls: 36
         mapped_controls: 34
         unmapped_controls: 2
-        mapped_rules: 1512
+        mapped_rules: 1513
         auditor_ready_controls: 36
         needs_enrichment_controls: 0
         placeholder_controls: 0
@@ -113222,8 +113227,9 @@ profiles:
             - framework_name: NIST 800-53 r5
               control_id: SI-4
           coverage_status: mapped
-          rule_count: 543
+          rule_count: 544
           mapped_rules:
+            - archetype-vulnerability-active
             - aurelius-promoted-vulnerability-active
             - aws-access-analyzer-unused-access-finding
             - aws-account-alternate-contact-security
@@ -113830,7 +113836,7 @@ profiles:
             - framework_name: NIST 800-53 r5
               control_id: RA-5
           coverage_status: mapped
-          rule_count: 564
+          rule_count: 565
           mapped_rules:
             - api-admin-function-public
             - api-cors-wildcard-credentials
@@ -113847,6 +113853,7 @@ profiles:
             - api-third-party-timeout-missing
             - api-third-party-tls-validation-disabled
             - api-token-ttl-too-long
+            - archetype-vulnerability-active
             - aurelius-promoted-vulnerability-active
             - aws-access-analyzer-unused-access-finding
             - aws-account-alternate-contact-security
@@ -115229,8 +115236,9 @@ profiles:
             - framework_name: NIST 800-53 r5
               control_id: RA-5
           coverage_status: mapped
-          rule_count: 421
+          rule_count: 422
           mapped_rules:
+            - archetype-vulnerability-active
             - aurelius-promoted-vulnerability-active
             - aws-ecr-scan-on-push
             - aws-guardduty-c2-traffic
@@ -116627,6 +116635,14 @@ profiles:
               control_id: CC6.7
             - framework_name: SOC 2
               control_id: CC7.1
+        - rule_id: archetype-vulnerability-active
+          controls:
+            - framework_name: SOC 2
+              control_id: CC7
+            - framework_name: SOC 2
+              control_id: CC7.1
+            - framework_name: SOC 2
+              control_id: CC7.5
         - rule_id: aurelius-promoted-vulnerability-active
           controls:
             - framework_name: SOC 2

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,12 +100,14 @@ type StateStoreConfig struct {
 
 // GraphStoreConfig selects and configures the graph projection store driver.
 type GraphStoreConfig struct {
-	Driver            string
-	Neo4jURI          string
-	Neo4jUsername     string
-	Neo4jPassword     string
-	Neo4jDatabase     string
-	Neo4jQueryTimeout time.Duration
+	Driver                          string
+	Neo4jURI                        string
+	Neo4jUsername                   string
+	Neo4jPassword                   string
+	Neo4jDatabase                   string
+	Neo4jQueryTimeout               time.Duration
+	Neo4jProjectionBatchSize        int
+	Neo4jProjectionWriteConcurrency int
 }
 
 // CacheConfig controls optional shared query/response caching.
@@ -600,6 +602,18 @@ func Load() (Config, error) {
 	cfg.StateStore = ApplyPostgresPoolDefaults(cfg.StateStore)
 	if cfg.GraphStore.Neo4jQueryTimeout, err = parseDurationEnv("CEREBRO_NEO4J_QUERY_TIMEOUT", 0); err != nil {
 		return Config{}, err
+	}
+	if cfg.GraphStore.Neo4jProjectionBatchSize, err = parseIntEnv("CEREBRO_NEO4J_PROJECTION_BATCH_SIZE", 500); err != nil {
+		return Config{}, err
+	}
+	if cfg.GraphStore.Neo4jProjectionBatchSize <= 0 {
+		return Config{}, errors.New("CEREBRO_NEO4J_PROJECTION_BATCH_SIZE must be greater than zero")
+	}
+	if cfg.GraphStore.Neo4jProjectionWriteConcurrency, err = parseIntEnv("CEREBRO_NEO4J_PROJECTION_WRITE_CONCURRENCY", 4); err != nil {
+		return Config{}, err
+	}
+	if cfg.GraphStore.Neo4jProjectionWriteConcurrency <= 0 {
+		return Config{}, errors.New("CEREBRO_NEO4J_PROJECTION_WRITE_CONCURRENCY must be greater than zero")
 	}
 	if cfg.GraphActions.AccessApprovals.Timeout, err = parseDurationEnv("CEREBRO_GRAPH_ACTIONS_ACCESS_APPROVALS_TIMEOUT", 10*time.Second); err != nil {
 		return Config{}, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -49,6 +49,8 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_NEO4J_PASSWORD", "")
 	t.Setenv("CEREBRO_NEO4J_DATABASE", "")
 	t.Setenv("CEREBRO_NEO4J_QUERY_TIMEOUT", "")
+	t.Setenv("CEREBRO_NEO4J_PROJECTION_BATCH_SIZE", "")
+	t.Setenv("CEREBRO_NEO4J_PROJECTION_WRITE_CONCURRENCY", "")
 	clearGraphAgentEnv(t)
 	clearOpenTelemetryEnv(t)
 	t.Setenv("CEREBRO_KUZU_PATH", "")
@@ -108,6 +110,9 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if cfg.GraphStore.Driver != "" {
 		t.Fatalf("GraphStore.Driver = %q, want empty", cfg.GraphStore.Driver)
+	}
+	if cfg.GraphStore.Neo4jProjectionBatchSize != 500 || cfg.GraphStore.Neo4jProjectionWriteConcurrency != 4 {
+		t.Fatalf("GraphStore projection defaults = %#v", cfg.GraphStore)
 	}
 	if cfg.GraphAgentLLM.Provider != "" || cfg.GraphAgentLLM.MaxTokens != 0 || cfg.GraphAgentLLM.TemperatureSet {
 		t.Fatalf("GraphAgentLLM = %#v, want empty/default", cfg.GraphAgentLLM)
@@ -199,6 +204,8 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_NEO4J_PASSWORD", "test-password")
 	t.Setenv("CEREBRO_NEO4J_DATABASE", "cerebro")
 	t.Setenv("CEREBRO_NEO4J_QUERY_TIMEOUT", "45s")
+	t.Setenv("CEREBRO_NEO4J_PROJECTION_BATCH_SIZE", "750")
+	t.Setenv("CEREBRO_NEO4J_PROJECTION_WRITE_CONCURRENCY", "8")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_PROVIDER", "stub")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL", "claude-sonnet-4-6")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_SONNET", "anthropic.claude-sonnet-example")
@@ -321,6 +328,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.GraphStore.Neo4jQueryTimeout != 45*time.Second {
 		t.Fatalf("Neo4jQueryTimeout = %v, want 45s", cfg.GraphStore.Neo4jQueryTimeout)
+	}
+	if cfg.GraphStore.Neo4jProjectionBatchSize != 750 || cfg.GraphStore.Neo4jProjectionWriteConcurrency != 8 {
+		t.Fatalf("GraphStore projection config = %#v", cfg.GraphStore)
 	}
 	if cfg.GraphAgentLLM.Provider != "stub" || cfg.GraphAgentLLM.MaxTokens != 900 || cfg.GraphAgentLLM.Temperature != 0.25 || !cfg.GraphAgentLLM.TemperatureSet {
 		t.Fatalf("GraphAgentLLM = %#v", cfg.GraphAgentLLM)
@@ -618,6 +628,8 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_NEO4J_PASSWORD", "")
 	t.Setenv("CEREBRO_NEO4J_DATABASE", "")
 	t.Setenv("CEREBRO_NEO4J_QUERY_TIMEOUT", "")
+	t.Setenv("CEREBRO_NEO4J_PROJECTION_BATCH_SIZE", "")
+	t.Setenv("CEREBRO_NEO4J_PROJECTION_WRITE_CONCURRENCY", "")
 	clearGraphAgentEnv(t)
 	clearOpenTelemetryEnv(t)
 	t.Setenv("CEREBRO_KUZU_PATH", "")
@@ -1266,6 +1278,28 @@ func TestLoadRejectsMissingNeo4jPassword(t *testing.T) {
 	t.Setenv("CEREBRO_NEO4J_PASSWORD", "")
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadRejectsInvalidNeo4jProjectionTuning(t *testing.T) {
+	cases := map[string]map[string]string{
+		"batch size zero":        {"CEREBRO_NEO4J_PROJECTION_BATCH_SIZE": "0"},
+		"write concurrency zero": {"CEREBRO_NEO4J_PROJECTION_WRITE_CONCURRENCY": "0"},
+	}
+	for name, env := range cases {
+		t.Run(name, func(t *testing.T) {
+			clearDependencyEnv(t)
+			t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", GraphStoreDriverNeo4j)
+			t.Setenv("CEREBRO_NEO4J_URI", "bolt://127.0.0.1:7687")
+			t.Setenv("CEREBRO_NEO4J_USERNAME", "neo4j")
+			t.Setenv("CEREBRO_NEO4J_PASSWORD", "test-password")
+			for key, value := range env {
+				t.Setenv(key, value)
+			}
+			if _, err := Load(); err == nil {
+				t.Fatal("Load() error = nil, want non-nil")
+			}
+		})
 	}
 }
 

--- a/internal/findings/archetype_vulnerability_rule.go
+++ b/internal/findings/archetype_vulnerability_rule.go
@@ -1,0 +1,186 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	archetypeVulnerabilityActiveRuleID    = "archetype-vulnerability-active"
+	archetypeVulnerabilityActiveTitle     = "Archetype Active Code Vulnerability"
+	archetypeVulnerabilityActiveStatus    = findingStatusOpen
+	archetypeVulnerabilityActiveCheckID   = "archetype-vulnerability-active-current"
+	archetypeVulnerabilityActiveCheckName = "Archetype Active Code Vulnerability (current state)"
+)
+
+var archetypeVulnerabilityActiveControlRefs = []ports.FindingControlRef{
+	{FrameworkName: "SOC 2", ControlID: "CC7.1"},
+	{FrameworkName: "ISO 27001:2022", ControlID: "A.8.8"},
+}
+
+type archetypeVulnerabilityActiveRule struct {
+	Rule
+	definition RuleDefinition
+}
+
+var archetypeVulnerabilityActiveDefinition = RuleDefinition{
+	ID:                 archetypeVulnerabilityActiveRuleID,
+	Name:               archetypeVulnerabilityActiveTitle,
+	Description:        "Detect current high or critical code vulnerabilities reported by Archetype scans.",
+	SourceID:           "archetype",
+	EventKinds:         []string{"archetype.vulnerability"},
+	OutputKind:         "finding.archetype_vulnerability_active",
+	Severity:           "dynamic",
+	Status:             archetypeVulnerabilityActiveStatus,
+	Maturity:           "test",
+	Tags:               []string{"archetype", "code", "vulnerability", "repository", "attack.initial-access"},
+	References:         []string{"https://archetype.dev/"},
+	FalsePositives:     []string{"The vulnerability was remediated after the latest scan, or the reported path is no longer reachable in the active codebase."},
+	Runbook:            "Review the affected repository path and category in Archetype, apply the recommended code or dependency fix, then rescan to clear the current-state finding.",
+	RequiredAttributes: []string{"vulnerability_id", "scan_id", "severity", "category", "file_path", "owner", "repo"},
+	FingerprintFields:  []string{"archetype_vulnerability_urn"},
+	ControlRefs:        archetypeVulnerabilityActiveControlRefs,
+	Lifecycle:          Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorGraphAnchored},
+}
+
+var archetypeVulnerabilityActiveKindMatcher = eventKindMatcher(archetypeVulnerabilityActiveDefinition.EventKinds...)
+
+func newArchetypeVulnerabilityActiveRule() Rule {
+	rule := newEventRule(eventRuleConfig{
+		definition: archetypeVulnerabilityActiveDefinition,
+		match:      matchesArchetypeVulnerabilityActive,
+		build: func(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+			return archetypeVulnerabilityActiveFinding(event, runtime.GetId())
+		},
+	})
+	return &archetypeVulnerabilityActiveRule{
+		Rule:       rule,
+		definition: archetypeVulnerabilityActiveDefinition,
+	}
+}
+
+func (r *archetypeVulnerabilityActiveRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
+func (r *archetypeVulnerabilityActiveRule) OpenAnchor(attributes map[string]string) string {
+	return identityCounterEventAnchor(map[string]string{
+		"archetype_vulnerability_urn": strings.TrimSpace(attributes["archetype_vulnerability_urn"]),
+	}, "archetype_vulnerability_urn")
+}
+
+func (r *archetypeVulnerabilityActiveRule) CloseOnEvent(event Event) (string, bool) {
+	if !archetypeVulnerabilityActiveKindMatcher(event) || !hasRequiredAttributes(event, "vulnerability_id", "severity") {
+		return "", false
+	}
+	attributes := eventAttributes(event)
+	if trivyVulnerabilitySeverityActionable(attributes["severity"]) {
+		return "", false
+	}
+	vulnerabilityURN := archetypeVulnerabilityURN(event.GetTenantId(), attributes["vulnerability_id"])
+	anchor := r.OpenAnchor(map[string]string{"archetype_vulnerability_urn": vulnerabilityURN})
+	return anchor, anchor != ""
+}
+
+func matchesArchetypeVulnerabilityActive(event *cerebrov1.EventEnvelope) bool {
+	if !archetypeVulnerabilityActiveKindMatcher(event) || !hasRequiredAttributes(event, archetypeVulnerabilityActiveDefinition.RequiredAttributes...) {
+		return false
+	}
+	return trivyVulnerabilitySeverityActionable(eventAttributes(event)["severity"])
+}
+
+func archetypeVulnerabilityActiveFinding(event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
+	attrs := event.GetAttributes()
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	vulnerabilityID := strings.TrimSpace(attrs["vulnerability_id"])
+	vulnerabilityURN := archetypeVulnerabilityURN(tenantID, vulnerabilityID)
+	if vulnerabilityURN == "" {
+		return nil, nil
+	}
+	repositoryURN := archetypeRepositoryURN(tenantID, attrs["owner"], attrs["repo"])
+	attributes := map[string]string{
+		"archetype_vulnerability_urn": vulnerabilityURN,
+		"archetype_repository_urn":    repositoryURN,
+		"primary_resource_urn":        vulnerabilityURN,
+		"vulnerability_id":            vulnerabilityID,
+		"scan_id":                     strings.TrimSpace(attrs["scan_id"]),
+		"repository_id":               strings.TrimSpace(attrs["repository_id"]),
+		"owner":                       strings.TrimSpace(attrs["owner"]),
+		"repo":                        strings.TrimSpace(attrs["repo"]),
+		"file_path":                   strings.TrimSpace(attrs["file_path"]),
+		"line_number":                 strings.TrimSpace(attrs["line_number"]),
+		"category":                    strings.TrimSpace(attrs["category"]),
+		"severity":                    strings.TrimSpace(attrs["severity"]),
+		"event_id":                    strings.TrimSpace(event.GetId()),
+		"source_runtime_id":           strings.TrimSpace(attrs[ports.EventAttributeSourceRuntimeID]),
+	}
+	for key, value := range archetypeVulnerabilityActiveDefinition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	observedAt := time.Time{}
+	if timestamp := event.GetOccurredAt(); timestamp != nil {
+		observedAt = timestamp.AsTime().UTC()
+	}
+	fingerprint := hashFindingFingerprint(archetypeVulnerabilityActiveRuleID, vulnerabilityURN)
+	resourceURNs := []string{vulnerabilityURN}
+	if repositoryURN != "" {
+		resourceURNs = append(resourceURNs, repositoryURN)
+	}
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       strings.TrimSpace(runtimeID),
+		RuleID:          archetypeVulnerabilityActiveRuleID,
+		Title:           archetypeVulnerabilityActiveTitle,
+		Severity:        normalizeFindingSeverity(attrs["severity"]),
+		Status:          archetypeVulnerabilityActiveStatus,
+		Summary:         archetypeVulnerabilityActiveSummary(attrs),
+		ResourceURNs:    resourceURNs,
+		EventIDs:        []string{strings.TrimSpace(event.GetId())},
+		PolicyID:        vulnerabilityID,
+		PolicyName:      strings.TrimSpace(attrs["category"]),
+		CheckID:         archetypeVulnerabilityActiveCheckID,
+		CheckName:       archetypeVulnerabilityActiveCheckName,
+		ControlRefs:     cloneFindingControlRefs(archetypeVulnerabilityActiveDefinition.ControlRefs),
+		Attributes:      attributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}
+
+func archetypeVulnerabilityURN(tenantID string, vulnerabilityID string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	vulnerabilityID = strings.TrimSpace(vulnerabilityID)
+	if tenantID == "" || vulnerabilityID == "" {
+		return ""
+	}
+	return fmt.Sprintf("urn:cerebro:%s:archetype_finding:%s", tenantID, vulnerabilityID)
+}
+
+func archetypeRepositoryURN(tenantID string, owner string, repo string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	repository := strings.Trim(strings.TrimSpace(owner)+"/"+strings.TrimSpace(repo), "/")
+	if tenantID == "" || repository == "" {
+		return ""
+	}
+	return fmt.Sprintf("urn:cerebro:%s:github_code_repository:%s", tenantID, repository)
+}
+
+func archetypeVulnerabilityActiveSummary(attrs map[string]string) string {
+	severity := normalizeFindingSeverity(attrs["severity"])
+	vulnerabilityID := firstNonEmpty(strings.TrimSpace(attrs["vulnerability_id"]), "vulnerability")
+	repository := firstNonEmpty(strings.Trim(strings.TrimSpace(attrs["owner"])+"/"+strings.TrimSpace(attrs["repo"]), "/"), "unknown repository")
+	path := firstNonEmpty(strings.TrimSpace(attrs["file_path"]), "unknown path")
+	category := firstNonEmpty(strings.TrimSpace(attrs["category"]), "unspecified category")
+	return fmt.Sprintf("%s Archetype vulnerability %s affects %s in %s (%s)", severity, vulnerabilityID, path, repository, category)
+}

--- a/internal/findings/archetype_vulnerability_rule_test.go
+++ b/internal/findings/archetype_vulnerability_rule_test.go
@@ -1,0 +1,160 @@
+package findings
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestArchetypeVulnerabilityActiveRuleSupportsRuntime(t *testing.T) {
+	rule := newArchetypeVulnerabilityActiveRule()
+	if !rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "archetype", Config: map[string]string{"family": "vulnerability"}}) {
+		t.Fatal("SupportsRuntime(archetype vulnerability) = false, want true")
+	}
+	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "archetype", Config: map[string]string{"family": "scan"}}) {
+		t.Fatal("SupportsRuntime(archetype scan) = true, want false")
+	}
+}
+
+func TestArchetypeVulnerabilityActiveRuleClosesOnDowngradedSeverity(t *testing.T) {
+	rule := newArchetypeVulnerabilityActiveRule()
+	counterRule, ok := durableStateCounterEventRule(rule)
+	if !ok {
+		t.Fatal("archetype-vulnerability-active does not implement durable CounterEventRule")
+	}
+	downgraded := archetypeVulnerabilityEvent("downgraded", map[string]string{
+		"vulnerability_id": "123",
+		"severity":         "medium",
+	})
+	anchor, closes := counterRule.CloseOnEvent(downgraded)
+	wantAnchor := counterRule.OpenAnchor(map[string]string{"archetype_vulnerability_urn": "urn:cerebro:writer:archetype_finding:123"})
+	if !closes || anchor != wantAnchor {
+		t.Fatalf("CloseOnEvent(downgraded) = %q/%v, want %q/true", anchor, closes, wantAnchor)
+	}
+
+	stillActionable := archetypeVulnerabilityEvent("critical", map[string]string{
+		"vulnerability_id": "123",
+		"severity":         "critical",
+	})
+	if anchor, closes := counterRule.CloseOnEvent(stillActionable); closes || anchor != "" {
+		t.Fatalf("CloseOnEvent(critical) = %q/%v, want empty/false", anchor, closes)
+	}
+
+	missingIdentity := archetypeVulnerabilityEvent("missing-identity", map[string]string{"severity": "medium"})
+	if anchor, closes := counterRule.CloseOnEvent(missingIdentity); closes || anchor != "" {
+		t.Fatalf("CloseOnEvent(missing identity) = %q/%v, want empty/false", anchor, closes)
+	}
+}
+
+func TestArchetypeVulnerabilityActiveRuleEmitsStableFinding(t *testing.T) {
+	rule := newArchetypeVulnerabilityActiveRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-archetype-vulnerability", SourceId: "archetype", TenantId: "writer", Config: map[string]string{"family": "vulnerability"}}
+	event := archetypeVulnerabilityEvent("event-1", map[string]string{
+		"vulnerability_id": "123",
+		"scan_id":          "456",
+		"repository_id":    "7",
+		"severity":         "critical",
+		"category":         "dependency",
+		"file_path":        "go.sum",
+		"line_number":      "42",
+		"owner":            "WriterInternal",
+		"repo":             "cerebro",
+	})
+
+	records, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Evaluate() emitted %d findings, want 1", len(records))
+	}
+	finding := records[0]
+	if finding.RuleID != archetypeVulnerabilityActiveRuleID || finding.Status != findingStatusOpen {
+		t.Fatalf("finding identity/status = %s/%s", finding.RuleID, finding.Status)
+	}
+	if finding.Severity != "CRITICAL" {
+		t.Fatalf("Severity = %q, want CRITICAL", finding.Severity)
+	}
+	if got := finding.Attributes["archetype_vulnerability_urn"]; got != "urn:cerebro:writer:archetype_finding:123" {
+		t.Fatalf("archetype_vulnerability_urn = %q", got)
+	}
+	if got := finding.Attributes["archetype_repository_urn"]; got != "urn:cerebro:writer:github_code_repository:WriterInternal/cerebro" {
+		t.Fatalf("archetype_repository_urn = %q", got)
+	}
+	if !strings.Contains(finding.Summary, "WriterInternal/cerebro") || !strings.Contains(finding.Summary, "go.sum") {
+		t.Fatalf("Summary = %q, want repository and path", finding.Summary)
+	}
+
+	replayed := archetypeVulnerabilityEvent("event-2", map[string]string{
+		"vulnerability_id": "123",
+		"scan_id":          "789",
+		"repository_id":    "7",
+		"severity":         "high",
+		"category":         "dependency",
+		"file_path":        "go.sum",
+		"line_number":      "45",
+		"owner":            "WriterInternal",
+		"repo":             "cerebro",
+	})
+	records, err = rule.Evaluate(context.Background(), runtime, replayed)
+	if err != nil {
+		t.Fatalf("Evaluate(replayed) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Evaluate(replayed) emitted %d findings, want 1", len(records))
+	}
+	if records[0].Fingerprint != finding.Fingerprint {
+		t.Fatalf("Fingerprint = %q, want stable %q", records[0].Fingerprint, finding.Fingerprint)
+	}
+}
+
+func TestArchetypeVulnerabilityActiveRuleFiltersLowAndIncompleteEvents(t *testing.T) {
+	rule := newArchetypeVulnerabilityActiveRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-archetype-vulnerability", SourceId: "archetype", TenantId: "writer", Config: map[string]string{"family": "vulnerability"}}
+	low := archetypeVulnerabilityEvent("low", map[string]string{
+		"vulnerability_id": "123",
+		"scan_id":          "456",
+		"severity":         "medium",
+		"category":         "dependency",
+		"file_path":        "go.sum",
+		"owner":            "WriterInternal",
+		"repo":             "cerebro",
+	})
+	records, err := rule.Evaluate(context.Background(), runtime, low)
+	if err != nil {
+		t.Fatalf("Evaluate(low) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("Evaluate(low) emitted %d findings, want 0", len(records))
+	}
+
+	missingRepo := archetypeVulnerabilityEvent("missing-repo", map[string]string{
+		"vulnerability_id": "123",
+		"scan_id":          "456",
+		"severity":         "high",
+		"category":         "dependency",
+		"file_path":        "go.sum",
+	})
+	records, err = rule.Evaluate(context.Background(), runtime, missingRepo)
+	if err != nil {
+		t.Fatalf("Evaluate(missing repo) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("Evaluate(missing repo) emitted %d findings, want 0", len(records))
+	}
+}
+
+func archetypeVulnerabilityEvent(id string, attributes map[string]string) *cerebrov1.EventEnvelope {
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   "archetype",
+		Kind:       "archetype.vulnerability",
+		Attributes: attributes,
+		OccurredAt: timestamppb.New(time.Date(2026, time.June, 27, 12, 0, 0, 0, time.UTC)),
+	}
+}

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -73,6 +73,58 @@
       ]
     },
     {
+      "id": "archetype-vulnerability-active",
+      "pack_id": "archetype",
+      "pack_name": "Archetype",
+      "name": "Archetype Active Code Vulnerability",
+      "description": "Detect current high or critical code vulnerabilities reported by Archetype scans.",
+      "source_id": "archetype",
+      "evaluation_mode": "event",
+      "event_kinds": [
+        "archetype.vulnerability"
+      ],
+      "output_kind": "finding.archetype_vulnerability_active",
+      "severity": "dynamic",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "archetype",
+        "attack.initial-access",
+        "code",
+        "repository",
+        "vulnerability"
+      ],
+      "references": [
+        "https://archetype.dev/"
+      ],
+      "false_positives": [
+        "The vulnerability was remediated after the latest scan, or the reported path is no longer reachable in the active codebase."
+      ],
+      "runbook": "Review the affected repository path and category in Archetype, apply the recommended code or dependency fix, then rescan to clear the current-state finding.",
+      "required_attributes": [
+        "category",
+        "file_path",
+        "owner",
+        "repo",
+        "scan_id",
+        "severity",
+        "vulnerability_id"
+      ],
+      "fingerprint_fields": [
+        "archetype_vulnerability_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC7.1"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.8.8"
+        }
+      ]
+    },
+    {
       "id": "aurelius-promoted-vulnerability-active",
       "pack_id": "aurelius",
       "pack_name": "Aurelius",

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -261,6 +261,14 @@ func builtinRulePacks() []RulePack {
 			},
 		},
 		{
+			ID:          "archetype",
+			Name:        "Archetype",
+			Description: "Archetype code vulnerability findings.",
+			Rules: []Rule{
+				newArchetypeVulnerabilityActiveRule(),
+			},
+		},
+		{
 			ID:          "aurelius",
 			Name:        "Aurelius",
 			Description: "Aurelius image attestation and promoted-image vulnerability posture findings.",

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -985,6 +985,7 @@ func repoRelativePath(t *testing.T, relPath string) string {
 
 func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 	return []rulepackAuditClassification{
+		{RuleID: "archetype-vulnerability-active", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "archetype"},
 		{RuleID: "cloud-effective-admin-permission", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "cloud"},
 		{RuleID: "cloud-privilege-path-granted", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "cloud"},
 		{RuleID: "cloud-public-exposure-privileged-principal", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "cloud"},

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -56,7 +56,11 @@ type Store struct {
 	database     string
 	queryTimeout time.Duration
 
-	mu          sync.Mutex
+	projectionBatchSize        int
+	projectionWriteConcurrency int
+	writeSlots                 chan struct{}
+
+	schemaMu    sync.Mutex
 	schemaReady bool
 }
 
@@ -99,7 +103,25 @@ func Open(cfg config.GraphStoreConfig) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open neo4j: %w", err)
 	}
-	return &Store{driver: driver, database: database, queryTimeout: cfg.Neo4jQueryTimeout}, nil
+	projectionBatchSize := cfg.Neo4jProjectionBatchSize
+	if projectionBatchSize <= 0 {
+		projectionBatchSize = defaultProjectionUpsertBatchSize
+	}
+	projectionWriteConcurrency := cfg.Neo4jProjectionWriteConcurrency
+	if projectionWriteConcurrency <= 0 {
+		projectionWriteConcurrency = defaultProjectionWriteConcurrency
+	}
+	if projectionWriteConcurrency > neo4jMaxConnectionPoolSize {
+		projectionWriteConcurrency = neo4jMaxConnectionPoolSize
+	}
+	return &Store{
+		driver:                     driver,
+		database:                   database,
+		queryTimeout:               cfg.Neo4jQueryTimeout,
+		projectionBatchSize:        projectionBatchSize,
+		projectionWriteConcurrency: projectionWriteConcurrency,
+		writeSlots:                 make(chan struct{}, projectionWriteConcurrency),
+	}, nil
 }
 
 // CloseContext closes the underlying driver.
@@ -537,8 +559,6 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 	if label == "" {
 		label = urn
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	params := map[string]any{
 		"urn":         urn,
 		"tenant_id":   tenantID,
@@ -595,8 +615,6 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	if err := s.ensureSchema(ctx); err != nil {
 		return err
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	params := map[string]any{
 		"from_urn":   fromURN,
 		"to_urn":     toURN,
@@ -641,12 +659,18 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	return fmt.Errorf("upsert projected link %q %q %q: %w", fromURN, relation, toURN, errConcurrentAttributeMerge)
 }
 
-// projectionUpsertBatchSize bounds how many entities or links are written per
+// defaultProjectionUpsertBatchSize bounds how many entities or links are written per
 // UNWIND transaction. Batching collapses the two round-trips per element of the
 // per-item upsert path (merge/load attributes, then version-checked update) into
 // two round-trips per batch, which is the dominant cost of graph ingest against
 // a remote Aura instance.
-const projectionUpsertBatchSize = 500
+const defaultProjectionUpsertBatchSize = 500
+
+// defaultProjectionWriteConcurrency allows multiple independent graph writes to
+// share the driver's connection pool instead of serializing every write behind a
+// process-wide mutex. Attribute-version checks and transient retry handling keep
+// overlapping writes safe.
+const defaultProjectionWriteConcurrency = 4
 
 // mergeProjectedEntitiesQuery is the batched counterpart of
 // mergeEntityAndLoadAttributesQuery: it MERGEs every entity in the batch and
@@ -743,7 +767,7 @@ func (s *Store) UpsertProjectedEntities(ctx context.Context, entities []*ports.P
 	if err := s.ensureSchema(ctx); err != nil {
 		return err
 	}
-	for _, chunk := range chunkSlice(prepared, projectionUpsertBatchSize) {
+	for _, chunk := range chunkSlice(prepared, s.projectionBatchSizeOrDefault()) {
 		if err := s.upsertProjectedEntityChunk(ctx, chunk); err != nil {
 			return err
 		}
@@ -768,7 +792,7 @@ func (s *Store) UpsertProjectedLinks(ctx context.Context, links []*ports.Project
 	if err := s.ensureSchema(ctx); err != nil {
 		return err
 	}
-	for _, chunk := range chunkSlice(prepared, projectionUpsertBatchSize) {
+	for _, chunk := range chunkSlice(prepared, s.projectionBatchSizeOrDefault()) {
 		if err := s.upsertProjectedLinkChunk(ctx, chunk); err != nil {
 			return err
 		}
@@ -790,8 +814,6 @@ func (s *Store) upsertProjectedEntityChunk(ctx context.Context, chunk []*prepare
 }
 
 func (s *Store) writeProjectedEntityChunk(ctx context.Context, chunk []*preparedProjectedEntity) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	_, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
 		mergeRows := make([]map[string]any, 0, len(chunk))
 		for _, entity := range chunk {
@@ -857,8 +879,6 @@ func (s *Store) upsertProjectedLinkChunk(ctx context.Context, chunk []*preparedP
 }
 
 func (s *Store) writeProjectedLinkChunk(ctx context.Context, chunk []*preparedProjectedLink) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	_, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
 		mergeRows := make([]map[string]any, 0, len(chunk))
 		for _, link := range chunk {
@@ -1877,8 +1897,8 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 	if err := s.requireConfigured(); err != nil {
 		return err
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
 	if s.schemaReady {
 		return nil
 	}
@@ -1912,6 +1932,25 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 	return nil
 }
 
+func (s *Store) projectionBatchSizeOrDefault() int {
+	if s != nil && s.projectionBatchSize > 0 {
+		return s.projectionBatchSize
+	}
+	return defaultProjectionUpsertBatchSize
+}
+
+func (s *Store) acquireWriteSlot(ctx context.Context) (func(), error) {
+	if s == nil || s.writeSlots == nil {
+		return func() {}, nil
+	}
+	select {
+	case s.writeSlots <- struct{}{}:
+		return func() { <-s.writeSlots }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 func (s *Store) read(ctx context.Context, work func(context.Context, neo4jdriver.ManagedTransaction) (any, error)) (any, error) {
 	attrs := neo4jTelemetryAttrs("read", s.database, s.queryTimeout)
 	if s.queryTimeout > 0 {
@@ -1938,6 +1977,11 @@ func (s *Store) read(ctx context.Context, work func(context.Context, neo4jdriver
 }
 
 func (s *Store) write(ctx context.Context, work neo4jdriver.ManagedTransactionWork) (any, error) {
+	release, err := s.acquireWriteSlot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	started := time.Now()
 	ctx, span := telemetry.StartQuiet(ctx, "neo4j.write", neo4jTelemetryAttrs("write", s.database, 0))
 	session := s.driver.NewSession(ctx, neo4jdriver.SessionConfig{DatabaseName: s.database})

--- a/sources/archetype/source.go
+++ b/sources/archetype/source.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
@@ -19,12 +18,18 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourcehttp"
+	"github.com/writer/cerebro/sources/internal/archetypeclient"
 )
 
 //go:embed catalog.yaml
 var catalogFS embed.FS
 
 const sourceID = "archetype"
+
+const (
+	defaultFanoutConcurrency = 4
+	maxFanoutConcurrency     = 16
+)
 
 type Source struct {
 	spec                 *cerebrov1.SourceSpec
@@ -38,42 +43,13 @@ type settings struct {
 	token                    string
 	apiPrefix                string
 	privateEndpointAllowlist []string
+	fanoutConcurrency        int
 }
-type scanRecord struct {
-	ID           int    `json:"id"`
-	RepositoryID int    `json:"repository_id"`
-	Status       string `json:"status"`
-	StartedAt    string `json:"started_at"`
-	CompletedAt  string `json:"completed_at"`
-	CreatedAt    string `json:"created_at"`
-}
-type vulnerabilityRecord struct {
-	ID            int     `json:"id"`
-	ScanID        int     `json:"scan_id"`
-	LineNumber    int     `json:"line_number"`
-	FilePath      string  `json:"file_path"`
-	Category      string  `json:"category"`
-	Severity      string  `json:"severity"`
-	Description   string  `json:"description"`
-	AnalyzerScore float64 `json:"analyzer_score"`
-	AnalyzerLabel string  `json:"analyzer_label"`
-	CreatedAt     string  `json:"created_at"`
-}
-type knowledgeEntryRecord struct {
-	Slug             string   `json:"slug"`
-	Title            string   `json:"title"`
-	Summary          string   `json:"summary"`
-	Topics           []string `json:"topics,omitempty"`
-	DominantSeverity string   `json:"dominant_severity,omitempty"`
-	RepositoryID     int      `json:"repository_id"`
-	RepositoryName   string   `json:"repository_name"`
-	Owner            string   `json:"owner"`
-}
-type repositoryRecord struct {
-	ID    int    `json:"id"`
-	Owner string `json:"owner"`
-	Name  string `json:"name"`
-}
+
+type scanRecord = archetypeclient.Scan
+type vulnerabilityRecord = archetypeclient.Vulnerability
+type knowledgeEntryRecord = archetypeclient.KnowledgeEntry
+type repositoryRecord = archetypeclient.Repository
 
 func New() (*Source, error) {
 	specBytes, err := catalogFS.ReadFile("catalog.yaml")
@@ -92,7 +68,7 @@ func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 	if err != nil {
 		return err
 	}
-	return s.get(ctx, st, "/scans", new([]scanRecord))
+	return archetypeclient.Get(ctx, s.clientSettings(st), "/scans", new([]scanRecord))
 }
 func (s *Source) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
 	return nil, nil
@@ -106,34 +82,42 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 		return sourcecdk.Pull{}, err
 	}
 	var scans []scanRecord
-	if err := s.get(ctx, st, "/scans", &scans); err != nil {
+	clientSettings := s.clientSettings(st)
+	if err := archetypeclient.Get(ctx, clientSettings, "/scans", &scans); err != nil {
 		return sourcecdk.Pull{}, err
 	}
 	sort.Slice(scans, func(i, j int) bool { return scans[i].ID < scans[j].ID })
 	last := lastScanID(cursor, checkpoint)
-	repos := map[int]repositoryRecord{}
+	newScans := make([]scanRecord, 0, len(scans))
+	for _, scan := range scans {
+		if scan.ID > last {
+			newScans = append(newScans, scan)
+		}
+	}
+	if len(newScans) == 0 {
+		return sourcecdk.NotModifiedPull(checkpoint), nil
+	}
+	repos := archetypeclient.Repositories(ctx, clientSettings)
+	vulnerabilities := make([][]vulnerabilityRecord, len(newScans))
+	if st.family != "scan" {
+		var err error
+		vulnerabilities, err = archetypeclient.VulnerabilitiesForScans(ctx, clientSettings, newScans)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+	}
 	knowledgeRepos := map[int]bool{}
 	events := []*primitives.Event{}
-	for _, scan := range scans {
-		if scan.ID <= last {
-			continue
-		}
-		if len(repos) == 0 {
-			repos = s.repositories(ctx, st)
-		}
+	for i, scan := range newScans {
 		events = append(events, scanEvent(st, scan, repos[scan.RepositoryID]))
 		if st.family == "scan" {
 			continue
 		}
-		var vulns []vulnerabilityRecord
-		if err := s.get(ctx, st, fmt.Sprintf("/scans/%d/vulnerabilities", scan.ID), &vulns); err != nil {
-			return sourcecdk.Pull{}, err
-		}
-		for _, vuln := range vulns {
+		for _, vuln := range vulnerabilities[i] {
 			events = append(events, vulnerabilityEvent(st, scan, vuln, repos[scan.RepositoryID]))
 		}
 		if !knowledgeRepos[scan.RepositoryID] {
-			entries, cacheable := s.repositoryKnowledge(ctx, st, scan.RepositoryID)
+			entries, cacheable := archetypeclient.RepositoryKnowledge(ctx, clientSettings, scan.RepositoryID)
 			knowledgeRepos[scan.RepositoryID] = cacheable
 			for _, entry := range entries {
 				if event := libraryNoteEvent(st, scan, entry, repos[scan.RepositoryID]); event != nil {
@@ -158,6 +142,10 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 		baseURL:   strings.TrimRight(sourcecdk.ConfigValue(cfg, "base_url"), "/"),
 		token:     first(sourcecdk.ConfigValue(cfg, "token"), sourcecdk.ConfigValue(cfg, "api_token")),
 		apiPrefix: first(sourcecdk.ConfigValue(cfg, "api_prefix"), "/api/v1"),
+	}
+	var err error
+	if st.fanoutConcurrency, err = parseFanoutConcurrency(sourcecdk.ConfigValue(cfg, "request_concurrency")); err != nil {
+		return st, err
 	}
 	if st.tenantID == "" || st.baseURL == "" {
 		return st, fmt.Errorf("%w: archetype tenant_id and base_url are required", sourcecdk.ErrInvalidConfig)
@@ -184,54 +172,30 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 	st.privateEndpointAllowlist = privateEndpointAllowlist
 	return st, nil
 }
-func (s *Source) get(ctx context.Context, st settings, path string, out any) error {
-	requestPath, err := sourcehttp.NormalizeRequestPath(sourceID, st.apiPrefix+path)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, st.baseURL+requestPath, nil)
-	if err != nil {
-		return err
-	}
-	if st.token != "" {
-		req.Header.Set("Authorization", "Bearer "+st.token)
-	}
-	req.Header.Set("Accept", "application/json")
-	resp, err := sourcehttp.DoWithRetry(ctx, sourcehttp.NewClient(sourcehttp.ClientOptions{
+func (s *Source) clientSettings(st settings) archetypeclient.Settings {
+	return archetypeclient.Settings{
 		SourceID:                 sourceID,
-		AllowLoopback:            s != nil && s.allowLoopbackBaseURL,
+		BaseURL:                  st.baseURL,
+		Token:                    st.token,
+		APIPrefix:                st.apiPrefix,
 		PrivateEndpointAllowlist: st.privateEndpointAllowlist,
-	}), req, sourcehttp.RetryOptions{})
+		AllowLoopback:            s != nil && s.allowLoopbackBaseURL,
+		FanoutConcurrency:        st.fanoutConcurrency,
+	}
+}
+func parseFanoutConcurrency(raw string) (int, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return defaultFanoutConcurrency, nil
+	}
+	value, err := strconv.Atoi(trimmed)
 	if err != nil {
-		return err
+		return 0, fmt.Errorf("%w: archetype request_concurrency must be an integer", sourcecdk.ErrInvalidConfig)
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &sourcecdk.HTTPStatusError{Code: resp.StatusCode, Message: fmt.Sprintf("archetype GET %s failed with status %d", path, resp.StatusCode)}
+	if value <= 0 || value > maxFanoutConcurrency {
+		return 0, fmt.Errorf("%w: archetype request_concurrency must be between 1 and %d", sourcecdk.ErrInvalidConfig, maxFanoutConcurrency)
 	}
-	return json.Unmarshal(resp.Body, out)
-}
-func (s *Source) repositories(ctx context.Context, st settings) map[int]repositoryRecord {
-	var repos []repositoryRecord
-	if err := s.get(ctx, st, "/repositories", &repos); err != nil {
-		return nil
-	}
-	out := map[int]repositoryRecord{}
-	for _, repo := range repos {
-		out[repo.ID] = repo
-	}
-	return out
-}
-func (s *Source) repositoryKnowledge(ctx context.Context, st settings, repositoryID int) ([]knowledgeEntryRecord, bool) {
-	var response struct {
-		Entries []knowledgeEntryRecord `json:"entries"`
-	}
-	if err := s.get(ctx, st, fmt.Sprintf("/repositories/%d/knowledge", repositoryID), &response); err != nil {
-		if sourcecdk.IsHTTPStatus(err, http.StatusNotFound) || sourcecdk.IsHTTPStatus(err, http.StatusForbidden) || sourcecdk.IsRetryableHTTPStatus(err) {
-			return nil, !sourcecdk.IsRetryableHTTPStatus(err)
-		}
-		return nil, false
-	}
-	return response.Entries, true
+	return value, nil
 }
 func scanEvent(st settings, scan scanRecord, repo repositoryRecord) *primitives.Event {
 	attrs := map[string]string{"scan_id": strconv.Itoa(scan.ID), "repository_id": strconv.Itoa(scan.RepositoryID), "status": scan.Status, "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}

--- a/sources/archetype/source_test.go
+++ b/sources/archetype/source_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -226,6 +227,82 @@ func TestSourceReadFetchesRepositoryKnowledgeOncePerRepo(t *testing.T) {
 	}
 	if libraryEvents != 1 {
 		t.Fatalf("library note events = %d, want 1", libraryEvents)
+	}
+}
+
+func TestSourceReadFetchesVulnerabilitiesConcurrentlyAndPreservesEventOrder(t *testing.T) {
+	started := make(chan int, 2)
+	release := make(chan struct{})
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		seen := map[int]bool{}
+		for len(seen) < 2 {
+			seen[<-started] = true
+		}
+		close(release)
+	}()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{
+				{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"},
+				{"id": 2, "repository_id": 8, "status": "completed", "completed_at": "2026-06-17T12:06:00Z"},
+				{"id": 3, "repository_id": 9, "status": "completed", "completed_at": "2026-06-17T12:07:00Z"},
+			})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{
+				{"id": 7, "owner": "WriterInternal", "name": "RepoOne"},
+				{"id": 8, "owner": "WriterInternal", "name": "RepoTwo"},
+				{"id": 9, "owner": "WriterInternal", "name": "RepoThree"},
+			})
+		case "/api/v1/scans/1/vulnerabilities":
+			started <- 1
+			<-release
+			writeJSON(t, w, []map[string]any{{"id": 10, "scan_id": 1, "severity": "high", "category": "dependency", "file_path": "one.lock"}})
+		case "/api/v1/scans/2/vulnerabilities":
+			started <- 2
+			<-release
+			writeJSON(t, w, []map[string]any{{"id": 20, "scan_id": 2, "severity": "critical", "category": "dependency", "file_path": "two.lock"}})
+		case "/api/v1/scans/3/vulnerabilities":
+			writeJSON(t, w, []map[string]any{{"id": 30, "scan_id": 3, "severity": "medium", "category": "dependency", "file_path": "three.lock"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	pull, err := source.ReadWithCheckpoint(ctx, sourcecdk.NewConfig(map[string]string{
+		"tenant_id":           "writer",
+		"base_url":            server.URL,
+		"request_concurrency": "2",
+	}), nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	<-released
+	if len(pull.Events) != 6 {
+		t.Fatalf("len(Events) = %d, want scan/vulnerability per scan", len(pull.Events))
+	}
+	wantKinds := []string{"archetype.scan", "archetype.vulnerability", "archetype.scan", "archetype.vulnerability", "archetype.scan", "archetype.vulnerability"}
+	wantVulns := map[int]string{1: "10", 3: "20", 5: "30"}
+	for i, event := range pull.Events {
+		if event.GetKind() != wantKinds[i] {
+			t.Fatalf("event %d kind = %q, want %q", i, event.GetKind(), wantKinds[i])
+		}
+		if want, ok := wantVulns[i]; ok {
+			if got := event.GetAttributes()["vulnerability_id"]; got != want {
+				t.Fatalf("event %d vulnerability_id = %q, want %q", i, got, want)
+			}
+		}
 	}
 }
 

--- a/sources/internal/archetypeclient/client.go
+++ b/sources/internal/archetypeclient/client.go
@@ -1,0 +1,140 @@
+package archetypeclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehttp"
+)
+
+const defaultFanoutConcurrency = 4
+
+type Settings struct {
+	SourceID                 string
+	BaseURL                  string
+	Token                    string
+	APIPrefix                string
+	PrivateEndpointAllowlist []string
+	AllowLoopback            bool
+	FanoutConcurrency        int
+}
+
+type JSONTarget interface{}
+
+type Scan struct {
+	ID           int    `json:"id"`
+	RepositoryID int    `json:"repository_id"`
+	Status       string `json:"status"`
+	StartedAt    string `json:"started_at"`
+	CompletedAt  string `json:"completed_at"`
+	CreatedAt    string `json:"created_at"`
+}
+
+type Vulnerability struct {
+	ID            int     `json:"id"`
+	ScanID        int     `json:"scan_id"`
+	LineNumber    int     `json:"line_number"`
+	FilePath      string  `json:"file_path"`
+	Category      string  `json:"category"`
+	Severity      string  `json:"severity"`
+	Description   string  `json:"description"`
+	AnalyzerScore float64 `json:"analyzer_score"`
+	AnalyzerLabel string  `json:"analyzer_label"`
+	CreatedAt     string  `json:"created_at"`
+}
+
+type KnowledgeEntry struct {
+	Slug             string   `json:"slug"`
+	Title            string   `json:"title"`
+	Summary          string   `json:"summary"`
+	Topics           []string `json:"topics,omitempty"`
+	DominantSeverity string   `json:"dominant_severity,omitempty"`
+	RepositoryID     int      `json:"repository_id"`
+	RepositoryName   string   `json:"repository_name"`
+	Owner            string   `json:"owner"`
+}
+
+type Repository struct {
+	ID    int    `json:"id"`
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
+}
+
+func Get(ctx context.Context, st Settings, path string, out JSONTarget) error {
+	requestPath, err := sourcehttp.NormalizeRequestPath(st.SourceID, st.APIPrefix+path)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, st.BaseURL+requestPath, nil)
+	if err != nil {
+		return err
+	}
+	if st.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+st.Token)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := sourcehttp.DoWithRetry(ctx, sourcehttp.NewClient(sourcehttp.ClientOptions{
+		SourceID:                 st.SourceID,
+		AllowLoopback:            st.AllowLoopback,
+		PrivateEndpointAllowlist: st.PrivateEndpointAllowlist,
+	}), req, sourcehttp.RetryOptions{})
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &sourcecdk.HTTPStatusError{Code: resp.StatusCode, Message: fmt.Sprintf("archetype GET %s failed with status %d", path, resp.StatusCode)}
+	}
+	return json.Unmarshal(resp.Body, out)
+}
+
+func Repositories(ctx context.Context, st Settings) map[int]Repository {
+	var repos []Repository
+	if err := Get(ctx, st, "/repositories", &repos); err != nil {
+		return nil
+	}
+	out := map[int]Repository{}
+	for _, repo := range repos {
+		out[repo.ID] = repo
+	}
+	return out
+}
+
+func RepositoryKnowledge(ctx context.Context, st Settings, repositoryID int) ([]KnowledgeEntry, bool) {
+	var response struct {
+		Entries []KnowledgeEntry `json:"entries"`
+	}
+	if err := Get(ctx, st, fmt.Sprintf("/repositories/%d/knowledge", repositoryID), &response); err != nil {
+		if sourcecdk.IsHTTPStatus(err, http.StatusNotFound) || sourcecdk.IsHTTPStatus(err, http.StatusForbidden) || sourcecdk.IsRetryableHTTPStatus(err) {
+			return nil, !sourcecdk.IsRetryableHTTPStatus(err)
+		}
+		return nil, false
+	}
+	return response.Entries, true
+}
+
+func VulnerabilitiesForScans(ctx context.Context, st Settings, scans []Scan) ([][]Vulnerability, error) {
+	out := make([][]Vulnerability, len(scans))
+	group, groupCtx := errgroup.WithContext(ctx)
+	fanout := st.FanoutConcurrency
+	if fanout <= 0 {
+		fanout = defaultFanoutConcurrency
+	}
+	group.SetLimit(fanout)
+	for i, scan := range scans {
+		i, scan := i, scan
+		group.Go(func() error {
+			var vulns []Vulnerability
+			if err := Get(groupCtx, st, fmt.Sprintf("/scans/%d/vulnerabilities", scan.ID), &vulns); err != nil {
+				return err
+			}
+			out[i] = vulns
+			return nil
+		})
+	}
+	return out, group.Wait()
+}

--- a/sources/internal/archetypeclient/client_test.go
+++ b/sources/internal/archetypeclient/client_test.go
@@ -1,0 +1,39 @@
+package archetypeclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestVulnerabilitiesForScansDefaultsZeroFanoutConcurrency(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/scans/1/vulnerabilities":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":10,"scan_id":1,"severity":"high"}]`))
+		case "/scans/2/vulnerabilities":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":20,"scan_id":2,"severity":"critical"}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := VulnerabilitiesForScans(ctx, Settings{
+		SourceID:      "archetype",
+		BaseURL:       server.URL,
+		AllowLoopback: true,
+	}, []Scan{{ID: 1}, {ID: 2}})
+	if err != nil {
+		t.Fatalf("VulnerabilitiesForScans() error = %v", err)
+	}
+	if len(got) != 2 || len(got[0]) != 1 || got[0][0].ID != 10 || len(got[1]) != 1 || got[1][0].ID != 20 {
+		t.Fatalf("VulnerabilitiesForScans() = %#v, want ordered vulnerability batches", got)
+	}
+}

--- a/tools/archtests/graph_store_guardrails_test.go
+++ b/tools/archtests/graph_store_guardrails_test.go
@@ -294,7 +294,16 @@ func TestGraphStoreConfigExposesApprovedFields(t *testing.T) {
 		}
 		return false
 	})
-	want := []string{"Driver", "Neo4jURI", "Neo4jUsername", "Neo4jPassword", "Neo4jDatabase", "Neo4jQueryTimeout"}
+	want := []string{
+		"Driver",
+		"Neo4jURI",
+		"Neo4jUsername",
+		"Neo4jPassword",
+		"Neo4jDatabase",
+		"Neo4jQueryTimeout",
+		"Neo4jProjectionBatchSize",
+		"Neo4jProjectionWriteConcurrency",
+	}
 	if strings.Join(fields, ",") != strings.Join(want, ",") {
 		t.Fatalf("GraphStoreConfig fields = %v, want exactly %v", fields, want)
 	}


### PR DESCRIPTION
## Summary
- replace the Neo4j process-wide write mutex with a bounded write concurrency limiter and configurable projection batch/write settings
- add a durable Archetype vulnerability finding rule so `writer-archetype-vulnerability` no longer skips finding evaluation due to missing rule coverage
- fetch Archetype scan vulnerabilities concurrently while preserving deterministic event order, with client/fan-out code extracted outside the source package LOC budget
- make cut-release wait for the already-running main CI instead of rerunning full `make verify` before tagging

## Validation
- go test ./...
- make test-race
- go vet ./...
- make check-structural check-structural-test check-arch
- make detection-catalog-check
- make lint
- make build

## Operational note
The sec-dev v2.1.586 image-bump PR in WriterInternal/cerebro was merged and the deploy completed: API task def `cerebro-sec-dev:428`, orchestrator task def `cerebro-sec-dev-orchestrator:283`, both on `v2.1.586`. The infra workflow fix and JetStream retention changes are in a separate internal PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->