### PR TITLE
feat(archetype): preserve context metadata

### DIFF
--- a/internal/sourceprojection/archetype.go
+++ b/internal/sourceprojection/archetype.go
@@ -95,6 +95,7 @@ func archetypeLibraryNoteProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 	}
 	attrs := event.GetAttributes()
 	payload := payloadMap(event)
+	metadata := archetypeMapValue(payload, "metadata")
 	slug := firstNonEmpty(attrs["knowledge_slug"], stringValue(payload, "slug"))
 	if slug == "" {
 		return nil, nil, nil
@@ -106,6 +107,8 @@ func archetypeLibraryNoteProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 	if noteURN == "" {
 		return nil, nil, nil
 	}
+	contextPack := firstNonEmpty(attrs["context_pack"], stringValue(metadata, "context_pack"))
+	contextKind := firstNonEmpty(attrs["context_kind"], stringValue(metadata, "context_kind"))
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        noteURN,
 		TenantID:   tenantID,
@@ -117,6 +120,25 @@ func archetypeLibraryNoteProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 			"title":             firstNonEmpty(attrs["title"], stringValue(payload, "title")),
 			"summary":           stringValue(payload, "summary"),
 			"topics":            firstNonEmpty(attrs["topics"], archetypeStringSliceValue(payload, "topics")),
+			"source_files":      firstNonEmpty(attrs["source_files"], archetypeStringSliceValue(payload, "source_files")),
+			"generated_at":      firstNonEmpty(attrs["generated_at"], stringValue(payload, "generated_at")),
+			"context_pack":      contextPack,
+			"context_kind":      contextKind,
+			"health_score":      firstNonEmpty(attrs["health_score"], stringValue(metadata, "health_score")),
+			"freshness_state":   firstNonEmpty(attrs["freshness_state"], stringValue(metadata, "freshness_state")),
+			"recommended_depth": firstNonEmpty(attrs["recommended_depth"], stringValue(metadata, "recommended_depth")),
+			"evidence_plane":    firstNonEmpty(attrs["evidence_plane"], stringValue(metadata, "evidence_plane")),
+			"state_store":       firstNonEmpty(attrs["state_store"], stringValue(metadata, "state_store")),
+			"context_stale":     firstNonEmpty(attrs["context_stale"], stringValue(metadata, "context_stale")),
+			"needs_learning":    firstNonEmpty(attrs["needs_learning"], stringValue(metadata, "needs_learning")),
+			"missing_description": firstNonEmpty(
+				attrs["missing_description"],
+				stringValue(metadata, "missing_description"),
+			),
+			"missing_latest_commit": firstNonEmpty(
+				attrs["missing_latest_commit"],
+				stringValue(metadata, "missing_latest_commit"),
+			),
 			"repository":        repository,
 			"repository_id":     attrs["repository_id"],
 			"scan_id":           attrs["scan_id"],
@@ -127,7 +149,13 @@ func archetypeLibraryNoteProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 	})
 	if repoURN := archetypeRepoURN(tenantID, attrs); repoURN != "" {
 		addArchetypeRepo(entities, tenantID, event.GetSourceId(), repoURN, attrs)
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), repoURN, noteURN, relationHasEvidence, map[string]string{"event_id": event.GetId(), "evidence_type": "archetype_library_note"}))
+		linkAttrs := compactAttributes(map[string]string{
+			"event_id":      event.GetId(),
+			"evidence_type": "archetype_library_note",
+			"context_pack":  contextPack,
+			"context_kind":  contextKind,
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), repoURN, noteURN, relationHasEvidence, linkAttrs))
 	}
 	if scanID := strings.TrimSpace(attrs["scan_id"]); scanID != "" {
 		scanURN := projectionURN(tenantID, "archetype_scan", scanID)
@@ -200,4 +228,13 @@ func archetypeStringSliceValue(values map[string]any, key string) string {
 	default:
 		return ""
 	}
+}
+
+func archetypeMapValue(values map[string]any, key string) map[string]any {
+	raw, ok := values[key]
+	if !ok {
+		return nil
+	}
+	typed, _ := raw.(map[string]any)
+	return typed
 }

--- a/internal/sourceprojection/archetype_test.go
+++ b/internal/sourceprojection/archetype_test.go
@@ -91,7 +91,7 @@ func TestProjectArchetypeLibraryNoteLinksRepositoryContext(t *testing.T) {
 			"repo":              "Archetype",
 			"dominant_severity": "info",
 		},
-		Payload: []byte(`{"slug":"repository-commit-learning","title":"Repository commit learning","summary":"Archetype learned the latest repository head.","topics":["gitops","commits","librarian"]}`),
+		Payload: []byte(`{"slug":"repository-commit-learning","title":"Repository commit learning","summary":"Archetype learned the latest repository head.","topics":["gitops","commits","librarian"],"source_files":["services/archetype-runtime/src/state.rs"],"metadata":{"context_pack":"repository_context_pack_v2","context_kind":"repository-commit-learning","health_score":72,"freshness_state":"stale","recommended_depth":"deep","context_stale":true,"needs_learning":true}}`),
 	})
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
@@ -116,6 +116,27 @@ func TestProjectArchetypeLibraryNoteLinksRepositoryContext(t *testing.T) {
 		}
 		if got := entity.Attributes["dominant_severity"]; got != "info" {
 			t.Fatalf("dominant_severity attr = %q, want info", got)
+		}
+		if got := entity.Attributes["context_pack"]; got != "repository_context_pack_v2" {
+			t.Fatalf("context_pack attr = %q, want repository_context_pack_v2", got)
+		}
+		if got := entity.Attributes["context_kind"]; got != "repository-commit-learning" {
+			t.Fatalf("context_kind attr = %q, want repository-commit-learning", got)
+		}
+		if got := entity.Attributes["health_score"]; got != "72" {
+			t.Fatalf("health_score attr = %q, want 72", got)
+		}
+		if got := entity.Attributes["freshness_state"]; got != "stale" {
+			t.Fatalf("freshness_state attr = %q, want stale", got)
+		}
+		if got := entity.Attributes["recommended_depth"]; got != "deep" {
+			t.Fatalf("recommended_depth attr = %q, want deep", got)
+		}
+		if got := entity.Attributes["context_stale"]; got != "true" {
+			t.Fatalf("context_stale attr = %q, want true", got)
+		}
+		if got := entity.Attributes["source_files"]; got != "services/archetype-runtime/src/state.rs" {
+			t.Fatalf("source_files attr = %q, want state source", got)
 		}
 	}
 	if entity := state.entities[scanURN]; entity == nil || entity.EntityType != "archetype.scan" {

--- a/sources/archetype/source.go
+++ b/sources/archetype/source.go
@@ -216,9 +216,22 @@ func libraryNoteEvent(st settings, scan scanRecord, entry knowledgeEntryRecord, 
 	}
 	attrs := map[string]string{
 		"knowledge_slug":    entry.Slug,
+		"title":             entry.Title,
 		"scan_id":           strconv.Itoa(scan.ID),
 		"repository_id":     strconv.Itoa(entry.RepositoryID),
 		"dominant_severity": entry.DominantSeverity,
+		"topics":            strings.Join(entry.Topics, ","),
+		"generated_at":      entry.GeneratedAt,
+		"source_files":      strings.Join(entry.SourceFiles, ","),
+		"context_pack":      metadataString(entry.Metadata, "context_pack"),
+		"context_kind":      metadataString(entry.Metadata, "context_kind"),
+		"health_score":      metadataString(entry.Metadata, "health_score"),
+		"freshness_state":   metadataString(entry.Metadata, "freshness_state"),
+		"recommended_depth": metadataString(entry.Metadata, "recommended_depth"),
+		"evidence_plane":    metadataString(entry.Metadata, "evidence_plane"),
+		"state_store":       metadataString(entry.Metadata, "state_store"),
+		"context_stale":     metadataString(entry.Metadata, "context_stale"),
+		"needs_learning":    metadataString(entry.Metadata, "needs_learning"),
 		"owner":             entry.Owner,
 		"repo":              entry.RepositoryName,
 	}
@@ -258,4 +271,20 @@ func compact(attrs map[string]string) map[string]string {
 		}
 	}
 	return attrs
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	switch value := metadata[key].(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case float64:
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(value)
+	default:
+		return ""
+	}
 }

--- a/sources/archetype/source_test.go
+++ b/sources/archetype/source_test.go
@@ -91,11 +91,21 @@ func TestSourceReadEmitsLibraryNoteEvents(t *testing.T) {
 		case "/api/v1/repositories/7/knowledge":
 			writeJSON(t, w, map[string]any{
 				"entries": []map[string]any{{
-					"slug":              "repository-commit-learning",
-					"title":             "Repository commit learning",
-					"summary":           "Archetype learned the latest repository head.",
-					"topics":            []string{"gitops", "commits", "librarian"},
-					"generated_at":      "2026-06-17T12:04:00Z",
+					"slug":         "repository-commit-learning",
+					"title":        "Repository commit learning",
+					"summary":      "Archetype learned the latest repository head.",
+					"topics":       []string{"gitops", "commits", "librarian"},
+					"generated_at": "2026-06-17T12:04:00Z",
+					"source_files": []string{"services/archetype-runtime/src/state.rs"},
+					"metadata": map[string]any{
+						"context_pack":      "repository_context_pack_v2",
+						"context_kind":      "repository-commit-learning",
+						"health_score":      72,
+						"freshness_state":   "stale",
+						"recommended_depth": "deep",
+						"context_stale":     true,
+						"needs_learning":    true,
+					},
 					"repository_id":     7,
 					"repository_name":   "Archetype",
 					"owner":             "WriterInternal",
@@ -139,6 +149,21 @@ func TestSourceReadEmitsLibraryNoteEvents(t *testing.T) {
 	if got := attrs["dominant_severity"]; got != "info" {
 		t.Fatalf("library dominant_severity attr = %q, want info", got)
 	}
+	if got := attrs["context_pack"]; got != "repository_context_pack_v2" {
+		t.Fatalf("library context_pack attr = %q, want repository_context_pack_v2", got)
+	}
+	if got := attrs["context_kind"]; got != "repository-commit-learning" {
+		t.Fatalf("library context_kind attr = %q, want repository-commit-learning", got)
+	}
+	if got := attrs["health_score"]; got != "72" {
+		t.Fatalf("library health_score attr = %q, want 72", got)
+	}
+	if got := attrs["freshness_state"]; got != "stale" {
+		t.Fatalf("library freshness_state attr = %q, want stale", got)
+	}
+	if got := attrs["source_files"]; got != "services/archetype-runtime/src/state.rs" {
+		t.Fatalf("library source_files attr = %q, want state source", got)
+	}
 	var payload map[string]any
 	if err := json.Unmarshal(pull.Events[1].GetPayload(), &payload); err != nil {
 		t.Fatalf("decode library payload: %v", err)
@@ -146,6 +171,10 @@ func TestSourceReadEmitsLibraryNoteEvents(t *testing.T) {
 	topics, ok := payload["topics"].([]any)
 	if !ok || len(topics) != 3 || topics[0] != "gitops" {
 		t.Fatalf("library payload topics = %#v, want gitops/commits/librarian", payload["topics"])
+	}
+	metadata, ok := payload["metadata"].(map[string]any)
+	if !ok || metadata["context_pack"] != "repository_context_pack_v2" {
+		t.Fatalf("library payload metadata = %#v, want context pack", payload["metadata"])
 	}
 }
 

--- a/sources/internal/archetypeclient/client.go
+++ b/sources/internal/archetypeclient/client.go
@@ -49,14 +49,19 @@ type Vulnerability struct {
 }
 
 type KnowledgeEntry struct {
-	Slug             string   `json:"slug"`
-	Title            string   `json:"title"`
-	Summary          string   `json:"summary"`
-	Topics           []string `json:"topics,omitempty"`
-	DominantSeverity string   `json:"dominant_severity,omitempty"`
-	RepositoryID     int      `json:"repository_id"`
-	RepositoryName   string   `json:"repository_name"`
-	Owner            string   `json:"owner"`
+	Slug              string         `json:"slug"`
+	Title             string         `json:"title"`
+	Summary           string         `json:"summary"`
+	Topics            []string       `json:"topics,omitempty"`
+	GeneratedAt       string         `json:"generated_at,omitempty"`
+	SourceFiles       []string       `json:"source_files,omitempty"`
+	Metadata          map[string]any `json:"metadata,omitempty"`
+	SeverityTags      []string       `json:"severity_tags,omitempty"`
+	DominantSeverity  string         `json:"dominant_severity,omitempty"`
+	SeverityBreakdown []any          `json:"severity_breakdown,omitempty"`
+	RepositoryID      int            `json:"repository_id"`
+	RepositoryName    string         `json:"repository_name"`
+	Owner             string         `json:"owner"`
 }
 
 type Repository struct {


### PR DESCRIPTION
## Summary
- preserve Archetype library-note metadata, generated timestamps, severity tags, and source files in source events
- project context pack, freshness, depth, stale-state, and evidence fields onto library-note graph nodes
- cover the adapter and projection with focused tests

## Validation
- go test ./sources/archetype ./sources/internal/archetypeclient ./internal/sourceprojection
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->