### PR TITLE
Fix Archetype context graph edges

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -5216,8 +5216,8 @@ func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
 	if got := ingestPayload["entities_projected"]; got != float64(4) {
 		t.Fatalf("entities_projected = %#v, want 4", got)
 	}
-	if got := ingestPayload["links_projected"]; got != float64(7) {
-		t.Fatalf("links_projected = %#v, want 7", got)
+	if got := ingestPayload["links_projected"]; got != float64(8) {
+		t.Fatalf("links_projected = %#v, want 8", got)
 	}
 	if !sawAuth.Load() {
 		t.Fatal("Archetype API did not receive bearer token")
@@ -5242,6 +5242,7 @@ func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
 	assertBootstrapProjectedLink(t, graphStore, repoURN, "has_evidence", scanURN)
 	assertBootstrapProjectedLink(t, graphStore, repoURN, "has_evidence", findingURN)
 	assertBootstrapProjectedLink(t, graphStore, repoURN, "has_evidence", noteURN)
+	assertBootstrapProjectedLink(t, graphStore, repoURN, "has_context", noteURN)
 	assertBootstrapProjectedLink(t, graphStore, findingURN, "belongs_to", scanURN)
 	assertBootstrapProjectedLink(t, graphStore, findingURN, "affects", repoURN)
 	assertBootstrapProjectedLink(t, graphStore, noteURN, "belongs_to", scanURN)

--- a/internal/fabriccontract/relations.go
+++ b/internal/fabriccontract/relations.go
@@ -25,6 +25,7 @@ const (
 	RelationDependsOn          = "depends_on"
 	RelationGrantsEntitlement  = "grants_entitlement"
 	RelationHasClassification  = "has_classification"
+	RelationHasContext         = "has_context"
 	RelationHasDNSRecord       = "has_dns_record"
 	RelationHasEvidence        = "has_evidence"
 	RelationHasFinding         = "has_finding"
@@ -62,6 +63,7 @@ var relationSet = map[string]struct{}{
 	RelationDependsOn:          {},
 	RelationGrantsEntitlement:  {},
 	RelationHasClassification:  {},
+	RelationHasContext:         {},
 	RelationHasDNSRecord:       {},
 	RelationHasEvidence:        {},
 	RelationHasFinding:         {},

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -86,6 +86,13 @@ var canonicalGraphOntology = GraphOntology{
 			ToTypes:     []string{"*"},
 		},
 		{
+			Relation:    fabriccontract.RelationHasContext,
+			Description: "Context edge from a resource Entity to supporting repository, runtime, or library-note context.",
+			Aliases:     []string{"HAS_CONTEXT", "repository context", "library context"},
+			FromTypes:   []string{"*"},
+			ToTypes:     []string{"*"},
+		},
+		{
 			Relation:    fabriccontract.RelationHasIdentifier,
 			Description: "Edge from a concrete identity/resource node to a normalized identifier node.",
 			Aliases:     []string{"HAS_IDENTIFIER", "identity_email", "email", "identifier"},

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -16,6 +16,9 @@ func TestOntologyCanonicalizesAliases(t *testing.T) {
 	if got, ok := canonicalRelation("BELONGS_TO_SOURCE"); !ok || got != "belongs_to" {
 		t.Fatalf("canonicalRelation(BELONGS_TO_SOURCE) = %q, %v; want belongs_to, true", got, ok)
 	}
+	if got, ok := canonicalRelation("repository context"); !ok || got != "has_context" {
+		t.Fatalf("canonicalRelation(repository context) = %q, %v; want has_context, true", got, ok)
+	}
 }
 
 func TestOntologyAliasesRoundTripToCanonicalValues(t *testing.T) {
@@ -58,6 +61,7 @@ func TestOntologyPromptMentionsCanonicalRepositoryShape(t *testing.T) {
 		"Entity `github.code.repository`",
 		"GitHub repository metadata such as `owner_login`, `repository`, `visibility`, and `default_branch` is stored in `attributes_json`",
 		"urn:cerebro:writer:github_code_repository:1",
+		"Relation `has_context`",
 	} {
 		if !strings.Contains(hint, want) {
 			t.Fatalf("PromptHint() missing %q:\n%s", want, hint)

--- a/internal/sourceprojection/archetype.go
+++ b/internal/sourceprojection/archetype.go
@@ -156,6 +156,7 @@ func archetypeLibraryNoteProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 			"context_kind":  contextKind,
 		})
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), repoURN, noteURN, relationHasEvidence, linkAttrs))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), repoURN, noteURN, relationHasContext, linkAttrs))
 	}
 	if scanID := strings.TrimSpace(attrs["scan_id"]); scanID != "" {
 		scanURN := projectionURN(tenantID, "archetype_scan", scanID)

--- a/internal/sourceprojection/archetype_test.go
+++ b/internal/sourceprojection/archetype_test.go
@@ -143,6 +143,7 @@ func TestProjectArchetypeLibraryNoteLinksRepositoryContext(t *testing.T) {
 		t.Fatalf("scan entity missing: %#v", entity)
 	}
 	assertProjectedLink(t, state, repoURN, relationHasEvidence, noteURN)
+	assertProjectedLink(t, state, repoURN, relationHasContext, noteURN)
 	assertProjectedLink(t, state, noteURN, relationBelongsTo, scanURN)
 }
 
@@ -173,7 +174,38 @@ func TestProjectArchetypeLibraryNoteWithoutScanIDDoesNotCreateScan(t *testing.T)
 		t.Fatalf("phantom scan entity = %#v, want none", entity)
 	}
 	assertProjectedLink(t, state, repoURN, relationHasEvidence, noteURN)
+	assertProjectedLink(t, state, repoURN, relationHasContext, noteURN)
 	assertProjectedLinkMissing(t, state, noteURN, relationBelongsTo, phantomScanURN)
+}
+
+func TestProjectArchetypeLibraryNoteUsesEntryRepositoryForContext(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "archetype-library-590-repository-commit-learning",
+		TenantId: "writer",
+		SourceId: "archetype",
+		Kind:     "archetype.library_note",
+		Attributes: map[string]string{
+			"knowledge_slug": "repository-commit-learning",
+			"repository_id":  "590",
+			"owner":          "WriterInternal",
+			"repo":           "context-service",
+		},
+		Payload: []byte(`{"slug":"repository-commit-learning","title":"Repository commit learning","summary":"Archetype learned the latest repository head."}`),
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	targetRepoURN := "urn:cerebro:writer:github_code_repository:WriterInternal/context-service"
+	archetypeRepoURN := "urn:cerebro:writer:github_code_repository:WriterInternal/archetype"
+	noteURN := "urn:cerebro:writer:archetype_library_note:WriterInternal/context-service:repository-commit-learning"
+
+	assertProjectedLink(t, state, targetRepoURN, relationHasContext, noteURN)
+	assertProjectedLink(t, state, targetRepoURN, relationHasEvidence, noteURN)
+	assertProjectedLinkMissing(t, state, archetypeRepoURN, relationHasContext, noteURN)
+	assertProjectedLinkMissing(t, state, archetypeRepoURN, relationHasEvidence, noteURN)
 }
 
 func TestProjectArchetypeLibraryNoteEscapesSlugURNPart(t *testing.T) {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -44,6 +44,7 @@ const (
 	relationDependsOn          = fabriccontract.RelationDependsOn
 	relationGrantsEntitlement  = fabriccontract.RelationGrantsEntitlement
 	relationHasClassification  = fabriccontract.RelationHasClassification
+	relationHasContext         = fabriccontract.RelationHasContext
 	relationHasDNSRecord       = fabriccontract.RelationHasDNSRecord
 	relationHasEvidence        = fabriccontract.RelationHasEvidence
 	relationMemberOf           = fabriccontract.RelationMemberOf


### PR DESCRIPTION
## Summary
- add `has_context` to the fabric relation contract
- project Archetype library notes as repository context as well as evidence
- assert library-note context attaches to the target repository, not the scanner repository

## Verification
- `go test ./internal/sourceprojection -run 'TestProjectArchetype'`\n- `go test ./internal/fabriccontract ./internal/sourceprojection`\n- Live dev check completed against a non-scanner repository: claims published, graph ingest completed, and graph verification found the target repository root with `has_context` and `has_scan` present.