### PR TITLE
[codex] Modularize GRC domain builders

### DIFF
--- a/docs/domains/grc-architecture.md
+++ b/docs/domains/grc-architecture.md
@@ -6,10 +6,11 @@ It complements [Architecture](../reference/architecture.md), [Compliance Control
 
 ## Why This Exists
 
-The GRC surface is the fastest-growing part of the Cerebro platform. It spans six packages:
+The GRC surface is the fastest-growing part of the Cerebro platform. It spans seven packages:
 
 - `internal/grccatalog` — bounded report source catalog for custom dashboards
 - `internal/grccontrol` — control evidence packet builder and report rendering
+- `internal/grcfindings` — GRC risk-inbox finding, control, evidence, and summary builders
 - `internal/grcinventory` — inventory posture, scope, accountability, and filtering
 - `internal/grcprogram` — program readiness scoring and work-item generation
 - `internal/grctrends` — time-bucketed finding trend aggregation
@@ -29,13 +30,13 @@ Before this doc, GRC behavior was described only in accumulating paragraphs insi
    (readiness)    (source catalog)  (posture/scope)
           |               |               |
           +-------+-------+-------+-------+
-                  |               |
-             grctrends        compliance
-           (trend buckets)   (control catalog)
-                  |               |
-                  v               v
-           Postgres trends    Control families
-           + findings         + coverage index
+                  |       |       |
+             grctrends grcfindings compliance
+           (trend buckets) (risk inbox) (control catalog)
+                  |       |       |
+                  v       v       v
+           Postgres trends + findings  Control families
+           + findings                 + coverage index
 ```
 
 ## Package Contracts
@@ -80,9 +81,36 @@ Boundaries:
 
 Dependencies: `compliance`, `ports`, `resourcescope`
 
+### grcfindings — Risk Inbox Rows
+
+`internal/grcfindings` converts persisted finding and evidence records into
+GRC-facing rows for risk-inbox, dashboard, control-posture, audit-packet, CSV,
+and inventory-detail surfaces. It owns finding status normalization, SLA state,
+control grouping, evidence row mapping, summary counts, recommended finding
+actions, and connector freshness labels used by GRC views.
+
+Key exports:
+
+- `FindingItems`, `EvidenceItems`, `ControlItems` — transform persisted records
+  into bounded GRC response rows
+- `BuildSummary` — builds dashboard-level counts from row previews or aggregate
+  store summaries
+- `SLAStatus`, `NormalizedFindingStatus`, `RecommendedAction` — common
+  presentation semantics for GRC finding rows
+
+Boundaries:
+
+- Does not list findings, evidence, runtimes, or graph records; bootstrap and
+  stores still own tenant-scoped data access
+- Does not own finding lifecycle, rule evaluation, or workflow persistence
+- Does not define control catalog semantics; control coverage and packet
+  readiness stay in `internal/compliance` and `internal/grccontrol`
+
+Dependencies: `ports`
+
 ### grcinventory — Inventory Posture
 
-`internal/grcinventory` manages GRC inventory posture logic: applies scope records and asset report summaries to graph inventory assets, computes review disposition and accountability states, filters assets by scope/review/accountability, and produces summary statistics.
+`internal/grcinventory` manages GRC inventory posture logic: applies scope records and asset report summaries to graph inventory assets, computes review disposition and accountability states, derives inventory detail tests, vulnerabilities, timelines, actions, and risk decoration, filters assets by scope/review/accountability, and produces summary statistics.
 
 Key exports:
 
@@ -91,6 +119,7 @@ Key exports:
 - `ApplyReviewPosture(asset)` — computes review disposition (baseline, needs_review, out_of_scope, reported_issue) and accountability (known, required, none)
 - `FilterByScope`, `FilterByReviewDisposition`, `FilterByAccountability` — filter assets by state
 - `Summarize(assets)` — produces aggregate `Summary` with totals, coverage percentages, risk distribution
+- `Tests`, `Vulnerabilities`, `Timeline`, `Actions`, `ApplyFindingRisk` — build inventory detail sections from finding, evidence, control, report, and asset context
 
 Review disposition states:
 
@@ -111,10 +140,10 @@ Accountability states:
 
 Boundaries:
 
-- Posture classification and inventory filtering remain in this package
+- Posture classification, inventory filtering, inventory detail sections, and asset risk decoration remain in this package
 - Bootstrap only handles GRC inventory request/response mapping and tenant authorization
 
-Dependencies: `graphquery`, `ports`
+Dependencies: `graphquery`, `grcfindings`, `ports`
 
 ### grcprogram — Program Readiness
 
@@ -166,8 +195,9 @@ Dependencies: `ports`
 3. `grccontrol` builds control evidence packets from findings, evidence, and runtime context using compliance control definitions.
 4. `grcprogram` consumes control packets to score readiness and generate work items.
 5. `grctrends` queries persisted findings for time-bucketed trend analysis.
-6. `grcinventory` applies scope and accountability posture to graph inventory assets.
-7. All reads are tenant-scoped; the bootstrap layer enforces tenant authorization before dispatching to any GRC package.
+6. `grcfindings` builds GRC-facing finding, control, evidence, and summary rows.
+7. `grcinventory` applies scope and accountability posture to graph inventory assets and builds inventory detail sections.
+8. All reads are tenant-scoped; the bootstrap layer enforces tenant authorization before dispatching to any GRC package.
 
 ## RBAC Ownership
 
@@ -186,7 +216,9 @@ The GRC domain maps to these RBAC roles defined in `internal/authz`:
 - `internal/grccontrol/packets.go` — control evidence packet builder
 - `internal/grccontrol/finding_reports.go` — finding report assembly
 - `internal/grccontrol/helpers.go` — shared control helpers
+- `internal/grcfindings/items.go` — risk-inbox finding, evidence, control, summary, and action builders
 - `internal/grcinventory/posture.go` — inventory posture, scope, accountability, filtering
+- `internal/grcinventory/detail.go` — inventory detail tests, vulnerabilities, risk decoration, timelines, and actions
 - `internal/grcprogram/readiness.go` — program readiness scoring and work items
 - `internal/grctrends/trends.go` — finding trend aggregation
 - `internal/compliance/` — control catalog, profiles, coverage (see [Compliance Controls](compliance-controls.md))

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -101,8 +101,8 @@ context, the platform job store, coverage context, and evidence authorizers into
 `internal/a2agateway`. Durable task lifecycle behavior stays in that domain
 package; bootstrap only wires the HTTP boundary into it.
 
-The GRC domain packages (grccatalog, grccontrol, grcinventory, grcprogram,
-grctrends, and compliance) are documented in
+The GRC domain packages (grccatalog, grccontrol, grcfindings, grcinventory,
+grcprogram, grctrends, and compliance) are documented in
 [docs/domains/grc-architecture.md](../domains/grc-architecture.md). The
 bootstrap-budget paragraphs below describe only the transport-boundary adapters
 that wire those domain packages into HTTP routes.

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -1366,18 +1366,6 @@ func grcLimitEvidence(items []grcEvidenceItem, limit int) []grcEvidenceItem {
 	return grcfindings.LimitEvidence(items, limit)
 }
 
-func primaryEntity(finding *ports.FindingRecord) string {
-	return grcfindings.PrimaryEntity(finding)
-}
-
-func normalizedFindingStatus(status string) string {
-	return grcfindings.NormalizedFindingStatus(status)
-}
-
-func grcSLAStatus(finding *ports.FindingRecord) string {
-	return grcfindings.SLAStatus(finding)
-}
-
 func grcRecommendedAction(finding grcFindingItem) string {
 	return grcfindings.RecommendedAction(finding)
 }

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/grccontrol"
+	"github.com/writer/cerebro/internal/grcfindings"
 	"github.com/writer/cerebro/internal/grcproductareas"
 	"github.com/writer/cerebro/internal/grctrends"
 	"github.com/writer/cerebro/internal/ports"
@@ -52,92 +53,13 @@ type grcDashboardResponse struct {
 	GeneratedAt        time.Time                    `json:"generated_at"`
 }
 
-type grcSummary struct {
-	OpenFindings     int `json:"open_findings"`
-	CriticalFindings int `json:"critical_findings"`
-	HighFindings     int `json:"high_findings"`
-	OverdueFindings  int `json:"overdue_findings"`
-	Unassigned       int `json:"unassigned"`
-	ControlsFailing  int `json:"controls_failing"`
-	EvidenceItems    int `json:"evidence_items"`
-	Connectors       int `json:"connectors"`
-	StaleConnectors  int `json:"stale_connectors"`
-}
-
-type grcFindingItem struct {
-	ID           string          `json:"id"`
-	Title        string          `json:"title"`
-	Severity     string          `json:"severity"`
-	Status       string          `json:"status"`
-	Summary      string          `json:"summary,omitempty"`
-	TenantID     string          `json:"tenant_id,omitempty"`
-	RuntimeID    string          `json:"runtime_id,omitempty"`
-	SourceID     string          `json:"source_id,omitempty"`
-	Entity       string          `json:"entity,omitempty"`
-	ResourceURNs []string        `json:"resource_urns,omitempty"`
-	RuleID       string          `json:"rule_id,omitempty"`
-	PolicyID     string          `json:"policy_id,omitempty"`
-	PolicyName   string          `json:"policy_name,omitempty"`
-	Controls     []grcControlRef `json:"controls,omitempty"`
-	GRCFindingRisk
-	GRCFindingWorkflowMetadata
-	EvidenceCount   int        `json:"evidence_count"`
-	Owner           string     `json:"owner"`
-	SLAStatus       string     `json:"sla_status"`
-	FirstObservedAt *time.Time `json:"first_observed_at,omitempty"`
-	LastObservedAt  *time.Time `json:"last_observed_at,omitempty"`
-}
-
-type GRCFindingWorkflowMetadata struct {
-	Disposition     string                     `json:"disposition,omitempty"`
-	StatusReason    string                     `json:"status_reason,omitempty"`
-	Assignee        string                     `json:"assignee,omitempty"`
-	DueAt           *time.Time                 `json:"due_at,omitempty"`
-	StatusUpdatedAt *time.Time                 `json:"status_updated_at,omitempty"`
-	Notes           []ports.FindingNote        `json:"notes,omitempty"`
-	Tickets         []ports.FindingTicket      `json:"tickets,omitempty"`
-	ExternalRefs    []ports.FindingExternalRef `json:"external_refs,omitempty"`
-}
-
-type GRCFindingRisk struct {
-	RiskScore       int      `json:"risk_score,omitempty"`
-	LikelihoodScore int      `json:"likelihood_score,omitempty"`
-	ImpactScore     int      `json:"impact_score,omitempty"`
-	ConfidenceScore int      `json:"confidence_score,omitempty"`
-	LikelihoodLevel string   `json:"likelihood_level,omitempty"`
-	ImpactLevel     string   `json:"impact_level,omitempty"`
-	RiskReasons     []string `json:"risk_reasons,omitempty"`
-	RiskModel       string   `json:"risk_model_version,omitempty"`
-}
-
-type grcControlRef struct {
-	FrameworkName string `json:"framework_name"`
-	ControlID     string `json:"control_id"`
-}
-
-type grcControlItem struct {
-	FrameworkName    string           `json:"framework_name"`
-	ControlID        string           `json:"control_id"`
-	Status           string           `json:"status"`
-	OpenFindings     int              `json:"open_findings"`
-	CriticalFindings int              `json:"critical_findings"`
-	HighFindings     int              `json:"high_findings"`
-	EvidenceItems    int              `json:"evidence_items"`
-	Findings         []grcFindingItem `json:"findings,omitempty"`
-}
-
-type grcEvidenceItem struct {
-	ID            string    `json:"id"`
-	RuntimeID     string    `json:"runtime_id,omitempty"`
-	RuleID        string    `json:"rule_id,omitempty"`
-	FindingID     string    `json:"finding_id,omitempty"`
-	FindingTitle  string    `json:"finding_title,omitempty"`
-	RunID         string    `json:"run_id,omitempty"`
-	ClaimIDs      []string  `json:"claim_ids,omitempty"`
-	EventIDs      []string  `json:"event_ids,omitempty"`
-	GraphRootURNs []string  `json:"graph_root_urns,omitempty"`
-	CreatedAt     time.Time `json:"created_at,omitempty"`
-}
+type grcSummary = grcfindings.Summary
+type grcFindingItem = grcfindings.FindingItem
+type GRCFindingWorkflowMetadata = grcfindings.GRCFindingWorkflowMetadata
+type GRCFindingRisk = grcfindings.GRCFindingRisk
+type grcControlRef = grcfindings.ControlRef
+type grcControlItem = grcfindings.ControlItem
+type grcEvidenceItem = grcfindings.EvidenceItem
 
 type grcConnector struct {
 	RuntimeID           string     `json:"runtime_id"`
@@ -1389,143 +1311,19 @@ func grcFindingTitleMap(findings []*ports.FindingRecord) map[string]string {
 }
 
 func grcFindingItems(findings []*ports.FindingRecord, sourceIDs map[string]string, evidenceCounts map[string]int) []grcFindingItem {
-	items := make([]grcFindingItem, 0, len(findings))
-	for _, finding := range findings {
-		if finding == nil {
-			continue
-		}
-		items = append(items, grcFindingItem{
-			ID:           finding.ID,
-			Title:        fallbackString(finding.Title, finding.RuleID, finding.ID),
-			Severity:     strings.ToUpper(strings.TrimSpace(finding.Severity)),
-			Status:       normalizedFindingStatus(finding.Status),
-			Summary:      finding.Summary,
-			TenantID:     finding.TenantID,
-			RuntimeID:    finding.RuntimeID,
-			SourceID:     sourceIDs[finding.RuntimeID],
-			Entity:       primaryEntity(finding),
-			ResourceURNs: append([]string(nil), finding.ResourceURNs...),
-			RuleID:       finding.RuleID,
-			PolicyID:     finding.PolicyID,
-			PolicyName:   finding.PolicyName,
-			Controls:     grcControlRefs(finding.ControlRefs),
-			GRCFindingRisk: GRCFindingRisk{
-				RiskScore:       finding.RiskScore,
-				LikelihoodScore: finding.LikelihoodScore,
-				ImpactScore:     finding.ImpactScore,
-				ConfidenceScore: finding.ConfidenceScore,
-				LikelihoodLevel: finding.LikelihoodLevel,
-				ImpactLevel:     finding.ImpactLevel,
-				RiskReasons:     append([]string(nil), finding.RiskReasons...),
-				RiskModel:       finding.RiskModelVersion,
-			},
-			GRCFindingWorkflowMetadata: GRCFindingWorkflowMetadata{
-				StatusReason:    finding.StatusReason,
-				Assignee:        finding.Assignee,
-				DueAt:           timePtr(finding.DueAt),
-				StatusUpdatedAt: timePtr(finding.StatusUpdatedAt),
-				Notes:           append([]ports.FindingNote(nil), finding.Notes...),
-				Tickets:         append([]ports.FindingTicket(nil), finding.Tickets...),
-				ExternalRefs:    append([]ports.FindingExternalRef(nil), finding.ExternalRefs...),
-			},
-			EvidenceCount:   evidenceCounts[finding.ID],
-			Owner:           fallbackString(finding.Assignee, "Unassigned"),
-			SLAStatus:       grcSLAStatus(finding),
-			FirstObservedAt: timePtr(finding.FirstObservedAt),
-			LastObservedAt:  timePtr(finding.LastObservedAt),
-		})
-	}
-	return items
+	return grcfindings.FindingItems(findings, sourceIDs, evidenceCounts)
 }
 
 func grcControlRefs(refs []ports.FindingControlRef) []grcControlRef {
-	items := make([]grcControlRef, 0, len(refs))
-	for _, ref := range refs {
-		framework := strings.TrimSpace(ref.FrameworkName)
-		controlID := strings.TrimSpace(ref.ControlID)
-		if framework == "" || controlID == "" {
-			continue
-		}
-		items = append(items, grcControlRef{FrameworkName: framework, ControlID: controlID})
-	}
-	return items
+	return grcfindings.ControlRefs(refs)
 }
 
 func grcEvidenceItems(evidence []*cerebrov1.FindingEvidence, findingTitles map[string]string) []grcEvidenceItem {
-	items := make([]grcEvidenceItem, 0, len(evidence))
-	for _, item := range evidence {
-		if item == nil {
-			continue
-		}
-		items = append(items, grcEvidenceItem{
-			ID:            item.GetId(),
-			RuntimeID:     item.GetRuntimeId(),
-			RuleID:        item.GetRuleId(),
-			FindingID:     item.GetFindingId(),
-			FindingTitle:  findingTitles[item.GetFindingId()],
-			RunID:         item.GetRunId(),
-			ClaimIDs:      append([]string(nil), item.GetClaimIds()...),
-			EventIDs:      append([]string(nil), item.GetEventIds()...),
-			GraphRootURNs: append([]string(nil), item.GetGraphRootUrns()...),
-			CreatedAt:     item.GetCreatedAt().AsTime(),
-		})
-	}
-	return items
+	return grcfindings.EvidenceItems(evidence, findingTitles)
 }
 
 func grcControlItems(findings []grcFindingItem, evidence []grcEvidenceItem) []grcControlItem {
-	controlMap := map[string]*grcControlItem{}
-	evidenceByFinding := map[string]int{}
-	for _, item := range evidence {
-		evidenceByFinding[item.FindingID]++
-	}
-	for _, finding := range findings {
-		refs := finding.Controls
-		if len(refs) == 0 {
-			refs = []grcControlRef{{FrameworkName: "Unmapped", ControlID: "Needs mapping"}}
-		}
-		for _, ref := range refs {
-			key := ref.FrameworkName + "\x00" + ref.ControlID
-			control := controlMap[key]
-			if control == nil {
-				control = &grcControlItem{
-					FrameworkName: ref.FrameworkName,
-					ControlID:     ref.ControlID,
-					Status:        "passing",
-				}
-				controlMap[key] = control
-			}
-			control.Findings = append(control.Findings, finding)
-			if finding.Status == "OPEN" || strings.EqualFold(finding.Status, "open") {
-				control.OpenFindings++
-				control.Status = "failing"
-				if finding.Severity == "CRITICAL" {
-					control.CriticalFindings++
-				}
-				if finding.Severity == "HIGH" {
-					control.HighFindings++
-				}
-			}
-			if finding.EvidenceCount != 0 {
-				control.EvidenceItems += finding.EvidenceCount
-			} else {
-				control.EvidenceItems += evidenceByFinding[finding.ID]
-			}
-		}
-	}
-	controls := make([]grcControlItem, 0, len(controlMap))
-	for _, control := range controlMap {
-		controls = append(controls, *control)
-	}
-	sort.Slice(controls, func(i, j int) bool {
-		left := controls[i]
-		right := controls[j]
-		if left.OpenFindings != right.OpenFindings {
-			return left.OpenFindings > right.OpenFindings
-		}
-		return left.FrameworkName+left.ControlID < right.FrameworkName+right.ControlID
-	})
-	return controls
+	return grcfindings.ControlItems(findings, evidence)
 }
 
 func grcConnectorItems(runtimes []*cerebrov1.SourceRuntime) []grcConnector {
@@ -1553,153 +1351,43 @@ func grcConnectorItems(runtimes []*cerebrov1.SourceRuntime) []grcConnector {
 }
 
 func grcBuildSummary(findings []grcFindingItem, controls []grcControlItem, evidence []grcEvidenceItem, runtimes []*cerebrov1.SourceRuntime, findingSummary *ports.FindingSummary, evidenceCount *int) grcSummary {
-	var summary grcSummary
-	if evidenceCount != nil {
-		summary.EvidenceItems = *evidenceCount
-	} else {
-		summary.EvidenceItems = len(evidence)
-	}
-	summary.Connectors = len(runtimes)
-	if findingSummary != nil {
-		summary.OpenFindings = findingSummary.OpenFindings
-		summary.CriticalFindings = findingSummary.CriticalFindings
-		summary.HighFindings = findingSummary.HighFindings
-		summary.OverdueFindings = findingSummary.OverdueFindings
-		summary.Unassigned = findingSummary.Unassigned
-		summary.ControlsFailing = findingSummary.ControlsFailing
-	} else {
-		for _, finding := range findings {
-			if finding.Status == "OPEN" {
-				summary.OpenFindings++
-				if finding.Severity == "CRITICAL" {
-					summary.CriticalFindings++
-				}
-				if finding.Severity == "HIGH" {
-					summary.HighFindings++
-				}
-				if finding.SLAStatus == "overdue" {
-					summary.OverdueFindings++
-				}
-				if finding.Owner == "Unassigned" {
-					summary.Unassigned++
-				}
-			}
-		}
-		for _, control := range controls {
-			if control.Status == "failing" {
-				summary.ControlsFailing++
-			}
-		}
-	}
-	for _, runtime := range runtimes {
-		if connectorStatus(timestampPtr(runtime.GetLastSyncedAt())) == "stale" {
-			summary.StaleConnectors++
-		}
-	}
-	return summary
+	return grcfindings.BuildSummary(findings, controls, evidence, runtimes, findingSummary, evidenceCount)
 }
 
 func grcLimitFindings(items []grcFindingItem, limit int) []grcFindingItem {
-	if len(items) > limit {
-		return items[:limit]
-	}
-	return items
+	return grcfindings.LimitFindings(items, limit)
 }
 
 func grcLimitControls(items []grcControlItem, limit int) []grcControlItem {
-	if len(items) > limit {
-		return items[:limit]
-	}
-	return items
+	return grcfindings.LimitControls(items, limit)
 }
 
 func grcLimitEvidence(items []grcEvidenceItem, limit int) []grcEvidenceItem {
-	if len(items) > limit {
-		return items[:limit]
-	}
-	return items
+	return grcfindings.LimitEvidence(items, limit)
 }
 
 func primaryEntity(finding *ports.FindingRecord) string {
-	if finding == nil {
-		return ""
-	}
-	for _, urn := range finding.ResourceURNs {
-		if strings.TrimSpace(urn) != "" {
-			return strings.TrimSpace(urn)
-		}
-	}
-	return fallbackString(finding.PolicyName, finding.PolicyID, finding.RuleID)
+	return grcfindings.PrimaryEntity(finding)
 }
 
 func normalizedFindingStatus(status string) string {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "open", "finding_status_open":
-		return "OPEN"
-	case "resolved", "finding_status_resolved":
-		return "RESOLVED"
-	case "suppressed", "finding_status_suppressed":
-		return "SUPPRESSED"
-	default:
-		return "UNKNOWN"
-	}
+	return grcfindings.NormalizedFindingStatus(status)
 }
 
 func grcSLAStatus(finding *ports.FindingRecord) string {
-	if finding == nil {
-		return "unknown"
-	}
-	if normalizedFindingStatus(finding.Status) != "OPEN" {
-		return "closed"
-	}
-	if finding.DueAt.IsZero() {
-		return "no_due_date"
-	}
-	if time.Now().UTC().After(finding.DueAt) {
-		return "overdue"
-	}
-	if time.Until(finding.DueAt) <= 72*time.Hour {
-		return "due_soon"
-	}
-	return "on_track"
+	return grcfindings.SLAStatus(finding)
 }
 
 func grcRecommendedAction(finding grcFindingItem) string {
-	if finding.Owner == "Unassigned" {
-		return "Assign an owner, confirm evidence, and set a remediation due date."
-	}
-	if finding.EvidenceCount == 0 {
-		return "Request supporting evidence before audit review."
-	}
-	if len(finding.Controls) == 0 {
-		return "Map this finding to the affected control objective."
-	}
-	return "Review evidence, confirm impact, and update remediation status."
+	return grcfindings.RecommendedAction(finding)
 }
 
 func connectorStatus(lastSyncedAt *time.Time) string {
-	if lastSyncedAt == nil {
-		return "unknown"
-	}
-	if time.Since(*lastSyncedAt) > 24*time.Hour {
-		return "stale"
-	}
-	return "healthy"
+	return grcfindings.ConnectorStatus(lastSyncedAt)
 }
 
 func connectorFreshness(lastSyncedAt *time.Time) string {
-	if lastSyncedAt == nil {
-		return "never_synced"
-	}
-	age := time.Since(*lastSyncedAt)
-	switch {
-	case age <= time.Hour:
-		return "fresh"
-	case age <= 24*time.Hour:
-		return "recent"
-	default:
-		return "stale"
-	}
+	return grcfindings.ConnectorFreshness(lastSyncedAt)
 }
 
 func grcRuntimeCheckpointWatermark(runtime *cerebrov1.SourceRuntime) *time.Time {
@@ -1722,20 +1410,7 @@ func timestampLagSeconds(value *time.Time) *int64 {
 }
 
 func severityRank(severity string) int {
-	switch strings.ToUpper(strings.TrimSpace(severity)) {
-	case "CRITICAL":
-		return 0
-	case "HIGH":
-		return 1
-	case "MEDIUM":
-		return 2
-	case "LOW":
-		return 3
-	case "INFO":
-		return 4
-	default:
-		return 5
-	}
+	return grcfindings.SeverityRank(severity)
 }
 
 func fallbackString(values ...string) string {

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -66,40 +66,10 @@ type grcInventoryAssetDetailResponse struct {
 	GeneratedAt     time.Time                              `json:"generated_at"`
 }
 
-type grcInventoryTimelineEvent struct {
-	At          *time.Time `json:"at,omitempty"`
-	Kind        string     `json:"kind"`
-	Title       string     `json:"title"`
-	Description string     `json:"description,omitempty"`
-	Status      string     `json:"status,omitempty"`
-}
-
-type grcInventoryAction struct {
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Priority    string `json:"priority"`
-	Href        string `json:"href,omitempty"`
-}
-
-type grcInventoryTestItem struct {
-	Name         string     `json:"name"`
-	Owner        string     `json:"owner"`
-	Status       string     `json:"status"`
-	DueAt        *time.Time `json:"due_at,omitempty"`
-	ControlID    string     `json:"control_id,omitempty"`
-	Framework    string     `json:"framework,omitempty"`
-	FindingID    string     `json:"finding_id,omitempty"`
-	FindingTitle string     `json:"finding_title,omitempty"`
-}
-
-type grcInventoryVulnerability struct {
-	ID        string `json:"id"`
-	Title     string `json:"title"`
-	Severity  string `json:"severity"`
-	Status    string `json:"status"`
-	SourceID  string `json:"source_id,omitempty"`
-	FindingID string `json:"finding_id,omitempty"`
-}
+type grcInventoryTimelineEvent = grcinventory.TimelineEvent
+type grcInventoryAction = grcinventory.Action
+type grcInventoryTestItem = grcinventory.TestItem
+type grcInventoryVulnerability = grcinventory.Vulnerability
 
 type grcResourceScopeResponse struct {
 	SourceID    string                      `json:"source_id"`
@@ -847,84 +817,15 @@ func (a *App) handleUpdateGRCInventoryAssetReportTriage(w http.ResponseWriter, r
 }
 
 func grcInventoryTests(findings []grcFindingItem, controls []grcControlItem) []grcInventoryTestItem {
-	tests := []grcInventoryTestItem{}
-	seen := map[string]struct{}{}
-	for _, finding := range findings {
-		refs := finding.Controls
-		if len(refs) == 0 {
-			refs = []grcControlRef{{FrameworkName: "Unmapped", ControlID: fallbackString(finding.PolicyName, finding.RuleID, finding.ID)}}
-		}
-		for _, ref := range refs {
-			name := fallbackString(finding.PolicyName, finding.Title, ref.ControlID)
-			key := name + "\x00" + ref.FrameworkName + "\x00" + ref.ControlID + "\x00" + finding.ID
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			tests = append(tests, grcInventoryTestItem{
-				Name:         name,
-				Owner:        finding.Owner,
-				Status:       inventoryTestStatus(finding),
-				DueAt:        finding.DueAt,
-				ControlID:    ref.ControlID,
-				Framework:    ref.FrameworkName,
-				FindingID:    finding.ID,
-				FindingTitle: finding.Title,
-			})
-		}
-	}
-	if len(tests) == 0 {
-		for _, control := range controls {
-			key := control.FrameworkName + "\x00" + control.ControlID
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			tests = append(tests, grcInventoryTestItem{
-				Name:      control.ControlID,
-				Owner:     "Unassigned",
-				Status:    control.Status,
-				ControlID: control.ControlID,
-				Framework: control.FrameworkName,
-			})
-		}
-	}
-	sort.Slice(tests, func(i, j int) bool {
-		if tests[i].Status != tests[j].Status {
-			return tests[i].Status < tests[j].Status
-		}
-		return tests[i].Name < tests[j].Name
-	})
-	return tests
+	return grcinventory.Tests(findings, controls)
 }
 
 func inventoryTestStatus(finding grcFindingItem) string {
-	if finding.Status == "OPEN" || strings.EqualFold(finding.Status, "open") {
-		if finding.SLAStatus == "overdue" {
-			return "overdue"
-		}
-		return "failing"
-	}
-	return "ok"
+	return grcinventory.TestStatus(finding)
 }
 
 func grcInventoryVulnerabilities(findings []grcFindingItem) []grcInventoryVulnerability {
-	vulnerabilities := []grcInventoryVulnerability{}
-	for _, finding := range findings {
-		text := strings.ToLower(strings.Join([]string{finding.Title, finding.Summary, finding.RuleID, finding.PolicyID}, " "))
-		if !strings.Contains(text, "vulnerab") && !strings.Contains(text, "cve-") && !strings.Contains(text, "package") {
-			continue
-		}
-		vulnerabilities = append(vulnerabilities, grcInventoryVulnerability{
-			ID:        fallbackString(finding.PolicyID, finding.RuleID, finding.ID),
-			Title:     finding.Title,
-			Severity:  finding.Severity,
-			Status:    finding.Status,
-			SourceID:  finding.SourceID,
-			FindingID: finding.ID,
-		})
-	}
-	return vulnerabilities
+	return grcinventory.Vulnerabilities(findings)
 }
 
 func (a *App) enrichGRCInventoryAssets(r *http.Request, scope grcScope, assets []graphquery.InventoryAsset) ([]graphquery.InventoryAsset, error) {
@@ -1020,146 +921,27 @@ func (a *App) listGRCInventoryAssetReportsForAsset(r *http.Request, scope grcSco
 }
 
 func applyFindingRiskToInventoryAsset(asset graphquery.InventoryAsset, findings []grcFindingItem, tests []grcInventoryTestItem, vulnerabilities []grcInventoryVulnerability) graphquery.InventoryAsset {
-	score := asset.RiskScore
-	reasons := append([]string{}, asset.RiskReasons...)
-	for _, finding := range findings {
-		if int(finding.RiskScore) > score {
-			score = int(finding.RiskScore)
-		}
-		if strings.EqualFold(finding.Status, "open") {
-			reasons = append(reasons, "open finding")
-		}
-	}
-	if failingGRCInventoryTests(tests) > 0 {
-		score += 10
-		reasons = append(reasons, "failing compliance tests")
-	}
-	if criticalHighGRCInventoryVulnerabilities(vulnerabilities) > 0 {
-		score += 15
-		reasons = append(reasons, "critical or high vulnerabilities")
-	}
-	if asset.ScopeState == grcinventory.ScopeStateOutScope {
-		reasons = append(reasons, "out of GRC purview")
-	}
-	asset.RiskScore = grcinventory.ClampRisk(score)
-	asset.RiskLevel = grcinventory.RiskLevel(asset.RiskScore)
-	asset.RiskReasons = grcinventory.UniqueStrings(reasons)
-	return asset
+	return grcinventory.ApplyFindingRisk(asset, findings, tests, vulnerabilities)
 }
 
 func grcInventoryTimeline(asset graphquery.InventoryAsset, findings []grcFindingItem, evidence []grcEvidenceItem, tests []grcInventoryTestItem, reports []*ports.GRCInventoryAssetReportRecord) []grcInventoryTimelineEvent {
-	events := []grcInventoryTimelineEvent{}
-	for _, key := range []string{"created_at", "first_seen_at"} {
-		if at := parseGRCInventoryTime(asset.Attributes[key]); at != nil {
-			events = append(events, grcInventoryTimelineEvent{At: at, Kind: "asset", Title: "Asset first observed", Status: "observed"})
-			break
-		}
-	}
-	for _, key := range []string{"updated_at", "last_seen_at", "last_synced_at"} {
-		if at := parseGRCInventoryTime(asset.Attributes[key]); at != nil {
-			events = append(events, grcInventoryTimelineEvent{At: at, Kind: "asset", Title: "Asset refreshed", Status: "observed"})
-			break
-		}
-	}
-	if asset.ScopeUpdatedAt != "" {
-		events = append(events, grcInventoryTimelineEvent{At: parseGRCInventoryTime(asset.ScopeUpdatedAt), Kind: "scope", Title: "GRC purview updated", Description: asset.ScopeReason, Status: asset.ScopeState})
-	}
-	for _, report := range reports {
-		if report == nil {
-			continue
-		}
-		createdAt := report.CreatedAt.UTC()
-		events = append(events, grcInventoryTimelineEvent{At: &createdAt, Kind: "asset_report", Title: "Asset reported for curation", Description: report.Reason, Status: report.TriageStatus})
-		if report.TriagedAt != nil {
-			events = append(events, grcInventoryTimelineEvent{At: report.TriagedAt, Kind: "asset_report", Title: "Asset report triaged", Description: report.TriageReason, Status: report.TriageStatus})
-		}
-	}
-	for _, finding := range findings {
-		events = append(events, grcInventoryTimelineEvent{At: finding.LastObservedAt, Kind: "finding", Title: finding.Title, Description: finding.ID, Status: finding.Status})
-	}
-	for _, item := range evidence {
-		events = append(events, grcInventoryTimelineEvent{At: timePtr(item.CreatedAt), Kind: "evidence", Title: "Evidence attached", Description: item.ID, Status: "collected"})
-	}
-	for _, test := range tests {
-		if test.DueAt != nil {
-			events = append(events, grcInventoryTimelineEvent{At: test.DueAt, Kind: "test", Title: test.Name, Description: test.ControlID, Status: test.Status})
-		}
-	}
-	sort.Slice(events, func(i, j int) bool {
-		left, right := events[i].At, events[j].At
-		if left == nil {
-			return false
-		}
-		if right == nil {
-			return true
-		}
-		return left.After(*right)
-	})
-	if len(events) > 25 {
-		return events[:25]
-	}
-	return events
+	return grcinventory.Timeline(asset, findings, evidence, tests, reports)
 }
 
 func grcInventoryActions(asset graphquery.InventoryAsset, findings []grcFindingItem, controls []grcControlItem, tests []grcInventoryTestItem, vulnerabilities []grcInventoryVulnerability) []grcInventoryAction {
-	grcinventory.ApplyReviewPosture(&asset)
-	actions := []grcInventoryAction{}
-	if asset.ScopeState == grcinventory.ScopeStateOutScope {
-		actions = append(actions, grcInventoryAction{Title: "Confirm GRC purview", Description: "This asset is scoped out. Scope it back in if it should participate in controls, tests, and evidence review.", Priority: "high"})
-	}
-	if asset.Accountability != nil && asset.Accountability.State == grcinventory.AccountabilityRequired {
-		actions = append(actions, grcInventoryAction{Title: "Assign accountable owner", Description: "Add ownership metadata for this GRC-relevant asset so evidence, findings, and remediation work have a responsible team.", Priority: "high"})
-	}
-	if criticalHighGRCInventoryVulnerabilities(vulnerabilities) > 0 {
-		actions = append(actions, grcInventoryAction{Title: "Remediate critical or high vulnerabilities", Description: "Review linked findings and confirm active remediation plans for severe vulnerability exposure.", Priority: "high"})
-	}
-	if failingGRCInventoryTests(tests) > 0 {
-		actions = append(actions, grcInventoryAction{Title: "Fix failing compliance tests", Description: "Prioritize failing or overdue tests mapped to this asset before audit evidence collection.", Priority: "medium"})
-	}
-	if len(controls) == 0 && len(findings) > 0 {
-		actions = append(actions, grcInventoryAction{Title: "Map framework scope", Description: "Attach affected findings to framework controls to make audit impact explicit.", Priority: "medium"})
-	}
-	if len(actions) == 0 {
-		actions = append(actions, grcInventoryAction{Title: "Keep monitoring", Description: "No immediate scope, accountability, vulnerability, or test gaps were detected for this asset.", Priority: "low"})
-	}
-	return actions
+	return grcinventory.Actions(asset, findings, controls, tests, vulnerabilities)
 }
 
 func failingGRCInventoryTests(tests []grcInventoryTestItem) int {
-	count := 0
-	for _, test := range tests {
-		switch strings.ToLower(test.Status) {
-		case "failing", "overdue", "open":
-			count++
-		}
-	}
-	return count
+	return grcinventory.FailingTests(tests)
 }
 
 func criticalHighGRCInventoryVulnerabilities(items []grcInventoryVulnerability) int {
-	count := 0
-	for _, item := range items {
-		switch strings.ToUpper(item.Severity) {
-		case "CRITICAL", "HIGH":
-			count++
-		}
-	}
-	return count
+	return grcinventory.CriticalHighVulnerabilities(items)
 }
 
 func parseGRCInventoryTime(value string) *time.Time {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return nil
-	}
-	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, time.DateOnly} {
-		parsed, err := time.Parse(layout, value)
-		if err == nil {
-			parsed = parsed.UTC()
-			return &parsed
-		}
-	}
-	return nil
+	return grcinventory.ParseTime(value)
 }
 
 func grcInventoryUpdatedBy(r *http.Request) string {

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -820,10 +820,6 @@ func grcInventoryTests(findings []grcFindingItem, controls []grcControlItem) []g
 	return grcinventory.Tests(findings, controls)
 }
 
-func inventoryTestStatus(finding grcFindingItem) string {
-	return grcinventory.TestStatus(finding)
-}
-
 func grcInventoryVulnerabilities(findings []grcFindingItem) []grcInventoryVulnerability {
 	return grcinventory.Vulnerabilities(findings)
 }
@@ -930,18 +926,6 @@ func grcInventoryTimeline(asset graphquery.InventoryAsset, findings []grcFinding
 
 func grcInventoryActions(asset graphquery.InventoryAsset, findings []grcFindingItem, controls []grcControlItem, tests []grcInventoryTestItem, vulnerabilities []grcInventoryVulnerability) []grcInventoryAction {
 	return grcinventory.Actions(asset, findings, controls, tests, vulnerabilities)
-}
-
-func failingGRCInventoryTests(tests []grcInventoryTestItem) int {
-	return grcinventory.FailingTests(tests)
-}
-
-func criticalHighGRCInventoryVulnerabilities(items []grcInventoryVulnerability) int {
-	return grcinventory.CriticalHighVulnerabilities(items)
-}
-
-func parseGRCInventoryTime(value string) *time.Time {
-	return grcinventory.ParseTime(value)
 }
 
 func grcInventoryUpdatedBy(r *http.Request) string {

--- a/internal/grcfindings/items.go
+++ b/internal/grcfindings/items.go
@@ -1,0 +1,434 @@
+package grcfindings
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type Summary struct {
+	OpenFindings     int `json:"open_findings"`
+	CriticalFindings int `json:"critical_findings"`
+	HighFindings     int `json:"high_findings"`
+	OverdueFindings  int `json:"overdue_findings"`
+	Unassigned       int `json:"unassigned"`
+	ControlsFailing  int `json:"controls_failing"`
+	EvidenceItems    int `json:"evidence_items"`
+	Connectors       int `json:"connectors"`
+	StaleConnectors  int `json:"stale_connectors"`
+}
+
+type FindingItem struct {
+	ID           string       `json:"id"`
+	Title        string       `json:"title"`
+	Severity     string       `json:"severity"`
+	Status       string       `json:"status"`
+	Summary      string       `json:"summary,omitempty"`
+	TenantID     string       `json:"tenant_id,omitempty"`
+	RuntimeID    string       `json:"runtime_id,omitempty"`
+	SourceID     string       `json:"source_id,omitempty"`
+	Entity       string       `json:"entity,omitempty"`
+	ResourceURNs []string     `json:"resource_urns,omitempty"`
+	RuleID       string       `json:"rule_id,omitempty"`
+	PolicyID     string       `json:"policy_id,omitempty"`
+	PolicyName   string       `json:"policy_name,omitempty"`
+	Controls     []ControlRef `json:"controls,omitempty"`
+	GRCFindingRisk
+	GRCFindingWorkflowMetadata
+	EvidenceCount   int        `json:"evidence_count"`
+	Owner           string     `json:"owner"`
+	SLAStatus       string     `json:"sla_status"`
+	FirstObservedAt *time.Time `json:"first_observed_at,omitempty"`
+	LastObservedAt  *time.Time `json:"last_observed_at,omitempty"`
+}
+
+type GRCFindingWorkflowMetadata struct {
+	Disposition     string                     `json:"disposition,omitempty"`
+	StatusReason    string                     `json:"status_reason,omitempty"`
+	Assignee        string                     `json:"assignee,omitempty"`
+	DueAt           *time.Time                 `json:"due_at,omitempty"`
+	StatusUpdatedAt *time.Time                 `json:"status_updated_at,omitempty"`
+	Notes           []ports.FindingNote        `json:"notes,omitempty"`
+	Tickets         []ports.FindingTicket      `json:"tickets,omitempty"`
+	ExternalRefs    []ports.FindingExternalRef `json:"external_refs,omitempty"`
+}
+
+type GRCFindingRisk struct {
+	RiskScore       int      `json:"risk_score,omitempty"`
+	LikelihoodScore int      `json:"likelihood_score,omitempty"`
+	ImpactScore     int      `json:"impact_score,omitempty"`
+	ConfidenceScore int      `json:"confidence_score,omitempty"`
+	LikelihoodLevel string   `json:"likelihood_level,omitempty"`
+	ImpactLevel     string   `json:"impact_level,omitempty"`
+	RiskReasons     []string `json:"risk_reasons,omitempty"`
+	RiskModel       string   `json:"risk_model_version,omitempty"`
+}
+
+type ControlRef struct {
+	FrameworkName string `json:"framework_name"`
+	ControlID     string `json:"control_id"`
+}
+
+type ControlItem struct {
+	FrameworkName    string        `json:"framework_name"`
+	ControlID        string        `json:"control_id"`
+	Status           string        `json:"status"`
+	OpenFindings     int           `json:"open_findings"`
+	CriticalFindings int           `json:"critical_findings"`
+	HighFindings     int           `json:"high_findings"`
+	EvidenceItems    int           `json:"evidence_items"`
+	Findings         []FindingItem `json:"findings,omitempty"`
+}
+
+type EvidenceItem struct {
+	ID            string    `json:"id"`
+	RuntimeID     string    `json:"runtime_id,omitempty"`
+	RuleID        string    `json:"rule_id,omitempty"`
+	FindingID     string    `json:"finding_id,omitempty"`
+	FindingTitle  string    `json:"finding_title,omitempty"`
+	RunID         string    `json:"run_id,omitempty"`
+	ClaimIDs      []string  `json:"claim_ids,omitempty"`
+	EventIDs      []string  `json:"event_ids,omitempty"`
+	GraphRootURNs []string  `json:"graph_root_urns,omitempty"`
+	CreatedAt     time.Time `json:"created_at,omitempty"`
+}
+
+func FindingItems(findings []*ports.FindingRecord, sourceIDs map[string]string, evidenceCounts map[string]int) []FindingItem {
+	items := make([]FindingItem, 0, len(findings))
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		items = append(items, FindingItem{
+			ID:           finding.ID,
+			Title:        fallbackString(finding.Title, finding.RuleID, finding.ID),
+			Severity:     strings.ToUpper(strings.TrimSpace(finding.Severity)),
+			Status:       NormalizedFindingStatus(finding.Status),
+			Summary:      finding.Summary,
+			TenantID:     finding.TenantID,
+			RuntimeID:    finding.RuntimeID,
+			SourceID:     sourceIDs[finding.RuntimeID],
+			Entity:       PrimaryEntity(finding),
+			ResourceURNs: append([]string(nil), finding.ResourceURNs...),
+			RuleID:       finding.RuleID,
+			PolicyID:     finding.PolicyID,
+			PolicyName:   finding.PolicyName,
+			Controls:     ControlRefs(finding.ControlRefs),
+			GRCFindingRisk: GRCFindingRisk{
+				RiskScore:       finding.RiskScore,
+				LikelihoodScore: finding.LikelihoodScore,
+				ImpactScore:     finding.ImpactScore,
+				ConfidenceScore: finding.ConfidenceScore,
+				LikelihoodLevel: finding.LikelihoodLevel,
+				ImpactLevel:     finding.ImpactLevel,
+				RiskReasons:     append([]string(nil), finding.RiskReasons...),
+				RiskModel:       finding.RiskModelVersion,
+			},
+			GRCFindingWorkflowMetadata: GRCFindingWorkflowMetadata{
+				StatusReason:    finding.StatusReason,
+				Assignee:        finding.Assignee,
+				DueAt:           timePtr(finding.DueAt),
+				StatusUpdatedAt: timePtr(finding.StatusUpdatedAt),
+				Notes:           append([]ports.FindingNote(nil), finding.Notes...),
+				Tickets:         append([]ports.FindingTicket(nil), finding.Tickets...),
+				ExternalRefs:    append([]ports.FindingExternalRef(nil), finding.ExternalRefs...),
+			},
+			EvidenceCount:   evidenceCounts[finding.ID],
+			Owner:           fallbackString(finding.Assignee, "Unassigned"),
+			SLAStatus:       SLAStatus(finding),
+			FirstObservedAt: timePtr(finding.FirstObservedAt),
+			LastObservedAt:  timePtr(finding.LastObservedAt),
+		})
+	}
+	return items
+}
+
+func ControlRefs(refs []ports.FindingControlRef) []ControlRef {
+	items := make([]ControlRef, 0, len(refs))
+	for _, ref := range refs {
+		framework := strings.TrimSpace(ref.FrameworkName)
+		controlID := strings.TrimSpace(ref.ControlID)
+		if framework == "" || controlID == "" {
+			continue
+		}
+		items = append(items, ControlRef{FrameworkName: framework, ControlID: controlID})
+	}
+	return items
+}
+
+func EvidenceItems(evidence []*cerebrov1.FindingEvidence, findingTitles map[string]string) []EvidenceItem {
+	items := make([]EvidenceItem, 0, len(evidence))
+	for _, item := range evidence {
+		if item == nil {
+			continue
+		}
+		items = append(items, EvidenceItem{
+			ID:            item.GetId(),
+			RuntimeID:     item.GetRuntimeId(),
+			RuleID:        item.GetRuleId(),
+			FindingID:     item.GetFindingId(),
+			FindingTitle:  findingTitles[item.GetFindingId()],
+			RunID:         item.GetRunId(),
+			ClaimIDs:      append([]string(nil), item.GetClaimIds()...),
+			EventIDs:      append([]string(nil), item.GetEventIds()...),
+			GraphRootURNs: append([]string(nil), item.GetGraphRootUrns()...),
+			CreatedAt:     item.GetCreatedAt().AsTime(),
+		})
+	}
+	return items
+}
+
+func ControlItems(findings []FindingItem, evidence []EvidenceItem) []ControlItem {
+	controlMap := map[string]*ControlItem{}
+	evidenceByFinding := map[string]int{}
+	for _, item := range evidence {
+		evidenceByFinding[item.FindingID]++
+	}
+	for _, finding := range findings {
+		refs := finding.Controls
+		if len(refs) == 0 {
+			refs = []ControlRef{{FrameworkName: "Unmapped", ControlID: "Needs mapping"}}
+		}
+		for _, ref := range refs {
+			key := ref.FrameworkName + "\x00" + ref.ControlID
+			control := controlMap[key]
+			if control == nil {
+				control = &ControlItem{
+					FrameworkName: ref.FrameworkName,
+					ControlID:     ref.ControlID,
+					Status:        "passing",
+				}
+				controlMap[key] = control
+			}
+			control.Findings = append(control.Findings, finding)
+			if finding.Status == "OPEN" || strings.EqualFold(finding.Status, "open") {
+				control.OpenFindings++
+				control.Status = "failing"
+				if finding.Severity == "CRITICAL" {
+					control.CriticalFindings++
+				}
+				if finding.Severity == "HIGH" {
+					control.HighFindings++
+				}
+			}
+			if finding.EvidenceCount != 0 {
+				control.EvidenceItems += finding.EvidenceCount
+			} else {
+				control.EvidenceItems += evidenceByFinding[finding.ID]
+			}
+		}
+	}
+	controls := make([]ControlItem, 0, len(controlMap))
+	for _, control := range controlMap {
+		controls = append(controls, *control)
+	}
+	sort.Slice(controls, func(i, j int) bool {
+		left := controls[i]
+		right := controls[j]
+		if left.OpenFindings != right.OpenFindings {
+			return left.OpenFindings > right.OpenFindings
+		}
+		return left.FrameworkName+left.ControlID < right.FrameworkName+right.ControlID
+	})
+	return controls
+}
+
+func BuildSummary(findings []FindingItem, controls []ControlItem, evidence []EvidenceItem, runtimes []*cerebrov1.SourceRuntime, findingSummary *ports.FindingSummary, evidenceCount *int) Summary {
+	var summary Summary
+	if evidenceCount != nil {
+		summary.EvidenceItems = *evidenceCount
+	} else {
+		summary.EvidenceItems = len(evidence)
+	}
+	summary.Connectors = len(runtimes)
+	if findingSummary != nil {
+		summary.OpenFindings = findingSummary.OpenFindings
+		summary.CriticalFindings = findingSummary.CriticalFindings
+		summary.HighFindings = findingSummary.HighFindings
+		summary.OverdueFindings = findingSummary.OverdueFindings
+		summary.Unassigned = findingSummary.Unassigned
+		summary.ControlsFailing = findingSummary.ControlsFailing
+	} else {
+		for _, finding := range findings {
+			if finding.Status == "OPEN" {
+				summary.OpenFindings++
+				if finding.Severity == "CRITICAL" {
+					summary.CriticalFindings++
+				}
+				if finding.Severity == "HIGH" {
+					summary.HighFindings++
+				}
+				if finding.SLAStatus == "overdue" {
+					summary.OverdueFindings++
+				}
+				if finding.Owner == "Unassigned" {
+					summary.Unassigned++
+				}
+			}
+		}
+		for _, control := range controls {
+			if control.Status == "failing" {
+				summary.ControlsFailing++
+			}
+		}
+	}
+	for _, runtime := range runtimes {
+		if ConnectorStatus(protoTimePtr(runtime.GetLastSyncedAt())) == "stale" {
+			summary.StaleConnectors++
+		}
+	}
+	return summary
+}
+
+func LimitFindings(items []FindingItem, limit int) []FindingItem {
+	if len(items) > limit {
+		return items[:limit]
+	}
+	return items
+}
+
+func LimitControls(items []ControlItem, limit int) []ControlItem {
+	if len(items) > limit {
+		return items[:limit]
+	}
+	return items
+}
+
+func LimitEvidence(items []EvidenceItem, limit int) []EvidenceItem {
+	if len(items) > limit {
+		return items[:limit]
+	}
+	return items
+}
+
+func PrimaryEntity(finding *ports.FindingRecord) string {
+	if finding == nil {
+		return ""
+	}
+	for _, urn := range finding.ResourceURNs {
+		if strings.TrimSpace(urn) != "" {
+			return strings.TrimSpace(urn)
+		}
+	}
+	return fallbackString(finding.PolicyName, finding.PolicyID, finding.RuleID)
+}
+
+func NormalizedFindingStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "open", "finding_status_open":
+		return "OPEN"
+	case "resolved", "finding_status_resolved":
+		return "RESOLVED"
+	case "suppressed", "finding_status_suppressed":
+		return "SUPPRESSED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func SLAStatus(finding *ports.FindingRecord) string {
+	if finding == nil {
+		return "unknown"
+	}
+	if NormalizedFindingStatus(finding.Status) != "OPEN" {
+		return "closed"
+	}
+	if finding.DueAt.IsZero() {
+		return "no_due_date"
+	}
+	if time.Now().UTC().After(finding.DueAt) {
+		return "overdue"
+	}
+	if time.Until(finding.DueAt) <= 72*time.Hour {
+		return "due_soon"
+	}
+	return "on_track"
+}
+
+func RecommendedAction(finding FindingItem) string {
+	if finding.Owner == "Unassigned" {
+		return "Assign an owner, confirm evidence, and set a remediation due date."
+	}
+	if finding.EvidenceCount == 0 {
+		return "Request supporting evidence before audit review."
+	}
+	if len(finding.Controls) == 0 {
+		return "Map this finding to the affected control objective."
+	}
+	return "Review evidence, confirm impact, and update remediation status."
+}
+
+func ConnectorStatus(lastSyncedAt *time.Time) string {
+	if lastSyncedAt == nil {
+		return "unknown"
+	}
+	if time.Since(*lastSyncedAt) > 24*time.Hour {
+		return "stale"
+	}
+	return "healthy"
+}
+
+func ConnectorFreshness(lastSyncedAt *time.Time) string {
+	if lastSyncedAt == nil {
+		return "never_synced"
+	}
+	age := time.Since(*lastSyncedAt)
+	switch {
+	case age <= time.Hour:
+		return "fresh"
+	case age <= 24*time.Hour:
+		return "recent"
+	default:
+		return "stale"
+	}
+}
+
+func SeverityRank(severity string) int {
+	switch strings.ToUpper(strings.TrimSpace(severity)) {
+	case "CRITICAL":
+		return 0
+	case "HIGH":
+		return 1
+	case "MEDIUM":
+		return 2
+	case "LOW":
+		return 3
+	case "INFO":
+		return 4
+	default:
+		return 5
+	}
+}
+
+func fallbackString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func timePtr(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	value = value.UTC()
+	return &value
+}
+
+func protoTimePtr(value *timestamppb.Timestamp) *time.Time {
+	if value == nil {
+		return nil
+	}
+	timestamp := value.AsTime()
+	if timestamp.IsZero() {
+		return nil
+	}
+	timestamp = timestamp.UTC()
+	return &timestamp
+}

--- a/internal/grcfindings/items_test.go
+++ b/internal/grcfindings/items_test.go
@@ -1,0 +1,85 @@
+package grcfindings
+
+import (
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestFindingItemsNormalizeRiskInboxRows(t *testing.T) {
+	dueAt := time.Now().UTC().Add(48 * time.Hour)
+	statusUpdatedAt := time.Now().UTC().Add(-time.Hour)
+	findings := []*ports.FindingRecord{{
+		ID:           "finding-1",
+		TenantID:     "tenant-1",
+		RuntimeID:    "runtime-1",
+		RuleID:       "rule-1",
+		Title:        "Privileged access needs review",
+		Severity:     "high",
+		Status:       "open",
+		Summary:      "Privileged access lacks review evidence.",
+		ResourceURNs: []string{"urn:cerebro:tenant-1:identity:user-1"},
+		PolicyID:     "policy-1",
+		PolicyName:   "Access review",
+		ControlRefs:  []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        72,
+			LikelihoodScore:  70,
+			ImpactScore:      80,
+			ConfidenceScore:  90,
+			LikelihoodLevel:  "high",
+			ImpactLevel:      "high",
+			RiskReasons:      []string{"privileged access"},
+			RiskModelVersion: "risk-v1",
+		},
+		FindingWorkflow: ports.FindingWorkflow{
+			Assignee:        "security-owner",
+			DueAt:           dueAt,
+			StatusReason:    "triaged",
+			StatusUpdatedAt: statusUpdatedAt,
+			Notes:           []ports.FindingNote{{ID: "note-1", Body: "Owner confirmed.", CreatedAt: statusUpdatedAt}},
+		},
+	}}
+	items := FindingItems(findings, map[string]string{"runtime-1": "okta"}, map[string]int{"finding-1": 3})
+	if len(items) != 1 {
+		t.Fatalf("len(FindingItems) = %d, want 1", len(items))
+	}
+	item := items[0]
+	if item.Severity != "HIGH" || item.Status != "OPEN" {
+		t.Fatalf("normalized severity/status = %q/%q, want HIGH/OPEN", item.Severity, item.Status)
+	}
+	if item.SourceID != "okta" || item.Entity != "urn:cerebro:tenant-1:identity:user-1" {
+		t.Fatalf("source/entity = %q/%q", item.SourceID, item.Entity)
+	}
+	if item.RiskScore != 72 || item.RiskModel != "risk-v1" {
+		t.Fatalf("risk fields = score %d model %q", item.RiskScore, item.RiskModel)
+	}
+	if item.Owner != "security-owner" || item.SLAStatus != "due_soon" || item.EvidenceCount != 3 {
+		t.Fatalf("workflow fields owner=%q sla=%q evidence=%d", item.Owner, item.SLAStatus, item.EvidenceCount)
+	}
+	if item.DueAt == nil || !item.DueAt.Equal(dueAt) {
+		t.Fatalf("DueAt = %v, want %v", item.DueAt, dueAt)
+	}
+	if len(item.Controls) != 1 || item.Controls[0].ControlID != "CC6.1" {
+		t.Fatalf("Controls = %#v, want SOC 2 CC6.1", item.Controls)
+	}
+}
+
+func TestControlItemsGroupOpenFindingsByControl(t *testing.T) {
+	items := ControlItems([]FindingItem{
+		{ID: "critical", Severity: "CRITICAL", Status: "OPEN", EvidenceCount: 2, Controls: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}}},
+		{ID: "high", Severity: "HIGH", Status: "OPEN", EvidenceCount: 1, Controls: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}}},
+		{ID: "resolved", Severity: "LOW", Status: "RESOLVED", Controls: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.2"}}},
+	}, nil)
+	if len(items) != 2 {
+		t.Fatalf("len(ControlItems) = %d, want 2", len(items))
+	}
+	control := items[0]
+	if control.FrameworkName != "SOC 2" || control.ControlID != "CC6.1" {
+		t.Fatalf("first control = %s %s, want SOC 2 CC6.1", control.FrameworkName, control.ControlID)
+	}
+	if control.Status != "failing" || control.OpenFindings != 2 || control.CriticalFindings != 1 || control.HighFindings != 1 || control.EvidenceItems != 3 {
+		t.Fatalf("control posture = %#v", control)
+	}
+}

--- a/internal/grcinventory/detail.go
+++ b/internal/grcinventory/detail.go
@@ -1,0 +1,278 @@
+package grcinventory
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/grcfindings"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type TimelineEvent struct {
+	At          *time.Time `json:"at,omitempty"`
+	Kind        string     `json:"kind"`
+	Title       string     `json:"title"`
+	Description string     `json:"description,omitempty"`
+	Status      string     `json:"status,omitempty"`
+}
+
+type Action struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Priority    string `json:"priority"`
+	Href        string `json:"href,omitempty"`
+}
+
+type TestItem struct {
+	Name         string     `json:"name"`
+	Owner        string     `json:"owner"`
+	Status       string     `json:"status"`
+	DueAt        *time.Time `json:"due_at,omitempty"`
+	ControlID    string     `json:"control_id,omitempty"`
+	Framework    string     `json:"framework,omitempty"`
+	FindingID    string     `json:"finding_id,omitempty"`
+	FindingTitle string     `json:"finding_title,omitempty"`
+}
+
+type Vulnerability struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Severity  string `json:"severity"`
+	Status    string `json:"status"`
+	SourceID  string `json:"source_id,omitempty"`
+	FindingID string `json:"finding_id,omitempty"`
+}
+
+func Tests(findings []grcfindings.FindingItem, controls []grcfindings.ControlItem) []TestItem {
+	tests := []TestItem{}
+	seen := map[string]struct{}{}
+	for _, finding := range findings {
+		refs := finding.Controls
+		if len(refs) == 0 {
+			refs = []grcfindings.ControlRef{{FrameworkName: "Unmapped", ControlID: fallback(finding.PolicyName, finding.RuleID, finding.ID)}}
+		}
+		for _, ref := range refs {
+			name := fallback(finding.PolicyName, finding.Title, ref.ControlID)
+			key := name + "\x00" + ref.FrameworkName + "\x00" + ref.ControlID + "\x00" + finding.ID
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			tests = append(tests, TestItem{
+				Name:         name,
+				Owner:        finding.Owner,
+				Status:       TestStatus(finding),
+				DueAt:        finding.DueAt,
+				ControlID:    ref.ControlID,
+				Framework:    ref.FrameworkName,
+				FindingID:    finding.ID,
+				FindingTitle: finding.Title,
+			})
+		}
+	}
+	if len(tests) == 0 {
+		for _, control := range controls {
+			key := control.FrameworkName + "\x00" + control.ControlID
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			tests = append(tests, TestItem{
+				Name:      control.ControlID,
+				Owner:     "Unassigned",
+				Status:    control.Status,
+				ControlID: control.ControlID,
+				Framework: control.FrameworkName,
+			})
+		}
+	}
+	sort.Slice(tests, func(i, j int) bool {
+		if tests[i].Status != tests[j].Status {
+			return tests[i].Status < tests[j].Status
+		}
+		return tests[i].Name < tests[j].Name
+	})
+	return tests
+}
+
+func TestStatus(finding grcfindings.FindingItem) string {
+	if finding.Status == "OPEN" || strings.EqualFold(finding.Status, "open") {
+		if finding.SLAStatus == "overdue" {
+			return "overdue"
+		}
+		return "failing"
+	}
+	return "ok"
+}
+
+func Vulnerabilities(findings []grcfindings.FindingItem) []Vulnerability {
+	vulnerabilities := []Vulnerability{}
+	for _, finding := range findings {
+		text := strings.ToLower(strings.Join([]string{finding.Title, finding.Summary, finding.RuleID, finding.PolicyID}, " "))
+		if !strings.Contains(text, "vulnerab") && !strings.Contains(text, "cve-") && !strings.Contains(text, "package") {
+			continue
+		}
+		vulnerabilities = append(vulnerabilities, Vulnerability{
+			ID:        fallback(finding.PolicyID, finding.RuleID, finding.ID),
+			Title:     finding.Title,
+			Severity:  finding.Severity,
+			Status:    finding.Status,
+			SourceID:  finding.SourceID,
+			FindingID: finding.ID,
+		})
+	}
+	return vulnerabilities
+}
+
+func ApplyFindingRisk(asset graphquery.InventoryAsset, findings []grcfindings.FindingItem, tests []TestItem, vulnerabilities []Vulnerability) graphquery.InventoryAsset {
+	score := asset.RiskScore
+	reasons := append([]string{}, asset.RiskReasons...)
+	for _, finding := range findings {
+		if int(finding.RiskScore) > score {
+			score = int(finding.RiskScore)
+		}
+		if strings.EqualFold(finding.Status, "open") {
+			reasons = append(reasons, "open finding")
+		}
+	}
+	if FailingTests(tests) > 0 {
+		score += 10
+		reasons = append(reasons, "failing compliance tests")
+	}
+	if CriticalHighVulnerabilities(vulnerabilities) > 0 {
+		score += 15
+		reasons = append(reasons, "critical or high vulnerabilities")
+	}
+	if asset.ScopeState == ScopeStateOutScope {
+		reasons = append(reasons, "out of GRC purview")
+	}
+	asset.RiskScore = ClampRisk(score)
+	asset.RiskLevel = RiskLevel(asset.RiskScore)
+	asset.RiskReasons = UniqueStrings(reasons)
+	return asset
+}
+
+func Timeline(asset graphquery.InventoryAsset, findings []grcfindings.FindingItem, evidence []grcfindings.EvidenceItem, tests []TestItem, reports []*ports.GRCInventoryAssetReportRecord) []TimelineEvent {
+	events := []TimelineEvent{}
+	for _, key := range []string{"created_at", "first_seen_at"} {
+		if at := ParseTime(asset.Attributes[key]); at != nil {
+			events = append(events, TimelineEvent{At: at, Kind: "asset", Title: "Asset first observed", Status: "observed"})
+			break
+		}
+	}
+	for _, key := range []string{"updated_at", "last_seen_at", "last_synced_at"} {
+		if at := ParseTime(asset.Attributes[key]); at != nil {
+			events = append(events, TimelineEvent{At: at, Kind: "asset", Title: "Asset refreshed", Status: "observed"})
+			break
+		}
+	}
+	if asset.ScopeUpdatedAt != "" {
+		events = append(events, TimelineEvent{At: ParseTime(asset.ScopeUpdatedAt), Kind: "scope", Title: "GRC purview updated", Description: asset.ScopeReason, Status: asset.ScopeState})
+	}
+	for _, report := range reports {
+		if report == nil {
+			continue
+		}
+		createdAt := report.CreatedAt.UTC()
+		events = append(events, TimelineEvent{At: &createdAt, Kind: "asset_report", Title: "Asset reported for curation", Description: report.Reason, Status: report.TriageStatus})
+		if report.TriagedAt != nil {
+			events = append(events, TimelineEvent{At: report.TriagedAt, Kind: "asset_report", Title: "Asset report triaged", Description: report.TriageReason, Status: report.TriageStatus})
+		}
+	}
+	for _, finding := range findings {
+		events = append(events, TimelineEvent{At: finding.LastObservedAt, Kind: "finding", Title: finding.Title, Description: finding.ID, Status: finding.Status})
+	}
+	for _, item := range evidence {
+		events = append(events, TimelineEvent{At: timePtr(item.CreatedAt), Kind: "evidence", Title: "Evidence attached", Description: item.ID, Status: "collected"})
+	}
+	for _, test := range tests {
+		if test.DueAt != nil {
+			events = append(events, TimelineEvent{At: test.DueAt, Kind: "test", Title: test.Name, Description: test.ControlID, Status: test.Status})
+		}
+	}
+	sort.Slice(events, func(i, j int) bool {
+		left, right := events[i].At, events[j].At
+		if left == nil {
+			return false
+		}
+		if right == nil {
+			return true
+		}
+		return left.After(*right)
+	})
+	if len(events) > 25 {
+		return events[:25]
+	}
+	return events
+}
+
+func Actions(asset graphquery.InventoryAsset, findings []grcfindings.FindingItem, controls []grcfindings.ControlItem, tests []TestItem, vulnerabilities []Vulnerability) []Action {
+	ApplyReviewPosture(&asset)
+	actions := []Action{}
+	if asset.ScopeState == ScopeStateOutScope {
+		actions = append(actions, Action{Title: "Confirm GRC purview", Description: "This asset is scoped out. Scope it back in if it should participate in controls, tests, and evidence review.", Priority: "high"})
+	}
+	if asset.Accountability != nil && asset.Accountability.State == AccountabilityRequired {
+		actions = append(actions, Action{Title: "Assign accountable owner", Description: "Add ownership metadata for this GRC-relevant asset so evidence, findings, and remediation work have a responsible team.", Priority: "high"})
+	}
+	if CriticalHighVulnerabilities(vulnerabilities) > 0 {
+		actions = append(actions, Action{Title: "Remediate critical or high vulnerabilities", Description: "Review linked findings and confirm active remediation plans for severe vulnerability exposure.", Priority: "high"})
+	}
+	if FailingTests(tests) > 0 {
+		actions = append(actions, Action{Title: "Fix failing compliance tests", Description: "Prioritize failing or overdue tests mapped to this asset before audit evidence collection.", Priority: "medium"})
+	}
+	if len(controls) == 0 && len(findings) > 0 {
+		actions = append(actions, Action{Title: "Map framework scope", Description: "Attach affected findings to framework controls to make audit impact explicit.", Priority: "medium"})
+	}
+	if len(actions) == 0 {
+		actions = append(actions, Action{Title: "Keep monitoring", Description: "No immediate scope, accountability, vulnerability, or test gaps were detected for this asset.", Priority: "low"})
+	}
+	return actions
+}
+
+func FailingTests(tests []TestItem) int {
+	count := 0
+	for _, test := range tests {
+		switch strings.ToLower(test.Status) {
+		case "failing", "overdue", "open":
+			count++
+		}
+	}
+	return count
+}
+
+func CriticalHighVulnerabilities(items []Vulnerability) int {
+	count := 0
+	for _, item := range items {
+		switch strings.ToUpper(item.Severity) {
+		case "CRITICAL", "HIGH":
+			count++
+		}
+	}
+	return count
+}
+
+func ParseTime(value string) *time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, time.DateOnly} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			parsed = parsed.UTC()
+			return &parsed
+		}
+	}
+	return nil
+}
+
+func timePtr(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	value = value.UTC()
+	return &value
+}

--- a/internal/grcinventory/detail_test.go
+++ b/internal/grcinventory/detail_test.go
@@ -1,0 +1,45 @@
+package grcinventory
+
+import (
+	"testing"
+
+	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/grcfindings"
+)
+
+func TestVulnerabilitiesReturnsEmptySlice(t *testing.T) {
+	got := Vulnerabilities([]grcfindings.FindingItem{{ID: "finding-1", Title: "Owner missing", Status: "OPEN"}})
+	if got == nil {
+		t.Fatal("Vulnerabilities() = nil, want empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("Vulnerabilities() len = %d, want 0", len(got))
+	}
+}
+
+func TestApplyFindingRiskCombinesInventorySignals(t *testing.T) {
+	asset := graphquery.InventoryAsset{RiskScore: 20, RiskReasons: []string{"existing"}}
+	got := ApplyFindingRisk(asset,
+		[]grcfindings.FindingItem{{ID: "finding-1", Status: "OPEN", GRCFindingRisk: grcfindings.GRCFindingRisk{RiskScore: 80}}},
+		[]TestItem{{Status: "failing"}},
+		[]Vulnerability{{Severity: "HIGH"}},
+	)
+	if got.RiskScore != 100 {
+		t.Fatalf("RiskScore = %d, want 100", got.RiskScore)
+	}
+	if got.RiskLevel != "critical" {
+		t.Fatalf("RiskLevel = %q, want critical", got.RiskLevel)
+	}
+	wantReasons := map[string]bool{
+		"existing":                         true,
+		"open finding":                     true,
+		"failing compliance tests":         true,
+		"critical or high vulnerabilities": true,
+	}
+	for _, reason := range got.RiskReasons {
+		delete(wantReasons, reason)
+	}
+	if len(wantReasons) != 0 {
+		t.Fatalf("RiskReasons missing %v from %#v", wantReasons, got.RiskReasons)
+	}
+}


### PR DESCRIPTION
## What changed

This starts the GRC modularization work by moving product-domain builders out of `internal/bootstrap` and into focused packages:

- Adds `internal/grcfindings` for GRC risk-inbox finding, control, evidence, summary, SLA, recommended-action, and connector freshness builders.
- Moves inventory detail tests, vulnerability rows, risk decoration, timelines, and recommended actions into `internal/grcinventory`.
- Leaves bootstrap as route wiring and request/response mapping through compatibility aliases and thin delegates.
- Updates the GRC architecture docs to include the new package boundary.

## Why

`internal/bootstrap` should own HTTP request handling, tenant/scope checks, and response writing. GRC product semantics are easier to test and evolve when finding rows and inventory detail sections live behind domain packages.

## Impact

No API behavior change is intended. Existing GRC response shapes are preserved while the implementation moves behind domain-owned builders.

## Validation

- `go test ./internal/grcfindings ./internal/grcinventory ./internal/bootstrap -count=1`
- `make check-arch`
- `make lint`
- PR checks are green on `4235c35`.

## Merge note

This PR is intentionally an early modularization slice. Follow-up work can remove more compatibility wrappers and continue moving GRC orchestration out of bootstrap once this boundary lands.
