### PR TITLE
fix: drop windows release artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,13 +15,9 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     goarch:
       - amd64
       - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
     ldflags:
       - -s -w -X github.com/writer/cerebro/internal/buildinfo.Version={{.Version}} -X github.com/writer/cerebro/internal/buildinfo.Commit={{.Commit}} -X github.com/writer/cerebro/internal/buildinfo.BuildDate={{.Date}}
 
@@ -30,10 +26,6 @@ archives:
     ids:
       - cerebro
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format_overrides:
-      - goos: windows
-        formats:
-          - zip
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
## Summary
- stop GoReleaser from building/publishing Windows binaries for Cerebro
- remove the now-unused Windows archive override

## Why
Cerebro is deployed as Linux runtime/container artifacts, and the release workflow is currently spending time in the GoReleaser artifact publishing path. This keeps release assets to Linux and macOS only.

## Validation
- make release-smoke
- verified `.goreleaser.yaml` has no remaining `windows` targets
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->