### PR TITLE
[codex] remove Windows release binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,13 +15,9 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     goarch:
       - amd64
       - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
     ldflags:
       - -s -w -X github.com/writer/cerebro/internal/buildinfo.Version={{.Version}} -X github.com/writer/cerebro/internal/buildinfo.Commit={{.Commit}} -X github.com/writer/cerebro/internal/buildinfo.BuildDate={{.Date}}
 
@@ -30,10 +26,6 @@ archives:
     ids:
       - cerebro
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format_overrides:
-      - goos: windows
-        formats:
-          - zip
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
## Summary

- Remove Windows from the GoReleaser CLI binary target list.
- Drop the Windows-only archive override now that Windows artifacts are not produced.

## Impact

Releases will continue publishing Linux and macOS binaries for amd64 and arm64. Windows release archives will no longer be built.

## Validation

- `make release-smoke`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->